### PR TITLE
fix: restore terminal colors in CLI lint output

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
+	"github.com/web-infra-dev/rslint/internal/term"
 )
 
 // lintArgs is the parsed CLI flag set, decoupled from the global flag
@@ -52,10 +53,15 @@ type lintArgs struct {
 	Format         string
 	NoColor        bool
 	ForceColor     bool
-	Quiet          bool
-	MaxWarnings    int
-	StartTimeMs    int64
-	RuleFlags      []string
+	// StdoutIsTTY is the TTY fact for the real output destination, reported
+	// by the Node host via the IPC init payload (the Go process's own stdout
+	// is an IPC pipe and says nothing about the user's terminal). False when
+	// unknown (old peer, wasm build).
+	StdoutIsTTY bool
+	Quiet       bool
+	MaxWarnings int
+	StartTimeMs int64
+	RuleFlags   []string
 	// Positional args resolved into existing-dir vs file paths.
 	AllowFiles []string
 	AllowDirs  []string
@@ -76,42 +82,41 @@ type ColorScheme struct {
 	BoldText    func(format string, a ...interface{}) string
 	BorderText  func(format string, a ...interface{}) string
 	WarnText    func(format string, a ...interface{}) string
+	// Reset is the trailing SGR reset sequence the summary lines emit (empty
+	// when colors are off) — byte-identical to the inline
+	// color.New().SprintFunc()("") emitters it replaces.
+	Reset string
 }
 
-// setupColors initializes the color scheme based on environment and flags
+// newPinnedColor builds a color object pinned to the resolved decision.
+// color.New seeds a per-object noColor switch from the NO_COLOR env at
+// creation time, which would silently override the pipeline-entry decision
+// (e.g. NO_COLOR set but --force-color given) — Enable/DisableColor makes
+// the object follow color.NoColor unconditionally.
+func newPinnedColor(attrs ...color.Attribute) *color.Color {
+	c := color.New(attrs...)
+	if color.NoColor {
+		c.DisableColor()
+	} else {
+		c.EnableColor()
+	}
+	return c
+}
+
+// setupColors builds the SprintfFunc scheme used by the formatters. It is a
+// pure factory: the on/off decision is owned by term.ResolveColorEnabled,
+// applied once at pipeline entry and propagated here via color.NoColor.
 func setupColors() *ColorScheme {
-	// Handle color flags and environment variables
-	if os.Getenv("NO_COLOR") != "" {
-		color.NoColor = true
-	}
-	if os.Getenv("FORCE_COLOR") != "" {
-		color.NoColor = false
-	}
-
-	// GitHub Actions specific handling
-	if os.Getenv("GITHUB_ACTIONS") != "" {
-		color.NoColor = false // Enable colors in GitHub Actions
-	}
-
-	// Create color functions
-	ruleNameColor := color.New(color.FgHiGreen).SprintfFunc()
-	fileNameColor := color.New(color.FgCyan, color.Italic).SprintfFunc()
-	errorTextColor := color.New(color.FgRed, color.Bold).SprintfFunc()
-	successColor := color.New(color.FgGreen, color.Bold).SprintfFunc()
-	dimColor := color.New(color.Faint).SprintfFunc()
-	boldColor := color.New(color.Bold).SprintfFunc()
-	borderColor := color.New(color.Faint).SprintfFunc()
-	WarnColor := color.New(color.FgYellow).SprintfFunc()
-
 	return &ColorScheme{
-		RuleName:    ruleNameColor,
-		FileName:    fileNameColor,
-		ErrorText:   errorTextColor,
-		SuccessText: successColor,
-		DimText:     dimColor,
-		BoldText:    boldColor,
-		BorderText:  borderColor,
-		WarnText:    WarnColor,
+		RuleName:    newPinnedColor(color.FgHiGreen).SprintfFunc(),
+		FileName:    newPinnedColor(color.FgCyan, color.Italic).SprintfFunc(),
+		ErrorText:   newPinnedColor(color.FgRed, color.Bold).SprintfFunc(),
+		SuccessText: newPinnedColor(color.FgGreen, color.Bold).SprintfFunc(),
+		DimText:     newPinnedColor(color.Faint).SprintfFunc(),
+		BoldText:    newPinnedColor(color.Bold).SprintfFunc(),
+		BorderText:  newPinnedColor(color.Faint).SprintfFunc(),
+		WarnText:    newPinnedColor(color.FgYellow).SprintfFunc(),
+		Reset:       newPinnedColor().SprintFunc()(""),
 	}
 }
 
@@ -772,8 +777,6 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	cpuprofOut := args.CpuprofOut
 	singleThreaded := args.SingleThreaded
 	format := args.Format
-	noColor := args.NoColor
-	forceColor := args.ForceColor
 	quiet := args.Quiet
 	maxWarnings := args.MaxWarnings
 	startTimeMs := args.StartTimeMs
@@ -781,13 +784,24 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	allowFiles := args.AllowFiles
 	allowDirs := args.AllowDirs
 
-	// Override color detection based on flags
-	if noColor {
-		color.NoColor = true
-	}
-	if forceColor {
-		color.NoColor = false
-	}
+	// The single color decision for the whole run. It unconditionally
+	// overwrites fatih/color's package-init value, whose isatty component
+	// keyed off the Go process's own stdout — an IPC pipe in every native
+	// lint run, never the user's terminal (its NO_COLOR/TERM components are
+	// re-derived in the tiers below). Nothing after this line mutates
+	// color.NoColor.
+	forceColorEnv, forceColorEnvSet := os.LookupEnv("FORCE_COLOR")
+	_, noColorEnvSet := os.LookupEnv("NO_COLOR")
+	color.NoColor = !term.ResolveColorEnabled(term.ColorInputs{
+		NoColorFlag:      args.NoColor,
+		ForceColorFlag:   args.ForceColor,
+		ForceColorEnv:    forceColorEnv,
+		ForceColorEnvSet: forceColorEnvSet,
+		NoColorEnvSet:    noColorEnvSet,
+		GithubActionsEnv: os.Getenv("GITHUB_ACTIONS"),
+		Term:             os.Getenv("TERM"),
+		StdoutIsTTY:      args.StdoutIsTTY,
+	})
 
 	enableVirtualTerminalProcessing()
 	timeBefore := resolveStartTime(startTimeMs)
@@ -1437,7 +1451,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				pluralize(typeCheckedFileCount, "file", "files"),
 				colors.BoldText("%v", time.Since(timeBefore).Round(time.Millisecond)),
 				colors.BoldText("%d", threadsCount),
-				color.New().SprintFunc()(""),
+				colors.Reset,
 			)
 		} else if fix && fixedCount > 0 {
 			fixText := pluralize(fixedCount, "issue", "issues")
@@ -1456,7 +1470,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				colors.BoldText("%d", threadsCount),
 				colors.SuccessText("%d", fixedCount),
 				fixText,
-				color.New().SprintFunc()(""), // Reset
+				colors.Reset,
 			)
 		} else {
 			fmt.Fprintf(
@@ -1472,7 +1486,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				rulesText,
 				colors.BoldText("%v", time.Since(timeBefore).Round(time.Millisecond)),
 				colors.BoldText("%d", threadsCount),
-				color.New().SprintFunc()(""), // Reset
+				colors.Reset,
 			)
 		}
 	}

--- a/cmd/rslint/enablevtprocessing_windows.go
+++ b/cmd/rslint/enablevtprocessing_windows.go
@@ -4,8 +4,13 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// enableVirtualTerminalProcessing arms ANSI rendering on the inherited
+// console stderr. Under IPC mode — the only native lint mode — this process's
+// stdout is Node's pipe (lint output renders in the Node parent, whose tty
+// layer owns VT processing there), so stderr is the only handle this process
+// still writes ANSI to directly (the syntactic-error pretty report).
 func enableVirtualTerminalProcessing() {
-	h, err := windows.GetStdHandle(windows.STD_OUTPUT_HANDLE)
+	h, err := windows.GetStdHandle(windows.STD_ERROR_HANDLE)
 	if err != nil || h == windows.InvalidHandle {
 		return
 	}

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -44,6 +44,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/ipc"
@@ -91,7 +92,11 @@ type initPayload struct {
 // runtimePayload is the IPC-bound subset of runtime knobs that don't have (or
 // shouldn't duplicate) a 1:1 user flag. Adding a field is a wire change.
 type runtimePayload struct {
-	ForceColor     bool `json:"forceColor,omitempty"`
+	// StdoutIsTTY reports whether the peer's real stdout — the terminal the
+	// forwarded lint output lands on — is a TTY. The Go process cannot
+	// observe this itself (its own stdout is the IPC pipe). Absent (false)
+	// with an older peer, which degrades to colorless output.
+	StdoutIsTTY    bool `json:"stdoutIsTTY,omitempty"`
 	SingleThreaded bool `json:"singleThreaded,omitempty"`
 }
 
@@ -223,9 +228,7 @@ func runCLI(args []string) int {
 	if payload.FixMode {
 		baseArgs.Fix = true
 	}
-	if payload.Runtime.ForceColor {
-		baseArgs.ForceColor = true
-	}
+	baseArgs.StdoutIsTTY = payload.Runtime.StdoutIsTTY
 	if payload.Runtime.SingleThreaded {
 		baseArgs.SingleThreaded = true
 	}
@@ -249,6 +252,12 @@ func runCLI(args []string) int {
 	stdoutDrainDone := make(chan struct{})
 	go drainStdoutToIPC(stdoutR, ch, stdoutDrainDone)
 	os.Stdout = stdoutW
+	// fatih/color captured its package-level Output at init, pointing at the
+	// real fd-1 — which in IPC mode is the frame stream. Re-aim it at the
+	// redirect pipe so a stray color.Print-family call degrades to ordinary
+	// forwarded text instead of corrupting the frame protocol. (color.Error
+	// already points at the inherited stderr; leave it.)
+	color.Output = stdoutW
 	// finalizeStdout flushes + restores stdout before the shutdown handshake.
 	finalizeStdout := func() {
 		os.Stdout = origStdout

--- a/cmd/rslint/ipc_cli_test.go
+++ b/cmd/rslint/ipc_cli_test.go
@@ -4,9 +4,13 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -113,5 +117,151 @@ func TestSplitAtUTF8Boundary(t *testing.T) {
 				t.Errorf("incomplete = %v, want %v", incomplete, tc.wantIncomplete)
 			}
 		})
+	}
+}
+
+// TestRunCLI_StdoutIsTTYWireToANSI pins the issue-#1080 seam end-to-end in
+// process: the runtime.stdoutIsTTY fact of a real init frame must cross the
+// wire (json tag), the payload→lintArgs merge, and the pipeline's color
+// decision, putting ANSI escapes into the forwarded `output` frames — and
+// only then. Every env tier above the TTY fact is neutralized so the result
+// is identical on dev machines and CI.
+func TestRunCLI_StdoutIsTTYWireToANSI(t *testing.T) {
+	cases := []struct {
+		name     string
+		tty      bool
+		wantANSI bool
+	}{
+		{"stdoutIsTTY=true colors output frames", true, true},
+		{"stdoutIsTTY=false stays colorless", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runStdoutTTYCase(t, tc.tty, tc.wantANSI)
+		})
+	}
+}
+
+func runStdoutTTYCase(t *testing.T, tty, wantANSI bool) {
+	// Truly unset NO_COLOR/FORCE_COLOR (set-but-empty would trip tiers 3/4);
+	// t.Setenv first arranges restoration and marks the test non-parallel,
+	// which the os.Stdin/os.Stdout/cwd swaps below require anyway.
+	for _, key := range []string{"NO_COLOR", "FORCE_COLOR"} {
+		if v, ok := os.LookupEnv(key); ok {
+			t.Setenv(key, v)
+			os.Unsetenv(key)
+		}
+	}
+	t.Setenv("GITHUB_ACTIONS", "") // non-empty check → falls through to the TTY fact
+	t.Setenv("TERM", "xterm-256color")
+
+	// EvalSymlinks: macOS t.TempDir lives under the /var → /private/var
+	// symlink; the pipeline matches normalized real paths, so anchor the
+	// fixture at the physical path.
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFixture := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFixture("tsconfig.json", `{"compilerOptions":{"strict":true},"include":["**/*.ts"]}`)
+	writeFixture("index.ts", "// @ts-ignore\nconst a = 1;\n")
+
+	// runCLI binds its IPC channel to the os.Stdin/os.Stdout globals and
+	// changes directory to the payload workingDirectory; swap in pipe ends
+	// and restore everything afterwards. t.Chdir into the current directory
+	// is a no-op move that registers automatic cwd restoration.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(wd)
+	stdinR, stdinW, err := os.Pipe() // test peer writes → CLI reads
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdoutR, stdoutW, err := os.Pipe() // CLI writes → test peer reads
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdin, origStdout := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = stdinR, stdoutW
+	t.Cleanup(func() {
+		os.Stdin, os.Stdout = origStdin, origStdout
+		_ = stdinR.Close()
+		_ = stdinW.Close()
+		_ = stdoutR.Close()
+		_ = stdoutW.Close()
+	})
+
+	// The test plays the Node peer on the other pipe ends.
+	peer := ipc.NewChannel(stdoutR, stdinW)
+	var outMu sync.Mutex
+	var out bytes.Buffer
+	peer.RegisterNotification(kindOutput, func(msg *ipc.Message) {
+		var d struct {
+			Text string `json:"text"`
+		}
+		if err := msg.Decode(&d); err != nil {
+			return
+		}
+		outMu.Lock()
+		out.WriteString(d.Text)
+		outMu.Unlock()
+	})
+	peer.SetInboundHandler(func(_ context.Context, msg *ipc.Message) (any, error) {
+		if msg.Kind == kindShutdown {
+			return map[string]any{"ok": true}, nil
+		}
+		return nil, fmt.Errorf("unexpected inbound kind %q", msg.Kind)
+	})
+	peer.Start()
+	t.Cleanup(func() { _ = peer.Close() })
+
+	codeCh := make(chan int, 1)
+	go func() { codeCh <- runCLI(nil) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	_, err = peer.SendRequest(ctx, kindInit, map[string]any{
+		"workingDirectory": dir,
+		"runtime":          map[string]any{"stdoutIsTTY": tty},
+		"configs": []map[string]any{{
+			"configDirectory": dir,
+			"entries": []map[string]any{{
+				"files":   []string{"**/*.ts"},
+				"rules":   map[string]any{"@typescript-eslint/ban-ts-comment": "error"},
+				"plugins": []string{"@typescript-eslint"},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("init request failed: %v", err)
+	}
+
+	var code int
+	select {
+	case code = <-codeCh:
+	case <-time.After(60 * time.Second):
+		t.Fatal("runCLI did not return within 60s")
+	}
+
+	// runCLI returns only after finalizeStdout drained every output frame and
+	// the shutdown round-trip completed, so `out` is complete here.
+	outMu.Lock()
+	text := out.String()
+	outMu.Unlock()
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1 (one lint error)", code)
+	}
+	if !strings.Contains(text, "ban-ts-comment") {
+		t.Fatalf("no diagnostic in forwarded output — lint did not run; output: %q", text)
+	}
+	if gotANSI := strings.Contains(text, "\x1b["); gotANSI != wantANSI {
+		t.Errorf("ANSI in output = %v, want %v (stdoutIsTTY=%v); output: %q", gotANSI, wantANSI, tty, text)
 	}
 }

--- a/internal/term/color.go
+++ b/internal/term/color.go
@@ -1,0 +1,99 @@
+// Package term owns the CLI's color-output decision.
+//
+// The decision is made exactly once, at lint-pipeline entry, by
+// ResolveColorEnabled. Nothing else in the process may mutate the resulting
+// color state afterwards; in particular, fatih/color's package-init guess
+// (which keys off the Go process's own stdout — a pipe in IPC mode, never the
+// user's terminal) is unconditionally overwritten by this decision.
+package term
+
+// ColorInputs carries every signal the color decision consumes. The caller
+// collects flags and raw environment values once; this package owns their
+// semantics. Env values are passed as (value, set) pairs where "set to empty
+// string" and "unset" differ in meaning.
+type ColorInputs struct {
+	// NoColorFlag and ForceColorFlag mirror the --no-color / --force-color
+	// CLI flags.
+	NoColorFlag    bool
+	ForceColorFlag bool
+
+	// ForceColorEnv / ForceColorEnvSet mirror os.LookupEnv("FORCE_COLOR").
+	ForceColorEnv    string
+	ForceColorEnvSet bool
+
+	// NoColorEnvSet is true when NO_COLOR is present in the environment,
+	// including set-but-empty (Node/ESLint v10 semantics; deliberately
+	// stricter than no-color.org's "non-empty" wording).
+	NoColorEnvSet bool
+
+	// GithubActionsEnv mirrors os.Getenv("GITHUB_ACTIONS").
+	GithubActionsEnv string
+
+	// Term mirrors os.Getenv("TERM").
+	Term string
+
+	// StdoutIsTTY is the fact reported by the owner of the real output fd.
+	// In IPC mode that owner is the Node host (its process.stdout receives
+	// the forwarded lint output), so the value travels in the init payload;
+	// when unknown (old peer, wasm build) it stays false.
+	StdoutIsTTY bool
+}
+
+// ResolveColorEnabled reports whether CLI output should be colorized.
+//
+// Precedence, strongest first — each tier is consulted only when every
+// stronger tier is absent, and deciding tiers terminate the walk:
+//
+//  1. --no-color flag        → off
+//  2. --force-color flag     → on
+//  3. FORCE_COLOR env set    → by value: "", "1", "true", "2", "3" → on;
+//     "0", "false", unrecognized → off
+//  4. NO_COLOR env set       → off (any value, including empty)
+//  5. TERM == "dumb"         → off
+//  6. GITHUB_ACTIONS env non-empty → on (any non-empty value, even "false")
+//  7. stdout-is-TTY fact     → on/off
+//
+// References: explicit flags beating env follows ESLint v10 (whose stylish
+// formatter colors via node:util styleText; an explicit --color there ignores
+// NO_COLOR). FORCE_COLOR value semantics and FORCE_COLOR-over-NO_COLOR follow
+// Node (which warns that NO_COLOR is ignored when FORCE_COLOR is set);
+// supports-color/chalk agree on the FORCE_COLOR values.
+//
+// Documented deviations from ESLint v10:
+//   - Tier 6: ESLint emits no color on GitHub Actions (piped stdout); rslint
+//     deliberately keeps its existing force-on so workflow logs render ANSI.
+//     TERM=dumb still wins over it, matching both references' relative order.
+//   - Tier 7: a bare TTY check, with no TERM capability lookup — fine for the
+//     16-color output rslint emits; exotic TERM values on a real TTY get
+//     color where ESLint might not.
+func ResolveColorEnabled(in ColorInputs) bool {
+	switch {
+	case in.NoColorFlag:
+		return false
+	case in.ForceColorFlag:
+		return true
+	case in.ForceColorEnvSet:
+		return forceColorValueEnables(in.ForceColorEnv)
+	case in.NoColorEnvSet:
+		return false
+	case in.Term == "dumb":
+		return false
+	case in.GithubActionsEnv != "":
+		return true
+	default:
+		return in.StdoutIsTTY
+	}
+}
+
+// forceColorValueEnables maps a FORCE_COLOR value to on/off following Node's
+// util.styleText / supports-color semantics: empty (set-but-empty), "1",
+// "true" and the higher color levels "2"/"3" enable; "0", "false" and any
+// unrecognized value disable.
+func forceColorValueEnables(v string) bool {
+	switch v {
+	case "", "1", "true", "2", "3":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/term/color_test.go
+++ b/internal/term/color_test.go
@@ -1,0 +1,93 @@
+package term
+
+import "testing"
+
+// TestResolveColorEnabled pins every precedence tier and the tier-vs-tier
+// orderings that differ from the pre-refactor behavior. Inputs are fully
+// explicit per case — no t.Setenv, no process env reads, no mutation of
+// fatih/color globals (writing color.NoColor from a test poisons other tests
+// in the same binary).
+func TestResolveColorEnabled(t *testing.T) {
+	t.Parallel()
+
+	// fc builds the FORCE_COLOR (value, set) pair.
+	fc := func(v string) ColorInputs {
+		return ColorInputs{ForceColorEnv: v, ForceColorEnvSet: true}
+	}
+
+	cases := []struct {
+		name string
+		in   ColorInputs
+		want bool
+	}{
+		// tier 7: the TTY fact baseline
+		{"all absent, not a TTY", ColorInputs{}, false},
+		{"all absent, TTY", ColorInputs{StdoutIsTTY: true}, true},
+		{"exotic TERM on a TTY still colors (documented tier-7 deviation)",
+			ColorInputs{Term: "xterm-nonsense", StdoutIsTTY: true}, true},
+
+		// tier 1: --no-color beats everything
+		{"--no-color beats --force-color and TTY",
+			ColorInputs{NoColorFlag: true, ForceColorFlag: true, StdoutIsTTY: true}, false},
+		{"--no-color beats FORCE_COLOR=1",
+			ColorInputs{NoColorFlag: true, ForceColorEnv: "1", ForceColorEnvSet: true}, false},
+		{"--no-color beats GITHUB_ACTIONS",
+			ColorInputs{NoColorFlag: true, GithubActionsEnv: "true"}, false},
+
+		// tier 2: --force-color beats env and the TTY fact
+		{"--force-color on a pipe", ColorInputs{ForceColorFlag: true}, true},
+		{"--force-color beats NO_COLOR env",
+			ColorInputs{ForceColorFlag: true, NoColorEnvSet: true}, true},
+		{"--force-color beats FORCE_COLOR=0",
+			ColorInputs{ForceColorFlag: true, ForceColorEnv: "0", ForceColorEnvSet: true}, true},
+		{"--force-color beats TERM=dumb",
+			ColorInputs{ForceColorFlag: true, Term: "dumb"}, true},
+
+		// tier 3: FORCE_COLOR is value-aware and terminal
+		{"FORCE_COLOR set-but-empty enables", fc(""), true},
+		{"FORCE_COLOR=1 enables", fc("1"), true},
+		{"FORCE_COLOR=true enables", fc("true"), true},
+		{"FORCE_COLOR=2 enables", fc("2"), true},
+		{"FORCE_COLOR=3 enables", fc("3"), true},
+		{"FORCE_COLOR=0 disables even on a TTY",
+			ColorInputs{ForceColorEnv: "0", ForceColorEnvSet: true, StdoutIsTTY: true}, false},
+		{"FORCE_COLOR=false disables", fc("false"), false},
+		{"FORCE_COLOR unrecognized value disables (Node semantics)", fc("yes"), false},
+		{"FORCE_COLOR=1 beats NO_COLOR (Node: NO_COLOR ignored when FORCE_COLOR set)",
+			ColorInputs{ForceColorEnv: "1", ForceColorEnvSet: true, NoColorEnvSet: true}, true},
+		{"FORCE_COLOR=0 with NO_COLOR also set disables",
+			ColorInputs{ForceColorEnv: "0", ForceColorEnvSet: true, NoColorEnvSet: true}, false},
+		{"FORCE_COLOR=1 beats TERM=dumb",
+			ColorInputs{ForceColorEnv: "1", ForceColorEnvSet: true, Term: "dumb"}, true},
+		{"FORCE_COLOR=0 beats GITHUB_ACTIONS",
+			ColorInputs{ForceColorEnv: "0", ForceColorEnvSet: true, GithubActionsEnv: "true"}, false},
+
+		// tier 4: NO_COLOR (presence, including empty value)
+		{"NO_COLOR set on a TTY disables", ColorInputs{NoColorEnvSet: true, StdoutIsTTY: true}, false},
+		{"NO_COLOR set-but-empty disables (Node semantics)", ColorInputs{NoColorEnvSet: true}, false},
+		{"NO_COLOR beats GITHUB_ACTIONS",
+			ColorInputs{NoColorEnvSet: true, GithubActionsEnv: "true"}, false},
+
+		// tier 5: TERM=dumb beats GITHUB_ACTIONS and the TTY fact
+		{"TERM=dumb on a TTY disables", ColorInputs{Term: "dumb", StdoutIsTTY: true}, false},
+		{"TERM=dumb beats GITHUB_ACTIONS",
+			ColorInputs{Term: "dumb", GithubActionsEnv: "true", StdoutIsTTY: true}, false},
+
+		// tier 6: GITHUB_ACTIONS forces on for piped CI logs (non-empty check:
+		// any value counts, set-but-empty falls through to the TTY fact)
+		{"GITHUB_ACTIONS on a pipe enables", ColorInputs{GithubActionsEnv: "true"}, true},
+		{"GITHUB_ACTIONS=false still enables (non-empty semantics)",
+			ColorInputs{GithubActionsEnv: "false"}, true},
+		{"GITHUB_ACTIONS set-but-empty falls through to the TTY fact",
+			ColorInputs{GithubActionsEnv: ""}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ResolveColorEnabled(tc.in); got != tc.want {
+				t.Errorf("ResolveColorEnabled(%+v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
   include: [
     // cli
     './tests/cli/basic.test.ts',
+    './tests/cli/color-matrix.test.ts',
     './tests/cli/file-args.test.ts',
     './tests/cli/disable-comments.test.ts',
     './tests/cli/js-config/normalize-config.test.ts',
@@ -26,6 +27,11 @@ export default defineConfig({
     './tests/cli/js-config/eslint-plugin-conformance/promise.test.ts',
     './tests/cli/js-config/eslint-plugin-conformance/stylistic.test.ts',
     './tests/cli/js-config/gitignore-integration.test.ts',
+    './tests/cli/fix/cascade.test.ts',
+    './tests/cli/fix/edge-cases.test.ts',
+    './tests/cli/fix/exit-code.test.ts',
+    './tests/cli/fix/output.test.ts',
+    './tests/cli/rule-flag.test.ts',
     './tests/cli/entry-point.test.ts',
     './tests/cli/type-check/type-check.test.ts',
     './tests/cli/type-check/type-check-snapshot.test.ts',

--- a/packages/rslint-test-tools/tests/cli/color-matrix.test.ts
+++ b/packages/rslint-test-tools/tests/cli/color-matrix.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, beforeAll, afterAll } from '@rstest/core';
+import { spawn } from 'child_process';
+import { RSLINT_BIN, createTempDir, cleanupTempDir } from './js-config/helpers';
+
+/**
+ * End-to-end pins for the color-decision behavior matrix (issue #1080).
+ *
+ * Each row spawns the real CLI (Node host + Go binary over IPC) with a fully
+ * explicit color environment and asserts the presence or absence of ANSI
+ * escapes in stdout. stdout here is always a pipe (never a TTY), so the
+ * colored rows exercise the force-on tiers and the colorless rows pin both
+ * the disable tiers and their precedence over weaker force-on signals.
+ * The TTY tier itself is pinned by packages/rslint/tests/engine.test.ts
+ * (fact wiring) plus the Go table test (decision).
+ */
+
+const ANSI = /\x1b\[/;
+
+interface CliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+// Baseline env: strip every color-deciding variable inherited from the
+// runner (CI sets GITHUB_ACTIONS; developers may set the others), then pin
+// TERM so a TERM=dumb runner can't flip tier 5. Each row layers its own
+// overrides on top of this deterministic base.
+const { GITHUB_ACTIONS, FORCE_COLOR, NO_COLOR, ...restEnv } = process.env;
+const BASE_ENV = { ...restEnv, TERM: 'xterm-256color' };
+
+function runCli(
+  args: string[],
+  cwd: string,
+  envOverrides: Record<string, string> = {},
+): Promise<CliResult> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [RSLINT_BIN, ...args], {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...BASE_ENV, ...envOverrides },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d: Buffer) => (stdout += d.toString()));
+    child.stderr.on('data', (d: Buffer) => (stderr += d.toString()));
+    child.on('close', (code) => {
+      resolve({ exitCode: code ?? 0, stdout, stderr });
+    });
+  });
+}
+
+describe('CLI color matrix', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = await createTempDir({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { target: 'ES2020', module: 'ESNext', strict: true },
+        include: ['**/*.ts'],
+      }),
+      'rslint.config.mjs': `export default [
+        {
+          files: ['**/*.ts'],
+          rules: { '@typescript-eslint/ban-ts-comment': 'error' },
+          plugins: ['@typescript-eslint'],
+        },
+      ];`,
+      'src/index.ts': '// @ts-ignore\nconst a = 1;\n',
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // Every row must observe a real diagnostic run: exit 1 with the rule name
+  // in stdout. Otherwise a broken/empty run would vacuously pass the
+  // "no ANSI" rows.
+  async function expectLintRun(
+    args: string[],
+    env: Record<string, string>,
+    colored: boolean,
+  ): Promise<void> {
+    const result = await runCli(args, tempDir, env);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('ban-ts-comment');
+    expect(ANSI.test(result.stdout)).toBe(colored);
+  }
+
+  test('piped stdout with clean env stays colorless', async () => {
+    await expectLintRun([], {}, false);
+  });
+
+  test('--force-color colors a piped stdout', async () => {
+    await expectLintRun(['--force-color'], {}, true);
+  });
+
+  test('FORCE_COLOR=1 colors a piped stdout', async () => {
+    await expectLintRun([], { FORCE_COLOR: '1' }, true);
+  });
+
+  test('FORCE_COLOR=0 force-disables, beating GITHUB_ACTIONS', async () => {
+    await expectLintRun(
+      [],
+      { FORCE_COLOR: '0', GITHUB_ACTIONS: 'true' },
+      false,
+    );
+  });
+
+  test('NO_COLOR disables', async () => {
+    await expectLintRun([], { NO_COLOR: '1' }, false);
+  });
+
+  test('FORCE_COLOR=1 beats NO_COLOR (Node semantics)', async () => {
+    await expectLintRun([], { NO_COLOR: '1', FORCE_COLOR: '1' }, true);
+  });
+
+  test('FORCE_COLOR set-but-empty enables (LookupEnv, not non-empty)', async () => {
+    await expectLintRun([], { FORCE_COLOR: '' }, true);
+  });
+
+  test('NO_COLOR set-but-empty disables, beating GITHUB_ACTIONS', async () => {
+    await expectLintRun([], { NO_COLOR: '', GITHUB_ACTIONS: 'true' }, false);
+  });
+
+  test('--no-color beats FORCE_COLOR=1', async () => {
+    await expectLintRun(['--no-color'], { FORCE_COLOR: '1' }, false);
+  });
+
+  test('--force-color beats NO_COLOR', async () => {
+    await expectLintRun(['--force-color'], { NO_COLOR: '1' }, true);
+  });
+
+  test('GITHUB_ACTIONS forces color on a pipe (documented deviation)', async () => {
+    await expectLintRun([], { GITHUB_ACTIONS: 'true' }, true);
+  });
+
+  test('TERM=dumb beats GITHUB_ACTIONS', async () => {
+    await expectLintRun([], { TERM: 'dumb', GITHUB_ACTIONS: 'true' }, false);
+  });
+});

--- a/packages/rslint-test-tools/tests/cli/fix/helpers.ts
+++ b/packages/rslint-test-tools/tests/cli/fix/helpers.ts
@@ -16,9 +16,14 @@ export async function runRslint(
   cwd?: string,
 ): Promise<CliTestResult> {
   return new Promise((resolve) => {
+    // Strip GITHUB_ACTIONS/FORCE_COLOR to prevent the binary from
+    // force-enabling ANSI colors, which would embed escape codes in stdout
+    // and break the substring assertions (same pattern as js-config/helpers).
+    const { GITHUB_ACTIONS, FORCE_COLOR, ...cleanEnv } = process.env;
     const child = spawn(process.execPath, [RSLINT_BIN, ...args], {
       cwd: cwd || process.cwd(),
       stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...cleanEnv, NO_COLOR: '1' },
     });
 
     let stdout = '';
@@ -72,6 +77,7 @@ export function makeConfig(rules: Record<string, string>): string {
   return `export default [{
   files: ['**/*.ts'],
   languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
+  plugins: ['@typescript-eslint'],
   rules: {
 ${rulesStr}
   }

--- a/packages/rslint/bin/rslint.cjs
+++ b/packages/rslint/bin/rslint.cjs
@@ -42,10 +42,14 @@ async function main() {
     pathToFileURL(path.resolve(__dirname, '../dist/cli.js')).href
   );
   const exitCode = await run(binPath, process.argv.slice(2), startTime);
-  process.exit(exitCode);
+  // process.exit() would tear down before async-buffered stdout writes (pipes,
+  // Windows TTYs) flush, truncating the lint tail. Setting exitCode lets the
+  // event loop drain naturally; run()'s cleanup guarantees nothing keeps it
+  // alive.
+  process.exitCode = exitCode;
 }
 
 main().catch((err) => {
   process.stderr.write(`rslint: ${err}\n`);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/packages/rslint/src/engine.ts
+++ b/packages/rslint/src/engine.ts
@@ -40,7 +40,7 @@ export interface EngineRunOptions {
   /** Working directory (defaults to process.cwd()). */
   cwd?: string;
   /** Runtime hints forwarded in the `init` payload's `runtime` block. */
-  runtime?: { forceColor?: boolean; singleThreaded?: boolean };
+  runtime?: { singleThreaded?: boolean };
   /**
    * Extra fields merged into the `init` payload (positional files, --format,
    * --fix, workingDirectory). Pass-through so the engine stays unaware of CLI
@@ -67,6 +67,12 @@ export interface EngineRunOptions {
 export async function runEngine(opts: EngineRunOptions): Promise<number> {
   const stdout = opts.stdout ?? process.stdout;
   const stderr = opts.stderr ?? process.stderr;
+  // TTY fact for the Go side's color decision, probed on the actual sink the
+  // forwarded output frames land on. Only this process can observe it — the
+  // Go child's own stdout is the IPC pipe. Non-TTY sinks (pipes, files, test
+  // streams) have no isTTY property, which coerces to false here.
+  // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const stdoutIsTTY = (stdout as Partial<NodeJS.WriteStream>).isTTY === true;
 
   const child = spawn(opts.binPath, opts.goArgs, {
     stdio: ['pipe', 'pipe', 'inherit'],
@@ -223,7 +229,7 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
             configs: opts.configs,
             eslintPlugins: opts.eslintPluginEntries,
             runtime: {
-              forceColor: opts.runtime?.forceColor,
+              stdoutIsTTY,
               singleThreaded: opts.runtime?.singleThreaded,
             },
           }),

--- a/packages/rslint/tests/engine.test.ts
+++ b/packages/rslint/tests/engine.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from '@rstest/core';
+import { PassThrough } from 'node:stream';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runEngine } from '../src/engine.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FAKE_BIN = path.resolve(__dirname, './fixtures/fake-ipc-binary.cjs');
+
+/**
+ * Runs the engine against the fake IPC binary, which echoes the `init`
+ * payload it received back through an `output` frame — letting the tests
+ * assert on what actually crossed the wire, not on engine internals.
+ */
+async function runWithSink(sink: PassThrough): Promise<{
+  exitCode: number;
+  payload: { runtime?: { stdoutIsTTY?: boolean } };
+}> {
+  let captured = '';
+  sink.on('data', (d: Buffer) => {
+    captured += d.toString();
+  });
+  const exitCode = await runEngine({
+    binPath: process.execPath,
+    goArgs: [FAKE_BIN],
+    configs: [],
+    stdout: sink,
+    stderr: new PassThrough(),
+  });
+  return { exitCode, payload: JSON.parse(captured) };
+}
+
+describe('runEngine init payload TTY fact', () => {
+  test('sends runtime.stdoutIsTTY=true when the output sink is a TTY', async () => {
+    const sink = Object.assign(new PassThrough(), { isTTY: true });
+    const { exitCode, payload } = await runWithSink(sink);
+    expect(exitCode).toBe(0);
+    expect(payload.runtime?.stdoutIsTTY).toBe(true);
+  });
+
+  test('sends runtime.stdoutIsTTY=false for a non-TTY sink', async () => {
+    const { exitCode, payload } = await runWithSink(new PassThrough());
+    expect(exitCode).toBe(0);
+    expect(payload.runtime?.stdoutIsTTY).toBe(false);
+  });
+});

--- a/packages/rslint/tests/fixtures/fake-ipc-binary.cjs
+++ b/packages/rslint/tests/fixtures/fake-ipc-binary.cjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Minimal Go-binary stand-in for engine tests, speaking the IPC frame
+// protocol ([4-byte u32 LE length][JSON {kind,id,data}]) over stdio:
+//   1. expects an `init` request → replies `response {ok:true}`,
+//   2. echoes the received init payload back as an `output` notification,
+//   3. sends a `shutdown` request and exits 0 once the peer acks it.
+// This mirrors the real binary's happy-path frame sequence so runEngine can
+// be exercised end-to-end without Go.
+
+let buf = Buffer.alloc(0);
+
+function send(msg) {
+  const body = Buffer.from(JSON.stringify(msg), 'utf8');
+  const head = Buffer.alloc(4);
+  head.writeUInt32LE(body.length, 0);
+  process.stdout.write(Buffer.concat([head, body]));
+}
+
+function onMessage(msg) {
+  if (msg.kind === 'init') {
+    send({ kind: 'response', id: msg.id, data: { ok: true } });
+    send({
+      kind: 'output',
+      id: 0,
+      data: { stream: 'stdout', text: JSON.stringify(msg.data) },
+    });
+    send({ kind: 'shutdown', id: 1000, data: {} });
+  } else if (msg.kind === 'response' && msg.id === 1000) {
+    process.exit(0);
+  }
+}
+
+process.stdin.on('data', (chunk) => {
+  buf = Buffer.concat([buf, chunk]);
+  while (buf.length >= 4) {
+    const len = buf.readUInt32LE(0);
+    if (buf.length < 4 + len) break;
+    const body = buf.subarray(4, 4 + len).toString('utf8');
+    buf = buf.subarray(4 + len);
+    onMessage(JSON.parse(body));
+  }
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -575,3 +575,4 @@ SIGSEGV
 zigbuild
 lockfiles
 smajobber
+isatty


### PR DESCRIPTION
## Summary

Since the IPC CLI architecture landed (0.6.0, #1037), the Go binary's stdout is an IPC pipe, so `fatih/color`'s isatty-based package init disabled colors on every `npx rslint` run (#1080).

**Design: the TTY fact is owned by the fd holder; the color decision is made exactly once.**

- `engine.ts` probes the actual output sink and sends `runtime.stdoutIsTTY` in the IPC init payload (replacing the never-sent `forceColor` field — engine and binary ship in lockstep).
- Go resolves the decision once at lint-pipeline entry via the new pure `term.ResolveColorEnabled`, precedence (strong → weak, each tier terminal):
  1. `--no-color` → off
  2. `--force-color` → on
  3. `FORCE_COLOR` env, value-aware: `''`/`1`/`true`/`2`/`3` → on; `0`/`false`/unrecognized → off (Node/ESLint v10 semantics — also fixes the pre-existing `FORCE_COLOR=0` force-ON bug)
  4. `NO_COLOR` (presence, incl. empty) → off
  5. `TERM=dumb` → off
  6. `GITHUB_ACTIONS` → on (documented deviation from ESLint v10, kept from current behavior; now ranked below `TERM=dumb`)
  7. the TTY fact
- `setupColors` becomes a pure factory with per-object pinning (`color.New` seeds a per-object switch from `NO_COLOR` at creation time, which would override the resolved decision).
- Windows VT arming retargets the inherited stderr (the only console handle Go still writes ANSI to under IPC; stdout VT is owned by the Node parent).
- `color.Output` is re-aimed off the IPC frame stream so a stray `color.Print` can't corrupt the protocol.
- `bin/rslint.cjs` exits via `process.exitCode` so async-buffered stdout drains before exit.

**Tests** (each pins a link the others can't reach):
- Go table test for every precedence tier and observable tier ordering (`internal/term`, runs in existing CI).
- `TestRunCLI_StdoutIsTTYWireToANSI`: in-process full loop — a real init frame with `stdoutIsTTY` must put ANSI into the forwarded `output` frames (mutation-verified: breaking the json tag fails it).
- `engine.test.ts` + fake IPC binary: the Node side detects and sends the fact.
- e2e `color-matrix.test.ts`: 12 rows over the real CLI pinning flag/env precedence on a piped stdout.
- Manual real-pty smoke: TTY → ANSI; `--no-color`/`NO_COLOR`/`FORCE_COLOR=0` → none.

Known limitations (match ESLint v10): Git Bash/mintty (msys pty) is not auto-detected (use `--force-color`); the global decision keys off stdout (stderr follows it, same as 0.5.x).

The second commit registers the dead `tests/cli/fix/**` + `rule-flag.test.ts` suites in the rstest allowlist (found during this work): they predate plugin enforcement, so their configs needed `plugins: ['@typescript-eslint']`, plus the color-env hygiene this PR's own e2e uses. 54/54 pass.

## Related Links

- Fixes #1080

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).