### PR TITLE
perf: parallelize lint across files within a program

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -281,15 +281,26 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	if diagnostics == nil {
 		diagnostics = []api.Diagnostic{}
 	}
-	// sort diagnostics
-	sort.Slice(diagnostics, func(i, j int) bool {
-		if diagnostics[i].FilePath != diagnostics[j].FilePath {
-			return diagnostics[i].FilePath < diagnostics[j].FilePath
+	// Sort diagnostics by (file, start position) only — deliberately NO
+	// end/rule tie-break: ESLint and the upstream rule tests order
+	// same-start diagnostics by emission order (parent reported before
+	// nested child), and a file's diagnostics are all emitted by a single
+	// worker, so under a STABLE sort this key is already fully
+	// deterministic. Keep this comparator in sync with the CLI one in
+	// cmd.go (same policy over rule.RuleDiagnostic).
+	// Known pre-existing exception: a file rooted by two tsconfigs at once
+	// is linted by both programs (duplicate diagnostics with
+	// scheduling-dependent interleaving) — neither introduced nor fixed
+	// here.
+	sort.SliceStable(diagnostics, func(i, j int) bool {
+		a, b := diagnostics[i], diagnostics[j]
+		if a.FilePath != b.FilePath {
+			return a.FilePath < b.FilePath
 		}
-		if diagnostics[i].Range.Start.Line != diagnostics[j].Range.Start.Line {
-			return diagnostics[i].Range.Start.Line < diagnostics[j].Range.Start.Line
+		if a.Range.Start.Line != b.Range.Start.Line {
+			return a.Range.Start.Line < b.Range.Start.Line
 		}
-		return diagnostics[i].Range.Start.Column < diagnostics[j].Range.Start.Column
+		return a.Range.Start.Column < b.Range.Start.Column
 	})
 
 	// Create response

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"runtime/trace"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1343,6 +1345,26 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			fixedCount += passFixed
 		}
 	}
+
+	// Diagnostics arrive in completion order — programs and, within a
+	// program, file shards run in parallel — so impose a deterministic
+	// order before printing. The key is (file, start position) only,
+	// deliberately with NO end/rule tie-break: ESLint orders same-start
+	// diagnostics by emission order (parent reported before nested child),
+	// and a file's diagnostics are all emitted by a single worker, so under
+	// a STABLE sort this key is already fully deterministic. Keep this
+	// comparator in sync with the --api one in api.go (same policy over
+	// api.Diagnostic).
+	// Known pre-existing exception: a file rooted by two tsconfigs at once
+	// is linted by both programs (duplicate diagnostics with
+	// scheduling-dependent interleaving) — neither introduced nor fixed
+	// here.
+	slices.SortStableFunc(allDiags, func(a, b rule.RuleDiagnostic) int {
+		if c := strings.Compare(a.FilePath, b.FilePath); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Range.Pos(), b.Range.Pos())
+	})
 
 	// Phase 3: Print diagnostics and count errors/warnings.
 	// allDiags contains: original diagnostics (no fix), or remaining after fix.

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
@@ -69,6 +70,9 @@ type runProgramOptions struct {
 	ExcludePaths    []string
 	FileFilter      FileFilter
 	GetRulesForFile RuleHandler
+	// SingleThreaded, when true, lints this program's file shards
+	// sequentially on the calling goroutine instead of in parallel workers.
+	SingleThreaded bool
 	// TypeInfoFiles is the set of files with reliable type information.
 	// Gap files (not in this set) get a nil TypeChecker passed to rule
 	// contexts as defense-in-depth — type-aware rules are already filtered
@@ -81,6 +85,11 @@ type runProgramOptions struct {
 // runLintRulesInProgram lints files in a single Program. Files are filtered
 // through ExcludePaths, Scope (Files+Dirs), and FileFilter before rule
 // execution. Pass FileFilter=nil to disable that layer.
+//
+// Unless SingleThreaded is set, files are linted in parallel shards — one
+// worker per pool checker, each worker owning its checker exclusively and
+// processing the files associated to it (see the sharding comment in the
+// function body for the invariants this preserves).
 //
 // This is the post-refactor internal implementation behind both RunLinter and
 // LintSingleFile. It does NOT run type-check — type-check is a program-level
@@ -108,14 +117,17 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 		return 0
 	}
 
-	// Run lint rules. Acquires a checker from the pool for type-aware rules.
-	checker, done := opts.Program.GetTypeChecker(context.Background())
-	for _, file := range filesToLint {
+	// lintFile lints one file with the given checker. All per-file state
+	// (listener map, comments, DisableManager, rule contexts) lives inside
+	// this function, so concurrent calls for different files are independent;
+	// the checker is the only shared resource and is owned exclusively by the
+	// calling worker (see the sharding below).
+	lintFile := func(file *ast.SourceFile, chk *checker.Checker) {
 		registeredListeners := make(map[ast.Kind][](func(node *ast.Node)), 20)
 
 		rules := getRulesForFile(file)
 		if len(rules) == 0 {
-			continue
+			return
 		}
 
 		comments := make([]*ast.CommentRange, 0)
@@ -128,7 +140,7 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 		// as defense-in-depth. Type-aware rules are already filtered out by
 		// getRulesForFile, but this ensures rules with optional TypeChecker
 		// usage degrade gracefully.
-		fileChecker := checker
+		fileChecker := chk
 		if opts.TypeInfoFiles != nil {
 			if _, hasTypeInfo := opts.TypeInfoFiles[file.FileName()]; !hasTypeInfo {
 				fileChecker = nil
@@ -345,7 +357,46 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 		file.Node.ForEachChild(childVisitor)
 		clear(registeredListeners)
 	}
-	done()
+
+	// Phase 1 parallelism is per-file within the program: files are grouped
+	// by the checker the pool associated to them (for the compiler pool this
+	// is the stable index%N mapping built in checkerpool.go), and each group
+	// is linted serially by ONE worker holding that checker exclusively.
+	// This keeps three invariants:
+	//   - a checker is never used by two goroutines at once (pool contract:
+	//     checkers must not be accessed concurrently);
+	//   - every file's diagnostics are emitted by a single worker, so the
+	//     file-internal diagnostic order stays deterministic — the fixer's
+	//     tie-breaking and reporters rely on this;
+	//   - Phase 2 type-check visits files through the same association,
+	//     reusing the type caches warmed during lint.
+	// The LSP project pool builds its file association dynamically on first
+	// GetChecker instead of precomputing index%N — with this loop's
+	// acquire/release probing, a fresh project pool associates every file
+	// to the first checker, so the grouping collapses to a single group
+	// (no intra-program parallelism on that path; today it is only reached
+	// via LintSingleFile, where one file means one group anyway).
+	// Correctness never depends on the grouping: each worker only uses the
+	// checker it acquired exclusively for its own shard.
+	ctx := context.Background()
+	checkerGroups := make(map[*checker.Checker][]*ast.SourceFile)
+	for _, file := range filesToLint {
+		chk, release := opts.Program.GetTypeCheckerForFile(ctx, file)
+		release()
+		checkerGroups[chk] = append(checkerGroups[chk], file)
+	}
+
+	wg := core.NewWorkGroup(opts.SingleThreaded)
+	for _, files := range checkerGroups {
+		wg.Queue(func() {
+			chk, done := opts.Program.GetTypeCheckerForFileExclusive(ctx, files[0])
+			defer done()
+			for _, file := range files {
+				lintFile(file, chk)
+			}
+		})
+	}
+	wg.RunAndWait()
 
 	return lintedFileCount
 }
@@ -357,6 +408,9 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 // Phase 1 — lint rules: each program is processed via
 // runLintRulesInProgram, with files filtered through opts.ExcludePaths,
 // opts.Scope, opts.PerProgramFilter and the program's own owned-file set.
+// Within a program, files are linted in parallel shards (one per pool
+// checker); diagnostics therefore arrive in nondeterministic cross-file
+// order and callers that print them should impose an explicit order.
 // When opts.GetRulesForFile is nil, Phase 1 is skipped entirely — no work
 // group is created, no per-program goroutines are spawned, and no
 // owned-file sets are built. This is how callers run a pure type-check
@@ -409,6 +463,7 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 				ExcludePaths:    opts.ExcludePaths,
 				FileFilter:      filter,
 				GetRulesForFile: trackedGetRules,
+				SingleThreaded:  opts.SingleThreaded,
 				TypeInfoFiles:   opts.TypeInfoFiles,
 				OnDiagnostic:    opts.OnDiagnostic,
 			}
@@ -535,7 +590,10 @@ func LintSingleFile(opts LintSingleFileOptions) {
 		Scope:           FileScope{Files: []string{opts.File}},
 		ExcludePaths:    opts.ExcludePaths,
 		GetRulesForFile: opts.GetRulesForFile,
-		OnDiagnostic:    opts.OnDiagnostic,
+		// A single file is a single shard — run it on the calling goroutine
+		// instead of spawning a worker.
+		SingleThreaded: true,
+		OnDiagnostic:   opts.OnDiagnostic,
 	})
 }
 

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -87,9 +87,10 @@ type LintResult struct {
 //   - OnDiagnostic=nil                    → diagnostics are dropped
 //
 // Thread-safety: OnDiagnostic is invoked from multiple goroutines
-// concurrently — Phase 1 fans out per program, Phase 2 (type-check) does
-// the same. Callers MUST make their handler safe for concurrent calls
-// (channel send, mutex-guarded slice append, sync.Map, etc.).
+// concurrently — Phase 1 fans out per program AND per file shard within
+// each program (one worker per pool checker), Phase 2 (type-check) fans
+// out per program. Callers MUST make their handler safe for concurrent
+// calls (channel send, mutex-guarded slice append, sync.Map, etc.).
 type RunLinterOptions struct {
 	Programs       []*compiler.Program
 	SingleThreaded bool

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -65,6 +65,7 @@ categorisation
 Cbar
 centralising
 CHARCLASS
+checkerpool
 classnames
 CLASSSET
 clazz


### PR DESCRIPTION
## Summary

Phase 1 lint previously ran **one goroutine per Program**, so a single-tsconfig project executed the whole lint phase on a single core while the checker pool's remaining checkers (4 by default) sat idle. This PR shards lint across files within each program:

- Files are grouped by their pool-associated checker (the stable `index%N` mapping for the compiler pool), and each group is linted serially by **one worker holding that checker exclusively** via `GetTypeCheckerForFileExclusive` (the previous `GetTypeChecker` call takes the non-exclusive path, which holds no lock at all).
- The grouping keeps three invariants: a checker is never used by two goroutines at once; every file's diagnostics are emitted by a single worker (file-internal order stays deterministic — the fixer's tie-breaking relies on it); Phase 2 type-check visits files through the same association, reusing the type caches warmed during lint.
- Cross-file arrival order is now scheduling-dependent, so the CLI sorts diagnostics by `(file, start position)` with a **stable** sort before printing, and the `--api` sort becomes stable with the same key. Same-start diagnostics keep their emission order (parent before nested child), matching ESLint and the upstream rule tests — deliberately no end/rule tie-break, which would flip ported upstream cases like `x!!!;`.
- `LintSingleFile` (LSP per-keystroke path) runs on the calling goroutine, unchanged.

The only user-visible behavior change is output ordering: the diagnostic set is unchanged, but it now prints in deterministic file-path order (previously scheduling-dependent across programs).

### Measurements (Apple Silicon, 10 cores; medians of interleaved runs)

| Scenario | Baseline | This PR |
|---|---|---|
| TypeScript `src/compiler` (77 files, 9.4MB, single tsconfig, all 125 rules) | 38.7-41.0s, parallelism ≈ 1.3 | **~30s**; floor is `checker.ts` alone at 27.7s — a single 3.1MB file caps file-level parallelism on this fixture |
| rslint self-lint (144 files, 8 tsconfigs) | 1.36-1.43s | 1.17-1.37s |
| rsbuild repo (2,027 files; baseline = published 0.6.0) | lint 3.14s · type-check 4.02s | lint 3.04s · type-check 3.89s; parallel vs `--singleThreaded`: 2.96s vs 9.31s |
| rspack repo (474 files; baseline = published 0.6.0) | lint 6.86s · type-check 7.04s | lint 6.50s · type-check 6.54s; parallel vs `--singleThreaded`: 6.45s vs 15.77s |

Multi-tsconfig monorepos already benefited from program-level parallelism, so per-file sharding adds 3-7% there; the large wins are single/few-tsconfig projects.

### Verification

- `go test ./internal/linter` incl. `-race`; race-instrumented binary on a full multi-program run: 0 data races.
- Serial (`--singleThreaded`) vs parallel dual-run diffs: diagnostics byte-identical on the rslint repo, TypeScript `src/compiler`, rsbuild, and rspack.
- Full `rslint-test-tools` suite passes (incl. the snapshot-order-sensitive rules: no-non-null-assertion, no-unsafe-type-assertion, no-iterator, no-bitwise, no-restricted-syntax, no-proto).
- Real-repo comparison against published 0.6.0 on rsbuild and rspack: identical diagnostic sets, exit codes, and `--help` output for plain lint / `--type-check`; color output correct in all four scenarios (piped → none, `FORCE_COLOR=1` → colored, pty → colored via the Node-TTY-over-IPC path, `NO_COLOR=1` on pty → none); both worktrees untouched.
- Concurrency audit: rules keep all state inside per-file `Run` closures; checker caches are checker-private; lazily-initialized AST structures touched during lint are all lock-protected; multi-checker concurrent use of one program is tsgo's default production path (`forEachCheckerGroupDo`), already exercised by Phase 2.

Known pre-existing exception documented in the sort comments: a file rooted by two tsconfigs at once is linted by both programs (duplicate diagnostics with scheduling-dependent interleaving) — neither introduced nor fixed here.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).