### PR TITLE
ci: windows-latest hang diagnostics (debug, do not merge)

### DIFF
--- a/.github/workflows/debug-hang.yml
+++ b/.github/workflows/debug-hang.yml
@@ -1,0 +1,165 @@
+# Debug-only workflow: hunt the intermittent windows-latest CLI hang and
+# capture WHY in one run. Builds rslint.exe with the (env-gated) hang
+# diagnostics from cmd/rslint/hangdiag.go, then loops many concurrent
+# type-aware lints on windows-latest with the Go watchdog armed. When an
+# invocation wedges, the watchdog dumps every goroutine stack (the deadlock
+# site) to stderr + a file, the loop fails the job, and the dumps are uploaded
+# as an artifact. Delete this workflow + the diagnostics once the root cause is
+# found.
+name: Debug Windows Hang
+
+on:
+  push:
+    branches: ['debug/windows-hang-diagnostics']
+  workflow_dispatch:
+    inputs:
+      rounds:
+        description: max rounds per hunt leg (a 70-min wall-clock budget caps it first)
+        default: '100000'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: debug-hang-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # NOT windows-latest: a from-scratch go build of rslint + typescript-go
+    # exhausts the GitHub-hosted runner's disk ("not enough space on the
+    # disk"). Build on the same large runner ci.yml uses; the amd64 binary
+    # runs fine on the windows-latest hunt jobs below.
+    name: Build rslint.exe (hangdiag)
+    runs-on: rspack-windows-2022-large
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: true
+          fetch-depth: 1
+      - uses: ./.github/actions/setup-go
+        with:
+          go-version: 1.26.0
+          cache-name: debug-hang-go
+      - name: Build rslint.exe
+        shell: pwsh
+        run: go build -o packages/rslint/bin/rslint.exe ./cmd/rslint
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: debug-hang-rslint-exe
+          path: packages/rslint/bin/rslint.exe
+          retention-days: 2
+          if-no-files-found: error
+
+  # Vector 1 — tight concurrent CLI-spawn loop (fast, max invocations).
+  hunt:
+    name: Hunt (${{ matrix.name }})
+    needs: build
+    runs-on: windows-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # exact shape of the failing test (1 lintable file = single shard)
+          - { name: single-file, nfiles: '1', concurrency: '8' }
+          # multi-file: exercises the per-file shard parallelism (#1088)
+          - { name: shards, nfiles: '24', concurrency: '6' }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: true
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-rust
+      - name: Build napi parser (native)
+        run: pnpm --filter @rslint/native run build
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: debug-hang-rslint-exe
+          path: packages/rslint/bin
+      - name: Build JS packages
+        shell: bash
+        run: |
+          pnpm --filter @rslint/api build
+          pnpm --filter @rslint/core run build:js
+      - name: Hunt the hang
+        shell: bash
+        env:
+          HANG_CONCURRENCY: ${{ matrix.concurrency }}
+          HANG_NFILES: ${{ matrix.nfiles }}
+          HANG_ROUNDS: ${{ github.event.inputs.rounds || '100000' }}
+          HANG_MAX_MINUTES: '70'
+          HANG_WATCHDOG_MS: '45000'
+          HANG_DUMP_DIR: ${{ github.workspace }}/hang-dumps
+        run: node scripts/hang-hunt.mjs
+      - name: Upload goroutine dumps
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: hang-dumps-${{ matrix.name }}
+          path: hang-dumps
+          if-no-files-found: ignore
+
+  # Vector 2 — the REAL full rslint-test-tools suite in a loop, the exact
+  # environment the hang occurs in (403 files / 1636 tests under rstest's
+  # tinypool, each spawning rslint — the contention a single-file loop can't
+  # recreate). Watchdog armed via env so a wedge dumps goroutines into the log;
+  # we grep for the dump marker and fail the job if it appears.
+  hunt-rstest:
+    name: Hunt (real full-suite loop)
+    needs: build
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: true
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-rust
+      - name: Build napi parser (native)
+        run: pnpm --filter @rslint/native run build
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: debug-hang-rslint-exe
+          path: packages/rslint/bin
+      - name: Build JS packages
+        shell: bash
+        run: |
+          pnpm --filter @rslint/api build
+          pnpm --filter @rslint/core run build:js
+          pnpm --filter @typescript-eslint/rule-tester build
+          pnpm --filter rslint build
+      - name: Loop the full rslint-test-tools suite under watchdog
+        shell: bash
+        env:
+          RSLINT_HANG_WATCHDOG_MS: '45000'
+          RSLINT_HANG_TRACE: '1'
+          RSLINT_HANG_DUMP_DIR: ${{ github.workspace }}/hang-dumps
+        run: |
+          mkdir -p "$RSLINT_HANG_DUMP_DIR"
+          # Loop the whole suite until a wedge dumps (grep marker) or the
+          # 70-min budget runs out — the per-test 120s timeout overrides the
+          # package's --testTimeout=0 so a wedge can't stall the runner.
+          end=$(( $(date +%s) + 70*60 ))
+          i=0
+          while [ "$(date +%s)" -lt "$end" ]; do
+            i=$((i+1))
+            echo "::group::full suite iteration $i"
+            pnpm --filter @rslint/test-tools exec rstest run --testTimeout=120000 \
+              2>&1 | tee -a rstest-loop.log || true
+            echo "::endgroup::"
+            if grep -q "RSLINT HANG DIAG" rstest-loop.log; then
+              echo "::error::reproduced the hang — goroutine dump in log + hang-dumps artifact"
+              exit 1
+            fi
+          done
+          echo "no hang reproduced in $i full-suite iterations"
+      - name: Upload goroutine dumps + log
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: hang-dumps-rstest
+          path: |
+            hang-dumps
+            rstest-loop.log
+          if-no-files-found: ignore

--- a/cmd/rslint/hangdiag.go
+++ b/cmd/rslint/hangdiag.go
@@ -1,0 +1,160 @@
+//go:build !js
+
+// hangdiag.go — opt-in hang diagnostics for hunting the intermittent
+// windows-latest CI hang (a tiny type-aware lint occasionally never exits;
+// see the disable-comments.test.ts SIGINT-after-30min symptom).
+//
+// Everything here is gated behind env vars and is a NO-OP unless they are
+// set, so production CLI runs are unaffected. The point is: when the hang
+// recurs under the debug workflow, ONE run captures *where* the Go side is
+// wedged.
+//
+//	RSLINT_HANG_TRACE=1            timestamped lifecycle markers to stderr,
+//	                              so the last marker before a hang localizes
+//	                              the wedged phase (init / lint / output /
+//	                              shutdown).
+//	RSLINT_HANG_WATCHDOG_MS=45000 arm a watchdog: if the process has not
+//	                              finished within the deadline, dump ALL
+//	                              goroutine stacks and exit(hangDiagExitCode).
+//	                              A normal run finishes in ~2s, so a 45s
+//	                              deadline only ever fires on a true hang.
+//	RSLINT_HANG_DUMP_DIR=<dir>    also write each dump to a file in <dir>
+//	                              (for CI artifact upload); stderr always gets
+//	                              it regardless (inherited → CI log).
+//
+// On-demand: while either trace or watchdog is enabled we also install a
+// dump-on-signal handler (SIGQUIT on unix, SIGBREAK/Ctrl-Break on Windows —
+// Windows has no SIGQUIT) so the parent or a human can extract live stacks
+// from a wedged child without killing it.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// hangDiagExitCode is the exit code the watchdog forces after dumping. Distinct
+// from rslint's own 0/1/2/130 so a watchdog kill is unambiguous in CI logs and
+// in the Node host (engine.ts maps it straight through from the child).
+const hangDiagExitCode = 99
+
+const (
+	envHangTrace    = "RSLINT_HANG_TRACE"
+	envHangWatchdog = "RSLINT_HANG_WATCHDOG_MS"
+	envHangDumpDir  = "RSLINT_HANG_DUMP_DIR"
+)
+
+// hangDiagStart anchors trace timestamps; set once at first use.
+var hangDiagStart = time.Now()
+
+// dumpSeq disambiguates multiple dumps from one process (watchdog + signals).
+var dumpSeq atomic.Int64
+
+func hangTraceEnabled() bool    { return os.Getenv(envHangTrace) != "" }
+func hangWatchdogEnabled() bool { return os.Getenv(envHangWatchdog) != "" }
+func hangDiagEnabled() bool     { return hangTraceEnabled() || hangWatchdogEnabled() }
+
+// tracePhase prints a timestamped lifecycle marker (elapsed since process
+// start + pid) when RSLINT_HANG_TRACE is set. The last marker emitted before a
+// hang tells us which phase wedged.
+func tracePhase(format string, args ...any) {
+	if !hangTraceEnabled() {
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	fmt.Fprintf(os.Stderr, "[hangdiag +%dms pid=%d] %s\n",
+		time.Since(hangDiagStart).Milliseconds(), os.Getpid(), msg)
+}
+
+// captureAllStacks returns a snapshot of every goroutine's stack, growing the
+// buffer until it fits (runtime.Stack truncates silently to the buffer).
+func captureAllStacks() []byte {
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return buf[:n]
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+// dumpAllGoroutines writes every goroutine stack to stderr (always — inherited
+// by the Node parent, so it lands in the CI log) and, when RSLINT_HANG_DUMP_DIR
+// is set, to a file there for artifact upload.
+func dumpAllGoroutines(reason string) {
+	seq := dumpSeq.Add(1)
+	var b strings.Builder
+	fmt.Fprintf(&b,
+		"\n===== RSLINT HANG DIAG: goroutine dump #%d (pid=%d, +%dms) =====\nreason: %s\nGOMAXPROCS=%d NumGoroutine=%d\n",
+		seq, os.Getpid(), time.Since(hangDiagStart).Milliseconds(),
+		reason, runtime.GOMAXPROCS(0), runtime.NumGoroutine())
+	b.Write(captureAllStacks())
+	fmt.Fprintf(&b, "===== end goroutine dump #%d =====\n", seq)
+	content := b.String()
+
+	// stderr is the inherited fd in IPC mode (only stdout is redirected), so
+	// this lands in the Node parent's stderr → the CI log.
+	fmt.Fprint(os.Stderr, content)
+
+	if dir := os.Getenv(envHangDumpDir); dir != "" {
+		name := filepath.Join(dir, fmt.Sprintf("goroutines-pid%d-%d.txt", os.Getpid(), seq))
+		if err := os.WriteFile(name, []byte(content), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "[hangdiag] could not write dump file %s: %v\n", name, err)
+		} else {
+			fmt.Fprintf(os.Stderr, "[hangdiag] dump #%d written to %s\n", seq, name)
+		}
+	}
+}
+
+// armHangWatchdog starts the watchdog when RSLINT_HANG_WATCHDOG_MS is set, and
+// returns a cancel func to call on normal completion. No-op (cancel is a noop)
+// when disabled. Scope the call to the lint run, NOT process-global, so the
+// long-lived LSP/API modes are never killed.
+func armHangWatchdog() (cancel func()) {
+	raw := os.Getenv(envHangWatchdog)
+	if raw == "" {
+		return func() {}
+	}
+	ms, err := strconv.Atoi(raw)
+	if err != nil || ms <= 0 {
+		fmt.Fprintf(os.Stderr, "[hangdiag] ignoring invalid %s=%q\n", envHangWatchdog, raw)
+		return func() {}
+	}
+	timer := time.AfterFunc(time.Duration(ms)*time.Millisecond, func() {
+		dumpAllGoroutines(fmt.Sprintf("watchdog: no exit within %dms (deadlock suspected)", ms))
+		// Force termination so the parent's `await childExit` resolves and the
+		// CI loop fails fast WITH the dump above, instead of hanging the job.
+		os.Exit(hangDiagExitCode)
+	})
+	return func() { timer.Stop() }
+}
+
+// installDumpSignalHandler wires an on-demand goroutine dump to the platform's
+// dump signal (unix: SIGQUIT; windows: SIGBREAK). Only installed when hang diag
+// is enabled, so default signal behavior is untouched in production. The
+// handler dumps and KEEPS RUNNING (unlike Go's built-in SIGQUIT crash), so the
+// parent can sample a wedged child repeatedly.
+func installDumpSignalHandler() {
+	if !hangDiagEnabled() {
+		return
+	}
+	sigs := dumpSignals()
+	if len(sigs) == 0 {
+		return
+	}
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, sigs...)
+	go func() {
+		for s := range ch {
+			dumpAllGoroutines(fmt.Sprintf("on-demand signal %v", s))
+		}
+	}()
+}

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -117,6 +117,11 @@ func runCLI(args []string) int {
 		return parseFatal // parseLintFlags already printed to stderr
 	}
 
+	// Opt-in hang diagnostics (no-op unless RSLINT_HANG_* env set). See
+	// hangdiag.go — the watchdog is armed later, once init is received.
+	installDumpSignalHandler()
+	tracePhase("runCLI: start")
+
 	// Two signal registrations: sigChInit aborts the init-handshake select
 	// before we have a lint context; lintCtx (NotifyContext) cancels the lint
 	// file-loop at its per-file boundary. SIGHUP guards against a closed
@@ -206,6 +211,14 @@ func runCLI(args []string) int {
 		_ = ch.Close() // peer disconnected before init
 		return 2
 	}
+
+	// init handshake done — arm the hang watchdog for the lint+output+shutdown
+	// phases (where the CI hang lives). A normal run unwinds in ~2s, so the
+	// deferred cancel almost always wins the race; the watchdog only fires on a
+	// genuine wedge, dumping all goroutines before forcing exit.
+	tracePhase("runCLI: init received (configs=%d, cwd=%q)", len(payload.Configs), payload.WorkingDirectory)
+	cancelWatchdog := armHangWatchdog()
+	defer cancelWatchdog()
 
 	// Apply the payload. Working directory, configs, and the positional file
 	// set are payload-authoritative; the rest supplement flag values.
@@ -324,15 +337,21 @@ func runCLI(args []string) int {
 		return &res, nil
 	}
 
+	tracePhase("runCLI: lint pipeline start")
 	exitCode := executeLintPipeline(baseArgs, lintCtx, dispatch)
+	tracePhase("runCLI: lint pipeline done (exit=%d)", exitCode)
 
 	finalizeStdout()
+	tracePhase("runCLI: stdout drained")
 	shutdownPeer(ch, state)
+	tracePhase("runCLI: shutdown acked")
 	_ = ch.Close()
 
 	if state.signalled.Load() {
+		tracePhase("runCLI: exiting 130 (signalled)")
 		return 130
 	}
+	tracePhase("runCLI: exiting %d", exitCode)
 	return exitCode
 }
 

--- a/cmd/rslint/signal_unix.go
+++ b/cmd/rslint/signal_unix.go
@@ -20,3 +20,10 @@ func waitForDebugSignal(pollInterval time.Duration) {
 	sig := <-sigCh
 	log.Println("SIGUSR2 signal:", sig)
 }
+
+// dumpSignals is the platform signal that triggers an on-demand goroutine dump
+// (see hangdiag.go). On unix this is SIGQUIT — same signal Go's built-in
+// traceback uses, but our handler dumps without crashing.
+func dumpSignals() []os.Signal {
+	return []os.Signal{syscall.SIGQUIT}
+}

--- a/cmd/rslint/signal_windows.go
+++ b/cmd/rslint/signal_windows.go
@@ -17,3 +17,12 @@ func waitForDebugSignal(pollInterval time.Duration) {
 	// In the future, we could implement Windows-specific debug mechanisms
 	// like named pipes, events, or polling a file
 }
+
+// dumpSignals returns no signal on Windows: the standard syscall package has
+// no SIGBREAK, and Go's runtime delivers CTRL_BREAK_EVENT as SIGINT, which the
+// lint signal handler already owns. The on-demand signal dump is therefore
+// unix-only; on Windows the hang watchdog (hangdiag.go) is the active dump
+// mechanism and needs no signal.
+func dumpSignals() []os.Signal {
+	return nil
+}

--- a/packages/rslint/src/engine.ts
+++ b/packages/rslint/src/engine.ts
@@ -74,10 +74,33 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
   // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const stdoutIsTTY = (stdout as Partial<NodeJS.WriteStream>).isTTY === true;
 
+  // Opt-in hang diagnostics (no-op unless RSLINT_HANG_* env set) — the Node
+  // half of the windows-latest hang hunt. Phase traces show how far the host
+  // got; the host watchdog is a backstop to the Go-side one (hangdiag.go) for
+  // a hang that wedges on the Node side (or if the Go watchdog can't fire),
+  // dumping host-side state and failing fast instead of waiting forever on
+  // `await childExit`.
+  const hangStart = Date.now();
+  const hangTraceOn = !!process.env.RSLINT_HANG_TRACE;
+  const hangTrace = (msg: string): void => {
+    if (hangTraceOn) {
+      stderr.write(`[hangdiag host +${Date.now() - hangStart}ms] ${msg}\n`);
+    }
+  };
+  // Host watchdog fires AFTER the Go watchdog (+15s margin) so the in-process
+  // goroutine dump wins the race on a Go-side wedge; this only takes over when
+  // the Go side never self-terminates.
+  const goWatchdogMs = Number(process.env.RSLINT_HANG_WATCHDOG_MS ?? 0);
+  const hostWatchdogMs = goWatchdogMs > 0 ? goWatchdogMs + 15_000 : 0;
+  let initAcked = false;
+  let lastOutputAt = 0;
+  let outputFrames = 0;
+
   const child = spawn(opts.binPath, opts.goArgs, {
     stdio: ['pipe', 'pipe', 'inherit'],
     cwd: opts.cwd ?? process.cwd(),
   });
+  hangTrace(`spawned Go child pid=${child.pid}`);
 
   // childExit always RESOLVES (never rejects); awaits race against it so a
   // child that drops out mid-handshake unwinds cleanly instead of hanging.
@@ -214,7 +237,11 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
       'output',
       (msg: IpcMessage<{ stream?: string; text?: string }>) => {
         const text = msg.data?.text;
-        if (text != null) stdout.write(text);
+        if (text != null) {
+          outputFrames++;
+          lastOutputAt = Date.now() - hangStart;
+          stdout.write(text);
+        }
       },
     );
     ipc.start();
@@ -267,9 +294,33 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
       }
     }
 
+    initAcked = true;
+    hangTrace('init acked — entering lint wait');
+
     // Output forwarding + shutdown ack happen in the handlers above; just wait
     // for the Go child to finish (it exits with its own lint exit code).
+    // Backstop host watchdog: if the child never exits (Node-side wedge, or
+    // the Go watchdog failed to fire), report host-side state and force the
+    // child down so this never hangs the CI job forever.
+    let hostWatchdog: ReturnType<typeof setTimeout> | undefined;
+    if (hostWatchdogMs > 0) {
+      hostWatchdog = setTimeout(() => {
+        stderr.write(
+          `\n===== RSLINT HANG DIAG (host): no child exit within ${hostWatchdogMs}ms =====\n` +
+            `  elapsed=${Date.now() - hangStart}ms initAcked=${initAcked} ` +
+            `outputFrames=${outputFrames} lastOutputAt=${lastOutputAt}ms ` +
+            `pluginHost=${pluginHost ? 'yes' : 'no'} childPid=${child.pid} ` +
+            `childExitCode=${child.exitCode} childKilled=${child.killed}\n` +
+            `  (the Go-side goroutine dump above, if present, localizes the wedge)\n` +
+            `===== end host hang diag =====\n`,
+        );
+        safeKillGo(child);
+      }, hostWatchdogMs);
+      hostWatchdog.unref?.();
+    }
     const finalExit = await childExit;
+    if (hostWatchdog) clearTimeout(hostWatchdog);
+    hangTrace(`child exited code=${finalExit.code}`);
     ipc.close();
     return finalExit.code;
   } finally {

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -580,3 +580,11 @@ zigbuild
 lockfiles
 smajobber
 isatty
+hangdiag
+SIGBREAK
+GOTRACEBACK
+lintable
+nfiles
+tinypool
+endgroup
+acked

--- a/scripts/hang-hunt.mjs
+++ b/scripts/hang-hunt.mjs
@@ -1,0 +1,150 @@
+// hang-hunt.mjs — drive the intermittent windows-latest CLI hang to the
+// surface in ONE CI run, and capture WHY when it fires.
+//
+// It loops many concurrent `@rslint/core` CLI invocations over a tiny
+// type-aware fixture (the exact shape of the test that hangs in CI:
+// disable-comments.test.ts), with the Go-side hang watchdog + phase trace
+// enabled (see cmd/rslint/hangdiag.go). When an invocation wedges, the Go
+// watchdog dumps every goroutine stack to stderr and exits with code 99; this
+// script detects that, prints the dump, copies any dump file to the artifact
+// dir, and exits non-zero so the job goes red WITH the deadlock stack attached.
+//
+// Env knobs (with CI-oriented defaults):
+//   HANG_CONCURRENCY   parallel invocations per round            (default 8)
+//   HANG_ROUNDS        number of rounds                          (default 400)
+//   HANG_NFILES        .ts files per invocation (1 == exact      (default 24)
+//                      failing-test shape; >1 exercises the
+//                      per-file shard parallelism from #1088)
+//   HANG_WATCHDOG_MS   per-invocation Go watchdog deadline       (default 45000)
+//   HANG_DUMP_DIR      artifact dir for goroutine dump files     (default ./hang-dumps)
+//   HANG_STOP_ON_FIRST stop+fail on the first hang (1) or run    (default 1)
+//                      all rounds collecting every hang (0)
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CJS = path.resolve(HERE, '../packages/rslint/bin/rslint.cjs');
+
+const CONCURRENCY = Number(process.env.HANG_CONCURRENCY ?? 8);
+const ROUNDS = Number(process.env.HANG_ROUNDS ?? 400);
+const NFILES = Number(process.env.HANG_NFILES ?? 24);
+const WATCHDOG_MS = Number(process.env.HANG_WATCHDOG_MS ?? 45_000);
+const DUMP_DIR = path.resolve(process.env.HANG_DUMP_DIR ?? './hang-dumps');
+const STOP_ON_FIRST = (process.env.HANG_STOP_ON_FIRST ?? '1') !== '0';
+// Wall-clock budget so the job ends cleanly (green "no repro" / red "with dump")
+// before the workflow's hard timeout-minutes cancels it mid-round.
+const MAX_MINUTES = Number(process.env.HANG_MAX_MINUTES ?? 70);
+const DEADLINE = Date.now() + MAX_MINUTES * 60_000;
+// Hard ceiling per invocation so a wedge that even the Go watchdog can't escape
+// (e.g. a Node-side wedge) still can't stall the runner indefinitely.
+const HARD_TIMEOUT_MS = WATCHDOG_MS + 30_000;
+const WATCHDOG_EXIT = 99;
+
+const cfg = `export default [${JSON.stringify({
+  files: ['**/*.ts'],
+  languageOptions: { parserOptions: { projectService: false, project: ['./tsconfig.json'] } },
+  rules: { '@typescript-eslint/no-explicit-any': 'error' },
+  plugins: ['@typescript-eslint'],
+})}];`;
+const TSCONFIG = JSON.stringify({
+  compilerOptions: { target: 'ES2020', module: 'ESNext', strict: true },
+  include: ['**/*.ts'],
+});
+
+async function createTempDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rslint-hang-'));
+  await fs.writeFile(path.join(dir, 'rslint.config.mjs'), cfg);
+  await fs.writeFile(path.join(dir, 'tsconfig.json'), TSCONFIG);
+  for (let i = 0; i < NFILES; i++) {
+    const imp = i > 0 ? `import { v${i - 1} } from './f${i - 1}';\n` : '';
+    await fs.writeFile(
+      path.join(dir, `f${i}.ts`),
+      `${imp}export const v${i}: any = ${i};\nconst local${i}: any = '${i}';\nexport { local${i} };\n`,
+    );
+  }
+  return dir;
+}
+
+function runOnce(dir, id) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CJS], {
+      cwd: dir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        RSLINT_HANG_WATCHDOG_MS: String(WATCHDOG_MS),
+        RSLINT_HANG_TRACE: '1',
+        RSLINT_HANG_DUMP_DIR: DUMP_DIR,
+        GOTRACEBACK: 'all',
+      },
+    });
+    let stderr = '';
+    let stdout = '';
+    child.stderr.on('data', (d) => (stderr += d));
+    child.stdout.on('data', (d) => (stdout += d));
+    let settled = false;
+    const finish = (status, exitCode) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ status, exitCode, stderr, stdout, id });
+    };
+    const timer = setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch {}
+      finish('hard-timeout', null);
+    }, HARD_TIMEOUT_MS);
+    child.on('close', (code) => {
+      if (code === WATCHDOG_EXIT) finish('watchdog-hang', code);
+      else finish('ok', code);
+    });
+  });
+}
+
+const hangs = [];
+let total = 0;
+
+await fs.mkdir(DUMP_DIR, { recursive: true });
+console.log(
+  `hang-hunt: concurrency=${CONCURRENCY} rounds=${ROUNDS} nfiles=${NFILES} ` +
+    `watchdog=${WATCHDOG_MS}ms bin=${CJS}`,
+);
+
+outer: for (let r = 1; r <= ROUNDS; r++) {
+  if (Date.now() > DEADLINE) {
+    console.log(`time budget (${MAX_MINUTES}min) reached at round ${r}; stopping.`);
+    break;
+  }
+  const dirs = await Promise.all(
+    Array.from({ length: CONCURRENCY }, () => createTempDir()),
+  );
+  const results = await Promise.all(dirs.map((d, i) => runOnce(d, `r${r}c${i}`)));
+  for (const res of results) {
+    total++;
+    if (res.status !== 'ok') {
+      hangs.push(res);
+      console.log(`\n################ HANG #${hangs.length} (id=${res.id}, ${res.status}) ################`);
+      console.log('--- captured child stderr (Go phase trace + goroutine dump) ---');
+      console.log(res.stderr || '(empty)');
+      console.log('--- end captured stderr ---');
+      await fs.writeFile(
+        path.join(DUMP_DIR, `hang-${res.id}-stderr.txt`),
+        res.stderr,
+      );
+      if (STOP_ON_FIRST) break outer;
+    }
+  }
+  for (const d of dirs) fs.rm(d, { recursive: true, force: true }).catch(() => {});
+  if (r % 10 === 0 || hangs.length) {
+    console.log(`round ${r}/${ROUNDS}: total=${total} hangs=${hangs.length}`);
+  }
+}
+
+console.log(`\nhang-hunt FINAL: total=${total} hangs=${hangs.length}`);
+if (hangs.length) {
+  console.log(`reproduced the hang ${hangs.length}×. Dumps in ${DUMP_DIR}.`);
+  process.exit(1);
+}
+console.log('no hang reproduced in this run.');


### PR DESCRIPTION
## Why

`Test npm packages (windows-latest)` intermittently hangs until the job
timeout (e.g. run 27521879692: a 3-line type-aware lint sat for 30 min, only
ending on a manual cancel). The whole chain is unbounded — the Go lint phase,
the IPC request, the engine's `await childExit`, the test helper, and rstest's
`--testTimeout=0` — so one wedged child eats the entire job.

~6800 faithful local runs on macOS (race build, single- and multi-file
fixtures, GOMAXPROCS 4 and 10) did **not** reproduce it → the deadlock looks
Windows-specific. Docker can't help (no Windows containers on macOS; the runner
is a Windows Server VM, not a container), so the only faithful repro is the
runner itself. The Go child is killed by SIGTERM with no goroutine traceback,
so CI logs never show where it wedges — this PR fixes that.

## What

Opt-in, env-gated diagnostics (a complete no-op unless `RSLINT_HANG_*` is set),
so **one** windows-latest run can capture *where* the Go side is stuck:

| Piece | Role |
|---|---|
| `cmd/rslint/hangdiag.go` | lifecycle phase trace + watchdog that dumps **all** goroutine stacks and exits 99 past a deadline; on-demand dump via SIGQUIT (unix) / SIGBREAK (Windows, no SIGQUIT) |
| `packages/rslint/src/engine.ts` | host-side phase trace + backstop watchdog (Node-side state, forces the child down) |
| `scripts/hang-hunt.mjs` | concurrent CLI-spawn loop over the failing fixture shape, wall-clock budget, fails with the captured dump |
| `.github/workflows/debug-hang.yml` | build `rslint.exe` + loop on windows-latest (CLI-spawn matrix + a real rstest loop); upload goroutine dumps as artifacts |

Verified locally end-to-end: a forced watchdog dumped all 10 goroutines
(including the typescript-go checker-pool ones) with file:line, wrote the dump
file, exited 99, and the host passed it through. Default-off path leaks nothing.

## How to read a run

- **Red `Hunt (...)` job** = reproduced. The failing step prints the Go phase
  trace (last marker = the wedged phase) + the full goroutine dump (the
  deadlock site). Same dump is in the `hang-dumps-*` artifact.
- **Green** = not reproduced this run (bump iterations / re-run).

> Debug-only. **Do not merge** — revert once the root cause is found.
