### PR TITLE
fix: avoid Windows IPC channel close deadlock

### DIFF
--- a/internal/ipc/channel.go
+++ b/internal/ipc/channel.go
@@ -36,9 +36,8 @@ type NotificationHandler func(msg *Message)
 // A write failure or a read fault is terminal: the channel closes and every
 // in-flight request fails with a stable error (mirrors the Node side).
 type Channel struct {
-	reader    *bufio.Reader
-	rawReader io.Reader // original reader, closed on shutdown to unblock readLoop
-	writer    io.Writer
+	reader *bufio.Reader
+	writer io.Writer
 
 	// writeTimeout bounds a single frame write (0 = none; defaulted in
 	// NewChannel). requestTimeout is the default deadline applied to a
@@ -75,7 +74,6 @@ func NewChannel(r io.Reader, w io.Writer) *Channel {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Channel{
 		reader:         bufio.NewReader(r),
-		rawReader:      r,
 		writer:         w,
 		pending:        make(map[int]chan *Message),
 		nextID:         1, // requests use id > 0; notifications use 0
@@ -353,9 +351,26 @@ func (c *Channel) isClosed() bool {
 }
 
 // closeWith shuts the channel down: marks closed, records the cause, cancels
-// inbound ctx, unblocks every pending SendRequest (they select on c.done),
-// and closes the underlying reader so readLoop's ReadFrame returns instead of
-// blocking forever. Idempotent.
+// inbound ctx, and unblocks every pending SendRequest (they select on c.done).
+// Idempotent.
+//
+// It deliberately does NOT close the underlying reader. readLoop may be parked
+// in a blocked ReadFrame on the peer's stdout pipe when the channel is closed
+// (the normal CLI shutdown order: lint done → shutdown acked → Close, while the
+// peer waits for THIS process to exit before closing its write end). Closing the
+// reader to interrupt that read is only reliable on pollable fds; on a Windows
+// synchronous-I/O stdin pipe (*os.File).Close blocks in semacquire until the
+// in-flight ReadFile returns — which it never will, since the peer is waiting on
+// us — so an inline close deadlocks the exit path and a backgrounded close just
+// leaks a second goroutine wedged the same way.
+//
+// Interrupting readLoop is unnecessary. This Channel is used only by the CLI
+// (cmd/rslint/ipc_cli.go), which always terminates via os.Exit (main.go); that
+// reaps a parked readLoop goroutine instantly. Everything other code observes on
+// close — closeErr, c.done, inbound ctx cancellation — is published here
+// regardless, so SendRequest waiters and Done() consumers wake exactly as
+// before. When readLoop itself originates the close (a ReadFrame error), its
+// reader has already returned and the goroutine exits on its own.
 func (c *Channel) closeWith(cause error) {
 	c.mu.Lock()
 	if c.closed {
@@ -373,12 +388,6 @@ func (c *Channel) closeWith(cause error) {
 
 	c.inCancel()
 	close(c.done)
-	// Unblock readLoop: closing the underlying reader makes its blocked
-	// ReadFrame return so the goroutine exits, instead of hanging until the
-	// peer happens to close its write end.
-	if rc, ok := c.rawReader.(io.Closer); ok {
-		_ = rc.Close()
-	}
 }
 
 // Close shuts the channel down. Pending requests fail with a stable error.

--- a/internal/ipc/channel_test.go
+++ b/internal/ipc/channel_test.go
@@ -380,3 +380,62 @@ func TestChannel_SendAfterClose(t *testing.T) {
 		t.Fatal("expected SendNotification error after close")
 	}
 }
+
+// blockingCloseReader models a Windows synchronous-I/O stdin pipe: Read parks
+// (so readLoop blocks in ReadFrame) and Close blocks until released — mirroring
+// (*os.File).Close on a fd whose in-flight ReadFile cannot be interrupted.
+type blockingCloseReader struct {
+	release     chan struct{} // test closes this to let Read and Close return
+	closeCalled chan struct{} // closed iff Close is ever invoked
+}
+
+func (r *blockingCloseReader) Read([]byte) (int, error) {
+	<-r.release
+	return 0, io.EOF
+}
+
+func (r *blockingCloseReader) Close() error {
+	close(r.closeCalled)
+	<-r.release // uninterruptible, like a Windows FD.Close awaiting a live read
+	return nil
+}
+
+// TestChannel_CloseDoesNotBlockOnReader pins the windows-latest hang fix:
+// closeWith must NOT close (or otherwise block on) the underlying reader. When
+// the channel closes, readLoop is typically parked in a blocked ReadFrame; on a
+// Windows synchronous pipe, closing the reader to interrupt it makes
+// (*os.File).Close block until that read returns — which it can't, since the
+// peer is waiting for this process to exit — deadlocking the CLI's exit path.
+// Reaping the parked readLoop is left to os.Exit (the sole caller is the CLI).
+func TestChannel_CloseDoesNotBlockOnReader(t *testing.T) {
+	r := &blockingCloseReader{
+		release:     make(chan struct{}),
+		closeCalled: make(chan struct{}),
+	}
+	t.Cleanup(func() { close(r.release) }) // unpark Read (and any Close) at the end
+	_, pw := io.Pipe()
+	t.Cleanup(func() { _ = pw.Close() })
+
+	c := NewChannel(r, pw)
+	c.Start() // readLoop parks in r.Read
+
+	done := make(chan struct{})
+	go func() { _ = c.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked while readLoop was parked in Read — closeWith must not close/await the reader")
+	}
+
+	// The channel is closed, and the reader was never touched.
+	select {
+	case <-c.Done():
+	default:
+		t.Fatal("Close did not shut the channel down")
+	}
+	select {
+	case <-r.closeCalled:
+		t.Fatal("closeWith closed the underlying reader; on Windows that deadlocks the exit path")
+	default:
+	}
+}

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -580,3 +580,8 @@ zigbuild
 lockfiles
 smajobber
 isatty
+semacquire
+pollable
+unpark
+acked
+backgrounded


### PR DESCRIPTION
## Symptom

`Test npm packages (windows-latest)` intermittently hung until the job timeout
— a tiny type-aware lint child process never exited (e.g. run 27521879692 sat
30 min before a manual cancel). Only on `windows-latest`, only under the
concurrent test suite.

## Root cause (captured goroutine dump)

A debug build with a watchdog caught it on CI. Phase trace showed all work
finished — lint done, stdout drained, **shutdown acked** — then the process
hung 45s in the *exit path*. Two interlocked goroutines:

```
main:     runCLI → ipc.(*Channel).Close → closeWith → os.File.Close
          → internal/poll.(*FD).Close → runtime_Semacquire   [blocked]
readLoop: ipc.(*Channel).readLoop → ReadFrame → os.File.Read
          → syscall.ReadFile                                 [blocked]
```

`closeWith` closed the underlying stdin reader to interrupt the parked
`readLoop`. On Unix that works (pollable fd). On a **Windows synchronous-I/O
pipe**, `(*os.File).Close` blocks in `semacquire` until the in-flight
`ReadFile` returns — which it never does, because `readLoop` awaits a frame the
Node parent won't send (it already has the shutdown ack and is waiting for this
process to **exit**). Circular wait → deadlock. Intermittent + load-correlated
(needs `readLoop` mid-`ReadFile` exactly when `closeWith` runs); could not
reproduce in ~6800 macOS runs.

## Fix

`closeWith` never needed to close the reader. Every synchronization edge other
code observes — `closeErr`, `c.done`, inbound ctx cancel — is published before
it; it only retired `readLoop` a few ms early. The sole user of `ipc.Channel`
is the CLI (`cmd/rslint/ipc_cli.go`), which always terminates via `os.Exit`
(`main.go`), and that reaps a parked `readLoop` instantly. So: drop the
`rawReader` field and the reader-close. `closeWith` now does only non-blocking
in-process work and cannot deadlock on any platform/path.

## Why this and not the alternatives

Vetted via an adversarial multi-agent review (3 proposals × 2 skeptics each,
6/6 verdict "sound", none could construct a remaining hang):

- **Background the close** (`go func(){ rc.Close() }()`): the spawned goroutine
  wedges the same way on Windows, leaving *two* parked goroutines for a
  Unix-only early-retirement that `os.Exit` makes moot. Strictly worse.
- **CancelIoEx on Windows**: a proven no-op — Go's `(*FD).Close` already issues
  `CancelIoEx` before the semaphore wait, and the dump shows it still blocks.
- **Overlapped/interruptible stdin**: large, risky fd-handling change for a
  CLI-only type that always `os.Exit`s. Overkill.

**Residual risk** (documented in the code): a *future* long-lived consumer of
`ipc.Channel` that closes channels without exiting would leak one parked
`readLoop` per close and would need to reintroduce an interruptible read. No
such consumer exists today (LSP/API never construct a Channel).

## Verification

- Regression test `TestChannel_CloseDoesNotBlockOnReader` pins the invariant
  (Close must not block on / close the reader) — **fails on the old code,
  passes on the fix**, under `-race`.
- Full `internal/ipc` suite green under `-race`; `go vet` + `gofmt` clean;
  cross-compiles for windows/amd64, darwin/arm64, linux/amd64.
- **CI proof (done)** — [green CI run ↗](https://github.com/web-infra-dev/rslint/actions/runs/27531377777): re-ran the exact
  windows-latest hunt that reproduced this deadlock twice. With the fix, both reproducing vectors ran the full
  45-min budget GREEN, zero watchdog dumps:
  - single-file: **32,032** invocations / 4005 rounds — **0 hangs**
  - multi-file shards: **28,830** invocations / 4806 rounds — **0 hangs**
  - full-suite loop: **0 hangs**

  For reference the buggy build reproduced the deadlock within ~108 rounds, so
  this is a ~40x margin over the original repro window.
