### PR TITLE
perf: prune gitignored directories during gap-file discovery

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -911,8 +911,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			//
 			// Config ignores are passed so that directories which are
 			// directory-level blocked (e.g. **/tests/**) are pruned during
-			// the .gitignore scan. This is safe because isDirPathBlocked is
-			// the same function used by the linter — blocked dirs' files
+			// the .gitignore scan. This is safe because isDirAbsolutelyBlocked is
+			// the same predicate used by the linter — blocked dirs' files
 			// are never linted, so their .gitignore patterns are irrelevant.
 			//
 			// Concurrency:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -336,50 +336,6 @@ func registerAllCoreEslintRules() {
 	}
 }
 
-// isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.
-// Later patterns override earlier ones; a `!` prefix negates (re-includes) a previously
-// ignored file. This aligns with ESLint v10's ignore semantics.
-//
-// For directory-level blocking (dir/** prevents traversal entirely), use isDirPathBlocked.
-func isFileIgnored(filePath string, ignorePatterns []string, cwd string) bool {
-	if cwd == "" {
-		return isFileIgnoredSimple(filePath, ignorePatterns)
-	}
-
-	// Normalize the file path relative to cwd
-	normalizedPath := normalizePath(filePath, cwd)
-	unixPath := strings.ReplaceAll(normalizedPath, "\\", "/")
-
-	// Evaluate patterns sequentially. Later patterns override earlier ones.
-	// A `!` prefix negates (re-includes) a previously ignored file.
-	// This aligns with ESLint v10's ignore semantics.
-	ignored := false
-	for _, pattern := range ignorePatterns {
-		negated := false
-		if strings.HasPrefix(pattern, "!") {
-			negated = true
-			pattern = pattern[1:]
-		}
-
-		normalizedPattern := normalizePattern(pattern)
-
-		// Match against the relative path only. Do NOT fall back to the
-		// absolute filePath — patterns with **/ prefix (e.g., **/tmp/**/*)
-		// would incorrectly match system directory names in the absolute path
-		// (e.g., /tmp/ on Linux/macOS).
-		matched := matchGlob(normalizedPattern, normalizedPath)
-		// Windows path separator fallback.
-		if !matched && unixPath != normalizedPath {
-			matched = matchGlob(normalizedPattern, unixPath)
-		}
-
-		if matched {
-			ignored = !negated
-		}
-	}
-	return ignored
-}
-
 // normalizePattern cleans up a glob pattern to match paths produced by normalizePath.
 // normalizePath uses tspath.NormalizePath on file paths (strips leading "./", collapses
 // "/./", resolves ".."), so patterns must undergo the same transformation.
@@ -389,24 +345,16 @@ func matchGlob(pattern, path string) bool {
 	return err == nil && m
 }
 
-// isFileLevelPattern returns true if the pattern only matches files (not directories).
-// File-level patterns end with /**/* or /* (but not /**).
-// These do NOT block directory traversal in ESLint v10's isDirectoryIgnored.
-func isFileLevelPattern(pattern string) bool {
-	return strings.HasSuffix(pattern, "/**/*") ||
-		(strings.HasSuffix(pattern, "/*") && !strings.HasSuffix(pattern, "/**"))
-}
-
 func normalizePattern(pattern string) string {
 	return tspath.NormalizePath(pattern)
 }
 
 // isDirBlockedByIgnores checks if the file's directory is blocked by a
-// directory-level ignore pattern (e.g., `dir/**`). File-level patterns
-// (`dir/**/*`, `dir/*`) and negation patterns are skipped.
-// This aligns with ESLint v10: `dir/**` blocks directory traversal entirely,
-// and `!` negation cannot undo it.
-func isDirBlockedByIgnores(filePath string, ignorePatterns []string, cwd string) bool {
+// directory-level ignore pattern (e.g., `dir/**`). File-level patterns and
+// negation patterns are excluded (by Kind) in isDirAbsolutelyBlocked. This
+// aligns with ESLint v10: `dir/**` blocks directory traversal entirely, and
+// `!` negation cannot undo it.
+func isDirBlockedByIgnores(filePath string, patterns []IgnorePattern, cwd string) bool {
 	var dirPath string
 	if cwd != "" {
 		dirPath = normalizePath(tspath.GetDirectoryPath(filePath), cwd)
@@ -418,39 +366,7 @@ func isDirBlockedByIgnores(filePath string, ignorePatterns []string, cwd string)
 	if dirPath == "" || dirPath == "." {
 		return false
 	}
-	return isDirPathBlocked(dirPath, ignorePatterns)
-}
-
-// isDirPathBlocked checks if a directory path is blocked by any directory-level ignore
-// pattern. Shared between GetConfigForFile and DiscoverGapFiles.
-//
-// A directory is blocked if a pattern matches the path itself or any parent segment.
-// For example, pattern "dir1/**" blocks "dir1", "dir1/sub", and "dir1/sub/deep".
-// File-level patterns (ending with /**/* or /*) and negation (!) patterns are skipped —
-// directory blocking is absolute and cannot be negated.
-func isDirPathBlocked(dirPath string, ignorePatterns []string) bool {
-	for _, pattern := range ignorePatterns {
-		if pattern == "" || strings.HasPrefix(pattern, "!") {
-			continue
-		}
-		if isFileLevelPattern(pattern) {
-			continue
-		}
-
-		normalizedPattern := normalizePattern(pattern)
-
-		if matchGlob(normalizedPattern, dirPath) || matchGlob(normalizedPattern, dirPath+"/x") {
-			return true
-		}
-		segments := strings.Split(dirPath, "/")
-		for i := 1; i < len(segments); i++ {
-			partial := strings.Join(segments[:i], "/")
-			if matchGlob(normalizedPattern, partial) || matchGlob(normalizedPattern, partial+"/x") {
-				return true
-			}
-		}
-	}
-	return false
+	return isDirAbsolutelyBlocked(dirPath, patterns)
 }
 
 // normalizePath converts file path to be relative to cwd for consistent matching
@@ -459,23 +375,6 @@ func normalizePath(filePath, cwd string) string {
 		UseCaseSensitiveFileNames: true,
 		CurrentDirectory:          cwd,
 	}))
-}
-
-// isFileIgnoredSimple provides fallback matching when cwd is unavailable
-func isFileIgnoredSimple(filePath string, ignorePatterns []string) bool {
-	ignored := false
-	for _, pattern := range ignorePatterns {
-		negated := false
-		if strings.HasPrefix(pattern, "!") {
-			negated = true
-			pattern = pattern[1:]
-		}
-		normalizedPattern := normalizePattern(pattern)
-		if matched, err := doublestar.Match(normalizedPattern, filePath); err == nil && matched {
-			ignored = !negated
-		}
-	}
-	return ignored
 }
 
 // MergedConfig is the final computed configuration for a single file
@@ -546,8 +445,10 @@ func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *Merged
 			continue
 		}
 
-		// 3. Entry-level ignores
-		if isFileIgnored(filePath, entry.Ignores, cwd) {
+		// 3. Entry-level ignores. Parsed per entry; entry.Ignores is usually
+		// empty (ESLint configs put ignores in a dedicated global-ignore entry),
+		// so ParseIgnorePatterns returns nil and this is free in the common case.
+		if isFileIgnored(filePath, ParseIgnorePatterns(entry.Ignores), cwd) {
 			continue
 		}
 

--- a/internal/config/config_ignore_test.go
+++ b/internal/config/config_ignore_test.go
@@ -105,7 +105,7 @@ func TestIsFileIgnored_Negation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isFileIgnored(tt.filePath, tt.patterns, cwd)
+			result := isFileIgnored(tt.filePath, ParseIgnorePatterns(tt.patterns), cwd)
 			if result != tt.shouldIgnore {
 				t.Errorf("isFileIgnored(%q, %v) = %v, expected %v",
 					tt.filePath, tt.patterns, result, tt.shouldIgnore)
@@ -175,7 +175,7 @@ func TestIsFileIgnored_NegationBeforePositive(t *testing.T) {
 
 	// Negation before positive pattern: ! has nothing to negate yet,
 	// then positive pattern ignores. Result: ignored.
-	result := isFileIgnored("build/test.js", []string{"!build/test.js", "build/**"}, cwd)
+	result := isFileIgnored("build/test.js", ParseIgnorePatterns([]string{"!build/test.js", "build/**"}), cwd)
 	if !result {
 		t.Error("Expected ignored: negation before positive has no effect, positive wins")
 	}
@@ -212,7 +212,7 @@ func TestIsFileIgnored_FileExtensionNegation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isFileIgnored(tt.filePath, tt.patterns, cwd)
+			result := isFileIgnored(tt.filePath, ParseIgnorePatterns(tt.patterns), cwd)
 			if result != tt.shouldIgnore {
 				t.Errorf("isFileIgnored(%q, %v) = %v, expected %v",
 					tt.filePath, tt.patterns, result, tt.shouldIgnore)
@@ -240,7 +240,7 @@ func TestIsFileIgnored_MultiLevelNegateAndReIgnore(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isFileIgnored(tt.filePath, patterns, cwd)
+			result := isFileIgnored(tt.filePath, ParseIgnorePatterns(patterns), cwd)
 			if result != tt.shouldIgnore {
 				t.Errorf("isFileIgnored(%q) = %v, expected %v", tt.filePath, result, tt.shouldIgnore)
 			}
@@ -284,7 +284,7 @@ func TestIsFileIgnoredSimple_Negation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isFileIgnoredSimple(tt.filePath, tt.patterns)
+			result := isFileIgnoredSimple(tt.filePath, ParseIgnorePatterns(tt.patterns))
 			if result != tt.shouldIgnore {
 				t.Errorf("isFileIgnoredSimple(%q, %v) = %v, expected %v",
 					tt.filePath, tt.patterns, result, tt.shouldIgnore)

--- a/internal/config/cwd_test.go
+++ b/internal/config/cwd_test.go
@@ -97,7 +97,7 @@ func TestCwdHandling(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isFileIgnored(tt.filePath, tt.patterns, originalCwd)
+			result := isFileIgnored(tt.filePath, ParseIgnorePatterns(tt.patterns), originalCwd)
 			if result != tt.shouldIgnore {
 				t.Errorf("%s: isFileIgnored(%q, %v) = %v, expected %v",
 					tt.description, tt.filePath, tt.patterns, result, tt.shouldIgnore)

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -92,7 +92,7 @@ func DiscoverGapFiles(
 
 	// 2. Prepend default directory ignores so they are always active
 	// regardless of user config.
-	globalIgnores = append(utils.DefaultIgnoreDirGlobs(), globalIgnores...)
+	globalIgnores = append(ParseIgnorePatterns(utils.DefaultIgnoreDirGlobs()), globalIgnores...)
 
 	// Use non-nil empty slice to distinguish "files field present, no gaps"
 	// from "no files field" (nil).
@@ -138,6 +138,11 @@ func DiscoverGapFiles(
 		seen      sync.Map // map[string]struct{} — file dedupe
 		dirIgnore sync.Map // map[string]bool — pattern check cache, write-once per path
 	)
+
+	// Precompute negation reaches once. canPruneDir uses them to prune gitignore
+	// file-level directories (e.g. target/ → **/target/**/*) without ever
+	// skipping a directory a `!` pattern could re-include.
+	neg := buildNegReach(globalIgnores)
 
 	// Defer the parallelism limit to GOMAXPROCS (Go's standard knob; aligned
 	// with container CGroup CPU limits). Lower bound of 2 keeps the walker
@@ -235,7 +240,11 @@ func DiscoverGapFiles(
 						continue
 					}
 				} else {
-					blocked := isDirPathBlocked(childPath, globalIgnores)
+					// canPruneDir unifies both directory-prune cases: absolute
+					// blocks (dir/**, bare names) and negation-aware file-level
+					// gitignore covers (dir/**/*). Sound — prunes only when every
+					// descendant file would be ignored by isFileIgnored.
+					blocked := canPruneDir(childPath, globalIgnores, neg)
 					dirIgnore.Store(childPath, blocked)
 					if blocked {
 						continue

--- a/internal/config/file_discovery_dir_prune_test.go
+++ b/internal/config/file_discovery_dir_prune_test.go
@@ -1,0 +1,377 @@
+package config
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"gotest.tools/v3/assert"
+)
+
+// Integration tests for gap-directory pruning: the canPruneDir predicate
+// (config.go) wired into the DiscoverGapFiles walk. Predicate unit tests live
+// in ignore_pattern_test.go.
+
+// dirAccessed reports whether any walked directory path is, or sits under, a
+// path segment named seg. Segment-anchored ("/seg" suffix or "/seg/" infix) to
+// avoid matching siblings like "target-x".
+func dirAccessed(dirs []string, seg string) bool {
+	for _, d := range dirs {
+		if strings.HasSuffix(d, "/"+seg) || strings.Contains(d, "/"+seg+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// Core fix: a gitignore file-level dir (target/ → **/target/**/*) is pruned
+// during the gap walk, and the gap-file set is unchanged.
+func TestDiscoverGapFiles_PrunesGitignoreFileLevelDir(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/index.ts",
+		"target/build/a.ts",
+		"target/build/deep/b.ts",
+	})
+	// Simulate gitignore `target/` → file-level glob (what convertSinglePattern emits).
+	config := RslintConfig{
+		{Ignores: []string{"**/target/**/*"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	spy := &spyFS{FS: osvfs.FS()}
+	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+
+	// target/ must NOT be entered.
+	for _, dir := range spy.snapshotAccessedDirs() {
+		if strings.Contains(dir, "target") {
+			t.Errorf("target was entered during walk: %s", dir)
+		}
+	}
+	// gapFiles == exactly src/index.ts.
+	assert.Equal(t, len(gapFiles), 1, "got %v", gapFiles)
+	assert.Assert(t, toSet(gapFiles)[paths["src/index.ts"]])
+}
+
+// Negation re-includes a full path (rspack's !tests/.../target case): the
+// top-level target is pruned, but the re-included path is walked.
+func TestDiscoverGapFiles_NegationReincludeFullPath(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/a.ts",
+		"target/x.ts",
+		"sub/path/target/y.ts",
+	})
+	config := RslintConfig{
+		{Ignores: []string{"**/target/**/*", "!sub/path/target/**/*"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	spy := &spyFS{FS: osvfs.FS()}
+	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	dirs := spy.snapshotAccessedDirs()
+
+	// Top-level target NOT entered; the re-included sub/path/target IS entered.
+	for _, d := range dirs {
+		if strings.HasSuffix(d, "/target") && !strings.Contains(d, "sub/path") {
+			t.Errorf("top-level target should be pruned, but entered: %s", d)
+		}
+	}
+	assert.Assert(t, dirAccessed(dirs, "sub/path/target"), "re-included target must be walked")
+
+	gapSet := toSet(gapFiles)
+	assert.Assert(t, gapSet[paths["src/a.ts"]])
+	assert.Assert(t, gapSet[paths["sub/path/target/y.ts"]], "re-included file must be a gap file")
+	assert.Assert(t, !gapSet[paths["target/x.ts"]], "top-level target file must stay ignored")
+}
+
+// Negation re-includes a child of an excluded directory: the parent must NOT
+// be pruned (rslint's file-level isFileIgnored re-includes the child).
+func TestDiscoverGapFiles_NegationReincludeChildNotOverPruned(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/a.ts",
+		"target/keep/x.ts",
+		"target/other/y.ts",
+	})
+	config := RslintConfig{
+		{Ignores: []string{"target/**/*", "!target/keep/**/*"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	spy := &spyFS{FS: osvfs.FS()}
+	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+
+	// Must reach target/keep.
+	assert.Assert(t, dirAccessed(spy.snapshotAccessedDirs(), "target/keep"), "target/keep must be walked")
+
+	gapSet := toSet(gapFiles)
+	assert.Assert(t, gapSet[paths["src/a.ts"]])
+	assert.Assert(t, gapSet[paths["target/keep/x.ts"]], "re-included child must be a gap file")
+	assert.Assert(t, !gapSet[paths["target/other/y.ts"]], "non-negated sibling must stay ignored")
+}
+
+// Unrooted negation (!**/keep/) forces conservative behavior: the file-level
+// directory is not pruned (a keep/ could appear at any depth inside it).
+func TestDiscoverGapFiles_UnrootedNegationConservative(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/a.ts",
+		"build/keep/x.ts",
+		"build/other/y.ts",
+	})
+	config := RslintConfig{
+		{Ignores: []string{"**/build/**/*", "!**/keep/**/*"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	spy := &spyFS{FS: osvfs.FS()}
+	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+
+	assert.Assert(t, dirAccessed(spy.snapshotAccessedDirs(), "build"), "build must be walked (unrooted negation)")
+
+	gapSet := toSet(gapFiles)
+	assert.Assert(t, gapSet[paths["src/a.ts"]])
+	assert.Assert(t, gapSet[paths["build/keep/x.ts"]], "unrooted negation re-includes build/keep")
+	assert.Assert(t, !gapSet[paths["build/other/y.ts"]])
+}
+
+// Directory-level `dir/**` (absolute, not negatable) vs file-level `dir/**/*`
+// (negation-aware): pruning behavior differs and stays aligned with ESLint v10.
+func TestDiscoverGapFiles_DirLevelVsFileLevel(t *testing.T) {
+	// 6a: dir-level — absolutely pruned; ! cannot re-include.
+	t.Run("dir-level absolute", func(t *testing.T) {
+		configDir, paths := setupDiscoveryFixture(t, []string{
+			"src/a.ts", "dist/keep.ts", "dist/other.ts",
+		})
+		config := RslintConfig{
+			{Ignores: []string{"dist/**", "!dist/keep.ts"}},
+			{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+		}
+		spy := &spyFS{FS: osvfs.FS()}
+		gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+		for _, d := range spy.snapshotAccessedDirs() {
+			if strings.Contains(d, "dist") {
+				t.Errorf("dir-level dist must be absolutely pruned, entered: %s", d)
+			}
+		}
+		gapSet := toSet(gapFiles)
+		assert.Assert(t, gapSet[paths["src/a.ts"]])
+		assert.Assert(t, !gapSet[paths["dist/keep.ts"]], "dir-level ! cannot re-include")
+	})
+
+	// 6b: file-level — not pruned (negation protects keep.ts).
+	t.Run("file-level negation-aware", func(t *testing.T) {
+		configDir, paths := setupDiscoveryFixture(t, []string{
+			"src/a.ts", "dist/keep.ts", "dist/other.ts",
+		})
+		config := RslintConfig{
+			{Ignores: []string{"dist/**/*", "!dist/keep.ts"}},
+			{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+		}
+		spy := &spyFS{FS: osvfs.FS()}
+		gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+		assert.Assert(t, dirAccessed(spy.snapshotAccessedDirs(), "dist"), "file-level dist must be walked for negation")
+		gapSet := toSet(gapFiles)
+		assert.Assert(t, gapSet[paths["dist/keep.ts"]], "file-level ! re-includes keep.ts")
+		assert.Assert(t, !gapSet[paths["dist/other.ts"]])
+	})
+}
+
+// Real gitignore conversion path: `target/` in a .gitignore prunes target/.
+// Uses a spy to assert the pruning actually happens (not just that the gap-file
+// set is correct, which would pass even with pruning disabled).
+func TestDiscoverGapFiles_GitignoreTargetPrunedE2E(t *testing.T) {
+	files := map[string]string{
+		".gitignore":       "target/\n",
+		"src/index.ts":     "x",
+		"target/a.ts":      "x",
+		"target/deep/b.ts": "x",
+	}
+	dir := setupGitignoreFixture(t, files)
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ExtractConfigIgnores(config))
+	if len(gitGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
+	}
+
+	spy := &spyFS{FS: osvfs.FS()}
+	gapFiles := DiscoverGapFiles(config, dir, spy, map[string]struct{}{}, nil, nil, false)
+
+	// The actual optimization: target/ must NOT be entered.
+	assert.Assert(t, !dirAccessed(spy.snapshotAccessedDirs(), "target"), "target should be pruned via gitignore")
+	// gap-file set unchanged.
+	assert.Equal(t, len(gapFiles), 1, "got %v", gapFiles)
+	assert.Assert(t, toSet(gapFiles)[tspath.NormalizePath(dir+"/src/index.ts")])
+	// Linter consistency: target files return nil.
+	assert.Assert(t, config.GetConfigForFile(tspath.NormalizePath(dir+"/target/a.ts"), dir) == nil)
+}
+
+// Nested .gitignore negation: root ignores build/, a sub/.gitignore re-includes
+// it. The re-included subtree must be walked and discovered; the top-level
+// build/ must still be pruned. Exercises the conversion → negPrefix → prune
+// chain for nested-gitignore negations end to end.
+func TestDiscoverGapFiles_NestedGitignoreNegationE2E(t *testing.T) {
+	files := map[string]string{
+		".gitignore":        "build/\n",
+		"sub/.gitignore":    "!build/\n",
+		"src/a.ts":          "x",
+		"build/top.ts":      "x",
+		"sub/build/keep.ts": "x",
+	}
+	dir := setupGitignoreFixture(t, files)
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ExtractConfigIgnores(config))
+	if len(gitGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
+	}
+
+	spy := &spyFS{FS: osvfs.FS()}
+	gapFiles := DiscoverGapFiles(config, dir, spy, map[string]struct{}{}, nil, nil, false)
+	gapSet := toSet(gapFiles)
+
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/src/a.ts")])
+	// Re-included nested build must be walked + discovered.
+	assert.Assert(t, dirAccessed(spy.snapshotAccessedDirs(), "build"), "sub/build must be walked")
+	if !gapSet[tspath.NormalizePath(dir+"/sub/build/keep.ts")] {
+		// Consistency cross-check: linter must agree it is lintable.
+		mc := config.GetConfigForFile(tspath.NormalizePath(dir+"/sub/build/keep.ts"), dir)
+		t.Errorf("sub/build/keep.ts should be a gap file; GetConfigForFile=%v", mc != nil)
+	}
+	// Top-level build/top.ts stays ignored.
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/build/top.ts")], "top-level build stays ignored")
+}
+
+// --- Strongest regression: pruning must not change the gap-file set ---
+//
+// Oracle = { f : f matches **/*.ts ∧ f∉programFiles ∧ GetConfigForFile(f)≠nil }.
+// This is exactly the linter's per-file decision; DiscoverGapFiles must equal
+// it regardless of directory pruning.
+func TestDiscoverGapFiles_PruningPreservesGapFiles(t *testing.T) {
+	filesPatterns := []string{"**/*.ts", "**/*.tsx"}
+	fixtures := []struct {
+		name    string
+		ignores []string
+	}{
+		{"gitignore target", []string{"**/target/**/*"}},
+		{"negation full path", []string{"**/target/**/*", "!sub/path/target/**/*"}},
+		{"negation child of excluded", []string{"target/**/*", "!target/keep/**/*"}},
+		{"unrooted negation", []string{"**/build/**/*", "!**/keep/**/*"}},
+		{"dir-level absolute", []string{"dist/**", "!dist/keep.ts"}},
+		{"single-star file-level", []string{"build/*"}},                       // regression: 致命#1
+		{"extension-filtered", []string{"target/**/*.log"}},                   // regression: ext filter must not prune
+		{"dotslash negation", []string{"target/**/*", "!./target/keep/**/*"}}, // regression: 致命#2
+		{"mixed", []string{"**/target/**/*", "**/tests/**", "!tests/e2e/**/*"}},
+		{"bare rooted", []string{"dist"}},                            // /dist → "dist": no /**/* suffix, must not prune
+		{"deep dir-only", []string{"a/b/target/**/*"}},               // deep-path positive cover
+		{"brace extension filter", []string{"target/**/*.{js,jsx}"}}, // brace ext filter must not prune .ts
+		{"multi-negation", []string{"**/target/**/*", "!target/keep/**/*", "!target/save/**/*"}},
+		{"sequential re-ignore", []string{"target/**/*", "!target/keep/**/*", "target/keep/sub/**/*"}},
+	}
+
+	// Layout mixes shallow (depth-1) and deep (depth-2+) files plus a .tsx and a
+	// non-matching .log, so single-star / extension-filter / pattern-match edges
+	// are exercised by the oracle.
+	layout := []string{
+		"src/a.ts",
+		"src/comp.tsx",
+		"target/shallow.ts",
+		"target/x.ts",
+		"target/keep/k.ts",
+		"target/other/o.ts",
+		"target/log/skip.log",
+		"sub/path/target/y.ts",
+		"build/shallow.ts",
+		"build/keep/bk.ts",
+		"build/other/bo.ts",
+		"dist/keep.ts",
+		"dist/other.ts",
+		"dist/sub/deep.ts", // bare-rooted "dist" witness: must not be pruned away
+		"tests/unit/u.ts",
+		"tests/e2e/e.ts",
+		"a/b/target/deep/d.ts",    // deep dir-only witness (pruned)
+		"a/b/other/o.ts",          // deep dir-only sibling witness (kept)
+		"target/save/s.ts",        // multi-negation second re-include
+		"target/keep/sub/deep.ts", // sequential re-ignore witness
+	}
+
+	for _, fx := range fixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			configDir, paths := setupDiscoveryFixture(t, layout)
+			config := RslintConfig{
+				{Ignores: fx.ignores},
+				{Files: filesPatterns, Rules: Rules{"test-rule": "error"}},
+			}
+
+			// Oracle = the linter's own per-file decision: matches a files
+			// pattern AND GetConfigForFile != nil. DiscoverGapFiles must equal
+			// this set regardless of directory pruning.
+			var oracle []string
+			for _, abs := range paths {
+				if !isFileMatched(abs, filesPatterns, configDir) {
+					continue
+				}
+				if config.GetConfigForFile(abs, configDir) != nil {
+					oracle = append(oracle, abs)
+				}
+			}
+			sort.Strings(oracle)
+
+			got := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+			sort.Strings(got)
+
+			assert.DeepEqual(t, got, oracle)
+		})
+	}
+}
+
+// A `!` negation inside a NON-global config entry (one carrying Files/Rules)
+// must not resurrect a globally-ignored file: GetConfigForFile evaluates global
+// ignores first, so entry-level ignores can only narrow. canPruneDir sees
+// only the global ignores and prunes target/ — which stays consistent with the
+// linter (it also excludes target/keep). Locks down the "per-entry config
+// cannot cause over-prune" invariant.
+func TestDiscoverGapFiles_PerEntryNegationDoesNotResurrect(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/a.ts",
+		"target/x.ts",
+		"target/keep/k.ts",
+	})
+	config := RslintConfig{
+		{Ignores: []string{"**/target/**/*"}},
+		{Files: []string{"**/*.ts"}, Ignores: []string{"!target/keep/**/*"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	spy := &spyFS{FS: osvfs.FS()}
+	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	gapSet := toSet(gapFiles)
+
+	assert.Assert(t, gapSet[paths["src/a.ts"]])
+	assert.Assert(t, !gapSet[paths["target/x.ts"]])
+	assert.Assert(t, !gapSet[paths["target/keep/k.ts"]], "per-entry ! must not resurrect a global ignore")
+	// Linter authority agrees, and target/ is pruned (consistent).
+	assert.Assert(t, config.GetConfigForFile(paths["target/keep/k.ts"], configDir) == nil)
+	assert.Assert(t, !dirAccessed(spy.snapshotAccessedDirs(), "target"), "target pruned; per-entry ! does not protect")
+}
+
+// Pruning must produce identical gap files in parallel and single-threaded mode.
+func TestDiscoverGapFiles_PruneSingleThreadedEquivalence(t *testing.T) {
+	configDir, _ := setupDiscoveryFixture(t, []string{
+		"src/a.ts",
+		"target/x.ts",
+		"target/keep/k.ts",
+		"sub/path/target/y.ts",
+	})
+	config := RslintConfig{
+		{Ignores: []string{"**/target/**/*", "!sub/path/target/**/*", "!target/keep/**/*"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	par := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+	seq := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, true)
+	sort.Strings(par)
+	sort.Strings(seq)
+	assert.DeepEqual(t, par, seq)
+}

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -713,7 +713,7 @@ func TestDiscoverGapFiles_EntersNonExcludedDirs(t *testing.T) {
 //   3. DiscoverGapFiles
 //   4. Verify GetConfigForFile (linter's per-file decision) is consistent
 //
-// The structural guarantee being tested: if isDirPathBlocked(dir, configIgnores)
+// The structural guarantee being tested: if isDirAbsolutelyBlocked(dir, configIgnores)
 // returns true in collectGitignoreGlobs (causing .gitignore skip), then
 // GetConfigForFile also returns nil for any file in that dir.
 // =============================================================================
@@ -820,10 +820,10 @@ func TestE2E_NestedGitignoreAffectsProgramFiles(t *testing.T) {
 // tests/e2e/ files should be discoverable as gap files.
 func TestE2E_FileLevelIgnoreWithNegation(t *testing.T) {
 	files := map[string]string{
-		"src/index.ts":        "x",
-		"tests/unit/a.ts":     "x",
-		"tests/e2e/smoke.ts":  "x",
-		"tests/.gitignore":    "tmp/\n",
+		"src/index.ts":         "x",
+		"tests/unit/a.ts":      "x",
+		"tests/e2e/smoke.ts":   "x",
+		"tests/.gitignore":     "tmp/\n",
 		"tests/e2e/.gitignore": "screenshots/\n",
 	}
 	config := RslintConfig{
@@ -977,8 +977,8 @@ func TestE2E_MultipleIgnoreEntries(t *testing.T) {
 // the linter correctly skips them (isDirBlockedByIgnores blocks the directory).
 func TestE2E_ConfigIgnoredDirInProgram(t *testing.T) {
 	files := map[string]string{
-		"src/index.ts":             "x",
-		"tests/helpers/setup.ts":   "x",
+		"src/index.ts":           "x",
+		"tests/helpers/setup.ts": "x",
 	}
 	config := RslintConfig{
 		{Ignores: []string{"**/tests/**"}},
@@ -1004,9 +1004,9 @@ func TestE2E_ConfigIgnoredDirInProgram(t *testing.T) {
 // Both mechanisms should work — the file should be excluded regardless of which one catches it.
 func TestE2E_OverlappingGitignoreAndConfigIgnore(t *testing.T) {
 	files := map[string]string{
-		".gitignore":       "dist/\n",
-		"src/index.ts":     "x",
-		"dist/bundle.ts":   "x",
+		".gitignore":     "dist/\n",
+		"src/index.ts":   "x",
+		"dist/bundle.ts": "x",
 	}
 	config := RslintConfig{
 		{Ignores: []string{"**/dist/**"}},
@@ -1027,7 +1027,7 @@ func TestE2E_OverlappingGitignoreAndConfigIgnore(t *testing.T) {
 // Only files in the allowed directory should be discovered, config ignores still apply.
 func TestE2E_AllowDirsWithConfigIgnores(t *testing.T) {
 	files := map[string]string{
-		".gitignore":              "dist/\n",
+		".gitignore":             "dist/\n",
 		"packages/foo/src/a.ts":  "x",
 		"packages/foo/dist/b.ts": "x",
 		"packages/bar/src/c.ts":  "x",
@@ -1198,11 +1198,11 @@ func TestDiscoverGapFiles_AllowFilesFastPathSorted(t *testing.T) {
 // `go test -race`, varied GOMAXPROCS, and CI background noise.
 func TestWalkPool_BoundsConcurrency(t *testing.T) {
 	const (
-		workers   = 4
-		dirCount  = 200
-		hold      = 2 * time.Millisecond // make work observable
-		fanout    = 3
-		maxDepth  = 3 // 3^3 = 27 leaves per root × 200 roots ≈ thousands of jobs
+		workers  = 4
+		dirCount = 200
+		hold     = 2 * time.Millisecond // make work observable
+		fanout   = 3
+		maxDepth = 3 // 3^3 = 27 leaves per root × 200 roots ≈ thousands of jobs
 	)
 
 	pool := newWalkPool(workers)

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -18,13 +18,13 @@ import (
 //     nested .gitignore with directory-scoped prefixes.
 //
 // configIgnores are the user-configured global ignore patterns (from config
-// entries with only ignores). Directories that are directory-level blocked by
-// these patterns are skipped during the descendant scan — their .gitignore
-// files are not collected because files in those directories will never be
-// linted (isDirPathBlocked guarantees this).
+// entries with only ignores), already parsed. Directories that are
+// directory-level blocked by these patterns are skipped during the descendant
+// scan — their .gitignore files are not collected because files in those
+// directories will never be linted (isDirAbsolutelyBlocked guarantees this).
 //
 // Returns nil if no .gitignore files are found.
-func ReadGitignoreAsGlobs(configDir string, fsys vfs.FS, configIgnores []string) []string {
+func ReadGitignoreAsGlobs(configDir string, fsys vfs.FS, configIgnores []IgnorePattern) []string {
 	if fsys == nil {
 		return nil
 	}
@@ -46,17 +46,20 @@ func ReadGitignoreAsGlobs(configDir string, fsys vfs.FS, configIgnores []string)
 	return allGlobs
 }
 
-// ExtractConfigIgnores collects global ignore patterns from config entries.
-// These are patterns from entries that have only ignores (no files/rules/etc.),
-// which represent user-configured directories to exclude from linting.
-func ExtractConfigIgnores(config RslintConfig) []string {
+// ExtractConfigIgnores collects global ignore patterns from config entries and
+// parses them once into structured form. These are patterns from entries that
+// have only ignores (no files/rules/etc.), representing user-configured
+// directories to exclude from linting. Parsing here (rather than per file/dir)
+// keeps the lint hot path and the directory walks off the string-classification
+// cost.
+func ExtractConfigIgnores(config RslintConfig) []IgnorePattern {
 	var ignores []string
 	for _, entry := range config {
 		if isGlobalIgnoreEntry(entry) {
 			ignores = append(ignores, entry.Ignores...)
 		}
 	}
-	return ignores
+	return ParseIgnorePatterns(ignores)
 }
 
 // collectAncestorGitignoreGlobs walks UP from dir to filesystem root,
@@ -109,16 +112,16 @@ func parentDir(dir string) string {
 // with thousands of subdirectories).
 //
 // configIgnores provides additional directory-level pruning from the user's
-// lint config. If isDirPathBlocked returns true for a directory against these
-// patterns, the directory is skipped. This is safe because isDirPathBlocked
-// is the same function used by the linter's GetConfigForFile
-// (via isDirBlockedByIgnores) — if a directory is blocked here, its files
-// will never be linted, so collecting its .gitignore is unnecessary.
-func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string, configIgnores []string) {
+// lint config. If isDirAbsolutelyBlocked returns true for a directory against
+// these patterns, the directory is skipped. This is safe because
+// isDirAbsolutelyBlocked is the same predicate used by the linter's
+// GetConfigForFile (via isDirBlockedByIgnores) — if a directory is blocked
+// here, its files will never be linted, so collecting its .gitignore is
+// unnecessary.
+func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string, configIgnores []IgnorePattern) {
 	gitignorePath := absDir + "/.gitignore"
-	var localGlobs []string
 	if content, ok := fsys.ReadFile(gitignorePath); ok {
-		localGlobs = convertGitignoreToGlobs(content, relDir)
+		localGlobs := convertGitignoreToGlobs(content, relDir)
 		*result = append(*result, localGlobs...)
 	}
 
@@ -134,7 +137,7 @@ func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]
 		}
 
 		// Prune directories that are directory-level blocked by config ignores.
-		// isDirPathBlocked is the same function the linter uses in
+		// isDirAbsolutelyBlocked is the same predicate the linter uses in
 		// GetConfigForFile → isDirBlockedByIgnores. If it returns true here,
 		// the linter will also return nil for any file in this directory,
 		// meaning files here are never linted. Therefore their .gitignore
@@ -143,13 +146,16 @@ func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]
 		// user-defined patterns), whereas *result grows as we collect more
 		// .gitignore patterns — checking configIgnores first avoids a linear
 		// scan of the longer list for directories blocked by config.
-		if len(configIgnores) > 0 && isDirPathBlocked(childRel, configIgnores) {
+		if len(configIgnores) > 0 && isDirAbsolutelyBlocked(childRel, configIgnores) {
 			continue
 		}
 
 		// Prune directories already matched by collected gitignore patterns.
-		// This is critical for performance: without it, scanning a repo like
-		// rspack enters target/ (6,277 Rust build dirs, 0 .ts files).
+		// This is a scan-local heuristic over the growing glob set (sequential
+		// `!` handling); the gap-file walk independently re-validates soundness
+		// via canPruneDir, so this stays a fast string-set match. Critical for
+		// performance: without it, scanning rspack enters target/ (6,277 Rust
+		// build dirs, 0 .ts files).
 		if isDirIgnoredByGlobs(*result, childRel) {
 			continue
 		}
@@ -159,9 +165,16 @@ func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]
 	}
 }
 
-// isDirIgnoredByGlobs checks if a relative directory path is matched by any
-// of the collected glob patterns (non-negated). Used for pruning during
-// .gitignore scanning only.
+// isDirIgnoredByGlobs reports whether relDir is ignored by the collected
+// gitignore globs (sequential `!` evaluation, later overrides earlier). It is
+// scan-local: a fast string-set match used only to prune which nested
+// .gitignore files get collected, NOT a soundness predicate. The gap-file walk
+// re-derives directory pruning from the structured patterns via canPruneDir, so
+// for the patterns that ARE collected the walk stays sound regardless. The one
+// behavior this skips is a `!` re-include inside an already-ignored directory's
+// nested .gitignore — which matches git's own rule that a file cannot be
+// re-included once a parent directory is excluded. This logic is unchanged by
+// the IgnorePattern refactor.
 func isDirIgnoredByGlobs(globs []string, relDir string) bool {
 	ignored := false
 	for _, pattern := range globs {
@@ -259,11 +272,12 @@ func convertSinglePattern(line string, baseDir string) string {
 	}
 
 	// Append /**/* for directory patterns to match all contents.
-	// Use /**/* (file-level) instead of /** (directory-level) because
-	// rslint's isDirPathBlocked treats dir/** as absolute blocking that
-	// cannot be overridden by ! negation. File-level /**/* allows the
-	// existing isFileIgnored sequential negation logic to work correctly
-	// with gitignore's ! override patterns.
+	// Use /**/* (file-level) instead of /** (directory-level) because gitignore
+	// directories must stay `!`-reversible: ParseIgnorePattern classifies
+	// `dir/**/*` as dirFileLevelCover (prunable but negation-aware) and `dir/**`
+	// as dirAbsoluteBlock (which `!` can never re-include). gitignore's `!`
+	// override patterns require the former so isFileIgnored's sequential
+	// negation can re-include individual files.
 	if dirOnly {
 		if !strings.HasSuffix(glob, "/**/*") {
 			glob = glob + "/**/*"

--- a/internal/config/gitignore_test.go
+++ b/internal/config/gitignore_test.go
@@ -133,7 +133,7 @@ func TestReadGitignoreAsGlobs_RootOnly(t *testing.T) {
 		"src/a.ts":   "x",
 	})
 	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
-	assert.Assert(t, len(globs) >= 2)
+	assert.Equal(t, len(globs), 2, "got: %v", globs)
 
 	hasDistGlob := false
 	hasLogGlob := false
@@ -307,6 +307,24 @@ func TestConvertGitignoreToGlobs_NestedStarMatchAll(t *testing.T) {
 	globs := convertGitignoreToGlobs("*\n", "packages/app")
 	assert.Equal(t, len(globs), 1)
 	assert.Equal(t, globs[0], "packages/app/**/*")
+}
+
+// The dirOnly suffix-append has a dedup guard: if the built glob already ends
+// "/**/*", appending again would yield "…/**/*/**/*". A trailing-slash gitignore
+// line whose body already ends "/**/*" (e.g. "src/**/*/") exercises it. Without
+// the guard the result over-matches one level deeper. Pin the deduped output so
+// the guard can't be silently dropped.
+func TestConvertGitignoreToGlobs_DirOnlySuffixDedup(t *testing.T) {
+	// Body "src/**/*" (rooted via the internal '/'), trailing '/' → dirOnly.
+	// glob already ends "/**/*" → must NOT become "src/**/*/**/*".
+	globs := convertGitignoreToGlobs("src/**/*/\n", "")
+	assert.Equal(t, len(globs), 1)
+	assert.Equal(t, globs[0], "src/**/*")
+
+	// Same with a nested baseDir prefix.
+	nested := convertGitignoreToGlobs("src/**/*/\n", "pkg/app")
+	assert.Equal(t, len(nested), 1)
+	assert.Equal(t, nested[0], "pkg/app/src/**/*")
 }
 
 // --- Ancestor inheritance tests ---
@@ -503,7 +521,7 @@ func TestReadGitignoreAsGlobs_ConfigIgnoresPrunesDir(t *testing.T) {
 		"tests/unit/a.test.ts":  "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/tests/**"})
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**"}))
 	gs := globSet(globs)
 
 	// Exactly 1 glob: root .gitignore "dist/" → "**/dist/**/*"
@@ -519,7 +537,7 @@ func TestReadGitignoreAsGlobs_FileLevelConfigIgnoreDoesNotPrune(t *testing.T) {
 		"tests/a.test.ts":  "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/tests/**/*"})
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**/*"}))
 	gs := globSet(globs)
 
 	// 2 globs: root dist + tests snapshots (file-level ignore doesn't prune dirs)
@@ -528,7 +546,7 @@ func TestReadGitignoreAsGlobs_FileLevelConfigIgnoreDoesNotPrune(t *testing.T) {
 	assert.Assert(t, gs["tests/**/snapshots/**/*"], "tests snapshots should be collected")
 }
 
-// A3: dir-level + negation — isDirPathBlocked skips negation → still prunes.
+// A3: dir-level + negation — isDirAbsolutelyBlocked skips negation → still prunes.
 func TestReadGitignoreAsGlobs_NegationInConfigIgnoreStillPrunes(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":           "dist/\n",
@@ -536,7 +554,7 @@ func TestReadGitignoreAsGlobs_NegationInConfigIgnoreStillPrunes(t *testing.T) {
 		"tests/e2e/a.ts":       "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/tests/**", "!tests/e2e/**"})
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**", "!tests/e2e/**"}))
 
 	// Exactly 1 glob: root dist. tests/e2e/.gitignore NOT collected.
 	assert.Equal(t, len(globs), 1, "should have exactly 1 glob, got: %v", globs)
@@ -553,7 +571,7 @@ func TestReadGitignoreAsGlobs_SiblingDirPreservesGitignore(t *testing.T) {
 		"tests/a.test.ts":         "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/tests/**"})
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**"}))
 	gs := globSet(globs)
 
 	// Exactly 2 globs: root dist + packages/foo tmp. tests/ pruned.
@@ -589,7 +607,7 @@ func TestReadGitignoreAsGlobs_DeepNestedConfigIgnore(t *testing.T) {
 		"src/a.ts":                     "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/vendor/**"})
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/vendor/**"}))
 	gs := globSet(globs)
 
 	// Exactly 2 globs: root *.log + src generated. All 3 vendor .gitignore pruned.
@@ -601,16 +619,16 @@ func TestReadGitignoreAsGlobs_DeepNestedConfigIgnore(t *testing.T) {
 // A7: wildcard config ignore (crates/**) — multiple nested .gitignore skipped.
 func TestReadGitignoreAsGlobs_WildcardConfigIgnoreSkipsNested(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
-		".gitignore":                    "dist/\n",
-		"crates/core/.gitignore":        "artifacts/\n",
-		"crates/binding/.gitignore":     "generated/\n",
-		"packages/rspack/.gitignore":    "tmp/\n",
-		"crates/core/src/lib.rs":        "x",
-		"crates/binding/src/lib.rs":     "x",
-		"packages/rspack/src/index.ts":  "x",
+		".gitignore":                   "dist/\n",
+		"crates/core/.gitignore":       "artifacts/\n",
+		"crates/binding/.gitignore":    "generated/\n",
+		"packages/rspack/.gitignore":   "tmp/\n",
+		"crates/core/src/lib.rs":       "x",
+		"crates/binding/src/lib.rs":    "x",
+		"packages/rspack/src/index.ts": "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"crates/**"})
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"crates/**"}))
 	gs := globSet(globs)
 
 	// Exactly 2: root dist + packages/rspack tmp. Both crates/ .gitignore pruned.
@@ -626,7 +644,7 @@ func TestReadGitignoreAsGlobs_EmptyConfigIgnores(t *testing.T) {
 		"tests/.gitignore": "snapshots/\n",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{})
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{}))
 	gs := globSet(globs)
 
 	assert.Equal(t, len(globs), 2, "empty slice = no pruning, got: %v", globs)
@@ -642,7 +660,7 @@ func TestReadGitignoreAsGlobs_ExactPathConfigIgnore(t *testing.T) {
 		"build/tools/.gitignore":  "tmp/\n",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"build/output/**"})
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"build/output/**"}))
 	gs := globSet(globs)
 
 	// 2 globs: root dist + build/tools tmp. build/output cache pruned.
@@ -656,21 +674,21 @@ func TestReadGitignoreAsGlobs_ExactPathConfigIgnore(t *testing.T) {
 // Note: {Files: []string{}} (empty slice) still counts as len(Files)==0, so IS global.
 func TestExtractConfigIgnores_OnlyGlobalEntries(t *testing.T) {
 	config := RslintConfig{
-		{Ignores: []string{"**/tests/**"}},                                             // global ignore ✓
-		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},                       // has files+rules → NOT global
-		{Ignores: []string{"scripts/**"}},                                              // global ignore ✓
-		{Files: []string{}, Ignores: []string{"also-global"}},                          // empty files + only ignores → IS global (len(Files)==0)
-		{Ignores: []string{"vendor/**"}, Rules: Rules{"r": "error"}},                   // has rules → NOT global
-		{Files: []string{"**/*.js"}, Ignores: []string{"not-global"}},                  // has non-empty files → NOT global
+		{Ignores: []string{"**/tests/**"}},                            // global ignore ✓
+		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},      // has files+rules → NOT global
+		{Ignores: []string{"scripts/**"}},                             // global ignore ✓
+		{Files: []string{}, Ignores: []string{"also-global"}},         // empty files + only ignores → IS global (len(Files)==0)
+		{Ignores: []string{"vendor/**"}, Rules: Rules{"r": "error"}},  // has rules → NOT global
+		{Files: []string{"**/*.js"}, Ignores: []string{"not-global"}}, // has non-empty files → NOT global
 	}
 
 	ignores := ExtractConfigIgnores(config)
 
 	// Entries 0, 2, 3 are global ignores. Entries 1, 4, 5 are not.
 	assert.Equal(t, len(ignores), 3, "should extract exactly 3 patterns, got: %v", ignores)
-	assert.Equal(t, ignores[0], "**/tests/**")
-	assert.Equal(t, ignores[1], "scripts/**")
-	assert.Equal(t, ignores[2], "also-global")
+	assert.Equal(t, ignores[0].Glob, "**/tests/**")
+	assert.Equal(t, ignores[1].Glob, "scripts/**")
+	assert.Equal(t, ignores[2].Glob, "also-global")
 }
 
 // A11: multiple global ignore entries — all patterns combined.
@@ -682,13 +700,13 @@ func TestExtractConfigIgnores_MultipleEntries(t *testing.T) {
 
 	ignores := ExtractConfigIgnores(config)
 	assert.Equal(t, len(ignores), 3, "should combine all patterns, got: %v", ignores)
-	assert.Equal(t, ignores[0], "**/tests/**")
-	assert.Equal(t, ignores[1], "packages/rspack/compiled/**")
-	assert.Equal(t, ignores[2], "crates/**")
+	assert.Equal(t, ignores[0].Glob, "**/tests/**")
+	assert.Equal(t, ignores[1].Glob, "packages/rspack/compiled/**")
+	assert.Equal(t, ignores[2].Glob, "crates/**")
 }
 
 // A12: bare config ignore without /** suffix (e.g., "tests" or "dist").
-// isDirPathBlocked matches the directory itself and all parents, so this
+// isDirAbsolutelyBlocked matches the directory itself and all parents, so this
 // should still prune. Verify via exact glob count.
 func TestReadGitignoreAsGlobs_BareConfigIgnorePattern(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
@@ -699,9 +717,9 @@ func TestReadGitignoreAsGlobs_BareConfigIgnorePattern(t *testing.T) {
 		"src/a.ts":         "x",
 	})
 
-	// Bare "tests" — no trailing /**. isDirPathBlocked("tests", ["tests"]) should
+	// Bare "tests" — no trailing /**. isDirAbsolutelyBlocked("tests", ["tests"]) should
 	// match via matchGlob("tests", "tests") → true → blocked.
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"tests"})
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"tests"}))
 	gs := globSet(globs)
 
 	// 2 globs: root *.log + src/generated. tests/ pruned by bare "tests" pattern.
@@ -711,9 +729,10 @@ func TestReadGitignoreAsGlobs_BareConfigIgnorePattern(t *testing.T) {
 }
 
 // A13: gitignore and config ignore both target the same directory.
-// collectGitignoreGlobs checks gitignore patterns FIRST (isDirIgnoredByGlobs),
-// then config ignores (isDirPathBlocked). If both match, the directory is pruned
-// by whichever check comes first. Verify the result is identical to having only one.
+// collectGitignoreGlobs checks config ignores FIRST (isDirAbsolutelyBlocked),
+// then the collected gitignore patterns (isDirIgnoredByGlobs). If both match,
+// the directory is pruned by whichever check comes first. Verify the result is
+// identical to having only one.
 func TestReadGitignoreAsGlobs_OverlappingGitignoreAndConfigIgnore(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":       "dist/\nbuild/\n",
@@ -727,12 +746,12 @@ func TestReadGitignoreAsGlobs_OverlappingGitignoreAndConfigIgnore(t *testing.T) 
 
 	// dist/ is in both .gitignore and config ignores.
 	// build/ is only in .gitignore.
-	configIgnores := []string{"**/dist/**"}
+	configIgnores := ParseIgnorePatterns([]string{"**/dist/**"})
 	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
 	gs := globSet(globs)
 
-	// dist/ pruned by GITIGNORE (isDirIgnoredByGlobs runs first → **/dist/**/* matches).
-	// build/ pruned by GITIGNORE.
+	// dist/ pruned by CONFIG IGNORE (isDirAbsolutelyBlocked runs first → **/dist/** matches).
+	// build/ pruned by the collected gitignore glob (isDirIgnoredByGlobs → **/build/**/* matches).
 	// Neither dist/.gitignore nor build/.gitignore collected.
 	// Only root .gitignore (dist/ + build/) and src/.gitignore (generated/) remain.
 	assert.Equal(t, len(globs), 3, "should have 3 globs, got: %v", globs)
@@ -750,12 +769,12 @@ func TestReadGitignoreAsGlobs_OverlappingGitignoreAndConfigIgnore(t *testing.T) 
 // from the config-ignored directory (and nothing else changes).
 func TestReadGitignoreAsGlobs_RegressionWithVsWithout(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
-		".gitignore":                "dist/\n",
-		"src/.gitignore":            "generated/\n",
-		"tests/.gitignore":          "snapshots/\n",
-		"tests/unit/.gitignore":     "coverage/\n",
-		"tests/unit/a.test.ts":      "x",
-		"src/a.ts":                  "x",
+		".gitignore":            "dist/\n",
+		"src/.gitignore":        "generated/\n",
+		"tests/.gitignore":      "snapshots/\n",
+		"tests/unit/.gitignore": "coverage/\n",
+		"tests/unit/a.test.ts":  "x",
+		"src/a.ts":              "x",
 	})
 
 	// WITHOUT configIgnores: all 4 .gitignore files collected → 4 patterns.
@@ -768,7 +787,7 @@ func TestReadGitignoreAsGlobs_RegressionWithVsWithout(t *testing.T) {
 	assert.Assert(t, gsWithout["tests/unit/**/coverage/**/*"])
 
 	// WITH configIgnores: tests/ pruned → only 2 patterns (root + src).
-	globsWith := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/tests/**"})
+	globsWith := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**"}))
 	gsWith := globSet(globsWith)
 	assert.Equal(t, len(globsWith), 2, "with configIgnores should collect 2 patterns (tests/ pruned), got: %v", globsWith)
 	assert.Assert(t, gsWith["**/dist/**/*"])
@@ -784,17 +803,17 @@ func TestReadGitignoreAsGlobs_RegressionWithVsWithout(t *testing.T) {
 // at the walk level (not entered then filtered), which is the performance win.
 func TestReadGitignoreAsGlobs_ConfigIgnoreSkipsWalkLevel(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
-		".gitignore":                    "dist/\n",
-		"src/a.ts":                      "x",
-		"src/.gitignore":                "generated/\n",
-		"tests/unit/a.test.ts":          "x",
-		"tests/.gitignore":              "snapshots/\n",
-		"tests/unit/.gitignore":         "coverage/\n",
-		"tests/unit/deep/nested/a.ts":   "x",
+		".gitignore":                  "dist/\n",
+		"src/a.ts":                    "x",
+		"src/.gitignore":              "generated/\n",
+		"tests/unit/a.test.ts":        "x",
+		"tests/.gitignore":            "snapshots/\n",
+		"tests/unit/.gitignore":       "coverage/\n",
+		"tests/unit/deep/nested/a.ts": "x",
 	})
 
 	spy := &gitignoreSpyFS{FS: osvfs.FS()}
-	globs := ReadGitignoreAsGlobs(dir, spy, []string{"**/tests/**"})
+	globs := ReadGitignoreAsGlobs(dir, spy, ParseIgnorePatterns([]string{"**/tests/**"}))
 
 	// Output correctness: only root + src patterns.
 	assert.Equal(t, len(globs), 2, "got: %v", globs)
@@ -826,13 +845,13 @@ func TestReadGitignoreAsGlobs_ConfigIgnoreSkipsWalkLevel(t *testing.T) {
 // Proves that configIgnores reduces the number of GetAccessibleEntries calls.
 func TestReadGitignoreAsGlobs_ConfigIgnoreReducesWalkCount(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
-		".gitignore":                  "*.log\n",
-		"tests/unit/a.ts":             "x",
-		"tests/unit/sub/b.ts":         "x",
-		"tests/.gitignore":            "tmp/\n",
-		"tests/unit/.gitignore":       "output/\n",
-		"tests/unit/sub/.gitignore":   "cache/\n",
-		"src/a.ts":                    "x",
+		".gitignore":                "*.log\n",
+		"tests/unit/a.ts":           "x",
+		"tests/unit/sub/b.ts":       "x",
+		"tests/.gitignore":          "tmp/\n",
+		"tests/unit/.gitignore":     "output/\n",
+		"tests/unit/sub/.gitignore": "cache/\n",
+		"src/a.ts":                  "x",
 	})
 
 	// Without configIgnores: walks everything including tests/ subtree.
@@ -842,7 +861,7 @@ func TestReadGitignoreAsGlobs_ConfigIgnoreReducesWalkCount(t *testing.T) {
 
 	// With configIgnores: skips tests/ subtree.
 	spyWith := &gitignoreSpyFS{FS: osvfs.FS()}
-	ReadGitignoreAsGlobs(dir, spyWith, []string{"**/tests/**"})
+	ReadGitignoreAsGlobs(dir, spyWith, ParseIgnorePatterns([]string{"**/tests/**"}))
 	countWith := len(spyWith.accessedDirs)
 
 	// With configIgnores should access FEWER directories.

--- a/internal/config/ignore_differential_test.go
+++ b/internal/config/ignore_differential_test.go
@@ -1,0 +1,282 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/microsoft/typescript-go/shim/tspath"
+)
+
+// Permanent differential guard for the IgnorePattern refactor.
+//
+// This refactor replaced the pre-refactor []string ignore pipeline
+// (isFileIgnored / isFileLevelPattern / isDirPathBlocked, each re-deriving
+// normalization and directory-role from the raw string per call) with the
+// structured IgnorePattern pipeline (ParseIgnorePattern → Glob/Negated/Kind,
+// consumed by isFileIgnored / isDirAbsolutelyBlocked). The refactor's contract
+// is byte-for-byte identical LINT decisions; the `./*` regression slipped past
+// one review round precisely because nothing pinned old==new.
+//
+// The functions below (mainX_*) are vendored verbatim from main @930924a7's
+// internal/config/config.go. They are the OLD oracle. We assert that the OLD
+// per-file lint decision (dir-block OR file-ignore) equals the NEW one over a
+// corpus engineered to stress every divergence-prone edge:
+//   - normalize-unstable raw patterns (`./`, `//`, `/.`, `/..`) whose suffix
+//     class differs before vs after normalization (the `./*` class),
+//   - the three suffix roles (X/**/* file-level cover, X/* single level,
+//     X/** absolute) and their `!`-negated forms,
+//   - glob metachars (`?`, `[abc]`, `{a,b}`, `**`) in both name and extension
+//     position,
+//   - sequential `!` override ordering, rooted vs unrooted.
+//
+// If a future change to ParseIgnorePattern / isDirAbsolutelyBlocked /
+// isFileIgnored reintroduces a `./*`-class misclassification, the new decision
+// diverges from this frozen oracle and the test fails. Keep mainX_* frozen — do
+// NOT "fix" them to track the new code; that would defeat the guard.
+
+// --- OLD oracle, verbatim from main @930924a7 (operates on []string) ---
+
+func mainX_isFileIgnored(filePath string, ignorePatterns []string, cwd string) bool {
+	if cwd == "" {
+		return mainX_isFileIgnoredSimple(filePath, ignorePatterns)
+	}
+	normalizedPath := normalizePath(filePath, cwd)
+	unixPath := strings.ReplaceAll(normalizedPath, "\\", "/")
+	ignored := false
+	for _, pattern := range ignorePatterns {
+		negated := false
+		if strings.HasPrefix(pattern, "!") {
+			negated = true
+			pattern = pattern[1:]
+		}
+		normalizedPattern := normalizePattern(pattern)
+		matched := matchGlob(normalizedPattern, normalizedPath)
+		if !matched && unixPath != normalizedPath {
+			matched = matchGlob(normalizedPattern, unixPath)
+		}
+		if matched {
+			ignored = !negated
+		}
+	}
+	return ignored
+}
+
+func mainX_isFileLevelPattern(pattern string) bool {
+	return strings.HasSuffix(pattern, "/**/*") ||
+		(strings.HasSuffix(pattern, "/*") && !strings.HasSuffix(pattern, "/**"))
+}
+
+func mainX_isDirBlockedByIgnores(filePath string, ignorePatterns []string, cwd string) bool {
+	var dirPath string
+	if cwd != "" {
+		dirPath = normalizePath(tspath.GetDirectoryPath(filePath), cwd)
+	} else {
+		dirPath = tspath.GetDirectoryPath(filePath)
+	}
+	dirPath = strings.ReplaceAll(dirPath, "\\", "/")
+	dirPath = strings.TrimSuffix(dirPath, "/")
+	if dirPath == "" || dirPath == "." {
+		return false
+	}
+	return mainX_isDirPathBlocked(dirPath, ignorePatterns)
+}
+
+func mainX_isDirPathBlocked(dirPath string, ignorePatterns []string) bool {
+	for _, pattern := range ignorePatterns {
+		if pattern == "" || strings.HasPrefix(pattern, "!") {
+			continue
+		}
+		if mainX_isFileLevelPattern(pattern) {
+			continue
+		}
+		normalizedPattern := normalizePattern(pattern)
+		if matchGlob(normalizedPattern, dirPath) || matchGlob(normalizedPattern, dirPath+"/x") {
+			return true
+		}
+		segments := strings.Split(dirPath, "/")
+		for i := 1; i < len(segments); i++ {
+			partial := strings.Join(segments[:i], "/")
+			if matchGlob(normalizedPattern, partial) || matchGlob(normalizedPattern, partial+"/x") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func mainX_isFileIgnoredSimple(filePath string, ignorePatterns []string) bool {
+	ignored := false
+	for _, pattern := range ignorePatterns {
+		negated := false
+		if strings.HasPrefix(pattern, "!") {
+			negated = true
+			pattern = pattern[1:]
+		}
+		normalizedPattern := normalizePattern(pattern)
+		if matched, err := doublestar.Match(normalizedPattern, filePath); err == nil && matched {
+			ignored = !negated
+		}
+	}
+	return ignored
+}
+
+// oldDecision is the OLD linter's per-file ignore decision: a file is excluded
+// iff its directory is absolutely blocked OR it is file-ignored. Mirrors the
+// pre-refactor GetConfigForFile/IsFileIgnored composition.
+func oldDecision(filePath string, patterns []string, cwd string) bool {
+	return mainX_isDirBlockedByIgnores(filePath, patterns, cwd) ||
+		mainX_isFileIgnored(filePath, patterns, cwd)
+}
+
+// newDecision is the SAME composition on the structured pipeline.
+func newDecision(filePath string, patterns []string, cwd string) bool {
+	parsed := ParseIgnorePatterns(patterns)
+	return isDirBlockedByIgnores(filePath, parsed, cwd) ||
+		isFileIgnored(filePath, parsed, cwd)
+}
+
+// differentialCorpus pairs each ignore-pattern set with probe paths chosen so
+// the dir-block vs file-ignore split, the suffix classes, and the normalize
+// edges all matter. Every (patternSet × path) must yield old==new.
+var differentialCorpus = []struct {
+	name     string
+	patterns []string
+	paths    []string
+}{
+	// The regression itself: `./*` normalizes to bare `*`. Old isFileLevelPattern
+	// sees raw `./*` ends `/*` → file-level → NOT a dir block. New classifies raw
+	// `./*` → dirNone likewise. A nested file must stay lintable under both.
+	{"dotstar regression", []string{"./*"}, []string{
+		"src/app/main.ts", "src/main.ts", "top.ts", "a/b/c/d.ts",
+	}},
+	{"dotstar double-slash", []string{".//*"}, []string{"src/app/main.ts", "top.ts"}},
+	{"dotstar negated", []string{"**/*", "!./*"}, []string{"src/main.ts", "top.ts"}},
+
+	// Suffix roles + negation. file-level cover allows `!` re-include; absolute
+	// block does not; single-level covers one depth only.
+	{"file-level cover", []string{"target/**/*"}, []string{
+		"target/a.ts", "target/sub/b.ts", "target.ts", "src/a.ts",
+	}},
+	{"file-level cover negated child", []string{"target/**/*", "!target/keep/**/*"}, []string{
+		"target/a.ts", "target/keep/k.ts", "target/keep/deep/d.ts", "target/other/o.ts",
+	}},
+	{"absolute block", []string{"build/**"}, []string{
+		"build/a.ts", "build/sub/b.ts", "build", "buildx/a.ts", "src/a.ts",
+	}},
+	{"absolute block defeats negation", []string{"build/**", "!build/keep.ts"}, []string{
+		"build/keep.ts", "build/other.ts",
+	}},
+	{"single level X/*", []string{"dist/*"}, []string{
+		"dist/a.ts", "dist/sub/b.ts", "dist/sub/deep/c.ts",
+	}},
+
+	// Normalize-unstable mid-pattern segments.
+	{"dotdot segment", []string{"src/../lib/**/*"}, []string{"lib/a.ts", "src/a.ts", "lib/sub/b.ts"}},
+	{"dot segment", []string{"src/./gen/**/*"}, []string{"src/gen/a.ts", "src/other/b.ts"}},
+	{"double-slash mid", []string{"a//b/**/*"}, []string{"a/b/c.ts", "a/b.ts", "a/x/c.ts"}},
+
+	// Glob metachars across name and extension positions.
+	{"question name", []string{"di?t/**"}, []string{"dist/a.ts", "dixt/a.ts", "distx/a.ts"}},
+	{"bracket name", []string{"[bd]ist/**"}, []string{"dist/a.ts", "bist/a.ts", "list/a.ts"}},
+	{"brace name cover", []string{"**/{target,dist}/**/*"}, []string{
+		"target/a.ts", "dist/sub/b.ts", "other/c.ts",
+	}},
+	{"brace ext filter not dir-level", []string{"target/**/*.{ts,tsx}"}, []string{
+		"target/a.ts", "target/sub/b.tsx", "target/c.js",
+	}},
+	{"ext filter not dir-level", []string{"logs/**/*.log"}, []string{
+		"logs/a.log", "logs/sub/b.log", "logs/a.ts",
+	}},
+	{"doublestar bare", []string{"**/node_modules/**"}, []string{
+		"node_modules/x/a.ts", "pkg/node_modules/y/b.ts", "src/a.ts",
+	}},
+
+	// Sequential override ordering (file-level so ! is meaningful at file level).
+	{"sequential re-ignore", []string{"**/*", "!src/**/*", "src/test/**/*", "!src/test/keep.ts"}, []string{
+		"README.md", "src/index.ts", "src/test/u.ts", "src/test/keep.ts",
+	}},
+	{"negation before positive", []string{"!build/test.js", "build/**"}, []string{
+		"build/test.js", "build/other.js",
+	}},
+
+	// Bare names and rooted forms (dir-level; ancestor scan).
+	{"bare name dir", []string{"target"}, []string{"target/a.ts", "target/sub/b.ts", "targetx/a.ts"}},
+	{"wildcard mid dir", []string{"packages/*/dist/**"}, []string{
+		"packages/app/dist/a.ts", "packages/app/src/b.ts", "packages/dist/c.ts",
+	}},
+}
+
+// TestDifferential_OldEqualsNew is the permanent guard: the NEW structured
+// pipeline's per-file lint decision must equal the OLD []string pipeline's, for
+// every (patternSet × path) in the corpus, under both cwd modes.
+func TestDifferential_OldEqualsNew(t *testing.T) {
+	const cwd = "/repo"
+	for _, c := range differentialCorpus {
+		for _, rel := range c.paths {
+			// cwd mode: absolute file resolved relative to cwd.
+			absPath := "/repo/" + rel
+			oldA := oldDecision(absPath, c.patterns, cwd)
+			newA := newDecision(absPath, c.patterns, cwd)
+			if oldA != newA {
+				t.Errorf("[cwd] %s: decision diverged for %q under %v: old=%v new=%v",
+					c.name, rel, c.patterns, oldA, newA)
+			}
+			// cwd="" simple mode: raw relative path, doublestar.Match only.
+			oldS := oldDecision(rel, c.patterns, "")
+			newS := newDecision(rel, c.patterns, "")
+			if oldS != newS {
+				t.Errorf("[simple] %s: decision diverged for %q under %v: old=%v new=%v",
+					c.name, rel, c.patterns, oldS, newS)
+			}
+		}
+	}
+}
+
+// TestDifferential_DirBlockComponentMatches isolates the directory-block
+// component (the part the `./*` regression corrupted): the NEW
+// isDirAbsolutelyBlocked over parsed patterns must agree with the OLD
+// isDirPathBlocked over raw strings, directly on directory paths (no file
+// wrapper). This pins the Kind classification independently of file-level
+// matching, so a misroute can't be masked by isFileIgnored happening to agree.
+func TestDifferential_DirBlockComponentMatches(t *testing.T) {
+	dirCorpus := []struct {
+		patterns []string
+		dirs     []string
+	}{
+		{[]string{"./*"}, []string{"src", "src/app", "a/b/c"}},
+		{[]string{"target/**"}, []string{"target", "target/sub", "targetx"}},
+		{[]string{"target/**/*"}, []string{"target", "target/sub"}},
+		{[]string{"dist/*"}, []string{"dist", "dist/sub"}},
+		{[]string{"**/build"}, []string{"build", "a/build", "a/b/build", "buildx"}},
+		{[]string{"packages/*/dist/**"}, []string{"packages/app/dist", "packages/app/src", "packages/dist"}},
+		{[]string{"[bd]ist/**"}, []string{"dist", "bist", "list"}},
+		{[]string{"di?t/**"}, []string{"dist", "dixt", "distx"}},
+		{[]string{"**/{target,dist}/**/*"}, []string{"target", "dist/sub", "other"}},
+		{[]string{"src/../lib/**"}, []string{"lib", "lib/sub", "src"}},
+		{[]string{"a//b/**"}, []string{"a/b", "a/b/c", "a/x"}},
+		{[]string{"foo"}, []string{"foo", "foo/bar", "foobar"}},
+		// Empty-normalizing patterns (`foo/..` → ""). Pre-refactor isDirPathBlocked
+		// keeps them absolute, and its empty normalized glob matches the empty
+		// LEADING segment of an ABSOLUTE dir path via the ancestor-segment scan —
+		// so it blocks "/repo" but not relative "src". Two review agents wrongly
+		// declared this unobservable (the empty glob looks harmless until the
+		// absolute-path ancestor loop). The empty guard keys on the raw body, not
+		// the normalized Glob, precisely to keep this byte-equivalent. Pin both
+		// directions (absolute dir blocked, relative dir not).
+		{[]string{"foo/.."}, []string{"/repo", "/a/b", "src", "src/app"}},
+		{[]string{"./a/.."}, []string{"/repo", "src"}},
+		{[]string{"."}, []string{"/repo", "src"}},
+	}
+	for _, c := range dirCorpus {
+		parsed := ParseIgnorePatterns(c.patterns)
+		for _, d := range c.dirs {
+			oldB := mainX_isDirPathBlocked(d, c.patterns)
+			newB := isDirAbsolutelyBlocked(d, parsed)
+			if oldB != newB {
+				t.Errorf("dir-block diverged for dir %q under %v: old=%v new=%v",
+					d, c.patterns, oldB, newB)
+			}
+		}
+	}
+}

--- a/internal/config/ignore_pattern.go
+++ b/internal/config/ignore_pattern.go
@@ -1,0 +1,273 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// dirKind classifies an ignore pattern by how it bears on DIRECTORY decisions.
+// It is derived once at parse time, replacing the per-call suffix-sniffing the
+// pre-refactor linter did via isFileLevelPattern (and isDirPathBlocked, which
+// called it) on every directory check.
+type dirKind uint8
+
+const (
+	// dirNone: the pattern does not authorize any directory-level handling.
+	// Pure file patterns (`*.log`) and single-level patterns (`dir/*`).
+	dirNone dirKind = iota
+	// dirAbsoluteBlock: an ESLint directory-level block (`dir/**`, bare names
+	// like `**/build`). Blocks both the lint decision (GetConfigForFile) and
+	// the walk; `!` negation can NEVER re-include inside it.
+	dirAbsoluteBlock
+	// dirFileLevelCover: a gitignore directory pattern in file-level form
+	// (`dir/**/*`). It covers the whole subtree for WALK pruning, but `!` can
+	// still re-include individual files (so pruning must be negation-aware).
+	dirFileLevelCover
+)
+
+// IgnorePattern is a parsed ignore pattern that carries the structural metadata
+// a raw glob string would otherwise force every consumer to re-derive:
+//   - Negated: the gitignore/ESLint `!` re-include flag.
+//   - Kind: the directory role (see dirKind), classified once here instead of
+//     by suffix inspection at each call site.
+//
+// Glob is the normalized, `!`-stripped matcher fed to doublestar — byte-for-byte
+// the same string the old []string pipeline matched against, so file-level
+// matching (isFileIgnored) is unchanged.
+type IgnorePattern struct {
+	Glob    string
+	Negated bool
+	Kind    dirKind
+}
+
+// ParseIgnorePattern parses one raw ignore string (user config or a
+// gitignore-converted glob) into the structured form. This is the SINGLE place
+// that derives directory role / negation from the string; downstream code reads
+// fields.
+//
+// PRINCIPLE: the directory role (Kind) is classified from the suffix of the RAW
+// body (after stripping `!`); Glob is separately normalized as the matcher. Kind
+// keys on the raw body — never the normalized Glob — because that is what the
+// pre-refactor isFileLevelPattern sniffed; classifying the normalized form would
+// drift for any pattern whose suffix class changes under normalization. Suffix
+// → role (empty raw body → none):
+//
+//	`X/**/*`              → fileLevelCover (gitignore dir, prunable, `!`-aware)
+//	`X/*` (not `X/**`)    → none           (single level, not subtree coverage)
+//	`X/**`, bare, `*.log` → absoluteBlock   (ESLint dir-level, `!`-proof)
+//
+// Two normalize-sensitive cases fall out of "classify the raw suffix", both
+// required for byte-equivalence with the pre-refactor linter:
+//   - `./*` (Glob normalizes to bare `*`): raw ends `/*` → none. Classifying the
+//     Glob would make it absoluteBlock, blocking every top-level dir while
+//     isFileIgnored of `*` stays false for nested files — silently dropping them.
+//   - `foo/..` (Glob normalizes to ""): raw is non-empty with no dir suffix →
+//     absoluteBlock with an empty Glob. Pre-refactor isDirPathBlocked also kept
+//     it absolute, its empty glob matching the empty leading segment of an
+//     absolute dir path. (A literal empty / `!`-only pattern is the none case,
+//     so the empty guard keys on body == "", not Glob == "".)
+func ParseIgnorePattern(raw string) IgnorePattern {
+	p := IgnorePattern{}
+	body := raw
+	if strings.HasPrefix(body, "!") {
+		p.Negated = true
+		body = body[1:]
+	}
+	p.Glob = normalizePattern(body)
+	switch {
+	case body == "":
+		p.Kind = dirNone
+	case strings.HasSuffix(body, "/**/*"):
+		p.Kind = dirFileLevelCover
+	case strings.HasSuffix(body, "/*") && !strings.HasSuffix(body, "/**"):
+		p.Kind = dirNone
+	default:
+		p.Kind = dirAbsoluteBlock
+	}
+	return p
+}
+
+// ParseIgnorePatterns parses a list of raw ignore strings. Prefer parsing once
+// per ignore set (it is fixed for a config / walk) and reusing the result — the
+// directory walks (DiscoverGapFiles, the gitignore scan) hoist it out of their
+// loops. The per-file GetConfigForFile path re-derives it, which is no costlier
+// than the pre-refactor code (that normalized every pattern inside each matcher
+// per file); centralizing the normalization here folds that work into one pass.
+func ParseIgnorePatterns(raw []string) []IgnorePattern {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]IgnorePattern, len(raw))
+	for i, s := range raw {
+		out[i] = ParseIgnorePattern(s)
+	}
+	return out
+}
+
+// isFileIgnored evaluates patterns sequentially (later overrides earlier; `!`
+// re-includes), aligned with ESLint v10. Matches only the cwd-relative path —
+// never the absolute path — so `**/`-prefixed patterns can't hit system dirs.
+func isFileIgnored(filePath string, patterns []IgnorePattern, cwd string) bool {
+	if cwd == "" {
+		return isFileIgnoredSimple(filePath, patterns)
+	}
+	normalizedPath := normalizePath(filePath, cwd)
+	unixPath := strings.ReplaceAll(normalizedPath, "\\", "/")
+
+	ignored := false
+	for _, p := range patterns {
+		matched := matchGlob(p.Glob, normalizedPath)
+		if !matched && unixPath != normalizedPath {
+			matched = matchGlob(p.Glob, unixPath)
+		}
+		if matched {
+			ignored = !p.Negated
+		}
+	}
+	return ignored
+}
+
+// isFileIgnoredSimple is the cwd-unavailable fallback (matches the raw path).
+func isFileIgnoredSimple(filePath string, patterns []IgnorePattern) bool {
+	ignored := false
+	for _, p := range patterns {
+		if matched, err := doublestar.Match(p.Glob, filePath); err == nil && matched {
+			ignored = !p.Negated
+		}
+	}
+	return ignored
+}
+
+// isDirAbsolutelyBlocked reports whether dirPath (or an ancestor segment) is
+// matched by a positive directory-level pattern (`dir/**`, bare names). This is
+// the ESLint "directory blocking is absolute and cannot be negated" semantics —
+// `!` and file-level patterns are excluded by Kind. Shared by GetConfigForFile
+// (lint) and canPruneDir (walk).
+func isDirAbsolutelyBlocked(dirPath string, patterns []IgnorePattern) bool {
+	for i := range patterns {
+		p := patterns[i]
+		if p.Negated || p.Kind != dirAbsoluteBlock {
+			continue
+		}
+		if matchGlob(p.Glob, dirPath) || matchGlob(p.Glob, dirPath+"/x") {
+			return true
+		}
+		segments := strings.Split(dirPath, "/")
+		for j := 1; j < len(segments); j++ {
+			partial := strings.Join(segments[:j], "/")
+			if matchGlob(p.Glob, partial) || matchGlob(p.Glob, partial+"/x") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// canPruneDir reports whether a directory walk may skip dirPath entirely. It is
+// the single, negation-aware directory-prune predicate for the gap-file walk.
+// The pre-refactor walk pruned only absolutely-blocked directories
+// (isDirPathBlocked); canPruneDir keeps that and ADDS pruning of gitignore
+// file-level covers (dir/**/*). Sound: prunes only when every descendant file
+// would be rejected by the linter's own ignore decision (directory block OR
+// isFileIgnored), so the gap-file set is unchanged.
+//
+//	absolute block (dir/**) → prune, ignoring `!` (ESLint absolute semantics)
+//	file-level cover (dir/**/*) → prune ONLY if no `!` reaches into the subtree
+func canPruneDir(dirPath string, patterns []IgnorePattern, neg negReach) bool {
+	if isDirAbsolutelyBlocked(dirPath, patterns) {
+		return true
+	}
+	if neg.overlaps(dirPath) {
+		return false
+	}
+	for i := range patterns {
+		p := patterns[i]
+		if p.Negated || p.Kind != dirFileLevelCover {
+			continue
+		}
+		// File-level `X/**/*` never matches the bare directory; probe `dir/x`.
+		if matchGlob(p.Glob, dirPath+"/x") {
+			return true
+		}
+	}
+	return false
+}
+
+// negReach describes how far the `!` negations in an ignore set can re-include,
+// so canPruneDir never prunes a directory whose subtree a `!` could re-include.
+// Built once per ignore set via buildNegReach.
+type negReach struct {
+	prefixes []negPrefix
+}
+
+// negPrefix is one negation's reach: unrooted means "any depth" (conservatively
+// blocks all file-level pruning); literal is the leading wildcard-free path of a
+// rooted negation, used for subtree-overlap checks.
+type negPrefix struct {
+	unrooted bool
+	literal  string
+}
+
+// buildNegReach extracts negation reaches from a parsed ignore set. Patterns
+// already carry Negated + a normalized Glob, so no string re-parsing.
+func buildNegReach(patterns []IgnorePattern) negReach {
+	var out []negPrefix
+	for i := range patterns {
+		p := patterns[i]
+		if !p.Negated {
+			continue
+		}
+		// A negation with no concrete leading segment (`!**/keep`, `!*.log`,
+		// empty) can re-include at any depth — literalSegmentPrefix returns ""
+		// for those, and we mark them unrooted to conservatively disable
+		// file-level pruning.
+		if lit := literalSegmentPrefix(p.Glob); lit != "" {
+			out = append(out, negPrefix{literal: lit})
+		} else {
+			out = append(out, negPrefix{unrooted: true})
+		}
+	}
+	return negReach{prefixes: out}
+}
+
+// overlaps reports whether any negation could re-include something in dirPath's
+// subtree (so the directory must not be pruned).
+func (n negReach) overlaps(dirPath string) bool {
+	for _, np := range n.prefixes {
+		if np.unrooted || segPrefixEither(np.literal, dirPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// literalSegmentPrefix returns the leading path segments of pattern before the
+// first glob metacharacter (`*`, `?`, `[`, `{`). For example `tests/e2e/**/*`
+// → `tests/e2e`, `a/b*c/d` → `a`. Returns "" when the first segment already
+// contains a metacharacter (the pattern is not anchored to a concrete path).
+func literalSegmentPrefix(pattern string) string {
+	i := strings.IndexAny(pattern, "*?[{")
+	if i < 0 {
+		return strings.TrimSuffix(pattern, "/")
+	}
+	prefix := pattern[:i]
+	if idx := strings.LastIndex(prefix, "/"); idx >= 0 {
+		return prefix[:idx]
+	}
+	return ""
+}
+
+// segPrefixEither reports whether a is a path-segment prefix of b or vice versa
+// (e.g. "target" vs "target/keep", or "tests/e2e" vs "tests") — the negation
+// target sits inside the directory, or the directory sits inside the negation's
+// covered range.
+func segPrefixEither(a, b string) bool {
+	return segPrefix(a, b) || segPrefix(b, a)
+}
+
+// segPrefix reports whether prefix equals path or path lies under prefix/
+// (segment-anchored, so "a/b" is a prefix of "a/b/c" but not of "a/bc").
+func segPrefix(prefix, path string) bool {
+	return path == prefix || strings.HasPrefix(path, prefix+"/")
+}

--- a/internal/config/ignore_pattern_realworld_test.go
+++ b/internal/config/ignore_pattern_realworld_test.go
@@ -1,0 +1,288 @@
+package config
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"gotest.tools/v3/assert"
+)
+
+// Tests anchored to REAL ignore configurations harvested from production repos
+// (rsbuild / rspack / create-rstack / agent-skills .gitignore + rslint.config.ts)
+// and the well-known ESLint flat-config idioms. The synthetic suites in
+// ignore_pattern_test.go / file_discovery_dir_prune_test.go already pin the
+// classification switch and the prune predicate on hand-built inputs; these add
+// the realistic patterns those suites do not exercise — specifically the
+// gitignore-converted forms and the wildcard-mid-path `!` re-includes that
+// rspack actually ships. Every assertion is exact; no loose matches.
+
+// --- Real gitignore lines, exact converted glob + classification ---
+//
+// convertSinglePattern is the production gitignore→glob converter. Pinning its
+// output for real lines guards the Kind boundary that drives directory pruning:
+// a `dir/` (→ fileLevelCover, prunable) vs a rooted nested path `a/b` (→
+// absoluteBlock) vs a single-level `dir/*` (→ dirNone, NOT prunable).
+func TestRealGitignoreLine_ConvertAndClassify(t *testing.T) {
+	cases := []struct {
+		line    string // raw .gitignore line (root .gitignore, baseDir="")
+		glob    string // expected convertSinglePattern output
+		negated bool
+		kind    dirKind
+	}{
+		// rsbuild
+		{"node_modules/", "**/node_modules/**/*", false, dirFileLevelCover},
+		{"dist/", "**/dist/**/*", false, dirFileLevelCover},
+		{"dist-*", "**/dist-*", false, dirAbsoluteBlock}, // glob name, not a dir cover
+		{"*.log*", "**/*.log*", false, dirAbsoluteBlock}, // file pattern
+		{"*.css.d.ts", "**/*.css.d.ts", false, dirAbsoluteBlock},
+		{".vscode/**/*", ".vscode/**/*", false, dirFileLevelCover},                   // contains / → rooted (no **/ prefix)
+		{"!.vscode/settings.json", "!.vscode/settings.json", true, dirAbsoluteBlock}, // rooted negation
+		{"test-results/", "**/test-results/**/*", false, dirFileLevelCover},
+		// rspack — rooted + nested + bracket + the wildcard-mid-path negations
+		{"target/", "**/target/**/*", false, dirFileLevelCover},
+		{"**/*.rs.bk", "**/*.rs.bk", false, dirAbsoluteBlock},
+		{"report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json", "**/report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json", false, dirAbsoluteBlock},
+		{"!scripts/node_modules/", "!scripts/node_modules/**/*", true, dirFileLevelCover}, // rooted (has /) dir negation
+		{"!tests/rspack-test/*/**/node_modules", "!tests/rspack-test/*/**/node_modules", true, dirAbsoluteBlock},
+		{"!packages/rspack-cli/tests/**/node_modules", "!packages/rspack-cli/tests/**/node_modules", true, dirAbsoluteBlock},
+		{"!tests/rspack-test/configCases/target", "!tests/rspack-test/configCases/target", true, dirAbsoluteBlock},
+		{"packages/*/tests/js", "packages/*/tests/js", false, dirAbsoluteBlock}, // rooted nested, no dir suffix
+		{"/github/", "github/**/*", false, dirFileLevelCover},                   // rooted dir
+		{"/artifacts/", "artifacts/**/*", false, dirFileLevelCover},
+		{"npm/**/*.node", "npm/**/*.node", false, dirAbsoluteBlock}, // rooted ext filter under dir
+		{"/npm/*", "npm/*", false, dirNone},                         // rooted single-level → NOT a subtree cover
+		{"!npm/darwin-arm64/", "!npm/darwin-arm64/**/*", true, dirFileLevelCover},
+		{"/packages/*/temp", "packages/*/temp", false, dirAbsoluteBlock},
+		// rslint self — nested-rooted dir name (build/Release) stays absolute
+		{"build/Release", "build/Release", false, dirAbsoluteBlock},
+		{".env.*", "**/.env.*", false, dirAbsoluteBlock},
+		{"!.env.example", "!**/.env.example", true, dirAbsoluteBlock},
+		// create-rstack
+		{".vscode/*", ".vscode/*", false, dirNone}, // contains / → rooted; single-level tail → dirNone
+	}
+	for _, c := range cases {
+		gotGlob := convertSinglePattern(c.line, "")
+		if gotGlob != c.glob {
+			t.Errorf("convertSinglePattern(%q) = %q, want %q", c.line, gotGlob, c.glob)
+			continue
+		}
+		// ParseIgnorePattern strips the leading `!` into Negated; its Glob is the
+		// `!`-free matcher. Derive the expected stripped glob from c.glob.
+		wantStrippedGlob := strings.TrimPrefix(c.glob, "!")
+		p := ParseIgnorePattern(gotGlob)
+		if p.Glob != wantStrippedGlob || p.Negated != c.negated || p.Kind != c.kind {
+			t.Errorf("ParseIgnorePattern(%q) = {Glob:%q Negated:%v Kind:%d}, want {Glob:%q Negated:%v Kind:%d}",
+				gotGlob, p.Glob, p.Negated, p.Kind, wantStrippedGlob, c.negated, c.kind)
+		}
+	}
+}
+
+// --- Real ESLint flat-config `ignores` strings, exact classification ---
+//
+// These are taken verbatim from the harvested rslint.config.ts / create-rstack /
+// agent-skills configs and the documented idioms. They bypass the gitignore
+// converter (ESLint configs author globs directly), so they exercise different
+// raw forms than the gitignore lines above.
+func TestRealConfigIgnore_Classify(t *testing.T) {
+	cases := []struct {
+		raw     string
+		negated bool
+		kind    dirKind
+	}{
+		{"**/dist/**", false, dirAbsoluteBlock},  // create-rstack
+		{"**/tests/**", false, dirAbsoluteBlock}, // rspack config
+		{"skills/**/scripts/*", false, dirNone},  // agent-skills: single-level tail → dirNone
+		{"packages/rspack/src/runtime/moduleFederationDefaultRuntime.js", false, dirAbsoluteBlock},
+		{"xtask/benchmark/benches/fixtures/rspack_sources/**", false, dirAbsoluteBlock},
+		// documented idioms
+		{"**/node_modules/**", false, dirAbsoluteBlock},
+		{"**/*.test.ts", false, dirAbsoluteBlock},
+		{"!**/*.integration.test.ts", true, dirAbsoluteBlock},
+		{"packages/*/dist", false, dirAbsoluteBlock},
+		{"packages/*/lib/**", false, dirAbsoluteBlock},
+		{"**/__tests__/**", false, dirAbsoluteBlock},
+		{"!.storybook", true, dirAbsoluteBlock},
+		{"/public", false, dirAbsoluteBlock},
+		{"!/public/keep", true, dirAbsoluteBlock},
+		{"*.generated.*", false, dirAbsoluteBlock},
+		{"apps/*/.next", false, dirAbsoluteBlock},
+		{"{dist,build}/", false, dirAbsoluteBlock}, // brace + trailing slash → "/" tail, NOT "/*" nor "/**/*"
+	}
+	for _, c := range cases {
+		p := ParseIgnorePattern(c.raw)
+		if p.Negated != c.negated || p.Kind != c.kind {
+			t.Errorf("ParseIgnorePattern(%q) = {Negated:%v Kind:%d}, want {Negated:%v Kind:%d}",
+				c.raw, p.Negated, p.Kind, c.negated, c.kind)
+		}
+	}
+}
+
+// --- agent-skills `skills/**/scripts/*`: dirNone must NOT prune, but direct
+// children ARE file-ignored (the `./*` regression class, deep variant) ---
+//
+// This is the realistic analogue of the fixed `./*` bug: a single-level tail on
+// a deep pattern. canPruneDir must keep the scripts dir (a nested file under it
+// is lintable), while isFileIgnored hides only the direct children.
+func TestRealConfigIgnore_SkillsScriptsSingleLevel(t *testing.T) {
+	pats := ParseIgnorePatterns([]string{"skills/**/scripts/*"})
+	neg := buildNegReach(pats)
+
+	// scripts dir must NOT be pruned (deep file under it stays lintable).
+	if canPruneDir("skills/a/scripts", pats, neg) {
+		t.Error(`"skills/**/scripts/*" must not prune dir skills/a/scripts (single-level tail)`)
+	}
+	if isDirAbsolutelyBlocked("skills/a/scripts", pats) {
+		t.Error(`"skills/**/scripts/*" must not absolutely-block skills/a/scripts`)
+	}
+
+	// File-level: direct child ignored; nested-deeper child NOT ignored.
+	cwd := "/repo"
+	directChild := cwd + "/skills/a/scripts/build.ts"
+	deeperChild := cwd + "/skills/a/scripts/sub/util.ts"
+	assert.Assert(t, isFileIgnored(directChild, pats, cwd), "direct child of scripts/* must be ignored")
+	assert.Assert(t, !isFileIgnored(deeperChild, pats, cwd), "nested-deeper child must NOT be ignored")
+
+	// Linter authority agrees, end to end.
+	cfg := RslintConfig{
+		{Ignores: []string{"skills/**/scripts/*"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},
+	}
+	assert.Assert(t, cfg.GetConfigForFile(directChild, cwd) == nil, "direct child not linted")
+	assert.Assert(t, cfg.GetConfigForFile(deeperChild, cwd) != nil, "nested-deeper child must still be linted")
+}
+
+// --- rspack wildcard-mid-path negation: `!tests/rspack-test/*/**/node_modules`
+// re-includes node_modules anywhere under tests/rspack-test/<pkg>/, so the
+// node_modules cover must NOT prune the protected subtree, but a node_modules
+// outside it stays pruned. literalSegmentPrefix truncates the negation reach at
+// the first wildcard (`tests/rspack-test`). ---
+func TestRealConfig_RspackNodeModulesReinclude(t *testing.T) {
+	// Production-shaped set: node_modules cover + the two real re-includes.
+	pats := ParseIgnorePatterns([]string{
+		"**/node_modules/**/*",
+		"!tests/rspack-test/*/**/node_modules", // wildcard mid-path
+		"!scripts/node_modules/**/*",           // rooted literal
+	})
+	neg := buildNegReach(pats)
+
+	// negReach literals: the wildcard one collapses to "tests/rspack-test".
+	gotLits := neg.prefixes
+	wantLits := []negPrefix{
+		{literal: "tests/rspack-test"},
+		{literal: "scripts/node_modules"},
+	}
+	assert.Equal(t, len(gotLits), len(wantLits), "negReach prefixes: %+v", gotLits)
+	for i := range wantLits {
+		assert.Equal(t, gotLits[i], wantLits[i], "negReach entry %d", i)
+	}
+
+	// A node_modules under the protected tests/rspack-test tree: parent must not
+	// be pruned (segment-overlap with the negation literal).
+	assert.Assert(t, !canPruneDir("tests/rspack-test", pats, neg),
+		"tests/rspack-test must not be pruned (protected node_modules inside)")
+	assert.Assert(t, !canPruneDir("scripts", pats, neg),
+		"scripts must not be pruned (protected node_modules inside)")
+	// An unrelated node_modules cover IS prunable (no negation reaches it).
+	assert.Assert(t, canPruneDir("packages/core/node_modules", pats, neg),
+		"unprotected node_modules must be pruned")
+}
+
+// --- rspack rooted ext-filter `npm/**/*.node` + `/npm/*` single-level +
+// `!npm/<triple>/` re-include: the npm dir is kept (only .node files and direct
+// children are ignored, re-included triples survive) ---
+func TestRealConfig_RspackNpmArtifacts(t *testing.T) {
+	pats := ParseIgnorePatterns([]string{
+		"npm/**/*.node", // ext filter under dir → absoluteBlock, but does NOT block npm dir
+		"npm/*",         // single-level → dirNone
+		"!npm/darwin-arm64/**/*",
+		"!npm/linux-x64-gnu/**/*",
+	})
+	neg := buildNegReach(pats)
+
+	// npm dir must NOT be pruned: re-included triples + non-.node files survive.
+	assert.Assert(t, !isDirAbsolutelyBlocked("npm", pats), "npm dir must not be absolutely blocked")
+	assert.Assert(t, !canPruneDir("npm", pats, neg), "npm dir must not be pruned")
+
+	cwd := "/repo"
+	// .node artifact ignored; .js under a re-included triple is linted.
+	assert.Assert(t, isFileIgnored(cwd+"/npm/foo/bar.node", pats, cwd), "*.node artifact ignored")
+	assert.Assert(t, !isFileIgnored(cwd+"/npm/darwin-arm64/index.js", pats, cwd),
+		"re-included triple .js must not be ignored")
+	// Direct child of npm (npm/*) ignored; nested deeper not (unless re-included).
+	assert.Assert(t, isFileIgnored(cwd+"/npm/index.js", pats, cwd), "npm/* direct child ignored")
+}
+
+// --- End-to-end on a real-shaped layout: a multi-source ignore set (rspack
+// config `**/tests/**` + gitignore-converted dir covers + the wildcard-mid-path
+// `!` re-include) must produce a gap-file set IDENTICAL to the linter's own
+// per-file decision (GetConfigForFile != nil), regardless of directory pruning.
+// Oracle = { f : f matches a files pattern ∧ GetConfigForFile(f) != nil }, the
+// same contract as TestDiscoverGapFiles_PruningPreservesGapFiles but on a
+// realistic merged ignore set rather than synthetic patterns. ---
+func TestRealWorld_DiscoverGapFiles_MatchesLinterOracle(t *testing.T) {
+	layout := []string{
+		"packages/core/src/index.ts",                          // lintable
+		"packages/core/dist/bundle.ts",                        // dist cover → ignored
+		"packages/core/node_modules/dep/i.ts",                 // node_modules cover → ignored
+		"target/build/a.ts",                                   // target cover → ignored
+		"tests/rspack-test/configCases/pkg/node_modules/d.ts", // node_modules re-included, BUT under **/tests/** → still ignored
+		"tests/rspack-test/configCases/c.ts",                  // under **/tests/** → ignored
+		"scripts/build.ts",                                    // lintable
+		"npm/darwin-arm64/index.ts",                           // re-included triple → lintable
+		"npm/win32-x64-msvc/index.ts",                         // npm/* direct? no, nested → lintable (not covered)
+		"npm/util.ts",                                         // npm/* direct child → ignored
+		"src/app/main.ts",                                     // lintable
+		"src/util.tsx",                                        // lintable (.tsx)
+	}
+	configDir, paths := setupDiscoveryFixture(t, layout)
+
+	// Realistic merged ignore set: config global ignores + gitignore-converted forms.
+	ignores := []string{
+		"**/tests/**",                          // rspack rslint.config.ts (absolute dir block)
+		"**/dist/**/*",                         // gitignore dist/
+		"**/node_modules/**/*",                 // gitignore node_modules/
+		"!tests/rspack-test/*/**/node_modules", // rspack gitignore re-include (wildcard mid-path)
+		"**/target/**/*",                       // gitignore target/
+		"npm/**/*.node",                        // gitignore npm/**/*.node
+		"npm/*",                                // gitignore /npm/*
+		"!npm/darwin-arm64/**/*",               // gitignore !npm/darwin-arm64/
+	}
+	filesPatterns := []string{"**/*.ts", "**/*.tsx"}
+	config := RslintConfig{
+		{Ignores: ignores},
+		{Files: filesPatterns, Rules: Rules{"test-rule": "error"}},
+	}
+
+	// Oracle = the linter's own per-file decision over the fixture's files.
+	var oracle []string
+	for _, abs := range paths {
+		if !isFileMatched(abs, filesPatterns, configDir) {
+			continue
+		}
+		if config.GetConfigForFile(abs, configDir) != nil {
+			oracle = append(oracle, abs)
+		}
+	}
+	sort.Strings(oracle)
+
+	got := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+	sort.Strings(got)
+
+	// Walker must equal the linter oracle exactly (no over-prune, no over-include).
+	assert.DeepEqual(t, got, oracle)
+
+	// Pin the expected lintable set explicitly so a silent oracle shift can't
+	// make this pass vacuously.
+	want := []string{
+		paths["npm/darwin-arm64/index.ts"],
+		paths["npm/win32-x64-msvc/index.ts"],
+		paths["packages/core/src/index.ts"],
+		paths["scripts/build.ts"],
+		paths["src/app/main.ts"],
+		paths["src/util.tsx"],
+	}
+	sort.Strings(want)
+	assert.DeepEqual(t, got, want)
+}

--- a/internal/config/ignore_pattern_test.go
+++ b/internal/config/ignore_pattern_test.go
@@ -1,0 +1,368 @@
+package config
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// Unit tests for ignore_pattern.go: the structured IgnorePattern pipeline and
+// the unified directory-prune predicate (canPruneDir) plus its negation-reach
+// helpers. The walk integration that consumes them lives in
+// file_discovery_dir_prune_test.go.
+
+// --- Unit: ParseIgnorePattern classification ---
+// ParseIgnorePattern is the SINGLE source of truth for (raw → Glob, Negated,
+// Kind); every predicate downstream reads these fields. Indirect coverage via
+// the predicates can mask a misclassification (e.g. target/**/*.ext lands in
+// dirAbsoluteBlock but canPruneDir still returns false because the matchGlob
+// probe misses), so pin every switch arm and boundary directly here.
+
+func TestParseIgnorePattern_Classification(t *testing.T) {
+	cases := []struct {
+		raw     string
+		glob    string
+		negated bool
+		kind    dirKind
+	}{
+		{"build", "build", false, dirAbsoluteBlock},                                  // bare name → default arm
+		{"*.log", "*.log", false, dirAbsoluteBlock},                                  // pure file pattern → default arm
+		{"**/build", "**/build", false, dirAbsoluteBlock},                            // **/ prefix bare
+		{"dir/*", "dir/*", false, dirNone},                                           // single level → none
+		{"dir/**", "dir/**", false, dirAbsoluteBlock},                                // dir-level absolute
+		{"dir/**/*", "dir/**/*", false, dirFileLevelCover},                           // file-level cover
+		{"dir/**/*.ext", "dir/**/*.ext", false, dirAbsoluteBlock},                    // ext filter → not /**/* suffix → default
+		{"", "", false, dirNone},                                                     // empty → none arm
+		{"!", "", true, dirNone},                                                     // negated-then-empty → none
+		{"!dir/**", "dir/**", true, dirAbsoluteBlock},                                // negation does not change Kind
+		{"!dir/**/*", "dir/**/*", true, dirFileLevelCover},                           // negated file-level
+		{"{a,b}", "{a,b}", false, dirAbsoluteBlock},                                  // brace bare
+		{"**/{target,dist}/**/*", "**/{target,dist}/**/*", false, dirFileLevelCover}, // brace name + /**/*
+		{"target/**/*.{ts,tsx}", "target/**/*.{ts,tsx}", false, dirAbsoluteBlock},    // brace ext filter
+		{"./dir/**", "dir/**", false, dirAbsoluteBlock},                              // ./ normalized away
+		{"dir//**", "dir/**", false, dirAbsoluteBlock},                               // // collapsed
+		{"node_modules/**", "node_modules/**", false, dirAbsoluteBlock},              // default-ignore glob actual class
+	}
+	for _, c := range cases {
+		p := ParseIgnorePattern(c.raw)
+		if p.Glob != c.glob || p.Negated != c.negated || p.Kind != c.kind {
+			t.Errorf("ParseIgnorePattern(%q) = {Glob:%q Negated:%v Kind:%d}, want {Glob:%q Negated:%v Kind:%d}",
+				c.raw, p.Glob, p.Negated, p.Kind, c.glob, c.negated, c.kind)
+		}
+	}
+}
+
+// The directory role is classified on the RAW suffix (after `!`-strip), NOT the
+// normalized Glob — required for byte-equivalence with the linter's pre-refactor
+// isFileLevelPattern. The `./*` case is the regression that drove this: it
+// normalizes to bare `*`; classifying the Glob would make it dirAbsoluteBlock
+// and silently drop nested files (isDirAbsolutelyBlocked("src") true, but
+// isFileIgnored("src/sub/f") false). On the raw `./*` it ends `/*` → dirNone, so
+// nothing is over-blocked. Glob remains the normalized matcher. Values verified
+// by running ParseIgnorePattern directly.
+func TestParseIgnorePattern_RawSuffixClassification(t *testing.T) {
+	cases := []struct {
+		raw  string
+		glob string
+		kind dirKind
+	}{
+		{"./*", "*", dirNone},                               // REGRESSION: raw ends "/*" → none (NOT absolute on bare "*")
+		{".//*", "*", dirNone},                              // same, double slash
+		{"./{a,b}/../*", "*", dirNone},                      // normalizes to bare "*" but raw ends "/*" → none
+		{"weird/*/.", "weird/*", dirAbsoluteBlock},          // raw ends "/." (not "/*" nor "/**/*") → absolute
+		{"target/../dist", "dist", dirAbsoluteBlock},        // raw has no dir suffix → absolute
+		{"x/./y/**/*", "x/y/**/*", dirFileLevelCover},       // raw ends "/**/*" → file-level cover
+		{"a//b", "a/b", dirAbsoluteBlock},                   // raw has no dir suffix → absolute
+		{"./target/**/*", "target/**/*", dirFileLevelCover}, // raw ends "/**/*" → still prunable (rspack path safe)
+		{"foo/..", "", dirAbsoluteBlock},                    // normalizes to empty but raw non-empty → absolute (empty Glob; matches main's empty-block quirk on absolute dirs)
+		{"", "", dirNone},                                   // raw empty → none (matches main's pattern=="" skip)
+		{"!", "", dirNone},                                  // !-only → empty body → none
+	}
+	for _, c := range cases {
+		p := ParseIgnorePattern(c.raw)
+		if p.Glob != c.glob || p.Kind != c.kind {
+			t.Errorf("ParseIgnorePattern(%q) = {Glob:%q Kind:%d}, want {Glob:%q Kind:%d}",
+				c.raw, p.Glob, p.Kind, c.glob, c.kind)
+		}
+	}
+}
+
+// Regression for the silent-skip bug: ignores ["./*"] must NOT cause a nested
+// file's dir to be treated as absolutely blocked. The prune decision must agree
+// with the file-level decision (sound), and GetConfigForFile must still lint the
+// nested file.
+func TestParseIgnorePattern_DotStarDoesNotOverBlock(t *testing.T) {
+	pats := ParseIgnorePatterns([]string{"./*"})
+	if isDirAbsolutelyBlocked("src", pats) {
+		t.Error(`"./*" must not absolutely-block dir "src"`)
+	}
+	if canPruneDir("src", pats, buildNegReach(pats)) {
+		t.Error(`"./*" must not prune dir "src"`)
+	}
+	cfg := RslintConfig{
+		{Ignores: []string{"./*"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},
+	}
+	if cfg.GetConfigForFile("/repo/src/app/main.ts", "/repo") == nil {
+		t.Error(`nested file src/app/main.ts must still be linted under ignores ["./*"]`)
+	}
+}
+
+// --- Unit: literalSegmentPrefix ---
+
+func TestLiteralSegmentPrefix(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"tests/e2e/**/*", "tests/e2e"},
+		{"target/keep/**/*", "target/keep"},
+		{"sub/path/target/**/*", "sub/path/target"},
+		{"target/important.ts", "target/important.ts"}, // no metachar
+		{"target/", "target"},                          // trailing slash trimmed
+		{"a/b*c/d", "a"},                               // '*' metachar in 2nd segment
+		{"a/b?c/d", "a"},                               // '?' metachar in 2nd segment
+		{"tests/{e2e,unit}/**/*", "tests"},             // brace in 2nd segment
+		{"*.log", ""},                                  // leading wildcard, no concrete segment
+		{"**/keep/**/*", ""},                           // leading **/ (handled as unrooted upstream)
+		{"[abc]/x", ""},                                // leading bracket
+		{"{a,b}/x", ""},                                // leading brace
+		{"a?b/x", ""},                                  // '?' in first segment
+	}
+	for _, c := range cases {
+		if got := literalSegmentPrefix(c.in); got != c.want {
+			t.Errorf("literalSegmentPrefix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// --- Unit: buildNegReach ---
+
+func TestBuildNegReach(t *testing.T) {
+	got := buildNegReach(ParseIgnorePatterns([]string{
+		"**/target/**/*",                    // positive, ignored
+		"!sub/path/target/**/*",             // rooted negation
+		"!**/keep/**/*",                     // unrooted negation
+		"!*.log",                            // leading wildcard → unrooted (conservative)
+		"!tests/rspack-test/*/node_modules", // metachar in middle → literal up to it
+		"!./dotslash/dir/**/*",              // normalized → literal "dotslash/dir"
+		"!src/{a,b}/keep/**/*",              // brace metachar → literal up to it
+	})).prefixes
+	want := []negPrefix{
+		{literal: "sub/path/target"},
+		{unrooted: true},
+		{unrooted: true},
+		{literal: "tests/rspack-test"},
+		{literal: "dotslash/dir"},
+		{literal: "src"},
+	}
+	assert.Equal(t, len(got), len(want), "got %+v", got)
+	for i := range want {
+		assert.Equal(t, got[i], want[i], "entry %d", i)
+	}
+}
+
+// --- Unit: canPruneDir predicate table ---
+// Mirrors the adversarial review matrix. Each row: ignore set + dir → prune?
+// canPruneDir is the UNIFIED predicate: it prunes both absolute blocks (dir/**)
+// and negation-aware file-level covers (dir/**/*), so a bare dir/** returns true
+// here (the pre-refactor walk pruned absolute blocks via isDirPathBlocked only).
+
+func TestCanPruneDir(t *testing.T) {
+	cases := []struct {
+		name    string
+		ignores []string
+		dir     string
+		want    bool
+	}{
+		{"file-level target, no negation", []string{"**/target/**/*"}, "target", true},
+		{"file-level target, nested dir", []string{"**/target/**/*"}, "target/build", true},
+		{"negation re-includes child of excluded → no prune", []string{"target/**/*", "!target/keep/**/*"}, "target", false},
+		{"negation re-includes child → keep dir itself not pruned", []string{"target/**/*", "!target/keep/**/*"}, "target/keep", false},
+		{"negation re-includes child → sibling still pruned", []string{"target/**/*", "!target/keep/**/*"}, "target/other", true},
+		{"negation full path → top-level target pruned", []string{"**/target/**/*", "!sub/path/target/**/*"}, "target", true},
+		{"negation full path → the re-included target not pruned", []string{"**/target/**/*", "!sub/path/target/**/*"}, "sub/path/target", false},
+		{"negation full path → ancestor of re-included not pruned", []string{"**/tests/**/*", "!tests/e2e/**/*"}, "tests", false},
+		{"unrooted negation → conservative, never prune", []string{"**/build/**/*", "!**/keep/**/*"}, "build", false},
+		{"sibling-name negation does not protect", []string{"**/target/**/*", "!targetX/keep/**/*"}, "target", true},
+		{"unrelated negation does not protect", []string{"target/**/*", "!dist/keep/**/*"}, "target", true},
+		{"directory-level pattern dir/** is an absolute block → prune", []string{"target/**"}, "target", true},
+		{"no matching pattern", []string{"**/dist/**/*"}, "target", false},
+		{"plain file pattern is not a directory cover", []string{"**/*.log"}, "target", false},
+		{"single-star X/* covers one level only → no prune", []string{"build/*"}, "build", false},
+		{"extension-filtered X/**/*.ext does not cover subtree", []string{"target/**/*.log"}, "target", false},
+		{"dotslash negation protects after normalize", []string{"target/**/*", "!./target/keep/**/*"}, "target", false},
+		{"double-slash negation protects after normalize", []string{"target/**/*", "!target//keep/**/*"}, "target", false},
+		{"uppercase pattern does not prune lowercase dir", []string{"**/Target/**/*"}, "target", false},
+		{"case-exact pattern prunes", []string{"**/Target/**/*"}, "Target", true},
+		{"brace-extension filter does not cover subtree", []string{"target/**/*.{ts,tsx}"}, "target", false},
+		{"brace-name dir cover prunes", []string{"**/{target,dist}/**/*"}, "target", true},
+	}
+	for _, c := range cases {
+		parsed := ParseIgnorePatterns(c.ignores)
+		if got := canPruneDir(c.dir, parsed, buildNegReach(parsed)); got != c.want {
+			t.Errorf("%s: canPruneDir(%q, %v) = %v, want %v", c.name, c.dir, c.ignores, got, c.want)
+		}
+	}
+}
+
+// --- Unit: ParseIgnorePattern remaining switch-arm inputs ---
+// TestParseIgnorePattern_Classification already pins braces/`**`/`./`/`//`. This
+// fills the glob-metachar and rooted/trailing forms the task flags: `?`,
+// `[abc]`, rooted `/foo`, trailing `foo/`, bare `**`. All land in
+// dirAbsoluteBlock (none ends `/**/*` nor `/*`-not-`/**`), so a future switch
+// change that special-cased any of them would flip a Kind here. Values verified
+// by running ParseIgnorePattern directly.
+func TestParseIgnorePattern_GlobMetacharAndRootedArms(t *testing.T) {
+	cases := []struct {
+		raw     string
+		glob    string
+		negated bool
+		kind    dirKind
+	}{
+		{"?", "?", false, dirAbsoluteBlock},                  // single-char wildcard, no dir suffix
+		{"[abc]", "[abc]", false, dirAbsoluteBlock},          // bracket class, no dir suffix
+		{"**", "**", false, dirAbsoluteBlock},                // bare doublestar
+		{"/foo", "/foo", false, dirAbsoluteBlock},            // rooted: leading "/" survives NormalizePath
+		{"foo/", "foo/", false, dirAbsoluteBlock},            // trailing slash: not "/*" nor "/**/*"
+		{"src/?.ts", "src/?.ts", false, dirAbsoluteBlock},    // `?` in name, file-ish, still default arm
+		{"a[bc]d", "a[bc]d", false, dirAbsoluteBlock},        // bracket mid-segment
+		{"!?", "?", true, dirAbsoluteBlock},                  // negated single-char wildcard
+		{"![abc]/x", "[abc]/x", true, dirAbsoluteBlock},      // negated bracket dir (no /**/* suffix)
+		{"!/foo/**/*", "/foo/**/*", true, dirFileLevelCover}, // rooted negated file-level cover
+	}
+	for _, c := range cases {
+		p := ParseIgnorePattern(c.raw)
+		if p.Glob != c.glob || p.Negated != c.negated || p.Kind != c.kind {
+			t.Errorf("ParseIgnorePattern(%q) = {Glob:%q Negated:%v Kind:%d}, want {Glob:%q Negated:%v Kind:%d}",
+				c.raw, p.Glob, p.Negated, p.Kind, c.glob, c.negated, c.kind)
+		}
+	}
+}
+
+// --- Unit: isDirAbsolutelyBlocked ancestor-segment scan ---
+// The predicate matches dirPath itself AND every ancestor prefix (probing both
+// `partial` and `partial+"/x"`). This is the "directory blocking is absolute"
+// machinery shared by GetConfigForFile and canPruneDir. The existing coverage
+// reaches it only indirectly (single-segment dirs in the canPruneDir table, or
+// via the walk); pin the multi-segment ancestor scan directly so a regression
+// in the segment loop (e.g. off-by-one on `j`, or dropping the `/x` probe)
+// can't hide behind file-level agreement. Values verified by running
+// isDirAbsolutelyBlocked directly.
+func TestIsDirAbsolutelyBlocked_AncestorScan(t *testing.T) {
+	cases := []struct {
+		name    string
+		dir     string
+		ignores []string
+		want    bool
+	}{
+		// pattern matches a MIDDLE ancestor segment of a/b/c.
+		{"**/b blocks via ancestor a/b", "a/b/c", []string{"**/b"}, true},
+		{"**/b/** blocks via ancestor a/b", "a/b/c", []string{"**/b/**"}, true},
+		{"a/** blocks via ancestor a", "a/b/c", []string{"a/**"}, true},
+		{"bare ancestor name blocks descendant", "foo/bar/baz", []string{"foo"}, true},
+		{"bare name blocks self", "foo", []string{"foo"}, true},
+		// negative: no ancestor segment matches.
+		{"**/b does not block x/y/z", "x/y/z", []string{"**/b"}, false},
+		{"sibling-name ancestor not matched", "target/sub", []string{"targetx"}, false},
+		// the `dir+"/x"` probe is what lets a bare-dir pattern match a leaf dir:
+		// `build` matches "build" directly; `**/dist` matches "a/dist" leaf.
+		{"**/dist blocks leaf dist via /x probe", "a/dist", []string{"**/dist"}, true},
+		// file-level and negation patterns are excluded by Kind — never block.
+		{"file-level cover never dir-blocks", "target/sub", []string{"target/**/*"}, false},
+		{"single-level X/* never dir-blocks", "dist/sub", []string{"dist/*"}, false},
+		{"negated absolute never dir-blocks", "build/sub", []string{"!build/**"}, false},
+	}
+	for _, c := range cases {
+		parsed := ParseIgnorePatterns(c.ignores)
+		if got := isDirAbsolutelyBlocked(c.dir, parsed); got != c.want {
+			t.Errorf("%s: isDirAbsolutelyBlocked(%q, %v) = %v, want %v", c.name, c.dir, c.ignores, got, c.want)
+		}
+	}
+}
+
+// --- Unit: segPrefixEither / negReach.overlaps segment boundary ---
+// overlaps drives the negation-aware half of canPruneDir. Its correctness hinges
+// on segPrefixEither being SEGMENT-anchored (bidirectional): a negation target
+// inside the dir, OR the dir inside the negation's covered range, but never a
+// mere string-prefix collision (`foo` vs `foobar`). The canPruneDir table hits
+// the happy paths; pin the boundary directly — especially the false cases that a
+// naive strings.HasPrefix would wrongly report true.
+func TestSegPrefixEither_Boundary(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"target", "target", true},        // equal
+		{"target", "target/keep", true},   // a is segment-prefix of b
+		{"tests/e2e", "tests", true},      // b is segment-prefix of a (dir inside negation range)
+		{"tests", "tests/e2e/spec", true}, // a is deep segment-prefix of b
+		{"target", "targetX", false},      // string-prefix but NOT segment-prefix
+		{"foo", "foobar", false},          // classic non-overlap
+		{"foobar", "foo", false},          // reversed non-overlap
+		{"a/b", "a/bc", false},            // segment boundary inside second segment
+		{"a/b", "a/b/c", true},            // nested
+		{"", "anything", false},           // empty is NOT a segment-prefix of a non-empty path (no leading "/")
+		{"", "", true},                    // empty equals empty
+	}
+	for _, c := range cases {
+		if got := segPrefixEither(c.a, c.b); got != c.want {
+			t.Errorf("segPrefixEither(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// overlaps composes segPrefixEither over a built negReach. Pin the boundary at
+// the negReach level too: a sibling-name negation (`!targetX/...`) must NOT
+// protect `target`, and an unrooted negation always overlaps. This is the exact
+// soundness lever canPruneDir relies on.
+func TestNegReach_OverlapsBoundary(t *testing.T) {
+	cases := []struct {
+		name     string
+		negation string
+		dir      string
+		want     bool
+	}{
+		{"exact target protects target", "!target/keep/**/*", "target", true},
+		{"sibling targetX does not protect target", "!targetX/keep/**/*", "target", false},
+		{"foo negation does not overlap foobar", "!foo/**/*", "foobar", false},
+		{"deep negation protects ancestor dir", "!tests/e2e/**/*", "tests", true},
+		{"deep negation protects exact dir", "!tests/e2e/**/*", "tests/e2e", true},
+		{"unrooted negation overlaps anything", "!**/keep/**/*", "whatever/deep", true},
+		{"leading-wildcard negation is unrooted", "!*.log", "anything", true},
+	}
+	for _, c := range cases {
+		parsed := ParseIgnorePatterns([]string{c.negation})
+		neg := buildNegReach(parsed)
+		if got := neg.overlaps(c.dir); got != c.want {
+			t.Errorf("%s: overlaps(%q) under %q = %v, want %v", c.name, c.dir, c.negation, got, c.want)
+		}
+	}
+}
+
+// --- Unit: buildNegReach with glob-metachar / double-slash negations ---
+// TestBuildNegReach covers brace, dotslash, and mid-pattern metachars. Fill the
+// `?`, `[abc]`, and double-slash forms: literalSegmentPrefix must stop at the
+// first metachar (so `?`/`[` in the FIRST segment → unrooted; in a LATER segment
+// → literal up to the segment before it), and normalize must collapse `//`
+// before the literal is extracted. Values verified by running buildNegReach
+// directly.
+func TestBuildNegReach_MetacharAndDoubleSlash(t *testing.T) {
+	got := buildNegReach(ParseIgnorePatterns([]string{
+		"!src/a?b/keep/**/*",   // `?` in 2nd segment → literal "src"
+		"!src/[abc]/keep/**/*", // bracket in 2nd segment → literal "src"
+		"!a?b/keep/**/*",       // `?` in 1st segment → no concrete prefix → unrooted
+		"![abc]/keep/**/*",     // bracket in 1st segment → unrooted
+		"!a/b//c/**/*",         // double-slash collapses → literal "a/b/c"
+		"!deep/path/no/meta",   // no metachar at all → whole path is the literal
+	})).prefixes
+	want := []negPrefix{
+		{literal: "src"},
+		{literal: "src"},
+		{unrooted: true},
+		{unrooted: true},
+		{literal: "a/b/c"},
+		{literal: "deep/path/no/meta"},
+	}
+	assert.Equal(t, len(got), len(want), "got %+v", got)
+	for i := range want {
+		assert.Equal(t, got[i], want[i], "entry %d", i)
+	}
+}


### PR DESCRIPTION
## Summary

`DiscoverGapFiles` (the gap-file walk that finds files matching a config `files` pattern but not covered by any tsconfig) descended into directories that gitignore already excludes. gitignore converts a directory pattern like `target/` into the **file-level** glob `**/target/**/*` (file-level so `!` re-includes keep working), but the dir-block check skipped file-level patterns — so the walk entered the ignored directory anyway. On **rspack** this walked the entire `target/` tree (~132k files) just to find a handful of gap files.

Every ignore pattern is now parsed **once** into a structured `IgnorePattern{Glob, Negated, Kind}`, replacing the string-suffix sniffing that was scattered across `isFileLevelPattern` / `isDirPathBlocked` / `canPruneGapDir`:

- `Kind` classifies the directory role from the raw pattern suffix: `dir/**` → absolute block (`!`-proof), `dir/**/*` → file-level cover (`!`-reversible), `dir/*` / `*.log` → none.
- A single negation-aware predicate `canPruneDir` drives the walk prune: a directory is skipped only when every file under it would be excluded — honoring `!` re-includes (rooted negations via literal-prefix overlap; unrooted `!**/…` conservatively disable file-level pruning).
- The gitignore-scan prune (`isDirIgnoredByGlobs`) is a separate concern and is left unchanged.

**Lint output is unchanged** — a pure traversal optimization. Verified byte-for-byte three ways: a differential test against the pre-refactor predicates (`isDirPathBlocked` / `isFileLevelPattern` / `isFileIgnored`), an oracle test asserting `DiscoverGapFiles` equals the linter's own per-file `GetConfigForFile` decision, and end-to-end `rslint` runs on rsbuild and rspack (identical files / rules / errors).

### Measured (end-to-end `rslint`, median, config discovery included)

| repo | before (main) | after |
|---|---|---|
| **rspack** | ~4.7s | **~1.9s** (~2.4×) |
| rsbuild | ~1.6s | ~1.6s (no large gitignored dir; unaffected) |

## Related Links

<!-- none -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
