### PR TITLE
refactor: reuse core.WorkGroup for gitignore fan-out concurrency

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
@@ -930,39 +931,30 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// pre-augmentation entries (createProgramsForConfig only reads
 			// languageOptions.parserOptions.project — Ignores entries are
 			// no-ops for it; verified in LoadTsConfigsFromRslintConfig).
+			// Read each config's gitignore on the shared WorkGroup (honoring
+			// --singleThreaded). In the parallel path these overlap with the
+			// serial createProgramsForConfig loop below; that is safe because
+			// createProgramsForConfig only reads parserOptions.project, never
+			// Ignores, so observing the pre-augmentation configMap is fine.
+			// Results are merged after the loop — DiscoverGapFiles needs them.
 			type giResult struct {
 				configDir string
 				globs     []string
 			}
 			var (
-				giResults chan giResult
-				giWG      sync.WaitGroup
+				giResults []giResult
+				giMu      sync.Mutex
 			)
-			if singleThreaded {
-				// Inline serial gitignore reads.
-				giResults = nil
-				for configDir, entries := range configMap {
-					configIgnores := rslintconfig.ExtractConfigIgnores(entries)
-					globs := rslintconfig.ReadGitignoreAsGlobs(configDir, fs, configIgnores)
-					if len(globs) > 0 {
-						configMap[configDir] = append(
-							rslintconfig.RslintConfig{{Ignores: globs}},
-							configMap[configDir]...,
-						)
+			giWG := core.NewWorkGroup(singleThreaded)
+			for configDir, entries := range configMap {
+				configIgnores := rslintconfig.ExtractConfigIgnores(entries)
+				giWG.Queue(func() {
+					if globs := rslintconfig.ReadGitignoreAsGlobs(configDir, fs, configIgnores); len(globs) > 0 {
+						giMu.Lock()
+						giResults = append(giResults, giResult{configDir, globs})
+						giMu.Unlock()
 					}
-				}
-			} else {
-				giResults = make(chan giResult, len(configMap))
-				for configDir, entries := range configMap {
-					configIgnores := rslintconfig.ExtractConfigIgnores(entries)
-					giWG.Add(1)
-					go func(dir string, ignores []string) {
-						defer giWG.Done()
-						globs := rslintconfig.ReadGitignoreAsGlobs(dir, fs, ignores)
-						giResults <- giResult{configDir: dir, globs: globs}
-					}(configDir, configIgnores)
-				}
-				go func() { giWG.Wait(); close(giResults) }()
+				})
 			}
 
 			seenTsConfigs := make(map[string]struct{})
@@ -978,18 +970,14 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				programs = append(programs, progs...)
 			}
 
-			// Drain gitignore results (parallel path only) and merge into
-			// configMap. Must complete before DiscoverGapFiles, which relies
-			// on the augmented configMap.
-			if giResults != nil {
-				for r := range giResults {
-					if len(r.globs) > 0 {
-						configMap[r.configDir] = append(
-							rslintconfig.RslintConfig{{Ignores: r.globs}},
-							configMap[r.configDir]...,
-						)
-					}
-				}
+			// Join the gitignore reads and merge into configMap. Must complete
+			// before DiscoverGapFiles, which relies on the augmented configMap.
+			giWG.RunAndWait()
+			for _, r := range giResults {
+				configMap[r.configDir] = append(
+					rslintconfig.RslintConfig{{Ignores: r.globs}},
+					configMap[r.configDir]...,
+				)
 			}
 		} else {
 			// Legacy single-config format

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"sync"
 
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
@@ -49,22 +48,18 @@ func parallelGitignoreAndPrograms(
 		progs    []*compiler.Program
 		exitCode int
 	)
-	if singleThreaded {
+	// gitignore reading and program creation are independent
+	// (createProgramsForConfig only reads parserOptions.project, never Ignores),
+	// so run them on the shared WorkGroup — which honors --singleThreaded the
+	// same way the lint and type-check phases do.
+	wg := core.NewWorkGroup(singleThreaded)
+	wg.Queue(func() {
 		gitGlobs = rslintconfig.ReadGitignoreAsGlobs(configDir, fsys, configIgnores)
+	})
+	wg.Queue(func() {
 		progs, exitCode = createProgramsForConfig(configDir, rslintConfig, singleThreaded, fsys, seenTsConfigs, parseCache)
-	} else {
-		var wg sync.WaitGroup
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			gitGlobs = rslintconfig.ReadGitignoreAsGlobs(configDir, fsys, configIgnores)
-		}()
-		go func() {
-			defer wg.Done()
-			progs, exitCode = createProgramsForConfig(configDir, rslintConfig, singleThreaded, fsys, seenTsConfigs, parseCache)
-		}()
-		wg.Wait()
-	}
+	})
+	wg.RunAndWait()
 
 	if exitCode != 0 {
 		return rslintConfig, nil, exitCode


### PR DESCRIPTION
## Summary

Two spots hand-rolled `sync.WaitGroup` to run gitignore reads concurrently with TS program creation:

- `parallelGitignoreAndPrograms` (single-config / legacy paths) — an `if singleThreaded { serial } else { 2 goroutines + WaitGroup }` split.
- the multi-config gitignore fan-out in `executeLintPipeline` — N goroutines writing a buffered channel + a closer goroutine, plus a separate inline serial path for `--singleThreaded`.

`core.WorkGroup` is the project's standard concurrency primitive — already used by the lint and type-check phases (`internal/linter`) — and honors `--singleThreaded` natively (`NewWorkGroup(true)` runs queued tasks serially). This PR replaces both hand-rolled sites with it, dropping the duplicated serial/parallel branches, the result channel, and the closer goroutine (net **−15 lines**).

### Behavior is unchanged (pure refactor)

- The gitignore reads still **overlap** with the serial `createProgramsForConfig` loop in the parallel path.
- The augmented `configMap` is **identical**. `createProgramsForConfig` → `ResolveTsConfigPaths` → `LoadTsConfigsFromRslintConfig` reads only `parserOptions.project`, **never** `Ignores` (a prepended `{Ignores}` entry has `LanguageOptions == nil` and is a no-op for it), so it doesn't matter whether the gitignore merge happens before or after program creation. Every consumer that needs the augmented `configMap` (gap discovery, `FindNearestConfig`, `buildFileFilters`, …) runs after the merge.
- `--singleThreaded` keeps everything serial via `NewWorkGroup(true)`.

`walkPool` (dynamic recursive directory walk) and the diagnostics-drain goroutine are intentionally left alone — they are different patterns that `WorkGroup` does not model.

### Verification

- Two independent adversarial reviews + a `-race` pattern probe confirmed strict behavioral equivalence and no new data races (negative control correctly reported a race).
- `go test ./cmd/rslint/ ./internal/config/ -race` green; `lint:go` / `check-spell` / `format:check` pass.
- End-to-end on **rsbuild** and **rspack** (single-config → `parallelGitignoreAndPrograms`): diagnostics byte-for-byte identical, no perf change. The multi-config fan-out was additionally exercised with a local multi-config monorepo fixture (`main` vs this branch, identical output).

## Related Links

<!-- none -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
