### PR TITLE
feat(eslint-plugin-jest): add `prefer-hooks-on-top` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -21,6 +21,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_each"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_equality_matcher"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_expect_resolves"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_hooks_on_top"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_strict_equal"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_be"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_contain"
@@ -56,6 +57,7 @@ func GetAllRules() []rule.Rule {
 		prefer_each.PreferEachRule,
 		prefer_equality_matcher.PreferEqualityMatcherRule,
 		prefer_expect_resolves.PreferExpectResolvesRule,
+		prefer_hooks_on_top.PreferHooksOnTopRule,
 		prefer_strict_equal.PreferStrictEqualRule,
 		prefer_to_be.PreferToBeRule,
 		prefer_to_contain.PreferToContainRule,

--- a/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top.go
+++ b/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top.go
@@ -1,0 +1,36 @@
+package prefer_hooks_on_top
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func buildNoHookOnTopMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noHookOnTop",
+		Description: "Hooks should come before test cases",
+	}
+}
+
+var PreferHooksOnTopRule = rule.Rule{
+	Name: "jest/prefer-hooks-on-top",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		hooksContext := []bool{false}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				if utils.IsTypeOfJestFnCall(node, ctx, utils.JestFnTypeTest) {
+					hooksContext[len(hooksContext)-1] = true
+				}
+				if hooksContext[len(hooksContext)-1] && utils.IsTypeOfJestFnCall(node, ctx, utils.JestFnTypeHook) {
+					ctx.ReportNode(node, buildNoHookOnTopMessage())
+				}
+				hooksContext = append(hooksContext, false)
+			},
+			rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
+				hooksContext = hooksContext[:len(hooksContext)-1]
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top.md
+++ b/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top.md
@@ -1,0 +1,122 @@
+# prefer-hooks-on-top
+
+## Rule Details
+
+Suggest placing Jest lifecycle hooks before any test cases in the same scope.
+
+Hooks (`beforeAll`, `beforeEach`, `afterEach`, `afterAll`) can appear anywhere in a
+`describe` callback, but Jest always runs them in a fixed order regardless of where
+they are written. Mixing hooks with `test` / `it` calls makes that execution order
+harder to follow, so this rule reports hooks registered **after** the first test case
+in the same scope.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+describe('foo', () => {
+  beforeEach(() => {
+    seedMyDatabase();
+  });
+
+  it('accepts this input', () => {
+    // ...
+  });
+
+  beforeAll(() => {
+    createMyDatabase();
+  });
+
+  it('returns that value', () => {
+    // ...
+  });
+
+  describe('when the database has specific values', () => {
+    const specificValue = '...';
+
+    beforeEach(() => {
+      seedMyDatabase(specificValue);
+    });
+
+    it('accepts that input', () => {
+      // ...
+    });
+
+    it('throws an error', () => {
+      // ...
+    });
+
+    afterEach(() => {
+      clearLogger();
+    });
+    beforeEach(() => {
+      mockLogger();
+    });
+
+    it('logs a message', () => {
+      // ...
+    });
+  });
+
+  afterAll(() => {
+    removeMyDatabase();
+  });
+});
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+describe('foo', () => {
+  beforeAll(() => {
+    createMyDatabase();
+  });
+
+  beforeEach(() => {
+    seedMyDatabase();
+  });
+
+  afterAll(() => {
+    clearMyDatabase();
+  });
+
+  it('accepts this input', () => {
+    // ...
+  });
+
+  it('returns that value', () => {
+    // ...
+  });
+
+  describe('when the database has specific values', () => {
+    const specificValue = '...';
+
+    beforeEach(() => {
+      seedMyDatabase(specificValue);
+    });
+
+    beforeEach(() => {
+      mockLogger();
+    });
+
+    afterEach(() => {
+      clearLogger();
+    });
+
+    it('accepts that input', () => {
+      // ...
+    });
+
+    it('throws an error', () => {
+      // ...
+    });
+
+    it('logs a message', () => {
+      // ...
+    });
+  });
+});
+```
+
+## Original Documentation
+
+- [jest/prefer-hooks-on-top](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-hooks-on-top.md)

--- a/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top_test.go
+++ b/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top_test.go
@@ -1,0 +1,164 @@
+package prefer_hooks_on_top_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_hooks_on_top"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferHooksOnTopRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_hooks_on_top.PreferHooksOnTopRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `describe('foo', () => {
+  beforeEach(() => {});
+  someSetupFn();
+  afterEach(() => {});
+
+  test('bar', () => {
+    someFn();
+  });
+})`},
+			{Code: `describe('foo', () => {
+  someSetupFn();
+  beforeEach(() => {});
+  afterEach(() => {});
+
+  test('bar', () => {
+    someFn();
+  });
+})`},
+			{Code: `describe.skip('foo', () => {
+  beforeEach(() => {});
+  beforeAll(() => {});
+
+  test('bar', () => {
+    someFn();
+  });
+});
+
+describe('foo', () => {
+  beforeEach(() => {});
+
+  test('bar', () => {
+    someFn();
+  });
+});`},
+			{Code: `describe('foo', () => {
+  beforeEach(() => {});
+  test('bar', () => {
+    someFn();
+  });
+
+  describe('inner_foo', () => {
+    beforeEach(() => {});
+    test('inner bar', () => {
+      someFn();
+    });
+  });
+})`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `describe('foo', () => {
+  beforeEach(() => {});
+  test('bar', () => {
+    someFn();
+  });
+
+  beforeAll(() => {});
+  test('bar', () => {
+    someFn();
+  });
+})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noHookOnTop", Line: 7, Column: 3},
+				},
+			},
+			{
+				Code: "describe('foo', () => {\n  beforeEach(() => {});\n  test.each``('bar', () => {\n    someFn();\n  });\n\n  beforeAll(() => {});\n  test.only('bar', () => {\n    someFn();\n  });\n})",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noHookOnTop", Line: 7, Column: 3},
+				},
+			},
+			{
+				Code: "describe('foo', () => {\n  beforeEach(() => {});\n  test.only.each``('bar', () => {\n    someFn();\n  });\n\n  beforeAll(() => {});\n  test.only('bar', () => {\n    someFn();\n  });\n})",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noHookOnTop", Line: 7, Column: 3},
+				},
+			},
+			{
+				Code: `describe.skip('foo', () => {
+  beforeEach(() => {});
+  test('bar', () => {
+    someFn();
+  });
+
+  beforeAll(() => {});
+  test('bar', () => {
+    someFn();
+  });
+});
+describe('foo', () => {
+  beforeEach(() => {});
+  beforeEach(() => {});
+  beforeAll(() => {});
+
+  test('bar', () => {
+    someFn();
+  });
+});
+
+describe('foo', () => {
+  test('bar', () => {
+    someFn();
+  });
+
+  beforeEach(() => {});
+  beforeEach(() => {});
+  beforeAll(() => {});
+})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noHookOnTop", Line: 7, Column: 3},
+					{MessageId: "noHookOnTop", Line: 27, Column: 3},
+					{MessageId: "noHookOnTop", Line: 28, Column: 3},
+					{MessageId: "noHookOnTop", Line: 29, Column: 3},
+				},
+			},
+			{
+				Code: `describe('foo', () => {
+  beforeAll(() => {});
+  test('bar', () => {
+    someFn();
+  });
+
+  describe('inner_foo', () => {
+    beforeEach(() => {});
+    test('inner bar', () => {
+      someFn();
+    });
+
+    test('inner bar', () => {
+      someFn();
+    });
+
+    beforeAll(() => {});
+    afterAll(() => {});
+    test('inner bar', () => {
+      someFn();
+    });
+  });
+})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noHookOnTop", Line: 17, Column: 5},
+					{MessageId: "noHookOnTop", Line: 18, Column: 5},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -457,6 +457,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/prefer-each.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-equality-matcher.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-expect-resolves.test.ts',
+    './tests/eslint-plugin-jest/rules/prefer-hooks-on-top.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-strict-equal.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-be.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-contain.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-hooks-on-top.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-hooks-on-top.test.ts
@@ -1,0 +1,234 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-hooks-on-top', {} as never, {
+  valid: [
+    {
+      code: `
+      describe('foo', () => {
+        beforeEach(() => {});
+        someSetupFn();
+        afterEach(() => {});
+
+        test('bar', () => {
+          someFn();
+        });
+      });
+    `,
+    },
+    {
+      code: `
+      describe('foo', () => {
+        someSetupFn();
+        beforeEach(() => {});
+        afterEach(() => {});
+
+        test('bar', () => {
+          someFn();
+        });
+      });
+    `,
+    },
+    {
+      code: `
+      describe.skip('foo', () => {
+        beforeEach(() => {});
+        beforeAll(() => {});
+
+        test('bar', () => {
+          someFn();
+        });
+      });
+
+      describe('foo', () => {
+        beforeEach(() => {});
+
+        test('bar', () => {
+          someFn();
+        });
+      });
+    `,
+    },
+    {
+      code: `
+      describe('foo', () => {
+        beforeEach(() => {});
+        test('bar', () => {
+          someFn();
+        });
+
+        describe('inner_foo', () => {
+          beforeEach(() => {});
+          test('inner bar', () => {
+            someFn();
+          });
+        });
+      });
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        describe('foo', () => {
+          beforeEach(() => {});
+          test('bar', () => {
+            someFn();
+          });
+
+          beforeAll(() => {});
+          test('bar', () => {
+            someFn();
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 7,
+        },
+      ],
+    },
+    {
+      code: `
+        describe('foo', () => {
+          beforeEach(() => {});
+          test.each\`\`('bar', () => {
+            someFn();
+          });
+
+          beforeAll(() => {});
+          test.only('bar', () => {
+            someFn();
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 7,
+        },
+      ],
+    },
+    {
+      code: `
+        describe('foo', () => {
+          beforeEach(() => {});
+          test.only.each\`\`('bar', () => {
+            someFn();
+          });
+
+          beforeAll(() => {});
+          test.only('bar', () => {
+            someFn();
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 7,
+        },
+      ],
+    },
+    {
+      code: `
+        describe.skip('foo', () => {
+          beforeEach(() => {});
+          test('bar', () => {
+            someFn();
+          });
+
+          beforeAll(() => {});
+          test('bar', () => {
+            someFn();
+          });
+        });
+        describe('foo', () => {
+          beforeEach(() => {});
+          beforeEach(() => {});
+          beforeAll(() => {});
+
+          test('bar', () => {
+            someFn();
+          });
+        });
+
+        describe('foo', () => {
+          test('bar', () => {
+            someFn();
+          });
+
+          beforeEach(() => {});
+          beforeEach(() => {});
+          beforeAll(() => {});
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 7,
+        },
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 27,
+        },
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 28,
+        },
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 29,
+        },
+      ],
+    },
+    {
+      code: `
+        describe('foo', () => {
+          beforeAll(() => {});
+          test('bar', () => {
+            someFn();
+          });
+
+          describe('inner_foo', () => {
+            beforeEach(() => {});
+            test('inner bar', () => {
+              someFn();
+            });
+
+            test('inner bar', () => {
+              someFn();
+            });
+
+            beforeAll(() => {});
+            afterAll(() => {});
+            test('inner bar', () => {
+              someFn();
+            });
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noHookOnTop',
+          column: 5,
+          line: 17,
+        },
+        {
+          messageId: 'noHookOnTop',
+          column: 5,
+          line: 18,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port `prefer-hooks-on-top` from eslint-plugin-jest to rslint

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/prefer-hooks-on-top [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-hooks-on-top.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/prefer-hooks-on-top.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
