### PR TITLE
fix: add SourceCode#isESTree to match ESLint v10

### DIFF
--- a/packages/rslint/src/eslint-plugin/source-code/source-code.ts
+++ b/packages/rslint/src/eslint-plugin/source-code/source-code.ts
@@ -82,6 +82,7 @@ export interface ESTreeNode {
 export interface SourceCode {
   text: string;
   ast: ESTreeNode;
+  isESTree: boolean;
   lines: string[];
   hasBOM: boolean;
   scopeManager: unknown;
@@ -576,6 +577,12 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
   const sc: SourceCode = {
     text,
     ast,
+    // ESLint sets `isESTree = (ast.type === "Program")` on ESTree-backed
+    // SourceCode (eslint/lib/languages/js/source-code/source-code.js:316).
+    // Stylistic's `indent` rule (alone among the 97 rules) guards
+    // `if (!isESTreeSourceCode(...)) return {}` and would otherwise register
+    // zero listeners under rslint. Mirror ESLint's exact predicate.
+    isESTree: ast.type === 'Program',
     get lines(): string[] {
       // ESLint splits on ALL ECMAScript line terminators (LF, CR, CRLF,
       // U+2028, U+2029) — see `LINE_TERMINATOR_RE`. Splitting on `\n`

--- a/packages/rslint/tests/eslint-plugin/source-code/is-estree.test.ts
+++ b/packages/rslint/tests/eslint-plugin/source-code/is-estree.test.ts
@@ -1,0 +1,51 @@
+/**
+ * `SourceCode#isESTree` mirrors ESLint v10's
+ *   `this.isESTree = (ast.type === "Program")`
+ * (eslint/lib/languages/js/source-code/source-code.js:316).
+ *
+ * The property exists so plugin rules that guard on it behave under rslint as
+ * they do under ESLint. Stylistic's `indent` rule, for instance, bails with
+ * `if (!isESTreeSourceCode(...)) return {}` — without this property it would
+ * register zero listeners and silently report nothing. These tests pin the
+ * exact predicate (the Program / non-Program split), not just a truthy value.
+ */
+import { describe, test, expect } from '@rstest/core';
+
+import { createSourceCode } from '../../../src/eslint-plugin/source-code/source-code.js';
+import type { ESTreeNode } from '../../../src/eslint-plugin/source-code/source-code.js';
+
+/** Minimal root node — only `type`/`range`/`loc` matter for `isESTree`. */
+function mkRoot(type: string, text: string): ESTreeNode {
+  return {
+    type,
+    range: [0, text.length],
+    loc: {
+      start: { line: 1, column: 0 },
+      end: { line: 1, column: text.length },
+    },
+    start: 0,
+    end: text.length,
+  };
+}
+
+describe('SourceCode#isESTree', () => {
+  test('is true when the AST root is a Program (ESTree-backed)', () => {
+    const text = 'const x = 1;';
+    const sc = createSourceCode({
+      text,
+      ast: mkRoot('Program', text),
+      scopeManagerFactory: () => ({}),
+    });
+    expect(sc.isESTree).toBe(true);
+  });
+
+  test('is false when the AST root is not a Program', () => {
+    const text = '{}';
+    const sc = createSourceCode({
+      text,
+      ast: mkRoot('JSONProgram', text),
+      scopeManagerFactory: () => ({}),
+    });
+    expect(sc.isESTree).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

ESLint v10's `SourceCode` exposes `isESTree = (ast.type === "Program")`. rslint's eslint-plugin `SourceCode` lacked it, so plugin rules that guard on it diverged under rslint — most visibly `@stylistic/indent`, which bails via `if (!isESTreeSourceCode(...)) return {}` and otherwise registers zero listeners (silently reporting nothing).

This adds the property on the `SourceCode` built for plugin rules, mirroring ESLint's exact predicate.

## Why now

Prerequisite for upcoming per-plugin conformance suites: with `isESTree` in place, `@stylistic/indent` reproduces ESLint v10 byte-for-byte (verified locally — `if` / `function` / object / `switch` indentation diagnostics match exactly, including endLine/endColumn). Those suites land in follow-up PRs.

## Test

`packages/rslint/tests/eslint-plugin/source-code/is-estree.test.ts` pins both branches of the predicate (Program → true, non-Program → false).