### PR TITLE
test: add simple-import-sort conformance against ESLint v10

### DIFF
--- a/packages/rslint-test-tools/package.json
+++ b/packages/rslint-test-tools/package.json
@@ -22,6 +22,7 @@
     "@typescript-eslint/utils": "workspace:*",
     "eslint": "10.5.0",
     "eslint-plugin-promise": "7.3.0",
+    "eslint-plugin-simple-import-sort": "^13.0.0",
     "eslint-plugin-sonarjs": "4.0.3",
     "eslint-plugin-unicorn": "64.0.0"
   },

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -26,6 +26,7 @@ export default defineConfig({
     './tests/cli/js-config/eslint-plugin-conformance/sonarjs.test.ts',
     './tests/cli/js-config/eslint-plugin-conformance/promise.test.ts',
     './tests/cli/js-config/eslint-plugin-conformance/stylistic.test.ts',
+    './tests/cli/js-config/eslint-plugin-conformance/simple-import-sort.test.ts',
     './tests/cli/js-config/gitignore-integration.test.ts',
     './tests/cli/fix/cascade.test.ts',
     './tests/cli/fix/edge-cases.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
@@ -72,6 +72,7 @@ export const ALIASES: Record<string, string> = {
   'eslint-plugin-sonarjs': 's',
   'eslint-plugin-promise': 'p',
   '@stylistic/eslint-plugin': 'st',
+  'eslint-plugin-simple-import-sort': 'sis',
 };
 
 /** Resolve + dynamically import a plugin package's live default export. */

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/simple-import-sort.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/simple-import-sort.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Conformance: eslint-plugin-simple-import-sort rules mounted in rslint via
+ * `plugins` must report identically to ESLint v10. Shared assertion lives in
+ * ./conformance.ts.
+ *
+ * Both rules emit a single `sort` diagnostic spanning the unsorted block. The
+ * sort is pure (no type information), so rslint and ESLint agree byte-for-byte
+ * on the message and the reported range. Cases are representative triggers
+ * drawn from the upstream test suite (v13.0.0), one or more per scenario.
+ */
+import { runConformanceSuite } from './conformance.js';
+import type { DiffCase } from './harness.js';
+
+const PKG = 'eslint-plugin-simple-import-sort';
+
+/** Triggers that must report IDENTICALLY on both engines. */
+const CASES: DiffCase[] = [
+  // imports — alphabetical sort of statements.
+  {
+    pkg: PKG,
+    rule: 'imports',
+    code: 'import x2 from "b"\nimport x1 from "a";\n',
+  },
+  // imports — semicolon-free style with a start-of-line guarding semicolon.
+  {
+    pkg: PKG,
+    rule: 'imports',
+    code: 'import x2 from "b"\nimport x1 from "a"\n\n;[].forEach()\n',
+  },
+  // imports — sorting named specifiers.
+  {
+    pkg: PKG,
+    rule: 'imports',
+    code: 'import { e, b, a as c } from "specifiers"\n',
+  },
+  // imports — specifiers alongside a default import.
+  {
+    pkg: PKG,
+    rule: 'imports',
+    code: 'import d, { e, b, a as c } from "specifiers-default"\n',
+  },
+  // imports — renamed specifiers sort by their external (stable) name.
+  {
+    pkg: PKG,
+    rule: 'imports',
+    code: 'import { a as c, a as b2, b, a } from "specifiers-renames"\n',
+  },
+  // imports — no spaces inside the braces.
+  {
+    pkg: PKG,
+    rule: 'imports',
+    code: 'import {e,b,a as c} from "specifiers-no-spaces"\n',
+  },
+  // imports — specifiers carrying line comments.
+  {
+    pkg: PKG,
+    rule: 'imports',
+    code: 'import {\n  // c\n  c,\n  b, // b\n  a\n  // last\n} from "specifiers-comments"\n',
+  },
+
+  // exports — alphabetical sort of statements.
+  {
+    pkg: PKG,
+    rule: 'exports',
+    code: 'export {x2} from "b"\nexport {x1} from "a";\n',
+  },
+  // exports — semicolon-free style with a guarding semicolon.
+  {
+    pkg: PKG,
+    rule: 'exports',
+    code: 'export {x2} from "b"\nexport {x1} from "a"\n\n;[].forEach()\n',
+  },
+  // exports — sorting named specifiers (the stable name wins on `a as c`).
+  {
+    pkg: PKG,
+    rule: 'exports',
+    code: 'export { d, a as c, a as b2, b, a } from "specifiers"\n',
+  },
+  // exports — `as default`.
+  {
+    pkg: PKG,
+    rule: 'exports',
+    code: "export { something, something as default } from './something'\n",
+  },
+  // exports — a type specifier sorts ahead of the same-named value specifier.
+  {
+    pkg: PKG,
+    rule: 'exports',
+    code: 'export {MyClass, type MyClass} from "../type";\n',
+  },
+];
+
+/** Snippets that must report NOTHING on both engines. */
+const CLEAN_CASES: DiffCase[] = [
+  // imports — already-correct forms.
+  { pkg: PKG, rule: 'imports', code: 'import "a"\n' },
+  { pkg: PKG, rule: 'imports', code: 'import a from "a"\n' },
+  { pkg: PKG, rule: 'imports', code: 'import {a,b} from "a"\n' },
+  { pkg: PKG, rule: 'imports', code: 'import * as a from "a"\n' },
+  {
+    pkg: PKG,
+    rule: 'imports',
+    code: 'import x1 from "a";\nimport x2 from "b"\n',
+  },
+  // Side-effect-only imports keep their original order.
+  { pkg: PKG, rule: 'imports', code: 'import "b";\nimport "a"\n' },
+
+  // exports — already-correct forms.
+  { pkg: PKG, rule: 'exports', code: 'export {a} from "a"\n' },
+  { pkg: PKG, rule: 'exports', code: 'export {a,b} from "a"\n' },
+  { pkg: PKG, rule: 'exports', code: 'export * as a from "a"\n' },
+  { pkg: PKG, rule: 'exports', code: 'export var one = 1;\n' },
+  { pkg: PKG, rule: 'exports', code: 'export default whatever;\n' },
+  {
+    pkg: PKG,
+    rule: 'exports',
+    code: 'export type {x1} from "a";\nexport type {x2} from "b"\n',
+  },
+  {
+    pkg: PKG,
+    rule: 'exports',
+    code: 'export { a, type b, c, type d } from "a"\n',
+  },
+];
+
+runConformanceSuite(PKG, CASES, CLEAN_CASES);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       eslint-plugin-promise:
         specifier: 7.3.0
         version: 7.3.0(eslint@10.5.0(jiti@2.6.1))
+      eslint-plugin-simple-import-sort:
+        specifier: ^13.0.0
+        version: 13.0.0(eslint@10.5.0(jiti@2.6.1))
       eslint-plugin-sonarjs:
         specifier: 4.0.3
         version: 4.0.3(eslint@10.5.0(jiti@2.6.1))
@@ -3658,6 +3661,11 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+
+  eslint-plugin-simple-import-sort@13.0.0:
+    resolution: {integrity: sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-plugin-sonarjs@4.0.3:
     resolution: {integrity: sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==}
@@ -9273,6 +9281,10 @@ snapshots:
   eslint-plugin-promise@7.3.0(eslint@10.5.0(jiti@2.6.1)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.6.1))
+      eslint: 10.5.0(jiti@2.6.1)
+
+  eslint-plugin-simple-import-sort@13.0.0(eslint@10.5.0(jiti@2.6.1)):
+    dependencies:
       eslint: 10.5.0(jiti@2.6.1)
 
   eslint-plugin-sonarjs@4.0.3(eslint@10.5.0(jiti@2.6.1)):


### PR DESCRIPTION
## What

Mount `eslint-plugin-simple-import-sort` in rslint via the `plugins` feature and assert each rule (`imports`, `exports`) reports identically to ESLint v10, under the existing differential conformance harness (`eslint-plugin-conformance/`).

## Coverage

Representative triggers per scenario for both rules — basic alphabetical sort, named specifiers, default + specifiers, renames, type specifiers, specifier comments, semicolon-free style. The sort is pure (no type information), so rslint and ESLint agree byte-for-byte on message and range. 12 trigger + 13 clean cases, all green.

## Note

Part of a series replacing the closed #1104 (full upstream RuleTester port) with per-plugin differential conformance. Independent — no dependency on the other PRs in the series.