### PR TITLE
test: add eslint-comments conformance against ESLint v10

### DIFF
--- a/packages/rslint-test-tools/package.json
+++ b/packages/rslint-test-tools/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
     "@rslint/core": "workspace:*",
     "@rstest/core": "0.9.2",
     "@stylistic/eslint-plugin": "5.10.0",

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -27,6 +27,7 @@ export default defineConfig({
     './tests/cli/js-config/eslint-plugin-conformance/promise.test.ts',
     './tests/cli/js-config/eslint-plugin-conformance/stylistic.test.ts',
     './tests/cli/js-config/eslint-plugin-conformance/simple-import-sort.test.ts',
+    './tests/cli/js-config/eslint-plugin-conformance/eslint-comments.test.ts',
     './tests/cli/js-config/gitignore-integration.test.ts',
     './tests/cli/fix/cascade.test.ts',
     './tests/cli/fix/edge-cases.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/eslint-comments.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/eslint-comments.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Conformance: @eslint-community/eslint-plugin-eslint-comments mounted in rslint
+ * via `plugins` must report identically to ESLint v10. Only the subset rslint
+ * reproduces byte-for-byte is included; each case was verified individually.
+ *
+ * Intentionally EXCLUDED — runner limitations surfaced by this comparison, not
+ * test gaps (kept honest, never faked green):
+ *   - Diagnostics pointing at a whole-comment disable/enable directive with NO
+ *     rule list (no-unlimited-disable, no-use, require-description,
+ *     no-aggregating-enable on a bare enable, no-restricted-disable on a bare
+ *     disable): rslint reports the start as (1,1) rather than the comment's real
+ *     start line/column, so they diverge from ESLint. Cases that name specific
+ *     rules in the directive locate correctly and ARE included.
+ *   - no-unused-disable: the rule patches Linter#verify /
+ *     reportUnusedDisableDirectives, which the rslint plugin runner does not
+ *     expose, so it never fires.
+ */
+import { runConformanceSuite } from './conformance.js';
+import type { DiffCase } from './harness.js';
+
+const CASES: DiffCase[] = [
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'disable-enable-pair',
+    code: '\n/*eslint-disable no-undef*/\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'disable-enable-pair',
+    code: '\n/*eslint-disable no-undef,no-unused-vars*/\n/*eslint-enable no-undef*/\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'disable-enable-pair',
+    code: '\n/*eslint-disable no-undef*/\nconsole.log();\n/*eslint-disable no-unused-vars*/\n',
+    options: [{ allowWholeFile: true }],
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'disable-enable-pair',
+    code: '\n{\n/*eslint-disable no-unused-vars -- description */\n}\n',
+    options: [{ allowWholeFile: true }],
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-duplicate-disable',
+    code: '\n/*eslint-disable no-undef*/\n//eslint-disable-line no-undef\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-duplicate-disable',
+    code: '\n/*eslint-disable no-undef*/\n//eslint-disable-next-line no-undef\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-duplicate-disable',
+    code: '\n//eslint-disable-next-line no-undef\n//eslint-disable-line no-undef\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-duplicate-disable',
+    code: '\n// eslint-disable-next-line no-undef -- description\n// eslint-disable-line no-undef -- description\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-restricted-disable',
+    code: '/*eslint-disable eqeqeq*/',
+    options: ['eqeqeq'],
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-restricted-disable',
+    code: '/*eslint-disable eqeqeq, no-undef, no-redeclare*/',
+    options: ['*', '!no-undef', '!no-redeclare'],
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-restricted-disable',
+    code: '/*eslint-disable semi, no-extra-semi, semi-style, comma-style*/',
+    options: ['*semi*'],
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-unused-enable',
+    code: '/*eslint-enable no-undef*/',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-unused-enable',
+    code: '\n/*eslint-disable no-unused-vars*/\n/*eslint-enable no-undef*/\n',
+  },
+];
+
+const CLEAN_CASES: DiffCase[] = [
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'disable-enable-pair',
+    code: '\n/*eslint-disable no-undef,no-unused-vars*/\n/*eslint-enable no-undef,no-unused-vars*/\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'disable-enable-pair',
+    code: '\n/*eslint-disable no-undef -- description*/\n/*eslint-enable no-undef*/\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-aggregating-enable',
+    code: '\n            /*eslint-disable no-redeclare*/\n            /*eslint-enable no-redeclare*/\n        ',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-aggregating-enable',
+    code: '\n            /*eslint-disable no-redeclare, no-shadow*/\n            /*eslint-enable no-redeclare*/\n            /*eslint-enable no-shadow*/\n        ',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-duplicate-disable',
+    code: '\n/*eslint-disable no-undef*/\n//eslint-disable-line no-unused-vars\n//eslint-disable-next-line semi\n/*eslint-disable eqeqeq*/\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-duplicate-disable',
+    code: '\n//eslint-disable-line\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-restricted-disable',
+    code: '/*eslint-disable eqeqeq*/',
+    options: ['no-unused-vars'],
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-restricted-disable',
+    code: '/*eslint-disable eqeqeq*/',
+    options: ['*', '!eqeqeq'],
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-unlimited-disable',
+    code: '/*eslint-disable eqeqeq*/',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-unlimited-disable',
+    code: 'var foo;\n//eslint-disable-line eqeqeq',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-unused-enable',
+    code: '\n/*eslint no-undef:error*/\n/*eslint-disable*/\nvar a = b\n/*eslint-enable*/\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-unused-enable',
+    code: '\n/*eslint no-undef:error, no-unused-vars:error*/\n/*eslint-disable no-undef,no-unused-vars*/\nvar a = b\n/*eslint-enable no-undef*/\n',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-use',
+    code: '/* just eslint in a normal comment */',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'no-use',
+    code: '/* eslint */',
+    options: [{ allow: ['eslint'] }],
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'require-description',
+    code: '/* eslint eqeqeq: "off", curly: "error" -- Here\'s a description about why this configuration is necessary. */',
+  },
+  {
+    pkg: '@eslint-community/eslint-plugin-eslint-comments',
+    rule: 'require-description',
+    code: '// eslint-disable-line eqeqeq -- description',
+    options: [{ ignore: ['eslint-disable-line'] }],
+  },
+];
+
+runConformanceSuite(
+  '@eslint-community/eslint-plugin-eslint-comments',
+  CASES,
+  CLEAN_CASES,
+);

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
@@ -73,6 +73,7 @@ export const ALIASES: Record<string, string> = {
   'eslint-plugin-promise': 'p',
   '@stylistic/eslint-plugin': 'st',
   'eslint-plugin-simple-import-sort': 'sis',
+  '@eslint-community/eslint-plugin-eslint-comments': 'ec',
 };
 
 /** Resolve + dynamically import a plugin package's live default export. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
 
   packages/rslint-test-tools:
     devDependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.7.2
+        version: 4.7.2(eslint@10.5.0(jiti@2.6.1))
       '@rslint/core':
         specifier: workspace:*
         version: link:../rslint
@@ -754,6 +757,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.2':
+    resolution: {integrity: sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -6364,6 +6373,12 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.0':
     optional: true
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.2(eslint@10.5.0(jiti@2.6.1))':
+    dependencies:
+      escape-string-regexp: 4.0.0
+      eslint: 10.5.0(jiti@2.6.1)
+      ignore: 7.0.5
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.6.1))':
     dependencies:


### PR DESCRIPTION
## What

Mount `@eslint-community/eslint-plugin-eslint-comments` in rslint via the `plugins` feature and assert each rule reports identically to ESLint v10 under the differential conformance harness. **13 trigger + 16 clean cases across 8 rules.**

## How

Triggers drawn from the upstream test suite, filtered to those rslint matches exactly — each run individually against live ESLint v10.

## Known limitations (excluded, not faked green)

The comparison surfaced two genuine rslint runner gaps, documented in the test file header:

- **Rule-less directive location** — for diagnostics on an `eslint-disable`/`eslint-enable` directive with no rule list (no-unlimited-disable, no-use, require-description, no-aggregating-enable on a bare enable), rslint reports the start as (1,1) instead of the comment's real start line/column. Cases that name specific rules locate correctly and are included.
- **no-unused-disable** — patches `Linter#verify` / `reportUnusedDisableDirectives`, which the rslint plugin runner doesn't expose, so the rule never fires.

## Note

Part of the series replacing the closed #1104 with per-plugin differential conformance.