### PR TITLE
test: add eslint-plugin-security conformance against ESLint v10

### DIFF
--- a/packages/rslint-test-tools/package.json
+++ b/packages/rslint-test-tools/package.json
@@ -23,6 +23,7 @@
     "@typescript-eslint/utils": "workspace:*",
     "eslint": "10.5.0",
     "eslint-plugin-promise": "7.3.0",
+    "eslint-plugin-security": "^4.0.1",
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "eslint-plugin-sonarjs": "4.0.3",
     "eslint-plugin-unicorn": "64.0.0"

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -34,6 +34,7 @@ export default defineConfig({
     './tests/cli/js-config/eslint-plugin-conformance/stylistic/ts-types.test.ts',
     './tests/cli/js-config/eslint-plugin-conformance/simple-import-sort.test.ts',
     './tests/cli/js-config/eslint-plugin-conformance/eslint-comments.test.ts',
+    './tests/cli/js-config/eslint-plugin-conformance/security.test.ts',
     './tests/cli/js-config/gitignore-integration.test.ts',
     './tests/cli/fix/cascade.test.ts',
     './tests/cli/fix/edge-cases.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
@@ -74,6 +74,7 @@ export const ALIASES: Record<string, string> = {
   '@stylistic/eslint-plugin': 'st',
   'eslint-plugin-simple-import-sort': 'sis',
   '@eslint-community/eslint-plugin-eslint-comments': 'ec',
+  'eslint-plugin-security': 'sec',
 };
 
 /** Resolve + dynamically import a plugin package's live default export. */

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/security.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/security.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Conformance: eslint-plugin-security (v4.0.1) mounted in rslint via `plugins`
+ * must report identically to ESLint v10. All 14 rules reproduce ESLint v10
+ * byte-for-byte: they are plain AST pattern matches (detect-* dangerous usage)
+ * with no type info, scope-heavy data flow, or directive handling, so rslint and
+ * ESLint agree exactly — no rules or cases excluded. Representative triggers from
+ * the upstream test suite.
+ */
+import { runConformanceSuite } from './conformance.js';
+import type { DiffCase } from './harness.js';
+
+const CASES: DiffCase[] = [
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-unsafe-regex',
+    code: '/(x+x+)+y/',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-unsafe-regex',
+    code: "new RegExp('x+x+)+y')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-regexp',
+    code: "var a = new RegExp(c, 'i')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-require',
+    code: 'var a = require(c)',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-require',
+    code: 'var a = require(`${c}`)',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-fs-filename',
+    code: "var something = require('fs');\n             var a = something.open(c);",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-fs-filename',
+    code: "var one = require('fs').readFile;\n             one(filename);",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-fs-filename',
+    code: "import { readFile as something } from 'fs';\n             something(filename);",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-fs-filename',
+    code: "var fs = require('fs');\nfs.readFile(`template with ${filename}`);",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-eval-with-expression',
+    code: 'eval(a);',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-pseudoRandomBytes',
+    code: 'crypto.pseudoRandomBytes',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-possible-timing-attacks',
+    code: "if (password === 'mypass') {}",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-possible-timing-attacks',
+    code: "if ('mypass' === password) {}",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-no-csrf-before-method-override',
+    code: 'express.csrf();express.methodOverride()',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-buffer-noassert',
+    code: 'a.readUInt8(0, true)',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-buffer-noassert',
+    code: 'a.writeUInt8(0, 0, true)',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-buffer-noassert',
+    code: 'a.readDoubleLE(0, true);',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-child-process',
+    code: "require('child_process')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-child-process',
+    code: "var child = require('child_process'); child.exec(com)",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-child-process',
+    code: "import child from 'child_process'; child.exec(com)",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-child-process',
+    code: "\n      const {exec} = require('child_process');\n      exec(str)",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-disable-mustache-escape',
+    code: 'a.escapeMarkup = false',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-object-injection',
+    code: 'var a = {}; a[b] = 4',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-new-buffer',
+    code: 'var a = new Buffer(c)',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-bidi-characters',
+    code: '\n      var accessLevel = "user";\n      if (accessLevel != "user\u202e \u2066// Check if admin\u2069 \u2066") {\n          console.log("You are an admin.");\n      }\n      ',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-bidi-characters',
+    code: '\n      var isAdmin = false;\n      /*\u202e } \u2066if (isAdmin)\u2069 \u2066 begin admins only */\n          console.log("You are an admin.");\n      /* end admins only \u202e\n\u2066*/\n      /* end admins only \u202e\n { \u2066*/\n        ',
+  },
+];
+
+const CLEAN_CASES: DiffCase[] = [
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-unsafe-regex',
+    code: '/^d+1337d+$/',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-unsafe-regex',
+    code: "new RegExp('^d+1337d+$')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-regexp',
+    code: "var a = new RegExp('ab+c', 'i')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-regexp',
+    code: "\n            var source = 'ab+c'\n            var a = new RegExp(source, 'i')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-require',
+    code: "var a = require('b')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-require',
+    code: 'var a = require(`b`)',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-fs-filename',
+    code: "var fs = require('fs');\n             var a = fs.open('test')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-non-literal-fs-filename',
+    code: "var something = require('some');\n             var a = something.readFile(c);",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-eval-with-expression',
+    code: "eval('alert()')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-eval-with-expression',
+    code: 'eval("some nefarious code");',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-pseudoRandomBytes',
+    code: 'crypto.randomBytes',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-possible-timing-attacks',
+    code: 'if (age === 5) {}',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-no-csrf-before-method-override',
+    code: 'express.methodOverride();express.csrf()',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-buffer-noassert',
+    code: 'a.readUInt8(0)',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-buffer-noassert',
+    code: 'a.readUInt8(0, false)',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-child-process',
+    code: "child_process.exec('ls')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-child-process',
+    code: "var { spawn } = require('child_process'); spawn(str);",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-disable-mustache-escape',
+    code: 'escapeMarkup = false',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-object-injection',
+    code: 'var a = {};',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-new-buffer',
+    code: "var a = new Buffer('test')",
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-bidi-characters',
+    code: '\n  var accessLevel = "user";\n  if (accessLevel != "user") { // Check if admin\n    console.log("You are an admin.");\n  }\n  ',
+  },
+  {
+    pkg: 'eslint-plugin-security',
+    rule: 'detect-bidi-characters',
+    code: '\n  var isAdmin = false;\n  /* begin admins only */ if (isAdmin) {\n    console.log("You are an admin.");\n  /* end admins only */ }\n  ',
+  },
+];
+
+runConformanceSuite('eslint-plugin-security', CASES, CLEAN_CASES);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       eslint-plugin-promise:
         specifier: 7.3.0
         version: 7.3.0(eslint@10.5.0(jiti@2.6.1))
+      eslint-plugin-security:
+        specifier: ^4.0.1
+        version: 4.0.1
       eslint-plugin-simple-import-sort:
         specifier: ^13.0.0
         version: 13.0.0(eslint@10.5.0(jiti@2.6.1))
@@ -3671,6 +3674,10 @@ packages:
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
+  eslint-plugin-security@4.0.1:
+    resolution: {integrity: sha512-/lZCkOxPOWaf1jXAqgICrS8St3BMBccIPvhOSUYuV6VCr1o5nFVG998FnTLt6w2Nxb8Uo0nM8fzmnhp+GY/aEg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-plugin-simple-import-sort@13.0.0:
     resolution: {integrity: sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==}
     peerDependencies:
@@ -5356,6 +5363,9 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex@2.1.1:
+    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -9298,6 +9308,10 @@ snapshots:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.6.1))
       eslint: 10.5.0(jiti@2.6.1)
 
+  eslint-plugin-security@4.0.1:
+    dependencies:
+      safe-regex: 2.1.1
+
   eslint-plugin-simple-import-sort@13.0.0(eslint@10.5.0(jiti@2.6.1)):
     dependencies:
       eslint: 10.5.0(jiti@2.6.1)
@@ -11469,6 +11483,10 @@ snapshots:
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
+
+  safe-regex@2.1.1:
+    dependencies:
+      regexp-tree: 0.1.27
 
   safer-buffer@2.1.2: {}
 


### PR DESCRIPTION
## What

Mount `eslint-plugin-security` in rslint via the `plugins` feature and assert each rule reports identically to ESLint v10 under the differential conformance harness. **All 14 rules**, **26 trigger + 22 clean cases**.

## Why so clean

Every case reproduces ESLint v10 byte-for-byte — zero exclusions. security's rules are plain AST pattern matches (`detect-eval-with-expression`, `detect-child-process`, `detect-non-literal-*`, `detect-bidi-characters`, etc.) with no type info, scope-heavy data flow, or directive handling, so rslint's plugin runner and ESLint agree exactly.

## How

Triggers drawn from the upstream test suite (v4.0.1), filtered to those rslint matches exactly — each run individually against live ESLint v10.

## Note

Part of the series adding per-plugin differential conformance for community ESLint plugins rslint hasn't natively ported.