### PR TITLE
test: add eslint-plugin-cypress conformance against ESLint v10

### DIFF
--- a/packages/rslint-test-tools/package.json
+++ b/packages/rslint-test-tools/package.json
@@ -22,6 +22,7 @@
     "@typescript-eslint/rule-tester": "workspace:*",
     "@typescript-eslint/utils": "workspace:*",
     "eslint": "10.5.0",
+    "eslint-plugin-cypress": "^6.4.1",
     "eslint-plugin-es-x": "^9.6.0",
     "eslint-plugin-promise": "7.3.0",
     "eslint-plugin-security": "^4.0.1",

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -49,6 +49,7 @@ export default defineConfig({
     './tests/cli/js-config/eslint-plugin-conformance/es-x/regexp.test.ts',
     './tests/cli/js-config/eslint-plugin-conformance/es-x/string.test.ts',
     './tests/cli/js-config/eslint-plugin-conformance/es-x/syntax.test.ts',
+    './tests/cli/js-config/eslint-plugin-conformance/cypress.test.ts',
     './tests/cli/js-config/gitignore-integration.test.ts',
     './tests/cli/fix/cascade.test.ts',
     './tests/cli/fix/edge-cases.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/cypress.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/cypress.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Conformance: eslint-plugin-cypress (v6.4.1) mounted in rslint via `plugins`
+ * must report identically to ESLint v10. All 13 rules covered; each case
+ * reproduces ESLint v10 byte-for-byte (the rules are AST pattern matches over
+ * Cypress `cy.*` command chains, no type info). Triggers from the upstream
+ * test suite.
+ */
+import { runConformanceSuite } from './conformance.js';
+import type { DiffCase } from './harness.js';
+
+const CASES: DiffCase[] = [
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'assertion-before-screenshot',
+    code: 'cy.screenshot()',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'assertion-before-screenshot',
+    code: 'cy.visit("somepage"); cy.screenshot();',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'assertion-before-screenshot',
+    code: 'cy.custom(); cy.screenshot()',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'assertion-before-screenshot',
+    code: 'cy.get(".some-element").click(); cy.screenshot()',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-and',
+    code: "cy.and('be.visible')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-and',
+    code: "cy.get('elem').and('have.text', 'blah')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-and',
+    code: "cy.get('foo').and('be.visible')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-and',
+    code: "cy.get('foo').find('.bar').and('have.class', 'active')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-assigning-return-values',
+    code: 'let a = cy.get("foo")',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-assigning-return-values',
+    code: 'const a = cy.get("foo")',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-assigning-return-values',
+    code: 'var a = cy.get("foo")',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-assigning-return-values',
+    code: 'let a = cy.contains("foo")',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-before',
+    code: "before('a test case', async () => { cy.get('.someClass'); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-before',
+    code: "beforeEach('a test case', async () => { cy.get('.someClass'); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-before',
+    code: "before('a test case', async function () { cy.get('.someClass'); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-before',
+    code: "beforeEach('a test case', async function () { cy.get('.someClass'); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-tests',
+    code: "it('a test case', async () => { cy.get('.someClass'); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-tests',
+    code: "test('a test case', async () => { cy.get('.someClass'); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-tests',
+    code: "it('a test case', async function () { cy.get('.someClass'); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-tests',
+    code: "test('a test case', async function () { cy.get('.someClass'); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-chained-get',
+    code: "cy.get('div').get('div')",
+  },
+  { pkg: 'eslint-plugin-cypress', rule: 'no-debug', code: 'cy.debug()' },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-debug',
+    code: 'cy.debug({ log: false })',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-debug',
+    code: "cy.get('button').debug()",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-debug',
+    code: "cy.get('a').should('have.attr', 'href').and('match', /dashboard/).debug()",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-force',
+    code: "cy.get('button').click({force: true})",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-force',
+    code: "cy.get('button').dblclick({force: true})",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-force',
+    code: "cy.get('input').type('somth', {force: true})",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-force',
+    code: "cy.get('div').find('.foo').type('somth', {force: true})",
+  },
+  { pkg: 'eslint-plugin-cypress', rule: 'no-pause', code: 'cy.pause()' },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-pause',
+    code: 'cy.pause({ log: false })',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-pause',
+    code: "cy.get('button').pause()",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-pause',
+    code: "cy.get('a').should('have.attr', 'href').and('match', /dashboard/).pause()",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-unnecessary-waiting',
+    code: 'cy.wait(0)',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-unnecessary-waiting',
+    code: 'cy.wait(100)',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-unnecessary-waiting',
+    code: 'cy.wait(5000)',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-unnecessary-waiting',
+    code: 'const someNumber=500; cy.wait(someNumber)',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-xpath',
+    code: 'cy.xpath(\'//div[@class="container"]/p[1]\').click()',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-xpath',
+    code: "cy.xpath('//p[1]').should('exist')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'require-data-selectors',
+    code: "cy.get('[daedta-cy=submit]').click()",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'require-data-selectors',
+    code: "cy.get('[d-cy=submit]')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'require-data-selectors',
+    code: 'cy.get(".btn-large").click()',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'require-data-selectors',
+    code: 'cy.get(".btn-.large").click()',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'unsafe-to-chain-command',
+    code: 'cy.get("new-todo").type("todo A{enter}").should("have.class", "active");',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'unsafe-to-chain-command',
+    code: 'cy.get("new-todo").type("todo A{enter}").type("todo B{enter}");',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'unsafe-to-chain-command',
+    code: 'cy.get("new-todo").focus().should("have.class", "active");',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'unsafe-to-chain-command',
+    code: 'cy.get("new-todo").customType("todo A{enter}").customClick();',
+    options: [{ methods: ['customType', 'customClick'] }],
+  },
+];
+
+const CLEAN_CASES: DiffCase[] = [
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'assertion-before-screenshot',
+    code: 'cy.get(".some-element"); cy.screenshot();',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'assertion-before-screenshot',
+    code: 'cy.get(".some-element").should("exist").screenshot();',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'assertion-before-screenshot',
+    code: 'cy.get(".some-element").should("exist").screenshot().click()',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-and',
+    code: "cy.get('elem').should('have.text', 'blah')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-and',
+    code: "cy.get('foo').should('be.visible')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-and',
+    code: "cy.get('foo').should('be.visible').should('have.text', 'bar')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-assigning-return-values',
+    code: 'var foo = true;',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-assigning-return-values',
+    code: 'let foo = true;',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-assigning-return-values',
+    code: 'const foo = true;',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-before',
+    code: "before('a before case', () => { cy.get('.someClass'); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-before',
+    code: "before('a before case', async () => { await somethingAsync(); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-before',
+    code: 'async function nonTestFn () { return await somethingAsync(); }',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-tests',
+    code: "it('a test case', () => { cy.get('.someClass'); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-tests',
+    code: "it('a test case', async () => { await somethingAsync(); })",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-async-tests',
+    code: 'async function nonTestFn () { return await somethingAsync(); }',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-chained-get',
+    code: "cy.get('div')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-chained-get',
+    code: "cy.get('.div').find().get()",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-chained-get',
+    code: "cy.get('input').should('be.disabled')",
+  },
+  { pkg: 'eslint-plugin-cypress', rule: 'no-debug', code: 'debug()' },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-debug',
+    code: "cy.get('button').dblclick()",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-force',
+    code: "cy.get('button').click()",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-force',
+    code: "cy.get('button').click({multiple: true})",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-force',
+    code: "cy.get('button').dblclick()",
+  },
+  { pkg: 'eslint-plugin-cypress', rule: 'no-pause', code: 'pause()' },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-pause',
+    code: "cy.get('button').dblclick()",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-unnecessary-waiting',
+    code: 'foo.wait(10)',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-unnecessary-waiting',
+    code: 'cy.wait("@someRequest")',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-unnecessary-waiting',
+    code: 'cy.wait("@someRequest", { log: false })',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'no-xpath',
+    code: 'cy.get("button").click({force: true})',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'require-data-selectors',
+    code: "cy.get('[data-cy=submit]').click()",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'require-data-selectors',
+    code: "cy.get('[data-QA=submit]')",
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'require-data-selectors',
+    code: 'cy.clock(5000)',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'unsafe-to-chain-command',
+    code: 'cy.focused().should("be.visible");',
+  },
+  {
+    pkg: 'eslint-plugin-cypress',
+    rule: 'unsafe-to-chain-command',
+    code: 'cy.submitBtn().click();',
+  },
+];
+
+runConformanceSuite('eslint-plugin-cypress', CASES, CLEAN_CASES);

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
@@ -76,6 +76,7 @@ export const ALIASES: Record<string, string> = {
   '@eslint-community/eslint-plugin-eslint-comments': 'ec',
   'eslint-plugin-security': 'sec',
   'eslint-plugin-es-x': 'esx',
+  'eslint-plugin-cypress': 'cy',
 };
 
 /** Resolve + dynamically import a plugin package's live default export. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       eslint:
         specifier: 10.5.0
         version: 10.5.0(jiti@2.6.1)
+      eslint-plugin-cypress:
+        specifier: ^6.4.1
+        version: 6.4.1(@typescript-eslint/parser@8.59.0(eslint@10.5.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.5.0(jiti@2.6.1))
       eslint-plugin-es-x:
         specifier: ^9.6.0
         version: 9.6.0(eslint@10.5.0(jiti@2.6.1))
@@ -3670,6 +3673,15 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  eslint-plugin-cypress@6.4.1:
+    resolution: {integrity: sha512-8mnfR3q0Lr41Fu9SYZGeZ5nbSBgtS44+bbtSs7k0KvfoQ2pPmK43IvaTP6FGTfwBTN6S7w027CpqjrLAd65AYA==}
+    peerDependencies:
+      '@typescript-eslint/parser': '>=8'
+      eslint: '>=9'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
 
   eslint-plugin-es-x@9.6.0:
     resolution: {integrity: sha512-F74Ceu0n+EuANGyZyt9jFsawVC88rhyXXqVkKr/+9S54n5omZvUqe5yTCuAUhBk37yRCOKS45Os9IuxJpiVYGw==}
@@ -9317,6 +9329,13 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
+
+  eslint-plugin-cypress@6.4.1(@typescript-eslint/parser@8.59.0(eslint@10.5.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.5.0(jiti@2.6.1)):
+    dependencies:
+      eslint: 10.5.0(jiti@2.6.1)
+      globals: 17.6.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.0(eslint@10.5.0(jiti@2.6.1))(typescript@5.9.3)
 
   eslint-plugin-es-x@9.6.0(eslint@10.5.0(jiti@2.6.1)):
     dependencies:


### PR DESCRIPTION
## What

Mount `eslint-plugin-cypress` (v6.4.1) in rslint via the `plugins` feature and assert each rule reports identically to ESLint v10 under the differential conformance harness. **All 13 rules**, **47 trigger + 34 clean cases**, zero exclusions.

## Why so clean

Cypress's rules are AST pattern matches over `cy.*` command chains (`no-assigning-return-values`, `no-async-tests`, `unsafe-to-chain-command`, `no-force`, etc.) — no type info, no scope-heavy analysis — so rslint's plugin runner and ESLint v10 agree byte-for-byte.

## How

Triggers from the upstream test suite (v6.4.1), filtered to those rslint matches exactly (each run individually against live ESLint v10).

## Note

Part of the series adding per-plugin differential conformance for community ESLint plugins rslint hasn't natively ported.