### PR TITLE
feat(eslint-plugin-jest): add `no-confusing-set-timeout` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -6,6 +6,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/max_nested_describe"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_alias_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_commented_out_tests"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_confusing_set_timeout"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_deprecated_functions"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_disabled_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_done_callback"
@@ -42,6 +43,7 @@ func GetAllRules() []rule.Rule {
 		max_nested_describe.MaxNestedDescribeRule,
 		no_alias_methods.NoAliasMethodsRule,
 		no_commented_out_tests.NoCommentedOutTestsRule,
+		no_confusing_set_timeout.NoConfusingSetTimeoutRule,
 		no_deprecated_functions.NoDeprecatedFunctionsRule,
 		no_disabled_tests.NoDisabledTestsRule,
 		no_done_callback.NoDoneCallbackRule,

--- a/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout.go
+++ b/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout.go
@@ -1,0 +1,104 @@
+package no_confusing_set_timeout
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func buildGlobalSetTimeoutMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "globalSetTimeout",
+		Description: "`jest.setTimeout` should be call in `global` scope",
+	}
+}
+
+func buildMultipleSetTimeoutsMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "multipleSetTimeouts",
+		Description: "Do not call `jest.setTimeout` multiple times, as only the last call will have an effect",
+	}
+}
+
+func buildOrderSetTimeoutMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "orderSetTimeout",
+		Description: "`jest.setTimeout` should be placed before any other jest methods",
+	}
+}
+
+func isJestSetTimeout(jestFnCall *utils.ParsedJestFnCall) bool {
+	return jestFnCall != nil &&
+		jestFnCall.Kind == utils.JestFnTypeJest &&
+		len(jestFnCall.Members) == 1 &&
+		len(jestFnCall.MemberEntries) == 1 &&
+		jestFnCall.MemberEntries[0].Node != nil &&
+		jestFnCall.MemberEntries[0].Node.Kind == ast.KindIdentifier &&
+		jestFnCall.Members[0] == "setTimeout"
+}
+
+func isInGlobalOrModuleScope(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	return ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
+		if ast.IsFunctionLikeOrClassStaticBlockDeclaration(n) || ast.IsClassLike(n) {
+			return true
+		}
+		switch n.Kind {
+		case ast.KindBlock,
+			ast.KindCatchClause,
+			ast.KindEnumDeclaration,
+			ast.KindModuleBlock,
+			ast.KindSwitchStatement,
+			ast.KindWithStatement:
+			return true
+		case ast.KindForStatement:
+			initializer := n.AsForStatement().Initializer
+			return initializer != nil &&
+				initializer.Kind == ast.KindVariableDeclarationList &&
+				initializer.Flags&ast.NodeFlagsBlockScoped != 0
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			initializer := n.AsForInOrOfStatement().Initializer
+			return initializer != nil &&
+				initializer.Kind == ast.KindVariableDeclarationList &&
+				initializer.Flags&ast.NodeFlagsBlockScoped != 0
+		}
+		return false
+	}) == nil
+}
+
+var NoConfusingSetTimeoutRule = rule.Rule{
+	Name: "jest/no-confusing-set-timeout",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		seenJestTimeout := false
+		shouldEmitOrderSetTimeout := false
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				jestFnCall := utils.ParseJestFnCall(node, ctx)
+				if jestFnCall == nil {
+					return
+				}
+
+				if !isJestSetTimeout(jestFnCall) {
+					shouldEmitOrderSetTimeout = true
+					return
+				}
+
+				if !isInGlobalOrModuleScope(node) {
+					ctx.ReportNode(node, buildGlobalSetTimeoutMessage())
+				}
+				if shouldEmitOrderSetTimeout {
+					ctx.ReportNode(node, buildOrderSetTimeoutMessage())
+				}
+				if seenJestTimeout {
+					ctx.ReportNode(node, buildMultipleSetTimeoutsMessage())
+				}
+
+				seenJestTimeout = true
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout.md
+++ b/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout.md
@@ -1,0 +1,83 @@
+# no-confusing-set-timeout
+
+## Rule Details
+
+Disallow confusing usages of `jest.setTimeout`. In a single test file Jest applies only the **last** `jest.setTimeout` call that runs **before** any tests execute; later calls and calls inside suites or cases do not change the timeout the way many authors expect. This rule flags patterns that look file- or suite-specific but are misleading.
+
+rslint walks each Jest API call site (including `jest` imported from `@jest/globals` and renamed bindings such as `Jest.setTimeout`). For every `jest.setTimeout` call it may report:
+
+- **`globalSetTimeout`**: the call is not at module/global top level (for example inside a `describe` / `test` / `it` callback, a `beforeEach` body, a block statement, or a class).
+- **`orderSetTimeout`**: another Jest API (`describe`, `test`, `it`, hooks, `expect`, and so on) appears **earlier** in the same file.
+- **`multipleSetTimeouts`**: `jest.setTimeout` is invoked more than once in the file (only the last pre-test call matters to Jest).
+
+Plain `setTimeout` and `window.setTimeout` are not checked.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+describe('test foo', () => {
+  jest.setTimeout(1000);
+  it('test-description', () => {
+    // test logic
+  });
+});
+
+describe('test bar', () => {
+  it('test-description', () => {
+    jest.setTimeout(1000);
+    // test logic
+  });
+});
+
+test('foo-bar', () => {
+  jest.setTimeout(1000);
+});
+
+describe('unit test', () => {
+  beforeEach(() => {
+    jest.setTimeout(1000);
+  });
+});
+
+jest.setTimeout(1000);
+describe('suite', () => {
+  it('case', () => {});
+});
+jest.setTimeout(800);
+
+jest.setTimeout(800);
+jest.setTimeout(900);
+
+import { jest } from '@jest/globals';
+{
+  jest.setTimeout(800);
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+jest.setTimeout(500);
+test('test test', () => {
+  // do some stuff
+});
+```
+
+```javascript
+jest.setTimeout(1000);
+describe('test bar bar', () => {
+  it('test-description', () => {
+    // test logic
+  });
+});
+```
+
+```javascript
+jest.setTimeout(1000);
+window.setTimeout(60000);
+setTimeout(1000);
+```
+
+## Original Documentation
+
+- [jest/no-confusing-set-timeout](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-confusing-set-timeout.md)

--- a/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout_test.go
+++ b/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout_test.go
@@ -1,0 +1,252 @@
+package no_confusing_set_timeout_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_confusing_set_timeout"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoConfusingSetTimeoutRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_confusing_set_timeout.NoConfusingSetTimeoutRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `
+      jest.setTimeout(1000);
+      describe('A', () => {
+        beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+      });
+    `},
+			{Code: `
+      jest.setTimeout(1000);
+      window.setTimeout(6000)
+      describe('A', () => {
+        beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('test foo', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+      });
+    `},
+			{Code: `
+        import { handler } from 'dep/mod';
+        jest.setTimeout(800);
+        describe('A', () => {
+          beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        });
+      `},
+			{Code: `
+      function handler() {}
+      jest.setTimeout(800);
+      describe('A', () => {
+        beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+      });
+    `},
+			{Code: `
+      const { handler } = require('dep/mod');
+      jest.setTimeout(800);
+      describe('A', () => {
+        beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+      });
+    `},
+			{Code: `
+      jest.setTimeout(1000);
+      window.setTimeout(60000);
+    `},
+			{Code: `window.setTimeout(60000);`},
+			{Code: `setTimeout(1000);`},
+			{Code: `
+      jest.setTimeout(1000);
+      test('test case', () => {
+        setTimeout(() => {
+          Promise.resolv();
+        }, 5000);
+      });
+    `},
+			{Code: `
+      test('test case', () => {
+        setTimeout(() => {
+          Promise.resolv();
+        }, 5000);
+      });
+    `},
+			{Code: `
+      jest['setTimeout'](1000);
+      describe('A', () => {
+        it('A.1', () => {});
+      });
+    `},
+			{Code: `for (var i = 0; i < 1; i++) jest.setTimeout(1000);`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `
+        jest.setTimeout(1000);
+        setTimeout(1000);
+        window.setTimeout(1000);
+        describe('A', () => {
+          beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        });
+        jest.setTimeout(800);
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "orderSetTimeout", Line: 10, Column: 9},
+					{MessageId: "multipleSetTimeouts", Line: 10, Column: 9},
+				},
+			},
+			{
+				Code: `
+        describe('A', () => {
+          jest.setTimeout(800);
+          beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 3, Column: 11},
+					{MessageId: "orderSetTimeout", Line: 3, Column: 11},
+				},
+			},
+			{
+				Code: `
+        describe('B', () => {
+          it('B.1', async () => {
+            await new Promise((resolve) => {
+              jest.setTimeout(1000);
+              setTimeout(resolve, 10000).unref();
+            });
+          });
+          it('B.2', async () => {
+            await new Promise((resolve) => { setTimeout(resolve, 10000).unref(); });
+          });
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 5, Column: 15},
+					{MessageId: "orderSetTimeout", Line: 5, Column: 15},
+				},
+			},
+			{
+				Code: `
+        test('test-suite', () => {
+          jest.setTimeout(1000);
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 3, Column: 11},
+					{MessageId: "orderSetTimeout", Line: 3, Column: 11},
+				},
+			},
+			{
+				Code: `
+        describe('A', () => {
+          beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        });
+        jest.setTimeout(1000);
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "orderSetTimeout", Line: 7, Column: 9},
+				},
+			},
+			{
+				Code: `
+        import { jest } from '@jest/globals';
+        {
+          jest.setTimeout(800);
+        }
+        describe('A', () => {
+          beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        });
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 4, Column: 11},
+				},
+			},
+			{
+				Code: `
+        jest.setTimeout(800);
+        jest.setTimeout(900);
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSetTimeouts", Line: 3, Column: 9},
+				},
+			},
+			{
+				Code: `
+        expect(1 + 2).toEqual(3);
+        jest.setTimeout(800);
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "orderSetTimeout", Line: 3, Column: 9},
+				},
+			},
+			{
+				Code: `
+        import { jest as Jest } from '@jest/globals';
+        {
+          Jest.setTimeout(800);
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 4, Column: 11},
+				},
+			},
+			{
+				Code: `
+        namespace JestScope {
+          jest.setTimeout(800);
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 3, Column: 11},
+				},
+			},
+			{
+				Code: "for (let i = 0; i < 1; i++) {\n  jest.setTimeout(1000);\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 2, Column: 3},
+				},
+			},
+			{
+				Code: "for (const value of values) jest.setTimeout(1000);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: "switch (value) {\n  case 1:\n    jest.setTimeout(1000);\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 3, Column: 5},
+				},
+			},
+			{
+				Code: "try {} catch ({ value = jest.setTimeout(1000) }) {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: "enum Timeout {\n  Value = jest.setTimeout(1000),\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalSetTimeout", Line: 2, Column: 11},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -451,6 +451,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/max-nested-describe.test.ts',
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',
     './tests/eslint-plugin-jest/rules/no-commented-out-tests.test.ts',
+    './tests/eslint-plugin-jest/rules/no-confusing-set-timeout.test.ts',
     './tests/eslint-plugin-jest/rules/no-deprecated-functions.test.ts',
     './tests/eslint-plugin-jest/rules/no-disabled-tests.test.ts',
     './tests/eslint-plugin-jest/rules/no-done-callback.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-confusing-set-timeout.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-confusing-set-timeout.test.ts
@@ -1,0 +1,261 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-confusing-set-timeout', {} as never, {
+  valid: [
+    {
+      code: `
+      jest.setTimeout(1000);
+      describe('A', () => {
+        beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+      });
+    `,
+    },
+    {
+      code: `
+      jest.setTimeout(1000);
+      window.setTimeout(6000)
+      describe('A', () => {
+        beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('test foo', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+      });
+    `,
+    },
+    {
+      code: `
+        import { handler } from 'dep/mod';
+        jest.setTimeout(800);
+        describe('A', () => {
+          beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        });
+      `,
+    },
+    {
+      code: `
+      function handler() {}
+      jest.setTimeout(800);
+      describe('A', () => {
+        beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+      });
+    `,
+    },
+    {
+      code: `
+      const { handler } = require('dep/mod');
+      jest.setTimeout(800);
+      describe('A', () => {
+        beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+      });
+    `,
+    },
+    {
+      code: `
+      jest.setTimeout(1000);
+      window.setTimeout(60000);
+    `,
+    },
+    { code: 'window.setTimeout(60000);' },
+    { code: 'setTimeout(1000);' },
+    {
+      code: `
+      jest.setTimeout(1000);
+      test('test case', () => {
+        setTimeout(() => {
+          Promise.resolv();
+        }, 5000);
+      });
+    `,
+    },
+    {
+      code: `
+      test('test case', () => {
+        setTimeout(() => {
+          Promise.resolv();
+        }, 5000);
+      });
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        jest.setTimeout(1000);
+        setTimeout(1000);
+        window.setTimeout(1000);
+        describe('A', () => {
+          beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        });
+        jest.setTimeout(800);
+      `,
+      errors: [
+        {
+          messageId: 'orderSetTimeout',
+          line: 9,
+          column: 1,
+        },
+        {
+          messageId: 'multipleSetTimeouts',
+          line: 9,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        describe('A', () => {
+          jest.setTimeout(800);
+          beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        });
+      `,
+      errors: [
+        {
+          messageId: 'globalSetTimeout',
+          line: 2,
+          column: 3,
+        },
+        {
+          messageId: 'orderSetTimeout',
+          line: 2,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        describe('B', () => {
+          it('B.1', async () => {
+            await new Promise((resolve) => {
+              jest.setTimeout(1000);
+              setTimeout(resolve, 10000).unref();
+            });
+          });
+          it('B.2', async () => {
+            await new Promise((resolve) => { setTimeout(resolve, 10000).unref(); });
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'globalSetTimeout',
+          line: 4,
+          column: 7,
+        },
+        {
+          messageId: 'orderSetTimeout',
+          line: 4,
+          column: 7,
+        },
+      ],
+    },
+    {
+      code: `
+        test('test-suite', () => {
+          jest.setTimeout(1000);
+        });
+      `,
+      errors: [
+        {
+          messageId: 'globalSetTimeout',
+          line: 2,
+          column: 3,
+        },
+        {
+          messageId: 'orderSetTimeout',
+          line: 2,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        describe('A', () => {
+          beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        });
+        jest.setTimeout(1000);
+      `,
+      errors: [
+        {
+          messageId: 'orderSetTimeout',
+          line: 6,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        import { jest } from '@jest/globals';
+        {
+          jest.setTimeout(800);
+        }
+        describe('A', () => {
+          beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.1', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+          it('A.2', async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
+        });
+      `,
+      errors: [
+        {
+          messageId: 'globalSetTimeout',
+          line: 3,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        jest.setTimeout(800);
+        jest.setTimeout(900);
+      `,
+      errors: [
+        {
+          messageId: 'multipleSetTimeouts',
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        expect(1 + 2).toEqual(3);
+        jest.setTimeout(800);
+      `,
+      errors: [
+        {
+          messageId: 'orderSetTimeout',
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        import { jest as Jest } from '@jest/globals';
+        {
+          Jest.setTimeout(800);
+        }
+      `,
+      errors: [
+        {
+          messageId: 'globalSetTimeout',
+          line: 3,
+          column: 3,
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -585,3 +585,5 @@ pollable
 unpark
 acked
 backgrounded
+resolv
+unref


### PR DESCRIPTION
## Summary

Port `no-confusing-set-timeout` from eslint-plugin-jest to rslint

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/no-confusing-set-timeout [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-confusing-set-timeout.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/no-confusing-set-timeout.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
