### PR TITLE
test: deflake worker-pool R4 onLog forwarding assertion

### DIFF
--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-multiconfig.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-multiconfig.test.ts
@@ -335,19 +335,40 @@ export default [{ plugins: { r4: p } }];
           },
         ]);
 
-        // The forwarded log line must contain the rule name + a hint at
-        // the failure path. Pre-R4 the string went to raw stderr and
-        // logs would not contain it.
-        const errLogs = logs.filter((r) => r.level === 'error');
-        const matched = errLogs.find((r) =>
-          /r4\/bad-fix.*fix\(\) threw.*R4_FIX_BOOM/.test(r.text),
-        );
+        // The forwarded error log rides the worker's stderr STREAM
+        // (spawnWorker wires `stderr.on('data')` to onLog), delivered
+        // INDEPENDENTLY of the `result` message that resolves lintBatch
+        // above: two separate async channels with no ordering guarantee,
+        // so the log chunk can still be in flight when the await settles
+        // (reliably so on Windows, where pipe scheduling differs from
+        // Linux). Drive the worker to exit first — shutdown() posts
+        // {kind:'shutdown'} → parentPort.close() → stderr EOF →
+        // flushOnEnd, forcing every buffered chunk out regardless of pipe
+        // buffering — then poll to absorb the residual gap between the
+        // worker's 'exit' (which shutdown awaits) and the host stream
+        // draining its final 'data' events.
+        await pool.shutdown();
+        // The forwarded line must carry the rule name + a failure-path
+        // hint; pre-R4 it went to raw stderr and never reached `logs`.
+        const findMatch = () =>
+          logs
+            .filter((r) => r.level === 'error')
+            .find((r) =>
+              /r4\/bad-fix.*fix\(\) threw.*R4_FIX_BOOM/.test(r.text),
+            );
+        let matched = findMatch();
+        for (let i = 0; !matched && i < 200; i++) {
+          await new Promise((r) => setTimeout(r, 10));
+          matched = findMatch();
+        }
         expect(matched).toBeDefined();
         // Source must be 'plugin' (runner-side console.error from
-        // diagnostic-builder running inside the worker, fed through the
-        // patched console).
+        // diagnostic-builder running inside the worker, forwarded through
+        // the worker's captured stderr stream).
         expect(matched!.source).toBe('plugin');
       } finally {
+        // Idempotent (this.closed guard) — the in-body shutdown already
+        // ran on the happy path; this also covers an early throw before it.
         await pool.shutdown();
         await Promise.all([
           fs.rm(pluginPath, { force: true }),


### PR DESCRIPTION
## Problem

`worker-pool-e2e-multiconfig.test.ts` → R4 ("rule fix() throw is forwarded through onLog") flakes on **windows-latest** with `expected undefined to be defined`.

The forwarded error log rides the worker's **stderr stream** (`spawnWorker`: `stderr.on('data')` → `onLog`), which is delivered **independently** of the `result` message that resolves `lintBatch` — two async channels with no ordering guarantee. The test asserted on `logs` synchronously right after `await lintBatch`, so on Windows (where pipe scheduling differs) the stderr chunk is still in flight at assert time → `logs` empty → flake.

## Fix (test-only)

Drive the worker to exit first — `shutdown()` → `parentPort.close()` → stderr EOF → `flushOnEnd` — forcing every buffered chunk out regardless of pipe buffering, then poll until the line appears (absorbs the residual gap between the worker's `'exit'`, which `shutdown` awaits, and the host stream draining its final `'data'` events).

## Verified locally

Injected a delay into stderr forwarding to reproduce the Windows timing:

| | result |
|---|---|
| original assertion + 200ms delay | **fail** (same `expected undefined`) |
| shutdown+poll + 200ms delay | **pass** |
| shutdown+poll + 500ms delay | **pass** |

No-delay run: 4/4 pass.

## Scope

Test-only timing fix. The product path is unchanged: lint results (diagnostics/fixes) travel the result message and are correct; the error log is an intentionally async best-effort stderr forward (`lint-worker.ts` deliberately leaves plugin `console.*` unpatched). Also drops a stale comment that referred to the old "patched console" mechanism.