### PR TITLE
feat(eslint-plugin-jest): add `no-export` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_disabled_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_done_callback"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_duplicate_hooks"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_export"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_focused_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_hooks"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_identical_title"
@@ -49,6 +50,7 @@ func GetAllRules() []rule.Rule {
 		no_disabled_tests.NoDisabledTestsRule,
 		no_done_callback.NoDoneCallbackRule,
 		no_duplicate_hooks.NoDuplicateHooksRule,
+		no_export.NoExportRule,
 		no_focused_tests.NoFocusedTestsRule,
 		no_hooks.NoHooksRule,
 		no_identical_title.NoIdenticalTitleRule,

--- a/internal/plugins/jest/rules/no_export/no_export.go
+++ b/internal/plugins/jest/rules/no_export/no_export.go
@@ -1,0 +1,114 @@
+package no_export
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	rslintutils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildUnexpectedExportMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpectedExport",
+		Description: "Do not export from a test file",
+	}
+}
+
+func isModuleExportsMemberExpression(node *ast.Node, ctx rule.RuleContext) bool {
+	if node == nil || !utils.IsMemberAccessNode(node) {
+		return false
+	}
+
+	current := node
+	innermostProperty := ""
+	for utils.IsMemberAccessNode(current) {
+		property, ok := rslintutils.AccessExpressionStaticName(current)
+		if !ok {
+			return false
+		}
+		innermostProperty = property
+		current = ast.SkipParentheses(rslintutils.AccessExpressionObject(current))
+	}
+
+	if current == nil || current.Kind != ast.KindIdentifier ||
+		current.AsIdentifier().Text != "module" || innermostProperty != "exports" {
+		return false
+	}
+
+	// A locally declared variable or parameter named `module` shadows the
+	// CommonJS global and must not be treated as an export target.
+	if ctx.TypeChecker != nil {
+		if symbol := ctx.TypeChecker.GetSymbolAtLocation(current); symbol != nil {
+			for _, declaration := range symbol.Declarations {
+				if ast.GetSourceFileOfNode(declaration) == ctx.SourceFile {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+func hasExportModifier(node *ast.Node) bool {
+	return ast.HasSyntacticModifier(node, ast.ModifierFlagsExport)
+}
+
+var NoExportRule = rule.Rule{
+	Name: "jest/no-export",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		_ = options
+		exportNodes := make([]*ast.Node, 0)
+		hasJestBlock := false
+
+		collectExport := func(node *ast.Node) {
+			exportNodes = append(exportNodes, node)
+		}
+
+		collectExportStatement := func(node *ast.Node) {
+			if hasExportModifier(node) {
+				collectExport(node)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				if utils.IsTypeOfJestFnCall(node, ctx, utils.JestFnTypeDescribe, utils.JestFnTypeTest) {
+					hasJestBlock = true
+				}
+			},
+			ast.KindVariableStatement:       collectExportStatement,
+			ast.KindFunctionDeclaration:     collectExportStatement,
+			ast.KindClassDeclaration:        collectExportStatement,
+			ast.KindInterfaceDeclaration:    collectExportStatement,
+			ast.KindTypeAliasDeclaration:    collectExportStatement,
+			ast.KindEnumDeclaration:         collectExportStatement,
+			ast.KindModuleDeclaration:       collectExportStatement,
+			ast.KindImportEqualsDeclaration: collectExportStatement,
+			ast.KindExportDeclaration:       collectExport,
+			ast.KindExportAssignment:        collectExport,
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				bin := node.AsBinaryExpression()
+				if bin == nil || bin.OperatorToken == nil || !ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
+					return
+				}
+
+				for _, operand := range []*ast.Node{bin.Left, bin.Right} {
+					operand = ast.SkipParentheses(operand)
+					if operand != nil && isModuleExportsMemberExpression(operand, ctx) {
+						collectExport(operand)
+					}
+				}
+			},
+			rule.ListenerOnExit(ast.KindEndOfFile): func(node *ast.Node) {
+				_ = node
+				if !hasJestBlock || len(exportNodes) == 0 {
+					return
+				}
+				for _, exportNode := range exportNodes {
+					ctx.ReportNode(exportNode, buildUnexpectedExportMessage())
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/no_export/no_export.go
+++ b/internal/plugins/jest/rules/no_export/no_export.go
@@ -14,40 +14,46 @@ func buildUnexpectedExportMessage() rule.RuleMessage {
 	}
 }
 
-func isModuleExportsMemberExpression(node *ast.Node, ctx rule.RuleContext) bool {
+func isLocallyDeclaredIdentifier(node *ast.Node, ctx rule.RuleContext) bool {
+	if ctx.TypeChecker == nil {
+		return false
+	}
+	if symbol := ctx.TypeChecker.GetSymbolAtLocation(node); symbol != nil {
+		for _, declaration := range symbol.Declarations {
+			if ast.GetSourceFileOfNode(declaration) == ctx.SourceFile {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isCommonJSExportsMemberExpression(node *ast.Node, ctx rule.RuleContext) bool {
 	if node == nil || !utils.IsMemberAccessNode(node) {
 		return false
 	}
 
 	current := node
 	innermostProperty := ""
+	innermostPropertyKnown := false
 	for utils.IsMemberAccessNode(current) {
-		property, ok := rslintUtils.AccessExpressionStaticName(current)
-		if !ok {
-			return false
-		}
-		innermostProperty = property
+		innermostProperty, innermostPropertyKnown = rslintUtils.AccessExpressionStaticName(current)
 		current = ast.SkipParentheses(rslintUtils.AccessExpressionObject(current))
 	}
 
-	if current == nil || current.Kind != ast.KindIdentifier ||
-		current.AsIdentifier().Text != "module" || innermostProperty != "exports" {
+	if current == nil || current.Kind != ast.KindIdentifier {
 		return false
 	}
 
-	// A locally declared variable or parameter named `module` shadows the
-	// CommonJS global and must not be treated as an export target.
-	if ctx.TypeChecker != nil {
-		if symbol := ctx.TypeChecker.GetSymbolAtLocation(current); symbol != nil {
-			for _, declaration := range symbol.Declarations {
-				if ast.GetSourceFileOfNode(declaration) == ctx.SourceFile {
-					return false
-				}
-			}
-		}
+	switch current.AsIdentifier().Text {
+	case "exports":
+		return !isLocallyDeclaredIdentifier(current, ctx)
+	case "module":
+		return innermostPropertyKnown && innermostProperty == "exports" &&
+			!isLocallyDeclaredIdentifier(current, ctx)
+	default:
+		return false
 	}
-
-	return true
 }
 
 func hasExportModifier(node *ast.Node) bool {
@@ -95,7 +101,7 @@ var NoExportRule = rule.Rule{
 
 				for _, operand := range []*ast.Node{bin.Left, bin.Right} {
 					operand = ast.SkipParentheses(operand)
-					if operand != nil && isModuleExportsMemberExpression(operand, ctx) {
+					if operand != nil && isCommonJSExportsMemberExpression(operand, ctx) {
 						collectExport(operand)
 					}
 				}

--- a/internal/plugins/jest/rules/no_export/no_export.go
+++ b/internal/plugins/jest/rules/no_export/no_export.go
@@ -4,7 +4,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	rslintutils "github.com/web-infra-dev/rslint/internal/utils"
+	rslintUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func buildUnexpectedExportMessage() rule.RuleMessage {
@@ -22,12 +22,12 @@ func isModuleExportsMemberExpression(node *ast.Node, ctx rule.RuleContext) bool 
 	current := node
 	innermostProperty := ""
 	for utils.IsMemberAccessNode(current) {
-		property, ok := rslintutils.AccessExpressionStaticName(current)
+		property, ok := rslintUtils.AccessExpressionStaticName(current)
 		if !ok {
 			return false
 		}
 		innermostProperty = property
-		current = ast.SkipParentheses(rslintutils.AccessExpressionObject(current))
+		current = ast.SkipParentheses(rslintUtils.AccessExpressionObject(current))
 	}
 
 	if current == nil || current.Kind != ast.KindIdentifier ||

--- a/internal/plugins/jest/rules/no_export/no_export.md
+++ b/internal/plugins/jest/rules/no_export/no_export.md
@@ -1,0 +1,52 @@
+# no-export
+
+## Rule Details
+
+Disallow exporting from files that contain Jest tests or suites. If a file has at least one `test` or `describe` (including equivalent aliases and chained forms), this rule reports any export in that file.
+
+Exporting from a test file is risky because importing that file runs its tests again in every consumer. That can duplicate test runs, slow down suites, and make failures harder to trace. Move shared helpers into a separate non-test module instead.
+
+This rule checks:
+
+- ES module exports (`export const`, `export default`, `export =`, and other `export` forms)
+- CommonJS-style assignments rooted at `module.exports` (including `module["exports"]` and deeply nested properties)
+
+Locally declared variables or parameters named `module` are not treated as the CommonJS global. Files that export but contain no Jest tests or suites are allowed.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+export function myHelper() {}
+
+module.exports = function () {};
+
+module.exports = {
+  something: 'that should be moved to a non-test file',
+};
+
+describe('a test', () => {
+  expect(1).toBe(1);
+});
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function myHelper() {}
+
+const myThing = {
+  something: 'that can live here',
+};
+
+describe('a test', () => {
+  expect(1).toBe(1);
+});
+```
+
+## When Not To Use It
+
+Do not enable this rule on files that are not Jest test files. For shared test utilities that must export helpers, either disable the rule for those files or keep helpers in a dedicated module that does not define tests.
+
+## Original Documentation
+
+- [jest/no-export](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md)

--- a/internal/plugins/jest/rules/no_export/no_export_test.go
+++ b/internal/plugins/jest/rules/no_export/no_export_test.go
@@ -26,6 +26,8 @@ func TestNoExportRule(t *testing.T) {
 			{Code: `const exports = "exports"; module[exports] = {}; test("a test", () => {});`},
 			{Code: `const module = { exports: {} }; module.exports.foo = "valid"; test("a test", () => {});`},
 			{Code: `const run = (module: { exports: object }) => { module.exports.foo = "valid" }; test("a test", () => {});`},
+			{Code: `const exports = { foo: "" }; exports.foo = "valid"; test("a test", () => {});`},
+			{Code: `const run = (exports: { foo: string }) => { exports.foo = "valid" }; test("a test", () => {});`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
@@ -116,6 +118,18 @@ test.only.each` + "`" + "`('my code', () => {\n  expect(1).toBe(1);\n});\n",
 				Code: `value = module.exports; test("a test", () => {});`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpectedExport", Line: 1, Column: 9, EndColumn: 23},
+				},
+			},
+			{
+				Code: `exports.foo = "invalid"; test("a test", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code: `exports["foo"].bar = "invalid"; test("a test", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 19},
 				},
 			},
 			{

--- a/internal/plugins/jest/rules/no_export/no_export_test.go
+++ b/internal/plugins/jest/rules/no_export/no_export_test.go
@@ -1,0 +1,135 @@
+package no_export_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_export"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoExportRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_export.NoExportRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `describe("a test", () => { expect(1).toBe(1); })`},
+			{Code: `window.location = "valid"`},
+			{Code: `module.somethingElse = "foo";`},
+			{Code: `export const myThing = "valid"`},
+			{Code: `export default function () {}`},
+			{Code: `module.exports = function(){}`},
+			{Code: `module.exports.myThing = "valid";`},
+			{Code: `module.export.foo = "valid"; test("a test", () => {});`},
+			{Code: `const exports = "exports"; module[exports] = {}; test("a test", () => {});`},
+			{Code: `const module = { exports: {} }; module.exports.foo = "valid"; test("a test", () => {});`},
+			{Code: `const run = (module: { exports: object }) => { module.exports.foo = "valid" }; test("a test", () => {});`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `export const myThing = "invalid"; test("a test", () => { expect(1).toBe(1);});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code: `
+export const myThing = 'invalid';
+
+test.each()('my code', () => {
+  expect(1).toBe(1);
+});
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 2, Column: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code: `
+export const myThing = 'invalid';
+
+test.each` + "`" + "`('my code', () => {\n  expect(1).toBe(1);\n});\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 2, Column: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code: `
+export const myThing = 'invalid';
+
+test.only.each` + "`" + "`('my code', () => {\n  expect(1).toBe(1);\n});\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 2, Column: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code: `export default function() {};  test("a test", () => { expect(1).toBe(1);});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 29},
+				},
+			},
+			{
+				Code: `export = function() {}; test("a test", () => { expect(1).toBe(1);});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code: `module.exports["invalid"] = function() {};  test("a test", () => { expect(1).toBe(1);});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code: `module.exports = function() {}; ;  test("a test", () => { expect(1).toBe(1);});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code: `module["exports"] = function() {}; test("a test", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code: "module[`exports`].foo = function() {}; test(\"a test\", () => {});",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 22},
+				},
+			},
+			{
+				Code: `module.exports.foo.bar = function() {}; test("a test", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code: `module.exports ||= {}; test("a test", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code: `value = module.exports; test("a test", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 9, EndColumn: 23},
+				},
+			},
+			{
+				Code: `export import foo = require("./foo"); test("a test", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 38},
+				},
+			},
+			{
+				Code: `export const myThing = "invalid"; describe("a suite", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedExport", Line: 1, Column: 1, EndColumn: 34},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -473,6 +473,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/no-deprecated-functions.test.ts',
     './tests/eslint-plugin-jest/rules/no-disabled-tests.test.ts',
     './tests/eslint-plugin-jest/rules/no-done-callback.test.ts',
+    './tests/eslint-plugin-jest/rules/no-export.test.ts',
     './tests/eslint-plugin-jest/rules/no-focused-tests.test.ts',
     './tests/eslint-plugin-jest/rules/no-hooks.test.ts',
     './tests/eslint-plugin-jest/rules/no-identical-title.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-export.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-export.test.ts
@@ -21,6 +21,12 @@ ruleTester.run('no-export', {} as never, {
     {
       code: 'const run = (module: { exports: object }) => { module.exports.foo = "valid" }; test("a test", () => {});',
     },
+    {
+      code: 'const exports = { foo: "" }; exports.foo = "valid"; test("a test", () => {});',
+    },
+    {
+      code: 'const run = (exports: { foo: string }) => { exports.foo = "valid" }; test("a test", () => {});',
+    },
   ],
   invalid: [
     {
@@ -92,6 +98,14 @@ ruleTester.run('no-export', {} as never, {
     {
       code: 'value = module.exports; test("a test", () => {});',
       errors: [{ endColumn: 23, column: 9, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'exports.foo = "invalid"; test("a test", () => {});',
+      errors: [{ endColumn: 12, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'exports["foo"].bar = "invalid"; test("a test", () => {});',
+      errors: [{ endColumn: 19, column: 1, messageId: 'unexpectedExport' }],
     },
     {
       code: 'export import foo = require("./foo"); test("a test", () => {});',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-export.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-export.test.ts
@@ -1,0 +1,105 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-export', {} as never, {
+  valid: [
+    { code: 'describe("a test", () => { expect(1).toBe(1); })' },
+    { code: 'window.location = "valid"' },
+    { code: 'module.somethingElse = "foo";' },
+    { code: 'export const myThing = "valid"' },
+    { code: 'export default function () {}' },
+    { code: 'module.exports = function(){}' },
+    { code: 'module.exports.myThing = "valid";' },
+    { code: 'module.export.foo = "valid"; test("a test", () => {});' },
+    {
+      code: 'const exports = "exports"; module[exports] = {}; test("a test", () => {});',
+    },
+    {
+      code: 'const module = { exports: {} }; module.exports.foo = "valid"; test("a test", () => {});',
+    },
+    {
+      code: 'const run = (module: { exports: object }) => { module.exports.foo = "valid" }; test("a test", () => {});',
+    },
+  ],
+  invalid: [
+    {
+      code: 'export const myThing = "invalid"; test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: `
+        export const myThing = 'invalid';
+
+        test.each()('my code', () => {
+          expect(1).toBe(1);
+        });
+      `,
+      errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: `
+        export const myThing = 'invalid';
+
+        test.each\`\`('my code', () => {
+          expect(1).toBe(1);
+        });
+      `,
+      errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: `
+        export const myThing = 'invalid';
+
+        test.only.each\`\`('my code', () => {
+          expect(1).toBe(1);
+        });
+      `,
+      errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'export default function() {};  test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 29, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'export = function() {}; test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 24, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'module.exports["invalid"] = function() {};  test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 26, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'module.exports = function() {}; ;  test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 15, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'module["exports"] = function() {}; test("a test", () => {});',
+      errors: [{ endColumn: 18, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'module[`exports`].foo = function() {}; test("a test", () => {});',
+      errors: [{ endColumn: 22, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'module.exports.foo.bar = function() {}; test("a test", () => {});',
+      errors: [{ endColumn: 23, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'module.exports ||= {}; test("a test", () => {});',
+      errors: [{ endColumn: 15, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'value = module.exports; test("a test", () => {});',
+      errors: [{ endColumn: 23, column: 9, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'export import foo = require("./foo"); test("a test", () => {});',
+      errors: [{ endColumn: 38, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'export const myThing = "invalid"; describe("a suite", () => {});',
+      errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedExport' }],
+    },
+  ],
+});

--- a/packages/rslint/src/configs/jest.ts
+++ b/packages/rslint/src/configs/jest.ts
@@ -12,7 +12,7 @@ const recommended: RslintConfigEntry = {
     'jest/no-deprecated-functions': 'error',
     'jest/no-disabled-tests': 'warn',
     'jest/no-done-callback': 'error',
-    // 'jest/no-export': 'error', // not implemented
+    'jest/no-export': 'error',
     'jest/no-focused-tests': 'error',
     'jest/no-identical-title': 'error',
     // 'jest/no-interpolation-in-snapshots': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `no-export` from eslint-plugin-jest to rslint

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/no-export [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-export.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/no-export.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
