### PR TITLE
feat: port rule arrow-body-style

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rules/accessor_pairs"
 	"github.com/web-infra-dev/rslint/internal/rules/array_callback_return"
+	"github.com/web-infra-dev/rslint/internal/rules/arrow_body_style"
 	"github.com/web-infra-dev/rslint/internal/rules/complexity"
 	"github.com/web-infra-dev/rslint/internal/rules/constructor_super"
 	"github.com/web-infra-dev/rslint/internal/rules/default_case"
@@ -133,6 +134,7 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		accessor_pairs.AccessorPairsRule,
 		array_callback_return.ArrayCallbackReturnRule,
+		arrow_body_style.ArrowBodyStyleRule,
 		complexity.ComplexityRule,
 		constructor_super.ConstructorSuperRule,
 		default_case.DefaultCaseRule,

--- a/internal/rules/arrow_body_style/arrow_body_style.go
+++ b/internal/rules/arrow_body_style/arrow_body_style.go
@@ -1,0 +1,372 @@
+package arrow_body_style
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// arrow-body-style enforces or disallows braces around arrow function bodies.
+// https://eslint.org/docs/latest/rules/arrow-body-style
+
+const (
+	styleAlways   = "always"
+	styleAsNeeded = "as-needed"
+	styleNever    = "never"
+)
+
+type options struct {
+	style                         string
+	requireReturnForObjectLiteral bool
+}
+
+func parseOptions(opts any) options {
+	o := options{style: styleAsNeeded}
+	if arr, ok := opts.([]interface{}); ok {
+		if len(arr) > 0 {
+			if s, ok := arr[0].(string); ok && s != "" {
+				o.style = s
+			}
+		}
+		if len(arr) > 1 {
+			if m, ok := arr[1].(map[string]interface{}); ok {
+				if v, ok := m["requireReturnForObjectLiteral"].(bool); ok {
+					o.requireReturnForObjectLiteral = v
+				}
+			}
+		}
+	} else if s, ok := opts.(string); ok && s != "" {
+		o.style = s
+	}
+	return o
+}
+
+func msgExpectedBlock() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "expectedBlock",
+		Description: "Expected block statement surrounding arrow body.",
+	}
+}
+
+func msgUnexpectedOtherBlock() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpectedOtherBlock",
+		Description: "Unexpected block statement surrounding arrow body.",
+	}
+}
+
+func msgUnexpectedEmptyBlock() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpectedEmptyBlock",
+		Description: "Unexpected block statement surrounding arrow body; put a value of `undefined` immediately after the `=>`.",
+	}
+}
+
+func msgUnexpectedObjectBlock() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpectedObjectBlock",
+		Description: "Unexpected block statement surrounding arrow body; parenthesize the returned value and move it immediately after the `=>`.",
+	}
+}
+
+func msgUnexpectedSingleBlock() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpectedSingleBlock",
+		Description: "Unexpected block statement surrounding arrow body; move the returned value immediately after the `=>`.",
+	}
+}
+
+// isInsideForLoopInitializer reports whether node sits inside the init clause of
+// an enclosing `for` statement. Mirrors upstream's recursive parent walk.
+func isInsideForLoopInitializer(node *ast.Node) bool {
+	return ast.FindAncestor(node, func(n *ast.Node) bool {
+		p := n.Parent
+		return p != nil && p.Kind == ast.KindForStatement && p.AsForStatement().Initializer == n
+	}) != nil
+}
+
+// subtreeHasInOperator reports whether node's subtree contains an `in`
+// BinaryExpression. Upstream tracks this with a funcInfo stack that the
+// `BinaryExpression[operator='in']` listener flags up the ancestor chain; an
+// arrow's flag ends up true exactly when its subtree holds an `in`, so a direct
+// subtree walk is equivalent.
+func subtreeHasInOperator(node *ast.Node) bool {
+	found := false
+	var visit func(n *ast.Node)
+	visit = func(n *ast.Node) {
+		if found || n == nil {
+			return
+		}
+		if n.Kind == ast.KindBinaryExpression {
+			if bin := n.AsBinaryExpression(); bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindInKeyword {
+				found = true
+				return
+			}
+		}
+		n.ForEachChild(func(c *ast.Node) bool {
+			visit(c)
+			return found
+		})
+	}
+	visit(node)
+	return found
+}
+
+// hasASIProblemAfter reports whether the first token at/after pos would fuse
+// with an unbraced body once the braces are removed. Upstream guards punctuators
+// starting with one of `([/+-`; backticks are template tokens (not punctuators),
+// so they are excluded.
+//
+// NOTE: Unlike ESLint, we keep `/` as a hazard. ESLint tokenizes a `/` after the
+// arrow block `}` as a regex literal and applies the fix; tsgo tokenizes the same
+// `/` as division, so the de-braced expression body (`() => x\n/y/.test(z)`) is a
+// syntax error under tsgo. Suppressing the fix keeps the output parseable.
+func hasASIProblemAfter(text string, pos int) bool {
+	p := scanner.SkipTrivia(text, pos)
+	if p < 0 || p >= len(text) {
+		return false
+	}
+	switch text[p] {
+	case '[', '(', '+', '-', '/':
+		return true
+	}
+	return false
+}
+
+// findClosingParenRange walks up from a parenthesized node to the nearest
+// enclosing ParenthesizedExpression and returns its closing `)` range. Mirrors
+// upstream's findClosingParen.
+func findClosingParenRange(objNode *ast.Node, sf *ast.SourceFile) (int, int, bool) {
+	wrapped := ast.FindAncestor(objNode, func(n *ast.Node) bool {
+		return n.Parent != nil && n.Parent.Kind == ast.KindParenthesizedExpression
+	})
+	if wrapped == nil {
+		return 0, 0, false
+	}
+	parenEnd := utils.TrimNodeTextRange(sf, wrapped.Parent).End()
+	return parenEnd - 1, parenEnd, true
+}
+
+var ArrowBodyStyleRule = rule.Rule{
+	Name: "arrow-body-style",
+	Run: func(ctx rule.RuleContext, opts any) rule.RuleListeners {
+		o := parseOptions(opts)
+		always := o.style == styleAlways
+		asNeeded := o.style == styleAsNeeded
+		never := o.style == styleNever
+		sf := ctx.SourceFile
+		text := sf.Text()
+
+		sameLine := func(a, b int) bool {
+			lineStarts := scanner.GetECMALineStarts(sf)
+			return scanner.ComputeLineOfPosition(lineStarts, a) == scanner.ComputeLineOfPosition(lineStarts, b)
+		}
+		insertAt := func(pos int, s string) rule.RuleFix {
+			return rule.RuleFixReplaceRange(core.NewTextRange(pos, pos), s)
+		}
+		removeR := func(start, end int) rule.RuleFix {
+			return rule.RuleFixRemoveRange(core.NewTextRange(start, end))
+		}
+
+		validate := func(node *ast.Node) {
+			arrow := node.AsArrowFunction()
+			if arrow == nil || arrow.Body == nil {
+				return
+			}
+			body := arrow.Body
+
+			if body.Kind == ast.KindBlock {
+				block := body.AsBlock()
+				var stmts []*ast.Node
+				if block != nil && block.Statements != nil {
+					stmts = block.Statements.Nodes
+				}
+				blockRange := utils.TrimNodeTextRange(sf, body)
+
+				if len(stmts) != 1 && !never {
+					return
+				}
+
+				var firstStmt *ast.Node
+				if len(stmts) >= 1 {
+					firstStmt = stmts[0]
+				}
+
+				// as-needed + requireReturnForObjectLiteral: a `return {obj}`
+				// keeps its braces, so do not report it.
+				if asNeeded && o.requireReturnForObjectLiteral && firstStmt != nil && firstStmt.Kind == ast.KindReturnStatement {
+					if ret := firstStmt.AsReturnStatement(); ret.Expression != nil &&
+						ast.SkipParentheses(ret.Expression).Kind == ast.KindObjectLiteralExpression {
+						return
+					}
+				}
+
+				blockReportable := never || (asNeeded && firstStmt != nil && firstStmt.Kind == ast.KindReturnStatement)
+				if !blockReportable {
+					return
+				}
+
+				var retExpr *ast.Node
+				if firstStmt != nil && firstStmt.Kind == ast.KindReturnStatement {
+					retExpr = firstStmt.AsReturnStatement().Expression
+				}
+
+				// Determine the messageId, mirroring upstream's branch order.
+				var msg rule.RuleMessage
+				switch {
+				case len(stmts) == 0:
+					msg = msgUnexpectedEmptyBlock()
+				case len(stmts) > 1 || firstStmt.Kind != ast.KindReturnStatement:
+					msg = msgUnexpectedOtherBlock()
+				case retExpr == nil:
+					msg = msgUnexpectedSingleBlock()
+				default:
+					fvs := scanner.SkipTrivia(text, retExpr.Pos())
+					if fvs < len(text) && text[fvs] == '{' {
+						msg = msgUnexpectedObjectBlock()
+					} else {
+						msg = msgUnexpectedSingleBlock()
+					}
+				}
+
+				// Build the autofix. It stays empty when upstream would emit no
+				// fix (more than one statement, no/empty return argument, or an
+				// ASI hazard on the token after the block).
+				var fixes []rule.RuleFix
+				if len(stmts) == 1 && firstStmt.Kind == ast.KindReturnStatement && retExpr != nil && !hasASIProblemAfter(text, body.End()) {
+					argument := ast.SkipParentheses(retExpr)
+
+					braceOpenStart := blockRange.Pos()
+					braceCloseEnd := blockRange.End()
+					braceCloseStart := braceCloseEnd - 1
+					firstValueStart := scanner.SkipTrivia(text, retExpr.Pos())
+					valueEnd := utils.TrimNodeTextRange(sf, retExpr).End()
+
+					semiStart, semiEnd := -1, -1
+					if p := scanner.SkipTrivia(text, valueEnd); p < braceCloseStart && p < len(text) && text[p] == ';' {
+						semiStart, semiEnd = p, p+1
+					}
+					lastValueEnd := valueEnd
+					if semiStart >= 0 {
+						lastValueEnd = semiEnd
+					}
+
+					// commentsExistBetween(openingBrace, firstValueToken) ||
+					// commentsExistBetween(lastValueToken, closingBrace). ForEachComment
+					// walks every token's trivia, so it catches a comment sitting after
+					// the `return` keyword too (which a position-anchored scan misses).
+					commentsExist := false
+					utils.ForEachComment(body, func(c *ast.CommentRange) {
+						if commentsExist {
+							return
+						}
+						if (c.Pos() >= braceOpenStart+1 && c.End() <= firstValueStart) ||
+							(c.Pos() >= lastValueEnd && c.End() <= braceCloseStart) {
+							commentsExist = true
+						}
+					}, sf)
+
+					if commentsExist {
+						returnKwStart := scanner.SkipTrivia(text, braceOpenStart+1)
+						fixes = append(fixes,
+							removeR(braceOpenStart, braceOpenStart+1),
+							removeR(braceCloseStart, braceCloseEnd),
+							removeR(returnKwStart, returnKwStart+len("return")),
+						)
+					} else {
+						fixes = append(fixes,
+							removeR(braceOpenStart, firstValueStart),
+							removeR(lastValueEnd, braceCloseEnd),
+						)
+					}
+
+					isSeq := argument.Kind == ast.KindBinaryExpression &&
+						argument.AsBinaryExpression() != nil &&
+						argument.AsBinaryExpression().OperatorToken != nil &&
+						argument.AsBinaryExpression().OperatorToken.Kind == ast.KindCommaToken
+					startsWithBrace := firstValueStart < len(text) && text[firstValueStart] == '{'
+					needsParens := startsWithBrace || isSeq ||
+						(isInsideForLoopInitializer(node) && subtreeHasInOperator(node))
+					if needsParens && retExpr.Kind != ast.KindParenthesizedExpression {
+						fixes = append(fixes,
+							insertAt(firstValueStart, "("),
+							insertAt(lastValueEnd, ")"),
+						)
+					}
+
+					if semiStart >= 0 {
+						fixes = append(fixes, removeR(semiStart, semiEnd))
+					}
+				}
+
+				if len(fixes) > 0 {
+					ctx.ReportRangeWithFixes(blockRange, msg, fixes...)
+				} else {
+					ctx.ReportRange(blockRange, msg)
+				}
+				return
+			}
+
+			// Expression body.
+			argument := ast.SkipParentheses(body)
+			exprReportable := always || (asNeeded && o.requireReturnForObjectLiteral && argument.Kind == ast.KindObjectLiteralExpression)
+			if !exprReportable {
+				return
+			}
+			reportRange := utils.TrimNodeTextRange(sf, argument)
+
+			arrowToken := arrow.EqualsGreaterThanToken
+			if arrowToken == nil {
+				ctx.ReportRange(reportRange, msgExpectedBlock())
+				return
+			}
+			firstTokenStart := scanner.SkipTrivia(text, arrowToken.End())
+			nodeEnd := utils.TrimNodeTextRange(sf, node).End()
+
+			var fixes []rule.RuleFix
+			handled := false
+			if firstTokenStart < len(text) && text[firstTokenStart] == '(' {
+				braceStart := scanner.SkipTrivia(text, firstTokenStart+1)
+				if braceStart < len(text) && text[braceStart] == '{' {
+					objNode := ast.GetNodeAtPosition(sf, braceStart, false)
+					// A `({a} = b)`-style destructuring target parses as an
+					// ObjectLiteralExpression in tsgo but is an ObjectPattern in
+					// ESTree, so exclude assignment targets to match ESLint (which
+					// keeps the forced parens via its else branch).
+					if objNode != nil && objNode.Kind == ast.KindObjectLiteralExpression && !ast.IsAssignmentTarget(objNode) {
+						if cpStart, cpEnd, ok := findClosingParenRange(objNode, sf); ok {
+							openParenStart := firstTokenStart
+							openParenEnd := firstTokenStart + 1
+							if sameLine(openParenStart, braceStart) {
+								fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(openParenStart, openParenEnd), "{return "))
+							} else {
+								// Different lines: keep the `return ` next to the
+								// object so ASI does not split the statement.
+								fixes = append(fixes,
+									rule.RuleFixReplaceRange(core.NewTextRange(openParenStart, openParenEnd), "{"),
+									insertAt(braceStart, "return "),
+								)
+							}
+							fixes = append(fixes, removeR(cpStart, cpEnd), insertAt(nodeEnd, "}"))
+							handled = true
+						}
+					}
+				}
+			}
+			if !handled {
+				fixes = append(fixes,
+					insertAt(firstTokenStart, "{return "),
+					insertAt(nodeEnd, "}"),
+				)
+			}
+
+			ctx.ReportRangeWithFixes(reportRange, msgExpectedBlock(), fixes...)
+		}
+
+		return rule.RuleListeners{
+			ast.KindArrowFunction: validate,
+		}
+	},
+}

--- a/internal/rules/arrow_body_style/arrow_body_style.md
+++ b/internal/rules/arrow_body_style/arrow_body_style.md
@@ -1,0 +1,142 @@
+# arrow-body-style
+
+## Rule Details
+
+This rule enforces or disallows the use of braces around arrow function bodies.
+
+Arrow functions have two syntactic forms for their function bodies. They may be defined with a _block_ body (denoted with curly braces) `() => { ... }` or with a single expression `() => ...`, whose value is implicitly returned.
+
+This rule has a string option and an object option.
+
+The string option is one of:
+
+- `"as-needed"` (default) enforces no braces where they can be omitted.
+- `"always"` enforces braces around the function body.
+- `"never"` enforces no braces around the function body (forbids any use of braces).
+
+The object option (only available with `"as-needed"`):
+
+- `requireReturnForObjectLiteral: true` requires braces and an explicit return for object literals. Default is `false`.
+
+### `"as-needed"`
+
+Examples of **incorrect** code for this rule with the default `"as-needed"` option:
+
+```javascript
+let foo = () => {
+  return 0;
+};
+let foo = () => {
+  return {
+    bar: {
+      foo: 1,
+      bar: 2,
+    },
+  };
+};
+```
+
+Examples of **correct** code for this rule with the default `"as-needed"` option:
+
+```javascript
+let foo = () => 0;
+let foo = () => ({ bar: { foo: 1, bar: 2 } });
+let foo = () => {
+  let retVal = 0;
+  return retVal;
+};
+let foo = () => {
+  /* do nothing */
+};
+let foo = () => {
+  // do nothing.
+};
+let foo = () => ({ bar: 0 });
+```
+
+### `requireReturnForObjectLiteral`
+
+Examples of **incorrect** code for this rule with the `{ "requireReturnForObjectLiteral": true }` option:
+
+```json
+{ "arrow-body-style": ["error", "as-needed", { "requireReturnForObjectLiteral": true }] }
+```
+
+```javascript
+let foo = () => ({});
+let foo = () => ({ bar: 0 });
+```
+
+Examples of **correct** code for this rule with the `{ "requireReturnForObjectLiteral": true }` option:
+
+```json
+{ "arrow-body-style": ["error", "as-needed", { "requireReturnForObjectLiteral": true }] }
+```
+
+```javascript
+let foo = () => {};
+let foo = () => {
+  return { bar: 0 };
+};
+```
+
+### `"always"`
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```json
+{ "arrow-body-style": ["error", "always"] }
+```
+
+```javascript
+let foo = () => 0;
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```json
+{ "arrow-body-style": ["error", "always"] }
+```
+
+```javascript
+let foo = () => {
+  return 0;
+};
+```
+
+### `"never"`
+
+Examples of **incorrect** code for this rule with the `"never"` option:
+
+```json
+{ "arrow-body-style": ["error", "never"] }
+```
+
+```javascript
+let foo = () => {
+  return 0;
+};
+let foo = (data, name) => {
+  data[name] = true;
+  return data;
+};
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```json
+{ "arrow-body-style": ["error", "never"] }
+```
+
+```javascript
+let foo = () => 0;
+let foo = () => ({ foo: 0 });
+```
+
+## Differences from ESLint
+
+- When an arrow function with a block body is immediately followed on the next line (no semicolon in between) by a token starting with `/` — e.g. `() => { return x }` then `/re/.test(y)` — rslint reports the rule but does not auto-fix it; ESLint removes the braces.
+
+## Original Documentation
+
+- [ESLint arrow-body-style](https://eslint.org/docs/latest/rules/arrow-body-style)

--- a/internal/rules/arrow_body_style/arrow_body_style_extras_test.go
+++ b/internal/rules/arrow_body_style/arrow_body_style_extras_test.go
@@ -1,0 +1,281 @@
+// TestArrowBodyStyleExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+package arrow_body_style
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestArrowBodyStyleExtras(t *testing.T) {
+	asNeeded := []any{"as-needed"}
+	always := []any{"always"}
+	never := []any{"never"}
+	requireReturn := []any{"as-needed", map[string]any{"requireReturnForObjectLiteral": true}}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ArrowBodyStyleRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream validate() early-return: as-needed +
+			// requireReturnForObjectLiteral keeps braces around a parenthesized
+			// object return too (tsgo wraps it in a ParenthesizedExpression; we
+			// SkipParentheses before the ObjectExpression check, matching ESTree).
+			{Code: "var foo = () => { return ({ bar: 0 }); };", Options: requireReturn},
+			// Locks in: requireReturnForObjectLiteral does not flag a non-object
+			// arrow returning a parenthesized non-object.
+			{Code: "var foo = () => (bar);", Options: requireReturn},
+			// ---- Dimension 4: async arrow container form (valid under as-needed) ----
+			{Code: "var foo = async () => bar();"},
+			// ---- N/A: access/key forms — the rule inspects the arrow body, not property keys ----
+			// ---- N/A: class/function declaration vs expression — the rule only matches arrow functions ----
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized-receiver body — tsgo preserves the
+			// ParenthesizedExpression nodes; the report location must still be the
+			// fully unwrapped inner expression (ESTree flattens parens). ----
+			{
+				Code:    "x => ((y))",
+				Output:  []string{"x => {return ((y))}"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 8, EndColumn: 9, MessageId: "expectedBlock"}},
+			},
+			// ---- Dimension 4: TS non-null assertion body ----
+			{
+				Code:    "var foo = () => x!;",
+				Output:  []string{"var foo = () => {return x!};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return x!; };",
+				Output:  []string{"var foo = () => x!;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- Dimension 4: TS `as` type-expression body ----
+			{
+				Code:    "var foo = () => x as string;",
+				Output:  []string{"var foo = () => {return x as string};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return x as string; };",
+				Output:  []string{"var foo = () => x as string;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- Dimension 4: TS `satisfies` type-expression body ----
+			{
+				Code:    "var foo = () => x satisfies string;",
+				Output:  []string{"var foo = () => {return x satisfies string};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "expectedBlock"}},
+			},
+			// ---- Dimension 4: optional-chain body (tsgo flag, no ChainExpression wrapper) ----
+			{
+				Code:    "var foo = () => a?.b;",
+				Output:  []string{"var foo = () => {return a?.b};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return a?.b; };",
+				Output:  []string{"var foo = () => a?.b;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- Dimension 4: TS return-type annotation on the arrow ----
+			{
+				Code:    "var f = (): number => { return 0; };",
+				Output:  []string{"var f = (): number => 0;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 23, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- Dimension 4: class-field arrow container form ----
+			{
+				Code:    "class C { f = () => { return 0; }; }",
+				Output:  []string{"class C { f = () => 0; }"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 21, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- Dimension 4: async arrow container form ----
+			{
+				Code:    "var f = async () => { return 0; };",
+				Output:  []string{"var f = async () => 0;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 21, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var f = async () => 0;",
+				Output:  []string{"var f = async () => {return 0};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 21, MessageId: "expectedBlock"}},
+			},
+			// ---- Dimension 4: same-kind nesting — only the inner arrow's block
+			// matches under as-needed; the listener must not bleed to the outer
+			// arrow (whose body is the inner arrow expression). ----
+			{
+				Code:    "var f = () => () => { return 0; };",
+				Output:  []string{"var f = () => () => 0;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 21, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- Dimension 4: graceful degradation — object spread in the returned literal ----
+			{
+				Code:    "var f = () => { return {...a}; };",
+				Output:  []string{"var f = () => ({...a});"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "unexpectedObjectBlock"}},
+			},
+			// ---- Dimension 4: graceful degradation — destructuring parameter ----
+			{
+				Code:    "var f = ({a}) => { return a; };",
+				Output:  []string{"var f = ({a}) => a;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 18, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- Real-user: React useCallback body collapse (eslint/eslint arrow-body-style usage) ----
+			{
+				Code:    "useCallback(() => { return x; }, [])",
+				Output:  []string{"useCallback(() => x, [])"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 19, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- Real-user: arrow returning a parenthesized object that is the
+			// callee of a member call — must keep exactly one paren layer. ----
+			{
+				Code:    "const f = () => { return ({ a: 1 }).a; };",
+				Output:  []string{"const f = () => ({ a: 1 }).a;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			// Locks in upstream validate() arm: argument === null under `never`
+			// reports unexpectedSingleBlock and emits no fix (no return value).
+			{
+				Code:    "var foo = () => { return };",
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			// Locks in upstream fix() arm: argument already parenthesized — the
+			// sequence wrap must NOT add a second paren layer.
+			{
+				Code:    "var foo = () => { return (a, b); };",
+				Output:  []string{"var foo = () => (a, b);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			// Locks in upstream hasASIProblem() arm: `+` punctuator after the
+			// block suppresses the fix (output unchanged).
+			{
+				Code:    "var foo = () => { return bar }\n+x",
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			// Locks in upstream hasASIProblem() arm: `-` punctuator after the block.
+			{
+				Code:    "var foo = () => { return bar }\n-x",
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- Dimension 4: 3-level arrow nesting — only the innermost block
+			// matches; the listener must not bleed across the two outer arrows. ----
+			{
+				Code:    "var f = () => () => () => { return 0; };",
+				Output:  []string{"var f = () => () => () => 0;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 27, MessageId: "unexpectedSingleBlock"}},
+			},
+			// Locks in upstream BinaryExpression[operator='in'] funcInfo propagation
+			// across a nested-arrow boundary: an `in` buried in a nested arrow still
+			// flags the outer for-init arrow, so its body is parenthesized on collapse.
+			{
+				Code:    "for (var f = () => { return g(() => a in b) } ;;);",
+				Output:  []string{"for (var f = () => (g(() => a in b)) ;;);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 20, MessageId: "unexpectedSingleBlock"}},
+			},
+			// Locks in upstream fix() comment arm: a comment sitting AFTER the
+			// `return` keyword (not adjacent to `{`) must still take the
+			// token-removal path and be preserved (golden output from ESLint).
+			{
+				Code:    "var f = () => { return /* c */ x; };",
+				Output:  []string{"var f = () =>   /* c */ x ;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "unexpectedSingleBlock"}},
+			},
+			// Comment between the value and the inner `;` lives inside the kept
+			// value span (non-comment branch); it is preserved verbatim.
+			{
+				Code:    "var f = () => { return x /* t */; };",
+				Output:  []string{"var f = () => x /* t */;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "unexpectedSingleBlock"}},
+			},
+			// Comment in the (lastValueToken, closingBrace) gap triggers the
+			// comment arm via the second range.
+			{
+				Code:    "var f = () => { return x; /* t */ };",
+				Output:  []string{"var f = () =>   x /* t */ ;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- tsgo↔ESTree: destructuring-assignment target ----
+			// `({b} = a)` — tsgo parses the LHS as an ObjectLiteralExpression, but
+			// ESTree models it as an ObjectPattern, so the forced parens must be
+			// kept (else branch), not unwrapped as a parenthesized object literal.
+			{
+				Code:    "var f = () => ({ b } = a);",
+				Output:  []string{"var f = () => {return ({ b } = a)};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 16, MessageId: "expectedBlock"}},
+			},
+			// Assignment target followed by a member access — still a pattern, parens kept.
+			{
+				Code:    "var f = () => ({a} = b).c;",
+				Output:  []string{"var f = () => {return ({a} = b).c};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "expectedBlock"}},
+			},
+			// `return {a} = b`: value starts with `{` (unexpectedObjectBlock), and the
+			// assignment is parenthesized on collapse.
+			{
+				Code:    "var f = () => { return {a} = b; };",
+				Output:  []string{"var f = () => ({a} = b);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "unexpectedObjectBlock"}},
+			},
+			// Array-destructuring assignment: value starts with `[`, not `{`
+			// (unexpectedSingleBlock), and needs no extra parens.
+			{
+				Code:    "var f = () => { return [a] = b; };",
+				Output:  []string{"var f = () => [a] = b;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- tsgo↔ESTree divergence (documented): `/` after an arrow block `}`
+			// is division under tsgo (regex under espree). De-bracing would yield
+			// `() => x\n/y/.test(z)` = `() => x / y / .test(z)`, a syntax error — so
+			// the fix is suppressed (no Output), unlike ESLint which de-braces. ----
+			{
+				Code:    "var f = () => { return x }\n/y/.test(z)",
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- Dimension 4: outer arrow block returns an inner arrow (no bleed) ----
+			{
+				Code:    "var f = () => { return () => ({ a: 1 }); };",
+				Output:  []string{"var f = () => () => ({ a: 1 });"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "unexpectedSingleBlock"}},
+			},
+		},
+	)
+}

--- a/internal/rules/arrow_body_style/arrow_body_style_upstream_test.go
+++ b/internal/rules/arrow_body_style/arrow_body_style_upstream_test.go
@@ -1,0 +1,423 @@
+// TestArrowBodyStyleUpstream migrates the full valid/invalid suite from upstream
+// tests/lib/rules/arrow-body-style.js 1:1. Position assertions cover line/column
+// for every invalid case (and endLine/endColumn where upstream asserts them).
+// rslint-specific lock-in cases live in the arrow_body_style_extras_test.go file.
+package arrow_body_style
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestArrowBodyStyleUpstream(t *testing.T) {
+	asNeeded := []any{"as-needed"}
+	always := []any{"always"}
+	never := []any{"never"}
+	requireReturn := []any{"as-needed", map[string]any{"requireReturnForObjectLiteral": true}}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ArrowBodyStyleRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "var foo = () => {};"},
+			{Code: "var foo = () => 0;"},
+			{Code: "var addToB = (a) => { b =  b + a };"},
+			{Code: "var foo = () => { /* do nothing */ };"},
+			{Code: "var foo = () => {\n /* do nothing */ \n};"},
+			{Code: "var foo = (data, name) => {\ndata[name] = true;\nreturn data;\n};"},
+			{Code: "var foo = () => ({});"},
+			{Code: "var foo = () => bar();"},
+			{Code: "var foo = () => { bar(); };"},
+			{Code: "var foo = () => { b = a };"},
+			{Code: "var foo = () => { bar: 1 };"},
+			{Code: "var foo = () => { return 0; };", Options: always},
+			{Code: "var foo = () => { return bar(); };", Options: always},
+			{Code: "var foo = () => 0;", Options: never},
+			{Code: "var foo = () => ({ foo: 0 });", Options: never},
+			{Code: "var foo = () => {};", Options: requireReturn},
+			{Code: "var foo = () => 0;", Options: requireReturn},
+			{Code: "var addToB = (a) => { b =  b + a };", Options: requireReturn},
+			{Code: "var foo = () => { /* do nothing */ };", Options: requireReturn},
+			{Code: "var foo = () => {\n /* do nothing */ \n};", Options: requireReturn},
+			{Code: "var foo = (data, name) => {\ndata[name] = true;\nreturn data;\n};", Options: requireReturn},
+			{Code: "var foo = () => bar();", Options: requireReturn},
+			{Code: "var foo = () => { bar(); };", Options: requireReturn},
+			{Code: "var foo = () => { return { bar: 0 }; };", Options: requireReturn},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- as-needed / default: `in`-operator inside for-loop init ----
+			{
+				Code:    "for (var foo = () => { return a in b ? bar : () => {} } ;;);",
+				Output:  []string{"for (var foo = () => (a in b ? bar : () => {}) ;;);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 22, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "a in b; for (var f = () => { return c };;);",
+				Output:  []string{"a in b; for (var f = () => c;;);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 28, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "for (a = b => { return c in d ? e : f } ;;);",
+				Output:  []string{"for (a = b => (c in d ? e : f) ;;);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "for (var f = () => { return a };;);",
+				Output:  []string{"for (var f = () => a;;);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 20, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "for (var f;f = () => { return a };);",
+				Output:  []string{"for (var f;f = () => a;);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 22, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "for (var f = () => { return a in c };;);",
+				Output:  []string{"for (var f = () => (a in c);;);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 20, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "for (var f;f = () => { return a in c };);",
+				Output:  []string{"for (var f;f = () => a in c;);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 22, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "for (;;){var f = () => { return a in c }}",
+				Output:  []string{"for (;;){var f = () => a in c}"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 24, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "for (a = b => { return c = d in e } ;;);",
+				Output:  []string{"for (a = b => (c = d in e) ;;);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 15, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "for (var a;;a = b => { return c = d in e } );",
+				Output:  []string{"for (var a;;a = b => c = d in e );"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 22, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "for (let a = (b, c, d) => { return vb && c in d; }; ;);",
+				Output: []string{"for (let a = (b, c, d) => (vb && c in d); ;);"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 27, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "for (let a = (b, c, d) => { return v in b && c in d; }; ;);",
+				Output: []string{"for (let a = (b, c, d) => (v in b && c in d); ;);"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 27, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "function foo(){ for (let a = (b, c, d) => { return v in b && c in d; }; ;); }",
+				Output: []string{"function foo(){ for (let a = (b, c, d) => (v in b && c in d); ;); }"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 43, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "for ( a = (b, c, d) => { return v in b && c in d; }; ;);",
+				Output: []string{"for ( a = (b, c, d) => (v in b && c in d); ;);"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 24, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "for ( a = (b) => { return (c in d) }; ;);",
+				Output: []string{"for ( a = (b) => (c in d); ;);"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 18, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "for (let a = (b, c, d) => { return vb in dd ; }; ;);",
+				Output: []string{"for (let a = (b, c, d) => (vb in dd ); ;);"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 27, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "for (let a = (b, c, d) => { return vb in c in dd ; }; ;);",
+				Output: []string{"for (let a = (b, c, d) => (vb in c in dd ); ;);"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 27, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "do{let a = () => {return f in ff}}while(true){}",
+				Output: []string{"do{let a = () => f in ff}while(true){}"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 18, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "do{for (let a = (b, c, d) => { return vb in c in dd ; }; ;);}while(true){}",
+				Output: []string{"do{for (let a = (b, c, d) => (vb in c in dd ); ;);}while(true){}"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 30, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "scores.map(score => { return x in +(score / maxScore).toFixed(2)});",
+				Output: []string{"scores.map(score => x in +(score / maxScore).toFixed(2));"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 21, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "const fn = (a, b) => { return a + x in Number(b) };",
+				Output: []string{"const fn = (a, b) => a + x in Number(b);"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 22, MessageId: "unexpectedSingleBlock"}},
+			},
+			// ---- always: expected block ----
+			{
+				Code:    "var foo = () => 0",
+				Output:  []string{"var foo = () => {return 0}"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, EndLine: 1, EndColumn: 18, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "var foo = () => 0;",
+				Output:  []string{"var foo = () => {return 0};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "var foo = () => ({});",
+				Output:  []string{"var foo = () => {return {}};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 18, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "var foo = () => (  {});",
+				Output:  []string{"var foo = () => {return   {}};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 20, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "(() => ({}))",
+				Output:  []string{"(() => {return {}})"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 9, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "(() => ( {}))",
+				Output:  []string{"(() => {return  {}})"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 10, MessageId: "expectedBlock"}},
+			},
+			// ---- as-needed: unexpected single/object block ----
+			{
+				Code:    "var foo = () => { return 0; };",
+				Output:  []string{"var foo = () => 0;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return 0 };",
+				Output:  []string{"var foo = () => 0;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return bar(); };",
+				Output:  []string{"var foo = () => bar();"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => {};",
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedEmptyBlock"}},
+			},
+			{
+				Code:    "var foo = () => {\nreturn 0;\n};",
+				Output:  []string{"var foo = () => 0;"},
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return { bar: 0 }; };",
+				Output:  []string{"var foo = () => ({ bar: 0 });"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedObjectBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return ({ bar: 0 }); };",
+				Output:  []string{"var foo = () => ({ bar: 0 });"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "var foo = () => { return a, b }",
+				Output: []string{"var foo = () => (a, b)"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return };",
+				Options: requireReturn,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return; };",
+				Options: requireReturn,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return ( /* a */ {ok: true} /* b */ ) };",
+				Output:  []string{"var foo = () => ( /* a */ {ok: true} /* b */ );"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return '{' };",
+				Output:  []string{"var foo = () => '{';"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return { bar: 0 }.bar; };",
+				Output:  []string{"var foo = () => ({ bar: 0 }.bar);"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedObjectBlock"}},
+			},
+			{
+				Code:    "var foo = (data, name) => {\ndata[name] = true;\nreturn data;\n};",
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 27, MessageId: "unexpectedOtherBlock"}},
+			},
+			{
+				Code:    "var foo = () => { bar };",
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedOtherBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return 0; };",
+				Output:  []string{"var foo = () => 0;"},
+				Options: requireReturn,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => { return bar(); };",
+				Output:  []string{"var foo = () => bar();"},
+				Options: requireReturn,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = () => ({});",
+				Output:  []string{"var foo = () => {return {}};"},
+				Options: requireReturn,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 18, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "var foo = () => ({ bar: 0 });",
+				Output:  []string{"var foo = () => {return { bar: 0 }};"},
+				Options: requireReturn,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 18, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "var foo = () => (((((((5)))))));",
+				Output:  []string{"var foo = () => {return (((((((5)))))))};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 24, MessageId: "expectedBlock"}},
+			},
+			{
+				// Not fixed; fixing would cause ASI issues.
+				Code:    "var foo = () => { return bar }\n[1, 2, 3].map(foo)",
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				// Not fixed; fixing would cause ASI issues.
+				Code:    "var foo = () => { return bar }\n(1).toString();",
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				// Fixing here is ok because the arrow function has a semicolon afterwards.
+				Code:    "var foo = () => { return bar };\n[1, 2, 3].map(foo)",
+				Output:  []string{"var foo = () => bar;\n[1, 2, 3].map(foo)"},
+				Options: never,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ { /* e */ return /* f */ 5 /* g */ ; /* h */ } /* i */ ;",
+				Output:  []string{"var foo = /* a */ ( /* b */ ) /* c */ => /* d */  /* e */  /* f */ 5 /* g */  /* h */  /* i */ ;"},
+				Options: asNeeded,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 50, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:    "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ ( /* e */ 5 /* f */ ) /* g */ ;",
+				Output:  []string{"var foo = /* a */ ( /* b */ ) /* c */ => /* d */ {return ( /* e */ 5 /* f */ )} /* g */ ;"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{Line: 1, Column: 60, MessageId: "expectedBlock"}},
+			},
+			{
+				Code:   "var foo = () => {\nreturn bar;\n};",
+				Output: []string{"var foo = () => bar;"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, EndLine: 3, EndColumn: 2, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "var foo = () => {\nreturn bar;};",
+				Output: []string{"var foo = () => bar;"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, EndLine: 2, EndColumn: 13, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code:   "var foo = () => {return bar;\n};",
+				Output: []string{"var foo = () => bar;"},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 1, Column: 17, EndLine: 2, EndColumn: 2, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code: "\n              var foo = () => {\n                return foo\n                  .bar;\n              };\n            ",
+				Output: []string{
+					"\n              var foo = () => foo\n                  .bar;\n            ",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 2, Column: 31, MessageId: "unexpectedSingleBlock"}},
+			},
+			{
+				Code: "\n              var foo = () => {\n                return {\n                  bar: 1,\n                  baz: 2\n                };\n              };\n            ",
+				Output: []string{
+					"\n              var foo = () => ({\n                  bar: 1,\n                  baz: 2\n                });\n            ",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{Line: 2, Column: 31, EndLine: 7, EndColumn: 16, MessageId: "unexpectedObjectBlock"}},
+			},
+			{
+				Code:    "var foo = () => ({foo: 1}).foo();",
+				Output:  []string{"var foo = () => {return {foo: 1}.foo()};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "var foo = () => ({foo: 1}.foo());",
+				Output:  []string{"var foo = () => {return {foo: 1}.foo()};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedBlock"}},
+			},
+			{
+				Code:    "var foo = () => ( {foo: 1} ).foo();",
+				Output:  []string{"var foo = () => {return  {foo: 1} .foo()};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedBlock"}},
+			},
+			{
+				Code: "\n              var foo = () => ({\n                  bar: 1,\n                  baz: 2\n                });\n            ",
+				Output: []string{
+					"\n              var foo = () => {return {\n                  bar: 1,\n                  baz: 2\n                }};\n            ",
+				},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedBlock"}},
+			},
+			{
+				Code: "\n              parsedYears = _map(years, (year) => (\n                  {\n                      index : year,\n                      title : splitYear(year)\n                  }\n              ));\n            ",
+				Output: []string{
+					"\n              parsedYears = _map(years, (year) => {\n                  return {\n                      index : year,\n                      title : splitYear(year)\n                  }\n              });\n            ",
+				},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedBlock"}},
+			},
+			// https://github.com/eslint/eslint/issues/14633
+			{
+				Code:    "const createMarker = (color) => ({ latitude, longitude }, index) => {};",
+				Output:  []string{"const createMarker = (color) => {return ({ latitude, longitude }, index) => {}};"},
+				Options: always,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedBlock"}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -67,6 +67,7 @@ export default defineConfig({
 
     // eslint
     './tests/eslint/rules/accessor-pairs.test.ts',
+    './tests/eslint/rules/arrow-body-style.test.ts',
     './tests/eslint/rules/default-case.test.ts',
     './tests/eslint/rules/no-case-declarations.test.ts',
     './tests/eslint/rules/no-console.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/arrow-body-style.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/arrow-body-style.test.ts.snap
@@ -1,0 +1,1675 @@
+// Rstest Snapshot v1
+
+exports[`arrow-body-style > invalid 1`] = `
+{
+  "code": "for (var foo = () => { return a in b ? bar : () => {} } ;;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 2`] = `
+{
+  "code": "a in b; for (var f = () => { return c };;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 3`] = `
+{
+  "code": "for (a = b => { return c in d ? e : f } ;;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 4`] = `
+{
+  "code": "for (var f = () => { return a };;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 5`] = `
+{
+  "code": "for (var f;f = () => { return a };);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 6`] = `
+{
+  "code": "for (var f = () => { return a in c };;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 7`] = `
+{
+  "code": "for (var f;f = () => { return a in c };);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 8`] = `
+{
+  "code": "for (;;){var f = () => { return a in c }}",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 9`] = `
+{
+  "code": "for (a = b => { return c = d in e } ;;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 10`] = `
+{
+  "code": "for (var a;;a = b => { return c = d in e } );",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 11`] = `
+{
+  "code": "for (let a = (b, c, d) => { return vb && c in d; }; ;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 12`] = `
+{
+  "code": "for (let a = (b, c, d) => { return v in b && c in d; }; ;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 13`] = `
+{
+  "code": "function foo(){ for (let a = (b, c, d) => { return v in b && c in d; }; ;); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 14`] = `
+{
+  "code": "for ( a = (b, c, d) => { return v in b && c in d; }; ;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 15`] = `
+{
+  "code": "for ( a = (b) => { return (c in d) }; ;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 16`] = `
+{
+  "code": "for (let a = (b, c, d) => { return vb in dd ; }; ;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 17`] = `
+{
+  "code": "for (let a = (b, c, d) => { return vb in c in dd ; }; ;);",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 18`] = `
+{
+  "code": "do{let a = () => {return f in ff}}while(true){}",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 19`] = `
+{
+  "code": "do{for (let a = (b, c, d) => { return vb in c in dd ; }; ;);}while(true){}",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 20`] = `
+{
+  "code": "scores.map(score => { return x in +(score / maxScore).toFixed(2)});",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 21`] = `
+{
+  "code": "const fn = (a, b) => { return a + x in Number(b) };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 22`] = `
+{
+  "code": "var foo = () => 0",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 23`] = `
+{
+  "code": "var foo = () => 0;",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 24`] = `
+{
+  "code": "var foo = () => ({});",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 25`] = `
+{
+  "code": "var foo = () => (  {});",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 26`] = `
+{
+  "code": "(() => ({}))",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 27`] = `
+{
+  "code": "(() => ( {}))",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 28`] = `
+{
+  "code": "var foo = () => { return 0; };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 29`] = `
+{
+  "code": "var foo = () => { return 0 };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 30`] = `
+{
+  "code": "var foo = () => { return bar(); };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 31`] = `
+{
+  "code": "var foo = () => {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; put a value of \`undefined\` immediately after the \`=>\`.",
+      "messageId": "unexpectedEmptyBlock",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 32`] = `
+{
+  "code": "var foo = () => {
+return 0;
+};",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 33`] = `
+{
+  "code": "var foo = () => { return { bar: 0 }; };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; parenthesize the returned value and move it immediately after the \`=>\`.",
+      "messageId": "unexpectedObjectBlock",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 34`] = `
+{
+  "code": "var foo = () => { return ({ bar: 0 }); };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 35`] = `
+{
+  "code": "var foo = () => { return a, b }",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 36`] = `
+{
+  "code": "var foo = () => { return };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 37`] = `
+{
+  "code": "var foo = () => { return; };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 38`] = `
+{
+  "code": "var foo = () => { return ( /* a */ {ok: true} /* b */ ) };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 39`] = `
+{
+  "code": "var foo = () => { return '{' };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 40`] = `
+{
+  "code": "var foo = () => { return { bar: 0 }.bar; };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; parenthesize the returned value and move it immediately after the \`=>\`.",
+      "messageId": "unexpectedObjectBlock",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 41`] = `
+{
+  "code": "var foo = (retv, name) => {
+retv[name] = true;
+return retv;
+};",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body.",
+      "messageId": "unexpectedOtherBlock",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 42`] = `
+{
+  "code": "var foo = () => { bar };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body.",
+      "messageId": "unexpectedOtherBlock",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 43`] = `
+{
+  "code": "var foo = () => { return 0; };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 44`] = `
+{
+  "code": "var foo = () => { return bar(); };",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 45`] = `
+{
+  "code": "var foo = () => ({});",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 46`] = `
+{
+  "code": "var foo = () => ({ bar: 0 });",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 47`] = `
+{
+  "code": "var foo = () => (((((((5)))))));",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 48`] = `
+{
+  "code": "var foo = () => { return bar }
+[1, 2, 3].map(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 49`] = `
+{
+  "code": "var foo = () => { return bar }
+(1).toString();",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 50`] = `
+{
+  "code": "var foo = () => { return bar };
+[1, 2, 3].map(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 51`] = `
+{
+  "code": "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ { /* e */ return /* f */ 5 /* g */ ; /* h */ } /* i */ ;",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 96,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 52`] = `
+{
+  "code": "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ ( /* e */ 5 /* f */ ) /* g */ ;",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 53`] = `
+{
+  "code": "var foo = () => {
+return bar;
+};",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 54`] = `
+{
+  "code": "var foo = () => {
+return bar;};",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 55`] = `
+{
+  "code": "var foo = () => {return bar;
+};",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 56`] = `
+{
+  "code": "
+              var foo = () => {
+                return foo
+                  .bar;
+              };
+            ",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; move the returned value immediately after the \`=>\`.",
+      "messageId": "unexpectedSingleBlock",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 5,
+        },
+        "start": {
+          "column": 31,
+          "line": 2,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 57`] = `
+{
+  "code": "
+              var foo = () => {
+                return {
+                  bar: 1,
+                  baz: 2
+                };
+              };
+            ",
+  "diagnostics": [
+    {
+      "message": "Unexpected block statement surrounding arrow body; parenthesize the returned value and move it immediately after the \`=>\`.",
+      "messageId": "unexpectedObjectBlock",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 7,
+        },
+        "start": {
+          "column": 31,
+          "line": 2,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 58`] = `
+{
+  "code": "var foo = () => ({foo: 1}).foo();",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 59`] = `
+{
+  "code": "var foo = () => ({foo: 1}.foo());",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 60`] = `
+{
+  "code": "var foo = () => ( {foo: 1} ).foo();",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 61`] = `
+{
+  "code": "
+              var foo = () => ({
+                  bar: 1,
+                  baz: 2
+                });
+            ",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 32,
+          "line": 2,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 62`] = `
+{
+  "code": "
+              parsedYears = _map(years, (year) => (
+                  {
+                      index : year,
+                      title : splitYear(year)
+                  }
+              ));
+            ",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 6,
+        },
+        "start": {
+          "column": 19,
+          "line": 3,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`arrow-body-style > invalid 63`] = `
+{
+  "code": "const createMarker = (color) => ({ latitude, longitude }, index) => {};",
+  "diagnostics": [
+    {
+      "message": "Expected block statement surrounding arrow body.",
+      "messageId": "expectedBlock",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "arrow-body-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/arrow-body-style.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/arrow-body-style.test.ts
@@ -1,0 +1,384 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('arrow-body-style', {
+  valid: [
+    'var foo = () => {};',
+    'var foo = () => 0;',
+    'var addToB = (a) => { b =  b + a };',
+    'var foo = () => { /* do nothing */ };',
+    'var foo = () => {\n /* do nothing */ \n};',
+    'var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};',
+    'var foo = () => ({});',
+    'var foo = () => bar();',
+    'var foo = () => { bar(); };',
+    'var foo = () => { b = a };',
+    'var foo = () => { bar: 1 };',
+    { code: 'var foo = () => { return 0; };', options: ['always'] as any },
+    { code: 'var foo = () => { return bar(); };', options: ['always'] as any },
+    { code: 'var foo = () => 0;', options: ['never'] as any },
+    { code: 'var foo = () => ({ foo: 0 });', options: ['never'] as any },
+    {
+      code: 'var foo = () => {};',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+    },
+    {
+      code: 'var foo = () => 0;',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+    },
+    {
+      code: 'var addToB = (a) => { b =  b + a };',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+    },
+    {
+      code: 'var foo = () => { /* do nothing */ };',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+    },
+    {
+      code: 'var foo = () => {\n /* do nothing */ \n};',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+    },
+    {
+      code: 'var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+    },
+    {
+      code: 'var foo = () => bar();',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+    },
+    {
+      code: 'var foo = () => { bar(); };',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+    },
+    {
+      code: 'var foo = () => { return { bar: 0 }; };',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+    },
+  ],
+  invalid: [
+    {
+      code: 'for (var foo = () => { return a in b ? bar : () => {} } ;;);',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'a in b; for (var f = () => { return c };;);',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (a = b => { return c in d ? e : f } ;;);',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (var f = () => { return a };;);',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (var f;f = () => { return a };);',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (var f = () => { return a in c };;);',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (var f;f = () => { return a in c };);',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (;;){var f = () => { return a in c }}',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (a = b => { return c = d in e } ;;);',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (var a;;a = b => { return c = d in e } );',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (let a = (b, c, d) => { return vb && c in d; }; ;);',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (let a = (b, c, d) => { return v in b && c in d; }; ;);',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'function foo(){ for (let a = (b, c, d) => { return v in b && c in d; }; ;); }',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for ( a = (b, c, d) => { return v in b && c in d; }; ;);',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for ( a = (b) => { return (c in d) }; ;);',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (let a = (b, c, d) => { return vb in dd ; }; ;);',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'for (let a = (b, c, d) => { return vb in c in dd ; }; ;);',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'do{let a = () => {return f in ff}}while(true){}',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'do{for (let a = (b, c, d) => { return vb in c in dd ; }; ;);}while(true){}',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'scores.map(score => { return x in +(score / maxScore).toFixed(2)});',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'const fn = (a, b) => { return a + x in Number(b) };',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => 0',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: 'var foo = () => 0;',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: 'var foo = () => ({});',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: 'var foo = () => (  {});',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: '(() => ({}))',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: '(() => ( {}))',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: 'var foo = () => { return 0; };',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return 0 };',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return bar(); };',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => {};',
+      options: ['never'] as any,
+      errors: [{ messageId: 'unexpectedEmptyBlock' }],
+    },
+    {
+      code: 'var foo = () => {\nreturn 0;\n};',
+      options: ['never'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return { bar: 0 }; };',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedObjectBlock' }],
+    },
+    {
+      code: 'var foo = () => { return ({ bar: 0 }); };',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return a, b }',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return };',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return; };',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return ( /* a */ {ok: true} /* b */ ) };',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: `var foo = () => { return '{' };`,
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return { bar: 0 }.bar; };',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedObjectBlock' }],
+    },
+    {
+      code: 'var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};',
+      options: ['never'] as any,
+      errors: [{ messageId: 'unexpectedOtherBlock' }],
+    },
+    {
+      code: 'var foo = () => { bar };',
+      options: ['never'] as any,
+      errors: [{ messageId: 'unexpectedOtherBlock' }],
+    },
+    {
+      code: 'var foo = () => { return 0; };',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return bar(); };',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => ({});',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: 'var foo = () => ({ bar: 0 });',
+      options: ['as-needed', { requireReturnForObjectLiteral: true }] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: 'var foo = () => (((((((5)))))));',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: 'var foo = () => { return bar }\n[1, 2, 3].map(foo)',
+      options: ['never'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return bar }\n(1).toString();',
+      options: ['never'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => { return bar };\n[1, 2, 3].map(foo)',
+      options: ['never'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = /* a */ ( /* b */ ) /* c */ => /* d */ { /* e */ return /* f */ 5 /* g */ ; /* h */ } /* i */ ;',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = /* a */ ( /* b */ ) /* c */ => /* d */ ( /* e */ 5 /* f */ ) /* g */ ;',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: 'var foo = () => {\nreturn bar;\n};',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => {\nreturn bar;};',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: 'var foo = () => {return bar;\n};',
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: `
+              var foo = () => {
+                return foo
+                  .bar;
+              };
+            `,
+      errors: [{ messageId: 'unexpectedSingleBlock' }],
+    },
+    {
+      code: `
+              var foo = () => {
+                return {
+                  bar: 1,
+                  baz: 2
+                };
+              };
+            `,
+      errors: [{ messageId: 'unexpectedObjectBlock' }],
+    },
+    {
+      code: 'var foo = () => ({foo: 1}).foo();',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: 'var foo = () => ({foo: 1}.foo());',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: 'var foo = () => ( {foo: 1} ).foo();',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: `
+              var foo = () => ({
+                  bar: 1,
+                  baz: 2
+                });
+            `,
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    {
+      code: `
+              parsedYears = _map(years, (year) => (
+                  {
+                      index : year,
+                      title : splitYear(year)
+                  }
+              ));
+            `,
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+    // https://github.com/eslint/eslint/issues/14633
+    {
+      code: 'const createMarker = (color) => ({ latitude, longitude }, index) => {};',
+      options: ['always'] as any,
+      errors: [{ messageId: 'expectedBlock' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `arrow-body-style` ESLint core rule. It enforces or disallows braces around arrow function bodies — modes `"as-needed"` (default) / `"always"` / `"never"`, plus the `requireReturnForObjectLiteral` option — with full autofix.

The full upstream `valid`/`invalid` suite is migrated 1:1, augmented with tsgo/TS-specific edge cases (parenthesized / optional-chain / non-null / `as` / `satisfies` bodies, destructuring-assignment targets, comment positions, nesting, ASI hazards). Output was differentially verified against ESLint 10.5.0 (default and `@typescript-eslint` parser): identical diagnostics and autofix. One difference is documented in the rule doc — when an arrow block body is immediately followed by `/…` on the next line, rslint reports but does not autofix, because ESLint's fix produces code that does not parse under TypeScript.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/arrow-body-style
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/arrow-body-style.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).