### PR TITLE
feat: port rule curly

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/arrow_body_style"
 	"github.com/web-infra-dev/rslint/internal/rules/complexity"
 	"github.com/web-infra-dev/rslint/internal/rules/constructor_super"
+	"github.com/web-infra-dev/rslint/internal/rules/curly"
 	"github.com/web-infra-dev/rslint/internal/rules/default_case"
 	"github.com/web-infra-dev/rslint/internal/rules/default_case_last"
 	"github.com/web-infra-dev/rslint/internal/rules/eqeqeq"
@@ -137,6 +138,7 @@ func GetAllRules() []rule.Rule {
 		arrow_body_style.ArrowBodyStyleRule,
 		complexity.ComplexityRule,
 		constructor_super.ConstructorSuperRule,
+		curly.CurlyRule,
 		default_case.DefaultCaseRule,
 		default_case_last.DefaultCaseLastRule,
 		for_direction.ForDirectionRule,

--- a/internal/rules/curly/curly.go
+++ b/internal/rules/curly/curly.go
@@ -1,0 +1,478 @@
+package curly
+
+import (
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// curlyOptions mirrors ESLint's positional options: the first element selects
+// the mode ("all" | "multi" | "multi-line" | "multi-or-nest"); the second, when
+// present, is the literal "consistent".
+type curlyOptions struct {
+	multiOnly   bool
+	multiLine   bool
+	multiOrNest bool
+	consistent  bool
+}
+
+func parseOptions(options any) curlyOptions {
+	opts := curlyOptions{}
+
+	var first, second string
+	switch v := options.(type) {
+	case string:
+		first = v
+	case []interface{}:
+		if len(v) > 0 {
+			if s, ok := v[0].(string); ok {
+				first = s
+			}
+		}
+		if len(v) > 1 {
+			if s, ok := v[1].(string); ok {
+				second = s
+			}
+		}
+	}
+
+	switch first {
+	case "multi":
+		opts.multiOnly = true
+	case "multi-line":
+		opts.multiLine = true
+	case "multi-or-nest":
+		opts.multiOrNest = true
+	}
+	if second == "consistent" {
+		opts.consistent = true
+	}
+	return opts
+}
+
+// expectation is a tri-state mirroring ESLint's `expected` (true / false / null).
+type expectation int
+
+const (
+	expectDontCare expectation = iota
+	expectBraces
+	expectNoBraces
+)
+
+// preparedCheck mirrors the object returned by ESLint's prepareCheck: whether
+// the body currently is a block (actual) and whether it should be (expected).
+type preparedCheck struct {
+	node      *ast.Node
+	body      *ast.Node
+	name      string
+	condition bool
+	actual    bool
+	expected  expectation
+}
+
+type curlyChecker struct {
+	ctx     rule.RuleContext
+	sf      *ast.SourceFile
+	text    string
+	lineMap []core.TextPos
+	opts    curlyOptions
+}
+
+// CurlyRule enforces consistent brace usage on control statements.
+// https://eslint.org/docs/latest/rules/curly
+var CurlyRule = rule.Rule{
+	Name: "curly",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		c := &curlyChecker{
+			ctx:     ctx,
+			sf:      ctx.SourceFile,
+			text:    ctx.SourceFile.Text(),
+			lineMap: ctx.SourceFile.ECMALineMap(),
+			opts:    parseOptions(options),
+		}
+
+		return rule.RuleListeners{
+			ast.KindIfStatement: c.checkIfStatement,
+			ast.KindWhileStatement: func(node *ast.Node) {
+				c.check(c.prepareCheck(node, node.AsWhileStatement().Statement, "while", true))
+			},
+			ast.KindDoStatement: func(node *ast.Node) {
+				c.check(c.prepareCheck(node, node.AsDoStatement().Statement, "do", false))
+			},
+			ast.KindForStatement: func(node *ast.Node) {
+				c.check(c.prepareCheck(node, node.AsForStatement().Statement, "for", true))
+			},
+			ast.KindForInStatement: func(node *ast.Node) {
+				c.check(c.prepareCheck(node, node.AsForInOrOfStatement().Statement, "for-in", false))
+			},
+			ast.KindForOfStatement: func(node *ast.Node) {
+				c.check(c.prepareCheck(node, node.AsForInOrOfStatement().Statement, "for-of", false))
+			},
+		}
+	},
+}
+
+func (c *curlyChecker) lineOf(pos int) int {
+	return scanner.ComputeLineOfPosition(c.lineMap, pos)
+}
+
+// checkIfStatement handles the whole if / else-if / else chain when visiting the
+// top `if`, and skips inner `else if`s (they are checked through the top `if`).
+func (c *curlyChecker) checkIfStatement(node *ast.Node) {
+	parent := node.Parent
+	isElseIf := parent != nil && parent.Kind == ast.KindIfStatement &&
+		parent.AsIfStatement().ElseStatement == node
+	if isElseIf {
+		return
+	}
+	for _, pc := range c.prepareIfChecks(node) {
+		c.check(pc)
+	}
+}
+
+func (c *curlyChecker) prepareIfChecks(node *ast.Node) []preparedCheck {
+	checks := []preparedCheck{}
+
+	for current := node; current != nil; current = current.AsIfStatement().ElseStatement {
+		ifStmt := current.AsIfStatement()
+		checks = append(checks, c.prepareCheck(current, ifStmt.ThenStatement, "if", true))
+		alt := ifStmt.ElseStatement
+		if alt != nil && alt.Kind != ast.KindIfStatement {
+			checks = append(checks, c.prepareCheck(current, alt, "else", false))
+			break
+		}
+	}
+
+	if c.opts.consistent {
+		// If any node should have, or already has, braces then they all must.
+		anyExpected := false
+		for _, pc := range checks {
+			var v bool
+			switch pc.expected {
+			case expectBraces:
+				v = true
+			case expectNoBraces:
+				v = false
+			default:
+				v = pc.actual
+			}
+			if v {
+				anyExpected = true
+				break
+			}
+		}
+		target := expectNoBraces
+		if anyExpected {
+			target = expectBraces
+		}
+		for i := range checks {
+			checks[i].expected = target
+		}
+	}
+
+	return checks
+}
+
+func (c *curlyChecker) prepareCheck(node, body *ast.Node, name string, condition bool) preparedCheck {
+	hasBlock := body.Kind == ast.KindBlock
+	expected := expectDontCare
+
+	switch {
+	case hasBlock && (len(c.blockStatements(body)) != 1 || c.areBracesNecessary(body)):
+		expected = expectBraces
+	case c.opts.multiOnly:
+		expected = expectNoBraces
+	case c.opts.multiLine:
+		if !c.isCollapsedOneLiner(body) {
+			expected = expectBraces
+		}
+		// otherwise the body may or may not have braces
+	case c.opts.multiOrNest:
+		if hasBlock {
+			statement := c.blockStatements(body)[0]
+			leadingComments := c.hasLeadingComments(body, statement)
+			if !c.isOneLiner(statement) || leadingComments {
+				expected = expectBraces
+			} else {
+				expected = expectNoBraces
+			}
+		} else {
+			if c.isOneLiner(body) {
+				expected = expectNoBraces
+			} else {
+				expected = expectBraces
+			}
+		}
+	default:
+		// "all"
+		expected = expectBraces
+	}
+
+	return preparedCheck{
+		node:      node,
+		body:      body,
+		name:      name,
+		condition: condition,
+		actual:    hasBlock,
+		expected:  expected,
+	}
+}
+
+func (c *curlyChecker) check(pc preparedCheck) {
+	if pc.expected == expectDontCare {
+		return
+	}
+	wantBraces := pc.expected == expectBraces
+	if wantBraces == pc.actual {
+		return
+	}
+
+	bodyRange := utils.TrimNodeTextRange(c.sf, pc.body)
+
+	if wantBraces {
+		fixText := "{" + c.text[bodyRange.Pos():bodyRange.End()] + "}"
+		c.ctx.ReportRangeWithFixes(
+			bodyRange,
+			c.message(true, pc.condition, pc.name),
+			rule.RuleFixReplaceRange(bodyRange, fixText),
+		)
+		return
+	}
+
+	// Unnecessary braces: body is a block statement.
+	if fix, ok := c.buildRemoveBracesFix(pc.node, pc.body, bodyRange); ok {
+		c.ctx.ReportRangeWithFixes(bodyRange, c.message(false, pc.condition, pc.name), fix)
+	} else {
+		c.ctx.ReportRange(bodyRange, c.message(false, pc.condition, pc.name))
+	}
+}
+
+func (c *curlyChecker) message(missing, condition bool, name string) rule.RuleMessage {
+	var id, desc string
+	switch {
+	case missing && condition:
+		id, desc = "missingCurlyAfterCondition", "Expected { after '"+name+"' condition."
+	case missing:
+		id, desc = "missingCurlyAfter", "Expected { after '"+name+"'."
+	case condition:
+		id, desc = "unexpectedCurlyAfterCondition", "Unnecessary { after '"+name+"' condition."
+	default:
+		id, desc = "unexpectedCurlyAfter", "Unnecessary { after '"+name+"'."
+	}
+	return rule.RuleMessage{Id: id, Description: desc, Data: map[string]string{"name": name}}
+}
+
+// buildRemoveBracesFix builds the fix that strips the braces from a block body.
+// It returns ok=false when removing the braces would change semantics due to
+// ASI, in which case the diagnostic is reported without a fix.
+func (c *curlyChecker) buildRemoveBracesFix(node, body *ast.Node, bodyRange core.TextRange) (rule.RuleFix, bool) {
+	openBraceStart := scanner.SkipTrivia(c.text, body.Pos()) // `{`
+	closeBracePos := body.End() - 1                          // `}`
+
+	if c.needsSemicolon(closeBracePos, openBraceStart+1) {
+		return rule.RuleFix{}, false
+	}
+
+	resultingBodyText := c.text[openBraceStart+1 : closeBracePos]
+	prefix := ""
+	if c.needsPrecedingSpace(node, body, openBraceStart) {
+		prefix = " "
+	}
+	return rule.RuleFixReplaceRange(bodyRange, prefix+resultingBodyText), true
+}
+
+// needsPrecedingSpace mirrors the `do{...}` special case: removing the braces
+// from a `do` body that is glued to the `do` keyword can fuse the keyword with
+// the first inner token (e.g. `do{foo()}` would lose the token boundary between
+// `do` and the call), so a space is required.
+func (c *curlyChecker) needsPrecedingSpace(node, body *ast.Node, openBraceStart int) bool {
+	if node.Kind != ast.KindDoStatement {
+		return false
+	}
+	// `do` is adjacent to `{` only when there is no trivia before the block.
+	if openBraceStart != body.Pos() {
+		return false
+	}
+	firstContent := scanner.SkipTrivia(c.text, openBraceStart+1)
+	if firstContent >= len(c.text) {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(c.text[firstContent:])
+	return scanner.IsIdentifierPart(r)
+}
+
+// needsSemicolon reports whether removing the braces would require a semicolon
+// to be inserted to preserve semantics (ASI hazard). Mirrors ESLint's
+// needsSemicolon; the curly fixer treats a true result as "don't fix".
+func (c *curlyChecker) needsSemicolon(closeBracePos, contentStart int) bool {
+	tbStart, tbEnd, tbKind := c.lastTokenBefore(contentStart, closeBracePos)
+
+	taStart := scanner.SkipTrivia(c.text, closeBracePos+1)
+	hasAfter := taStart < len(c.text) &&
+		scanner.ScanTokenAtPosition(c.sf, taStart) != ast.KindEndOfFile
+
+	if tbKind == ast.KindSemicolonToken {
+		// The last statement already has a semicolon.
+		return false
+	}
+	if !hasAfter {
+		// No statements after this block.
+		return false
+	}
+
+	// If the last node surrounded by braces is itself a BlockStatement (other
+	// than a function/arrow body), removing the braces can't break ASI.
+	lastBlockNode := ast.GetNodeAtPosition(c.sf, tbStart, false)
+	if lastBlockNode != nil && lastBlockNode.Kind == ast.KindBlock {
+		p := lastBlockNode.Parent
+		if p != nil && p.Kind != ast.KindFunctionExpression && p.Kind != ast.KindArrowFunction {
+			return false
+		}
+	}
+
+	if c.lineOf(tbEnd) == c.lineOf(taStart) {
+		// The next token is on the same line.
+		return true
+	}
+	// The next token starts with a character that would disrupt ASI.
+	switch c.text[taStart] {
+	case '(', '[', '/', '`', '+', '-':
+		return true
+	}
+	// The last token is ++ or --.
+	if tbKind == ast.KindPlusPlusToken || tbKind == ast.KindMinusMinusToken {
+		return true
+	}
+	return false
+}
+
+// lastTokenBefore scans tokens in [fromPos, beforePos) and returns the last one.
+func (c *curlyChecker) lastTokenBefore(fromPos, beforePos int) (start, end int, kind ast.Kind) {
+	s := scanner.GetScannerForSourceFile(c.sf, fromPos)
+	for s.TokenStart() < beforePos && s.Token() != ast.KindEndOfFile {
+		start, end, kind = s.TokenStart(), s.TokenEnd(), s.Token()
+		s.Scan()
+	}
+	return
+}
+
+// areBracesNecessary mirrors astUtils.areBracesNecessary: a single-statement
+// block still needs its braces when the statement is a lexical declaration, or
+// when it ends with an `if` that would capture a trailing `else`.
+func (c *curlyChecker) areBracesNecessary(block *ast.Node) bool {
+	statement := c.blockStatements(block)[0]
+	return isLexicalDeclaration(statement) ||
+		(hasUnsafeIf(statement) && c.isFollowedByElseKeyword(block))
+}
+
+func (c *curlyChecker) isFollowedByElseKeyword(block *ast.Node) bool {
+	nextStart := scanner.SkipTrivia(c.text, block.End())
+	if nextStart >= len(c.text) {
+		return false
+	}
+	return scanner.ScanTokenAtPosition(c.sf, nextStart) == ast.KindElseKeyword
+}
+
+// isCollapsedOneLiner reports whether the body sits on the same line as the
+// token that precedes it (its closing `)` / `do` / `else`).
+func (c *curlyChecker) isCollapsedOneLiner(node *ast.Node) bool {
+	// node.Pos() lands right after the preceding token, so its line is that
+	// token's line.
+	return c.lineOf(node.Pos()) == c.lineOf(c.lastNonSemiTokenEnd(node))
+}
+
+// isOneLiner reports whether the node spans a single line, ignoring a trailing
+// semicolon.
+func (c *curlyChecker) isOneLiner(node *ast.Node) bool {
+	if node.Kind == ast.KindEmptyStatement {
+		return true
+	}
+	start := scanner.SkipTrivia(c.text, node.Pos())
+	return c.lineOf(start) == c.lineOf(c.lastNonSemiTokenEnd(node))
+}
+
+// lastNonSemiTokenEnd returns the end position of the node's last token,
+// excluding a trailing semicolon.
+func (c *curlyChecker) lastNonSemiTokenEnd(node *ast.Node) int {
+	start := scanner.SkipTrivia(c.text, node.Pos())
+	trimmedEnd := utils.TrimNodeTextRange(c.sf, node).End()
+	// Fast path: when the whole node is on one line, a trailing semicolon
+	// can't move the end onto another line.
+	if c.lineOf(start) == c.lineOf(trimmedEnd) {
+		return trimmedEnd
+	}
+	s := scanner.GetScannerForSourceFile(c.sf, start)
+	end := start
+	for s.TokenStart() < node.End() && s.Token() != ast.KindEndOfFile {
+		if s.Token() != ast.KindSemicolonToken {
+			end = s.TokenEnd()
+		}
+		s.Scan()
+	}
+	return end
+}
+
+// hasLeadingComments reports whether there are comments between the block's
+// opening `{` and its first statement (ESLint's getCommentsBefore(statement)).
+func (c *curlyChecker) hasLeadingComments(block, statement *ast.Node) bool {
+	openBraceStart := scanner.SkipTrivia(c.text, block.Pos())
+	stmtStart := scanner.SkipTrivia(c.text, statement.Pos())
+	return utils.HasCommentsInRange(c.sf, core.NewTextRange(openBraceStart+1, stmtStart))
+}
+
+func (c *curlyChecker) blockStatements(block *ast.Node) []*ast.Node {
+	return block.AsBlock().Statements.Nodes
+}
+
+// isLexicalDeclaration mirrors astUtils.isLexicalDeclaration: let/const/using/
+// await using variable declarations and function/class declarations.
+//
+// NOTE: Unlike ESLint (which only sees JavaScript), tsgo also parses TypeScript
+// declarations that are equally illegal as an unbraced control-statement body
+// (`if (a) enum E {}` is a syntax error). They are treated the same as lexical
+// declarations so the autofix never strips a required block.
+func isLexicalDeclaration(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindVariableStatement:
+		declList := node.AsVariableStatement().DeclarationList
+		return declList.Flags&ast.NodeFlagsBlockScoped != 0
+	case ast.KindFunctionDeclaration,
+		ast.KindClassDeclaration,
+		ast.KindEnumDeclaration,
+		ast.KindModuleDeclaration,
+		ast.KindInterfaceDeclaration,
+		ast.KindTypeAliasDeclaration,
+		ast.KindImportEqualsDeclaration:
+		return true
+	}
+	return false
+}
+
+// hasUnsafeIf reports whether the code contains an `if` that would become
+// associated with an `else` appended directly after it.
+func hasUnsafeIf(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindIfStatement:
+		ifStmt := node.AsIfStatement()
+		if ifStmt.ElseStatement == nil {
+			return true
+		}
+		return hasUnsafeIf(ifStmt.ElseStatement)
+	case ast.KindForStatement:
+		return hasUnsafeIf(node.AsForStatement().Statement)
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		return hasUnsafeIf(node.AsForInOrOfStatement().Statement)
+	case ast.KindLabeledStatement:
+		return hasUnsafeIf(node.AsLabeledStatement().Statement)
+	case ast.KindWithStatement:
+		return hasUnsafeIf(node.AsWithStatement().Statement)
+	case ast.KindWhileStatement:
+		return hasUnsafeIf(node.AsWhileStatement().Statement)
+	default:
+		return false
+	}
+}

--- a/internal/rules/curly/curly.md
+++ b/internal/rules/curly/curly.md
@@ -1,0 +1,147 @@
+# curly
+
+## Rule Details
+
+This rule enforces consistent use of curly braces around blocks that follow
+`if`, `else`, `for`, `for...in`, `for...of`, `while`, and `do...while`
+statements. By default it requires braces everywhere, but it can also be
+configured to forbid them where they are unnecessary.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+if (foo) foo++;
+
+while (bar) baz();
+
+if (foo) {
+  baz();
+} else qux();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+if (foo) {
+  foo++;
+}
+
+while (bar) {
+  baz();
+}
+
+if (foo) {
+  baz();
+} else {
+  qux();
+}
+```
+
+## Options
+
+The rule accepts a primary string option and an optional secondary
+`"consistent"` modifier: `["error", "multi", "consistent"]`.
+
+### `"all"` (default)
+
+Requires braces around every block.
+
+### `"multi"`
+
+Forbids braces around blocks that contain a single statement, and requires them
+when the block contains two or more statements.
+
+```json
+{ "curly": ["error", "multi"] }
+```
+
+Examples of **incorrect** code for `"multi"`:
+
+```javascript
+if (foo) {
+  foo++;
+}
+
+for (var i = 0; foo; i++) {
+  doSomething();
+}
+```
+
+Examples of **correct** code for `"multi"`:
+
+```javascript
+if (foo) foo++;
+
+while (true) {
+  doSomething();
+  doSomethingElse();
+}
+```
+
+### `"multi-line"`
+
+Allows brace-less single-line statements, but requires braces once a statement
+spans multiple lines.
+
+```json
+{ "curly": ["error", "multi-line"] }
+```
+
+Examples of **correct** code for `"multi-line"`:
+
+```javascript
+if (foo) foo++;
+else doSomething();
+
+while (true) {
+  doSomething();
+  doSomethingElse();
+}
+```
+
+### `"multi-or-nest"`
+
+Forces brace-less syntax for a single-line statement, and requires braces for a
+multi-line statement or a statement that contains a nested block.
+
+```json
+{ "curly": ["error", "multi-or-nest"] }
+```
+
+Examples of **correct** code for `"multi-or-nest"`:
+
+```javascript
+if (foo) bar();
+
+if (foo) {
+  bar();
+  baz();
+}
+```
+
+### `"consistent"`
+
+Used together with `"multi"`, `"multi-line"`, or `"multi-or-nest"`, this option
+forces all branches of an `if`/`else if`/`else` chain to agree: either all have
+braces or none do.
+
+```json
+{ "curly": ["error", "multi", "consistent"] }
+```
+
+Examples of **correct** code for `["multi", "consistent"]`:
+
+```javascript
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+
+if (foo) bar();
+else baz();
+```
+
+## Original Documentation
+
+- [ESLint curly](https://eslint.org/docs/latest/rules/curly)

--- a/internal/rules/curly/curly_extras_test.go
+++ b/internal/rules/curly/curly_extras_test.go
@@ -1,0 +1,664 @@
+// TestCurlyExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the
+// specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+// Cases are grouped by `// ==== <area> ====` separators: Dimension-4 edge
+// shapes, deep nesting & `consistent` chains, real-user / expression / TS-only
+// bodies, statement-kind bodies & needsSemicolon resolution, and autofix
+// boundaries. Everything past the upstream floor was differentially validated
+// against ESLint (9.39.4 / v10.5.0) as oracle.
+//
+// Dimension 4 walk (rows that don't apply to curly, with reasons):
+//   - N/A receiver/expression wrappers ((X).y, X!.y, (X as T).y, X?.y): curly
+//     classifies the *statement* kind of a control-flow body, never an inner
+//     expression/receiver, so paren/non-null/as/optional-chain wrappers can't
+//     change which statement is matched.
+//   - N/A access/key forms (dotted vs computed vs private): curly never inspects
+//     member access or property keys.
+//   - N/A three-way name/key equivalence classes: curly compares nothing by name.
+package curly
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestCurlyExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&CurlyRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: declaration/container forms (function variants) ----
+			// async / generator / async-generator function declarations are
+			// FunctionDeclaration → braces required even under "multi".
+			{Code: "if (a) { async function f() {} }", Options: "multi"},
+			{Code: "if (a) { function* g() {} }", Options: "multi"},
+			{Code: "if (a) { async function* h() {} }", Options: "multi"},
+			// ---- Dimension 4: declaration/container forms (class variants) ----
+			{Code: "if (a) { class C {} }", Options: "multi"},
+			{Code: "if (a) { abstract class C {} }", Options: "multi"},
+
+			// ---- Dimension 4: TS-only declarations (keep braces; unbraced is a syntax error) ----
+			// Locks in the isLexicalDeclaration TS extension over ESLint's set.
+			{Code: "if (a) { enum E { X } }", Options: "multi"},
+			{Code: "if (a) { const enum E { X } }", Options: "multi"},
+			{Code: "if (a) { namespace N { f(); } }", Options: "multi"},
+			{Code: "if (a) { module M { f(); } }", Options: "multi"},
+			{Code: "if (a) { interface I {} }", Options: "multi"},
+			{Code: "if (a) { type T = number; }", Options: "multi"},
+			// Same, under multi-or-nest (single-line block still keeps braces).
+			{Code: "if (a) { enum E { X } }", Options: "multi-or-nest"},
+			{Code: "if (a) { type T = number; }", Options: "multi-or-nest"},
+
+			// ---- Dimension 4: graceful degradation (empty bodies) ----
+			// Empty block has 0 statements (!= 1) → braces kept by every mode.
+			{Code: "if (a) {}", Options: "multi"},
+			{Code: "while (a) {}", Options: "multi"},
+			{Code: "for (;;) {}", Options: "multi"},
+			{Code: "if (a) {}"},
+			// EmptyStatement body under multi / multi-or-nest is a one-liner → no braces wanted.
+			{Code: "if (a);", Options: "multi"},
+			{Code: "while (a);", Options: "multi-or-nest"},
+
+			// ---- Real-user/tsgo: type annotation on a let keeps it lexical ----
+			{Code: "if (a) { let x: number = 1; }", Options: "multi"},
+			{Code: "if (a) { const x: Foo = bar; }", Options: "multi-or-nest"},
+
+			// ---- Real-user/tsgo: optional chain / as-cast bodies are plain statements ----
+			// (one-liners, so "multi-or-nest" wants them brace-less, and they are)
+			{Code: "if (a) foo?.bar();", Options: "multi-or-nest"},
+			{Code: "if (a) x = y as Foo;", Options: "multi"},
+
+			// ---- Dimension 4: TS import-equals body keeps braces (unbraced is a syntax error) ----
+			{Code: "if (a) { import X = N.M; }", Options: "multi"},
+			// Locks in upstream hasUnsafeIf() WithStatement arm: a single-level
+			// `with` wrapping an else-less `if`, followed by `else`, keeps braces.
+			{Code: "if (a) { with (o) if (b) foo(); } else bar();", Options: "multi"},
+			// ---- Dimension 4: parenthesized one-liner body, no braces wanted ----
+			{Code: "if (a) (b());", Options: "multi-or-nest"},
+
+			// ---- Graceful degradation: rslint does not schema-validate options
+			// (no native rule does), so invalid combos degrade instead of erroring.
+			// `["consistent"]` alone has no multi* mode → behaves like "all". ----
+			{Code: "if (a) { b() }", Options: []interface{}{"consistent"}},
+			// Unknown 2nd option is ignored → behaves like plain "multi".
+			{Code: "if (a) b()", Options: []interface{}{"multi", "foo"}},
+
+			// ==== deep nesting & consistent chains ====
+			// else-if chains, all one-liners, under "multi" → no braces anywhere
+			{Code: "if (a) foo(); else if (b) bar(); else baz();", Options: "multi"},
+			// 4-branch chain: first is multi-statement (keeps), rest one-liners
+			{Code: "if (a) { x(); y(); } else if (b) z(); else if (c) w(); else v();", Options: "multi"},
+			// consistent + multi, all three branches braceless → consistent already
+			{Code: "if (a) foo(); else if (b) bar(); else baz();", Options: []interface{}{"multi", "consistent"}},
+			// consistent + multi-or-nest, nested removable everywhere
+			{Code: "if (a) { if (b) c(); } else { d(); }", Options: []interface{}{"multi-or-nest", "consistent"}},
+			// consistent + multi-line, multiline only in the condition → no braces forced
+			{Code: "if (a &&\n b) foo()", Options: []interface{}{"multi-line", "consistent"}},
+
+			// ==== real-user shapes & expression / TS-only bodies ====
+			// ---- Real-user issue #12972: leading-comment forcing applies ONLY to block
+			// bodies, not bare bodies → a comment before a bare one-liner reports nothing ----
+			{Code: "if (foo)\n    // some comment\n    bar();", Options: "multi-or-nest"},
+			{Code: "if (foo)\n    // some comment\n    bar();", Options: "multi"},
+			// same comment INSIDE a single-stmt block under multi-or-nest → keep braces
+			{Code: "if (foo) {\n    // some comment\n    bar();\n}", Options: "multi-or-nest"},
+			// ---- Real-user issue #13280: real nested for-of/if/for-of/if-else, braces necessary ----
+			{Code: "function find() {\n  for (const [lineId, line] of lines.entries())\n    if (regexp === false) {\n      for (const reg of regionRegexps)\n        if (testLine(line, reg, regionName)) {\n          start = lineId + 1;\n          regexp = reg;\n          break;\n        }\n    } else if (testLine(line, regexp, regionName, true))\n      return { start, end: lineId, regexp };\n}", Options: "multi"},
+			// return one-liner body under multi
+			{Code: "function f() { if (a) return; }", Options: "multi"},
+
+			// ---- TS-only valid (declarations keep braces; one-liner TS exprs need none) ----
+			{Code: "async function f() { for await (const x of y) z(); }", Options: "multi"},
+			{Code: "if (a) { @dec class C {} }", Options: "multi"},
+			{Code: "if (a) { @dec class C {} }", Options: "multi-or-nest"},
+			{Code: "if (a) { declare const x: number; }", Options: "multi"},
+			{Code: "if (a) { abstract class C { abstract m(): void; } }", Options: "multi"},
+			{Code: "if (a)\n foo<number>();", Options: "multi-or-nest"},
+			{Code: "if (a)\n x = y satisfies Foo;", Options: "multi-or-nest"},
+
+			// ==== statement-kind bodies & needsSemicolon node resolution ====
+			// do-while with a multi-statement body keeps its braces under "multi"
+			{Code: "do { f(); g(); } while (x)", Options: "multi"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Real-user/tsgo: as-cast body, braces unnecessary under multi ----
+			{
+				Code:    "if (foo) { x = y as Foo; }",
+				Output:  []string{"if (foo)  x = y as Foo; "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 27},
+				},
+			},
+			// ---- Real-user/tsgo: optional-chain call body, braces unnecessary under multi ----
+			{
+				Code:    "if (foo) { a?.b(); }",
+				Output:  []string{"if (foo)  a?.b(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 21},
+				},
+			},
+
+			// ---- Dimension 4: EmptyStatement body under "all" wants braces ----
+			{
+				Code:   "if (a);",
+				Output: []string{"if (a){;}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Message: "Expected { after 'if' condition.", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+				},
+			},
+
+			// ---- Dimension 4: same-kind nesting (both ifs flagged, fixed across passes) ----
+			{
+				Code:   "if (a) if (b) foo()",
+				Output: []string{"if (a) {if (b) foo()}", "if (a) {if (b) {foo()}}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 20},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 15, EndLine: 1, EndColumn: 20},
+				},
+			},
+
+			// Locks in needsSemicolon arm: next token starts with backtick → no fix.
+			{
+				Code:    "if (foo) { bar }\n`x`.length;",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// Locks in needsSemicolon arm: next token starts with `-` → no fix.
+			{
+				Code:    "if (foo) { bar }\n-baz;",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// Locks in needsSemicolon arm: last token is `--` → no fix.
+			{
+				Code:    "if (foo) { bar-- }\nbaz;",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 19},
+				},
+			},
+
+			// ---- Message-text contract: every messageId × name the rule emits ----
+			{
+				Code:   "do foo(); while (bar)",
+				Output: []string{"do {foo();} while (bar)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Message: "Expected { after 'do'.", Line: 1, Column: 4, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code:   "for (x in y) z();",
+				Output: []string{"for (x in y) {z();}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Message: "Expected { after 'for-in'.", Line: 1, Column: 14, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:   "for (x of y) z();",
+				Output: []string{"for (x of y) {z();}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Message: "Expected { after 'for-of'.", Line: 1, Column: 14, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:   "for (;;) z();",
+				Output: []string{"for (;;) {z();}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Message: "Expected { after 'for' condition.", Line: 1, Column: 10, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code:   "while (a) b();",
+				Output: []string{"while (a) {b();}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Message: "Expected { after 'while' condition.", Line: 1, Column: 11, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:   "if (a) {b()} else c();",
+				Output: []string{"if (a) {b()} else {c();}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Message: "Expected { after 'else'.", Line: 1, Column: 19, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code:    "for (x in y) { z(); }",
+				Output:  []string{"for (x in y)  z(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Message: "Unnecessary { after 'for-in'.", Line: 1, Column: 14, EndLine: 1, EndColumn: 22},
+				},
+			},
+			// Locks in needsSemicolon arm: last statement already ends with `;`
+			// (tokenBefore is `;`) → fix proceeds even though `}` and `c` share a line.
+			{
+				Code:    "if (a) { b(); } c();",
+				Output:  []string{"if (a)  b();  c();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code:    "while (a) { b(); }",
+				Output:  []string{"while (a)  b(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Message: "Unnecessary { after 'while' condition.", Line: 1, Column: 11, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code:    "do { foo(); } while (bar)",
+				Output:  []string{"do  foo();  while (bar)"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Message: "Unnecessary { after 'do'.", Line: 1, Column: 4, EndLine: 1, EndColumn: 14},
+				},
+			},
+
+			// ---- needsPrecedingSpace: do{...} glued, first inner token decides space ----
+			// Identifier-part (numeric) → space inserted (matches canTokensBeAdjacent).
+			{
+				Code:    "do{5;}while(x)",
+				Output:  []string{"do 5;while(x)"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 3, EndLine: 1, EndColumn: 7},
+				},
+			},
+			// Punctuator `(` → no space.
+			{
+				Code:    "do{(1);}while(x)",
+				Output:  []string{"do(1);while(x)"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 3, EndLine: 1, EndColumn: 9},
+				},
+			},
+			// Template backtick → no space.
+			{
+				Code:    "do{`x`;}while(x)",
+				Output:  []string{"do`x`;while(x)"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 3, EndLine: 1, EndColumn: 9},
+				},
+			},
+
+			// ---- Dimension 4: labeled statement as the sole removable body ----
+			{
+				Code:    "if (a) { lbl: foo(); }",
+				Output:  []string{"if (a)  lbl: foo(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 23},
+				},
+			},
+			// ---- Dimension 4: parenthesized expression body ----
+			{
+				Code:    "if (a) { (b()); }",
+				Output:  []string{"if (a)  (b()); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 18},
+				},
+			},
+			// ---- Real-user/tsgo: `satisfies` and non-null `!` bodies are plain statements ----
+			{
+				Code:    "if (foo) { x = y satisfies Foo; }",
+				Output:  []string{"if (foo)  x = y satisfies Foo; "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code:    "if (foo) { x = y!; }",
+				Output:  []string{"if (foo)  x = y!; "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 21},
+				},
+			},
+
+			// ---- Message-text contract: remaining messageId × name combos ----
+			{
+				Code:    "if (foo) { bar() }",
+				Output:  []string{"if (foo)  bar() "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Message: "Unnecessary { after 'if' condition.", Line: 1, Column: 10, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code:    "for (;;) { foo(); }",
+				Output:  []string{"for (;;)  foo(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Message: "Unnecessary { after 'for' condition.", Line: 1, Column: 10, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				Code:    "if (foo) baz(); else { bar() }",
+				Output:  []string{"if (foo) baz(); else  bar() "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Message: "Unnecessary { after 'else'.", Line: 1, Column: 22, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code:    "for (x of y) { z() }",
+				Output:  []string{"for (x of y)  z() "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Message: "Unnecessary { after 'for-of'.", Line: 1, Column: 14, EndLine: 1, EndColumn: 21},
+				},
+			},
+
+			// ---- needsSemicolon × comments: the token scan skips comments, matching
+			// ESLint's getTokenBefore/getTokenAfter ----
+			// Comment after `}` on the same line as `bar` → still same-line ASI → no fix.
+			{
+				Code:    "if (a) { foo() } /* c */ bar()",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// Comment skipped to reach `[` → ASI hazard → no fix.
+			{
+				Code:    "if (a) { bar }\n/* c */[1, 2, 3].map(x)",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// Multi-line comment pushes `bar` to the next line; `bar` is safe → fix proceeds.
+			{
+				Code:    "if (a) { foo() } /*\nc*/ bar()",
+				Output:  []string{"if (a)  foo()  /*\nc*/ bar()"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// Comment between last statement and `}` — tokenBefore skips it to `)`.
+			{
+				Code:    "if (a) { foo() /* c */ } bar()",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 25},
+				},
+			},
+
+			// ---- Dimension 4: multi-byte chars — report columns are UTF-16 units,
+			// matching ESLint. An astral char (😀 = 2 UTF-16 units) widens endColumn. ----
+			{
+				Code:   `if (a) foo("😀")`,
+				Output: []string{`if (a) {foo("😀")}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 17},
+				},
+			},
+			// BMP multi-byte (日本 = 1 UTF-16 unit each) in the condition does not shift the body column.
+			{
+				Code:   "if (日本) foo()",
+				Output: []string{"if (日本) {foo()}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 9, EndLine: 1, EndColumn: 14},
+				},
+			},
+			// ---- Graceful degradation (invalid option schema): no crash, predictable mode ----
+			{
+				Code:    "if (a) b()",
+				Output:  []string{"if (a) {b()}"},
+				Options: []interface{}{"consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 11},
+				},
+			},
+
+			// ==== deep nesting & consistent chains ====
+			// ---- 3-level if/while/for under "all": braces added one level per pass ----
+			{
+				Code: "if (a) while (b) for (;;) c();",
+				Output: []string{
+					"if (a) {while (b) for (;;) c();}",
+					"if (a) {while (b) {for (;;) c();}}",
+					"if (a) {while (b) {for (;;) {c();}}}",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 31},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 18, EndLine: 1, EndColumn: 31},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 27, EndLine: 1, EndColumn: 31},
+				},
+			},
+			// ---- 4-level for nesting under "all" (4 passes) ----
+			{
+				Code: "for(;;) for(;;) for(;;) for(;;) x();",
+				Output: []string{
+					"for(;;) {for(;;) for(;;) for(;;) x();}",
+					"for(;;) {for(;;) {for(;;) for(;;) x();}}",
+					"for(;;) {for(;;) {for(;;) {for(;;) x();}}}",
+					"for(;;) {for(;;) {for(;;) {for(;;) {x();}}}}",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 9, EndLine: 1, EndColumn: 37},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 17, EndLine: 1, EndColumn: 37},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 25, EndLine: 1, EndColumn: 37},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 33, EndLine: 1, EndColumn: 37},
+				},
+			},
+			// ---- 3-level nesting under multi-or-nest ----
+			{
+				Code:    "if (a)\n if (b)\n for (;;)\n c();",
+				Output:  []string{"if (a)\n {if (b)\n for (;;)\n c();}", "if (a)\n {if (b)\n {for (;;)\n c();}}"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 2, EndLine: 4, EndColumn: 6},
+					{MessageId: "missingCurlyAfterCondition", Line: 3, Column: 2, EndLine: 4, EndColumn: 6},
+				},
+			},
+			// ---- else-if chain, 3 branches, "all" (single pass) ----
+			{
+				Code:   "if (a) foo(); else if (b) bar(); else baz();",
+				Output: []string{"if (a) {foo();} else if (b) {bar();} else {baz();}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 14},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 27, EndLine: 1, EndColumn: 33},
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 39, EndLine: 1, EndColumn: 45},
+				},
+			},
+			// ---- consistent + multi: only 1st braced → all forced braceless ----
+			{
+				Code:    "if (a) { foo(); } else if (b) bar(); else baz();",
+				Output:  []string{"if (a)  foo();  else if (b) bar(); else baz();"},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 18},
+				},
+			},
+			// ---- consistent + multi: all three one-liner branches braced → remove all ----
+			{
+				Code:    "if (a) { foo(); } else if (b) { bar(); } else { baz(); }",
+				Output:  []string{"if (a)  foo();  else if (b)  bar();  else  baz(); "},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 18},
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 31, EndLine: 1, EndColumn: 41},
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 47, EndLine: 1, EndColumn: 57},
+				},
+			},
+			// ---- consistent + multi-or-nest: only 2nd braced single-liner → remove ----
+			{
+				Code:    "if (a) foo(); else if (b) { bar(); } else baz();",
+				Output:  []string{"if (a) foo(); else if (b)  bar();  else baz();"},
+				Options: []interface{}{"multi-or-nest", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 27, EndLine: 1, EndColumn: 37},
+				},
+			},
+			// ---- consistent + multi-line: one multiline branch forces braces on ALL ----
+			{
+				Code:    "if (a) foo(); else if (b) bar(); else\nbaz()",
+				Output:  []string{"if (a) {foo();} else if (b) {bar();} else\n{baz()}"},
+				Options: []interface{}{"multi-line", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 14},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 27, EndLine: 1, EndColumn: 33},
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 1, EndLine: 2, EndColumn: 6},
+				},
+			},
+			// ---- consistent forcing ADD: else is lexical/multi-stmt → if branch forced to brace ----
+			{
+				Code:    "if (a) foo(); else { let x = 1; }",
+				Output:  []string{"if (a) {foo();} else { let x = 1; }"},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code:    "if (a) { if (b) foo(); } else bar();",
+				Output:  []string{"if (a) { if (b) foo(); } else {bar();}"},
+				Options: []interface{}{"multi-or-nest", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 31, EndLine: 1, EndColumn: 37},
+				},
+			},
+
+			// ==== real-user shapes & expression / TS-only bodies ====
+			// ---- Real-user issue #13216: multi-line parenthesized return body wants braces (all) ----
+			{
+				Code:   "function C() { if (open) return (\n  foo\n); }",
+				Output: []string{"function C() { if (open) {return (\n  foo\n);} }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 26, EndLine: 3, EndColumn: 3},
+				},
+			},
+			// ---- Expression-statement body variety under "all" ----
+			{Code: "if (a) b ? c() : d();", Output: []string{"if (a) {b ? c() : d();}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 22}}},
+			{Code: "if (a) throw new Error('x');", Output: []string{"if (a) {throw new Error('x');}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 29}}},
+			{Code: "if (a) b = 1, c = 2;", Output: []string{"if (a) {b = 1, c = 2;}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 21}}},
+			{Code: "async function f() { if (a) await g(); }", Output: []string{"async function f() { if (a) {await g();} }"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 29, EndLine: 1, EndColumn: 39}}},
+			{Code: "function* f() { if (a) yield x; }", Output: []string{"function* f() { if (a) {yield x;} }"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 24, EndLine: 1, EndColumn: 32}}},
+			// ---- arrow-returning-object / IIFE block bodies removable under multi ----
+			{Code: "if (a) { foo(() => ({ x: 1 })); }", Output: []string{"if (a)  foo(() => ({ x: 1 })); "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 34}}},
+			{Code: "if (a) { (function(){})(); }", Output: []string{"if (a)  (function(){})(); "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 29}}},
+
+			// ---- TS-only: for-await-of behaves like for-of ----
+			{Code: "async function f() { for await (const x of y) z(); }",
+				Output: []string{"async function f() { for await (const x of y) {z();} }"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfter", Line: 1, Column: 47, EndLine: 1, EndColumn: 51}}},
+			{Code: "async function f() { for await (const x of y) { z(); } }",
+				Output: []string{"async function f() { for await (const x of y)  z();  }"}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 47, EndLine: 1, EndColumn: 55}}},
+			// ---- TS-only: using / await using in for-of head ----
+			{Code: "for (using x of y) { z(); }", Output: []string{"for (using x of y)  z(); "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 20, EndLine: 1, EndColumn: 28}}},
+			{Code: "async function f() { for (await using x of y) { z(); } }",
+				Output: []string{"async function f() { for (await using x of y)  z();  }"}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 47, EndLine: 1, EndColumn: 55}}},
+			// ---- TS-only: generic call expression body behaves like a plain call ----
+			{Code: "if (a) { foo<T>(); }", Output: []string{"if (a)  foo<T>(); "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 21}}},
+
+			// ==== statement-kind bodies & needsSemicolon node resolution ====
+			// ---- switch-statement body ----
+			{Code: "if (a) switch (b) { case 1: f(); }", Output: []string{"if (a) {switch (b) { case 1: f(); }}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 35}}},
+			{Code: "if (a) { switch (b) { case 1: f(); } }", Output: []string{"if (a)  switch (b) { case 1: f(); } "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 39}}},
+			// ---- try/catch and try/finally bodies ----
+			{Code: "if (a) try { f(); } catch (e) {}", Output: []string{"if (a) {try { f(); } catch (e) {}}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 33}}},
+			{Code: "if (a) try { f(); } finally { g(); }", Output: []string{"if (a) {try { f(); } finally { g(); }}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 37}}},
+			{Code: "if (a) { try { f(); } catch (e) {} }", Output: []string{"if (a)  try { f(); } catch (e) {} "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 37}}},
+			// ---- bare block body — 2-pass removal (outer then inner) ----
+			{Code: "if (a) { { x(); } }", Output: []string{"if (a)  { x(); } ", "if (a)   x();  "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 20}}},
+			// ---- do-while single-stmt body inside an if-block, removable ----
+			{Code: "if (a) { do x(); while (y) }", Output: []string{"if (a)  do x(); while (y) "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 29}}},
+
+			// ---- needsSemicolon lastBlockNode resolution (which tail makes removal unfixable) ----
+			// switch tail → resolves to SwitchStatement (not Block) → same-line ASI → NO fix
+			{Code: "if (a) { switch (b) {} } bar()", Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 25}}},
+			// switch tail then `;` → still NO fix
+			{Code: "if (a) { switch (b) {} } ; bar()", Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 25}}},
+			// try/catch tail → catch Block (parent CatchClause) → FIX proceeds
+			{Code: "if (a) { try {} catch (e) {} } bar()", Output: []string{"if (a)  try {} catch (e) {}  bar()"}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 31}}},
+			// bare-block tail → BlockStatement → FIX proceeds
+			{Code: "if (a) { { foo() } } bar()", Output: []string{"if (a)  { foo() }  bar()"}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 21}}},
+			// do-while tail → last token `)` not a block → same-line ASI → NO fix
+			{Code: "if (a) { do {} while (x) } bar()", Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 27}}},
+
+			// ---- for-in block whose single stmt is `var` (non-lexical) → removable ----
+			{Code: "for (k in o) { var x = 1; }", Output: []string{"for (k in o)  var x = 1; "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 14, EndLine: 1, EndColumn: 28}}},
+			// ---- empty-statement body of a for under "all" → wrap ----
+			{Code: "for (;;);", Output: []string{"for (;;){;}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 9, EndLine: 1, EndColumn: 10}}},
+			// ---- labeled `if` (label wraps the if; body still flagged) ----
+			{Code: "lbl: if (a) b();", Output: []string{"lbl: if (a) {b();}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 13, EndLine: 1, EndColumn: 17}}},
+
+			// ==== autofix boundaries: comments / whitespace / multi-pass ====
+			// ---- comment INSIDE the block preserved on brace removal ----
+			{Code: "if (a) { /* c */ foo(); }", Output: []string{"if (a)  /* c */ foo(); "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 26}}},
+			{Code: "if (a) { foo(); /* c */ }", Output: []string{"if (a)  foo(); /* c */ "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 26}}},
+			{Code: "if (a) { foo() /* trailing */ }", Output: []string{"if (a)  foo() /* trailing */ "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 32}}},
+			{Code: "if (a) { // keep\n foo();\n}", Output: []string{"if (a)  // keep\n foo();\n"}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 3, EndColumn: 2}}},
+			// ---- comment BETWEEN condition and `{` preserved; report range starts at `{` ----
+			{Code: "if (a) /*c*/ { foo(); }", Output: []string{"if (a) /*c*/  foo(); "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 14, EndLine: 1, EndColumn: 24}}},
+			// ---- multi-level parenthesized body ----
+			{Code: "if (a) { ((b())); }", Output: []string{"if (a)  ((b())); "}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 20}}},
+			// ---- arbitrary whitespace preserved verbatim on removal (blank lines / tab / CRLF) ----
+			{Code: "if (a) {\n\n  foo();\n\n}", Output: []string{"if (a) \n\n  foo();\n\n"}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 5, EndColumn: 2}}},
+			{Code: "if (a) {\n\tfoo();\n}", Output: []string{"if (a) \n\tfoo();\n"}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 3, EndColumn: 2}}},
+			{Code: "if (a) {\r\n foo();\r\n}", Output: []string{"if (a) \r\n foo();\r\n"}, Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 3, EndColumn: 2}}},
+			// ---- multi-pass add-braces (fix result still violates → 2nd pass) ----
+			{Code: "while (a) if (b) c();", Output: []string{"while (a) {if (b) c();}", "while (a) {if (b) {c();}}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 11, EndLine: 1, EndColumn: 22},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 18, EndLine: 1, EndColumn: 22}}},
+			// ---- `}` then comment then `else` → diagnostic but NO fix (else follows the block) ----
+			{Code: "if (a) { foo() } /* c */ else b()", Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 17}}},
+		},
+	)
+}

--- a/internal/rules/curly/curly_upstream_test.go
+++ b/internal/rules/curly/curly_upstream_test.go
@@ -1,0 +1,1047 @@
+// TestCurlyUpstream migrates the full valid/invalid suite from upstream
+// eslint/tests/lib/rules/curly.js 1:1. Position assertions cover
+// line/column/endLine/endColumn for every invalid case (values upstream pins
+// down are mirrored verbatim; the rest are the rule's actual report ranges).
+// rslint-specific lock-in cases live in the curly_extras_test.go file.
+package curly
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestCurlyUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&CurlyRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "if (foo) { bar() }"},
+			{Code: "if (foo) { bar() } else if (foo2) { baz() }"},
+			{Code: "while (foo) { bar() }"},
+			{Code: "do { bar(); } while (foo)"},
+			{Code: "for (;foo;) { bar() }"},
+			{Code: "for (var foo in bar) { console.log(foo) }"},
+			{Code: "for (var foo of bar) { console.log(foo) }"},
+			{Code: "for (;foo;) bar()", Options: "multi"},
+			{Code: "if (foo) bar()", Options: "multi"},
+			{Code: "if (a) { b; c; }", Options: "multi"},
+			{Code: "for (var foo in bar) console.log(foo)", Options: "multi"},
+			{Code: "for (var foo in bar) { console.log(1); console.log(2) }", Options: "multi"},
+			{Code: "for (var foo of bar) console.log(foo)", Options: "multi"},
+			{Code: "for (var foo of bar) { console.log(1); console.log(2) }", Options: "multi"},
+			{Code: "if (foo) bar()", Options: "multi-line"},
+			{Code: "if (foo) bar() \n", Options: "multi-line"},
+			{Code: "if (foo) bar(); else baz()", Options: "multi-line"},
+			{Code: "if (foo) bar(); \n else baz()", Options: "multi-line"},
+			{Code: "if (foo) bar() \n else if (foo) bar() \n else baz()", Options: "multi-line"},
+			{Code: "do baz(); while (foo)", Options: "multi-line"},
+			{Code: "if (foo) { bar() }", Options: "multi-line"},
+			{Code: "for (var foo in bar) console.log(foo)", Options: "multi-line"},
+			{Code: "for (var foo in bar) { \n console.log(1); \n console.log(2); \n }", Options: "multi-line"},
+			{Code: "for (var foo of bar) console.log(foo)", Options: "multi-line"},
+			{Code: "for (var foo of bar) { \n console.log(1); \n console.log(2); \n }", Options: "multi-line"},
+			{Code: "if (foo) { \n bar(); \n baz(); \n }", Options: "multi-line"},
+			{Code: "do bar() \n while (foo)", Options: "multi-line"},
+			{Code: "if (foo) { \n quz = { \n bar: baz, \n qux: foo \n }; \n }", Options: "multi-or-nest"},
+			{Code: "while (true) { \n if (foo) \n doSomething(); \n else \n doSomethingElse(); \n }", Options: "multi-or-nest"},
+			{Code: "if (foo) \n quz = true;", Options: "multi-or-nest"},
+			{Code: "if (foo) { \n // line of comment \n quz = true; \n }", Options: "multi-or-nest"},
+			{Code: "// line of comment \n if (foo) \n quz = true; \n", Options: "multi-or-nest"},
+			{Code: "while (true) \n doSomething();", Options: "multi-or-nest"},
+			{Code: "for (var i = 0; foo; i++) \n doSomething();", Options: "multi-or-nest"},
+			{Code: "if (foo) { \n if(bar) \n doSomething(); \n } else \n doSomethingElse();", Options: "multi-or-nest"},
+			{Code: "for (var foo in bar) \n console.log(foo)", Options: "multi-or-nest"},
+			{Code: "for (var foo in bar) { \n if (foo) console.log(1); \n else console.log(2) \n }", Options: "multi-or-nest"},
+			{Code: "for (var foo of bar) \n console.log(foo)", Options: "multi-or-nest"},
+			{Code: "for (var foo of bar) { \n if (foo) console.log(1); \n else console.log(2) \n }", Options: "multi-or-nest"},
+			{Code: "if (foo) { const bar = 'baz'; }", Options: "multi"},
+			{Code: "if (foo) { using bar = getThing(); }", Options: "multi"},
+			{Code: "if (foo) { await using bar = getThing(); }", Options: "multi"},
+			{Code: "while (foo) { let bar = 'baz'; }", Options: "multi"},
+			{Code: "for(;;) { function foo() {} }", Options: "multi"},
+			{Code: "for (foo in bar) { class Baz {} }", Options: "multi"},
+			{Code: "if (foo) { let bar; } else { baz(); }", Options: []interface{}{"multi", "consistent"}},
+			{Code: "if (foo) { bar(); } else { const baz = 'quux'; }", Options: []interface{}{"multi", "consistent"}},
+			{Code: "if (foo) { \n const bar = 'baz'; \n }", Options: "multi-or-nest"},
+			{Code: "if (foo) { \n let bar = 'baz'; \n }", Options: "multi-or-nest"},
+			{Code: "if (foo) { \n function bar() {} \n }", Options: "multi-or-nest"},
+			{Code: "if (foo) { \n class bar {} \n }", Options: "multi-or-nest"},
+
+			// https://github.com/eslint/eslint/issues/12370
+			{Code: "if (foo) doSomething() \n ;", Options: "multi-or-nest"},
+			{Code: "if (foo) doSomething(); \n else if (bar) doSomethingElse() \n ;", Options: "multi-or-nest"},
+			{Code: "if (foo) doSomething(); \n else doSomethingElse() \n ;", Options: "multi-or-nest"},
+			{Code: "if (foo) doSomething(); \n else if (bar) doSomethingElse(); \n else doAnotherThing() \n ;", Options: "multi-or-nest"},
+			{Code: "for (var i = 0; foo; i++) doSomething() \n ;", Options: "multi-or-nest"},
+			{Code: "for (var foo in bar) console.log(foo) \n ;", Options: "multi-or-nest"},
+			{Code: "for (var foo of bar) console.log(foo) \n ;", Options: "multi-or-nest"},
+			{Code: "while (foo) doSomething() \n ;", Options: "multi-or-nest"},
+			{Code: "do doSomething() \n ;while (foo)", Options: "multi-or-nest"},
+			{Code: "if (foo)\n;", Options: "multi-or-nest"},
+			{Code: "if (foo) doSomething(); \n else if (bar)\n;", Options: "multi-or-nest"},
+			{Code: "if (foo) doSomething(); \n else\n;", Options: "multi-or-nest"},
+			{Code: "if (foo) doSomething(); \n else if (bar) doSomethingElse(); \n else\n;", Options: "multi-or-nest"},
+			{Code: "for (var i = 0; foo; i++)\n;", Options: "multi-or-nest"},
+			{Code: "for (var foo in bar)\n;", Options: "multi-or-nest"},
+			{Code: "for (var foo of bar)\n;", Options: "multi-or-nest"},
+			{Code: "while (foo)\n;", Options: "multi-or-nest"},
+			{Code: "do\n;while (foo)", Options: "multi-or-nest"},
+
+			// https://github.com/eslint/eslint/issues/3856
+			{Code: "if (true) { if (false) console.log(1) } else console.log(2)", Options: "multi"},
+			{Code: "if (a) { if (b) console.log(1); else if (c) console.log(2) } else console.log(3)", Options: "multi"},
+			{Code: "if (true) { while(false) if (true); } else;", Options: "multi"},
+			{Code: "if (true) { label: if (false); } else;", Options: "multi"},
+			{Code: "if (true) { with(0) if (false); } else;", Options: "multi"},
+			{Code: "if (true) { while(a) if(b) while(c) if (d); else; } else;", Options: "multi"},
+			{Code: "if (true) foo(); else { bar(); baz(); }", Options: "multi"},
+			{Code: "if (true) { foo(); } else { bar(); baz(); }", Options: []interface{}{"multi", "consistent"}},
+			{Code: "if (true) { foo(); } else if (true) { faa(); } else { bar(); baz(); }", Options: []interface{}{"multi", "consistent"}},
+			{Code: "if (true) { foo(); faa(); } else { bar(); }", Options: []interface{}{"multi", "consistent"}},
+
+			// https://github.com/feross/standard/issues/664
+			{Code: "if (true) foo()\n;[1, 2, 3].bar()", Options: "multi-line"},
+
+			// https://github.com/eslint/eslint/issues/12928 (also in invalid[])
+			{Code: "if (x) for (var i in x) { if (i > 0) console.log(i); } else console.log('whoops');", Options: "multi"},
+			{Code: "if (a) { if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) { if (b) foo(); } else bar();", Options: "multi-or-nest"},
+			{Code: "if (a) { if (b) foo(); } else { bar(); }", Options: []interface{}{"multi", "consistent"}},
+			{Code: "if (a) { if (b) foo(); } else { bar(); }", Options: []interface{}{"multi-or-nest", "consistent"}},
+			{Code: "if (a) { if (b) { foo(); bar(); } } else baz();", Options: "multi"},
+			{Code: "if (a) foo(); else if (b) { if (c) bar(); } else baz();", Options: "multi"},
+			{Code: "if (a) { if (b) foo(); else if (c) bar(); } else baz();", Options: "multi"},
+			{Code: "if (a) if (b) foo(); else { if (c) bar(); } else baz();", Options: "multi"},
+			{Code: "if (a) { lbl:if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) { lbl1:lbl2:if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) { for (;;) if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) { for (key in obj) if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) { for (elem of arr) if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) { with (obj) if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) { while (cond) if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) { while (cond) for (;;) for (key in obj) if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) while (cond) { for (;;) for (key in obj) if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) while (cond) for (;;) { for (key in obj) if (b) foo(); } else bar();", Options: "multi"},
+			{Code: "if (a) while (cond) for (;;) for (key in obj) { if (b) foo(); } else bar();", Options: "multi"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   "if (foo) bar()",
+				Output: []string{"if (foo) {bar()}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:   "if (foo) \n bar()",
+				Output: []string{"if (foo) \n {bar()}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 2, EndLine: 2, EndColumn: 7},
+				},
+			},
+			{
+				Code:   "if (foo) { bar() } else baz()",
+				Output: []string{"if (foo) { bar() } else {baz()}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 25, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code:   "if (foo) { bar() } else if (faa) baz()",
+				Output: []string{"if (foo) { bar() } else if (faa) {baz()}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 34, EndLine: 1, EndColumn: 39},
+				},
+			},
+			{
+				Code:   "while (foo) bar()",
+				Output: []string{"while (foo) {bar()}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 13, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:   "while (foo) \n bar()",
+				Output: []string{"while (foo) \n {bar()}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 2, EndLine: 2, EndColumn: 7},
+				},
+			},
+			{
+				Code:   "do bar(); while (foo)",
+				Output: []string{"do {bar();} while (foo)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 4, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code:   "do \n bar(); while (foo)",
+				Output: []string{"do \n {bar();} while (foo)"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 2, EndLine: 2, EndColumn: 8},
+				},
+			},
+			{
+				Code:   "for (;foo;) bar()",
+				Output: []string{"for (;foo;) {bar()}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 13, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:   "for (var foo in bar) console.log(foo)",
+				Output: []string{"for (var foo in bar) {console.log(foo)}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 38},
+				},
+			},
+			{
+				Code:   "for (var foo of bar) console.log(foo)",
+				Output: []string{"for (var foo of bar) {console.log(foo)}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 38},
+				},
+			},
+			{
+				Code:   "for (var foo of bar) \n console.log(foo)",
+				Output: []string{"for (var foo of bar) \n {console.log(foo)}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 2, EndLine: 2, EndColumn: 18},
+				},
+			},
+			{
+				Code:   "for (a;;) console.log(foo)",
+				Output: []string{"for (a;;) {console.log(foo)}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 11, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				Code:   "for (a;;) \n console.log(foo)",
+				Output: []string{"for (a;;) \n {console.log(foo)}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 2, EndLine: 2, EndColumn: 18},
+				},
+			},
+			{
+				Code:    "for (var foo of bar) {console.log(foo)}",
+				Output:  []string{"for (var foo of bar) console.log(foo)"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				Code:    "do{foo();} while(bar);",
+				Output:  []string{"do foo(); while(bar);"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 3, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
+				Code:    "for (;foo;) { bar() }",
+				Output:  []string{"for (;foo;)  bar() "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 13, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				Code:   "for (;foo;) \n bar()",
+				Output: []string{"for (;foo;) \n {bar()}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 2, EndLine: 2, EndColumn: 7},
+				},
+			},
+			{
+				Code:    "if (foo) { bar() }",
+				Output:  []string{"if (foo)  bar() "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code:    "if (foo) if (bar) { baz() }",
+				Output:  []string{"if (foo) if (bar)  baz() "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 19, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				Code:    "if (foo) if (bar) baz(); else if (quux) { quuux(); }",
+				Output:  []string{"if (foo) if (bar) baz(); else if (quux)  quuux(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 41, EndLine: 1, EndColumn: 53},
+				},
+			},
+			{
+				Code:    "while (foo) { bar() }",
+				Output:  []string{"while (foo)  bar() "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 13, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				Code:    "if (foo) baz(); else { bar() }",
+				Output:  []string{"if (foo) baz(); else  bar() "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code:    "if (foo) if (bar); else { baz() }",
+				Output:  []string{"if (foo) if (bar); else  baz() "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 25, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code:    "if (true) { if (false) console.log(1) }",
+				Output:  []string{"if (true)  if (false) console.log(1) "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 11, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				Code:    "if (a) { if (b) console.log(1); else console.log(2) } else console.log(3)",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 54},
+				},
+			},
+			{
+				Code: "if (0)\n    console.log(0)\nelse if (1) {\n    console.log(1)\n    console.log(1)\n} else {\n    if (2)\n        console.log(2)\n    else\n        console.log(3)\n}",
+				Output: []string{
+					"if (0)\n    console.log(0)\nelse if (1) {\n    console.log(1)\n    console.log(1)\n} else \n    if (2)\n        console.log(2)\n    else\n        console.log(3)\n",
+				},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 6, Column: 8, EndLine: 11, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "for (var foo in bar) { console.log(foo) }",
+				Output:  []string{"for (var foo in bar)  console.log(foo) "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 42},
+				},
+			},
+			{
+				Code:    "for (var foo of bar) { console.log(foo) }",
+				Output:  []string{"for (var foo of bar)  console.log(foo) "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 42},
+				},
+			},
+			{
+				Code:    "if (foo) \n baz()",
+				Output:  []string{"if (foo) \n {baz()}"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 2, EndLine: 2, EndColumn: 7},
+				},
+			},
+			{
+				Code:   "if (foo) baz()",
+				Output: []string{"if (foo) {baz()}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:    "while (foo) \n baz()",
+				Output:  []string{"while (foo) \n {baz()}"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 2, EndLine: 2, EndColumn: 7},
+				},
+			},
+			{
+				Code:    "for (;foo;) \n bar()",
+				Output:  []string{"for (;foo;) \n {bar()}"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 2, EndLine: 2, EndColumn: 7},
+				},
+			},
+			{
+				Code:    "while (bar && \n baz) \n foo()",
+				Output:  []string{"while (bar && \n baz) \n {foo()}"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 3, Column: 2, EndLine: 3, EndColumn: 7},
+				},
+			},
+			{
+				Code:    "if (foo) bar(baz, \n baz)",
+				Output:  []string{"if (foo) {bar(baz, \n baz)}"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 10, EndLine: 2, EndColumn: 6},
+				},
+			},
+			{
+				Code:    "do foo(); while (bar)",
+				Output:  []string{"do {foo();} while (bar)"},
+				Options: "all",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 4, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code:    "do \n foo(); \n while (bar)",
+				Output:  []string{"do \n {foo();} \n while (bar)"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 2, EndLine: 2, EndColumn: 8},
+				},
+			},
+			{
+				Code:    "for (var foo in bar) {console.log(foo)}",
+				Output:  []string{"for (var foo in bar) console.log(foo)"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				Code:    "for (var foo in bar) \n console.log(foo)",
+				Output:  []string{"for (var foo in bar) \n {console.log(foo)}"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 2, EndLine: 2, EndColumn: 18},
+				},
+			},
+			{
+				Code:    "for (var foo in bar) \n console.log(1); \n console.log(2)",
+				Output:  []string{"for (var foo in bar) \n {console.log(1);} \n console.log(2)"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 2, EndLine: 2, EndColumn: 17},
+				},
+			},
+			{
+				Code:    "for (var foo of bar) \n console.log(foo)",
+				Output:  []string{"for (var foo of bar) \n {console.log(foo)}"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 2, EndLine: 2, EndColumn: 18},
+				},
+			},
+			{
+				Code:    "for (var foo of bar) \n console.log(1); \n console.log(2)",
+				Output:  []string{"for (var foo of bar) \n {console.log(1);} \n console.log(2)"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 2, EndLine: 2, EndColumn: 17},
+				},
+			},
+			{
+				Code:    "if (foo) \n quz = { \n bar: baz, \n qux: foo \n };",
+				Output:  []string{"if (foo) \n {quz = { \n bar: baz, \n qux: foo \n };}"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 2, EndLine: 5, EndColumn: 4},
+				},
+			},
+			{
+				Code:    "while (true) \n if (foo) \n doSomething(); \n else \n doSomethingElse(); \n",
+				Output:  []string{"while (true) \n {if (foo) \n doSomething(); \n else \n doSomethingElse();} \n"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 2, EndLine: 5, EndColumn: 20},
+				},
+			},
+			{
+				Code:    "if (foo) { \n quz = true; \n }",
+				Output:  []string{"if (foo)  \n quz = true; \n "},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 3, EndColumn: 3},
+				},
+			},
+			{
+				Code:    "if (foo) { var bar = 'baz'; }",
+				Output:  []string{"if (foo)  var bar = 'baz'; "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code:    "if (foo) { let bar; } else baz();",
+				Output:  []string{"if (foo) { let bar; } else {baz();}"},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 28, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code:    "if (foo) bar(); else { const baz = 'quux' }",
+				Output:  []string{"if (foo) {bar();} else { const baz = 'quux' }"},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code:    "if (foo) { \n var bar = 'baz'; \n }",
+				Output:  []string{"if (foo)  \n var bar = 'baz'; \n "},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 3, EndColumn: 3},
+				},
+			},
+			{
+				Code:    "while (true) { \n doSomething(); \n }",
+				Output:  []string{"while (true)  \n doSomething(); \n "},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 14, EndLine: 3, EndColumn: 3},
+				},
+			},
+			{
+				Code:    "for (var i = 0; foo; i++) { \n doSomething(); \n }",
+				Output:  []string{"for (var i = 0; foo; i++)  \n doSomething(); \n "},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 27, EndLine: 3, EndColumn: 3},
+				},
+			},
+			{
+				Code:    "for (var foo in bar) if (foo) console.log(1); else console.log(2);",
+				Output:  []string{"for (var foo in bar) {if (foo) console.log(1); else console.log(2);}", "for (var foo in bar) {if (foo) {console.log(1);} else {console.log(2);}}"},
+				Options: "all",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 67},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 31, EndLine: 1, EndColumn: 46},
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 52, EndLine: 1, EndColumn: 67},
+				},
+			},
+			{
+				Code:    "for (var foo in bar) \n if (foo) console.log(1); \n else console.log(2);",
+				Output:  []string{"for (var foo in bar) \n {if (foo) console.log(1); \n else console.log(2);}"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 2, EndLine: 3, EndColumn: 22},
+				},
+			},
+			{
+				Code:    "for (var foo in bar) { if (foo) console.log(1) }",
+				Output:  []string{"for (var foo in bar)  if (foo) console.log(1) "},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 49},
+				},
+			},
+			{
+				Code:    "for (var foo of bar) \n if (foo) console.log(1); \n else console.log(2);",
+				Output:  []string{"for (var foo of bar) \n {if (foo) console.log(1); \n else console.log(2);}"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 2, EndLine: 3, EndColumn: 22},
+				},
+			},
+			{
+				Code:    "for (var foo of bar) { if (foo) console.log(1) }",
+				Output:  []string{"for (var foo of bar)  if (foo) console.log(1) "},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 22, EndLine: 1, EndColumn: 49},
+				},
+			},
+			{
+				Code:    "if (true) foo(); \n else { \n bar(); \n baz(); \n }",
+				Output:  []string{"if (true) {foo();} \n else { \n bar(); \n baz(); \n }"},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 11, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    "if (true) { foo(); faa(); }\n else bar();",
+				Output:  []string{"if (true) { foo(); faa(); }\n else {bar();}"},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 2, Column: 7, EndLine: 2, EndColumn: 13},
+				},
+			},
+			{
+				Code:    "if (true) foo(); else { baz(); }",
+				Output:  []string{"if (true) foo(); else  baz(); "},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 23, EndLine: 1, EndColumn: 33},
+				},
+			},
+			{
+				Code:    "if (true) foo(); else if (true) faa(); else { bar(); baz(); }",
+				Output:  []string{"if (true) {foo();} else if (true) {faa();} else { bar(); baz(); }"},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 11, EndLine: 1, EndColumn: 17},
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 33, EndLine: 1, EndColumn: 39},
+				},
+			},
+			{
+				Code:    "if (true) if (true) foo(); else { bar(); baz(); }",
+				Output:  []string{"if (true) if (true) {foo();} else { bar(); baz(); }"},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 21, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				Code:    "do{foo();} while (bar)",
+				Output:  []string{"do foo(); while (bar)"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 3, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
+				Code:    "do\n{foo();} while (bar)",
+				Output:  []string{"do\nfoo(); while (bar)"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 2, Column: 1, EndLine: 2, EndColumn: 9},
+				},
+			},
+			{
+				Code:    "while (bar) { foo(); }",
+				Output:  []string{"while (bar)  foo(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 13, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code:    "while (bar) \n{\n foo(); }",
+				Output:  []string{"while (bar) \n\n foo(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 2, Column: 1, EndLine: 3, EndColumn: 10},
+				},
+			},
+			{
+				Code:    "for (;;) { foo(); }",
+				Output:  []string{"for (;;)  foo(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				Code:    "do{[1, 2, 3].map(bar);} while (bar)",
+				Output:  []string{"do[1, 2, 3].map(bar); while (bar)"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 3, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code:    "if (foo) {bar()} baz()",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    "do {foo();} while (bar)",
+				Output:  []string{"do foo(); while (bar)"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 4, EndLine: 1, EndColumn: 12},
+				},
+			},
+
+			// Don't remove curly braces if it would cause issues due to ASI.
+			{
+				Code:    "if (foo) { bar }\n++baz;",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    "if (foo) { bar; }\n++baz;",
+				Output:  []string{"if (foo)  bar; \n++baz;"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:    "if (foo) { bar++ }\nbaz;",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code:    "if (foo) { bar }\n[1, 2, 3].map(foo);",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    "if (foo) { bar }\n(1).toString();",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    "if (foo) { bar }\n/regex/.test('foo');",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    "if (foo) { bar }\nBaz();",
+				Output:  []string{"if (foo)  bar \nBaz();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code:    "if (a) {\n  while (b) {\n    c();\n    d();\n  }\n} else e();",
+				Output:  []string{"if (a) \n  while (b) {\n    c();\n    d();\n  }\n else e();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 6, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "if (foo) { while (bar) {} } else {}",
+				Output:  []string{"if (foo)  while (bar) {}  else {}"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				Code:    "if (foo) { var foo = () => {} } else {}",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 32},
+				},
+			},
+			{
+				Code:    "if (foo) { var foo = function() {} } else {}",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				Code:    "if (foo) { var foo = function*() {} } else {}",
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 1, EndColumn: 38},
+				},
+			},
+			{
+				Code:    "if (true)\nfoo()\n;[1, 2, 3].bar()",
+				Output:  []string{"if (true)\n{foo()\n;}[1, 2, 3].bar()"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 2, Column: 1, EndLine: 3, EndColumn: 2},
+				},
+			},
+
+			// https://github.com/eslint/eslint/issues/12370
+			{
+				Code:    "if (foo) {\ndoSomething()\n;\n}",
+				Output:  []string{"if (foo) \ndoSomething()\n;\n"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 10, EndLine: 4, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "if (foo) doSomething();\nelse if (bar) {\ndoSomethingElse()\n;\n}",
+				Output:  []string{"if (foo) doSomething();\nelse if (bar) \ndoSomethingElse()\n;\n"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 2, Column: 15, EndLine: 5, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "if (foo) doSomething();\nelse {\ndoSomethingElse()\n;\n}",
+				Output:  []string{"if (foo) doSomething();\nelse \ndoSomethingElse()\n;\n"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 2, Column: 6, EndLine: 5, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "for (var i = 0; foo; i++) {\ndoSomething()\n;\n}",
+				Output:  []string{"for (var i = 0; foo; i++) \ndoSomething()\n;\n"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 27, EndLine: 4, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "for (var foo in bar) {\ndoSomething()\n;\n}",
+				Output:  []string{"for (var foo in bar) \ndoSomething()\n;\n"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 22, EndLine: 4, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "for (var foo of bar) {\ndoSomething()\n;\n}",
+				Output:  []string{"for (var foo of bar) \ndoSomething()\n;\n"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 22, EndLine: 4, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "while (foo) {\ndoSomething()\n;\n}",
+				Output:  []string{"while (foo) \ndoSomething()\n;\n"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 13, EndLine: 4, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "do {\ndoSomething()\n;\n} while (foo)",
+				Output:  []string{"do \ndoSomething()\n;\n while (foo)"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 4, EndLine: 4, EndColumn: 2},
+				},
+			},
+
+			// https://github.com/eslint/eslint/issues/12928 (also in valid[])
+			{
+				Code:    "if (a) { if (b) foo(); }",
+				Output:  []string{"if (a)  if (b) foo(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code:    "if (a) { if (b) foo(); else bar(); }",
+				Output:  []string{"if (a)  if (b) foo(); else bar(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				Code:    "if (a) { if (b) foo(); else bar(); } baz();",
+				Output:  []string{"if (a)  if (b) foo(); else bar();  baz();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				Code:    "if (a) { while (cond) if (b) foo(); }",
+				Output:  []string{"if (a)  while (cond) if (b) foo(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 38},
+				},
+			},
+			{
+				Code:    "if (a) while (cond) { if (b) foo(); }",
+				Output:  []string{"if (a) while (cond)  if (b) foo(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 21, EndLine: 1, EndColumn: 38},
+				},
+			},
+			{
+				Code:    "if (a) while (cond) { if (b) foo(); else bar(); }",
+				Output:  []string{"if (a) while (cond)  if (b) foo(); else bar(); "},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 21, EndLine: 1, EndColumn: 50},
+				},
+			},
+			{
+				Code:    "if (a) { while (cond) { if (b) foo(); } bar(); baz() } else quux();",
+				Output:  []string{"if (a) { while (cond)  if (b) foo();  bar(); baz() } else quux();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 23, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				Code:    "if (a) { if (b) foo(); } bar();",
+				Output:  []string{"if (a)  if (b) foo();  bar();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code:    "if(a) { if (b) foo(); } if (c) bar(); else baz();",
+				Output:  []string{"if(a)  if (b) foo();  if (c) bar(); else baz();"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 7, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code:    "if (a) { do if (b) foo(); while (cond); } else bar();",
+				Output:  []string{"if (a)  do if (b) foo(); while (cond);  else bar();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 42},
+				},
+			},
+			{
+				Code:    "if (a) do { if (b) foo(); } while (cond); else bar();",
+				Output:  []string{"if (a) do  if (b) foo();  while (cond); else bar();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 1, Column: 11, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				Code:    "if (a) { if (b) foo(); else bar(); } else baz();",
+				Output:  []string{"if (a)  if (b) foo(); else bar();  else baz();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				Code:    "if (a) while (cond) { bar(); } else baz();",
+				Output:  []string{"if (a) while (cond)  bar();  else baz();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 21, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code:    "if (a) { for (;;); } else bar();",
+				Output:  []string{"if (a)  for (;;);  else bar();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code:    "if (a) { while (cond) if (b) foo() } else bar();",
+				Output:  []string{"if (a) { while (cond) if (b) foo() } else {bar();}"},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 1, Column: 43, EndLine: 1, EndColumn: 49},
+				},
+			},
+			{
+				Code:    "if (a)  while (cond) if (b) foo()  \nelse\n {bar();}",
+				Output:  []string{"if (a)  while (cond) if (b) foo()  \nelse\n bar();"},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfter", Line: 3, Column: 2, EndLine: 3, EndColumn: 10},
+				},
+			},
+			{
+				Code:   "if (a) foo() \nelse\n bar();",
+				Output: []string{"if (a) {foo()} \nelse\n {bar();}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 13},
+					{MessageId: "missingCurlyAfter", Line: 3, Column: 2, EndLine: 3, EndColumn: 8},
+				},
+			},
+			{
+				Code:    "if (a) { while (cond) if (b) foo() } ",
+				Output:  []string{"if (a)  while (cond) if (b) foo()  "},
+				Options: []interface{}{"multi", "consistent"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				Code:    "if(a) { if (b) foo(); } if (c) bar(); else if(foo){bar();}",
+				Output:  []string{"if(a)  if (b) foo();  if (c) bar(); else if(foo)bar();"},
+				Options: "multi-or-nest",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 7, EndLine: 1, EndColumn: 24},
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 51, EndLine: 1, EndColumn: 59},
+				},
+			},
+			{
+				Code:    "if (true) [1, 2, 3]\n.bar()",
+				Output:  []string{"if (true) {[1, 2, 3]\n.bar()}"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 11, EndLine: 2, EndColumn: 7},
+				},
+			},
+			{
+				Code:    "for(\n;\n;\n) {foo()}",
+				Output:  []string{"for(\n;\n;\n) foo()"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 4, Column: 3, EndLine: 4, EndColumn: 10},
+				},
+			},
+			{
+				Code:    "for(\n;\n;\n) \nfoo()\n",
+				Output:  []string{"for(\n;\n;\n) \n{foo()}\n"},
+				Options: "multi-line",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 5, Column: 1, EndLine: 5, EndColumn: 6},
+				},
+			},
+			{
+				// Reports 2 errors, but one pair of braces is necessary if the other pair gets removed.
+				Code:    "if (a) { while (cond) { if (b) foo(); } } else bar();",
+				Output:  []string{"if (a)  while (cond) { if (b) foo(); }  else bar();"},
+				Options: "multi",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 42},
+					{MessageId: "unexpectedCurlyAfterCondition", Line: 1, Column: 23, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				Code:   "for(;;)foo()\n",
+				Output: []string{"for(;;){foo()}\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfterCondition", Line: 1, Column: 8, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:   "for(var \ni \n in \n z)foo()\n",
+				Output: []string{"for(var \ni \n in \n z){foo()}\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 4, Column: 4, EndLine: 4, EndColumn: 9},
+				},
+			},
+			{
+				Code:   "for(var i of \n z)\nfoo()\n",
+				Output: []string{"for(var i of \n z)\n{foo()}\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingCurlyAfter", Line: 3, Column: 1, EndLine: 3, EndColumn: 6},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -68,6 +68,7 @@ export default defineConfig({
     // eslint
     './tests/eslint/rules/accessor-pairs.test.ts',
     './tests/eslint/rules/arrow-body-style.test.ts',
+    './tests/eslint/rules/curly.test.ts',
     './tests/eslint/rules/default-case.test.ts',
     './tests/eslint/rules/no-case-declarations.test.ts',
     './tests/eslint/rules/no-console.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/curly.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/curly.test.ts.snap
@@ -1,0 +1,476 @@
+// Rstest Snapshot v1
+
+exports[`curly > invalid 1`] = `
+{
+  "code": "if (foo) bar()",
+  "diagnostics": [
+    {
+      "message": "Expected { after 'if' condition.",
+      "messageId": "missingCurlyAfterCondition",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 2`] = `
+{
+  "code": "while (foo) bar()",
+  "diagnostics": [
+    {
+      "message": "Expected { after 'while' condition.",
+      "messageId": "missingCurlyAfterCondition",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 3`] = `
+{
+  "code": "for (;foo;) bar()",
+  "diagnostics": [
+    {
+      "message": "Expected { after 'for' condition.",
+      "messageId": "missingCurlyAfterCondition",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 4`] = `
+{
+  "code": "do bar(); while (foo)",
+  "diagnostics": [
+    {
+      "message": "Expected { after 'do'.",
+      "messageId": "missingCurlyAfter",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 5`] = `
+{
+  "code": "for (var foo in bar) console.log(foo)",
+  "diagnostics": [
+    {
+      "message": "Expected { after 'for-in'.",
+      "messageId": "missingCurlyAfter",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 6`] = `
+{
+  "code": "for (var foo of bar) console.log(foo)",
+  "diagnostics": [
+    {
+      "message": "Expected { after 'for-of'.",
+      "messageId": "missingCurlyAfter",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 7`] = `
+{
+  "code": "if (foo) { bar() } else baz()",
+  "diagnostics": [
+    {
+      "message": "Expected { after 'else'.",
+      "messageId": "missingCurlyAfter",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 8`] = `
+{
+  "code": "if (foo) { bar() }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary { after 'if' condition.",
+      "messageId": "unexpectedCurlyAfterCondition",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 9`] = `
+{
+  "code": "while (foo) { bar() }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary { after 'while' condition.",
+      "messageId": "unexpectedCurlyAfterCondition",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 10`] = `
+{
+  "code": "for (;foo;) { bar() }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary { after 'for' condition.",
+      "messageId": "unexpectedCurlyAfterCondition",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 11`] = `
+{
+  "code": "do{foo();} while(bar);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary { after 'do'.",
+      "messageId": "unexpectedCurlyAfter",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 12`] = `
+{
+  "code": "for (var foo in bar) {console.log(foo)}",
+  "diagnostics": [
+    {
+      "message": "Unnecessary { after 'for-in'.",
+      "messageId": "unexpectedCurlyAfter",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 13`] = `
+{
+  "code": "if (foo) baz(); else { bar() }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary { after 'else'.",
+      "messageId": "unexpectedCurlyAfter",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 14`] = `
+{
+  "code": "if (foo) 
+ baz()",
+  "diagnostics": [
+    {
+      "message": "Expected { after 'if' condition.",
+      "messageId": "missingCurlyAfterCondition",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 2,
+        },
+        "start": {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 15`] = `
+{
+  "code": "if (foo) { 
+ quz = true; 
+ }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary { after 'if' condition.",
+      "messageId": "unexpectedCurlyAfterCondition",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 16`] = `
+{
+  "code": "if (foo) 
+ quz = { 
+ bar: baz, 
+ qux: foo 
+ };",
+  "diagnostics": [
+    {
+      "message": "Expected { after 'if' condition.",
+      "messageId": "missingCurlyAfterCondition",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 17`] = `
+{
+  "code": "if (foo) { let bar; } else baz();",
+  "diagnostics": [
+    {
+      "message": "Expected { after 'else'.",
+      "messageId": "missingCurlyAfter",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`curly > invalid 18`] = `
+{
+  "code": "if (foo) {bar()} baz()",
+  "diagnostics": [
+    {
+      "message": "Unnecessary { after 'if' condition.",
+      "messageId": "unexpectedCurlyAfterCondition",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "curly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/curly.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/curly.test.ts
@@ -1,0 +1,159 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// Mirrors the upstream curly valid/invalid semantic set (Layer 1). It verifies
+// rule registration + wire protocol + ESLint-compatible diagnostic shape; the
+// exhaustive edge-shape / branch lock-in coverage lives in the Go suite.
+ruleTester.run('curly', {
+  valid: [
+    // ── "all" (default) ──
+    'if (foo) { bar() }',
+    'if (foo) { bar() } else if (foo2) { baz() }',
+    'while (foo) { bar() }',
+    'do { bar(); } while (foo)',
+    'for (;foo;) { bar() }',
+    'for (var foo in bar) { console.log(foo) }',
+    'for (var foo of bar) { console.log(foo) }',
+
+    // ── "multi" ──
+    { code: 'if (foo) bar()', options: ['multi'] as any },
+    { code: 'if (a) { b; c; }', options: ['multi'] as any },
+    {
+      code: 'for (var foo in bar) console.log(foo)',
+      options: ['multi'] as any,
+    },
+    {
+      code: 'for (var foo of bar) console.log(foo)',
+      options: ['multi'] as any,
+    },
+    { code: "if (foo) { const bar = 'baz'; }", options: ['multi'] as any },
+    { code: "while (foo) { let bar = 'baz'; }", options: ['multi'] as any },
+    { code: 'for(;;) { function foo() {} }', options: ['multi'] as any },
+    { code: 'for (foo in bar) { class Baz {} }', options: ['multi'] as any },
+
+    // ── "multi-line" ──
+    { code: 'if (foo) bar()', options: ['multi-line'] as any },
+    { code: 'if (foo) bar(); else baz()', options: ['multi-line'] as any },
+    { code: 'do baz(); while (foo)', options: ['multi-line'] as any },
+    { code: 'if (foo) { bar() }', options: ['multi-line'] as any },
+
+    // ── "multi-or-nest" ──
+    { code: 'if (foo) \n quz = true;', options: ['multi-or-nest'] as any },
+    {
+      code: 'if (foo) { \n // line of comment \n quz = true; \n }',
+      options: ['multi-or-nest'] as any,
+    },
+    {
+      code: 'while (true) \n doSomething();',
+      options: ['multi-or-nest'] as any,
+    },
+    {
+      code: "if (foo) { \n const bar = 'baz'; \n }",
+      options: ['multi-or-nest'] as any,
+    },
+
+    // ── "consistent" ──
+    {
+      code: 'if (foo) { let bar; } else { baz(); }',
+      options: ['multi', 'consistent'] as any,
+    },
+    {
+      code: 'if (true) { foo(); } else if (true) { faa(); } else { bar(); baz(); }',
+      options: ['multi', 'consistent'] as any,
+    },
+  ],
+  invalid: [
+    // ── missingCurlyAfterCondition ──
+    {
+      code: 'if (foo) bar()',
+      errors: [{ messageId: 'missingCurlyAfterCondition' }],
+    },
+    {
+      code: 'while (foo) bar()',
+      errors: [{ messageId: 'missingCurlyAfterCondition' }],
+    },
+    {
+      code: 'for (;foo;) bar()',
+      errors: [{ messageId: 'missingCurlyAfterCondition' }],
+    },
+    // ── missingCurlyAfter ──
+    {
+      code: 'do bar(); while (foo)',
+      errors: [{ messageId: 'missingCurlyAfter' }],
+    },
+    {
+      code: 'for (var foo in bar) console.log(foo)',
+      errors: [{ messageId: 'missingCurlyAfter' }],
+    },
+    {
+      code: 'for (var foo of bar) console.log(foo)',
+      errors: [{ messageId: 'missingCurlyAfter' }],
+    },
+    {
+      code: 'if (foo) { bar() } else baz()',
+      errors: [{ messageId: 'missingCurlyAfter' }],
+    },
+    // ── unexpectedCurlyAfterCondition (multi) ──
+    {
+      code: 'if (foo) { bar() }',
+      options: ['multi'] as any,
+      errors: [{ messageId: 'unexpectedCurlyAfterCondition' }],
+    },
+    {
+      code: 'while (foo) { bar() }',
+      options: ['multi'] as any,
+      errors: [{ messageId: 'unexpectedCurlyAfterCondition' }],
+    },
+    {
+      code: 'for (;foo;) { bar() }',
+      options: ['multi'] as any,
+      errors: [{ messageId: 'unexpectedCurlyAfterCondition' }],
+    },
+    // ── unexpectedCurlyAfter (multi) ──
+    {
+      code: 'do{foo();} while(bar);',
+      options: ['multi'] as any,
+      errors: [{ messageId: 'unexpectedCurlyAfter' }],
+    },
+    {
+      code: 'for (var foo in bar) {console.log(foo)}',
+      options: ['multi'] as any,
+      errors: [{ messageId: 'unexpectedCurlyAfter' }],
+    },
+    {
+      code: 'if (foo) baz(); else { bar() }',
+      options: ['multi'] as any,
+      errors: [{ messageId: 'unexpectedCurlyAfter' }],
+    },
+    // ── multi-line ──
+    {
+      code: 'if (foo) \n baz()',
+      options: ['multi-line'] as any,
+      errors: [{ messageId: 'missingCurlyAfterCondition' }],
+    },
+    // ── multi-or-nest ──
+    {
+      code: 'if (foo) { \n quz = true; \n }',
+      options: ['multi-or-nest'] as any,
+      errors: [{ messageId: 'unexpectedCurlyAfterCondition' }],
+    },
+    {
+      code: 'if (foo) \n quz = { \n bar: baz, \n qux: foo \n };',
+      options: ['multi-or-nest'] as any,
+      errors: [{ messageId: 'missingCurlyAfterCondition' }],
+    },
+    // ── consistent ──
+    {
+      code: 'if (foo) { let bar; } else baz();',
+      options: ['multi', 'consistent'] as any,
+      errors: [{ messageId: 'missingCurlyAfter' }],
+    },
+    // ── ASI hazard: reported, but not auto-fixed ──
+    {
+      code: 'if (foo) {bar()} baz()',
+      options: ['multi'] as any,
+      errors: [{ messageId: 'unexpectedCurlyAfterCondition' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `curly` rule from ESLint to rslint — enforce consistent brace style for `if` / `else` / `for` / `for-in` / `for-of` / `while` / `do-while`, supporting all options (`all`, `multi`, `multi-line`, `multi-or-nest`, `consistent`) and autofix (with ASI-safety and the `do{...}` spacing edge case).

Coverage:
- Upstream `tests/lib/rules/curly.js` migrated 1:1 — 100 valid + 116 invalid, with line/column/endLine/endColumn cross-checked against ESLint for every case.
- 130 extra Go-only cases for the tsgo/Go divergence surface: deep nesting (3–4 levels), `consistent` across all mode combinations, TS-only bodies (`enum`/`namespace`/`interface`/`type`/`import-equals` keep braces; `for await`, `using`, generic call, `satisfies` behave like their JS equivalents), `switch`/`try`/bare-block/`do-while` bodies + `needsSemicolon` node resolution, comment/whitespace autofix boundaries, and multi-byte (UTF-16) columns.
- All differentially validated against ESLint 9.39.4 and v10.5.0 as oracle (zero divergences). JS suite mirrors the Layer-1 upstream set over IPC.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/curly
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/curly.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).