### PR TITLE
fix: prevent crash on class property without initializer in no-unused-state

### DIFF
--- a/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods.go
+++ b/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods.go
@@ -60,22 +60,13 @@ func newClassInfo(isClass bool, className string) *classInfo {
 	}
 }
 
-// skipAssertionsAndParens strips parentheses and TS assertion wrappers,
-// matching ESLint's `uncast` which peels TypeCastExpression wrappers.
-func skipAssertionsAndParens(node *ast.Node) *ast.Node {
-	if node == nil {
-		return nil
-	}
-	return ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKAssertions)
-}
-
 // isThisExpression reports whether `node` (after unwrapping assertions /
 // parens) is a bare `this`.
 func isThisExpression(node *ast.Node) bool {
 	if node == nil {
 		return false
 	}
-	return skipAssertionsAndParens(node).Kind == ast.KindThisKeyword
+	return utils.SkipAssertionsAndParens(node).Kind == ast.KindThisKeyword
 }
 
 // resolveLiteralKey extracts the static name from a property-key / member-name
@@ -100,7 +91,7 @@ func resolveLiteralKey(nameNode *ast.Node) (string, *ast.Node) {
 		return "", nil
 	}
 	if nameNode.Kind == ast.KindComputedPropertyName {
-		return name, skipAssertionsAndParens(nameNode.AsComputedPropertyName().Expression)
+		return name, utils.SkipAssertionsAndParens(nameNode.AsComputedPropertyName().Expression)
 	}
 	return name, nameNode
 }
@@ -115,7 +106,7 @@ func resolveLiteralAccessKey(keyExpr *ast.Node) (string, *ast.Node) {
 	if keyExpr == nil {
 		return "", nil
 	}
-	keyExpr = skipAssertionsAndParens(keyExpr)
+	keyExpr = utils.SkipAssertionsAndParens(keyExpr)
 	switch keyExpr.Kind {
 	case ast.KindStringLiteral:
 		return keyExpr.AsStringLiteral().Text, keyExpr

--- a/internal/plugins/react/rules/no_unused_state/no_unused_state.go
+++ b/internal/plugins/react/rules/no_unused_state/no_unused_state.go
@@ -10,13 +10,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// skipAssertionsAndParens strips parentheses and all TS assertion wrappers
-// (as, satisfies, !, <T>) from an expression, matching ESLint's
-// unwrapTSAsExpression(uncast(node)) pattern.
-func skipAssertionsAndParens(node *ast.Node) *ast.Node {
-	return ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKAssertions)
-}
-
 // getName extracts a static string name from a node. For Identifiers returns
 // the text, for StringLiterals returns the text, for NumericLiterals returns
 // the string representation, for NoSubstitutionTemplateLiterals returns the
@@ -25,7 +18,7 @@ func getName(node *ast.Node) string {
 	if node == nil {
 		return ""
 	}
-	node = skipAssertionsAndParens(node)
+	node = utils.SkipAssertionsAndParens(node)
 	switch node.Kind {
 	case ast.KindIdentifier:
 		return node.AsIdentifier().Text
@@ -49,7 +42,7 @@ func isThisExpression(node *ast.Node) bool {
 	if node == nil {
 		return false
 	}
-	return skipAssertionsAndParens(node).Kind == ast.KindThisKeyword
+	return utils.SkipAssertionsAndParens(node).Kind == ast.KindThisKeyword
 }
 
 // isSetStateCall checks if a node is a this.setState(...) call.
@@ -58,7 +51,7 @@ func isSetStateCall(node *ast.Node) bool {
 		return false
 	}
 	call := node.AsCallExpression()
-	callee := skipAssertionsAndParens(call.Expression)
+	callee := utils.SkipAssertionsAndParens(call.Expression)
 	if callee.Kind != ast.KindPropertyAccessExpression {
 		return false
 	}
@@ -175,7 +168,7 @@ func (ci *classInfo) isStateReference(node *ast.Node) bool {
 	if ci == nil || ci.abandoned {
 		return false
 	}
-	node = skipAssertionsAndParens(node)
+	node = utils.SkipAssertionsAndParens(node)
 
 	// Direct: this.state
 	if node.Kind == ast.KindPropertyAccessExpression {
@@ -374,7 +367,7 @@ func (ci *classInfo) handleAssignment(left, right *ast.Node) {
 	if ci == nil || ci.abandoned {
 		return
 	}
-	right = skipAssertionsAndParens(right)
+	right = utils.SkipAssertionsAndParens(right)
 
 	switch left.Kind {
 	case ast.KindIdentifier:
@@ -465,7 +458,7 @@ func walkES6Component(ci *classInfo, classNode *ast.Node) {
 func processPropertyDeclaration(ci *classInfo, member *ast.Node) {
 	pd := member.AsPropertyDeclaration()
 	nameNode := pd.Name()
-	init := skipAssertionsAndParens(pd.Initializer)
+	init := utils.SkipAssertionsAndParens(pd.Initializer)
 
 	isStatic := ast.IsStatic(member)
 
@@ -561,7 +554,7 @@ func processGDSFPBody(ci *classInfo, fn *ast.Node) {
 		}
 		if n.Kind == ast.KindPropertyAccessExpression {
 			pa := n.AsPropertyAccessExpression()
-			obj := skipAssertionsAndParens(pa.Expression)
+			obj := utils.SkipAssertionsAndParens(pa.Expression)
 			if isStateParam(obj) {
 				ci.addUsedStateField(pa.Name())
 			}
@@ -668,7 +661,7 @@ func processGetInitialState(ci *classInfo, prop *ast.Node) {
 	if rs.Expression == nil {
 		return
 	}
-	retVal := skipAssertionsAndParens(rs.Expression)
+	retVal := utils.SkipAssertionsAndParens(rs.Expression)
 	if retVal.Kind == ast.KindObjectLiteralExpression {
 		ci.addStateFields(retVal)
 	}
@@ -745,7 +738,7 @@ func processNode(ci *classInfo, node *ast.Node) {
 // processCallExpression handles this.setState() calls.
 func processCallExpression(ci *classInfo, node *ast.Node) {
 	call := node.AsCallExpression()
-	unwrappedNode := skipAssertionsAndParens(node)
+	unwrappedNode := utils.SkipAssertionsAndParens(node)
 	if unwrappedNode.Kind != ast.KindCallExpression {
 		return
 	}
@@ -758,14 +751,14 @@ func processCallExpression(ci *classInfo, node *ast.Node) {
 	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
 		return
 	}
-	firstArg := skipAssertionsAndParens(callExpr.Arguments.Nodes[0])
+	firstArg := utils.SkipAssertionsAndParens(callExpr.Arguments.Nodes[0])
 
 	switch firstArg.Kind {
 	case ast.KindObjectLiteralExpression:
 		ci.addStateFields(firstArg)
 	case ast.KindArrowFunction:
 		af := firstArg.AsArrowFunction()
-		body := skipAssertionsAndParens(af.Body)
+		body := utils.SkipAssertionsAndParens(af.Body)
 		if body != nil && body.Kind == ast.KindObjectLiteralExpression {
 			ci.addStateFields(body)
 		}
@@ -799,8 +792,8 @@ func processAssignmentExpression(ci *classInfo, node *ast.Node) {
 		return
 	}
 
-	left := skipAssertionsAndParens(bin.Left)
-	right := skipAssertionsAndParens(bin.Right)
+	left := utils.SkipAssertionsAndParens(bin.Left)
+	right := utils.SkipAssertionsAndParens(bin.Right)
 
 	// Check for `this.state = { ... }`
 	if left.Kind == ast.KindPropertyAccessExpression {
@@ -857,7 +850,7 @@ func processVariableDeclarator(ci *classInfo, node *ast.Node) {
 // `this.state.foo` and `alias.foo`.
 func processMemberExpression(ci *classInfo, node *ast.Node) {
 	pa := node.AsPropertyAccessExpression()
-	obj := skipAssertionsAndParens(pa.Expression)
+	obj := utils.SkipAssertionsAndParens(pa.Expression)
 
 	if ci.isStateReference(obj) {
 		// Record that we saw this property being accessed
@@ -877,14 +870,14 @@ func processMemberExpression(ci *classInfo, node *ast.Node) {
 // `this.state['foo']` and `this.state[expr]`.
 func processElementAccess(ci *classInfo, node *ast.Node) {
 	ea := node.AsElementAccessExpression()
-	obj := skipAssertionsAndParens(ea.Expression)
+	obj := utils.SkipAssertionsAndParens(ea.Expression)
 
 	if ci.isStateReference(obj) {
 		argExpr := ea.ArgumentExpression
 		if argExpr == nil {
 			return
 		}
-		argExpr = skipAssertionsAndParens(argExpr)
+		argExpr = utils.SkipAssertionsAndParens(argExpr)
 		// If the access key is a static literal, record the used field.
 		// In ESTree, true/false/null are Literals, so ESLint's
 		// `node.property.type !== 'Literal'` check does NOT give up on them.

--- a/internal/plugins/react/rules/no_unused_state/no_unused_state_test.go
+++ b/internal/plugins/react/rules/no_unused_state/no_unused_state_test.go
@@ -1293,6 +1293,30 @@ func TestNoUnusedStateRule(t *testing.T) {
           }
         }
       `, Tsx: true},
+
+		// ---- Regression: class property without initializer must not panic ----
+		// processPropertyDeclaration passed the optional (nil) initializer
+		// straight into SkipOuterExpressions, causing a SIGSEGV.
+		{Code: `
+        class NoInitializerPropertyTest extends React.Component {
+          editor: any;
+          KEY: any;
+          render() {
+            return <div />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Regression: uninitialized property coexists with used state ----
+		{Code: `
+        class NoInitializerWithUsedStateTest extends React.Component {
+          editor: any;
+          state = { foo: 1 };
+          render() {
+            return <div>{this.state.foo}</div>;
+          }
+        }
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: unused getInitialState ----
 		{
@@ -2002,6 +2026,23 @@ func TestNoUnusedStateRule(t *testing.T) {
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 3, Column: 21},
+			},
+		},
+
+		// ---- Regression: uninitialized property must not mask unused state ----
+		{
+			Code: `
+        class NoInitializerWithUnusedStateTest extends React.Component {
+          editor: any;
+          state = { foo: 1 };
+          render() {
+            return <div />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 21},
 			},
 		},
 	})

--- a/internal/rules/no_obj_calls/no_obj_calls.go
+++ b/internal/rules/no_obj_calls/no_obj_calls.go
@@ -12,12 +12,6 @@ var nonCallableGlobals = map[string]bool{
 	"Math": true, "JSON": true, "Reflect": true, "Atomics": true, "Intl": true,
 }
 
-// skipAssertionsAndParens strips parentheses and all TS assertion wrappers
-// (as, satisfies, !, <T>) from an expression using tsgo's built-in utility.
-func skipAssertionsAndParens(node *ast.Node) *ast.Node {
-	return ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKAssertions)
-}
-
 // https://eslint.org/docs/latest/rules/no-obj-calls
 var NoObjCallsRule = rule.Rule{
 	Name:             "no-obj-calls",
@@ -38,7 +32,7 @@ var NoObjCallsRule = rule.Rule{
 		// - TS type assertions (as, satisfies, !, <T>) via SkipOuterExpressions
 		var resolveExprToGlobal func(node *ast.Node) (string, bool)
 		resolveExprToGlobal = func(node *ast.Node) (string, bool) {
-			node = skipAssertionsAndParens(node)
+			node = utils.SkipAssertionsAndParens(node)
 			switch node.Kind {
 			case ast.KindIdentifier, ast.KindPropertyAccessExpression:
 				symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
@@ -103,7 +97,7 @@ var NoObjCallsRule = rule.Rule{
 				return
 			}
 
-			callee := skipAssertionsAndParens(calleeNode)
+			callee := utils.SkipAssertionsAndParens(calleeNode)
 			symbol := ctx.TypeChecker.GetSymbolAtLocation(callee)
 			if symbol == nil {
 				return

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -7,6 +7,17 @@ import (
 // skipTransparentKinds matches parentheses + TS type assertions.
 const skipTransparentKinds = ast.OEKParentheses | ast.OEKAssertions
 
+// SkipAssertionsAndParens strips parentheses and all TS assertion wrappers
+// (as, satisfies, !, <T>) from an expression, mirroring ESLint's
+// unwrapTSAsExpression(uncast(node)). Returns nil when node is nil so callers
+// can safely pass optional AST fields such as an absent initializer.
+func SkipAssertionsAndParens(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	return ast.SkipOuterExpressions(node, skipTransparentKinds)
+}
+
 // IsCallee checks if a node is the callee of a CallExpression or NewExpression,
 // skipping parentheses and TS type assertions between the node and the call.
 func IsCallee(node *ast.Node) bool {


### PR DESCRIPTION
## Summary

Fixes a SIGSEGV in `react/no-unused-state` when linting a React class component that declares a class property **without an initializer** (e.g. `editor: any;`). The crash takes down the whole process, producing **zero lint output** for the affected package.

**Root cause:** `skipAssertionsAndParens` was duplicated across three rules (`no_unused_state`, `no_obj_calls`, `no_unused_class_component_methods`) with an inconsistent nil contract — only `no_unused_class_component_methods` guarded nil. `no_unused_state` passed the optional (nil) property initializer straight into `ast.SkipOuterExpressions`, which dereferences `node.Kind` on a nil node.

**Fix:** consolidate the three copies into a single nil-safe `utils.SkipAssertionsAndParens` (returns nil for nil input, reusing the existing `skipTransparentKinds` constant). The existing `init == nil` guard in `processPropertyDeclaration` then handles it correctly. This also removes the duplication and unifies the nil contract so the same crash cannot reappear in the other two rules.

**Verification:**
- Red/green: removing the nil guard reproduces the exact reported panic (`SkipOuterExpressions ← processPropertyDeclaration`); restoring it passes.
- Regression tests added: uninitialized property (valid), coexisting with used state (valid), coexisting with unused state (invalid — still reported, asserted on exact messageId/line/column).
- End-to-end on the reported trigger files with the fixed binary: linted without crash; a control probe with a known unused-state field still reports correctly.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
