### PR TITLE
fix: align consistent-type-assertions with typescript-eslint

### DIFF
--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.go
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.go
@@ -1,8 +1,11 @@
 package consistent_type_assertions
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 type AssertionStyle string
@@ -27,7 +30,18 @@ type ConsistentTypeAssertionsOptions struct {
 	ArrayLiteralTypeAssertions  LiteralAssertion `json:"arrayLiteralTypeAssertions"`
 }
 
-// ConsistentTypeAssertionsRule enforces consistent type assertions
+// ConsistentTypeAssertionsRule is the rslint port of upstream
+// `@typescript-eslint/consistent-type-assertions`. It mirrors upstream v8
+// observably: the same diagnostics (message ids + texts), the same
+// `annotation`/`satisfies` suggestions, and the same angle-bracket→as autofix.
+//
+// AST note: upstream runs on ESTree, where parentheses are not nodes, so
+// `node.expression` / `node.parent` transparently see through them. tsgo
+// preserves `ParenthesizedExpression`, so the literal check skips parens on the
+// expression (`ast.SkipParentheses`) and the parameter / variable-declarator
+// lookups skip parens on the way up (`skipParensUp`). This is what makes
+// `({ ... }) as T` — the parenthesized object literal — get detected, matching
+// upstream.
 var ConsistentTypeAssertionsRule = rule.CreateRule(rule.Rule{
 	Name: "consistent-type-assertions",
 	Run:  run,
@@ -39,8 +53,6 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 		ObjectLiteralTypeAssertions: LiteralAssertionAllow,
 		ArrayLiteralTypeAssertions:  LiteralAssertionAllow,
 	}
-
-	// Parse options
 	if options != nil {
 		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
 			if optsMap, ok := optArray[0].(map[string]interface{}); ok {
@@ -51,369 +63,280 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 		}
 	}
 
-	// Helper to check if a node is a const assertion
-	isConstAssertion := func(node *ast.Node) bool {
-		if node == nil {
-			return false
-		}
-
-		var typeNode *ast.Node
-
-		switch node.Kind {
-		case ast.KindAsExpression:
-			asExpr := node.AsAsExpression()
-			if asExpr != nil {
-				typeNode = asExpr.Type
-			}
-		case ast.KindTypeAssertionExpression:
-			typeAssertion := node.AsTypeAssertion()
-			if typeAssertion != nil {
-				typeNode = typeAssertion.Type
-			}
-		}
-
-		if typeNode != nil && typeNode.Kind == ast.KindTypeReference {
-			typeRef := typeNode.AsTypeReferenceNode()
-			if typeRef != nil && typeRef.TypeName != nil {
-				typeName := typeRef.TypeName
-				if typeName.Kind == ast.KindIdentifier {
-					ident := typeName.AsIdentifier()
-					if ident != nil && ident.Text == "const" {
-						return true
-					}
-				}
-			}
-		}
-
-		return false
+	src := ctx.SourceFile
+	getText := func(n *ast.Node) string {
+		return utils.TrimmedNodeText(src, n)
 	}
 
-	// Helper to check if type is any or unknown
-	isAnyOrUnknown := func(typeNode *ast.Node) bool {
-		if typeNode == nil {
+	// isConst reports whether the assertion target is `const` (the `as const` /
+	// `<const>` assertion). Mirrors upstream `isConst`.
+	isConst := func(typeNode *ast.Node) bool {
+		if typeNode == nil || typeNode.Kind != ast.KindTypeReference {
 			return false
 		}
+		tr := typeNode.AsTypeReferenceNode()
+		if tr == nil || tr.TypeName == nil || tr.TypeName.Kind != ast.KindIdentifier {
+			return false
+		}
+		return tr.TypeName.AsIdentifier().Text == "const"
+	}
 
-		if typeNode.Kind == ast.KindAnyKeyword || typeNode.Kind == ast.KindUnknownKeyword {
+	// checkType reports whether a literal assertion to `typeNode` should be
+	// flagged. Mirrors upstream `checkType`: only the *bare* `any` / `unknown`
+	// keywords are exempt (a union such as `any | string` is NOT), and `as
+	// const` is exempt.
+	checkType := func(typeNode *ast.Node) bool {
+		switch typeNode.Kind {
+		case ast.KindAnyKeyword, ast.KindUnknownKeyword:
+			return false
+		case ast.KindTypeReference:
+			return !isConst(typeNode)
+		default:
 			return true
 		}
-
-		// Check for union types containing any/unknown
-		if typeNode.Kind == ast.KindUnionType {
-			unionType := typeNode.AsUnionTypeNode()
-			if unionType != nil {
-				types := unionType.Types.Nodes
-				for _, t := range types {
-					if t.Kind == ast.KindAnyKeyword || t.Kind == ast.KindUnknownKeyword {
-						return true
-					}
-				}
-			}
-		}
-
-		return false
 	}
 
-	// Helper to check if assertion is used as a parameter
-	var isAsParameter func(node *ast.Node) bool
-	isAsParameter = func(node *ast.Node) bool {
-		if node == nil || node.Parent == nil {
+	// skipParensUp returns the first non-parenthesis ancestor of `node`. ESTree
+	// has no parenthesis nodes, so upstream's `node.parent` is exactly this.
+	skipParensUp := func(node *ast.Node) *ast.Node {
+		p := node.Parent
+		for p != nil && p.Kind == ast.KindParenthesizedExpression {
+			p = p.Parent
+		}
+		return p
+	}
+
+	// isAsParameter mirrors upstream `isAsParameter`: the assertion is in a
+	// position where an object/array literal is "passed" rather than assigned to
+	// a typeable binding (call / new / throw arguments, JSX expression
+	// containers, default values, tagged-template substitutions).
+	isAsParameter := func(node *ast.Node) bool {
+		p := skipParensUp(node)
+		if p == nil {
 			return false
 		}
-
-		parent := node.Parent
-
-		switch parent.Kind {
-		case ast.KindCallExpression:
-			// Check if node is in arguments
-			callExpr := parent.AsCallExpression()
-			if callExpr != nil {
-				args := callExpr.Arguments.Nodes
-				for _, arg := range args {
-					if arg == node {
-						return true
-					}
-				}
-			}
-		case ast.KindNewExpression:
-			// Check if node is in arguments
-			newExpr := parent.AsNewExpression()
-			if newExpr != nil && newExpr.Arguments != nil {
-				args := newExpr.Arguments.Nodes
-				for _, arg := range args {
-					if arg == node {
-						return true
-					}
-				}
-			}
-		case ast.KindThrowStatement:
+		switch p.Kind {
+		case ast.KindNewExpression, ast.KindCallExpression, ast.KindThrowStatement,
+			ast.KindJsxExpression, ast.KindParameter, ast.KindBindingElement,
+			ast.KindShorthandPropertyAssignment:
+			// Parameter / BindingElement / ShorthandPropertyAssignment cover the
+			// ESTree `AssignmentPattern` default-value cases; the assertion can
+			// only be the default/initializer in those nodes.
 			return true
 		case ast.KindTemplateSpan:
-			return true
-		case ast.KindParameter:
-			return true
-		case ast.KindBindingElement:
-			// Default value in a destructuring pattern, e.g. `function f({ x = {} as Foo }) {}`.
-			// The equivalent of ESTree AssignmentPattern.
-			return true
-		case ast.KindJsxExpression:
-			// JSX attribute value, e.g. `<Foo style={{} as Bar} />`.
-			return true
-		case ast.KindParenthesizedExpression:
-			// ESTree has no explicit parenthesis node, so upstream treats
-			// `foo(({} as Foo))` as having CallExpression as the parent.
-			// TypeScript's AST preserves the parens, so recurse through them.
-			return isAsParameter(parent)
-		case ast.KindPropertyAssignment:
-			// Check if it's a default value in a parameter
-			propAssignment := parent.AsPropertyAssignment()
-			if propAssignment != nil && propAssignment.Initializer == node {
-				return isAsParameter(parent)
-			}
+			// Only tagged templates count: the substitution's TemplateExpression
+			// must itself be the argument of a TaggedTemplateExpression.
+			return p.Parent != nil && p.Parent.Parent != nil &&
+				p.Parent.Parent.Kind == ast.KindTaggedTemplateExpression
 		}
-
 		return false
 	}
 
-	// Helper to check if expression is an object literal
-	isObjectLiteral := func(node *ast.Node) bool {
-		return node != nil && node.Kind == ast.KindObjectLiteralExpression
-	}
+	// asPrecedence is the precedence of an `x as T` expression — the pivot the
+	// angle-bracket→as autofix uses to decide where wrapping parens are needed.
+	asPrecedence := ast.GetOperatorPrecedence(ast.KindAsExpression, ast.KindUnknown, ast.OperatorPrecedenceFlagsNone)
 
-	// Helper to check if expression is an array literal
-	isArrayLiteral := func(node *ast.Node) bool {
-		return node != nil && node.Kind == ast.KindArrayLiteralExpression
-	}
-
-	// Helper to check if a variable declaration can use type annotation
-	canUseTypeAnnotation := func(node *ast.Node) bool {
-		if node == nil || node.Parent == nil {
-			return false
+	// getWrappedCode mirrors upstream's helper of the same name: wrap `text` in
+	// parens unless its precedence is strictly higher than the surrounding
+	// context's.
+	getWrappedCode := func(text string, nodePrec, parentPrec ast.OperatorPrecedence) string {
+		if nodePrec > parentPrec {
+			return text
 		}
+		return "(" + text + ")"
+	}
+
+	subst := func(tmpl, cast string) string {
+		return strings.ReplaceAll(tmpl, "{{cast}}", cast)
+	}
+
+	// textWithParentheses mirrors upstream `getTextWithParentheses`: the text of
+	// the (paren-stripped) expression, wrapped in a single pair of parens when
+	// it was parenthesized in source. ESTree exposes only the inner node, so the
+	// wrapping is always exactly one level regardless of nesting depth.
+	textWithParentheses := func(exprRaw *ast.Node) string {
+		inner := ast.SkipParentheses(exprRaw)
+		t := getText(inner)
+		if inner != exprRaw {
+			return "(" + t + ")"
+		}
+		return t
+	}
+
+	// buildSuggestions mirrors upstream `getSuggestions`: an annotation
+	// suggestion (only when the assertion initializes a variable with no type
+	// annotation) plus a `satisfies` suggestion (always). `exprRaw` is the raw
+	// expression (parens preserved) — upstream uses `getTextWithParentheses`.
+	buildSuggestions := func(node, exprRaw, typeNode *ast.Node, annID, annTmpl, satID, satTmpl string) []rule.RuleSuggestion {
+		typeText := getText(typeNode)
+		exprText := textWithParentheses(exprRaw)
+		suggestions := make([]rule.RuleSuggestion, 0, 2)
+		if eff := skipParensUp(node); eff != nil && eff.Kind == ast.KindVariableDeclaration {
+			if vd := eff.AsVariableDeclaration(); vd.Type == nil {
+				if name := vd.Name(); name != nil {
+					suggestions = append(suggestions, rule.RuleSuggestion{
+						Message: rule.RuleMessage{
+							Id:          annID,
+							Description: subst(annTmpl, typeText),
+							Data:        map[string]string{"cast": typeText},
+						},
+						FixesArr: []rule.RuleFix{
+							rule.RuleFixInsertAfter(name, ": "+typeText),
+							rule.RuleFixReplace(src, node, exprText),
+						},
+					})
+				}
+			}
+		}
+		suggestions = append(suggestions, rule.RuleSuggestion{
+			Message: rule.RuleMessage{
+				Id:          satID,
+				Description: subst(satTmpl, typeText),
+				Data:        map[string]string{"cast": typeText},
+			},
+			FixesArr: []rule.RuleFix{
+				rule.RuleFixReplace(src, node, exprText),
+				rule.RuleFixInsertAfter(node, " satisfies "+typeText),
+			},
+		})
+		return suggestions
+	}
+
+	// checkObject / checkArray mirror upstream's checkExpressionForObjectAssertion
+	// / checkExpressionForArrayAssertion. `exprRaw` is the assertion's raw
+	// expression; the literal check uses the paren-stripped form.
+	checkObject := func(node, exprRaw, typeNode *ast.Node) {
+		expr := ast.SkipParentheses(exprRaw)
+		if opts.AssertionStyle == AssertionStyleNever ||
+			opts.ObjectLiteralTypeAssertions == LiteralAssertionAllow ||
+			expr.Kind != ast.KindObjectLiteralExpression {
+			return
+		}
+		if opts.ObjectLiteralTypeAssertions == LiteralAssertionAllowAsParam && isAsParameter(node) {
+			return
+		}
+		if checkType(typeNode) {
+			ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{
+				Id:          "unexpectedObjectTypeAssertion",
+				Description: "Always prefer const x: T = { ... }.",
+			}, buildSuggestions(node, exprRaw, typeNode,
+				"replaceObjectTypeAssertionWithAnnotation", "Use const x: {{cast}} = { ... } instead.",
+				"replaceObjectTypeAssertionWithSatisfies", "Use const x = { ... } satisfies {{cast}} instead.")...)
+		}
+	}
+
+	checkArray := func(node, exprRaw, typeNode *ast.Node) {
+		expr := ast.SkipParentheses(exprRaw)
+		if opts.AssertionStyle == AssertionStyleNever ||
+			opts.ArrayLiteralTypeAssertions == LiteralAssertionAllow ||
+			expr.Kind != ast.KindArrayLiteralExpression {
+			return
+		}
+		if opts.ArrayLiteralTypeAssertions == LiteralAssertionAllowAsParam && isAsParameter(node) {
+			return
+		}
+		if checkType(typeNode) {
+			ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{
+				Id:          "unexpectedArrayTypeAssertion",
+				Description: "Always prefer const x: T[] = [ ... ].",
+			}, buildSuggestions(node, exprRaw, typeNode,
+				"replaceArrayTypeAssertionWithAnnotation", "Use const x: {{cast}} = [ ... ] instead.",
+				"replaceArrayTypeAssertionWithSatisfies", "Use const x = [ ... ] satisfies {{cast}} instead.")...)
+		}
+	}
+
+	// buildAngleToAsFix converts an angle-bracket assertion `<T>expr` into
+	// `expr as T`, wrapping the expression and/or the whole assertion in parens
+	// exactly where precedence requires. Mirrors upstream's `as` fixer.
+	buildAngleToAsFix := func(node, exprRaw, typeNode *ast.Node) rule.RuleFix {
+		skipExpr := ast.SkipParentheses(exprRaw)
+		exprText := getWrappedCode(getText(skipExpr), ast.GetExpressionPrecedence(skipExpr), asPrecedence)
+		text := exprText + " as " + getText(typeNode)
 
 		parent := node.Parent
-
-		// Check if parent is a variable declaration
-		if parent.Kind == ast.KindVariableDeclaration {
-			return true
+		if parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+			// Already parenthesized in source — the existing parens suffice.
+			return rule.RuleFixReplace(src, node, text)
 		}
 
-		// Check if parent is a property declaration
-		if parent.Kind == ast.KindPropertyDeclaration {
-			return true
+		parentKind := ast.KindUnknown
+		operatorKind := ast.KindUnknown
+		flags := ast.OperatorPrecedenceFlagsNone
+		if parent != nil {
+			parentKind = parent.Kind
+			switch parent.Kind {
+			case ast.KindBinaryExpression:
+				if op := parent.AsBinaryExpression().OperatorToken; op != nil {
+					operatorKind = op.Kind
+				}
+			case ast.KindNewExpression:
+				ne := parent.AsNewExpression()
+				if ne.Arguments == nil || len(ne.Arguments.Nodes) == 0 {
+					flags = ast.OperatorPrecedenceFlagsNewWithoutArguments
+				}
+			}
 		}
-
-		return false
+		parentPrec := ast.GetOperatorPrecedence(parentKind, operatorKind, flags)
+		return rule.RuleFixReplace(src, node, getWrappedCode(text, asPrecedence, parentPrec))
 	}
 
-	checkAsExpression := func(node *ast.Node) {
-		// Always allow const assertions
-		if isConstAssertion(node) {
+	// reportIncorrectAssertionType handles the assertion-style mismatch reports
+	// (`as` / `angle-bracket` / `never`). Mirrors upstream
+	// `reportIncorrectAssertionType`.
+	reportIncorrectAssertionType := func(node, exprRaw, typeNode *ast.Node) {
+		style := opts.AssertionStyle
+		// `as const` / `<const>` is never reported under `never`.
+		if style == AssertionStyleNever && isConst(typeNode) {
 			return
 		}
-
-		asExpr := node.AsAsExpression()
-		if asExpr == nil {
-			return
-		}
-
-		expression := asExpr.Expression
-		typeNode := asExpr.Type
-
-		// Check assertion style
-		if opts.AssertionStyle == AssertionStyleNever {
-			ctx.ReportNode(node, rule.RuleMessage{
-				Id:          "never",
-				Description: "Do not use any type assertions.",
-			})
-			return
-		}
-
-		if opts.AssertionStyle == AssertionStyleAngleBracket {
-			ctx.ReportNode(node, rule.RuleMessage{
+		switch style {
+		case AssertionStyleAs:
+			cast := getText(typeNode)
+			ctx.ReportNodeWithFixes(node, rule.RuleMessage{
 				Id:          "as",
-				Description: "Use angle-bracket type assertions instead of 'as' assertions.",
-			})
-			return
-		}
-
-		// Check object literal assertions
-		if isObjectLiteral(expression) && !isAnyOrUnknown(typeNode) {
-			if opts.ObjectLiteralTypeAssertions == LiteralAssertionNever {
-				if canUseTypeAnnotation(node) {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "object-literal-with-type-annotation",
-						Description: "Use a type annotation instead of a type assertion for object literals.",
-					})
-				} else {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "never-object-literal",
-						Description: "Use a type annotation or satisfies instead of a type assertion for object literals.",
-					})
-				}
-				return
-			}
-
-			if opts.ObjectLiteralTypeAssertions == LiteralAssertionAllowAsParam {
-				if !isAsParameter(node) {
-					if canUseTypeAnnotation(node) {
-						ctx.ReportNode(node, rule.RuleMessage{
-							Id:          "object-literal-with-type-annotation",
-							Description: "Use a type annotation instead of a type assertion for object literals.",
-						})
-					} else {
-						ctx.ReportNode(node, rule.RuleMessage{
-							Id:          "never-object-literal",
-							Description: "Use a type annotation or satisfies instead of a type assertion for object literals.",
-						})
-					}
-					return
-				}
-			}
-		}
-
-		// Check array literal assertions
-		if isArrayLiteral(expression) && !isAnyOrUnknown(typeNode) {
-			if opts.ArrayLiteralTypeAssertions == LiteralAssertionNever {
-				if canUseTypeAnnotation(node) {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "array-literal-with-type-annotation",
-						Description: "Use a type annotation instead of a type assertion for array literals.",
-					})
-				} else {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "never-array-literal",
-						Description: "Use a type annotation or satisfies instead of a type assertion for array literals.",
-					})
-				}
-				return
-			}
-
-			if opts.ArrayLiteralTypeAssertions == LiteralAssertionAllowAsParam {
-				if !isAsParameter(node) {
-					if canUseTypeAnnotation(node) {
-						ctx.ReportNode(node, rule.RuleMessage{
-							Id:          "array-literal-with-type-annotation",
-							Description: "Use a type annotation instead of a type assertion for array literals.",
-						})
-					} else {
-						ctx.ReportNode(node, rule.RuleMessage{
-							Id:          "never-array-literal",
-							Description: "Use a type annotation or satisfies instead of a type assertion for array literals.",
-						})
-					}
-					return
-				}
-			}
-		}
-	}
-
-	checkTypeAssertion := func(node *ast.Node) {
-		// Always allow const assertions
-		if isConstAssertion(node) {
-			return
-		}
-
-		typeAssertion := node.AsTypeAssertion()
-		if typeAssertion == nil {
-			return
-		}
-
-		expression := typeAssertion.Expression
-		typeNode := typeAssertion.Type
-
-		// Check assertion style 'never' first
-		if opts.AssertionStyle == AssertionStyleNever {
-			ctx.ReportNode(node, rule.RuleMessage{
-				Id:          "never",
-				Description: "Do not use any type assertions.",
-			})
-			return
-		}
-
-		// Check object literal assertions BEFORE checking assertion style
-		if isObjectLiteral(expression) && !isAnyOrUnknown(typeNode) {
-			if opts.ObjectLiteralTypeAssertions == LiteralAssertionNever {
-				if canUseTypeAnnotation(node) {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "object-literal-with-type-annotation",
-						Description: "Use a type annotation instead of a type assertion for object literals.",
-					})
-				} else {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "never-object-literal",
-						Description: "Use a type annotation or satisfies instead of a type assertion for object literals.",
-					})
-				}
-				return
-			}
-
-			if opts.ObjectLiteralTypeAssertions == LiteralAssertionAllowAsParam {
-				if !isAsParameter(node) {
-					if canUseTypeAnnotation(node) {
-						ctx.ReportNode(node, rule.RuleMessage{
-							Id:          "object-literal-with-type-annotation",
-							Description: "Use a type annotation instead of a type assertion for object literals.",
-						})
-					} else {
-						ctx.ReportNode(node, rule.RuleMessage{
-							Id:          "never-object-literal",
-							Description: "Use a type annotation or satisfies instead of a type assertion for object literals.",
-						})
-					}
-					return
-				}
-			}
-		}
-
-		// Check array literal assertions
-		if isArrayLiteral(expression) && !isAnyOrUnknown(typeNode) {
-			if opts.ArrayLiteralTypeAssertions == LiteralAssertionNever {
-				if canUseTypeAnnotation(node) {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "array-literal-with-type-annotation",
-						Description: "Use a type annotation instead of a type assertion for array literals.",
-					})
-				} else {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "never-array-literal",
-						Description: "Use a type annotation or satisfies instead of a type assertion for array literals.",
-					})
-				}
-				return
-			}
-
-			if opts.ArrayLiteralTypeAssertions == LiteralAssertionAllowAsParam {
-				if !isAsParameter(node) {
-					if canUseTypeAnnotation(node) {
-						ctx.ReportNode(node, rule.RuleMessage{
-							Id:          "array-literal-with-type-annotation",
-							Description: "Use a type annotation instead of a type assertion for array literals.",
-						})
-					} else {
-						ctx.ReportNode(node, rule.RuleMessage{
-							Id:          "never-array-literal",
-							Description: "Use a type annotation or satisfies instead of a type assertion for array literals.",
-						})
-					}
-					return
-				}
-			}
-		}
-
-		// Check assertion style (after literal checks)
-		if opts.AssertionStyle == AssertionStyleAs {
+				Description: subst("Use 'as {{cast}}' instead of '<{{cast}}>'.", cast),
+				Data:        map[string]string{"cast": cast},
+			}, buildAngleToAsFix(node, exprRaw, typeNode))
+		case AssertionStyleAngleBracket:
+			cast := getText(typeNode)
 			ctx.ReportNode(node, rule.RuleMessage{
 				Id:          "angle-bracket",
-				Description: "Use 'as' assertions instead of angle-bracket type assertions.",
+				Description: subst("Use '<{{cast}}>' instead of 'as {{cast}}'.", cast),
+				Data:        map[string]string{"cast": cast},
 			})
-			return
+		case AssertionStyleNever:
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "never",
+				Description: "Do not use any type assertions.",
+			})
 		}
 	}
 
 	return rule.RuleListeners{
-		ast.KindAsExpression:            checkAsExpression,
-		ast.KindTypeAssertionExpression: checkTypeAssertion,
+		ast.KindAsExpression: func(node *ast.Node) {
+			asExpr := node.AsAsExpression()
+			if asExpr == nil {
+				return
+			}
+			if opts.AssertionStyle != AssertionStyleAs {
+				reportIncorrectAssertionType(node, asExpr.Expression, asExpr.Type)
+				return
+			}
+			checkObject(node, asExpr.Expression, asExpr.Type)
+			checkArray(node, asExpr.Expression, asExpr.Type)
+		},
+		ast.KindTypeAssertionExpression: func(node *ast.Node) {
+			typeAssertion := node.AsTypeAssertion()
+			if typeAssertion == nil {
+				return
+			}
+			if opts.AssertionStyle != AssertionStyleAngleBracket {
+				reportIncorrectAssertionType(node, typeAssertion.Expression, typeAssertion.Type)
+				return
+			}
+			checkObject(node, typeAssertion.Expression, typeAssertion.Type)
+			checkArray(node, typeAssertion.Expression, typeAssertion.Type)
+		},
 	}
 }
 

--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions_test.go
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions_test.go
@@ -7,17 +7,28 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
+// Helpers to keep the option maps terse.
+func opt(m map[string]interface{}) []interface{} { return []interface{}{m} }
+
 func TestConsistentTypeAssertionsRule(t *testing.T) {
+	angleStyle := opt(map[string]interface{}{"assertionStyle": "angle-bracket"})
+	neverStyle := opt(map[string]interface{}{"assertionStyle": "never"})
+	objNever := opt(map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"})
+	objParam := opt(map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"})
+	arrNever := opt(map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"})
+	arrParam := opt(map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"})
+	bothParam := opt(map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter", "arrayLiteralTypeAssertions": "allow-as-parameter"})
+	angleObjNever := opt(map[string]interface{}{"assertionStyle": "angle-bracket", "objectLiteralTypeAssertions": "never"})
+	angleArrNever := opt(map[string]interface{}{"assertionStyle": "angle-bracket", "arrayLiteralTypeAssertions": "never"})
+
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ConsistentTypeAssertionsRule, []rule_tester.ValidTestCase{
-		// Default options (assertionStyle: 'as')
+		// Default options (assertionStyle: 'as', literals 'allow')
 		{Code: `const x = b as A;`},
 		{Code: `const x = [1] as readonly number[];`},
 		{Code: `const x = 'string' as a | b;`},
 		{Code: `const x = () => ({ bar: 5 }) as Foo;`},
 		{Code: `const x = { key: 'value' } as const;`},
-		{Code: `const x = <const>{ key: 'value' };`},
 		{Code: `const x = [1] as const;`},
-		{Code: `const x = <const>[1];`},
 		{Code: `const x = { foo: 1 } as Foo;`},
 		{Code: `const x = [] as Foo[];`},
 		{Code: `const x = new Generic<int>() as Foo;`},
@@ -25,408 +36,387 @@ func TestConsistentTypeAssertionsRule(t *testing.T) {
 		{Code: `const x = [1, 2, 3] as number[];`},
 
 		// assertionStyle: 'angle-bracket'
-		{Code: `const x = <A>b;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}}},
-		{Code: `const x = <readonly number[]>[1];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}}},
-		{Code: `const x = <a | b>'string';`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}}},
-		{Code: `const x = <Foo>(() => ({ bar: 5 }));`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}}},
-		{Code: `const x = <const>{ key: 'value' };`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}}},
-		{Code: `const x = { key: 'value' } as const;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}}},
-		{Code: `const x = <const>[1];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}}},
-		{Code: `const x = [1] as const;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}}},
-		{Code: `const x = <Foo>{ foo: 1 };`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}}},
-		{Code: `const x = <Foo[]>[];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}}},
+		{Code: `const x = <A>b;`, Options: angleStyle},
+		{Code: `const x = <readonly number[]>[1];`, Options: angleStyle},
+		{Code: `const x = <a | b>'string';`, Options: angleStyle},
+		{Code: `const x = <Foo>(() => ({ bar: 5 }));`, Options: angleStyle},
+		{Code: `const x = <const>{ key: 'value' };`, Options: angleStyle},
+		{Code: `const x = <const>[1];`, Options: angleStyle},
+		{Code: `const x = <Foo>{ foo: 1 };`, Options: angleStyle},
+		{Code: `const x = <Foo[]>[];`, Options: angleStyle},
 
-		// assertionStyle: 'never'
-		{Code: `const x = { key: 'value' } as const;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "never"}}},
-		{Code: `const x = <const>{ key: 'value' };`, Options: []interface{}{map[string]interface{}{"assertionStyle": "never"}}},
-		{Code: `const x = [1] as const;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "never"}}},
-		{Code: `const x = <const>[1];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "never"}}},
+		// assertionStyle: 'never' — `const` is exempt
+		{Code: `const x = { key: 'value' } as const;`, Options: neverStyle},
+		{Code: `const x = <const>{ key: 'value' };`, Options: neverStyle},
+		{Code: `const x = [1] as const;`, Options: neverStyle},
+		{Code: `const x = <const>[1];`, Options: neverStyle},
 
-		// objectLiteralTypeAssertions: 'never'
-		{Code: `const x: Foo = { bar: 5 };`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = { bar: 5 } as any;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = { bar: 5 } as unknown;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = { bar: 5 } as const;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = 'string' as Foo;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = 123 as Foo;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = true as Foo;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}}},
+		// objectLiteralTypeAssertions: 'never' — bare any/unknown/const & non-objects exempt
+		{Code: `const x: Foo = { bar: 5 };`, Options: objNever},
+		{Code: `const x = { bar: 5 } as any;`, Options: objNever},
+		{Code: `const x = { bar: 5 } as unknown;`, Options: objNever},
+		{Code: `const x = { bar: 5 } as const;`, Options: objNever},
+		{Code: `const x = 'string' as Foo;`, Options: objNever},
+		{Code: `const x = 123 as Foo;`, Options: objNever},
+		{Code: `const x = true as Foo;`, Options: objNever},
 
 		// objectLiteralTypeAssertions: 'allow-as-parameter'
-		{Code: `const x: Foo = { bar: 5 };`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `foo({ bar: 5 } as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `new Foo({ bar: 5 } as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `throw { bar: 5 } as Foo;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const x = { bar: 5 } as any;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const x = { bar: 5 } as unknown;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const x = { bar: 5 } as const;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `function foo() { throw { bar: 5 } as Foo; }`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const foo = (x = { bar: 5 } as Foo) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const foo = ({ x = { bar: 5 } as Foo } = {}) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const foo = ({ x = {} as Record<string, string[]> }) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const foo = ([x = {} as Foo]) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `function b({ x = {} as Foo.Bar }) {}`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const foo = ({ a: { b = {} as Foo } = {} }) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `print?.({ bar: 5 } as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `print?.call({ bar: 5 } as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: "print`${{ bar: 5 } as Foo}`;", Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const bar = <Foo style={{ bar: 5 } as Bar} />;`, Tsx: true, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `foo(({ bar: 5 } as Foo));`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const x: Foo = { bar: 5 };`, Options: objParam},
+		{Code: `foo({ bar: 5 } as Foo);`, Options: objParam},
+		{Code: `new Foo({ bar: 5 } as Foo);`, Options: objParam},
+		{Code: `throw { bar: 5 } as Foo;`, Options: objParam},
+		{Code: `const x = { bar: 5 } as any;`, Options: objParam},
+		{Code: `const x = { bar: 5 } as unknown;`, Options: objParam},
+		{Code: `const x = { bar: 5 } as const;`, Options: objParam},
+		{Code: `function foo() { throw { bar: 5 } as Foo; }`, Options: objParam},
+		{Code: `const foo = (x = { bar: 5 } as Foo) => {};`, Options: objParam},
+		{Code: `const foo = ({ x = { bar: 5 } as Foo } = {}) => {};`, Options: objParam},
+		{Code: `const foo = ({ x = {} as Record<string, string[]> }) => {};`, Options: objParam},
+		{Code: `const foo = ([x = {} as Foo]) => {};`, Options: objParam},
+		{Code: `function b({ x = {} as Foo.Bar }) {}`, Options: objParam},
+		{Code: `const foo = ({ a: { b = {} as Foo } = {} }) => {};`, Options: objParam},
+		{Code: `print?.({ bar: 5 } as Foo);`, Options: objParam},
+		{Code: `print?.call({ bar: 5 } as Foo);`, Options: objParam},
+		{Code: "print`${{ bar: 5 } as Foo}`;", Options: objParam},
+		{Code: `const bar = <Foo style={{ bar: 5 } as Bar} />;`, Tsx: true, Options: objParam},
+		{Code: `foo(({ bar: 5 } as Foo));`, Options: objParam},
 
 		// arrayLiteralTypeAssertions: 'never'
-		{Code: `const x: string[] = [];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}}},
-		{Code: `const x = [] as any;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}}},
-		{Code: `const x = [] as unknown;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}}},
-		{Code: `const x = [] as const;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}}},
-		{Code: `const x = 'string' as Foo;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}}},
+		{Code: `const x: string[] = [];`, Options: arrNever},
+		{Code: `const x = [] as any;`, Options: arrNever},
+		{Code: `const x = [] as unknown;`, Options: arrNever},
+		{Code: `const x = [] as const;`, Options: arrNever},
+		{Code: `const x = 'string' as Foo;`, Options: arrNever},
 
 		// arrayLiteralTypeAssertions: 'allow-as-parameter'
-		{Code: `const x: string[] = [];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const foo = ({ x = [] as string[] }) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const foo = ([x = [] as string[]]) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `function b(x = [5] as Foo.Bar) {}`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `print?.([5] as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `print?.call([5] as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: "print`${[5] as Foo}`;", Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const bar = <Foo style={[5] as Bar} />;`, Tsx: true, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `foo(([5] as Foo));`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `foo([] as string[]);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `new Foo([] as string[]);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `throw [] as string[];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const x = [] as any;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const x = [] as unknown;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const x = [] as const;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `function foo() { throw [] as string[]; }`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const x: string[] = [];`, Options: arrParam},
+		{Code: `const foo = ({ x = [] as string[] }) => {};`, Options: arrParam},
+		{Code: `const foo = ([x = [] as string[]]) => {};`, Options: arrParam},
+		{Code: `function b(x = [5] as Foo.Bar) {}`, Options: arrParam},
+		{Code: `print?.([5] as Foo);`, Options: arrParam},
+		{Code: `print?.call([5] as Foo);`, Options: arrParam},
+		{Code: "print`${[5] as Foo}`;", Options: arrParam},
+		{Code: `const bar = <Foo style={[5] as Bar} />;`, Tsx: true, Options: arrParam},
+		{Code: `foo(([5] as Foo));`, Options: arrParam},
+		{Code: `foo([] as string[]);`, Options: arrParam},
+		{Code: `new Foo([] as string[]);`, Options: arrParam},
+		{Code: `throw [] as string[];`, Options: arrParam},
+		{Code: `const x = [] as any;`, Options: arrParam},
+		{Code: `const x = [] as unknown;`, Options: arrParam},
+		{Code: `const x = [] as const;`, Options: arrParam},
+		{Code: `function foo() { throw [] as string[]; }`, Options: arrParam},
 
 		// Both objectLiteralTypeAssertions and arrayLiteralTypeAssertions: 'allow-as-parameter'
-		{Code: `const x: Foo = { bar: 5 };`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `const x: string[] = [];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `foo({ bar: 5 } as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `foo([] as string[]);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
-		{Code: `foo({ bar: 5 } as Foo, [] as string[]);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const x: Foo = { bar: 5 };`, Options: bothParam},
+		{Code: `const x: string[] = [];`, Options: bothParam},
+		{Code: `foo({ bar: 5 } as Foo);`, Options: bothParam},
+		{Code: `foo([] as string[]);`, Options: bothParam},
+		{Code: `foo({ bar: 5 } as Foo, [] as string[]);`, Options: bothParam},
 
-		// angle-bracket with objectLiteralTypeAssertions: 'never'
-		{Code: `const x: Foo = { bar: 5 };`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = <any>{ bar: 5 };`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = <unknown>{ bar: 5 };`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = <const>{ bar: 5 };`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "objectLiteralTypeAssertions": "never"}}},
+		// angle-bracket with literal 'never' — literals via angle bracket allowed
+		{Code: `const x: Foo = { bar: 5 };`, Options: angleObjNever},
+		{Code: `const x = <any>{ bar: 5 };`, Options: angleObjNever},
+		{Code: `const x = <unknown>{ bar: 5 };`, Options: angleObjNever},
+		{Code: `const x = <const>{ bar: 5 };`, Options: angleObjNever},
+		{Code: `const x: string[] = [];`, Options: angleArrNever},
+		{Code: `const x = <any>[];`, Options: angleArrNever},
+		{Code: `const x = <unknown>[];`, Options: angleArrNever},
+		{Code: `const x = <const>[];`, Options: angleArrNever},
 
-		// angle-bracket with arrayLiteralTypeAssertions: 'never'
-		{Code: `const x: string[] = [];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "arrayLiteralTypeAssertions": "never"}}},
-		{Code: `const x = <any>[];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "arrayLiteralTypeAssertions": "never"}}},
-		{Code: `const x = <unknown>[];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "arrayLiteralTypeAssertions": "never"}}},
-		{Code: `const x = <const>[];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "arrayLiteralTypeAssertions": "never"}}},
-
-		// Additional edge cases
+		// Additional edge cases — assertions on non object/array literals
 		{Code: `const x = value as string | number;`},
 		{Code: `const x = value as (string | number)[];`},
 		{Code: `const x = (value as Foo) as Bar;`},
 		{Code: `const x = (value as Foo).bar;`},
 		{Code: `const x = (value as Foo)();`},
 		{Code: "const x = `template ${value as string}`;"},
-
-		// Union types containing any/unknown
-		{Code: `const x = {} as any | string;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = {} as unknown | string;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}}},
-		{Code: `const x = [] as any | string[];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}}},
-		{Code: `const x = [] as unknown | string[];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}}},
 	}, []rule_tester.InvalidTestCase{
-		// Default options - using angle-bracket when 'as' is required
+		// ---- assertionStyle: 'as' (default) — angle bracket used, autofix to `as` ----
 		{
-			Code: `const x = <A>b;`,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "angle-bracket"},
-			},
+			Code:   `const x = <A>b;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = b as A;`},
 		},
 		{
-			Code: `const x = <readonly number[]>[1];`,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "angle-bracket"},
-			},
+			Code:   `const x = <readonly number[]>[1];`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = [1] as readonly number[];`},
 		},
 		{
-			Code: `const x = <Foo>{ bar: 5 };`,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "angle-bracket"},
-			},
+			Code:   `const x = <Foo>{ bar: 5 };`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = { bar: 5 } as Foo;`},
 		},
 		{
-			Code: `const x = <Foo>[];`,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "angle-bracket"},
-			},
-		},
-
-		// assertionStyle: 'angle-bracket' - using 'as' when angle-bracket is required
-		{
-			Code:    `const x = b as A;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "as"},
-			},
+			Code:   `const x = <Foo>[];`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = [] as Foo;`},
 		},
 		{
-			Code:    `const x = [1] as readonly number[];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "as"},
-			},
+			Code:   `const x = <const>{ key: 'value' };`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = { key: 'value' } as const;`},
 		},
 		{
-			Code:    `const x = { bar: 5 } as Foo;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "as"},
-			},
+			Code:   `const x = <const>[1];`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = [1] as const;`},
 		},
-
-		// assertionStyle: 'never'
-		{
-			Code:    `const x = b as A;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "never"},
-			},
-		},
-		{
-			Code:    `const x = <A>b;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "never"},
-			},
-		},
-		{
-			Code:    `const x = { bar: 5 } as Foo;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "never"},
-			},
-		},
+		// angle-bracket assertion on an object literal under 'as' style reports the
+		// style mismatch (NOT the object-literal rule), and autofixes to `as`.
 		{
 			Code:    `const x = <Foo>{ bar: 5 };`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "never"},
-			},
+			Options: objNever,
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output:  []string{`const x = { bar: 5 } as Foo;`},
+		},
+		// Autofix precedence wrapping: the result is parenthesized only where the
+		// surrounding context requires it, and the expression only where its own
+		// precedence is lower than `as`.
+		{
+			Code:   `const x = <T>a + b;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = (a as T) + b;`},
+		},
+		{
+			Code:   `foo(<T>x);`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`foo((x as T));`},
+		},
+		{
+			Code:   `const x = (<T>a).b;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = (a as T).b;`},
+		},
+		{
+			Code:   `const x = <T>(a ? b : c);`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = (a ? b : c) as T;`},
+		},
+		{
+			Code:   `const x = -<T>a;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = -(a as T);`},
+		},
+		{
+			Code:   `const x = <T>a.b;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "as"}},
+			Output: []string{`const x = a.b as T;`},
 		},
 
-		// objectLiteralTypeAssertions: 'never'
+		// ---- assertionStyle: 'angle-bracket' — `as` used ----
+		{Code: `const x = b as A;`, Options: angleStyle, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "angle-bracket"}}},
+		{Code: `const x = [1] as readonly number[];`, Options: angleStyle, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "angle-bracket"}}},
+		{Code: `const x = { bar: 5 } as Foo;`, Options: angleStyle, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "angle-bracket"}}},
+		{Code: `const x = { key: 'value' } as const;`, Options: angleStyle, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "angle-bracket"}}},
+		{Code: `const x = [1] as const;`, Options: angleStyle, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "angle-bracket"}}},
+
+		// ---- assertionStyle: 'never' ----
+		{Code: `const x = b as A;`, Options: neverStyle, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "never"}}},
+		{Code: `const x = <A>b;`, Options: neverStyle, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "never"}}},
+		{Code: `const x = { bar: 5 } as Foo;`, Options: neverStyle, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "never"}}},
+		{Code: `const x = <Foo>{ bar: 5 };`, Options: neverStyle, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "never"}}},
+
+		// ---- objectLiteralTypeAssertions: 'never' ----
 		{
 			Code:    `const x = {} as Foo;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: Foo = {};`},
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = {} satisfies Foo;`},
+				},
+			}},
 		},
 		{
 			Code:    `const x = { bar: 5 } as Foo;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: Foo = { bar: 5 };`},
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = { bar: 5 } satisfies Foo;`},
+				},
+			}},
 		},
 		{
 			Code:    `const x = { bar: 5 } as Foo<int>;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: Foo<int> = { bar: 5 };`},
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = { bar: 5 } satisfies Foo<int>;`},
+				},
+			}},
 		},
 		{
 			Code:    `const x = { bar: 5 } as a | b;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: a | b = { bar: 5 };`},
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = { bar: 5 } satisfies a | b;`},
+				},
+			}},
 		},
+		// `any`/`unknown` inside a union ARE reported (only the bare keyword is exempt).
+		{
+			Code:    `const x = {} as any | string;`,
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: any | string = {};`},
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = {} satisfies any | string;`},
+				},
+			}},
+		},
+		{
+			Code:    `const x = {} as unknown | string;`,
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: unknown | string = {};`},
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = {} satisfies unknown | string;`},
+				},
+			}},
+		},
+		// Qualified-name target (`Foo.Bar`) is reported.
+		{
+			Code:    `const x = {} as Foo.Bar;`,
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: Foo.Bar = {};`},
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = {} satisfies Foo.Bar;`},
+				},
+			}},
+		},
+		// Parenthesized object literal — `({ ... }) as T` — must be detected. The
+		// report spans from the opening paren (column 11).
+		{
+			Code:    `const x = ({}) as Foo;`,
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Line:      1, Column: 11, EndColumn: 22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: Foo = ({});`},
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = ({}) satisfies Foo;`},
+				},
+			}},
+		},
+		// Nested parens.
+		{
+			Code:    `const x = (({})) as Foo;`,
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: Foo = ({});`},
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = ({}) satisfies Foo;`},
+				},
+			}},
+		},
+		// Arrow-function return of a parenthesized object literal (the real-world
+		// shape from the migration report). Only the `satisfies` suggestion applies
+		// (the assertion does not initialize a plain variable).
+		{
+			Code:    `const f = (): Foo => ({ bar: 5 }) as Foo;`,
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const f = (): Foo => ({ bar: 5 }) satisfies Foo;`},
+				},
+			}},
+		},
+		// Assertion nested in a larger expression — only `satisfies` suggestion.
 		{
 			Code:    `const x = ({} as A) + b;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "never-object-literal"},
-			},
-		},
-		{
-			Code:    `const x = <Foo>{ bar: 5 };`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
+			Options: objNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = ({} satisfies A) + b;`},
+				},
+			}},
 		},
 
-		// objectLiteralTypeAssertions: 'allow-as-parameter'
+		// ---- objectLiteralTypeAssertions: 'allow-as-parameter' (non-parameter positions) ----
 		{
 			Code:    `const x = { bar: 5 } as Foo;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
+			Options: objParam,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithAnnotation", Output: `const x: Foo = { bar: 5 };`},
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `const x = { bar: 5 } satisfies Foo;`},
+				},
+			}},
 		},
 		{
 			Code:    `class C { x = {} as Foo; }`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
+			Options: objParam,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `class C { x = {} satisfies Foo; }`},
+				},
+			}},
 		},
+		// A property value is NOT an "as parameter" — it is reported.
 		{
-			Code:    `const foo = () => ({ bar: 5 } as Foo);`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "never-object-literal"},
-			},
-		},
-		{
-			Code:    `const x = [{ a: {} as Foo }];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "never-object-literal"},
-			},
-		},
-		{
-			Code:    `const x = {} as Foo;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
-		},
-		{
-			Code:    `const x = ({ bar: 5 } as Foo).baz;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "never-object-literal"},
-			},
-		},
-		{
-			Code:    `const x = <Foo>{ bar: 5 };`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
+			Code:    `foo({ x: {} as Foo });`,
+			Options: objParam,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedObjectTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceObjectTypeAssertionWithSatisfies", Output: `foo({ x: {} satisfies Foo });`},
+				},
+			}},
 		},
 
-		// arrayLiteralTypeAssertions: 'never'
+		// ---- arrayLiteralTypeAssertions: 'never' ----
 		{
-			Code:    `const x = [] as string[];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "array-literal-with-type-annotation"},
-			},
+			Code:    `const x = [] as Foo;`,
+			Options: arrNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedArrayTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceArrayTypeAssertionWithAnnotation", Output: `const x: Foo = [];`},
+					{MessageId: "replaceArrayTypeAssertionWithSatisfies", Output: `const x = [] satisfies Foo;`},
+				},
+			}},
+		},
+		// Parenthesized array literal — `([ ... ]) as T`.
+		{
+			Code:    `const x = ([]) as Foo;`,
+			Options: arrNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedArrayTypeAssertion",
+				Line:      1, Column: 11, EndColumn: 22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceArrayTypeAssertionWithAnnotation", Output: `const x: Foo = ([]);`},
+					{MessageId: "replaceArrayTypeAssertionWithSatisfies", Output: `const x = ([]) satisfies Foo;`},
+				},
+			}},
 		},
 		{
-			Code:    `const x = [1, 2] as number[];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "array-literal-with-type-annotation"},
-			},
-		},
-		{
-			Code:    `const x = <string[]>[];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "array-literal-with-type-annotation"},
-			},
-		},
-		{
-			Code:    `const x = ([] as A) + b;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "never-array-literal"},
-			},
-		},
-
-		// arrayLiteralTypeAssertions: 'allow-as-parameter'
-		{
-			Code:    `const x = [] as string[];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "array-literal-with-type-annotation"},
-			},
-		},
-		{
-			Code:    `const x = [1, 2] as number[];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "array-literal-with-type-annotation"},
-			},
-		},
-		{
-			Code:    `const x = ([] as string[]).length;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "never-array-literal"},
-			},
-		},
-
-		// Both objectLiteralTypeAssertions and arrayLiteralTypeAssertions: 'allow-as-parameter'
-		{
-			Code:    `const x = { bar: 5 } as Foo;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter", "arrayLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
-		},
-		{
-			Code:    `const x = [] as string[];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter", "arrayLiteralTypeAssertions": "allow-as-parameter"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "array-literal-with-type-annotation"},
-			},
-		},
-
-		// angle-bracket with objectLiteralTypeAssertions: 'never'
-		{
-			Code:    `const x = <Foo>{ bar: 5 };`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "objectLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
-		},
-		{
-			Code:    `const x = <Foo>{};`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "objectLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
-		},
-
-		// angle-bracket with arrayLiteralTypeAssertions: 'never'
-		{
-			Code:    `const x = <string[]>[];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "arrayLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "array-literal-with-type-annotation"},
-			},
-		},
-		{
-			Code:    `const x = <number[]>[1, 2];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "angle-bracket", "arrayLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "array-literal-with-type-annotation"},
-			},
-		},
-
-		// Additional edge cases
-		{
-			Code: `const x = <string | number>value;`,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "angle-bracket"},
-			},
-		},
-
-		// Nested object/array literals
-		{
-			Code:    `const x = { bar: { baz: 5 } } as Foo;`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "object-literal-with-type-annotation"},
-			},
-		},
-		{
-			Code:    `const x = [[]] as string[][];`,
-			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "array-literal-with-type-annotation"},
-			},
+			Code:    `const x = [5] as any | string[];`,
+			Options: arrNever,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "unexpectedArrayTypeAssertion",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "replaceArrayTypeAssertionWithAnnotation", Output: `const x: any | string[] = [5];`},
+					{MessageId: "replaceArrayTypeAssertionWithSatisfies", Output: `const x = [5] satisfies any | string[];`},
+				},
+			}},
 		},
 	})
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -248,7 +248,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/consistent-generic-constructors.test.ts',
     // './tests/typescript-eslint/rules/consistent-indexed-object-style.test.ts',
     // './tests/typescript-eslint/rules/consistent-return.test.ts',
-    // './tests/typescript-eslint/rules/consistent-type-assertions.test.ts',
+    './tests/typescript-eslint/rules/consistent-type-assertions.test.ts',
     './tests/typescript-eslint/rules/consistent-type-definitions.test.ts',
     // './tests/typescript-eslint/rules/consistent-type-exports.test.ts',
     // './tests/typescript-eslint/rules/consistent-type-imports.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/consistent-type-assertions.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/consistent-type-assertions.test.ts.snap
@@ -1,0 +1,2679 @@
+// Rstest Snapshot v1
+
+exports[`consistent-type-assertions > invalid 1`] = `
+{
+  "code": "const x = new Generic<int>() as Foo;",
+  "diagnostics": [
+    {
+      "message": "Use '<Foo>' instead of 'as Foo'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 2`] = `
+{
+  "code": "const x = b as A;",
+  "diagnostics": [
+    {
+      "message": "Use '<A>' instead of 'as A'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 3`] = `
+{
+  "code": "const x = [1] as readonly number[];",
+  "diagnostics": [
+    {
+      "message": "Use '<readonly number[]>' instead of 'as readonly number[]'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 4`] = `
+{
+  "code": "const x = 'string' as a | b;",
+  "diagnostics": [
+    {
+      "message": "Use '<a | b>' instead of 'as a | b'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 5`] = `
+{
+  "code": "const x = !'string' as A;",
+  "diagnostics": [
+    {
+      "message": "Use '<A>' instead of 'as A'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 6`] = `
+{
+  "code": "const x = (a as A) + b;",
+  "diagnostics": [
+    {
+      "message": "Use '<A>' instead of 'as A'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 7`] = `
+{
+  "code": "const x = new Generic<string>() as Foo;",
+  "diagnostics": [
+    {
+      "message": "Use '<Foo>' instead of 'as Foo'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 8`] = `
+{
+  "code": "const x = new (Generic<string> as Foo)();",
+  "diagnostics": [
+    {
+      "message": "Use '<Foo>' instead of 'as Foo'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 9`] = `
+{
+  "code": "const x = new (Generic<string> as Foo)('string');",
+  "diagnostics": [
+    {
+      "message": "Use '<Foo>' instead of 'as Foo'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 10`] = `
+{
+  "code": "const x = () => ({ bar: 5 }) as Foo;",
+  "diagnostics": [
+    {
+      "message": "Use '<Foo>' instead of 'as Foo'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 11`] = `
+{
+  "code": "const x = () => bar as Foo;",
+  "diagnostics": [
+    {
+      "message": "Use '<Foo>' instead of 'as Foo'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 12`] = `
+{
+  "code": "const x = bar<string>\`\${'baz'}\` as Foo;",
+  "diagnostics": [
+    {
+      "message": "Use '<Foo>' instead of 'as Foo'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 13`] = `
+{
+  "code": "const x = { key: 'value' } as const;",
+  "diagnostics": [
+    {
+      "message": "Use '<const>' instead of 'as const'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 14`] = `
+{
+  "code": "const x = <Foo>new Generic<int>();",
+  "diagnostics": [
+    {
+      "message": "Use 'as Foo' instead of '<Foo>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = new Generic<int>() as Foo;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 15`] = `
+{
+  "code": "const x = <A>b;",
+  "diagnostics": [
+    {
+      "message": "Use 'as A' instead of '<A>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = b as A;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 16`] = `
+{
+  "code": "const x = <readonly number[]>[1];",
+  "diagnostics": [
+    {
+      "message": "Use 'as readonly number[]' instead of '<readonly number[]>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = [1] as readonly number[];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 17`] = `
+{
+  "code": "const x = <a | b>'string';",
+  "diagnostics": [
+    {
+      "message": "Use 'as a | b' instead of '<a | b>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = 'string' as a | b;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 18`] = `
+{
+  "code": "const x = <A>!'string';",
+  "diagnostics": [
+    {
+      "message": "Use 'as A' instead of '<A>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = !'string' as A;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 19`] = `
+{
+  "code": "const x = <A>a + b;",
+  "diagnostics": [
+    {
+      "message": "Use 'as A' instead of '<A>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = (a as A) + b;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 20`] = `
+{
+  "code": "const x = <Foo>new Generic<string>();",
+  "diagnostics": [
+    {
+      "message": "Use 'as Foo' instead of '<Foo>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = new Generic<string>() as Foo;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 21`] = `
+{
+  "code": "const x = new (<Foo>Generic<string>)();",
+  "diagnostics": [
+    {
+      "message": "Use 'as Foo' instead of '<Foo>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = new ((Generic<string>) as Foo)();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 22`] = `
+{
+  "code": "const x = new (<Foo>Generic<string>)('string');",
+  "diagnostics": [
+    {
+      "message": "Use 'as Foo' instead of '<Foo>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = new ((Generic<string>) as Foo)('string');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 23`] = `
+{
+  "code": "const x = () => <Foo>{ bar: 5 };",
+  "diagnostics": [
+    {
+      "message": "Use 'as Foo' instead of '<Foo>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = () => ({ bar: 5 } as Foo);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 24`] = `
+{
+  "code": "const x = () => <Foo>bar;",
+  "diagnostics": [
+    {
+      "message": "Use 'as Foo' instead of '<Foo>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = () => (bar as Foo);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 25`] = `
+{
+  "code": "const x = <Foo>bar<string>\`\${'baz'}\`;",
+  "diagnostics": [
+    {
+      "message": "Use 'as Foo' instead of '<Foo>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = bar<string>\`\${'baz'}\` as Foo;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 26`] = `
+{
+  "code": "const x = <const>{ key: 'value' };",
+  "diagnostics": [
+    {
+      "message": "Use 'as const' instead of '<const>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = { key: 'value' } as const;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 27`] = `
+{
+  "code": "const x = new Generic<int>() as Foo;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 28`] = `
+{
+  "code": "const x = b as A;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 29`] = `
+{
+  "code": "const x = [1] as readonly number[];",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 30`] = `
+{
+  "code": "const x = 'string' as a | b;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 31`] = `
+{
+  "code": "const x = !'string' as A;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 32`] = `
+{
+  "code": "const x = (a as A) + b;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 33`] = `
+{
+  "code": "const x = new Generic<string>() as Foo;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 34`] = `
+{
+  "code": "const x = new (Generic<string> as Foo)();",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 35`] = `
+{
+  "code": "const x = new (Generic<string> as Foo)('string');",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 36`] = `
+{
+  "code": "const x = () => ({ bar: 5 }) as Foo;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 37`] = `
+{
+  "code": "const x = () => bar as Foo;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 38`] = `
+{
+  "code": "const x = bar<string>\`\${'baz'}\` as Foo;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 39`] = `
+{
+  "code": "const x = <Foo>new Generic<int>();",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 40`] = `
+{
+  "code": "const x = <A>b;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 41`] = `
+{
+  "code": "const x = <readonly number[]>[1];",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 42`] = `
+{
+  "code": "const x = <a | b>'string';",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 43`] = `
+{
+  "code": "const x = <A>!'string';",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 44`] = `
+{
+  "code": "const x = <A>a + b;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 45`] = `
+{
+  "code": "const x = <Foo>new Generic<string>();",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 46`] = `
+{
+  "code": "const x = new (<Foo>Generic<string>)();",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 47`] = `
+{
+  "code": "const x = new (<Foo>Generic<string>)('string');",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 48`] = `
+{
+  "code": "const x = () => <Foo>{ bar: 5 };",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 49`] = `
+{
+  "code": "const x = () => <Foo>bar;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 50`] = `
+{
+  "code": "const x = <Foo>bar<string>\`\${'baz'}\`;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 51`] = `
+{
+  "code": "const x = {} as Foo<int>;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 52`] = `
+{
+  "code": "const x = {} as a | b;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 53`] = `
+{
+  "code": "const x = ({} as A) + b;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 54`] = `
+{
+  "code": "const x = <Foo<int>>{};",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 55`] = `
+{
+  "code": "const x = <a | b>{};",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 56`] = `
+{
+  "code": "const x = <A>{} + b;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 57`] = `
+{
+  "code": "const x = {} as Foo<int>;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 58`] = `
+{
+  "code": "const x = {} as a | b;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 59`] = `
+{
+  "code": "const x = ({} as A) + b;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 60`] = `
+{
+  "code": "print({ bar: 5 } as Foo);",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 61`] = `
+{
+  "code": "new print({ bar: 5 } as Foo);",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 62`] = `
+{
+  "code": "
+function foo() {
+  throw { bar: 5 } as Foo;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 63`] = `
+{
+  "code": "function b(x = {} as Foo.Bar) {}",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 64`] = `
+{
+  "code": "function c(x = {} as Foo) {}",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 65`] = `
+{
+  "code": "print?.({ bar: 5 } as Foo);",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 66`] = `
+{
+  "code": "print?.call({ bar: 5 } as Foo);",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 67`] = `
+{
+  "code": "print\`\${{ bar: 5 } as Foo}\`;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 68`] = `
+{
+  "code": "const x = <Foo<int>>{};",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 69`] = `
+{
+  "code": "const x = <a | b>{};",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 70`] = `
+{
+  "code": "const x = <A>{} + b;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 71`] = `
+{
+  "code": "print(<Foo>{ bar: 5 });",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 72`] = `
+{
+  "code": "new print(<Foo>{ bar: 5 });",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 73`] = `
+{
+  "code": "
+function foo() {
+  throw <Foo>{ bar: 5 };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 74`] = `
+{
+  "code": "print?.(<Foo>{ bar: 5 });",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 75`] = `
+{
+  "code": "print?.call(<Foo>{ bar: 5 });",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 76`] = `
+{
+  "code": "print\`\${<Foo>{ bar: 5 }}\`;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T = { ... }.",
+      "messageId": "unexpectedObjectTypeAssertion",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 77`] = `
+{
+  "code": "const foo = <Foo style={{ bar: 5 } as Bar} />;",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 78`] = `
+{
+  "code": "const a = <any>(b, c);",
+  "diagnostics": [
+    {
+      "message": "Use 'as any' instead of '<any>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = (b, c) as any;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 79`] = `
+{
+  "code": "const f = <any>(() => {});",
+  "diagnostics": [
+    {
+      "message": "Use 'as any' instead of '<any>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const f = (() => {}) as any;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 80`] = `
+{
+  "code": "const f = <any>function () {};",
+  "diagnostics": [
+    {
+      "message": "Use 'as any' instead of '<any>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const f = function () {} as any;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 81`] = `
+{
+  "code": "const f = <any>(async () => {});",
+  "diagnostics": [
+    {
+      "message": "Use 'as any' instead of '<any>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const f = (async () => {}) as any;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 82`] = `
+{
+  "code": "
+function* g() {
+  const y = <any>(yield a);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Use 'as any' instead of '<any>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function* g() {
+  const y = (yield a) as any;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 83`] = `
+{
+  "code": "
+declare let x: number, y: number;
+const bs = <any>(x <<= y);
+      ",
+  "diagnostics": [
+    {
+      "message": "Use 'as any' instead of '<any>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+declare let x: number, y: number;
+const bs = (x <<= y) as any;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 84`] = `
+{
+  "code": "const ternary = <any>(true ? x : y);",
+  "diagnostics": [
+    {
+      "message": "Use 'as any' instead of '<any>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const ternary = (true ? x : y) as any;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 85`] = `
+{
+  "code": "const x = [] as string[];",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 86`] = `
+{
+  "code": "const x = <string[]>[];",
+  "diagnostics": [
+    {
+      "message": "Do not use any type assertions.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 87`] = `
+{
+  "code": "const x = [] as string[];",
+  "diagnostics": [
+    {
+      "message": "Use '<string[]>' instead of 'as string[]'.",
+      "messageId": "angle-bracket",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 88`] = `
+{
+  "code": "const x = <string[]>[];",
+  "diagnostics": [
+    {
+      "message": "Use 'as string[]' instead of '<string[]>'.",
+      "messageId": "as",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const x = [] as string[];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 89`] = `
+{
+  "code": "const x = [] as string[];",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 90`] = `
+{
+  "code": "const x = <string[]>[];",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 91`] = `
+{
+  "code": "print([5] as Foo);",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 92`] = `
+{
+  "code": "new print([5] as Foo);",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 93`] = `
+{
+  "code": "function b(x = [5] as Foo.Bar) {}",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 94`] = `
+{
+  "code": "
+function foo() {
+  throw [5] as Foo;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 95`] = `
+{
+  "code": "print\`\${[5] as Foo}\`;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 96`] = `
+{
+  "code": "const foo = () => [5] as Foo;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 97`] = `
+{
+  "code": "new print(<Foo>[5]);",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 98`] = `
+{
+  "code": "function b(x = <Foo.Bar>[5]) {}",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 99`] = `
+{
+  "code": "
+function foo() {
+  throw <Foo>[5];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 100`] = `
+{
+  "code": "print\`\${<Foo>[5]}\`;",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`consistent-type-assertions > invalid 101`] = `
+{
+  "code": "const foo = <Foo>[5];",
+  "diagnostics": [
+    {
+      "message": "Always prefer const x: T[] = [ ... ].",
+      "messageId": "unexpectedArrayTypeAssertion",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/consistent-type-assertions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rule-tester/src/index.ts
+++ b/packages/rule-tester/src/index.ts
@@ -93,9 +93,11 @@ function checkDiagnosticEqual(
   for (let i = 0; i < rslintDiagnostic.length; i++) {
     const rslintDiag = rslintDiagnostic[i];
     const tsDiag = tsDiagnostic[i];
-    // check rule match
+    // check rule match. Normalize both sides: some messageIds are kebab-case
+    // (e.g. `angle-bracket`) and toCamelCase must apply to the expected side
+    // too, otherwise a hyphenated id can never match.
     assert(
-      toCamelCase(rslintDiag.messageId) === tsDiag.messageId,
+      toCamelCase(rslintDiag.messageId) === toCamelCase(tsDiag.messageId ?? ''),
       `Message mismatch: ${rslintDiag.messageId} !== ${tsDiag.messageId}`,
     );
 


### PR DESCRIPTION
## Summary

`@typescript-eslint/consistent-type-assertions` missed **parenthesized** object/array literal assertions such as `({ ... }) as T` — most commonly the body of an arrow function, `() => ({ ... }) as T`. Because the asserted expression sits behind a parenthesis node, the object/array-literal check never matched, so `objectLiteralTypeAssertions: "never"` / `arrayLiteralTypeAssertions: "never"` produced false negatives. The literal check now strips parentheses before matching, which is how the upstream rule behaves (its AST has no parenthesis nodes).

While bringing the rule in line with the upstream implementation, this change also:

- exempts `any` / `unknown` only as the **bare** keyword — unions such as `{} as any | string` are now reported;
- emits the `unexpectedObjectTypeAssertion` / `unexpectedArrayTypeAssertion` message ids and fixes the previously **swapped** `as` / `angle-bracket` ids (now carrying the `{{cast}}` text);
- reports `as const` / `<const>` assertions used with the wrong `assertionStyle`;
- adds the type-annotation / `satisfies` suggestions and the angle-bracket → `as` autofix (with precedence-correct wrapping).

The upstream conformance test for this rule is enabled **verbatim** (the fixture is not edited); instead the rule-tester's messageId comparison is normalized on both sides so kebab-case ids such as `angle-bracket` match. Extra parenthesized-form cases live in the Go test.

## Related Links

Found during rslint migration validation (false negatives reported for `consistent-type-assertions`).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
