### PR TITLE
fix: stop no-array-index-key flagging logical-operator key fallbacks

### DIFF
--- a/internal/plugins/react/rules/no_array_index_key/no_array_index_key.go
+++ b/internal/plugins/react/rules/no_array_index_key/no_array_index_key.go
@@ -24,6 +24,26 @@ var indexParamPositions = map[string]int{
 	"some":        1,
 }
 
+// isLogicalBinary reports whether a tsgo KindBinaryExpression is what ESTree
+// models as a LogicalExpression — operator `&&`, `||`, or `??` — rather than a
+// BinaryExpression. upstream eslint-plugin-react's `checkPropValue` and
+// `getIdentifiersFromBinaryExpression` only ever handle an ESTree
+// `BinaryExpression` (arithmetic / comparison operators); a LogicalExpression
+// matches none of their branches and is left untouched. tsgo collapses both
+// ESTree shapes into KindBinaryExpression, so logical-operator nodes must be
+// treated as opaque here — otherwise `key={foo || index}`, `key={foo ?? index}`
+// and friends report an index reference that upstream never flags.
+func isLogicalBinary(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	switch node.AsBinaryExpression().OperatorToken.Kind {
+	case ast.KindAmpersandAmpersandToken, ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+		return true
+	}
+	return false
+}
+
 // isImportSpecifierFromReact reports whether `ident` resolves to a binding
 // introduced by `import { <anything> } from 'react'`. Mirrors upstream
 // `eslint-plugin-react`'s `isCreateCloneElement` Identifier branch
@@ -288,7 +308,11 @@ var NoArrayIndexKeyRule = rule.Rule{
 			if node.Kind == ast.KindIdentifier {
 				return []*ast.Node{node}
 			}
-			if node.Kind == ast.KindBinaryExpression {
+			// upstream's getIdentifiersFromBinaryExpression recurses ONLY through
+			// an ESTree BinaryExpression; a LogicalExpression (`&&` / `||` / `??`)
+			// returns null. Mirror that — logical-operator nodes are opaque, so a
+			// tracked index buried inside `foo || index` is never collected.
+			if node.Kind == ast.KindBinaryExpression && !isLogicalBinary(node) {
 				be := node.AsBinaryExpression()
 				return append(collectIdentifiersFromBinary(be.Left), collectIdentifiersFromBinary(be.Right)...)
 			}
@@ -338,7 +362,12 @@ var NoArrayIndexKeyRule = rule.Rule{
 				return
 			}
 
-			if node.Kind == ast.KindBinaryExpression {
+			// Only an ESTree BinaryExpression reaches upstream's binary branch; a
+			// LogicalExpression (`&&` / `||` / `??`) matches no branch of
+			// checkPropValue and is never reported. tsgo represents both as
+			// KindBinaryExpression, so exclude logical operators to keep
+			// `key={foo || index}` valid, exactly as upstream leaves it.
+			if node.Kind == ast.KindBinaryExpression && !isLogicalBinary(node) {
 				for _, id := range collectIdentifiersFromBinary(node) {
 					if isArrayIndex(id) {
 						report(node)

--- a/internal/plugins/react/rules/no_array_index_key/no_array_index_key_test.go
+++ b/internal/plugins/react/rules/no_array_index_key/no_array_index_key_test.go
@@ -201,6 +201,26 @@ foo.map((baz, i) => cloneElement(someChild, { key: i }))
 		// identifier; a member-access argument is NOT a match.
 		{Code: `foo.map((bar, i) => <Foo key={String(i.foo)} />)`, Tsx: true},
 
+		// ---- Logical-operator key values (ESTree LogicalExpression) ----
+		// ESTree models `||`, `&&`, and `??` as LogicalExpression, NOT a
+		// BinaryExpression. upstream's checkPropValue has no
+		// LogicalExpression branch and getIdentifiersFromBinaryExpression
+		// bails on it, so the `key={fallback || index}` idiom is left
+		// untouched. tsgo collapses both shapes into KindBinaryExpression;
+		// these lock the alignment so logical fallbacks are never flagged.
+		{Code: `foo.map((bar, i) => <Foo key={bar.id || i} />)`, Tsx: true},
+		{Code: `foo.map((bar, i) => <Foo key={bar.id ?? i} />)`, Tsx: true},
+		{Code: `foo.map((bar, i) => <Foo key={i && bar.id} />)`, Tsx: true},
+		{Code: `foo.map((bar, i) => <Foo key={bar.a || bar.b || i} />)`, Tsx: true},
+		{Code: `foo.map((bar, i) => <Foo key={(bar.id || i)} />)`, Tsx: true},
+		// Same logical fallback through the createElement props path.
+		{Code: `foo.map((bar, i) => React.createElement('Foo', { key: bar.id || i }))`, Tsx: true},
+		// Logical nested INSIDE a real BinaryExpression — the `+` enters
+		// the binary branch, but the recursion stops at the `||` subtree,
+		// so the index hidden there is NOT collected. Without the logical
+		// guard on the recursion this would false-positive.
+		{Code: `foo.map((bar, i) => <Foo key={'x' + (bar.id || i)} />)`, Tsx: true},
+
 		// ---- TS expression wrappers on the pragma identifier / key value ----
 		// ESLint's JavaScript parser cannot produce `as` / `!` / `<T>x` /
 		// `satisfies` shapes, so its `no-array-index-key` never sees
@@ -342,6 +362,17 @@ foo.map((baz, i) => cloneElement(someChild, { key: i }))
 		},
 		{
 			Code: `foo.map((bar, i) => <Foo key={'foo-' + i + '-bar'} />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noArrayIndex", Line: 1, Column: 31},
+			},
+		},
+
+		// Real BinaryExpression whose right operand is a logical subtree —
+		// the `+` reports the index on the left while the `||` subtree is
+		// skipped: one report, no crash, no double-count.
+		{
+			Code: `foo.map((bar, i) => <Foo key={i + (bar.id || 0)} />)`,
 			Tsx:  true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noArrayIndex", Line: 1, Column: 31},

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-array-index-key.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-array-index-key.test.ts
@@ -212,6 +212,18 @@ ruleTester.run('no-array-index-key', {} as never, {
     { code: `foo.map((bar, i) => <Foo key={i?.toString()} />);` },
     { code: `foo.map((bar, i) => <Foo key={String?.(i)} />);` },
     { code: `foo.map((bar, i) => <Foo key={i?.toString?.()} />);` },
+
+    // ---- Logical-operator fallback (ESTree LogicalExpression) ----
+    // `||` / `&&` / `??` are LogicalExpression upstream, not a
+    // BinaryExpression, so `key={fallback || index}` is never flagged.
+    { code: `foo.map((bar, i) => <Foo key={bar.id || i} />);` },
+    { code: `foo.map((bar, i) => <Foo key={bar.id ?? i} />);` },
+    { code: `foo.map((bar, i) => <Foo key={i && bar.id} />);` },
+    { code: `foo.map((bar, i) => <Foo key={bar.a || bar.b || i} />);` },
+    {
+      code: `foo.map((bar, i) => React.createElement('Foo', { key: bar.id || i }));`,
+    },
+    { code: `foo.map((bar, i) => <Foo key={'x' + (bar.id || i)} />);` },
   ],
 
   invalid: [
@@ -242,6 +254,13 @@ ruleTester.run('no-array-index-key', {} as never, {
     },
     {
       code: `foo.map((bar, i) => <Foo key={'foo-' + i + '-bar'} />);`,
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+
+    // Real BinaryExpression whose right operand is a logical subtree —
+    // the `+` reports the index on the left; the `||` subtree is skipped.
+    {
+      code: `foo.map((bar, i) => <Foo key={i + (bar.id || 0)} />);`,
       errors: [{ messageId: 'noArrayIndex' }],
     },
 


### PR DESCRIPTION
## Summary

`react/no-array-index-key` reported false positives on the common logical-fallback idiom `key={item.id || index}` (and the `??` / `&&` variants), which `eslint-plugin-react` never flags.

**Root cause:** ESTree models `||` / `&&` / `??` as `LogicalExpression`, distinct from `BinaryExpression`. Upstream's `checkPropValue` / `getIdentifiersFromBinaryExpression` only ever inspect a `BinaryExpression` (arithmetic / comparison), so a `LogicalExpression` falls through every branch and is left untouched. tsgo collapses both ESTree shapes into a single `KindBinaryExpression`, and the rule's binary handling didn't distinguish them — so logical fallbacks had their index operand collected and reported.

**Fix:** add `isLogicalBinary` (operator ∈ `{&&, ||, ??}`, reusing the same operator set already used in `exhaustive_deps` / `rules_of_hooks`) and treat such nodes as opaque in both the `checkPropValue` binary branch and the `collectIdentifiersFromBinary` recursion. Real `BinaryExpression`s (`'foo-' + i`, `i + 1`) still report exactly as before. Adds Go + TS regression tests covering `||` / `??` / `&&`, chained, parenthesized, createElement-props, and nested-in-real-binary shapes.

**Verification on a real monorepo** (60 packages, rslint 0.6.2 before vs this fix, identical files):

| | no-array-index-key reports |
|---|---|
| before | 66 |
| after | 41 |

The 25 eliminated reports are exactly the logical-fallback false positives; the 41 true positives (direct `key={index}`, etc.) are all preserved — 0 new reports, i.e. no false negatives introduced.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).