### PR TITLE
fix: prevent crash in no-deprecated on catch-clause bindings

### DIFF
--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
@@ -164,7 +164,7 @@ func hasDeprecatedTagInSource(node *ast.Node) bool {
 		if variableDeclaration != nil && variableDeclaration.Name() != nil {
 			anchor = variableDeclaration.Name().Pos()
 		}
-		if declarationNode.Parent != nil && declarationNode.Parent.Parent != nil {
+		if declarationNode.Parent != nil && declarationNode.Parent.Kind == ast.KindVariableDeclarationList && declarationNode.Parent.Parent != nil {
 			declList := declarationNode.Parent.AsVariableDeclarationList()
 			if declList != nil && declList.Declarations != nil && len(declList.Declarations.Nodes) > 0 && declList.Declarations.Nodes[0] == declarationNode {
 				anchor = declarationNode.Parent.Parent.Pos()

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
@@ -107,6 +107,19 @@ oldValue;
 				},
 			},
 		},
+		{
+			// Regression: referencing a catch-clause binding must not panic.
+			// The binding is a VariableDeclaration whose parent is a
+			// CatchClause, not a VariableDeclarationList.
+			Code: `
+declare function log(x: unknown): void;
+try {
+  log(1);
+} catch (error) {
+  log(error);
+}
+`,
+		},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `/** @deprecated */ const oldValue = 1; oldValue;`,

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-deprecated.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-deprecated.test.ts
@@ -615,6 +615,17 @@ exists('/foo');
       `,
       languageOptions: jsxLanguageOptions,
     },
+    // Regression: referencing a catch-clause binding must not crash. The
+    // binding is a VariableDeclaration whose parent is a CatchClause, not a
+    // VariableDeclarationList.
+    `
+declare function log(x: unknown): void;
+try {
+  log(1);
+} catch (error) {
+  log(error);
+}
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
## Summary

`@typescript-eslint/no-deprecated` crashed with a panic whenever a `catch`-clause binding was referenced:

```ts
try {
  // ...
} catch (error) {
  log(error); // panic: interface conversion: *ast.CatchClause, not *ast.VariableDeclarationList
}
```

Root cause: in `hasDeprecatedTagInSource`, the `KindVariableDeclaration` branch assumed the declaration's parent is always a `VariableDeclarationList`. A `catch`-clause binding is also a `VariableDeclaration`, but its parent is a `CatchClause`, so the unguarded `AsVariableDeclarationList()` cast panicked when the rule resolved a reference to the binding.

Fix: guard the cast with a parent-kind check (`Kind == KindVariableDeclarationList`) before it. The catch-binding path now skips the declaration-list anchor logic; normal `var`/`let`/`const` detection is unchanged.

Audited the rest of the rule while here: every other parent-node cast is already kind-guarded (this was the only gap), and the full ported test suite still passes — behavior stays aligned with the original rule.

## Related Links

Found while validating rule alignment on real-world code. No existing issue.

## Checklist

- [x] Tests updated (or not required). Added a regression case (catch-clause binding) to both the Go and the JS test suites; verified it reproduces the panic without the fix.
- [x] Documentation updated (or not required). Crash-only fix — no behavior or option change.
