### PR TITLE
fix: prevent crash in no-unnecessary-type-arguments with excess type arguments

### DIFF
--- a/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
@@ -108,6 +108,12 @@ var NoUnnecessaryTypeArgumentsRule = rule.CreateRule(rule.Rule{
 
 			// Just check the last one. Must specify previous type parameters if the last one is specified.
 			i := len(arguments.Nodes) - 1
+			// More type arguments than parameters is a type error in the source;
+			// upstream's `param?.default` short-circuits to undefined there, so bail
+			// out instead of indexing past the parameter list.
+			if i >= len(parameters) {
+				return
+			}
 			arg := arguments.Nodes[i]
 			param := parameters[i]
 

--- a/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
@@ -209,6 +209,14 @@ interface Bar extends Foo {
 function f<T = Foo>() {}
 f<Bar>();
 		`},
+		{
+			// Regression: more type arguments than parameters must not panic by
+			// indexing past the type-parameter list (it is a type error in the
+			// source, so the rule reports nothing, matching upstream).
+			Code: `
+function f<T, U>(): void {}
+f<number, string, boolean>();
+    `},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `


### PR DESCRIPTION
## Summary

`@typescript-eslint/no-unnecessary-type-arguments` crashed with a panic whenever a call or type reference had more type arguments than the target has type parameters:

```ts
function f<T, U>(): void {}
f<number, string, boolean>(); // panic: index out of range [2] with length 2
```

`checkArgsAndParameters` indexes the type-parameter list with `i = len(typeArguments) - 1`. When there are more type arguments than parameters (a type error in the source), `parameters[i]` is out of range. The original rule optional-chains here (`param?.default`), which yields `undefined` and bails — so this adds the equivalent bounds check before indexing.

## Related Links

Found while validating rule alignment on real-world code. No existing issue.

## Checklist

- [x] Tests updated (or not required). Added a Go regression case (more type arguments than parameters); verified it reproduces the panic without the fix. The JS conformance test for this rule is currently disabled in `rstest.config.mts` due to a separate, pre-existing alignment gap, so the regression is covered at the Go level.
- [x] Documentation updated (or not required). Crash-only fix — no behavior or option change.
