### PR TITLE
fix: mark JSX factory as used under all jsx runtimes in no-unused-vars

### DIFF
--- a/internal/plugins/react/rules/jsx_uses_react/jsx_uses_react.go
+++ b/internal/plugins/react/rules/jsx_uses_react/jsx_uses_react.go
@@ -6,11 +6,18 @@ import (
 
 // JsxUsesReactRule is a no-op in rslint.
 //
-// In ESLint, this rule prevents React from being marked as unused when JSX is
-// used, since ESLint's no-unused-vars rule does not understand that JSX
-// implicitly references React. In rslint, the TypeScript type checker already
-// tracks JSX factory usage and correctly marks React as used, so this rule is
-// unnecessary. It exists only for configuration compatibility.
+// In ESLint, this rule (eslint-plugin-react) marks the JSX pragma as used
+// whenever JSX appears, so no-unused-vars does not flag it. rslint handles the
+// default pragma inside no-unused-vars itself: markJsxFactoryUsed marks the JSX
+// factory import (default "React", or the tsconfig `jsxFactory`) as used
+// whenever a file contains JSX, in any jsx runtime — matching
+// @typescript-eslint/parser's `jsxPragma` baseline. So this rule is redundant
+// for the default pragma and exists only for configuration compatibility.
+//
+// Known gap: a custom pragma declared via an `@jsx X` comment or
+// `settings.react.pragma` is not marked as used (rslint has no cross-rule
+// "mark as used" channel yet), so such an import may still be reported as
+// unused even with this rule enabled.
 var JsxUsesReactRule = rule.Rule{
 	Name: "react/jsx-uses-react",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/fixtures/tsconfig.react-jsx.json
+++ b/internal/plugins/typescript/rules/fixtures/tsconfig.react-jsx.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
+    "experimentalDecorators": true,
+    "types": []
+  }
+}

--- a/internal/plugins/typescript/rules/fixtures/tsconfig.react.json
+++ b/internal/plugins/typescript/rules/fixtures/tsconfig.react.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
+    "experimentalDecorators": true,
+    "types": []
+  }
+}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
-	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -1481,25 +1480,28 @@ func collectSymbolUsages(ctx rule.RuleContext, sourceFile *ast.Node, usages map[
 	}
 	walk(sourceFile)
 
-	// For JSX files with jsx: "preserve" or "react-native", TypeScript doesn't
-	// create references from JSX elements to the factory function (e.g., React).
-	// Detect JSX usage and mark the factory import as used.
+	// TypeScript only creates a reference from JSX to the factory function in
+	// the classic `jsx: "react"` runtime, and even then via an implicit
+	// `React.createElement` call that has no identifier node for the AST walk
+	// above to find. For every other mode (preserve, react-native, react-jsx)
+	// the factory import has no textual reference at all. Mark it as used,
+	// matching @typescript-eslint/parser's `jsxPragma` behavior (the factory
+	// is considered used whenever the file contains JSX, in any runtime).
 	markJsxFactoryUsed(ctx, sourceFile, usages)
 }
 
-// markJsxFactoryUsed checks if the source file contains JSX elements and,
-// when jsx is "preserve" or "react-native", marks the JSX factory and
-// fragment factory imports as used.
+// markJsxFactoryUsed checks if the source file contains JSX and, if so, marks
+// the JSX factory (and fragment factory) imports as used. This runs for every
+// jsx mode: TS never produces an AST identifier reference to the factory, so
+// without this an `import React` whose only "use" is JSX would be falsely
+// reported. Mirrors @typescript-eslint/parser, which treats the jsxPragma
+// (default "React") as used whenever JSX is present, regardless of runtime.
 func markJsxFactoryUsed(ctx rule.RuleContext, sourceFile *ast.Node, usages map[*ast.Symbol][]*ast.Node) {
 	if ctx.Program == nil {
 		return
 	}
 	opts := ctx.Program.Options()
 	if opts == nil {
-		return
-	}
-	// Only needed for preserve/react-native modes where TS doesn't resolve the factory
-	if opts.Jsx != core.JsxEmitPreserve && opts.Jsx != core.JsxEmitReactNative {
 		return
 	}
 	firstJsx, firstFragment := findJsxNodes(sourceFile)

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_jsx_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_jsx_test.go
@@ -1,0 +1,105 @@
+package no_unused_vars
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUnusedVarsJsxFactory covers the JSX factory pragma being marked as used
+// whenever a file contains JSX, in every jsx runtime. This mirrors
+// @typescript-eslint/parser's `jsxPragma` baseline (default "React"), which
+// treats the factory as used on any JSX regardless of runtime. Before the fix
+// this only worked for jsx: "preserve"/"react-native".
+func TestNoUnusedVarsJsxFactory(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// react-jsx (automatic runtime): React is referenced only by JSX.
+		{
+			Code:     "import React from 'react';\nexport const A = () => <div />;\n",
+			Tsx:      true,
+			TSConfig: "tsconfig.react-jsx.json",
+		},
+		// react-jsx: fragment-only usage still marks the factory.
+		{
+			Code:     "import React from 'react';\nexport const A = () => <></>;\n",
+			Tsx:      true,
+			TSConfig: "tsconfig.react-jsx.json",
+		},
+		// react-jsx: mixed import where the named binding is used in code and
+		// the default (React) is used only by JSX — neither is reported.
+		{
+			Code:     "import React, { useMemo } from 'react';\nexport const A = () => {\n  useMemo(() => 1, []);\n  return <div />;\n};\n",
+			Tsx:      true,
+			TSConfig: "tsconfig.react-jsx.json",
+		},
+		// classic react runtime: TS resolves JSX to React.createElement, but the
+		// reference is implicit (no identifier node), so it must still be marked.
+		{
+			Code:     "import React from 'react';\nexport const A = () => <div />;\n",
+			Tsx:      true,
+			TSConfig: "tsconfig.react.json",
+		},
+		// preserve (default fixture): unchanged behavior — still not reported.
+		{
+			Code: "import React from 'react';\nexport const A = () => <div />;\n",
+			Tsx:  true,
+		},
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// react-jsx: React imported but the file has no JSX at all → genuinely
+		// unused, still reported.
+		{
+			Code:     "import React from 'react';\nexport const x = 1;\n",
+			Tsx:      true,
+			TSConfig: "tsconfig.react-jsx.json",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unusedVar", Line: 1, Column: 8,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "removeUnusedImportDeclaration",
+						Output:    "export const x = 1;\n",
+					}},
+				},
+			},
+		},
+		// react-jsx: a non-pragma import that is unused must still be reported
+		// even though the file contains JSX — only the JSX factory is exempt.
+		{
+			Code:     "import { Foo } from './foo';\nexport const A = () => <div />;\n",
+			Tsx:      true,
+			TSConfig: "tsconfig.react-jsx.json",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unusedVar", Line: 1, Column: 10,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "removeUnusedImportDeclaration",
+						Output:    "export const A = () => <div />;\n",
+					}},
+				},
+			},
+		},
+		// react-jsx: documented gap — a custom pragma declared via `@jsx X` is
+		// NOT recognized (that requires eslint-plugin-react's jsx-uses-react,
+		// which is a no-op in rslint), so `X` is still reported.
+		{
+			Code:     "/** @jsx X.createElement */\nimport X from './x';\nexport const A = () => <div />;\n",
+			Tsx:      true,
+			TSConfig: "tsconfig.react-jsx.json",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unusedVar", Line: 2, Column: 8,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "removeUnusedImportDeclaration",
+						// removeImportLine starts at node.Pos(), which includes the
+						// leading `@jsx` block comment as trivia, so it is removed too.
+						Output: "export const A = () => <div />;\n",
+					}},
+				},
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, valid, invalid)
+}

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars.test.ts.snap
@@ -840,9 +840,7 @@ exports[`no-unused-vars > invalid 27`] = `
   "code": "
 import React from 'react';
 
-export const ComponentFoo = () => {
-  return <div>Foo Foo</div>;
-};
+export const x = 1;
       ",
   "diagnostics": [
     {
@@ -868,6 +866,39 @@ export const ComponentFoo = () => {
 `;
 
 exports[`no-unused-vars > invalid 28`] = `
+{
+  "code": "
+/** @jsx X.createElement */
+import X from './x';
+
+export const ComponentFoo = () => {
+  return <div>Foo Foo</div>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "'X' is defined but never used.",
+      "messageId": "unusedVar",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-vars > invalid 29`] = `
 {
   "code": "
 declare module 'foo' {
@@ -899,7 +930,7 @@ declare module 'foo' {
 }
 `;
 
-exports[`no-unused-vars > invalid 29`] = `
+exports[`no-unused-vars > invalid 30`] = `
 {
   "code": "
 // not declared
@@ -981,7 +1012,7 @@ export namespace Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 30`] = `
+exports[`no-unused-vars > invalid 31`] = `
 {
   "code": "
 interface Foo {
@@ -1014,7 +1045,7 @@ interface Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 31`] = `
+exports[`no-unused-vars > invalid 32`] = `
 {
   "code": "
 let x = null;
@@ -1043,7 +1074,7 @@ x = foo(x);
 }
 `;
 
-exports[`no-unused-vars > invalid 32`] = `
+exports[`no-unused-vars > invalid 33`] = `
 {
   "code": "
 interface Foo {
@@ -1074,7 +1105,7 @@ const Foo = 'bar';
 }
 `;
 
-exports[`no-unused-vars > invalid 33`] = `
+exports[`no-unused-vars > invalid 34`] = `
 {
   "code": "
 let foo = 1;
@@ -1103,7 +1134,7 @@ foo += 1;
 }
 `;
 
-exports[`no-unused-vars > invalid 34`] = `
+exports[`no-unused-vars > invalid 35`] = `
 {
   "code": "
 interface Foo {
@@ -1135,7 +1166,7 @@ export = Bar;
 }
 `;
 
-exports[`no-unused-vars > invalid 35`] = `
+exports[`no-unused-vars > invalid 36`] = `
 {
   "code": "
 interface Foo {
@@ -1167,7 +1198,7 @@ export = Foo;
 }
 `;
 
-exports[`no-unused-vars > invalid 36`] = `
+exports[`no-unused-vars > invalid 37`] = `
 {
   "code": "
 namespace Foo {
@@ -1200,7 +1231,7 @@ export namespace Bar {
 }
 `;
 
-exports[`no-unused-vars > invalid 37`] = `
+exports[`no-unused-vars > invalid 38`] = `
 {
   "code": "
 const foo: number = 1;
@@ -1228,7 +1259,7 @@ const foo: number = 1;
 }
 `;
 
-exports[`no-unused-vars > invalid 38`] = `
+exports[`no-unused-vars > invalid 39`] = `
 {
   "code": "
 enum Foo {
@@ -1259,7 +1290,7 @@ enum Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 39`] = `
+exports[`no-unused-vars > invalid 40`] = `
 {
   "code": "
 type _Foo = 1;
@@ -1288,7 +1319,7 @@ export const x: _Foo = 1;
 }
 `;
 
-exports[`no-unused-vars > invalid 40`] = `
+exports[`no-unused-vars > invalid 41`] = `
 {
   "code": "
 interface _Foo {}
@@ -1317,7 +1348,7 @@ export const x: _Foo = 1;
 }
 `;
 
-exports[`no-unused-vars > invalid 41`] = `
+exports[`no-unused-vars > invalid 42`] = `
 {
   "code": "
 enum _Foo {
@@ -1348,7 +1379,7 @@ export const x = _Foo.A;
 }
 `;
 
-exports[`no-unused-vars > invalid 42`] = `
+exports[`no-unused-vars > invalid 43`] = `
 {
   "code": "
 namespace _Foo {}
@@ -1377,7 +1408,7 @@ export const x = _Foo;
 }
 `;
 
-exports[`no-unused-vars > invalid 43`] = `
+exports[`no-unused-vars > invalid 44`] = `
 {
   "code": "
         const foo: number = 1;
@@ -1407,7 +1438,7 @@ exports[`no-unused-vars > invalid 43`] = `
 }
 `;
 
-exports[`no-unused-vars > invalid 44`] = `
+exports[`no-unused-vars > invalid 45`] = `
 {
   "code": "
         declare const foo: number;
@@ -1437,7 +1468,7 @@ exports[`no-unused-vars > invalid 44`] = `
 }
 `;
 
-exports[`no-unused-vars > invalid 45`] = `
+exports[`no-unused-vars > invalid 46`] = `
 {
   "code": "
         const foo: number = 1;
@@ -1467,46 +1498,12 @@ exports[`no-unused-vars > invalid 45`] = `
 }
 `;
 
-exports[`no-unused-vars > invalid 46`] = `
+exports[`no-unused-vars > invalid 47`] = `
 {
   "code": "
         const foo: number = 1;
 
         export type Foo = (typeof foo | string) & { __brand: 'foo' };
-      ",
-  "diagnostics": [
-    {
-      "message": "'foo' is assigned a value but only used as a type.",
-      "messageId": "usedOnlyAsType",
-      "range": {
-        "end": {
-          "column": 18,
-          "line": 2,
-        },
-        "start": {
-          "column": 15,
-          "line": 2,
-        },
-      },
-      "ruleName": "@typescript-eslint/no-unused-vars",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`no-unused-vars > invalid 47`] = `
-{
-  "code": "
-        const foo = {
-          bar: {
-            baz: 123,
-          },
-        };
-
-        export type Bar = typeof foo.bar;
       ",
   "diagnostics": [
     {
@@ -1540,7 +1537,7 @@ exports[`no-unused-vars > invalid 48`] = `
           },
         };
 
-        export type Bar = (typeof foo)['bar'];
+        export type Bar = typeof foo.bar;
       ",
   "diagnostics": [
     {
@@ -1566,6 +1563,40 @@ exports[`no-unused-vars > invalid 48`] = `
 `;
 
 exports[`no-unused-vars > invalid 49`] = `
+{
+  "code": "
+        const foo = {
+          bar: {
+            baz: 123,
+          },
+        };
+
+        export type Bar = (typeof foo)['bar'];
+      ",
+  "diagnostics": [
+    {
+      "message": "'foo' is assigned a value but only used as a type.",
+      "messageId": "usedOnlyAsType",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-vars > invalid 50`] = `
 {
   "code": "
 const command = (): ParameterDecorator => {
@@ -1599,7 +1630,7 @@ export class Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 50`] = `
+exports[`no-unused-vars > invalid 51`] = `
 {
   "code": "
 declare const deco: () => ParameterDecorator;
@@ -1646,7 +1677,7 @@ export class Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 51`] = `
+exports[`no-unused-vars > invalid 52`] = `
 {
   "code": "
 export namespace Foo {
@@ -1677,7 +1708,7 @@ export namespace Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 52`] = `
+exports[`no-unused-vars > invalid 53`] = `
 {
   "code": "
 const foo: 1234;
@@ -1706,7 +1737,7 @@ export {};
 }
 `;
 
-exports[`no-unused-vars > invalid 53`] = `
+exports[`no-unused-vars > invalid 54`] = `
 {
   "code": "
 declare module 'foo' {
@@ -1737,7 +1768,7 @@ declare module 'foo' {
 }
 `;
 
-exports[`no-unused-vars > invalid 54`] = `
+exports[`no-unused-vars > invalid 55`] = `
 {
   "code": "
 export namespace Foo {
@@ -1770,7 +1801,7 @@ export namespace Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 55`] = `
+exports[`no-unused-vars > invalid 56`] = `
 {
   "code": "
 const foo: 1234;
@@ -1801,7 +1832,7 @@ export { bar };
 }
 `;
 
-exports[`no-unused-vars > invalid 56`] = `
+exports[`no-unused-vars > invalid 57`] = `
 {
   "code": "
 declare module 'foo' {
@@ -1834,7 +1865,7 @@ declare module 'foo' {
 }
 `;
 
-exports[`no-unused-vars > invalid 57`] = `
+exports[`no-unused-vars > invalid 58`] = `
 {
   "code": "
 export namespace Foo {
@@ -1868,7 +1899,7 @@ export namespace Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 58`] = `
+exports[`no-unused-vars > invalid 59`] = `
 {
   "code": "
 const foo: 1234;
@@ -1900,7 +1931,7 @@ export { bar };
 }
 `;
 
-exports[`no-unused-vars > invalid 59`] = `
+exports[`no-unused-vars > invalid 60`] = `
 {
   "code": "
 declare module 'foo' {
@@ -1934,7 +1965,7 @@ declare module 'foo' {
 }
 `;
 
-exports[`no-unused-vars > invalid 60`] = `
+exports[`no-unused-vars > invalid 61`] = `
 {
   "code": "
 export namespace Foo {
@@ -1967,7 +1998,7 @@ export namespace Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 61`] = `
+exports[`no-unused-vars > invalid 62`] = `
 {
   "code": "
 const foo: string;
@@ -1998,7 +2029,7 @@ export default bar;
 }
 `;
 
-exports[`no-unused-vars > invalid 62`] = `
+exports[`no-unused-vars > invalid 63`] = `
 {
   "code": "
 declare module 'foo' {
@@ -2031,7 +2062,7 @@ declare module 'foo' {
 }
 `;
 
-exports[`no-unused-vars > invalid 63`] = `
+exports[`no-unused-vars > invalid 64`] = `
 {
   "code": "
 export namespace Foo {
@@ -2065,7 +2096,7 @@ export namespace Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 64`] = `
+exports[`no-unused-vars > invalid 65`] = `
 {
   "code": "
 const foo: string;
@@ -2097,7 +2128,7 @@ export default bar;
 }
 `;
 
-exports[`no-unused-vars > invalid 65`] = `
+exports[`no-unused-vars > invalid 66`] = `
 {
   "code": "
 declare module 'foo' {
@@ -2131,7 +2162,7 @@ declare module 'foo' {
 }
 `;
 
-exports[`no-unused-vars > invalid 66`] = `
+exports[`no-unused-vars > invalid 67`] = `
 {
   "code": "
 export namespace Foo {
@@ -2164,7 +2195,7 @@ export namespace Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 67`] = `
+exports[`no-unused-vars > invalid 68`] = `
 {
   "code": "
 const foo: string;
@@ -2195,7 +2226,7 @@ export * from '...';
 }
 `;
 
-exports[`no-unused-vars > invalid 68`] = `
+exports[`no-unused-vars > invalid 69`] = `
 {
   "code": "
 declare module 'foo' {
@@ -2228,7 +2259,7 @@ declare module 'foo' {
 }
 `;
 
-exports[`no-unused-vars > invalid 69`] = `
+exports[`no-unused-vars > invalid 70`] = `
 {
   "code": "
 namespace Foo {
@@ -2261,7 +2292,7 @@ namespace Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 70`] = `
+exports[`no-unused-vars > invalid 71`] = `
 {
   "code": "
 type Foo = 1;
@@ -2292,7 +2323,7 @@ export = Bar;
 }
 `;
 
-exports[`no-unused-vars > invalid 71`] = `
+exports[`no-unused-vars > invalid 72`] = `
 {
   "code": "
 declare module 'foo' {
@@ -2325,7 +2356,7 @@ declare module 'foo' {
 }
 `;
 
-exports[`no-unused-vars > invalid 72`] = `
+exports[`no-unused-vars > invalid 73`] = `
 {
   "code": "
 declare module 'foo' {
@@ -2356,7 +2387,7 @@ declare module 'foo' {
 }
 `;
 
-exports[`no-unused-vars > invalid 73`] = `
+exports[`no-unused-vars > invalid 74`] = `
 {
   "code": "
 export declare namespace Foo {
@@ -2394,7 +2425,7 @@ export declare namespace Foo {
 }
 `;
 
-exports[`no-unused-vars > invalid 74`] = `
+exports[`no-unused-vars > invalid 75`] = `
 {
   "code": "
 declare module 'foo' {
@@ -2432,7 +2463,7 @@ declare module 'foo' {
 }
 `;
 
-exports[`no-unused-vars > invalid 75`] = `
+exports[`no-unused-vars > invalid 76`] = `
 {
   "code": "
 declare enum Foo {}
@@ -2461,7 +2492,7 @@ export {};
 }
 `;
 
-exports[`no-unused-vars > invalid 76`] = `
+exports[`no-unused-vars > invalid 77`] = `
 {
   "code": "
 class Foo {}
@@ -2507,7 +2538,7 @@ export {};
 }
 `;
 
-exports[`no-unused-vars > invalid 77`] = `
+exports[`no-unused-vars > invalid 78`] = `
 {
   "code": "
 export interface RpcResponse<T = unknown> {
@@ -2537,7 +2568,7 @@ export interface RpcResponse<T = unknown> {
 }
 `;
 
-exports[`no-unused-vars > invalid 78`] = `
+exports[`no-unused-vars > invalid 79`] = `
 {
   "code": "
 export type Alias<T = unknown> = string;
@@ -2565,7 +2596,7 @@ export type Alias<T = unknown> = string;
 }
 `;
 
-exports[`no-unused-vars > invalid 79`] = `
+exports[`no-unused-vars > invalid 80`] = `
 {
   "code": "
 export function fn<T>(): void {}
@@ -2593,7 +2624,7 @@ export function fn<T>(): void {}
 }
 `;
 
-exports[`no-unused-vars > invalid 80`] = `
+exports[`no-unused-vars > invalid 81`] = `
 {
   "code": "
 export class Cls<T = unknown> {}
@@ -2621,7 +2652,7 @@ export class Cls<T = unknown> {}
 }
 `;
 
-exports[`no-unused-vars > invalid 81`] = `
+exports[`no-unused-vars > invalid 82`] = `
 {
   "code": "
 export interface CrossRef<T, U extends T> {}

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/no-unused-vars.test.ts
@@ -387,11 +387,37 @@ export const ComponentFoo = () => {
         },
       },
     },
-    // https://github.com/typescript-eslint/typescript-eslint/issues/3303
-    // jsx: "react-jsx" mode — factory is auto-imported, React import is unused
+    // jsx: "react-jsx" with a React import but NO JSX in the file — React is
+    // genuinely unused and must still be reported.
     {
       code: `
 import React from 'react';
+
+export const x = 1;
+      `,
+      errors: [
+        {
+          messageId: 'unusedVar',
+        },
+      ],
+      filename: 'react.tsx',
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+          project: './tsconfig.jsx-reactjsx.json',
+        },
+      },
+    },
+    // Documented gap: a custom pragma declared via an `@jsx X` comment is not
+    // recognized (that requires eslint-plugin-react's jsx-uses-react, which is a
+    // no-op in rslint), so `X` is still reported even though it is the active
+    // JSX factory for this file.
+    {
+      code: `
+/** @jsx X.createElement */
+import X from './x';
 
 export const ComponentFoo = () => {
   return <div>Foo Foo</div>;
@@ -402,6 +428,7 @@ export const ComponentFoo = () => {
           messageId: 'unusedVar',
         },
       ],
+      filename: 'react.tsx',
       languageOptions: {
         parserOptions: {
           ecmaFeatures: {
@@ -1173,6 +1200,48 @@ export interface CrossRef<T, U extends T> {}
   ],
 
   valid: [
+    // jsx: "react-jsx" — React is referenced only by JSX. Matching
+    // @typescript-eslint/parser's jsxPragma default ("React"), the factory is
+    // treated as used whenever JSX is present, so React is NOT reported.
+    // (Reporting it would require opting into parserOptions.jsxPragma=null per
+    // typescript-eslint #3303, which rslint does not expose.)
+    {
+      code: `
+import React from 'react';
+
+export const ComponentFoo = () => {
+  return <div>Foo Foo</div>;
+};
+      `,
+      filename: 'react.tsx',
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+          project: './tsconfig.jsx-reactjsx.json',
+        },
+      },
+    },
+    // jsx: "react-jsx" — fragment-only usage also marks the React factory used.
+    {
+      code: `
+import React from 'react';
+
+export const ComponentFoo = () => {
+  return <>Foo</>;
+};
+      `,
+      filename: 'react.tsx',
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+          project: './tsconfig.jsx-reactjsx.json',
+        },
+      },
+    },
     `
 import { ClassDecoratorFactory } from 'decorators';
 @ClassDecoratorFactory()


### PR DESCRIPTION
## Summary

`no-unused-vars` only marked the JSX factory import (e.g. `React`) as used for `jsx: "preserve"` / `"react-native"`. Under `jsx: "react-jsx"` (and classic `react`) an `import React` whose only use is JSX was falsely reported as unused, because TypeScript never produces an AST identifier reference to the factory.

The factory is now marked as used whenever the file contains JSX, in **any** jsx runtime — matching `@typescript-eslint/parser`'s `jsxPragma` baseline (default `"React"`), verified against typescript-eslint v8.62 (with and without a type-aware project, with and without `react/jsx-uses-react`). A genuinely unused factory (no JSX in the file) is still reported, and non-factory unused imports are unaffected.

This also corrects an existing test that encoded the opposite behavior citing typescript-eslint #3303 — that issue's resolution makes flagging React under `react-jsx` an explicit opt-in (`parserOptions.jsxPragma: null`), not the default; the default is "not reported".

Verified on real code: the React false positives in the OLA repo (diff-viewer 11→0, features/rl, ui/common, sdks/plugins) are gone.

### Known limitation
A custom pragma declared via an `@jsx X` comment / `settings.react.pragma` is still reported — that suppression requires eslint-plugin-react's `jsx-uses-react`, which is a no-op in rslint (no cross-rule "mark as used" channel yet). Documented in `jsx_uses_react.go` and covered by a test.

## Related Links

Found via OLA repo eslint→rslint migration validation (`@typescript-eslint/no-unused-vars` false positives on `import React` under `jsx: react-jsx`).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).