### PR TITLE
fix: report no-unnecessary-type-arguments on error-typed type arguments

### DIFF
--- a/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
@@ -101,6 +101,13 @@ var NoUnnecessaryTypeArgumentsRule = rule.CreateRule(rule.Rule{
 			return nil
 		}
 
+		getTypeForComparison := func(t *checker.Type) (*checker.Type, []*checker.Type) {
+			if utils.IsTypeReference(t) {
+				return t.Target(), checker.Checker_getTypeArguments(ctx.TypeChecker, t)
+			}
+			return t, nil
+		}
+
 		checkArgsAndParameters := func(arguments *ast.NodeList, parameters []*ast.Node) {
 			if arguments == nil || parameters == nil || len(arguments.Nodes) == 0 || len(parameters) == 0 {
 				return
@@ -123,16 +130,23 @@ var NoUnnecessaryTypeArgumentsRule = rule.CreateRule(rule.Rule{
 			}
 
 			paramType := ctx.TypeChecker.GetTypeAtLocation(defaultType)
-			if utils.IsIntrinsicErrorType(paramType) {
-				return
-			}
-
 			argType := ctx.TypeChecker.GetTypeAtLocation(arg)
-			if utils.IsIntrinsicErrorType(argType) {
-				return
-			}
-			if argType != paramType && (utils.IsTypeAnyType(argType) || utils.IsTypeAnyType(paramType) || (!checker.Checker_isTypeStrictSubtypeOf(ctx.TypeChecker, argType, paramType) || !checker.Checker_isTypeStrictSubtypeOf(ctx.TypeChecker, paramType, argType))) {
-				return
+
+			// Identical types are unnecessary. Otherwise compare the resolved
+			// type-reference target and its type arguments (matching upstream's
+			// getTypeForComparison): differing target, arity, or any argument
+			// means the explicit type argument is not the default.
+			if paramType != argType {
+				paramTarget, paramTypeArguments := getTypeForComparison(paramType)
+				argTarget, argTypeArguments := getTypeForComparison(argType)
+				if paramTarget != argTarget || len(paramTypeArguments) != len(argTypeArguments) {
+					return
+				}
+				for idx := range paramTypeArguments {
+					if paramTypeArguments[idx] != argTypeArguments[idx] {
+						return
+					}
+				}
 			}
 
 			var removeRange core.TextRange

--- a/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments_test.go
@@ -393,8 +393,6 @@ function bar<T = F<string>>() {}
 bar();
       `,
 			},
-			// TODO(port): why do we need to report on `error` types?
-			Skip: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "unnecessaryTypeParameter",

--- a/internal/utils/ts_api_utils.go
+++ b/internal/utils/ts_api_utils.go
@@ -54,6 +54,9 @@ func IsTypeUnknownType(t *checker.Type) bool {
 func IsObjectType(t *checker.Type) bool {
 	return IsTypeFlagSet(t, checker.TypeFlagsObject)
 }
+func IsTypeReference(t *checker.Type) bool {
+	return IsObjectType(t) && checker.Type_objectFlags(t)&checker.ObjectFlagsReference != 0
+}
 func IsTypeParameter(t *checker.Type) bool {
 	return IsTypeFlagSet(t, checker.TypeFlagsTypeParameter)
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -333,7 +333,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-unnecessary-parameter-property-assignment.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-qualifier.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-template-expression.test.ts',
-    // './tests/typescript-eslint/rules/no-unnecessary-type-arguments.test.ts',
+    './tests/typescript-eslint/rules/no-unnecessary-type-arguments.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-type-assertion.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-type-constraint.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-type-conversion.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-type-arguments.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-type-arguments.test.ts.snap
@@ -1,0 +1,816 @@
+// Rstest Snapshot v1
+
+exports[`no-unnecessary-type-arguments > invalid 1`] = `
+{
+  "code": "
+function f<T = number>() {}
+f<number>();
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function f<T = number>() {}
+f();
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 2`] = `
+{
+  "code": "
+function g<T = number, U = string>() {}
+g<string, string>();
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function g<T = number, U = string>() {}
+g<string>();
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 3`] = `
+{
+  "code": "
+function f<T = number>(templates: TemplateStringsArray, arg: T) {}
+f<number>\`\${1}\`;
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function f<T = number>(templates: TemplateStringsArray, arg: T) {}
+f\`\${1}\`;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 4`] = `
+{
+  "code": "
+class C<T = number> {}
+function h(c: C<number>) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class C<T = number> {}
+function h(c: C) {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 5`] = `
+{
+  "code": "
+class C<T = number> {}
+new C<number>();
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class C<T = number> {}
+new C();
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 6`] = `
+{
+  "code": "
+class C<T = number> {}
+class D extends C<number> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 19,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class C<T = number> {}
+class D extends C {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 7`] = `
+{
+  "code": "
+interface I<T = number> {}
+class Impl implements I<number> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 25,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+interface I<T = number> {}
+class Impl implements I {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 8`] = `
+{
+  "code": "
+class Foo<T = number> {}
+const foo = new Foo<number>();
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 21,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class Foo<T = number> {}
+const foo = new Foo();
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 9`] = `
+{
+  "code": "
+interface Bar<T = string> {}
+class Foo<T = number> implements Bar<string> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 3,
+        },
+        "start": {
+          "column": 38,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+interface Bar<T = string> {}
+class Foo<T = number> implements Bar {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 10`] = `
+{
+  "code": "
+class Bar<T = string> {}
+class Foo<T = number> extends Bar<string> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 3,
+        },
+        "start": {
+          "column": 35,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class Bar<T = string> {}
+class Foo<T = number> extends Bar {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 11`] = `
+{
+  "code": "
+import { F } from './missing';
+function bar<T = F<string>>() {}
+bar<F<string>>();
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+import { F } from './missing';
+function bar<T = F<string>>() {}
+bar();
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 12`] = `
+{
+  "code": "
+type DefaultE = { foo: string };
+type T<E = DefaultE> = { box: E };
+type G = T<DefaultE>;
+declare module 'bar' {
+  type DefaultE = { somethingElse: true };
+  type G = T<DefaultE>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type DefaultE = { foo: string };
+type T<E = DefaultE> = { box: E };
+type G = T;
+declare module 'bar' {
+  type DefaultE = { somethingElse: true };
+  type G = T<DefaultE>;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 13`] = `
+{
+  "code": "
+type A<T = Map<string, string>> = T;
+type B = A<Map<string, string>>;
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type A<T = Map<string, string>> = T;
+type B = A;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 14`] = `
+{
+  "code": "
+type A = Map<string, string>;
+type B<T = A> = T;
+type C = B<A>;
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type A = Map<string, string>;
+type B<T = A> = T;
+type C = B;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 15`] = `
+{
+  "code": "
+type A = Map<string, string>;
+type B<T = A> = T;
+type C = B<Map<string, string>>;
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type A = Map<string, string>;
+type B<T = A> = T;
+type C = B;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 16`] = `
+{
+  "code": "
+type A = Map<string, string>;
+type B = Map<string, string>;
+type C<T = A> = T;
+type D = C<B>;
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 5,
+        },
+        "start": {
+          "column": 12,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type A = Map<string, string>;
+type B = Map<string, string>;
+type C<T = A> = T;
+type D = C;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 17`] = `
+{
+  "code": "
+type A = Map<string, string>;
+type B = A;
+type C = Map<string, string>;
+type D = C;
+type E<T = B> = T;
+type F = E<D>;
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 7,
+        },
+        "start": {
+          "column": 12,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type A = Map<string, string>;
+type B = A;
+type C = Map<string, string>;
+type D = C;
+type E<T = B> = T;
+type F = E;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 18`] = `
+{
+  "code": "
+interface Foo {}
+declare var Foo: {
+  new <T = string>(type: T): any;
+};
+class Bar extends Foo<string> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 6,
+        },
+        "start": {
+          "column": 23,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+interface Foo {}
+declare var Foo: {
+  new <T = string>(type: T): any;
+};
+class Bar extends Foo {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 19`] = `
+{
+  "code": "
+declare var Foo: {
+  new <T = string>(type: T): any;
+};
+interface Foo {}
+class Bar extends Foo<string> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 6,
+        },
+        "start": {
+          "column": 23,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+declare var Foo: {
+  new <T = string>(type: T): any;
+};
+interface Foo {}
+class Bar extends Foo {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 20`] = `
+{
+  "code": "
+class Foo<T> {}
+interface Foo<T = string> {}
+class Bar implements Foo<string> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 4,
+        },
+        "start": {
+          "column": 26,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class Foo<T> {}
+interface Foo<T = string> {}
+class Bar implements Foo {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 21`] = `
+{
+  "code": "
+class Foo<T = string> {}
+namespace Foo {
+  export class Bar {}
+}
+class Bar extends Foo<string> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 6,
+        },
+        "start": {
+          "column": 23,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class Foo<T = string> {}
+namespace Foo {
+  export class Bar {}
+}
+class Bar extends Foo {}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 22`] = `
+{
+  "code": "
+function Button<T = string>() {
+  return <div></div>;
+}
+const button = <Button<string>></Button>;
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 5,
+        },
+        "start": {
+          "column": 24,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function Button<T = string>() {
+  return <div></div>;
+}
+const button = <Button></Button>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-arguments > invalid 23`] = `
+{
+  "code": "
+function Button<T = string>() {
+  return <div></div>;
+}
+const button = <Button<string> />;
+      ",
+  "diagnostics": [
+    {
+      "message": "This is the default value for this type parameter, so it can be omitted.",
+      "messageId": "unnecessaryTypeParameter",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 5,
+        },
+        "start": {
+          "column": 24,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-arguments",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function Button<T = string>() {
+  return <div></div>;
+}
+const button = <Button />;
+      ",
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

`@typescript-eslint/no-unnecessary-type-arguments` failed to report an explicit type argument that equals an **error-typed default** (e.g. when the type comes from an unresolved import), so its conformance test was disabled. Case the original rule flags but the port missed:

```ts
import { F } from './missing';
function bar<T = F<string>>() {}
bar<F<string>>(); // `<F<string>>` is the default — should be flagged
```

The port diverged from the original rule's comparison in two ways:
1. It bailed out whenever the default or the argument resolved to an error type.
2. It compared types with a custom subtype check instead of the original's structural comparison.

This replaces the comparison with the original `getTypeForComparison` logic: identical types are unnecessary; otherwise compare the resolved type-reference target plus its type arguments (target, arity, and each argument). Error-typed type references still carry a target and type arguments, so `F<string>` vs `F<string>` is now flagged while `F` vs `F<number>` is correctly left alone.

Re-enables the rule's conformance test (previously commented out) and un-skips the corresponding Go case.

## Related Links

Follow-up to #1133, found while validating rule alignment on real-world code. No existing issue.

## Checklist

- [x] Tests updated (or not required). Re-enabled the JS conformance test and un-skipped the Go error-type case; verified the case fails without the fix and that output matches the original rule.
- [x] Documentation updated (or not required). Behavior aligns with the original rule; no option change.
