### PR TITLE
feat(rslint): add lintText convenience API for in-memory linting

### DIFF
--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -1,6 +1,7 @@
 import { NodeRslintService } from './node.js';
 import {
   LintOptions,
+  LintTextOptions,
   LintResponse,
   RSLintService,
   ApplyFixesRequest,
@@ -41,6 +42,25 @@ export async function lint(options: LintOptions): Promise<LintResponse> {
   return result;
 }
 
+// Convenience function for in-memory linting (no disk write), mirroring ESLint's lintText
+export async function lintText(
+  code: string,
+  options: LintTextOptions = {},
+): Promise<LintResponse> {
+  const service = new RSLintService(
+    new NodeRslintService({
+      workingDirectory: options.workingDirectory,
+    }),
+  );
+  let result: LintResponse;
+  try {
+    result = await service.lintText(code, options);
+  } finally {
+    await service.close();
+  }
+  return result;
+}
+
 // Convenience function for applying fixes
 export async function applyFixes(
   options: ApplyFixesRequest,
@@ -65,6 +85,7 @@ export async function getAstInfo(
 export {
   type Diagnostic,
   type LintOptions,
+  type LintTextOptions,
   type LintResponse,
   type ApplyFixesRequest,
   type ApplyFixesResponse,

--- a/packages/rslint/src/service.ts
+++ b/packages/rslint/src/service.ts
@@ -1,6 +1,7 @@
 import type {
   RslintServiceInterface as RslintServiceBackend,
   LintOptions,
+  LintTextOptions,
   LintResponse,
   ApplyFixesRequest,
   ApplyFixesResponse,
@@ -45,6 +46,25 @@ export class RSLintService {
       languageOptions,
       includeEncodedSourceFiles,
       format: 'jsonline',
+    });
+  }
+
+  /**
+   * Run the linter on an in-memory source string without writing to disk.
+   *
+   * Mirrors ESLint's `lintText`: the `code` is linted under a virtual
+   * `filePath` (default `virtual.tsx`) via the existing VFS `fileContents`
+   * plumbing. No file is ever written to disk.
+   */
+  async lintText(
+    code: string,
+    options: LintTextOptions = {},
+  ): Promise<LintResponse> {
+    const { filePath = 'virtual.tsx', ...rest } = options;
+    return this.lint({
+      ...rest,
+      files: [filePath],
+      fileContents: { [filePath]: code },
     });
   }
 
@@ -111,6 +131,7 @@ export class RSLintService {
 export type {
   Diagnostic,
   LintOptions,
+  LintTextOptions,
   LintResponse,
   ApplyFixesRequest,
   ApplyFixesResponse,

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -40,6 +40,15 @@ export interface LintOptions {
   includeEncodedSourceFiles?: boolean; // Whether to include encoded source files in response
 }
 
+export interface LintTextOptions {
+  filePath?: string; // Virtual path to lint the code under. Defaults to a virtual TSX name. Determines the parser (ts/tsx/js/jsx) by extension.
+  config?: string; // Path to rslint.json config file
+  workingDirectory?: string;
+  ruleOptions?: Record<string, string>;
+  languageOptions?: LanguageOptions; // Override languageOptions from config file
+  includeEncodedSourceFiles?: boolean;
+}
+
 export interface LanguageOptions {
   parserOptions?: ParserOptions;
 }

--- a/packages/rslint/tests/lint-text.test.mjs
+++ b/packages/rslint/tests/lint-text.test.mjs
@@ -1,0 +1,73 @@
+import { lintText, RSLintService, NodeRslintService } from '@rslint/core';
+import { describe, test, expect } from '@rstest/core';
+import path from 'node:path';
+
+describe('lintText api', async (t) => {
+  let cwd = path.resolve(import.meta.dirname, '../fixtures');
+  let config = path.resolve(
+    import.meta.dirname,
+    '../fixtures/rslint.virtual.json',
+  );
+  let virtual_entry = path.resolve(cwd, 'src/virtual.ts');
+  let ruleOptions = {
+    '@typescript-eslint/no-unsafe-member-access': 'error',
+  };
+  let code = `let a:any = 10;
+ a.b =10;`;
+
+  test('lints in-memory content with fixture config', async (t) => {
+    const diags = await lintText(code, {
+      config,
+      workingDirectory: cwd,
+      ruleOptions,
+      filePath: virtual_entry,
+    });
+
+    expect(Array.isArray(diags.diagnostics)).toBe(true);
+    expect(diags.diagnostics.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('uses default filePath', async (t) => {
+    const diags = await lintText('const value = 1;', {
+      config,
+      workingDirectory: cwd,
+    });
+
+    expect(Array.isArray(diags.diagnostics)).toBe(true);
+  });
+
+  test('returns diagnostics array for clean code', async (t) => {
+    const diags = await lintText('const value = 1;\n', {
+      config,
+      workingDirectory: cwd,
+      ruleOptions,
+      filePath: virtual_entry,
+    });
+
+    expect(Array.isArray(diags.diagnostics)).toBe(true);
+  });
+
+  test('service lintText matches standalone helper', async (t) => {
+    const options = {
+      config,
+      workingDirectory: cwd,
+      ruleOptions,
+      filePath: virtual_entry,
+    };
+    const standalone = await lintText(code, options);
+    const service = new RSLintService(
+      new NodeRslintService({
+        workingDirectory: cwd,
+      }),
+    );
+
+    try {
+      const diags = await service.lintText(code, options);
+
+      expect(Array.isArray(diags.diagnostics)).toBe(true);
+      expect(diags.diagnostics.length).toBe(standalone.diagnostics.length);
+    } finally {
+      await service.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `lintText()` convenience API for linting an in-memory source string without writing it to disk, mirroring ESLint's `lintText(code, { filePath })` and Biome's `lintContent`. This is the in-generation-loop entry point requested in #1106 for tools (like LLM coding agents) that want to lint freshly generated source before it ever touches the filesystem.

The change is purely an ergonomic TypeScript surface over the existing `LintOptions.fileContents` VFS map that the Go server already honors (the same plumbing exercised by the existing "virtual file support" API test). No Go/server changes are required.

What's added:

- **`lintText(code, options?)`** standalone convenience function in `src/index.ts`, mirroring the existing `lint()` / `applyFixes()` / `getAstInfo()` wrappers: it spins up a service, lints, and closes it (now in a `finally` so the spawned `rslint --api` subprocess is always released, even on a rejected lint).
- **`RSLintService.lintText(code, options?)`** method in `src/service.ts` for callers holding a long-lived service who want to avoid per-call spin-up. It builds a single-entry VFS request (`files: [filePath]`, `fileContents: { [filePath]: code }`) and delegates to the existing `lint()` path. `filePath` defaults to a virtual `virtual.tsx` when omitted.
- **`LintTextOptions`** public type in `src/types.ts` (re-exported from `index.ts` and `service.ts`).
- Structural test coverage in `tests/lint-text.test.mjs` (happy path, default `filePath`, clean code, and service-vs-standalone parity), following the fixture conventions of the existing `tests/api.test.mjs`.

Example:

```ts
import { lintText } from '@rslint/core';

const { diagnostics } = await lintText('const a = 1; a = 2;', {
  filePath: 'virtual/Component.tsx',
  config: './rslint.json',
});
```

### Known limitations

- When `filePath` is omitted (or set to a path not matched by the configured tsconfig's `include` globs), diagnostics are scoped to that virtual path; the Go program is still built from tsconfig roots, so a virtual file outside those roots may produce zero diagnostics. Passing a `filePath` that the config already includes (the documented usage) lints as expected. Fully decoupling the virtual entry from tsconfig roots would require a server-side change and is intentionally out of scope here.

## Related Links

Closes #1106

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
