### PR TITLE
feat(tsgo): collect node flags in semantic output

### DIFF
--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -102,7 +102,7 @@ type Semantic struct {
 	AliasSymbols map[ast.SymbolId]ast.SymbolId    `json:"alias_symbols"`
 	Node2sym     map[NodeReference]ast.SymbolId   `json:"node2sym"`
 	Node2type    map[NodeReference]checker.TypeId `json:"node2type"`
-	NodeFlags    map[NodeReference]int            `json:"node_flags"`
+	NodeFlags    map[NodeReference]uint32         `json:"node_flags"`
 	Primtypes    PrimTypes                        `json:"primtypes"`
 	TypeExtra    TypeExtra                        `json:"type_extra"`
 	FuncData     FunctionData                     `json:"func_data"`
@@ -119,7 +119,7 @@ func NewSemantic() Semantic {
 		AliasSymbols:     make(map[ast.SymbolId]ast.SymbolId),
 		Node2sym:         make(map[NodeReference]ast.SymbolId),
 		Node2type:        make(map[NodeReference]checker.TypeId),
-		NodeFlags:        make(map[NodeReference]int),
+		NodeFlags:        make(map[NodeReference]uint32),
 		ShorthandSymbols: make(map[NodeReference]ast.SymbolId),
 		Primtypes:        PrimTypes{},
 		TypeExtra: TypeExtra{

--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -222,7 +222,9 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 				Start:        utf16(node.Pos()),
 				End:          utf16(node.End()),
 			}
-			semantic.NodeFlags[key] = int(node.Flags)
+			if node.Flags != 0 {
+				semantic.NodeFlags[key] = uint32(node.Flags)
+			}
 			// typescript will panic if we pass typeDeclaration to GetTypeAtLocation
 			if !ast.IsTypeDeclaration(node) {
 				if tyAtNode := tc.GetTypeAtLocation(node); tyAtNode != nil {

--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -102,6 +102,7 @@ type Semantic struct {
 	AliasSymbols map[ast.SymbolId]ast.SymbolId    `json:"alias_symbols"`
 	Node2sym     map[NodeReference]ast.SymbolId   `json:"node2sym"`
 	Node2type    map[NodeReference]checker.TypeId `json:"node2type"`
+	NodeFlags    map[NodeReference]int            `json:"node_flags"`
 	Primtypes    PrimTypes                        `json:"primtypes"`
 	TypeExtra    TypeExtra                        `json:"type_extra"`
 	FuncData     FunctionData                     `json:"func_data"`
@@ -118,6 +119,7 @@ func NewSemantic() Semantic {
 		AliasSymbols:     make(map[ast.SymbolId]ast.SymbolId),
 		Node2sym:         make(map[NodeReference]ast.SymbolId),
 		Node2type:        make(map[NodeReference]checker.TypeId),
+		NodeFlags:        make(map[NodeReference]int),
 		ShorthandSymbols: make(map[NodeReference]ast.SymbolId),
 		Primtypes:        PrimTypes{},
 		TypeExtra: TypeExtra{
@@ -220,6 +222,7 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 				Start:        utf16(node.Pos()),
 				End:          utf16(node.End()),
 			}
+			semantic.NodeFlags[key] = int(node.Flags)
 			// typescript will panic if we pass typeDeclaration to GetTypeAtLocation
 			if !ast.IsTypeDeclaration(node) {
 				if tyAtNode := tc.GetTypeAtLocation(node); tyAtNode != nil {

--- a/crates/tsgo-client/src/proto.rs
+++ b/crates/tsgo-client/src/proto.rs
@@ -43,6 +43,8 @@ pub struct Semantic {
     pub node2sym: Vec<(NodeReference, u32)>,
     #[serde(deserialize_with = "vecmap")]
     pub node2type: Vec<(NodeReference, u32)>,
+    #[serde(default, deserialize_with = "vecmap_or_empty")]
+    pub node_flags: Vec<(NodeReference, u32)>,
     pub type_extra: TypeExtra,
     pub primtypes: PrimTypes,
     // (aliasSymbolId, targetSymbolId)


### PR DESCRIPTION
## Summary

- Collect non-zero TypeScript `NodeFlags` per semantic `NodeReference`
- Expose the new `node_flags` map in the tsgo client protocol

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
