### PR TITLE
fix: align react-hooks/exhaustive-deps with latest eslint-plugin-react-hooks

### DIFF
--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
@@ -152,20 +152,46 @@ func nodeText(sf *ast.SourceFile, node *ast.Node) string {
 // rule reports them as "complex expression" rather than treating them as
 // transparent.
 func analyzePropertyChainText(node *ast.Node, optionalChains map[string]bool) (string, bool) {
+	return analyzePropertyChain(node, optionalChains, false)
+}
+
+// analyzeDepsArrayElement applies upstream's STRICT `analyzePropertyChain`
+// semantics for elements of the dependency array. Upstream has no case for
+// type assertions (`as` / `satisfies`) or non-null assertions (`!`), so any
+// of them makes the element a "complex expression". Non-optional computed
+// access (`foo[bar]`) is also complex, while optional computed access
+// (`foo?.[bar]`) with an analyzable (non-literal) key is a valid chain — a
+// quirk of upstream's `ChainExpression` branch, which doesn't re-check
+// `computed`. The callback-collection path stays lenient (it strips `as`),
+// so the strict behavior is confined to this entry point.
+func analyzeDepsArrayElement(node *ast.Node, optionalChains map[string]bool) (string, bool) {
+	return analyzePropertyChain(node, optionalChains, true)
+}
+
+func analyzePropertyChain(node *ast.Node, optionalChains map[string]bool, strict bool) (string, bool) {
 	if node == nil {
 		return "", false
 	}
 	n := ast.SkipParentheses(node)
-	for {
+	if strict {
+		// Upstream throws on these node kinds -> "complex expression".
 		switch n.Kind {
-		case ast.KindAsExpression:
-			n = ast.SkipParentheses(n.AsAsExpression().Expression)
-			continue
-		case ast.KindSatisfiesExpression:
-			n = ast.SkipParentheses(n.AsSatisfiesExpression().Expression)
-			continue
+		case ast.KindAsExpression, ast.KindSatisfiesExpression, ast.KindNonNullExpression:
+			return "", false
 		}
-		break
+	} else {
+		// Callback path: `as` / `satisfies` are transparent.
+		for {
+			switch n.Kind {
+			case ast.KindAsExpression:
+				n = ast.SkipParentheses(n.AsAsExpression().Expression)
+				continue
+			case ast.KindSatisfiesExpression:
+				n = ast.SkipParentheses(n.AsSatisfiesExpression().Expression)
+				continue
+			}
+			break
+		}
 	}
 	switch n.Kind {
 	case ast.KindIdentifier:
@@ -181,7 +207,7 @@ func analyzePropertyChainText(node *ast.Node, optionalChains map[string]bool) (s
 		return "", false
 	case ast.KindPropertyAccessExpression:
 		pae := n.AsPropertyAccessExpression()
-		object, ok := analyzePropertyChainText(pae.Expression, optionalChains)
+		object, ok := analyzePropertyChain(pae.Expression, optionalChains, strict)
 		if !ok {
 			return "", false
 		}
@@ -193,6 +219,32 @@ func analyzePropertyChainText(node *ast.Node, optionalChains map[string]bool) (s
 		if optionalChains != nil {
 			optional := pae.QuestionDotToken != nil
 			markOptionalChain(optionalChains, result, optional)
+		}
+		return result, true
+	case ast.KindElementAccessExpression:
+		// Computed access. Upstream only accepts it as part of an optional
+		// chain (`foo?.[bar]`) whose key is itself an analyzable chain
+		// (Identifier / member access, never a literal). Non-optional
+		// `foo[bar]` and literal keys are "complex". The callback path never
+		// reaches here (it resolves computed reads via scope analysis).
+		if !strict {
+			return "", false
+		}
+		eae := n.AsElementAccessExpression()
+		if eae.QuestionDotToken == nil {
+			return "", false
+		}
+		object, ok := analyzePropertyChain(eae.Expression, optionalChains, strict)
+		if !ok {
+			return "", false
+		}
+		property, ok := analyzePropertyChain(eae.ArgumentExpression, nil, strict)
+		if !ok {
+			return "", false
+		}
+		result := object + "." + property
+		if optionalChains != nil {
+			markOptionalChain(optionalChains, result, true)
 		}
 		return result, true
 	}
@@ -671,6 +723,26 @@ func isObjectLiteralShorthandReference(id *ast.Node) bool {
 	return id.Parent.Name() == id && !utils.IsInDestructuringAssignment(id.Parent)
 }
 
+// resolveValueSymbol resolves an identifier to its value symbol. For
+// object-literal shorthand reads (`{ value }`), tsgo's TypeChecker reports the
+// ShorthandPropertyAssignment's own property symbol instead of the outer
+// binding, so we first ask for the shorthand value symbol and only fall back
+// to the plain lookup. Sharing this across every reference-collection path
+// keeps shorthand reads resolving identically whether they are scanned
+// directly in the effect body or recursively inside a local function (the
+// latter previously missed them, masking captured reactive values).
+func resolveValueSymbol(tc *checker.Checker, id *ast.Node) *ast.Symbol {
+	if tc == nil {
+		return nil
+	}
+	if isObjectLiteralShorthandReference(id) {
+		if sym := tc.GetShorthandAssignmentValueSymbol(id.Parent); sym != nil {
+			return sym
+		}
+	}
+	return tc.GetSymbolAtLocation(id)
+}
+
 // isReferenceIdentifier reports whether the given Identifier appears in a
 // value-reference position (as opposed to a property name, label, declaration
 // name, etc).
@@ -1134,11 +1206,6 @@ func isUsedOutsideHook(name *ast.Node, hookCallback *ast.Node, depsNode *ast.Nod
 	}
 	visit(scope)
 	return used
-}
-
-// isComponentOrHookFunction delegates to the shared classifier.
-func isComponentOrHookFunction(fn *ast.Node) bool {
-	return react_hooksutil.IsComponentOrHookFn(fn)
 }
 
 // getUnknownDependenciesMessage mirrors upstream's same-named helper.

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_alignment_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_alignment_test.go
@@ -1,0 +1,163 @@
+package exhaustive_deps
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Alignment lock-in tests. Each case pins a behavior that previously diverged
+// from eslint-plugin-react-hooks and was verified against BOTH v4.6.2 and
+// v7.1.1 (identical output) before being encoded here.
+
+var alignmentValid = []rule_tester.ValidTestCase{
+	// A local function whose only captures are stable hook values is itself
+	// stable when referenced directly in an effect — no missing-dep report.
+	{Code: `
+function useNoCapture() {
+  const [s, setS] = useState(0);
+  const transform = (x: number) => x;
+  useEffect(() => { setS(transform(1)); }, []);
+  return s;
+}
+`, Tsx: true},
+}
+
+var alignmentInvalid = []rule_tester.InvalidTestCase{
+	// (1) HOC wrapper (observer/mobx) no longer gates analysis: the effect
+	// inside an `observer(() => {...})` component is analyzed like any other.
+	{
+		Code: `
+const C = observer((props: any) => {
+  const [s, setS] = useState(0);
+  useEffect(() => { console.log(props.x); setS(1); }, []);
+  return null;
+});
+`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a missing dependency: 'props.x'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+const C = observer((props: any) => {
+  const [s, setS] = useState(0);
+  useEffect(() => { console.log(props.x); setS(1); }, [props.x]);
+  return null;
+});
+`}}},
+		},
+	},
+	// (2) A reactive value captured ONLY via an object-literal shorthand
+	// (`{ apId }`) inside a local function is still a capture, so the function
+	// is unstable and must be a dependency.
+	{
+		Code: `
+function useShorthand({ apId }: { apId: string }) {
+  const [t, setT] = useState<any[]>([]);
+  const fetchTree = () => { setT([{ apId }]); };
+  useEffect(() => { fetchTree(); }, []);
+  return t;
+}
+`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a missing dependency: 'fetchTree'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function useShorthand({ apId }: { apId: string }) {
+  const [t, setT] = useState<any[]>([]);
+  const fetchTree = () => { setT([{ apId }]); };
+  useEffect(() => { fetchTree(); }, [fetchTree]);
+  return t;
+}
+`}}},
+		},
+	},
+	// (3) A local function is unstable when it calls ANOTHER local function
+	// (upstream "won't check functions deeper": the inner function is not a
+	// known-stable hook value, so the outer one captures it).
+	{
+		Code: `
+function useCallsLocal({ apId }: { apId: string }) {
+  const [t, setT] = useState<any[]>([]);
+  const transform = (x: string) => [x];
+  const query = () => { setT(transform(apId)); };
+  useEffect(() => { query(); }, []);
+  return t;
+}
+`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a missing dependency: 'query'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function useCallsLocal({ apId }: { apId: string }) {
+  const [t, setT] = useState<any[]>([]);
+  const transform = (x: string) => [x];
+  const query = () => { setT(transform(apId)); };
+  useEffect(() => { query(); }, [query]);
+  return t;
+}
+`}}},
+		},
+	},
+	// (4) A recursive local function is unstable (its self-reference resolves
+	// to the component-scope binding, which is a capture).
+	{
+		Code: `
+function useRecursive({ tree, id }: { tree: any[]; id: string }) {
+  const findLabel = (data: any[], target: string): string => {
+    for (const node of data) {
+      if (node.id === target) return node.label;
+      if (node.children) { const r = findLabel(node.children, target); if (r) return r; }
+    }
+    return '';
+  };
+  return useMemo(() => findLabel(tree, id), [tree, id]);
+}
+`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useMemo has a missing dependency: 'findLabel'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+function useRecursive({ tree, id }: { tree: any[]; id: string }) {
+  const findLabel = (data: any[], target: string): string => {
+    for (const node of data) {
+      if (node.id === target) return node.label;
+      if (node.children) { const r = findLabel(node.children, target); if (r) return r; }
+    }
+    return '';
+  };
+  return useMemo(() => findLabel(tree, id), [findLabel, tree, id]);
+}
+`}}},
+		},
+	},
+	// (5) When a ref's `.current` is read multiple times inside the cleanup
+	// function, the warning points at the LAST occurrence (upstream overwrites
+	// per dependency), not the first.
+	{
+		Code: `
+function useRefCleanup() {
+  const handleRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    handleRef.current?.addEventListener('a', () => {});
+    return () => {
+      handleRef.current?.removeEventListener('a', () => {});
+      handleRef.current?.removeEventListener('b', () => {});
+    };
+  }, []);
+}
+`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "The ref value 'handleRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'handleRef.current' to a variable inside the effect, and use that variable in the cleanup function."},
+		},
+	},
+}
+
+func TestExhaustiveDeps_Alignment(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ExhaustiveDepsRule,
+		alignmentValid,
+		alignmentInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_boundary_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_boundary_test.go
@@ -395,10 +395,14 @@ var boundaryInvalid = []rule_tester.InvalidTestCase{
 	// Nested useEffect inside useEffect callback — mirrors upstream's
 	// `gatherDependenciesRecursively` walk, which descends into every
 	// child scope of the callback (including nested function bodies).
-	// The outer hook collects BOTH `inner` (captured transitively via
-	// the nested callback) AND `outer` as missing deps, producing one
-	// combined "missing dependencies: 'inner' and 'outer'" report.
-	// The inner hook is analyzed independently in its own listener pass.
+	// The outer hook's component scope is `MyComponent`, so it collects
+	// BOTH `outer` AND `inner` (the latter captured transitively by
+	// descending into the nested callback) into one combined report.
+	// The inner hook's component scope is the OUTER effect callback (the
+	// nearest enclosing function), and `inner` is declared above that in
+	// `MyComponent` — i.e. outside the inner hook's pure scope — so the
+	// inner hook reports nothing. This matches eslint-plugin-react-hooks
+	// v4 and v7 exactly (verified: both emit only the single 6:6 report).
 	{
 		Code: `
 			function MyComponent({ outer, inner }: { outer: number; inner: number }) {
@@ -411,9 +415,6 @@ var boundaryInvalid = []rule_tester.InvalidTestCase{
 		Tsx: true,
 		Errors: []rule_tester.InvalidTestCaseError{
 			{
-				// Outer effect's combined missing deps. The visitor fires
-				// the outer CallExpression listener before descending
-				// into the callback body, so this report comes first.
 				Message: "React Hook useEffect has missing dependencies: 'inner' and 'outer'. Either include them or remove the dependency array.",
 				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
 			function MyComponent({ outer, inner }: { outer: number; inner: number }) {
@@ -421,18 +422,6 @@ var boundaryInvalid = []rule_tester.InvalidTestCase{
 					console.log(outer);
 					useEffect(() => { console.log(inner); }, []);
 				}, [inner, outer]);
-			}
-		`}},
-			},
-			{
-				// Inner effect's missing dep, fired during the descent.
-				Message: "React Hook useEffect has a missing dependency: 'inner'. Either include it or remove the dependency array.",
-				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
-			function MyComponent({ outer, inner }: { outer: number; inner: number }) {
-				useEffect(() => {
-					console.log(outer);
-					useEffect(() => { console.log(inner); }, [inner]);
-				}, []);
 			}
 		`}},
 			},

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_extras_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_extras_test.go
@@ -66,13 +66,6 @@ var extrasValid = []rule_tester.ValidTestCase{
 		}
 	`, Tsx: true},
 
-	// `as` cast on a dep is allowed — should normalize to the underlying chain.
-	{Code: `
-		function MyComponent({ id }: { id: number }) {
-			useEffect(() => { console.log(id); }, [id as number]);
-		}
-	`, Tsx: true},
-
 	// Non-null assertion `!` on receiver inside the callback. Mirrors
 	// upstream: the dep key for `user!.name` is the receiver `user` (the
 	// NonNullExpression breaks the receiver walk in `getDependency`),
@@ -365,6 +358,27 @@ var extrasInvalid = []rule_tester.InvalidTestCase{
 				useEffect(() => { console.log((id as number) + 1); }, [id]);
 			}
 		`}}},
+		},
+	},
+
+	// `as` cast on a deps-array ELEMENT is a complex expression (upstream's
+	// analyzePropertyChain has no `as`/`satisfies` case so it throws); the
+	// underlying `id` is then a missing dependency. Matches v4/v7.
+	{
+		Code: `
+				function MyComponent({ id }: { id: number }) {
+					useEffect(() => { console.log(id); }, [id as number]);
+				}
+			`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "React Hook useEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `
+				function MyComponent({ id }: { id: number }) {
+					useEffect(() => { console.log(id); }, [id]);
+				}
+			`}}},
+			{Message: "React Hook useEffect has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked."},
 		},
 	},
 

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/rule.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/rule.go
@@ -317,17 +317,18 @@ func visitFunctionWithDependencies(
 		return
 	}
 
-	// Component scope = the nearest enclosing function-like that
-	// classifies as a React component or custom hook (PascalCase or
-	// `use*`). Walk past intermediate anonymous IIFEs / non-component
-	// closures (e.g. nested useEffect callbacks) so that a hook defined
-	// inside another hook's body still resolves component-scope props
-	// correctly. Mirrors upstream's `componentScope = currentScope`
-	// loop in `visitFunctionWithDependencies`.
+	// Component scope = the nearest enclosing function-like, whatever it is.
+	// Upstream's `visitFunctionWithDependencies` walks `scope.upper` to the
+	// first scope of `type === 'function'` and bails only when there is none;
+	// it deliberately does NOT require that function to be a PascalCase
+	// component or a `use*` Hook. Requiring that (the previous behavior) made
+	// the whole effect silently skip analysis whenever the component was made
+	// by a HOC the recognizer didn't know about — e.g. `observer(() => {...})`
+	// (mobx-react) — even though `forwardRef`/`memo` happened to be special-
+	// cased. Taking the bare enclosing function matches upstream for every
+	// wrapper and is consistent with `emitConstructionWarnings`, which already
+	// uses the unfiltered enclosing function.
 	componentFn := findEnclosingFunction(callback)
-	for componentFn != nil && !isComponentOrHookFunction(componentFn) {
-		componentFn = findEnclosingFunction(componentFn)
-	}
 	if componentFn == nil {
 		return
 	}
@@ -1105,7 +1106,7 @@ func parseDeclaredDeps(
 			}
 		}
 
-		key, ok := analyzePropertyChainText(el, nil)
+		key, ok := analyzeDepsArrayElement(el, nil)
 		if !ok {
 			// Literal value or complex expression. Mirrors upstream's full
 			// set of `Literal` value kinds — string, number, bigint, null,
@@ -1583,23 +1584,26 @@ func gatherDeps(
 	hasExtraWrite := func(s *ast.Symbol) bool {
 		return cachedHasExtraWrite(s, componentFn, tc, caches)
 	}
-	// Forward-declared so isFunctionWithoutCapturedValues can recurse
-	// through it for transitive function stability.
-	var stableForId func(id *ast.Node, sym *ast.Symbol) bool
-	stableForId = func(id *ast.Node, sym *ast.Symbol) bool {
+	// isStableKnownHookValue mirrors upstream's `isStableKnownHookValue`:
+	// the setter/dispatch from useState/useReducer/useTransition and the
+	// results of useRef/useMemo/useCallback (etc.). It deliberately does NOT
+	// treat a user-defined function-without-captured-values as stable — that
+	// is a separate classification (stableForId). The capture check inside
+	// `isFunctionWithoutCapturedValues` must use THIS predicate, because
+	// upstream "won't check functions deeper": a function whose only capture
+	// is another local function is itself not stable.
+	knownStableCache := map[*ast.Symbol]bool{}
+	isStableKnownHookValue := func(_ *ast.Node, sym *ast.Symbol) bool {
 		if sym == nil {
 			return false
 		}
-		if v, ok := stableSymCache[sym]; ok {
+		if v, ok := knownStableCache[sym]; ok {
 			return v
 		}
-		// Tag the symbol as in-progress to break recursion cycles
-		// (mutual recursion between two functions): treat as not-stable
-		// while we're still computing.
-		stableSymCache[sym] = false
+		knownStableCache[sym] = false
 		// Setter / dispatch from useState/useReducer/useTransition.
 		if _, ok := setStateCallSites[sym]; ok {
-			stableSymCache[sym] = true
+			knownStableCache[sym] = true
 			return true
 		}
 		if len(sym.Declarations) > 0 {
@@ -1615,35 +1619,47 @@ func gatherDeps(
 					vdNode = vdNode.Parent
 				}
 			}
-			stable, _ := isStableHookValue(vdNode, bindingId)
-			if stable {
+			if stable, _ := isStableHookValue(vdNode, bindingId); stable {
 				// Mirrors upstream's `writeCount > 1` gate: a stable hook
 				// binding that is reassigned anywhere is no longer stable.
 				if tc != nil && hasExtraWrite(sym) {
 					return false
 				}
-				stableSymCache[sym] = true
+				knownStableCache[sym] = true
 				return true
 			}
-			// Upstream's `isFunctionWithoutCapturedValues`: a user-defined
-			// function declared in component scope is stable iff it
-			// doesn't capture any non-stable variables from pure scope.
-			// We use the TypeChecker to resolve every Identifier inside
-			// the function body to its declaring symbol, then test each
-			// captured one against `stableForId` recursively. This mirrors
-			// upstream's `fnScope.through` walk (which we don't have access
-			// to without ESLint's scope manager).
-			//
-			// Reassignment guard: if the binding itself is reassigned
-			// elsewhere (e.g. `handler = somethingElse`), the resolved
-			// function may no longer point at our analyzed body. Mirrors
-			// upstream's `writeCount > 1` gate that disables the
-			// stable-function classification under reassignment.
-			if tc != nil && !hasExtraWrite(sym) {
-				if isFunctionWithoutCapturedValues(decl, componentFn, tc, stableForId) {
-					stableSymCache[sym] = true
-					return true
-				}
+		}
+		return false
+	}
+
+	// stableForId decides whether a directly-referenced value may be omitted
+	// from the deps array. A reference is stable if it's a known stable hook
+	// value, OR it's a user-defined function declared in component scope that
+	// doesn't capture any non-stable value (upstream's
+	// `isFunctionWithoutCapturedValues`). The capture check passes
+	// `isStableKnownHookValue` — NOT stableForId — so the classification does
+	// not recurse through other local functions, matching upstream exactly.
+	stableForId := func(id *ast.Node, sym *ast.Symbol) bool {
+		if sym == nil {
+			return false
+		}
+		if v, ok := stableSymCache[sym]; ok {
+			return v
+		}
+		stableSymCache[sym] = false
+		if isStableKnownHookValue(id, sym) {
+			stableSymCache[sym] = true
+			return true
+		}
+		// Reassignment guard: if the binding itself is reassigned elsewhere
+		// (e.g. `handler = somethingElse`), the resolved function may no
+		// longer point at our analyzed body. Mirrors upstream's
+		// `writeCount > 1` gate that disables the stable-function class.
+		if len(sym.Declarations) > 0 && tc != nil && !hasExtraWrite(sym) {
+			decl := sym.Declarations[0]
+			if isFunctionWithoutCapturedValues(decl, componentFn, tc, isStableKnownHookValue) {
+				stableSymCache[sym] = true
+				return true
 			}
 		}
 		return false
@@ -1714,16 +1730,8 @@ func processIdentifier(
 		ref        *depReference
 	},
 ) {
-	// Resolve.
-	var sym *ast.Symbol
-	if tc != nil {
-		if isObjectLiteralShorthandReference(id) {
-			sym = tc.GetShorthandAssignmentValueSymbol(id.Parent)
-		}
-		if sym == nil {
-			sym = tc.GetSymbolAtLocation(id)
-		}
-	}
+	// Resolve (shorthand-aware).
+	sym := resolveValueSymbol(tc, id)
 	// Determine if the symbol's declaration is in component scope (between
 	// callback exclusive and componentFn inclusive).
 	//
@@ -1845,12 +1853,15 @@ func processIdentifier(
 	dep.Refs = append(dep.Refs, ref)
 
 	if inCleanup {
-		if _, has := currentRefsInCleanup[key]; !has {
-			currentRefsInCleanup[key] = struct {
-				dependency string
-				ref        *depReference
-			}{dependency: key, ref: ref}
-		}
+		// Upstream keeps the LAST cleanup reference per dependency — its
+		// `currentRefsInEffectCleanup.set(dependency, …)` overwrites on every
+		// matching `ref.current` use, so the warning points at the final use
+		// inside the cleanup function. Always overwrite (the gather walk is in
+		// document order) rather than keeping the first occurrence.
+		currentRefsInCleanup[key] = struct {
+			dependency string
+			ref        *depReference
+		}{dependency: key, ref: ref}
 	}
 }
 
@@ -2038,17 +2049,18 @@ func isFunctionWithoutCapturedValues(
 			return true
 		}
 		if n.Kind == ast.KindIdentifier && isReferenceIdentifier(n) {
-			sym := tc.GetSymbolAtLocation(n)
+			sym := resolveValueSymbol(tc, n)
 			if sym != nil && len(sym.Declarations) > 0 {
 				d := sym.Declarations[0]
-				// Capture iff declaration is in component scope but
-				// outside fnNode itself. Self-reference (the function
-				// referencing its own binding) is allowed.
+				// Capture iff the declaration is in component scope but
+				// outside fnNode itself. This includes the function's own
+				// name when it recurses (`const f = () => { f() }`): the
+				// self-reference resolves to the component-scope binding, and
+				// upstream counts it as a capture, so a non-memoized recursive
+				// function is itself unstable. `isStable` is the non-recursive
+				// `isStableKnownHookValue`, so evaluating the self-reference
+				// here cannot loop.
 				if containsNode(componentFn, d) && !containsNode(fnNode, d) {
-					// Self-reference (recursion) — skip.
-					if d == decl {
-						return false
-					}
 					if !isStable(n, sym) {
 						captured = true
 						return true

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/exhaustive-deps.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/exhaustive-deps.test.ts
@@ -95,6 +95,18 @@ ruleTester.run('exhaustive-deps', {} as never, {
       `,
       options: [{ additionalHooks: '(useMyEffect)' }],
     },
+    // (alignment) a local function whose only captures are stable hook values
+    // is itself stable when used directly in an effect
+    {
+      code: `
+        function useNoCapture() {
+          const [s, setS] = useState(0);
+          const transform = (x) => x;
+          useEffect(() => { setS(transform(1)); }, []);
+          return s;
+        }
+      `,
+    },
   ],
   invalid: [
     // Missing dep
@@ -238,6 +250,99 @@ ruleTester.run('exhaustive-deps', {} as never, {
         {
           message:
             'Functions returned from `useEffectEvent` must not be included in the dependency array. Remove `onClick` from the list.',
+        },
+      ],
+    },
+    // (alignment) HOC wrapper (observer/mobx) does not gate analysis
+    {
+      code: `
+        const C = observer((props) => {
+          const [s, setS] = useState(0);
+          useEffect(() => { console.log(props.x); setS(1); }, []);
+          return null;
+        });
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'props.x'. Either include it or remove the dependency array.",
+        },
+      ],
+    },
+    // (alignment) reactive value captured only via object shorthand inside a local function
+    {
+      code: `
+        function useShorthand({ apId }) {
+          const [t, setT] = useState([]);
+          const fetchTree = () => { setT([{ apId }]); };
+          useEffect(() => { fetchTree(); }, []);
+          return t;
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'fetchTree'. Either include it or remove the dependency array.",
+        },
+      ],
+    },
+    // (alignment) local function is unstable when it calls another local function
+    {
+      code: `
+        function useCallsLocal({ apId }) {
+          const [t, setT] = useState([]);
+          const transform = (x) => [x];
+          const query = () => { setT(transform(apId)); };
+          useEffect(() => { query(); }, []);
+          return t;
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'query'. Either include it or remove the dependency array.",
+        },
+      ],
+    },
+    // (alignment) recursive local function is unstable (self-reference is a capture)
+    {
+      code: `
+        function useRecursive({ tree, id }) {
+          const findLabel = (data, target) => {
+            for (const node of data) {
+              if (node.id === target) return node.label;
+              if (node.children) { const r = findLabel(node.children, target); if (r) return r; }
+            }
+            return '';
+          };
+          return useMemo(() => findLabel(tree, id), [tree, id]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useMemo has a missing dependency: 'findLabel'. Either include it or remove the dependency array.",
+        },
+      ],
+    },
+    // (alignment) ref.current read multiple times in cleanup -> warning at the LAST occurrence
+    {
+      code: `
+        function useRefCleanup() {
+          const handleRef = useRef(null);
+          useEffect(() => {
+            handleRef.current?.addEventListener('a', () => {});
+            return () => {
+              handleRef.current?.removeEventListener('a', () => {});
+              handleRef.current?.removeEventListener('b', () => {});
+            };
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "The ref value 'handleRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'handleRef.current' to a variable inside the effect, and use that variable in the cleanup function.",
         },
       ],
     },


### PR DESCRIPTION
## Summary

Aligns `react-hooks/exhaustive-deps` output with `eslint-plugin-react-hooks`
(behavior verified identical between v4.6.2 and v7.1.1). Five divergences from
the upstream rule are fixed:

1. **HOC wrappers no longer gate analysis.** The rule required the enclosing
   function to be a recognized PascalCase component or `use*` hook (only
   `forwardRef`/`memo` were special-cased), so every effect inside
   `observer(() => {…})` (mobx-react) — or any other unrecognized HOC — was
   silently skipped. It now takes the nearest enclosing function as the
   component scope, mirroring upstream's `visitFunctionWithDependencies`.
2. **Object-literal shorthand captures.** A reactive value captured only via
   `{ x }` inside a local function was missed (the shorthand resolved to the
   property symbol instead of the outer binding), making the function look
   stable. It is now resolved through a shared shorthand-aware helper.
3. **Local-function stability.** The "function without captured values" check
   recursed through other local functions and skipped self-references, so a
   function that calls another local function (or recurses) was wrongly treated
   as stable. The capture check now uses only known-stable hook values
   (upstream "won't check functions deeper").
4. **ref-cleanup position.** When `ref.current` is read multiple times inside a
   cleanup function, the warning now points at the last occurrence (upstream
   overwrites per dependency), not the first.
5. **Dependency-array complex expressions.** `as` / `satisfies` / non-null
   assertions and non-optional computed access are now reported as "complex
   expressions"; optional computed access (`foo?.[bar]`) stays a valid chain.

### Validation

- Real-world monorepo: across **1157 hook-using files**, rslint now produces
  **749 findings identical to v7.1.1** — 0 false negatives, 0 false positives,
  0 position differences. Previously rslint matched only 22 of 81 stable
  findings (≈73% missed).
- Added Go + JS lock-in tests for each fix, and corrected two prior tests that
  had encoded the old divergent behavior (nested-effect scoping and the
  `[id as number]` element).

## Related Links

<!-- N/A -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
