### PR TITLE
fix: align no-unnecessary-condition `??` operand position with typescript-eslint

### DIFF
--- a/internal/plugins/typescript/rules/no_unnecessary_condition/edge_cases_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/edge_cases_test.go
@@ -562,7 +562,8 @@ func TestEdgeCases_DeepNesting(t *testing.T) {
 		{
 			Code: "declare const a: string;\ndeclare const b: string | null;\nconst x = (a ?? 'x') ?? b;\n",
 			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "neverNullish", Line: 3, Column: 11},
+				// outer `??` LHS `(a ?? 'x')` anchors at `a` (col 12), not `(`, matching upstream's paren-less ESTree node
+				{MessageId: "neverNullish", Line: 3, Column: 12},
 				{MessageId: "neverNullish", Line: 3, Column: 12},
 			},
 		},

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -461,6 +461,11 @@ var NoUnnecessaryConditionRule = rule.CreateRule(rule.Rule{
 		}
 
 		checkNodeForNullish := func(node *ast.Node) {
+			// Match upstream: the rule operates on the ESTree node, which has no
+			// parenthesized-expression wrapper, so `(x) ?? y` reports on `x`.
+			// tsgo's AST keeps ParenthesizedExpression nodes, so skip them to
+			// align the reported range with typescript-eslint (mirrors checkNode).
+			node = ast.SkipParentheses(node)
 			t := utils.GetConstrainedTypeAtLocation(tc, node)
 
 			// Conditional is always necessary if it involves any, unknown, or type parameter


### PR DESCRIPTION
## Summary

`@typescript-eslint/no-unnecessary-condition`'s nullish checks (`??` / `??=`)
reported on the **raw left operand**, so a parenthesized operand like
`(x) ?? y` anchored the diagnostic (and the suggestion fix range) at `(` and
included the trailing `)`. typescript-eslint runs on the ESTree AST, which has
no parenthesized-expression node, so upstream reports on `x`.

tsgo's AST keeps `ParenthesizedExpression` nodes, so `checkNodeForNullish` now
calls `ast.SkipParentheses(node)` at its top — mirroring what `checkNode`
already does — so `(x) ?? y` reports on `x`, matching upstream exactly.

Differentially validated against **@typescript-eslint v8.62** over 60 real
packages: this removes **33 position-only false positives** (`(X) ?? Y`
`neverNullish` reported one column wider on each side), with **no regressions**
and **zero genuine over-reports remaining**. The ported typescript-eslint
conformance suite and the Go unit tests both pass; one Go edge case
(`(a ?? 'x') ?? b`) had its expected column corrected from 11 (the `(`) to 12
(the operand), confirmed against v8.62.

## Related Links

<!-- Found via a real-repo differential against the @typescript-eslint v8.62 oracle; no tracking issue. -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).