### PR TITLE
chore: drop stale references to removed bin/rslint binary path

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -1,5 +1,4 @@
 {
-  "rslint.binPath": "./packages/rslint/bin/rslint",
   "rslint.enable": true,
   "[json]": {
     "editor.tabSize": 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,11 +42,11 @@ After building, you can test the rslint CLI:
 
 ```bash
 # Test the binary
-./packages/rslint/bin/rslint --help
+./packages/rslint/bin/rslint.cjs --help
 
 
 # Lint the project itself
-./packages/rslint/bin/rslint --config rslint.json
+./packages/rslint/bin/rslint.cjs
 ```
 
 ## Debugging VSCode Extension


### PR DESCRIPTION
## Summary

The CLI entry point is `bin/rslint.cjs`; the bare `bin/rslint` binary is no longer produced by the build, so the docs and config that still referenced it were broken in a clean checkout:

- **`CONTRIBUTING.md`** — switched the example commands to `./packages/rslint/bin/rslint.cjs`, and dropped the non-existent `--config rslint.json` (`rslint.config.ts` is auto-discovered).
- **`.vscode/settings.template.json`** — `rslint.binPath` is an enum (`local` | `built-in` | `custom`), not a file path. The stale `"./packages/rslint/bin/rslint"` value matched none of the branches, leaving the language server with a null binary path. Removed the line so it falls back to the `built-in` default.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required). — not required (docs/config cleanup, no code logic change)
- [x] Documentation updated (or not required). — `CONTRIBUTING.md` updated
