### PR TITLE
ci: list explicit go.sum paths to fix hashFiles timeout on self-hosted Windows

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -22,13 +22,22 @@ runs:
         go-version: ${{ inputs.go-version }}
         cache: false
 
+    # Enumerate go.sum paths explicitly rather than '**/go.sum': the recursive
+    # glob walks the entire working tree (~240k files — node_modules + the
+    # typescript-go submodule's testdata) just to find the go.sum files, which
+    # exceeds hashFiles' 120s evaluation limit on the self-hosted Windows runner
+    # and fails the cache post-step. The explicit list scans only shim/ (~75
+    # files) plus two direct stats, covering every go.sum that feeds the module
+    # cache (root + shim modules + the typescript-go submodule's main module).
+    # typescript-go uses an exact path, not 'typescript-go/**/go.sum', since
+    # that glob would walk the submodule's ~152k testdata files all over again.
     - name: Go cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       if: runner.environment == 'github-hosted'
       with:
-        key: setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('**/go.sum') }}
+        key: setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('go.sum', 'shim/**/go.sum', 'typescript-go/go.sum') }}
         restore-keys: |
-          setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('**/go.sum') }}
+          setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('go.sum', 'shim/**/go.sum', 'typescript-go/go.sum') }}
         # Only cache module downloads, not build cache (GOCACHE is too large
         # and fills up disk on self-hosted runners)
         path: |
@@ -38,9 +47,9 @@ runs:
       uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
       if: runner.environment == 'self-hosted'
       with:
-        key: setup-go-SH-2-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('**/go.sum') }}
+        key: setup-go-SH-2-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('go.sum', 'shim/**/go.sum', 'typescript-go/go.sum') }}
         restore-keys: |
-          setup-go-SH-2-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('**/go.sum') }}
+          setup-go-SH-2-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('go.sum', 'shim/**/go.sum', 'typescript-go/go.sum') }}
         # Only cache module downloads, not build cache (GOCACHE is too large
         # and fills up disk on self-hosted runners)
         path: |


### PR DESCRIPTION
## Summary

Several recent `main` commits show a red CI on the **Test npm packages (rspack-windows-2022-large)** job, with the `Post Setup Go` step failing:

> The template is not valid. ... `hashFiles('**/go.sum')` couldn't finish within 120 seconds.

**Root cause:** `hashFiles('**/go.sum')` in `setup-go/action.yml` recursively walks the entire working tree to locate go.sum files. On this self-hosted Windows runner the tree holds ~240k files (`node_modules` ~90k + the `typescript-go` submodule's testdata ~152k) for only a couple dozen actual go.sum files, blowing past hashFiles' built-in 120s evaluation limit and failing the cache post-step.

**Fix:** Enumerate the go.sum paths explicitly — `go.sum`, `shim/**/go.sum`, `typescript-go/go.sum`. This scans only `shim/` (~75 files) plus two direct stats, covering every go.sum that feeds the module cache (`~/go/pkg/mod`) without the full-tree walk. Applies to all workflows that use this composite action.

Two deliberate choices:

- `typescript-go` uses an exact path rather than `typescript-go/**/go.sum` — that glob would re-walk the submodule's ~152k testdata files and reintroduce the timeout. `shim/**` stays a glob because that subtree is only ~75 files.
- `typescript-go/_tools/go.sum` is excluded — it is not in `go.work` and never feeds rslint's build cache, so hashing it would only cause spurious cache invalidation.

> [!NOTE]
> This PR addresses the `Post Setup Go` failure class only. The same Windows job also has an independent, intermittent `worker-pool-e2e-lifecycle.test.ts` (U11) timeout that is tracked separately.

## Related Links

- Failing run (`Post Setup Go`): https://github.com/web-infra-dev/rslint/actions/runs/28079526220

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
