### PR TITLE
feat(eslint-plugin-jest): add `prefer-jest-mocked` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -25,6 +25,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_expect_resolves"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_hooks_in_order"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_hooks_on_top"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_jest_mocked"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_strict_equal"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_be"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_contain"
@@ -64,6 +65,7 @@ func GetAllRules() []rule.Rule {
 		prefer_expect_resolves.PreferExpectResolvesRule,
 		prefer_hooks_in_order.PreferHooksInOrderRule,
 		prefer_hooks_on_top.PreferHooksOnTopRule,
+		prefer_jest_mocked.PreferJestMockedRule,
 		prefer_strict_equal.PreferStrictEqualRule,
 		prefer_to_be.PreferToBeRule,
 		prefer_to_contain.PreferToContainRule,

--- a/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.go
+++ b/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.go
@@ -1,0 +1,91 @@
+package prefer_jest_mocked
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildUseJestMockedMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "useJestMocked",
+		Description: "Prefer `jest.mocked()` over type assertions",
+	}
+}
+
+func isJestMockType(typeNode *ast.Node) bool {
+	if typeNode == nil || typeNode.Kind != ast.KindTypeReference {
+		return false
+	}
+
+	typeRef := typeNode.AsTypeReferenceNode()
+	if typeRef == nil || typeRef.TypeName == nil || typeRef.TypeName.Kind != ast.KindQualifiedName {
+		return false
+	}
+
+	qualifiedName := typeRef.TypeName.AsQualifiedName()
+	if qualifiedName == nil ||
+		qualifiedName.Left == nil ||
+		qualifiedName.Left.Kind != ast.KindIdentifier ||
+		qualifiedName.Right == nil ||
+		qualifiedName.Right.Kind != ast.KindIdentifier {
+		return false
+	}
+
+	if qualifiedName.Left.AsIdentifier().Text != "jest" {
+		return false
+	}
+
+	switch qualifiedName.Right.AsIdentifier().Text {
+	case "Mock", "MockedFunction", "MockedClass", "MockedObject":
+		return true
+	default:
+		return false
+	}
+}
+
+func reportJestMockedAssertion(ctx rule.RuleContext, assertionNode *ast.Node, expression *ast.Node) {
+	innerExpression := ast.SkipOuterExpressions(expression, ast.OEKTypeAssertions)
+	fnName := utils.TrimmedNodeText(ctx.SourceFile, innerExpression)
+
+	ctx.ReportNodeWithFixes(
+		assertionNode,
+		buildUseJestMockedMessage(),
+		rule.RuleFixReplace(ctx.SourceFile, assertionNode, "jest.mocked("+fnName+")"),
+	)
+}
+
+func checkJestMockAssertion(ctx rule.RuleContext, node *ast.Node, typeNode, expression *ast.Node) {
+	if node.Kind == ast.KindAsExpression {
+		if parent := node.Parent; parent != nil && parent.Kind == ast.KindAsExpression {
+			return
+		}
+	}
+	if !isJestMockType(typeNode) {
+		return
+	}
+
+	reportJestMockedAssertion(ctx, node, expression)
+}
+
+var PreferJestMockedRule = rule.Rule{
+	Name: "jest/prefer-jest-mocked",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindAsExpression: func(node *ast.Node) {
+				asExpression := node.AsAsExpression()
+				if asExpression == nil {
+					return
+				}
+				checkJestMockAssertion(ctx, node, asExpression.Type, asExpression.Expression)
+			},
+			ast.KindTypeAssertionExpression: func(node *ast.Node) {
+				typeAssertion := node.AsTypeAssertion()
+				if typeAssertion == nil {
+					return
+				}
+				checkJestMockAssertion(ctx, node, typeAssertion.Type, typeAssertion.Expression)
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.go
+++ b/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.go
@@ -45,7 +45,7 @@ func isJestMockType(typeNode *ast.Node) bool {
 }
 
 func reportJestMockedAssertion(ctx rule.RuleContext, assertionNode *ast.Node, expression *ast.Node) {
-	innerExpression := ast.SkipOuterExpressions(expression, ast.OEKTypeAssertions)
+	innerExpression := ast.SkipOuterExpressions(expression, ast.OEKParentheses|ast.OEKTypeAssertions)
 	fnName := utils.TrimmedNodeText(ctx.SourceFile, innerExpression)
 
 	ctx.ReportNodeWithFixes(
@@ -57,7 +57,7 @@ func reportJestMockedAssertion(ctx rule.RuleContext, assertionNode *ast.Node, ex
 
 func checkJestMockAssertion(ctx rule.RuleContext, node *ast.Node, typeNode, expression *ast.Node) {
 	if node.Kind == ast.KindAsExpression {
-		if parent := node.Parent; parent != nil && parent.Kind == ast.KindAsExpression {
+		if parent := ast.WalkUpParenthesizedExpressions(node.Parent); parent != nil && parent.Kind == ast.KindAsExpression {
 			return
 		}
 	}

--- a/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.md
+++ b/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.md
@@ -1,0 +1,41 @@
+# prefer-jest-mocked
+
+## Rule Details
+
+Prefer `jest.mocked()` over type assertions such as `fn as jest.Mock` when
+working with mocked functions in Jest. The `jest.mocked()` helper preserves
+correct mock typings without manual casts, which improves type safety and keeps
+mock setup easier to read.
+
+This rule reports type assertions and angle-bracket casts to Jest mock types,
+including chained assertions like `as unknown as jest.Mock`. It is fixable.
+
+Restricted types:
+
+- `jest.Mock`
+- `jest.MockedFunction`
+- `jest.MockedClass`
+- `jest.MockedObject`
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+(foo as jest.Mock).mockReturnValue(1);
+const mock = (foo as jest.Mock).mockReturnValue(1);
+(foo as unknown as jest.Mock).mockReturnValue(1);
+(Obj.foo as jest.Mock).mockReturnValue(1);
+([].foo as jest.Mock).mockReturnValue(1);
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+jest.mocked(foo).mockReturnValue(1);
+const mock = jest.mocked(foo).mockReturnValue(1);
+jest.mocked(Obj.foo).mockReturnValue(1);
+jest.mocked([].foo).mockReturnValue(1);
+```
+
+## Original Documentation
+
+- [jest/prefer-jest-mocked](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-jest-mocked.md)

--- a/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked_test.go
+++ b/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked_test.go
@@ -1,0 +1,203 @@
+package prefer_jest_mocked_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_jest_mocked"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferJestMockedRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_jest_mocked.PreferJestMockedRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `foo();`},
+			{Code: `jest.mocked(foo).mockReturnValue(1);`},
+			{Code: `bar.mockReturnValue(1);`},
+			{Code: `sinon.stub(foo).returns(1);`},
+			{Code: `foo.mockImplementation(() => 1);`},
+			{Code: `obj.foo();`},
+			{Code: `mockFn.mockReturnValue(1);`},
+			{Code: `arr[0]();`},
+			{Code: `obj.foo.mockReturnValue(1);`},
+			{Code: `jest.spyOn(obj, 'foo').mockReturnValue(1);`},
+			{Code: `(foo as Mock.jest).mockReturnValue(1);`},
+			{Code: `
+      type MockType = jest.Mock;
+      const mockFn = jest.fn();
+      (mockFn as MockType).mockReturnValue(1);
+    `},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `(foo as jest.Mock).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:   `(foo as unknown as string as unknown as jest.Mock).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 50},
+				},
+			},
+			{
+				Code:   `(foo as unknown as jest.Mock as unknown as jest.Mock).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 53},
+				},
+			},
+			{
+				Code:   `(<jest.Mock>foo).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code:   `(foo as jest.Mock).mockImplementation(1);`,
+				Output: []string{`(jest.mocked(foo)).mockImplementation(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:   `(foo as unknown as jest.Mock).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 29},
+				},
+			},
+			{
+				Code:   `(<jest.Mock>foo as unknown).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(foo) as unknown).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code:   `(Obj.foo as jest.Mock).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(Obj.foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				Code:   `([].foo as jest.Mock).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked([].foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code:   `(foo as jest.MockedFunction).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				Code:   `(foo as jest.MockedFunction).mockImplementation(1);`,
+				Output: []string{`(jest.mocked(foo)).mockImplementation(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				Code:   `(foo as unknown as jest.MockedFunction).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 39},
+				},
+			},
+			{
+				Code:   `(Obj.foo as jest.MockedFunction).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(Obj.foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 32},
+				},
+			},
+			{
+				Code:   `(new Array(0).fill(null).foo as jest.MockedFunction).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(new Array(0).fill(null).foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 52},
+				},
+			},
+			{
+				Code:   `(jest.fn(() => foo) as jest.MockedFunction).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(jest.fn(() => foo))).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 43},
+				},
+			},
+			{
+				Code:   `const mockedUseFocused = useFocused as jest.MockedFunction<typeof useFocused>;`,
+				Output: []string{`const mockedUseFocused = jest.mocked(useFocused);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 26, EndLine: 1, EndColumn: 78},
+				},
+			},
+			{
+				Code:   `const filter = (MessageService.getMessage as jest.Mock).mock.calls[0][0];`,
+				Output: []string{`const filter = (jest.mocked(MessageService.getMessage)).mock.calls[0][0];`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 17, EndLine: 1, EndColumn: 55},
+				},
+			},
+			{
+				Code: `class A {}
+(foo as jest.MockedClass<A>)
+`,
+				Output: []string{`class A {}
+(jest.mocked(foo))
+`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 2, Column: 2, EndLine: 2, EndColumn: 28},
+				},
+			},
+			{
+				Code:   `(foo as jest.MockedObject<{method: () => void}>)`,
+				Output: []string{`(jest.mocked(foo))`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 48},
+				},
+			},
+			{
+				Code:   `(Obj['foo'] as jest.MockedFunction).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(Obj['foo'])).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 35},
+				},
+			},
+			{
+				Code: `(
+  new Array(100)
+    .fill(undefined)
+    .map(x => x.value)
+    .filter(v => !!v).myProperty as jest.MockedFunction<{
+    method: () => void;
+  }>
+).mockReturnValue(1);
+`,
+				Output: []string{`(
+  jest.mocked(new Array(100)
+    .fill(undefined)
+    .map(x => x.value)
+    .filter(v => !!v).myProperty)
+).mockReturnValue(1);
+`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 2, Column: 3, EndLine: 7, EndColumn: 5},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked_test.go
+++ b/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked_test.go
@@ -31,6 +31,7 @@ func TestPreferJestMockedRule(t *testing.T) {
       const mockFn = jest.fn();
       (mockFn as MockType).mockReturnValue(1);
     `},
+			{Code: `((foo as jest.Mock) as unknown).mockReturnValue(1);`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
@@ -48,6 +49,13 @@ func TestPreferJestMockedRule(t *testing.T) {
 				},
 			},
 			{
+				Code:   `((foo as unknown) as jest.Mock).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
 				Code:   `(foo as unknown as jest.Mock as unknown as jest.Mock).mockReturnValue(1);`,
 				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
 				Errors: []rule_tester.InvalidTestCaseError{
@@ -59,6 +67,13 @@ func TestPreferJestMockedRule(t *testing.T) {
 				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code:   `(((foo)) as jest.Mock).mockReturnValue(1);`,
+				Output: []string{`(jest.mocked(foo)).mockReturnValue(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useJestMocked", Line: 1, Column: 2, EndLine: 1, EndColumn: 22},
 				},
 			},
 			{

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -490,6 +490,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/prefer-expect-resolves.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-hooks-in-order.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-hooks-on-top.test.ts',
+    './tests/eslint-plugin-jest/rules/prefer-jest-mocked.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-strict-equal.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-be.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-contain.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-jest-mocked.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-jest-mocked.test.ts
@@ -1,0 +1,344 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-jest-mocked', {} as never, {
+  valid: [
+    { code: 'foo();' },
+    { code: 'jest.mocked(foo).mockReturnValue(1);' },
+    { code: 'bar.mockReturnValue(1);' },
+    { code: 'sinon.stub(foo).returns(1);' },
+    { code: 'foo.mockImplementation(() => 1);' },
+    { code: 'obj.foo();' },
+    { code: 'mockFn.mockReturnValue(1);' },
+    { code: `arr[0]();` },
+    { code: 'obj.foo.mockReturnValue(1);' },
+    { code: `jest.spyOn(obj, 'foo').mockReturnValue(1);` },
+    { code: '(foo as Mock.jest).mockReturnValue(1);' },
+    {
+      code: `
+      type MockType = jest.Mock;
+      const mockFn = jest.fn();
+      (mockFn as MockType).mockReturnValue(1);
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `(foo as jest.Mock).mockReturnValue(1);`,
+      output: `(jest.mocked(foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 18,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(foo as unknown as string as unknown as jest.Mock).mockReturnValue(1);`,
+      output: `(jest.mocked(foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 50,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(foo as unknown as jest.Mock as unknown as jest.Mock).mockReturnValue(1);`,
+      output: `(jest.mocked(foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 53,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(<jest.Mock>foo).mockReturnValue(1);`,
+      output: `(jest.mocked(foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 16,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(foo as jest.Mock).mockImplementation(1);`,
+      output: `(jest.mocked(foo)).mockImplementation(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 18,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(foo as unknown as jest.Mock).mockReturnValue(1);`,
+      output: `(jest.mocked(foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 29,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(<jest.Mock>foo as unknown).mockReturnValue(1);`,
+      output: `(jest.mocked(foo) as unknown).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 16,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(Obj.foo as jest.Mock).mockReturnValue(1);`,
+      output: `(jest.mocked(Obj.foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 22,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `([].foo as jest.Mock).mockReturnValue(1);`,
+      output: `(jest.mocked([].foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 21,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(foo as jest.MockedFunction).mockReturnValue(1);`,
+      output: `(jest.mocked(foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 28,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(foo as jest.MockedFunction).mockImplementation(1);`,
+      output: `(jest.mocked(foo)).mockImplementation(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 28,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(foo as unknown as jest.MockedFunction).mockReturnValue(1);`,
+      output: `(jest.mocked(foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 39,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(Obj.foo as jest.MockedFunction).mockReturnValue(1);`,
+      output: `(jest.mocked(Obj.foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 32,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(new Array(0).fill(null).foo as jest.MockedFunction).mockReturnValue(1);`,
+      output: `(jest.mocked(new Array(0).fill(null).foo)).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 52,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(jest.fn(() => foo) as jest.MockedFunction).mockReturnValue(1);`,
+      output: `(jest.mocked(jest.fn(() => foo))).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 43,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `const mockedUseFocused = useFocused as jest.MockedFunction<typeof useFocused>;`,
+      output: `const mockedUseFocused = jest.mocked(useFocused);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 26,
+          line: 1,
+          endColumn: 78,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `const filter = (MessageService.getMessage as jest.Mock).mock.calls[0][0];`,
+      output: `const filter = (jest.mocked(MessageService.getMessage)).mock.calls[0][0];`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 17,
+          line: 1,
+          endColumn: 55,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        class A {}
+        (foo as jest.MockedClass<A>)
+      `,
+      output: `
+        class A {}
+        (jest.mocked(foo))
+      `,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 2,
+          endColumn: 28,
+          endLine: 2,
+        },
+      ],
+    },
+    {
+      code: `(foo as jest.MockedObject<{method: () => void}>)`,
+      output: `(jest.mocked(foo))`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 48,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `(Obj['foo'] as jest.MockedFunction).mockReturnValue(1);`,
+      output: `(jest.mocked(Obj['foo'])).mockReturnValue(1);`,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 2,
+          line: 1,
+          endColumn: 35,
+          endLine: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        (
+          new Array(100)
+            .fill(undefined)
+            .map(x => x.value)
+            .filter(v => !!v).myProperty as jest.MockedFunction<{
+            method: () => void;
+          }>
+        ).mockReturnValue(1);
+      `,
+      output: `
+        (
+          jest.mocked(new Array(100)
+            .fill(undefined)
+            .map(x => x.value)
+            .filter(v => !!v).myProperty)
+        ).mockReturnValue(1);
+      `,
+      options: [],
+      errors: [
+        {
+          messageId: 'useJestMocked',
+          column: 3,
+          line: 2,
+          endColumn: 5,
+          endLine: 7,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-jest-mocked.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-jest-mocked.test.ts
@@ -1,21 +1,23 @@
 import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
+const filename = 'src/virtual.ts';
 
 ruleTester.run('prefer-jest-mocked', {} as never, {
   valid: [
-    { code: 'foo();' },
-    { code: 'jest.mocked(foo).mockReturnValue(1);' },
-    { code: 'bar.mockReturnValue(1);' },
-    { code: 'sinon.stub(foo).returns(1);' },
-    { code: 'foo.mockImplementation(() => 1);' },
-    { code: 'obj.foo();' },
-    { code: 'mockFn.mockReturnValue(1);' },
-    { code: `arr[0]();` },
-    { code: 'obj.foo.mockReturnValue(1);' },
-    { code: `jest.spyOn(obj, 'foo').mockReturnValue(1);` },
-    { code: '(foo as Mock.jest).mockReturnValue(1);' },
+    { code: 'foo();', filename },
+    { code: 'jest.mocked(foo).mockReturnValue(1);', filename },
+    { code: 'bar.mockReturnValue(1);', filename },
+    { code: 'sinon.stub(foo).returns(1);', filename },
+    { code: 'foo.mockImplementation(() => 1);', filename },
+    { code: 'obj.foo();', filename },
+    { code: 'mockFn.mockReturnValue(1);', filename },
+    { code: `arr[0]();`, filename },
+    { code: 'obj.foo.mockReturnValue(1);', filename },
+    { code: `jest.spyOn(obj, 'foo').mockReturnValue(1);`, filename },
+    { code: '(foo as Mock.jest).mockReturnValue(1);', filename },
     {
+      filename,
       code: `
       type MockType = jest.Mock;
       const mockFn = jest.fn();
@@ -25,6 +27,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
   ],
   invalid: [
     {
+      filename,
       code: `(foo as jest.Mock).mockReturnValue(1);`,
       output: `(jest.mocked(foo)).mockReturnValue(1);`,
       options: [],
@@ -39,6 +42,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(foo as unknown as string as unknown as jest.Mock).mockReturnValue(1);`,
       output: `(jest.mocked(foo)).mockReturnValue(1);`,
       options: [],
@@ -53,6 +57,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(foo as unknown as jest.Mock as unknown as jest.Mock).mockReturnValue(1);`,
       output: `(jest.mocked(foo)).mockReturnValue(1);`,
       options: [],
@@ -67,6 +72,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(<jest.Mock>foo).mockReturnValue(1);`,
       output: `(jest.mocked(foo)).mockReturnValue(1);`,
       options: [],
@@ -81,6 +87,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(foo as jest.Mock).mockImplementation(1);`,
       output: `(jest.mocked(foo)).mockImplementation(1);`,
       options: [],
@@ -95,6 +102,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(foo as unknown as jest.Mock).mockReturnValue(1);`,
       output: `(jest.mocked(foo)).mockReturnValue(1);`,
       options: [],
@@ -109,6 +117,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(<jest.Mock>foo as unknown).mockReturnValue(1);`,
       output: `(jest.mocked(foo) as unknown).mockReturnValue(1);`,
       options: [],
@@ -123,6 +132,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(Obj.foo as jest.Mock).mockReturnValue(1);`,
       output: `(jest.mocked(Obj.foo)).mockReturnValue(1);`,
       options: [],
@@ -137,6 +147,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `([].foo as jest.Mock).mockReturnValue(1);`,
       output: `(jest.mocked([].foo)).mockReturnValue(1);`,
       options: [],
@@ -151,6 +162,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(foo as jest.MockedFunction).mockReturnValue(1);`,
       output: `(jest.mocked(foo)).mockReturnValue(1);`,
       options: [],
@@ -165,6 +177,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(foo as jest.MockedFunction).mockImplementation(1);`,
       output: `(jest.mocked(foo)).mockImplementation(1);`,
       options: [],
@@ -179,6 +192,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(foo as unknown as jest.MockedFunction).mockReturnValue(1);`,
       output: `(jest.mocked(foo)).mockReturnValue(1);`,
       options: [],
@@ -193,6 +207,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(Obj.foo as jest.MockedFunction).mockReturnValue(1);`,
       output: `(jest.mocked(Obj.foo)).mockReturnValue(1);`,
       options: [],
@@ -207,6 +222,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(new Array(0).fill(null).foo as jest.MockedFunction).mockReturnValue(1);`,
       output: `(jest.mocked(new Array(0).fill(null).foo)).mockReturnValue(1);`,
       options: [],
@@ -221,6 +237,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(jest.fn(() => foo) as jest.MockedFunction).mockReturnValue(1);`,
       output: `(jest.mocked(jest.fn(() => foo))).mockReturnValue(1);`,
       options: [],
@@ -235,6 +252,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `const mockedUseFocused = useFocused as jest.MockedFunction<typeof useFocused>;`,
       output: `const mockedUseFocused = jest.mocked(useFocused);`,
       options: [],
@@ -249,6 +267,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `const filter = (MessageService.getMessage as jest.Mock).mock.calls[0][0];`,
       output: `const filter = (jest.mocked(MessageService.getMessage)).mock.calls[0][0];`,
       options: [],
@@ -263,6 +282,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `
         class A {}
         (foo as jest.MockedClass<A>)
@@ -283,6 +303,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(foo as jest.MockedObject<{method: () => void}>)`,
       output: `(jest.mocked(foo))`,
       options: [],
@@ -297,6 +318,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `(Obj['foo'] as jest.MockedFunction).mockReturnValue(1);`,
       output: `(jest.mocked(Obj['foo'])).mockReturnValue(1);`,
       options: [],
@@ -311,6 +333,7 @@ ruleTester.run('prefer-jest-mocked', {} as never, {
       ],
     },
     {
+      filename,
       code: `
         (
           new Array(100)


### PR DESCRIPTION
## Summary

Port `prefer-jest-mocked` from eslint-plugin-jest to rslint

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/prefer-jest-mocked [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-jest-mocked.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/prefer-jest-mocked.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
