### PR TITLE
fix: reduce lint errors

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -49,6 +49,9 @@ func NewAstInfoBuilder(c *checker.Checker, sf *ast.SourceFile) *AstInfoBuilder {
 
 // Application-level message kinds handled by this service. The transport-
 // level kinds (response/error/handshake/exit) live in internal/ipc.
+//
+// NOTE: these structs mirror RslintMessageMap in packages/rslint/src/types.ts;
+// keep both sides in sync when changing a field or adding a Kind*.
 const (
 	// KindLint is sent from JS to Go to request linting.
 	KindLint ipc.MessageKind = "lint"
@@ -61,18 +64,18 @@ const (
 // Version is the IPC protocol version.
 const Version = "1.0.0"
 
-// HandshakeRequest represents a handshake request
+// HandshakeRequest represents a handshake request.
 type HandshakeRequest struct {
 	Version string `json:"version"`
 }
 
-// HandshakeResponse represents a handshake response
+// HandshakeResponse represents a handshake response.
 type HandshakeResponse struct {
 	Version string `json:"version"`
 	OK      bool   `json:"ok"`
 }
 
-// LintRequest represents a lint request from JS to Go
+// LintRequest represents a lint request from JS to Go.
 type LintRequest struct {
 	Files            []string `json:"files,omitempty"`
 	Config           string   `json:"config,omitempty"` // Path to rslint.json config file
@@ -118,7 +121,7 @@ type ParserOptions struct {
 }
 type ByteArray []byte
 
-// LintResponse represents a lint response from Go to JS
+// LintResponse represents a lint response from Go to JS.
 type LintResponse struct {
 	Diagnostics        []Diagnostic         `json:"diagnostics"`
 	ErrorCount         int                  `json:"errorCount"`
@@ -127,13 +130,13 @@ type LintResponse struct {
 	EncodedSourceFiles map[string]ByteArray `json:"encodedSourceFiles,omitempty"`
 }
 
-// ApplyFixesRequest represents a request to apply fixes from JS to Go
+// ApplyFixesRequest represents a request to apply fixes from JS to Go.
 type ApplyFixesRequest struct {
 	FileContent string       `json:"fileContent"` // Current content of the file
 	Diagnostics []Diagnostic `json:"diagnostics"` // Diagnostics with fixes to apply
 }
 
-// ApplyFixesResponse represents a response after applying fixes
+// ApplyFixesResponse represents a response after applying fixes.
 type ApplyFixesResponse struct {
 	FixedContent   []string `json:"fixedContent"`   // The content after applying fixes (array of intermediate versions)
 	WasFixed       bool     `json:"wasFixed"`       // Whether any fixes were actually applied

--- a/internal/inspector/types.go
+++ b/internal/inspector/types.go
@@ -5,7 +5,11 @@ package inspector
 // Request/Response Types
 // ============================================================================
 
-// GetAstInfoRequest represents a request for AST info at a specific position
+// GetAstInfoRequest represents a request for AST info at a specific position.
+//
+// NOTE: this struct and the types below it (GetAstInfoResponse, NodeInfo,
+// TypeInfo, SymbolInfo, SignatureInfo, FlowInfo) mirror their namesakes in
+// packages/rslint/src/types.ts; keep both sides in sync.
 type GetAstInfoRequest struct {
 	FileContent     string         `json:"fileContent"`               // Source code content
 	Position        int            `json:"position"`                  // Start position (pos)

--- a/internal/ipc/frame.go
+++ b/internal/ipc/frame.go
@@ -35,6 +35,9 @@ const maxFrameSize = 256 * 1024 * 1024 // 256 MiB
 // protocol-level kinds below; application kinds (e.g. task dispatch,
 // output, log) are declared by the layers above and travel through the
 // same opaque envelope.
+//
+// NOTE: mirrored by the `MessageKind`/`RslintMessageMap` union in
+// packages/rslint/src/types.ts; keep both sides in sync.
 type MessageKind string
 
 const (
@@ -68,8 +71,8 @@ func (m *Message) Decode(v any) error {
 	return nil
 }
 
-// ErrorResponseData is the canonical body of an `error` frame. Mirrors the
-// Node side's ErrorResponseData.
+// ErrorResponseData is the canonical body of an `error` frame. Mirrors
+// ErrorResponseData in packages/rslint/src/types.ts — keep in sync.
 type ErrorResponseData struct {
 	Message string `json:"message"`
 }

--- a/packages/rslint-wasm/src/index.ts
+++ b/packages/rslint-wasm/src/index.ts
@@ -1,7 +1,9 @@
 import { BrowserRslintService } from '@rslint/core/browser';
 import { RSLintService, Diagnostic } from '@rslint/core/service';
+
 declare const WEB_WORKER_SOURCE_CODE: string;
-async function initialize(options: { wasmURL: string }) {
+
+function initialize(options: { wasmURL: string }) {
   const blob = new Blob([WEB_WORKER_SOURCE_CODE], { type: 'text/javascript' });
   const service = new RSLintService(
     new BrowserRslintService({

--- a/packages/rslint/src/browser.ts
+++ b/packages/rslint/src/browser.ts
@@ -5,6 +5,9 @@ import type {
   RSlintOptions,
   PendingMessage,
   IpcMessage,
+  MessageKind,
+  RslintMessageMap,
+  ErrorResponseData,
 } from './types.js';
 
 /**
@@ -35,7 +38,7 @@ export class BrowserRslintService implements RslintServiceInterface {
   /**
    * Initialize the web worker
    */
-  private async ensureWorker(wasmUrl: string): Promise<Worker> {
+  private ensureWorker(wasmUrl: string): Worker {
     if (!this.worker) {
       this.worker = new Worker(this.workerUrl, { name: 'rslint-worker.js' });
 
@@ -135,13 +138,19 @@ export class BrowserRslintService implements RslintServiceInterface {
   /**
    * Send a message to the worker
    */
-  async sendMessage(kind: string, data: any): Promise<any> {
+  async sendMessage<K extends MessageKind>(
+    kind: K,
+    data: RslintMessageMap[K]['request'],
+  ): Promise<RslintMessageMap[K]['response']> {
     return new Promise((resolve, reject) => {
       const id = this.nextMessageId++;
       const message: IpcMessage = { id, kind, data };
 
-      // Register promise callbacks
-      this.pendingMessages.set(id, { resolve, reject });
+      // Register promise callbacks. The map is keyed by id, not kind, so it
+      // can't carry K through to storage; resolve/reject are paired with the
+      // correct response type at the call site above, which is what matters.
+      // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      this.pendingMessages.set(id, { resolve, reject } as PendingMessage);
 
       // Send message to worker
       this.worker!.postMessage(message);
@@ -159,7 +168,8 @@ export class BrowserRslintService implements RslintServiceInterface {
     this.pendingMessages.delete(id);
 
     if (kind === 'error') {
-      pending.reject(new Error(data.message));
+      // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      pending.reject(new Error((data as ErrorResponseData).message));
     } else {
       pending.resolve(data);
     }

--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -72,6 +72,12 @@ export {
   type ParserOptions,
   type RSlintOptions,
   type RslintServiceInterface,
+  // IPC protocol types
+  type MessageKind,
+  type RslintMessageMap,
+  type HandshakeRequest,
+  type HandshakeResponse,
+  type ErrorResponseData,
   // AST Info types
   type GetAstInfoRequest,
   type GetAstInfoResponse,

--- a/packages/rslint/src/node.ts
+++ b/packages/rslint/src/node.ts
@@ -5,6 +5,9 @@ import type {
   RSlintOptions,
   PendingMessage,
   IpcMessage,
+  MessageKind,
+  RslintMessageMap,
+  ErrorResponseData,
 } from './types.js';
 
 const require = createRequire(import.meta.url);
@@ -73,13 +76,19 @@ export class NodeRslintService implements RslintServiceInterface {
   /**
    * Send a message to the rslint process
    */
-  async sendMessage(kind: string, data: any): Promise<any> {
+  async sendMessage<K extends MessageKind>(
+    kind: K,
+    data: RslintMessageMap[K]['request'],
+  ): Promise<RslintMessageMap[K]['response']> {
     return new Promise((resolve, reject) => {
       const id = this.nextMessageId++;
       const message: IpcMessage = { id, kind, data };
 
-      // Register promise callbacks
-      this.pendingMessages.set(id, { resolve, reject });
+      // Register promise callbacks. The map is keyed by id, not kind, so it
+      // can't carry K through to storage; resolve/reject are paired with the
+      // correct response type at the call site above, which is what matters.
+      // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      this.pendingMessages.set(id, { resolve, reject } as PendingMessage);
 
       // Write message length as 4 bytes in little endian
       const json = JSON.stringify(message);
@@ -147,7 +156,8 @@ export class NodeRslintService implements RslintServiceInterface {
     this.pendingMessages.delete(id);
 
     if (kind === 'error') {
-      pending.reject(new Error(data.message));
+      // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      pending.reject(new Error((data as ErrorResponseData).message));
     } else {
       pending.resolve(data);
     }

--- a/packages/rslint/src/service.ts
+++ b/packages/rslint/src/service.ts
@@ -98,12 +98,11 @@ export class RSLintService {
    * Close the service
    */
   async close(): Promise<void> {
-    return new Promise((resolve) => {
-      this.service.sendMessage('exit', {}).finally(() => {
-        this.service.terminate();
-        resolve();
-      });
-    });
+    try {
+      await this.service.sendMessage('exit', {});
+    } finally {
+      this.service.terminate();
+    }
   }
 }
 
@@ -118,6 +117,12 @@ export type {
   ParserOptions,
   RSlintOptions,
   RslintServiceInterface,
+  // IPC protocol types
+  MessageKind,
+  RslintMessageMap,
+  HandshakeRequest,
+  HandshakeResponse,
+  ErrorResponseData,
   // AST Info types
   GetAstInfoRequest,
   GetAstInfoResponse,

--- a/packages/rslint/src/service.ts
+++ b/packages/rslint/src/service.ts
@@ -100,6 +100,9 @@ export class RSLintService {
   async close(): Promise<void> {
     try {
       await this.service.sendMessage('exit', {});
+    } catch {
+      // The exit handshake is best-effort cleanup; a failure here (e.g. the
+      // process already exited) shouldn't fail an otherwise-successful call.
     } finally {
       this.service.terminate();
     }

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -104,7 +104,7 @@ export interface RslintMessageMap {
   lint: { request: LintRequestData; response: LintResponse };
   applyFixes: { request: ApplyFixesRequest; response: ApplyFixesResponse };
   getAstInfo: { request: GetAstInfoRequest; response: GetAstInfoResponse };
-  exit: { request: ExitRequest; response: null };
+  exit: { request: ExitRequest; response: undefined };
 }
 
 export type MessageKind = keyof RslintMessageMap;

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -66,20 +66,63 @@ export interface RSlintOptions {
   workingDirectory?: string;
 }
 
-export interface PendingMessage {
-  resolve: (data: any) => void;
+export interface PendingMessage<T = unknown> {
+  resolve: (data: T) => void;
   reject: (error: Error) => void;
 }
 
+// ============================================================================
+// IPC protocol - request/response payloads for each `sendMessage` kind
+// Mirrors the Go side: internal/ipc, internal/api, internal/inspector.
+// NOTE: not type-checked against the Go structs — keep both sides in sync.
+// ============================================================================
+
+export interface HandshakeRequest {
+  version: string;
+}
+
+export interface HandshakeResponse {
+  version: string;
+  ok: boolean;
+}
+
+// LintOptions plus the wire-only `format` field service.ts attaches to every
+// lint request (ignored by the Go handler, which always returns structured data).
+export interface LintRequestData extends LintOptions {
+  format?: string;
+}
+
+export type ExitRequest = Record<string, never>;
+
+export interface ErrorResponseData {
+  message: string;
+}
+
+/** Maps each `sendMessage` kind to its request/response payload shapes. */
+export interface RslintMessageMap {
+  handshake: { request: HandshakeRequest; response: HandshakeResponse };
+  lint: { request: LintRequestData; response: LintResponse };
+  applyFixes: { request: ApplyFixesRequest; response: ApplyFixesResponse };
+  getAstInfo: { request: GetAstInfoRequest; response: GetAstInfoResponse };
+  exit: { request: ExitRequest; response: null };
+}
+
+export type MessageKind = keyof RslintMessageMap;
+
+// The wire envelope: outbound messages carry a MessageKind; inbound replies
+// carry 'response' or 'error' (see internal/ipc.KindResponse/KindError).
 export interface IpcMessage {
   id: number;
-  kind: string;
-  data: any;
+  kind: MessageKind | 'response' | 'error';
+  data: unknown;
 }
 
 // Service interface that all implementations must follow
 export interface RslintServiceInterface {
-  sendMessage(kind: string, data: any): Promise<any>;
+  sendMessage<K extends MessageKind>(
+    kind: K,
+    data: RslintMessageMap[K]['request'],
+  ): Promise<RslintMessageMap[K]['response']>;
   terminate(): void;
 }
 


### PR DESCRIPTION
## Summary
- Fixes rslint lint warnings, reducing the count from ~140 to ~80+.
- Strongly types the IPC `sendMessage(kind, data)` boundary with a new `RslintMessageMap` so each message kind carries its own request/response shape across `BrowserRslintService` and `NodeRslintService`.
- Fixes `RSLintService.close()` so an exit-handshake failure no longer discards an already-successful `lint()`/`applyFixes()`/`getAstInfo()` result.
- Fixes the `exit` response type from `null` to `undefined`, matching the actual wire payload.

## Test plan
- [x] `pnpm lint` passes with 0 errors
- [x] CI build/test