### PR TITLE
test: isolate forced-terminate worker-pool e2e tests in subprocesses

### DIFF
--- a/packages/rslint/tests/eslint-plugin/pool-isolation/harness.ts
+++ b/packages/rslint/tests/eslint-plugin/pool-isolation/harness.ts
@@ -1,0 +1,186 @@
+// Parent-side harness for process-isolated worker-pool scenarios.
+//
+// rstest tests call `runPoolScenario(name)`, which spawns runner.mjs in a
+// throwaway subprocess, lets it drive the real dist WorkerPool through a
+// terminate-churning scenario, and applies a MILESTONE-DRIVEN verdict. The
+// point: a native napi-terminate abort (Windows) crashes only that subprocess,
+// never this test process.
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RUNNER = path.join(HERE, 'runner.mjs');
+// tests/eslint-plugin/pool-isolation → packages/rslint, then dist/eslint-plugin.
+// The runner imports this built artifact (tests already require `pnpm build`;
+// the worker entry is the dist sibling).
+const DIST_ESLINT_PLUGIN = path.resolve(
+  HERE,
+  '../../../dist/eslint-plugin/index.js',
+);
+
+export type Verdict = 'PASS' | 'TOLERATED-PASS' | 'FAIL';
+
+export interface ScenarioResult {
+  scenario: string;
+  verdict: Verdict;
+  milestones: string[];
+  asserts: { name: string; pass: boolean; detail?: string }[];
+  error?: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  stderr: string;
+}
+
+interface Rec {
+  kind: 'milestone' | 'assert' | 'error';
+  name?: string;
+  pass?: boolean;
+  detail?: string;
+}
+
+export async function runPoolScenario(
+  scenario: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<ScenarioResult> {
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rslint-pool-iso-'));
+  const milestoneFile = path.join(tmpDir, 'milestones.ndjson');
+  fs.writeFileSync(milestoneFile, '');
+
+  return new Promise<ScenarioResult>((resolve) => {
+    const child = spawn(process.execPath, [RUNNER, scenario], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        RSLINT_MILESTONE_FILE: milestoneFile,
+        RSLINT_DIST_ESLINT_PLUGIN: DIST_ESLINT_PLUGIN,
+      },
+    });
+    let stderr = '';
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+
+    let settled = false;
+    const finish = (
+      exitCode: number | null,
+      signal: NodeJS.Signals | null,
+      timedOut: boolean,
+    ): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const recs = readMilestones(milestoneFile);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      const milestones = recs
+        .filter((r) => r.kind === 'milestone')
+        .map((r) => r.name!);
+      const asserts = recs
+        .filter((r) => r.kind === 'assert')
+        .map((r) => ({ name: r.name!, pass: !!r.pass, detail: r.detail }));
+      const error = recs.find((r) => r.kind === 'error')?.detail;
+      resolve({
+        scenario,
+        verdict: classify(milestones, asserts, error, timedOut),
+        milestones,
+        asserts,
+        error,
+        exitCode,
+        signal,
+        timedOut,
+        stderr,
+      });
+    };
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish(null, 'SIGKILL', true);
+    }, timeoutMs);
+    child.on('exit', (code, signal) => finish(code, signal, false));
+    child.on('error', () => finish(-1, null, false));
+  });
+}
+
+function readMilestones(file: string): Rec[] {
+  let text: string;
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch {
+    return [];
+  }
+  const out: Rec[] = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    try {
+      out.push(JSON.parse(line) as Rec);
+    } catch {
+      /* ignore a torn final line (process died mid-write) */
+    }
+  }
+  return out;
+}
+
+// MILESTONE-DRIVEN verdict (validated by the spike). Deliberately ignores exit
+// code/signal: a real napi abort on Windows can surface as exit code 0
+// (indistinguishable from a clean exit), and an orderly failure exits non-zero
+// — exit codes cannot tell them apart, but the child's own milestones can.
+function classify(
+  milestones: string[],
+  asserts: { pass: boolean }[],
+  error: string | undefined,
+  timedOut: boolean,
+): Verdict {
+  const reached = (m: string): boolean => milestones.includes(m);
+  if (asserts.some((a) => !a.pass)) return 'FAIL'; // in-child assertion failed
+  if (error) return 'FAIL'; // child reported an orderly error
+  if (reached('done')) return 'PASS'; // explicit success
+  if (timedOut) return 'FAIL'; // pool hung
+  // Silent abnormal exit with no done/error/failed-assert: tolerate ONLY if the
+  // pool provably reached the terminate step — that's the isolated native
+  // abort. Anything earlier is a real crash and must fail.
+  //
+  // Coverage note: a TOLERATED-PASS means the in-child asserts AFTER the
+  // terminate point did not run (the process aborted there). Those business
+  // invariants (drain / respawn / closed-rejection / no-leak) are still fully
+  // verified on mac/linux, where terminate is clean and the child runs through
+  // to `done` (PASS). The Windows abort path only confirms the pool reached the
+  // terminate step and the isolation held — the business assertions are
+  // guaranteed by the non-Windows runners, which is sound because those
+  // invariants are platform-independent.
+  return reached('terminate-point') ? 'TOLERATED-PASS' : 'FAIL';
+}
+
+/**
+ * Human-readable failure report for a scenario that did not pass. Surfaces the
+ * failed in-child assertion(s) (name + detail), the child's error / timeout /
+ * exit code, the milestones it reached, and the child stderr — so a CI failure
+ * reads like a normal assertion report instead of a JSON blob. Pass it as
+ * expect()'s second arg:
+ *   expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL')
+ */
+export function formatScenarioFailure(r: ScenarioResult): string {
+  const lines: string[] = [
+    `pool-isolation scenario "${r.scenario}" did not pass (verdict=${r.verdict}).`,
+  ];
+  const failed = r.asserts.filter((a) => !a.pass);
+  if (failed.length > 0) {
+    lines.push('  failed in-child assertions:');
+    for (const a of failed) {
+      lines.push(`    x ${a.name}${a.detail ? ` - ${a.detail}` : ''}`);
+    }
+  }
+  if (r.error) lines.push(`  child error: ${r.error}`);
+  if (r.timedOut) {
+    lines.push('  child TIMED OUT - the pool hung and never exited');
+  }
+  lines.push(`  milestones reached: ${r.milestones.join(' > ') || '(none)'}`);
+  lines.push(
+    `  child exit: code=${r.exitCode ?? 'null'} signal=${r.signal ?? 'null'}`,
+  );
+  if (r.stderr.trim()) {
+    lines.push('  child stderr:');
+    for (const l of r.stderr.trim().split('\n')) lines.push(`    ${l}`);
+  }
+  return lines.join('\n');
+}

--- a/packages/rslint/tests/eslint-plugin/pool-isolation/runner.mjs
+++ b/packages/rslint/tests/eslint-plugin/pool-isolation/runner.mjs
@@ -1,0 +1,360 @@
+// Subprocess entry for process-isolated worker-pool scenarios.
+//
+// Why this exists: the worker-pool e2e scenarios that force a worker
+// `terminate()` can native-abort BELOW the JS layer on Windows — libuv tears
+// down the oxc-napi worker's stdio pipes during terminate and faults. When the
+// pool runs inside the rstest test process, that abort crashes the test process
+// itself ("Rstest exited unexpectedly"). Running the pool in THIS throwaway
+// subprocess confines the abort here; the parent rstest test (harness.ts)
+// observes our outcome via milestones and never crashes.
+//
+// Progress is reported to a milestone FILE (env RSLINT_MILESTONE_FILE) via
+// synchronous appendFileSync: a milestone written immediately before a native
+// abort is already on disk, so the parent can always tell how far the pool got.
+// process.stdout is NOT used for milestones — its userland buffer can be lost
+// when the process aborts.
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// Shared fixtures live one level up (tests/eslint-plugin/fixtures); the worker
+// imports the config via plugin-loader's pathToFileURL, so absolute paths work
+// cross-platform.
+const FIXTURES = path.resolve(HERE, '../fixtures');
+const LOCAL_CONFIG = {
+  configPath: path.join(FIXTURES, 'local.config.mjs'),
+  configDirectory: FIXTURES,
+};
+const HANG_CONFIG = {
+  configPath: path.join(FIXTURES, 'hang.config.mjs'),
+  configDirectory: FIXTURES,
+};
+
+const MILESTONE_FILE = process.env.RSLINT_MILESTONE_FILE;
+const report = (obj) => {
+  if (!MILESTONE_FILE) return;
+  try {
+    fs.appendFileSync(MILESTONE_FILE, JSON.stringify(obj) + '\n');
+  } catch {
+    /* parent or disk gone — nothing we can do, and we must not throw */
+  }
+};
+const milestone = (name) => report({ kind: 'milestone', name });
+const check = (name, pass, detail) =>
+  report({ kind: 'assert', name, pass: !!pass, detail });
+
+async function loadWorkerPool() {
+  const dist = process.env.RSLINT_DIST_ESLINT_PLUGIN;
+  if (!dist) throw new Error('RSLINT_DIST_ESLINT_PLUGIN not set');
+  // Production resolution path: WorkerPool resolves its sibling
+  // dist/eslint-plugin/lint-worker.js automatically — no setWorkerEntryForTests.
+  // pathToFileURL is required on Windows: ESM import() rejects a bare absolute
+  // path like `C:\...` (ERR_UNSUPPORTED_ESM_URL_SCHEME) and needs a file:// URL.
+  const mod = await import(pathToFileURL(dist).href);
+  return mod.WorkerPool;
+}
+
+const makeFixtureDir = (files) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rslint-pool-iso-fx-'));
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), content);
+  }
+  return dir;
+};
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const localTask = (filePath, text, rule = 'local/no-null') => ({
+  filePath,
+  text,
+  rules: { [rule]: { options: [] } },
+  collectFixes: false,
+  suggestionsMode: 'off',
+  configKey: FIXTURES,
+});
+
+// Each scenario drives the real dist WorkerPool through one forced-terminate
+// flow and reports `check(...)` assertions + an emitted `terminate-point`
+// milestone just before the terminate that can native-abort on Windows.
+const scenarios = {
+  // U11: a refed top-level setInterval keeps the worker event loop alive, so
+  // shutdown must escalate to a forced terminate().
+  u11: async () => {
+    const WorkerPool = await loadWorkerPool();
+    const dir = makeFixtureDir({
+      'plugin.mjs':
+        'const _i = setInterval(() => {}, 60_000);\n' +
+        "export default { meta: { name: 'u11' }, rules: { noop: { meta: {}, create() { return {}; } } } };\n",
+      'config.mjs':
+        "import plugin from './plugin.mjs';\nexport default [{ plugins: { u11: plugin } }];\n",
+    });
+    const pool = new WorkerPool({
+      configs: [
+        { configPath: path.join(dir, 'config.mjs'), configDirectory: dir },
+      ],
+      workerCount: 1,
+    });
+    await pool.init();
+    milestone('init-done');
+    milestone('terminate-point');
+    const start = Date.now();
+    await pool.shutdown();
+    const elapsed = Date.now() - start;
+    check('shutdown-bounded', elapsed < 8_000, `elapsed=${elapsed}ms`);
+    check(
+      'pool-drained',
+      Array.isArray(pool.workers) && pool.workers.length === 0,
+      `workers=${pool.workers?.length}`,
+    );
+  },
+
+  // sync-wedged: the hang plugin spins forever on Program, so the worker can't
+  // even process the inbound shutdown message — shutdown must escalate to a
+  // forced terminate() after the 5s grace.
+  'hang-shutdown': async () => {
+    const WorkerPool = await loadWorkerPool();
+    const pool = new WorkerPool({
+      configs: [HANG_CONFIG],
+      workerCount: 1,
+      // 60s so a task_timeout respawn can't preempt the shutdown path.
+      taskTimeoutMs: 60_000,
+    });
+    await pool.init();
+    milestone('init-done');
+    const wedgeP = pool.lintBatch([
+      localTask('wedge.ts', 'const x = 1;\n', 'hang/hang'),
+    ]);
+    await sleep(200); // let the worker enter the sync hang before shutdown
+    milestone('terminate-point');
+    const start = Date.now();
+    await pool.shutdown();
+    const elapsed = Date.now() - start;
+    check(
+      'shutdown-bounded',
+      elapsed >= 4_500 && elapsed < 8_000,
+      `elapsed=${elapsed}ms`,
+    );
+    const wedge = await wedgeP;
+    check(
+      'wedge-shutdown',
+      wedge.length === 1 && wedge[0]?.parseError === 'shutdown',
+      `len=${wedge.length} parseError=${wedge[0]?.parseError}`,
+    );
+    check(
+      'pool-drained',
+      pool.workers.length === 0,
+      `workers=${pool.workers.length}`,
+    );
+    const s2 = Date.now();
+    await pool.shutdown(); // idempotent + instant
+    check(
+      'second-shutdown-fast',
+      Date.now() - s2 < 50,
+      `2nd=${Date.now() - s2}ms`,
+    );
+  },
+
+  // worker-exit-race: directly terminate one worker of a 2-worker pool, then
+  // shutdown. The leaked respawn must not survive; lintBatch after shutdown
+  // rejects /closed/.
+  'worker-exit-race': async () => {
+    const WorkerPool = await loadWorkerPool();
+    const pool = new WorkerPool({
+      configs: [LOCAL_CONFIG],
+      workerCount: 2,
+      taskTimeoutMs: 5_000,
+    });
+    await pool.init();
+    milestone('init-done');
+    check(
+      'workers-spawned',
+      pool.workers.length > 0,
+      `workers=${pool.workers.length}`,
+    );
+    milestone('terminate-point');
+    void pool.workers[0].worker.terminate();
+    const start = Date.now();
+    await pool.shutdown();
+    check(
+      'shutdown-bounded',
+      Date.now() - start < 10_000,
+      `elapsed=${Date.now() - start}ms`,
+    );
+    let rejectedClosed = false;
+    try {
+      await pool.lintBatch([localTask('x.ts', 'const x = 1;')]);
+    } catch (e) {
+      rejectedClosed = /closed/.test(String(e?.message ?? e));
+    }
+    check('lint-batch-rejects-closed', rejectedClosed, '');
+    await sleep(200);
+    check(
+      'pool-drained',
+      pool.workers.length === 0,
+      `workers=${pool.workers.length}`,
+    );
+  },
+
+  // task-timeout: the hang plugin trips the 600ms per-task timeout, which
+  // terminates the worker and respawns it; the next batch must succeed on the
+  // replacement.
+  'task-timeout': async () => {
+    const WorkerPool = await loadWorkerPool();
+    const logs = [];
+    const pool = new WorkerPool({
+      configs: [HANG_CONFIG],
+      workerCount: 1,
+      taskTimeoutMs: 600,
+      onLog: (rec) => logs.push(rec),
+    });
+    await pool.init();
+    milestone('init-done');
+    milestone('terminate-point'); // the timeout-driven terminate fires below
+    const hangResult = await pool.lintBatch([
+      localTask('wedge.ts', 'const x = 1;\n', 'hang/hang'),
+    ]);
+    check(
+      'hang-task-timeout',
+      hangResult.length === 1 && hangResult[0]?.parseError === 'task_timeout',
+      `len=${hangResult.length} parseError=${hangResult[0]?.parseError}`,
+    );
+    await sleep(500);
+    const okResult = await pool.lintBatch([
+      localTask('ok.ts', 'const TRIGGER = 1;\n', 'hang/noop'),
+    ]);
+    check(
+      'recovery-ok',
+      okResult.length === 1 &&
+        okResult[0]?.parseError === undefined &&
+        okResult[0]?.diagnostics?.length === 1 &&
+        okResult[0]?.diagnostics[0]?.message === 'noop fired',
+      JSON.stringify(okResult[0]),
+    );
+    check(
+      'respawn-logged',
+      logs.some((l) => l.text.includes('respawning')),
+      '',
+    );
+    await pool.shutdown();
+  },
+
+  // all-degraded: drive every slot past its respawn cap (crashCount=cap +
+  // terminate), so the in-flight batch drains as parseError:pool_degraded.
+  'all-degraded': async () => {
+    const WorkerPool = await loadWorkerPool();
+    const pool = new WorkerPool({
+      configs: [LOCAL_CONFIG],
+      workerCount: 1,
+      retryCap: 1,
+    });
+    await pool.init();
+    milestone('init-done');
+    pool.workers[0].ready = false; // hold non-ready so kickQueue can't dispatch
+    const batchP = pool.lintBatch(
+      [1, 2].map((i) => localTask(`q${i}.ts`, 'const x = null;\n')),
+    );
+    await sleep(30);
+    milestone('terminate-point');
+    pool.workers[0].crashCount = pool.opts.retryCap;
+    await pool.workers[0].worker.terminate();
+    const result = await batchP;
+    check(
+      'degraded-drain',
+      result.length === 2 &&
+        result.every(
+          (r) =>
+            r.parseError === 'pool_degraded' &&
+            r.cancelled === false &&
+            Array.isArray(r.diagnostics) &&
+            r.diagnostics.length === 0,
+        ),
+      JSON.stringify(result.map((r) => r.parseError)),
+    );
+    check(
+      'queue-drained',
+      pool.pendingQueue.length === 0,
+      `pending=${pool.pendingQueue.length}`,
+    );
+    await pool.shutdown();
+  },
+
+  // lint-batch-after-degraded: like all-degraded, but a SECOND batch issued
+  // AFTER the pool settled terminal must also resolve pool_degraded (not hang).
+  'lint-batch-after-degraded': async () => {
+    const WorkerPool = await loadWorkerPool();
+    const pool = new WorkerPool({
+      configs: [LOCAL_CONFIG],
+      workerCount: 1,
+      retryCap: 1,
+    });
+    await pool.init();
+    milestone('init-done');
+    pool.workers[0].ready = false;
+    const firstBatch = pool.lintBatch([
+      localTask('first.ts', 'const x = null;\n'),
+    ]);
+    await sleep(30);
+    milestone('terminate-point');
+    pool.workers[0].crashCount = pool.opts.retryCap;
+    await pool.workers[0].worker.terminate();
+    const firstResult = await firstBatch;
+    check(
+      'first-degraded',
+      firstResult.length === 1 && firstResult[0].parseError === 'pool_degraded',
+      JSON.stringify(firstResult.map((r) => r.parseError)),
+    );
+    check(
+      'terminal-state',
+      pool.closed === false &&
+        pool.workers.length === 1 &&
+        pool.workers[0].ready === false &&
+        pool.workers[0].respawning === false &&
+        pool.workers[0].exited === true,
+      `closed=${pool.closed} ready=${pool.workers[0]?.ready} exited=${pool.workers[0]?.exited}`,
+    );
+    const secondBatch = pool.lintBatch([
+      localTask('second-a.ts', 'const y = null;\n'),
+      localTask('second-b.ts', 'const z = null;\n'),
+    ]);
+    const guard = new Promise((_, rej) =>
+      setTimeout(() => rej(new Error('second lintBatch hung')), 4_000),
+    );
+    const secondResult = await Promise.race([secondBatch, guard]);
+    check(
+      'second-degraded',
+      secondResult.length === 2 &&
+        secondResult.every(
+          (r) =>
+            r.parseError === 'pool_degraded' &&
+            r.cancelled === false &&
+            Array.isArray(r.diagnostics) &&
+            r.diagnostics.length === 0,
+        ),
+      JSON.stringify(secondResult.map((r) => r.parseError)),
+    );
+    check(
+      'queue-drained',
+      pool.pendingQueue.length === 0,
+      `pending=${pool.pendingQueue.length}`,
+    );
+    await pool.shutdown();
+  },
+};
+
+const name = process.argv[2];
+const fn = scenarios[name];
+if (typeof fn !== 'function') {
+  report({ kind: 'error', detail: `unknown scenario: ${name}` });
+  process.exit(2);
+}
+try {
+  await fn();
+  milestone('done'); // explicit success — the last line on the happy path
+  process.exit(0);
+} catch (err) {
+  // An ORDERLY error (import/init threw) — report it so the parent fails the
+  // test, rather than mistaking a silent exit for a tolerable native abort.
+  report({ kind: 'error', detail: String(err?.stack ?? err) });
+  process.exit(1);
+}

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-lifecycle.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-lifecycle.test.ts
@@ -1,5 +1,4 @@
 import { describe, test, expect } from '@rstest/core';
-import path from 'node:path';
 
 import { WorkerPool } from '../../src/eslint-plugin/worker-pool.js';
 import type { LintTask } from '../../src/eslint-plugin/worker-pool.js';
@@ -10,6 +9,10 @@ import {
   task,
 } from './worker-pool-e2e-helpers.js';
 import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
+import {
+  runPoolScenario,
+  formatScenarioFailure,
+} from './pool-isolation/harness.js';
 
 /**
  * WorkerPool end-to-end — lifecycle: init + lintBatch + shutdown happy
@@ -156,90 +159,17 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
       await pool.shutdown();
     });
 
-    // pool.shutdown() posts {kind:'shutdown'} to every worker and waits
-    // up to 5 s for each to exit cooperatively before falling back to
-    // `worker.terminate()`. This invariant matters when the host (CLI
-    // parent on Ctrl-C, VS Code on extension dispose, …) tears the pool
-    // down while a plugin listener is wedged in a sync infinite loop —
-    // the worker can't even process the inbound shutdown message, so
-    // graceful exit is impossible and the pool must escalate to a forced
-    // terminate. Test fires a never-completing task, calls shutdown
-    // without a per-task timeout, and asserts the pool fully drains
-    // within grace + slack.
+    // A plugin listener wedged in a sync infinite loop can't process the
+    // inbound shutdown message, so shutdown must escalate to a forced
+    // terminate() after the 5s grace. Terminating an oxc-napi worker can
+    // native-abort below the JS layer on Windows — run it isolated (see
+    // ./pool-isolation/runner.mjs). PASS = clean terminate; TOLERATED-PASS =
+    // pool reached terminate then the subprocess aborted; FAIL = hang, failed
+    // in-child assertion, or a crash before the terminate point.
     test('shutdown drains a sync-wedged worker via terminate fallback within grace', async () => {
-      const hangConfigPath = path.resolve(
-        __dirname,
-        'fixtures',
-        'hang.config.mjs',
-      );
-      const hangConfigDir = path.dirname(hangConfigPath);
-
-      const pool = new WorkerPool({
-        configs: [
-          {
-            configPath: hangConfigPath,
-            configDirectory: hangConfigDir,
-          },
-        ],
-        workerCount: 1,
-        // 60 s — longer than the test ceiling, so a task_timeout-driven
-        // respawn can't preempt the shutdown path we're trying to test.
-        taskTimeoutMs: 60_000,
-      });
-      await pool.init();
-
-      // Fire-and-forget: the hang listener spins forever on Program, so
-      // the task never resolves naturally. shutdown is the only force
-      // that can free the pool.
-      const wedgeP = pool.lintBatch([
-        {
-          filePath: 'wedge.ts',
-          text: 'const x = 1;\n',
-          rules: { 'hang/hang': { options: [] } },
-          collectFixes: false,
-          suggestionsMode: 'off',
-          configKey: hangConfigDir,
-        },
-      ]);
-
-      // Brief grace so the worker is actually inside the sync hang
-      // when shutdown lands. Without this the worker might still be
-      // sitting in its inbound queue and could process the shutdown
-      // message before entering the loop — a different (faster) path
-      // that doesn't exercise the terminate fallback we're testing.
-      await new Promise((r) => setTimeout(r, 200));
-
-      const shutdownStart = Date.now();
-      await pool.shutdown();
-      const elapsed = Date.now() - shutdownStart;
-
-      // worker-pool.ts grace = 5 s; total elapsed = grace + small
-      // overhead for terminate() to actually kill the worker thread.
-      // Lower bound 4.5 s catches a regression where shutdown returns
-      // immediately (without waiting for the worker). Upper bound 8 s
-      // catches a regression where the terminate fallback never fires.
-      expect(elapsed).toBeGreaterThanOrEqual(4_500);
-      expect(elapsed).toBeLessThan(8_000);
-
-      // In-flight tasks resolve with a sentinel parseError instead of
-      // hanging the caller forever. worker-pool.ts:539-548 maps the
-      // shutdown-kind rejection back to a result-shaped failure so
-      // callers (internal/linter) see one file as plugin-lint-failed rather
-      // than the whole batch throwing.
-      const wedgeResults = await wedgeP;
-      expect(wedgeResults).toHaveLength(1);
-      expect(wedgeResults[0].parseError).toBe('shutdown');
-
-      // Pool is fully drained — no leaked worker slot.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const finalWorkers = (pool as any).workers as Array<unknown>;
-      expect(finalWorkers.length).toBe(0);
-
-      // Idempotent: a second shutdown returns instantly without throwing.
-      const secondStart = Date.now();
-      await pool.shutdown();
-      expect(Date.now() - secondStart).toBeLessThan(50);
-    }, 15_000);
+      const r = await runPoolScenario('hang-shutdown');
+      expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
+    }, 20_000);
 
     // U12: a single WorkerPool instance must support N lintBatch calls
     // in sequence (the CLI's fix-loop and the LSP's continuous edit
@@ -291,79 +221,22 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
       await pool.shutdown();
     }, 30_000);
 
-    // U11: a plugin that installs a `setInterval` (or any unref-able
-    // timer) during its module top-level must NOT prevent the worker
-    // from exiting on shutdown. The worker process keeps running until
-    // the event loop drains; an unref'd timer is fine, but a refed
-    // setInterval would keep the worker alive past `pool.shutdown()`,
-    // hanging the parent's Wait.
+    // U11: a plugin with a refed top-level `setInterval` keeps the worker event
+    // loop alive, so `pool.shutdown()` can't drain it cooperatively and must
+    // escalate to a forced `terminate()`. Terminating a worker that holds the
+    // oxc-napi addon can native-abort below the JS layer on Windows — which
+    // would crash THIS test process if the pool ran in-process. So the scenario
+    // runs in an isolated subprocess (see ./pool-isolation/runner.mjs): a native
+    // abort is confined there, and the pool's outcome comes back via milestones.
     //
-    // The test uses a fixture plugin that creates a setInterval in its
-    // top-level, then verifies pool.shutdown completes in bounded time.
-    // If the timer kept the worker alive, shutdown would either time
-    // out (caught by Jest's per-test timeout) or rely on terminate()
-    // fallback (visible via a longer-than-expected elapsed time).
+    //   PASS           = clean terminate (mac/linux): shutdown bounded + drained
+    //   TOLERATED-PASS = pool reached terminate, then the subprocess aborted
+    //                    (Windows napi teardown) — the pool still did its job
+    //   FAIL           = hang, failed in-child assertion, or a crash BEFORE the
+    //                    terminate point — a real regression
     test('U11: plugin with a top-level setInterval — shutdown still terminates the worker', async () => {
-      const cfgDir = path.resolve(__dirname, 'fixtures');
-      const cfgPath = path.join(cfgDir, '_u11.config.mjs');
-      const pluginPath = path.join(cfgDir, '_u11-plugin.mjs');
-      await import('node:fs/promises').then((fs) =>
-        Promise.all([
-          fs.writeFile(
-            pluginPath,
-            `// Intentionally schedules a REFED interval that would
-// otherwise keep the worker alive forever. The test pins that
-// pool.shutdown() still tears the worker down within a bounded
-// elapsed window (5 s graceful + terminate fallback).
-const _interval = setInterval(() => { /* never fires within test */ }, 60_000);
-// eslint-disable-next-line no-unused-vars
-export default {
-  meta: { name: 'u11-interval-plugin' },
-  rules: { noop: { meta: {}, create() { return {}; } } },
-};
-`,
-            'utf8',
-          ),
-          fs.writeFile(
-            cfgPath,
-            `import plugin from './_u11-plugin.mjs';
-export default [{ plugins: { u11: plugin } }];
-`,
-            'utf8',
-          ),
-        ]),
-      );
-
-      try {
-        const pool = new WorkerPool({
-          configs: [{ configPath: cfgPath, configDirectory: cfgDir }],
-          workerCount: 1,
-        });
-        await pool.init();
-
-        const start = Date.now();
-        await pool.shutdown();
-        const elapsed = Date.now() - start;
-
-        // Worker pool's shutdown gives each worker up to 5s graceful
-        // before terminate(). A worker keeping its event loop alive
-        // via setInterval would hit terminate fallback — bounded by
-        // grace + small overhead. Test fails if shutdown is unbounded
-        // (i.e. hangs past 10s) or if terminate fallback itself fails
-        // (worker_threads.terminate is OS-level and very reliable).
-        expect(elapsed).toBeLessThan(8_000);
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const workers = (pool as any).workers as Array<unknown>;
-        expect(workers).toHaveLength(0);
-      } finally {
-        await import('node:fs/promises').then((fs) =>
-          Promise.all([
-            fs.rm(cfgPath, { force: true }),
-            fs.rm(pluginPath, { force: true }),
-          ]),
-        );
-      }
-    }, 15_000);
+      const r = await runPoolScenario('u11');
+      expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
+    }, 20_000);
   },
 );

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-queue.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-queue.test.ts
@@ -3,12 +3,12 @@ import { describe, test, expect } from '@rstest/core';
 import { WorkerPool } from '../../src/eslint-plugin/worker-pool.js';
 import type { LintTask } from '../../src/eslint-plugin/worker-pool.js';
 
-import {
-  LOCAL_CONFIG_DIR,
-  localConfigs,
-  task,
-} from './worker-pool-e2e-helpers.js';
+import { LOCAL_CONFIG_DIR, localConfigs } from './worker-pool-e2e-helpers.js';
 import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
+import {
+  runPoolScenario,
+  formatScenarioFailure,
+} from './pool-isolation/harness.js';
 
 /**
  * WorkerPool end-to-end — queue model: tasks wait in `pendingQueue`
@@ -87,62 +87,14 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
       expect((pool as any).pendingQueue.length).toBe(0);
     }, 15_000);
 
+    // Driving every slot past its respawn cap (crashCount=cap + terminate)
+    // drains the in-flight batch as parseError:pool_degraded. The terminate of
+    // an oxc-napi worker can native-abort on Windows — run it isolated (see
+    // ./pool-isolation). The in-child asserts pin the pool_degraded drain.
     test('all workers degraded → pendingQueue drains as parseError:pool_degraded (no hang)', async () => {
-      // Regression for review P0 #2. When every worker exhausts its
-      // respawn cap (default 3), the 'exit' handler used to JUST log;
-      // `kickQueue` skips not-ready slots, so anything in
-      // `pendingQueue` waited forever — `await pool.lintBatch(tasks)`
-      // never returned and the host had no path to recover.
-      //
-      // Fix: in the cap-reached branch, drain `pendingQueue` with
-      // `parseError: 'pool_degraded'` once every slot is `ready=false`.
-      const pool = new WorkerPool({
-        configs: localConfigs,
-        workerCount: 1,
-        retryCap: 1,
-      });
-      await pool.init();
-
-      // Wedge: enqueue a couple of tasks but hold the worker non-ready
-      // so kickQueue can't dispatch.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const internals = pool as any;
-      internals.workers[0].ready = false;
-
-      const batchP = pool.lintBatch(
-        [1, 2].map((i) => ({
-          filePath: `q${i}.ts`,
-          text: 'const x = null;\n',
-          rules: { 'local/no-null': { options: [] } },
-          collectFixes: false,
-          suggestionsMode: 'off',
-          configKey: LOCAL_CONFIG_DIR,
-        })),
-      );
-      await new Promise((r) => setTimeout(r, 30));
-
-      // Simulate the terminal "all workers exhausted retryCap" state by
-      // bumping crashCount and re-running the exit handler. The exit
-      // handler is wired during `attachOngoingHandlers`; the simplest
-      // path is to terminate the worker (triggers a real 'exit') after
-      // setting crashCount to the cap.
-      internals.workers[0].crashCount = internals.opts.retryCap;
-      await internals.workers[0].worker.terminate();
-
-      const result = await batchP;
-      expect(result).toHaveLength(2);
-      for (const r of result) {
-        expect(r.parseError).toBe('pool_degraded');
-        expect(r.cancelled).toBe(false);
-        expect(r.diagnostics).toEqual([]);
-      }
-      // Pending queue fully drained.
-      expect(internals.pendingQueue.length).toBe(0);
-
-      // Tear down cleanly — the pool is in a degraded state but
-      // shutdown() should still work.
-      await pool.shutdown();
-    }, 15_000);
+      const r = await runPoolScenario('all-degraded');
+      expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
+    }, 20_000);
 
     // Queue-model regression suite — five tests pinning the design
     // properties that the Finding 3 refactor introduced.
@@ -267,81 +219,14 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
       }
     }, 30_000);
 
+    // A SECOND batch issued AFTER the pool settled into the terminal degraded
+    // state must also resolve pool_degraded (not hang) — Fix A. Reaching that
+    // state needs a forced terminate of an oxc-napi worker, which can
+    // native-abort on Windows, so run it isolated (see ./pool-isolation). The
+    // in-child asserts pin the terminal-state sanity checks and both drains.
     test('lintBatch issued AFTER the pool settled into the terminal degraded state resolves as pool_degraded (does not hang)', async () => {
-      // Regression for Fix A. The existing "all workers degraded →
-      // pendingQueue drains as parseError:pool_degraded" test only covers
-      // tasks ALREADY in-flight when the terminal exit fires. A
-      // `lintBatch` issued AFTER the pool has settled into the degraded
-      // state was never drained: it passed the `closed` guard (pool is
-      // degraded, not closed) and the `workers.length === 0` guard, then
-      // `kickQueue` skipped the not-ready slot and NO future event would
-      // ever call the drain again → `Promise.all` never settled →
-      // permanent hang. Fix: `lintBatch` calls
-      // `drainQueueIfAllSlotsDegraded()` after the enqueue/kick so a
-      // batch handed to an already-terminal pool resolves immediately.
-      const pool = new WorkerPool({
-        configs: localConfigs,
-        workerCount: 1,
-        retryCap: 1,
-      });
-      await pool.init();
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const internals = pool as any;
-
-      // Drive the pool to the terminal degraded state EXACTLY the way the
-      // existing in-flight-drain test does: hold the slot non-ready,
-      // enqueue a first batch, push crashCount to the cap, and terminate
-      // the worker so its real 'exit' handler takes the cap-reached
-      // branch and drains that first batch as pool_degraded.
-      internals.workers[0].ready = false;
-      const firstBatch = pool.lintBatch([
-        task('first.ts', 'const x = null;\n'),
-      ]);
-      await new Promise((r) => setTimeout(r, 30));
-      internals.workers[0].crashCount = internals.opts.retryCap;
-      await internals.workers[0].worker.terminate();
-
-      const firstResult = await firstBatch;
-      expect(firstResult).toHaveLength(1);
-      expect(firstResult[0].parseError).toBe('pool_degraded');
-
-      // Pool is now terminal: slot is ready=false, respawning=false,
-      // EXITED (the worker thread really died — this is the discriminator
-      // that separates this from a benign not-ready-but-alive worker),
-      // crashCount>=cap, and NOT closed. Sanity-check that state so the
-      // test is exercising the intended scenario.
-      expect(internals.closed).toBe(false);
-      expect(internals.workers).toHaveLength(1);
-      expect(internals.workers[0].ready).toBe(false);
-      expect(internals.workers[0].respawning).toBe(false);
-      expect(internals.workers[0].exited).toBe(true);
-
-      // Issue a SECOND batch against the already-degraded pool. With the
-      // fix it must RESOLVE (every result pool_degraded). Without the fix
-      // it hangs forever — race it against a rejecting timer so the
-      // negative-check produces a clean, fast failure instead of wedging
-      // the whole suite on the per-test timeout.
-      const secondBatch = pool.lintBatch([
-        task('second-a.ts', 'const y = null;\n'),
-        task('second-b.ts', 'const z = null;\n'),
-      ]);
-      const guard = new Promise<never>((_, rej) =>
-        setTimeout(
-          () => rej(new Error('second lintBatch hung — Fix A regression')),
-          4_000,
-        ),
-      );
-      const secondResult = await Promise.race([secondBatch, guard]);
-      expect(secondResult).toHaveLength(2);
-      for (const r of secondResult) {
-        expect(r.parseError).toBe('pool_degraded');
-        expect(r.cancelled).toBe(false);
-        expect(r.diagnostics).toEqual([]);
-      }
-      expect(internals.pendingQueue.length).toBe(0);
-
-      await pool.shutdown();
-    }, 15_000);
+      const r = await runPoolScenario('lint-batch-after-degraded');
+      expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
+    }, 20_000);
   },
 );

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-resilience.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-resilience.test.ts
@@ -1,5 +1,4 @@
 import { describe, test, expect } from '@rstest/core';
-import path from 'node:path';
 
 import { WorkerPool } from '../../src/eslint-plugin/worker-pool.js';
 import type { LintTask } from '../../src/eslint-plugin/worker-pool.js';
@@ -10,6 +9,10 @@ import {
   task,
 } from './worker-pool-e2e-helpers.js';
 import { SKIP_WIN32_NAPI_TEARDOWN } from './win32-napi-teardown.js';
+import {
+  runPoolScenario,
+  formatScenarioFailure,
+} from './pool-isolation/harness.js';
 
 /**
  * WorkerPool end-to-end — resilience: a non-cloneable task degrades to
@@ -116,110 +119,23 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
       await pool.shutdown();
     }, 30_000);
 
-    // Respawn-during-shutdown race regression — see the long jsdoc on
-    // the failing case in the previous version of this file. Same
-    // contract under configs-flow: shutdown completes promptly and the
-    // workers array stays empty after a leaked respawn settles.
+    // Directly terminating one worker of a 2-worker pool then shutting down
+    // exercises the respawn-during-shutdown race. The terminate of an oxc-napi
+    // worker can native-abort on Windows — run it isolated (see
+    // ./pool-isolation). Verdict != FAIL means the pool drained without leaking
+    // the respawn (or reached terminate then the subprocess aborted on Windows).
     test('worker exit racing shutdown does not leak the respawn', async () => {
-      const pool = new WorkerPool({
-        configs: localConfigs,
-        workerCount: 2,
-        taskTimeoutMs: 5_000,
-      });
-      await pool.init();
+      const r = await runPoolScenario('worker-exit-race');
+      expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
+    }, 20_000);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const workers = (pool as any).workers as Array<{
-        worker: { terminate(): Promise<number> };
-      }>;
-      expect(workers.length).toBeGreaterThan(0);
-      void workers[0].worker.terminate();
-
-      const shutdownStart = Date.now();
-      await pool.shutdown();
-      const shutdownElapsed = Date.now() - shutdownStart;
-      expect(shutdownElapsed).toBeLessThan(10_000);
-
-      await expect(
-        pool.lintBatch([
-          {
-            filePath: 'x.ts',
-            text: 'const x = 1;',
-            rules: {},
-            collectFixes: false,
-            suggestionsMode: 'off',
-            configKey: LOCAL_CONFIG_DIR,
-          },
-        ]),
-      ).rejects.toThrow(/closed/);
-
-      await new Promise<void>((r) => setTimeout(r, 200));
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const finalWorkers = (pool as any).workers as Array<unknown>;
-      expect(finalWorkers.length).toBe(0);
-    });
-
+    // A hung listener trips the per-task timeout, which terminates the worker
+    // and respawns it; the next batch must succeed on the replacement. The
+    // timeout-driven terminate of an oxc-napi worker can native-abort on
+    // Windows — run it isolated (see ./pool-isolation).
     test('hung listener → task_timeout → respawn → next batch succeeds', async () => {
-      const hangConfigPath = path.resolve(
-        __dirname,
-        'fixtures',
-        'hang.config.mjs',
-      );
-      const hangConfigDir = path.dirname(hangConfigPath);
-
-      const logs: Array<{ level: string; source: string; text: string }> = [];
-      const pool = new WorkerPool({
-        configs: [
-          {
-            configPath: hangConfigPath,
-            configDirectory: hangConfigDir,
-          },
-        ],
-        workerCount: 1,
-        // Aggressive timeout so the test doesn't sit for 30 s. 600 ms
-        // is comfortably above worker startup + import latency on CI
-        // (the existing happy-path tests in this file complete in ~50–
-        // 200 ms once the worker is up), but well below the 60-s test
-        // ceiling.
-        taskTimeoutMs: 600,
-        onLog: (rec) => logs.push(rec),
-      });
-      await pool.init();
-
-      const hangResult = await pool.lintBatch([
-        {
-          filePath: 'wedge.ts',
-          text: 'const x = 1;\n',
-          rules: { 'hang/hang': { options: [] } },
-          collectFixes: false,
-          suggestionsMode: 'off',
-          configKey: hangConfigDir,
-        },
-      ]);
-      expect(hangResult).toHaveLength(1);
-      expect(hangResult[0].parseError).toBe('task_timeout');
-
-      await new Promise((r) => setTimeout(r, 500));
-
-      const okResult = await pool.lintBatch([
-        {
-          filePath: 'ok.ts',
-          text: 'const TRIGGER = 1;\n',
-          rules: { 'hang/noop': { options: [] } },
-          collectFixes: false,
-          suggestionsMode: 'off',
-          configKey: hangConfigDir,
-        },
-      ]);
-      expect(okResult).toHaveLength(1);
-      expect(okResult[0].parseError).toBeUndefined();
-      expect(okResult[0].diagnostics).toHaveLength(1);
-      expect(okResult[0].diagnostics[0].message).toBe('noop fired');
-
-      const respawnLog = logs.find((l) => l.text.includes('respawning'));
-      expect(respawnLog).toBeDefined();
-
-      await pool.shutdown();
+      const r = await runPoolScenario('task-timeout');
+      expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
     }, 30_000);
   },
 );


### PR DESCRIPTION
## Summary

Worker-pool e2e tests that force a worker `terminate()` can native-abort **below the JS layer** on Windows — libuv tears down the oxc-napi worker's stdio pipes during terminate and faults, crashing the rstest test process itself. This is the recurring `Rstest exited unexpectedly` red on the `Test npm packages (rspack-windows-2022-large)` job that flakily failed unrelated commits on `main`.

**Fix — test-side process isolation, no runtime change.** Run each forced-terminate scenario in a throwaway subprocess (`tests/eslint-plugin/pool-isolation`): a native abort, if it happens, is confined to that subprocess; the parent rstest test observes the pool's outcome via a milestone file and never crashes. `worker-pool.ts` is **untouched**.

The verdict is **milestone-driven, not exit-code-driven** — a real napi abort on Windows can surface as exit code `0` (indistinguishable from a clean exit), and an orderly failure exits non-zero, so exit codes can't tell them apart; the child's own emitted milestones can:

- `PASS` — clean terminate (mac/linux): the pool finished its asserts.
- `TOLERATED-PASS` — the pool provably reached the terminate point, then the subprocess aborted (Windows napi teardown) — the pool still did its job.
- `FAIL` — hang, a failed in-child assertion, or a crash **before** the terminate point — a real regression.

Migrated all **6 forced-terminate tests**; the **23 cooperative tests** (which shut workers down gracefully and never trigger `terminate()`) stay in-process:

| suite | isolated tests |
|---|---|
| lifecycle | U11 setInterval, sync-wedged |
| resilience | worker-exit-race, task-timeout |
| queue | all-degraded, lint-batch-after-degraded |

> [!NOTE]
> The `win32-napi-teardown` skip flag (already `false`, i.e. not skipping) is left as-is. It is also shared by `host-cancel` and `packaged-isolation`; the latter has its own `execFileSync` subprocess isolation. Pruning that flag is a separate, out-of-scope cleanup.

## Related Links

- Windows CI confirming the isolation works (U11 green after the fix): https://github.com/web-infra-dev/rslint/actions/runs/28146123432

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
