### PR TITLE
feat: add gitlab output format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ This document summarizes how to work on rslint effectively and consistently.
 - Lint JS: `pnpm run lint`
 - Format JS/TS/MD: `pnpm run format`
 - CLI: `go run ./cmd/rslint --help`
-  - Examples: `go run ./cmd/rslint --config rslint.jsonc`, `--fix`, `--format default|jsonline|github`, `--quiet`, `--max-warnings 0`
+  - Examples: `go run ./cmd/rslint --config rslint.jsonc`, `--fix`, `--format default|jsonline|github|gitlab`, `--quiet`, `--max-warnings 0`
 - LSP: `go run ./cmd/rslint --lsp` | IPC API: `go run ./cmd/rslint --api`
 
 ## Coding Style & Naming Conventions
@@ -55,7 +55,7 @@ This document summarizes how to work on rslint effectively and consistently.
 - If a change affects the high-level architecture, runtime data flow, or major integration paths, update `architecture.md` in the same change.
 - rslint loads `rslint.json`/`rslint.jsonc`; rules accept ESLint-style levels/options.
 - The linter walks each file once and dispatches to registered listeners; `--singleThreaded` disables parallelism.
-- Use `--format github` in CI to emit GitHub workflow annotations.
+- Use `--format github` in CI to emit GitHub workflow annotations, or `--format gitlab` to emit a Code Quality report (`codequality` artifact) for GitLab CI merge requests.
 
 ## Website UI Guidelines (shadcn/ui)
 

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"cmp"
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -150,7 +152,7 @@ func reportSyntacticErrors(err error, w *bufio.Writer, comparePathOptions tspath
 	return rendered
 }
 
-func printDiagnostic(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOptions tspath.ComparePathsOptions, format string) {
+func printDiagnostic(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOptions tspath.ComparePathsOptions, format string, gitlabState *gitlabReportState) {
 	switch format {
 	case "default":
 		printDiagnosticDefault(d, w, comparePathOptions)
@@ -158,9 +160,141 @@ func printDiagnostic(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOptions 
 		printDiagnosticJsonLine(d, w, comparePathOptions)
 	case "github":
 		printDiagnosticGitHub(d, w, comparePathOptions)
+	case "gitlab":
+		printDiagnosticGitLab(d, w, comparePathOptions, gitlabState)
 	default:
 		panic("not supported format " + format)
 	}
+}
+
+// gitlabReportState tracks the streaming state needed to emit the gitlab
+// format as a single JSON array (one open bracket, comma-separated entries,
+// one close bracket) while diagnostics are still printed one at a time, plus
+// a fingerprint occurrence counter so two diagnostics that would otherwise
+// hash identically (rare) don't collapse into one entry in the GitLab MR
+// widget, which merges issues sharing a fingerprint.
+type gitlabReportState struct {
+	wroteFirst   bool
+	fingerprints map[string]int
+}
+
+func newGitlabReportState() *gitlabReportState {
+	return &gitlabReportState{fingerprints: make(map[string]int)}
+}
+
+// finish closes the JSON array. Must be called exactly once after all
+// diagnostics have been printed.
+func (s *gitlabReportState) finish(w *bufio.Writer) {
+	if s.wroteFirst {
+		w.WriteString("]\n")
+	} else {
+		w.WriteString("[]\n")
+	}
+}
+
+// gitlabFingerprint derives a stable identifier for a diagnostic from its
+// location and content. md5 is used only to derive a short opaque key (no
+// cryptographic resistance is needed), and the seen map breaks ties
+// deterministically instead of the random salt some other gitlab formatters
+// use, which keeps report output reproducible across runs.
+func gitlabFingerprint(seen map[string]int, filePath, ruleName, message string, startLine, startColumn, endLine, endColumn int) string {
+	input := fmt.Sprintf("%s:%s:%s:%d:%d:%d:%d", filePath, ruleName, message, startLine, startColumn, endLine, endColumn)
+	digest := func(s string) string {
+		sum := md5.Sum([]byte(s)) //nolint:gosec // opaque identifier, not a security boundary
+		return hex.EncodeToString(sum[:])
+	}
+
+	fingerprint := digest(input)
+	if n, ok := seen[fingerprint]; ok {
+		seen[fingerprint] = n + 1
+		return digest(input + ":" + strconv.Itoa(n))
+	}
+	seen[fingerprint] = 1
+	return fingerprint
+}
+
+// print as [GitLab Code Quality report](https://docs.gitlab.com/ci/testing/code_quality/)
+// format: a single JSON array of issues, suitable for the `codequality`
+// report artifact consumed by GitLab CI merge request widgets.
+func printDiagnosticGitLab(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOptions tspath.ComparePathsOptions, state *gitlabReportState) {
+	diagnosticStart := d.Range.Pos()
+	diagnosticEnd := d.Range.End()
+
+	startLine, startColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticStart)
+	endLine, endColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticEnd)
+
+	filePath := tspath.ConvertToRelativePath(d.FilePath, comparePathOptions)
+
+	var severity string
+	switch d.Severity {
+	case rule.SeverityError:
+		severity = "major"
+	case rule.SeverityWarning:
+		severity = "minor"
+	default:
+		severity = "info"
+	}
+
+	type gitlabPosition struct {
+		Line   int `json:"line"`
+		Column int `json:"column"`
+	}
+	type gitlabPositions struct {
+		Begin gitlabPosition `json:"begin"`
+		End   gitlabPosition `json:"end"`
+	}
+	type gitlabLines struct {
+		Begin int `json:"begin"`
+		End   int `json:"end"`
+	}
+	type gitlabLocation struct {
+		Path      string          `json:"path"`
+		Lines     gitlabLines     `json:"lines"`
+		Positions gitlabPositions `json:"positions"`
+	}
+	type gitlabIssue struct {
+		Description string         `json:"description"`
+		CheckName   string         `json:"check_name"`
+		Fingerprint string         `json:"fingerprint"`
+		Severity    string         `json:"severity"`
+		Location    gitlabLocation `json:"location"`
+	}
+
+	beginLine, beginColumn := int(startLine)+1, int(startColumn)+1
+	endLineNum, endColumnNum := int(endLine)+1, int(endColumn)+1
+
+	issue := gitlabIssue{
+		Description: d.Message.Description,
+		CheckName:   d.RuleName,
+		Fingerprint: gitlabFingerprint(state.fingerprints, filePath, d.RuleName, d.Message.Description, beginLine, beginColumn, endLineNum, endColumnNum),
+		Severity:    severity,
+		Location: gitlabLocation{
+			Path: filePath,
+			Lines: gitlabLines{
+				Begin: beginLine,
+				End:   endLineNum,
+			},
+			Positions: gitlabPositions{
+				Begin: gitlabPosition{Line: beginLine, Column: beginColumn},
+				End:   gitlabPosition{Line: endLineNum, Column: endColumnNum},
+			},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(issue)
+	if err != nil {
+		// gitlabIssue contains only strings and ints, so Marshal cannot fail
+		// in practice; skip rather than risk corrupting the JSON array.
+		return
+	}
+
+	if state.wroteFirst {
+		w.WriteByte(',')
+	} else {
+		w.WriteByte('[')
+		state.wroteFirst = true
+	}
+	w.Write(jsonBytes)
 }
 
 // print as [Workflow commands for GitHub Actions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands) format
@@ -484,7 +618,7 @@ Usage:
 Options:
   --init                Initialize a default config in the current directory.
   --config PATH         Which rslint config file to use.
-  --format FORMAT       Output format: default | jsonline | github
+  --format FORMAT       Output format: default | jsonline | github | gitlab
   --fix                 Automatically fix problems
   --type-check          Enable TypeScript type checking
   --type-check-only     Run only TypeScript type checking (skip all lint rules)
@@ -1380,6 +1514,10 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	typeErrorsCount := 0
 	{
 		w := bufio.NewWriterSize(os.Stdout, 4096*100)
+		var gitlabState *gitlabReportState
+		if format == "gitlab" {
+			gitlabState = newGitlabReportState()
+		}
 		for i, d := range allDiags {
 			switch d.Severity {
 			case rule.SeverityError:
@@ -1398,10 +1536,13 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			if quiet && d.Severity != rule.SeverityError {
 				continue
 			}
-			printDiagnostic(d, w, comparePathOptions, format)
+			printDiagnostic(d, w, comparePathOptions, format, gitlabState)
 			if w.Available() < 4096 {
 				w.Flush()
 			}
+		}
+		if gitlabState != nil {
+			gitlabState.finish(w)
 		}
 		w.Flush()
 	}

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -260,8 +260,8 @@ func printDiagnosticGitLab(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOp
 		Location    gitlabLocation `json:"location"`
 	}
 
-	beginLine, beginColumn := int(startLine)+1, int(startColumn)+1
-	endLineNum, endColumnNum := int(endLine)+1, int(endColumn)+1
+	beginLine, beginColumn := startLine+1, int(startColumn)+1
+	endLineNum, endColumnNum := endLine+1, int(endColumn)+1
 
 	issue := gitlabIssue{
 		Description: d.Message.Description,

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -213,7 +213,7 @@ func renderDiagnostic(t *testing.T, d rule.RuleDiagnostic, opts tspath.ComparePa
 func TestPrintDiagnosticFold(t *testing.T) {
 	// Generate a source file with many lines
 	var sb strings.Builder
-	sb.WriteString("const a = 1;\n")                // line 1
+	sb.WriteString("const a = 1;\n") // line 1
 	for i := 2; i <= 20; i++ {
 		fmt.Fprintf(&sb, "const v%d = %d;\n", i, i) // lines 2-20
 	}

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -921,5 +922,114 @@ func TestCollectAllowFileWarnings_EmptyReturnsNil(t *testing.T) {
 	got = collectAllowFileWarnings([]string{}, nil, nil, nil, "/work")
 	if got != nil {
 		t.Errorf("empty allowFiles (non-nil slice) should still produce nil, got %+v", got)
+	}
+}
+
+// TestGitlabReportState_EmptyProducesEmptyArray verifies a run with no
+// diagnostics still produces a valid (empty) JSON array, not an empty file.
+func TestGitlabReportState_EmptyProducesEmptyArray(t *testing.T) {
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	state := newGitlabReportState()
+	state.finish(w)
+	w.Flush()
+
+	if got := buf.String(); got != "[]\n" {
+		t.Errorf("expected %q, got %q", "[]\n", got)
+	}
+}
+
+// TestPrintDiagnosticGitLab verifies the gitlab format emits a single valid
+// JSON array with the fields GitLab's Code Quality report requires:
+// https://docs.gitlab.com/ci/testing/code_quality/
+func TestPrintDiagnosticGitLab(t *testing.T) {
+	source := "const unused = 42;\n"
+	startOffset := strings.Index(source, "unused")
+	diagWarning, opts := createTestDiagnostic(t, source, startOffset, startOffset+len("unused"))
+	diagWarning.Severity = rule.SeverityWarning
+	diagWarning.RuleName = "no-unused-vars"
+	diagWarning.Message = rule.RuleMessage{Id: "test", Description: "'unused' is never read."}
+
+	diagError, _ := createTestDiagnostic(t, source, 0, len("const"))
+	diagError.Severity = rule.SeverityError
+	diagError.RuleName = "prefer-const"
+	diagError.Message = rule.RuleMessage{Id: "test", Description: "Use const."}
+
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	state := newGitlabReportState()
+	printDiagnosticGitLab(diagWarning, w, opts, state)
+	printDiagnosticGitLab(diagError, w, opts, state)
+	state.finish(w)
+	w.Flush()
+
+	var issues []struct {
+		Description string `json:"description"`
+		CheckName   string `json:"check_name"`
+		Fingerprint string `json:"fingerprint"`
+		Severity    string `json:"severity"`
+		Location    struct {
+			Path  string `json:"path"`
+			Lines struct {
+				Begin int `json:"begin"`
+				End   int `json:"end"`
+			} `json:"lines"`
+			Positions struct {
+				Begin struct {
+					Line   int `json:"line"`
+					Column int `json:"column"`
+				} `json:"begin"`
+				End struct {
+					Line   int `json:"line"`
+					Column int `json:"column"`
+				} `json:"end"`
+			} `json:"positions"`
+		} `json:"location"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &issues); err != nil {
+		t.Fatalf("output is not a valid JSON array: %v\noutput: %s", err, buf.String())
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+
+	if issues[0].Severity != "minor" {
+		t.Errorf("warning should map to severity 'minor', got %q", issues[0].Severity)
+	}
+	if issues[1].Severity != "major" {
+		t.Errorf("error should map to severity 'major', got %q", issues[1].Severity)
+	}
+	if issues[0].CheckName != "no-unused-vars" {
+		t.Errorf("unexpected check_name: %q", issues[0].CheckName)
+	}
+	if issues[0].Location.Path != "index.ts" {
+		t.Errorf("expected relative path 'index.ts', got %q", issues[0].Location.Path)
+	}
+	if issues[0].Fingerprint == "" || issues[0].Fingerprint == issues[1].Fingerprint {
+		t.Errorf("each issue should have a distinct, non-empty fingerprint, got %q and %q", issues[0].Fingerprint, issues[1].Fingerprint)
+	}
+	if issues[0].Location.Positions.Begin.Line != 1 {
+		t.Errorf("expected 1-based line number, got %d", issues[0].Location.Positions.Begin.Line)
+	}
+}
+
+// TestGitlabFingerprint_CollisionsDeterministicallyDistinguished verifies
+// that two diagnostics with identical inputs (same file, rule, message,
+// position) still get distinct fingerprints, since GitLab's MR widget merges
+// issues sharing a fingerprint into a single entry.
+func TestGitlabFingerprint_CollisionsDeterministicallyDistinguished(t *testing.T) {
+	seen := make(map[string]int)
+	a := gitlabFingerprint(seen, "f.ts", "rule", "msg", 1, 1, 1, 5)
+	b := gitlabFingerprint(seen, "f.ts", "rule", "msg", 1, 1, 1, 5)
+	if a == b {
+		t.Errorf("identical inputs should still produce distinct fingerprints, got %q twice", a)
+	}
+
+	// Same inputs in a fresh run should reproduce the same first fingerprint
+	// (no randomness), so report diffs across CI runs stay stable.
+	seen2 := make(map[string]int)
+	a2 := gitlabFingerprint(seen2, "f.ts", "rule", "msg", 1, 1, 1, 5)
+	if a != a2 {
+		t.Errorf("fingerprint should be deterministic, got %q then %q", a, a2)
 	}
 }

--- a/packages/rslint-test-tools/tests/cli/basic.test.ts
+++ b/packages/rslint-test-tools/tests/cli/basic.test.ts
@@ -262,6 +262,100 @@ describe('CLI Configuration Tests', () => {
     }
   });
 
+  test('should output in gitlab code quality format when --format gitlab is used', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
+          },
+        },
+        rules: {
+          'prefer-const': 'off',
+          '@typescript-eslint/no-explicit-any': 'warn',
+          '@typescript-eslint/no-unsafe-member-access': 'error',
+        },
+        plugins: ['@typescript-eslint'],
+      })}];`,
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2020',
+          module: 'ESNext',
+          strict: true,
+        },
+        include: ['**/*.ts'],
+      }),
+      'test.ts': `
+        let a: any = 10;
+        a.b = 20;
+      `,
+    });
+
+    try {
+      const result = await runRslint(['--format', 'gitlab'], tempDir);
+
+      const issues = JSON.parse(result.stdout);
+      expect(Array.isArray(issues)).toBe(true);
+      expect(issues).toHaveLength(2);
+
+      expect(issues[0]).toMatchObject({
+        check_name: '@typescript-eslint/no-explicit-any',
+        severity: 'minor',
+        location: {
+          path: 'test.ts',
+          lines: { begin: 2, end: 2 },
+        },
+      });
+      expect(issues[1]).toMatchObject({
+        check_name: '@typescript-eslint/no-unsafe-member-access',
+        severity: 'major',
+        location: {
+          path: 'test.ts',
+          lines: { begin: 3, end: 3 },
+        },
+      });
+
+      // Fingerprints must be present and distinct.
+      expect(issues[0].fingerprint).toBeTruthy();
+      expect(issues[0].fingerprint).not.toBe(issues[1].fingerprint);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('should output an empty array for --format gitlab with no diagnostics', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
+          },
+        },
+        rules: {},
+      })}];`,
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2020',
+          module: 'ESNext',
+          strict: true,
+        },
+        include: ['**/*.ts'],
+      }),
+      'test.ts': `export const a = 1;\n`,
+    });
+
+    try {
+      const result = await runRslint(['--format', 'gitlab'], tempDir);
+      expect(JSON.parse(result.stdout)).toEqual([]);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   test('should only report errors when --quiet flag is used', async () => {
     const tempDir = await createTempDir({
       'rslint.config.mjs': `export default [${JSON.stringify({

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -77,6 +77,7 @@ co-locate
 codemod
 codemods
 codepoint
+codequality
 codspeed
 CODSPEED
 colcount
@@ -190,6 +191,7 @@ gojs
 golangci
 GOMAXPROCS
 goroutines
+gosec
 gotest
 graphlib
 handl

--- a/website/docs/en/guide/cli.md
+++ b/website/docs/en/guide/cli.md
@@ -8,19 +8,19 @@ rslint [options] [files/directories...]
 
 ## Options
 
-| Flag                 | Description                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------ |
-| `--init`             | Generate a default config file, or migrate an existing JSON config to JS/TS          |
-| `--config <path>`    | Specify which config file to use                                                     |
-| `--fix`              | Automatically fix problems                                                           |
-| `--type-check`       | Enable TypeScript semantic type checking ([details](/guide/type-checking))           |
-| `--format <format>`  | Output format: `default`, `jsonline`, or `github` ([details](/guide/output-formats)) |
-| `--quiet`            | Report errors only, suppress warnings                                                |
-| `--max-warnings <n>` | Exit with error if warning count exceeds this number                                 |
-| `--rule <rule>`      | Override a rule's severity or options (repeatable, see [details](#rule-overrides))   |
-| `--no-color`         | Disable colored output ([details](/guide/environment-variables))                     |
-| `--force-color`      | Force colored output ([details](/guide/environment-variables))                       |
-| `--help`, `-h`       | Show help information                                                                |
+| Flag                 | Description                                                                                    |
+| -------------------- | ---------------------------------------------------------------------------------------------- |
+| `--init`             | Generate a default config file, or migrate an existing JSON config to JS/TS                    |
+| `--config <path>`    | Specify which config file to use                                                               |
+| `--fix`              | Automatically fix problems                                                                     |
+| `--type-check`       | Enable TypeScript semantic type checking ([details](/guide/type-checking))                     |
+| `--format <format>`  | Output format: `default`, `jsonline`, `github`, or `gitlab` ([details](/guide/output-formats)) |
+| `--quiet`            | Report errors only, suppress warnings                                                          |
+| `--max-warnings <n>` | Exit with error if warning count exceeds this number                                           |
+| `--rule <rule>`      | Override a rule's severity or options (repeatable, see [details](#rule-overrides))             |
+| `--no-color`         | Disable colored output ([details](/guide/environment-variables))                               |
+| `--force-color`      | Force colored output ([details](/guide/environment-variables))                                 |
+| `--help`, `-h`       | Show help information                                                                          |
 
 ## File and Directory Arguments
 

--- a/website/docs/en/guide/output-formats.md
+++ b/website/docs/en/guide/output-formats.md
@@ -48,3 +48,41 @@ GitHub Actions workflow command format. Creates annotations directly on pull req
 ```bash
 rslint --format github .
 ```
+
+## gitlab
+
+[GitLab Code Quality report](https://docs.gitlab.com/ci/testing/code_quality/) format. A single JSON array, suitable for the `codequality` report artifact that GitLab CI uses to annotate merge requests.
+
+```bash
+rslint --format gitlab . > gl-code-quality-report.json
+```
+
+```json
+[
+  {
+    "description": "'foo' is declared but its value is never read.",
+    "check_name": "@typescript-eslint/no-unused-vars",
+    "fingerprint": "27e4b8b16cb47e2d6e6d4b8b6f6c6b6f",
+    "severity": "major",
+    "location": {
+      "path": "src/index.ts",
+      "lines": { "begin": 5, "end": 5 },
+      "positions": {
+        "begin": { "line": 5, "column": 7 },
+        "end": { "line": 5, "column": 10 }
+      }
+    }
+  }
+]
+```
+
+Error diagnostics map to `major` severity and warnings map to `minor`. To wire this into a pipeline, add the report as a `codequality` artifact in `.gitlab-ci.yml`:
+
+```yaml
+lint:
+  script:
+    - rslint --format gitlab . > gl-code-quality-report.json
+  artifacts:
+    reports:
+      codequality: gl-code-quality-report.json
+```


### PR DESCRIPTION
## Summary

Implements a GitLab Code Quality report formatter, following the [GitLab spec](https://docs.gitlab.com/ci/testing/code_quality/) (CodeClimate-compatible JSON), so rslint output can be wired up as a codequality artifact in `.gitlab-ci.yml` to get inline merge request annotations.

Use it by `rslint --format gitlab`.

Example output:

```json
[
  {
    "description": "Forbidden non-null assertion.",
    "check_name": "@typescript-eslint/no-non-null-assertion",
    "fingerprint": "361e2e065af277e4587372b068f2ab71",
    "severity": "minor",
    "location": {
      "path": "website/theme/components/RuleConfig.tsx",
      "lines": {
        "begin": 9,
        "end": 9
      },
      "positions": {
        "begin": {
          "line": 9,
          "column": 43
        },
        "end": {
          "line": 9,
          "column": 56
        }
      }
    }
  }
]
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
