### PR TITLE
feat: expose parameter property symbols in tsgo semantic output

### DIFF
--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -274,15 +274,12 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 			// Collect shorthand assignment value symbol
 			if valueSymbol := tc.GetShorthandAssignmentValueSymbol(node); valueSymbol != nil {
 				value_sym_id := ast.GetSymbolId(valueSymbol)
-				semantic.ShorthandSymbols[key] = value_sym_id
-
 				// Also record this symbol if not already recorded
 				if _, exists := semantic.Symtab[value_sym_id]; !exists {
 					if ty := tc.GetTypeOfSymbol(valueSymbol); ty != nil {
 						typeID := recordType(ty)
-
 						declRef := nodeReference(valueSymbol.ValueDeclaration)
-
+						semantic.ShorthandSymbols[key] = value_sym_id
 						semantic.Symtab[value_sym_id] = SymbolInfo{
 							Id:         value_sym_id,
 							Name:       sanitizeSymbolName(valueSymbol.Name),
@@ -302,13 +299,11 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 						parameterSymbol, _ := tc.GetSymbolsOfParameterPropertyDeclaration(node, name.Text())
 						if parameterSymbol != nil {
 							parameterSymbolID := ast.GetSymbolId(parameterSymbol)
-							semantic.ParameterPropertySymbols[*nameKey] = parameterSymbolID
 							if _, exists := semantic.Symtab[parameterSymbolID]; !exists {
 								if ty := tc.GetTypeOfSymbol(parameterSymbol); ty != nil {
 									typeID := recordType(ty)
-
 									declRef := nodeReference(parameterSymbol.ValueDeclaration)
-
+									semantic.ParameterPropertySymbols[*nameKey] = parameterSymbolID
 									semantic.Symtab[parameterSymbolID] = SymbolInfo{
 										Id:         parameterSymbolID,
 										Name:       sanitizeSymbolName(parameterSymbol.Name),

--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -274,12 +274,12 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 			// Collect shorthand assignment value symbol
 			if valueSymbol := tc.GetShorthandAssignmentValueSymbol(node); valueSymbol != nil {
 				value_sym_id := ast.GetSymbolId(valueSymbol)
+				semantic.ShorthandSymbols[key] = value_sym_id
 				// Also record this symbol if not already recorded
 				if _, exists := semantic.Symtab[value_sym_id]; !exists {
 					if ty := tc.GetTypeOfSymbol(valueSymbol); ty != nil {
 						typeID := recordType(ty)
 						declRef := nodeReference(valueSymbol.ValueDeclaration)
-						semantic.ShorthandSymbols[key] = value_sym_id
 						semantic.Symtab[value_sym_id] = SymbolInfo{
 							Id:         value_sym_id,
 							Name:       sanitizeSymbolName(valueSymbol.Name),
@@ -299,11 +299,11 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 						parameterSymbol, _ := tc.GetSymbolsOfParameterPropertyDeclaration(node, name.Text())
 						if parameterSymbol != nil {
 							parameterSymbolID := ast.GetSymbolId(parameterSymbol)
+							semantic.ParameterPropertySymbols[*nameKey] = parameterSymbolID
 							if _, exists := semantic.Symtab[parameterSymbolID]; !exists {
 								if ty := tc.GetTypeOfSymbol(parameterSymbol); ty != nil {
 									typeID := recordType(ty)
 									declRef := nodeReference(parameterSymbol.ValueDeclaration)
-									semantic.ParameterPropertySymbols[*nameKey] = parameterSymbolID
 									semantic.Symtab[parameterSymbolID] = SymbolInfo{
 										Id:         parameterSymbolID,
 										Name:       sanitizeSymbolName(parameterSymbol.Name),

--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -109,19 +109,23 @@ type Semantic struct {
 	// ShorthandSymbols maps node reference to the value symbol for shorthand property assignments
 	// (node -> value_symbol_id)
 	ShorthandSymbols map[NodeReference]ast.SymbolId `json:"shorthand_symbols"`
+	// ParameterPropertySymbols maps a parameter property name node to the other symbol declared at that location.
+	// The primary symbol remains recorded in Node2sym.
+	ParameterPropertySymbols map[NodeReference]ast.SymbolId `json:"parameter_property_symbols"`
 }
 
 func NewSemantic() Semantic {
 	return Semantic{
-		Symtab:           make(map[ast.SymbolId]SymbolInfo),
-		Typetab:          make(map[checker.TypeId]TypeInfo),
-		Sym2type:         make(map[ast.SymbolId]checker.TypeId),
-		AliasSymbols:     make(map[ast.SymbolId]ast.SymbolId),
-		Node2sym:         make(map[NodeReference]ast.SymbolId),
-		Node2type:        make(map[NodeReference]checker.TypeId),
-		NodeFlags:        make(map[NodeReference]uint32),
-		ShorthandSymbols: make(map[NodeReference]ast.SymbolId),
-		Primtypes:        PrimTypes{},
+		Symtab:                   make(map[ast.SymbolId]SymbolInfo),
+		Typetab:                  make(map[checker.TypeId]TypeInfo),
+		Sym2type:                 make(map[ast.SymbolId]checker.TypeId),
+		AliasSymbols:             make(map[ast.SymbolId]ast.SymbolId),
+		Node2sym:                 make(map[NodeReference]ast.SymbolId),
+		Node2type:                make(map[NodeReference]checker.TypeId),
+		NodeFlags:                make(map[NodeReference]uint32),
+		ShorthandSymbols:         make(map[NodeReference]ast.SymbolId),
+		ParameterPropertySymbols: make(map[NodeReference]ast.SymbolId),
+		Primtypes:                PrimTypes{},
 		TypeExtra: TypeExtra{
 			Name: make(map[int]CString),
 			Func: make(map[int]FunctionData),
@@ -287,6 +291,35 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 							Decl:       declRef,
 						}
 						semantic.Sym2type[value_sym_id] = typeID
+					}
+				}
+			}
+
+			if ast.IsParameterPropertyDeclaration(node, node.Parent) {
+				name := node.Name()
+				if name != nil && ast.IsIdentifier(name) {
+					if nameKey := nodeReference(name); nameKey != nil {
+						parameterSymbol, _ := tc.GetSymbolsOfParameterPropertyDeclaration(node, name.Text())
+						if parameterSymbol != nil {
+							parameterSymbolID := ast.GetSymbolId(parameterSymbol)
+							semantic.ParameterPropertySymbols[*nameKey] = parameterSymbolID
+							if _, exists := semantic.Symtab[parameterSymbolID]; !exists {
+								if ty := tc.GetTypeOfSymbol(parameterSymbol); ty != nil {
+									typeID := recordType(ty)
+
+									declRef := nodeReference(parameterSymbol.ValueDeclaration)
+
+									semantic.Symtab[parameterSymbolID] = SymbolInfo{
+										Id:         parameterSymbolID,
+										Name:       sanitizeSymbolName(parameterSymbol.Name),
+										Flags:      int(parameterSymbol.Flags),
+										CheckFlags: int(parameterSymbol.CheckFlags),
+										Decl:       declRef,
+									}
+									semantic.Sym2type[parameterSymbolID] = typeID
+								}
+							}
+						}
 					}
 				}
 			}

--- a/crates/tsgo-client/src/proto.rs
+++ b/crates/tsgo-client/src/proto.rs
@@ -53,6 +53,9 @@ pub struct Semantic {
     // Shorthand property assignment value symbols (node -> value_symbol_id)
     #[serde(default, deserialize_with = "vecmap_or_empty")]
     pub shorthand_symbols: Vec<(NodeReference, u32)>,
+    // Parameter property declarations create another symbol at the same name node; node2sym keeps the primary symbol.
+    #[serde(default, deserialize_with = "vecmap_or_empty")]
+    pub parameter_property_symbols: Vec<(NodeReference, u32)>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -228,6 +231,22 @@ impl Semantic {
     pub fn get_shorthand_assignment_value_symbol(&self, location: &NodeReference) -> Option<u32> {
         // Look up in the shorthand_symbols mapping
         self.shorthand_symbols
+            .iter()
+            .find(|(node_ref, _)| {
+                node_ref.sourcefile_id == location.sourcefile_id
+                    && node_ref.start == location.start
+                    && node_ref.end == location.end
+            })
+            .map(|(_, sym_id)| *sym_id)
+    }
+
+    /// Returns the extra symbol declared by a parameter property name.
+    ///
+    /// TypeScript parameter properties such as `constructor(private x: string)` declare two
+    /// symbols at the same source location. The primary symbol remains in `node2sym`; this
+    /// method returns the other one.
+    pub fn get_parameter_property_symbol(&self, location: &NodeReference) -> Option<u32> {
+        self.parameter_property_symbols
             .iter()
             .find(|(node_ref, _)| {
                 node_ref.sourcefile_id == location.sourcefile_id

--- a/crates/tsgo-client/tests/fixtures/simple-project/src/index.ts
+++ b/crates/tsgo-client/tests/fixtures/simple-project/src/index.ts
@@ -25,5 +25,17 @@ export class Calculator {
   }
 }
 
+export class ParameterPropertyExample {
+  constructor(
+    private testType: string,
+    public readonly count: number,
+    protected enabled: boolean,
+  ) {}
+
+  getTestType() {
+    return this.testType;
+  }
+}
+
 const message = greet('World');
 console.log(message);

--- a/crates/tsgo-client/tests/integration_test.rs
+++ b/crates/tsgo-client/tests/integration_test.rs
@@ -286,3 +286,136 @@ fn test_get_shorthand_assignment_value_symbol() {
     // Generate snapshot
     insta::assert_json_snapshot!(shorthand_mappings);
 }
+
+#[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+struct ParameterPropertySymbolMapping {
+    source_node_span: String,
+    primary_symbol_name: String,
+    extra_symbol_name: String,
+    primary_decl_span: String,
+    extra_decl_span: String,
+}
+
+#[test]
+fn test_get_parameter_property_symbols() {
+    let tsgo_path = get_tsgo_path().expect(
+        "Could not find tsgo executable. \
+         Please build tsgo first or ensure it's in your PATH.",
+    );
+
+    let fixture_dir = get_fixtures_dir().join("simple-project");
+    let config_file = fixture_dir.join("tsconfig.json");
+
+    let options = Options {
+        cwd: Some(fixture_dir.clone()),
+        log_file: None,
+        config_file: config_file.to_string_lossy().to_string(),
+    };
+
+    let uninitialized_client = Client::builder(OsStr::new(&tsgo_path), options)
+        .build()
+        .expect("Failed to build client");
+
+    let api =
+        Api::with_uninitialized_client(uninitialized_client).expect("Failed to initialize API");
+
+    let mut buffer = Vec::new();
+    let project = api
+        .load_project(&mut buffer)
+        .expect("Failed to load project");
+
+    let semantic = &project.semantic;
+    let mut mappings = Vec::new();
+
+    for (node_ref, extra_symbol_id) in &semantic.parameter_property_symbols {
+        let Some(extra_symbol_id_from_lookup) = semantic.get_parameter_property_symbol(node_ref)
+        else {
+            panic!("parameter property lookup should find the recorded location");
+        };
+
+        assert_eq!(*extra_symbol_id, extra_symbol_id_from_lookup);
+
+        let Some((_, primary_symbol_id)) = semantic.node2sym.iter().find(|(location, _)| {
+            location.sourcefile_id == node_ref.sourcefile_id
+                && location.start == node_ref.start
+                && location.end == node_ref.end
+        }) else {
+            panic!("primary parameter property symbol should be present in node2sym");
+        };
+        let primary_symbol_id = *primary_symbol_id;
+        let extra_symbol_id = *extra_symbol_id;
+
+        assert_ne!(
+            primary_symbol_id, extra_symbol_id,
+            "extra parameter property symbol should differ from node2sym"
+        );
+
+        let Some((_, primary_symbol_data)) = semantic
+            .symtab
+            .iter()
+            .find(|(id, _)| *id == primary_symbol_id)
+        else {
+            panic!("primary symbol should be present in symtab");
+        };
+
+        let Some((_, extra_symbol_data)) = semantic
+            .symtab
+            .iter()
+            .find(|(id, _)| *id == extra_symbol_id)
+        else {
+            panic!("extra symbol should be present in symtab");
+        };
+
+        let primary_flags = SymbolFlags::from_bits_truncate(primary_symbol_data.flags);
+        let extra_flags = SymbolFlags::from_bits_truncate(extra_symbol_data.flags);
+        assert!(
+            primary_flags.intersects(SymbolFlags::PROPERTY | SymbolFlags::CLASS_MEMBER),
+            "node2sym for parameter property should be the property symbol, got: {primary_flags:?}"
+        );
+        assert!(
+            extra_flags.contains(SymbolFlags::FUNCTION_SCOPED_VARIABLE),
+            "extra parameter property symbol should be the parameter symbol, got: {extra_flags:?}"
+        );
+
+        let primary_symbol_name = String::from_utf8_lossy(&primary_symbol_data.name).to_string();
+        let extra_symbol_name = String::from_utf8_lossy(&extra_symbol_data.name).to_string();
+
+        if ["testType", "count", "enabled"].contains(&primary_symbol_name.as_str()) {
+            assert_eq!(primary_symbol_name, extra_symbol_name);
+
+            let source_node_span = format!(
+                "{}:{}..{}",
+                node_ref.sourcefile_id, node_ref.start, node_ref.end
+            );
+            let primary_decl_span = if let Some(decl) = &primary_symbol_data.decl {
+                format!("{}:{}..{}", decl.sourcefile_id, decl.start, decl.end)
+            } else {
+                "unknown".to_string()
+            };
+            let extra_decl_span = if let Some(decl) = &extra_symbol_data.decl {
+                format!("{}:{}..{}", decl.sourcefile_id, decl.start, decl.end)
+            } else {
+                "unknown".to_string()
+            };
+
+            mappings.push(ParameterPropertySymbolMapping {
+                source_node_span,
+                primary_symbol_name,
+                extra_symbol_name,
+                primary_decl_span,
+                extra_decl_span,
+            });
+        }
+    }
+
+    mappings.sort();
+
+    assert_eq!(
+        mappings.len(),
+        3,
+        "Expected 3 parameter property mappings, found {}",
+        mappings.len()
+    );
+
+    insta::assert_json_snapshot!(mappings);
+}

--- a/crates/tsgo-client/tests/snapshots/integration_test__get_parameter_property_symbols.snap
+++ b/crates/tsgo-client/tests/snapshots/integration_test__get_parameter_property_symbols.snap
@@ -1,0 +1,28 @@
+---
+source: crates/tsgo-client/tests/integration_test.rs
+assertion_line: 423
+expression: mappings
+---
+[
+  {
+    "source_node_span": "51:538..547",
+    "primary_symbol_name": "testType",
+    "extra_symbol_name": "testType",
+    "primary_decl_span": "51:526..555",
+    "extra_decl_span": "51:526..555"
+  },
+  {
+    "source_node_span": "51:576..582",
+    "primary_symbol_name": "count",
+    "extra_symbol_name": "count",
+    "primary_decl_span": "51:556..590",
+    "extra_decl_span": "51:556..590"
+  },
+  {
+    "source_node_span": "51:605..613",
+    "primary_symbol_name": "enabled",
+    "extra_symbol_name": "enabled",
+    "primary_decl_span": "51:591..622",
+    "extra_decl_span": "51:591..622"
+  }
+]


### PR DESCRIPTION
## Summary

Adds semantic support for TypeScript parameter properties by recording the extra parameter symbol declared at the same name node as the property symbol.

For parameter properties, `node2sym` continues to expose the primary property/class-member symbol, while the new `parameter_property_symbols` mapping exposes the additional function-scoped parameter symbol. The Rust client also gets a helper API to look up this extra symbol by `NodeReference`.

## Example

Given:

```ts
class ParameterPropertyExample {
  constructor(
    private testType: string,
    public readonly count: number,
    protected enabled: boolean,
  ) {}
}
```

The semantic output now records both symbols for each parameter property name:
`node2sym` maps `testType`, `count`, and `enabled` to their property symbols.
`parameter_property_symbols` maps the same source locations to their extra parameter symbols.

Rust client usage:
```rs
let extra_symbol_id = semantic.get_parameter_property_symbol(node_ref);
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
