### PR TITLE
feat(eslint-plugin-jest): add `no-unneeded-async-expect-function` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -19,6 +19,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_mocks_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_standalone_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_test_prefixes"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_unneeded_async_expect_function"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_called_with"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_each"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_equality_matcher"
@@ -60,6 +61,7 @@ func GetAllRules() []rule.Rule {
 		no_mocks_import.NoMocksImportRule,
 		no_standalone_expect.NoStandaloneExpectRule,
 		no_test_prefixes.NoTestPrefixesRule,
+		no_unneeded_async_expect_function.NoUnneededAsyncExpectFunctionRule,
 		prefer_called_with.PreferCalledWithRule,
 		prefer_each.PreferEachRule,
 		prefer_equality_matcher.PreferEqualityMatcherRule,

--- a/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function.go
+++ b/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function.go
@@ -1,0 +1,127 @@
+package no_unneeded_async_expect_function
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	rslintUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildNoAsyncWrapperForExpectedPromiseMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noAsyncWrapperForExpectedPromise",
+		Description: "Avoid wrapping asynchronous expectations in an unnecessary async function.",
+	}
+}
+
+func isAsyncFunction(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipParentheses(node)
+	return node != nil &&
+		ast.IsFunctionExpressionOrArrowFunction(node) &&
+		ast.IsAsyncFunction(node)
+}
+
+func functionBody(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	node = ast.SkipParentheses(node)
+
+	switch node.Kind {
+	case ast.KindArrowFunction:
+		return node.AsArrowFunction().Body
+	case ast.KindFunctionExpression:
+		return node.AsFunctionExpression().Body
+	default:
+		return nil
+	}
+}
+
+func singleStatementExpression(body *ast.Node) *ast.Node {
+	if body == nil || body.Kind != ast.KindBlock {
+		return body
+	}
+
+	block := body.AsBlock()
+	if block == nil || block.Statements == nil || len(block.Statements.Nodes) != 1 {
+		return nil
+	}
+
+	stmt := block.Statements.Nodes[0]
+	if stmt == nil || stmt.Kind != ast.KindExpressionStatement {
+		return nil
+	}
+
+	return stmt.AsExpressionStatement().Expression
+}
+
+func getUnwrappedAwaitedExpression(fn *ast.Node) *ast.Node {
+	expr := singleStatementExpression(functionBody(fn))
+	if expr == nil {
+		return nil
+	}
+	expr = ast.SkipParentheses(expr)
+	if expr == nil || expr.Kind != ast.KindAwaitExpression {
+		return nil
+	}
+
+	awaited := expr.AsAwaitExpression().Expression
+	if awaited == nil {
+		return nil
+	}
+	awaited = ast.SkipParentheses(awaited)
+	if awaited == nil || awaited.Kind != ast.KindCallExpression {
+		return nil
+	}
+
+	return awaited
+}
+
+func hasPromiseExpectModifier(jestFnCall *jestUtils.ParsedJestFnCall) bool {
+	return slices.Contains(jestFnCall.Modifiers, "resolves") ||
+		slices.Contains(jestFnCall.Modifiers, "rejects")
+}
+
+var NoUnneededAsyncExpectFunctionRule = rule.Rule{
+	Name: "jest/no-unneeded-async-expect-function",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				jestFnCall := jestUtils.ParseJestFnCall(node, ctx)
+				if jestFnCall == nil ||
+					jestFnCall.Kind != jestUtils.JestFnTypeExpect ||
+					!hasPromiseExpectModifier(jestFnCall) {
+					return
+				}
+
+				expectCall := jestFnCall.Head.Local.Node.Parent
+				if expectCall == nil || expectCall.Kind != ast.KindCallExpression {
+					return
+				}
+
+				args := expectCall.Arguments()
+				if len(args) == 0 || !isAsyncFunction(args[0]) {
+					return
+				}
+
+				awaited := getUnwrappedAwaitedExpression(args[0])
+				if awaited == nil {
+					return
+				}
+
+				sourceFile := ctx.SourceFile
+				replacement := rslintUtils.TrimmedNodeText(sourceFile, awaited)
+				ctx.ReportNodeWithFixes(
+					args[0],
+					buildNoAsyncWrapperForExpectedPromiseMessage(),
+					rule.RuleFixReplace(sourceFile, args[0], replacement),
+				)
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function.md
+++ b/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function.md
@@ -1,0 +1,52 @@
+# no-unneeded-async-expect-function
+
+## Rule Details
+
+Disallow wrapping an expected promise in an unnecessary async function when
+using Jest promise assertions.
+
+Jest promise assertions can receive the promise directly:
+`await expect(doSomethingAsync()).rejects.toThrow()` or
+`await expect(doSomethingAsync()).resolves.toBe(value)`. Wrapping that call in
+`async () => { await doSomethingAsync(); }` is more verbose and makes the test
+harder to read without changing the assertion.
+
+This rule reports `expect()` calls whose first argument is an async function
+with a single awaited call expression. It is fixable: the async wrapper is
+replaced with the awaited call. Renamed `expect` bindings imported from
+`@jest/globals` are also recognized.
+
+Examples of **incorrect** code for this rule:
+
+```js
+it('wrong1', async () => {
+  await expect(async () => {
+    await doSomethingAsync();
+  }).rejects.toThrow();
+});
+
+it('wrong2', async () => {
+  await expect(async function () {
+    await doSomethingAsync();
+  }).rejects.toThrow();
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it('right1', async () => {
+  await expect(doSomethingAsync()).rejects.toThrow();
+});
+```
+
+## Differences from ESLint
+
+rslint also fixes equivalent concise arrow functions and parenthesized async
+function arguments, such as `expect(async () => await doSomethingAsync())` and
+`expect((async () => { await doSomethingAsync(); }))`. These shapes are handled
+as the same safe unwrap because tsgo preserves them explicitly in the AST.
+
+## Original Documentation
+
+- [jest/no-unneeded-async-expect-function](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-unneeded-async-expect-function.md)

--- a/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function_test.go
+++ b/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function_test.go
@@ -1,0 +1,276 @@
+package no_unneeded_async_expect_function_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_unneeded_async_expect_function"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnneededAsyncExpectFunctionRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_unneeded_async_expect_function.NoUnneededAsyncExpectFunctionRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect.hasAssertions()`},
+			{Code: `
+      it('pass', async () => {
+        expect();
+      })
+    `},
+			{Code: `
+      it('pass', async () => {
+        await expect(doSomethingAsync()).rejects.toThrow();
+      })
+    `},
+			{Code: `
+      it('pass', async () => {
+        await expect(doSomethingAsync(1, 2)).resolves.toBe(1);
+      })
+    `},
+			{Code: `
+      it('pass', async () => {
+        await expect(async () => {
+          await doSomethingAsync();
+          await doSomethingTwiceAsync(1, 2);
+        }).rejects.toThrow();
+      })
+    `},
+			{Code: `
+        import { expect as pleaseExpect } from '@jest/globals';
+        it('pass', async () => {
+          await pleaseExpect(doSomethingAsync()).rejects.toThrow();
+        })
+      `},
+			{Code: `
+      it('pass', async () => {
+        await expect(async () => {
+          doSomethingAsync();
+        }).rejects.toThrow();
+      })
+    `},
+			{Code: `
+      it('pass', async () => {
+        await expect(async () => {
+          const a = 1;
+          await doSomethingAsync(a);
+        }).rejects.toThrow();
+      })
+    `},
+			{Code: `
+      it('pass for non-async expect', async () => {
+        await expect(() => {
+          doSomethingSync(a);
+        }).rejects.toThrow();
+      })
+    `},
+			{Code: `
+      it('pass for await in expect', async () => {
+        await expect(await doSomethingAsync()).rejects.toThrow();
+      })
+    `},
+			{Code: `
+      it('pass for different matchers', async () => {
+        await expect(await doSomething()).not.toThrow();
+        await expect(await doSomething()).toHaveLength(2);
+        await expect(await doSomething()).toHaveReturned();
+        await expect(await doSomething()).not.toHaveBeenCalled();
+        await expect(await doSomething()).not.toBeDefined();
+        await expect(await doSomething()).toEqual(2);
+      })
+    `},
+			{Code: `
+      it('pass for using await within for-loop', async () => {
+        const b = [async () => Promise.resolve(1), async () => Promise.reject(2)];
+        await expect(async() => {
+          for (const a of b) {
+            await b();
+          }
+        }).rejects.toThrow();
+      })
+    `},
+			{Code: `
+      it('pass for using await within array', async () => {
+        await expect(async() => [await Promise.reject(2)]).rejects.toThrow(2);
+      })
+    `},
+			{Code: `
+      it('does not unwrap awaited identifiers', async () => {
+        const promise = doSomethingAsync();
+        await expect(async () => {
+          await promise;
+        }).rejects.toThrow();
+      })
+    `},
+			{Code: `
+      it('does not unwrap async functions for sync matchers', async () => {
+        expect(async () => {
+          await doSomethingAsync();
+        }).toThrow();
+      })
+    `},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `
+        it('should be fixed', async () => {
+          await expect(async () => {
+            await doSomethingAsync();
+          }).rejects.toThrow(); 
+        })
+      `,
+				Output: []string{`
+        it('should be fixed', async () => {
+          await expect(doSomethingAsync()).rejects.toThrow(); 
+        })
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAsyncWrapperForExpectedPromise"},
+				},
+			},
+			{
+				Code: `
+        it('should be fixed', async () => {
+          await expect(async function () {
+            await doSomethingAsync();
+          }).rejects.toThrow(); 
+        })
+      `,
+				Output: []string{`
+        it('should be fixed', async () => {
+          await expect(doSomethingAsync()).rejects.toThrow(); 
+        })
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAsyncWrapperForExpectedPromise"},
+				},
+			},
+			{
+				Code: `
+        it('should be fixed for async arrow function', async () => {
+          await expect(async () => {
+            await doSomethingAsync(1, 2);
+          }).rejects.toThrow(); 
+        })
+      `,
+				Output: []string{`
+        it('should be fixed for async arrow function', async () => {
+          await expect(doSomethingAsync(1, 2)).rejects.toThrow(); 
+        })
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAsyncWrapperForExpectedPromise"},
+				},
+			},
+			{
+				Code: `
+        it('should be fixed for async normal function', async () => {
+          await expect(async function () {
+            await doSomethingAsync(1, 2);
+          }).rejects.toThrow(); 
+        })
+      `,
+				Output: []string{`
+        it('should be fixed for async normal function', async () => {
+          await expect(doSomethingAsync(1, 2)).rejects.toThrow(); 
+        })
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAsyncWrapperForExpectedPromise"},
+				},
+			},
+			{
+				Code: `
+        it('should be fixed for Promise.all', async () => {
+          await expect(async function () {
+            await Promise.all([doSomethingAsync(1, 2), doSomethingAsync()]);
+          }).rejects.toThrow(); 
+        })
+      `,
+				Output: []string{`
+        it('should be fixed for Promise.all', async () => {
+          await expect(Promise.all([doSomethingAsync(1, 2), doSomethingAsync()])).rejects.toThrow(); 
+        })
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAsyncWrapperForExpectedPromise"},
+				},
+			},
+			{
+				Code: `
+        it('should be fixed for async ref to expect', async () => {
+          const a = async () => { await doSomethingAsync() };
+          await expect(async () => {
+            await a();
+          }).rejects.toThrow();
+        })
+      `,
+				Output: []string{`
+        it('should be fixed for async ref to expect', async () => {
+          const a = async () => { await doSomethingAsync() };
+          await expect(a()).rejects.toThrow();
+        })
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAsyncWrapperForExpectedPromise"},
+				},
+			},
+			{
+				Code: `
+        it('should be fixed for resolves', async () => {
+          await expect(async () => {
+            await doSomethingAsync();
+          }).resolves.toBe(1);
+        })
+      `,
+				Output: []string{`
+        it('should be fixed for resolves', async () => {
+          await expect(doSomethingAsync()).resolves.toBe(1);
+        })
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAsyncWrapperForExpectedPromise"},
+				},
+			},
+			{
+				// rslint enhancement: tsgo exposes concise arrow bodies directly,
+				// so the same safe unwrap can be applied without a block body.
+				Code: `
+        it('fixes concise async arrow functions', async () => {
+          await expect(async () => await doSomethingAsync()).rejects.toThrow();
+        })
+      `,
+				Output: []string{`
+        it('fixes concise async arrow functions', async () => {
+          await expect(doSomethingAsync()).rejects.toThrow();
+        })
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAsyncWrapperForExpectedPromise"},
+				},
+			},
+			{
+				// rslint enhancement: parenthesized async function arguments are
+				// matched even though ESTree-based upstream tests do not cover them.
+				Code: `
+        it('fixes parenthesized async functions', async () => {
+          await expect((async () => {
+            await doSomethingAsync();
+          })).rejects.toThrow();
+        })
+      `,
+				Output: []string{`
+        it('fixes parenthesized async functions', async () => {
+          await expect(doSomethingAsync()).rejects.toThrow();
+        })
+      `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAsyncWrapperForExpectedPromise"},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -483,6 +483,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/no-mocks-import.test.ts',
     './tests/eslint-plugin-jest/rules/no-standalone-expect.test.ts',
     './tests/eslint-plugin-jest/rules/no-test-prefixes.test.ts',
+    './tests/eslint-plugin-jest/rules/no-unneeded-async-expect-function.test.ts',
     './tests/eslint-plugin-jest/rules/no-duplicate-hooks.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-called-with.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-each.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-unneeded-async-expect-function.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-unneeded-async-expect-function.test.ts
@@ -1,0 +1,275 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unneeded-async-expect-function', {} as never, {
+  valid: [
+    { code: 'expect.hasAssertions()' },
+    {
+      code: `
+      it('pass', async () => {
+        expect();
+      })
+    `,
+    },
+    {
+      code: `
+      it('pass', async () => {
+        await expect(doSomethingAsync()).rejects.toThrow();
+      })
+    `,
+    },
+    {
+      code: `
+      it('pass', async () => {
+        await expect(doSomethingAsync(1, 2)).resolves.toBe(1);
+      })
+    `,
+    },
+    {
+      code: `
+      it('pass', async () => {
+        await expect(async () => {
+          await doSomethingAsync();
+          await doSomethingTwiceAsync(1, 2);
+        }).rejects.toThrow();
+      })
+    `,
+    },
+    {
+      code: `
+        import { expect as pleaseExpect } from '@jest/globals';
+        it('pass', async () => {
+          await pleaseExpect(doSomethingAsync()).rejects.toThrow();
+        })
+      `,
+    },
+    {
+      code: `
+      it('pass', async () => {
+        await expect(async () => {
+          doSomethingAsync();
+        }).rejects.toThrow();
+      })
+    `,
+    },
+    {
+      code: `
+      it('pass', async () => {
+        await expect(async () => {
+          const a = 1;
+          await doSomethingAsync(a);
+        }).rejects.toThrow();
+      })
+    `,
+    },
+    {
+      code: `
+      it('pass for non-async expect', async () => {
+        await expect(() => {
+          doSomethingSync(a);
+        }).rejects.toThrow();
+      })
+    `,
+    },
+    {
+      code: `
+      it('pass for await in expect', async () => {
+        await expect(await doSomethingAsync()).rejects.toThrow();
+      })
+    `,
+    },
+    {
+      code: `
+      it('pass for different matchers', async () => {
+        await expect(await doSomething()).not.toThrow();
+        await expect(await doSomething()).toHaveLength(2);
+        await expect(await doSomething()).toHaveReturned();
+        await expect(await doSomething()).not.toHaveBeenCalled();
+        await expect(await doSomething()).not.toBeDefined();
+        await expect(await doSomething()).toEqual(2);
+      })
+    `,
+    },
+    {
+      code: `
+      it('pass for using await within for-loop', async () => {
+        const b = [async () => Promise.resolve(1), async () => Promise.reject(2)];
+        await expect(async() => {
+          for (const a of b) {
+            await b();
+          }
+        }).rejects.toThrow();
+      })
+    `,
+    },
+    {
+      code: `
+      it('pass for using await within array', async () => {
+        await expect(async() => [await Promise.reject(2)]).rejects.toThrow(2);
+      })
+    `,
+    },
+    {
+      code: `
+      it('does not unwrap awaited identifiers', async () => {
+        const promise = doSomethingAsync();
+        await expect(async () => {
+          await promise;
+        }).rejects.toThrow();
+      })
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        it('should be fixed', async () => {
+          await expect(async () => {
+            await doSomethingAsync();
+          }).rejects.toThrow(); 
+        })
+      `,
+      output: `
+        it('should be fixed', async () => {
+          await expect(doSomethingAsync()).rejects.toThrow(); 
+        })
+      `,
+      errors: [
+        {
+          endColumn: 4,
+          column: 16,
+          messageId: 'noAsyncWrapperForExpectedPromise',
+        },
+      ],
+    },
+    {
+      code: `
+        it('should be fixed', async () => {
+          await expect(async function () {
+            await doSomethingAsync();
+          }).rejects.toThrow(); 
+        })
+      `,
+      output: `
+        it('should be fixed', async () => {
+          await expect(doSomethingAsync()).rejects.toThrow(); 
+        })
+    `,
+      errors: [
+        {
+          endColumn: 4,
+          column: 16,
+          messageId: 'noAsyncWrapperForExpectedPromise',
+        },
+      ],
+    },
+    {
+      code: `
+        it('should be fixed for async arrow function', async () => {
+          await expect(async () => {
+            await doSomethingAsync(1, 2);
+          }).rejects.toThrow(); 
+        })
+      `,
+      output: `
+        it('should be fixed for async arrow function', async () => {
+          await expect(doSomethingAsync(1, 2)).rejects.toThrow(); 
+        })
+      `,
+      errors: [
+        {
+          endColumn: 4,
+          column: 16,
+          messageId: 'noAsyncWrapperForExpectedPromise',
+        },
+      ],
+    },
+    {
+      code: `
+        it('should be fixed for async normal function', async () => {
+          await expect(async function () {
+            await doSomethingAsync(1, 2);
+          }).rejects.toThrow(); 
+        })
+      `,
+      output: `
+        it('should be fixed for async normal function', async () => {
+          await expect(doSomethingAsync(1, 2)).rejects.toThrow(); 
+        })
+      `,
+      errors: [
+        {
+          endColumn: 4,
+          column: 16,
+          messageId: 'noAsyncWrapperForExpectedPromise',
+        },
+      ],
+    },
+    {
+      code: `
+        it('should be fixed for Promise.all', async () => {
+          await expect(async function () {
+            await Promise.all([doSomethingAsync(1, 2), doSomethingAsync()]);
+          }).rejects.toThrow(); 
+        })
+      `,
+      output: `
+        it('should be fixed for Promise.all', async () => {
+          await expect(Promise.all([doSomethingAsync(1, 2), doSomethingAsync()])).rejects.toThrow(); 
+        })
+      `,
+      errors: [
+        {
+          endColumn: 4,
+          column: 16,
+          messageId: 'noAsyncWrapperForExpectedPromise',
+        },
+      ],
+    },
+    {
+      code: `
+        it('should be fixed for async ref to expect', async () => {
+          const a = async () => { await doSomethingAsync() };
+          await expect(async () => {
+            await a();
+          }).rejects.toThrow();
+        })
+      `,
+      output: `
+        it('should be fixed for async ref to expect', async () => {
+          const a = async () => { await doSomethingAsync() };
+          await expect(a()).rejects.toThrow();
+        })
+      `,
+      errors: [
+        {
+          endColumn: 4,
+          column: 16,
+          messageId: 'noAsyncWrapperForExpectedPromise',
+        },
+      ],
+    },
+    {
+      code: `
+        it('should be fixed for resolves', async () => {
+          await expect(async () => {
+            await doSomethingAsync();
+          }).resolves.toBe(1);
+        })
+      `,
+      output: `
+        it('should be fixed for resolves', async () => {
+          await expect(doSomethingAsync()).resolves.toBe(1);
+        })
+      `,
+      errors: [
+        {
+          endColumn: 4,
+          column: 16,
+          messageId: 'noAsyncWrapperForExpectedPromise',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port `no-unneeded-async-expect-function` from eslint-plugin-jest to rslint

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/no-unneeded-async-expect-function [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-unneeded-async-expect-function.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/no-unneeded-async-expect-function.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
