### PR TITLE
ci: lock Rust toolchain to 1.96.1

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -35,6 +35,7 @@ runs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       with:
+        toolchain: 1.96.1
         targets: ${{ inputs.targets }}
         components: ${{ inputs.components }}
 


### PR DESCRIPTION
## Summary
- Pin the `toolchain` input passed to `dtolnay/rust-toolchain` in `.github/actions/setup-rust/action.yml` to `1.96.1`, so all CI/release jobs use an exact Rust version instead of whatever the action's `stable` branch currently resolves to.

Temporary fix to our windows runner.