### PR TITLE
fix: skip type checking synthetic programs

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -152,10 +152,9 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	// type-aware rules off no-type-info files. Identical to the CLI via the
 	// shared helper. configMap is nil: the --api path is always single-config
 	// (the JS side resolves any multi-config merge into one entry list).
-	// fallbackProgramIndex is unused here — the --api path never runs the
-	// type-check phase (RunLinterOptions.TypeCheck stays false), so there is no
-	// per-program type-check skip mask to build.
-	programs, typeInfoFiles, _, _ := buildProgramsWithGapFallback(
+	// The --api path never runs the type-check phase (RunLinterOptions.TypeCheck
+	// stays false), so there is no per-program type-check skip mask to build.
+	programs, typeInfoFiles, _ := buildProgramsWithGapFallback(
 		programs, nil, rslintConfig, configDirectory, fs, allowedFiles, nil, parseCache, false,
 	)
 

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -1197,7 +1197,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// resolve gap files, the fallback Program, and the type-info set (the
 	// type-aware gate's only input) identically. cwd == currentDirectory here
 	// (see above), so passing currentDirectory preserves prior behavior.
-	programs, typeInfoFiles, fallbackProgramIndex, capturedGapFiles := buildProgramsWithGapFallback(
+	programs, typeInfoFiles, capturedGapFiles := buildProgramsWithGapFallback(
 		programs, configMap, rslintConfig, currentDirectory, fs, allowFiles, allowDirs, parseCache, singleThreaded,
 	)
 
@@ -1208,38 +1208,37 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	parseCache.RetainOnly(programs)
 
 	// createPrograms rebuilds programs (needed for multi-pass --fix re-linting).
-	// Returns the program slice and the index of the fallback gap-file program
-	// (or -1 if none), so callers can mark it skipped during type-check.
-	createPrograms := func() ([]*compiler.Program, int, error) {
+	// The gap-file fallback is appended last, but callers no longer need its
+	// index: buildTypeCheckSkipMask reads each program's ConfigFilePath to decide
+	// what to exclude from type-check.
+	createPrograms := func() ([]*compiler.Program, error) {
 		var baseProgs []*compiler.Program
 		if configMap != nil {
 			seen := make(map[string]struct{})
 			for configDir, entries := range configMap {
 				progs, exitCode := createProgramsForConfig(configDir, entries, singleThreaded, fs, seen, parseCache)
 				if exitCode != 0 {
-					return nil, -1, fmt.Errorf("failed to create programs for %s", configDir)
+					return nil, fmt.Errorf("failed to create programs for %s", configDir)
 				}
 				baseProgs = append(baseProgs, progs...)
 			}
 		} else {
 			progs, exitCode := createProgramsForConfig(currentDirectory, rslintConfig, singleThreaded, fs, nil, parseCache)
 			if exitCode != 0 {
-				return nil, -1, errors.New("failed to create programs")
+				return nil, errors.New("failed to create programs")
 			}
 			baseProgs = append(baseProgs, progs...)
 		}
 
 		// Rebuild fallback Program for gap files (content may have changed after fixes).
-		fallbackIdx := -1
 		if len(capturedGapFiles) > 0 {
 			fallback, _ := createFallbackProgram(capturedGapFiles, singleThreaded, cwd, fs, parseCache)
 			if fallback != nil {
 				baseProgs = append(baseProgs, fallback)
-				fallbackIdx = len(baseProgs) - 1
 			}
 		}
 
-		return baseProgs, fallbackIdx, nil
+		return baseProgs, nil
 	}
 
 	// Phase 1: Collect all diagnostics (no printing yet).
@@ -1277,12 +1276,12 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	//   - config `ignores` exclusion (applies to rules and counts)
 	fileFilters := buildFileFilters(programs, configMap, programConfigDirs, rslintConfig, currentDirectory)
 
-	// fallback gap program (if any) is excluded from --type-check: its
-	// CompilerOptions are synthesized defaults, not the user's tsconfig,
-	// so semantic diagnostics there would be unreliable. This honors the
-	// commitment in website/docs/en/guide/type-checking.md ("Files Without
-	// tsconfig Coverage").
-	skipTypeCheck := buildTypeCheckSkipMask(len(programs), fallbackProgramIndex)
+	// Programs not backed by a real tsconfig (the gap-file fallback AND the
+	// no-tsconfig directory-scan program) are excluded from --type-check: their
+	// CompilerOptions are synthesized defaults, not the user's tsconfig, so
+	// semantic diagnostics there would be unreliable. This honors the "Gap files"
+	// contract in website/docs/en/guide/type-checking.md.
+	skipTypeCheck := buildTypeCheckSkipMask(programs)
 
 	// In --type-check-only mode, skip the lint phase entirely by passing
 	// nil for GetRulesForFile. RunLinter's Phase 1 is gated on this being
@@ -1369,7 +1368,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		// Re-lint → fix → re-lint → fix → ... until stable or maxFixPasses.
 		// Skip if nothing was fixed in the first pass (no need to re-lint).
 		for pass := 1; pass < maxFixPasses && fixedCount > 0; pass++ {
-			newPrograms, newFallbackIdx, err := createPrograms()
+			newPrograms, err := createPrograms()
 			if err != nil || len(newPrograms) == 0 {
 				break
 			}
@@ -1385,7 +1384,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// Re-lint: collect remaining diagnostics.
 			// Rebuild file filters for the new programs (ownership + ignores).
 			fixFileFilters := buildFileFilters(newPrograms, configMap, programConfigDirs, rslintConfig, currentDirectory)
-			fixSkipMask := buildTypeCheckSkipMask(len(newPrograms), newFallbackIdx)
+			fixSkipMask := buildTypeCheckSkipMask(newPrograms)
 			var passDiags []rule.RuleDiagnostic
 			fixRunOpts := linter.RunLinterOptions{
 				Programs:              newPrograms,

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -173,8 +173,12 @@ func createFallbackProgram(
 // `files` patterns (or explicitly requested and matched by config) but absent
 // from every tsconfig Program — and appends one AST-only fallback Program for
 // them. It returns the (possibly extended) program slice, the type-info file
-// set, the index of the fallback Program within that slice (-1 if none), and
-// the gap files retained for --fix rebuilds.
+// set, and the gap files retained for --fix rebuilds.
+//
+// The appended fallback Program (like the no-tsconfig directory-scan Program)
+// carries synthesized CompilerOptions with no ConfigFilePath, which is how
+// buildTypeCheckSkipMask later recognizes and excludes it from the CLI
+// --type-check phase — no index needs to be threaded out of here.
 //
 // The type-info set is captured from the tsconfig Programs BEFORE the fallback
 // is appended, so fallback files are deliberately absent from it. That absence
@@ -198,10 +202,9 @@ func buildProgramsWithGapFallback(
 	allowDirs []string,
 	parseCache *utils.ParseCache,
 	singleThreaded bool,
-) ([]*compiler.Program, map[string]struct{}, int, []string) {
+) ([]*compiler.Program, map[string]struct{}, []string) {
 	var typeInfoFiles map[string]struct{}
 	var capturedGapFiles []string
-	fallbackProgramIndex := -1
 
 	programFiles := utils.CollectProgramFiles(programs, fs, singleThreaded)
 
@@ -254,12 +257,11 @@ func buildProgramsWithGapFallback(
 			fallback, _ := createFallbackProgram(gapFiles, singleThreaded, currentDirectory, fs, parseCache)
 			if fallback != nil {
 				programs = append(programs, fallback)
-				fallbackProgramIndex = len(programs) - 1
 			}
 		}
 	}
 
-	return programs, typeInfoFiles, fallbackProgramIndex, capturedGapFiles
+	return programs, typeInfoFiles, capturedGapFiles
 }
 
 // buildFileOwnerMap determines which config directory "owns" each file across
@@ -357,17 +359,39 @@ func toFileFilters(in []func(string) bool) []linter.FileFilter {
 	return out
 }
 
-// buildTypeCheckSkipMask returns a parallel-to-Programs []bool where the entry
-// at fallbackIdx is true (skip type-check) and all others are false. Returns
-// nil when fallbackIdx is -1 (no fallback program), so callers don't allocate
-// an all-false slice.
-func buildTypeCheckSkipMask(numPrograms int, fallbackIdx int) []bool {
-	if fallbackIdx < 0 {
-		return nil
-	}
-	mask := make([]bool, numPrograms)
-	if fallbackIdx < numPrograms {
-		mask[fallbackIdx] = true
+// buildTypeCheckSkipMask returns a parallel-to-programs []bool marking which
+// programs must be excluded from the type-check phase. A program is skipped
+// when it was NOT built from a real tsconfig on disk — i.e. its CompilerOptions
+// carry no ConfigFilePath. That covers both synthetic-options program kinds:
+//
+//   - the no-tsconfig directory-scan Program (createProgramsForConfig's else
+//     branch), built with default options for a config directory that has no
+//     tsconfig; and
+//   - the gap-file fallback Program (createFallbackProgram).
+//
+// Their options are synthesized, not the user's tsconfig, so semantic
+// diagnostics there are unreliable and must not be surfaced. Concretely, the
+// scan program sets neither Target nor Lib, so its default lib can lack modern
+// globals like Symbol.asyncDispose and emit spurious diagnostics against
+// typings pulled in from node_modules. This mirrors the type-checking boundary:
+// only Programs backed by parserOptions.project or the auto-detected
+// tsconfig.json participate in program-level --type-check diagnostics. Programs
+// built via utils.CreateProgram -> GetParsedCommandLineOfConfigFile carry a
+// non-empty ConfigFilePath.
+//
+// Returns nil when every program is tsconfig-backed, so callers don't allocate
+// an all-false slice. Deriving from the programs keeps the CLI initial build
+// and the --fix rebuild path consistent by construction.
+func buildTypeCheckSkipMask(programs []*compiler.Program) []bool {
+	var mask []bool
+	for i, prog := range programs {
+		opts := prog.Options()
+		if opts == nil || opts.ConfigFilePath == "" {
+			if mask == nil {
+				mask = make([]bool, len(programs))
+			}
+			mask[i] = true
+		}
 	}
 	return mask
 }

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func writeProgramTestFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+}
+
+func collectProgramTypeDiagnostics(
+	t *testing.T,
+	programs []*compiler.Program,
+	skip []bool,
+	typeInfoFiles map[string]struct{},
+) []rule.RuleDiagnostic {
+	t.Helper()
+
+	var diags []rule.RuleDiagnostic
+	_, err := linter.RunLinter(linter.RunLinterOptions{
+		Programs:              programs,
+		SingleThreaded:        true,
+		TypeCheck:             true,
+		SkipTypeCheckPrograms: skip,
+		TypeInfoFiles:         typeInfoFiles,
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			diags = append(diags, d)
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	return diags
+}
+
+func containsTSDiagnostic(diags []rule.RuleDiagnostic, code string) bool {
+	needle := "TypeScript(" + code + ")"
+	for _, d := range diags {
+		if d.RuleName == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestTypeCheck_SkipsNoTsconfigFallbackPrograms(t *testing.T) {
+	dir := t.TempDir()
+	writeProgramTestFiles(t, dir, map[string]string{
+		"rslint.config.ts": `import type { Bad } from './bad';
+export default [{ files: ['**/*.ts'], rules: {} }] satisfies Bad;
+`,
+		"bad.d.ts": `export type Bad = MissingGlobalType;
+`,
+	})
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	programs, exitCode := createProgramsForConfig(
+		dir,
+		rslintconfig.RslintConfig{{Files: []string{"**/*.ts"}}},
+		true,
+		fs,
+		nil,
+		utils.NewParseCache(),
+	)
+	if exitCode != 0 {
+		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	}
+	if len(programs) != 1 {
+		t.Fatalf("expected one synthesized fallback program, got %d", len(programs))
+	}
+	if got := programs[0].Options().ConfigFilePath; got != "" {
+		t.Fatalf("expected synthesized fallback program to have no ConfigFilePath, got %q", got)
+	}
+	skip := buildTypeCheckSkipMask(programs)
+	if len(skip) != 1 || !skip[0] {
+		t.Fatalf("expected no-tsconfig fallback program to be skipped for type-check, got %v", skip)
+	}
+
+	if diags := collectProgramTypeDiagnostics(t, programs, skip, nil); containsTSDiagnostic(diags, "TS2304") {
+		t.Fatalf("did not expect declaration diagnostics from a no-tsconfig fallback program: %+v", diags)
+	}
+
+	// Prove the fixture is capable of surfacing the bad declaration if the
+	// synthesized Program is not skipped. This pins the regression directly.
+	if diags := collectProgramTypeDiagnostics(t, programs, nil, nil); !containsTSDiagnostic(diags, "TS2304") {
+		t.Fatalf("expected TS2304 without the skip mask, got: %+v", diags)
+	}
+}
+
+func TestTypeCheck_TsconfigBackedProgramReportsCoveredDeclarationErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeProgramTestFiles(t, dir, map[string]string{
+		"tsconfig.json": `{
+  "compilerOptions": { "skipLibCheck": false },
+  "include": ["rslint.config.ts"]
+}
+`,
+		"rslint.config.ts": `import type { Bad } from './bad';
+export const value: Bad | null = null;
+`,
+		"bad.d.ts": `export type Bad = MissingGlobalType;
+`,
+	})
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	programs, exitCode := createProgramsForConfig(
+		dir,
+		rslintconfig.RslintConfig{{
+			Files: []string{"**/*.ts"},
+			LanguageOptions: &rslintconfig.LanguageOptions{
+				ParserOptions: &rslintconfig.ParserOptions{
+					Project: rslintconfig.ProjectPaths{"./tsconfig.json"},
+				},
+			},
+		}},
+		true,
+		fs,
+		nil,
+		utils.NewParseCache(),
+	)
+	if exitCode != 0 {
+		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	}
+	if len(programs) != 1 {
+		t.Fatalf("expected one tsconfig-backed program, got %d", len(programs))
+	}
+	if got := programs[0].Options().ConfigFilePath; got == "" {
+		t.Fatal("expected tsconfig-backed program to carry ConfigFilePath")
+	}
+	skip := buildTypeCheckSkipMask(programs)
+	if skip != nil {
+		t.Fatalf("expected tsconfig-backed program to participate in type-check, got %v", skip)
+	}
+
+	diags := collectProgramTypeDiagnostics(t, programs, skip, nil)
+	if !containsTSDiagnostic(diags, "TS2304") {
+		var rendered []string
+		for _, d := range diags {
+			rendered = append(rendered, d.RuleName+": "+d.Message.Description)
+		}
+		t.Fatalf("expected TS2304 from the tsconfig-covered declaration graph, got:\n%s", strings.Join(rendered, "\n"))
+	}
+}
+
+func TestTypeCheck_SkipsGapFallbackPrograms(t *testing.T) {
+	dir := t.TempDir()
+	writeProgramTestFiles(t, dir, map[string]string{
+		"tsconfig.json": `{
+  "compilerOptions": { "skipLibCheck": false },
+  "include": ["src/in-project.ts"]
+}
+`,
+		"src/in-project.ts": `export const ok = 1;
+`,
+		"gap.ts": `import type { Bad } from './bad';
+export const value: Bad | null = null;
+`,
+		"bad.d.ts": `export type Bad = MissingGlobalType;
+`,
+	})
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	parseCache := utils.NewParseCache()
+	cfg := rslintconfig.RslintConfig{{
+		Files: []string{"**/*.ts"},
+		LanguageOptions: &rslintconfig.LanguageOptions{
+			ParserOptions: &rslintconfig.ParserOptions{
+				Project: rslintconfig.ProjectPaths{"./tsconfig.json"},
+			},
+		},
+	}}
+	programs, exitCode := createProgramsForConfig(
+		dir,
+		cfg,
+		true,
+		fs,
+		nil,
+		parseCache,
+	)
+	if exitCode != 0 {
+		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	}
+	if len(programs) != 1 {
+		t.Fatalf("expected one tsconfig-backed program before gap fallback, got %d", len(programs))
+	}
+	if skip := buildTypeCheckSkipMask(programs); skip != nil {
+		t.Fatalf("expected tsconfig-backed program to participate in type-check, got %v", skip)
+	}
+
+	programs, typeInfoFiles, gapFiles := buildProgramsWithGapFallback(
+		programs,
+		nil,
+		cfg,
+		dir,
+		fs,
+		nil,
+		nil,
+		parseCache,
+		true,
+	)
+	if len(programs) != 2 {
+		t.Fatalf("expected the gap fallback program to be appended, got %d programs", len(programs))
+	}
+	gapPath := filepath.ToSlash(filepath.Join(dir, "gap.ts"))
+	if !slices.Contains(gapFiles, gapPath) {
+		t.Fatalf("expected gap.ts to be discovered as a gap file, got %v", gapFiles)
+	}
+	if got := programs[0].Options().ConfigFilePath; got == "" {
+		t.Fatal("expected original tsconfig-backed program to carry ConfigFilePath")
+	}
+	if got := programs[1].Options().ConfigFilePath; got != "" {
+		t.Fatalf("expected gap fallback program to have no ConfigFilePath, got %q", got)
+	}
+	skip := buildTypeCheckSkipMask(programs)
+	if len(skip) != 2 || skip[0] || !skip[1] {
+		t.Fatalf("expected only the gap fallback program to be skipped, got %v", skip)
+	}
+
+	if diags := collectProgramTypeDiagnostics(t, programs, skip, typeInfoFiles); containsTSDiagnostic(diags, "TS2304") {
+		t.Fatalf("did not expect declaration diagnostics from a gap fallback program: %+v", diags)
+	}
+}

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -83,7 +83,8 @@ type LintResult struct {
 //   - SkipTypeCheckPrograms=nil           → every program participates in
 //     type-check. When non-nil, must be parallel to Programs; entries set
 //     to true mark the corresponding program to be skipped (typically the
-//     gap-file fallback program with synthesized CompilerOptions).
+//     gap-file fallback or no-tsconfig fallback Program with synthesized
+//     CompilerOptions).
 //   - OnDiagnostic=nil                    → diagnostics are dropped
 //
 // Thread-safety: OnDiagnostic is invoked from multiple goroutines

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "format:check": "prettier --check .",
     "test": "pnpm -r --filter=@rslint/test-tools... --filter=rslint... test",
     "test:go": "go test ./cmd/... ./internal/...",
-    "typecheck": "pnpm tsgo -b tsconfig.json",
+    "typecheck": "pnpm tsgo -b tsconfig.json --noEmit",
     "lint": "rslint --config rslint.config.ts",
     "lint:go": "golangci-lint run ./cmd/... ./internal/...",
     "format:go": "golangci-lint fmt ./cmd/... ./internal/...",

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -1,3 +1,5 @@
+/// <reference lib="esnext.disposable" preserve="true" />
+
 /**
  * The `Rslint` class — the ESLint-style programmatic API (issue #1106).
  *

--- a/packages/rslint/tests/rslint.test.mjs
+++ b/packages/rslint/tests/rslint.test.mjs
@@ -3,7 +3,7 @@ import { lint } from '@rslint/core/internal';
 import { describe, test, expect } from '@rstest/core';
 import path from 'node:path';
 import os from 'node:os';
-import { writeFile, rm, mkdtemp } from 'node:fs/promises';
+import { writeFile, rm, mkdtemp, mkdir, readFile, cp } from 'node:fs/promises';
 
 const fixturesDir = path.resolve(import.meta.dirname, '../fixtures');
 
@@ -19,6 +19,66 @@ const arrayTypeConfig = [
 ];
 
 describe('Rslint class', () => {
+  test('published declarations expose async disposal under ES2022 consumer libs', async () => {
+    const distDir = path.resolve(import.meta.dirname, '../dist');
+    const packageJson = JSON.parse(
+      await readFile(
+        path.resolve(import.meta.dirname, '../package.json'),
+        'utf8',
+      ),
+    );
+    const distDts = await readFile(path.join(distDir, 'index.d.ts'), 'utf8');
+    expect(distDts).toContain('reference lib="esnext.disposable"');
+    expect(distDts).toContain('[Symbol.asyncDispose](): Promise<void>');
+
+    const ts = await import('typescript');
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-dts-consumer-'));
+    try {
+      const packageRoot = path.join(tmp, 'node_modules', '@rslint', 'core');
+      await mkdir(packageRoot, { recursive: true });
+      await writeFile(
+        path.join(packageRoot, 'package.json'),
+        JSON.stringify({
+          name: packageJson.name,
+          type: packageJson.type,
+          exports: {
+            '.': packageJson.exports['.'],
+          },
+        }),
+      );
+      await cp(distDir, path.join(packageRoot, 'dist'), { recursive: true });
+      const entry = path.join(tmp, 'index.ts');
+      await writeFile(
+        entry,
+        [
+          "import { Rslint } from '@rslint/core';",
+          'const rslint: Rslint = new Rslint();',
+          'rslint.close();',
+          '',
+        ].join('\n'),
+      );
+
+      const options = {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.NodeNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        lib: ['lib.es2022.d.ts'],
+        noEmit: true,
+        strict: true,
+        skipLibCheck: false,
+      };
+      const program = ts.createProgram([entry], options);
+      const diagnostics = ts.getPreEmitDiagnostics(program);
+      const rendered = diagnostics
+        .map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'))
+        .join('\n');
+      expect(rendered).not.toContain('asyncDispose');
+      expect(diagnostics).toEqual([]);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('lintText returns ESLint-shaped LintResult[]', async () => {
     const rslint = new Rslint({
       cwd: fixturesDir,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -80,7 +80,7 @@
     "build": "node scripts/build.js",
     "watch": "node scripts/build.js --watch",
     "package": "vsce package",
-    "test": "tsgo -p tsconfig.spec.json && node .vscode-test-out/runTest.js"
+    "test": "tsgo -p tsconfig.spec.emit.json && node .vscode-test-out/runTest.js"
   },
   "devDependencies": {
     "@rslint/core": "workspace:*",

--- a/packages/vscode-extension/tsconfig.spec.emit.json
+++ b/packages/vscode-extension/tsconfig.spec.emit.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.spec.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "incremental": false,
+    "noEmit": false
+  }
+}

--- a/packages/vscode-extension/tsconfig.spec.json
+++ b/packages/vscode-extension/tsconfig.spec.json
@@ -5,7 +5,6 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "rootDir": "./__tests__",
-    "noEmit": false,
     "skipLibCheck": true,
     "allowArbitraryExtensions": true,
     "allowImportingTsExtensions": false,


### PR DESCRIPTION
## Summary

- Skip program-level `--type-check` diagnostics for synthetic Programs that are not backed by a real tsconfig, covering no-tsconfig directory scans and gap fallback Programs.
- Preserve the `esnext.disposable` reference in published API declarations so ES2022 consumers can import `@rslint/core` with `skipLibCheck: false`.
- Make root `pnpm typecheck` run with `--noEmit` so it validates project references without overwriting rslib build artifacts in `dist`.
- Add regression coverage for no-tsconfig fallback, tsconfig-backed Programs, gap fallback Programs, and declaration consumption.

## Related Links

- CI coverage for `cmd` Go package tests: #1166

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).