### PR TITLE
ci: test cmd go packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,16 +51,16 @@ jobs:
 
       - name: Unit Test
         if: matrix.runner != 'rspack-windows-2022-large'
-        run: go test -count=1 ./internal/...
+        run: go test -count=1 ./cmd/... ./internal/...
 
       - name: Unit Test (Windows)
         if: matrix.runner == 'rspack-windows-2022-large'
         shell: pwsh
         run: |
           # Pre-build shared dependencies to warm the build cache
-          go build ./internal/...
+          go build ./cmd/... ./internal/...
 
-          $packages = go list ./internal/... | Where-Object { $_ -ne "" }
+          $packages = go list ./cmd/... ./internal/... | Where-Object { $_ -ne "" }
           $batchSize = 64
           $batch = @()
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "pnpm -r --filter=@rslint/test-tools... --filter=rslint... test",
-    "test:go": "go test ./internal/...",
+    "test:go": "go test ./cmd/... ./internal/...",
     "typecheck": "pnpm tsgo -b tsconfig.json",
     "lint": "rslint --config rslint.config.ts",
     "lint:go": "golangci-lint run ./cmd/... ./internal/...",


### PR DESCRIPTION
## Summary

- Include `./cmd/...` in the root `test:go` script so CLI package tests run with the standard Go test command.
- Include `./cmd/...` in CI Go unit tests on Linux/macOS and Windows so `cmd/rslint` regressions are covered.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).