### PR TITLE
perf: strip Go release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,11 +342,11 @@ jobs:
 
       - name: Go Build rslint
         run: |
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o ${{ matrix.node_os }}-${{ matrix.node_arch }}-rslint ./cmd/rslint
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o ${{ matrix.node_os }}-${{ matrix.node_arch }}-rslint ./cmd/rslint
 
       - name: Go Build tsgo
         run: |
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o ${{ matrix.node_os }}-${{ matrix.node_arch }}-tsgo ./cmd/tsgo
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o ${{ matrix.node_os }}-${{ matrix.node_arch }}-tsgo ./cmd/tsgo
 
       - name: Upload rslint artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
Strips debug symbol tables and DWARF tables from release Go binaries (rslint and tsgo) to optimize size in production packages.

## Results

Test on linux-x64 machine.

| binary name | unstripped | stripped |
| ----- | ---- | ---- |
| rslint | 41.54 MiB | 29.21 MiB (-29.7%) |
| tsgo | 26.53 MiB | 19.22 MiB (-27.5%) |