### PR TITLE
feat: port rule prefer-arrow-callback

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -117,6 +117,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
 	"github.com/web-infra-dev/rslint/internal/rules/object_shorthand"
 	"github.com/web-infra-dev/rslint/internal/rules/one_var"
+	"github.com/web-infra-dev/rslint/internal/rules/prefer_arrow_callback"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_const"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
@@ -248,6 +249,7 @@ func GetAllRules() []rule.Rule {
 		require_atomic_updates.RequireAtomicUpdatesRule,
 		object_shorthand.ObjectShorthandRule,
 		one_var.OneVarRule,
+		prefer_arrow_callback.PreferArrowCallbackRule,
 		no_dupe_else_if.NoDupeElseIfRule,
 		no_throw_literal.NoThrowLiteralRule,
 		no_useless_backreference.NoUselessBackreferenceRule,

--- a/internal/rules/prefer_arrow_callback/prefer_arrow_callback.go
+++ b/internal/rules/prefer_arrow_callback/prefer_arrow_callback.go
@@ -1,0 +1,548 @@
+package prefer_arrow_callback
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// prefer-arrow-callback requires arrow functions for callbacks when doing so
+// preserves the callback's binding semantics.
+// https://eslint.org/docs/latest/rules/prefer-arrow-callback
+
+type options struct {
+	allowNamedFunctions bool
+	allowUnboundThis    bool
+}
+
+type scopeInfo struct {
+	this  bool
+	super bool
+	meta  bool
+}
+
+type callbackInfo struct {
+	isCallback    bool
+	isLexicalThis bool
+	bindMember    *ast.Node
+	bindCall      *ast.Node
+}
+
+func parseOptions(raw any) options {
+	opts := options{allowUnboundThis: true}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	if v, ok := m["allowNamedFunctions"].(bool); ok {
+		opts.allowNamedFunctions = v
+	}
+	if v, ok := m["allowUnboundThis"].(bool); ok {
+		opts.allowUnboundThis = v
+	}
+	return opts
+}
+
+func preferArrowCallbackMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferArrowCallback",
+		Description: "Unexpected function expression.",
+	}
+}
+
+func isLogicalExpression(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	bin := node.AsBinaryExpression()
+	if bin == nil || bin.OperatorToken == nil {
+		return false
+	}
+	switch bin.OperatorToken.Kind {
+	case ast.KindAmpersandAmpersandToken, ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+		return true
+	default:
+		return false
+	}
+}
+
+func functionScopeRoots(node *ast.Node) []*ast.Node {
+	roots := make([]*ast.Node, 0, len(node.Parameters())+1)
+	roots = append(roots, node.Parameters()...)
+	if body := node.Body(); body != nil {
+		roots = append(roots, body)
+	}
+	return roots
+}
+
+func walkCurrentFunctionScope(node *ast.Node, visit func(*ast.Node)) {
+	var walk func(*ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Kind {
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression:
+			return
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+			// Method bodies have their own `this`/`arguments`, but computed
+			// method names run in the containing scope and can still make an
+			// outer callback unsafe to convert.
+			walk(n.Name())
+			return
+		case ast.KindConstructor:
+			return
+		}
+
+		visit(n)
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	for _, root := range functionScopeRoots(node) {
+		walk(root)
+	}
+}
+
+func getFunctionScopeInfo(node *ast.Node) scopeInfo {
+	info := scopeInfo{}
+	walkCurrentFunctionScope(node, func(n *ast.Node) {
+		switch n.Kind {
+		case ast.KindThisKeyword:
+			info.this = true
+		case ast.KindSuperKeyword:
+			info.super = true
+		case ast.KindMetaProperty:
+			meta := n.AsMetaProperty()
+			name := meta.Name()
+			if meta.KeywordToken == ast.KindNewKeyword && name != nil && name.Text() == "target" {
+				info.meta = true
+			}
+		}
+	})
+	return info
+}
+
+func hasDuplicateParams(params []*ast.Node) bool {
+	seen := map[string]bool{}
+	for _, param := range params {
+		if param == nil || param.Name() == nil || param.Name().Kind != ast.KindIdentifier {
+			return false
+		}
+		name := param.Name().Text()
+		if seen[name] {
+			return true
+		}
+		seen[name] = true
+	}
+	return false
+}
+
+func firstParamName(node *ast.Node) string {
+	params := node.Parameters()
+	if len(params) == 0 || params[0] == nil || params[0].Name() == nil {
+		return ""
+	}
+	name := params[0].Name()
+	if name.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return name.Text()
+}
+
+func hasArgumentsBinding(node *ast.Node) bool {
+	found := false
+	for _, param := range node.Parameters() {
+		if param == nil {
+			continue
+		}
+		utils.CollectBindingNames(param.Name(), func(_ *ast.Node, name string) {
+			if name == "arguments" {
+				found = true
+			}
+		})
+	}
+	if found {
+		return true
+	}
+	var walk func(*ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil || found {
+			return
+		}
+		switch n.Kind {
+		case ast.KindFunctionDeclaration:
+			if name := n.Name(); name != nil && name.Kind == ast.KindIdentifier && name.Text() == "arguments" {
+				found = true
+			}
+			return
+		case ast.KindFunctionExpression, ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+			return
+		case ast.KindVariableDeclaration:
+			utils.CollectBindingNames(n.AsVariableDeclaration().Name(), func(_ *ast.Node, name string) {
+				if name == "arguments" {
+					found = true
+				}
+			})
+		case ast.KindClassDeclaration:
+			if name := n.Name(); name != nil && name.Kind == ast.KindIdentifier && name.Text() == "arguments" {
+				found = true
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return found
+		})
+	}
+	for _, root := range functionScopeRoots(node) {
+		walk(root)
+	}
+	return found
+}
+
+func isValueIdentifier(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindIdentifier {
+		return false
+	}
+	if ast.IsPartOfTypeNode(node) {
+		return false
+	}
+	return !utils.IsNonReferenceIdentifier(node)
+}
+
+func hasArgumentsReference(ctx rule.RuleContext, node *ast.Node) bool {
+	found := false
+	walkCurrentFunctionScope(node, func(n *ast.Node) {
+		if found {
+			return
+		}
+		if isValueIdentifier(n) && n.Text() == "arguments" {
+			if ctx.TypeChecker != nil {
+				symbol := utils.GetReferenceSymbol(n, ctx.TypeChecker)
+				if symbol != nil && len(symbol.Declarations) > 0 {
+					return
+				}
+				found = true
+				return
+			}
+			if hasArgumentsBinding(node) {
+				return
+			}
+			found = true
+		}
+	})
+	return found
+}
+
+func functionNameReferenced(ctx rule.RuleContext, node *ast.Node) bool {
+	name := node.Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return false
+	}
+	targetName := name.Text()
+	var targetSymbol *ast.Symbol
+	if ctx.TypeChecker != nil {
+		targetSymbol = utils.GetReferenceSymbol(name, ctx.TypeChecker)
+	}
+
+	found := false
+	var walk func(*ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil || found {
+			return
+		}
+		if n == name {
+			return
+		}
+		if isValueIdentifier(n) && n.Text() == targetName {
+			if targetSymbol == nil || utils.GetReferenceSymbol(n, ctx.TypeChecker) == targetSymbol {
+				found = true
+				return
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return found
+		})
+	}
+	for _, root := range functionScopeRoots(node) {
+		walk(root)
+	}
+	return found
+}
+
+func getCallForCallee(node *ast.Node) *ast.Node {
+	// Deliberately skip only parentheses here. utils.IsCallee also treats TS
+	// assertion wrappers as transparent, but upstream getCallbackInfo does not:
+	// `(function() {}) as any` is not considered a callback by this rule.
+	current := node
+	parent := current.Parent
+	for parent != nil && ast.IsParenthesizedExpression(parent) {
+		current = parent
+		parent = parent.Parent
+	}
+	if parent == nil || parent.Kind != ast.KindCallExpression {
+		return nil
+	}
+	call := parent.AsCallExpression()
+	if call != nil && call.Expression == current {
+		return parent
+	}
+	return nil
+}
+
+func callHasSingleThisArg(call *ast.Node) bool {
+	if call == nil || call.Kind != ast.KindCallExpression {
+		return false
+	}
+	args := call.AsCallExpression().Arguments
+	if args == nil || len(args.Nodes) != 1 {
+		return false
+	}
+	return ast.SkipParentheses(args.Nodes[0]).Kind == ast.KindThisKeyword
+}
+
+func getCallbackInfo(node *ast.Node) callbackInfo {
+	ret := callbackInfo{}
+	current := node
+	parent := current.Parent
+	bound := false
+
+	for current != nil && parent != nil {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression:
+			current = parent
+			parent = parent.Parent
+			continue
+
+		case ast.KindConditionalExpression:
+			// ESLint's ESTree walk treats every branch of a ConditionalExpression
+			// as transparent while looking for the outer call/new callback site.
+
+		case ast.KindBinaryExpression:
+			if !isLogicalExpression(parent) {
+				return ret
+			}
+
+		case ast.KindPropertyAccessExpression:
+			member := parent.AsPropertyAccessExpression()
+			name := member.Name()
+			if member.Expression != current ||
+				name == nil ||
+				name.Kind != ast.KindIdentifier ||
+				name.Text() != "bind" {
+				return ret
+			}
+			call := getCallForCallee(parent)
+			if call == nil {
+				return ret
+			}
+			if !bound {
+				bound = true
+				ret.isLexicalThis = callHasSingleThisArg(call)
+				ret.bindMember = parent
+				ret.bindCall = call
+			}
+			current = call
+			parent = call.Parent
+			continue
+
+		case ast.KindCallExpression:
+			if parent.AsCallExpression().Expression != current {
+				ret.isCallback = true
+			}
+			return ret
+
+		case ast.KindNewExpression:
+			if parent.AsNewExpression().Expression != current {
+				ret.isCallback = true
+			}
+			return ret
+
+		default:
+			return ret
+		}
+		current = parent
+		parent = parent.Parent
+	}
+
+	return ret
+}
+
+func hasCommentInRange(sf *ast.SourceFile, start, end int) bool {
+	// utils.HasCommentsInRange checks comments anchored at the range start.
+	// This rule needs ESLint's commentsExistBetween semantics over arbitrary
+	// token pairs such as `.bind(/* comment */ this)`, so scan all comments.
+	found := false
+	utils.ForEachComment(sf.AsNode(), func(comment *ast.CommentRange) {
+		if comment.Pos() >= start && comment.End() <= end {
+			found = true
+		}
+	}, sf)
+	return found
+}
+
+func findTokenRange(sf *ast.SourceFile, start, end int, kind ast.Kind) (core.TextRange, bool) {
+	s := scanner.GetScannerForSourceFile(sf, start)
+	for s.Token() != ast.KindEndOfFile && s.TokenStart() < end {
+		if s.Token() == kind {
+			return core.NewTextRange(s.TokenStart(), s.TokenEnd()), true
+		}
+		s.Scan()
+	}
+	return core.TextRange{}, false
+}
+
+func previousTokenEndBefore(text string, pos int) int {
+	i := pos
+	for i > 0 {
+		i = utils.SkipTrailingWhitespace(text, 0, i)
+		if i >= 2 && text[i-2:i] == "*/" {
+			if start := strings.LastIndex(text[:i-2], "/*"); start >= 0 {
+				i = start
+				continue
+			}
+		}
+		lineStart := strings.LastIndexByte(text[:i], '\n') + 1
+		if comment := strings.Index(text[lineStart:i], "//"); comment >= 0 {
+			i = lineStart + comment
+			continue
+		}
+		return i
+	}
+	return pos
+}
+
+func sameLine(sf *ast.SourceFile, a, b int) bool {
+	lineA, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, a)
+	lineB, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, b)
+	return lineA == lineB
+}
+
+func isParenthesized(node *ast.Node) bool {
+	return node != nil && node.Parent != nil && ast.IsParenthesizedExpression(node.Parent)
+}
+
+func bindMemberDirectlyWrapsNode(member, node *ast.Node) bool {
+	if member == nil || member.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	return ast.SkipParentheses(member.AsPropertyAccessExpression().Expression) == node
+}
+
+func buildFixes(ctx rule.RuleContext, node *ast.Node, scope scopeInfo, info callbackInfo) []rule.RuleFix {
+	if (!info.isLexicalThis && scope.this) || hasDuplicateParams(node.Parameters()) || firstParamName(node) == "this" {
+		return nil
+	}
+
+	sf := ctx.SourceFile
+	text := sf.Text()
+	body := node.Body()
+	if body == nil {
+		return nil
+	}
+	bodyStart := scanner.SkipTrivia(text, body.Pos())
+	if bodyStart < 0 {
+		return nil
+	}
+	nodeRange := utils.TrimNodeTextRange(sf, node)
+	functionToken, ok := findTokenRange(sf, nodeRange.Pos(), bodyStart, ast.KindFunctionKeyword)
+	if !ok {
+		return nil
+	}
+	leftParenToken, ok := findTokenRange(sf, functionToken.End(), bodyStart, ast.KindOpenParenToken)
+	if !ok {
+		return nil
+	}
+	flags := ast.GetFunctionFlags(node)
+	if flags&ast.FunctionFlagsAsync != 0 && !sameLine(sf, functionToken.End(), leftParenToken.Pos()) {
+		return nil
+	}
+	insertArrowAt := previousTokenEndBefore(text, bodyStart)
+
+	fixes := []rule.RuleFix{}
+	if info.isLexicalThis {
+		if !bindMemberDirectlyWrapsNode(info.bindMember, node) || isParenthesized(info.bindMember) {
+			return nil
+		}
+		object := info.bindMember.AsPropertyAccessExpression().Expression
+		removeStart := scanner.SkipTrivia(text, object.End())
+		removeEnd := utils.TrimNodeTextRange(sf, info.bindCall).End()
+		if removeStart < 0 || removeStart >= removeEnd || hasCommentInRange(sf, removeStart, removeEnd) {
+			return nil
+		}
+		fixes = append(fixes, rule.RuleFixRemoveRange(core.NewTextRange(removeStart, removeEnd)))
+	}
+
+	if hasCommentInRange(sf, functionToken.End(), leftParenToken.Pos()) {
+		fixes = append(fixes, rule.RuleFixRemoveRange(functionToken))
+		if name := node.Name(); name != nil {
+			fixes = append(fixes, rule.RuleFixRemove(sf, name))
+		}
+	} else {
+		fixes = append(fixes, rule.RuleFixRemoveRange(core.NewTextRange(functionToken.Pos(), leftParenToken.Pos())))
+	}
+	fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(insertArrowAt, insertArrowAt), " =>"))
+
+	replacedNode := node
+	if info.isLexicalThis {
+		replacedNode = info.bindCall
+	}
+	if replacedNode == nil || replacedNode.Parent == nil {
+		return fixes
+	}
+	if replacedNode.Parent.Kind != ast.KindCallExpression &&
+		replacedNode.Parent.Kind != ast.KindConditionalExpression &&
+		!isParenthesized(replacedNode) &&
+		!isParenthesized(node) {
+		fixes = append(fixes,
+			rule.RuleFixReplaceRange(core.NewTextRange(utils.TrimNodeTextRange(sf, replacedNode).Pos(), utils.TrimNodeTextRange(sf, replacedNode).Pos()), "("),
+			rule.RuleFixReplaceRange(core.NewTextRange(utils.TrimNodeTextRange(sf, replacedNode).End(), utils.TrimNodeTextRange(sf, replacedNode).End()), ")"),
+		)
+	}
+
+	return fixes
+}
+
+var PreferArrowCallbackRule = rule.Rule{
+	Name: "prefer-arrow-callback",
+	Run: func(ctx rule.RuleContext, raw any) rule.RuleListeners {
+		opts := parseOptions(raw)
+		return rule.RuleListeners{
+			ast.KindFunctionExpression: func(node *ast.Node) {
+				if opts.allowNamedFunctions {
+					if name := node.Name(); name != nil && name.Kind == ast.KindIdentifier && name.Text() != "" {
+						return
+					}
+				}
+				if ast.GetFunctionFlags(node)&ast.FunctionFlagsGenerator != 0 {
+					return
+				}
+				if functionNameReferenced(ctx, node) || hasArgumentsReference(ctx, node) {
+					return
+				}
+
+				scope := getFunctionScopeInfo(node)
+				info := getCallbackInfo(node)
+				if !info.isCallback {
+					return
+				}
+				if (opts.allowUnboundThis && scope.this && !info.isLexicalThis) || scope.super || scope.meta {
+					return
+				}
+
+				msg := preferArrowCallbackMessage()
+				if fixes := buildFixes(ctx, node, scope, info); len(fixes) > 0 {
+					ctx.ReportNodeWithFixes(node, msg, fixes...)
+				} else {
+					ctx.ReportNode(node, msg)
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/prefer_arrow_callback/prefer_arrow_callback.md
+++ b/internal/rules/prefer_arrow_callback/prefer_arrow_callback.md
@@ -1,0 +1,70 @@
+# prefer-arrow-callback
+
+## Rule Details
+
+Requires using arrow functions for callbacks when the function expression can be
+replaced without changing `this`, `super`, `arguments`, or `new.target`
+semantics.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+foo(function (value) {
+  return value;
+});
+
+foo(function () {
+  return this.value;
+}.bind(this));
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+foo((value) => {
+  return value;
+});
+
+foo(() => {
+  return this.value;
+});
+
+foo(function () {
+  return this.value;
+});
+```
+
+## Options
+
+This rule accepts an options object with the following properties:
+
+- `allowNamedFunctions` defaults to `false`. When `true`, named function
+  expressions are allowed.
+- `allowUnboundThis` defaults to `true`. When `false`, callbacks that reference
+  their own `this` are still reported, but they are not automatically fixed.
+
+Examples of **correct** code for this rule with `{ "allowNamedFunctions": true }`:
+
+```json
+{ "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }] }
+```
+
+```javascript
+foo(function namedCallback() {});
+```
+
+Examples of **incorrect** code for this rule with `{ "allowUnboundThis": false }`:
+
+```json
+{ "prefer-arrow-callback": ["error", { "allowUnboundThis": false }] }
+```
+
+```javascript
+foo(function () {
+  return this.value;
+});
+```
+
+## Original Documentation
+
+- [ESLint: prefer-arrow-callback](https://eslint.org/docs/latest/rules/prefer-arrow-callback)

--- a/internal/rules/prefer_arrow_callback/prefer_arrow_callback_extras_test.go
+++ b/internal/rules/prefer_arrow_callback/prefer_arrow_callback_extras_test.go
@@ -1,0 +1,181 @@
+// TestPreferArrowCallbackExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+package prefer_arrow_callback
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferArrowCallbackExtras(t *testing.T) {
+	disallowUnboundThisMap := map[string]any{"allowUnboundThis": false}
+	allowNamedMap := map[string]any{"allowNamedFunctions": true}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferArrowCallbackRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: TS assertion wrappers are not transparent to ESLint's getCallbackInfo ----
+			{Code: "foo((function() {}) as any);"},
+			{Code: "foo((function() {})!);"},
+			{Code: "foo((function() {}) satisfies Function);"},
+
+			// ---- Dimension 4: generator and non-callback function container forms ----
+			{Code: "foo(function* named() { yield 1; });"},
+			{Code: "const callback = function() {};"},
+			{Code: "const obj = { callback: function() {} };"},
+
+			// Locks in upstream FunctionExpression:exit arm 1: allowNamedFunctions skips named callbacks.
+			{Code: "foo(function keep() {});", Options: allowNamedMap},
+
+			// Locks in upstream FunctionExpression:exit arm 3: recursive named functions are skipped.
+			{Code: "foo(function recur(n) { return n ? recur(n - 1) : 0; });"},
+
+			// Locks in upstream FunctionExpression:exit arm 3: recursive references from nested functions still count.
+			{Code: "foo(function recur() { function inner() { return recur; } });"},
+
+			// ---- Dimension 2: default parameters share the callback's `this`/`arguments` binding ----
+			{Code: "foo(function(a = this.value) {});"},
+			{Code: "foo(function(a = arguments[0]) {});"},
+
+			// ---- Dimension 2: computed method names run in the outer callback scope ----
+			{Code: "foo(function() { class C { [this.key]() {} } });"},
+			{Code: "foo(function() { class C { [arguments[0]]() {} } });"},
+
+			// Locks in upstream getCallbackInfo MemberExpression arm: non-bind members are not callbacks.
+			{Code: "foo((function() {}).call);"},
+
+			// Locks in upstream getCallbackInfo MemberExpression arm: `.bind` must be the callee.
+			{Code: "foo((function() {}).bind.prop);"},
+
+			// Locks in upstream FunctionExpression:exit arm 4: `arguments` in an arrow still belongs to the callback.
+			{Code: "foo(function() { (() => arguments); });"},
+
+			// Locks in upstream FunctionExpression:exit arm 4: implicit `arguments` remains unsafe even if a nested block shadows it.
+			{Code: "foo(function() { arguments; { const arguments = 1; } });"},
+
+			// ---- Real-user: dynamic `this` callbacks stay valid by default ----
+			{Code: "button.addEventListener('click', function(event) { this.disabled = event.defaultPrevented; });"},
+			{Code: "describe('suite', function() { this.timeout(1000); });"},
+			{Code: "emitter.on('data', function(chunk) { this.emit('seen', chunk); });"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: single parenthesized callback expression ----
+			invalidCase("foo((function() {}));", "foo((() => {}));", nil, 1),
+
+			// ---- Dimension 4: multi-level parenthesized callback expression ----
+			invalidCase("foo(((function(a) { return a; })));", "foo((((a) => { return a; })));", nil, 1),
+
+			// ---- Dimension 4: optional call target with callback argument ----
+			invalidCase("foo?.bar?.(function(value) { return value; });", "foo?.bar?.((value) => { return value; });", nil, 1),
+
+			// ---- Dimension 4: optional `.bind(this)` access ----
+			invalidCase("foo(function() { return this.value; }?.bind(this));", "foo(() => { return this.value; });", nil, 1),
+
+			// ---- Dimension 4: async callback with TypeScript return type ----
+			invalidCase("foo(async function(value: number): Promise<number> { return value; });", "foo(async (value: number): Promise<number> => { return value; });", nil, 1),
+
+			// ---- Dimension 4: scanner-based parameter paren lookup; comment text contains `(` ----
+			invalidCase("foo(function /* comment ( */ (value) { return value; });", "foo( /* comment ( */ (value) => { return value; });", nil, 1),
+
+			// ---- Dimension 4: same-kind nesting boundary; nested function `this` does not block outer report ----
+			invalidCase("foo(function() { return function() { this; }; });", "foo(() => { return function() { this; }; });", nil, 1),
+
+			// ---- Dimension 4: nested function's own `arguments` does not block the outer callback report ----
+			invalidCase("foo(function() { function inner() { arguments; } return 1; });", "foo(() => { function inner() { arguments; } return 1; });", nil, 1),
+
+			// ---- Dimension 4: local declaration named `arguments` shadows the implicit arguments binding ----
+			invalidCase("foo(function() { function arguments() {} return arguments; });", "foo(() => { function arguments() {} return arguments; });", nil, 1),
+
+			// ---- Dimension 4: catch binding named `arguments` is local, not the callback's implicit arguments object ----
+			invalidCase("foo(function() { try { throw 1; } catch (arguments) { return arguments; } });", "foo(() => { try { throw 1; } catch (arguments) { return arguments; } });", nil, 1),
+
+			// ---- Dimension 4: nested method `this` must not block the outer callback report ----
+			invalidCase("foo(function() { return { m() { return this.x; } }; });", "foo(() => { return { m() { return this.x; } }; });", nil, 1),
+
+			// ---- Dimension 4: member/access key forms are N/A; keys inside the callback do not affect matching ----
+			invalidCase("foo(function() { return { ['x']: 1, '#x': 2 }; });", "foo(() => { return { ['x']: 1, '#x': 2 }; });", nil, 1),
+
+			// ---- Dimension 4: graceful degradation for body-absent TS declarations inside callbacks ----
+			invalidCase("foo(function() { declare function nested(): void; });", "foo(() => { declare function nested(): void; });", nil, 1),
+
+			// ---- Dimension 4: empty arguments list ----
+			invalidCase("new Foo(function() {});", "new Foo((() => {}));", nil, 1),
+
+			// ---- Real-user: Promise callback ----
+			invalidCase("Promise.resolve(1).then(function(value) { return value + 1; });", "Promise.resolve(1).then((value) => { return value + 1; });", nil, 1),
+
+			// ---- Real-user: Array callback with bare object options uses ESLint defaults ----
+			invalidCase("items.forEach(function(item) { item.save(); });", "items.forEach((item) => { item.save(); });", map[string]any{}, 1),
+
+			// ---- Real-user: timer callback with lexical `this` binding ----
+			invalidCase("setTimeout(function() { this.flush(); }.bind(this), 0);", "setTimeout(() => { this.flush(); }, 0);", nil, 1),
+
+			// ---- Real-user: async task callback ----
+			invalidCase("queueMicrotask(async function() { await flush(); });", "queueMicrotask(async () => { await flush(); });", nil, 1),
+
+			// ---- Real-user: new Promise executor keeps upstream's parenthesized arrow fix ----
+			invalidCase("new Promise(function(resolve, reject) { resolve(reject); });", "new Promise(((resolve, reject) => { resolve(reject); }));", nil, 1),
+
+			// ---- Real-user: #16718 Allman-style body with a named callback ----
+			invalidCase(`
+            test(
+                function named()
+                { return 1; }
+            );
+            `, `
+            test(
+                () =>
+                { return 1; }
+            );
+            `, nil, 1),
+
+			// ---- Real-user: #16718 Allman-style body with parameter comment ----
+			invalidCase(`
+            queue.push(
+                function (
+                    value
+                ) // keep parameter layout
+                { return value; }
+            );
+            `, `
+            queue.push(
+                (
+                    value
+                ) => // keep parameter layout
+                { return value; }
+            );
+            `, nil, 1),
+
+			// Locks in upstream getCallbackInfo LogicalExpression arm.
+			invalidCase("foo(left && function() {});", "foo(left && (() => {}));", nil, 1),
+
+			// Locks in upstream getCallbackInfo ConditionalExpression arm.
+			invalidCase("foo(cond ? noop : function() {});", "foo(cond ? noop : () => {});", nil, 1),
+
+			// Locks in upstream FunctionExpression:exit arm 5: allowUnboundThis=false reports unbound `this` but emits no fix.
+			invalidCase("foo(function() { return this.value; });", "", disallowUnboundThisMap, 1),
+
+			// ---- Real-user: dynamic `this` callbacks report without fix when allowUnboundThis=false ----
+			invalidCase("button.addEventListener('click', function(event) { this.disabled = event.defaultPrevented; });", "", disallowUnboundThisMap, 1),
+
+			// Locks in upstream FunctionExpression:exit arm 5: `this` in default params is also unbound callback `this`.
+			invalidCase("foo(function(a = this.value) {});", "", disallowUnboundThisMap, 1),
+
+			// Locks in upstream FunctionExpression:exit arm 5: `this` in computed method names is outer callback `this`.
+			invalidCase("foo(function() { class C { [this.key]() {} } });", "", disallowUnboundThisMap, 1),
+
+			// Locks in upstream fix arm: duplicate simple params report but are not fixed.
+			invalidCase("foo(function(a, a) { return a; });", "", nil, 1),
+
+			// Locks in upstream fix arm: `.bind(this)` containing comments reports but is not fixed.
+			invalidCase("foo(function() { return this; }.bind(/* keep */ this));", "", nil, 1),
+		},
+	)
+}

--- a/internal/rules/prefer_arrow_callback/prefer_arrow_callback_upstream_test.go
+++ b/internal/rules/prefer_arrow_callback/prefer_arrow_callback_upstream_test.go
@@ -1,0 +1,284 @@
+// TestPreferArrowCallbackUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/prefer-arrow-callback.js 1:1. Position assertions
+// cover line/column for every invalid case. rslint-specific lock-in cases live
+// in the prefer_arrow_callback_extras_test.go file.
+// cspell:ignore amet
+package prefer_arrow_callback
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const preferArrowCallbackMessageText = "Unexpected function expression."
+
+func preferArrowErrorAt(line, column int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		Line:      line,
+		Column:    column,
+		MessageId: "preferArrowCallback",
+		Message:   preferArrowCallbackMessageText,
+	}
+}
+
+func preferArrowErrors(code string, count int) []rule_tester.InvalidTestCaseError {
+	errors := make([]rule_tester.InvalidTestCaseError, 0, count)
+	offset := 0
+	for len(errors) < count {
+		nextAsync := strings.Index(code[offset:], "async function")
+		nextFunction := strings.Index(code[offset:], "function")
+		if nextAsync >= 0 {
+			nextAsync += offset
+		}
+		if nextFunction >= 0 {
+			nextFunction += offset
+		}
+		pos := nextFunction
+		if nextAsync >= 0 && (pos < 0 || nextAsync < pos) {
+			pos = nextAsync
+		}
+		if pos < 0 {
+			panic("missing function token in test case")
+		}
+		line, column := lineColumnForOffset(code, pos)
+		errors = append(errors, preferArrowErrorAt(line, column))
+		offset = pos + len("function")
+	}
+	return errors
+}
+
+func lineColumnForOffset(code string, offset int) (int, int) {
+	line, column := 1, 1
+	for i, r := range code {
+		if i >= offset {
+			break
+		}
+		if r == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+	return line, column
+}
+
+func invalidCase(code string, output string, options any, count int) rule_tester.InvalidTestCase {
+	tc := rule_tester.InvalidTestCase{
+		Code:    code,
+		Options: options,
+		Errors:  preferArrowErrors(code, count),
+	}
+	if output != "" {
+		tc.Output = []string{output}
+	}
+	return tc
+}
+
+func TestPreferArrowCallbackUpstream(t *testing.T) {
+	allowNamed := []any{map[string]any{"allowNamedFunctions": true}}
+	disallowNamed := []any{map[string]any{"allowNamedFunctions": false}}
+	disallowUnboundThis := []any{map[string]any{"allowUnboundThis": false}}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferArrowCallbackRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "foo(a => a);"},
+			{Code: "foo(function*() {});"},
+			{Code: "foo(function() { this; });"},
+			{Code: "foo(function bar() {});", Options: allowNamed},
+			{Code: "foo(function() { (() => this); });"},
+			{Code: "foo(function() { this; }.bind(obj));"},
+			{Code: "foo(function() { this; }.call(this));"},
+			{Code: "foo(a => { (function() {}); });"},
+			{Code: "var foo = function foo() {};"},
+			{Code: "(function foo() {})();"},
+			{Code: "foo(function bar() { bar; });"},
+			{Code: "foo(function bar() { arguments; });"},
+			{Code: "foo(function bar() { arguments; }.bind(this));"},
+			{Code: "foo(function bar() { new.target; });"},
+			{Code: "foo(function bar() { new.target; }.bind(this));"},
+			{Code: "foo(function bar() { this; }.bind(this, somethingElse));"},
+			{Code: "foo((function() {}).bind.bar)"},
+			{Code: "foo((function() { this.bar(); }).bind(obj).bind(this))"},
+		},
+		[]rule_tester.InvalidTestCase{
+			invalidCase("foo(function bar() {});", "foo(() => {});", nil, 1),
+			invalidCase("foo(function() {});", "foo(() => {});", allowNamed, 1),
+			invalidCase("foo(function bar() {});", "foo(() => {});", disallowNamed, 1),
+			invalidCase("foo(function() {});", "foo(() => {});", nil, 1),
+			invalidCase("foo(nativeCb || function() {});", "foo(nativeCb || (() => {}));", nil, 1),
+			invalidCase("foo(bar ? function() {} : function() {});", "foo(bar ? () => {} : () => {});", nil, 2),
+			invalidCase("foo(function() { (function() { this; }); });", "foo(() => { (function() { this; }); });", nil, 1),
+			invalidCase("foo(function() { this; }.bind(this));", "foo(() => { this; });", nil, 1),
+			invalidCase("foo(bar || function() { this; }.bind(this));", "foo(bar || (() => { this; }));", nil, 1),
+			invalidCase("foo(function() { (() => this); }.bind(this));", "foo(() => { (() => this); });", nil, 1),
+			invalidCase("foo(function bar(a) { a; });", "foo((a) => { a; });", nil, 1),
+			invalidCase("foo(function(a) { a; });", "foo((a) => { a; });", nil, 1),
+			invalidCase("foo(function(arguments) { arguments; });", "foo((arguments) => { arguments; });", nil, 1),
+			invalidCase("foo(function() { this; });", "", disallowUnboundThis, 1),
+			invalidCase("foo(function() { (() => this); });", "", disallowUnboundThis, 1),
+			invalidCase("qux(function(foo, bar, baz) { return foo * 2; })", "qux((foo, bar, baz) => { return foo * 2; })", nil, 1),
+			invalidCase("qux(function(foo, bar, baz) { return foo * bar; }.bind(this))", "qux((foo, bar, baz) => { return foo * bar; })", nil, 1),
+			invalidCase("qux(function(foo, bar, baz) { return foo * this.qux; }.bind(this))", "qux((foo, bar, baz) => { return foo * this.qux; })", nil, 1),
+			invalidCase("foo(function() {}.bind(this, somethingElse))", "foo((() => {}).bind(this, somethingElse))", nil, 1),
+			invalidCase("qux(function(foo = 1, [bar = 2] = [], {qux: baz = 3} = {foo: 'bar'}) { return foo + bar; });", "qux((foo = 1, [bar = 2] = [], {qux: baz = 3} = {foo: 'bar'}) => { return foo + bar; });", nil, 1),
+			invalidCase("qux(function(baz, baz) { })", "", nil, 1),
+			invalidCase("qux(function( /* no params */ ) { })", "qux(( /* no params */ ) => { })", nil, 1),
+			invalidCase("qux(function( /* a */ foo /* b */ , /* c */ bar /* d */ , /* e */ baz /* f */ ) { return foo; })", "qux(( /* a */ foo /* b */ , /* c */ bar /* d */ , /* e */ baz /* f */ ) => { return foo; })", nil, 1),
+			invalidCase("qux(async function (foo = 1, bar = 2, baz = 3) { return baz; })", "qux(async (foo = 1, bar = 2, baz = 3) => { return baz; })", nil, 1),
+			invalidCase("qux(async function (foo = 1, bar = 2, baz = 3) { return this; }.bind(this))", "qux(async (foo = 1, bar = 2, baz = 3) => { return this; })", nil, 1),
+			invalidCase("foo(async function /*\n*/ () { return 1; });", "", nil, 1),
+			invalidCase("foo(async function // c\n () { return 1; });", "", nil, 1),
+			invalidCase("foo(async function\n () { return 1; });", "", nil, 1),
+			invalidCase("foo(async function /* c */ () { return 1; });", "foo(async  /* c */ () => { return 1; });", nil, 1),
+			invalidCase("foo((bar || function() {}).bind(this))", "", nil, 1),
+			invalidCase("foo(function() {}.bind(this).bind(obj))", "foo((() => {}).bind(obj))", nil, 1),
+
+			// ---- Optional chaining ----
+			invalidCase("foo?.(function() {});", "foo?.(() => {});", nil, 1),
+			invalidCase("foo?.(function() { return this; }.bind(this));", "foo?.(() => { return this; });", nil, 1),
+			invalidCase("foo(function() { return this; }?.bind(this));", "foo(() => { return this; });", nil, 1),
+			invalidCase("foo((function() { return this; }?.bind)(this));", "", nil, 1),
+
+			// ---- https://github.com/eslint/eslint/issues/16718 ----
+			invalidCase(`
+            test(
+                function ()
+                { }
+            );
+            `, `
+            test(
+                () =>
+                { }
+            );
+            `, nil, 1),
+			invalidCase(`
+            test(
+                function (
+                    ...args
+                ) /* Lorem ipsum
+                dolor sit amet. */ {
+                    return args;
+                }
+            );
+            `, `
+            test(
+                (
+                    ...args
+                ) => /* Lorem ipsum
+                dolor sit amet. */ {
+                    return args;
+                }
+            );
+            `, nil, 1),
+		},
+	)
+}
+
+func TestPreferArrowCallbackUpstreamTypeScript(t *testing.T) {
+	allowNamed := []any{map[string]any{"allowNamedFunctions": true}}
+	disallowNamed := []any{map[string]any{"allowNamedFunctions": false}}
+	disallowUnboundThis := []any{map[string]any{"allowUnboundThis": false}}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferArrowCallbackRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "foo(a => a);"},
+			{Code: "foo((a:string) => a);"},
+			{Code: "foo(function*() {});"},
+			{Code: "foo(function() { this; });"},
+			{Code: "foo(function bar(a:string) {});", Options: allowNamed},
+			{Code: "foo(function() { (() => this); });"},
+			{Code: "foo(function() { this; }.bind(obj));"},
+			{Code: "foo(function() { this; }.call(this));"},
+			{Code: "foo(a => { (function() {}); });"},
+			{Code: "var foo = function foo() {};"},
+			{Code: "(function foo() {})();"},
+			{Code: "foo(function bar() { bar; });"},
+			{Code: "foo(function bar() { arguments; });"},
+			{Code: "foo(function bar() { arguments; }.bind(this));"},
+			{Code: "foo(function bar() { new.target; });"},
+			{Code: "foo(function bar() { new.target; }.bind(this));"},
+			{Code: "foo(function bar() { this; }.bind(this, somethingElse));"},
+			{Code: "foo((function() {}).bind.bar)"},
+			{Code: "foo((function() { this.bar(); }).bind(obj).bind(this))"},
+			{Code: "test('clean', function (this: any) { this.foo = 'Cleaned!';});"},
+			{Code: "obj.test('clean', function (foo) { this.foo = 'Cleaned!'; });"},
+		},
+		[]rule_tester.InvalidTestCase{
+			invalidCase("foo(function bar() {});", "foo(() => {});", nil, 1),
+			invalidCase("foo(function(a:string) {});", "foo((a:string) => {});", allowNamed, 1),
+			invalidCase("foo(function bar() {});", "foo(() => {});", disallowNamed, 1),
+			invalidCase("foo(function() {});", "foo(() => {});", nil, 1),
+			invalidCase("foo(nativeCb || function() {});", "foo(nativeCb || (() => {}));", nil, 1),
+			invalidCase("foo(bar ? function() {} : function() {});", "foo(bar ? () => {} : () => {});", nil, 2),
+			invalidCase("foo(function() { (function() { this; }); });", "foo(() => { (function() { this; }); });", nil, 1),
+			invalidCase("foo(function() { this; }.bind(this));", "foo(() => { this; });", nil, 1),
+			invalidCase("foo(bar || function() { this; }.bind(this));", "foo(bar || (() => { this; }));", nil, 1),
+			invalidCase("foo(function() { (() => this); }.bind(this));", "foo(() => { (() => this); });", nil, 1),
+			invalidCase("foo(function bar(a:string) { a; });", "foo((a:string) => { a; });", nil, 1),
+			invalidCase("foo(function(a:any) { a; });", "foo((a:any) => { a; });", nil, 1),
+			invalidCase("foo(function(arguments:any) { arguments; });", "foo((arguments:any) => { arguments; });", nil, 1),
+			invalidCase("foo(function(a:string) { this; });", "", disallowUnboundThis, 1),
+			invalidCase("foo(function() { (() => this); });", "", disallowUnboundThis, 1),
+			invalidCase("qux(function(foo:string, bar:number, baz:string) { return foo * 2; })", "qux((foo:string, bar:number, baz:string) => { return foo * 2; })", nil, 1),
+			invalidCase("qux(function(foo:number, bar:number, baz:number) { return foo * bar; }.bind(this))", "qux((foo:number, bar:number, baz:number) => { return foo * bar; })", nil, 1),
+			invalidCase("qux(function(foo:any, bar:any, baz:any) { return foo * this.qux; }.bind(this))", "qux((foo:any, bar:any, baz:any) => { return foo * this.qux; })", nil, 1),
+			invalidCase("foo(function() {}.bind(this, somethingElse))", "foo((() => {}).bind(this, somethingElse))", nil, 1),
+			invalidCase("qux(function(foo = 1, [bar = 2] = [], {qux: baz = 3} = {foo: 'bar'}) { return foo + bar; });", "qux((foo = 1, [bar = 2] = [], {qux: baz = 3} = {foo: 'bar'}) => { return foo + bar; });", nil, 1),
+			invalidCase("qux(function(baz:string, baz:string) { })", "", nil, 1),
+			invalidCase("qux(function( /* no params */ ) { })", "qux(( /* no params */ ) => { })", nil, 1),
+			invalidCase("qux(function( /* a */ foo:string /* b */ , /* c */ bar:string /* d */ , /* e */ baz:string /* f */ ) { return foo; })", "qux(( /* a */ foo:string /* b */ , /* c */ bar:string /* d */ , /* e */ baz:string /* f */ ) => { return foo; })", nil, 1),
+			invalidCase("qux(async function (foo:number = 1, bar:number = 2, baz:number = 3) { return baz; })", "qux(async (foo:number = 1, bar:number = 2, baz:number = 3) => { return baz; })", nil, 1),
+			invalidCase("qux(async function (foo:number = 1, bar:number = 2, baz:number = 3) { return this; }.bind(this))", "qux(async (foo:number = 1, bar:number = 2, baz:number = 3) => { return this; })", nil, 1),
+			invalidCase("foo((bar || function() {}).bind(this))", "", nil, 1),
+			invalidCase("foo(function() {}.bind(this).bind(obj))", "foo((() => {}).bind(obj))", nil, 1),
+			invalidCase("foo?.(function() {});", "foo?.(() => {});", nil, 1),
+			invalidCase("foo?.(function() { return this; }.bind(this));", "foo?.(() => { return this; });", nil, 1),
+			invalidCase("foo(function() { return this; }?.bind(this));", "foo(() => { return this; });", nil, 1),
+			invalidCase("foo((function() { return this; }?.bind)(this));", "", nil, 1),
+			invalidCase(`
+            test(
+                function ()
+                { }
+            );
+            `, `
+            test(
+                () =>
+                { }
+            );
+            `, nil, 1),
+			invalidCase(`
+            test(
+                function (
+                    ...args
+                ) /* Lorem ipsum
+                dolor sit amet. */ {
+                    return args;
+                }
+            );
+            `, `
+            test(
+                (
+                    ...args
+                ) => /* Lorem ipsum
+                dolor sit amet. */ {
+                    return args;
+                }
+            );
+            `, nil, 1),
+			invalidCase("foo(function():string { return 'foo' });", "foo(():string => { return 'foo' });", nil, 1),
+			invalidCase("test('foo', function (this: any) {});", "", nil, 1),
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -109,6 +109,7 @@ export default defineConfig({
     './tests/eslint/rules/no-undef-init.test.ts',
     './tests/eslint/rules/no-var.test.ts',
     './tests/eslint/rules/one-var.test.ts',
+    './tests/eslint/rules/prefer-arrow-callback.test.ts',
     './tests/eslint/rules/prefer-const.test.ts',
     './tests/eslint/rules/no-this-before-super.test.ts',
     './tests/eslint/rules/prefer-rest-params.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-arrow-callback.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-arrow-callback.test.ts.snap
@@ -1,0 +1,1359 @@
+// Rstest Snapshot v1
+
+exports[`prefer-arrow-callback > invalid 1`] = `
+{
+  "code": "foo(function bar() {});",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 2`] = `
+{
+  "code": "foo(function() {});",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 3`] = `
+{
+  "code": "foo(function bar() {});",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 4`] = `
+{
+  "code": "foo(function() {});",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 5`] = `
+{
+  "code": "foo(nativeCb || function() {});",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 6`] = `
+{
+  "code": "foo(bar ? function() {} : function() {});",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 7`] = `
+{
+  "code": "foo(function() { (function() { this; }); });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 8`] = `
+{
+  "code": "foo(function() { this; }.bind(this));",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 9`] = `
+{
+  "code": "foo(bar || function() { this; }.bind(this));",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 10`] = `
+{
+  "code": "foo(function() { (() => this); }.bind(this));",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 11`] = `
+{
+  "code": "foo(function bar(a) { a; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 12`] = `
+{
+  "code": "foo(function(a) { a; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 13`] = `
+{
+  "code": "foo(function(arguments) { arguments; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 14`] = `
+{
+  "code": "foo(function() { this; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 15`] = `
+{
+  "code": "foo(function() { (() => this); });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 16`] = `
+{
+  "code": "qux(function(foo, bar, baz) { return foo * 2; })",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 17`] = `
+{
+  "code": "qux(function(foo, bar, baz) { return foo * bar; }.bind(this))",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 18`] = `
+{
+  "code": "qux(function(foo, bar, baz) { return foo * this.qux; }.bind(this))",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 19`] = `
+{
+  "code": "foo(function() {}.bind(this, somethingElse))",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 20`] = `
+{
+  "code": "qux(function(foo = 1, [bar = 2] = [], {qux: baz = 3} = {foo: 'bar'}) { return foo + bar; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 91,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 21`] = `
+{
+  "code": "qux(function(baz, baz) { })",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 22`] = `
+{
+  "code": "qux(function( /* no params */ ) { })",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 23`] = `
+{
+  "code": "qux(function( /* a */ foo /* b */ , /* c */ bar /* d */ , /* e */ baz /* f */ ) { return foo; })",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 96,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 24`] = `
+{
+  "code": "qux(async function (foo = 1, bar = 2, baz = 3) { return baz; })",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 25`] = `
+{
+  "code": "qux(async function (foo = 1, bar = 2, baz = 3) { return this; }.bind(this))",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 26`] = `
+{
+  "code": "foo(async function /*
+*/ () { return 1; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 27`] = `
+{
+  "code": "foo(async function // c
+ () { return 1; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 28`] = `
+{
+  "code": "foo(async function
+ () { return 1; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 29`] = `
+{
+  "code": "foo(async function /* c */ () { return 1; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 30`] = `
+{
+  "code": "foo((bar || function() {}).bind(this))",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 31`] = `
+{
+  "code": "foo(function() {}.bind(this).bind(obj))",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 32`] = `
+{
+  "code": "foo?.(function() {});",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 33`] = `
+{
+  "code": "foo?.(function() { return this; }.bind(this));",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 34`] = `
+{
+  "code": "foo(function() { return this; }?.bind(this));",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 35`] = `
+{
+  "code": "foo((function() { return this; }?.bind)(this));",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 36`] = `
+{
+  "code": "
+            test(
+                function ()
+                { }
+            );
+            ",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 37`] = `
+{
+  "code": "
+            test(
+                function (
+                    ...args
+                ) /* Lorem ipsum
+                dolor sit amet. */ {
+                    return args;
+                }
+            );
+            ",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 8,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 38`] = `
+{
+  "code": "foo(function(a:string) {});",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 39`] = `
+{
+  "code": "foo(function bar(a:string) { a; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 40`] = `
+{
+  "code": "foo(function(a:any) { a; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 41`] = `
+{
+  "code": "foo(function(arguments:any) { arguments; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 42`] = `
+{
+  "code": "foo(function(a:string) { this; });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 43`] = `
+{
+  "code": "qux(function(foo:string, bar:number, baz:string) { return foo * 2; })",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 44`] = `
+{
+  "code": "qux(function(foo:number, bar:number, baz:number) { return foo * bar; }.bind(this))",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 45`] = `
+{
+  "code": "qux(function(foo:any, bar:any, baz:any) { return foo * this.qux; }.bind(this))",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 46`] = `
+{
+  "code": "qux(function(baz:string, baz:string) { })",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 47`] = `
+{
+  "code": "qux(function( /* a */ foo:string /* b */ , /* c */ bar:string /* d */ , /* e */ baz:string /* f */ ) { return foo; })",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 117,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 48`] = `
+{
+  "code": "qux(async function (foo:number = 1, bar:number = 2, baz:number = 3) { return baz; })",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 49`] = `
+{
+  "code": "qux(async function (foo:number = 1, bar:number = 2, baz:number = 3) { return this; }.bind(this))",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 85,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 50`] = `
+{
+  "code": "foo(function():string { return 'foo' });",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-arrow-callback > invalid 51`] = `
+{
+  "code": "test('foo', function (this: any) {});",
+  "diagnostics": [
+    {
+      "message": "Unexpected function expression.",
+      "messageId": "preferArrowCallback",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-arrow-callback",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/prefer-arrow-callback.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/prefer-arrow-callback.test.ts
@@ -1,0 +1,272 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const errors = [{ messageId: 'preferArrowCallback' }];
+
+ruleTester.run('prefer-arrow-callback', {
+  valid: [
+    'foo(a => a);',
+    'foo(function*() {});',
+    'foo(function() { this; });',
+    {
+      code: 'foo(function bar() {});',
+      options: [{ allowNamedFunctions: true }] as any,
+    },
+    'foo(function() { (() => this); });',
+    'foo(function() { this; }.bind(obj));',
+    'foo(function() { this; }.call(this));',
+    'foo(a => { (function() {}); });',
+    'var foo = function foo() {};',
+    '(function foo() {})();',
+    'foo(function bar() { bar; });',
+    'foo(function bar() { arguments; });',
+    'foo(function bar() { arguments; }.bind(this));',
+    'foo(function bar() { new.target; });',
+    'foo(function bar() { new.target; }.bind(this));',
+    'foo(function bar() { this; }.bind(this, somethingElse));',
+    'foo((function() {}).bind.bar)',
+    'foo((function() { this.bar(); }).bind(obj).bind(this))',
+
+    // TypeScript upstream valid cases
+    'foo((a:string) => a);',
+    {
+      code: 'foo(function bar(a:string) {});',
+      options: [{ allowNamedFunctions: true }] as any,
+    },
+    "test('clean', function (this: any) { this.foo = 'Cleaned!';});",
+    "obj.test('clean', function (foo) { this.foo = 'Cleaned!'; });",
+  ],
+  invalid: [
+    {
+      code: 'foo(function bar() {});',
+      errors,
+    },
+    {
+      code: 'foo(function() {});',
+      options: [{ allowNamedFunctions: true }] as any,
+      errors,
+    },
+    {
+      code: 'foo(function bar() {});',
+      options: [{ allowNamedFunctions: false }] as any,
+      errors,
+    },
+    {
+      code: 'foo(function() {});',
+      errors,
+    },
+    {
+      code: 'foo(nativeCb || function() {});',
+      errors,
+    },
+    {
+      code: 'foo(bar ? function() {} : function() {});',
+      errors: [errors[0], errors[0]],
+    },
+    {
+      code: 'foo(function() { (function() { this; }); });',
+      errors,
+    },
+    {
+      code: 'foo(function() { this; }.bind(this));',
+      errors,
+    },
+    {
+      code: 'foo(bar || function() { this; }.bind(this));',
+      errors,
+    },
+    {
+      code: 'foo(function() { (() => this); }.bind(this));',
+      errors,
+    },
+    {
+      code: 'foo(function bar(a) { a; });',
+      errors,
+    },
+    {
+      code: 'foo(function(a) { a; });',
+      errors,
+    },
+    {
+      code: 'foo(function(arguments) { arguments; });',
+      errors,
+    },
+    {
+      code: 'foo(function() { this; });',
+      options: [{ allowUnboundThis: false }] as any,
+      errors,
+    },
+    {
+      code: 'foo(function() { (() => this); });',
+      options: [{ allowUnboundThis: false }] as any,
+      errors,
+    },
+    {
+      code: 'qux(function(foo, bar, baz) { return foo * 2; })',
+      errors,
+    },
+    {
+      code: 'qux(function(foo, bar, baz) { return foo * bar; }.bind(this))',
+      errors,
+    },
+    {
+      code: 'qux(function(foo, bar, baz) { return foo * this.qux; }.bind(this))',
+      errors,
+    },
+    {
+      code: 'foo(function() {}.bind(this, somethingElse))',
+      errors,
+    },
+    {
+      code: "qux(function(foo = 1, [bar = 2] = [], {qux: baz = 3} = {foo: 'bar'}) { return foo + bar; });",
+      errors,
+    },
+    {
+      code: 'qux(function(baz, baz) { })',
+      errors,
+    },
+    {
+      code: 'qux(function( /* no params */ ) { })',
+      errors,
+    },
+    {
+      code: 'qux(function( /* a */ foo /* b */ , /* c */ bar /* d */ , /* e */ baz /* f */ ) { return foo; })',
+      errors,
+    },
+    {
+      code: 'qux(async function (foo = 1, bar = 2, baz = 3) { return baz; })',
+      errors,
+    },
+    {
+      code: 'qux(async function (foo = 1, bar = 2, baz = 3) { return this; }.bind(this))',
+      errors,
+    },
+    {
+      code: 'foo(async function /*\n*/ () { return 1; });',
+      errors,
+    },
+    {
+      code: 'foo(async function // c\n () { return 1; });',
+      errors,
+    },
+    {
+      code: 'foo(async function\n () { return 1; });',
+      errors,
+    },
+    {
+      code: 'foo(async function /* c */ () { return 1; });',
+      errors,
+    },
+    {
+      code: 'foo((bar || function() {}).bind(this))',
+      errors,
+    },
+    {
+      code: 'foo(function() {}.bind(this).bind(obj))',
+      errors,
+    },
+
+    // Optional chaining
+    {
+      code: 'foo?.(function() {});',
+      errors,
+    },
+    {
+      code: 'foo?.(function() { return this; }.bind(this));',
+      errors,
+    },
+    {
+      code: 'foo(function() { return this; }?.bind(this));',
+      errors,
+    },
+    {
+      code: 'foo((function() { return this; }?.bind)(this));',
+      errors,
+    },
+
+    // https://github.com/eslint/eslint/issues/16718
+    {
+      code: `
+            test(
+                function ()
+                { }
+            );
+            `,
+      errors,
+    },
+    {
+      code: `
+            test(
+                function (
+                    ...args
+                ) /* Lorem ipsum
+                dolor sit amet. */ {
+                    return args;
+                }
+            );
+            `,
+      errors,
+    },
+
+    // TypeScript upstream invalid cases
+    {
+      code: 'foo(function(a:string) {});',
+      options: [{ allowNamedFunctions: true }] as any,
+      errors,
+    },
+    {
+      code: 'foo(function bar(a:string) { a; });',
+      errors,
+    },
+    {
+      code: 'foo(function(a:any) { a; });',
+      errors,
+    },
+    {
+      code: 'foo(function(arguments:any) { arguments; });',
+      errors,
+    },
+    {
+      code: 'foo(function(a:string) { this; });',
+      options: [{ allowUnboundThis: false }] as any,
+      errors,
+    },
+    {
+      code: 'qux(function(foo:string, bar:number, baz:string) { return foo * 2; })',
+      errors,
+    },
+    {
+      code: 'qux(function(foo:number, bar:number, baz:number) { return foo * bar; }.bind(this))',
+      errors,
+    },
+    {
+      code: 'qux(function(foo:any, bar:any, baz:any) { return foo * this.qux; }.bind(this))',
+      errors,
+    },
+    {
+      code: 'qux(function(baz:string, baz:string) { })',
+      errors,
+    },
+    {
+      code: 'qux(function( /* a */ foo:string /* b */ , /* c */ bar:string /* d */ , /* e */ baz:string /* f */ ) { return foo; })',
+      errors,
+    },
+    {
+      code: 'qux(async function (foo:number = 1, bar:number = 2, baz:number = 3) { return baz; })',
+      errors,
+    },
+    {
+      code: 'qux(async function (foo:number = 1, bar:number = 2, baz:number = 3) { return this; }.bind(this))',
+      errors,
+    },
+    {
+      code: "foo(function():string { return 'foo' });",
+      errors,
+    },
+    {
+      code: "test('foo', function (this: any) {});",
+      errors,
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -581,6 +581,7 @@ serde
 SIGSEGV
 zigbuild
 lockfiles
+Microtask
 smajobber
 isatty
 semacquire


### PR DESCRIPTION
## Summary

Port the ESLint core `prefer-arrow-callback` rule to rslint.

- Add Go implementation, documentation, upstream and extra rule tests.
- Register the rule and add rslint-test-tools coverage/snapshot.
- Validate diagnostics against upstream ESLint on real rsbuild and rspack repositories: rsbuild 2/2 matched, rspack 131/131 matched.

Validation run:

- `pnpm check-spell`
- `pnpm format:check`
- `golangci-lint run ./internal/rules ./internal/rules/prefer_arrow_callback`
- `go test -count=1 ./internal/rules/prefer_arrow_callback`
- `pnpm build` in `packages/rslint`
- `npx rstest run --testTimeout=10000 prefer-arrow-callback`

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/prefer-arrow-callback
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/prefer-arrow-callback.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
