### PR TITLE
fix(core): convert bin launcher to ESM

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,11 +42,11 @@ After building, you can test the rslint CLI:
 
 ```bash
 # Test the binary
-./packages/rslint/bin/rslint.cjs --help
+./packages/rslint/bin/rslint.js --help
 
 
 # Lint the project itself
-./packages/rslint/bin/rslint.cjs
+./packages/rslint/bin/rslint.js
 ```
 
 ## Debugging VSCode Extension

--- a/packages/rslint-test-tools/tests/cli/entry-point.test.ts
+++ b/packages/rslint-test-tools/tests/cli/entry-point.test.ts
@@ -15,7 +15,7 @@ interface CliTestResult {
 /**
  * Run the rslint entry point explicitly via `node`, matching how pnpm/.cmd
  * wrappers invoke it on Windows. This ensures the dynamic `import()` inside
- * bin/rslint.cjs is exercised — on Windows, bare `spawn('file.cjs')` may
+ * bin/rslint.js is exercised — on Windows, bare `spawn('file.js')` may
  * bypass Node.js entirely because shebangs are not supported.
  */
 function runRslintViaNode(
@@ -61,7 +61,7 @@ async function cleanupTempDir(tempDir: string): Promise<void> {
   await fs.rm(tempDir, { recursive: true, force: true });
 }
 
-describe('Entry point (bin/rslint.cjs)', () => {
+describe('Entry point (bin/rslint.js)', () => {
   test('should load ESM cli module without ERR_UNSUPPORTED_ESM_URL_SCHEME', async () => {
     const result = await runRslintViaNode(['--help']);
     expect(result.stderr).not.toContain('ERR_UNSUPPORTED_ESM_URL_SCHEME');

--- a/packages/rslint/bin/rslint.js
+++ b/packages/rslint/bin/rslint.js
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
+import { createRequire } from 'node:module';
+import os from 'node:os';
+
+const require = createRequire(import.meta.url);
 const startTime = Date.now();
-const path = require('node:path');
-const { pathToFileURL } = require('node:url');
-const os = require('node:os');
 
 function getBinPath() {
   // The Go binary lives in the @rslint/native-{tuple} platform package, reached
   // via its `./bin` export. Resolution is identical in dev and prod: `pnpm build`
   // drops the host binary into npm/rslint/{tuple}/, and npm installs only the
   // subpackage matching the host os/cpu/libc. On linux we just try gnu then musl
-  // and use whichever resolved — no libc sniffing (Go binaries are static, the
+  // and use whichever resolved - no libc sniffing (Go binaries are static, the
   // gnu/musl distinction doesn't matter to them).
   const arch = os.arch();
   const tuples =
@@ -31,9 +32,7 @@ function getBinPath() {
 
 async function main() {
   const binPath = getBinPath();
-  const { run } = await import(
-    pathToFileURL(path.resolve(__dirname, '../dist/cli.js')).href
-  );
+  const { run } = await import('../dist/cli.js');
   const exitCode = await run(binPath, process.argv.slice(2), startTime);
   // process.exit() would tear down before async-buffered stdout writes (pipes,
   // Windows TTYs) flush, truncating the lint tail. Setting exitCode lets the

--- a/packages/rslint/package.json
+++ b/packages/rslint/package.json
@@ -22,7 +22,7 @@
       "@typescript/source": "./src/eslint-plugin/index.ts",
       "default": "./dist/eslint-plugin/index.js"
     },
-    "./bin": "./bin/rslint.cjs",
+    "./bin": "./bin/rslint.js",
     "./package.json": "./package.json"
   },
   "type": "module",
@@ -40,11 +40,11 @@
     "test:update": "rstest run -u"
   },
   "files": [
-    "bin/rslint.cjs",
+    "bin/rslint.js",
     "dist/"
   ],
   "bin": {
-    "rslint": "./bin/rslint.cjs"
+    "rslint": "./bin/rslint.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rslint/src/internal/node.ts
+++ b/packages/rslint/src/internal/node.ts
@@ -16,7 +16,7 @@ const require = createRequire(import.meta.url);
 /**
  * Resolve the rslint Go binary from the matching `@rslint/native-<tuple>`
  * platform package (its `./bin` export) — the same resolution the CLI launcher
- * (`bin/rslint.cjs`) uses. Linux tries gnu then musl (Go is statically linked,
+ * (`bin/rslint.js`) uses. Linux tries gnu then musl (Go is statically linked,
  * so the libc split is irrelevant to it).
  */
 function resolveRslintBinary(): string {

--- a/packages/vscode-extension/scripts/build.js
+++ b/packages/vscode-extension/scripts/build.js
@@ -85,7 +85,7 @@ function stageRuntimeAssets() {
   const distDir = path.join(__dirname, '../dist');
   const coreDir = path.dirname(require.resolve('@rslint/core/package.json'));
 
-  // 1. Launcher (`rslint.cjs`) from core/bin + the Go LSP binary. build:bin now
+  // 1. Launcher (`rslint.js`) from core/bin + the Go LSP binary. build:bin now
   //    lands the Go binary in the host platform package (not core/bin), so copy
   //    it from there. In CI, publish-marketplace.mjs overwrites dist/rslint with
   //    the target-platform binary; locally this makes `pnpm build` dev-ready.

--- a/packages/vscode-extension/src/utils.ts
+++ b/packages/vscode-extension/src/utils.ts
@@ -23,7 +23,7 @@ export const fileExists = async (uri: Uri): Promise<boolean> => {
 
 /**
  * Returns the ordered list of platform-package requests to try-resolve when
- * locating the bundled Go binary, mirroring `packages/rslint/bin/rslint.cjs`.
+ * locating the bundled Go binary, mirroring `packages/rslint/bin/rslint.js`.
  *
  * The Go binary lives in the `@rslint/native-{tuple}` subpackage, reached via
  * its `./bin` export. npm installs only the subpackage matching the host

--- a/scripts/place-host-build.mjs
+++ b/scripts/place-host-build.mjs
@@ -2,7 +2,7 @@
 /**
  * Place host-platform build outputs into the matching `@rslint/native-<tuple>`
  * platform package, so the core loader (`load-binding.ts`) and the bin launcher
- * (`bin/rslint.cjs`) resolve them in dev EXACTLY as in prod — no dev-only path.
+ * (`bin/rslint.js`) resolve them in dev EXACTLY as in prod — no dev-only path.
  *
  *   node scripts/place-host-build.mjs bin [--debug]   # go build the rslint CLI
  *   node scripts/place-host-build.mjs node            # copy the napi .node

--- a/tests/bench-cli/src/cli.bench.ts
+++ b/tests/bench-cli/src/cli.bench.ts
@@ -17,7 +17,7 @@ import {
 // 1) `cli@vscode`: parent start -> CLI process completion
 // 2) `cli@vscode_before_go_exec`: parent start -> first Go binary invocation
 const repoRoot = path.resolve(import.meta.dirname, '../../../');
-const cliEntrypoint = path.join(repoRoot, 'packages/rslint/bin/rslint.cjs');
+const cliEntrypoint = path.join(repoRoot, 'packages/rslint/bin/rslint.js');
 const vscodeRepoDir = path.join(os.tmpdir(), 'rslint-bench', 'vscode');
 const benchmarkTaskName = 'cli@vscode';
 const preBinaryBenchmarkName = 'cli@vscode_before_go_exec';


### PR DESCRIPTION
## Summary

Converts the packaged rslint CLI launcher from CommonJS `bin/rslint.cjs` to ESM `bin/rslint.js` so it matches the package's module format.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
