### PR TITLE
feat(core): export RslintConfig type

### DIFF
--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -1,5 +1,6 @@
 export { defineConfig, globalIgnores } from './config/define-config.js';
 export type {
+  RslintConfig,
   RslintConfigEntry,
   ESLintPlugin,
 } from './config/define-config.js';


### PR DESCRIPTION
## Summary

Exports the top-level `RslintConfig` type from `@rslint/core` so users can import the complete config array type from the package root.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
