### PR TITLE
feat: port rule no-new-native-nonconstructor

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -71,6 +71,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_nested_ternary"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_func"
+	"github.com/web-infra-dev/rslint/internal/rules/no_new_native_nonconstructor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_object"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
@@ -194,6 +195,7 @@ func GetAllRules() []rule.Rule {
 		no_misleading_character_class.NoMisleadingCharacterClassRule,
 		no_new.NoNewRule,
 		no_new_func.NoNewFuncRule,
+		no_new_native_nonconstructor.NoNewNativeNonconstructorRule,
 		no_new_wrappers.NoNewWrappersRule,
 		no_restricted_imports.NoRestrictedImportsRule,
 		no_restricted_syntax.NoRestrictedSyntaxRule,

--- a/internal/rules/no_new_native_nonconstructor/no_new_native_nonconstructor.go
+++ b/internal/rules/no_new_native_nonconstructor/no_new_native_nonconstructor.go
@@ -1,0 +1,44 @@
+package no_new_native_nonconstructor
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var nativeNonconstructorNames = map[string]struct{}{
+	"Symbol": {},
+	"BigInt": {},
+}
+
+// https://eslint.org/docs/latest/rules/no-new-native-nonconstructor
+var NoNewNativeNonconstructorRule = rule.Rule{
+	Name: "no-new-native-nonconstructor",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindNewExpression: func(node *ast.Node) {
+				newExpr := node.AsNewExpression()
+				if newExpr == nil || newExpr.Expression == nil {
+					return
+				}
+
+				callee := utils.SkipAssertionsAndParens(newExpr.Expression)
+				if callee == nil || callee.Kind != ast.KindIdentifier {
+					return
+				}
+
+				name := callee.AsIdentifier().Text
+					if _, ok := nativeNonconstructorNames[name]; !ok || utils.IsShadowed(callee, name) {
+					return
+				}
+
+				ctx.ReportNode(callee, rule.RuleMessage{
+					Id:          "noNewNonconstructor",
+					Description: fmt.Sprintf("`%s` cannot be called as a constructor.", name),
+				})
+			},
+		}
+	},
+}

--- a/internal/rules/no_new_native_nonconstructor/no_new_native_nonconstructor.md
+++ b/internal/rules/no_new_native_nonconstructor/no_new_native_nonconstructor.md
@@ -1,0 +1,30 @@
+# no-new-native-nonconstructor
+
+## Rule Details
+
+Disallows using the `new` operator with native global functions that are not constructors.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const foo = new Symbol('foo');
+const bar = new BigInt(9007199254740991);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const foo = Symbol('foo');
+const bar = BigInt(9007199254740991);
+
+function baz(Symbol) {
+  const qux = new Symbol('baz');
+}
+
+const SymbolCtor = Symbol;
+new SymbolCtor();
+```
+
+## Original Documentation
+
+- [ESLint no-new-native-nonconstructor](https://eslint.org/docs/latest/rules/no-new-native-nonconstructor)

--- a/internal/rules/no_new_native_nonconstructor/no_new_native_nonconstructor_extras_test.go
+++ b/internal/rules/no_new_native_nonconstructor/no_new_native_nonconstructor_extras_test.go
@@ -1,0 +1,192 @@
+package no_new_native_nonconstructor
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoNewNativeNonconstructorExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the specific
+// branch / Dimension 4 row / tsgo AST quirk it covers, so future refactors can't silently
+// regress them without breaking a named lock-in.
+func TestNoNewNativeNonconstructorExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoNewNativeNonconstructorRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream Program:exit arm 1: bare calls are references but not NewExpression callees.
+			{Code: `Symbol('foo'); BigInt(1);`},
+
+			// Locks in upstream Program:exit arm 2: new-expression arguments are references but not callees.
+			{Code: `new Foo(Symbol, BigInt);`},
+
+			// Locks in upstream parent check: indirect references are not reported unless the
+			// native identifier itself is the NewExpression callee.
+			{Code: `const C = Symbol; new C(); const D = BigInt; new D();`},
+			{Code: `new (condition ? Symbol : Foo)(); new (BigInt || Foo)(); new (0, Symbol)();`},
+
+			// Locks in upstream variable.defs.length guard: local value declarations shadow native globals.
+			{Code: `let Symbol = class {}; const BigInt = class {}; new Symbol(); new BigInt();`},
+
+			// ---- Dimension 4: Shadowing declaration forms ----
+			{Code: `class Symbol {} enum BigInt { A } new Symbol(); new BigInt();`},
+			{Code: `class Symbol {} var BigInt = class {}; new Symbol(); new BigInt();`},
+			{Code: `namespace Symbol { export const x = 1; } namespace BigInt { export const x = 1; } new Symbol(); new BigInt();`},
+			{Code: `declare class Symbol {} declare function BigInt(): void; new Symbol(); new BigInt();`},
+			{Code: `import Symbol, { BigInt } from "mod"; new Symbol(); new BigInt();`},
+			{Code: `import * as Symbol from "mod"; import { BigInt } from "mod2"; new Symbol(); new BigInt();`},
+
+			// ---- Dimension 4: Shadowing parameter and destructuring forms ----
+			{Code: `function f(Symbol = class {}) { new Symbol(); } function g(...BigInt) { new BigInt(); }`},
+			{Code: `function f({ a: { Symbol } }) { new Symbol(); } function g([, BigInt]) { new BigInt(); }`},
+
+			// ---- Dimension 4: Shadowing loop/catch/class scopes ----
+			{Code: `for (let Symbol of xs) { new Symbol(); } for (const BigInt in xs) { new BigInt(); }`},
+			{Code: `try {} catch ({ Symbol }) { new Symbol(); } try {} catch ([BigInt]) { new BigInt(); }`},
+			{Code: `class C { method(Symbol) { new Symbol(); } field = (BigInt) => new BigInt(); }`},
+			{Code: `function f() { new Symbol(); var Symbol; } function g() { new BigInt(); function BigInt() {} }`},
+
+			// ---- Dimension 4: Access / key forms ----
+			{Code: `new foo.Symbol(); new foo["BigInt"](); new globalThis.Symbol(); new globalThis["BigInt"]();`},
+			{Code: `new this.Symbol(); class C extends B { m() { new super.BigInt(); } }`},
+
+			// ---- Dimension 4: Nesting / traversal boundaries ----
+			{Code: `function f(Symbol) { new Symbol(); } function g(BigInt) { new BigInt(); }`},
+
+			// ---- Dimension 4: Graceful degradation ----
+			{Code: `const { ...Symbol } = obj; new Symbol(); const [...BigInt] = arr; new BigInt();`},
+			{Code: `new class Symbol {}; new (class BigInt {})();`},
+
+			// ---- Dimension 4: Optional chain forms ----
+			{Code: `new (Symbol?.for("x"))(); new (BigInt?.(1))();`},
+
+			// N/A: Declaration/container rows for object/class members do not apply; this rule only inspects NewExpression callees.
+			// N/A: Autofix rows do not apply; this rule does not provide fixes.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: Receiver / expression wrappers ----
+			{
+				Code: `new (Symbol)(); new ((BigInt))();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 6},
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `new (Symbol as any)(); new (BigInt satisfies any)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 6},
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: `new Symbol!(); new (BigInt!)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 5},
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `new ((Symbol as any)!)(); new (<any>BigInt)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 7},
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 37},
+				},
+			},
+			{
+				Code: `new Symbol<string>(); new BigInt<number>();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 5},
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 27},
+				},
+			},
+
+			// Locks in upstream nonConstructorGlobalFunctionNames arm 1: Symbol.
+			{
+				Code: `new Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Message: "`Symbol` cannot be called as a constructor.", Line: 1, Column: 5, EndLine: 1, EndColumn: 11},
+				},
+			},
+
+			// Locks in upstream nonConstructorGlobalFunctionNames arm 2: BigInt.
+			{
+				Code: `new BigInt();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Message: "`BigInt` cannot be called as a constructor.", Line: 1, Column: 5, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
+				Code: `new Symbol(); new BigInt();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Message: "`Symbol` cannot be called as a constructor.", Line: 1, Column: 5, EndLine: 1, EndColumn: 11},
+					{MessageId: "noNewNonconstructor", Message: "`BigInt` cannot be called as a constructor.", Line: 1, Column: 19, EndLine: 1, EndColumn: 25},
+				},
+			},
+
+			// Locks in upstream variable.defs.length guard: nested function names do not shadow outer global references.
+			{
+				Code: `function f() { return function Symbol() {}; } new Symbol(); function g() { return function BigInt() {}; } new BigInt();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 51},
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 111},
+				},
+			},
+
+			// ---- Dimension 4: Type-only declarations do not shadow value-space globals ----
+			{
+				Code: `type Symbol = string; interface BigInt {} new Symbol(); new BigInt();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 47},
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 61},
+				},
+			},
+
+			// ---- Dimension 4: Shadowing boundaries do not leak out of nested scopes ----
+			{
+				Code: `{ let Symbol = class {}; new Symbol(); } new Symbol(); function f(BigInt) { new BigInt(); } new BigInt();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 46},
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 97},
+				},
+			},
+
+				// ---- Dimension 4: Multiple nested global-name reports ----
+			{
+				Code: `new Symbol(); function f() { if (ok) { class C { static { new BigInt(); } } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 5},
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 63},
+				},
+			},
+
+			// ---- Real-user: eslint/eslint#16322 BigInt constructor confusion ----
+			{
+				Code: `const b = new BigInt(9007199254740991);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 15},
+				},
+			},
+
+			// ---- Real-user: eslint/eslint#16513 overlap with deprecated no-new-symbol ----
+			{
+				Code: `const s = new Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 15},
+				},
+			},
+
+			// ---- Dimension 4: multiline position lock-in ----
+			{
+				Code: "const value =\n  new Symbol();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 2, Column: 7, EndLine: 2, EndColumn: 13},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_new_native_nonconstructor/no_new_native_nonconstructor_upstream_test.go
+++ b/internal/rules/no_new_native_nonconstructor/no_new_native_nonconstructor_upstream_test.go
@@ -1,0 +1,75 @@
+package no_new_native_nonconstructor
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoNewNativeNonconstructorUpstream migrates the full valid/invalid suite from upstream
+// tests/lib/rules/no-new-native-nonconstructor.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in the
+// no_new_native_nonconstructor_extras_test.go file.
+func TestNoNewNativeNonconstructorUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoNewNativeNonconstructorRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Symbol ----
+			{Code: `var foo = Symbol('foo');`},
+			{Code: `function bar(Symbol) { var baz = new Symbol('baz');}`},
+			{Code: `function Symbol() {} new Symbol();`},
+			{Code: `new foo(Symbol);`},
+			{Code: `new foo(bar, Symbol);`},
+
+			// ---- BigInt ----
+			{Code: `var foo = BigInt(9007199254740991);`},
+			{Code: `function bar(BigInt) { var baz = new BigInt(9007199254740991);}`},
+			{Code: `function BigInt() {} new BigInt();`},
+			{Code: `new foo(BigInt);`},
+			{Code: `new foo(bar, BigInt);`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Symbol ----
+			{
+				Code: `var foo = new Symbol('foo');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noNewNonconstructor",
+						Message:   "`Symbol` cannot be called as a constructor.",
+						Line:      1,
+						Column:    15,
+					},
+				},
+			},
+			{
+				Code: `function bar() { return function Symbol() {}; } var baz = new Symbol('baz');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 63},
+				},
+			},
+
+			// ---- BigInt ----
+			{
+				Code: `var foo = new BigInt(9007199254740991);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noNewNonconstructor",
+						Message:   "`BigInt` cannot be called as a constructor.",
+						Line:      1,
+						Column:    15,
+					},
+				},
+			},
+			{
+				Code: `function bar() { return function BigInt() {}; } var baz = new BigInt(9007199254740991);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewNonconstructor", Line: 1, Column: 63},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -101,6 +101,7 @@ export default defineConfig({
     './tests/eslint/rules/no-irregular-whitespace.test.ts',
     './tests/eslint/rules/no-new.test.ts',
     './tests/eslint/rules/no-new-func.test.ts',
+    './tests/eslint/rules/no-new-native-nonconstructor.test.ts',
     './tests/eslint/rules/no-new-object.test.ts',
     './tests/eslint/rules/no-new-wrappers.test.ts',
     './tests/eslint/rules/no-param-reassign.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-new-native-nonconstructor.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-new-native-nonconstructor.test.ts.snap
@@ -1,0 +1,105 @@
+// Rstest Snapshot v1
+
+exports[`no-new-native-nonconstructor > invalid 1`] = `
+{
+  "code": "var foo = new Symbol('foo');",
+  "diagnostics": [
+    {
+      "message": "\`Symbol\` cannot be called as a constructor.",
+      "messageId": "noNewNonconstructor",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-native-nonconstructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-native-nonconstructor > invalid 2`] = `
+{
+  "code": "function bar() { return function Symbol() {}; } var baz = new Symbol('baz');",
+  "diagnostics": [
+    {
+      "message": "\`Symbol\` cannot be called as a constructor.",
+      "messageId": "noNewNonconstructor",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 63,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-native-nonconstructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-native-nonconstructor > invalid 3`] = `
+{
+  "code": "var foo = new BigInt(9007199254740991);",
+  "diagnostics": [
+    {
+      "message": "\`BigInt\` cannot be called as a constructor.",
+      "messageId": "noNewNonconstructor",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-native-nonconstructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-native-nonconstructor > invalid 4`] = `
+{
+  "code": "function bar() { return function BigInt() {}; } var baz = new BigInt(9007199254740991);",
+  "diagnostics": [
+    {
+      "message": "\`BigInt\` cannot be called as a constructor.",
+      "messageId": "noNewNonconstructor",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 63,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-native-nonconstructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-new-native-nonconstructor.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-new-native-nonconstructor.test.ts
@@ -1,0 +1,42 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-new-native-nonconstructor', {
+  valid: [
+    // Symbol
+    "var foo = Symbol('foo');",
+    "function bar(Symbol) { var baz = new Symbol('baz');}",
+    'function Symbol() {} new Symbol();',
+    'new foo(Symbol);',
+    'new foo(bar, Symbol);',
+
+    // BigInt
+    'var foo = BigInt(9007199254740991);',
+    'function bar(BigInt) { var baz = new BigInt(9007199254740991);}',
+    'function BigInt() {} new BigInt();',
+    'new foo(BigInt);',
+    'new foo(bar, BigInt);',
+  ],
+  invalid: [
+    // Symbol
+    {
+      code: "var foo = new Symbol('foo');",
+      errors: [{ messageId: 'noNewNonconstructor' }],
+    },
+    {
+      code: "function bar() { return function Symbol() {}; } var baz = new Symbol('baz');",
+      errors: [{ messageId: 'noNewNonconstructor' }],
+    },
+
+    // BigInt
+    {
+      code: 'var foo = new BigInt(9007199254740991);',
+      errors: [{ messageId: 'noNewNonconstructor' }],
+    },
+    {
+      code: 'function bar() { return function BigInt() {}; } var baz = new BigInt(9007199254740991);',
+      errors: [{ messageId: 'noNewNonconstructor' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-new-native-nonconstructor` rule from ESLint to rslint.

This rule reports `new Symbol()` and `new BigInt()` calls while respecting value shadowing and TypeScript assertion or parenthesis wrappers.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-new-native-nonconstructor
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-new-native-nonconstructor.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
