### PR TITLE
feat: port rule no-unused-labels

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -105,6 +105,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unused_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_backreference"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_call"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
@@ -250,6 +251,7 @@ func GetAllRules() []rule.Rule {
 		no_unreachable.NoUnreachableRule,
 		require_atomic_updates.RequireAtomicUpdatesRule,
 		object_shorthand.ObjectShorthandRule,
+		no_unused_labels.NoUnusedLabelsRule,
 		one_var.OneVarRule,
 		prefer_arrow_callback.PreferArrowCallbackRule,
 		no_dupe_else_if.NoDupeElseIfRule,

--- a/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.go
+++ b/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.go
@@ -260,26 +260,6 @@ func maybePrefixSpace(sourceFile *ast.SourceFile, replaceRange core.TextRange, r
 	return replacement
 }
 
-// hasCommentsInSpan reports whether any `//` or `/*` sequence appears in
-// the half-open source range [start, end). `utils.HasCommentsInRange`
-// only surfaces comments anchored at the range start, so a raw text
-// scan is required to catch comments sprinkled *between* children
-// (e.g. `!!/* keep */foo`).
-func hasCommentsInSpan(src string, start, end int) bool {
-	if start < 0 {
-		start = 0
-	}
-	if end > len(src) {
-		end = len(src)
-	}
-	for i := start; i+1 < end; i++ {
-		if src[i] == '/' && (src[i+1] == '/' || src[i+1] == '*') {
-			return true
-		}
-	}
-	return false
-}
-
 // buildNegationFix returns the fix for a redundant `!!expr`. outerUnary
 // is the outer `!` of `!!expr`.
 func buildNegationFix(ctx rule.RuleContext, outerUnary *ast.Node) []rule.RuleFix {
@@ -293,7 +273,7 @@ func buildNegationFix(ctx rule.RuleContext, outerUnary *ast.Node) []rule.RuleFix
 	}
 
 	replaceRange := utils.TrimNodeTextRange(ctx.SourceFile, outerUnary)
-	if hasCommentsInSpan(ctx.SourceFile.Text(), replaceRange.Pos(), replaceRange.End()) {
+	if utils.HasCommentInSpan(ctx.SourceFile, replaceRange.Pos(), replaceRange.End()) {
 		return nil
 	}
 
@@ -331,13 +311,13 @@ func buildCallFix(ctx rule.RuleContext, callNode *ast.Node) []rule.RuleFix {
 		if parent != nil && parent.Kind == ast.KindPrefixUnaryExpression &&
 			parent.AsPrefixUnaryExpression().Operator == ast.KindExclamationToken {
 			parentRange := utils.TrimNodeTextRange(ctx.SourceFile, parent)
-			if hasCommentsInSpan(ctx.SourceFile.Text(), parentRange.Pos(), parentRange.End()) {
+			if utils.HasCommentInSpan(ctx.SourceFile, parentRange.Pos(), parentRange.End()) {
 				return nil
 			}
 			return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, parent, maybePrefixSpace(ctx.SourceFile, parentRange, "true"))}
 		}
 
-		if hasCommentsInSpan(ctx.SourceFile.Text(), callRange.Pos(), callRange.End()) {
+		if utils.HasCommentInSpan(ctx.SourceFile, callRange.Pos(), callRange.End()) {
 			return nil
 		}
 		return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, callNode, maybePrefixSpace(ctx.SourceFile, callRange, "false"))}
@@ -348,7 +328,7 @@ func buildCallFix(ctx rule.RuleContext, callNode *ast.Node) []rule.RuleFix {
 		if ast.IsSpreadElement(arg) {
 			return nil
 		}
-		if hasCommentsInSpan(ctx.SourceFile.Text(), callRange.Pos(), callRange.End()) {
+		if utils.HasCommentInSpan(ctx.SourceFile, callRange.Pos(), callRange.End()) {
 			return nil
 		}
 		// Peel parens to match ESLint's paren-less AST; see buildNegationFix.

--- a/internal/rules/no_unused_labels/no_unused_labels.go
+++ b/internal/rules/no_unused_labels/no_unused_labels.go
@@ -1,0 +1,155 @@
+package no_unused_labels
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type labelScope struct {
+	label string
+	used  bool
+	upper *labelScope
+}
+
+func buildUnusedMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unused",
+		Description: fmt.Sprintf("'%s:' is defined but never used.", name),
+		Data:        map[string]string{"name": name},
+	}
+}
+
+func isFunctionBodyBlock(node *ast.Node) bool {
+	return node != nil &&
+		node.Kind == ast.KindBlock &&
+		node.Parent != nil &&
+		ast.IsFunctionLike(node.Parent)
+}
+
+// A removable label before a string-like expression can create a directive
+// prologue entry after this or another fix pass, so ESLint intentionally skips
+// the fix in program and function-body containers.
+func isPotentialDirectiveLabel(node *ast.Node) bool {
+	ls := node.AsLabeledStatement()
+	if ls == nil || ls.Statement == nil || ls.Statement.Kind != ast.KindExpressionStatement {
+		return false
+	}
+
+	ancestor := ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
+		return n.Kind != ast.KindLabeledStatement
+	})
+	if ancestor == nil || (ancestor.Kind != ast.KindSourceFile && !isFunctionBodyBlock(ancestor)) {
+		return false
+	}
+
+	expr := ast.SkipParentheses(ls.Statement.AsExpressionStatement().Expression)
+	return ast.IsStringLiteralLike(expr)
+}
+
+func labelSeparatorRange(ctx rule.RuleContext, labelEnd int, bodyStart int) (core.TextRange, bool) {
+	s := scanner.GetScannerForSourceFile(ctx.SourceFile, labelEnd)
+	for s.Token() != ast.KindEndOfFile && s.TokenStart() < bodyStart {
+		if s.Token() == ast.KindColonToken {
+			return core.NewTextRange(s.TokenStart(), s.TokenEnd()), true
+		}
+		s.Scan()
+	}
+	return core.TextRange{}, false
+}
+
+func hasCommentBetweenLabelAndBody(ctx rule.RuleContext, node *ast.Node) bool {
+	ls := node.AsLabeledStatement()
+	labelToken := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, ls.Label.Pos())
+	bodyStart := scanner.SkipTrivia(ctx.SourceFile.Text(), ls.Statement.Pos())
+	colon, ok := labelSeparatorRange(ctx, labelToken.End(), bodyStart)
+	if !ok {
+		return utils.HasCommentInSpan(ctx.SourceFile, labelToken.End(), bodyStart)
+	}
+	return utils.HasCommentInSpan(ctx.SourceFile, labelToken.End(), colon.Pos()) ||
+		utils.HasCommentInSpan(ctx.SourceFile, colon.End(), bodyStart)
+}
+
+func isFixable(ctx rule.RuleContext, node *ast.Node) bool {
+	ls := node.AsLabeledStatement()
+	if ls == nil || ls.Label == nil || ls.Statement == nil {
+		return false
+	}
+
+	if hasCommentBetweenLabelAndBody(ctx, node) {
+		return false
+	}
+
+	return !isPotentialDirectiveLabel(node)
+}
+
+// https://eslint.org/docs/latest/rules/no-unused-labels
+var NoUnusedLabelsRule = rule.Rule{
+	Name: "no-unused-labels",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		var scopeInfo *labelScope
+
+		enterLabeledScope := func(node *ast.Node) {
+			ls := node.AsLabeledStatement()
+			scopeInfo = &labelScope{
+				label: ls.Label.Text(),
+				used:  false,
+				upper: scopeInfo,
+			}
+		}
+
+		exitLabeledScope := func(node *ast.Node) {
+			if scopeInfo == nil {
+				return
+			}
+
+			current := scopeInfo
+			if !current.used {
+				msg := buildUnusedMessage(current.label)
+				if isFixable(ctx, node) {
+					ls := node.AsLabeledStatement()
+					start := utils.TrimNodeTextRange(ctx.SourceFile, node).Pos()
+					end := scanner.SkipTrivia(ctx.SourceFile.Text(), ls.Statement.Pos())
+					ctx.ReportNodeWithFixes(
+						ls.Label,
+						msg,
+						rule.RuleFixRemoveRange(core.NewTextRange(start, end)),
+					)
+				} else {
+					ctx.ReportNode(node.AsLabeledStatement().Label, msg)
+				}
+			}
+
+			scopeInfo = current.upper
+		}
+
+		markAsUsed := func(labelNode *ast.Node) {
+			if labelNode == nil {
+				return
+			}
+
+			label := labelNode.Text()
+			for info := scopeInfo; info != nil; info = info.upper {
+				if info.label == label {
+					info.used = true
+					return
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindLabeledStatement:                      enterLabeledScope,
+			rule.ListenerOnExit(ast.KindLabeledStatement): exitLabeledScope,
+			ast.KindBreakStatement: func(node *ast.Node) {
+				markAsUsed(node.AsBreakStatement().Label)
+			},
+			ast.KindContinueStatement: func(node *ast.Node) {
+				markAsUsed(node.AsContinueStatement().Label)
+			},
+		}
+	},
+}

--- a/internal/rules/no_unused_labels/no_unused_labels.md
+++ b/internal/rules/no_unused_labels/no_unused_labels.md
@@ -1,0 +1,46 @@
+# no-unused-labels
+
+## Rule Details
+
+This rule disallows labels that are declared but never used by a labeled
+`break` or `continue` statement.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+A: var foo = 0;
+
+B: {
+    foo();
+}
+
+C: for (let i = 0; i < 10; ++i) {
+    foo();
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+A: {
+    if (foo()) {
+        break A;
+    }
+    bar();
+}
+
+B: for (let i = 0; i < 10; ++i) {
+    if (foo()) {
+        continue B;
+    }
+    bar();
+}
+```
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- [ESLint rule: no-unused-labels](https://eslint.org/docs/latest/rules/no-unused-labels)

--- a/internal/rules/no_unused_labels/no_unused_labels_extras_test.go
+++ b/internal/rules/no_unused_labels/no_unused_labels_extras_test.go
@@ -1,0 +1,263 @@
+package no_unused_labels
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUnusedLabelsExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row it covers, so future refactors can't
+// silently regress them without breaking a named lock-in.
+func TestNoUnusedLabelsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedLabelsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: nesting/traversal boundary ----
+			{Code: `A: { function f() { B: { break B; } } break A; }`},
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: `A: { class C { method() { B: { break B; } } } break A; }`},
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: `A: { const f = () => { B: { break B; } }; break A; }`},
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: `async function* f() { A: { break A; } }`},
+			// ---- Dimension 4: nesting/traversal boundary ----
+			{Code: `class C { static { A: { break A; } } }`},
+			// ---- Dimension 4: nesting/traversal boundary ----
+			{Code: `A: { B: { C: { if (ok) break C; } break B; } break A; }`},
+			// ---- Dimension 4: nesting/traversal boundary ----
+			{Code: `A: switch (kind) { case 1: while (ok) break A; default: break; }`},
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: `A: for (const x of xs) { switch (x.kind) { case "skip": continue A; case "stop": break A; } }`},
+			// ---- Dimension 4: access/key forms are non-label object keys ----
+			{Code: `const obj = { A: foo, "B": bar, 0: baz, [key]: value, ...rest };`},
+			// ---- Real-user: eslint/eslint#5052 nested loop label used from inner loop ----
+			{Code: `B: for (let i = 0; i < 10; ++i) { for (let j = 0; j < 10; ++j) { if (foo()) { break B; } } bar(); }`},
+			// ---- Real-user: eslint/eslint#14191 object expression in arrow return is not labels ----
+			{Code: `const get = () => Promise.resolve({ json: () => ({ billing_contact: { id: "54321" } }) });`},
+			// N/A: receiver/access/key expression wrappers do not apply; labels are identifiers, not member/key expressions.
+			// N/A: overload/abstract/declare members cannot be labeled statements.
+		},
+		[]rule_tester.InvalidTestCase{
+			// Locks in upstream markAsUsed() arm 1: unlabeled break/continue are ignored.
+			{
+				Code:   `A: while (a) { break; continue; }`,
+				Output: []string{`while (a) { break; continue; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// Locks in upstream markAsUsed() arm 3: unmatched labels do not mark another label as used.
+			{
+				Code:   `A: while (a) { while (b) { break; } }`,
+				Output: []string{`while (a) { while (b) { break; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// Locks in upstream exitLabeledScope() arm 1: unused labels report with exact message text.
+			{
+				Code:   `A: foo();`,
+				Output: []string{`foo();`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unused",
+						Message:   "'A:' is defined but never used.",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 2,
+					},
+				},
+			},
+			// Locks in upstream markAsUsed() arm 2: continue marks a matching outer loop label as used.
+			{
+				Code:   `A: for (const x of xs) { B: { if (x) continue A; } }`,
+				Output: []string{`A: for (const x of xs) { { if (x) continue A; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 26, EndLine: 1, EndColumn: 27},
+				},
+			},
+			// Locks in upstream isFixable() arm 1: comments between label and body suppress autofix.
+			{
+				Code: `A
+/* comment */: foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// Locks in upstream isFixable() arm 1: comments after the colon also suppress autofix.
+			{
+				Code: `A: // comment
+foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// Locks in upstream isFixable() arm 2: ordinary expression labels are fixable.
+			{
+				Code:   "A:\nfoo();",
+				Output: []string{"foo();"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: type-expression wrappers in the labeled body ----
+			{
+				Code:   `A: (foo as any);`,
+				Output: []string{`(foo as any);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: type-expression wrappers in the labeled body ----
+			{
+				Code:   `A: (foo satisfies T);`,
+				Output: []string{`(foo satisfies T);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: expression wrappers in the labeled body ----
+			{
+				Code:   `A: foo!;`,
+				Output: []string{`foo!;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: optional-chain expression in the labeled body ----
+			{
+				Code:   `A: foo?.();`,
+				Output: []string{`foo?.();`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: declaration/container forms ----
+			{
+				Code:   `A: switch (kind) { case 1: break; default: break; }`,
+				Output: []string{`switch (kind) { case 1: break; default: break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: nesting/traversal boundary ----
+			{
+				Code:   `A: { B: { break A; } }`,
+				Output: []string{`A: { { break A; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				},
+			},
+			// ---- Dimension 4: declaration/container forms ----
+			{
+				Code:   `A: { function f() {} }`,
+				Output: []string{`{ function f() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: declaration/container forms ----
+			{
+				Code:   `class C { static { A: foo(); } }`,
+				Output: []string{`class C { static { foo(); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+				},
+			},
+			// ---- Dimension 4: Unicode label and UTF-16 positions ----
+			{
+				Code:   "const face = \"😀\";\n中文: foo();",
+				Output: []string{"const face = \"😀\";\nfoo();"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Message: "'中文:' is defined but never used.", Line: 2, Column: 1, EndLine: 2, EndColumn: 3},
+				},
+			},
+			// ---- Dimension 4: object spread in expression body must not be confused with labeled object keys ----
+			{
+				Code:   `A: ({ ...obj, value: 1 });`,
+				Output: []string{`({ ...obj, value: 1 });`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: graceful degradation ----
+			{
+				Code:   `A: {}`,
+				Output: []string{`{}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: graceful degradation ----
+			{
+				Code:   `A: ;`,
+				Output: []string{`;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- Real-user: eslint/eslint#16988 function-body directive creation ----
+			{
+				Code: `function test3() {
+    NoDirective: "use strict";
+    return 7;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 2, Column: 5, EndLine: 2, EndColumn: 16},
+				},
+			},
+			// ---- Real-user: eslint/eslint#16988 parenthesized directive candidate ----
+			{
+				Code: `function test3() {
+    NoDirective: ("use strict");
+    return 7;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 2, Column: 5, EndLine: 2, EndColumn: 16},
+				},
+			},
+			// Locks in upstream isFixable() directive branch: conservative even after a previous statement.
+			{
+				Code: `function test3() {
+    foo();
+    NoDirective: "use strict";
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 3, Column: 5, EndLine: 3, EndColumn: 16},
+				},
+			},
+			// Locks in upstream isFixable() directive branch: template expressions with substitutions are fixable.
+			{
+				Code:   "function test3() { NoDirective: `use ${mode}`; }",
+				Output: []string{"function test3() { `use ${mode}`; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 20, EndLine: 1, EndColumn: 31},
+				},
+			},
+			// Locks in upstream isFixable() ancestor branch: a string label in a non-function block is fixable.
+			{
+				Code:   `if (foo) { bar: "baz" }`,
+				Output: []string{`if (foo) { "baz" }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 12, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// ---- Real-user: eslint/eslint#14191 arrow block body with labels, not an object expression ----
+			{
+				Code:   `const get = () => Promise.resolve({ json: () => { billing_contact: { id: "54321" } } });`,
+				Output: []string{`const get = () => Promise.resolve({ json: () => { { "54321" } } });`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 70, EndLine: 1, EndColumn: 72},
+					{MessageId: "unused", Line: 1, Column: 51, EndLine: 1, EndColumn: 66},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_unused_labels/no_unused_labels_upstream_test.go
+++ b/internal/rules/no_unused_labels/no_unused_labels_upstream_test.go
@@ -1,0 +1,180 @@
+package no_unused_labels
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUnusedLabelsUpstream migrates the full valid/invalid suite from upstream
+// tests/lib/rules/no-unused-labels.js 1:1. Position assertions cover line/column
+// for every invalid case. rslint-specific lock-in cases live in the
+// no_unused_labels_extras_test.go file.
+func TestNoUnusedLabelsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedLabelsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- upstream valid ----
+			{Code: `A: break A;`},
+			{Code: `A: { foo(); break A; bar(); }`},
+			{Code: `A: if (a) { foo(); if (b) break A; bar(); }`},
+			{Code: `A: for (var i = 0; i < 10; ++i) { foo(); if (a) break A; bar(); }`},
+			{Code: `A: for (var i = 0; i < 10; ++i) { foo(); if (a) continue A; bar(); }`},
+			{Code: `A: { B: break B; C: for (var i = 0; i < 10; ++i) { foo(); if (a) break A; if (c) continue C; bar(); } }`},
+			{Code: `A: { var A = 0; console.log(A); break A; console.log(A); }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- upstream invalid ----
+			{
+				Code:   `A: var foo = 0;`,
+				Output: []string{`var foo = 0;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unused",
+						Message:   "'A:' is defined but never used.",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 2,
+					},
+				},
+			},
+			{
+				Code:   `A: { foo(); bar(); }`,
+				Output: []string{`{ foo(); bar(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `A: if (a) { foo(); bar(); }`,
+				Output: []string{`if (a) { foo(); bar(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `A: for (var i = 0; i < 10; ++i) { foo(); if (a) break; bar(); }`,
+				Output: []string{`for (var i = 0; i < 10; ++i) { foo(); if (a) break; bar(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `A: for (var i = 0; i < 10; ++i) { foo(); if (a) continue; bar(); }`,
+				Output: []string{`for (var i = 0; i < 10; ++i) { foo(); if (a) continue; bar(); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `A: for (var i = 0; i < 10; ++i) { B: break A; }`,
+				Output: []string{`A: for (var i = 0; i < 10; ++i) { break A; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 35, EndLine: 1, EndColumn: 36},
+				},
+			},
+			{
+				Code:   `A: { var A = 0; console.log(A); }`,
+				Output: []string{`{ var A = 0; console.log(A); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code: `A: /* comment */ foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code: `A /* comment */: foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// ---- upstream invalid: https://github.com/eslint/eslint/issues/16988 ----
+			{
+				Code: `A: "use strict"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code: `"use strict"; foo: "bar"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 15, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code: `A: ("use strict")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code: "A: `use strict`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `if (foo) { bar: 'baz' }`,
+				Output: []string{`if (foo) { 'baz' }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 12, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:   `A: B: 'foo'`,
+				Output: []string{`B: 'foo'`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 4, EndLine: 1, EndColumn: 5},
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `A: B: C: 'foo'`,
+				Output: []string{`C: 'foo'`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+					{MessageId: "unused", Line: 1, Column: 4, EndLine: 1, EndColumn: 5},
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `A: B: C: D: 'foo'`,
+				Output: []string{`D: 'foo'`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+					{MessageId: "unused", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+					{MessageId: "unused", Line: 1, Column: 4, EndLine: 1, EndColumn: 5},
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `A: B: C: D: E: 'foo'`,
+				Output: []string{`E: 'foo'`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+					{MessageId: "unused", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+					{MessageId: "unused", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+					{MessageId: "unused", Line: 1, Column: 4, EndLine: 1, EndColumn: 5},
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:   `A: 42`,
+				Output: []string{`42`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unused", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			// SKIP: upstream lists the remaining cases as parser-fatal syntax errors.
+		},
+	)
+}

--- a/internal/rules/prefer_arrow_callback/prefer_arrow_callback.go
+++ b/internal/rules/prefer_arrow_callback/prefer_arrow_callback.go
@@ -374,19 +374,6 @@ func getCallbackInfo(node *ast.Node) callbackInfo {
 	return ret
 }
 
-func hasCommentInRange(sf *ast.SourceFile, start, end int) bool {
-	// utils.HasCommentsInRange checks comments anchored at the range start.
-	// This rule needs ESLint's commentsExistBetween semantics over arbitrary
-	// token pairs such as `.bind(/* comment */ this)`, so scan all comments.
-	found := false
-	utils.ForEachComment(sf.AsNode(), func(comment *ast.CommentRange) {
-		if comment.Pos() >= start && comment.End() <= end {
-			found = true
-		}
-	}, sf)
-	return found
-}
-
 func findTokenRange(sf *ast.SourceFile, start, end int, kind ast.Kind) (core.TextRange, bool) {
 	s := scanner.GetScannerForSourceFile(sf, start)
 	for s.Token() != ast.KindEndOfFile && s.TokenStart() < end {
@@ -473,13 +460,13 @@ func buildFixes(ctx rule.RuleContext, node *ast.Node, scope scopeInfo, info call
 		object := info.bindMember.AsPropertyAccessExpression().Expression
 		removeStart := scanner.SkipTrivia(text, object.End())
 		removeEnd := utils.TrimNodeTextRange(sf, info.bindCall).End()
-		if removeStart < 0 || removeStart >= removeEnd || hasCommentInRange(sf, removeStart, removeEnd) {
+		if removeStart < 0 || removeStart >= removeEnd || utils.HasCommentInSpan(sf, removeStart, removeEnd) {
 			return nil
 		}
 		fixes = append(fixes, rule.RuleFixRemoveRange(core.NewTextRange(removeStart, removeEnd)))
 	}
 
-	if hasCommentInRange(sf, functionToken.End(), leftParenToken.Pos()) {
+	if utils.HasCommentInSpan(sf, functionToken.End(), leftParenToken.Pos()) {
 		fixes = append(fixes, rule.RuleFixRemoveRange(functionToken))
 		if name := node.Name(); name != nil {
 			fixes = append(fixes, rule.RuleFixRemove(sf, name))

--- a/internal/utils/for_each_comment_test.go
+++ b/internal/utils/for_each_comment_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -82,5 +83,41 @@ func TestForEachComment_ReuseFactoryReportsAllCommentsPerToken(t *testing.T) {
 		if seen[text] != 1 {
 			t.Errorf("comment %q expected exactly once, got %d (factory reuse smeared/dropped?)", text, seen[text])
 		}
+	}
+}
+
+func TestHasCommentInSpan(t *testing.T) {
+	src := `const a = "/* not a comment */"; const b = 1 /* real */ + 2;`
+
+	tmpDir := t.TempDir()
+	file := filepath.Join(tmpDir, "f.ts")
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := CreateCompilerHost(tmpDir, fs)
+	prog, err := CreateProgramFromOptions(true, &core.CompilerOptions{}, []string{file}, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sf := prog.GetSourceFile(file)
+	if sf == nil {
+		t.Fatal("source file not found")
+	}
+
+	commentGapStart := strings.Index(src, "1")
+	commentGapEnd := strings.Index(src, "+")
+	if !HasCommentInSpan(sf, commentGapStart, commentGapEnd) {
+		t.Fatal("expected real block comment in numeric-expression gap")
+	}
+
+	stringStart := strings.Index(src, `"/*`)
+	stringEnd := strings.Index(src, `*/"`) + len(`*/"`)
+	if HasCommentInSpan(sf, stringStart, stringEnd) {
+		t.Fatal("string literal comment markers must not count as comments")
+	}
+
+	if HasCommentInSpan(sf, commentGapStart, commentGapStart) {
+		t.Fatal("empty span must not contain comments")
 	}
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -111,6 +111,30 @@ func HasCommentInsideNode(sourceFile *ast.SourceFile, node *ast.Node) bool {
 	return hasComment
 }
 
+// HasCommentInSpan reports whether any parsed comment overlaps the half-open
+// source span [start, end). Unlike HasCommentsInRange, this scans the whole
+// file's comment table, so callers can use it for ESLint-style
+// commentsExistBetween checks over arbitrary token gaps.
+func HasCommentInSpan(sourceFile *ast.SourceFile, start int, end int) bool {
+	if sourceFile == nil || start >= end {
+		return false
+	}
+	if start < 0 {
+		start = 0
+	}
+	if end > len(sourceFile.Text()) {
+		end = len(sourceFile.Text())
+	}
+
+	found := false
+	ForEachComment(sourceFile.AsNode(), func(comment *ast.CommentRange) {
+		if comment.Pos() < end && comment.End() > start {
+			found = true
+		}
+	}, sourceFile)
+	return found
+}
+
 func TypeRecurser(t *checker.Type, predicate func(t *checker.Type) /* should stop */ bool) bool {
 	if IsTypeFlagSet(t, checker.TypeFlagsUnionOrIntersection) {
 		for _, subtype := range t.Types() {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -442,6 +442,7 @@ export default defineConfig({
     './tests/eslint/rules/no-label-var.test.ts',
     './tests/eslint/rules/no-shadow.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
+    './tests/eslint/rules/no-unused-labels.test.ts',
     './tests/eslint/rules/no-lone-blocks.test.ts',
     './tests/eslint/rules/no-loop-func.test.ts',
     './tests/eslint/rules/no-multi-assign.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unused-labels.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unused-labels.test.ts.snap
@@ -1,0 +1,645 @@
+// Rstest Snapshot v1
+
+exports[`no-unused-labels > invalid 1`] = `
+{
+  "code": "A: var foo = 0;",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 2`] = `
+{
+  "code": "A: { foo(); bar(); }",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 3`] = `
+{
+  "code": "A: if (a) { foo(); bar(); }",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 4`] = `
+{
+  "code": "A: for (var i = 0; i < 10; ++i) { foo(); if (a) break; bar(); }",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 5`] = `
+{
+  "code": "A: for (var i = 0; i < 10; ++i) { foo(); if (a) continue; bar(); }",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 6`] = `
+{
+  "code": "A: for (var i = 0; i < 10; ++i) { B: break A; }",
+  "diagnostics": [
+    {
+      "message": "'B:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 7`] = `
+{
+  "code": "A: { var A = 0; console.log(A); }",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 8`] = `
+{
+  "code": "A: /* comment */ foo",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 9`] = `
+{
+  "code": "A /* comment */: foo",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 10`] = `
+{
+  "code": "A: "use strict"",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 11`] = `
+{
+  "code": ""use strict"; foo: "bar"",
+  "diagnostics": [
+    {
+      "message": "'foo:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 12`] = `
+{
+  "code": "A: ("use strict")",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 13`] = `
+{
+  "code": "A: \`use strict\`",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 14`] = `
+{
+  "code": "if (foo) { bar: 'baz' }",
+  "diagnostics": [
+    {
+      "message": "'bar:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 15`] = `
+{
+  "code": "A: B: 'foo'",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+    {
+      "message": "'B:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 16`] = `
+{
+  "code": "A: B: C: 'foo'",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+    {
+      "message": "'B:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+    {
+      "message": "'C:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 17`] = `
+{
+  "code": "A: B: C: D: 'foo'",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+    {
+      "message": "'B:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+    {
+      "message": "'C:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+    {
+      "message": "'D:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 18`] = `
+{
+  "code": "A: B: C: D: E: 'foo'",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+    {
+      "message": "'B:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+    {
+      "message": "'C:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+    {
+      "message": "'D:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+    {
+      "message": "'E:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 5,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-labels > invalid 19`] = `
+{
+  "code": "A: 42",
+  "diagnostics": [
+    {
+      "message": "'A:' is defined but never used.",
+      "messageId": "unused",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unused-labels.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unused-labels.test.ts
@@ -1,0 +1,78 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unused-labels', {
+  valid: [
+    'A: break A;',
+    'A: { foo(); break A; bar(); }',
+    'A: if (a) { foo(); if (b) break A; bar(); }',
+    'A: for (var i = 0; i < 10; ++i) { foo(); if (a) break A; bar(); }',
+    'A: for (var i = 0; i < 10; ++i) { foo(); if (a) continue A; bar(); }',
+    'A: { B: break B; C: for (var i = 0; i < 10; ++i) { foo(); if (a) break A; if (c) continue C; bar(); } }',
+    'A: { var A = 0; console.log(A); break A; console.log(A); }',
+  ],
+  invalid: [
+    { code: 'A: var foo = 0;', errors: [{ messageId: 'unused' }] },
+    { code: 'A: { foo(); bar(); }', errors: [{ messageId: 'unused' }] },
+    {
+      code: 'A: if (a) { foo(); bar(); }',
+      errors: [{ messageId: 'unused' }],
+    },
+    {
+      code: 'A: for (var i = 0; i < 10; ++i) { foo(); if (a) break; bar(); }',
+      errors: [{ messageId: 'unused' }],
+    },
+    {
+      code: 'A: for (var i = 0; i < 10; ++i) { foo(); if (a) continue; bar(); }',
+      errors: [{ messageId: 'unused' }],
+    },
+    {
+      code: 'A: for (var i = 0; i < 10; ++i) { B: break A; }',
+      errors: [{ messageId: 'unused' }],
+    },
+    {
+      code: 'A: { var A = 0; console.log(A); }',
+      errors: [{ messageId: 'unused' }],
+    },
+    { code: 'A: /* comment */ foo', errors: [{ messageId: 'unused' }] },
+    { code: 'A /* comment */: foo', errors: [{ messageId: 'unused' }] },
+    { code: 'A: "use strict"', errors: [{ messageId: 'unused' }] },
+    { code: '"use strict"; foo: "bar"', errors: [{ messageId: 'unused' }] },
+    { code: 'A: ("use strict")', errors: [{ messageId: 'unused' }] },
+    { code: 'A: `use strict`', errors: [{ messageId: 'unused' }] },
+    { code: "if (foo) { bar: 'baz' }", errors: [{ messageId: 'unused' }] },
+    {
+      code: "A: B: 'foo'",
+      errors: [{ messageId: 'unused' }, { messageId: 'unused' }],
+    },
+    {
+      code: "A: B: C: 'foo'",
+      errors: [
+        { messageId: 'unused' },
+        { messageId: 'unused' },
+        { messageId: 'unused' },
+      ],
+    },
+    {
+      code: "A: B: C: D: 'foo'",
+      errors: [
+        { messageId: 'unused' },
+        { messageId: 'unused' },
+        { messageId: 'unused' },
+        { messageId: 'unused' },
+      ],
+    },
+    {
+      code: "A: B: C: D: E: 'foo'",
+      errors: [
+        { messageId: 'unused' },
+        { messageId: 'unused' },
+        { messageId: 'unused' },
+        { messageId: 'unused' },
+        { messageId: 'unused' },
+      ],
+    },
+    { code: 'A: 42', errors: [{ messageId: 'unused' }] },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the ESLint core `no-unused-labels` rule to rslint.

This adds the Go rule implementation, upstream and extra Go coverage, JS integration snapshots, documentation, and shared comment-span helper reuse for fixer safety.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-unused-labels
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-unused-labels.js
- Upstream tests: https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-unused-labels.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).