### PR TITLE
docs: update port-rule verification workflow

### DIFF
--- a/.agents/skills/port-rule/SKILL.md
+++ b/.agents/skills/port-rule/SKILL.md
@@ -138,7 +138,7 @@ Follow the phases in [PORT_RULE.md](references/PORT_RULE.md) sequentially:
 2. **Phase 1: Preparation** - Collect test cases, walk Dimensions 1–4 edge cases (including the universal edge-shape checklist), and do an upstream semantic walk that enumerates each branch in the ESLint source
 3. **Phase 2: Implementation** - Before writing helpers, grep same-plugin neighbors and extract any near-duplicates to `<plugin>util/`. Then write Go rule, two-file test split (`<rule>_upstream_test.go` for Layer 1 + `<rule>_extras_test.go` for Layers 2 + 3 — see PORT_RULE.md Testing Philosophy), and documentation (see the "Differences from ESLint" writing rules in PORT_RULE.md Phase 2 Step 3 — user-facing only, no implementation talk)
 4. **Phase 3: Integration** - Add JS tests and register rule
-5. **Phase 4: Verification** - Build binary; run the rule's Go + JS tests; if a shared helper (`<plugin>util/`, `internal/utils/`) was added or modified, also rerun the whole plugin (or whole tree) test suite; then run the BLOCKING pre-commit gate: `pnpm typecheck && pnpm lint && pnpm -w run check-spell && pnpm format:check && pnpm lint:go`
+5. **Phase 4: Verification** - Build binary; run the rule's Go + JS tests; if a shared helper (`<plugin>util/`, `internal/utils/`) was added or modified, also rerun the whole plugin (or whole tree) test suite; then run the BLOCKING pre-commit gate from Phase 4 Step 7, with Go lint restricted to changed Go files
 6. **Phase 5: Submission** - Commit and create PR
 
 For each phase: mark its task as `in_progress` (via `TaskUpdate`) before starting, and `completed` after finishing. Update the text checklist as well.
@@ -257,7 +257,8 @@ go test -count=1 ./internal/rules/<rule_name>
 cd packages/rslint-test-tools && npx rstest run --testTimeout=10000 <rule-name>
 
 # Pre-commit gate (BLOCKING — all must pass before commit)
-pnpm typecheck && pnpm lint && pnpm -w run check-spell && pnpm format:check && pnpm lint:go
+pnpm typecheck && pnpm lint && pnpm -w run check-spell && pnpm format:check
+# Then run changed-package Go lint from PORT_RULE.md Phase 4 Step 7.
 
 # Auto-fix formatting issues
 pnpm format && pnpm format:go

--- a/.agents/skills/port-rule/references/PORT_RULE.md
+++ b/.agents/skills/port-rule/references/PORT_RULE.md
@@ -750,12 +750,26 @@ Follow this **strict order** — each step depends on the previous one:
    # Spell check (catches typos in comments and strings)
    pnpm -w run check-spell
 
-   # Format and Go lint checks
-   pnpm format:check && pnpm lint:go
+   # Format check
+   pnpm format:check
+
+   # Go lint (packages containing changed Go files only)
+   changed_go_dirs="$(
+     {
+       git diff --name-only --diff-filter=ACMR origin/main...HEAD -- '*.go'
+       git diff --name-only --diff-filter=ACMR --cached -- '*.go'
+       git diff --name-only --diff-filter=ACMR -- '*.go'
+       git ls-files --others --exclude-standard -- '*.go'
+     } | sort -u | grep -E '^(cmd|internal)/' | while IFS= read -r file; do dirname "$file"; done | sort -u
+   )"
+   if [ -n "$changed_go_dirs" ]; then
+     printf '%s\n' "$changed_go_dirs" | xargs golangci-lint run --new-from-rev=origin/main --timeout=10m
+   fi
    ```
 
    These are BLOCKING. If any fails, fix before moving on — **do not** commit, push, or open a PR with any of them red.
-   - **Unknown-word failures from `check-spell`**: add the word to `scripts/dictionary.txt` (repo convention for ESLint-ecosystem identifiers that aren't real English). Use the original case.
+   - **Go lint scope**: lint only packages containing changed `.go` files under `cmd/` and `internal/` during port-rule pre-commit verification, with `--new-from-rev=origin/main` so only issues introduced by the branch are reported. Do not run `pnpm lint:go` here; it lints the full `cmd/` and `internal/` trees and is reserved for explicit full-tree checks / CI. Do not pass changed files from multiple directories to one `golangci-lint run` invocation; named file arguments must all be in one directory and can also produce typecheck false positives when a file depends on sibling files.
+   - **Unknown-word failures from `check-spell`**: inspect each reported word in context before changing anything. Fix misspellings, invented words, or other accidental text in the source. Add a word to `scripts/dictionary.txt` only when it is intentional: a valid standard word, ESLint ecosystem identifier, Go module/package name, API name, or similar technical token. Use the original case. Do not add `cspell` ignore comments in Markdown files; they can cause documentation compilation failures.
    - **Format failures**: auto-fix (`pnpm format && pnpm format:go`); never silence.
    - **Lint failures**: fix the code. Don't bypass with `//nolint`, `// eslint-disable`, or equivalent, unless the exception is already justified by an in-file comment pattern this repo uses.
 

--- a/.agents/skills/port-rule/references/QUICK_REFERENCE.md
+++ b/.agents/skills/port-rule/references/QUICK_REFERENCE.md
@@ -8,20 +8,20 @@ A quick reference for common commands, file locations, and checklists when porti
 
 ## Commands Cheatsheet
 
-| Task          | Command                                                                           |
-| ------------- | --------------------------------------------------------------------------------- |
-| Create branch | `git checkout -b feat/port-rule-<name>-$(date +%Y%m%d)`                           |
-| Go unit test  | `go test -count=1 ./internal/rules/<rule_name>`                                   |
-| Go full test  | `go test -count=1 ./internal/rules/...`                                           |
-| Build binary  | `cd packages/rslint && pnpm run build:bin`                                        |
-| JS unit test  | `cd packages/rslint-test-tools && npx rstest run --testTimeout=10000 <rule-name>` |
-| Type check    | `pnpm typecheck`                                                                  |
-| Lint check    | `pnpm lint`                                                                       |
-| Format check  | `pnpm format:check`                                                               |
-| Format fix    | `pnpm format`                                                                     |
-| Spell check   | `pnpm -w run check-spell`                                                         |
-| Go lint check | `pnpm lint:go`                                                                    |
-| Go format fix | `pnpm format:go`                                                                  |
+| Task                     | Command                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------ |
+| Create branch            | `git checkout -b feat/port-rule-<name>-$(date +%Y%m%d)`                                          |
+| Go unit test             | `go test -count=1 ./internal/rules/<rule_name>`                                                  |
+| Go full test             | `go test -count=1 ./internal/rules/...`                                                          |
+| Build binary             | `cd packages/rslint && pnpm run build:bin`                                                       |
+| JS unit test             | `cd packages/rslint-test-tools && npx rstest run --testTimeout=10000 <rule-name>`                |
+| Type check               | `pnpm typecheck`                                                                                 |
+| Lint check               | `pnpm lint`                                                                                      |
+| Format check             | `pnpm format:check`                                                                              |
+| Format fix               | `pnpm format`                                                                                    |
+| Spell check              | `pnpm -w run check-spell`                                                                        |
+| Go lint changed packages | `golangci-lint run --new-from-rev=origin/main --timeout=10m <dirs containing changed .go files>` |
+| Go format fix            | `pnpm format:go`                                                                                 |
 
 ---
 
@@ -114,7 +114,7 @@ import (
 - [ ] Lint check passes (`pnpm lint`)
 - [ ] Spell check passes (`pnpm -w run check-spell`)
 - [ ] Format check passes (`pnpm format:check`)
-- [ ] Go lint check passes (`pnpm lint:go`)
+- [ ] Changed-package Go lint passes (packages containing changed `.go` files under `cmd/` and `internal/`; see Phase 4 Step 7 in `PORT_RULE.md`)
 - [ ] Rule registered (in the appropriate `all.go`: `internal/rules/all.go` for core, `internal/plugins/<plugin>/all.go` otherwise)
 - [ ] Test file registered (`packages/rslint-test-tools/rstest.config.mts`)
 - [ ] Documentation created (`<rule_name>.md`)


### PR DESCRIPTION
## Summary

Update the port-rule skill verification workflow to lint only changed Go files during the port-rule pre-commit gate, while keeping full-tree Go lint reserved for explicit full checks and CI.

Clarify check-spell handling so misspellings are fixed in source text, intentional technical terms can go into the dictionary, and Markdown files do not use cspell ignore comments.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).