### PR TITLE
ci: raise rslint rstest timeout

### DIFF
--- a/packages/rslint/rstest.config.ts
+++ b/packages/rslint/rstest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   testEnvironment: 'node',
   globals: true,
+  // The self-hosted Windows runner can stall under concurrent main CI. Keep
+  // ordinary async tests from tripping Rstest's 5s default.
+  testTimeout: 30_000,
   // The eslint-plugin worker tests spawn the built `dist/eslint-plugin/
   // lint-worker.js` (worker_threads can't run TS); this setup file points the
   // pool at it via setWorkerEntryForTests(). Run `pnpm build` once before testing.


### PR DESCRIPTION
## Summary

- raise `@rslint/core` Rstest `testTimeout` from the 5s default to 30s
- document why the Windows self-hosted runner needs extra headroom under concurrent CI load

## Context

The recent main-branch flakes were Windows npm-package CI failures in `rstest run`, with several async tests timing out at Rstest's 5000ms default. The `@rslint/native-win32-x64-msvc` missing-module stack in the logs is from an expected packaged-isolation negative test and is not the root failure.

## Validation

- `pnpm exec prettier --check packages/rslint/rstest.config.ts`
- `git diff --check`
- `pnpm --filter @rslint/core exec rstest run tests/config-discovery.test.ts --testNamePattern "no files/dirs uses cwd" --pool.maxWorkers 1`
- workflow_dispatch: https://github.com/web-infra-dev/rslint/actions/runs/28662639598
- target job passed: `Test npm packages (rspack-windows-2022-large)` https://github.com/web-infra-dev/rslint/actions/runs/28662639598/job/85006688612

Note: the workflow_dispatch run was still waiting on unrelated macOS Go / Windows VSCode extension jobs when this PR was opened.