### PR TITLE
docs: scope port-rule go tests

### DIFF
--- a/.agents/skills/port-rule/SKILL.md
+++ b/.agents/skills/port-rule/SKILL.md
@@ -138,7 +138,7 @@ Follow the phases in [PORT_RULE.md](references/PORT_RULE.md) sequentially:
 2. **Phase 1: Preparation** - Collect test cases, walk Dimensions 1–4 edge cases (including the universal edge-shape checklist), and do an upstream semantic walk that enumerates each branch in the ESLint source
 3. **Phase 2: Implementation** - Before writing helpers, grep same-plugin neighbors and extract any near-duplicates to `<plugin>util/`. Then write Go rule, two-file test split (`<rule>_upstream_test.go` for Layer 1 + `<rule>_extras_test.go` for Layers 2 + 3 — see PORT_RULE.md Testing Philosophy), and documentation (see the "Differences from ESLint" writing rules in PORT_RULE.md Phase 2 Step 3 — user-facing only, no implementation talk)
 4. **Phase 3: Integration** - Add JS tests and register rule
-5. **Phase 4: Verification** - Build binary; run the rule's Go + JS tests; if a shared helper (`<plugin>util/`, `internal/utils/`) was added or modified, also rerun the whole plugin (or whole tree) test suite; then run the BLOCKING pre-commit gate from Phase 4 Step 7, with Go lint restricted to changed Go files
+5. **Phase 4: Verification** - Build binary; run the rule's Go + JS tests; if a shared helper (`<plugin>util/`, `internal/utils/`) was added or modified, also run tests for the affected Go package(s) and direct consumer package(s); then run the BLOCKING pre-commit gate from Phase 4 Step 7, with Go lint restricted to packages containing changed Go files
 6. **Phase 5: Submission** - Commit and create PR
 
 For each phase: mark its task as `in_progress` (via `TaskUpdate`) before starting, and `completed` after finishing. Update the text checklist as well.
@@ -152,7 +152,7 @@ Follow the batch workflow in [PORT_RULE.md](references/PORT_RULE.md):
    - **Phase 1: Preparation** - Collect test cases; walk Dimensions 1–4 edge cases; do an upstream semantic walk (enumerate branches in the ESLint source, add lock-in tests for branches upstream itself doesn't test)
    - **Phase 2: Implementation** - grep same-plugin neighbors and extract near-duplicate helpers to `<plugin>util/` FIRST; then write Go rule, tests, and documentation (Differences section is user-facing only)
    - **Phase 3: Integration** - Add JS tests and register rule
-   - **Phase 4: Verification** - Build binary; run Go + JS tests; if a shared helper was touched, rerun the plugin-wide (or repo-wide) test suite; then the BLOCKING pre-commit gate
+   - **Phase 4: Verification** - Build binary; run Go + JS tests; if a shared helper was touched, run tests for the affected Go package(s) and direct consumer package(s); then the BLOCKING pre-commit gate
    - **Commit** - Create an independent commit: `feat: port rule <rule-name>`
    - **Report** - Briefly report the result before moving to the next rule
 3. **Phase 5: Create PR** - One PR summarizing all ported rules (once), see [Phase 5 Details](#phase-5-commit--pr-details) below

--- a/.agents/skills/port-rule/references/PORT_RULE.md
+++ b/.agents/skills/port-rule/references/PORT_RULE.md
@@ -661,17 +661,13 @@ Follow this **strict order** — each step depends on the previous one:
    go test -count=1 ./internal/plugins/<plugin>/rules/<rule_name>
    ```
 
-   **Related-rule regression**: if this port introduced or modified any exported symbol in a shared package (e.g. `internal/plugins/<plugin>/<plugin>util/`, or `internal/utils/`), you MUST also rerun every rule that consumes it. When in doubt about the blast radius, rerun the whole plugin or the whole tree:
+   **Related-rule regression**: if this port introduced or modified any exported symbol in a shared package (e.g. `internal/plugins/<plugin>/<plugin>util/`, or `internal/utils/`), you MUST also run tests for the changed package and the direct consumer packages that import or call the changed API. Keep the scope related to the changed Go code; do not run whole-plugin or whole-tree Go tests as part of the port-rule workflow.
 
    ```bash
-   # When you extracted a helper to or modified <plugin>util/:
-   go test -count=1 ./internal/plugins/<plugin>/...
-
-   # When you touched internal/utils/ (cross-plugin shared):
-   go test -count=1 ./internal/...
+   go test -count=1 <changed-package-dir> <direct-consumer-package-dir>
    ```
 
-   Extracting / renaming a helper is a silent-regression hotspot; running the narrower `./rules/<rule_name>` in isolation is not enough.
+   Extracting / renaming a helper is a silent-regression hotspot; running only the new rule package is not enough when another package consumes the helper. Identify direct consumers with `rg` / `git grep`, run their package tests, and do not fall back to `go test ./internal/...`, `go test ./internal/plugins/<plugin>/...`, or `pnpm run test:go`.
 
 3. **Build binary** (REQUIRED before JS tests — they spawn the binary via IPC):
 

--- a/.agents/skills/port-rule/references/QUICK_REFERENCE.md
+++ b/.agents/skills/port-rule/references/QUICK_REFERENCE.md
@@ -12,7 +12,7 @@ A quick reference for common commands, file locations, and checklists when porti
 | ------------------------ | ------------------------------------------------------------------------------------------------ |
 | Create branch            | `git checkout -b feat/port-rule-<name>-$(date +%Y%m%d)`                                          |
 | Go unit test             | `go test -count=1 ./internal/rules/<rule_name>`                                                  |
-| Go full test             | `go test -count=1 ./internal/rules/...`                                                          |
+| Go related tests         | `go test -count=1 <changed package dirs and direct consumer package dirs>`                       |
 | Build binary             | `cd packages/rslint && pnpm run build:bin`                                                       |
 | JS unit test             | `cd packages/rslint-test-tools && npx rstest run --testTimeout=10000 <rule-name>`                |
 | Type check               | `pnpm typecheck`                                                                                 |
@@ -105,7 +105,7 @@ import (
 
 ## Checklist Before Submission
 
-- [ ] Go tests pass (`go test -count=1 ./internal/rules/<name>`)
+- [ ] Go tests pass for the rule package and any changed-related Go package directories (see Phase 4 Step 2 in `PORT_RULE.md`)
 - [ ] Build binary (`cd packages/rslint && pnpm run build:bin`)
 - [ ] JS snapshots generated (`npx rstest run <name> -u`)
 - [ ] JS tests pass (`cd packages/rslint-test-tools && npx rstest run <name>`)


### PR DESCRIPTION
## Summary

Update the port-rule skill to avoid whole-plugin or whole-tree Go test runs during verification.

Document testing only the rule package, changed Go package directories, and direct consumer package directories when shared helpers are changed.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).