### PR TITLE
feat: port rule prefer-exponentiation-operator

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -121,6 +121,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/one_var"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_arrow_callback"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_const"
+	"github.com/web-infra-dev/rslint/internal/rules/prefer_exponentiation_operator"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_regex_literals"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
@@ -227,6 +228,7 @@ func GetAllRules() []rule.Rule {
 		no_undef.NoUndefRule,
 		no_undef_init.NoUndefInitRule,
 		prefer_const.PreferConstRule,
+		prefer_exponentiation_operator.PreferExponentiationOperatorRule,
 		prefer_promise_reject_errors.PreferPromiseRejectErrorsRule,
 		prefer_regex_literals.PreferRegexLiteralsRule,
 		prefer_template.PreferTemplateRule,

--- a/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator.go
+++ b/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator.go
@@ -1,0 +1,493 @@
+package prefer_exponentiation_operator
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageUseExponentiation = "Use the '**' operator instead of 'Math.pow'."
+
+var continuationChars = map[byte]bool{
+	'(': true,
+	'[': true,
+	'/': true,
+	'`': true,
+}
+
+func buildUseExponentiationMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "useExponentiation",
+		Description: messageUseExponentiation,
+	}
+}
+
+func staticExpressionString(node *ast.Node) (string, bool) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return "", false
+	}
+
+	if value, ok := utils.GetStaticExpressionValue(node); ok {
+		return value, true
+	}
+
+	switch node.Kind {
+	case ast.KindTemplateExpression:
+		tpl := node.AsTemplateExpression()
+		var b strings.Builder
+		if tpl.Head != nil {
+			b.WriteString(tpl.Head.AsTemplateHead().Text)
+		}
+		if tpl.TemplateSpans != nil {
+			for _, spanNode := range tpl.TemplateSpans.Nodes {
+				span := spanNode.AsTemplateSpan()
+				value, ok := staticExpressionString(span.Expression)
+				if !ok {
+					return "", false
+				}
+				b.WriteString(value)
+				if span.Literal != nil {
+					b.WriteString(span.Literal.TemplateLiteralLikeData().Text)
+				}
+			}
+		}
+		return b.String(), true
+	case ast.KindBinaryExpression:
+		bin := node.AsBinaryExpression()
+		if bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindPlusToken {
+			return "", false
+		}
+		left, ok := staticExpressionString(bin.Left)
+		if !ok {
+			return "", false
+		}
+		right, ok := staticExpressionString(bin.Right)
+		if !ok {
+			return "", false
+		}
+		return left + right, true
+	}
+
+	return "", false
+}
+
+func staticAccessName(node *ast.Node) (string, bool) {
+	node = ast.SkipParentheses(node)
+	if node == nil || !ast.IsAccessExpression(node) {
+		return "", false
+	}
+
+	if name, ok := utils.AccessExpressionStaticName(node); ok {
+		return name, true
+	}
+
+	// ESLint's static property matcher also folds simple string templates and
+	// string concatenations, which rslint's shared literal-only helper does not.
+	if node.Kind == ast.KindElementAccessExpression {
+		return staticExpressionString(node.AsElementAccessExpression().ArgumentExpression)
+	}
+
+	return "", false
+}
+
+func staticAccessObject(node *ast.Node) *ast.Node {
+	return utils.AccessExpressionObject(ast.SkipParentheses(node))
+}
+
+func isGlobalNameReference(node *ast.Node, name string) bool {
+	node = utils.SkipAssertionsAndParens(node)
+	return node != nil &&
+		node.Kind == ast.KindIdentifier &&
+		node.AsIdentifier().Text == name &&
+		!utils.IsShadowed(node, name)
+}
+
+func isGlobalMathExpression(node *ast.Node) bool {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return false
+	}
+
+	if isGlobalNameReference(node, "Math") {
+		return true
+	}
+
+	name, ok := staticAccessName(node)
+	if !ok || name != "Math" {
+		return false
+	}
+
+	object := staticAccessObject(node)
+	if object == nil {
+		return false
+	}
+	return isGlobalNameReference(object, "globalThis")
+}
+
+func isMathPowCall(node *ast.Node) bool {
+	call := node.AsCallExpression()
+	if call == nil {
+		return false
+	}
+
+	callee := utils.SkipAssertionsAndParens(call.Expression)
+	name, ok := staticAccessName(callee)
+	if !ok || name != "pow" {
+		return false
+	}
+
+	object := staticAccessObject(callee)
+	if object == nil {
+		return false
+	}
+	return isGlobalMathExpression(object)
+}
+
+func unparenthesized(node *ast.Node) *ast.Node {
+	return ast.SkipParentheses(node)
+}
+
+func expressionText(sf *ast.SourceFile, node *ast.Node) string {
+	return utils.TrimmedNodeText(sf, unparenthesized(node))
+}
+
+func expressionPrecedence(node *ast.Node) ast.OperatorPrecedence {
+	return ast.GetExpressionPrecedence(unparenthesized(node))
+}
+
+func doesBaseNeedParens(base *ast.Node) bool {
+	base = unparenthesized(base)
+	if base == nil {
+		return false
+	}
+
+	isUnaryBase := false
+	if base.Kind == ast.KindPrefixUnaryExpression {
+		switch base.AsPrefixUnaryExpression().Operator {
+		case ast.KindPlusPlusToken, ast.KindMinusMinusToken:
+			isUnaryBase = false
+		default:
+			isUnaryBase = true
+		}
+	}
+
+	return expressionPrecedence(base) <= ast.OperatorPrecedenceExponentiation ||
+		base.Kind == ast.KindAwaitExpression ||
+		isUnaryBase
+}
+
+func doesExponentNeedParens(exponent *ast.Node) bool {
+	exponent = unparenthesized(exponent)
+	if exponent == nil {
+		return false
+	}
+	return expressionPrecedence(exponent) < ast.OperatorPrecedenceExponentiation
+}
+
+func isParenthesized(node *ast.Node) bool {
+	return node != nil && node.Parent != nil && node.Parent.Kind == ast.KindParenthesizedExpression
+}
+
+func isBinaryExponentRightChild(parent *ast.Node, node *ast.Node) bool {
+	if parent == nil || parent.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	bin := parent.AsBinaryExpression()
+	return bin.OperatorToken != nil &&
+		bin.OperatorToken.Kind == ast.KindAsteriskAsteriskToken &&
+		bin.Right == node
+}
+
+func isArgumentOfCallOrNew(parent *ast.Node, node *ast.Node) bool {
+	if parent == nil {
+		return false
+	}
+	if ast.IsCallExpression(parent) {
+		args := parent.AsCallExpression().Arguments
+		if args == nil {
+			return false
+		}
+		for _, arg := range args.Nodes {
+			if arg == node {
+				return true
+			}
+		}
+		return false
+	}
+	if parent.Kind == ast.KindNewExpression {
+		args := parent.AsNewExpression().Arguments
+		if args == nil {
+			return false
+		}
+		for _, arg := range args.Nodes {
+			if arg == node {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isTypeWrapperParent(parent *ast.Node, node *ast.Node) bool {
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindAsExpression:
+		return parent.AsAsExpression().Expression == node
+	case ast.KindSatisfiesExpression:
+		return parent.AsSatisfiesExpression().Expression == node
+	case ast.KindTypeAssertionExpression:
+		return parent.AsTypeAssertion().Expression == node
+	}
+	return false
+}
+
+func doesExponentiationExpressionNeedParens(node *ast.Node) bool {
+	if isParenthesized(node) {
+		return false
+	}
+
+	parent := node.Parent
+	if parent != nil && (ast.IsExpressionWithTypeArgumentsInClassExtendsClause(parent) || isTypeWrapperParent(parent, node)) {
+		return true
+	}
+	if parent == nil || !ast.IsExpression(parent) {
+		return false
+	}
+
+	parentPrecedence := ast.GetExpressionPrecedence(parent)
+	needsParens := parentPrecedence == ast.OperatorPrecedenceInvalid ||
+		parentPrecedence >= ast.OperatorPrecedenceExponentiation
+	if !needsParens {
+		return false
+	}
+
+	return !isBinaryExponentRightChild(parent, node) &&
+		!isArgumentOfCallOrNew(parent, node) &&
+		!ast.IsArgumentExpressionOfElementAccess(node) &&
+		!ast.IsArrayLiteralExpression(parent)
+}
+
+func parenthesizeIfShould(text string, shouldParenthesize bool) string {
+	if shouldParenthesize {
+		return "(" + text + ")"
+	}
+	return text
+}
+
+func isStartOfExpressionStatement(sf *ast.SourceFile, node *ast.Node) bool {
+	nodeStart := utils.TrimNodeTextRange(sf, node).Pos()
+	for current := node.Parent; current != nil; current = current.Parent {
+		if current.Kind == ast.KindParenthesizedExpression {
+			return false
+		}
+		if current.Kind == ast.KindExpressionStatement {
+			return nodeStart == utils.TrimNodeTextRange(sf, current).Pos()
+		}
+		if !ast.IsExpression(current) {
+			return false
+		}
+	}
+	return false
+}
+
+func firstTokenKind(sf *ast.SourceFile, node *ast.Node) ast.Kind {
+	node = unparenthesized(node)
+	if node == nil {
+		return ast.KindUnknown
+	}
+	return scanner.ScanTokenAtPosition(sf, utils.TrimNodeTextRange(sf, node).Pos())
+}
+
+func isBaseStartThatNeedsWholeParens(sf *ast.SourceFile, base *ast.Node) bool {
+	switch firstTokenKind(sf, base) {
+	case ast.KindOpenBraceToken, ast.KindFunctionKeyword, ast.KindClassKeyword:
+		return true
+	default:
+		return false
+	}
+}
+
+func trimTokenText(text string) string {
+	return strings.TrimFunc(text, unicode.IsSpace)
+}
+
+func canTokenTextsBeAdjacent(left string, right string) bool {
+	left = trimTokenText(left)
+	right = trimTokenText(right)
+	if left == "" || right == "" {
+		return true
+	}
+
+	leftRune, _ := utf8.DecodeLastRuneInString(left)
+	rightRune, _ := utf8.DecodeRuneInString(right)
+	if scanner.IsIdentifierPart(leftRune) && scanner.IsIdentifierPart(rightRune) {
+		return false
+	}
+	if (leftRune == '+' && rightRune == '+') || (leftRune == '-' && rightRune == '-') {
+		return false
+	}
+	if leftRune == '/' && (rightRune == '/' || rightRune == '*') {
+		return false
+	}
+	return true
+}
+
+func previousAdjacentTokenText(sf *ast.SourceFile, pos int) (string, bool) {
+	text := sf.Text()
+	if pos <= 0 || pos > len(text) {
+		return "", false
+	}
+	if text[pos-1] == '/' && pos >= 2 && text[pos-2] == '*' {
+		return "", false
+	}
+	if unicode.IsSpace(rune(text[pos-1])) {
+		return "", false
+	}
+
+	start := pos - 1
+	for start > 0 && !unicode.IsSpace(rune(text[start-1])) {
+		ch := text[start-1]
+		if strings.ContainsRune("()[]{};,.?:", rune(ch)) {
+			break
+		}
+		start--
+	}
+	return text[start:pos], true
+}
+
+func nextAdjacentTokenText(sf *ast.SourceFile, pos int) (string, bool) {
+	text := sf.Text()
+	if pos < 0 || pos >= len(text) {
+		return "", false
+	}
+	if unicode.IsSpace(rune(text[pos])) {
+		return "", false
+	}
+	if text[pos] == '/' && pos+1 < len(text) && (text[pos+1] == '*' || text[pos+1] == '/') {
+		return "", false
+	}
+
+	end := pos + 1
+	for end < len(text) && !unicode.IsSpace(rune(text[end])) {
+		ch := text[end]
+		if strings.ContainsRune("()[]{};,.?:", rune(ch)) {
+			break
+		}
+		end++
+	}
+	return text[pos:end], true
+}
+
+func needsPrecedingSemicolon(sf *ast.SourceFile, node *ast.Node) bool {
+	nodeStart := utils.TrimNodeTextRange(sf, node).Pos()
+
+	scan := scanner.GetScannerForSourceFile(sf, 0)
+	prevKind := ast.KindUnknown
+	for scan.Token() != ast.KindEndOfFile && scan.TokenStart() < nodeStart {
+		prevKind = scan.Token()
+		scan.Scan()
+	}
+	if prevKind == ast.KindUnknown || scan.TokenStart() != nodeStart || !scan.HasPrecedingLineBreak() {
+		return false
+	}
+
+	switch prevKind {
+	case ast.KindSemicolonToken, ast.KindCloseBraceToken:
+		return false
+	}
+	return true
+}
+
+func buildFix(sf *ast.SourceFile, node *ast.Node) *rule.RuleFix {
+	call := node.AsCallExpression()
+	if call == nil || call.Arguments == nil {
+		return nil
+	}
+	args := call.Arguments.Nodes
+	if len(args) != 2 {
+		return nil
+	}
+	for _, arg := range args {
+		if arg.Kind == ast.KindSpreadElement {
+			return nil
+		}
+	}
+	if utils.HasCommentInsideNode(sf, node) {
+		return nil
+	}
+
+	base := args[0]
+	exponent := args[1]
+	baseText := expressionText(sf, base)
+	exponentText := expressionText(sf, exponent)
+	shouldParenthesizeBase := doesBaseNeedParens(base)
+	shouldParenthesizeExponent := doesExponentNeedParens(exponent)
+	isStart := isStartOfExpressionStatement(sf, node)
+	shouldParenthesizeAll := doesExponentiationExpressionNeedParens(node)
+
+	if !shouldParenthesizeAll && !shouldParenthesizeBase && isStart && isBaseStartThatNeedsWholeParens(sf, base) {
+		shouldParenthesizeAll = true
+	}
+
+	prefix := ""
+	suffix := ""
+	nodeRange := utils.TrimNodeTextRange(sf, node)
+
+	if !shouldParenthesizeAll {
+		if !shouldParenthesizeBase {
+			if before, ok := previousAdjacentTokenText(sf, nodeRange.Pos()); ok {
+				if !canTokenTextsBeAdjacent(before, baseText) {
+					prefix = " "
+				}
+			}
+		}
+		if !shouldParenthesizeExponent {
+			if after, ok := nextAdjacentTokenText(sf, nodeRange.End()); ok {
+				if !canTokenTextsBeAdjacent(exponentText, after) {
+					suffix = " "
+				}
+			}
+		}
+	}
+
+	baseReplacement := parenthesizeIfShould(baseText, shouldParenthesizeBase)
+	exponentReplacement := parenthesizeIfShould(exponentText, shouldParenthesizeExponent)
+	replacement := parenthesizeIfShould(baseReplacement+"**"+exponentReplacement, shouldParenthesizeAll)
+
+	if prefix == "" && isStart && len(replacement) > 0 && continuationChars[replacement[0]] && needsPrecedingSemicolon(sf, node) {
+		prefix = ";"
+	}
+
+	fix := rule.RuleFixReplaceRange(core.NewTextRange(nodeRange.Pos(), nodeRange.End()), prefix+replacement+suffix)
+	return &fix
+}
+
+// https://eslint.org/docs/latest/rules/prefer-exponentiation-operator
+var PreferExponentiationOperatorRule = rule.Rule{
+	Name: "prefer-exponentiation-operator",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				if !isMathPowCall(node) {
+					return
+				}
+
+				if fix := buildFix(ctx.SourceFile, node); fix != nil {
+					ctx.ReportNodeWithFixes(node, buildUseExponentiationMessage(), *fix)
+					return
+				}
+
+				ctx.ReportNode(node, buildUseExponentiationMessage())
+			},
+		}
+	},
+}

--- a/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator.md
+++ b/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator.md
@@ -1,0 +1,33 @@
+# prefer-exponentiation-operator
+
+## Rule Details
+
+This rule disallows calls to `Math.pow` and suggests using the `**` operator
+instead.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const foo = Math.pow(2, 8);
+const bar = Math.pow(a, b);
+let baz = Math.pow(a + b, c + d);
+let quux = Math.pow(-1, n);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const foo = 2 ** 8;
+const bar = a ** b;
+let baz = (a + b) ** (c + d);
+let quux = (-1) ** n;
+```
+
+## When Not To Use It
+
+Do not enable this rule if your runtime target does not support the
+exponentiation operator (`**`).
+
+## Original Documentation
+
+- [ESLint prefer-exponentiation-operator](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator)

--- a/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator_extras_test.go
+++ b/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator_extras_test.go
@@ -1,0 +1,148 @@
+package prefer_exponentiation_operator
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestPreferExponentiationOperatorExtras locks in branches and edge shapes that the upstream test suite doesn't exercise.
+// Each case carries an inline comment pointing at the specific branch, Dimension 4 row, or tsgo AST quirk it covers, so future refactors can't silently regress them without breaking a named lock-in.
+func TestPreferExponentiationOperatorExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferExponentiationOperatorRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: dynamic element access keys stay unmatched ----
+			{Code: "const key = 'pow'; Math[key](a, b);"},
+			{Code: "Math[Symbol.for('pow')](a, b);"},
+			{Code: "Math[0](a, b);"},
+			{Code: "globalThis[getName()].pow(a, b);"},
+			{Code: "Math[`p${suffix}`](a, b);"},
+			{Code: "Math['po' + suffix](a, b);"},
+
+			// ---- Dimension 4: value-shadowed receivers stay unmatched ----
+			{Code: "let Math = other; (Math as any).pow(a, b);"},
+			{Code: "const globalThis = other; (globalThis as any).Math.pow(a, b);"},
+			{Code: "import { Math } from 'math-lib'; Math.pow(a, b);"},
+			{Code: "enum Math { pow } Math.pow(a, b);"},
+			{Code: "namespace Math { export const pow = f; } Math.pow(a, b);"},
+			{Code: "const { Math } = ns; Math.pow(a, b);"},
+			{Code: "try {} catch (Math) { Math.pow(a, b); }"},
+			{Code: "for (let Math of items) { Math.pow(a, b); }"},
+
+			// ---- Dimension 4: private names are a different key class from the string "pow" ----
+			{Code: "class C { #pow; foo() { Math.#pow(a, b); } }"},
+
+			// ---- Dimension 4: non-CALL uses of Math.pow stay unmatched ----
+			{Code: "new (Math.pow)(a, b);"},
+			{Code: "Math.pow.call(Math, a, b);"},
+			{Code: "Reflect.apply(Math.pow, Math, [a, b]);"},
+
+			// N/A: declaration/container forms do not affect this call-expression-only rule.
+			// N/A: same-kind nesting is covered by shadowed receiver cases; the rule keeps no per-container traversal state.
+			// N/A: overload signatures, abstract members, declare members, empty class/function bodies, and binding patterns are not inputs this rule inspects.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parentheses and TS wrappers around the receiver or callee are transparent ----
+			invalidFixed("((Math)).pow(a, b)", "a**b"),
+			invalidFixed("(Math as any).pow(a, b)", "a**b"),
+			invalidFixed("Math!.pow(a, b)", "a**b"),
+			invalidFixed("(Math satisfies any).pow(a, b)", "a**b"),
+			invalidFixed("(globalThis as any).Math['pow'](a, b)", "a**b"),
+			invalidFixed("(globalThis.Math as any).pow(a, b)", "a**b"),
+			invalidFixed("((Math.pow as any))(a, b)", "a**b"),
+			invalidFixed("(Math.pow!)(a, b)", "a**b"),
+			invalidFixed("(Math['pow'] satisfies Function)(a, b)", "a**b"),
+			invalidFixed("((globalThis['Math']).pow)(a, b)", "a**b"),
+
+			// ---- Dimension 4: optional-chain receiver and optional-call wrappers still target global Math.pow ----
+			invalidFixed("((Math?.pow))?.(a, b)", "a**b"),
+			invalidFixed("globalThis?.Math?.['pow']?.(a, b)", "a**b"),
+
+			// ---- Dimension 4: static element access keys include simple templates and string concatenation ----
+			invalidFixed(`Math["pow"](a, b)`, "a**b"),
+			invalidFixed("Math[`p${'ow'}`](a, b)", "a**b"),
+			invalidFixed("Math[('pow' as const)](a, b)", "a**b"),
+			invalidFixed("Math['p' + 'o' + 'w'](a, b)", "a**b"),
+			invalidFixed("globalThis['Ma' + 'th'][`p${'ow'}`](a, b)", "a**b"),
+
+			// ---- Dimension 4: type-only declarations do not shadow global Math/globalThis values ----
+			invalidFixed("type Math = unknown; Math.pow(a, b);", "type Math = unknown; a**b;"),
+			invalidFixed("interface Math { pow: unknown } Math.pow(a, b);", "interface Math { pow: unknown } a**b;"),
+			invalidFixed("type globalThis = unknown; globalThis.Math.pow(a, b);", "type globalThis = unknown; a**b;"),
+
+			// ---- Dimension 4: TS wrappers on inspected arguments and the whole replacement keep the resulting expression valid ----
+			invalidFixed("Math.pow(a!, b!)", "a!**b!"),
+			invalidFixed("Math.pow((a satisfies number), b)", "(a satisfies number)**b"),
+			invalidFixed("const value = Math.pow(a, b) as number;", "const value = (a**b) as number;"),
+			invalidFixed("const value = Math.pow(a, b)!;", "const value = (a**b)!;"),
+
+			// Spread arguments are reported without an unsafe fix.
+			invalidNoFix("Math.pow(...[], a)"),
+
+			// globalThis path is independent from a local Math binding.
+			invalidFixed("function f(Math) { return globalThis.Math.pow(a, b); }", "function f(Math) { return a**b; }"),
+
+			// ---- Real-user: eslint/eslint#10482 original distance formula shape ----
+			invalidFixed("const distance = Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2));", "const distance = Math.sqrt(dx**2 + dy**2);"),
+
+			// ---- Real-user: eslint/eslint#17173 TypeScript assertion around both operands ----
+			invalidFixed("const v = Math.pow((value as number) + 1, exp as number);", "const v = ((value as number) + 1)**(exp as number);"),
+
+			// ---- Real-user: eslint/eslint#20987 declaration-like base at expression-statement start ----
+			invalidFixed("Math.pow(class Named { static x = 2 }.x, n) + scale;", "(class Named { static x = 2 }.x**n) + scale;"),
+
+			// Locks in upstream doesBaseNeedParens() arm 1: lower-precedence base.
+			invalidFixed("Math.pow(a || b, c)", "(a || b)**c"),
+
+			// Locks in upstream doesBaseNeedParens() arm 2: unary base.
+			invalidFixed("Math.pow(~a, b)", "(~a)**b"),
+
+			// Locks in upstream doesBaseNeedParens() negative arm: update expressions are not unary expressions in ESTree.
+			invalidFixed("Math.pow(++a, b)", "++a**b"),
+
+			// Locks in upstream doesExponentNeedParens() arm 1: lower-precedence exponent.
+			invalidFixed("Math.pow(a, b || c)", "a**(b || c)"),
+
+			// Locks in upstream doesExponentNeedParens() negative arm: exponentiation is right-associative.
+			invalidFixed("Math.pow(a, b ** c)", "a**b ** c"),
+
+			// Locks in upstream doesBaseNeedParens() and doesExponentNeedParens() lower-precedence arms for conditional expressions.
+			invalidFixed("const value = Math.pow(a ? b : c, d ? e : f);", "const value = (a ? b : c)**(d ? e : f);"),
+
+			// Locks in upstream doesExponentiationExpressionNeedParens() call-argument exception.
+			invalidFixed("callee(Math.pow(a, b)).prop", "callee(a**b).prop"),
+
+			// Locks in upstream doesExponentiationExpressionNeedParens() computed-member-key exception.
+			invalidFixed("object[Math.pow(a, b)].prop", "object[a**b].prop"),
+			invalidFixed("const obj = { [Math.pow(a, b)]: value };", "const obj = { [a**b]: value };"),
+
+			// Nested exponentiation fixes can require multiple fix passes to preserve associativity.
+			invalidWithOutputs("const value = Math.pow(a, Math.pow(b, c));", "const value = a**Math.pow(b, c);", "const value = a**b**c;"),
+			invalidWithOutputs("const value = Math.pow(Math.pow(a, b), c);", "const value = Math.pow(a, b)**c;", "const value = (a**b)**c;"),
+
+			// Contexts where the whole replacement must be wrapped.
+			invalidFixed("class C extends Math.pow(A, B) {}", "class C extends (A**B) {}"),
+			invalidFixed("new (Math.pow(a, b).constructor)()", "new ((a**b).constructor)()"),
+
+			// Fixes keep adjacent tokens from merging into a different token.
+			invalidFixed("const x = a/Math.pow(/re/, b);", "const x = a/ /re/**b;"),
+			invalidFixed("const x = a-Math.pow(--b, c);", "const x = a- --b**c;"),
+			invalidFixed("const x = Math.pow(a, b)instanceof C;", "const x = a**b instanceof C;"),
+			invalidFixed("const x = Math.pow(a, b)as number;", "const x = (a**b)as number;"),
+			invalidFixed("const x = Math.pow(a, b)satisfies number;", "const x = (a**b)satisfies number;"),
+
+			// ECMAScript line terminators beyond LF/CR still need ASI protection.
+			invalidFixed("foo\u2028Math.pow({a:1}.a, 2)", "foo\u2028;({a:1}.a**2)"),
+			invalidFixed("foo/*\n*/Math.pow([a, b].find(fn), c)", "foo/*\n*/;[a, b].find(fn)**c"),
+			invalidFixed("foo// comment\nMath.pow(`template`, c)", "foo// comment\n;`template`**c"),
+
+			// Locks in upstream report() no-fix arm: comments inside the call are preserved by skipping the fix.
+			invalidNoFix("Math.pow(a /* base */, b)"),
+		},
+	)
+}

--- a/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator_upstream_test.go
+++ b/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator_upstream_test.go
@@ -1,0 +1,378 @@
+package prefer_exponentiation_operator
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// TestPreferExponentiationOperatorUpstream migrates the full valid/invalid suite from upstream tests/lib/rules/prefer-exponentiation-operator.js 1:1.
+// Position assertions cover line/column for every invalid case. rslint-specific lock-in cases live in the prefer_exponentiation_operator_extras_test.go file.
+func TestPreferExponentiationOperatorUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferExponentiationOperatorRule,
+		[]rule_tester.ValidTestCase{
+			// ---- not Math.pow() ----
+			{Code: "Object.pow(a, b)"},
+			{Code: "Math.max(a, b)"},
+			{Code: "Math"},
+			{Code: "Math(a, b)"},
+			{Code: "pow"},
+			{Code: "pow(a, b)"},
+			{Code: "Math.pow"},
+			{Code: "Math.Pow(a, b)"},
+			{Code: "math.pow(a, b)"},
+			{Code: "foo.Math.pow(a, b)"},
+			{Code: "new Math.pow(a, b)"},
+			{Code: "Math[pow](a, b)"},
+			{Code: "globalThis.Object.pow(a, b)"},
+			{Code: "globalThis.Math.max(a, b)"},
+
+			// ---- not the global Math ----
+			{Code: "/* globals Math:off*/ Math.pow(a, b)", Skip: true}, // SKIP: rslint does not support ESLint's /* globals */ directive comments.
+			{Code: "let Math; Math.pow(a, b);"},
+			{Code: "if (foo) { const Math = 1; Math.pow(a, b); }"},
+			{Code: "var x = function Math() { Math.pow(a, b); }"},
+			{Code: "function foo(Math) { Math.pow(a, b); }"},
+			{Code: "function foo() { Math.pow(a, b); var Math; }"},
+
+			{Code: "globalThis.Math.pow(a, b)", Skip: true}, // SKIP: mirrors upstream ecmaVersion 2019 case; rslint does not expose ecmaVersion-specific globalThis availability.
+			{Code: "globalThis.Math.pow(a, b)", Skip: true}, // SKIP: mirrors upstream ecmaVersion 6 case; rslint does not expose ecmaVersion-specific globalThis availability.
+			{Code: "globalThis.Math.pow(a, b)", Skip: true}, // SKIP: mirrors upstream ecmaVersion 2017 case; rslint does not expose ecmaVersion-specific globalThis availability.
+			{Code: `
+                var globalThis = bar;
+                globalThis.Math.pow(a, b)
+            `},
+
+			{Code: "class C { #pow; foo() { Math.#pow(a, b); } }"},
+		},
+		[]rule_tester.InvalidTestCase{
+			invalidFixed("Math.pow(a, b)", "a**b"),
+			invalidFixed("(Math).pow(a, b)", "a**b"),
+			invalidFixed("Math['pow'](a, b)", "a**b"),
+			invalidFixed("(Math)['pow'](a, b)", "a**b"),
+			invalidFixed("var x=Math\n.  pow( a, \n b )", "var x=a**b"),
+			invalidFixed("globalThis.Math.pow(a, b)", "a**b"),
+			invalidFixed("globalThis.Math['pow'](a, b)", "a**b"),
+
+			// ---- able to catch some workarounds ----
+			invalidFixed("Math[`pow`](a, b)", "a**b"),
+			invalidFixed("Math[`${'pow'}`](a, b)", "a**b"),
+			invalidFixed("Math['p' + 'o' + 'w'](a, b)", "a**b"),
+
+			// ---- non-expression parents that don't require parens ----
+			invalidFixed("var x = Math.pow(a, b);", "var x = a**b;"),
+			invalidFixed("if(Math.pow(a, b)){}", "if(a**b){}"),
+			invalidFixed("for(;Math.pow(a, b);){}", "for(;a**b;){}"),
+			invalidFixed("switch(foo){ case Math.pow(a, b): break; }", "switch(foo){ case a**b: break; }"),
+			invalidFixed("{ foo: Math.pow(a, b) }", "{ foo: a**b }"),
+			invalidFixed("function foo(bar, baz = Math.pow(a, b), quux){}", "function foo(bar, baz = a**b, quux){}"),
+			invalidFixed("`${Math.pow(a, b)}`", "`${a**b}`"),
+
+			// ---- non-expression parents that do require parens ----
+			invalidFixed("class C extends Math.pow(a, b) {}", "class C extends (a**b) {}"),
+
+			// ---- parents with a higher precedence ----
+			invalidFixed("+ Math.pow(a, b)", "+ (a**b)"),
+			invalidFixed("- Math.pow(a, b)", "- (a**b)"),
+			invalidFixed("! Math.pow(a, b)", "! (a**b)"),
+			invalidFixed("typeof Math.pow(a, b)", "typeof (a**b)"),
+			invalidFixed("void Math.pow(a, b)", "void (a**b)"),
+			invalidFixed("Math.pow(a, b) .toString()", "(a**b) .toString()"),
+			invalidFixed("Math.pow(a, b) ()", "(a**b) ()"),
+			invalidFixed("Math.pow(a, b) ``", "(a**b) ``"),
+			invalidFixed("(class extends Math.pow(a, b) {})", "(class extends (a**b) {})"),
+
+			// ---- already parenthesised, shouldn't insert extra parens ----
+			invalidFixed("+(Math.pow(a, b))", "+(a**b)"),
+			invalidFixed("(Math.pow(a, b)).toString()", "(a**b).toString()"),
+			invalidFixed("(class extends (Math.pow(a, b)) {})", "(class extends (a**b) {})"),
+			invalidFixed("class C extends (Math.pow(a, b)) {}", "class C extends (a**b) {}"),
+
+			// ---- parents with a higher precedence, but the expression's role doesn't require parens ----
+			invalidFixed("f(Math.pow(a, b))", "f(a**b)"),
+			invalidFixed("f(foo, Math.pow(a, b))", "f(foo, a**b)"),
+			invalidFixed("f(Math.pow(a, b), foo)", "f(a**b, foo)"),
+			invalidFixed("f(foo, Math.pow(a, b), bar)", "f(foo, a**b, bar)"),
+			invalidFixed("new F(Math.pow(a, b))", "new F(a**b)"),
+			invalidFixed("new F(foo, Math.pow(a, b))", "new F(foo, a**b)"),
+			invalidFixed("new F(Math.pow(a, b), foo)", "new F(a**b, foo)"),
+			invalidFixed("new F(foo, Math.pow(a, b), bar)", "new F(foo, a**b, bar)"),
+			invalidFixed("obj[Math.pow(a, b)]", "obj[a**b]"),
+			invalidFixed("[foo, Math.pow(a, b), bar]", "[foo, a**b, bar]"),
+
+			// ---- parents with a lower precedence ----
+			invalidFixed("a * Math.pow(b, c)", "a * b**c"),
+			invalidFixed("Math.pow(a, b) * c", "a**b * c"),
+			invalidFixed("a + Math.pow(b, c)", "a + b**c"),
+			invalidFixed("Math.pow(a, b)/c", "a**b/c"),
+			invalidFixed("a < Math.pow(b, c)", "a < b**c"),
+			invalidFixed("Math.pow(a, b) > c", "a**b > c"),
+			invalidFixed("a === Math.pow(b, c)", "a === b**c"),
+			invalidFixed("a ? Math.pow(b, c) : d", "a ? b**c : d"),
+			invalidFixed("a = Math.pow(b, c)", "a = b**c"),
+			invalidFixed("a += Math.pow(b, c)", "a += b**c"),
+			invalidFixed("function *f() { yield Math.pow(a, b) }", "function *f() { yield a**b }"),
+			invalidFixed("a, Math.pow(b, c), d", "a, b**c, d"),
+
+			// ---- '**' is right-associative, that applies to both parent and child nodes ----
+			invalidFixed("a ** Math.pow(b, c)", "a ** b**c"),
+			invalidFixed("Math.pow(a, b) ** c", "(a**b) ** c"),
+			invalidFixed("Math.pow(a, b ** c)", "a**b ** c"),
+			invalidFixed("Math.pow(a ** b, c)", "(a ** b)**c"),
+			invalidFixed("a ** Math.pow(b ** c, d ** e) ** f", "a ** ((b ** c)**d ** e) ** f"),
+
+			// ---- doesn't remove already existing unnecessary parens around the whole expression ----
+			invalidFixed("(Math.pow(a, b))", "(a**b)"),
+			invalidFixed("foo + (Math.pow(a, b))", "foo + (a**b)"),
+			invalidFixed("(Math.pow(a, b)) + foo", "(a**b) + foo"),
+			invalidFixed("`${(Math.pow(a, b))}`", "`${(a**b)}`"),
+
+			// ---- base and exponent with a higher precedence ----
+			invalidFixed("Math.pow(2, 3)", "2**3"),
+			invalidFixed("Math.pow(a.foo, b)", "a.foo**b"),
+			invalidFixed("Math.pow(a, b.foo)", "a**b.foo"),
+			invalidFixed("Math.pow(a(), b)", "a()**b"),
+			invalidFixed("Math.pow(a, b())", "a**b()"),
+			invalidFixed("Math.pow(++a, ++b)", "++a**++b"),
+			invalidFixed("Math.pow(a++, ++b)", "a++**++b"),
+			invalidFixed("Math.pow(a--, b--)", "a--**b--"),
+			invalidFixed("Math.pow(--a, b--)", "--a**b--"),
+
+			// ---- doesn't preserve unnecessary parens around base and exponent ----
+			invalidFixed("Math.pow((a), (b))", "a**b"),
+			invalidFixed("Math.pow(((a)), ((b)))", "a**b"),
+			invalidFixed("Math.pow((a.foo), b)", "a.foo**b"),
+			invalidFixed("Math.pow(a, (b.foo))", "a**b.foo"),
+			invalidFixed("Math.pow((a()), b)", "a()**b"),
+			invalidFixed("Math.pow(a, (b()))", "a**b()"),
+
+			// ---- unary expressions are exception by the language ----
+			invalidFixed("Math.pow(+a, b)", "(+a)**b"),
+			invalidFixed("Math.pow(a, +b)", "a**+b"),
+			invalidFixed("Math.pow(-a, b)", "(-a)**b"),
+			invalidFixed("Math.pow(a, -b)", "a**-b"),
+			invalidFixed("Math.pow(-2, 3)", "(-2)**3"),
+			invalidFixed("Math.pow(2, -3)", "2**-3"),
+			invalidFixed("async () => Math.pow(await a, b)", "async () => (await a)**b"),
+			invalidFixed("async () => Math.pow(a, await b)", "async () => a**await b"),
+
+			// ---- base and exponent with a lower precedence ----
+			invalidFixed("Math.pow(a * b, c)", "(a * b)**c"),
+			invalidFixed("Math.pow(a, b * c)", "a**(b * c)"),
+			invalidFixed("Math.pow(a / b, c)", "(a / b)**c"),
+			invalidFixed("Math.pow(a, b / c)", "a**(b / c)"),
+			invalidFixed("Math.pow(a + b, 3)", "(a + b)**3"),
+			invalidFixed("Math.pow(2, a - b)", "2**(a - b)"),
+			invalidFixed("Math.pow(a + b, c + d)", "(a + b)**(c + d)"),
+			invalidFixed("Math.pow(a = b, c = d)", "(a = b)**(c = d)"),
+			invalidFixed("Math.pow(a += b, c -= d)", "(a += b)**(c -= d)"),
+			invalidFixed("Math.pow((a, b), (c, d))", "(a, b)**(c, d)"),
+			invalidFixed("function *f() { Math.pow(yield, yield) }", "function *f() { (yield)**(yield) }"),
+
+			// ---- doesn't put extra parens ----
+			invalidFixed("Math.pow((a + b), (c + d))", "(a + b)**(c + d)"),
+
+			// ---- tokens that can be adjacent ----
+			invalidFixed("a+Math.pow(b, c)+d", "a+b**c+d"),
+
+			// ---- tokens that cannot be adjacent ----
+			invalidFixed("a+Math.pow(++b, c)", "a+ ++b**c"),
+			invalidFixed("(a)+(Math).pow((++b), c)", "(a)+ ++b**c"),
+			invalidFixed("Math.pow(a, b)in c", "a**b in c"),
+			invalidFixed("Math.pow(a, (b))in (c)", "a**b in (c)"),
+			invalidFixed("a+Math.pow(++b, c)in d", "a+ ++b**c in d"),
+			invalidFixed("a+Math.pow( ++b, c )in d", "a+ ++b**c in d"),
+
+			// ---- tokens that cannot be adjacent, but there is already space or something else between ----
+			invalidFixed("a+ Math.pow(++b, c) in d", "a+ ++b**c in d"),
+			invalidFixed("a+/**/Math.pow(++b, c)/**/in d", "a+/**/++b**c/**/in d"),
+			invalidFixed("a+(Math.pow(++b, c))in d", "a+(++b**c)in d"),
+
+			// ---- tokens that cannot be adjacent, but parens required for precedence make extra space unnecessary ----
+			invalidFixed("+Math.pow(++a, b)", "+(++a**b)"),
+			invalidFixed("Math.pow(a, b + c)in d", "a**(b + c)in d"),
+
+			invalidFixed("Math.pow(a, b) + Math.pow(c,\n d)", "a**b + c**d"),
+			invalidWithOutputs("Math.pow(Math.pow(a, b), Math.pow(c, d))", "Math.pow(a, b)**Math.pow(c, d)", "(a**b)**c**d"),
+			invalidWithOutputs("Math.pow(a, b)**Math.pow(c, d)", "(a**b)**c**d"),
+
+			// ---- shouldn't autofix if the call doesn't have exactly two arguments ----
+			invalidNoFix("Math.pow()"),
+			invalidNoFix("Math.pow(a)"),
+			invalidNoFix("Math.pow(a, b, c)"),
+			invalidNoFix("Math.pow(a, b, c, d)"),
+
+			// ---- shouldn't autofix if any of the arguments is spread ----
+			invalidNoFix("Math.pow(...a)"),
+			invalidNoFix("Math.pow(...a, b)"),
+			invalidNoFix("Math.pow(a, ...b)"),
+			invalidNoFix("Math.pow(a, b, ...c)"),
+
+			// ---- shouldn't autofix if that would remove comments ----
+			invalidFixed("/* comment */Math.pow(a, b)", "/* comment */a**b"),
+			invalidNoFix("Math/**/.pow(a, b)"),
+			invalidNoFix("Math//\n.pow(a, b)"),
+			invalidNoFix("Math[//\n'pow'](a, b)"),
+			invalidNoFix("Math['pow'/**/](a, b)"),
+			invalidNoFix("Math./**/pow(a, b)"),
+			invalidNoFix("Math.pow/**/(a, b)"),
+			invalidNoFix("Math.pow//\n(a, b)"),
+			invalidNoFix("Math.pow(/**/a, b)"),
+			invalidNoFix("Math.pow(a,//\n b)"),
+			invalidNoFix("Math.pow(a, b/**/)"),
+			invalidNoFix("Math.pow(a, b//\n)"),
+			invalidFixed("Math.pow(a, b)/* comment */;", "a**b/* comment */;"),
+			invalidFixed("Math.pow(a, b)// comment\n;", "a**b// comment\n;"),
+
+			// ---- Optional chaining ----
+			invalidFixed("Math.pow?.(a, b)", "a**b"),
+			invalidFixed("Math?.pow(a, b)", "a**b"),
+			invalidFixed("Math?.pow?.(a, b)", "a**b"),
+			invalidFixed("(Math?.pow)(a, b)", "a**b"),
+			invalidFixed("(Math?.pow)?.(a, b)", "a**b"),
+
+			// ---- https://github.com/eslint/eslint/issues/17173 ----
+			invalidFixed("Math.pow(a, b as any)", "a**(b as any)"),
+			invalidFixed("Math.pow(a as any, b)", "(a as any)**b"),
+			invalidFixed("Math.pow(a, b) as any", "(a**b) as any"),
+
+			// ---- https://github.com/eslint/eslint/issues/20987 ----
+			invalidFixed("Math.pow({a:1}.a, 2);", "({a:1}.a**2);"),
+			invalidFixed("Math.pow({a:1}.a, 2) + 100;", "({a:1}.a**2) + 100;"),
+			invalidFixed("(Math.pow({a:1}.a, 2));", "({a:1}.a**2);"),
+			invalidFixed("100 + Math.pow({a:1}.a, 2);", "100 + {a:1}.a**2;"),
+			invalidFixed("Math.pow({a:1}.a + 100, 2);", "({a:1}.a + 100)**2;"),
+			invalidFixed("Math.pow(function(){return 2}(), 3);", "(function(){return 2}()**3);"),
+			invalidFixed("Math.pow(function(){return 2}(), 3) + 100;", "(function(){return 2}()**3) + 100;"),
+			invalidFixed("(Math.pow(function(){return 2}(), 3));", "(function(){return 2}()**3);"),
+			invalidFixed("100 + Math.pow(function(){return 2}(), 3);", "100 + function(){return 2}()**3;"),
+			invalidFixed("Math.pow(function(){return 2}() + 100, 3);", "(function(){return 2}() + 100)**3;"),
+			invalidFixed("Math.pow(class{static x=2}.x, 4);", "(class{static x=2}.x**4);"),
+			invalidFixed("Math.pow(class{static x=2}.x, 4) + 100;", "(class{static x=2}.x**4) + 100;"),
+			invalidFixed("(Math.pow(class{static x=2}.x, 4));", "(class{static x=2}.x**4);"),
+			invalidFixed("100 + Math.pow(class{static x=2}.x, 4);", "100 + class{static x=2}.x**4;"),
+			invalidFixed("Math.pow(class{static x=2}.x + 100, 4);", "(class{static x=2}.x + 100)**4;"),
+
+			// ---- preceding semicolon needed ----
+			invalidFixed("foo\nMath.pow(a + b, c)", "foo\n;(a + b)**c"),
+			invalidFixed("foo\nMath.pow(+a, b)", "foo\n;(+a)**b"),
+			invalidFixed("foo\nMath.pow(-a, b)", "foo\n;(-a)**b"),
+			invalidFixed("foo\nMath.pow({a:1}.a, 2)", "foo\n;({a:1}.a**2)"),
+			invalidFixed("foo\nMath.pow((a).b, c)", "foo\n;(a).b**c"),
+			invalidFixed("foo\nMath.pow([a, b].find(fn), c)", "foo\n;[a, b].find(fn)**c"),
+			invalidFixed("foo\nMath.pow(/regex/, 2)", "foo\n;/regex/**2"),
+			invalidFixed("foo\nMath.pow(`template literal`, 2)", "foo\n;`template literal`**2"),
+
+			// ---- preceding semicolon not needed ----
+			invalidFixed("foo\n100 + Math.pow((a).b, c)", "foo\n100 + (a).b**c"),
+			invalidFixed("foo\nMath.pow(a.b, c)", "foo\na.b**c"),
+			invalidFixed("Math.pow((a).b, c)", "(a).b**c"),
+			invalidFixed("foo;\nMath.pow((a).b, c)", "foo;\n(a).b**c"),
+			invalidFixed("if (foo) {}\nMath.pow((a).b, c)", "if (foo) {}\n(a).b**c"),
+		},
+	)
+}
+
+func invalidFixed(code string, output string) rule_tester.InvalidTestCase {
+	return invalidWithOutputs(code, output)
+}
+
+func invalidNoFix(code string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:   code,
+		Errors: expectedFirstCallError(code),
+	}
+}
+
+func invalidWithOutputs(code string, outputs ...string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:   code,
+		Output: outputs,
+		Errors: expectedErrors(code),
+	}
+}
+
+func expectedErrors(code string) []rule_tester.InvalidTestCaseError {
+	opts := ast.SourceFileParseOptions{
+		FileName: "/tmp/prefer_exponentiation_operator.ts",
+		Path:     tspath.Path("/tmp/prefer_exponentiation_operator.ts"),
+	}
+	sf := parser.ParseSourceFile(opts, code, core.ScriptKindTS)
+	var errors []rule_tester.InvalidTestCaseError
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node.Kind == ast.KindCallExpression && isMathPowCall(node) {
+			rng := utils.TrimNodeTextRange(sf, node)
+			line, column := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, rng.Pos())
+			endLine, endColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, rng.End())
+			errors = append(errors, rule_tester.InvalidTestCaseError{
+				MessageId: "useExponentiation",
+				Message:   messageUseExponentiation,
+				Line:      line + 1,
+				Column:    int(column) + 1,
+				EndLine:   endLine + 1,
+				EndColumn: int(endColumn) + 1,
+			})
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(sf.AsNode())
+	return errors
+}
+
+func expectedFirstCallError(code string) []rule_tester.InvalidTestCaseError {
+	opts := ast.SourceFileParseOptions{
+		FileName: "/tmp/prefer_exponentiation_operator.ts",
+		Path:     tspath.Path("/tmp/prefer_exponentiation_operator.ts"),
+	}
+	sf := parser.ParseSourceFile(opts, code, core.ScriptKindTS)
+
+	var callNode *ast.Node
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil || callNode != nil {
+			return
+		}
+		if node.Kind == ast.KindCallExpression {
+			callNode = node
+			return
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return callNode != nil
+		})
+	}
+	walk(sf.AsNode())
+	if callNode == nil {
+		return nil
+	}
+
+	rng := utils.TrimNodeTextRange(sf, callNode)
+	line, column := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, rng.Pos())
+	endLine, endColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, rng.End())
+	return []rule_tester.InvalidTestCaseError{{
+		MessageId: "useExponentiation",
+		Message:   messageUseExponentiation,
+		Line:      line + 1,
+		Column:    int(column) + 1,
+		EndLine:   endLine + 1,
+		EndColumn: int(endColumn) + 1,
+	}}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -112,6 +112,7 @@ export default defineConfig({
     './tests/eslint/rules/one-var.test.ts',
     './tests/eslint/rules/prefer-arrow-callback.test.ts',
     './tests/eslint/rules/prefer-const.test.ts',
+    './tests/eslint/rules/prefer-exponentiation-operator.test.ts',
     './tests/eslint/rules/no-this-before-super.test.ts',
     './tests/eslint/rules/prefer-rest-params.test.ts',
     './tests/eslint/rules/prefer-spread.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-exponentiation-operator.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-exponentiation-operator.test.ts.snap
@@ -1,0 +1,4502 @@
+// Rstest Snapshot v1
+
+exports[`prefer-exponentiation-operator > invalid 1`] = `
+{
+  "code": "Math.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 2`] = `
+{
+  "code": "(Math).pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 3`] = `
+{
+  "code": "Math['pow'](a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 4`] = `
+{
+  "code": "(Math)['pow'](a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 5`] = `
+{
+  "code": "var x=Math
+.  pow( a, 
+ b )",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 6`] = `
+{
+  "code": "globalThis.Math.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 7`] = `
+{
+  "code": "globalThis.Math['pow'](a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 8`] = `
+{
+  "code": "Math[\`pow\`](a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 9`] = `
+{
+  "code": "Math[\`\${'pow'}\`](a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 10`] = `
+{
+  "code": "Math['p' + 'o' + 'w'](a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 11`] = `
+{
+  "code": "var x = Math.pow(a, b);",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 12`] = `
+{
+  "code": "if(Math.pow(a, b)){}",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 13`] = `
+{
+  "code": "for(;Math.pow(a, b);){}",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 14`] = `
+{
+  "code": "switch(foo){ case Math.pow(a, b): break; }",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 15`] = `
+{
+  "code": "{ foo: Math.pow(a, b) }",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 16`] = `
+{
+  "code": "function foo(bar, baz = Math.pow(a, b), quux){}",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 17`] = `
+{
+  "code": "\`\${Math.pow(a, b)}\`",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 18`] = `
+{
+  "code": "class C extends Math.pow(a, b) {}",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 19`] = `
+{
+  "code": "+ Math.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 20`] = `
+{
+  "code": "- Math.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 21`] = `
+{
+  "code": "! Math.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 22`] = `
+{
+  "code": "typeof Math.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 23`] = `
+{
+  "code": "void Math.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 24`] = `
+{
+  "code": "Math.pow(a, b) .toString()",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 25`] = `
+{
+  "code": "Math.pow(a, b) ()",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 26`] = `
+{
+  "code": "Math.pow(a, b) \`\`",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 27`] = `
+{
+  "code": "(class extends Math.pow(a, b) {})",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 28`] = `
+{
+  "code": "+(Math.pow(a, b))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 29`] = `
+{
+  "code": "(Math.pow(a, b)).toString()",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 30`] = `
+{
+  "code": "(class extends (Math.pow(a, b)) {})",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 31`] = `
+{
+  "code": "class C extends (Math.pow(a, b)) {}",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 32`] = `
+{
+  "code": "f(Math.pow(a, b))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 33`] = `
+{
+  "code": "f(foo, Math.pow(a, b))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 34`] = `
+{
+  "code": "f(Math.pow(a, b), foo)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 35`] = `
+{
+  "code": "f(foo, Math.pow(a, b), bar)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 36`] = `
+{
+  "code": "new F(Math.pow(a, b))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 37`] = `
+{
+  "code": "new F(foo, Math.pow(a, b))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 38`] = `
+{
+  "code": "new F(Math.pow(a, b), foo)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 39`] = `
+{
+  "code": "new F(foo, Math.pow(a, b), bar)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 40`] = `
+{
+  "code": "obj[Math.pow(a, b)]",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 41`] = `
+{
+  "code": "[foo, Math.pow(a, b), bar]",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 42`] = `
+{
+  "code": "a * Math.pow(b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 43`] = `
+{
+  "code": "Math.pow(a, b) * c",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 44`] = `
+{
+  "code": "a + Math.pow(b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 45`] = `
+{
+  "code": "Math.pow(a, b)/c",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 46`] = `
+{
+  "code": "a < Math.pow(b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 47`] = `
+{
+  "code": "Math.pow(a, b) > c",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 48`] = `
+{
+  "code": "a === Math.pow(b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 49`] = `
+{
+  "code": "a ? Math.pow(b, c) : d",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 50`] = `
+{
+  "code": "a = Math.pow(b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 51`] = `
+{
+  "code": "a += Math.pow(b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 52`] = `
+{
+  "code": "function *f() { yield Math.pow(a, b) }",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 53`] = `
+{
+  "code": "a, Math.pow(b, c), d",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 54`] = `
+{
+  "code": "a ** Math.pow(b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 55`] = `
+{
+  "code": "Math.pow(a, b) ** c",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 56`] = `
+{
+  "code": "Math.pow(a, b ** c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 57`] = `
+{
+  "code": "Math.pow(a ** b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 58`] = `
+{
+  "code": "a ** Math.pow(b ** c, d ** e) ** f",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 59`] = `
+{
+  "code": "(Math.pow(a, b))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 60`] = `
+{
+  "code": "foo + (Math.pow(a, b))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 61`] = `
+{
+  "code": "(Math.pow(a, b)) + foo",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 62`] = `
+{
+  "code": "\`\${(Math.pow(a, b))}\`",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 63`] = `
+{
+  "code": "Math.pow(2, 3)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 64`] = `
+{
+  "code": "Math.pow(a.foo, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 65`] = `
+{
+  "code": "Math.pow(a, b.foo)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 66`] = `
+{
+  "code": "Math.pow(a(), b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 67`] = `
+{
+  "code": "Math.pow(a, b())",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 68`] = `
+{
+  "code": "Math.pow(++a, ++b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 69`] = `
+{
+  "code": "Math.pow(a++, ++b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 70`] = `
+{
+  "code": "Math.pow(a--, b--)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 71`] = `
+{
+  "code": "Math.pow(--a, b--)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 72`] = `
+{
+  "code": "Math.pow((a), (b))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 73`] = `
+{
+  "code": "Math.pow(((a)), ((b)))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 74`] = `
+{
+  "code": "Math.pow((a.foo), b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 75`] = `
+{
+  "code": "Math.pow(a, (b.foo))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 76`] = `
+{
+  "code": "Math.pow((a()), b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 77`] = `
+{
+  "code": "Math.pow(a, (b()))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 78`] = `
+{
+  "code": "Math.pow(+a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 79`] = `
+{
+  "code": "Math.pow(a, +b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 80`] = `
+{
+  "code": "Math.pow(-a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 81`] = `
+{
+  "code": "Math.pow(a, -b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 82`] = `
+{
+  "code": "Math.pow(-2, 3)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 83`] = `
+{
+  "code": "Math.pow(2, -3)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 84`] = `
+{
+  "code": "async () => Math.pow(await a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 85`] = `
+{
+  "code": "async () => Math.pow(a, await b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 86`] = `
+{
+  "code": "Math.pow(a * b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 87`] = `
+{
+  "code": "Math.pow(a, b * c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 88`] = `
+{
+  "code": "Math.pow(a / b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 89`] = `
+{
+  "code": "Math.pow(a, b / c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 90`] = `
+{
+  "code": "Math.pow(a + b, 3)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 91`] = `
+{
+  "code": "Math.pow(2, a - b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 92`] = `
+{
+  "code": "Math.pow(a + b, c + d)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 93`] = `
+{
+  "code": "Math.pow(a = b, c = d)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 94`] = `
+{
+  "code": "Math.pow(a += b, c -= d)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 95`] = `
+{
+  "code": "Math.pow((a, b), (c, d))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 96`] = `
+{
+  "code": "function *f() { Math.pow(yield, yield) }",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 97`] = `
+{
+  "code": "Math.pow((a + b), (c + d))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 98`] = `
+{
+  "code": "a+Math.pow(b, c)+d",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 99`] = `
+{
+  "code": "a+Math.pow(++b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 100`] = `
+{
+  "code": "(a)+(Math).pow((++b), c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 101`] = `
+{
+  "code": "Math.pow(a, b)in c",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 102`] = `
+{
+  "code": "Math.pow(a, (b))in (c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 103`] = `
+{
+  "code": "a+Math.pow(++b, c)in d",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 104`] = `
+{
+  "code": "a+Math.pow( ++b, c )in d",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 105`] = `
+{
+  "code": "a+ Math.pow(++b, c) in d",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 106`] = `
+{
+  "code": "a+/**/Math.pow(++b, c)/**/in d",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 107`] = `
+{
+  "code": "a+(Math.pow(++b, c))in d",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 108`] = `
+{
+  "code": "+Math.pow(++a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 109`] = `
+{
+  "code": "Math.pow(a, b + c)in d",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 110`] = `
+{
+  "code": "Math.pow(a, b) + Math.pow(c,
+ d)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 2,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 111`] = `
+{
+  "code": "Math.pow(Math.pow(a, b), Math.pow(c, d))",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 112`] = `
+{
+  "code": "Math.pow(a, b)**Math.pow(c, d)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 113`] = `
+{
+  "code": "Math.pow()",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 114`] = `
+{
+  "code": "Math.pow(a)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 115`] = `
+{
+  "code": "Math.pow(a, b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 116`] = `
+{
+  "code": "Math.pow(a, b, c, d)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 117`] = `
+{
+  "code": "Math.pow(...a)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 118`] = `
+{
+  "code": "Math.pow(...a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 119`] = `
+{
+  "code": "Math.pow(a, ...b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 120`] = `
+{
+  "code": "Math.pow(a, b, ...c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 121`] = `
+{
+  "code": "/* comment */Math.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 122`] = `
+{
+  "code": "Math/**/.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 123`] = `
+{
+  "code": "Math//
+.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 124`] = `
+{
+  "code": "Math[//
+'pow'](a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 125`] = `
+{
+  "code": "Math['pow'/**/](a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 126`] = `
+{
+  "code": "Math./**/pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 127`] = `
+{
+  "code": "Math.pow/**/(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 128`] = `
+{
+  "code": "Math.pow//
+(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 129`] = `
+{
+  "code": "Math.pow(/**/a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 130`] = `
+{
+  "code": "Math.pow(a,//
+ b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 131`] = `
+{
+  "code": "Math.pow(a, b/**/)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 132`] = `
+{
+  "code": "Math.pow(a, b//
+)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 133`] = `
+{
+  "code": "Math.pow(a, b)/* comment */;",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 134`] = `
+{
+  "code": "Math.pow(a, b)// comment
+;",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 135`] = `
+{
+  "code": "Math.pow?.(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 136`] = `
+{
+  "code": "Math?.pow(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 137`] = `
+{
+  "code": "Math?.pow?.(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 138`] = `
+{
+  "code": "(Math?.pow)(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 139`] = `
+{
+  "code": "(Math?.pow)?.(a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 140`] = `
+{
+  "code": "Math.pow(a, b as any)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 141`] = `
+{
+  "code": "Math.pow(a as any, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 142`] = `
+{
+  "code": "Math.pow(a, b) as any",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 143`] = `
+{
+  "code": "Math.pow({a:1}.a, 2);",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 144`] = `
+{
+  "code": "Math.pow({a:1}.a, 2) + 100;",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 145`] = `
+{
+  "code": "(Math.pow({a:1}.a, 2));",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 146`] = `
+{
+  "code": "100 + Math.pow({a:1}.a, 2);",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 147`] = `
+{
+  "code": "Math.pow({a:1}.a + 100, 2);",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 148`] = `
+{
+  "code": "Math.pow(function(){return 2}(), 3);",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 149`] = `
+{
+  "code": "Math.pow(function(){return 2}(), 3) + 100;",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 150`] = `
+{
+  "code": "(Math.pow(function(){return 2}(), 3));",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 151`] = `
+{
+  "code": "100 + Math.pow(function(){return 2}(), 3);",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 152`] = `
+{
+  "code": "Math.pow(function(){return 2}() + 100, 3);",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 153`] = `
+{
+  "code": "Math.pow(class{static x=2}.x, 4);",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 154`] = `
+{
+  "code": "Math.pow(class{static x=2}.x, 4) + 100;",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 155`] = `
+{
+  "code": "(Math.pow(class{static x=2}.x, 4));",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 156`] = `
+{
+  "code": "100 + Math.pow(class{static x=2}.x, 4);",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 157`] = `
+{
+  "code": "Math.pow(class{static x=2}.x + 100, 4);",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 158`] = `
+{
+  "code": "foo
+Math.pow(a + b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 159`] = `
+{
+  "code": "foo
+Math.pow(+a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 160`] = `
+{
+  "code": "foo
+Math.pow(-a, b)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 161`] = `
+{
+  "code": "foo
+Math.pow({a:1}.a, 2)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 162`] = `
+{
+  "code": "foo
+Math.pow((a).b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 163`] = `
+{
+  "code": "foo
+Math.pow([a, b].find(fn), c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 164`] = `
+{
+  "code": "foo
+Math.pow(/regex/, 2)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 165`] = `
+{
+  "code": "foo
+Math.pow(\`template literal\`, 2)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 166`] = `
+{
+  "code": "foo
+100 + Math.pow((a).b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 2,
+        },
+        "start": {
+          "column": 7,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 167`] = `
+{
+  "code": "foo
+Math.pow(a.b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 168`] = `
+{
+  "code": "Math.pow((a).b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 169`] = `
+{
+  "code": "foo;
+Math.pow((a).b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-exponentiation-operator > invalid 170`] = `
+{
+  "code": "if (foo) {}
+Math.pow((a).b, c)",
+  "diagnostics": [
+    {
+      "message": "Use the '**' operator instead of 'Math.pow'.",
+      "messageId": "useExponentiation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "prefer-exponentiation-operator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/prefer-exponentiation-operator.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/prefer-exponentiation-operator.test.ts
@@ -1,0 +1,272 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const invalid = (code: string, count = 1) => ({
+  code,
+  errors: Array.from({ length: count }, () => ({
+    messageId: 'useExponentiation',
+  })),
+});
+
+ruleTester.run('prefer-exponentiation-operator', {
+  valid: [
+    // not Math.pow()
+    'Object.pow(a, b)',
+    'Math.max(a, b)',
+    'Math',
+    'Math(a, b)',
+    'pow',
+    'pow(a, b)',
+    'Math.pow',
+    'Math.Pow(a, b)',
+    'math.pow(a, b)',
+    'foo.Math.pow(a, b)',
+    'new Math.pow(a, b)',
+    'Math[pow](a, b)',
+    'globalThis.Object.pow(a, b)',
+    'globalThis.Math.max(a, b)',
+
+    // not the global Math
+    {
+      code: '/* globals Math:off*/ Math.pow(a, b)',
+      skip: true,
+    },
+    'let Math; Math.pow(a, b);',
+    'if (foo) { const Math = 1; Math.pow(a, b); }',
+    'var x = function Math() { Math.pow(a, b); }',
+    'function foo(Math) { Math.pow(a, b); }',
+    'function foo() { Math.pow(a, b); var Math; }',
+    // Mirrors upstream ecmaVersion 2019 / 6 / 2017 cases; rslint does not expose ecmaVersion-specific globalThis availability.
+    {
+      code: 'globalThis.Math.pow(a, b)',
+      skip: true,
+    },
+    {
+      code: 'globalThis.Math.pow(a, b)',
+      skip: true,
+    },
+    {
+      code: 'globalThis.Math.pow(a, b)',
+      skip: true,
+    },
+    `
+      var globalThis = bar;
+      globalThis.Math.pow(a, b)
+    `,
+    'class C { #pow; foo() { Math.#pow(a, b); } }',
+  ],
+  invalid: [
+    invalid('Math.pow(a, b)'),
+    invalid('(Math).pow(a, b)'),
+    invalid("Math['pow'](a, b)"),
+    invalid("(Math)['pow'](a, b)"),
+    invalid('var x=Math\n.  pow( a, \n b )'),
+    invalid('globalThis.Math.pow(a, b)'),
+    invalid("globalThis.Math['pow'](a, b)"),
+
+    // able to catch some workarounds
+    invalid('Math[`pow`](a, b)'),
+    invalid("Math[`${'pow'}`](a, b)"),
+    invalid("Math['p' + 'o' + 'w'](a, b)"),
+
+    // non-expression parents that don't require parens
+    invalid('var x = Math.pow(a, b);'),
+    invalid('if(Math.pow(a, b)){}'),
+    invalid('for(;Math.pow(a, b);){}'),
+    invalid('switch(foo){ case Math.pow(a, b): break; }'),
+    invalid('{ foo: Math.pow(a, b) }'),
+    invalid('function foo(bar, baz = Math.pow(a, b), quux){}'),
+    invalid('`${Math.pow(a, b)}`'),
+
+    // non-expression parents that do require parens
+    invalid('class C extends Math.pow(a, b) {}'),
+
+    // parents with a higher precedence
+    invalid('+ Math.pow(a, b)'),
+    invalid('- Math.pow(a, b)'),
+    invalid('! Math.pow(a, b)'),
+    invalid('typeof Math.pow(a, b)'),
+    invalid('void Math.pow(a, b)'),
+    invalid('Math.pow(a, b) .toString()'),
+    invalid('Math.pow(a, b) ()'),
+    invalid('Math.pow(a, b) ``'),
+    invalid('(class extends Math.pow(a, b) {})'),
+
+    // already parenthesised, shouldn't insert extra parens
+    invalid('+(Math.pow(a, b))'),
+    invalid('(Math.pow(a, b)).toString()'),
+    invalid('(class extends (Math.pow(a, b)) {})'),
+    invalid('class C extends (Math.pow(a, b)) {}'),
+
+    // parents with a higher precedence, but the expression's role doesn't require parens
+    invalid('f(Math.pow(a, b))'),
+    invalid('f(foo, Math.pow(a, b))'),
+    invalid('f(Math.pow(a, b), foo)'),
+    invalid('f(foo, Math.pow(a, b), bar)'),
+    invalid('new F(Math.pow(a, b))'),
+    invalid('new F(foo, Math.pow(a, b))'),
+    invalid('new F(Math.pow(a, b), foo)'),
+    invalid('new F(foo, Math.pow(a, b), bar)'),
+    invalid('obj[Math.pow(a, b)]'),
+    invalid('[foo, Math.pow(a, b), bar]'),
+
+    // parents with a lower precedence
+    invalid('a * Math.pow(b, c)'),
+    invalid('Math.pow(a, b) * c'),
+    invalid('a + Math.pow(b, c)'),
+    invalid('Math.pow(a, b)/c'),
+    invalid('a < Math.pow(b, c)'),
+    invalid('Math.pow(a, b) > c'),
+    invalid('a === Math.pow(b, c)'),
+    invalid('a ? Math.pow(b, c) : d'),
+    invalid('a = Math.pow(b, c)'),
+    invalid('a += Math.pow(b, c)'),
+    invalid('function *f() { yield Math.pow(a, b) }'),
+    invalid('a, Math.pow(b, c), d'),
+
+    // '**' is right-associative, that applies to both parent and child nodes
+    invalid('a ** Math.pow(b, c)'),
+    invalid('Math.pow(a, b) ** c'),
+    invalid('Math.pow(a, b ** c)'),
+    invalid('Math.pow(a ** b, c)'),
+    invalid('a ** Math.pow(b ** c, d ** e) ** f'),
+
+    // doesn't remove already existing unnecessary parens around the whole expression
+    invalid('(Math.pow(a, b))'),
+    invalid('foo + (Math.pow(a, b))'),
+    invalid('(Math.pow(a, b)) + foo'),
+    invalid('`${(Math.pow(a, b))}`'),
+
+    // base and exponent with a higher precedence
+    invalid('Math.pow(2, 3)'),
+    invalid('Math.pow(a.foo, b)'),
+    invalid('Math.pow(a, b.foo)'),
+    invalid('Math.pow(a(), b)'),
+    invalid('Math.pow(a, b())'),
+    invalid('Math.pow(++a, ++b)'),
+    invalid('Math.pow(a++, ++b)'),
+    invalid('Math.pow(a--, b--)'),
+    invalid('Math.pow(--a, b--)'),
+
+    // doesn't preserve unnecessary parens around base and exponent
+    invalid('Math.pow((a), (b))'),
+    invalid('Math.pow(((a)), ((b)))'),
+    invalid('Math.pow((a.foo), b)'),
+    invalid('Math.pow(a, (b.foo))'),
+    invalid('Math.pow((a()), b)'),
+    invalid('Math.pow(a, (b()))'),
+
+    // unary expressions are exception by the language
+    invalid('Math.pow(+a, b)'),
+    invalid('Math.pow(a, +b)'),
+    invalid('Math.pow(-a, b)'),
+    invalid('Math.pow(a, -b)'),
+    invalid('Math.pow(-2, 3)'),
+    invalid('Math.pow(2, -3)'),
+    invalid('async () => Math.pow(await a, b)'),
+    invalid('async () => Math.pow(a, await b)'),
+
+    // base and exponent with a lower precedence
+    invalid('Math.pow(a * b, c)'),
+    invalid('Math.pow(a, b * c)'),
+    invalid('Math.pow(a / b, c)'),
+    invalid('Math.pow(a, b / c)'),
+    invalid('Math.pow(a + b, 3)'),
+    invalid('Math.pow(2, a - b)'),
+    invalid('Math.pow(a + b, c + d)'),
+    invalid('Math.pow(a = b, c = d)'),
+    invalid('Math.pow(a += b, c -= d)'),
+    invalid('Math.pow((a, b), (c, d))'),
+    invalid('function *f() { Math.pow(yield, yield) }'),
+    invalid('Math.pow((a + b), (c + d))'),
+
+    // token adjacency
+    invalid('a+Math.pow(b, c)+d'),
+    invalid('a+Math.pow(++b, c)'),
+    invalid('(a)+(Math).pow((++b), c)'),
+    invalid('Math.pow(a, b)in c'),
+    invalid('Math.pow(a, (b))in (c)'),
+    invalid('a+Math.pow(++b, c)in d'),
+    invalid('a+Math.pow( ++b, c )in d'),
+    invalid('a+ Math.pow(++b, c) in d'),
+    invalid('a+/**/Math.pow(++b, c)/**/in d'),
+    invalid('a+(Math.pow(++b, c))in d'),
+    invalid('+Math.pow(++a, b)'),
+    invalid('Math.pow(a, b + c)in d'),
+
+    invalid('Math.pow(a, b) + Math.pow(c,\n d)', 2),
+    invalid('Math.pow(Math.pow(a, b), Math.pow(c, d))', 3),
+    invalid('Math.pow(a, b)**Math.pow(c, d)', 2),
+
+    // no autofix branches still report
+    invalid('Math.pow()'),
+    invalid('Math.pow(a)'),
+    invalid('Math.pow(a, b, c)'),
+    invalid('Math.pow(a, b, c, d)'),
+    invalid('Math.pow(...a)'),
+    invalid('Math.pow(...a, b)'),
+    invalid('Math.pow(a, ...b)'),
+    invalid('Math.pow(a, b, ...c)'),
+
+    // comments
+    invalid('/* comment */Math.pow(a, b)'),
+    invalid('Math/**/.pow(a, b)'),
+    invalid('Math//\n.pow(a, b)'),
+    invalid("Math[//\n'pow'](a, b)"),
+    invalid("Math['pow'/**/](a, b)"),
+    invalid('Math./**/pow(a, b)'),
+    invalid('Math.pow/**/(a, b)'),
+    invalid('Math.pow//\n(a, b)'),
+    invalid('Math.pow(/**/a, b)'),
+    invalid('Math.pow(a,//\n b)'),
+    invalid('Math.pow(a, b/**/)'),
+    invalid('Math.pow(a, b//\n)'),
+    invalid('Math.pow(a, b)/* comment */;'),
+    invalid('Math.pow(a, b)// comment\n;'),
+
+    // Optional chaining
+    invalid('Math.pow?.(a, b)'),
+    invalid('Math?.pow(a, b)'),
+    invalid('Math?.pow?.(a, b)'),
+    invalid('(Math?.pow)(a, b)'),
+    invalid('(Math?.pow)?.(a, b)'),
+
+    // https://github.com/eslint/eslint/issues/17173
+    invalid('Math.pow(a, b as any)'),
+    invalid('Math.pow(a as any, b)'),
+    invalid('Math.pow(a, b) as any'),
+
+    // https://github.com/eslint/eslint/issues/20987
+    invalid('Math.pow({a:1}.a, 2);'),
+    invalid('Math.pow({a:1}.a, 2) + 100;'),
+    invalid('(Math.pow({a:1}.a, 2));'),
+    invalid('100 + Math.pow({a:1}.a, 2);'),
+    invalid('Math.pow({a:1}.a + 100, 2);'),
+    invalid('Math.pow(function(){return 2}(), 3);'),
+    invalid('Math.pow(function(){return 2}(), 3) + 100;'),
+    invalid('(Math.pow(function(){return 2}(), 3));'),
+    invalid('100 + Math.pow(function(){return 2}(), 3);'),
+    invalid('Math.pow(function(){return 2}() + 100, 3);'),
+    invalid('Math.pow(class{static x=2}.x, 4);'),
+    invalid('Math.pow(class{static x=2}.x, 4) + 100;'),
+    invalid('(Math.pow(class{static x=2}.x, 4));'),
+    invalid('100 + Math.pow(class{static x=2}.x, 4);'),
+    invalid('Math.pow(class{static x=2}.x + 100, 4);'),
+
+    // preceding semicolon
+    invalid('foo\nMath.pow(a + b, c)'),
+    invalid('foo\nMath.pow(+a, b)'),
+    invalid('foo\nMath.pow(-a, b)'),
+    invalid('foo\nMath.pow({a:1}.a, 2)'),
+    invalid('foo\nMath.pow((a).b, c)'),
+    invalid('foo\nMath.pow([a, b].find(fn), c)'),
+    invalid('foo\nMath.pow(/regex/, 2)'),
+    invalid('foo\nMath.pow(`template literal`, 2)'),
+    invalid('foo\n100 + Math.pow((a).b, c)'),
+    invalid('foo\nMath.pow(a.b, c)'),
+    invalid('Math.pow((a).b, c)'),
+    invalid('foo;\nMath.pow((a).b, c)'),
+    invalid('if (foo) {}\nMath.pow((a).b, c)'),
+  ],
+});


### PR DESCRIPTION
## Summary

Port the ESLint core `prefer-exponentiation-operator` rule to rslint.

Adds the Go rule implementation, documentation, upstream parity coverage, extra edge-case coverage, JS integration coverage, and rule registration.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/prefer-exponentiation-operator
- ESLint source: https://github.com/eslint/eslint/blob/main/lib/rules/prefer-exponentiation-operator.js
- ESLint tests: https://github.com/eslint/eslint/blob/main/tests/lib/rules/prefer-exponentiation-operator.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).