### PR TITLE
feat: port rule no-else-return

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -41,6 +41,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_keys"
 	"github.com/web-infra-dev/rslint/internal/rules/no_duplicate_case"
 	"github.com/web-infra-dev/rslint/internal/rules/no_duplicate_imports"
+	"github.com/web-infra-dev/rslint/internal/rules/no_else_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_character_class"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_pattern"
@@ -174,6 +175,7 @@ func GetAllRules() []rule.Rule {
 		no_dupe_keys.NoDupeKeysRule,
 		no_duplicate_case.NoDuplicateCaseRule,
 		no_duplicate_imports.NoDuplicateImportsRule,
+		no_else_return.NoElseReturnRule,
 		no_empty.NoEmptyRule,
 		no_empty_pattern.NoEmptyPatternRule,
 		no_eval.NoEvalRule,

--- a/internal/rules/no_else_return/no_else_return.go
+++ b/internal/rules/no_else_return/no_else_return.go
@@ -1,0 +1,548 @@
+package no_else_return
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type options struct {
+	allowElseIf bool
+}
+
+func parseOptions(ruleOptions any) options {
+	opts := options{allowElseIf: true}
+	optsMap := utils.GetOptionsMap(ruleOptions)
+	if optsMap == nil {
+		return opts
+	}
+	if allowElseIf, ok := optsMap["allowElseIf"].(bool); ok {
+		opts.allowElseIf = allowElseIf
+	}
+	return opts
+}
+
+var unexpectedMessage = rule.RuleMessage{
+	Id:          "unexpected",
+	Description: "Unnecessary 'else' after 'return'.",
+}
+
+type tokenInfo struct {
+	kind       ast.Kind
+	start, end int
+	text       string
+}
+
+// https://eslint.org/docs/latest/rules/no-else-return
+var NoElseReturnRule = rule.Rule{
+	Name: "no-else-return",
+	Run: func(ctx rule.RuleContext, ruleOptions any) rule.RuleListeners {
+		opts := parseOptions(ruleOptions)
+		check := checkIfWithoutElse
+		if !opts.allowElseIf {
+			check = checkIfWithElse
+		}
+
+		return rule.RuleListeners{
+			rule.ListenerOnExit(ast.KindIfStatement): func(node *ast.Node) {
+				check(ctx, node)
+			},
+		}
+	},
+}
+
+func checkForReturn(node *ast.Node) bool {
+	return node != nil && node.Kind == ast.KindReturnStatement
+}
+
+func naiveHasReturn(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindBlock {
+		block := node.AsBlock()
+		if block == nil || block.Statements == nil || len(block.Statements.Nodes) == 0 {
+			return false
+		}
+		return checkForReturn(block.Statements.Nodes[len(block.Statements.Nodes)-1])
+	}
+	return checkForReturn(node)
+}
+
+func hasElse(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindIfStatement {
+		return false
+	}
+	ifStmt := node.AsIfStatement()
+	return ifStmt != nil && ifStmt.ThenStatement != nil && ifStmt.ElseStatement != nil
+}
+
+func checkForIf(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindIfStatement || !hasElse(node) {
+		return false
+	}
+	ifStmt := node.AsIfStatement()
+	return naiveHasReturn(ifStmt.ThenStatement) && naiveHasReturn(ifStmt.ElseStatement)
+}
+
+func checkForReturnOrIf(node *ast.Node) bool {
+	return checkForReturn(node) || checkForIf(node)
+}
+
+func alwaysReturns(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindBlock {
+		block := node.AsBlock()
+		if block == nil || block.Statements == nil {
+			return false
+		}
+		for _, stmt := range block.Statements.Nodes {
+			if checkForReturnOrIf(stmt) {
+				return true
+			}
+		}
+		return false
+	}
+	return checkForReturnOrIf(node)
+}
+
+func checkIfWithoutElse(ctx rule.RuleContext, node *ast.Node) {
+	if !isStatementListParent(node.Parent) {
+		return
+	}
+
+	consequents := []*ast.Node{}
+	var alternate *ast.Node
+	for current := node; current != nil && current.Kind == ast.KindIfStatement; {
+		ifStmt := current.AsIfStatement()
+		if ifStmt == nil || ifStmt.ElseStatement == nil {
+			return
+		}
+		consequents = append(consequents, ifStmt.ThenStatement)
+		alternate = ifStmt.ElseStatement
+		current = ifStmt.ElseStatement
+	}
+
+	for _, consequent := range consequents {
+		if !alwaysReturns(consequent) {
+			return
+		}
+	}
+	displayReport(ctx, alternate)
+}
+
+func checkIfWithElse(ctx rule.RuleContext, node *ast.Node) {
+	if !isStatementListParent(node.Parent) {
+		return
+	}
+	ifStmt := node.AsIfStatement()
+	if ifStmt == nil || ifStmt.ElseStatement == nil {
+		return
+	}
+	if alwaysReturns(ifStmt.ThenStatement) {
+		displayReport(ctx, ifStmt.ElseStatement)
+	}
+}
+
+func displayReport(ctx rule.RuleContext, elseNode *ast.Node) {
+	if fixes := buildFixes(ctx, elseNode); len(fixes) > 0 {
+		ctx.ReportNodeWithFixes(elseNode, unexpectedMessage, fixes...)
+		return
+	}
+	ctx.ReportNode(elseNode, unexpectedMessage)
+}
+
+func isStatementListParent(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindSourceFile, ast.KindBlock, ast.KindModuleBlock,
+		ast.KindCaseClause, ast.KindDefaultClause, ast.KindClassStaticBlockDeclaration:
+		return true
+	}
+	return false
+}
+
+func buildFixes(ctx rule.RuleContext, elseNode *ast.Node) []rule.RuleFix {
+	if elseNode == nil || elseNode.Parent == nil || !isSafeFromNameCollisions(elseNode) {
+		return nil
+	}
+
+	sf := ctx.SourceFile
+	text := sf.Text()
+	elseStart := findElseKeywordStart(sf, elseNode.Parent, elseNode)
+	if elseStart < 0 {
+		return nil
+	}
+
+	startToken, ok := tokenAtOrAfter(sf, utils.TrimNodeTextRange(sf, elseNode).Pos())
+	if !ok {
+		return nil
+	}
+	firstTokenOfElseBlock := startToken
+	if startToken.text == "{" {
+		var found bool
+		firstTokenOfElseBlock, found = tokenAtOrAfter(sf, startToken.end)
+		if !found {
+			return nil
+		}
+	}
+
+	lastIfToken, ok := previousTokenBefore(sf, elseNode.Parent, elseStart)
+	if !ok {
+		return nil
+	}
+
+	ifStmt := elseNode.Parent.AsIfStatement()
+	if ifStmt == nil || ifStmt.ThenStatement == nil {
+		return nil
+	}
+
+	ifBlockMaybeUnsafe := ifStmt.ThenStatement.Kind != ast.KindBlock && lastIfToken.text != ";"
+	elseBlockUnsafe := startsUnsafeForASI(firstTokenOfElseBlock.text)
+	if ifBlockMaybeUnsafe && elseBlockUnsafe {
+		return nil
+	}
+
+	elseTokens := tokensOf(sf, elseNode)
+	if len(elseTokens) == 0 {
+		return nil
+	}
+	endToken := elseTokens[len(elseTokens)-1]
+	lastTokenOfElseBlock := endToken
+	if len(elseTokens) > 1 {
+		lastTokenOfElseBlock = elseTokens[len(elseTokens)-2]
+	}
+	if lastTokenOfElseBlock.text != ";" {
+		if nextToken, found := tokenAtOrAfter(sf, endToken.end); found {
+			nextTokenUnsafe := startsUnsafeForASI(nextToken.text)
+			nextTokenOnSameLine := lineOf(sf, nextToken.start) == lineOf(sf, lastTokenOfElseBlock.start)
+			if nextTokenUnsafe || (nextTokenOnSameLine && nextToken.text != "}") {
+				return nil
+			}
+		}
+	}
+
+	fixedSource := utils.TrimmedNodeText(sf, elseNode)
+	if startToken.text == "{" {
+		trimmed := utils.TrimNodeTextRange(sf, elseNode)
+		if trimmed.End()-trimmed.Pos() >= 2 {
+			fixedSource = text[trimmed.Pos()+1 : trimmed.End()-1]
+		}
+	}
+
+	retainStart := enclosingFunctionStart(sf, elseNode)
+	return []rule.RuleFix{
+		rule.RuleFixReplaceRange(core.NewTextRange(retainStart, retainStart), ""),
+		rule.RuleFixReplaceRange(core.NewTextRange(elseStart, elseNode.End()), fixedSource),
+	}
+}
+
+func enclosingFunctionStart(sf *ast.SourceFile, node *ast.Node) int {
+	for current := node.Parent; current != nil; current = current.Parent {
+		if ast.IsFunctionLikeDeclaration(current) || current.Kind == ast.KindClassStaticBlockDeclaration {
+			return utils.TrimNodeTextRange(sf, current).Pos()
+		}
+	}
+	return 0
+}
+
+func startsUnsafeForASI(text string) bool {
+	return strings.HasPrefix(text, "(") ||
+		strings.HasPrefix(text, "[") ||
+		strings.HasPrefix(text, "/") ||
+		strings.HasPrefix(text, "+") ||
+		strings.HasPrefix(text, "`") ||
+		strings.HasPrefix(text, "-")
+}
+
+func lineOf(sf *ast.SourceFile, pos int) int {
+	return scanner.ComputeLineOfPosition(sf.ECMALineMap(), pos)
+}
+
+func tokensOf(sf *ast.SourceFile, node *ast.Node) []tokenInfo {
+	tokens := []tokenInfo{}
+	sourceText := sf.Text()
+	utils.ForEachToken(node, func(token *ast.Node) {
+		trimmed := utils.TrimNodeTextRange(sf, token)
+		if trimmed.Pos() >= trimmed.End() {
+			return
+		}
+		tokens = append(tokens, tokenInfo{
+			kind:  token.Kind,
+			start: trimmed.Pos(),
+			end:   trimmed.End(),
+			text:  sourceText[trimmed.Pos():trimmed.End()],
+		})
+	}, sf)
+	return tokens
+}
+
+func tokenAtOrAfter(sf *ast.SourceFile, pos int) (tokenInfo, bool) {
+	sourceText := sf.Text()
+	start := scanner.SkipTrivia(sourceText, pos)
+	if start >= len(sourceText) {
+		return tokenInfo{}, false
+	}
+	r := scanner.GetRangeOfTokenAtPosition(sf, start)
+	if r.Pos() >= r.End() || r.End() > len(sourceText) {
+		return tokenInfo{}, false
+	}
+	return tokenInfo{
+		kind:  scanner.ScanTokenAtPosition(sf, start),
+		start: r.Pos(),
+		end:   r.End(),
+		text:  sourceText[r.Pos():r.End()],
+	}, true
+}
+
+func findElseKeywordStart(sf *ast.SourceFile, ifNode, elseNode *ast.Node) int {
+	elseNodeStart := utils.TrimNodeTextRange(sf, elseNode).Pos()
+	elseStart := -1
+	for _, token := range tokensOf(sf, ifNode) {
+		if token.kind == ast.KindElseKeyword && token.end <= elseNodeStart {
+			elseStart = token.start
+		}
+	}
+	return elseStart
+}
+
+func previousTokenBefore(sf *ast.SourceFile, node *ast.Node, pos int) (tokenInfo, bool) {
+	var prev tokenInfo
+	found := false
+	for _, token := range tokensOf(sf, node) {
+		if token.start >= pos {
+			break
+		}
+		if token.end <= pos {
+			prev = token
+			found = true
+		}
+	}
+	return prev, found
+}
+
+func isSafeFromNameCollisions(elseNode *ast.Node) bool {
+	if elseNode.Kind == ast.KindFunctionDeclaration {
+		return false
+	}
+	if elseNode.Kind != ast.KindBlock {
+		return true
+	}
+
+	names := directBlockScopedNames(elseNode)
+	if len(names) == 0 {
+		return true
+	}
+
+	target := elseNode.Parent
+	if target != nil {
+		target = target.Parent
+	}
+	if target == nil {
+		return true
+	}
+
+	for name := range names {
+		if hasConflictingDeclaration(target, name) || hasUnsafeReference(target, elseNode, name) {
+			return false
+		}
+	}
+	return true
+}
+
+func directBlockScopedNames(blockNode *ast.Node) map[string]struct{} {
+	names := map[string]struct{}{}
+	block := blockNode.AsBlock()
+	if block == nil || block.Statements == nil {
+		return names
+	}
+	for _, stmt := range block.Statements.Nodes {
+		collectDirectBlockScopedStatementNames(stmt, names)
+	}
+	return names
+}
+
+func collectDirectBlockScopedStatementNames(stmt *ast.Node, names map[string]struct{}) {
+	if stmt == nil {
+		return
+	}
+	switch stmt.Kind {
+	case ast.KindVariableStatement:
+		varStmt := stmt.AsVariableStatement()
+		if varStmt == nil || varStmt.DeclarationList == nil ||
+			varStmt.DeclarationList.Flags&ast.NodeFlagsBlockScoped == 0 {
+			return
+		}
+		declList := varStmt.DeclarationList.AsVariableDeclarationList()
+		if declList == nil || declList.Declarations == nil {
+			return
+		}
+		for _, decl := range declList.Declarations.Nodes {
+			if decl == nil || decl.Kind != ast.KindVariableDeclaration {
+				continue
+			}
+			if name := decl.AsVariableDeclaration().Name(); name != nil {
+				utils.CollectBindingNames(name, func(_ *ast.Node, name string) {
+					names[name] = struct{}{}
+				})
+			}
+		}
+	case ast.KindFunctionDeclaration, ast.KindClassDeclaration, ast.KindEnumDeclaration, ast.KindModuleDeclaration:
+		if name := stmt.Name(); name != nil && name.Kind == ast.KindIdentifier {
+			names[name.Text()] = struct{}{}
+		}
+	}
+}
+
+func hasConflictingDeclaration(target *ast.Node, name string) bool {
+	if hasCatchBindingForTarget(target, name) {
+		return true
+	}
+	if fn := functionOwningBody(target); fn != nil {
+		if hasFunctionNameOrParameter(fn, name) {
+			return true
+		}
+	}
+	if utils.HasHoistedVarDeclaration(target, name) {
+		return true
+	}
+	return hasDirectLexicalDeclaration(target, name)
+}
+
+func hasCatchBindingForTarget(target *ast.Node, name string) bool {
+	if target == nil || target.Kind != ast.KindBlock || target.Parent == nil || target.Parent.Kind != ast.KindCatchClause {
+		return false
+	}
+	catchClause := target.Parent.AsCatchClause()
+	if catchClause == nil || catchClause.Block != target || catchClause.VariableDeclaration == nil {
+		return false
+	}
+	varDecl := catchClause.VariableDeclaration.AsVariableDeclaration()
+	return varDecl != nil && varDecl.Name() != nil && utils.HasNameInBindingPattern(varDecl.Name(), name)
+}
+
+func functionOwningBody(target *ast.Node) *ast.Node {
+	if target == nil || target.Parent == nil {
+		return nil
+	}
+	parent := target.Parent
+	if ast.IsFunctionLikeDeclaration(parent) && parent.Body() == target {
+		return parent
+	}
+	return nil
+}
+
+func hasFunctionNameOrParameter(fn *ast.Node, name string) bool {
+	if fn.Kind == ast.KindFunctionDeclaration || fn.Kind == ast.KindFunctionExpression {
+		if n := fn.Name(); n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+			return true
+		}
+	}
+	return utils.HasShadowingParameter(fn, name)
+}
+
+func hasDirectLexicalDeclaration(target *ast.Node, name string) bool {
+	for _, stmt := range directStatements(target) {
+		if stmt == nil {
+			continue
+		}
+		switch stmt.Kind {
+		case ast.KindVariableStatement:
+			varStmt := stmt.AsVariableStatement()
+			if varStmt == nil || varStmt.DeclarationList == nil ||
+				varStmt.DeclarationList.Flags&ast.NodeFlagsBlockScoped == 0 {
+				continue
+			}
+			if utils.HasVarDeclListWithName(varStmt.DeclarationList, name) {
+				return true
+			}
+		case ast.KindFunctionDeclaration, ast.KindClassDeclaration, ast.KindEnumDeclaration, ast.KindModuleDeclaration:
+			if n := stmt.Name(); n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func directStatements(target *ast.Node) []*ast.Node {
+	if target == nil {
+		return nil
+	}
+	switch target.Kind {
+	case ast.KindSourceFile:
+		if sf := target.AsSourceFile(); sf != nil && sf.Statements != nil {
+			return sf.Statements.Nodes
+		}
+	case ast.KindBlock:
+		if block := target.AsBlock(); block != nil && block.Statements != nil {
+			return block.Statements.Nodes
+		}
+	case ast.KindModuleBlock:
+		if block := target.AsModuleBlock(); block != nil && block.Statements != nil {
+			return block.Statements.Nodes
+		}
+	case ast.KindCaseClause, ast.KindDefaultClause:
+		if clause := target.AsCaseOrDefaultClause(); clause != nil && clause.Statements != nil {
+			return clause.Statements.Nodes
+		}
+	case ast.KindClassStaticBlockDeclaration:
+		staticBlock := target.AsClassStaticBlockDeclaration()
+		if staticBlock != nil && staticBlock.Body != nil {
+			body := staticBlock.Body.AsBlock()
+			if body != nil && body.Statements != nil {
+				return body.Statements.Nodes
+			}
+		}
+	}
+	return nil
+}
+
+func hasUnsafeReference(target, elseNode *ast.Node, name string) bool {
+	found := false
+	var walk func(*ast.Node) bool
+	walk = func(node *ast.Node) bool {
+		if node == nil || node == elseNode {
+			return false
+		}
+		if node.Kind == ast.KindIdentifier && node.Text() == name && isReferenceIdentifier(node) {
+			found = true
+			return true
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			return walk(child)
+		})
+		return found
+	}
+	walk(target)
+	return found
+}
+
+func isReferenceIdentifier(node *ast.Node) bool {
+	if utils.IsDeclarationIdentifier(node) {
+		return false
+	}
+	parent := node.Parent
+	if parent == nil {
+		return true
+	}
+	switch parent.Kind {
+	case ast.KindPropertyAccessExpression:
+		return parent.AsPropertyAccessExpression().Name() != node
+	case ast.KindPropertyAssignment, ast.KindMethodDeclaration,
+		ast.KindGetAccessor, ast.KindSetAccessor, ast.KindPropertyDeclaration,
+		ast.KindEnumMember:
+		return parent.Name() != node
+	case ast.KindLabeledStatement, ast.KindBreakStatement, ast.KindContinueStatement:
+		return false
+	}
+	return true
+}

--- a/internal/rules/no_else_return/no_else_return.go
+++ b/internal/rules/no_else_return/no_else_return.go
@@ -1,11 +1,8 @@
 package no_else_return
 
 import (
-	"strings"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
-	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -29,12 +26,6 @@ func parseOptions(ruleOptions any) options {
 var unexpectedMessage = rule.RuleMessage{
 	Id:          "unexpected",
 	Description: "Unnecessary 'else' after 'return'.",
-}
-
-type tokenInfo struct {
-	kind       ast.Kind
-	start, end int
-	text       string
 }
 
 // https://eslint.org/docs/latest/rules/no-else-return
@@ -182,20 +173,20 @@ func buildFixes(ctx rule.RuleContext, elseNode *ast.Node) []rule.RuleFix {
 		return nil
 	}
 
-	startToken, ok := tokenAtOrAfter(sf, utils.TrimNodeTextRange(sf, elseNode).Pos())
+	startToken, ok := utils.TokenAtOrAfter(sf, utils.TrimNodeTextRange(sf, elseNode).Pos())
 	if !ok {
 		return nil
 	}
 	firstTokenOfElseBlock := startToken
-	if startToken.text == "{" {
+	if startToken.Text == "{" {
 		var found bool
-		firstTokenOfElseBlock, found = tokenAtOrAfter(sf, startToken.end)
+		firstTokenOfElseBlock, found = utils.TokenAtOrAfter(sf, startToken.End)
 		if !found {
 			return nil
 		}
 	}
 
-	lastIfToken, ok := previousTokenBefore(sf, elseNode.Parent, elseStart)
+	lastIfToken, ok := utils.PreviousTokenBefore(sf, elseNode.Parent, elseStart)
 	if !ok {
 		return nil
 	}
@@ -205,13 +196,13 @@ func buildFixes(ctx rule.RuleContext, elseNode *ast.Node) []rule.RuleFix {
 		return nil
 	}
 
-	ifBlockMaybeUnsafe := ifStmt.ThenStatement.Kind != ast.KindBlock && lastIfToken.text != ";"
-	elseBlockUnsafe := startsUnsafeForASI(firstTokenOfElseBlock.text)
+	ifBlockMaybeUnsafe := ifStmt.ThenStatement.Kind != ast.KindBlock && lastIfToken.Text != ";"
+	elseBlockUnsafe := startsUnsafeForASI(firstTokenOfElseBlock.Text)
 	if ifBlockMaybeUnsafe && elseBlockUnsafe {
 		return nil
 	}
 
-	elseTokens := tokensOf(sf, elseNode)
+	elseTokens := utils.TokensOfNode(sf, elseNode)
 	if len(elseTokens) == 0 {
 		return nil
 	}
@@ -220,18 +211,18 @@ func buildFixes(ctx rule.RuleContext, elseNode *ast.Node) []rule.RuleFix {
 	if len(elseTokens) > 1 {
 		lastTokenOfElseBlock = elseTokens[len(elseTokens)-2]
 	}
-	if lastTokenOfElseBlock.text != ";" {
-		if nextToken, found := tokenAtOrAfter(sf, endToken.end); found {
-			nextTokenUnsafe := startsUnsafeForASI(nextToken.text)
-			nextTokenOnSameLine := lineOf(sf, nextToken.start) == lineOf(sf, lastTokenOfElseBlock.start)
-			if nextTokenUnsafe || (nextTokenOnSameLine && nextToken.text != "}") {
+	if lastTokenOfElseBlock.Text != ";" {
+		if nextToken, found := utils.TokenAtOrAfter(sf, endToken.End); found {
+			nextTokenUnsafe := startsUnsafeForASI(nextToken.Text)
+			nextTokenOnSameLine := utils.IsSameLine(sf, nextToken.Start, lastTokenOfElseBlock.Start)
+			if nextTokenUnsafe || (nextTokenOnSameLine && nextToken.Text != "}") {
 				return nil
 			}
 		}
 	}
 
 	fixedSource := utils.TrimmedNodeText(sf, elseNode)
-	if startToken.text == "{" {
+	if startToken.Text == "{" {
 		trimmed := utils.TrimNodeTextRange(sf, elseNode)
 		if trimmed.End()-trimmed.Pos() >= 2 {
 			fixedSource = text[trimmed.Pos()+1 : trimmed.End()-1]
@@ -247,7 +238,7 @@ func buildFixes(ctx rule.RuleContext, elseNode *ast.Node) []rule.RuleFix {
 
 func enclosingFunctionStart(sf *ast.SourceFile, node *ast.Node) int {
 	for current := node.Parent; current != nil; current = current.Parent {
-		if ast.IsFunctionLikeDeclaration(current) || current.Kind == ast.KindClassStaticBlockDeclaration {
+		if ast.IsFunctionLikeOrClassStaticBlockDeclaration(current) {
 			return utils.TrimNodeTextRange(sf, current).Pos()
 		}
 	}
@@ -255,78 +246,25 @@ func enclosingFunctionStart(sf *ast.SourceFile, node *ast.Node) int {
 }
 
 func startsUnsafeForASI(text string) bool {
-	return strings.HasPrefix(text, "(") ||
-		strings.HasPrefix(text, "[") ||
-		strings.HasPrefix(text, "/") ||
-		strings.HasPrefix(text, "+") ||
-		strings.HasPrefix(text, "`") ||
-		strings.HasPrefix(text, "-")
-}
-
-func lineOf(sf *ast.SourceFile, pos int) int {
-	return scanner.ComputeLineOfPosition(sf.ECMALineMap(), pos)
-}
-
-func tokensOf(sf *ast.SourceFile, node *ast.Node) []tokenInfo {
-	tokens := []tokenInfo{}
-	sourceText := sf.Text()
-	utils.ForEachToken(node, func(token *ast.Node) {
-		trimmed := utils.TrimNodeTextRange(sf, token)
-		if trimmed.Pos() >= trimmed.End() {
-			return
-		}
-		tokens = append(tokens, tokenInfo{
-			kind:  token.Kind,
-			start: trimmed.Pos(),
-			end:   trimmed.End(),
-			text:  sourceText[trimmed.Pos():trimmed.End()],
-		})
-	}, sf)
-	return tokens
-}
-
-func tokenAtOrAfter(sf *ast.SourceFile, pos int) (tokenInfo, bool) {
-	sourceText := sf.Text()
-	start := scanner.SkipTrivia(sourceText, pos)
-	if start >= len(sourceText) {
-		return tokenInfo{}, false
+	if text == "" {
+		return false
 	}
-	r := scanner.GetRangeOfTokenAtPosition(sf, start)
-	if r.Pos() >= r.End() || r.End() > len(sourceText) {
-		return tokenInfo{}, false
+	switch text[0] {
+	case '(', '[', '/', '+', '`', '-':
+		return true
 	}
-	return tokenInfo{
-		kind:  scanner.ScanTokenAtPosition(sf, start),
-		start: r.Pos(),
-		end:   r.End(),
-		text:  sourceText[r.Pos():r.End()],
-	}, true
+	return false
 }
 
 func findElseKeywordStart(sf *ast.SourceFile, ifNode, elseNode *ast.Node) int {
 	elseNodeStart := utils.TrimNodeTextRange(sf, elseNode).Pos()
 	elseStart := -1
-	for _, token := range tokensOf(sf, ifNode) {
-		if token.kind == ast.KindElseKeyword && token.end <= elseNodeStart {
-			elseStart = token.start
+	for _, token := range utils.TokensOfNode(sf, ifNode) {
+		if token.Kind == ast.KindElseKeyword && token.End <= elseNodeStart {
+			elseStart = token.Start
 		}
 	}
 	return elseStart
-}
-
-func previousTokenBefore(sf *ast.SourceFile, node *ast.Node, pos int) (tokenInfo, bool) {
-	var prev tokenInfo
-	found := false
-	for _, token := range tokensOf(sf, node) {
-		if token.start >= pos {
-			break
-		}
-		if token.end <= pos {
-			prev = token
-			found = true
-		}
-	}
-	return prev, found
 }
 
 func isSafeFromNameCollisions(elseNode *ast.Node) bool {
@@ -395,10 +333,17 @@ func collectDirectBlockScopedStatementNames(stmt *ast.Node, names map[string]str
 				})
 			}
 		}
-	case ast.KindFunctionDeclaration, ast.KindClassDeclaration, ast.KindEnumDeclaration, ast.KindModuleDeclaration:
-		if name := stmt.Name(); name != nil && name.Kind == ast.KindIdentifier {
-			names[name.Text()] = struct{}{}
-		}
+	case ast.KindFunctionDeclaration, ast.KindClassDeclaration,
+		ast.KindEnumDeclaration, ast.KindModuleDeclaration,
+		ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration,
+		ast.KindImportEqualsDeclaration:
+		collectDeclarationName(stmt, names)
+	}
+}
+
+func collectDeclarationName(decl *ast.Node, names map[string]struct{}) {
+	if name := decl.Name(); name != nil && name.Kind == ast.KindIdentifier {
+		names[name.Text()] = struct{}{}
 	}
 }
 
@@ -464,9 +409,18 @@ func hasDirectLexicalDeclaration(target *ast.Node, name string) bool {
 			if utils.HasVarDeclListWithName(varStmt.DeclarationList, name) {
 				return true
 			}
-		case ast.KindFunctionDeclaration, ast.KindClassDeclaration, ast.KindEnumDeclaration, ast.KindModuleDeclaration:
+		case ast.KindFunctionDeclaration, ast.KindClassDeclaration,
+			ast.KindEnumDeclaration, ast.KindModuleDeclaration,
+			ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration,
+			ast.KindImportEqualsDeclaration:
 			if n := stmt.Name(); n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
 				return true
+			}
+		case ast.KindImportDeclaration:
+			for _, binding := range utils.GetImportBindingNodes(stmt) {
+				if binding != nil && binding.Text() == name {
+					return true
+				}
 			}
 		}
 	}
@@ -513,7 +467,7 @@ func hasUnsafeReference(target, elseNode *ast.Node, name string) bool {
 		if node == nil || node == elseNode {
 			return false
 		}
-		if node.Kind == ast.KindIdentifier && node.Text() == name && isReferenceIdentifier(node) {
+		if node.Kind == ast.KindIdentifier && node.Text() == name && !utils.IsNonReferenceIdentifier(node) {
 			found = true
 			return true
 		}
@@ -524,25 +478,4 @@ func hasUnsafeReference(target, elseNode *ast.Node, name string) bool {
 	}
 	walk(target)
 	return found
-}
-
-func isReferenceIdentifier(node *ast.Node) bool {
-	if utils.IsDeclarationIdentifier(node) {
-		return false
-	}
-	parent := node.Parent
-	if parent == nil {
-		return true
-	}
-	switch parent.Kind {
-	case ast.KindPropertyAccessExpression:
-		return parent.AsPropertyAccessExpression().Name() != node
-	case ast.KindPropertyAssignment, ast.KindMethodDeclaration,
-		ast.KindGetAccessor, ast.KindSetAccessor, ast.KindPropertyDeclaration,
-		ast.KindEnumMember:
-		return parent.Name() != node
-	case ast.KindLabeledStatement, ast.KindBreakStatement, ast.KindContinueStatement:
-		return false
-	}
-	return true
 }

--- a/internal/rules/no_else_return/no_else_return.go
+++ b/internal/rules/no_else_return/no_else_return.go
@@ -467,6 +467,13 @@ func hasUnsafeReference(target, elseNode *ast.Node, name string) bool {
 		if node == nil || node == elseNode {
 			return false
 		}
+		if node.Kind == ast.KindShorthandPropertyAssignment && !utils.IsInDestructuringAssignment(node) {
+			shorthand := node.AsShorthandPropertyAssignment()
+			if shorthand != nil && shorthand.Name() != nil && shorthand.Name().Text() == name {
+				found = true
+				return true
+			}
+		}
 		if node.Kind == ast.KindIdentifier && node.Text() == name && !utils.IsNonReferenceIdentifier(node) {
 			found = true
 			return true

--- a/internal/rules/no_else_return/no_else_return.go
+++ b/internal/rules/no_else_return/no_else_return.go
@@ -108,20 +108,20 @@ func checkIfWithoutElse(ctx rule.RuleContext, node *ast.Node) {
 		return
 	}
 
-	consequents := []*ast.Node{}
+	thenStatements := []*ast.Node{}
 	var alternate *ast.Node
 	for current := node; current != nil && current.Kind == ast.KindIfStatement; {
 		ifStmt := current.AsIfStatement()
 		if ifStmt == nil || ifStmt.ElseStatement == nil {
 			return
 		}
-		consequents = append(consequents, ifStmt.ThenStatement)
+		thenStatements = append(thenStatements, ifStmt.ThenStatement)
 		alternate = ifStmt.ElseStatement
 		current = ifStmt.ElseStatement
 	}
 
-	for _, consequent := range consequents {
-		if !alwaysReturns(consequent) {
+	for _, thenStatement := range thenStatements {
+		if !alwaysReturns(thenStatement) {
 			return
 		}
 	}

--- a/internal/rules/no_else_return/no_else_return.md
+++ b/internal/rules/no_else_return/no_else_return.md
@@ -88,6 +88,10 @@ function foo() {
 }
 ```
 
+## Autofix Safety
+
+This rule can remove unnecessary `else` wrappers automatically. The fixer is skipped when moving the `else` contents could change declaration scope or automatic semicolon insertion behavior.
+
 ## Original Documentation
 
 https://eslint.org/docs/latest/rules/no-else-return

--- a/internal/rules/no_else_return/no_else_return.md
+++ b/internal/rules/no_else_return/no_else_return.md
@@ -1,0 +1,93 @@
+# no-else-return
+
+## Rule Details
+
+Disallows `else` blocks after `return` statements in `if` statements. When every preceding branch returns, the `else` block is unnecessary and its contents can be placed after the `if` statement.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function foo() {
+  if (x) {
+    return y;
+  } else {
+    return z;
+  }
+}
+```
+
+```javascript
+function foo() {
+  if (x) {
+    return y;
+  } else if (z) {
+    return w;
+  } else {
+    return q;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function foo() {
+  if (x) {
+    return y;
+  }
+
+  return z;
+}
+```
+
+```javascript
+function foo() {
+  if (x) {
+    doSomething();
+  } else {
+    return y;
+  }
+}
+```
+
+## Options
+
+This rule has an object option:
+
+- `allowElseIf` (default: `true`): allows `else if` blocks after a `return`.
+
+Examples of **correct** code for this rule with `{ "allowElseIf": true }`:
+
+```json
+{ "no-else-return": ["error", { "allowElseIf": true }] }
+```
+
+```javascript
+function foo() {
+  if (error) {
+    return "failed";
+  } else if (loading) {
+    return "loading";
+  }
+}
+```
+
+Examples of **incorrect** code for this rule with `{ "allowElseIf": false }`:
+
+```json
+{ "no-else-return": ["error", { "allowElseIf": false }] }
+```
+
+```javascript
+function foo() {
+  if (error) {
+    return "failed";
+  } else if (loading) {
+    return "loading";
+  }
+}
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-else-return

--- a/internal/rules/no_else_return/no_else_return.md
+++ b/internal/rules/no_else_return/no_else_return.md
@@ -2,7 +2,9 @@
 
 ## Rule Details
 
-Disallows `else` blocks after `return` statements in `if` statements. When every preceding branch returns, the `else` block is unnecessary and its contents can be placed after the `if` statement.
+Disallow `else` blocks after `return` statements in `if` statements. When every
+preceding branch returns, the `else` block is unnecessary and its contents can
+be placed after the `if` statement.
 
 Examples of **incorrect** code for this rule:
 
@@ -87,10 +89,6 @@ function foo() {
   }
 }
 ```
-
-## Autofix Safety
-
-This rule can remove unnecessary `else` wrappers automatically. The fixer is skipped when moving the `else` contents could change declaration scope or automatic semicolon insertion behavior.
 
 ## Original Documentation
 

--- a/internal/rules/no_else_return/no_else_return_extras_test.go
+++ b/internal/rules/no_else_return/no_else_return_extras_test.go
@@ -1,0 +1,123 @@
+package no_else_return
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoElseReturnExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row it covers, so future refactors can't
+// silently regress them without breaking a named lock-in.
+func TestNoElseReturnExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoElseReturnRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: receiver / expression wrappers ----
+			// N/A: the rule does not inspect receiver, member, call, or literal
+			// expression children; only statement/control-flow shape matters.
+
+			// ---- Dimension 4: access / key forms ----
+			// N/A: the rule does not inspect object/class property keys.
+
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: `const f = () => { if (a) { foo(); } else { return 1; } };`},
+			{Code: `class C { m() { if (a) { foo(); } else { return 1; } } }`},
+			{Code: `async function f() { if (a) { foo(); } else { return 1; } }`},
+			{Code: `function *f() { if (a) { foo(); } else { return 1; } }`},
+
+			// ---- Dimension 4: nesting / traversal boundaries ----
+			// Locks in upstream checkIfWithoutElse parent guard: an if in a
+			// single-statement position cannot be safely split into two statements.
+			{Code: `function f() { while (foo) if (bar) return; else baz(); }`},
+			// Locks in upstream checkIfWithoutElse early return: no alternate
+			// means the rule must not continue walking the chain.
+			{Code: `function f() { if (bar) return; }`},
+
+			// ---- Dimension 4: graceful degradation ----
+			{Code: `function f() { if (bar) {} else {} }`},
+			{Code: `function f() { if (bar) { return; } }`},
+			{Code: `declare function f(): void;`},
+			{Code: `abstract class C { abstract m(): void }`},
+
+			// ---- Real-user: eslint/eslint#3015 else-if false positive ----
+			{Code: `function f() { if (x) { doOneThing(); } else if (y) { return true; } else { doAnotherThing(); } }`},
+			// ---- Real-user: eslint/eslint#9228 default allowElseIf behavior ----
+			{Code: `const res = (() => { if (error) { return "It failed"; } else if (loading) { return "Still loading"; } return result; })();`},
+			// ---- Real-user: eslint/eslint#15496 break/continue are intentionally not return ----
+			{Code: `function f(list) { for (const item of list) { if (foo) { if (a) { break; } else { return item; } } if (bar) { if (a) { continue; } else { return item; } } } }`},
+
+			// Locks in upstream checkIfWithElse arm: no alternate means no report
+			// even when allowElseIf is disabled.
+			{Code: `function f() { if (bar) return; }`, Options: map[string]interface{}{"allowElseIf": false}},
+			// Locks in upstream alwaysReturns false arm: the consequent contains
+			// no return-like statement, so the else is still necessary.
+			{Code: `function f() { if (bar) { foo(); } else { baz(); } }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: declaration/container forms ----
+			{
+				Code:   `const f = () => { if (a) { return 1; } else { return 2; } };`,
+				Output: []string{`const f = () => { if (a) { return 1; }  return 2;  };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`const f = () => { if (a) { return 1; } else { return 2; } };`, `{ return 2; }`),
+				},
+			},
+			{
+				Code:   `class C { m() { if (a) return 1; else return 2; } }`,
+				Output: []string{`class C { m() { if (a) return 1; return 2; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`class C { m() { if (a) return 1; else return 2; } }`, `return 2;`),
+				},
+			},
+			{
+				Code:   `async function f() { if (a) return 1; else return 2; }`,
+				Output: []string{`async function f() { if (a) return 1; return 2; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`async function f() { if (a) return 1; else return 2; }`, `return 2;`),
+				},
+			},
+			{
+				Code:   `function *f() { if (a) { return 1; } else { return 2; } }`,
+				Output: []string{`function *f() { if (a) { return 1; }  return 2;  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function *f() { if (a) { return 1; } else { return 2; } }`, `{ return 2; }`),
+				},
+			},
+
+			// Locks in upstream alwaysReturns BlockStatement arm: any return-like
+			// statement in the consequent block is enough, not only the final one.
+			{
+				Code:   `function f() { if (a) { return 1; foo(); } else { foo(); } }`,
+				Output: []string{`function f() { if (a) { return 1; foo(); }  foo();  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { if (a) { return 1; foo(); } else { foo(); } }`, `{ foo(); }`),
+				},
+			},
+			// Locks in upstream checkIfWithElse arm: allowElseIf false reports
+			// the else-if statement itself. This uses array-wrapped options to
+			// exercise the JSON option path.
+			{
+				Code:    `function f() { if (a) return 1; else if (b) return 2; }`,
+				Output:  []string{`function f() { if (a) return 1; if (b) return 2; }`},
+				Options: []interface{}{map[string]interface{}{"allowElseIf": false}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { if (a) return 1; else if (b) return 2; }`, `if (b) return 2;`),
+				},
+			},
+			// Locks in upstream isSafeFromNameCollisions branch: a conditional
+			// function declaration alternate is reported but not fixed.
+			{
+				Code: `function f() { if (a) { return 1; } else function g() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { if (a) { return 1; } else function g() {} }`, `function g() {}`),
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_else_return/no_else_return_extras_test.go
+++ b/internal/rules/no_else_return/no_else_return_extras_test.go
@@ -55,13 +55,36 @@ func TestNoElseReturnExtras(t *testing.T) {
 			// Locks in upstream checkIfWithElse arm: no alternate means no report
 			// even when allowElseIf is disabled.
 			{Code: `function f() { if (bar) return; }`, Options: map[string]interface{}{"allowElseIf": false}},
+			// ---- Options contract: empty object keeps ESLint default allowElseIf=true ----
+			{
+				Code:    `function f() { if (error) { return "failed"; } else if (loading) { return "loading"; } }`,
+				Options: map[string]interface{}{},
+			},
+			{
+				Code:    `function f() { if (error) { return "failed"; } else if (loading) { return "loading"; } }`,
+				Options: []interface{}{map[string]interface{}{}},
+			},
 			// Locks in upstream alwaysReturns false arm: the consequent contains
 			// no return-like statement, so the else is still necessary.
 			{Code: `function f() { if (bar) { foo(); } else { baz(); } }`},
+			// Locks in upstream alwaysReturns() shallow semantics: a return in
+			// a nested function or a throw statement is not a branch return.
+			{Code: `function f() { if (bar) { function g() { return 1; } } else { return 2; } }`},
+			{Code: `function f() { if (bar) { throw err; } else { return 2; } }`},
+			// Locks in upstream naiveHasReturn() arm: for nested if blocks,
+			// only the last direct child of each nested branch counts.
+			{Code: `function f() { if (bar) { if (baz) { foo(); } else { return 2; } } else { return 3; } }`},
 
 			// TypeScript declarations in an else block are handled structurally
 			// by the fixer only; the reporting decision still follows upstream.
 			{Code: `function f() { if (bar) { foo(); } else { type T = string; } }`},
+
+			// ---- Dimension 4: nesting / traversal boundaries ----
+			// Labels, loop bodies, and do bodies accept only one child statement.
+			// Splitting the if/else into two statements would be invalid there.
+			{Code: `function f() { label: if (bar) return; else baz(); }`},
+			{Code: `function f() { for (;;) if (bar) return; else baz(); }`},
+			{Code: `function f() { do if (bar) return; else baz(); while (ok); }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: declaration/container forms ----
@@ -93,6 +116,37 @@ func TestNoElseReturnExtras(t *testing.T) {
 					unexpectedAt(`function *f() { if (a) { return 1; } else { return 2; } }`, `{ return 2; }`),
 				},
 			},
+			{
+				Code:   `const f = function() { if (a) return 1; else return 2; };`,
+				Output: []string{`const f = function() { if (a) return 1; return 2; };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`const f = function() { if (a) return 1; else return 2; };`, `return 2;`),
+				},
+			},
+			{
+				Code:   `const obj = { m() { if (a) return 1; else return 2; } };`,
+				Output: []string{`const obj = { m() { if (a) return 1; return 2; } };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`const obj = { m() { if (a) return 1; else return 2; } };`, `return 2;`),
+				},
+			},
+			{
+				Code:   `async function *f() { if (a) { return 1; } else { return 2; } }`,
+				Output: []string{`async function *f() { if (a) { return 1; }  return 2;  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`async function *f() { if (a) { return 1; } else { return 2; } }`, `{ return 2; }`),
+				},
+			},
+
+			// ---- Options contract: empty object is identical to omitted options ----
+			{
+				Code:    `function f() { if (a) { return 1; } else if (b) { return 2; } else { return 3; } }`,
+				Output:  []string{`function f() { if (a) { return 1; } else if (b) { return 2; }  return 3;  }`},
+				Options: map[string]interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { if (a) { return 1; } else if (b) { return 2; } else { return 3; } }`, `{ return 3; }`),
+				},
+			},
 
 			// Locks in upstream alwaysReturns BlockStatement arm: any return-like
 			// statement in the consequent block is enough, not only the final one.
@@ -101,6 +155,19 @@ func TestNoElseReturnExtras(t *testing.T) {
 				Output: []string{`function f() { if (a) { return 1; foo(); }  foo();  }`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					unexpectedAt(`function f() { if (a) { return 1; foo(); } else { foo(); } }`, `{ foo(); }`),
+				},
+			},
+			// Locks in upstream alwaysReturns() arm where a nested if returns on
+			// both paths and therefore makes the outer else unnecessary.
+			{
+				Code: `function f() { if (a) { if (b) return 1; else return 2; } else { return 3; } }`,
+				Output: []string{
+					`function f() { if (a) { if (b) return 1; return 2; } else { return 3; } }`,
+					`function f() { if (a) { if (b) return 1; return 2; }  return 3;  }`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { if (a) { if (b) return 1; else return 2; } else { return 3; } }`, `return 2;`),
+					unexpectedAt(`function f() { if (a) { if (b) return 1; else return 2; } else { return 3; } }`, `{ return 3; }`),
 				},
 			},
 			// Locks in upstream checkIfWithElse arm: allowElseIf false reports
@@ -131,6 +198,13 @@ func TestNoElseReturnExtras(t *testing.T) {
 					unexpectedAt(`function f(x) { switch (x) { case 1: let a; if (bar) { return true; } else { let a; } } }`, `{ let a; }`),
 				},
 			},
+			{
+				Code:   `function f(x) { switch (x) { default: if (bar) { return true; } else { baz(); } } }`,
+				Output: []string{`function f(x) { switch (x) { default: if (bar) { return true; }  baz();  } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f(x) { switch (x) { default: if (bar) { return true; } else { baz(); } } }`, `{ baz(); }`),
+				},
+			},
 			// Destructured parameters are also same-scope bindings after the
 			// else block is removed, so the diagnostic is intentionally no-fix.
 			{
@@ -155,6 +229,18 @@ func TestNoElseReturnExtras(t *testing.T) {
 					unexpectedAt(`function f() { if (a) { if (b) { return 1; } else { type T = string; } let value: T; } }`, `{ type T = string; }`),
 				},
 			},
+			{
+				Code: `function f() { interface I {} if (bar) { return true; } else { interface I {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { interface I {} if (bar) { return true; } else { interface I {} } }`, `{ interface I {} }`),
+				},
+			},
+			{
+				Code: `function f() { if (a) { if (b) { return 1; } else { interface I {} } let value: I; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { if (a) { if (b) { return 1; } else { interface I {} } let value: I; } }`, `{ interface I {} }`),
+				},
+			},
 			// Only direct declarations in the removed else block are hoisted to
 			// the parent. A nested block keeps its own `let a` scope, so the fix
 			// remains safe even when the parent already has `a`.
@@ -163,6 +249,90 @@ func TestNoElseReturnExtras(t *testing.T) {
 				Output: []string{`function f() { let a; if (bar) { return true; }  { let a; }  }`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					unexpectedAt(`function f() { let a; if (bar) { return true; } else { { let a; } } }`, `{ { let a; } }`),
+				},
+			},
+
+			// Locks in upstream fixer ASI guard: an unbraced consequent without
+			// a semicolon cannot be followed by else contents starting with
+			// punctuation that can continue the previous statement.
+			{
+				Code: "function f() { if (a) return b\nelse { (foo).bar(); } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function f() { if (a) return b\nelse { (foo).bar(); } }", `{ (foo).bar(); }`),
+				},
+			},
+			{
+				Code: "function f() { if (a) return b\nelse { +foo; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function f() { if (a) return b\nelse { +foo; } }", `{ +foo; }`),
+				},
+			},
+			{
+				Code: "function f() { if (a) return b\nelse { -foo; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function f() { if (a) return b\nelse { -foo; } }", `{ -foo; }`),
+				},
+			},
+			{
+				Code: "function f() { if (a) return b\nelse { /foo/.test(bar); } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function f() { if (a) return b\nelse { /foo/.test(bar); } }", `{ /foo/.test(bar); }`),
+				},
+			},
+			{
+				Code: "function f() { if (a) return b\nelse { `tmpl`; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function f() { if (a) return b\nelse { `tmpl`; } }", "{ `tmpl`; }"),
+				},
+			},
+			// Same-line `}` after an unterminated else body is explicitly safe
+			// in upstream's fixer.
+			{
+				Code:   `function f() { if (a) return; else { foo() } }`,
+				Output: []string{`function f() { if (a) return;  foo()  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { if (a) return; else { foo() } }`, `{ foo() }`),
+				},
+			},
+			// But a following token that can continue the statement is not safe.
+			{
+				Code: "function f() { if (a) return; else { foo() }\n(bar)() }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function f() { if (a) return; else { foo() }\n(bar)() }", `{ foo() }`),
+				},
+			},
+
+			// Name-collision safety must distinguish property keys from real
+			// references after the else block is removed.
+			{
+				Code:   `function f() { if (bar) { if (baz) { return true; } else { let a; } const o = { a: 1 }; obj.a; } }`,
+				Output: []string{`function f() { if (bar) { if (baz) { return true; }  let a;  const o = { a: 1 }; obj.a; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { if (bar) { if (baz) { return true; } else { let a; } const o = { a: 1 }; obj.a; } }`, `{ let a; }`),
+				},
+			},
+			{
+				Code: `function f() { if (bar) { if (baz) { return true; } else { let a; } const o = { a }; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { if (bar) { if (baz) { return true; } else { let a; } const o = { a }; } }`, `{ let a; }`),
+				},
+			},
+
+			// ---- Real-user: Express-style guard clauses ----
+			{
+				Code:   `function handler(req, res, next) { if (!req.user) { return res.status(401).end(); } else { next(); } }`,
+				Output: []string{`function handler(req, res, next) { if (!req.user) { return res.status(401).end(); }  next();  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function handler(req, res, next) { if (!req.user) { return res.status(401).end(); } else { next(); } }`, `{ next(); }`),
+				},
+			},
+			// ---- Real-user: config fallback with allowElseIf disabled ----
+			{
+				Code:    `function load(config) { if (!config) { return defaults; } else if (config.extends) { return merge(config); } }`,
+				Output:  []string{`function load(config) { if (!config) { return defaults; } if (config.extends) { return merge(config); } }`},
+				Options: map[string]interface{}{"allowElseIf": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function load(config) { if (!config) { return defaults; } else if (config.extends) { return merge(config); } }`, `if (config.extends) { return merge(config); }`),
 				},
 			},
 		},

--- a/internal/rules/no_else_return/no_else_return_extras_test.go
+++ b/internal/rules/no_else_return/no_else_return_extras_test.go
@@ -58,6 +58,10 @@ func TestNoElseReturnExtras(t *testing.T) {
 			// Locks in upstream alwaysReturns false arm: the consequent contains
 			// no return-like statement, so the else is still necessary.
 			{Code: `function f() { if (bar) { foo(); } else { baz(); } }`},
+
+			// TypeScript declarations in an else block are handled structurally
+			// by the fixer only; the reporting decision still follows upstream.
+			{Code: `function f() { if (bar) { foo(); } else { type T = string; } }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: declaration/container forms ----
@@ -116,6 +120,49 @@ func TestNoElseReturnExtras(t *testing.T) {
 				Code: `function f() { if (a) { return 1; } else function g() {} }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					unexpectedAt(`function f() { if (a) { return 1; } else function g() {} }`, `function g() {}`),
+				},
+			},
+			// Switch clauses are valid statement-list parents. The existing
+			// direct lexical declaration blocks the fix because moving `let a`
+			// out of else would create a same-scope redeclaration.
+			{
+				Code: `function f(x) { switch (x) { case 1: let a; if (bar) { return true; } else { let a; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f(x) { switch (x) { case 1: let a; if (bar) { return true; } else { let a; } } }`, `{ let a; }`),
+				},
+			},
+			// Destructured parameters are also same-scope bindings after the
+			// else block is removed, so the diagnostic is intentionally no-fix.
+			{
+				Code: `function f({ a }) { if (bar) { return true; } else { let a; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f({ a }) { if (bar) { return true; } else { let a; } }`, `{ let a; }`),
+				},
+			},
+			// TS type aliases are block-scoped too. Moving this alias out of the
+			// else block would collide with the outer type alias.
+			{
+				Code: `function f() { type T = string; if (bar) { return true; } else { type T = number; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { type T = string; if (bar) { return true; } else { type T = number; } }`, `{ type T = number; }`),
+				},
+			},
+			// A TS type reference after the nested else would resolve differently
+			// if the alias were moved to the parent block, so the fix is skipped.
+			{
+				Code: `function f() { if (a) { if (b) { return 1; } else { type T = string; } let value: T; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { if (a) { if (b) { return 1; } else { type T = string; } let value: T; } }`, `{ type T = string; }`),
+				},
+			},
+			// Only direct declarations in the removed else block are hoisted to
+			// the parent. A nested block keeps its own `let a` scope, so the fix
+			// remains safe even when the parent already has `a`.
+			{
+				Code:   `function f() { let a; if (bar) { return true; } else { { let a; } } }`,
+				Output: []string{`function f() { let a; if (bar) { return true; }  { let a; }  }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt(`function f() { let a; if (bar) { return true; } else { { let a; } } }`, `{ { let a; } }`),
 				},
 			},
 		},

--- a/internal/rules/no_else_return/no_else_return_upstream_test.go
+++ b/internal/rules/no_else_return/no_else_return_upstream_test.go
@@ -196,10 +196,10 @@ func TestNoElseReturnUpstream(t *testing.T) {
 				},
 			},
 			{
-				Code:   "function foo17() { if (foo) return bar \nelse { baz() } \nqaz() }",
-				Output: []string{"function foo17() { if (foo) return bar \n baz()  \nqaz() }"},
+				Code:   "function foo17() { if (foo) return bar \nelse { baz() } \n" + "qaz() }",
+				Output: []string{"function foo17() { if (foo) return bar \n baz()  \n" + "qaz() }"},
 				Errors: []rule_tester.InvalidTestCaseError{
-					unexpectedAt("function foo17() { if (foo) return bar \nelse { baz() } \nqaz() }", "{ baz() }"),
+					unexpectedAt("function foo17() { if (foo) return bar \nelse { baz() } \n"+"qaz() }", "{ baz() }"),
 				},
 			},
 			{

--- a/internal/rules/no_else_return/no_else_return_upstream_test.go
+++ b/internal/rules/no_else_return/no_else_return_upstream_test.go
@@ -1,0 +1,358 @@
+package no_else_return
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoElseReturnUpstream migrates the full valid/invalid suite from upstream
+// ESLint tests/lib/rules/no-else-return.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// the no_else_return_extras_test.go file.
+func TestNoElseReturnUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoElseReturnRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "function foo() { if (true) { if (false) { return x; } } else { return y; } }"},
+			{Code: "function foo() { if (true) { return x; } return y; }"},
+			{Code: "function foo() { if (true) { for (;;) { return x; } } else { return y; } }"},
+			{Code: "function foo() { var x = true; if (x) { return x; } else if (x === false) { return false; } }"},
+			{Code: "function foo() { if (true) notAReturn(); else return y; }"},
+			{Code: "function foo() {if (x) { notAReturn(); } else if (y) { return true; } else { notAReturn(); } }"},
+			{Code: "function foo() {if (x) { return true; } else if (y) { notAReturn() } else { notAReturn(); } }"},
+			{Code: "if (0) { if (0) {} else {} } else {}"},
+			{Code: `
+            function foo() {
+                if (foo)
+                    if (bar) return;
+                    else baz;
+                else qux;
+            }
+        `},
+			{Code: `
+            function foo() {
+                while (foo)
+                    if (bar) return;
+                    else baz;
+            }
+        `},
+			{
+				Code:    "function foo19() { if (true) { return x; } else if (false) { return y; } }",
+				Options: map[string]interface{}{"allowElseIf": true},
+			},
+			{
+				Code:    "function foo20() {if (x) { return true; } else if (y) { notAReturn() } else { notAReturn(); } }",
+				Options: map[string]interface{}{"allowElseIf": true},
+			},
+			{
+				Code:    "function foo21() { var x = true; if (x) { return x; } else if (x === false) { return false; } }",
+				Options: map[string]interface{}{"allowElseIf": true},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   "function foo1() { if (true) { return x; } else { return y; } }",
+				Output: []string{"function foo1() { if (true) { return x; }  return y;  }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo1() { if (true) { return x; } else { return y; } }", "{ return y; }"),
+				},
+			},
+			{
+				Code:   "function foo2() { if (true) { var x = bar; return x; } else { var y = baz; return y; } }",
+				Output: []string{"function foo2() { if (true) { var x = bar; return x; }  var y = baz; return y;  }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo2() { if (true) { var x = bar; return x; } else { var y = baz; return y; } }", "{ var y = baz; return y; }"),
+				},
+			},
+			{
+				Code:   "function foo3() { if (true) return x; else return y; }",
+				Output: []string{"function foo3() { if (true) return x; return y; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo3() { if (true) return x; else return y; }", "return y;"),
+				},
+			},
+			{
+				Code: "function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }",
+				Output: []string{
+					"function foo4() { if (true) { if (false) return x; return y; } else { return z; } }",
+					"function foo4() { if (true) { if (false) return x; return y; }  return z;  }",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }", "return y;"),
+					unexpectedAt("function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }", "{ return z; }"),
+				},
+			},
+			{
+				Code:   "function foo5() { if (true) { if (false) { if (true) return x; else { w = y; } } else { w = x; } } else { return z; } }",
+				Output: []string{"function foo5() { if (true) { if (false) { if (true) return x;  w = y;  } else { w = x; } } else { return z; } }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo5() { if (true) { if (false) { if (true) return x; else { w = y; } } else { w = x; } } else { return z; } }", "{ w = y; }"),
+				},
+			},
+			{
+				Code:   "function foo6() { if (true) { if (false) { if (true) return x; else return y; } } else { return z; } }",
+				Output: []string{"function foo6() { if (true) { if (false) { if (true) return x; return y; } } else { return z; } }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo6() { if (true) { if (false) { if (true) return x; else return y; } } else { return z; } }", "return y;"),
+				},
+			},
+			{
+				Code: "function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }",
+				Output: []string{
+					"function foo7() { if (true) { if (false) { if (true) return x; return y; } return w; } else { return z; } }",
+					"function foo7() { if (true) { if (false) { if (true) return x; return y; } return w; }  return z;  }",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }", "return y;"),
+					unexpectedAt("function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }", "{ return z; }"),
+				},
+			},
+			{
+				Code: "function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }",
+				Output: []string{
+					"function foo8() { if (true) { if (false) { if (true) return x; return y; } else { w = x; } } else { return z; } }",
+					"function foo8() { if (true) { if (false) { if (true) return x; return y; }  w = x;  } else { return z; } }",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }", "return y;"),
+					unexpectedAt("function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }", "{ w = x; }"),
+				},
+			},
+			{
+				Code:   "function foo9() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }",
+				Output: []string{"function foo9() {if (x) { return true; } else if (y) { return true; }  notAReturn();  }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo9() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }", "{ notAReturn(); }"),
+				},
+			},
+			{
+				Code: "function foo9a() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }",
+				Output: []string{
+					"function foo9a() {if (x) { return true; } if (y) { return true; } else { notAReturn(); } }",
+					"function foo9a() {if (x) { return true; } if (y) { return true; }  notAReturn();  }",
+				},
+				Options: map[string]interface{}{"allowElseIf": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo9a() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }", "if (y) { return true; } else { notAReturn(); }"),
+				},
+			},
+			{
+				Code:    "function foo9b() {if (x) { return true; } if (y) { return true; } else { notAReturn(); } }",
+				Output:  []string{"function foo9b() {if (x) { return true; } if (y) { return true; }  notAReturn();  }"},
+				Options: map[string]interface{}{"allowElseIf": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo9b() {if (x) { return true; } if (y) { return true; } else { notAReturn(); } }", "{ notAReturn(); }"),
+				},
+			},
+			{
+				Code:   "function foo10() { if (foo) return bar; else (foo).bar(); }",
+				Output: []string{"function foo10() { if (foo) return bar; (foo).bar(); }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo10() { if (foo) return bar; else (foo).bar(); }", "(foo).bar();"),
+				},
+			},
+			{
+				Code: "function foo11() { if (foo) return bar \nelse { [1, 2, 3].map(foo) } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo11() { if (foo) return bar \nelse { [1, 2, 3].map(foo) } }", "{ [1, 2, 3].map(foo) }"),
+				},
+			},
+			{
+				Code: "function foo12() { if (foo) return bar \nelse { baz() } \n[1, 2, 3].map(foo) }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo12() { if (foo) return bar \nelse { baz() } \n[1, 2, 3].map(foo) }", "{ baz() }"),
+				},
+			},
+			{
+				Code:   "function foo13() { if (foo) return bar; \nelse { [1, 2, 3].map(foo) } }",
+				Output: []string{"function foo13() { if (foo) return bar; \n [1, 2, 3].map(foo)  }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo13() { if (foo) return bar; \nelse { [1, 2, 3].map(foo) } }", "{ [1, 2, 3].map(foo) }"),
+				},
+			},
+			{
+				Code:   "function foo14() { if (foo) return bar \nelse { baz(); } \n[1, 2, 3].map(foo) }",
+				Output: []string{"function foo14() { if (foo) return bar \n baz();  \n[1, 2, 3].map(foo) }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo14() { if (foo) return bar \nelse { baz(); } \n[1, 2, 3].map(foo) }", "{ baz(); }"),
+				},
+			},
+			{
+				Code: "function foo15() { if (foo) return bar; else { baz() } qaz() }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo15() { if (foo) return bar; else { baz() } qaz() }", "{ baz() }"),
+				},
+			},
+			{
+				Code: "function foo16() { if (foo) return bar \nelse { baz() } qaz() }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo16() { if (foo) return bar \nelse { baz() } qaz() }", "{ baz() }"),
+				},
+			},
+			{
+				Code:   "function foo17() { if (foo) return bar \nelse { baz() } \nqaz() }",
+				Output: []string{"function foo17() { if (foo) return bar \n baz()  \nqaz() }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo17() { if (foo) return bar \nelse { baz() } \nqaz() }", "{ baz() }"),
+				},
+			},
+			{
+				Code: "function foo18() { if (foo) return function() {} \nelse [1, 2, 3].map(bar) }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo18() { if (foo) return function() {} \nelse [1, 2, 3].map(bar) }", "[1, 2, 3].map(bar)"),
+				},
+			},
+			{
+				Code:    "function foo19() { if (true) { return x; } else if (false) { return y; } }",
+				Output:  []string{"function foo19() { if (true) { return x; } if (false) { return y; } }"},
+				Options: map[string]interface{}{"allowElseIf": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo19() { if (true) { return x; } else if (false) { return y; } }", "if (false) { return y; }"),
+				},
+			},
+			{
+				Code:    "function foo20() {if (x) { return true; } else if (y) { notAReturn() } else { notAReturn(); } }",
+				Output:  []string{"function foo20() {if (x) { return true; } if (y) { notAReturn() } else { notAReturn(); } }"},
+				Options: map[string]interface{}{"allowElseIf": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo20() {if (x) { return true; } else if (y) { notAReturn() } else { notAReturn(); } }", "if (y) { notAReturn() } else { notAReturn(); }"),
+				},
+			},
+			{
+				Code:    "function foo21() { var x = true; if (x) { return x; } else if (x === false) { return false; } }",
+				Output:  []string{"function foo21() { var x = true; if (x) { return x; } if (x === false) { return false; } }"},
+				Options: map[string]interface{}{"allowElseIf": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo21() { var x = true; if (x) { return x; } else if (x === false) { return false; } }", "if (x === false) { return false; }"),
+				},
+			},
+
+			// https://github.com/eslint/eslint/issues/11069
+			upstreamInvalid("function foo() { var a; if (bar) { return true; } else { var a; } }", "{ var a; }", "function foo() { var a; if (bar) { return true; }  var a;  }", nil),
+			upstreamInvalid("function foo() { if (bar) { var a; if (baz) { return true; } else { var a; } } }", "{ var a; }", "function foo() { if (bar) { var a; if (baz) { return true; }  var a;  } }", nil),
+			upstreamInvalid("function foo() { var a; if (bar) { return true; } else { var a; } }", "{ var a; }", "function foo() { var a; if (bar) { return true; }  var a;  }", nil),
+			upstreamInvalid("function foo() { if (bar) { var a; if (baz) { return true; } else { var a; } } }", "{ var a; }", "function foo() { if (bar) { var a; if (baz) { return true; }  var a;  } }", nil),
+			upstreamInvalidNoFix("function foo() { let a; if (bar) { return true; } else { let a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("class foo { bar() { let a; if (baz) { return true; } else { let a; } } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { let a; if (baz) { return true; } else { let a; } } }", "{ let a; }"),
+			upstreamInvalid("function foo() {let a; if (bar) { if (baz) { return true; } else { let a; } } }", "{ let a; }", "function foo() {let a; if (bar) { if (baz) { return true; }  let a;  } }", nil),
+			upstreamInvalidNoFix("function foo() { const a = 1; if (bar) { return true; } else { let a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { const a = 1; if (baz) { return true; } else { let a; } } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { let a; if (bar) { return true; } else { const a = 1 } }", "{ const a = 1 }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { let a; if (baz) { return true; } else { const a = 1; } } }", "{ const a = 1; }"),
+			upstreamInvalidNoFix("function foo() { class a {}; if (bar) { return true; } else { const a = 1; } }", "{ const a = 1; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { class a {}; if (baz) { return true; } else { const a = 1; } } }", "{ const a = 1; }"),
+			upstreamInvalidNoFix("function foo() { const a = 1; if (bar) { return true; } else { class a {} } }", "{ class a {} }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { const a = 1; if (baz) { return true; } else { class a {} } } }", "{ class a {} }"),
+			upstreamInvalidNoFix("function foo() { var a; if (bar) { return true; } else { let a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { var a; return true; } else { let a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { return true; } else { let a; }  while (baz) { var a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo(a) { if (bar) { return true; } else { let a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo(a = 1) { if (bar) { return true; } else { let a; } }", "{ let a; }"),
+			{
+				Code: "function foo(a, b = a) { if (bar) { return true; } else { let a; }  if (bar) { return true; } else { let b; }}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unexpectedAt("function foo(a, b = a) { if (bar) { return true; } else { let a; }  if (bar) { return true; } else { let b; }}", "{ let a; }"),
+					unexpectedAt("function foo(a, b = a) { if (bar) { return true; } else { let a; }  if (bar) { return true; } else { let b; }}", "{ let b; }"),
+				},
+			},
+			upstreamInvalidNoFix("function foo(...args) { if (bar) { return true; } else { let args; } }", "{ let args; }"),
+			upstreamInvalidNoFix("function foo() { try {} catch (a) { if (bar) { return true; } else { let a; } } }", "{ let a; }"),
+			upstreamInvalid("function foo() { try {} catch (a) { if (bar) { if (baz) { return true; } else { let a; } } } }", "{ let a; }", "function foo() { try {} catch (a) { if (bar) { if (baz) { return true; }  let a;  } } }", nil),
+			upstreamInvalidNoFix("function foo() { try {} catch ({bar, a = 1}) { if (baz) { return true; } else { let a; } } }", "{ let a; }"),
+			upstreamInvalid("function foo() { if (bar) { return true; } else { let arguments; } }", "{ let arguments; }", "function foo() { if (bar) { return true; }  let arguments;  }", nil),
+			upstreamInvalidNoFix("function foo() { if (bar) { return true; } else { let arguments; } return arguments[0]; }", "{ let arguments; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { return true; } else { let arguments; } if (baz) { return arguments[0]; } }", "{ let arguments; }"),
+			upstreamInvalid("function foo() { if (bar) { if (baz) { return true; } else { let arguments; } } }", "{ let arguments; }", "function foo() { if (bar) { if (baz) { return true; }  let arguments;  } }", nil),
+			upstreamInvalidNoFix("function foo() { if (bar) { return true; } else { let a; } a; }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { return true; } else { let a; } if (baz) { a; } }", "{ let a; }"),
+			upstreamInvalid("function foo() { if (bar) { if (baz) { return true; } else { let a; } } a; }", "{ let a; }", "function foo() { if (bar) { if (baz) { return true; }  let a;  } a; }", nil),
+			upstreamInvalidNoFix("function foo() { if (bar) { if (baz) { return true; } else { let a; } a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { a; } } }", "{ let a; }"),
+			upstreamInvalidNoFix("function a() { if (foo) { return true; } else { let a; } a(); }", "{ let a; }"),
+			upstreamInvalidNoFix("function a() { if (a) { return true; } else { let a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function a() { if (foo) { return a; } else { let a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { return true; } else { let a; } function baz() { a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { if (baz) { return true; } else { let a; } (() => a) } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { return true; } else { let a; } var a; }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { if (baz) { return true; } else { let a; } var a; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { if (baz) { return true; } else { let a; } var { a } = {}; } }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { var a; } } }", "{ let a; }"),
+			upstreamInvalid("function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { var a; } }", "{ let a; }", "function foo() { if (bar) { if (baz) { return true; }  let a;  } if (quux) { var a; } }", nil),
+			upstreamInvalid("function foo() { if (quux) { var a; } if (bar) { if (baz) { return true; } else { let a; } } }", "{ let a; }", "function foo() { if (quux) { var a; } if (bar) { if (baz) { return true; }  let a;  } }", nil),
+			upstreamInvalidNoFix("function foo() { if (bar) { return true; } else { let a; } function a(){} }", "{ let a; }"),
+			upstreamInvalidNoFix("function foo() { if (baz) { if (bar) { return true; } else { let a; } function a(){} } }", "{ let a; }"),
+			upstreamInvalid("function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { function a(){}  } }", "{ let a; }", "function foo() { if (bar) { if (baz) { return true; }  let a;  } if (quux) { function a(){}  } }", nil),
+			upstreamInvalid("function foo() { if (bar) { if (baz) { return true; } else { let a; } } function a(){} }", "{ let a; }", "function foo() { if (bar) { if (baz) { return true; }  let a;  } function a(){} }", nil),
+			upstreamInvalidNoFix("function foo() { let a; if (bar) { return true; } else { function a(){} } }", "{ function a(){} }"),
+			upstreamInvalidNoFix("function foo() { var a; if (bar) { return true; } else { function a(){} } }", "{ function a(){} }"),
+			upstreamInvalidNoFix("function foo() { if (bar) { return true; } else function baz() {} };", "function baz() {}"),
+			upstreamInvalid("if (foo) { return true; } else { let a; }", "{ let a; }", "if (foo) { return true; }  let a; ", nil),
+			upstreamInvalidNoFix("let a; if (foo) { return true; } else { let a; }", "{ let a; }"),
+		},
+	)
+}
+
+func upstreamInvalid(code, reportSnippet, output string, options any) rule_tester.InvalidTestCase {
+	tc := rule_tester.InvalidTestCase{
+		Code: code,
+		Output: []string{
+			output,
+		},
+		Errors: []rule_tester.InvalidTestCaseError{
+			unexpectedAt(code, reportSnippet),
+		},
+	}
+	if options != nil {
+		tc.Options = options
+	}
+	return tc
+}
+
+func upstreamInvalidNoFix(code, reportSnippet string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code: code,
+		Errors: []rule_tester.InvalidTestCaseError{
+			unexpectedAt(code, reportSnippet),
+		},
+	}
+}
+
+func unexpectedAt(code, snippet string) rule_tester.InvalidTestCaseError {
+	start := strings.Index(code, snippet)
+	if start < 0 {
+		panic("test snippet not found: " + snippet)
+	}
+	end := start + len(snippet)
+	line, column := lineColumn(code, start)
+	endLine, endColumn := lineColumn(code, end)
+	return rule_tester.InvalidTestCaseError{
+		MessageId:   "unexpected",
+		Message:     "Unnecessary 'else' after 'return'.",
+		Line:        line,
+		Column:      column,
+		EndLine:     endLine,
+		EndColumn:   endColumn,
+		Suggestions: nil,
+	}
+}
+
+func lineColumn(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for i := 0; i < offset && i < len(code); i++ {
+		if code[i] == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+	return line, column
+}

--- a/internal/utils/tokens.go
+++ b/internal/utils/tokens.go
@@ -1,0 +1,81 @@
+package utils
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+)
+
+// SourceToken is a source-backed token with its kind, byte span, and text.
+type SourceToken struct {
+	Kind       ast.Kind
+	Start, End int
+	Text       string
+}
+
+// TokensOfNode returns all parser tokens contained in node, in source order.
+func TokensOfNode(sourceFile *ast.SourceFile, node *ast.Node) []SourceToken {
+	tokens := []SourceToken{}
+	sourceText := sourceFile.Text()
+	ForEachToken(node, func(token *ast.Node) {
+		trimmed := TrimNodeTextRange(sourceFile, token)
+		if trimmed.Pos() >= trimmed.End() {
+			return
+		}
+		tokens = append(tokens, SourceToken{
+			Kind:  token.Kind,
+			Start: trimmed.Pos(),
+			End:   trimmed.End(),
+			Text:  sourceText[trimmed.Pos():trimmed.End()],
+		})
+	}, sourceFile)
+	return tokens
+}
+
+// TokenAtOrAfter returns the first non-trivia token at or after pos.
+func TokenAtOrAfter(sourceFile *ast.SourceFile, pos int) (SourceToken, bool) {
+	sourceText := sourceFile.Text()
+	if pos < 0 {
+		pos = 0
+	}
+	if pos >= len(sourceText) {
+		return SourceToken{}, false
+	}
+
+	start := scanner.SkipTrivia(sourceText, pos)
+	if start >= len(sourceText) {
+		return SourceToken{}, false
+	}
+
+	tokenRange := scanner.GetRangeOfTokenAtPosition(sourceFile, start)
+	if tokenRange.Pos() >= tokenRange.End() || tokenRange.End() > len(sourceText) {
+		return SourceToken{}, false
+	}
+	return SourceToken{
+		Kind:  scanner.ScanTokenAtPosition(sourceFile, start),
+		Start: tokenRange.Pos(),
+		End:   tokenRange.End(),
+		Text:  sourceText[tokenRange.Pos():tokenRange.End()],
+	}, true
+}
+
+// PreviousTokenBefore returns the last token in node whose end is not after pos.
+func PreviousTokenBefore(sourceFile *ast.SourceFile, node *ast.Node, pos int) (SourceToken, bool) {
+	var previous SourceToken
+	found := false
+	for _, token := range TokensOfNode(sourceFile, node) {
+		if token.Start >= pos {
+			break
+		}
+		if token.End <= pos {
+			previous = token
+			found = true
+		}
+	}
+	return previous, found
+}
+
+// IsSameLine reports whether two positions are on the same ECMAScript line.
+func IsSameLine(sourceFile *ast.SourceFile, a int, b int) bool {
+	lineMap := sourceFile.ECMALineMap()
+	return scanner.ComputeLineOfPosition(lineMap, a) == scanner.ComputeLineOfPosition(lineMap, b)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -77,6 +77,7 @@ export default defineConfig({
     './tests/eslint/rules/no-dupe-keys.test.ts',
     './tests/eslint/rules/no-duplicate-case.test.ts',
     './tests/eslint/rules/no-duplicate-imports.test.ts',
+    './tests/eslint/rules/no-else-return.test.ts',
     './tests/eslint/rules/no-empty.test.ts',
     './tests/eslint/rules/no-empty-pattern.test.ts',
     './tests/eslint/rules/no-eval.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-else-return.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-else-return.test.ts.snap
@@ -1,0 +1,2047 @@
+// Rstest Snapshot v1
+
+exports[`no-else-return > invalid 1`] = `
+{
+  "code": "function foo1() { if (true) { return x; } else { return y; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 2`] = `
+{
+  "code": "function foo2() { if (true) { var x = bar; return x; } else { var y = baz; return y; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 87,
+          "line": 1,
+        },
+        "start": {
+          "column": 61,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 3`] = `
+{
+  "code": "function foo3() { if (true) return x; else return y; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 4`] = `
+{
+  "code": "function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 57,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 87,
+          "line": 1,
+        },
+        "start": {
+          "column": 74,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 5`] = `
+{
+  "code": "function foo5() { if (true) { if (false) { if (true) return x; else { w = y; } } else { w = x; } } else { return z; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 79,
+          "line": 1,
+        },
+        "start": {
+          "column": 69,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 6`] = `
+{
+  "code": "function foo6() { if (true) { if (false) { if (true) return x; else return y; } } else { return z; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 69,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 7`] = `
+{
+  "code": "function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 69,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 111,
+          "line": 1,
+        },
+        "start": {
+          "column": 98,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 8`] = `
+{
+  "code": "function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 69,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 96,
+          "line": 1,
+        },
+        "start": {
+          "column": 86,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 9`] = `
+{
+  "code": "function foo9() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 93,
+          "line": 1,
+        },
+        "start": {
+          "column": 76,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 10`] = `
+{
+  "code": "function foo9a() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 94,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 11`] = `
+{
+  "code": "function foo9b() {if (x) { return true; } if (y) { return true; } else { notAReturn(); } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 1,
+        },
+        "start": {
+          "column": 72,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 12`] = `
+{
+  "code": "function foo10() { if (foo) return bar; else (foo).bar(); }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 13`] = `
+{
+  "code": "function foo11() { if (foo) return bar
+else { [1, 2, 3].map(foo) } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 2,
+        },
+        "start": {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 14`] = `
+{
+  "code": "function foo12() { if (foo) return bar
+else { baz() }
+[1, 2, 3].map(foo) }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 15`] = `
+{
+  "code": "function foo13() { if (foo) return bar;
+else { [1, 2, 3].map(foo) } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 2,
+        },
+        "start": {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 16`] = `
+{
+  "code": "function foo14() { if (foo) return bar
+else { baz(); }
+[1, 2, 3].map(foo) }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 17`] = `
+{
+  "code": "function foo15() { if (foo) return bar; else { baz() } qaz() }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 18`] = `
+{
+  "code": "function foo16() { if (foo) return bar
+else { baz() } qaz() }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 19`] = `
+{
+  "code": "function foo17() { if (foo) return bar
+else { baz() }
+qaz() }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 20`] = `
+{
+  "code": "function foo18() { if (foo) return function() {}
+else [1, 2, 3].map(bar) }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 2,
+        },
+        "start": {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 21`] = `
+{
+  "code": "function foo19() { if (true) { return x; } else if (false) { return y; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 22`] = `
+{
+  "code": "function foo20() {if (x) { return true; } else if (y) { notAReturn() } else { notAReturn(); } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 94,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 23`] = `
+{
+  "code": "function foo21() { var x = true; if (x) { return x; } else if (x === false) { return false; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 94,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 24`] = `
+{
+  "code": "function foo() { var a; if (bar) { return true; } else { var a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 25`] = `
+{
+  "code": "function foo() { if (bar) { var a; if (baz) { return true; } else { var a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 1,
+        },
+        "start": {
+          "column": 67,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 26`] = `
+{
+  "code": "function foo() { let a; if (bar) { return true; } else { let a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 27`] = `
+{
+  "code": "class foo { bar() { let a; if (baz) { return true; } else { let a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 59,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 28`] = `
+{
+  "code": "function foo() { if (bar) { let a; if (baz) { return true; } else { let a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 1,
+        },
+        "start": {
+          "column": 67,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 29`] = `
+{
+  "code": "function foo() {let a; if (bar) { if (baz) { return true; } else { let a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 76,
+          "line": 1,
+        },
+        "start": {
+          "column": 66,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 30`] = `
+{
+  "code": "function foo() { const a = 1; if (bar) { return true; } else { let a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 1,
+        },
+        "start": {
+          "column": 62,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 31`] = `
+{
+  "code": "function foo() { if (bar) { const a = 1; if (baz) { return true; } else { let a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 83,
+          "line": 1,
+        },
+        "start": {
+          "column": 73,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 32`] = `
+{
+  "code": "function foo() { let a; if (bar) { return true; } else { const a = 1 } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 33`] = `
+{
+  "code": "function foo() { if (bar) { let a; if (baz) { return true; } else { const a = 1; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 83,
+          "line": 1,
+        },
+        "start": {
+          "column": 67,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 34`] = `
+{
+  "code": "function foo() { class a {}; if (bar) { return true; } else { const a = 1; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 1,
+        },
+        "start": {
+          "column": 61,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 35`] = `
+{
+  "code": "function foo() { if (bar) { class a {}; if (baz) { return true; } else { const a = 1; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 88,
+          "line": 1,
+        },
+        "start": {
+          "column": 72,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 36`] = `
+{
+  "code": "function foo() { const a = 1; if (bar) { return true; } else { class a {} } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 76,
+          "line": 1,
+        },
+        "start": {
+          "column": 62,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 37`] = `
+{
+  "code": "function foo() { if (bar) { const a = 1; if (baz) { return true; } else { class a {} } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 87,
+          "line": 1,
+        },
+        "start": {
+          "column": 73,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 38`] = `
+{
+  "code": "function foo() { var a; if (bar) { return true; } else { let a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 39`] = `
+{
+  "code": "function foo() { if (bar) { var a; return true; } else { let a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 40`] = `
+{
+  "code": "function foo() { if (bar) { return true; } else { let a; }  while (baz) { var a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 41`] = `
+{
+  "code": "function foo(a) { if (bar) { return true; } else { let a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 42`] = `
+{
+  "code": "function foo(a = 1) { if (bar) { return true; } else { let a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 43`] = `
+{
+  "code": "function foo(a, b = a) { if (bar) { return true; } else { let a; }  if (bar) { return true; } else { let b; }}",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 57,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 110,
+          "line": 1,
+        },
+        "start": {
+          "column": 100,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 44`] = `
+{
+  "code": "function foo(...args) { if (bar) { return true; } else { let args; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 45`] = `
+{
+  "code": "function foo() { try {} catch (a) { if (bar) { return true; } else { let a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 68,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 46`] = `
+{
+  "code": "function foo() { try {} catch (a) { if (bar) { if (baz) { return true; } else { let a; } } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 1,
+        },
+        "start": {
+          "column": 79,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 47`] = `
+{
+  "code": "function foo() { try {} catch ({bar, a = 1}) { if (baz) { return true; } else { let a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 1,
+        },
+        "start": {
+          "column": 79,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 48`] = `
+{
+  "code": "function foo() { if (bar) { return true; } else { let arguments; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 49`] = `
+{
+  "code": "function foo() { if (bar) { return true; } else { let arguments; } return arguments[0]; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 50`] = `
+{
+  "code": "function foo() { if (bar) { return true; } else { let arguments; } if (baz) { return arguments[0]; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 51`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let arguments; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 52`] = `
+{
+  "code": "function foo() { if (bar) { return true; } else { let a; } a; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 53`] = `
+{
+  "code": "function foo() { if (bar) { return true; } else { let a; } if (baz) { a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 54`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let a; } } a; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 55`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let a; } a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 56`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 57`] = `
+{
+  "code": "function a() { if (foo) { return true; } else { let a; } a(); }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 58`] = `
+{
+  "code": "function a() { if (a) { return true; } else { let a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 59`] = `
+{
+  "code": "function a() { if (foo) { return a; } else { let a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 60`] = `
+{
+  "code": "function foo() { if (bar) { return true; } else { let a; } function baz() { a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 61`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let a; } (() => a) } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 62`] = `
+{
+  "code": "function foo() { if (bar) { return true; } else { let a; } var a; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 63`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let a; } var a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 64`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let a; } var { a } = {}; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 65`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { var a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 66`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { var a; } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 67`] = `
+{
+  "code": "function foo() { if (quux) { var a; } if (bar) { if (baz) { return true; } else { let a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 91,
+          "line": 1,
+        },
+        "start": {
+          "column": 81,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 68`] = `
+{
+  "code": "function foo() { if (bar) { return true; } else { let a; } function a(){} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 69`] = `
+{
+  "code": "function foo() { if (baz) { if (bar) { return true; } else { let a; } function a(){} } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 70`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { function a(){}  } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 71`] = `
+{
+  "code": "function foo() { if (bar) { if (baz) { return true; } else { let a; } } function a(){} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 72`] = `
+{
+  "code": "function foo() { let a; if (bar) { return true; } else { function a(){} } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 73`] = `
+{
+  "code": "function foo() { var a; if (bar) { return true; } else { function a(){} } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 74`] = `
+{
+  "code": "function foo() { if (bar) { return true; } else function baz() {} };",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 75`] = `
+{
+  "code": "if (foo) { return true; } else { let a; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-else-return > invalid 76`] = `
+{
+  "code": "let a; if (foo) { return true; } else { let a; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'else' after 'return'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-else-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-else-return.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-else-return.test.ts
@@ -1,0 +1,276 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const unexpected = (count = 1) =>
+  Array.from({ length: count }, () => ({ messageId: 'unexpected' }));
+
+const invalid = (
+  code: string,
+  count = 1,
+  options?: Record<string, unknown>,
+) => ({
+  code,
+  errors: unexpected(count),
+  ...(options ? { options } : {}),
+});
+
+ruleTester.run('no-else-return', {
+  valid: [
+    'function foo() { if (true) { if (false) { return x; } } else { return y; } }',
+    'function foo() { if (true) { return x; } return y; }',
+    'function foo() { if (true) { for (;;) { return x; } } else { return y; } }',
+    'function foo() { var x = true; if (x) { return x; } else if (x === false) { return false; } }',
+    'function foo() { if (true) notAReturn(); else return y; }',
+    'function foo() {if (x) { notAReturn(); } else if (y) { return true; } else { notAReturn(); } }',
+    'function foo() {if (x) { return true; } else if (y) { notAReturn() } else { notAReturn(); } }',
+    'if (0) { if (0) {} else {} } else {}',
+    `
+            function foo() {
+                if (foo)
+                    if (bar) return;
+                    else baz;
+                else qux;
+            }
+        `,
+    `
+            function foo() {
+                while (foo)
+                    if (bar) return;
+                    else baz;
+            }
+        `,
+    {
+      code: 'function foo19() { if (true) { return x; } else if (false) { return y; } }',
+      options: { allowElseIf: true },
+    },
+    {
+      code: 'function foo20() {if (x) { return true; } else if (y) { notAReturn() } else { notAReturn(); } }',
+      options: { allowElseIf: true },
+    },
+    {
+      code: 'function foo21() { var x = true; if (x) { return x; } else if (x === false) { return false; } }',
+      options: { allowElseIf: true },
+    },
+  ],
+  invalid: [
+    invalid('function foo1() { if (true) { return x; } else { return y; } }'),
+    invalid(
+      'function foo2() { if (true) { var x = bar; return x; } else { var y = baz; return y; } }',
+    ),
+    invalid('function foo3() { if (true) return x; else return y; }'),
+    invalid(
+      'function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }',
+      2,
+    ),
+    invalid(
+      'function foo5() { if (true) { if (false) { if (true) return x; else { w = y; } } else { w = x; } } else { return z; } }',
+    ),
+    invalid(
+      'function foo6() { if (true) { if (false) { if (true) return x; else return y; } } else { return z; } }',
+    ),
+    invalid(
+      'function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }',
+      2,
+    ),
+    invalid(
+      'function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }',
+      2,
+    ),
+    invalid(
+      'function foo9() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }',
+    ),
+    invalid(
+      'function foo9a() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }',
+      1,
+      { allowElseIf: false },
+    ),
+    invalid(
+      'function foo9b() {if (x) { return true; } if (y) { return true; } else { notAReturn(); } }',
+      1,
+      { allowElseIf: false },
+    ),
+    invalid('function foo10() { if (foo) return bar; else (foo).bar(); }'),
+    invalid(
+      'function foo11() { if (foo) return bar\nelse { [1, 2, 3].map(foo) } }',
+    ),
+    invalid(
+      'function foo12() { if (foo) return bar\nelse { baz() }\n[1, 2, 3].map(foo) }',
+    ),
+    invalid(
+      'function foo13() { if (foo) return bar;\nelse { [1, 2, 3].map(foo) } }',
+    ),
+    invalid(
+      'function foo14() { if (foo) return bar\nelse { baz(); }\n[1, 2, 3].map(foo) }',
+    ),
+    invalid('function foo15() { if (foo) return bar; else { baz() } qaz() }'),
+    invalid('function foo16() { if (foo) return bar\nelse { baz() } qaz() }'),
+    invalid('function foo17() { if (foo) return bar\nelse { baz() }\nqaz() }'),
+    invalid(
+      'function foo18() { if (foo) return function() {}\nelse [1, 2, 3].map(bar) }',
+    ),
+    invalid(
+      'function foo19() { if (true) { return x; } else if (false) { return y; } }',
+      1,
+      { allowElseIf: false },
+    ),
+    invalid(
+      'function foo20() {if (x) { return true; } else if (y) { notAReturn() } else { notAReturn(); } }',
+      1,
+      { allowElseIf: false },
+    ),
+    invalid(
+      'function foo21() { var x = true; if (x) { return x; } else if (x === false) { return false; } }',
+      1,
+      { allowElseIf: false },
+    ),
+
+    // https://github.com/eslint/eslint/issues/11069
+    invalid(
+      'function foo() { var a; if (bar) { return true; } else { var a; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { var a; if (baz) { return true; } else { var a; } } }',
+    ),
+    invalid(
+      'function foo() { let a; if (bar) { return true; } else { let a; } }',
+    ),
+    invalid(
+      'class foo { bar() { let a; if (baz) { return true; } else { let a; } } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { let a; if (baz) { return true; } else { let a; } } }',
+    ),
+    invalid(
+      'function foo() {let a; if (bar) { if (baz) { return true; } else { let a; } } }',
+    ),
+    invalid(
+      'function foo() { const a = 1; if (bar) { return true; } else { let a; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { const a = 1; if (baz) { return true; } else { let a; } } }',
+    ),
+    invalid(
+      'function foo() { let a; if (bar) { return true; } else { const a = 1 } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { let a; if (baz) { return true; } else { const a = 1; } } }',
+    ),
+    invalid(
+      'function foo() { class a {}; if (bar) { return true; } else { const a = 1; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { class a {}; if (baz) { return true; } else { const a = 1; } } }',
+    ),
+    invalid(
+      'function foo() { const a = 1; if (bar) { return true; } else { class a {} } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { const a = 1; if (baz) { return true; } else { class a {} } } }',
+    ),
+    invalid(
+      'function foo() { var a; if (bar) { return true; } else { let a; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { var a; return true; } else { let a; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { return true; } else { let a; }  while (baz) { var a; } }',
+    ),
+    invalid('function foo(a) { if (bar) { return true; } else { let a; } }'),
+    invalid(
+      'function foo(a = 1) { if (bar) { return true; } else { let a; } }',
+    ),
+    invalid(
+      'function foo(a, b = a) { if (bar) { return true; } else { let a; }  if (bar) { return true; } else { let b; }}',
+      2,
+    ),
+    invalid(
+      'function foo(...args) { if (bar) { return true; } else { let args; } }',
+    ),
+    invalid(
+      'function foo() { try {} catch (a) { if (bar) { return true; } else { let a; } } }',
+    ),
+    invalid(
+      'function foo() { try {} catch (a) { if (bar) { if (baz) { return true; } else { let a; } } } }',
+    ),
+    invalid(
+      'function foo() { try {} catch ({bar, a = 1}) { if (baz) { return true; } else { let a; } } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { return true; } else { let arguments; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { return true; } else { let arguments; } return arguments[0]; }',
+    ),
+    invalid(
+      'function foo() { if (bar) { return true; } else { let arguments; } if (baz) { return arguments[0]; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let arguments; } } }',
+    ),
+    invalid('function foo() { if (bar) { return true; } else { let a; } a; }'),
+    invalid(
+      'function foo() { if (bar) { return true; } else { let a; } if (baz) { a; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let a; } } a; }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let a; } a; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { a; } } }',
+    ),
+    invalid('function a() { if (foo) { return true; } else { let a; } a(); }'),
+    invalid('function a() { if (a) { return true; } else { let a; } }'),
+    invalid('function a() { if (foo) { return a; } else { let a; } }'),
+    invalid(
+      'function foo() { if (bar) { return true; } else { let a; } function baz() { a; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let a; } (() => a) } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { return true; } else { let a; } var a; }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let a; } var a; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let a; } var { a } = {}; } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { var a; } } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { var a; } }',
+    ),
+    invalid(
+      'function foo() { if (quux) { var a; } if (bar) { if (baz) { return true; } else { let a; } } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { return true; } else { let a; } function a(){} }',
+    ),
+    invalid(
+      'function foo() { if (baz) { if (bar) { return true; } else { let a; } function a(){} } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { function a(){}  } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { if (baz) { return true; } else { let a; } } function a(){} }',
+    ),
+    invalid(
+      'function foo() { let a; if (bar) { return true; } else { function a(){} } }',
+    ),
+    invalid(
+      'function foo() { var a; if (bar) { return true; } else { function a(){} } }',
+    ),
+    invalid(
+      'function foo() { if (bar) { return true; } else function baz() {} };',
+    ),
+    invalid('if (foo) { return true; } else { let a; }'),
+    invalid('let a; if (foo) { return true; } else { let a; }'),
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-else-return` rule from ESLint to rslint.

Adds the core rule implementation, documentation, upstream parity tests, additional edge-case coverage, JS registration coverage, and real-repo validation for rsbuild/rspack.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-else-return
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-else-return.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).