### PR TITLE
feat: port rule prefer-numeric-literals

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -123,6 +123,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_arrow_callback"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_const"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_exponentiation_operator"
+	"github.com/web-infra-dev/rslint/internal/rules/prefer_numeric_literals"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_regex_literals"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
@@ -231,6 +232,7 @@ func GetAllRules() []rule.Rule {
 		no_undef_init.NoUndefInitRule,
 		prefer_const.PreferConstRule,
 		prefer_exponentiation_operator.PreferExponentiationOperatorRule,
+		prefer_numeric_literals.PreferNumericLiteralsRule,
 		prefer_promise_reject_errors.PreferPromiseRejectErrorsRule,
 		prefer_regex_literals.PreferRegexLiteralsRule,
 		prefer_template.PreferTemplateRule,

--- a/internal/rules/prefer_numeric_literals/prefer_numeric_literals.go
+++ b/internal/rules/prefer_numeric_literals/prefer_numeric_literals.go
@@ -1,0 +1,128 @@
+package prefer_numeric_literals
+
+import (
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type radixLiteralInfo struct {
+	radix         int
+	system        string
+	literalPrefix string
+}
+
+var radixLiteralInfos = map[int]radixLiteralInfo{
+	2:  {radix: 2, system: "binary", literalPrefix: "0b"},
+	8:  {radix: 8, system: "octal", literalPrefix: "0o"},
+	16: {radix: 16, system: "hexadecimal", literalPrefix: "0x"},
+}
+
+func useLiteralMessage(system string, functionName string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "useLiteral",
+		Description: "Use " + system + " literals instead of " + functionName + "().",
+		Data: map[string]string{
+			"system":       system,
+			"functionName": functionName,
+		},
+	}
+}
+
+// https://eslint.org/docs/latest/rules/prefer-numeric-literals
+var PreferNumericLiteralsRule = rule.Rule{
+	Name: "prefer-numeric-literals",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) != 2 {
+					return
+				}
+
+				args := call.Arguments.Nodes
+				// ESTree treats parentheses as transparent here, but TS-only
+				// assertion wrappers must remain opaque to match ESLint.
+				str, ok := utils.GetStaticStringLiteralValue(ast.SkipParentheses(args[0]))
+				if !ok {
+					return
+				}
+
+				radixInfo, ok := numericRadixInfo(args[1])
+				if !ok {
+					return
+				}
+
+				if !utils.IsGlobalParseIntCallee(call.Expression) {
+					return
+				}
+
+				functionName := utils.TrimmedNodeText(ctx.SourceFile, ast.SkipParentheses(call.Expression))
+				msg := useLiteralMessage(radixInfo.system, functionName)
+				if fix := numericLiteralFix(ctx, node, str, radixInfo); fix != nil {
+					ctx.ReportNodeWithFixes(node, msg, *fix)
+					return
+				}
+				ctx.ReportNode(node, msg)
+			},
+		}
+	},
+}
+
+func numericRadixInfo(node *ast.Node) (radixLiteralInfo, bool) {
+	node = ast.SkipParentheses(node)
+	if node == nil || node.Kind != ast.KindNumericLiteral {
+		return radixLiteralInfo{}, false
+	}
+
+	text := utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text)
+	value, err := strconv.Atoi(text)
+	if err != nil {
+		return radixLiteralInfo{}, false
+	}
+
+	info, ok := radixLiteralInfos[value]
+	return info, ok
+}
+
+func numericLiteralFix(ctx rule.RuleContext, node *ast.Node, str string, radixInfo radixLiteralInfo) *rule.RuleFix {
+	if utils.HasCommentInsideNode(ctx.SourceFile, node) {
+		return nil
+	}
+	if !canRepresentAsNumericLiteral(str, radixInfo.radix) {
+		return nil
+	}
+
+	replacement := radixInfo.literalPrefix + str
+	fix := rule.RuleFixReplace(
+		ctx.SourceFile,
+		node,
+		utils.SafeReplacementText(ctx.SourceFile, node, replacement),
+	)
+	return &fix
+}
+
+// parseInt accepts prefixes, signs, separators, whitespace, and then stops at
+// the first invalid character. Numeric literals need the whole string to be a
+// valid digit sequence for the target radix, so this safety check stays
+// rule-specific rather than using a general static-value helper.
+func canRepresentAsNumericLiteral(str string, radix int) bool {
+	if str == "" {
+		return false
+	}
+	for _, r := range str {
+		switch {
+		case r >= '0' && r <= '9':
+			if int(r-'0') >= radix {
+				return false
+			}
+		case radix == 16 && r >= 'a' && r <= 'f':
+		case radix == 16 && r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/rules/prefer_numeric_literals/prefer_numeric_literals.md
+++ b/internal/rules/prefer_numeric_literals/prefer_numeric_literals.md
@@ -1,0 +1,30 @@
+# prefer-numeric-literals
+
+## Rule Details
+
+This rule disallows `parseInt()` and `Number.parseInt()` when binary, octal,
+or hexadecimal numeric literals can be used instead.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+parseInt("111110111", 2) === 503;
+parseInt(`767`, 8) === 503;
+Number.parseInt("1F7", 16) === 255;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+0b111110111 === 503;
+0o767 === 503;
+0x1F7 === 503;
+
+parseInt(foo, 2);
+parseInt("11", 10);
+Number.parseInt("11", 36);
+```
+
+## Original Documentation
+
+- [ESLint prefer-numeric-literals](https://eslint.org/docs/latest/rules/prefer-numeric-literals)

--- a/internal/rules/prefer_numeric_literals/prefer_numeric_literals_extras_test.go
+++ b/internal/rules/prefer_numeric_literals/prefer_numeric_literals_extras_test.go
@@ -1,0 +1,108 @@
+package prefer_numeric_literals
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestPreferNumericLiteralsExtras locks in branches and edge shapes that the upstream test suite doesn't exercise. Each case carries an inline comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future refactors can't silently regress them without breaking a named lock-in.
+func TestPreferNumericLiteralsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferNumericLiteralsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: TS-only wrappers around the callee do not match ESLint's identifier/member checks ----
+			{Code: `(parseInt as Function)("11", 2);`},
+			{Code: `parseInt!("11", 2);`},
+			{Code: `(Number as any).parseInt("11", 2);`},
+			{Code: `Number!.parseInt("11", 2);`},
+			{Code: `parseInt("11" as string, 2);`},
+			{Code: `parseInt("11", 2 as number);`},
+
+			// ---- Dimension 4: dynamic and non-matching element keys are not Number.parseInt ----
+			{Code: `Number[parseInt]("11", 2);`},
+			{Code: `Number[0]("11", 2);`},
+			{Code: `Number["notParseInt"]("11", 2);`},
+			{Code: `Number["parseInt" as string]("11", 2);`},
+
+			// ---- Dimension 4: shadowed globals remain valid across nesting boundaries ----
+			{Code: `function f(parseInt) { parseInt("11", 2); }`},
+			{Code: `function f(Number) { Number.parseInt("11", 2); }`},
+			{Code: `const parseInt = Number.parseInt; parseInt("11", 2);`},
+			{Code: `function f(Number) { Number?.parseInt("11", 2); }`},
+
+			// ---- Dimension 4: graceful degradation for spread and missing argument shapes ----
+			{Code: `parseInt(...args);`},
+			{Code: `parseInt("11", ...radix);`},
+			{Code: `parseInt();`},
+
+			// Locks in upstream create() condition arm: radix number is outside the tracked map.
+			{Code: `parseInt("11", 10);`},
+			{Code: `Number.parseInt("11", 36);`},
+
+			// Locks in upstream create() condition arm: first argument is static-looking but not a string/template literal.
+			{Code: `parseInt(11n, 2);`},
+
+			// N/A: object/property declaration key forms are not inspected by this call-expression rule.
+			// N/A: function/class declaration containers do not create rule-owned traversal state.
+			// N/A: body-absent TS declarations are not parseInt call expressions.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: deeply parenthesized callee ----
+			preferNumericInvalidFixed(`((parseInt))("11", 2);`, `((parseInt))("11", 2)`, `0b11;`, "binary", "parseInt"),
+
+			// ---- Dimension 4: parenthesized arguments are transparent, matching ESTree's flattened parentheses ----
+			preferNumericInvalidFixed(`parseInt(("767"), (8));`, `parseInt(("767"), (8))`, `0o767;`, "octal", "parseInt"),
+
+			// ---- Dimension 4: static element keys for Number.parseInt match ESLint's isSpecificMemberAccess ----
+			preferNumericInvalidFixed(`Number["parseInt"]("11", 2);`, `Number["parseInt"]("11", 2)`, `0b11;`, "binary", `Number["parseInt"]`),
+			preferNumericInvalidFixed("Number[`parseInt`](`767`, 8);", "Number[`parseInt`](`767`, 8)", `0o767;`, "octal", "Number[`parseInt`]"),
+			preferNumericInvalidFixed(`Number?.["parseInt"]("11", 2);`, `Number?.["parseInt"]("11", 2)`, `0b11;`, "binary", `Number?.["parseInt"]`),
+
+			// ---- Dimension 4: non-decimal numeric radix literals normalize to 2/8/16 ----
+			preferNumericInvalidFixed(`parseInt("11", 0b10);`, `parseInt("11", 0b10)`, `0b11;`, "binary", "parseInt"),
+			preferNumericInvalidFixed(`parseInt("767", 0o10);`, `parseInt("767", 0o10)`, `0o767;`, "octal", "parseInt"),
+			preferNumericInvalidFixed(`parseInt("1F7", 0x10);`, `parseInt("1F7", 0x10)`, `0x1F7;`, "hexadecimal", "parseInt"),
+			preferNumericInvalidFixed(`parseInt("11", 2.0);`, `parseInt("11", 2.0)`, `0b11;`, "binary", "parseInt"),
+			preferNumericInvalidFixed(`parseInt("767", 8e0);`, `parseInt("767", 8e0)`, `0o767;`, "octal", "parseInt"),
+
+			// ---- Dimension 4: multi-line report range and fix replacement ----
+			preferNumericInvalidFixed("const value = Number.parseInt(\n  \"1F7\",\n  16\n);", "Number.parseInt(\n  \"1F7\",\n  16\n)", `const value = 0x1F7;`, "hexadecimal", "Number.parseInt"),
+
+			// ---- Dimension 4: nested expression containers and multiple reports in the same file ----
+			preferNumericInvalidFixed(`const value = () => parseInt("11", 2);`, `parseInt("11", 2)`, `const value = () => 0b11;`, "binary", "parseInt"),
+			preferNumericInvalidFixed(`class C { field = Number.parseInt("1F", 16); }`, `Number.parseInt("1F", 16)`, `class C { field = 0x1F; }`, "hexadecimal", "Number.parseInt"),
+			preferNumericInvalidFixed(`const obj = { [parseInt("11", 2)]: true };`, `parseInt("11", 2)`, `const obj = { [0b11]: true };`, "binary", "parseInt"),
+			preferNumericInvalidFixed(`class C { [Number.parseInt("1F", 16)]() {} }`, `Number.parseInt("1F", 16)`, `class C { [0x1F]() {} }`, "hexadecimal", "Number.parseInt"),
+			preferNumericInvalidFixedTwo(
+				`foo(parseInt("11", 2), Number.parseInt("1F", 16));`,
+				`parseInt("11", 2)`,
+				"binary",
+				"parseInt",
+				`Number.parseInt("1F", 16)`,
+				"hexadecimal",
+				"Number.parseInt",
+				`foo(0b11, 0x1F);`,
+			),
+
+			// ---- Real-user: eslint/eslint#13045 no-substitution template literals should report ----
+			preferNumericInvalidFixed("Number.parseInt(`111110111`, 2) === 503;", "Number.parseInt(`111110111`, 2)", `0b111110111 === 503;`, "binary", "Number.parseInt"),
+
+			// ---- Real-user: eslint/eslint#13568 numeric separators should report but not autofix ----
+			preferNumericInvalidNoFix("Number.parseInt(`5_000`, 8);", "Number.parseInt(`5_000`, 8)", "octal", "Number.parseInt"),
+
+			// Locks in upstream isParseInt() identifier arm: only the outer call that is not shadowed reports.
+			preferNumericInvalidFixed(`parseInt("11", 2); function f(parseInt) { parseInt("11", 2); }`, `parseInt("11", 2)`, `0b11; function f(parseInt) { parseInt("11", 2); }`, "binary", "parseInt"),
+
+			// Locks in upstream fix() prefix arm: keyword before replacement needs whitespace.
+			preferNumericInvalidFixed(`function *f(){ yield((parseInt))("11", 2) }`, `((parseInt))("11", 2)`, `function *f(){ yield 0b11 }`, "binary", "parseInt"),
+
+			// Locks in upstream fix() suffix arm: keyword after replacement needs whitespace.
+			preferNumericInvalidFixed(`const ok = parseInt("11", 2)in foo;`, `parseInt("11", 2)`, `const ok = 0b11 in foo;`, "binary", "parseInt"),
+		},
+	)
+}

--- a/internal/rules/prefer_numeric_literals/prefer_numeric_literals_upstream_test.go
+++ b/internal/rules/prefer_numeric_literals/prefer_numeric_literals_upstream_test.go
@@ -1,0 +1,224 @@
+package prefer_numeric_literals
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestPreferNumericLiteralsUpstream migrates the full valid/invalid suite from upstream tests/lib/rules/prefer-numeric-literals.js 1:1. Position assertions cover line/column for every invalid case. rslint-specific lock-in cases live in the prefer_numeric_literals_extras_test.go file.
+func TestPreferNumericLiteralsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferNumericLiteralsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `parseInt(1);`},
+			{Code: `parseInt(1, 3);`},
+			{Code: `Number.parseInt(1);`},
+			{Code: `Number.parseInt(1, 3);`},
+			{Code: `0b111110111 === 503;`},
+			{Code: `0o767 === 503;`},
+			{Code: `0x1F7 === 503;`},
+			{Code: `a[parseInt](1,2);`},
+			{Code: `parseInt(foo);`},
+			{Code: `parseInt(foo, 2);`},
+			{Code: `Number.parseInt(foo);`},
+			{Code: `Number.parseInt(foo, 2);`},
+			{Code: `parseInt(11, 2);`},
+			{Code: `Number.parseInt(1, 8);`},
+			{Code: `parseInt(1e5, 16);`},
+			{Code: `parseInt('11', '2');`},
+			{Code: `Number.parseInt('11', '8');`},
+			{Code: `parseInt(/foo/, 2);`},
+			{Code: "parseInt(`11${foo}`, 2);"},
+			{Code: `parseInt('11', 2n);`},
+			{Code: `Number.parseInt('11', 8n);`},
+			{Code: `parseInt('11', 16n);`},
+			{Code: "parseInt(`11`, 16n);"},
+			{Code: `parseInt(1n, 2);`},
+			{Code: `class C { #parseInt; foo() { Number.#parseInt("111110111", 2); } }`},
+
+			// Shadowed `parseInt` and `Number` should not be reported.
+			{Code: `function foo(parseInt) { parseInt("111110111", 2); }`},
+			{Code: `function foo() { var parseInt; parseInt("111110111", 2); }`},
+			{Code: `function foo(Number) { Number.parseInt("111110111", 2); }`},
+			{Code: `function foo() { var Number; Number.parseInt("111110111", 2); }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			preferNumericInvalidFixed(`parseInt("111110111", 2) === 503;`, `parseInt("111110111", 2)`, `0b111110111 === 503;`, "binary", "parseInt"),
+			preferNumericInvalidFixed(`parseInt("767", 8) === 503;`, `parseInt("767", 8)`, `0o767 === 503;`, "octal", "parseInt"),
+			preferNumericInvalidFixed(`parseInt("1F7", 16) === 255;`, `parseInt("1F7", 16)`, `0x1F7 === 255;`, "hexadecimal", "parseInt"),
+			preferNumericInvalidFixed(`Number.parseInt("111110111", 2) === 503;`, `Number.parseInt("111110111", 2)`, `0b111110111 === 503;`, "binary", "Number.parseInt"),
+			preferNumericInvalidFixed(`Number.parseInt("767", 8) === 503;`, `Number.parseInt("767", 8)`, `0o767 === 503;`, "octal", "Number.parseInt"),
+			preferNumericInvalidFixed(`Number.parseInt("1F7", 16) === 255;`, `Number.parseInt("1F7", 16)`, `0x1F7 === 255;`, "hexadecimal", "Number.parseInt"),
+			preferNumericInvalidNoFix(`parseInt('7999', 8);`, `parseInt('7999', 8)`, "octal", "parseInt"),
+			preferNumericInvalidNoFix(`parseInt('1234', 2);`, `parseInt('1234', 2)`, "binary", "parseInt"),
+			preferNumericInvalidNoFix(`parseInt('1234.5', 8);`, `parseInt('1234.5', 8)`, "octal", "parseInt"),
+			preferNumericInvalidNoFix(`parseInt('\u0031\ufe0f\u20e3\u0033\ufe0f\u20e3\u0033\ufe0f\u20e3\u0037\ufe0f\u20e3', 16);`, `parseInt('\u0031\ufe0f\u20e3\u0033\ufe0f\u20e3\u0033\ufe0f\u20e3\u0037\ufe0f\u20e3', 16)`, "hexadecimal", "parseInt"),
+			preferNumericInvalidNoFix(`Number.parseInt('7999', 8);`, `Number.parseInt('7999', 8)`, "octal", "Number.parseInt"),
+			preferNumericInvalidNoFix(`Number.parseInt('1234', 2);`, `Number.parseInt('1234', 2)`, "binary", "Number.parseInt"),
+			preferNumericInvalidNoFix(`Number.parseInt('1234.5', 8);`, `Number.parseInt('1234.5', 8)`, "octal", "Number.parseInt"),
+			preferNumericInvalidNoFix(`Number.parseInt('\u0031\ufe0f\u20e3\u0033\ufe0f\u20e3\u0033\ufe0f\u20e3\u0037\ufe0f\u20e3', 16);`, `Number.parseInt('\u0031\ufe0f\u20e3\u0033\ufe0f\u20e3\u0033\ufe0f\u20e3\u0037\ufe0f\u20e3', 16)`, "hexadecimal", "Number.parseInt"),
+			preferNumericInvalidFixed("parseInt(`111110111`, 2) === 503;", "parseInt(`111110111`, 2)", `0b111110111 === 503;`, "binary", "parseInt"),
+			preferNumericInvalidFixed("parseInt(`767`, 8) === 503;", "parseInt(`767`, 8)", `0o767 === 503;`, "octal", "parseInt"),
+			preferNumericInvalidFixed("parseInt(`1F7`, 16) === 255;", "parseInt(`1F7`, 16)", `0x1F7 === 255;`, "hexadecimal", "parseInt"),
+			preferNumericInvalidNoFix(`parseInt('', 8);`, `parseInt('', 8)`, "octal", "parseInt"),
+			preferNumericInvalidNoFix("parseInt(``, 8);", "parseInt(``, 8)", "octal", "parseInt"),
+			preferNumericInvalidNoFix("parseInt(`7999`, 8);", "parseInt(`7999`, 8)", "octal", "parseInt"),
+			preferNumericInvalidNoFix("parseInt(`1234`, 2);", "parseInt(`1234`, 2)", "binary", "parseInt"),
+			preferNumericInvalidNoFix("parseInt(`1234.5`, 8);", "parseInt(`1234.5`, 8)", "octal", "parseInt"),
+
+			// Adjacent tokens tests
+			preferNumericInvalidFixed(`parseInt('11', 2)`, `parseInt('11', 2)`, `0b11`, "binary", "parseInt"),
+			preferNumericInvalidFixed(`Number.parseInt('67', 8)`, `Number.parseInt('67', 8)`, `0o67`, "octal", "Number.parseInt"),
+			preferNumericInvalidFixed(`5+parseInt('A', 16)`, `parseInt('A', 16)`, `5+0xA`, "hexadecimal", "parseInt"),
+			preferNumericInvalidFixed(`function *f(){ yield(Number).parseInt('11', 2) }`, `(Number).parseInt('11', 2)`, `function *f(){ yield 0b11 }`, "binary", "(Number).parseInt"),
+			preferNumericInvalidFixed(`function *f(){ yield(Number.parseInt)('67', 8) }`, `(Number.parseInt)('67', 8)`, `function *f(){ yield 0o67 }`, "octal", "Number.parseInt"),
+			preferNumericInvalidFixed(`function *f(){ yield(parseInt)('A', 16) }`, `(parseInt)('A', 16)`, `function *f(){ yield 0xA }`, "hexadecimal", "parseInt"),
+			preferNumericInvalidFixed(`function *f(){ yield Number.parseInt('11', 2) }`, `Number.parseInt('11', 2)`, `function *f(){ yield 0b11 }`, "binary", "Number.parseInt"),
+			preferNumericInvalidFixed(`function *f(){ yield/**/Number.parseInt('67', 8) }`, `Number.parseInt('67', 8)`, `function *f(){ yield/**/0o67 }`, "octal", "Number.parseInt"),
+			preferNumericInvalidFixed(`function *f(){ yield(parseInt('A', 16)) }`, `parseInt('A', 16)`, `function *f(){ yield(0xA) }`, "hexadecimal", "parseInt"),
+			preferNumericInvalidFixed(`parseInt('11', 2)+5`, `parseInt('11', 2)`, `0b11+5`, "binary", "parseInt"),
+			preferNumericInvalidFixed(`Number.parseInt('17', 8)+5`, `Number.parseInt('17', 8)`, `0o17+5`, "octal", "Number.parseInt"),
+			preferNumericInvalidFixed(`parseInt('A', 16)+5`, `parseInt('A', 16)`, `0xA+5`, "hexadecimal", "parseInt"),
+			preferNumericInvalidFixed(`parseInt('11', 2)in foo`, `parseInt('11', 2)`, `0b11 in foo`, "binary", "parseInt"),
+			preferNumericInvalidFixed(`Number.parseInt('17', 8)in foo`, `Number.parseInt('17', 8)`, `0o17 in foo`, "octal", "Number.parseInt"),
+			preferNumericInvalidFixed(`parseInt('A', 16)in foo`, `parseInt('A', 16)`, `0xA in foo`, "hexadecimal", "parseInt"),
+			preferNumericInvalidFixed(`parseInt('11', 2) in foo`, `parseInt('11', 2)`, `0b11 in foo`, "binary", "parseInt"),
+			preferNumericInvalidFixed(`Number.parseInt('17', 8)/**/in foo`, `Number.parseInt('17', 8)`, `0o17/**/in foo`, "octal", "Number.parseInt"),
+			preferNumericInvalidFixed(`(parseInt('A', 16))in foo`, `parseInt('A', 16)`, `(0xA)in foo`, "hexadecimal", "parseInt"),
+
+			// Should not autofix if it would remove comments
+			preferNumericInvalidFixedNoMessage(`/* comment */Number.parseInt('11', 2);`, `Number.parseInt('11', 2)`, `/* comment */0b11;`),
+			preferNumericInvalidNoFixNoMessage(`Number/**/.parseInt('11', 2);`, `Number/**/.parseInt('11', 2)`),
+			preferNumericInvalidNoFixNoMessage("Number//\n.parseInt('11', 2);", "Number//\n.parseInt('11', 2)"),
+			preferNumericInvalidNoFixNoMessage(`Number./**/parseInt('11', 2);`, `Number./**/parseInt('11', 2)`),
+			preferNumericInvalidNoFixNoMessage(`Number.parseInt(/**/'11', 2);`, `Number.parseInt(/**/'11', 2)`),
+			preferNumericInvalidNoFixNoMessage(`Number.parseInt('11', /**/2);`, `Number.parseInt('11', /**/2)`),
+			preferNumericInvalidFixedNoMessage(`Number.parseInt('11', 2)/* comment */;`, `Number.parseInt('11', 2)`, `0b11/* comment */;`),
+			preferNumericInvalidNoFixNoMessage(`parseInt/**/('11', 2);`, `parseInt/**/('11', 2)`),
+			preferNumericInvalidNoFixNoMessage("parseInt(//\n'11', 2);", "parseInt(//\n'11', 2)"),
+			preferNumericInvalidNoFixNoMessage(`parseInt('11'/**/, 2);`, `parseInt('11'/**/, 2)`),
+			preferNumericInvalidNoFixNoMessage("parseInt(`11`/**/, 2);", "parseInt(`11`/**/, 2)"),
+			preferNumericInvalidNoFixNoMessage(`parseInt('11', 2 /**/);`, `parseInt('11', 2 /**/)`),
+			preferNumericInvalidFixedNoMessage("parseInt('11', 2)//comment\n;", "parseInt('11', 2)", "0b11//comment\n;"),
+
+			// Optional chaining
+			preferNumericInvalidFixed(`parseInt?.("1F7", 16) === 255;`, `parseInt?.("1F7", 16)`, `0x1F7 === 255;`, "hexadecimal", "parseInt"),
+			preferNumericInvalidFixed(`Number?.parseInt("1F7", 16) === 255;`, `Number?.parseInt("1F7", 16)`, `0x1F7 === 255;`, "hexadecimal", "Number?.parseInt"),
+			preferNumericInvalidFixed(`Number?.parseInt?.("1F7", 16) === 255;`, `Number?.parseInt?.("1F7", 16)`, `0x1F7 === 255;`, "hexadecimal", "Number?.parseInt"),
+			preferNumericInvalidFixed(`(Number?.parseInt)("1F7", 16) === 255;`, `(Number?.parseInt)("1F7", 16)`, `0x1F7 === 255;`, "hexadecimal", "Number?.parseInt"),
+			preferNumericInvalidFixed(`(Number?.parseInt)?.("1F7", 16) === 255;`, `(Number?.parseInt)?.("1F7", 16)`, `0x1F7 === 255;`, "hexadecimal", "Number?.parseInt"),
+
+			// `parseInt` doesn't support numeric separators. The rule shouldn't autofix in those cases.
+			preferNumericInvalidNoFix(`parseInt('1_0', 2);`, `parseInt('1_0', 2)`, "binary", "parseInt"),
+			preferNumericInvalidNoFix(`Number.parseInt('5_000', 8);`, `Number.parseInt('5_000', 8)`, "octal", "Number.parseInt"),
+			preferNumericInvalidNoFix(`parseInt('0_1', 16);`, `parseInt('0_1', 16)`, "hexadecimal", "parseInt"),
+			preferNumericInvalidNoFix(`Number.parseInt('0_0', 16);`, `Number.parseInt('0_0', 16)`, "hexadecimal", "Number.parseInt"),
+		},
+	)
+}
+
+func preferNumericInvalidFixed(code string, target string, output string, system string, functionName string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:   code,
+		Output: []string{output},
+		Errors: []rule_tester.InvalidTestCaseError{
+			preferNumericError(code, target, system, functionName, true),
+		},
+	}
+}
+
+func preferNumericInvalidNoFix(code string, target string, system string, functionName string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code: code,
+		Errors: []rule_tester.InvalidTestCaseError{
+			preferNumericError(code, target, system, functionName, true),
+		},
+	}
+}
+
+func preferNumericInvalidFixedTwo(
+	code string,
+	firstTarget string,
+	firstSystem string,
+	firstFunctionName string,
+	secondTarget string,
+	secondSystem string,
+	secondFunctionName string,
+	output string,
+) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:   code,
+		Output: []string{output},
+		Errors: []rule_tester.InvalidTestCaseError{
+			preferNumericError(code, firstTarget, firstSystem, firstFunctionName, true),
+			preferNumericError(code, secondTarget, secondSystem, secondFunctionName, true),
+		},
+	}
+}
+
+func preferNumericInvalidFixedNoMessage(code string, target string, output string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:   code,
+		Output: []string{output},
+		Errors: []rule_tester.InvalidTestCaseError{
+			preferNumericError(code, target, "", "", false),
+		},
+	}
+}
+
+func preferNumericInvalidNoFixNoMessage(code string, target string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code: code,
+		Errors: []rule_tester.InvalidTestCaseError{
+			preferNumericError(code, target, "", "", false),
+		},
+	}
+}
+
+func preferNumericError(code string, target string, system string, functionName string, checkMessage bool) rule_tester.InvalidTestCaseError {
+	start := strings.Index(code, target)
+	if start < 0 {
+		panic("target not found in prefer-numeric-literals test: " + target)
+	}
+	end := start + len(target)
+	line, column := utf16LineColumn(code, start)
+	endLine, endColumn := utf16LineColumn(code, end)
+	err := rule_tester.InvalidTestCaseError{
+		MessageId: "useLiteral",
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+	if checkMessage {
+		err.Message = "Use " + system + " literals instead of " + functionName + "()."
+	}
+	return err
+}
+
+func utf16LineColumn(text string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for i, r := range text {
+		if i >= offset {
+			break
+		}
+		if r == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		if r >= 0x10000 {
+			column += 2
+		} else {
+			column++
+		}
+	}
+	return line, column
+}

--- a/internal/rules/radix/radix.go
+++ b/internal/rules/radix/radix.go
@@ -80,47 +80,6 @@ func isValidRadix(radix *ast.Node) bool {
 	return true
 }
 
-// isParseIntCallee reports whether a callee is a reference to the global
-// `parseInt` or `Number.parseInt` function that is not shadowed. Mirrors
-// ESLint's scope-based check, with the same constraints:
-//
-//   - `Number['parseInt']()` is NOT matched (ESLint's isParseIntMethod rejects
-//     computed member access).
-//   - `Number.#parseInt()` is NOT matched (PrivateIdentifier, not Identifier).
-//   - TS-only wrappers (`!`, `as`, `<T>`, `satisfies`) on the callee or on
-//     `Number` cause ESLint's check to fail because the callee node is no
-//     longer an Identifier. We mirror that by only peeling parentheses, not
-//     other outer expressions.
-func isParseIntCallee(callee *ast.Node) bool {
-	callee = ast.SkipParentheses(callee)
-	if callee == nil {
-		return false
-	}
-
-	switch callee.Kind {
-	case ast.KindIdentifier:
-		return callee.AsIdentifier().Text == "parseInt" &&
-			!utils.IsShadowed(callee, "parseInt")
-
-	case ast.KindPropertyAccessExpression:
-		pae := callee.AsPropertyAccessExpression()
-		name := pae.Name()
-		if name == nil || !ast.IsIdentifier(name) {
-			return false
-		}
-		if name.AsIdentifier().Text != "parseInt" {
-			return false
-		}
-		obj := ast.SkipParentheses(pae.Expression)
-		if obj == nil || !ast.IsIdentifier(obj) {
-			return false
-		}
-		return obj.AsIdentifier().Text == "Number" &&
-			!utils.IsShadowed(obj, "Number")
-	}
-	return false
-}
-
 // hasTrailingComma reports whether the CallExpression source text has a
 // trailing comma after the last argument. It skips whitespace and comments
 // between the last argument and the closing paren.
@@ -139,7 +98,7 @@ var RadixRule = rule.Rule{
 				if call == nil {
 					return
 				}
-				if !isParseIntCallee(call.Expression) {
+				if !utils.IsGlobalParseIntCallee(call.Expression) {
 					return
 				}
 				checkArguments(ctx, node, call)

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -39,20 +39,64 @@ func IsCallee(node *ast.Node) bool {
 	return false
 }
 
+// GetStaticStringLiteralValue returns the string value and a presence flag if
+// node is a string literal or a no-substitution template literal. It does not
+// unwrap parentheses or TS assertions; callers choose which wrappers are
+// transparent for their rule.
+func GetStaticStringLiteralValue(node *ast.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text, true
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text, true
+	}
+	return "", false
+}
+
 // GetStaticStringValue returns the string value if the node is a string literal
 // or a no-substitution template literal. Returns "" if the value cannot be
 // statically determined.
 func GetStaticStringValue(node *ast.Node) string {
-	if node == nil {
-		return ""
+	value, _ := GetStaticStringLiteralValue(node)
+	return value
+}
+
+// IsGlobalParseIntCallee reports whether callee references the built-in
+// `parseInt` or `Number.parseInt` function. It mirrors ESLint's
+// astUtils.isSpecificId / isSpecificMemberAccess shape: outer parentheses and
+// optional chaining are transparent, TS-only assertion wrappers are not.
+func IsGlobalParseIntCallee(callee *ast.Node) bool {
+	callee = ast.SkipParentheses(callee)
+	if callee == nil {
+		return false
 	}
+
+	if ast.IsIdentifier(callee) {
+		return callee.AsIdentifier().Text == "parseInt" && !IsShadowed(callee, "parseInt")
+	}
+
+	if !IsSpecificMemberAccess(callee, "Number", "parseInt") {
+		return false
+	}
+
+	obj := memberAccessObject(callee)
+	obj = ast.SkipParentheses(obj)
+	return obj != nil && ast.IsIdentifier(obj) &&
+		obj.AsIdentifier().Text == "Number" &&
+		!IsShadowed(obj, "Number")
+}
+
+func memberAccessObject(node *ast.Node) *ast.Node {
 	switch node.Kind {
-	case ast.KindStringLiteral:
-		return node.AsStringLiteral().Text
-	case ast.KindNoSubstitutionTemplateLiteral:
-		return node.AsNoSubstitutionTemplateLiteral().Text
+	case ast.KindPropertyAccessExpression:
+		return node.AsPropertyAccessExpression().Expression
+	case ast.KindElementAccessExpression:
+		return node.AsElementAccessExpression().Expression
 	}
-	return ""
+	return nil
 }
 
 // IsNonReferenceIdentifier checks if an identifier is NOT a value reference

--- a/internal/utils/tokens.go
+++ b/internal/utils/tokens.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"strings"
+	"unicode/utf8"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 )
@@ -58,6 +61,29 @@ func TokenAtOrAfter(sourceFile *ast.SourceFile, pos int) (SourceToken, bool) {
 	}, true
 }
 
+// TokenBeforePosition returns the last non-trivia token whose end is not after
+// pos.
+func TokenBeforePosition(sourceFile *ast.SourceFile, pos int) (SourceToken, bool) {
+	sourceText := sourceFile.Text()
+	scan := scanner.GetScannerForSourceFile(sourceFile, 0)
+
+	var previous SourceToken
+	found := false
+	for scan.Token() != ast.KindEndOfFile && scan.TokenStart() < pos {
+		if scan.TokenEnd() <= pos {
+			previous = SourceToken{
+				Kind:  scan.Token(),
+				Start: scan.TokenStart(),
+				End:   scan.TokenEnd(),
+				Text:  sourceTokenText(sourceText, scan.Token(), scan.TokenStart(), scan.TokenEnd()),
+			}
+			found = true
+		}
+		scan.Scan()
+	}
+	return previous, found
+}
+
 // PreviousTokenBefore returns the last token in node whose end is not after pos.
 func PreviousTokenBefore(sourceFile *ast.SourceFile, node *ast.Node, pos int) (SourceToken, bool) {
 	var previous SourceToken
@@ -72,6 +98,65 @@ func PreviousTokenBefore(sourceFile *ast.SourceFile, node *ast.Node, pos int) (S
 		}
 	}
 	return previous, found
+}
+
+// SafeReplacementText adds a single leading or trailing space when replacing
+// node with replacement would otherwise merge with an adjacent token.
+func SafeReplacementText(sourceFile *ast.SourceFile, node *ast.Node, replacement string) string {
+	nodeRange := TrimNodeTextRange(sourceFile, node)
+	output := replacement
+
+	if before, ok := TokenBeforePosition(sourceFile, nodeRange.Pos()); ok &&
+		before.End == nodeRange.Pos() &&
+		!CanTokenTextsBeAdjacent(before.Text, output) {
+		output = " " + output
+	}
+
+	if after, ok := TokenAtOrAfter(sourceFile, nodeRange.End()); ok &&
+		after.Start == nodeRange.End() &&
+		!CanTokenTextsBeAdjacent(output, after.Text) {
+		output += " "
+	}
+
+	return output
+}
+
+// CanTokenTextsBeAdjacent is a small source-text analogue of ESLint's
+// astUtils.canTokensBeAdjacent. It returns false for token pairs that would
+// merge into a different token if printed without whitespace.
+func CanTokenTextsBeAdjacent(left string, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return true
+	}
+
+	leftRune, _ := utf8.DecodeLastRuneInString(left)
+	rightRune, _ := utf8.DecodeRuneInString(right)
+	if leftRune == utf8.RuneError || rightRune == utf8.RuneError {
+		return true
+	}
+
+	if scanner.IsIdentifierPart(leftRune) && scanner.IsIdentifierPart(rightRune) {
+		return false
+	}
+	if (leftRune == '+' && rightRune == '+') || (leftRune == '-' && rightRune == '-') {
+		return false
+	}
+	if leftRune == '/' && (rightRune == '/' || rightRune == '*' || scanner.IsIdentifierPart(rightRune)) {
+		return false
+	}
+	return true
+}
+
+func sourceTokenText(sourceText string, kind ast.Kind, start int, end int) string {
+	if start >= 0 && start < end && end <= len(sourceText) {
+		return sourceText[start:end]
+	}
+	if text := scanner.TokenToString(kind); text != "" {
+		return text
+	}
+	return kind.String()
 }
 
 // IsSameLine reports whether two positions are on the same ECMAScript line.

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -83,6 +83,36 @@ func TestHasCommentInsideNode(t *testing.T) {
 	}
 }
 
+func TestGetStaticStringLiteralValue(t *testing.T) {
+	source := "const empty = \"\";\n" +
+		"const template = `raw`;\n" +
+		"const number = 0;\n" +
+		"const parenthesized = (\"x\");\n"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, source, core.ScriptKindTS)
+
+	tests := []struct {
+		name     string
+		text     string
+		want     string
+		wantOkay bool
+	}{
+		{name: "empty string", text: `""`, want: "", wantOkay: true},
+		{name: "no substitution template", text: "`raw`", want: "raw", wantOkay: true},
+		{name: "numeric literal", text: "0", want: "", wantOkay: false},
+		{name: "parentheses are caller controlled", text: `("x")`, want: "", wantOkay: false},
+	}
+	for _, tt := range tests {
+		node := findNodeWithText(t, sourceFile, tt.text)
+		got, ok := GetStaticStringLiteralValue(node)
+		if got != tt.want || ok != tt.wantOkay {
+			t.Errorf("%s: GetStaticStringLiteralValue() = (%q, %v), want (%q, %v)", tt.name, got, ok, tt.want, tt.wantOkay)
+		}
+	}
+}
+
 func findNodeWithText(t *testing.T, sourceFile *ast.SourceFile, text string) *ast.Node {
 	t.Helper()
 	var found *ast.Node

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -114,6 +114,7 @@ export default defineConfig({
     './tests/eslint/rules/prefer-arrow-callback.test.ts',
     './tests/eslint/rules/prefer-const.test.ts',
     './tests/eslint/rules/prefer-exponentiation-operator.test.ts',
+    './tests/eslint/rules/prefer-numeric-literals.test.ts',
     './tests/eslint/rules/no-this-before-super.test.ts',
     './tests/eslint/rules/prefer-rest-params.test.ts',
     './tests/eslint/rules/prefer-spread.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint/rule-tester.ts
@@ -96,8 +96,9 @@ export class RuleTester {
       valid: ValidTestCase[];
       invalid: InvalidTestCase[];
     },
+    testName = ruleName,
   ) {
-    describe(ruleName, () => {
+    describe(testName, () => {
       const cwd = path.resolve(import.meta.dirname);
       const config = path.resolve(cwd, './rslint.config.mjs');
 

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-numeric-literals.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-numeric-literals.test.ts.snap
@@ -1,0 +1,1617 @@
+// Rstest Snapshot v1
+
+exports[`prefer-numeric-literals invalid 1 > invalid 1`] = `
+{
+  "code": "parseInt("111110111", 2) === 503;",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 1 > invalid 2`] = `
+{
+  "code": "parseInt("767", 8) === 503;",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 1 > invalid 3`] = `
+{
+  "code": "parseInt("1F7", 16) === 255;",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 1 > invalid 4`] = `
+{
+  "code": "Number.parseInt("111110111", 2) === 503;",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 1 > invalid 5`] = `
+{
+  "code": "Number.parseInt("767", 8) === 503;",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 1 > invalid 6`] = `
+{
+  "code": "Number.parseInt("1F7", 16) === 255;",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 1 > invalid 7`] = `
+{
+  "code": "parseInt('7999', 8);",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 1 > invalid 8`] = `
+{
+  "code": "parseInt('1234', 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 1 > invalid 9`] = `
+{
+  "code": "parseInt('1234.5', 8);",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 1 > invalid 10`] = `
+{
+  "code": "parseInt('\\u0031\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0037\\ufe0f\\u20e3', 16);",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 2 > invalid 1`] = `
+{
+  "code": "Number.parseInt('7999', 8);",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 2 > invalid 2`] = `
+{
+  "code": "Number.parseInt('1234', 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 2 > invalid 3`] = `
+{
+  "code": "Number.parseInt('1234.5', 8);",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 2 > invalid 4`] = `
+{
+  "code": "Number.parseInt('\\u0031\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0037\\ufe0f\\u20e3', 16);",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 96,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 2 > invalid 5`] = `
+{
+  "code": "parseInt(\`111110111\`, 2) === 503;",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 2 > invalid 6`] = `
+{
+  "code": "parseInt(\`767\`, 8) === 503;",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 2 > invalid 7`] = `
+{
+  "code": "parseInt(\`1F7\`, 16) === 255;",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 2 > invalid 8`] = `
+{
+  "code": "parseInt('', 8);",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 2 > invalid 9`] = `
+{
+  "code": "parseInt(\`\`, 8);",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 2 > invalid 10`] = `
+{
+  "code": "parseInt(\`7999\`, 8);",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 3 > invalid 1`] = `
+{
+  "code": "parseInt(\`1234\`, 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 3 > invalid 2`] = `
+{
+  "code": "parseInt(\`1234.5\`, 8);",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 3 > invalid 3`] = `
+{
+  "code": "parseInt('11', 2)",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 3 > invalid 4`] = `
+{
+  "code": "Number.parseInt('67', 8)",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 3 > invalid 5`] = `
+{
+  "code": "5+parseInt('A', 16)",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 3 > invalid 6`] = `
+{
+  "code": "function *f(){ yield(Number).parseInt('11', 2) }",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of (Number).parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 3 > invalid 7`] = `
+{
+  "code": "function *f(){ yield(Number.parseInt)('67', 8) }",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 3 > invalid 8`] = `
+{
+  "code": "function *f(){ yield(parseInt)('A', 16) }",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 3 > invalid 9`] = `
+{
+  "code": "function *f(){ yield Number.parseInt('11', 2) }",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 3 > invalid 10`] = `
+{
+  "code": "function *f(){ yield/**/Number.parseInt('67', 8) }",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 4 > invalid 1`] = `
+{
+  "code": "function *f(){ yield(parseInt('A', 16)) }",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 4 > invalid 2`] = `
+{
+  "code": "parseInt('11', 2)+5",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 4 > invalid 3`] = `
+{
+  "code": "Number.parseInt('17', 8)+5",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 4 > invalid 4`] = `
+{
+  "code": "parseInt('A', 16)+5",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 4 > invalid 5`] = `
+{
+  "code": "parseInt('11', 2)in foo",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 4 > invalid 6`] = `
+{
+  "code": "Number.parseInt('17', 8)in foo",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 4 > invalid 7`] = `
+{
+  "code": "parseInt('A', 16)in foo",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 4 > invalid 8`] = `
+{
+  "code": "parseInt('11', 2) in foo",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 4 > invalid 9`] = `
+{
+  "code": "Number.parseInt('17', 8)/**/in foo",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 4 > invalid 10`] = `
+{
+  "code": "(parseInt('A', 16))in foo",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 5 > invalid 1`] = `
+{
+  "code": "/* comment */Number.parseInt('11', 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 5 > invalid 2`] = `
+{
+  "code": "Number/**/.parseInt('11', 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of Number/**/.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 5 > invalid 3`] = `
+{
+  "code": "Number//
+.parseInt('11', 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of Number//
+.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 5 > invalid 4`] = `
+{
+  "code": "Number./**/parseInt('11', 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of Number./**/parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 5 > invalid 5`] = `
+{
+  "code": "Number.parseInt(/**/'11', 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 5 > invalid 6`] = `
+{
+  "code": "Number.parseInt('11', /**/2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 5 > invalid 7`] = `
+{
+  "code": "Number.parseInt('11', 2)/* comment */;",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 5 > invalid 8`] = `
+{
+  "code": "parseInt/**/('11', 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 5 > invalid 9`] = `
+{
+  "code": "parseInt(//
+'11', 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 5 > invalid 10`] = `
+{
+  "code": "parseInt('11'/**/, 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 6 > invalid 1`] = `
+{
+  "code": "parseInt(\`11\`/**/, 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 6 > invalid 2`] = `
+{
+  "code": "parseInt('11', 2 /**/);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 6 > invalid 3`] = `
+{
+  "code": "parseInt('11', 2)//comment
+;",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 6 > invalid 4`] = `
+{
+  "code": "parseInt?.("1F7", 16) === 255;",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 6 > invalid 5`] = `
+{
+  "code": "Number?.parseInt("1F7", 16) === 255;",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of Number?.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 6 > invalid 6`] = `
+{
+  "code": "Number?.parseInt?.("1F7", 16) === 255;",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of Number?.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 6 > invalid 7`] = `
+{
+  "code": "(Number?.parseInt)("1F7", 16) === 255;",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of Number?.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 6 > invalid 8`] = `
+{
+  "code": "(Number?.parseInt)?.("1F7", 16) === 255;",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of Number?.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 6 > invalid 9`] = `
+{
+  "code": "parseInt('1_0', 2);",
+  "diagnostics": [
+    {
+      "message": "Use binary literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 6 > invalid 10`] = `
+{
+  "code": "Number.parseInt('5_000', 8);",
+  "diagnostics": [
+    {
+      "message": "Use octal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 7 > invalid 1`] = `
+{
+  "code": "parseInt('0_1', 16);",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-numeric-literals invalid 7 > invalid 2`] = `
+{
+  "code": "Number.parseInt('0_0', 16);",
+  "diagnostics": [
+    {
+      "message": "Use hexadecimal literals instead of Number.parseInt().",
+      "messageId": "useLiteral",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-numeric-literals",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/prefer-numeric-literals.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/prefer-numeric-literals.test.ts
@@ -1,0 +1,194 @@
+import { RuleTester, type InvalidTestCase } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+function invalid(code: string, target: string): InvalidTestCase {
+  const index = code.indexOf(target);
+  if (index < 0) {
+    throw new Error(
+      `target not found in prefer-numeric-literals test: ${target}`,
+    );
+  }
+  const before = code.slice(0, index);
+  const lines = before.split('\n');
+  return {
+    code,
+    errors: [
+      {
+        messageId: 'useLiteral',
+        line: lines.length,
+        column: lines[lines.length - 1].length + 1,
+      },
+    ],
+  };
+}
+
+const validCases = [
+  'parseInt(1);',
+  'parseInt(1, 3);',
+  'Number.parseInt(1);',
+  'Number.parseInt(1, 3);',
+  '0b111110111 === 503;',
+  '0o767 === 503;',
+  '0x1F7 === 503;',
+  'a[parseInt](1,2);',
+  'parseInt(foo);',
+  'parseInt(foo, 2);',
+  'Number.parseInt(foo);',
+  'Number.parseInt(foo, 2);',
+  'parseInt(11, 2);',
+  'Number.parseInt(1, 8);',
+  'parseInt(1e5, 16);',
+  "parseInt('11', '2');",
+  "Number.parseInt('11', '8');",
+  'parseInt(/foo/, 2);',
+  'parseInt(`11${foo}`, 2);',
+  "parseInt('11', 2n);",
+  "Number.parseInt('11', 8n);",
+  "parseInt('11', 16n);",
+  'parseInt(`11`, 16n);',
+  'parseInt(1n, 2);',
+  'class C { #parseInt; foo() { Number.#parseInt("111110111", 2); } }',
+
+  // Shadowed `parseInt` and `Number` should not be reported.
+  'function foo(parseInt) { parseInt("111110111", 2); }',
+  'function foo() { var parseInt; parseInt("111110111", 2); }',
+  'function foo(Number) { Number.parseInt("111110111", 2); }',
+  'function foo() { var Number; Number.parseInt("111110111", 2); }',
+];
+
+const invalidCases = [
+  invalid('parseInt("111110111", 2) === 503;', 'parseInt("111110111", 2)'),
+  invalid('parseInt("767", 8) === 503;', 'parseInt("767", 8)'),
+  invalid('parseInt("1F7", 16) === 255;', 'parseInt("1F7", 16)'),
+  invalid(
+    'Number.parseInt("111110111", 2) === 503;',
+    'Number.parseInt("111110111", 2)',
+  ),
+  invalid('Number.parseInt("767", 8) === 503;', 'Number.parseInt("767", 8)'),
+  invalid('Number.parseInt("1F7", 16) === 255;', 'Number.parseInt("1F7", 16)'),
+  invalid("parseInt('7999', 8);", "parseInt('7999', 8)"),
+  invalid("parseInt('1234', 2);", "parseInt('1234', 2)"),
+  invalid("parseInt('1234.5', 8);", "parseInt('1234.5', 8)"),
+  invalid(
+    "parseInt('\\u0031\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0037\\ufe0f\\u20e3', 16);",
+    "parseInt('\\u0031\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0037\\ufe0f\\u20e3', 16)",
+  ),
+  invalid("Number.parseInt('7999', 8);", "Number.parseInt('7999', 8)"),
+  invalid("Number.parseInt('1234', 2);", "Number.parseInt('1234', 2)"),
+  invalid("Number.parseInt('1234.5', 8);", "Number.parseInt('1234.5', 8)"),
+  invalid(
+    "Number.parseInt('\\u0031\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0037\\ufe0f\\u20e3', 16);",
+    "Number.parseInt('\\u0031\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0033\\ufe0f\\u20e3\\u0037\\ufe0f\\u20e3', 16)",
+  ),
+  invalid('parseInt(`111110111`, 2) === 503;', 'parseInt(`111110111`, 2)'),
+  invalid('parseInt(`767`, 8) === 503;', 'parseInt(`767`, 8)'),
+  invalid('parseInt(`1F7`, 16) === 255;', 'parseInt(`1F7`, 16)'),
+  invalid("parseInt('', 8);", "parseInt('', 8)"),
+  invalid('parseInt(``, 8);', 'parseInt(``, 8)'),
+  invalid('parseInt(`7999`, 8);', 'parseInt(`7999`, 8)'),
+  invalid('parseInt(`1234`, 2);', 'parseInt(`1234`, 2)'),
+  invalid('parseInt(`1234.5`, 8);', 'parseInt(`1234.5`, 8)'),
+
+  // Adjacent tokens tests
+  invalid("parseInt('11', 2)", "parseInt('11', 2)"),
+  invalid("Number.parseInt('67', 8)", "Number.parseInt('67', 8)"),
+  invalid("5+parseInt('A', 16)", "parseInt('A', 16)"),
+  invalid(
+    "function *f(){ yield(Number).parseInt('11', 2) }",
+    "(Number).parseInt('11', 2)",
+  ),
+  invalid(
+    "function *f(){ yield(Number.parseInt)('67', 8) }",
+    "(Number.parseInt)('67', 8)",
+  ),
+  invalid("function *f(){ yield(parseInt)('A', 16) }", "(parseInt)('A', 16)"),
+  invalid(
+    "function *f(){ yield Number.parseInt('11', 2) }",
+    "Number.parseInt('11', 2)",
+  ),
+  invalid(
+    "function *f(){ yield/**/Number.parseInt('67', 8) }",
+    "Number.parseInt('67', 8)",
+  ),
+  invalid("function *f(){ yield(parseInt('A', 16)) }", "parseInt('A', 16)"),
+  invalid("parseInt('11', 2)+5", "parseInt('11', 2)"),
+  invalid("Number.parseInt('17', 8)+5", "Number.parseInt('17', 8)"),
+  invalid("parseInt('A', 16)+5", "parseInt('A', 16)"),
+  invalid("parseInt('11', 2)in foo", "parseInt('11', 2)"),
+  invalid("Number.parseInt('17', 8)in foo", "Number.parseInt('17', 8)"),
+  invalid("parseInt('A', 16)in foo", "parseInt('A', 16)"),
+  invalid("parseInt('11', 2) in foo", "parseInt('11', 2)"),
+  invalid("Number.parseInt('17', 8)/**/in foo", "Number.parseInt('17', 8)"),
+  invalid("(parseInt('A', 16))in foo", "parseInt('A', 16)"),
+
+  // Should not autofix if it would remove comments
+  invalid("/* comment */Number.parseInt('11', 2);", "Number.parseInt('11', 2)"),
+  invalid("Number/**/.parseInt('11', 2);", "Number/**/.parseInt('11', 2)"),
+  invalid("Number//\n.parseInt('11', 2);", "Number//\n.parseInt('11', 2)"),
+  invalid("Number./**/parseInt('11', 2);", "Number./**/parseInt('11', 2)"),
+  invalid("Number.parseInt(/**/'11', 2);", "Number.parseInt(/**/'11', 2)"),
+  invalid("Number.parseInt('11', /**/2);", "Number.parseInt('11', /**/2)"),
+  invalid("Number.parseInt('11', 2)/* comment */;", "Number.parseInt('11', 2)"),
+  invalid("parseInt/**/('11', 2);", "parseInt/**/('11', 2)"),
+  invalid("parseInt(//\n'11', 2);", "parseInt(//\n'11', 2)"),
+  invalid("parseInt('11'/**/, 2);", "parseInt('11'/**/, 2)"),
+  invalid('parseInt(`11`/**/, 2);', 'parseInt(`11`/**/, 2)'),
+  invalid("parseInt('11', 2 /**/);", "parseInt('11', 2 /**/)"),
+  invalid("parseInt('11', 2)//comment\n;", "parseInt('11', 2)"),
+
+  // Optional chaining
+  invalid('parseInt?.("1F7", 16) === 255;', 'parseInt?.("1F7", 16)'),
+  invalid(
+    'Number?.parseInt("1F7", 16) === 255;',
+    'Number?.parseInt("1F7", 16)',
+  ),
+  invalid(
+    'Number?.parseInt?.("1F7", 16) === 255;',
+    'Number?.parseInt?.("1F7", 16)',
+  ),
+  invalid(
+    '(Number?.parseInt)("1F7", 16) === 255;',
+    '(Number?.parseInt)("1F7", 16)',
+  ),
+  invalid(
+    '(Number?.parseInt)?.("1F7", 16) === 255;',
+    '(Number?.parseInt)?.("1F7", 16)',
+  ),
+
+  // `parseInt` doesn't support numeric separators. The rule shouldn't autofix in those cases.
+  invalid("parseInt('1_0', 2);", "parseInt('1_0', 2)"),
+  invalid("Number.parseInt('5_000', 8);", "Number.parseInt('5_000', 8)"),
+  invalid("parseInt('0_1', 16);", "parseInt('0_1', 16)"),
+  invalid("Number.parseInt('0_0', 16);", "Number.parseInt('0_0', 16)"),
+];
+
+for (const [index, cases] of chunks(validCases, 10).entries()) {
+  ruleTester.run(
+    'prefer-numeric-literals',
+    {
+      valid: cases,
+      invalid: [],
+    },
+    `prefer-numeric-literals valid ${index + 1}`,
+  );
+}
+
+for (const [index, cases] of chunks(invalidCases, 10).entries()) {
+  ruleTester.run(
+    'prefer-numeric-literals',
+    {
+      valid: [],
+      invalid: cases,
+    },
+    `prefer-numeric-literals invalid ${index + 1}`,
+  );
+}
+
+function chunks<T>(items: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    result.push(items.slice(index, index + size));
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Port the ESLint core `prefer-numeric-literals` rule to rslint.

This adds the Go rule implementation, upstream and extra edge-case tests, rule registration, documentation, shared utility helpers, and JS integration coverage.

## Related Links

- ESLint rule documentation: https://eslint.org/docs/latest/rules/prefer-numeric-literals

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).