### PR TITLE
feat: port rule unicorn/no-useless-switch-case

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -3,6 +3,7 @@ package unicorn_plugin
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -10,5 +11,6 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		filename_case.FilenameCaseRule,
 		no_static_only_class.NoStaticOnlyClassRule,
+		no_useless_switch_case.NoUselessSwitchCaseRule,
 	}
 }

--- a/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case.go
+++ b/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case.go
@@ -1,0 +1,122 @@
+package no_useless_switch_case
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	messageIDError      = "no-useless-switch-case/error"
+	messageIDSuggestion = "no-useless-switch-case/suggestion"
+)
+
+var NoUselessSwitchCaseRule = rule.Rule{
+	Name: "unicorn/no-useless-switch-case",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindSwitchStatement: func(node *ast.Node) {
+				switchStmt := node.AsSwitchStatement()
+				if switchStmt == nil || switchStmt.CaseBlock == nil {
+					return
+				}
+
+				caseBlock := switchStmt.CaseBlock.AsCaseBlock()
+				if caseBlock == nil || caseBlock.Clauses == nil {
+					return
+				}
+
+				clauses := caseBlock.Clauses.Nodes
+				if len(clauses) < 2 || clauses[len(clauses)-1].Kind != ast.KindDefaultClause {
+					return
+				}
+
+				// Upstream walks backward from the final `default` and stops at
+				// the first non-empty case, but ESLint still emits diagnostics in
+				// source order. Collect first, then report in source order.
+				candidates := make([]*ast.Node, 0, len(clauses)-1)
+				for index := len(clauses) - 2; index >= 0; index-- {
+					clause := clauses[index]
+					if !isEmptySwitchCase(clause) {
+						break
+					}
+
+					candidates = append(candidates, clause)
+				}
+
+				for index := len(candidates) - 1; index >= 0; index-- {
+					clause := candidates[index]
+					ctx.ReportRangeWithSuggestions(
+						switchCaseHeadRange(clause, ctx.SourceFile),
+						rule.RuleMessage{
+							Id:          messageIDError,
+							Description: "Useless case in switch statement.",
+						},
+						rule.RuleSuggestion{
+							Message: rule.RuleMessage{
+								Id:          messageIDSuggestion,
+								Description: "Remove this case.",
+							},
+							FixesArr: []rule.RuleFix{rule.RuleFixRemove(ctx.SourceFile, clause)},
+						},
+					)
+				}
+			},
+		}
+	},
+}
+
+func isEmptySwitchCase(node *ast.Node) bool {
+	clause := node.AsCaseOrDefaultClause()
+	if clause == nil || clause.Statements == nil {
+		return true
+	}
+	for _, statement := range clause.Statements.Nodes {
+		if !isEmptyNode(statement) {
+			return false
+		}
+	}
+	return true
+}
+
+func isEmptyNode(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if ast.IsEmptyStatement(node) {
+		return true
+	}
+	if ast.IsBlock(node) {
+		block := node.AsBlock()
+		if block == nil || block.Statements == nil {
+			return true
+		}
+		for _, statement := range block.Statements.Nodes {
+			if !isEmptyNode(statement) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func switchCaseHeadRange(node *ast.Node, sourceFile *ast.SourceFile) core.TextRange {
+	start := utils.TrimNodeTextRange(sourceFile, node).Pos()
+	scanStart := start
+	if clause := node.AsCaseOrDefaultClause(); clause != nil && clause.Expression != nil {
+		scanStart = clause.Expression.End()
+	}
+
+	s := scanner.GetScannerForSourceFile(sourceFile, scanStart)
+	for s.Token() != ast.KindEndOfFile && s.TokenStart() < node.End() {
+		if s.Token() == ast.KindColonToken {
+			return core.NewTextRange(start, s.TokenEnd())
+		}
+		s.Scan()
+	}
+
+	return core.NewTextRange(start, start)
+}

--- a/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case.md
+++ b/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case.md
@@ -1,0 +1,65 @@
+# no-useless-switch-case
+
+## Rule Details
+
+Disallows empty `case` clauses immediately before the final `default` clause in
+a `switch` statement.
+
+An empty case before the last `default` case is useless because execution falls
+through to the same default body. Empty blocks and empty statements inside that
+case still count as empty.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+switch (foo) {
+  case 1:
+  default:
+    handleDefaultCase();
+    break;
+}
+```
+
+```javascript
+switch (foo) {
+  case 1: {
+  }
+  default:
+    handleDefaultCase();
+    break;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+switch (foo) {
+  default:
+    handleDefaultCase();
+    break;
+}
+```
+
+```javascript
+switch (foo) {
+  case 1:
+  case 2:
+    handleCase1And2();
+    break;
+}
+```
+
+```javascript
+switch (foo) {
+  case 1:
+    handleCase1();
+  default:
+    handleDefaultCase();
+    break;
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-useless-switch-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-switch-case.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-useless-switch-case.js)

--- a/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case_extras_test.go
@@ -1,0 +1,450 @@
+package no_useless_switch_case_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUselessSwitchCaseExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / real-user scenario it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+func TestNoUselessSwitchCaseExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_useless_switch_case.NoUselessSwitchCaseRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream create() guard arm 1: fewer than two clauses.
+			jsValid(lines(
+				"switch (foo) {",
+				"\tdefault:",
+				"\t\thandleDefaultCase();",
+				"}",
+			)),
+
+			// Locks in upstream create() guard arm 2 / Real-user: #1779 known
+			// limitation. A non-last default is intentionally ignored.
+			jsValid(lines(
+				"switch (value) {",
+				"\tcase 1:",
+				"\tdefault:",
+				"\t\tconsole.log('one');",
+				"\tcase 2:",
+				"\t\tconsole.log('two');",
+				"}",
+			)),
+
+			// Locks in upstream loop arm 1: scanning stops at the first non-empty
+			// case, so earlier empty cases are not inspected.
+			jsValid(lines(
+				"switch (foo) {",
+				"\tcase a:",
+				"\tcase b:",
+				"\t\thandleB();",
+				"\tdefault:",
+				"\t\thandleDefaultCase();",
+				"}",
+			)),
+
+			// N/A: access/key forms are not inspected by this rule.
+			// N/A: declaration/container forms do not affect switch-case
+			// semantics; the invalid nested-switch case below covers traversal
+			// boundaries.
+			// N/A: spread/rest and body-absent declaration forms cannot appear
+			// as switch case bodies in a way this rule treats specially.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized nullish case test in JS file ----
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase (undefined):",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 2, 2, 19, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: .mjs is not a TypeScript file ----
+			{
+				Code: lines(
+					"switch (foo) {",
+					"\tcase undefined:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				FileName: "file.mjs",
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedError(2, 2, 2, 17, lines(
+						"switch (foo) {",
+						"\t",
+						"\tdefault:",
+						"\t\thandleDefaultCase();",
+						"}",
+					)),
+				},
+			},
+
+			// ---- Dimension 4: TypeScript nullish cases are normal empty cases ----
+			tsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase undefined:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 2, 2, 17, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+			),
+
+			tsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase null:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 2, 2, 12, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: parenthesized nullish case tests in TS files ----
+			tsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase ((undefined)):",
+					"\tcase ((null)):",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 2, 2, 21, lines(
+					"switch (foo) {",
+					"\t",
+					"\tcase ((null)):",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+				expectedError(3, 2, 3, 16, lines(
+					"switch (foo) {",
+					"\tcase ((undefined)):",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: .mts follows the same behavior ----
+			{
+				Code: lines(
+					"switch (foo) {",
+					"\tcase undefined:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				FileName: "file.mts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedError(2, 2, 2, 17, lines(
+						"switch (foo) {",
+						"\t",
+						"\tdefault:",
+						"\t\thandleDefaultCase();",
+						"}",
+					)),
+				},
+			},
+
+			// ---- Real-user: #2670 still reports under upstream semantics ----
+			tsInvalid(
+				lines(
+					"switch (when) {",
+					"\tcase 'today': {",
+					"\t\treturn date;",
+					"\t}",
+					"\tcase 'tomorrow': {",
+					"\t\treturn today.add({days: 1});",
+					"\t}",
+					"\tcase undefined:",
+					"\tdefault: {",
+					"\t\tthrow new RangeError('Bug: Unhandled date keyword');",
+					"\t}",
+					"}",
+				),
+				expectedError(8, 2, 8, 17, lines(
+					"switch (when) {",
+					"\tcase 'today': {",
+					"\t\treturn date;",
+					"\t}",
+					"\tcase 'tomorrow': {",
+					"\t\treturn today.add({days: 1});",
+					"\t}",
+					"\t",
+					"\tdefault: {",
+					"\t\tthrow new RangeError('Bug: Unhandled date keyword');",
+					"\t}",
+					"}",
+				)),
+			),
+
+			// ---- Real-user: #2670 nullable union with explicit nullish arms ----
+			tsInvalid(
+				lines(
+					"switch (state) {",
+					"\tcase 'ready':",
+					"\t\treturn state;",
+					"\tcase null:",
+					"\tcase undefined:",
+					"\tdefault:",
+					"\t\tthrow new Error('Unexpected state');",
+					"}",
+				),
+				expectedError(4, 2, 4, 12, lines(
+					"switch (state) {",
+					"\tcase 'ready':",
+					"\t\treturn state;",
+					"\t",
+					"\tcase undefined:",
+					"\tdefault:",
+					"\t\tthrow new Error('Unexpected state');",
+					"}",
+				)),
+				expectedError(5, 2, 5, 17, lines(
+					"switch (state) {",
+					"\tcase 'ready':",
+					"\t\treturn state;",
+					"\tcase null:",
+					"\t",
+					"\tdefault:",
+					"\t\tthrow new Error('Unexpected state');",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: TS non-null assertion wrapper is a normal empty case ----
+			tsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase undefined!:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 2, 2, 18, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: TS type assertion wrapper is a normal empty case ----
+			tsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase undefined as any:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 2, 2, 24, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: TS satisfies wrapper is a normal empty case ----
+			tsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase undefined satisfies any:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 2, 2, 31, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: optional-chain case test is a normal empty case ----
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase foo?.bar:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 2, 2, 16, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: comments before the case colon stay in the report range ----
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a /* comment */:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 2, 2, 23, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: multi-line case head range ----
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"  case (",
+					"    a",
+					"  ):",
+					"  default:",
+					"    handleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 3, 4, 5, lines(
+					"switch (foo) {",
+					"  ",
+					"  default:",
+					"    handleDefaultCase();",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: empty block comments stay empty for this rule ----
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a: {",
+					"\t\t// comment",
+					"\t}",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				),
+				expectedError(2, 2, 2, 9, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"}",
+				)),
+			),
+
+			// ---- Dimension 4: nested switches report independently ----
+			jsInvalid(
+				lines(
+					"switch (outer) {",
+					"\tcase outerA:",
+					"\tdefault:",
+					"\t\tswitch (inner) {",
+					"\t\t\tcase innerA:",
+					"\t\t\tdefault:",
+					"\t\t\t\thandleInnerDefault();",
+					"\t\t}",
+					"}",
+				),
+				expectedError(2, 2, 2, 14, lines(
+					"switch (outer) {",
+					"\t",
+					"\tdefault:",
+					"\t\tswitch (inner) {",
+					"\t\t\tcase innerA:",
+					"\t\t\tdefault:",
+					"\t\t\t\thandleInnerDefault();",
+					"\t\t}",
+					"}",
+				)),
+				expectedError(5, 4, 5, 16, lines(
+					"switch (outer) {",
+					"\tcase outerA:",
+					"\tdefault:",
+					"\t\tswitch (inner) {",
+					"\t\t\t",
+					"\t\t\tdefault:",
+					"\t\t\t\thandleInnerDefault();",
+					"\t\t}",
+					"}",
+				)),
+			),
+
+			// Locks in upstream isEmptySwitchCase() branch: a non-empty inner
+			// switch consequent prevents the outer case from being reported, but
+			// the nested switch is still checked independently.
+			jsInvalid(
+				lines(
+					"switch (outer) {",
+					"\tcase outerA:",
+					"\t\thandleOuterA();",
+					"\tdefault:",
+					"\t\tswitch (inner) {",
+					"\t\t\tcase innerA:",
+					"\t\t\tdefault:",
+					"\t\t\t\thandleInnerDefault();",
+					"\t\t}",
+					"}",
+				),
+				expectedError(6, 4, 6, 16, lines(
+					"switch (outer) {",
+					"\tcase outerA:",
+					"\t\thandleOuterA();",
+					"\tdefault:",
+					"\t\tswitch (inner) {",
+					"\t\t\t",
+					"\t\t\tdefault:",
+					"\t\t\t\thandleInnerDefault();",
+					"\t\t}",
+					"}",
+				)),
+			),
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case_upstream_test.go
@@ -1,0 +1,442 @@
+package no_useless_switch_case_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	noUselessSwitchCaseMessage      = "Useless case in switch statement."
+	noUselessSwitchCaseMessageID    = "no-useless-switch-case/error"
+	noUselessSwitchCaseSuggestionID = "no-useless-switch-case/suggestion"
+)
+
+// TestNoUselessSwitchCaseUpstream migrates the full valid/invalid suite from
+// upstream test/no-useless-switch-case.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// the no_useless_switch_case_extras_test.go file.
+func TestNoUselessSwitchCaseUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_useless_switch_case.NoUselessSwitchCaseRule,
+		[]rule_tester.ValidTestCase{
+			// ---- test.snapshot valid ----
+			jsValid(lines(
+				"switch (foo) {",
+				"\tcase a:",
+				"\tcase b:",
+				"\t\thandleDefaultCase();",
+				"\t\tbreak;",
+				"}",
+			)),
+			jsValid(lines(
+				"switch (foo) {",
+				"\tcase a:",
+				"\t\thandleCaseA();",
+				"\t\tbreak;",
+				"\tdefault:",
+				"\t\thandleDefaultCase();",
+				"\t\tbreak;",
+				"}",
+			)),
+			jsValid(lines(
+				"switch (foo) {",
+				"\tcase a:",
+				"\t\thandleCaseA();",
+				"\tdefault:",
+				"\t\thandleDefaultCase();",
+				"\t\tbreak;",
+				"}",
+			)),
+			jsValid(lines(
+				"switch (foo) {",
+				"\tcase a:",
+				"\t\tbreak;",
+				"\tdefault:",
+				"\t\thandleDefaultCase();",
+				"\t\tbreak;",
+				"}",
+			)),
+			jsValid(lines(
+				"switch (foo) {",
+				"\tcase a:",
+				"\t\thandleCaseA();",
+				"\t\t// Fallthrough",
+				"\tdefault:",
+				"\t\thandleDefaultCase();",
+				"\t\tbreak;",
+				"}",
+			)),
+			jsValid(lines(
+				"switch (foo) {",
+				"\tcase a:",
+				"\tdefault:",
+				"\t\thandleDefaultCase();",
+				"\t\tbreak;",
+				"\tcase b:",
+				"\t\thandleCaseB();",
+				"\t\tbreak;",
+				"}",
+			)),
+			jsValid(lines(
+				"switch (1) {",
+				"\t\t// This is not useless",
+				"\t\tcase 1:",
+				"\t\tdefault:",
+				"\t\t\t\tconsole.log('1')",
+				"\t\tcase 1:",
+				"\t\t\t\tconsole.log('2')",
+				"}",
+			)),
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- test.snapshot invalid ----
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase undefined:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 17, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase null:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 12, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			tsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\tcase undefined:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 9, lines(
+					"switch (foo) {",
+					"\t",
+					"\tcase undefined:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+				expectedError(3, 2, 3, 17, lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase undefined:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 17, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			tsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 9, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 9, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a: {",
+					"\t}",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 9, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a: {",
+					"\t\t;;",
+					"\t\t{",
+					"\t\t\t;;",
+					"\t\t\t{",
+					"\t\t\t\t;;",
+					"\t\t\t}",
+					"\t\t}",
+					"\t}",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 9, lines(
+					"switch (foo) {",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\tcase (( b ))         :",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 9, lines(
+					"switch (foo) {",
+					"\t",
+					"\tcase (( b ))         :",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+				expectedError(3, 2, 3, 24, lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\tcase b:",
+					"\t\thandleCaseAB();",
+					"\t\tbreak;",
+					"\tcase d:",
+					"\tcase d:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(6, 2, 6, 9, lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\tcase b:",
+					"\t\thandleCaseAB();",
+					"\t\tbreak;",
+					"\t",
+					"\tcase d:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+				expectedError(7, 2, 7, 9, lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\tcase b:",
+					"\t\thandleCaseAB();",
+					"\t\tbreak;",
+					"\tcase d:",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\tcase b:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 9, lines(
+					"switch (foo) {",
+					"\t",
+					"\tcase b:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+				expectedError(3, 2, 3, 9, lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\t// eslint-disable-next-line",
+					"\tcase a:",
+					"\tcase b:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(4, 2, 4, 9, lines(
+					"switch (foo) {",
+					"\t// eslint-disable-next-line",
+					"\tcase a:",
+					"\t",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+			jsInvalid(
+				lines(
+					"switch (foo) {",
+					"\tcase a:",
+					"\t// eslint-disable-next-line",
+					"\tcase b:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				),
+				expectedError(2, 2, 2, 9, lines(
+					"switch (foo) {",
+					"\t",
+					"\t// eslint-disable-next-line",
+					"\tcase b:",
+					"\tdefault:",
+					"\t\thandleDefaultCase();",
+					"\t\tbreak;",
+					"}",
+				)),
+			),
+		},
+	)
+}
+
+func lines(parts ...string) string {
+	return strings.Join(parts, "\n")
+}
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.js"}
+}
+
+func jsInvalid(code string, errors ...rule_tester.InvalidTestCaseError) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{Code: code, FileName: "file.js", Errors: errors}
+}
+
+func tsInvalid(code string, errors ...rule_tester.InvalidTestCaseError) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{Code: code, FileName: "file.ts", Errors: errors}
+}
+
+func expectedError(line, column, endLine, endColumn int, suggestionOutput string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: noUselessSwitchCaseMessageID,
+		Message:   noUselessSwitchCaseMessage,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+		Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+			{
+				MessageId: noUselessSwitchCaseSuggestionID,
+				Output:    suggestionOutput,
+			},
+		},
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -528,6 +528,7 @@ export default defineConfig({
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
 
     './tests/eslint/rules/no-shadow-restricted-names.test.ts',
   ],

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts
@@ -1,0 +1,327 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+const message = 'Useless case in switch statement.';
+const error = { message };
+
+const lines = (...parts: string[]) => parts.join('\n');
+const js = (code: string) => ({ code, filename: 'file.js' });
+const ts = (code: string) => ({ code, filename: 'file.ts' });
+
+ruleTester.run('no-useless-switch-case', null as never, {
+  valid: [
+    js(
+      lines(
+        'switch (foo) {',
+        '\tcase a:',
+        '\tcase b:',
+        '\t\thandleDefaultCase();',
+        '\t\tbreak;',
+        '}',
+      ),
+    ),
+    js(
+      lines(
+        'switch (foo) {',
+        '\tcase a:',
+        '\t\thandleCaseA();',
+        '\t\tbreak;',
+        '\tdefault:',
+        '\t\thandleDefaultCase();',
+        '\t\tbreak;',
+        '}',
+      ),
+    ),
+    js(
+      lines(
+        'switch (foo) {',
+        '\tcase a:',
+        '\t\thandleCaseA();',
+        '\tdefault:',
+        '\t\thandleDefaultCase();',
+        '\t\tbreak;',
+        '}',
+      ),
+    ),
+    js(
+      lines(
+        'switch (foo) {',
+        '\tcase a:',
+        '\t\tbreak;',
+        '\tdefault:',
+        '\t\thandleDefaultCase();',
+        '\t\tbreak;',
+        '}',
+      ),
+    ),
+    js(
+      lines(
+        'switch (foo) {',
+        '\tcase a:',
+        '\t\thandleCaseA();',
+        '\t\t// Fallthrough',
+        '\tdefault:',
+        '\t\thandleDefaultCase();',
+        '\t\tbreak;',
+        '}',
+      ),
+    ),
+    js(
+      lines(
+        'switch (foo) {',
+        '\tcase a:',
+        '\tdefault:',
+        '\t\thandleDefaultCase();',
+        '\t\tbreak;',
+        '\tcase b:',
+        '\t\thandleCaseB();',
+        '\t\tbreak;',
+        '}',
+      ),
+    ),
+    js(
+      lines(
+        'switch (1) {',
+        '\t\t// This is not useless',
+        '\t\tcase 1:',
+        '\t\tdefault:',
+        "\t\t\t\tconsole.log('1')",
+        '\t\tcase 1:',
+        "\t\t\t\tconsole.log('2')",
+        '}',
+      ),
+    ),
+  ],
+  invalid: [
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\tcase undefined:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\tcase null:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+    {
+      ...ts(
+        lines(
+          'switch (foo) {',
+          '\tcase undefined:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+    {
+      ...ts(
+        lines(
+          'switch (foo) {',
+          '\tcase null:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+    {
+      ...ts(
+        lines(
+          'switch (foo) {',
+          '\tcase null:',
+          '\tcase undefined:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error, error],
+    },
+    {
+      ...ts(
+        lines(
+          'switch (foo) {',
+          '\tcase a:',
+          '\tcase undefined:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error, error],
+    },
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\tcase undefined:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+    {
+      ...ts(
+        lines(
+          'switch (foo) {',
+          '\tcase a:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\tcase a:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\tcase a: {',
+          '\t}',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\tcase a: {',
+          '\t\t;;',
+          '\t\t{',
+          '\t\t\t;;',
+          '\t\t\t{',
+          '\t\t\t\t;;',
+          '\t\t\t}',
+          '\t\t}',
+          '\t}',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\tcase a:',
+          '\tcase (( b ))         :',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error, error],
+    },
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\tcase a:',
+          '\tcase b:',
+          '\t\thandleCaseAB();',
+          '\t\tbreak;',
+          '\tcase d:',
+          '\tcase d:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error, error],
+    },
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\tcase a:',
+          '\tcase b:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error, error],
+    },
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\t// eslint-disable-next-line',
+          '\tcase a:',
+          '\tcase b:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+    {
+      ...js(
+        lines(
+          'switch (foo) {',
+          '\tcase a:',
+          '\t// eslint-disable-next-line',
+          '\tcase b:',
+          '\tdefault:',
+          '\t\thandleDefaultCase();',
+          '\t\tbreak;',
+          '}',
+        ),
+      ),
+      errors: [error],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `unicorn/no-useless-switch-case` rule from eslint-plugin-unicorn to rslint.

Disallows empty `case` clauses immediately before the final `default` clause in switch statements and provides a suggestion fix to remove useless cases.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-switch-case.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-useless-switch-case.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
