### PR TITLE
feat: port rule unicorn/prefer-array-flat-map

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -12,5 +13,6 @@ func GetAllRules() []rule.Rule {
 		filename_case.FilenameCaseRule,
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_useless_switch_case.NoUselessSwitchCaseRule,
+		prefer_array_flat_map.PreferArrayFlatMapRule,
 	}
 }

--- a/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map.go
@@ -1,0 +1,160 @@
+package prefer_array_flat_map
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageID = "prefer-array-flat-map"
+
+var preferArrayFlatMapMessage = rule.RuleMessage{
+	Id:          messageID,
+	Description: "Prefer `.flatMap(…)` over `.map(…).flat()`.",
+}
+
+type dotMethodCall struct {
+	call      *ast.Node
+	rawCallee *ast.Node
+	callee    *ast.Node
+	object    *ast.Node
+	property  *ast.Node
+}
+
+// matchDotMethodCall mirrors unicorn's isMethodCall with computed:false. The
+// wider utils.IsSpecificMemberAccess helper also matches static bracket access,
+// which would make foo["map"](...).flat() a false positive for this rule.
+func matchDotMethodCall(node *ast.Node, method string, optionalCallFalse bool, optionalMemberFalse bool) (dotMethodCall, bool) {
+	if node == nil || !ast.IsCallExpression(node) {
+		return dotMethodCall{}, false
+	}
+
+	call := node.AsCallExpression()
+	// Check the direct optional token, not ast.IsOptionalChain: in tsgo,
+	// foo?.map(...).flat() marks later links as optional-chain nodes too, but
+	// upstream still reports because only map's member access is optional.
+	if optionalCallFalse && call.QuestionDotToken != nil {
+		return dotMethodCall{}, false
+	}
+
+	rawCallee := call.Expression
+	callee := ast.SkipParentheses(rawCallee)
+	// Parentheses around an optional-chain callee are not transparent to
+	// upstream isMethodCall: (foo?.map)(cb) is not treated as foo?.map(cb).
+	if callee == nil || (rawCallee != callee && ast.IsOptionalChain(callee)) || !ast.IsPropertyAccessExpression(callee) {
+		return dotMethodCall{}, false
+	}
+
+	propAccess := callee.AsPropertyAccessExpression()
+	if optionalMemberFalse && propAccess.QuestionDotToken != nil {
+		return dotMethodCall{}, false
+	}
+
+	property := propAccess.Name()
+	if property == nil || !ast.IsIdentifier(property) || property.AsIdentifier().Text != method {
+		return dotMethodCall{}, false
+	}
+
+	return dotMethodCall{
+		call:      node,
+		rawCallee: rawCallee,
+		callee:    callee,
+		object:    propAccess.Expression,
+		property:  property,
+	}, true
+}
+
+func hasNoDepthOrRawDepthOne(sf *ast.SourceFile, call *ast.Node) bool {
+	args := call.AsCallExpression().Arguments
+	if args == nil || len(args.Nodes) == 0 {
+		return true
+	}
+	if len(args.Nodes) != 1 {
+		return false
+	}
+
+	arg := ast.SkipParentheses(args.Nodes[0])
+	if arg == nil || arg.Kind != ast.KindNumericLiteral {
+		return false
+	}
+	return scanner.GetSourceTextOfNodeFromSourceFile(sf, arg, false) == "1"
+}
+
+func isIgnoredMapObject(node *ast.Node) bool {
+	return nodeMatchesPath(node, "Children") || nodeMatchesPath(node, "React.Children")
+}
+
+// nodeMatchesPath mirrors unicorn's isNodeMatches for the React.Children
+// exception: parentheses are transparent, while computed and optional members
+// are not. That keeps React["Children"].map(...).flat() reportable.
+func nodeMatchesPath(node *ast.Node, path string) bool {
+	parts := strings.Split(path, ".")
+	return nodeMatchesPathParts(ast.SkipParentheses(node), parts)
+}
+
+func nodeMatchesPathParts(node *ast.Node, parts []string) bool {
+	if node == nil || len(parts) == 0 {
+		return false
+	}
+	if len(parts) == 1 {
+		return ast.IsIdentifier(node) && node.AsIdentifier().Text == parts[0]
+	}
+	if !ast.IsPropertyAccessExpression(node) {
+		return false
+	}
+
+	propAccess := node.AsPropertyAccessExpression()
+	if propAccess.QuestionDotToken != nil {
+		return false
+	}
+	name := propAccess.Name()
+	if name == nil || !ast.IsIdentifier(name) || name.AsIdentifier().Text != parts[len(parts)-1] {
+		return false
+	}
+	return nodeMatchesPathParts(ast.SkipParentheses(propAccess.Expression), parts[:len(parts)-1])
+}
+
+func buildFixes(sf *ast.SourceFile, flatCall dotMethodCall, mapCall dotMethodCall) []rule.RuleFix {
+	mapPropertyRange := utils.TrimNodeTextRange(sf, mapCall.property)
+	// Remove the .flat member and the following call separately, preserving any
+	// parentheses around the callee: (foo.map(cb).flat)() -> (foo.flatMap(cb)).
+	removeFlatPropertyRange := core.NewTextRange(flatCall.object.End(), flatCall.callee.End())
+	removeFlatArgumentsRange := core.NewTextRange(flatCall.rawCallee.End(), flatCall.call.End())
+	return []rule.RuleFix{
+		rule.RuleFixReplaceRange(mapPropertyRange, "flatMap"),
+		rule.RuleFixRemoveRange(removeFlatPropertyRange),
+		rule.RuleFixRemoveRange(removeFlatArgumentsRange),
+	}
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-array-flat-map.md
+var PreferArrayFlatMapRule = rule.Rule{
+	Name: "unicorn/prefer-array-flat-map",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				flatCall, ok := matchDotMethodCall(node, "flat", true, true)
+				if !ok || !hasNoDepthOrRawDepthOne(ctx.SourceFile, node) {
+					return
+				}
+
+				mapCallObject := ast.SkipParentheses(flatCall.object)
+				mapCall, ok := matchDotMethodCall(mapCallObject, "map", true, false)
+				if !ok || isIgnoredMapObject(mapCall.object) {
+					return
+				}
+
+				reportRange := utils.TrimNodeTextRange(ctx.SourceFile, mapCall.property).WithEnd(node.End())
+				ctx.ReportRangeWithFixes(
+					reportRange,
+					preferArrayFlatMapMessage,
+					buildFixes(ctx.SourceFile, flatCall, mapCall)...,
+				)
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map.md
+++ b/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map.md
@@ -1,0 +1,25 @@
+# prefer-array-flat-map
+
+## Rule Details
+
+Prefer `Array#flatMap()` over chaining `Array#map()` and `Array#flat()` when the flat depth is omitted or exactly `1`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const foo = bar.map(element => unicorn(element)).flat();
+const foo = bar.map(element => unicorn(element)).flat(1);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const foo = bar.flatMap(element => unicorn(element));
+const foo = bar.map(element => unicorn(element)).flat(2);
+const foo = React.Children.map(children, fn).flat();
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: prefer-array-flat-map](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/prefer-array-flat-map.js)

--- a/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map_extras_test.go
@@ -1,0 +1,312 @@
+package prefer_array_flat_map_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const messageID = "prefer-array-flat-map"
+
+// TestPreferArrayFlatMapExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / upstream issue it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+func TestPreferArrayFlatMapExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_array_flat_map.PreferArrayFlatMapRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: computed access does not match dotted method calls ----
+			{Code: `const bar = foo["map"](i => [i]).flat()`},
+			{Code: `const bar = foo.map(i => [i])["flat"]()`},
+			{Code: "const bar = foo[`map`](i => [i]).flat()"},
+
+			// ---- Dimension 4: raw flat depth must be exactly `1` ----
+			{Code: `const bar = foo.map(i => [i]).flat(0x1)`},
+			{Code: `const bar = foo.map(i => [i]).flat(1_0)`},
+			{Code: `const bar = foo.map(i => [i]).flat(+1)`},
+			{Code: `const bar = foo.map(i => [i]).flat(1n)`},
+			{Code: `const bar = foo.map(i => [i]).flat(1 as number)`},
+			{Code: `const bar = foo.map(callback).flat(1e0)`},
+			{Code: `const bar = foo.map(callback).flat(0b1)`},
+			{Code: `const bar = foo.map(callback).flat(0o1)`},
+			{Code: `const bar = foo.map(callback).flat(1.)`},
+			{Code: "const bar = foo.map(callback).flat(`1`)"},
+
+			// ---- Dimension 4: optional call/member exclusions ----
+			{Code: `const bar = foo.map?.(i => [i]).flat()`},
+			{Code: `const bar = foo.map(i => [i])?.flat()`},
+			{Code: `const bar = foo.map(i => [i]).flat?.()`},
+			{Code: `const bar = React.Children?.map(children, fn).flat()`},
+			{Code: `const bar = Children?.map(children, fn).flat()`},
+			{Code: `const bar = (foo?.map)(callback).flat()`},
+			{Code: `const bar = (foo?.bar.map)(callback).flat()`},
+			{Code: `const bar = (foo.bar?.map)(callback).flat()`},
+			{Code: `const bar = (foo.map)?.(callback).flat()`},
+			{Code: `const bar = foo?.map?.(callback).flat()`},
+
+			// ---- Dimension 4: TS wrappers between map() and flat() are not transparent upstream ----
+			{Code: `const bar = (foo.map(i => [i]) as any).flat()`},
+			{Code: `const bar = foo.map(i => [i])!.flat()`},
+			{Code: `const bar = (foo.map(i => [i]) satisfies unknown[]).flat()`},
+
+			// ---- Dimension 4: computed access remains unmatched inside ignored React.Children shapes ----
+			{Code: `const bar = React.Children["map"](children, fn).flat()`},
+			{Code: `const bar = React.Children.map(children, fn)["flat"]()`},
+
+			// ---- Real-user: #751 React.Children.map has no flatMap equivalent ----
+			{Code: `const bar = (React.Children).map(children, fn).flat()`},
+			{Code: `const bar = ((Children)).map(children, fn).flat()`},
+
+			// ---- Real-user: #848 depth Infinity should not be rewritten to flatMap ----
+			{Code: `const bar = a.map(v => v).flat(Infinity)`},
+
+			// ---- Real-user: #315 depth greater than 1 should not be rewritten to flatMap ----
+			{Code: `const foo = [[1]].map(i => [i]).flat(2)`},
+
+			// ---- Real-user: #1298 concat-spread case was removed from this rule ----
+			{Code: `const foo = [].concat(...array.map(item => [item]))`},
+
+			// N/A: declaration/container forms do not apply; this rule only inspects CallExpression chains.
+			// N/A: object/class property key forms do not apply; method names are member-access properties.
+			// N/A: cross-scope traversal boundaries do not apply; every CallExpression is checked independently.
+			// N/A: empty class/function/destructuring forms do not apply to method-call chain detection.
+			// N/A: overload/abstract/declare members do not apply to expression-call chains.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized receiver before map ----
+			{
+				Code:   `const bar = ((foo)).map(i => [i]).flat()`,
+				Output: []string{`const bar = ((foo)).flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 21, EndLine: 1, EndColumn: 41,
+				}},
+			},
+
+			// ---- Dimension 4: TS wrappers before map are ordinary receivers ----
+			{
+				Code:   `const bar = (foo as any).map(i => [i]).flat()`,
+				Output: []string{`const bar = (foo as any).flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 26}},
+			},
+			{
+				Code:   `const bar = foo!.map(i => [i]).flat()`,
+				Output: []string{`const bar = foo!.flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 18}},
+			},
+			{
+				Code:   `const bar = (foo satisfies any[]).map(i => [i]).flat()`,
+				Output: []string{`const bar = (foo satisfies any[]).flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 35}},
+			},
+
+			// ---- Dimension 4: optional member on map is allowed by upstream ----
+			{
+				Code:   `const bar = foo?.map(i => [i]).flat()`,
+				Output: []string{`const bar = foo?.flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 18}},
+			},
+			{
+				Code:   `const bar = foo?.bar.map(callback).flat()`,
+				Output: []string{`const bar = foo?.bar.flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 22}},
+			},
+			{
+				Code:   `const bar = foo?.bar?.map(callback).flat()`,
+				Output: []string{`const bar = foo?.bar?.flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 23}},
+			},
+
+			// ---- Dimension 4: parenthesized raw depth 1 matches ESTree's paren-flattened literal ----
+			{
+				Code:   `const bar = foo.map(i => [i]).flat((1))`,
+				Output: []string{`const bar = foo.flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+			{
+				Code:   `const bar = foo.map(callback).flat(1 /* c */)`,
+				Output: []string{`const bar = foo.flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+
+			// ---- Dimension 4: comments between map() and flat() are removed with the flat call ----
+			{
+				Code:   "const bar = foo.map(i => [i]) /* keep? */ .flat()",
+				Output: []string{"const bar = foo.flatMap(i => [i])"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+			{
+				Code:   `const bar = foo.map /* map */ (callback).flat()`,
+				Output: []string{`const bar = foo.flatMap /* map */ (callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+			{
+				Code:   `const bar = foo.map(callback) /* a */ .flat /* b */ (1)`,
+				Output: []string{`const bar = foo.flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+
+			// ---- Dimension 4: TS call syntax is preserved or removed like upstream ----
+			{
+				Code:   `const bar = foo.map<string>(callback).flat()`,
+				Output: []string{`const bar = foo.flatMap<string>(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+			{
+				Code:   `const bar = foo.map(callback).flat<number>()`,
+				Output: []string{`const bar = foo.flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+			{
+				Code:   `const bar = (<any>foo).map(callback).flat()`,
+				Output: []string{`const bar = (<any>foo).flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 24}},
+			},
+
+			// ---- Real-user: #316 Apollo/TypeScript chain used to expose overlapping fixes upstream ----
+			{
+				Code: `
+const cartItemsWithVariants: CartItem[] = filteredProducts
+	.filter(product => !!product.variants)
+	.map(product => transformProduct(product))
+	.flat();`,
+				Output: []string{`
+const cartItemsWithVariants: CartItem[] = filteredProducts
+	.filter(product => !!product.variants)
+	.flatMap(product => transformProduct(product));`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      4, Column: 3, EndLine: 5, EndColumn: 9,
+				}},
+			},
+
+			// Locks in upstream create() arm 1: .flat() with no arguments.
+			{
+				Code:   `const bar = foo.map(callback).flat()`,
+				Output: []string{`const bar = foo.flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+
+			// Locks in upstream create() arm 2: .flat(1) with raw literal `1`.
+			{
+				Code:   `const bar = foo.map(callback).flat(1)`,
+				Output: []string{`const bar = foo.flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+
+			// Locks in upstream create() arm 3: map call may itself be parenthesized.
+			{
+				Code:   `const bar = (foo.map(callback)).flat()`,
+				Output: []string{`const bar = (foo.flatMap(callback))`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 18}},
+			},
+
+			// Locks in upstream removeMethodCall(): parenthesized flat callee preserves the callee wrapper.
+			{
+				Code:   `const bar = (foo.map(callback).flat)()`,
+				Output: []string{`const bar = (foo.flatMap(callback))`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 18}},
+			},
+
+			// Locks in upstream isMethodCall(): map's callee may be parenthesized.
+			{
+				Code:   `const bar = (foo.map)(callback).flat()`,
+				Output: []string{`const bar = (foo.flatMap)(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 18}},
+			},
+			{
+				Code:   `const bar = ((foo.map))(callback).flat()`,
+				Output: []string{`const bar = ((foo.flatMap))(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 19}},
+			},
+
+			// Locks in upstream removeMethodCall(): comments between flat and the call parens are removed.
+			{
+				Code:   `const bar = foo.map(callback).flat /* c */ ()`,
+				Output: []string{`const bar = foo.flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+
+			// Locks in upstream create() arm 2: comments around raw depth 1 do not block the rewrite.
+			{
+				Code:   `const bar = foo.map(callback).flat(/* c */ 1)`,
+				Output: []string{`const bar = foo.flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 17}},
+			},
+
+			// ---- Dimension 4: ignored React.Children path stays dotted-only and non-optional ----
+			{
+				Code:   `const bar = React?.Children.map(children, fn).flat()`,
+				Output: []string{`const bar = React?.Children.flatMap(children, fn)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 29}},
+			},
+			{
+				Code:   `const bar = React["Children"].map(children, fn).flat()`,
+				Output: []string{`const bar = React["Children"].flatMap(children, fn)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 31}},
+			},
+			{
+				Code:   `const bar = globalThis.React.Children.map(children, fn).flat()`,
+				Output: []string{`const bar = globalThis.React.Children.flatMap(children, fn)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 39}},
+			},
+			{
+				Code:   `class C { m() { return this.Children.map(children, fn).flat(); } }`,
+				Output: []string{`class C { m() { return this.Children.flatMap(children, fn); } }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 38}},
+			},
+
+			// ---- Real-user: factory and control-flow receivers are syntactic candidates ----
+			{
+				Code:   `const bar = getItems().map(callback).flat()`,
+				Output: []string{`const bar = getItems().flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 24}},
+			},
+			{
+				Code:   `const bar = (condition ? first : second).map(callback).flat()`,
+				Output: []string{`const bar = (condition ? first : second).flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 42}},
+			},
+			{
+				Code:   `const bar = (first, second).map(callback).flat()`,
+				Output: []string{`const bar = (first, second).flatMap(callback)`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 29}},
+			},
+			{
+				Code:   `function f(items) { return items.map(callback).flat(); }`,
+				Output: []string{`function f(items) { return items.flatMap(callback); }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageID, Line: 1, Column: 34}},
+			},
+
+			// ---- Dimension 4: nested chains report independently and converge after repeated fixes ----
+			{
+				Code: `const bar = foo.map(x => x.map(y => [y]).flat()).flat()`,
+				Output: []string{
+					`const bar = foo.flatMap(x => x.map(y => [y]).flat())`,
+					`const bar = foo.flatMap(x => x.flatMap(y => [y]))`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 1, Column: 17},
+					{MessageId: messageID, Line: 1, Column: 28},
+				},
+			},
+			{
+				Code:   `const bar = foo.map(x => [x]).flat().map(y => [y]).flat()`,
+				Output: []string{`const bar = foo.flatMap(x => [x]).flatMap(y => [y])`},
+				// The outer final flat() is visited before its receiver, so the
+				// diagnostics are not source-sorted even though the fixes are.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: messageID, Line: 1, Column: 38},
+					{MessageId: messageID, Line: 1, Column: 17},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map_upstream_test.go
@@ -1,0 +1,269 @@
+package prefer_array_flat_map_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const preferArrayFlatMapMessage = "Prefer `.flatMap(…)` over `.map(…).flat()`."
+
+// TestPreferArrayFlatMapUpstream migrates the full valid/invalid suite from
+// upstream test/prefer-array-flat-map.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// the prefer_array_flat_map_extras_test.go file.
+func TestPreferArrayFlatMapUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_array_flat_map.PreferArrayFlatMapRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Upstream snapshot: valid ----
+			{Code: `const bar = [1,2,3].map()`},
+			{Code: `const bar = [1,2,3].map(i => i)`},
+			{Code: `const bar = [1,2,3].map((i) => i)`},
+			{Code: `const bar = [1,2,3].map((i) => { return i; })`},
+			{Code: `const bar = foo.map(i => i)`},
+			{Code: `const bar = foo.map?.(i => [i]).flat()`},
+			{Code: `const bar = foo.map(i => [i])?.flat()`},
+			{Code: `const bar = foo.map(i => [i]).flat?.()`},
+			{Code: `const bar = [[1],[2],[3]].flat()`},
+			{Code: `const bar = [1,2,3].map(i => [i]).sort().flat()`},
+			{Code: `
+let bar = [1,2,3].map(i => [i]);
+bar = bar.flat();`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(2)`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(1, null)`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(Infinity)`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(Number.POSITIVE_INFINITY)`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(Number.MAX_VALUE)`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(Number.MAX_SAFE_INTEGER)`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(...[1])`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(0.4 +.6)`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(+1)`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(foo)`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(foo.bar)`},
+			{Code: `const bar = [[1],[2],[3]].map(i => [i]).flat(1.00)`},
+
+			// Allowed
+			{Code: `Children.map(children, fn).flat()`},
+			{Code: `React.Children.map(children, fn).flat()`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Upstream snapshot: invalid ----
+			{
+				Code:   `const bar = [[1],[2],[3]].map(i => [i]).flat()`,
+				Output: []string{`const bar = [[1],[2],[3]].flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID, Message: preferArrayFlatMapMessage,
+					Line: 1, Column: 27, EndLine: 1, EndColumn: 47,
+				}},
+			},
+			{
+				Code:   `const bar = [[1],[2],[3]].map(i => [i]).flat(1,)`,
+				Output: []string{`const bar = [[1],[2],[3]].flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 27, EndLine: 1, EndColumn: 49,
+				}},
+			},
+			{
+				Code:   `const bar = [1,2,3].map(i => [i]).flat()`,
+				Output: []string{`const bar = [1,2,3].flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 21, EndLine: 1, EndColumn: 41,
+				}},
+			},
+			{
+				Code:   `const bar = [1,2,3].map((i) => [i]).flat()`,
+				Output: []string{`const bar = [1,2,3].flatMap((i) => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 21, EndLine: 1, EndColumn: 43,
+				}},
+			},
+			{
+				Code:   `const bar = [1,2,3].map((i) => { return [i]; }).flat()`,
+				Output: []string{`const bar = [1,2,3].flatMap((i) => { return [i]; })`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 21, EndLine: 1, EndColumn: 55,
+				}},
+			},
+			{
+				Code:   `const bar = [1,2,3].map(foo).flat()`,
+				Output: []string{`const bar = [1,2,3].flatMap(foo)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 21, EndLine: 1, EndColumn: 36,
+				}},
+			},
+			{
+				Code:   `const bar = foo.map(i => [i]).flat()`,
+				Output: []string{`const bar = foo.flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 17, EndLine: 1, EndColumn: 37,
+				}},
+			},
+			{
+				Code:   `const bar = foo?.map(i => [i]).flat()`,
+				Output: []string{`const bar = foo?.flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 18, EndLine: 1, EndColumn: 38,
+				}},
+			},
+			{
+				Code:   `const bar = { map: () => {} }.map(i => [i]).flat()`,
+				Output: []string{`const bar = { map: () => {} }.flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 31, EndLine: 1, EndColumn: 51,
+				}},
+			},
+			{
+				Code:   `const bar = [1,2,3].map(i => i).map(i => [i]).flat()`,
+				Output: []string{`const bar = [1,2,3].map(i => i).flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 33, EndLine: 1, EndColumn: 53,
+				}},
+			},
+			{
+				Code:   `const bar = [1,2,3].sort().map(i => [i]).flat()`,
+				Output: []string{`const bar = [1,2,3].sort().flatMap(i => [i])`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 28, EndLine: 1, EndColumn: 48,
+				}},
+			},
+			{
+				Code:   `const bar = (([1,2,3].map(i => [i]))).flat()`,
+				Output: []string{`const bar = (([1,2,3].flatMap(i => [i])))`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 23, EndLine: 1, EndColumn: 45,
+				}},
+			},
+			{
+				Code: `
+let bar = [1,2,3].map(i => {
+	return [i];
+}).flat();`,
+				Output: []string{`
+let bar = [1,2,3].flatMap(i => {
+	return [i];
+});`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      2, Column: 19, EndLine: 4, EndColumn: 10,
+				}},
+			},
+			{
+				Code: `
+let bar = [1,2,3].map(i => {
+	return [i];
+})
+.flat();`,
+				Output: []string{`
+let bar = [1,2,3].flatMap(i => {
+	return [i];
+});`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      2, Column: 19, EndLine: 5, EndColumn: 8,
+				}},
+			},
+			{
+				Code: `
+let bar = [1,2,3].map(i => {
+	return [i];
+}) // comment
+.flat();`,
+				Output: []string{`
+let bar = [1,2,3].flatMap(i => {
+	return [i];
+});`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      2, Column: 19, EndLine: 5, EndColumn: 8,
+				}},
+			},
+			{
+				Code: `
+let bar = [1,2,3].map(i => {
+	return [i];
+}) // comment
+.flat(); // other`,
+				Output: []string{`
+let bar = [1,2,3].flatMap(i => {
+	return [i];
+}); // other`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      2, Column: 19, EndLine: 5, EndColumn: 8,
+				}},
+			},
+			{
+				Code: `
+let bar = [1,2,3]
+	.map(i => { return [i]; })
+	.flat();`,
+				Output: []string{`
+let bar = [1,2,3]
+	.flatMap(i => { return [i]; });`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      3, Column: 3, EndLine: 4, EndColumn: 9,
+				}},
+			},
+			{
+				Code: `
+let bar = [1,2,3].map(i => { return [i]; })
+	.flat();`,
+				Output: []string{`
+let bar = [1,2,3].flatMap(i => { return [i]; });`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      2, Column: 19, EndLine: 3, EndColumn: 9,
+				}},
+			},
+			{
+				Code:   `let bar = [1,2,3] . map( x => y ) . flat () // 🤪`,
+				Output: []string{`let bar = [1,2,3] . flatMap( x => y ) // 🤪`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 21, EndLine: 1, EndColumn: 44,
+				}},
+			},
+			{
+				Code:   `const bar = [1,2,3].map(i => [i]).flat(1);`,
+				Output: []string{`const bar = [1,2,3].flatMap(i => [i]);`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1, Column: 21, EndLine: 1, EndColumn: 42,
+				}},
+			},
+			{
+				Code: `
+const foo = bars
+	.filter(foo => !!foo.zaz)
+	.map(foo => doFoo(foo))
+	.flat();`,
+				Output: []string{`
+const foo = bars
+	.filter(foo => !!foo.zaz)
+	.flatMap(foo => doFoo(foo));`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      4, Column: 3, EndLine: 5, EndColumn: 9,
+				}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -530,6 +530,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
+    './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',
 
     './tests/eslint/rules/no-shadow-restricted-names.test.ts',
   ],

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts
@@ -1,0 +1,87 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string) => ({ code });
+const invalid = (code: string) => ({ code, errors: 1 });
+
+ruleTester.run('prefer-array-flat-map', null as never, {
+  valid: [
+    valid('const bar = [1,2,3].map()'),
+    valid('const bar = [1,2,3].map(i => i)'),
+    valid('const bar = [1,2,3].map((i) => i)'),
+    valid('const bar = [1,2,3].map((i) => { return i; })'),
+    valid('const bar = foo.map(i => i)'),
+    valid('const bar = foo.map?.(i => [i]).flat()'),
+    valid('const bar = foo.map(i => [i])?.flat()'),
+    valid('const bar = foo.map(i => [i]).flat?.()'),
+    valid('const bar = [[1],[2],[3]].flat()'),
+    valid('const bar = [1,2,3].map(i => [i]).sort().flat()'),
+    valid('let bar = [1,2,3].map(i => [i]);\n' + 'bar = bar.flat();'),
+    valid('const bar = [[1],[2],[3]].map(i => [i]).flat(2)'),
+    valid('const bar = [[1],[2],[3]].map(i => [i]).flat(1, null)'),
+    valid('const bar = [[1],[2],[3]].map(i => [i]).flat(Infinity)'),
+    valid(
+      'const bar = [[1],[2],[3]].map(i => [i]).flat(Number.POSITIVE_INFINITY)',
+    ),
+    valid('const bar = [[1],[2],[3]].map(i => [i]).flat(Number.MAX_VALUE)'),
+    valid(
+      'const bar = [[1],[2],[3]].map(i => [i]).flat(Number.MAX_SAFE_INTEGER)',
+    ),
+    valid('const bar = [[1],[2],[3]].map(i => [i]).flat(...[1])'),
+    valid('const bar = [[1],[2],[3]].map(i => [i]).flat(0.4 +.6)'),
+    valid('const bar = [[1],[2],[3]].map(i => [i]).flat(+1)'),
+    valid('const bar = [[1],[2],[3]].map(i => [i]).flat(foo)'),
+    valid('const bar = [[1],[2],[3]].map(i => [i]).flat(foo.bar)'),
+    valid('const bar = [[1],[2],[3]].map(i => [i]).flat(1.00)'),
+    valid('Children.map(children, fn).flat()'),
+    valid('React.Children.map(children, fn).flat()'),
+  ],
+  invalid: [
+    invalid('const bar = [[1],[2],[3]].map(i => [i]).flat()'),
+    invalid('const bar = [[1],[2],[3]].map(i => [i]).flat(1,)'),
+    invalid('const bar = [1,2,3].map(i => [i]).flat()'),
+    invalid('const bar = [1,2,3].map((i) => [i]).flat()'),
+    invalid('const bar = [1,2,3].map((i) => { return [i]; }).flat()'),
+    invalid('const bar = [1,2,3].map(foo).flat()'),
+    invalid('const bar = foo.map(i => [i]).flat()'),
+    invalid('const bar = foo?.map(i => [i]).flat()'),
+    invalid('const bar = { map: () => {} }.map(i => [i]).flat()'),
+    invalid('const bar = [1,2,3].map(i => i).map(i => [i]).flat()'),
+    invalid('const bar = [1,2,3].sort().map(i => [i]).flat()'),
+    invalid('const bar = (([1,2,3].map(i => [i]))).flat()'),
+    invalid(
+      'let bar = [1,2,3].map(i => {\n' + '\treturn [i];\n' + '}).flat();',
+    ),
+    invalid(
+      'let bar = [1,2,3].map(i => {\n' +
+        '\treturn [i];\n' +
+        '})\n' +
+        '.flat();',
+    ),
+    invalid(
+      'let bar = [1,2,3].map(i => {\n' +
+        '\treturn [i];\n' +
+        '}) // comment\n' +
+        '.flat();',
+    ),
+    invalid(
+      'let bar = [1,2,3].map(i => {\n' +
+        '\treturn [i];\n' +
+        '}) // comment\n' +
+        '.flat(); // other',
+    ),
+    invalid(
+      'let bar = [1,2,3]\n' + '\t.map(i => { return [i]; })\n' + '\t.flat();',
+    ),
+    invalid('let bar = [1,2,3].map(i => { return [i]; })\n' + '\t.flat();'),
+    invalid('let bar = [1,2,3] . map( x => y ) . flat () // 🤪'),
+    invalid('const bar = [1,2,3].map(i => [i]).flat(1);'),
+    invalid(
+      'const foo = bars\n' +
+        '\t.filter(foo => !!foo.zaz)\n' +
+        '\t.map(foo => doFoo(foo))\n' +
+        '\t.flat();',
+    ),
+  ],
+});


### PR DESCRIPTION
## Summary

Port `unicorn/prefer-array-flat-map` to rslint.

This adds the native Go rule implementation, upstream parity tests, rslint-specific edge coverage, documentation, and JS integration coverage for the compiled CLI path.

## Related Links

- Original documentation: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/prefer-array-flat-map.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
