### PR TITLE
feat: port rule unicorn/new-for-builtins

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -2,6 +2,7 @@ package unicorn_plugin
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
@@ -11,6 +12,7 @@ import (
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		filename_case.FilenameCaseRule,
+		new_for_builtins.NewForBuiltinsRule,
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_useless_switch_case.NoUselessSwitchCaseRule,
 		prefer_array_flat_map.PreferArrayFlatMapRule,

--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.go
@@ -1,0 +1,826 @@
+package new_for_builtins
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	messageIDEnforce             = "enforce"
+	messageIDDisallow            = "disallow"
+	messageIDDisallowCallOrNew   = "disallowCallOrNew"
+	messageIDErrorDate           = "error-date"
+	messageIDSuggestionDate      = "suggestion-date"
+	messageDateDescription       = "Use `String(new Date())` instead of `Date()`."
+	messageDateSuggestion        = "Switch to `String(new Date())`."
+	replacementStringNewDateCall = "String(new Date())"
+)
+
+var NewForBuiltinsRule = rule.Rule{
+	Name: "unicorn/new-for-builtins",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		state := newRuleState(ctx)
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				state.checkCallExpression(node)
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				state.checkNewExpression(node)
+			},
+		}
+	},
+}
+
+var enforceNewBuiltins = map[string]bool{
+	"Object":                   true,
+	"Array":                    true,
+	"ArrayBuffer":              true,
+	"DataView":                 true,
+	"Date":                     true,
+	"Function":                 true,
+	"Map":                      true,
+	"WeakMap":                  true,
+	"Set":                      true,
+	"WeakSet":                  true,
+	"Promise":                  true,
+	"RegExp":                   true,
+	"SharedArrayBuffer":        true,
+	"Proxy":                    true,
+	"WeakRef":                  true,
+	"FinalizationRegistry":     true,
+	"DisposableStack":          true,
+	"AsyncDisposableStack":     true,
+	"Error":                    true,
+	"AggregateError":           true,
+	"EvalError":                true,
+	"RangeError":               true,
+	"ReferenceError":           true,
+	"SuppressedError":          true,
+	"SyntaxError":              true,
+	"TypeError":                true,
+	"URIError":                 true,
+	"Float16Array":             true,
+	"Float32Array":             true,
+	"Float64Array":             true,
+	"Int8Array":                true,
+	"Int16Array":               true,
+	"Int32Array":               true,
+	"BigInt64Array":            true,
+	"BigUint64Array":           true,
+	"Uint8Array":               true,
+	"Uint16Array":              true,
+	"Uint32Array":              true,
+	"Uint8ClampedArray":        true,
+	"Intl.Collator":            true,
+	"Intl.DateTimeFormat":      true,
+	"Intl.DisplayNames":        true,
+	"Intl.DurationFormat":      true,
+	"Intl.ListFormat":          true,
+	"Intl.Locale":              true,
+	"Intl.NumberFormat":        true,
+	"Intl.PluralRules":         true,
+	"Intl.RelativeTimeFormat":  true,
+	"Intl.Segmenter":           true,
+	"Temporal.Duration":        true,
+	"Temporal.Instant":         true,
+	"Temporal.PlainDate":       true,
+	"Temporal.PlainDateTime":   true,
+	"Temporal.PlainMonthDay":   true,
+	"Temporal.PlainTime":       true,
+	"Temporal.PlainYearMonth":  true,
+	"Temporal.ZonedDateTime":   true,
+	"WebAssembly.Module":       true,
+	"WebAssembly.Instance":     true,
+	"WebAssembly.Memory":       true,
+	"WebAssembly.Table":        true,
+	"WebAssembly.Global":       true,
+	"WebAssembly.Tag":          true,
+	"WebAssembly.Exception":    true,
+	"WebAssembly.CompileError": true,
+	"WebAssembly.LinkError":    true,
+	"WebAssembly.RuntimeError": true,
+}
+
+var disallowNewBuiltins = map[string]bool{
+	"BigInt":  true,
+	"Boolean": true,
+	"Number":  true,
+	"String":  true,
+	"Symbol":  true,
+}
+
+var disallowCallOrNewBuiltins = map[string]bool{
+	"Temporal.Now":      true,
+	"WebAssembly":       true,
+	"WebAssembly.JSTag": true,
+}
+
+var globalObjectNames = map[string]bool{
+	"globalThis": true,
+	"global":     true,
+	"self":       true,
+	"window":     true,
+}
+
+type ruleState struct {
+	ctx         rule.RuleContext
+	aliases     map[*ast.Node]aliasInfo
+	aliasesByID map[string][]aliasInfo
+}
+
+type aliasInfo struct {
+	binding *ast.Node
+	scope   *ast.Node
+	path    []string
+}
+
+type reference struct {
+	name string
+	path []string
+}
+
+type referenceSource uint8
+
+const (
+	referenceSourceBareGlobal referenceSource = iota
+	referenceSourceGlobalObject
+	referenceSourceAlias
+)
+
+type globalReference struct {
+	path   []string
+	source referenceSource
+}
+
+func newRuleState(ctx rule.RuleContext) *ruleState {
+	state := &ruleState{
+		ctx:         ctx,
+		aliases:     map[*ast.Node]aliasInfo{},
+		aliasesByID: map[string][]aliasInfo{},
+	}
+	state.collectAliases()
+	return state
+}
+
+func (state *ruleState) checkCallExpression(node *ast.Node) {
+	call := node.AsCallExpression()
+	if call == nil {
+		return
+	}
+
+	ref, ok := state.referenceFromExpression(call.Expression)
+	if !ok {
+		return
+	}
+
+	if disallowCallOrNewBuiltins[ref.name] {
+		state.ctx.ReportNode(node, messageDisallowCallOrNew(ref.name))
+		return
+	}
+
+	if !enforceNewBuiltins[ref.name] {
+		return
+	}
+
+	// An optional chain (`Array?.()` or `Intl?.DateTimeFormat()`) can't be
+	// rewritten to a `new` expression, which cannot itself be optional.
+	if hasOptionalChain(node) || hasOptionalChain(call.Expression) {
+		return
+	}
+
+	if ref.name == "Object" && isStrictObjectComparison(node) {
+		return
+	}
+
+	if ref.name == "Date" {
+		state.reportDateCall(node, call)
+		return
+	}
+
+	state.ctx.ReportNodeWithFixes(node, messageEnforce(ref.name), state.enforceNewFix(node))
+}
+
+func (state *ruleState) checkNewExpression(node *ast.Node) {
+	newExpression := node.AsNewExpression()
+	if newExpression == nil {
+		return
+	}
+
+	ref, ok := state.referenceFromExpression(newExpression.Expression)
+	if !ok {
+		return
+	}
+
+	if disallowCallOrNewBuiltins[ref.name] {
+		state.ctx.ReportNode(node, messageDisallowCallOrNew(ref.name))
+		return
+	}
+
+	if !disallowNewBuiltins[ref.name] {
+		return
+	}
+
+	message := messageDisallow(ref.name)
+	if ref.name == "String" || ref.name == "Boolean" || ref.name == "Number" {
+		state.ctx.ReportNode(node, message)
+		return
+	}
+
+	fixes := state.newToCallFixes(node, newExpression)
+	if len(fixes) == 0 {
+		state.ctx.ReportNode(node, message)
+		return
+	}
+	state.ctx.ReportNodeWithFixes(node, message, fixes...)
+}
+
+func (state *ruleState) reportDateCall(node *ast.Node, call *ast.CallExpression) {
+	message := rule.RuleMessage{Id: messageIDErrorDate, Description: messageDateDescription}
+	fix := rule.RuleFixReplaceRange(utils.TrimNodeTextRange(state.ctx.SourceFile, node), state.dateReplacement(node))
+
+	hasArguments := call.Arguments != nil && len(call.Arguments.Nodes) > 0
+	if !hasArguments && !utils.HasCommentInsideNode(state.ctx.SourceFile, node) {
+		state.ctx.ReportNodeWithFixes(node, message, fix)
+		return
+	}
+
+	state.ctx.ReportNodeWithSuggestions(node, message, rule.RuleSuggestion{
+		Message:  rule.RuleMessage{Id: messageIDSuggestionDate, Description: messageDateSuggestion},
+		FixesArr: []rule.RuleFix{fix},
+	})
+}
+
+func (state *ruleState) newToCallFixes(node *ast.Node, newExpression *ast.NewExpression) []rule.RuleFix {
+	nodeRange := utils.TrimNodeTextRange(state.ctx.SourceFile, node)
+	expressionRange := utils.TrimNodeTextRange(state.ctx.SourceFile, newExpression.Expression)
+	if nodeRange.Pos() >= expressionRange.Pos() {
+		return nil
+	}
+
+	source := state.ctx.SourceFile.Text()
+	removeEnd := nodeRange.Pos() + len("new")
+	for removeEnd < expressionRange.Pos() && isWhitespace(source[removeEnd]) {
+		removeEnd++
+	}
+
+	fixes := []rule.RuleFix{
+		rule.RuleFixRemoveRange(core.NewTextRange(nodeRange.Pos(), removeEnd)),
+	}
+
+	insertAfterExpression := ""
+	if newExpression.Arguments == nil {
+		insertAfterExpression = "()"
+	}
+
+	if state.needsReturnOrThrowParentheses(node, nodeRange.Pos(), expressionRange.Pos()) {
+		if opening, closing, ok := returnOrThrowParenthesesRanges(state.ctx.SourceFile, node.Parent); ok {
+			fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(opening, opening), " ("))
+			if closing == expressionRange.End() {
+				insertAfterExpression += ")"
+			} else {
+				fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(closing, closing), ")"))
+			}
+		}
+	}
+
+	if insertAfterExpression != "" {
+		fixes = append(fixes, rule.RuleFixReplaceRange(
+			core.NewTextRange(expressionRange.End(), expressionRange.End()),
+			insertAfterExpression,
+		))
+	}
+	return fixes
+}
+
+func (state *ruleState) needsReturnOrThrowParentheses(node *ast.Node, newPos int, expressionPos int) bool {
+	if node.Parent == nil || node.Parent.Kind == ast.KindParenthesizedExpression {
+		return false
+	}
+	if node.Parent.Kind != ast.KindReturnStatement && node.Parent.Kind != ast.KindThrowStatement {
+		return false
+	}
+	return !sameLine(state.ctx.SourceFile, newPos, expressionPos)
+}
+
+func returnOrThrowParenthesesRanges(sourceFile *ast.SourceFile, statement *ast.Node) (int, int, bool) {
+	if sourceFile == nil || statement == nil {
+		return 0, 0, false
+	}
+
+	statementRange := utils.TrimNodeTextRange(sourceFile, statement)
+	keywordLength := len("return")
+	if statement.Kind == ast.KindThrowStatement {
+		keywordLength = len("throw")
+	}
+
+	opening := statementRange.Pos() + keywordLength
+	closing := statementRange.End()
+	source := sourceFile.Text()
+	for pos := closing - 1; pos >= statementRange.Pos(); pos-- {
+		if isWhitespace(source[pos]) {
+			continue
+		}
+		if source[pos] == ';' {
+			closing = pos
+		}
+		break
+	}
+	return opening, closing, true
+}
+
+func (state *ruleState) enforceNewFix(node *ast.Node) rule.RuleFix {
+	nodeRange := utils.TrimNodeTextRange(state.ctx.SourceFile, node)
+	text := "new "
+	source := state.ctx.SourceFile.Text()
+	if utils.NeedsLeadingSpaceForReplacement(source, nodeRange.Pos(), text) {
+		text = " " + text
+	}
+	return rule.RuleFixReplaceRange(core.NewTextRange(nodeRange.Pos(), nodeRange.Pos()), text)
+}
+
+func (state *ruleState) dateReplacement(node *ast.Node) string {
+	nodeRange := utils.TrimNodeTextRange(state.ctx.SourceFile, node)
+	if utils.NeedsLeadingSpaceForReplacement(state.ctx.SourceFile.Text(), nodeRange.Pos(), replacementStringNewDateCall) {
+		return " " + replacementStringNewDateCall
+	}
+	return replacementStringNewDateCall
+}
+
+func (state *ruleState) referenceFromExpression(node *ast.Node) (reference, bool) {
+	path, ok := state.globalReferencePath(node)
+	if !ok || len(path) == 0 {
+		return reference{}, false
+	}
+	name := pathKey(path)
+	if !isWatchedBuiltin(name) {
+		return reference{}, false
+	}
+	return reference{name: name, path: path}, true
+}
+
+func (state *ruleState) collectAliases() {
+	if state.ctx.SourceFile == nil || state.ctx.SourceFile.AsNode() == nil {
+		return
+	}
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node.Kind == ast.KindVariableDeclaration {
+			state.collectVariableAlias(node)
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(state.ctx.SourceFile.AsNode())
+}
+
+func (state *ruleState) collectVariableAlias(node *ast.Node) {
+	declaration := node.AsVariableDeclaration()
+	if declaration == nil || declaration.Name() == nil || declaration.Initializer == nil {
+		return
+	}
+
+	baseReference, ok := state.globalReferenceInfo(declaration.Initializer)
+	if !ok {
+		return
+	}
+
+	name := declaration.Name()
+	switch name.Kind {
+	case ast.KindIdentifier:
+		if state.shouldRegisterAlias(baseReference) {
+			state.registerAlias(name, baseReference.path, node)
+		}
+	case ast.KindObjectBindingPattern:
+		state.collectBindingPatternAliases(name, baseReference)
+	}
+}
+
+func (state *ruleState) collectBindingPatternAliases(pattern *ast.Node, baseReference globalReference) {
+	bindingPattern := pattern.AsBindingPattern()
+	if bindingPattern == nil || bindingPattern.Elements == nil {
+		return
+	}
+	for _, elementNode := range bindingPattern.Elements.Nodes {
+		element := elementNode.AsBindingElement()
+		if element == nil || element.DotDotDotToken != nil || element.Name() == nil {
+			continue
+		}
+
+		propertyName := element.PropertyName
+		if propertyName == nil {
+			propertyName = element.Name()
+		}
+		staticName, ok := utils.GetStaticPropertyName(propertyName)
+		if !ok {
+			continue
+		}
+		reference := globalReference{
+			path:   appendPath(baseReference.path, staticName),
+			source: baseReference.source,
+		}
+
+		switch element.Name().Kind {
+		case ast.KindIdentifier:
+			if state.shouldRegisterAlias(reference) {
+				state.registerAlias(element.Name(), reference.path, elementNode)
+			}
+		case ast.KindObjectBindingPattern:
+			state.collectBindingPatternAliases(element.Name(), reference)
+		}
+	}
+}
+
+func (state *ruleState) shouldRegisterAlias(reference globalReference) bool {
+	if len(reference.path) == 0 {
+		return false
+	}
+
+	// ESLint's ReferenceTracker does not follow aliases that originate from a
+	// bare `WebAssembly` read, but it does follow `globalThis.WebAssembly` and
+	// destructured aliases from a global object.
+	if reference.source == referenceSourceBareGlobal && reference.path[0] == "WebAssembly" {
+		return false
+	}
+
+	name := pathKey(reference.path)
+	return isWatchedBuiltin(name) || isWatchedNamespace(name)
+}
+
+func (state *ruleState) registerAlias(binding *ast.Node, path []string, declarations ...*ast.Node) {
+	if binding == nil || binding.Kind != ast.KindIdentifier {
+		return
+	}
+
+	info := aliasInfo{
+		binding: binding,
+		scope:   state.aliasScopeForBinding(binding),
+		path:    slices.Clone(path),
+	}
+
+	state.aliases[binding] = info
+	for _, declaration := range declarations {
+		if declaration != nil {
+			state.aliases[declaration] = info
+		}
+	}
+	state.aliasesByID[binding.AsIdentifier().Text] = append(state.aliasesByID[binding.AsIdentifier().Text], info)
+}
+
+func (state *ruleState) globalReferencePath(node *ast.Node) ([]string, bool) {
+	reference, ok := state.globalReferenceInfo(node)
+	if !ok {
+		return nil, false
+	}
+	return reference.path, true
+}
+
+func (state *ruleState) globalReferenceInfo(node *ast.Node) (globalReference, bool) {
+	path, root, ok := state.expressionPath(node)
+	if !ok || len(path) == 0 {
+		return globalReference{}, false
+	}
+
+	if globalObjectNames[path[0]] {
+		if state.isLocalNonAliasIdentifier(root) {
+			return globalReference{}, false
+		}
+		return globalReference{path: slices.Clone(path[1:]), source: referenceSourceGlobalObject}, true
+	}
+
+	if aliasPath, ok := state.aliasPathForIdentifier(root); ok {
+		return globalReference{path: appendPath(aliasPath, path[1:]...), source: referenceSourceAlias}, true
+	}
+
+	if state.isLocalNonAliasIdentifier(root) {
+		return globalReference{}, false
+	}
+
+	return globalReference{path: slices.Clone(path), source: referenceSourceBareGlobal}, true
+}
+
+func (state *ruleState) expressionPath(node *ast.Node) ([]string, *ast.Node, bool) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return nil, nil, false
+	}
+
+	if node.Kind == ast.KindIdentifier {
+		return []string{node.AsIdentifier().Text}, node, true
+	}
+
+	if ast.IsAccessExpression(node) {
+		name, ok := accessExpressionStaticName(node)
+		if !ok {
+			return nil, nil, false
+		}
+		path, root, ok := state.expressionPath(utils.AccessExpressionObject(node))
+		if !ok {
+			return nil, nil, false
+		}
+		return appendPath(path, name), root, true
+	}
+
+	return nil, nil, false
+}
+
+func accessExpressionStaticName(node *ast.Node) (string, bool) {
+	if node.Kind == ast.KindElementAccessExpression {
+		access := node.AsElementAccessExpression()
+		if access == nil || access.ArgumentExpression == nil {
+			return "", false
+		}
+		// Element keys can be wrapped in TS assertions; keep those wrappers
+		// transparent while still requiring a compile-time static key.
+		return utils.GetStaticExpressionValue(utils.SkipAssertionsAndParens(access.ArgumentExpression))
+	}
+	return utils.AccessExpressionStaticName(node)
+}
+
+func (state *ruleState) aliasPathForIdentifier(node *ast.Node) ([]string, bool) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil || node.Kind != ast.KindIdentifier {
+		return nil, false
+	}
+	if state.ctx.TypeChecker != nil {
+		symbol := utils.GetReferenceSymbol(node, state.ctx.TypeChecker)
+		if symbol != nil {
+			for _, declaration := range symbol.Declarations {
+				if info, ok := state.aliases[declaration]; ok && state.aliasInfoApplies(node, info) {
+					return slices.Clone(info.path), true
+				}
+			}
+		}
+	}
+	infos := state.aliasesByID[node.AsIdentifier().Text]
+	for i := len(infos) - 1; i >= 0; i-- {
+		if state.aliasInfoApplies(node, infos[i]) {
+			return slices.Clone(infos[i].path), true
+		}
+	}
+	return nil, false
+}
+
+func (state *ruleState) aliasInfoApplies(node *ast.Node, info aliasInfo) bool {
+	if node == nil || node.Kind != ast.KindIdentifier || info.binding == nil || len(info.path) == 0 {
+		return false
+	}
+	scope := info.scope
+	if scope == nil && state.ctx.SourceFile != nil {
+		scope = state.ctx.SourceFile.AsNode()
+	}
+	if scope != nil {
+		if !nodeWithin(node, scope) {
+			return false
+		}
+		if aliasHasCloserShadow(node, scope, node.AsIdentifier().Text, info.binding) {
+			return false
+		}
+	}
+	return true
+}
+
+func (state *ruleState) aliasScopeForBinding(binding *ast.Node) *ast.Node {
+	variableDeclaration := ast.FindAncestorKind(binding, ast.KindVariableDeclaration)
+	if variableDeclaration == nil {
+		if state.ctx.SourceFile != nil {
+			return state.ctx.SourceFile.AsNode()
+		}
+		return nil
+	}
+
+	declarationList := ast.FindAncestorKind(variableDeclaration, ast.KindVariableDeclarationList)
+	if declarationList != nil && utils.IsVarKeyword(declarationList) {
+		return varAliasScope(variableDeclaration)
+	}
+
+	if declarationList != nil && declarationList.Parent != nil {
+		switch declarationList.Parent.Kind {
+		case ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement:
+			return declarationList.Parent
+		}
+	}
+
+	scope := ast.FindAncestor(variableDeclaration, func(node *ast.Node) bool {
+		switch node.Kind {
+		case ast.KindBlock, ast.KindCaseBlock, ast.KindModuleBlock, ast.KindSourceFile:
+			return true
+		default:
+			return false
+		}
+	})
+	if scope != nil {
+		return scope
+	}
+	if state.ctx.SourceFile != nil {
+		return state.ctx.SourceFile.AsNode()
+	}
+	return nil
+}
+
+func varAliasScope(node *ast.Node) *ast.Node {
+	for current := node; current != nil; current = current.Parent {
+		if current.Kind == ast.KindSourceFile || current.Kind == ast.KindModuleBlock {
+			return current
+		}
+		if ast.IsFunctionLikeDeclaration(current) {
+			if body := current.Body(); body != nil {
+				return body
+			}
+			return current
+		}
+	}
+	return nil
+}
+
+func nodeWithin(node *ast.Node, container *ast.Node) bool {
+	return node != nil && container != nil &&
+		node.Pos() >= container.Pos() && node.End() <= container.End()
+}
+
+// aliasHasCloserShadow mirrors utils.IsNameShadowedBetween, but ignores
+// ancestor scopes that contain the alias binding itself. This keeps `var`
+// aliases inside blocks from looking like shadows of their own references.
+func aliasHasCloserShadow(node *ast.Node, boundary *ast.Node, name string, binding *ast.Node) bool {
+	for current := node.Parent; current != nil && current != boundary; current = current.Parent {
+		if nodeWithin(binding, current) {
+			continue
+		}
+		if ast.IsFunctionLikeDeclaration(current) && utils.HasShadowingParameter(current, name) {
+			return true
+		}
+		switch current.Kind {
+		case ast.KindBlock:
+			if utils.HasShadowingDeclaration(current, name) {
+				return true
+			}
+		case ast.KindCatchClause:
+			catchClause := current.AsCatchClause()
+			if catchClause != nil && catchClause.VariableDeclaration != nil {
+				variableDeclaration := catchClause.VariableDeclaration.AsVariableDeclaration()
+				if variableDeclaration != nil && variableDeclaration.Name() != nil &&
+					utils.HasNameInBindingPattern(variableDeclaration.Name(), name) {
+					return true
+				}
+			}
+		case ast.KindForStatement:
+			forStatement := current.AsForStatement()
+			if forStatement != nil && forStatement.Initializer != nil &&
+				forStatement.Initializer.Kind == ast.KindVariableDeclarationList &&
+				utils.HasVarDeclListWithName(forStatement.Initializer, name) {
+				return true
+			}
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			statement := current.AsForInOrOfStatement()
+			if statement != nil && statement.Initializer != nil &&
+				statement.Initializer.Kind == ast.KindVariableDeclarationList &&
+				utils.HasVarDeclListWithName(statement.Initializer, name) {
+				return true
+			}
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			if n := current.Name(); n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (state *ruleState) isLocalNonAliasIdentifier(node *ast.Node) bool {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil || node.Kind != ast.KindIdentifier {
+		return false
+	}
+	if _, ok := state.aliasPathForIdentifier(node); ok {
+		return false
+	}
+
+	name := node.AsIdentifier().Text
+	if state.ctx.TypeChecker != nil && state.ctx.SourceFile != nil {
+		symbol := utils.GetReferenceSymbol(node, state.ctx.TypeChecker)
+		if utils.IsSymbolDeclaredInFile(symbol, state.ctx.SourceFile) {
+			return true
+		}
+	}
+
+	return utils.IsShadowed(node, name)
+}
+
+func hasOptionalChain(node *ast.Node) bool {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return false
+	}
+	if ast.IsOptionalChain(node) {
+		return true
+	}
+	switch node.Kind {
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		return call != nil && hasOptionalChain(call.Expression)
+	case ast.KindPropertyAccessExpression:
+		access := node.AsPropertyAccessExpression()
+		return access != nil && hasOptionalChain(access.Expression)
+	case ast.KindElementAccessExpression:
+		access := node.AsElementAccessExpression()
+		return access != nil && hasOptionalChain(access.Expression)
+	case ast.KindNonNullExpression:
+		expression := node.AsNonNullExpression()
+		return expression != nil && hasOptionalChain(expression.Expression)
+	default:
+		return false
+	}
+}
+
+func isStrictObjectComparison(node *ast.Node) bool {
+	current := node
+	for current.Parent != nil && current.Parent.Kind == ast.KindParenthesizedExpression {
+		current = current.Parent
+	}
+
+	parent := current.Parent
+	if parent == nil || parent.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	binary := parent.AsBinaryExpression()
+	if binary == nil || binary.OperatorToken == nil {
+		return false
+	}
+	if binary.OperatorToken.Kind != ast.KindEqualsEqualsEqualsToken && binary.OperatorToken.Kind != ast.KindExclamationEqualsEqualsToken {
+		return false
+	}
+	return binary.Left == current || binary.Right == current
+}
+
+func messageEnforce(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDEnforce,
+		Description: fmt.Sprintf("Use `new %s()` instead of `%s()`.", name, name),
+		Data:        map[string]string{"name": name},
+	}
+}
+
+func messageDisallow(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDDisallow,
+		Description: fmt.Sprintf("Use `%s()` instead of `new %s()`.", name, name),
+		Data:        map[string]string{"name": name},
+	}
+}
+
+func messageDisallowCallOrNew(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDDisallowCallOrNew,
+		Description: fmt.Sprintf("`%s` is not a function or constructor.", name),
+		Data:        map[string]string{"name": name},
+	}
+}
+
+func isWatchedBuiltin(name string) bool {
+	return enforceNewBuiltins[name] || disallowNewBuiltins[name] || disallowCallOrNewBuiltins[name]
+}
+
+func isWatchedNamespace(name string) bool {
+	prefix := name + "."
+	for builtin := range enforceNewBuiltins {
+		if strings.HasPrefix(builtin, prefix) {
+			return true
+		}
+	}
+	for builtin := range disallowCallOrNewBuiltins {
+		if strings.HasPrefix(builtin, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathKey(path []string) string {
+	return strings.Join(path, ".")
+}
+
+func appendPath(path []string, parts ...string) []string {
+	return append(slices.Clone(path), parts...)
+}
+
+func sameLine(sourceFile *ast.SourceFile, a int, b int) bool {
+	lineStarts := sourceFile.ECMALineMap()
+	return scanner.ComputeLineOfPosition(lineStarts, a) ==
+		scanner.ComputeLineOfPosition(lineStarts, b)
+}
+
+func isWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f' || ch == '\v'
+}

--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.md
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.md
@@ -1,0 +1,35 @@
+# new-for-builtins
+
+## Rule Details
+
+Many builtin constructors can be called with or without `new`, but constructor
+calls are clearer and more consistent when they use `new`. This rule also
+reports selected builtin namespace objects that are neither callable nor
+constructible.
+
+Optional calls that would need to become optional constructors are ignored,
+because `new` cannot be optional.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const list = Array(10);
+const map = Map([["foo", "bar"]]);
+const now = Date();
+const tag = WebAssembly.JSTag();
+const text = new String("value");
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const list = new Array(10);
+const map = new Map([["foo", "bar"]]);
+const now = String(new Date());
+const text = String("value");
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: new-for-builtins](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/new-for-builtins.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/new-for-builtins.js)

--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_extras_test.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_extras_test.go
@@ -1,0 +1,286 @@
+package new_for_builtins_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNewForBuiltinsExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Inline comments describe the behavior each case
+// protects so future refactors don't silently loosen the matching logic.
+func TestNewForBuiltinsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&new_for_builtins.NewForBuiltinsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: optional calls that would require optional `new` are ignored ----
+			jsValid("const value = (globalThis?.Array)();"),
+			// ---- Dimension 4: dynamic element access is not a static builtin reference ----
+			jsValid("const key = 'Array'; globalThis[key]();"),
+			// ---- Dimension 4: numeric element keys do not match builtin names ----
+			jsValid("globalThis[0]();"),
+			// ---- Dimension 4: computed destructuring with a dynamic key does not create an alias ----
+			jsValid(lines(
+				"const key = 'Array';",
+				"const {[key]: A} = globalThis;",
+				"A();",
+			)),
+			// ---- Dimension 4: spread/rest object shapes do not crash alias collection ----
+			jsValid("const {...rest} = globalThis; rest.Array();"),
+			// ---- Dimension 4: empty destructuring patterns do not crash alias collection ----
+			jsValid("const {} = globalThis;"),
+			// ---- Dimension 4: nested function parameters shadow globals with the same name ----
+			jsValid(lines(
+				"function outer() {",
+				"\tfunction inner(Array) {",
+				"\t\treturn Array();",
+				"\t}",
+				"}",
+			)),
+			// ---- Dimension 4: alias scope does not leak out of a block ----
+			jsValid(lines(
+				"{",
+				"\tconst {Array: A} = globalThis;",
+				"}",
+				"A();",
+			)),
+			// ---- Dimension 4: inner bindings shadow a tracked outer alias ----
+			jsValid(lines(
+				"const {Array: A} = globalThis;",
+				"{",
+				"\tconst A = function() {};",
+				"\tA();",
+				"}",
+			)),
+			// ---- Dimension 4: function parameters shadow a tracked outer alias ----
+			jsValid(lines(
+				"function outer() {",
+				"\tconst {Array: A} = globalThis;",
+				"\tfunction inner(A) {",
+				"\t\treturn A();",
+				"\t}",
+				"}",
+			)),
+			// ---- Dimension 4: for-initializer alias scope does not leak after the loop ----
+			jsValid(lines(
+				"for (const {Array: A} = globalThis; false;) {}",
+				"A();",
+			)),
+			// ---- Dimension 4: aliases from non-global objects are not tracked ----
+			jsValid(lines(
+				"const {Array: A} = maybeGlobal;",
+				"A();",
+			)),
+			// ---- Dimension 4: local global-object names shadow the real globals ----
+			jsValid("const globalThis = {Array() {}}; globalThis.Array();"),
+			// ---- Dimension 4: bare WebAssembly namespace aliases are not tracked by upstream ----
+			jsValid(lines(
+				"const WA = WebAssembly;",
+				"WA.Module(buffer);",
+				"WA.JSTag();",
+				"new WA();",
+			)),
+			// ---- Dimension 4: bare WebAssembly member aliases are not tracked by upstream ----
+			jsValid(lines(
+				"const Module = WebAssembly.Module;",
+				"Module(buffer);",
+			)),
+			// N/A: private identifiers are not valid property names on global builtin references.
+			// N/A: declaration/container forms do not apply; this rule targets CallExpression and NewExpression.
+			// N/A: overload, abstract, and declare body-absent forms do not apply to call/new expressions.
+
+			// ---- Real-user: #122 immutable Map import must shadow the builtin ----
+			jsValid(lines(
+				"import {Map as ImmutableMap} from 'immutable';",
+				"const m = ImmutableMap();",
+			)),
+			// ---- Real-user: #917 Object identity guard remains allowed in nested expression ----
+			jsValid("const isObject = value => value !== null && Object(value) === value;"),
+
+			// Locks in upstream enforceNewExpression() arm 1: optional chain early return.
+			jsValid("const value = globalThis?.Map();"),
+			// Locks in upstream enforceCallExpression() arm 1: String wrapper reports without fix.
+			jsValid("const value = String('test');"),
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized receiver and callee wrappers are transparent ----
+			enforceInvalid("const value = (globalThis).Array();", "(globalThis).Array()", "Array"),
+			// ---- Dimension 4: multi-level parenthesized receivers are transparent ----
+			enforceInvalid("const value = ((globalThis)).Array();", "((globalThis)).Array()", "Array"),
+			// ---- Dimension 4: TS type-expression wrappers on receivers are transparent ----
+			tsEnforceInvalid("const value = (globalThis as any).Array();", "(globalThis as any).Array()", "Array"),
+			// ---- Dimension 4: TS non-null wrappers on receivers are transparent ----
+			tsEnforceInvalid("const value = (globalThis!).Array();", "(globalThis!).Array()", "Array"),
+			// ---- Dimension 4: TS satisfies wrappers on receivers are transparent ----
+			tsEnforceInvalid(
+				"const value = (globalThis satisfies typeof globalThis).Array();",
+				"(globalThis satisfies typeof globalThis).Array()",
+				"Array",
+			),
+			// ---- Dimension 4: static string element access matches dotted access ----
+			enforceInvalid("const value = globalThis['Array']();", "globalThis['Array']()", "Array"),
+			// ---- Dimension 4: static template element access matches dotted access ----
+			enforceInvalid("const value = globalThis[`Array`]();", "globalThis[`Array`]()", "Array"),
+			// ---- Dimension 4: static element access composes across namespace paths ----
+			enforceInvalid(
+				"const value = globalThis['Intl']['DateTimeFormat']();",
+				"globalThis['Intl']['DateTimeFormat']()",
+				"Intl.DateTimeFormat",
+			),
+			// ---- Dimension 4: static element access to Date keeps Date's special replacement ----
+			dateFixInvalid("const value = globalThis['Date']();", "globalThis['Date']()", "const value = String(new Date());"),
+			// ---- Dimension 4: sibling block declarations do not shadow a later outer global reference ----
+			enforceInvalid(lines(
+				"function outer() {",
+				"\t{ const Array = function() {}; }",
+				"\treturn Array();",
+				"}",
+			), "Array()", "Array"),
+			// ---- Dimension 4: static element access can pass through TS assertions ----
+			tsEnforceInvalid("const value = globalThis[('Array' as const)]();", "globalThis[('Array' as const)]()", "Array"),
+			// ---- Dimension 4: static computed destructuring keys create aliases ----
+			enforceInvalid(lines(
+				"const {['Array']: A} = globalThis;",
+				"A();",
+			), "A()", "Array"),
+			// ---- Dimension 4: static template computed destructuring keys create aliases ----
+			enforceInvalid(lines(
+				"const {[`Array`]: A} = globalThis;",
+				"A();",
+			), "A()", "Array"),
+			// ---- Dimension 4: destructuring aliases remain tracked with default values ----
+			enforceInvalid(lines(
+				"const {Array: A = function() {}} = globalThis;",
+				"A();",
+			), "A()", "Array"),
+			// ---- Dimension 4: function-scoped destructuring aliases behave like globals ----
+			enforceInvalid(lines(
+				"function outer() {",
+				"\tconst {Array: A} = globalThis;",
+				"\treturn A();",
+				"}",
+			), "A()", "Array"),
+			// ---- Dimension 4: nested object destructuring preserves the full builtin path ----
+			enforceInvalid(
+				"const {Intl: {DateTimeFormat: Format}} = globalThis; Format();",
+				"Format()",
+				"Intl.DateTimeFormat",
+			),
+			// ---- Dimension 4: aliases can be chained before the call site ----
+			enforceInvalid(lines(
+				"const {Array: A} = globalThis;",
+				"const B = A;",
+				"B();",
+			), "B()", "Array"),
+			// ---- Dimension 4: alias declarations after a use still match upstream scope tracing ----
+			enforceInvalid(lines(
+				"A();",
+				"const {Array: A} = globalThis;",
+			), "A()", "Array"),
+			// ---- Dimension 4: bare Intl namespace aliases are tracked by upstream ----
+			enforceInvalid(lines(
+				"const I = Intl;",
+				"I.DateTimeFormat();",
+			), "I.DateTimeFormat()", "Intl.DateTimeFormat"),
+			// ---- Dimension 4: namespace aliases from global objects are tracked ----
+			enforceInvalid(lines(
+				"const I = globalThis.Intl;",
+				"I.DateTimeFormat();",
+			), "I.DateTimeFormat()", "Intl.DateTimeFormat"),
+			// ---- Dimension 4: bare Temporal namespace aliases are tracked by upstream ----
+			enforceInvalid(lines(
+				"const T = Temporal;",
+				"T.PlainDate(2024, 1, 1);",
+			), "T.PlainDate(2024, 1, 1)", "Temporal.PlainDate"),
+			// ---- Dimension 4: disallowed Temporal children are tracked through namespace aliases ----
+			disallowCallOrNewInvalid(lines(
+				"const T = Temporal;",
+				"T.Now?.();",
+			), "T.Now?.()", "Temporal.Now"),
+			// ---- Dimension 4: aliasing a disallowed Temporal member is tracked ----
+			disallowCallOrNewInvalid(lines(
+				"const Now = Temporal.Now;",
+				"Now();",
+			), "Now()", "Temporal.Now"),
+			// ---- Dimension 4: global-object WebAssembly aliases report direct invalid calls ----
+			disallowCallOrNewInvalid(lines(
+				"const WA = globalThis.WebAssembly;",
+				"WA();",
+			), "WA()", "WebAssembly"),
+			// ---- Dimension 4: namespace aliases from global objects report disallowed child constructors ----
+			disallowCallOrNewInvalid(lines(
+				"const {WebAssembly: WA} = globalThis;",
+				"new WA.JSTag();",
+			), "new WA.JSTag()", "WebAssembly.JSTag"),
+			// ---- Dimension 4: member aliases from global object namespaces are tracked ----
+			enforceInvalid(lines(
+				"const Module = globalThis.WebAssembly.Module;",
+				"Module(buffer);",
+			), "Module(buffer)", "WebAssembly.Module"),
+			// ---- Dimension 4: aliases declared in a for initializer are usable inside the loop ----
+			enforceInvalid(lines(
+				"for (const {Array: A} = globalThis; false;) {",
+				"\tA();",
+				"}",
+			), "A()", "Array"),
+			// ---- Dimension 4: var aliases declared inside a block are usable in that block ----
+			enforceInvalid(lines(
+				"if (condition) {",
+				"\tvar A = Array;",
+				"\tA();",
+				"}",
+			), "A()", "Array"),
+			// ---- Dimension 4: var aliases declared inside a block are hoisted to the outer scope ----
+			enforceInvalid(lines(
+				"if (condition) {",
+				"\tvar A = Array;",
+				"}",
+				"A();",
+			), "A()", "Array"),
+
+			// ---- Real-user: #901 new String('test') reports but has no autofix ----
+			disallowNoFixInvalid("const str = new String('test');", "new String('test')", "String"),
+			// ---- Real-user: #1835 namespace object call is not fixable ----
+			disallowCallOrNewInvalid("const tag = WebAssembly.JSTag();", "WebAssembly.JSTag()", "WebAssembly.JSTag"),
+
+			// Locks in upstream enforceNewExpression() arm 2: Object loose equality is not exempt.
+			enforceInvalid("const isObject = value => Object(value) != value;", "Object(value)", "Object"),
+			// Locks in upstream enforceNewExpression() arm 3: Date with comments uses a suggestion.
+			dateSuggestionInvalid("const value = Date(/* now */);", "Date(/* now */)", "const value = String(new Date());"),
+			// Locks in upstream enforceCallExpression() arm 2: Symbol is autofixable.
+			disallowInvalid("const symbol = new Symbol('x');", "new Symbol('x')", "Symbol", "const symbol = Symbol('x');"),
+			// Locks in the same multiline remove-`new` fixer branch for BigInt.
+			disallowInvalid(lines(
+				"const big = new // bigint",
+				"\tBigInt(1);",
+			), "new // bigint\n\tBigInt(1)", "BigInt", lines(
+				"const big = // bigint",
+				"\tBigInt(1);",
+			)),
+			// Locks in upstream disallowCallOrNewExpression() construct path.
+			disallowCallOrNewInvalid("const invalid = new WebAssembly();", "new WebAssembly()", "WebAssembly"),
+			// Locks in upstream GlobalReferenceTracker alias path from globalThis destructuring.
+			disallowNoFixInvalid(lines(
+				"const {Number: RenamedNumber} = globalThis;",
+				"new RenamedNumber(1);",
+			), "new RenamedNumber(1)", "Number"),
+			// Locks in fixSpaceAroundKeyword-equivalent behavior for keyword fusion.
+			enforceInvalid(lines(
+				"function f() {",
+				"\treturn(globalThis).Array();",
+				"}",
+			), "(globalThis).Array()", "Array"),
+		},
+	)
+}
+
+func tsEnforceInvalid(code string, target string, name string) rule_tester.InvalidTestCase {
+	testCase := enforceInvalid(code, target, name)
+	testCase.FileName = "file.ts"
+	return testCase
+}

--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_upstream_test.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_upstream_test.go
@@ -1,0 +1,648 @@
+package new_for_builtins_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	messageIDEnforce           = "enforce"
+	messageIDDisallow          = "disallow"
+	messageIDDisallowCallOrNew = "disallowCallOrNew"
+	messageIDErrorDate         = "error-date"
+	messageIDSuggestionDate    = "suggestion-date"
+	messageDate                = "Use `String(new Date())` instead of `Date()`."
+	messageDateSuggestion      = "Switch to `String(new Date())`."
+)
+
+// TestNewForBuiltinsUpstream migrates the full valid/invalid suite from
+// upstream test/new-for-builtins.js 1:1. Position assertions cover line/column
+// for every invalid case. rslint-specific lock-in cases live in the
+// new_for_builtins_extras_test.go file.
+func TestNewForBuiltinsUpstream(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- test.snapshot valid ----
+		jsValid("const foo = new Object()"),
+		jsValid("const foo = new Array()"),
+		// Optional calls can't become `new` expressions.
+		jsValid("const foo = Array?.()"),
+		jsValid("const foo = Map?.()"),
+		jsValid("const foo = Date?.()"),
+		jsValid("const foo = globalThis?.Date()"),
+		jsValid("const foo = Intl.DateTimeFormat?.()"),
+		jsValid("const foo = Intl?.DateTimeFormat()"),
+		jsValid("const foo = Temporal.PlainDate?.(2024, 1, 1)"),
+		jsValid("const foo = WebAssembly.Module?.(buffer)"),
+		jsValid("const foo = WebAssembly?.Module(buffer)"),
+	}
+
+	for _, name := range []string{
+		"ArrayBuffer", "BigInt64Array", "BigUint64Array", "DataView", "Error",
+		"Float16Array", "Float32Array", "Float64Array", "Function", "Int8Array",
+		"Int16Array", "Int32Array", "Map", "WeakMap", "Set", "WeakSet",
+		"Promise", "RegExp", "Uint8Array", "Uint16Array", "Uint32Array",
+		"Uint8ClampedArray", "AggregateError", "TypeError", "SuppressedError",
+		"DisposableStack", "AsyncDisposableStack",
+	} {
+		valid = append(valid, jsValid(fmt.Sprintf("const foo = new %s()", name)))
+	}
+	valid = append(valid,
+		jsValid("const foo = new Map([['foo', 'bar'], ['unicorn', 'rainbow']])"),
+		jsValid("const foo = new AggregateError([])"),
+		jsValid("const foo = new SuppressedError(error, suppressed)"),
+		jsValid("const foo = BigInt()"),
+		jsValid("const foo = Boolean()"),
+		jsValid("const foo = Number()"),
+		jsValid("const foo = String()"),
+		jsValid("const foo = Symbol()"),
+		jsValid("const foo = new Intl.DateTimeFormat()"),
+		jsValid("const foo = new globalThis.Intl.DateTimeFormat()"),
+		jsValid("const foo = new Intl.DisplayNames('en', {type: 'language'})"),
+		jsValid("const foo = new Intl.Locale('en')"),
+		jsValid("const foo = new Intl.Segmenter()"),
+		jsValid("const foo = new Temporal.PlainDate(2024, 1, 1)"),
+		jsValid("const foo = new globalThis.Temporal.PlainDate(2024, 1, 1)"),
+		jsValid("const foo = new Temporal.ZonedDateTime(0n, 'UTC')"),
+		jsValid("const foo = Temporal.Now.instant()"),
+		jsValid("const foo = new WebAssembly.Module(buffer)"),
+		jsValid("const foo = new globalThis.WebAssembly.Module(buffer)"),
+		jsValid("const foo = new WebAssembly.Memory({initial: 1})"),
+		jsValid("const foo = new WebAssembly.CompileError()"),
+		jsValid("const foo = WebAssembly.instantiate(buffer)"),
+		jsValid("const foo = WebAssembly.JSTag"),
+	)
+
+	shadowedCallObjects := append([]string{}, enforceNewObjects...)
+	shadowedCallObjects = append(shadowedCallObjects, disallowCallOrNewObjects...)
+	shadowedNewObjects := append([]string{}, disallowNewObjects...)
+	shadowedNewObjects = append(shadowedNewObjects, disallowCallOrNewObjects...)
+	for _, object := range shadowedCallObjects {
+		valid = append(valid,
+			jsValid(createShadowedCallTest(object)),
+			jsValid(createNestedShadowedCallTest(object)),
+		)
+	}
+	for _, object := range shadowedNewObjects {
+		valid = append(valid,
+			jsValid(createShadowedNewTest(object)),
+			jsValid(createNestedShadowedNewTest(object)),
+		)
+	}
+
+	valid = append(valid,
+		// #122
+		jsValid(lines(
+			"import { Map } from 'immutable';",
+			"const m = Map();",
+		)),
+		jsValid(lines(
+			"const {Map} = require('immutable');",
+			"const foo = Map();",
+		)),
+		jsValid(lines(
+			"const {String} = require('guitar');",
+			"const lowE = new String();",
+		)),
+		jsValid(lines(
+			"import {String} from 'guitar';",
+			"const lowE = new String();",
+		)),
+		// Not builtin
+		jsValid("new Foo();Bar();"),
+		jsValid("Foo();new Bar();"),
+		// Ignored
+		jsValid("const isObject = v => Object(v) === v;"),
+		jsValid("const isObject = v => globalThis.Object(v) === v;"),
+		jsValid("(x) !== Object(x)"),
+		// SKIP: rslint does not support ESLint's languageOptions.globals override.
+		rule_tester.ValidTestCase{Code: `new Symbol("")`, Skip: true},
+	)
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- test.snapshot invalid ----
+		enforceInvalid("const object = (Object)();", "(Object)()", "Object"),
+		enforceInvalid("const isObject = v => Object(v) == v;", "Object(v)", "Object"),
+		disallowInvalid(`const symbol = new (Symbol)("");`, `new (Symbol)("")`, "Symbol", `const symbol = (Symbol)("");`),
+		disallowInvalid(`const symbol = new /* comment */ Symbol("");`, `new /* comment */ Symbol("")`, "Symbol", `const symbol = /* comment */ Symbol("");`),
+		disallowInvalid("const symbol = new Symbol;", "new Symbol", "Symbol", "const symbol = Symbol();"),
+		tsDisallowInvalid("const s = new Symbol()!;", "new Symbol()", "Symbol", "const s = Symbol()!;"),
+		disallowInvalid(lines(
+			"() => {",
+			"\treturn new // 1",
+			"\t\tSymbol();",
+			"}",
+		), "new // 1\n\t\tSymbol()", "Symbol", lines(
+			"() => {",
+			"\treturn ( // 1",
+			"\t\tSymbol());",
+			"}",
+		)),
+		disallowInvalid(lines(
+			"() => {",
+			"\treturn (",
+			"\t\tnew // 2",
+			"\t\t\tSymbol()",
+			"\t);",
+			"}",
+		), "new // 2\n\t\t\tSymbol()", "Symbol", lines(
+			"() => {",
+			"\treturn (",
+			"\t\t// 2",
+			"\t\t\tSymbol()",
+			"\t);",
+			"}",
+		)),
+		disallowInvalid(lines(
+			"() => {",
+			"\treturn new // 3",
+			"\t\t(Symbol);",
+			"}",
+		), "new // 3\n\t\t(Symbol)", "Symbol", lines(
+			"() => {",
+			"\treturn ( // 3",
+			"\t\t(Symbol)());",
+			"}",
+		)),
+		disallowInvalid(lines(
+			"() => {",
+			"\treturn new // 4",
+			"\t\tSymbol;",
+			"}",
+		), "new // 4\n\t\tSymbol", "Symbol", lines(
+			"() => {",
+			"\treturn ( // 4",
+			"\t\tSymbol());",
+			"}",
+		)),
+		disallowInvalid(lines(
+			"() => {",
+			"\treturn (",
+			"\t\tnew // 5",
+			"\t\t\tSymbol",
+			"\t);",
+			"}",
+		), "new // 5\n\t\t\tSymbol", "Symbol", lines(
+			"() => {",
+			"\treturn (",
+			"\t\t// 5",
+			"\t\t\tSymbol()",
+			"\t);",
+			"}",
+		)),
+		disallowInvalid(lines(
+			"() => {",
+			"\treturn (",
+			"\t\tnew // 6",
+			"\t\t\t(Symbol)",
+			"\t);",
+			"}",
+		), "new // 6\n\t\t\t(Symbol)", "Symbol", lines(
+			"() => {",
+			"\treturn (",
+			"\t\t// 6",
+			"\t\t\t(Symbol)()",
+			"\t);",
+			"}",
+		)),
+		disallowInvalid(lines(
+			"() => {",
+			"\tthrow new // 1",
+			"\t\tSymbol();",
+			"}",
+		), "new // 1\n\t\tSymbol()", "Symbol", lines(
+			"() => {",
+			"\tthrow ( // 1",
+			"\t\tSymbol());",
+			"}",
+		)),
+		disallowInvalid(lines(
+			"() => {",
+			"\treturn new /**/ Symbol;",
+			"}",
+		), "new /**/ Symbol", "Symbol", lines(
+			"() => {",
+			"\treturn /**/ Symbol();",
+			"}",
+		)),
+		disallowNoFixInvalid("new globalThis.String()", "new globalThis.String()", "String"),
+		disallowNoFixInvalid("new global.String()", "new global.String()", "String"),
+		disallowNoFixInvalid("new self.String()", "new self.String()", "String"),
+		disallowNoFixInvalid("new window.String()", "new window.String()", "String"),
+		disallowNoFixInvalid(lines(
+			"const {String} = globalThis;",
+			"new String();",
+		), "new String()", "String"),
+		disallowNoFixInvalid(lines(
+			"const {String: RenamedString} = globalThis;",
+			"new RenamedString();",
+		), "new RenamedString()", "String"),
+		disallowNoFixInvalid(lines(
+			"const RenamedString = globalThis.String;",
+			"new RenamedString();",
+		), "new RenamedString()", "String"),
+		enforceInvalid("globalThis.Array()", "globalThis.Array()", "Array"),
+		enforceInvalid("global.Array()", "global.Array()", "Array"),
+		enforceInvalid("self.Array()", "self.Array()", "Array"),
+		enforceInvalid("window.Array()", "window.Array()", "Array"),
+		enforceInvalid(lines(
+			"const {Array: RenamedArray} = globalThis;",
+			"RenamedArray();",
+		), "RenamedArray()", "Array"),
+		// SKIP: rslint does not support ESLint's languageOptions.globals override.
+		{Code: "globalThis.Array()", Skip: true},
+		// SKIP: rslint does not support ESLint's languageOptions.globals override.
+		{Code: lines("const {Array} = globalThis;", "Array();"), Skip: true},
+	}
+
+	for _, name := range []string{
+		"Object", "Array", "ArrayBuffer", "BigInt64Array", "BigUint64Array",
+		"DataView", "Error", "AggregateError", "EvalError", "RangeError",
+		"ReferenceError", "SuppressedError", "SyntaxError", "TypeError", "URIError",
+		"DisposableStack", "AsyncDisposableStack", "Float16Array", "Float32Array",
+		"Float64Array", "Function", "Int8Array", "Int16Array", "Int32Array",
+		"WeakMap", "Set", "WeakSet", "Promise", "RegExp", "Uint8Array",
+		"Uint16Array", "Uint32Array", "Uint8ClampedArray", "Intl.Collator",
+		"Intl.DateTimeFormat", "Intl.DurationFormat", "Intl.ListFormat",
+		"Intl.NumberFormat", "Intl.PluralRules", "Intl.RelativeTimeFormat",
+		"Intl.Segmenter", "Temporal.Duration", "Temporal.Instant",
+		"Temporal.PlainDateTime", "Temporal.PlainMonthDay", "Temporal.PlainTime",
+		"Temporal.PlainYearMonth", "Temporal.ZonedDateTime", "WebAssembly.Module",
+		"WebAssembly.Instance", "WebAssembly.Memory", "WebAssembly.Table",
+		"WebAssembly.Global", "WebAssembly.Tag", "WebAssembly.Exception",
+		"WebAssembly.CompileError", "WebAssembly.LinkError", "WebAssembly.RuntimeError",
+	} {
+		code := fmt.Sprintf("const foo = %s()", name)
+		invalid = append(invalid, enforceInvalid(code, name+"()", name))
+	}
+	invalid = append(invalid,
+		enforceInvalid("const foo = Error('Foo bar')", "Error('Foo bar')", "Error"),
+		enforceInvalid("const foo = AggregateError([])", "AggregateError([])", "AggregateError"),
+		enforceInvalid("const foo = SuppressedError(error, suppressed)", "SuppressedError(error, suppressed)", "SuppressedError"),
+		enforceInvalid("const foo = (( Map ))()", "(( Map ))()", "Map"),
+		enforceInvalid("const foo = Map([['foo', 'bar'], ['unicorn', 'rainbow']])", "Map([['foo', 'bar'], ['unicorn', 'rainbow']])", "Map"),
+		enforceInvalid("const foo = Intl.DisplayNames('en', {type: 'language'})", "Intl.DisplayNames('en', {type: 'language'})", "Intl.DisplayNames"),
+		enforceInvalid("const foo = Intl.Locale('en')", "Intl.Locale('en')", "Intl.Locale"),
+		enforceInvalid("const foo = Temporal.Instant(0n)", "Temporal.Instant(0n)", "Temporal.Instant"),
+		enforceInvalid("const foo = Temporal.PlainDate(2024, 1, 1)", "Temporal.PlainDate(2024, 1, 1)", "Temporal.PlainDate"),
+		enforceInvalid("const foo = globalThis.Temporal.PlainDate(2024, 1, 1)", "globalThis.Temporal.PlainDate(2024, 1, 1)", "Temporal.PlainDate"),
+		disallowCallOrNewInvalid("const foo = Temporal.Now()", "Temporal.Now()", "Temporal.Now"),
+		disallowCallOrNewInvalid("const foo = Temporal.Now?.()", "Temporal.Now?.()", "Temporal.Now"),
+		disallowCallOrNewInvalid("const foo = Temporal?.Now()", "Temporal?.Now()", "Temporal.Now"),
+		disallowCallOrNewInvalid("const foo = new Temporal.Now()", "new Temporal.Now()", "Temporal.Now"),
+		disallowCallOrNewInvalid("const foo = globalThis.Temporal.Now()", "globalThis.Temporal.Now()", "Temporal.Now"),
+		disallowCallOrNewInvalid("const foo = globalThis.Temporal?.Now()", "globalThis.Temporal?.Now()", "Temporal.Now"),
+		disallowCallOrNewInvalid("const foo = globalThis?.Temporal.Now()", "globalThis?.Temporal.Now()", "Temporal.Now"),
+		disallowCallOrNewInvalid("const foo = new globalThis.Temporal.Now()", "new globalThis.Temporal.Now()", "Temporal.Now"),
+		disallowCallOrNewInvalid("const foo = WebAssembly()", "WebAssembly()", "WebAssembly"),
+		disallowCallOrNewInvalid("const foo = new WebAssembly()", "new WebAssembly()", "WebAssembly"),
+		disallowCallOrNewInvalid("const foo = globalThis.WebAssembly()", "globalThis.WebAssembly()", "WebAssembly"),
+		disallowCallOrNewInvalid("const foo = new globalThis.WebAssembly()", "new globalThis.WebAssembly()", "WebAssembly"),
+		disallowCallOrNewInvalid("const foo = WebAssembly.JSTag()", "WebAssembly.JSTag()", "WebAssembly.JSTag"),
+		disallowCallOrNewInvalid("const foo = new WebAssembly.JSTag()", "new WebAssembly.JSTag()", "WebAssembly.JSTag"),
+		disallowCallOrNewInvalid("const foo = globalThis.WebAssembly.JSTag()", "globalThis.WebAssembly.JSTag()", "WebAssembly.JSTag"),
+		disallowCallOrNewInvalid("const foo = globalThis.WebAssembly?.JSTag()", "globalThis.WebAssembly?.JSTag()", "WebAssembly.JSTag"),
+		disallowCallOrNewInvalid("const foo = new globalThis.WebAssembly.JSTag()", "new globalThis.WebAssembly.JSTag()", "WebAssembly.JSTag"),
+		enforceInvalid("const foo = WebAssembly.Module(buffer)", "WebAssembly.Module(buffer)", "WebAssembly.Module"),
+		enforceInvalid("const foo = globalThis.WebAssembly.Module(buffer)", "globalThis.WebAssembly.Module(buffer)", "WebAssembly.Module"),
+		enforceInvalid("const foo = WebAssembly.Instance(module, imports)", "WebAssembly.Instance(module, imports)", "WebAssembly.Instance"),
+		enforceInvalid("const foo = WebAssembly.Table({initial: 1, element: 'anyfunc'})", "WebAssembly.Table({initial: 1, element: 'anyfunc'})", "WebAssembly.Table"),
+		enforceInvalid("const foo = WebAssembly.Global({value: 'i32', mutable: true}, 0)", "WebAssembly.Global({value: 'i32', mutable: true}, 0)", "WebAssembly.Global"),
+		enforceInvalid("const foo = WebAssembly.Tag({parameters: ['i32']})", "WebAssembly.Tag({parameters: ['i32']})", "WebAssembly.Tag"),
+		enforceInvalid("const foo = WebAssembly.Exception(tag, [1])", "WebAssembly.Exception(tag, [1])", "WebAssembly.Exception"),
+		disallowInvalid("const foo = new BigInt(123)", "new BigInt(123)", "BigInt", "const foo = BigInt(123)"),
+		disallowNoFixInvalid("const foo = new Boolean()", "new Boolean()", "Boolean"),
+		disallowNoFixInvalid("const foo = new Number()", "new Number()", "Number"),
+		disallowNoFixInvalid("const foo = new Number('123')", "new Number('123')", "Number"),
+		disallowNoFixInvalid("const foo = new String()", "new String()", "String"),
+		disallowInvalid("const foo = new Symbol()", "new Symbol()", "Symbol", "const foo = Symbol()"),
+	)
+
+	blockShadowCode := lines(
+		"function varCheck() {",
+		"\t{",
+		"\t\tvar WeakMap = function() {};",
+		"\t}",
+		"\t// This should not be reported",
+		"\treturn WeakMap()",
+		"}",
+		"function constCheck() {",
+		"\t{",
+		"\t\tconst Array = function() {};",
+		"\t}",
+		"\treturn Array()",
+		"}",
+		"function letCheck() {",
+		"\t{",
+		"\t\tlet Map = function() {};",
+		"\t}",
+		"\treturn Map()",
+		"}",
+	)
+	invalid = append(invalid, rule_tester.InvalidTestCase{
+		Code:   blockShadowCode,
+		Output: []string{strings.Replace(strings.Replace(blockShadowCode, "return Array()", "return new Array()", 1), "return Map()", "return new Map()", 1)},
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(blockShadowCode, "Array()", messageIDEnforce, enforceMessage("Array")),
+			expectedErrorAfter(blockShadowCode, "function letCheck()", "Map()", messageIDEnforce, enforceMessage("Map")),
+		},
+	})
+	invalid = append(invalid,
+		enforceInvalid(lines(
+			"function foo() {",
+			"\treturn(globalThis).Map()",
+			"}",
+		), "(globalThis).Map()", "Map"),
+	)
+
+	invalid = append(invalid,
+		// ---- `Date` invalid ----
+		dateFixInvalid("const foo = Date();", "Date()", "const foo = String(new Date());"),
+		dateFixInvalid("const foo = globalThis.Date();", "globalThis.Date()", "const foo = String(new Date());"),
+		dateFixInvalid(lines(
+			"function foo() {",
+			"\treturn(globalThis).Date();",
+			"}",
+		), "(globalThis).Date()", lines(
+			"function foo() {",
+			"\treturn String(new Date());",
+			"}",
+		)),
+		dateSuggestionInvalid("const foo = Date(/*comment*/);", "Date(/*comment*/)", "const foo = String(new Date());"),
+		dateSuggestionInvalid("const foo = globalThis/*comment*/.Date();", "globalThis/*comment*/.Date()", "const foo = String(new Date());"),
+		dateSuggestionInvalid("const foo = Date(bar);", "Date(bar)", "const foo = String(new Date());"),
+	)
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&new_for_builtins.NewForBuiltinsRule,
+		valid,
+		invalid,
+	)
+}
+
+var enforceNewObjects = []string{
+	"Object", "Array", "ArrayBuffer", "DataView", "Date", "Function", "Map",
+	"WeakMap", "Set", "WeakSet", "Promise", "RegExp", "SharedArrayBuffer",
+	"Proxy", "WeakRef", "FinalizationRegistry", "DisposableStack",
+	"AsyncDisposableStack", "Error", "AggregateError", "EvalError", "RangeError",
+	"ReferenceError", "SuppressedError", "SyntaxError", "TypeError", "URIError",
+	"Intl.Collator", "Intl.DateTimeFormat", "Intl.DisplayNames",
+	"Intl.DurationFormat", "Intl.ListFormat", "Intl.Locale", "Intl.NumberFormat",
+	"Intl.PluralRules", "Intl.RelativeTimeFormat", "Intl.Segmenter",
+	"Temporal.Duration", "Temporal.Instant", "Temporal.PlainDate",
+	"Temporal.PlainDateTime", "Temporal.PlainMonthDay", "Temporal.PlainTime",
+	"Temporal.PlainYearMonth", "Temporal.ZonedDateTime", "WebAssembly.Module",
+	"WebAssembly.Instance", "WebAssembly.Memory", "WebAssembly.Table",
+	"WebAssembly.Global", "WebAssembly.Tag", "WebAssembly.Exception",
+	"WebAssembly.CompileError", "WebAssembly.LinkError", "WebAssembly.RuntimeError",
+	"Float16Array", "Float32Array", "Float64Array", "Int8Array", "Int16Array",
+	"Int32Array", "BigInt64Array", "BigUint64Array", "Uint8Array", "Uint16Array",
+	"Uint32Array", "Uint8ClampedArray",
+}
+
+var disallowNewObjects = []string{"BigInt", "Boolean", "Number", "String", "Symbol"}
+var disallowCallOrNewObjects = []string{"Temporal.Now", "WebAssembly", "WebAssembly.JSTag"}
+
+func createShadowedCallTest(object string) string {
+	objectName, propertyName, ok := strings.Cut(object, ".")
+	if !ok {
+		return lines(
+			fmt.Sprintf("const %s = function() {};", object),
+			fmt.Sprintf("const foo = %s();", object),
+		)
+	}
+	return lines(
+		fmt.Sprintf("const %s = {%s() {}};", objectName, propertyName),
+		fmt.Sprintf("const foo = %s();", object),
+	)
+}
+
+func createShadowedNewTest(object string) string {
+	objectName, propertyName, ok := strings.Cut(object, ".")
+	if !ok {
+		return lines(
+			fmt.Sprintf("const %s = function() {};", object),
+			fmt.Sprintf("const foo = new %s();", object),
+		)
+	}
+	return lines(
+		fmt.Sprintf("const %s = {%s: class {}};", objectName, propertyName),
+		fmt.Sprintf("const foo = new %s();", object),
+	)
+}
+
+func createNestedShadowedCallTest(object string) string {
+	objectName, propertyName, ok := strings.Cut(object, ".")
+	if !ok {
+		return lines(
+			"function outer() {",
+			fmt.Sprintf("\tconst %s = function() {};", object),
+			"\tfunction inner() {",
+			fmt.Sprintf("\t\tconst foo = %s();", object),
+			"\t}",
+			"}",
+		)
+	}
+	return lines(
+		"function outer() {",
+		fmt.Sprintf("\tconst %s = {%s() {}};", objectName, propertyName),
+		"\tfunction inner() {",
+		fmt.Sprintf("\t\tconst foo = %s();", object),
+		"\t}",
+		"}",
+	)
+}
+
+func createNestedShadowedNewTest(object string) string {
+	objectName, propertyName, ok := strings.Cut(object, ".")
+	if !ok {
+		return lines(
+			"function insideFunction() {",
+			fmt.Sprintf("\tconst %s = function() {};", object),
+			"\tfunction inner() {",
+			fmt.Sprintf("\t\tconst foo = new %s();", object),
+			"\t}",
+			"}",
+		)
+	}
+	return lines(
+		"function insideFunction() {",
+		fmt.Sprintf("\tconst %s = {%s: class {}};", objectName, propertyName),
+		"\tfunction inner() {",
+		fmt.Sprintf("\t\tconst foo = new %s();", object),
+		"\t}",
+		"}",
+	)
+}
+
+func lines(parts ...string) string {
+	return strings.Join(parts, "\n")
+}
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.js"}
+}
+
+func enforceInvalid(code string, target string, name string) rule_tester.InvalidTestCase {
+	output := insertBeforeFirst(code, target, enforceFixText(code, target))
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Output:   []string{output},
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, messageIDEnforce, enforceMessage(name)),
+		},
+	}
+}
+
+func disallowInvalid(code string, target string, name string, output string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Output:   []string{output},
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, messageIDDisallow, disallowMessage(name)),
+		},
+	}
+}
+
+func tsDisallowInvalid(code string, target string, name string, output string) rule_tester.InvalidTestCase {
+	testCase := disallowInvalid(code, target, name, output)
+	testCase.FileName = "file.ts"
+	return testCase
+}
+
+func disallowNoFixInvalid(code string, target string, name string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, messageIDDisallow, disallowMessage(name)),
+		},
+	}
+}
+
+func disallowCallOrNewInvalid(code string, target string, name string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, messageIDDisallowCallOrNew, disallowCallOrNewMessage(name)),
+		},
+	}
+}
+
+func dateFixInvalid(code string, target string, output string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Output:   []string{output},
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, messageIDErrorDate, messageDate),
+		},
+	}
+}
+
+func dateSuggestionInvalid(code string, target string, output string) rule_tester.InvalidTestCase {
+	err := expectedError(code, target, messageIDErrorDate, messageDate)
+	err.Suggestions = []rule_tester.InvalidTestCaseSuggestion{{
+		MessageId: messageIDSuggestionDate,
+		Output:    output,
+	}}
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Errors:   []rule_tester.InvalidTestCaseError{err},
+	}
+}
+
+func expectedError(code string, target string, messageID string, message string) rule_tester.InvalidTestCaseError {
+	start := strings.Index(code, target)
+	if start < 0 {
+		panic(fmt.Sprintf("target %q not found in %q", target, code))
+	}
+	end := start + len(target)
+	line, column := lineColumnForOffset(code, start)
+	endLine, endColumn := lineColumnForOffset(code, end)
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   message,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func expectedErrorAfter(code string, anchor string, target string, messageID string, message string) rule_tester.InvalidTestCaseError {
+	anchorIndex := strings.Index(code, anchor)
+	if anchorIndex < 0 {
+		panic(fmt.Sprintf("anchor %q not found in %q", anchor, code))
+	}
+	relativeIndex := strings.Index(code[anchorIndex:], target)
+	if relativeIndex < 0 {
+		panic(fmt.Sprintf("target %q not found after %q in %q", target, anchor, code))
+	}
+	start := anchorIndex + relativeIndex
+	end := start + len(target)
+	line, column := lineColumnForOffset(code, start)
+	endLine, endColumn := lineColumnForOffset(code, end)
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   message,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func lineColumnForOffset(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for i := range offset {
+		if code[i] == '\n' {
+			line++
+			column = 1
+		} else {
+			column++
+		}
+	}
+	return line, column
+}
+
+func insertBeforeFirst(code string, target string, insertion string) string {
+	index := strings.Index(code, target)
+	if index < 0 {
+		panic(fmt.Sprintf("target %q not found in %q", target, code))
+	}
+	return code[:index] + insertion + code[index:]
+}
+
+func enforceFixText(code string, target string) string {
+	index := strings.Index(code, target)
+	if utils.NeedsLeadingSpaceForReplacement(code, index, "new ") {
+		return " new "
+	}
+	return "new "
+}
+
+func enforceMessage(name string) string {
+	return fmt.Sprintf("Use `new %s()` instead of `%s()`.", name, name)
+}
+
+func disallowMessage(name string) string {
+	return fmt.Sprintf("Use `%s()` instead of `new %s()`.", name, name)
+}
+
+func disallowCallOrNewMessage(name string) string {
+	return fmt.Sprintf("`%s` is not a function or constructor.", name)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -528,6 +528,7 @@ export default defineConfig({
 
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
+    './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts
@@ -1,0 +1,381 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const lines = (...parts: string[]) => parts.join('\n');
+const js = (code: string) => ({ code, filename: 'file.js' });
+const invalid = (code: string, message: string) => ({
+  ...js(code),
+  errors: [{ message }],
+});
+
+const enforceMessage = (name: string) =>
+  `Use \`new ${name}()\` instead of \`${name}()\`.`;
+const disallowMessage = (name: string) =>
+  `Use \`${name}()\` instead of \`new ${name}()\`.`;
+const disallowCallOrNewMessage = (name: string) =>
+  `\`${name}\` is not a function or constructor.`;
+const dateMessage = 'Use `String(new Date())` instead of `Date()`.';
+
+const enforceNewObjects = [
+  'Object',
+  'Array',
+  'ArrayBuffer',
+  'DataView',
+  'Date',
+  'Function',
+  'Map',
+  'WeakMap',
+  'Set',
+  'WeakSet',
+  'Promise',
+  'RegExp',
+  'SharedArrayBuffer',
+  'Proxy',
+  'WeakRef',
+  'FinalizationRegistry',
+  'DisposableStack',
+  'AsyncDisposableStack',
+  'Error',
+  'AggregateError',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'SuppressedError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+  'Intl.Collator',
+  'Intl.DateTimeFormat',
+  'Intl.DisplayNames',
+  'Intl.DurationFormat',
+  'Intl.ListFormat',
+  'Intl.Locale',
+  'Intl.NumberFormat',
+  'Intl.PluralRules',
+  'Intl.RelativeTimeFormat',
+  'Intl.Segmenter',
+  'Temporal.Duration',
+  'Temporal.Instant',
+  'Temporal.PlainDate',
+  'Temporal.PlainDateTime',
+  'Temporal.PlainMonthDay',
+  'Temporal.PlainTime',
+  'Temporal.PlainYearMonth',
+  'Temporal.ZonedDateTime',
+  'WebAssembly.Module',
+  'WebAssembly.Instance',
+  'WebAssembly.Memory',
+  'WebAssembly.Table',
+  'WebAssembly.Global',
+  'WebAssembly.Tag',
+  'WebAssembly.Exception',
+  'WebAssembly.CompileError',
+  'WebAssembly.LinkError',
+  'WebAssembly.RuntimeError',
+  'Float16Array',
+  'Float32Array',
+  'Float64Array',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'BigInt64Array',
+  'BigUint64Array',
+  'Uint8Array',
+  'Uint16Array',
+  'Uint32Array',
+  'Uint8ClampedArray',
+];
+
+const disallowNewObjects = ['BigInt', 'Boolean', 'Number', 'String', 'Symbol'];
+
+const disallowCallOrNewObjects = [
+  'Temporal.Now',
+  'WebAssembly',
+  'WebAssembly.JSTag',
+];
+
+const createShadowedCallTest = (object: string) => {
+  const [objectName, propertyName] = object.split('.');
+
+  if (!propertyName) {
+    return lines(
+      `const ${object} = function() {};`,
+      `const foo = ${object}();`,
+    );
+  }
+
+  return lines(
+    `const ${objectName} = {${propertyName}() {}};`,
+    `const foo = ${object}();`,
+  );
+};
+
+const createShadowedNewTest = (object: string) => {
+  const [objectName, propertyName] = object.split('.');
+
+  if (!propertyName) {
+    return lines(
+      `const ${object} = function() {};`,
+      `const foo = new ${object}();`,
+    );
+  }
+
+  return lines(
+    `const ${objectName} = {${propertyName}: class {}};`,
+    `const foo = new ${object}();`,
+  );
+};
+
+const valid = [
+  js('const foo = new Object()'),
+  js('const foo = new Array()'),
+  js('const foo = Array?.()'),
+  js('const foo = Map?.()'),
+  js('const foo = Date?.()'),
+  js('const foo = globalThis?.Date()'),
+  js('const foo = Intl.DateTimeFormat?.()'),
+  js('const foo = Intl?.DateTimeFormat()'),
+  js('const foo = Temporal.PlainDate?.(2024, 1, 1)'),
+  js('const foo = WebAssembly.Module?.(buffer)'),
+  js('const foo = WebAssembly?.Module(buffer)'),
+  js('const foo = BigInt()'),
+  js('const foo = Boolean()'),
+  js('const foo = Number()'),
+  js('const foo = String()'),
+  js('const foo = Symbol()'),
+  js('const foo = new Intl.DateTimeFormat()'),
+  js('const foo = new globalThis.Intl.DateTimeFormat()'),
+  js("const foo = new Intl.DisplayNames('en', {type: 'language'})"),
+  js("const foo = new Intl.Locale('en')"),
+  js('const foo = new Intl.Segmenter()'),
+  js('const foo = new Temporal.PlainDate(2024, 1, 1)'),
+  js('const foo = new globalThis.Temporal.PlainDate(2024, 1, 1)'),
+  js("const foo = new Temporal.ZonedDateTime(0n, 'UTC')"),
+  js('const foo = Temporal.Now.instant()'),
+  js('const foo = new WebAssembly.Module(buffer)'),
+  js('const foo = new globalThis.WebAssembly.Module(buffer)'),
+  js('const foo = new WebAssembly.Memory({initial: 1})'),
+  js('const foo = new WebAssembly.CompileError()'),
+  js('const foo = WebAssembly.instantiate(buffer)'),
+  js('const foo = WebAssembly.JSTag'),
+  js(lines("import { Map } from 'immutable';", 'const m = Map();')),
+  js(lines("const {Map} = require('immutable');", 'const foo = Map();')),
+  js(
+    lines("const {String} = require('guitar');", 'const lowE = new String();'),
+  ),
+  js(lines("import {String} from 'guitar';", 'const lowE = new String();')),
+  js('new Foo();Bar();'),
+  js('Foo();new Bar();'),
+  js('const isObject = v => Object(v) === v;'),
+  js('const isObject = v => globalThis.Object(v) === v;'),
+  js('(x) !== Object(x)'),
+];
+
+for (const name of [
+  'ArrayBuffer',
+  'BigInt64Array',
+  'BigUint64Array',
+  'DataView',
+  'Error',
+  'Float16Array',
+  'Float32Array',
+  'Float64Array',
+  'Function',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'Map',
+  'WeakMap',
+  'Set',
+  'WeakSet',
+  'Promise',
+  'RegExp',
+  'Uint8Array',
+  'Uint16Array',
+  'Uint32Array',
+  'Uint8ClampedArray',
+  'AggregateError',
+  'TypeError',
+  'SuppressedError',
+  'DisposableStack',
+  'AsyncDisposableStack',
+]) {
+  valid.push(js(`const foo = new ${name}()`));
+}
+
+for (const object of [...enforceNewObjects, ...disallowCallOrNewObjects]) {
+  valid.push(js(createShadowedCallTest(object)));
+}
+
+for (const object of [...disallowNewObjects, ...disallowCallOrNewObjects]) {
+  valid.push(js(createShadowedNewTest(object)));
+}
+
+const invalidCases = [
+  invalid('const object = (Object)();', enforceMessage('Object')),
+  invalid('const isObject = v => Object(v) == v;', enforceMessage('Object')),
+  invalid('const symbol = new (Symbol)("");', disallowMessage('Symbol')),
+  invalid(
+    'const symbol = new /* comment */ Symbol("");',
+    disallowMessage('Symbol'),
+  ),
+  invalid('const symbol = new Symbol;', disallowMessage('Symbol')),
+  {
+    ...invalid('const s = new Symbol()!;', disallowMessage('Symbol')),
+    filename: 'file.ts',
+  },
+  invalid('new globalThis.String()', disallowMessage('String')),
+  invalid('new global.String()', disallowMessage('String')),
+  invalid('new self.String()', disallowMessage('String')),
+  invalid('new window.String()', disallowMessage('String')),
+  invalid(
+    lines('const {String} = globalThis;', 'new String();'),
+    disallowMessage('String'),
+  ),
+  invalid(
+    lines(
+      'const {String: RenamedString} = globalThis;',
+      'new RenamedString();',
+    ),
+    disallowMessage('String'),
+  ),
+  invalid(
+    lines('const RenamedString = globalThis.String;', 'new RenamedString();'),
+    disallowMessage('String'),
+  ),
+  invalid('globalThis.Array()', enforceMessage('Array')),
+  invalid('global.Array()', enforceMessage('Array')),
+  invalid('self.Array()', enforceMessage('Array')),
+  invalid('window.Array()', enforceMessage('Array')),
+  invalid(
+    lines('const {Array: RenamedArray} = globalThis;', 'RenamedArray();'),
+    enforceMessage('Array'),
+  ),
+  invalid('const foo = Error("Foo bar")', enforceMessage('Error')),
+  invalid('const foo = (( Map ))()', enforceMessage('Map')),
+  invalid(
+    "const foo = Map([['foo', 'bar'], ['unicorn', 'rainbow']])",
+    enforceMessage('Map'),
+  ),
+  invalid(
+    "const foo = Intl.DisplayNames('en', {type: 'language'})",
+    enforceMessage('Intl.DisplayNames'),
+  ),
+  invalid("const foo = Intl.Locale('en')", enforceMessage('Intl.Locale')),
+  invalid(
+    'const foo = Temporal.PlainDate(2024, 1, 1)',
+    enforceMessage('Temporal.PlainDate'),
+  ),
+  invalid(
+    'const foo = globalThis.Temporal.PlainDate(2024, 1, 1)',
+    enforceMessage('Temporal.PlainDate'),
+  ),
+  invalid(
+    'const foo = Temporal.Now()',
+    disallowCallOrNewMessage('Temporal.Now'),
+  ),
+  invalid(
+    'const foo = Temporal.Now?.()',
+    disallowCallOrNewMessage('Temporal.Now'),
+  ),
+  invalid(
+    'const foo = Temporal?.Now()',
+    disallowCallOrNewMessage('Temporal.Now'),
+  ),
+  invalid(
+    'const foo = new Temporal.Now()',
+    disallowCallOrNewMessage('Temporal.Now'),
+  ),
+  invalid('const foo = WebAssembly()', disallowCallOrNewMessage('WebAssembly')),
+  invalid(
+    'const foo = new WebAssembly()',
+    disallowCallOrNewMessage('WebAssembly'),
+  ),
+  invalid(
+    'const foo = WebAssembly.JSTag()',
+    disallowCallOrNewMessage('WebAssembly.JSTag'),
+  ),
+  invalid(
+    'const foo = new WebAssembly.JSTag()',
+    disallowCallOrNewMessage('WebAssembly.JSTag'),
+  ),
+  invalid('const foo = new BigInt(123)', disallowMessage('BigInt')),
+  invalid('const foo = new Boolean()', disallowMessage('Boolean')),
+  invalid('const foo = new Number()', disallowMessage('Number')),
+  invalid("const foo = new Number('123')", disallowMessage('Number')),
+  invalid('const foo = new String()', disallowMessage('String')),
+  invalid('const foo = new Symbol()', disallowMessage('Symbol')),
+  invalid('const foo = Date();', dateMessage),
+  invalid('const foo = globalThis.Date();', dateMessage),
+  invalid('const foo = Date(/*comment*/);', dateMessage),
+  invalid('const foo = globalThis/*comment*/.Date();', dateMessage),
+  invalid('const foo = Date(bar);', dateMessage),
+];
+
+for (const name of [
+  'Object',
+  'Array',
+  'ArrayBuffer',
+  'BigInt64Array',
+  'BigUint64Array',
+  'DataView',
+  'AggregateError',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'SuppressedError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+  'DisposableStack',
+  'AsyncDisposableStack',
+  'Float16Array',
+  'Float32Array',
+  'Float64Array',
+  'Function',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'WeakMap',
+  'Set',
+  'WeakSet',
+  'Promise',
+  'RegExp',
+  'Uint8Array',
+  'Uint16Array',
+  'Uint32Array',
+  'Uint8ClampedArray',
+  'Intl.Collator',
+  'Intl.DateTimeFormat',
+  'Intl.DurationFormat',
+  'Intl.ListFormat',
+  'Intl.NumberFormat',
+  'Intl.PluralRules',
+  'Intl.RelativeTimeFormat',
+  'Intl.Segmenter',
+  'Temporal.Duration',
+  'Temporal.Instant',
+  'Temporal.PlainDateTime',
+  'Temporal.PlainMonthDay',
+  'Temporal.PlainTime',
+  'Temporal.PlainYearMonth',
+  'Temporal.ZonedDateTime',
+  'WebAssembly.Module',
+  'WebAssembly.Instance',
+  'WebAssembly.Memory',
+  'WebAssembly.Table',
+  'WebAssembly.Global',
+  'WebAssembly.Tag',
+  'WebAssembly.Exception',
+  'WebAssembly.CompileError',
+  'WebAssembly.LinkError',
+  'WebAssembly.RuntimeError',
+]) {
+  invalidCases.push(invalid(`const foo = ${name}()`, enforceMessage(name)));
+}
+
+ruleTester.run('new-for-builtins', null as never, {
+  valid,
+  invalid: invalidCases,
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -597,3 +597,4 @@ outputfixes
 pendings
 relskip
 ruleopts
+anyfunc


### PR DESCRIPTION
## Summary

Port `unicorn/new-for-builtins` to rslint.

- Add the Go rule implementation, registration, and documentation.
- Add migrated upstream coverage plus rslint-specific edge and real-user cases.
- Add JS integration coverage for the rule.

## Related Links

- Rule docs: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/new-for-builtins.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/new-for-builtins.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
