### PR TITLE
feat: port rule unicorn/no-thenable

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_number_properties"
@@ -15,6 +16,7 @@ func GetAllRules() []rule.Rule {
 		filename_case.FilenameCaseRule,
 		new_for_builtins.NewForBuiltinsRule,
 		no_static_only_class.NoStaticOnlyClassRule,
+		no_thenable.NoThenableRule,
 		no_useless_switch_case.NoUselessSwitchCaseRule,
 		prefer_array_flat_map.PreferArrayFlatMapRule,
 		prefer_number_properties.PreferNumberPropertiesRule,

--- a/internal/plugins/unicorn/rules/no_thenable/no_thenable.go
+++ b/internal/plugins/unicorn/rules/no_thenable/no_thenable.go
@@ -1,0 +1,348 @@
+package no_thenable
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	messageIDObject = "no-thenable-object"
+	messageIDExport = "no-thenable-export"
+	messageIDClass  = "no-thenable-class"
+)
+
+var (
+	messageObject = rule.RuleMessage{
+		Id:          messageIDObject,
+		Description: "Do not add `then` to an object.",
+	}
+	messageExport = rule.RuleMessage{
+		Id:          messageIDExport,
+		Description: "Do not export `then`.",
+	}
+	messageClass = rule.RuleMessage{
+		Id:          messageIDClass,
+		Description: "Do not add `then` to a class.",
+	}
+)
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-thenable.md
+var NoThenableRule = rule.Rule{
+	Name: "unicorn/no-thenable",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		state := &ruleState{
+			ctx:           ctx,
+			staticStrings: utils.NewStaticStringEvaluatorWithSourceFile(ctx.TypeChecker, ctx.SourceFile),
+		}
+
+		return rule.RuleListeners{
+			ast.KindObjectLiteralExpression: state.checkObjectExpression,
+			ast.KindPropertyDeclaration:     state.checkClassMember,
+			ast.KindMethodDeclaration:       state.checkClassMember,
+			ast.KindGetAccessor:             state.checkClassMember,
+			ast.KindSetAccessor:             state.checkClassMember,
+			ast.KindBinaryExpression:        state.checkAssignmentExpression,
+			ast.KindCallExpression:          state.checkCallExpression,
+			ast.KindExportDeclaration:       state.checkExportDeclaration,
+			ast.KindFunctionDeclaration:     state.checkExportedDeclaration,
+			ast.KindClassDeclaration:        state.checkExportedDeclaration,
+			ast.KindVariableStatement:       state.checkExportedVariableStatement,
+		}
+	},
+}
+
+type ruleState struct {
+	ctx           rule.RuleContext
+	staticStrings *utils.StaticStringEvaluator
+}
+
+func (state *ruleState) checkObjectExpression(node *ast.Node) {
+	objectExpression := node.AsObjectLiteralExpression()
+	if objectExpression == nil || objectExpression.Properties == nil {
+		return
+	}
+
+	for _, property := range objectExpression.Properties.Nodes {
+		name := objectPropertyName(property)
+		if name == nil || !state.isThenPropertyName(name) {
+			continue
+		}
+
+		state.ctx.ReportNode(reportPropertyNameNode(name), messageObject)
+	}
+}
+
+func (state *ruleState) checkClassMember(node *ast.Node) {
+	if node.Parent == nil || (node.Parent.Kind != ast.KindClassDeclaration && node.Parent.Kind != ast.KindClassExpression) {
+		return
+	}
+
+	name := node.Name()
+	if name == nil || !state.isThenPropertyName(name) {
+		return
+	}
+
+	state.ctx.ReportNode(reportPropertyNameNode(name), messageClass)
+}
+
+func (state *ruleState) checkAssignmentExpression(node *ast.Node) {
+	binaryExpression := node.AsBinaryExpression()
+	if binaryExpression == nil || binaryExpression.OperatorToken == nil ||
+		!ast.IsAssignmentOperator(binaryExpression.OperatorToken.Kind) {
+		return
+	}
+
+	left := ast.SkipParentheses(binaryExpression.Left)
+	reportNode, ok := state.thenAccessReportNode(left)
+	if !ok {
+		return
+	}
+
+	state.ctx.ReportNode(reportNode, messageObject)
+}
+
+func (state *ruleState) checkCallExpression(node *ast.Node) {
+	state.checkDefinePropertyCall(node)
+	state.checkFromEntriesCall(node)
+}
+
+func (state *ruleState) checkDefinePropertyCall(node *ast.Node) {
+	if !isNonOptionalMethodCall(node, []string{"Object", "Reflect"}, "defineProperty", 3, -1) {
+		return
+	}
+
+	args := node.Arguments()
+	if ast.IsSpreadElement(args[0]) {
+		return
+	}
+
+	secondArgument := args[1]
+	if !state.isStringThen(secondArgument) {
+		return
+	}
+
+	state.ctx.ReportNode(reportExpressionNode(secondArgument), messageObject)
+}
+
+func (state *ruleState) checkFromEntriesCall(node *ast.Node) {
+	if !isNonOptionalMethodCall(node, []string{"Object"}, "fromEntries", -1, 1) {
+		return
+	}
+
+	args := node.Arguments()
+	if len(args) != 1 || ast.IsSpreadElement(args[0]) {
+		return
+	}
+
+	firstArgument := ast.SkipParentheses(args[0])
+	if firstArgument == nil || firstArgument.Kind != ast.KindArrayLiteralExpression {
+		return
+	}
+
+	outerElements := firstArgument.AsArrayLiteralExpression().Elements
+	if outerElements == nil {
+		return
+	}
+
+	for _, pair := range outerElements.Nodes {
+		pair = ast.SkipParentheses(pair)
+		if pair == nil || pair.Kind != ast.KindArrayLiteralExpression {
+			continue
+		}
+
+		elements := pair.AsArrayLiteralExpression().Elements
+		if elements == nil || len(elements.Nodes) == 0 {
+			continue
+		}
+
+		key := elements.Nodes[0]
+		if key == nil || ast.IsSpreadElement(key) || !state.isStringThen(key) {
+			continue
+		}
+
+		state.ctx.ReportNode(reportExpressionNode(key), messageObject)
+	}
+}
+
+func (state *ruleState) checkExportDeclaration(node *ast.Node) {
+	exportDeclaration := node.AsExportDeclaration()
+	if exportDeclaration == nil || exportDeclaration.IsTypeOnly ||
+		exportDeclaration.ExportClause == nil ||
+		exportDeclaration.ExportClause.Kind != ast.KindNamedExports {
+		return
+	}
+
+	namedExports := exportDeclaration.ExportClause.AsNamedExports()
+	if namedExports == nil || namedExports.Elements == nil {
+		return
+	}
+
+	for _, specifierNode := range namedExports.Elements.Nodes {
+		specifier := specifierNode.AsExportSpecifier()
+		if specifier == nil || specifier.IsTypeOnly {
+			continue
+		}
+
+		exported := specifier.Name()
+		if isIdentifierNamed(exported, "then") {
+			state.ctx.ReportNode(exported, messageExport)
+		}
+	}
+}
+
+func (state *ruleState) checkExportedDeclaration(node *ast.Node) {
+	if !ast.HasSyntacticModifier(node, ast.ModifierFlagsExport) ||
+		ast.HasSyntacticModifier(node, ast.ModifierFlagsDefault) ||
+		!isIdentifierNamed(node.Name(), "then") {
+		return
+	}
+
+	state.ctx.ReportNode(node.Name(), messageExport)
+}
+
+func (state *ruleState) checkExportedVariableStatement(node *ast.Node) {
+	if !ast.HasSyntacticModifier(node, ast.ModifierFlagsExport) {
+		return
+	}
+
+	variableStatement := node.AsVariableStatement()
+	if variableStatement == nil || variableStatement.DeclarationList == nil {
+		return
+	}
+
+	declarationList := variableStatement.DeclarationList.AsVariableDeclarationList()
+	if declarationList == nil || declarationList.Declarations == nil {
+		return
+	}
+
+	for _, declarationNode := range declarationList.Declarations.Nodes {
+		declaration := declarationNode.AsVariableDeclaration()
+		if declaration == nil || declaration.Name() == nil {
+			continue
+		}
+
+		utils.CollectBindingNames(declaration.Name(), func(identifier *ast.Node, name string) {
+			if name == "then" {
+				state.ctx.ReportNode(identifier, messageExport)
+			}
+		})
+	}
+}
+
+func objectPropertyName(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+
+	switch node.Kind {
+	case ast.KindPropertyAssignment,
+		ast.KindShorthandPropertyAssignment,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		return node.Name()
+	default:
+		return nil
+	}
+}
+
+func (state *ruleState) isThenPropertyName(name *ast.Node) bool {
+	value, ok := state.staticPropertyName(name)
+	return ok && value == "then"
+}
+
+func (state *ruleState) staticPropertyName(name *ast.Node) (string, bool) {
+	if name == nil {
+		return "", false
+	}
+
+	if name.Kind == ast.KindComputedPropertyName {
+		return state.staticStrings.Eval(name.AsComputedPropertyName().Expression)
+	}
+
+	return utils.GetStaticPropertyName(name)
+}
+
+func (state *ruleState) thenAccessReportNode(node *ast.Node) (*ast.Node, bool) {
+	if node == nil {
+		return nil, false
+	}
+
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		name := node.AsPropertyAccessExpression().Name()
+		if isIdentifierNamed(name, "then") {
+			return name, true
+		}
+	case ast.KindElementAccessExpression:
+		argument := node.AsElementAccessExpression().ArgumentExpression
+		if state.isStringThen(argument) {
+			return reportExpressionNode(argument), true
+		}
+	}
+
+	return nil, false
+}
+
+func (state *ruleState) isStringThen(node *ast.Node) bool {
+	value, ok := state.staticStrings.Eval(node)
+	return ok && value == "then"
+}
+
+func reportPropertyNameNode(name *ast.Node) *ast.Node {
+	if name != nil && name.Kind == ast.KindComputedPropertyName {
+		return reportExpressionNode(name.AsComputedPropertyName().Expression)
+	}
+	return name
+}
+
+func reportExpressionNode(node *ast.Node) *ast.Node {
+	unwrapped := utils.SkipAssertionsAndParens(node)
+	if unwrapped != nil {
+		return unwrapped
+	}
+	return node
+}
+
+// isNonOptionalMethodCall mirrors unicorn's isMethodCall with computed:false,
+// optionalCall:false, and optionalMember:false. The wider
+// utils.IsSpecificMemberAccess intentionally accepts bracket access and
+// optional chains, which would diverge from this rule's upstream matcher.
+func isNonOptionalMethodCall(node *ast.Node, objects []string, method string, minimumArguments int, argumentsLength int) bool {
+	call := node.AsCallExpression()
+	if call == nil || call.QuestionDotToken != nil {
+		return false
+	}
+
+	args := node.Arguments()
+	if minimumArguments >= 0 && len(args) < minimumArguments {
+		return false
+	}
+	if argumentsLength >= 0 && len(args) != argumentsLength {
+		return false
+	}
+
+	rawCallee := call.Expression
+	callee := ast.SkipParentheses(rawCallee)
+	if callee == nil || (rawCallee != callee && ast.IsOptionalChain(callee)) ||
+		callee.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+
+	propertyAccess := callee.AsPropertyAccessExpression()
+	if propertyAccess == nil || propertyAccess.QuestionDotToken != nil ||
+		!isIdentifierNamed(propertyAccess.Name(), method) {
+		return false
+	}
+
+	object := ast.SkipParentheses(propertyAccess.Expression)
+	return object != nil && object.Kind == ast.KindIdentifier &&
+		slices.Contains(objects, object.AsIdentifier().Text)
+}
+
+func isIdentifierNamed(node *ast.Node, name string) bool {
+	return node != nil && node.Kind == ast.KindIdentifier && node.AsIdentifier().Text == name
+}

--- a/internal/plugins/unicorn/rules/no_thenable/no_thenable.md
+++ b/internal/plugins/unicorn/rules/no_thenable/no_thenable.md
@@ -1,0 +1,49 @@
+# no-thenable
+
+## Rule Details
+
+Disallow adding a `then` property to objects or classes, and disallow exporting
+a binding named `then`.
+
+Objects with a `then` property can be treated as thenables when they are
+awaited. Modules with a named `then` export can also behave unexpectedly with
+dynamic `import()`.
+
+Computed property names are also checked when they can be statically resolved to `then`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const value = {
+  then() {},
+};
+
+class Value {
+  then() {}
+}
+
+foo.then = () => {};
+
+export function then() {}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const value = {
+  success() {},
+};
+
+class Value {
+  success() {}
+}
+
+foo.success = () => {};
+
+export function success() {}
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-thenable](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-thenable.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-thenable.js)

--- a/internal/plugins/unicorn/rules/no_thenable/no_thenable_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_thenable/no_thenable_extras_test.go
@@ -1,0 +1,204 @@
+package no_thenable_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoThenableExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the
+// specific branch / Dimension 4 row / upstream issue it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+func TestNoThenableExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_thenable.NoThenableRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: unresolved computed identifiers are dynamic keys ----
+			tsValid(`const foo = {[(then)]: 1}`),
+			tsValid(`class Foo {[(then)]() {}}`),
+			tsValid(`foo[(then)] = 1`),
+
+			// ---- Dimension 4: optional Object/Reflect method calls do not match upstream optionalCall/member false ----
+			tsValid(`Object?.defineProperty(foo, "then", 1)`),
+			tsValid(`Object.defineProperty?.(foo, "then", 1)`),
+			tsValid(`(Object?.defineProperty)(foo, "then", 1)`),
+			tsValid(`Reflect?.defineProperty(foo, "then", 1)`),
+			tsValid(`Object?.fromEntries([["then", 1]])`),
+			tsValid(`Object.fromEntries?.([["then", 1]])`),
+			tsValid(`(Object?.fromEntries)([["then", 1]])`),
+
+			// ---- Dimension 4: upstream isMethodCall uses computed:false for Object helpers ----
+			tsValid(`Object["defineProperty"](foo, "then", 1)`),
+			tsValid(`Reflect["defineProperty"](foo, "then", 1)`),
+			tsValid(`Object["fromEntries"]([["then", 1]])`),
+
+			// ---- Dimension 4: dynamic and non-string key forms do not match ----
+			tsValid(`const foo = {0: 1, [Symbol.iterator]: 2}`),
+			tsValid(`class Foo {#then; #thenMethod() {}}`),
+			tsValid(`foo[Symbol.iterator] = 1`),
+			tsValid(`Object.fromEntries([[Symbol.iterator, 1]])`),
+			tsValid(`const prefix = "th"; const foo = {[prefix + suffix]: 1}`),
+			tsValid(`const key = flag ? "then" : "no"; const foo = {[key]: 1}`),
+			tsValid(`{ const String = value => "then"; Object.defineProperty(foo, String("x"), {value: 1}) }`),
+			tsValid(`let key = "then"; key = "other"; const foo = {[key]: 1}`),
+
+			// ---- Dimension 4: non-assignment member access is allowed ----
+			tsValid(`const value = foo.then`),
+			tsValid(`foo.then++`),
+			tsValid(`delete foo.then`),
+
+			// ---- Dimension 4: graceful degradation for empty and spread-only containers ----
+			tsValid(`const foo = {...bar}`),
+			tsValid(`class Foo {}`),
+			tsValid(`function foo({}) {}`),
+
+			// ---- Upstream final implementation only checks array-entry pairs in fromEntries ----
+			tsValid(`Object.fromEntries(["then", 1])`),
+
+			// N/A: autofix boundaries do not apply; this rule has no fix.
+			// N/A: call/new declaration container variants do not apply beyond object, class, assignment, call, and export nodes.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: direct string-literal object key ----
+			tsObjectInvalid(`const foo = {"then": 1}`, `"then"`),
+
+			// ---- Dimension 4: shorthand object property is still an object `then` key ----
+			tsObjectInvalid(`const then = 1; const foo = {then}`, `then`, 2),
+
+			// ---- Dimension 4: parenthesized and TS-wrapped computed keys resolve through const literals ----
+			tsObjectInvalid(`const key = "then"; const foo = {[(key)]: 1}`, `key`, 2),
+			tsObjectInvalid(`const key = "then"; const foo = {[key as string]: 1}`, `key`, 2),
+			tsClassInvalid(`const key = "then"; class Foo {[(key)]() {}}`, `key`, 2),
+			tsClassInvalid(`const key = "then"; class Foo {[key satisfies string] = 1}`, `key`, 2),
+			tsObjectInvalid(`const key = "then"; foo[(key)] = 1`, `key`, 2),
+			tsObjectInvalid(`const key = "then"; foo[key as string] = 1`, `key`, 2),
+
+			// ---- Dimension 4: computed keys use static string evaluation through nested expressions ----
+			tsObjectInvalid(`const prefix = "th"; const foo = {[prefix + "en"]: 1}`, `prefix + "en"`),
+			tsClassInvalid("const prefix = \"th\"; const key = `${prefix}en`; class Foo {[key]() {}}", `key`, 2),
+			tsObjectInvalid(`const key = "then"; foo.bar[key] = 1`, `key`, 2),
+			tsObjectInvalid(`const key = ("then" satisfies string); foo[key] = 1`, `key`, 2),
+			tsObjectInvalid(`const prefix = "th"; Object.defineProperty(foo, prefix + "en", {value: 1})`, `prefix + "en"`),
+			tsObjectInvalid(`const prefix = "th"; Object.fromEntries([[prefix + "en", 1]])`, `prefix + "en"`),
+			tsObjectInvalid(`const prefix = "th"; Object.fromEntries([([prefix + "en", 1])])`, `prefix + "en"`),
+			tsObjectInvalid(`const key = true ? "then" : "no"; const foo = {[key]: 1}`, `key`, 2),
+			tsClassInvalid(`const key = "" || "then"; class Foo {[key]() {}}`, `key`, 2),
+			tsObjectInvalid(`const key = "then" && "then"; foo[key] = 1`, `key`, 2),
+			tsObjectInvalid("const key = String.raw`then`; Object.defineProperty(foo, key, {value: 1})", `key`, 2),
+			tsObjectInvalid(`const key = String("then"); Object.fromEntries([[key, 1]])`, `key`, 2),
+			tsObjectInvalid(`let key = "then"; const foo = {[key]: 1}`, `key`, 2),
+			tsObjectInvalid(`var key = "then"; Object.defineProperty(foo, key, {value: 1})`, `key`, 2),
+
+			// ---- Dimension 4: spread properties do not mask sibling checks ----
+			tsObjectInvalid(`const foo = {...bar, then: 1}`, `then`),
+
+			// ---- Dimension 4: TS body-absent class member forms are still thenable class members ----
+			tsClassInvalid(`declare class Foo { then(): void }`, `then`),
+			tsClassInvalid(`declare class Foo { then: string }`, `then`),
+			tsClassInvalid(`class Foo { accessor then = 1 }`, `then`),
+
+			// ---- Dimension 4: nested containers report independently without traversal bleed ----
+			{
+				Code:     `const foo = {then: 1, nested: {then: 2}}`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedError(`const foo = {then: 1, nested: {then: 2}}`, `then`, messageIDObject, messageObject),
+					expectedError(`const foo = {then: 1, nested: {then: 2}}`, `then`, messageIDObject, messageObject, 2),
+				},
+			},
+			{
+				Code:     `const prefix = "th"; const foo = {[prefix + "en"]: {nested: {[prefix + "en"]: 1}}}`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					expectedError(`const prefix = "th"; const foo = {[prefix + "en"]: {nested: {[prefix + "en"]: 1}}}`, `prefix + "en"`, messageIDObject, messageObject),
+					expectedError(`const prefix = "th"; const foo = {[prefix + "en"]: {nested: {[prefix + "en"]: 1}}}`, `prefix + "en"`, messageIDObject, messageObject, 2),
+				},
+			},
+
+			// ---- Real-user: #1710 yup conditional validation object reports the `then` branch ----
+			tsObjectInvalid(`
+const validationSchema = Yup.object().shape(
+	{
+		addEntry: Yup.string()
+			.nullable()
+			.notRequired()
+			.when('addEntry', {
+				is: () => entryType === 'EMAIL',
+				then: rule => rule.email('Please enter a valid email.'),
+				otherwise: rule => rule.matches(anyDomainRegex, 'Please enter a correct domain format.'),
+			}),
+	},
+	[['addEntry', 'addEntry']],
+);`, `then`),
+
+			// ---- Real-user: #1841 yup object schema conditional validation reports the `then` branch ----
+			tsObjectInvalid(`
+const mySchema = yup.object({
+	requireUsername: yup.bool(),
+	username: yup.string().when('requireUsername', {
+		is: true,
+		then: yup.string().required('Username is required'),
+	}),
+});`, `then`),
+
+			// Locks in upstream ObjectExpression arm: method/getter/setter/property all use isThenKey().
+			tsObjectInvalid(`const foo = {get then() { return 1 }}`, `then`),
+
+			// Locks in upstream class-member arm: class fields and methods share the class message.
+			tsClassInvalid(`class Foo {static then = 1}`, `then`),
+
+			// Locks in upstream MemberExpression arm: only assignment left-hand sides report.
+			tsObjectInvalid(`foo.then = foo.then`, `then`),
+
+			// Locks in member-chain assignments from the original rule proposal.
+			tsObjectInvalid(`Foo.prototype.then = () => {}`, `then`),
+
+			// Locks in upstream defineProperty arm: Object and Reflect calls both report their second argument.
+			tsObjectInvalid(`Reflect.defineProperty(foo, "then", {value: 1})`, `"then"`),
+
+			// Locks in upstream fromEntries arm: non-pair elements are skipped, later pairs still report.
+			tsObjectInvalid(`Object.fromEntries([foo, , ["then", 1]])`, `"then"`),
+
+			// Locks in upstream export-specifier arm: exported name, not local name, is checked.
+			tsExportInvalid(`const local = 1; export {local as then}`, `then`),
+
+			// Locks in upstream exported declaration arm: named export reports, default export does not.
+			tsExportInvalid(`export async function * then() {}`, `then`),
+
+			// Locks in upstream exported variable arm: nested binding identifiers are collected.
+			tsExportInvalid(`export const {foo: [{bar: then}]} = value`, `then`),
+		},
+	)
+}
+
+func tsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.ts"}
+}
+
+func tsObjectInvalid(code string, target string, occurrence ...int) rule_tester.InvalidTestCase {
+	return tsInvalid(code, target, messageIDObject, messageObject, occurrence...)
+}
+
+func tsClassInvalid(code string, target string, occurrence ...int) rule_tester.InvalidTestCase {
+	return tsInvalid(code, target, messageIDClass, messageClass, occurrence...)
+}
+
+func tsExportInvalid(code string, target string, occurrence ...int) rule_tester.InvalidTestCase {
+	return tsInvalid(code, target, messageIDExport, messageExport, occurrence...)
+}
+
+func tsInvalid(code string, target string, messageID string, message string, occurrence ...int) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.ts",
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, messageID, message, occurrence...),
+		},
+	}
+}

--- a/internal/plugins/unicorn/rules/no_thenable/no_thenable_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_thenable/no_thenable_upstream_test.go
@@ -1,0 +1,311 @@
+package no_thenable_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageIDObject = "no-thenable-object"
+	messageIDExport = "no-thenable-export"
+	messageIDClass  = "no-thenable-class"
+
+	messageObject = "Do not add `then` to an object."
+	messageExport = "Do not export `then`."
+	messageClass  = "Do not add `then` to a class."
+)
+
+// TestNoThenableUpstream migrates the full valid/invalid suite from upstream
+// test/no-thenable.js 1:1. Position assertions cover line/column for every
+// invalid case. rslint-specific lock-in cases live in the
+// no_thenable_extras_test.go file.
+func TestNoThenableUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_thenable.NoThenableRule,
+		[]rule_tester.ValidTestCase{
+			// ---- `object` ----
+			jsValid(`const then = {}`),
+			jsValid(`const notThen = then`),
+			jsValid(`const then = then.then`),
+			jsValid(`const foo = {notThen: 1}`),
+			jsValid(`const foo = {notThen() {}}`),
+			jsValid(`const foo = {[then]: 1}`),
+			jsValid(`const NOT_THEN = "no-then";const foo = {[NOT_THEN]: 1}`),
+			jsValid(`function foo({then}) {}`),
+			jsValid(`({[Symbol.prototype]: 1})`),
+
+			// ---- `class` ----
+			jsValid(`class then {}`),
+			jsValid(`class Foo {notThen}`),
+			jsValid(`class Foo {notThen() {}}`),
+			jsValid(`class Foo {[then]}`),
+			jsValid(`class Foo {#then}`),
+			jsValid(`class Foo {#then() {}}`),
+			jsValid(`class Foo {[then]() {}}`),
+			jsValid(`class Foo {get notThen() {}}`),
+			jsValid(`class Foo {get #then() {}}`),
+			jsValid(`class Foo {get [then]() {}}`),
+			jsValid(`class Foo {static notThen}`),
+			jsValid(`class Foo {static notThen() {}}`),
+			jsValid(`class Foo {static #then}`),
+			jsValid(`class Foo {static #then() {}}`),
+			jsValid(`class Foo {static [then]}`),
+			jsValid(`class Foo {static [then]() {}}`),
+			jsValid(`class Foo {static get notThen() {}}`),
+			jsValid(`class Foo {static get #then() {}}`),
+			jsValid(`class Foo {static get [then]() {}}`),
+			jsValid(`class Foo {notThen = then}`),
+			jsValid(`class Foo {[Symbol.property]}`),
+			jsValid(`class Foo {static [Symbol.property]}`),
+			jsValid(`class Foo {get [Symbol.property]() {}}`),
+			jsValid(`class Foo {[Symbol.property]() {}}`),
+			jsValid(`class Foo {static get [Symbol.property]() {}}`),
+
+			// ---- Assign ----
+			jsValid(`foo[then] = 1`),
+			jsValid(`foo.notThen = 1`),
+			jsValid(`then.notThen = then.then`),
+			jsValid(`const NOT_THEN = "no-then";foo[NOT_THEN] = 1`),
+			jsValid(`foo.then ++`),
+			jsValid(`++ foo.then`),
+			jsValid(`delete foo.then`),
+			jsValid(`typeof foo.then`),
+			jsValid(`foo.then != 1`),
+			jsValid(`foo[Symbol.property] = 1`),
+
+			// ---- `Object.fromEntries` ----
+			jsValid(`Object.fromEntries([then, 1])`),
+			jsValid(`Object.fromEntries([,,])`),
+			jsValid(`Object.fromEntries([[,,],[]])`),
+			jsValid(`const NOT_THEN = "not-then";Object.fromEntries([[NOT_THEN, 1]])`),
+			jsValid(`Object.fromEntries([[["then", 1]]])`),
+			jsValid(`NotObject.fromEntries([["then", 1]])`),
+			jsValid(`Object.notFromEntries([["then", 1]])`),
+			jsValid(`Object.fromEntries?.([["then", 1]])`),
+			jsValid(`Object?.fromEntries([["then", 1]])`),
+			jsValid(`Object.fromEntries([[..."then", 1]])`),
+			jsValid(`Object.fromEntries([["then", 1]], extraArgument)`),
+			jsValid(`Object.fromEntries(...[["then", 1]])`),
+			jsValid(`Object.fromEntries([[Symbol.property, 1]])`),
+
+			// ---- `{Object,Reflect}.defineProperty` ----
+			jsValid(`Object.defineProperty(foo, then, 1)`),
+			jsValid(`Object.defineProperty(foo, "not-then", 1)`),
+			jsValid(`const then = "no-then";Object.defineProperty(foo, then, 1)`),
+			jsValid(`Reflect.defineProperty(foo, then, 1)`),
+			jsValid(`Reflect.defineProperty(foo, "not-then", 1)`),
+			jsValid(`const then = "no-then";Reflect.defineProperty(foo, then, 1)`),
+			jsValid(`Object.defineProperty(foo, "then", )`),
+			jsValid(`Object.defineProperty(...foo, "then", 1)`),
+			jsValid(`Object.defineProperty(foo, ...["then", 1])`),
+			jsValid(`Object.defineProperty(foo, Symbol.property, 1)`),
+			jsValid(`Reflect.defineProperty(foo, Symbol.property, 1)`),
+
+			// ---- `export` ----
+			jsValid(`export {default} from "then"`),
+			jsValid(`const then = 1; export {then as notThen}`),
+			jsValid(`export default then`),
+			jsValid(`export function notThen(){}`),
+			jsValid(`export class notThen {}`),
+			jsValid(`export default function then (){}`),
+			jsValid(`export default class then {}`),
+			jsValid(`export default function (){}`),
+			jsValid(`export default class {}`),
+
+			// ---- `export variables` ----
+			jsValid(`export const notThen = 1`),
+			jsValid(`export const {then: notThen} = 1`),
+			jsValid(`export const {then: notThen = then} = 1`),
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- `object` ----
+			objectInvalid(`const foo = {then: 1}`, `then`),
+			objectInvalid(`const foo = {["then"]: 1}`, `"then"`),
+			objectInvalid("const foo = {[`then`]: 1}", "`then`"),
+			objectInvalid(`const THEN = "then";const foo = {[THEN]: 1}`, `THEN`, 2),
+			objectInvalid(`const foo = {then() {}}`, `then`),
+			objectInvalid(`const foo = {["then"]() {}}`, `"then"`),
+			objectInvalid("const foo = {[`then`]() {}}", "`then`"),
+			objectInvalid(`const THEN = "then";const foo = {[THEN]() {}}`, `THEN`, 2),
+			objectInvalid(`const foo = {get then() {}}`, `then`),
+			objectInvalid(`const foo = {set then(v) {}}`, `then`),
+			objectInvalid(`const foo = {get ["then"]() {}}`, `"then"`),
+			objectInvalid("const foo = {get [`then`]() {}}", "`then`"),
+			objectInvalid(`const THEN = "then";const foo = {get [THEN]() {}}`, `THEN`, 2),
+
+			// ---- `class` ----
+			classInvalid(`class Foo {then}`, `then`),
+			classInvalid(`const Foo = class {then}`, `then`),
+			classInvalid(`class Foo {["then"]}`, `"then"`),
+			classInvalid("class Foo {[`then`]}", "`then`"),
+			classInvalid(`const THEN = "then";class Foo {[THEN]}`, `THEN`, 2),
+			classInvalid(`class Foo {then() {}}`, `then`),
+			classInvalid(`class Foo {["then"]() {}}`, `"then"`),
+			classInvalid("class Foo {[`then`]() {}}", "`then`"),
+			classInvalid(`const THEN = "then";class Foo {[THEN]() {}}`, `THEN`, 2),
+			classInvalid(`class Foo {static then}`, `then`),
+			classInvalid(`class Foo {static ["then"]}`, `"then"`),
+			classInvalid("class Foo {static [`then`]}", "`then`"),
+			classInvalid(`const THEN = "then";class Foo {static [THEN]}`, `THEN`, 2),
+			classInvalid(`class Foo {static then() {}}`, `then`),
+			classInvalid(`class Foo {static ["then"]() {}}`, `"then"`),
+			classInvalid("class Foo {static [`then`]() {}}", "`then`"),
+			classInvalid(`const THEN = "then";class Foo {static [THEN]() {}}`, `THEN`, 2),
+			classInvalid(`class Foo {get then() {}}`, `then`),
+			classInvalid(`class Foo {get ["then"]() {}}`, `"then"`),
+			classInvalid("class Foo {get [`then`]() {}}", "`then`"),
+			classInvalid(`const THEN = "then";class Foo {get [THEN]() {}}`, `THEN`, 2),
+			classInvalid(`class Foo {set then(v) {}}`, `then`),
+			classInvalid(`class Foo {set ["then"](v) {}}`, `"then"`),
+			classInvalid("class Foo {set [`then`](v) {}}", "`then`"),
+			classInvalid(`const THEN = "then";class Foo {set [THEN](v) {}}`, `THEN`, 2),
+			classInvalid(`class Foo {static get then() {}}`, `then`),
+			classInvalid(`class Foo {static set then(v) {}}`, `then`),
+			classInvalid(`class Foo {static get ["then"]() {}}`, `"then"`),
+			classInvalid("class Foo {static get [`then`]() {}}", "`then`"),
+			classInvalid(`const THEN = "then";class Foo {static get [THEN]() {}}`, `THEN`, 2),
+
+			// ---- Assign ----
+			objectInvalid(`foo.then = 1`, `then`),
+			objectInvalid(`foo["then"] = 1`, `"then"`),
+			objectInvalid("foo[`then`] = 1", "`then`"),
+			objectInvalid(`const THEN = "then";foo[THEN] = 1`, `THEN`, 2),
+			objectInvalid(`foo.then += 1`, `then`),
+			objectInvalid(`foo.then ||= 1`, `then`),
+			objectInvalid(`foo.then ??= 1`, `then`),
+
+			// ---- `{Object,Reflect}.defineProperty` ----
+			objectInvalid(`Object.defineProperty(foo, "then", 1)`, `"then"`),
+			objectInvalid("Object.defineProperty(foo, `then`, 1)", "`then`"),
+			objectInvalid(`const THEN = "then";Object.defineProperty(foo, THEN, 1)`, `THEN`, 2),
+			objectInvalid(`Reflect.defineProperty(foo, "then", 1)`, `"then"`),
+			objectInvalid("Reflect.defineProperty(foo, `then`, 1)", "`then`"),
+			objectInvalid(`const THEN = "then";Reflect.defineProperty(foo, THEN, 1)`, `THEN`, 2),
+
+			// ---- `Object.fromEntries` ----
+			objectInvalid(`Object.fromEntries([["then", 1]])`, `"then"`),
+			objectInvalid(`Object.fromEntries([["then"]])`, `"then"`),
+			objectInvalid("Object.fromEntries([[`then`, 1]])", "`then`"),
+			objectInvalid(`const THEN = "then";Object.fromEntries([[THEN, 1]])`, `THEN`, 2),
+			objectInvalid(`Object.fromEntries([foo, ["then", 1]])`, `"then"`),
+
+			// ---- `export` ----
+			exportInvalid(`const then = 1; export {then}`, `then`, 2),
+			exportInvalid(`const notThen = 1; export {notThen as then}`, `then`),
+			exportInvalid(`export {then} from "foo"`, `then`),
+			exportInvalid(`export function then() {}`, `then`),
+			exportInvalid(`export async function then() {}`, `then`),
+			exportInvalid(`export function * then() {}`, `then`),
+			exportInvalid(`export async function * then() {}`, `then`),
+			exportInvalid(`export class then {}`, `then`),
+
+			// ---- `export variables` ----
+			exportInvalid(`export const then = 1`, `then`),
+			exportInvalid(`export let then = 1`, `then`),
+			exportInvalid(`export var then = 1`, `then`),
+			exportInvalid(`export const [then] = 1`, `then`),
+			exportInvalid(`export let [then] = 1`, `then`),
+			exportInvalid(`export var [then] = 1`, `then`),
+			exportInvalid(`export const [, then] = 1`, `then`),
+			exportInvalid(`export let [, then] = 1`, `then`),
+			exportInvalid(`export var [, then] = 1`, `then`),
+			exportInvalid(`export const [, ...then] = 1`, `then`),
+			exportInvalid(`export let [, ...then] = 1`, `then`),
+			exportInvalid(`export var [, ...then] = 1`, `then`),
+			exportInvalid(`export const {then} = 1`, `then`),
+			exportInvalid(`export let {then} = 1`, `then`),
+			exportInvalid(`export var {then} = 1`, `then`),
+			exportInvalid(`export const {foo, ...then} = 1`, `then`),
+			exportInvalid(`export let {foo, ...then} = 1`, `then`),
+			exportInvalid(`export var {foo, ...then} = 1`, `then`),
+			exportInvalid(`export const {foo: {bar: [{baz: then}]}} = 1`, `then`),
+			exportInvalid(`export const notThen = 1, then = 1`, `then`),
+		},
+	)
+}
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.js"}
+}
+
+func objectInvalid(code string, target string, occurrence ...int) rule_tester.InvalidTestCase {
+	return invalid(code, target, messageIDObject, messageObject, occurrence...)
+}
+
+func classInvalid(code string, target string, occurrence ...int) rule_tester.InvalidTestCase {
+	return invalid(code, target, messageIDClass, messageClass, occurrence...)
+}
+
+func exportInvalid(code string, target string, occurrence ...int) rule_tester.InvalidTestCase {
+	return invalid(code, target, messageIDExport, messageExport, occurrence...)
+}
+
+func invalid(code string, target string, messageID string, message string, occurrence ...int) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, target, messageID, message, occurrence...),
+		},
+	}
+}
+
+func expectedError(code string, target string, messageID string, message string, occurrence ...int) rule_tester.InvalidTestCaseError {
+	nth := 1
+	if len(occurrence) > 0 {
+		nth = occurrence[0]
+	}
+
+	offset := nthIndex(code, target, nth)
+	if offset < 0 {
+		panic("target not found in no-thenable test: " + target + " in " + code)
+	}
+
+	line, column := lineColumnForOffset(code, offset)
+	endLine, endColumn := lineColumnForOffset(code, offset+len(target))
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageID,
+		Message:   message,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func nthIndex(s string, target string, nth int) int {
+	searchStart := 0
+	for i := range nth {
+		offset := strings.Index(s[searchStart:], target)
+		if offset < 0 {
+			return -1
+		}
+		searchStart += offset
+		if i == nth-1 {
+			return searchStart
+		}
+		searchStart += len(target)
+	}
+	return -1
+}
+
+func lineColumnForOffset(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for i := range offset {
+		if code[i] == '\n' {
+			line++
+			column = 1
+		} else {
+			column++
+		}
+	}
+	return line, column
+}

--- a/internal/utils/static_string_evaluator.go
+++ b/internal/utils/static_string_evaluator.go
@@ -1,0 +1,478 @@
+package utils
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/evaluator"
+)
+
+// StaticStringEvaluator folds expressions to string constants. It wraps tsgo's
+// evaluator and adds local const identifier resolution through the TypeChecker.
+// Create one evaluator per linted file; it keeps a small recursion guard.
+type StaticStringEvaluator struct {
+	typeChecker       *checker.Checker
+	sourceFile        *ast.SourceFile
+	evaluator         evaluator.Evaluator
+	resolving         map[*ast.Symbol]bool
+	writeRefsComputed bool
+	writeRefs         map[*ast.Symbol]bool
+}
+
+func NewStaticStringEvaluator(typeChecker *checker.Checker) *StaticStringEvaluator {
+	return NewStaticStringEvaluatorWithSourceFile(typeChecker, nil)
+}
+
+func NewStaticStringEvaluatorWithSourceFile(typeChecker *checker.Checker, sourceFile *ast.SourceFile) *StaticStringEvaluator {
+	staticEvaluator := &StaticStringEvaluator{
+		typeChecker: typeChecker,
+		sourceFile:  sourceFile,
+		resolving:   map[*ast.Symbol]bool{},
+	}
+	staticEvaluator.evaluator = evaluator.NewEvaluator(staticEvaluator.evaluateEntity, ast.OEKAssertions)
+	return staticEvaluator
+}
+
+type staticNullValue struct{}
+type staticUndefinedValue struct{}
+
+type staticEvalResult struct {
+	value any
+	ok    bool
+}
+
+// Eval returns the static string value of node, if it can be determined. It
+// covers the string-producing subset of ESLint's getStaticValue that rules use
+// for computed property names and key arguments, including nested conditionals,
+// logical short-circuiting, String(), String.raw, and local variables with
+// stable initializers.
+func (staticEvaluator *StaticStringEvaluator) Eval(node *ast.Node) (string, bool) {
+	if staticEvaluator == nil || node == nil {
+		return "", false
+	}
+	result := staticEvaluator.evalValue(node)
+	if !result.ok {
+		return "", false
+	}
+	value, ok := result.value.(string)
+	return value, ok
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalValue(node *ast.Node) staticEvalResult {
+	node = SkipAssertionsAndParens(node)
+	if node == nil {
+		return staticEvalResult{}
+	}
+
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return staticEvalResult{value: node.AsStringLiteral().Text, ok: true}
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return staticEvalResult{value: node.AsNoSubstitutionTemplateLiteral().Text, ok: true}
+	case ast.KindTrueKeyword:
+		return staticEvalResult{value: true, ok: true}
+	case ast.KindFalseKeyword:
+		return staticEvalResult{value: false, ok: true}
+	case ast.KindNullKeyword:
+		return staticEvalResult{value: staticNullValue{}, ok: true}
+	case ast.KindUndefinedKeyword:
+		return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+	case ast.KindIdentifier:
+		identifier := node.AsIdentifier()
+		if identifier != nil && identifier.Text == "undefined" && !IsShadowed(node, "undefined") {
+			return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+		}
+		return staticEvaluator.evalIdentifier(node)
+	case ast.KindTemplateExpression:
+		return staticEvaluator.evalTemplateExpression(node)
+	case ast.KindBinaryExpression:
+		return staticEvaluator.evalBinaryExpression(node)
+	case ast.KindPrefixUnaryExpression:
+		return staticEvaluator.evalPrefixUnaryExpression(node)
+	case ast.KindConditionalExpression:
+		return staticEvaluator.evalConditionalExpression(node)
+	case ast.KindVoidExpression:
+		return staticEvalResult{value: staticUndefinedValue{}, ok: true}
+	case ast.KindCallExpression:
+		if result := staticEvaluator.evalStringCall(node); result.ok {
+			return result
+		}
+	case ast.KindTaggedTemplateExpression:
+		if result := staticEvaluator.evalStringRawTag(node); result.ok {
+			return result
+		}
+	}
+
+	return staticEvaluator.evalWithTsgo(node)
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalIdentifier(node *ast.Node) staticEvalResult {
+	if staticEvaluator.typeChecker == nil {
+		return staticEvalResult{}
+	}
+
+	expr := SkipAssertionsAndParens(node)
+	if expr == nil || expr.Kind != ast.KindIdentifier {
+		return staticEvalResult{}
+	}
+
+	symbol := GetReferenceSymbol(expr, staticEvaluator.typeChecker)
+	if symbol == nil || len(symbol.Declarations) != 1 || staticEvaluator.resolving[symbol] {
+		return staticEvalResult{}
+	}
+
+	declarationNode := symbol.Declarations[0]
+	if declarationNode == nil || declarationNode.Kind != ast.KindVariableDeclaration {
+		return staticEvalResult{}
+	}
+
+	declaration := declarationNode.AsVariableDeclaration()
+	if declaration == nil || declaration.Initializer == nil || !isIdentifierWithText(declaration.Name(), expr.AsIdentifier().Text) {
+		return staticEvalResult{}
+	}
+
+	declarationList := declarationNode.Parent
+	if declarationList == nil || declarationList.Kind != ast.KindVariableDeclarationList {
+		return staticEvalResult{}
+	}
+	if ast.IsVarUsing(declarationList) || ast.IsVarAwaitUsing(declarationList) {
+		return staticEvalResult{}
+	}
+	if !ast.IsVarConst(declarationList) && staticEvaluator.hasWrites(symbol) {
+		return staticEvalResult{}
+	}
+
+	staticEvaluator.resolving[symbol] = true
+	defer delete(staticEvaluator.resolving, symbol)
+	return staticEvaluator.evalValue(declaration.Initializer)
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalTemplateExpression(node *ast.Node) staticEvalResult {
+	template := node.AsTemplateExpression()
+	if template == nil {
+		return staticEvalResult{}
+	}
+
+	var builder strings.Builder
+	if template.Head != nil {
+		builder.WriteString(template.Head.Text())
+	}
+	if template.TemplateSpans != nil {
+		for _, spanNode := range template.TemplateSpans.Nodes {
+			span := spanNode.AsTemplateSpan()
+			if span == nil {
+				return staticEvalResult{}
+			}
+			result := staticEvaluator.evalValue(span.Expression)
+			if !result.ok {
+				return staticEvalResult{}
+			}
+			value, ok := staticValueToString(result.value)
+			if !ok {
+				return staticEvalResult{}
+			}
+			builder.WriteString(value)
+			if span.Literal != nil {
+				builder.WriteString(span.Literal.Text())
+			}
+		}
+	}
+	return staticEvalResult{value: builder.String(), ok: true}
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalBinaryExpression(node *ast.Node) staticEvalResult {
+	binary := node.AsBinaryExpression()
+	if binary == nil || binary.OperatorToken == nil {
+		return staticEvalResult{}
+	}
+
+	switch binary.OperatorToken.Kind {
+	case ast.KindBarBarToken:
+		left := staticEvaluator.evalValue(binary.Left)
+		if !left.ok {
+			return staticEvalResult{}
+		}
+		truthy, ok := staticValueTruthy(left.value)
+		if !ok {
+			return staticEvalResult{}
+		}
+		if truthy {
+			return left
+		}
+		return staticEvaluator.evalValue(binary.Right)
+	case ast.KindAmpersandAmpersandToken:
+		left := staticEvaluator.evalValue(binary.Left)
+		if !left.ok {
+			return staticEvalResult{}
+		}
+		truthy, ok := staticValueTruthy(left.value)
+		if !ok {
+			return staticEvalResult{}
+		}
+		if !truthy {
+			return left
+		}
+		return staticEvaluator.evalValue(binary.Right)
+	case ast.KindQuestionQuestionToken:
+		left := staticEvaluator.evalValue(binary.Left)
+		if !left.ok {
+			return staticEvalResult{}
+		}
+		if staticValueNullish(left.value) {
+			return staticEvaluator.evalValue(binary.Right)
+		}
+		return left
+	case ast.KindPlusToken:
+		left := staticEvaluator.evalValue(binary.Left)
+		right := staticEvaluator.evalValue(binary.Right)
+		if !left.ok || !right.ok {
+			return staticEvalResult{}
+		}
+		if _, ok := left.value.(string); ok {
+			return staticEvaluator.concatStaticValues(left.value, right.value)
+		}
+		if _, ok := right.value.(string); ok {
+			return staticEvaluator.concatStaticValues(left.value, right.value)
+		}
+	}
+
+	return staticEvaluator.evalWithTsgo(node)
+}
+
+func (staticEvaluator *StaticStringEvaluator) concatStaticValues(left any, right any) staticEvalResult {
+	leftString, ok := staticValueToString(left)
+	if !ok {
+		return staticEvalResult{}
+	}
+	rightString, ok := staticValueToString(right)
+	if !ok {
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: leftString + rightString, ok: true}
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalPrefixUnaryExpression(node *ast.Node) staticEvalResult {
+	prefix := node.AsPrefixUnaryExpression()
+	if prefix == nil || prefix.Operator != ast.KindExclamationToken {
+		return staticEvaluator.evalWithTsgo(node)
+	}
+
+	operand := staticEvaluator.evalValue(prefix.Operand)
+	if !operand.ok {
+		return staticEvalResult{}
+	}
+	truthy, ok := staticValueTruthy(operand.value)
+	if !ok {
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: !truthy, ok: true}
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalConditionalExpression(node *ast.Node) staticEvalResult {
+	conditional := node.AsConditionalExpression()
+	if conditional == nil {
+		return staticEvalResult{}
+	}
+
+	condition := staticEvaluator.evalValue(conditional.Condition)
+	if !condition.ok {
+		return staticEvalResult{}
+	}
+	truthy, ok := staticValueTruthy(condition.value)
+	if !ok {
+		return staticEvalResult{}
+	}
+	if truthy {
+		return staticEvaluator.evalValue(conditional.WhenTrue)
+	}
+	return staticEvaluator.evalValue(conditional.WhenFalse)
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalStringCall(node *ast.Node) staticEvalResult {
+	call := node.AsCallExpression()
+	if call == nil || call.QuestionDotToken != nil {
+		return staticEvalResult{}
+	}
+
+	callee := ast.SkipOuterExpressions(call.Expression, ast.OEKParentheses|ast.OEKAssertions)
+	if callee == nil || callee.Kind != ast.KindIdentifier ||
+		callee.AsIdentifier().Text != "String" || IsShadowed(callee, "String") {
+		return staticEvalResult{}
+	}
+
+	args := node.Arguments()
+	if len(args) == 0 {
+		return staticEvalResult{value: "", ok: true}
+	}
+	if ast.IsSpreadElement(args[0]) {
+		return staticEvalResult{}
+	}
+	arg := staticEvaluator.evalValue(args[0])
+	if !arg.ok {
+		return staticEvalResult{}
+	}
+	value, ok := staticValueToString(arg.value)
+	if !ok {
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: value, ok: true}
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalStringRawTag(node *ast.Node) staticEvalResult {
+	tagged := node.AsTaggedTemplateExpression()
+	if tagged == nil || tagged.Template == nil || !isStringRawTag(tagged.Tag) {
+		return staticEvalResult{}
+	}
+
+	switch tagged.Template.Kind {
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return staticEvalResult{value: tagged.Template.Text(), ok: true}
+	case ast.KindTemplateExpression:
+		return staticEvaluator.evalTemplateExpression(tagged.Template)
+	default:
+		return staticEvalResult{}
+	}
+}
+
+func isStringRawTag(tag *ast.Node) bool {
+	tag = ast.SkipOuterExpressions(tag, ast.OEKParentheses|ast.OEKAssertions)
+	if tag == nil || tag.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+
+	propertyAccess := tag.AsPropertyAccessExpression()
+	if propertyAccess == nil || propertyAccess.QuestionDotToken != nil ||
+		!isIdentifierWithText(propertyAccess.Name(), "raw") {
+		return false
+	}
+
+	object := ast.SkipOuterExpressions(propertyAccess.Expression, ast.OEKParentheses|ast.OEKAssertions)
+	return isIdentifierWithText(object, "String") && !IsShadowed(object, "String")
+}
+
+func (staticEvaluator *StaticStringEvaluator) evalWithTsgo(node *ast.Node) (result staticEvalResult) {
+	defer func() {
+		if recover() != nil {
+			result = staticEvalResult{}
+		}
+	}()
+
+	value := staticEvaluator.evaluator(node, node).Value
+	if value == nil {
+		return staticEvalResult{}
+	}
+	return staticEvalResult{value: value, ok: true}
+}
+
+func (staticEvaluator *StaticStringEvaluator) evaluateEntity(expr *ast.Node, location *ast.Node) evaluator.Result {
+	result := staticEvaluator.evalIdentifier(expr)
+	if !result.ok || !staticValueIsTsgoSafe(result.value) {
+		return evaluator.Result{}
+	}
+
+	return evaluator.Result{Value: result.value}
+}
+
+func (staticEvaluator *StaticStringEvaluator) hasWrites(symbol *ast.Symbol) bool {
+	if staticEvaluator.sourceFile == nil || staticEvaluator.typeChecker == nil {
+		return true
+	}
+	if !staticEvaluator.writeRefsComputed {
+		staticEvaluator.computeWriteRefs()
+	}
+	return staticEvaluator.writeRefs[symbol]
+}
+
+func (staticEvaluator *StaticStringEvaluator) computeWriteRefs() {
+	staticEvaluator.writeRefsComputed = true
+	staticEvaluator.writeRefs = map[*ast.Symbol]bool{}
+
+	var visit func(node *ast.Node)
+	visit = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node.Kind == ast.KindIdentifier && IsWriteReference(node) {
+			if symbol := staticEvaluator.typeChecker.GetSymbolAtLocation(node); symbol != nil {
+				staticEvaluator.writeRefs[symbol] = true
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return false
+		})
+	}
+	visit(&staticEvaluator.sourceFile.Node)
+}
+
+func staticValueIsTsgoSafe(value any) bool {
+	switch value.(type) {
+	case bool, staticNullValue, staticUndefinedValue:
+		return false
+	default:
+		return value != nil
+	}
+}
+
+func staticValueNullish(value any) bool {
+	switch value.(type) {
+	case staticNullValue, staticUndefinedValue:
+		return true
+	default:
+		return false
+	}
+}
+
+func staticValueTruthy(value any) (truthy bool, ok bool) {
+	switch value := value.(type) {
+	case string:
+		return value != "", true
+	case bool:
+		return value, true
+	case staticNullValue, staticUndefinedValue:
+		return false, true
+	default:
+		return evaluatorBool(func() bool { return evaluator.IsTruthy(value) })
+	}
+}
+
+func staticValueToString(value any) (string, bool) {
+	switch value := value.(type) {
+	case string:
+		return value, true
+	case bool:
+		if value {
+			return "true", true
+		}
+		return "false", true
+	case staticNullValue:
+		return "null", true
+	case staticUndefinedValue:
+		return "undefined", true
+	default:
+		return evaluatorString(func() string { return evaluator.AnyToString(value) })
+	}
+}
+
+func evaluatorBool(fn func() bool) (value bool, ok bool) {
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+	return fn(), true
+}
+
+func evaluatorString(fn func() string) (value string, ok bool) {
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+	return fn(), true
+}
+
+func isIdentifierWithText(node *ast.Node, text string) bool {
+	return node != nil && node.Kind == ast.KindIdentifier && node.AsIdentifier().Text == text
+}

--- a/internal/utils/static_string_evaluator_test.go
+++ b/internal/utils/static_string_evaluator_test.go
@@ -1,0 +1,139 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"gotest.tools/v3/assert"
+)
+
+func TestStaticStringEvaluator(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir, "file.ts")
+	code := "\n" +
+		"const direct = \"then\";\n" +
+		"const left = \"th\";\n" +
+		"const concat = left + \"en\";\n" +
+		"const template = `${left}en`;\n" +
+		"const asserted = (\"then\" as string);\n" +
+		"const satisfiesValue = \"then\" satisfies string;\n" +
+		"const nested = `${concat}`;\n" +
+		"const templateBoolean = `${false}`;\n" +
+		"const conditional = true ? \"then\" : \"no\";\n" +
+		"const conditionalFromConst = direct ? direct : \"no\";\n" +
+		"const unresolvedConditional = flag ? \"then\" : \"no\";\n" +
+		"const logicalOr = \"\" || \"then\";\n" +
+		"const logicalAnd = \"then\" && \"then\";\n" +
+		"const nullish = null ?? \"then\";\n" +
+		"const undefinedNullish = undefined ?? \"then\";\n" +
+		"const stringCall = String(\"then\");\n" +
+		"const stringNumberCall = String(1 + 2);\n" +
+		"const stringNoArgumentCall = String();\n" +
+		"const stringRaw = String.raw`then`;\n" +
+		"const stringRawSubstitution = String.raw`th${\"e\"}n`;\n" +
+		"{ const String = value => \"then\"; const shadowedStringCall = String(\"then\"); }\n" +
+		"let letStatic = \"then\";\n" +
+		"var varStatic = \"then\";\n" +
+		"const letStaticUse = letStatic;\n" +
+		"const varStaticUse = varStatic;\n" +
+		"let letWritten = \"then\";\n" +
+		"letWritten = \"other\";\n" +
+		"const letWrittenUse = letWritten;\n" +
+		"var varWritten = \"then\";\n" +
+		"varWritten++;\n" +
+		"const varWrittenUse = varWritten;\n" +
+		"const notThen = \"not-then\";\n" +
+		"const cycle = cycle;\n" +
+		"let letValue = \"then\";\n" +
+		"const letUse = letValue;\n" +
+		"const numeric = 1 + 2;\n" +
+		"const unknownUse = unknownValue;\n"
+
+	fs := NewOverlayVFSForFile(filePath, code)
+	program, err := CreateProgram(true, fs, rootDir, "tsconfig.json", CreateCompilerHost(rootDir, fs))
+	assert.NilError(t, err, "couldn't create program")
+
+	sourceFile := program.GetSourceFile(filePath)
+	assert.Assert(t, sourceFile != nil)
+
+	typeChecker, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	staticEvaluator := NewStaticStringEvaluatorWithSourceFile(typeChecker, sourceFile)
+	tests := []struct {
+		name string
+		want string
+		ok   bool
+	}{
+		{name: "direct", want: "then", ok: true},
+		{name: "concat", want: "then", ok: true},
+		{name: "template", want: "then", ok: true},
+		{name: "asserted", want: "then", ok: true},
+		{name: "satisfiesValue", want: "then", ok: true},
+		{name: "nested", want: "then", ok: true},
+		{name: "templateBoolean", want: "false", ok: true},
+		{name: "conditional", want: "then", ok: true},
+		{name: "conditionalFromConst", want: "then", ok: true},
+		{name: "unresolvedConditional"},
+		{name: "logicalOr", want: "then", ok: true},
+		{name: "logicalAnd", want: "then", ok: true},
+		{name: "nullish", want: "then", ok: true},
+		{name: "undefinedNullish", want: "then", ok: true},
+		{name: "stringCall", want: "then", ok: true},
+		{name: "stringNumberCall", want: "3", ok: true},
+		{name: "stringNoArgumentCall", want: "", ok: true},
+		{name: "stringRaw", want: "then", ok: true},
+		{name: "stringRawSubstitution", want: "then", ok: true},
+		{name: "shadowedStringCall"},
+		{name: "letStatic", want: "then", ok: true},
+		{name: "varStatic", want: "then", ok: true},
+		{name: "letStaticUse", want: "then", ok: true},
+		{name: "varStaticUse", want: "then", ok: true},
+		{name: "letWritten", want: "then", ok: true},
+		{name: "letWrittenUse"},
+		{name: "varWritten", want: "then", ok: true},
+		{name: "varWrittenUse"},
+		{name: "notThen", want: "not-then", ok: true},
+		{name: "cycle"},
+		{name: "letUse", want: "then", ok: true},
+		{name: "numeric"},
+		{name: "unknownUse"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := staticEvaluator.Eval(findVariableInitializer(t, sourceFile, tt.name))
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("Eval(%s) = (%q, %v), want (%q, %v)", tt.name, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func findVariableInitializer(t *testing.T, sourceFile *ast.SourceFile, bindingName string) *ast.Node {
+	t.Helper()
+
+	var initializer *ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node == nil {
+			return false
+		}
+		if node.Kind == ast.KindVariableDeclaration {
+			declaration := node.AsVariableDeclaration()
+			if declaration != nil && declaration.Name() != nil &&
+				declaration.Name().Kind == ast.KindIdentifier &&
+				declaration.Name().AsIdentifier().Text == bindingName {
+				initializer = declaration.Initializer
+				return true
+			}
+		}
+		return node.ForEachChild(visit)
+	}
+	visit(sourceFile.AsNode())
+	if initializer == nil {
+		t.Fatalf("missing initializer for %q", bindingName)
+	}
+	return initializer
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -530,6 +530,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-number-properties.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-thenable.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-thenable.test.ts
@@ -1,0 +1,226 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const objectMessage = 'Do not add `then` to an object.';
+const exportMessage = 'Do not export `then`.';
+const classMessage = 'Do not add `then` to a class.';
+
+const valid = (code: string) => ({ code, filename: 'file.js' });
+const invalidObject = (code: string) => ({
+  code,
+  filename: 'file.js',
+  errors: [{ message: objectMessage }],
+});
+const invalidExport = (code: string) => ({
+  code,
+  filename: 'file.js',
+  errors: [{ message: exportMessage }],
+});
+const invalidClass = (code: string) => ({
+  code,
+  filename: 'file.js',
+  errors: [{ message: classMessage }],
+});
+
+ruleTester.run('no-thenable', null as never, {
+  valid: [
+    // `object`
+    valid('const then = {}'),
+    valid('const notThen = then'),
+    valid('const then = then.then'),
+    valid('const foo = {notThen: 1}'),
+    valid('const foo = {notThen() {}}'),
+    valid('const foo = {[then]: 1}'),
+    valid('const NOT_THEN = "no-then";const foo = {[NOT_THEN]: 1}'),
+    valid('function foo({then}) {}'),
+    valid('({[Symbol.prototype]: 1})'),
+
+    // `class`
+    valid('class then {}'),
+    valid('class Foo {notThen}'),
+    valid('class Foo {notThen() {}}'),
+    valid('class Foo {[then]}'),
+    valid('class Foo {#then}'),
+    valid('class Foo {#then() {}}'),
+    valid('class Foo {[then]() {}}'),
+    valid('class Foo {get notThen() {}}'),
+    valid('class Foo {get #then() {}}'),
+    valid('class Foo {get [then]() {}}'),
+    valid('class Foo {static notThen}'),
+    valid('class Foo {static notThen() {}}'),
+    valid('class Foo {static #then}'),
+    valid('class Foo {static #then() {}}'),
+    valid('class Foo {static [then]}'),
+    valid('class Foo {static [then]() {}}'),
+    valid('class Foo {static get notThen() {}}'),
+    valid('class Foo {static get #then() {}}'),
+    valid('class Foo {static get [then]() {}}'),
+    valid('class Foo {notThen = then}'),
+    valid('class Foo {[Symbol.property]}'),
+    valid('class Foo {static [Symbol.property]}'),
+    valid('class Foo {get [Symbol.property]() {}}'),
+    valid('class Foo {[Symbol.property]() {}}'),
+    valid('class Foo {static get [Symbol.property]() {}}'),
+
+    // Assign
+    valid('foo[then] = 1'),
+    valid('foo.notThen = 1'),
+    valid('then.notThen = then.then'),
+    valid('const NOT_THEN = "no-then";foo[NOT_THEN] = 1'),
+    valid('foo.then ++'),
+    valid('++ foo.then'),
+    valid('delete foo.then'),
+    valid('typeof foo.then'),
+    valid('foo.then != 1'),
+    valid('foo[Symbol.property] = 1'),
+
+    // `Object.fromEntries`
+    valid('Object.fromEntries([then, 1])'),
+    valid('Object.fromEntries([,,])'),
+    valid('Object.fromEntries([[,,],[]])'),
+    valid('const NOT_THEN = "not-then";Object.fromEntries([[NOT_THEN, 1]])'),
+    valid('Object.fromEntries([[["then", 1]]])'),
+    valid('NotObject.fromEntries([["then", 1]])'),
+    valid('Object.notFromEntries([["then", 1]])'),
+    valid('Object.fromEntries?.([["then", 1]])'),
+    valid('Object?.fromEntries([["then", 1]])'),
+    valid('Object.fromEntries([[..."then", 1]])'),
+    valid('Object.fromEntries([["then", 1]], extraArgument)'),
+    valid('Object.fromEntries(...[["then", 1]])'),
+    valid('Object.fromEntries([[Symbol.property, 1]])'),
+
+    // `{Object,Reflect}.defineProperty`
+    valid('Object.defineProperty(foo, then, 1)'),
+    valid('Object.defineProperty(foo, "not-then", 1)'),
+    valid('const then = "no-then";Object.defineProperty(foo, then, 1)'),
+    valid('Reflect.defineProperty(foo, then, 1)'),
+    valid('Reflect.defineProperty(foo, "not-then", 1)'),
+    valid('const then = "no-then";Reflect.defineProperty(foo, then, 1)'),
+    valid('Object.defineProperty(foo, "then", )'),
+    valid('Object.defineProperty(...foo, "then", 1)'),
+    valid('Object.defineProperty(foo, ...["then", 1])'),
+    valid('Object.defineProperty(foo, Symbol.property, 1)'),
+    valid('Reflect.defineProperty(foo, Symbol.property, 1)'),
+
+    // `export`
+    valid('export {default} from "then"'),
+    valid('const then = 1; export {then as notThen}'),
+    valid('export default then'),
+    valid('export function notThen(){}'),
+    valid('export class notThen {}'),
+    valid('export default function then (){}'),
+    valid('export default class then {}'),
+    valid('export default function (){}'),
+    valid('export default class {}'),
+
+    // `export variables`
+    valid('export const notThen = 1'),
+    valid('export const {then: notThen} = 1'),
+    valid('export const {then: notThen = then} = 1'),
+  ],
+  invalid: [
+    // `object`
+    invalidObject('const foo = {then: 1}'),
+    invalidObject('const foo = {["then"]: 1}'),
+    invalidObject('const foo = {[`then`]: 1}'),
+    invalidObject('const THEN = "then";const foo = {[THEN]: 1}'),
+    invalidObject('const foo = {then() {}}'),
+    invalidObject('const foo = {["then"]() {}}'),
+    invalidObject('const foo = {[`then`]() {}}'),
+    invalidObject('const THEN = "then";const foo = {[THEN]() {}}'),
+    invalidObject('const foo = {get then() {}}'),
+    invalidObject('const foo = {set then(v) {}}'),
+    invalidObject('const foo = {get ["then"]() {}}'),
+    invalidObject('const foo = {get [`then`]() {}}'),
+    invalidObject('const THEN = "then";const foo = {get [THEN]() {}}'),
+
+    // `class`
+    invalidClass('class Foo {then}'),
+    invalidClass('const Foo = class {then}'),
+    invalidClass('class Foo {["then"]}'),
+    invalidClass('class Foo {[`then`]}'),
+    invalidClass('const THEN = "then";class Foo {[THEN]}'),
+    invalidClass('class Foo {then() {}}'),
+    invalidClass('class Foo {["then"]() {}}'),
+    invalidClass('class Foo {[`then`]() {}}'),
+    invalidClass('const THEN = "then";class Foo {[THEN]() {}}'),
+    invalidClass('class Foo {static then}'),
+    invalidClass('class Foo {static ["then"]}'),
+    invalidClass('class Foo {static [`then`]}'),
+    invalidClass('const THEN = "then";class Foo {static [THEN]}'),
+    invalidClass('class Foo {static then() {}}'),
+    invalidClass('class Foo {static ["then"]() {}}'),
+    invalidClass('class Foo {static [`then`]() {}}'),
+    invalidClass('const THEN = "then";class Foo {static [THEN]() {}}'),
+    invalidClass('class Foo {get then() {}}'),
+    invalidClass('class Foo {get ["then"]() {}}'),
+    invalidClass('class Foo {get [`then`]() {}}'),
+    invalidClass('const THEN = "then";class Foo {get [THEN]() {}}'),
+    invalidClass('class Foo {set then(v) {}}'),
+    invalidClass('class Foo {set ["then"](v) {}}'),
+    invalidClass('class Foo {set [`then`](v) {}}'),
+    invalidClass('const THEN = "then";class Foo {set [THEN](v) {}}'),
+    invalidClass('class Foo {static get then() {}}'),
+    invalidClass('class Foo {static set then(v) {}}'),
+    invalidClass('class Foo {static get ["then"]() {}}'),
+    invalidClass('class Foo {static get [`then`]() {}}'),
+    invalidClass('const THEN = "then";class Foo {static get [THEN]() {}}'),
+
+    // Assign
+    invalidObject('foo.then = 1'),
+    invalidObject('foo["then"] = 1'),
+    invalidObject('foo[`then`] = 1'),
+    invalidObject('const THEN = "then";foo[THEN] = 1'),
+    invalidObject('foo.then += 1'),
+    invalidObject('foo.then ||= 1'),
+    invalidObject('foo.then ??= 1'),
+
+    // `{Object,Reflect}.defineProperty`
+    invalidObject('Object.defineProperty(foo, "then", 1)'),
+    invalidObject('Object.defineProperty(foo, `then`, 1)'),
+    invalidObject('const THEN = "then";Object.defineProperty(foo, THEN, 1)'),
+    invalidObject('Reflect.defineProperty(foo, "then", 1)'),
+    invalidObject('Reflect.defineProperty(foo, `then`, 1)'),
+    invalidObject('const THEN = "then";Reflect.defineProperty(foo, THEN, 1)'),
+
+    // `Object.fromEntries`
+    invalidObject('Object.fromEntries([["then", 1]])'),
+    invalidObject('Object.fromEntries([["then"]])'),
+    invalidObject('Object.fromEntries([[`then`, 1]])'),
+    invalidObject('const THEN = "then";Object.fromEntries([[THEN, 1]])'),
+    invalidObject('Object.fromEntries([foo, ["then", 1]])'),
+
+    // `export`
+    invalidExport('const then = 1; export {then}'),
+    invalidExport('const notThen = 1; export {notThen as then}'),
+    invalidExport('export {then} from "foo"'),
+    invalidExport('export function then() {}'),
+    invalidExport('export async function then() {}'),
+    invalidExport('export function * then() {}'),
+    invalidExport('export async function * then() {}'),
+    invalidExport('export class then {}'),
+
+    // `export variables`
+    invalidExport('export const then = 1'),
+    invalidExport('export let then = 1'),
+    invalidExport('export var then = 1'),
+    invalidExport('export const [then] = 1'),
+    invalidExport('export let [then] = 1'),
+    invalidExport('export var [then] = 1'),
+    invalidExport('export const [, then] = 1'),
+    invalidExport('export let [, then] = 1'),
+    invalidExport('export var [, then] = 1'),
+    invalidExport('export const [, ...then] = 1'),
+    invalidExport('export let [, ...then] = 1'),
+    invalidExport('export var [, ...then] = 1'),
+    invalidExport('export const {then} = 1'),
+    invalidExport('export let {then} = 1'),
+    invalidExport('export var {then} = 1'),
+    invalidExport('export const {foo, ...then} = 1'),
+    invalidExport('export let {foo, ...then} = 1'),
+    invalidExport('export var {foo, ...then} = 1'),
+    invalidExport('export const {foo: {bar: [{baz: then}]}} = 1'),
+    invalidExport('export const notThen = 1, then = 1'),
+  ],
+});


### PR DESCRIPTION
## Summary

Port `unicorn/no-thenable` to rslint.

The rule reports object/class `then` properties, assignments that create `then` members, `Object.defineProperty` / `Reflect.defineProperty`, `Object.fromEntries` entries, and named exports of `then`, aligned with eslint-plugin-unicorn behavior.

## Related Links

- eslint-plugin-unicorn docs: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-thenable.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-thenable.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
