### PR TITLE
feat: port rule unicorn/no-instanceof-builtins

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -3,6 +3,7 @@ package unicorn_plugin
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_thenable"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
@@ -15,6 +16,7 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		filename_case.FilenameCaseRule,
 		new_for_builtins.NewForBuiltinsRule,
+		no_instanceof_builtins.NoInstanceofBuiltinsRule,
 		no_static_only_class.NoStaticOnlyClassRule,
 		no_thenable.NoThenableRule,
 		no_useless_switch_case.NoUselessSwitchCaseRule,

--- a/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins.go
+++ b/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins.go
@@ -1,0 +1,291 @@
+package no_instanceof_builtins
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	messageIDNoInstanceofBuiltins = "no-instanceof-builtins"
+	messageIDSwitchToTypeOf       = "switch-to-type-of"
+)
+
+var primitiveWrappers = utils.NewSetFromItems("String", "Number", "Boolean", "BigInt", "Symbol")
+
+var strictStrategyConstructors = utils.NewSetFromItems(
+	// Error types
+	"Error",
+	"EvalError",
+	"RangeError",
+	"ReferenceError",
+	"SyntaxError",
+	"TypeError",
+	"URIError",
+	"AggregateError",
+	"SuppressedError",
+
+	// Collection types
+	"Map",
+	"Set",
+	"WeakMap",
+	"WeakRef",
+	"WeakSet",
+
+	// Arrays and Typed Arrays
+	"ArrayBuffer",
+	"Int8Array",
+	"Uint8Array",
+	"Uint8ClampedArray",
+	"Int16Array",
+	"Uint16Array",
+	"Int32Array",
+	"Uint32Array",
+	"Float16Array",
+	"Float32Array",
+	"Float64Array",
+	"BigInt64Array",
+	"BigUint64Array",
+
+	// Data types
+	"Object",
+
+	// Regular Expressions
+	"RegExp",
+
+	// Async and functions
+	"Promise",
+	"Proxy",
+
+	// Other
+	"DataView",
+	"Date",
+	"SharedArrayBuffer",
+	"FinalizationRegistry",
+)
+
+type options struct {
+	useErrorIsError bool
+	strategy        string
+	include         *utils.Set[string]
+	exclude         *utils.Set[string]
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/no-instanceof-builtins.md
+var NoInstanceofBuiltinsRule = rule.Rule{
+	Name: "unicorn/no-instanceof-builtins",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				checkBinaryExpression(ctx, node, opts)
+			},
+		}
+	},
+}
+
+func checkBinaryExpression(ctx rule.RuleContext, node *ast.Node, opts options) {
+	binary := node.AsBinaryExpression()
+	if binary == nil || !ast.IsInstanceOfExpression(node) {
+		return
+	}
+
+	right := ast.SkipParentheses(binary.Right)
+	if right == nil || !ast.IsIdentifier(right) {
+		return
+	}
+
+	constructorName := right.AsIdentifier().Text
+	if opts.exclude.Has(constructorName) {
+		return
+	}
+
+	message := messageNoInstanceofBuiltins()
+	switch {
+	case constructorName == "Array":
+		ctx.ReportNodeWithFixes(
+			node,
+			message,
+			replaceWithFunctionCall(ctx.SourceFile, binary, "Array.isArray")...,
+		)
+	case constructorName == "Error" && opts.useErrorIsError:
+		ctx.ReportNodeWithFixes(
+			node,
+			message,
+			replaceWithFunctionCall(ctx.SourceFile, binary, "Error.isError")...,
+		)
+	case constructorName == "Function":
+		ctx.ReportNodeWithFixes(
+			node,
+			message,
+			replaceWithTypeOfExpression(ctx.SourceFile, binary, constructorName)...,
+		)
+	case primitiveWrappers.Has(constructorName):
+		ctx.ReportNodeWithSuggestions(
+			node,
+			message,
+			rule.RuleSuggestion{
+				Message:  messageSwitchToTypeOf(constructorName),
+				FixesArr: replaceWithTypeOfExpression(ctx.SourceFile, binary, constructorName),
+			},
+		)
+	case opts.forbids(constructorName):
+		ctx.ReportNode(node, message)
+	}
+}
+
+func parseOptions(rawOptions any) options {
+	opts := options{
+		useErrorIsError: false,
+		strategy:        "loose",
+		include:         utils.NewSetFromItems[string](),
+		exclude:         utils.NewSetFromItems[string](),
+	}
+
+	optsMap := utils.GetOptionsMap(rawOptions)
+	if optsMap == nil {
+		return opts
+	}
+
+	if useErrorIsError, ok := optsMap["useErrorIsError"].(bool); ok {
+		opts.useErrorIsError = useErrorIsError
+	}
+	if strategy, ok := optsMap["strategy"].(string); ok && (strategy == "loose" || strategy == "strict") {
+		opts.strategy = strategy
+	}
+	opts.include = parseStringSet(optsMap["include"])
+	opts.exclude = parseStringSet(optsMap["exclude"])
+
+	return opts
+}
+
+func (opts options) forbids(constructorName string) bool {
+	if opts.strategy == "strict" && strictStrategyConstructors.Has(constructorName) {
+		return true
+	}
+	return opts.include.Has(constructorName)
+}
+
+func parseStringSet(value any) *utils.Set[string] {
+	if array, ok := value.([]string); ok {
+		return utils.NewSetFromItems(array...)
+	}
+	return utils.NewSetFromItems(utils.ToStringSlice(value)...)
+}
+
+// Use token-level edits so comments around `instanceof` and the right operand
+// are preserved the same way as upstream's fixers.
+func replaceWithFunctionCall(sourceFile *ast.SourceFile, binary *ast.BinaryExpression, functionName string) []rule.RuleFix {
+	leftRange := utils.TrimNodeTextRange(sourceFile, binary.Left)
+	insertBefore := functionName + "("
+	if utils.NeedsLeadingSpaceForReplacement(sourceFile.Text(), leftRange.Pos(), insertBefore) {
+		insertBefore = " " + insertBefore
+	}
+
+	fixes := []rule.RuleFix{
+		insertAt(leftRange.Pos(), insertBefore),
+		insertAt(leftRange.End(), ")"),
+		removeRangeAndSpacesBefore(sourceFile, utils.TrimNodeTextRange(sourceFile, binary.OperatorToken)),
+	}
+	fixes = append(fixes, removeNodeSyntaxAndSpacesBefore(sourceFile, binary.Right)...)
+	return fixes
+}
+
+func replaceWithTypeOfExpression(sourceFile *ast.SourceFile, binary *ast.BinaryExpression, constructorName string) []rule.RuleFix {
+	leftRange := utils.TrimNodeTextRange(sourceFile, binary.Left)
+	insertBefore := "typeof "
+	if utils.NeedsLeadingSpaceForReplacement(sourceFile.Text(), leftRange.Pos(), insertBefore) {
+		insertBefore = " " + insertBefore
+	}
+
+	return []rule.RuleFix{
+		insertAt(leftRange.Pos(), insertBefore),
+		rule.RuleFixReplaceRange(utils.TrimNodeTextRange(sourceFile, binary.OperatorToken), "==="),
+		rule.RuleFixReplaceRange(utils.TrimNodeTextRange(sourceFile, binary.Right), fmt.Sprintf("'%s'", strings.ToLower(constructorName))),
+	}
+}
+
+func insertAt(pos int, text string) rule.RuleFix {
+	return rule.RuleFixReplaceRange(core.NewTextRange(pos, pos), text)
+}
+
+func removeNodeSyntaxAndSpacesBefore(sourceFile *ast.SourceFile, node *ast.Node) []rule.RuleFix {
+	if node == nil {
+		return nil
+	}
+
+	if node.Kind == ast.KindParenthesizedExpression {
+		nodeRange := utils.TrimNodeTextRange(sourceFile, node)
+		expression := node.AsParenthesizedExpression().Expression
+		fixes := make([]rule.RuleFix, 0, 3)
+		if text := sourceFile.Text(); nodeRange.Pos() < nodeRange.End() && text[nodeRange.Pos()] == '(' {
+			fixes = append(fixes, removeRangeAndSpacesBefore(sourceFile, core.NewTextRange(nodeRange.Pos(), nodeRange.Pos()+1)))
+		}
+		fixes = append(fixes, removeNodeSyntaxAndSpacesBefore(sourceFile, expression)...)
+
+		closeParenEnd := utils.SkipTrailingWhitespace(sourceFile.Text(), nodeRange.Pos(), nodeRange.End())
+		if closeParenEnd > nodeRange.Pos() && sourceFile.Text()[closeParenEnd-1] == ')' {
+			fixes = append(fixes, removeRangeAndSpacesBefore(sourceFile, core.NewTextRange(closeParenEnd-1, closeParenEnd)))
+		}
+		return fixes
+	}
+
+	return []rule.RuleFix{removeRangeAndSpacesBefore(sourceFile, utils.TrimNodeTextRange(sourceFile, node))}
+}
+
+func removeRangeAndSpacesBefore(sourceFile *ast.SourceFile, textRange core.TextRange) rule.RuleFix {
+	text := sourceFile.Text()
+	start := textRange.Pos()
+	trimmedStart := utils.SkipTrailingWhitespace(text, 0, start)
+	return rule.RuleFixReplaceRange(
+		textRange.WithPos(trimmedStart),
+		firstLineBreak(text[trimmedStart:start]),
+	)
+}
+
+func firstLineBreak(text string) string {
+	for index := range len(text) {
+		switch text[index] {
+		case '\r':
+			if index+1 < len(text) && text[index+1] == '\n' {
+				return "\r\n"
+			}
+			return "\r"
+		case '\n':
+			return "\n"
+		case 0xE2:
+			if index+2 < len(text) && text[index+1] == 0x80 {
+				switch text[index+2] {
+				case 0xA8:
+					return "\u2028"
+				case 0xA9:
+					return "\u2029"
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func messageNoInstanceofBuiltins() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDNoInstanceofBuiltins,
+		Description: "Avoid using `instanceof` for type checking as it can lead to unreliable results.",
+	}
+}
+
+func messageSwitchToTypeOf(constructorName string) rule.RuleMessage {
+	typeName := strings.ToLower(constructorName)
+	return rule.RuleMessage{
+		Id:          messageIDSwitchToTypeOf,
+		Description: fmt.Sprintf("Switch to `typeof … === '%s'`.", typeName),
+		Data: map[string]string{
+			"type": typeName,
+		},
+	}
+}

--- a/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins.md
+++ b/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins.md
@@ -1,0 +1,108 @@
+# no-instanceof-builtins
+
+## Rule Details
+
+Disallow `instanceof` with built-in objects. `instanceof` can be unreliable across realms, so safer checks such as `typeof`, `Array.isArray()`, `Object.prototype.toString.call()`, or dedicated type helpers are preferred.
+
+This rule can automatically fix `Array`, `Function`, and `Error` checks when `useErrorIsError` is enabled. Primitive wrapper checks such as `String`, `Number`, and `Boolean` provide suggestions instead of automatic fixes because converting object-wrapper values to `typeof` checks can change behavior.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+foo instanceof String;
+foo instanceof Number;
+foo instanceof Array;
+foo instanceof Function;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+typeof foo === "string";
+typeof foo === "number";
+Array.isArray(foo);
+typeof foo === "function";
+```
+
+Examples of **incorrect** code for this rule with `{ "strategy": "strict" }`:
+
+```json
+{ "unicorn/no-instanceof-builtins": ["error", { "strategy": "strict" }] }
+```
+
+```javascript
+foo instanceof Map;
+foo instanceof Error;
+foo instanceof Date;
+```
+
+Examples of **incorrect** code for this rule with `{ "include": ["HTMLElement"] }`:
+
+```json
+{ "unicorn/no-instanceof-builtins": ["error", { "include": ["HTMLElement"] }] }
+```
+
+```javascript
+foo instanceof HTMLElement;
+```
+
+Examples of **correct** code for this rule with `{ "exclude": ["String"] }`:
+
+```json
+{ "unicorn/no-instanceof-builtins": ["error", { "exclude": ["String"] }] }
+```
+
+```javascript
+foo instanceof String;
+```
+
+Examples of **incorrect** code for this rule with `{ "strategy": "strict", "useErrorIsError": true }`:
+
+```json
+{
+  "unicorn/no-instanceof-builtins": [
+    "error",
+    { "strategy": "strict", "useErrorIsError": true }
+  ]
+}
+```
+
+```javascript
+foo instanceof Error;
+```
+
+## Options
+
+### `strategy`
+
+Type: `"loose" | "strict"`  
+Default: `"loose"`
+
+- `"loose"` reports primitive wrapper constructors, `Function`, `Array`, and constructors listed in `include`.
+- `"strict"` also reports built-in constructors such as `Error`, `Map`, `Set`, `Date`, typed arrays, `Object`, and `RegExp`.
+
+### `include`
+
+Type: `string[]`  
+Default: `[]`
+
+Additional constructor names to report.
+
+### `exclude`
+
+Type: `string[]`  
+Default: `[]`
+
+Constructor names to ignore. This takes precedence over `strategy`, `include`, and `useErrorIsError`.
+
+### `useErrorIsError`
+
+Type: `boolean`  
+Default: `false`
+
+When enabled, `Error` checks are reported with an autofix to `Error.isError(value)`.
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: no-instanceof-builtins](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-instanceof-builtins.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-instanceof-builtins.js)

--- a/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins_extras_test.go
@@ -1,0 +1,244 @@
+package no_instanceof_builtins_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoInstanceofBuiltinsExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+func TestNoInstanceofBuiltinsExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Dimension 4: optional/member wrappers on the left are just operands and do not crash ----
+		jsValid("foo?.bar instanceof WebWorker"),
+		// ---- Dimension 4: element access on the left is just an operand and does not affect matching ----
+		jsValid("foo['bar'] instanceof WebWorker"),
+		// ---- Dimension 4: dynamic right-hand member access is not an Identifier ----
+		jsValid("foo instanceof constructors.Array"),
+		// ---- Dimension 4: element right-hand access is not an Identifier ----
+		jsValid("foo instanceof constructors['Array']"),
+		// ---- Dimension 4: optional right-hand member access is not an Identifier ----
+		jsValid("foo instanceof constructors?.Array"),
+		// ---- Dimension 4: call right-hand side is not an Identifier ----
+		jsValid("foo instanceof getConstructor()"),
+		// ---- Dimension 4: array literal right-hand side is ignored without crashing ----
+		jsValid("foo instanceof []"),
+		// ---- Dimension 4: object literal right-hand side is ignored without crashing ----
+		jsValid("foo instanceof {}"),
+		// Locks in upstream create() arm 3: exclude returns before every reporting branch.
+		jsValidOptions("foo instanceof Array", map[string]interface{}{"exclude": []interface{}{"Array"}}),
+		// ---- Dimension 4: exclude still wins when strict strategy would otherwise report ----
+		jsValidOptions("foo instanceof Map", []interface{}{map[string]interface{}{"strategy": "strict", "exclude": []interface{}{"Map"}}}),
+		// ---- Dimension 4: malformed include option is ignored rather than widening matches ----
+		jsValidOptions("foo instanceof WebWorker", []interface{}{map[string]interface{}{"include": "WebWorker"}}),
+		// ---- Dimension 4: TS assertion on the right is not transparent to upstream's Identifier gate ----
+		tsValid("foo instanceof (Array as any)"),
+		// ---- Dimension 4: TS non-null on the right is not transparent to upstream's Identifier gate ----
+		tsValid("foo instanceof (Array!)"),
+		// ---- Dimension 4: TS satisfies on the right is not transparent to upstream's Identifier gate ----
+		tsValid("foo instanceof (Array satisfies unknown)"),
+		// N/A: access/key forms on object/class members do not apply; this rule only reads BinaryExpression.Right.
+		// N/A: private identifiers are not valid right-hand operands for `instanceof`.
+		// N/A: declaration/container forms only surround the binary expression; method and arrow bodies are covered below.
+		// N/A: overload, abstract, and declare body-absent forms do not apply to binary expressions.
+
+		// ---- Real-user: #2842 many unrelated binary expressions stay cheap and unreported ----
+		jsValid(strings.Repeat("foo + bar;\n", 64) + "foo instanceof WebWorker"),
+
+		// Locks in upstream create() arm 1: non-instanceof binary operators return early.
+		jsValid("foo in Array"),
+		// Locks in upstream create() arm 2: loose strategy does not report strict-only constructors.
+		jsValid("foo instanceof Map"),
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: parenthesized left and right expressions are transparent ----
+		arrayInvalid("((foo)) instanceof ((Array))", "((foo)) instanceof ((Array))", "((foo))"),
+		// ---- Dimension 4: TS non-null wrappers on the left are preserved by the Array autofix ----
+		tsArrayInvalid("foo! instanceof Array", "foo! instanceof Array", "foo!"),
+		// ---- Dimension 4: TS assertion wrappers on the left are preserved by the Function autofix ----
+		tsFunctionInvalid("(foo as unknown) instanceof Function", "(foo as unknown) instanceof Function", "(foo as unknown)"),
+		// ---- Dimension 4: TS satisfies wrappers on the left are preserved by the primitive suggestion ----
+		tsPrimitiveInvalid("(foo satisfies unknown) instanceof String", "(foo satisfies unknown) instanceof String", "(foo satisfies unknown)", "String"),
+		// ---- Dimension 4: optional property access on the left is preserved by the Array autofix ----
+		arrayInvalid("foo?.bar instanceof Array", "foo?.bar instanceof Array", "foo?.bar"),
+		// ---- Dimension 4: optional call on the left is preserved by the Function autofix ----
+		functionInvalidOptions("foo?.() instanceof Function", "foo?.() instanceof Function", "foo?.()", nil),
+		// ---- Dimension 3: comments around Array checks are preserved like upstream's token-level fix ----
+		arrayInvalidWithOutput(
+			"foo /*a*/ instanceof /*b*/ Array",
+			"foo /*a*/ instanceof /*b*/ Array",
+			"Array.isArray(foo) /*a*/ /*b*/",
+		),
+		// ---- Dimension 3: comments around Error checks are preserved when useErrorIsError fixes to a call ----
+		invalidWithOutputOptions(
+			"foo /*a*/ instanceof /*b*/ Error",
+			"foo /*a*/ instanceof /*b*/ Error",
+			"Error.isError(foo) /*a*/ /*b*/",
+			map[string]interface{}{"useErrorIsError": true},
+		),
+		// ---- Dimension 3: comments around Function checks stay in place around the rewritten operator ----
+		invalidWithOutputOptions(
+			"foo /*a*/ instanceof /*b*/ Function",
+			"foo /*a*/ instanceof /*b*/ Function",
+			"typeof foo /*a*/ === /*b*/ 'function'",
+			nil,
+		),
+		// ---- Dimension 3: primitive wrapper suggestions preserve comments around the operator ----
+		primitiveInvalidWithSuggestionOutput(
+			"foo /*a*/ instanceof /*b*/ String",
+			"foo /*a*/ instanceof /*b*/ String",
+			"typeof foo /*a*/ === /*b*/ 'string'",
+		),
+		// ---- Dimension 4: multi-line parenthesized left expression is preserved by the Function autofix ----
+		functionInvalidOptions(
+			lines(
+				"const result = (",
+				"\tfoo",
+				") instanceof Function;",
+			),
+			lines(
+				"(",
+				"\tfoo",
+				") instanceof Function",
+			),
+			lines(
+				"(",
+				"\tfoo",
+				")",
+			),
+			nil,
+		),
+		// ---- Dimension 4: await expressions on the left stay grouped inside the Array autofix ----
+		arrayInvalid("async function test() { return await values instanceof Array; }", "await values instanceof Array", "await values"),
+		// ---- Dimension 4: method-body traversal reports nested instance checks ----
+		arrayInvalid("class C { method() { return this.value instanceof Array; } }", "this.value instanceof Array", "this.value"),
+		// ---- Dimension 4: constructor bodies are traversed ----
+		arrayInvalid("class C { constructor() { this.value instanceof Array; } }", "this.value instanceof Array", "this.value"),
+		// ---- Dimension 4: getter bodies are traversed ----
+		arrayInvalid("class C { get value() { return items instanceof Array; } }", "items instanceof Array", "items"),
+		// ---- Dimension 4: setter bodies are traversed ----
+		arrayInvalid("class C { set value(items) { items instanceof Array; } }", "items instanceof Array", "items"),
+		// ---- Dimension 4: arrow-body traversal reports nested instance checks ----
+		arrayInvalid("const check = value => value instanceof Array;", "value instanceof Array", "value"),
+		// ---- Dimension 4: function-expression bodies are traversed ----
+		arrayInvalid("const check = function (value) { return value instanceof Array; };", "value instanceof Array", "value"),
+		// ---- Dimension 4: generator bodies are traversed ----
+		arrayInvalid("function* check() { return value instanceof Array; }", "value instanceof Array", "value"),
+		// ---- Dimension 4: async generator bodies are traversed ----
+		arrayInvalid("async function* check() { return value instanceof Array; }", "value instanceof Array", "value"),
+		// ---- Dimension 4: class-field arrow bodies are traversed ----
+		arrayInvalid("class C { check = value => value instanceof Array; }", "value instanceof Array", "value"),
+		// ---- Dimension 4: class static blocks are traversed ----
+		arrayInvalid("class C { static { value instanceof Array; } }", "value instanceof Array", "value"),
+		// ---- Dimension 4: class extends clauses are traversed ----
+		functionInvalidOptions("class C extends (base instanceof Function ? Base : Object) {}", "base instanceof Function", "base", nil),
+		// ---- Dimension 4: computed class keys are traversed ----
+		arrayInvalid("class C { [value instanceof Array]() {} }", "value instanceof Array", "value"),
+		// ---- Dimension 4: computed object keys are traversed ----
+		arrayInvalid("const object = { [value instanceof Array]: true };", "value instanceof Array", "value"),
+		// ---- Dimension 4: multiple sibling reports keep source order and apply non-overlapping autofixes together ----
+		multiInvalidWithOutput(
+			"const result = foo instanceof Array || bar instanceof Function;",
+			"const result = Array.isArray(foo) || typeof bar === 'function';",
+			"foo instanceof Array",
+			"bar instanceof Function",
+		),
+
+		// ---- Real-user: #2452 proposal examples report under strict strategy ----
+		noFixInvalid("foo instanceof Map", "foo instanceof Map", map[string]interface{}{"strategy": "strict"}),
+		noFixInvalid("foo instanceof Promise", "foo instanceof Promise", map[string]interface{}{"strategy": "strict"}),
+		// ---- Real-user: #2537 unsafe primitive wrapper conversion remains a suggestion only ----
+		primitiveInvalidOptions("new Number instanceof Number", "new Number instanceof Number", "new Number", "Number", nil),
+		// ---- Real-user: #2157 Function checks get the safe typeof autofix ----
+		functionInvalidOptions("foo instanceof Function", "foo instanceof Function", "foo", nil),
+
+		// Locks in upstream create() arm 7: include reports custom constructors with no fix.
+		noFixInvalid("foo instanceof HTMLElement", "foo instanceof HTMLElement", map[string]interface{}{"include": []interface{}{"HTMLElement"}}),
+		// Locks in upstream create() arm 4: Array uses an autofix function call.
+		arrayInvalid("foo instanceof Array", "foo instanceof Array", "foo"),
+		// Locks in upstream create() arm 5: Error + useErrorIsError uses Error.isError even in loose mode.
+		errorIsErrorInvalid("foo instanceof Error", "foo instanceof Error", "foo", map[string]interface{}{"useErrorIsError": true}),
+		// Locks in upstream create() arm 6: primitive wrappers report with a suggestion, not an autofix.
+		primitiveInvalidOptions("foo instanceof String", "foo instanceof String", "foo", "String", nil),
+		// Locks in upstream create() arm 8: include also reports custom constructors outside the DOM family.
+		noFixInvalid("foo instanceof WebWorker", "foo instanceof WebWorker", map[string]interface{}{"include": []interface{}{"WebWorker"}}),
+		// Locks in option parsing: array-wrapped rule options use the same path as JS tests.
+		noFixInvalid("foo instanceof WebWorker", "foo instanceof WebWorker", []interface{}{map[string]interface{}{"include": []interface{}{"WebWorker"}}}),
+		// Locks in strict strategy: strict-only constructors report without fixes.
+		noFixInvalid("new (class {})() instanceof Object", "new (class {})() instanceof Object", map[string]interface{}{"strategy": "strict"}),
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_instanceof_builtins.NoInstanceofBuiltinsRule,
+		valid,
+		invalid,
+	)
+}
+
+func tsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.ts"}
+}
+
+func tsArrayInvalid(code string, target string, left string) rule_tester.InvalidTestCase {
+	testCase := arrayInvalid(code, target, left)
+	testCase.FileName = "file.ts"
+	return testCase
+}
+
+func tsFunctionInvalid(code string, target string, left string) rule_tester.InvalidTestCase {
+	testCase := functionInvalidOptions(code, target, left, nil)
+	testCase.FileName = "file.ts"
+	return testCase
+}
+
+func tsPrimitiveInvalid(code string, target string, left string, constructorName string) rule_tester.InvalidTestCase {
+	testCase := primitiveInvalidOptions(code, target, left, constructorName, nil)
+	testCase.FileName = "file.ts"
+	return testCase
+}
+
+func invalidWithOutputOptions(code string, target string, output string, options any) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Options:  options,
+		Output:   []string{output},
+		Errors:   []rule_tester.InvalidTestCaseError{expectedError(code, target)},
+	}
+}
+
+func primitiveInvalidWithSuggestionOutput(code string, target string, output string) rule_tester.InvalidTestCase {
+	err := expectedError(code, target)
+	err.Suggestions = []rule_tester.InvalidTestCaseSuggestion{{
+		MessageId: messageIDSwitchToTypeOf,
+		Output:    output,
+	}}
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Errors:   []rule_tester.InvalidTestCaseError{err},
+	}
+}
+
+func multiInvalidWithOutput(code string, output string, targets ...string) rule_tester.InvalidTestCase {
+	errors := make([]rule_tester.InvalidTestCaseError, 0, len(targets))
+	for _, target := range targets {
+		errors = append(errors, expectedError(code, target))
+	}
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Output:   []string{output},
+		Errors:   errors,
+	}
+}

--- a/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins_upstream_test.go
+++ b/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins_upstream_test.go
@@ -1,0 +1,434 @@
+package no_instanceof_builtins_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_instanceof_builtins"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageIDNoInstanceofBuiltins = "no-instanceof-builtins"
+	messageIDSwitchToTypeOf       = "switch-to-type-of"
+	messageNoInstanceofBuiltins   = "Avoid using `instanceof` for type checking as it can lead to unreliable results."
+)
+
+var looseStrategyInvalid = []string{
+	// Primitive types
+	"foo instanceof String",
+	"foo instanceof Number",
+	"foo instanceof Boolean",
+	"foo instanceof BigInt",
+	"foo instanceof Symbol",
+	"foo instanceof Function",
+	"foo instanceof Array",
+}
+
+var strictStrategyInvalid = []string{
+	// Error types
+	"foo instanceof Error",
+	"foo instanceof EvalError",
+	"foo instanceof RangeError",
+	"foo instanceof ReferenceError",
+	"foo instanceof SyntaxError",
+	"foo instanceof TypeError",
+	"foo instanceof URIError",
+	"foo instanceof AggregateError",
+	"foo instanceof SuppressedError",
+
+	// Collection types
+	"foo instanceof Map",
+	"foo instanceof Set",
+	"foo instanceof WeakMap",
+	"foo instanceof WeakRef",
+	"foo instanceof WeakSet",
+
+	// Arrays and Typed Arrays
+	"foo instanceof ArrayBuffer",
+	"foo instanceof Int8Array",
+	"foo instanceof Uint8Array",
+	"foo instanceof Uint8ClampedArray",
+	"foo instanceof Int16Array",
+	"foo instanceof Uint16Array",
+	"foo instanceof Int32Array",
+	"foo instanceof Uint32Array",
+	"foo instanceof Float16Array",
+	"foo instanceof Float32Array",
+	"foo instanceof Float64Array",
+	"foo instanceof BigInt64Array",
+	"foo instanceof BigUint64Array",
+
+	// Data types
+	"foo instanceof Object",
+
+	// Regular Expressions
+	"foo instanceof RegExp",
+
+	// Async and functions
+	"foo instanceof Promise",
+	"foo instanceof Proxy",
+
+	// Other
+	"foo instanceof DataView",
+	"foo instanceof Date",
+	"foo instanceof SharedArrayBuffer",
+	"foo instanceof FinalizationRegistry",
+}
+
+// TestNoInstanceofBuiltinsUpstream migrates the full valid/invalid suite from
+// upstream test/no-instanceof-builtins.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// the no_instanceof_builtins_extras_test.go file.
+func TestNoInstanceofBuiltinsUpstream(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Loose strategy valid ----
+		jsValid("fooLoose instanceof WebWorker"),
+	}
+	for _, code := range strictStrategyInvalid {
+		valid = append(valid, jsValid(strings.Replace(code, "foo", "fooLoose", 1)))
+	}
+
+	valid = append(valid,
+		// ---- Exclude the specified constructors ----
+		jsValidOptions("fooExclude instanceof Function", map[string]interface{}{"exclude": []interface{}{"Function"}}),
+		jsValidOptions("fooExclude instanceof Array", map[string]interface{}{"exclude": []interface{}{"Array"}}),
+		jsValidOptions("fooExclude instanceof String", map[string]interface{}{"exclude": []interface{}{"String"}}),
+
+		// ---- Port from no-instanceof-array valid ----
+		jsValid("Array.isArray(arr)"),
+		jsValid("arr instanceof array"),
+		jsValid("a instanceof 'array'"),
+		jsValid("a instanceof ArrayA"),
+		jsValid("a.x[2] instanceof foo()"),
+		jsValid("Array.isArray([1,2,3]) === true"),
+		jsValid(`"arr instanceof Array"`),
+	)
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- UseErrorIsError option with loose strategy ----
+		errorIsErrorInvalid("fooErr instanceof Error", "fooErr instanceof Error", "fooErr", map[string]interface{}{"useErrorIsError": true, "strategy": "loose"}),
+		errorIsErrorInvalid("(fooErr) instanceof (Error)", "(fooErr) instanceof (Error)", "(fooErr)", map[string]interface{}{"useErrorIsError": true, "strategy": "loose"}),
+	}
+
+	for _, code := range looseStrategyInvalid {
+		invalid = append(invalid, upstreamInvalid(code, nil))
+	}
+
+	for _, code := range append([]string{}, looseStrategyInvalid...) {
+		code = strings.Replace(code, "foo", "fooStrict", 1)
+		invalid = append(invalid, upstreamInvalid(code, map[string]interface{}{"strategy": "strict"}))
+	}
+	for _, code := range strictStrategyInvalid {
+		code = strings.Replace(code, "foo", "fooStrict", 1)
+		invalid = append(invalid, upstreamInvalid(code, map[string]interface{}{"strategy": "strict"}))
+	}
+
+	for _, code := range []string{
+		"err instanceof Error",
+		"err instanceof EvalError",
+		"err instanceof RangeError",
+		"err instanceof ReferenceError",
+		"err instanceof SyntaxError",
+		"err instanceof TypeError",
+		"err instanceof URIError",
+		"err instanceof AggregateError",
+		"err instanceof SuppressedError",
+	} {
+		invalid = append(invalid, upstreamInvalid(code, map[string]interface{}{"useErrorIsError": true, "strategy": "strict"}))
+	}
+
+	invalid = append(invalid,
+		// ---- Include the specified constructors ----
+		noFixInvalid("fooInclude instanceof WebWorker", "fooInclude instanceof WebWorker", map[string]interface{}{"include": []interface{}{"WebWorker"}}),
+		noFixInvalid("fooInclude instanceof HTMLElement", "fooInclude instanceof HTMLElement", map[string]interface{}{"include": []interface{}{"HTMLElement"}}),
+
+		// ---- Port from no-instanceof-array invalid ----
+		arrayInvalid("arr instanceof Array", "arr instanceof Array", "arr"),
+		arrayInvalid("[] instanceof Array", "[] instanceof Array", "[]"),
+		arrayInvalid("[1,2,3] instanceof Array === true", "[1,2,3] instanceof Array", "[1,2,3]"),
+		arrayInvalid("fun.call(1, 2, 3) instanceof Array", "fun.call(1, 2, 3) instanceof Array", "fun.call(1, 2, 3)"),
+		arrayInvalid("obj.arr instanceof Array", "obj.arr instanceof Array", "obj.arr"),
+		arrayInvalid("foo.bar[2] instanceof Array", "foo.bar[2] instanceof Array", "foo.bar[2]"),
+		arrayInvalid("(0, array) instanceof Array", "(0, array) instanceof Array", "(0, array)"),
+		arrayInvalidWithOutput(
+			"function foo(){return[]instanceof Array}",
+			"[]instanceof Array",
+			"function foo(){return Array.isArray([])}",
+		),
+		arrayInvalidWithOutput(complexArrayCase(), complexArrayTarget(), complexArrayOutput()),
+
+		// SKIP: rslint does not support vue-eslint-parser / Vue template expressions.
+		rule_tester.InvalidTestCase{Code: `<template><div v-if="array instanceof Array" v-for="element of array"></div></template>`, FileName: "file.vue", Skip: true},
+		// SKIP: rslint does not support vue-eslint-parser / Vue template expressions.
+		rule_tester.InvalidTestCase{Code: `<template><div v-if="(( (( array )) instanceof (( Array )) ))" v-for="element of array"></div></template>`, FileName: "file.vue", Skip: true},
+		// SKIP: rslint does not support vue-eslint-parser / Vue template expressions.
+		rule_tester.InvalidTestCase{Code: `<template><div>{{(( (( array )) instanceof (( Array )) )) ? array.join(" | ") : array}}</div></template>`, FileName: "file.vue", Skip: true},
+		// SKIP: rslint does not support vue-eslint-parser / Vue SFC script blocks.
+		rule_tester.InvalidTestCase{Code: `<script>const foo = array instanceof Array</script>`, FileName: "file.vue", Skip: true},
+		// SKIP: rslint does not support vue-eslint-parser / Vue SFC script blocks.
+		rule_tester.InvalidTestCase{Code: `<script>const foo = (( (( array )) instanceof (( Array )) ))</script>`, FileName: "file.vue", Skip: true},
+		// SKIP: rslint does not support vue-eslint-parser / Vue SFC script blocks.
+		rule_tester.InvalidTestCase{Code: `<script>foo instanceof Function</script>`, FileName: "file.vue", Skip: true},
+	)
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_instanceof_builtins.NoInstanceofBuiltinsRule,
+		valid,
+		invalid,
+	)
+}
+
+func upstreamInvalid(code string, options any) rule_tester.InvalidTestCase {
+	target := code
+	constructorName := constructorNameFromTarget(target)
+	switch constructorName {
+	case "Array":
+		return arrayInvalidOptions(code, target, leftFromTarget(target), options)
+	case "Function":
+		return functionInvalidOptions(code, target, leftFromTarget(target), options)
+	case "String", "Number", "Boolean", "BigInt", "Symbol":
+		return primitiveInvalidOptions(code, target, leftFromTarget(target), constructorName, options)
+	case "Error":
+		if optsMap, ok := options.(map[string]interface{}); ok {
+			if useErrorIsError, _ := optsMap["useErrorIsError"].(bool); useErrorIsError {
+				return errorIsErrorInvalid(code, target, leftFromTarget(target), options)
+			}
+		}
+		return noFixInvalid(code, target, options)
+	default:
+		return noFixInvalid(code, target, options)
+	}
+}
+
+func jsValid(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.js"}
+}
+
+func jsValidOptions(code string, options any) rule_tester.ValidTestCase {
+	testCase := jsValid(code)
+	testCase.Options = options
+	return testCase
+}
+
+func noFixInvalid(code string, target string, options any) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Options:  options,
+		Errors:   []rule_tester.InvalidTestCaseError{expectedError(code, target)},
+	}
+}
+
+func arrayInvalid(code string, target string, left string) rule_tester.InvalidTestCase {
+	return arrayInvalidOptions(code, target, left, nil)
+}
+
+func arrayInvalidOptions(code string, target string, left string, options any) rule_tester.InvalidTestCase {
+	output := replaceFirst(code, target, "Array.isArray("+left+")")
+	return arrayInvalidWithOutputOptions(code, target, output, options)
+}
+
+func arrayInvalidWithOutput(code string, target string, output string) rule_tester.InvalidTestCase {
+	return arrayInvalidWithOutputOptions(code, target, output, nil)
+}
+
+func arrayInvalidWithOutputOptions(code string, target string, output string, options any) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Options:  options,
+		Output:   []string{output},
+		Errors:   []rule_tester.InvalidTestCaseError{expectedError(code, target)},
+	}
+}
+
+func functionInvalidOptions(code string, target string, left string, options any) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Options:  options,
+		Output:   []string{replaceFirst(code, target, "typeof "+left+" === 'function'")},
+		Errors:   []rule_tester.InvalidTestCaseError{expectedError(code, target)},
+	}
+}
+
+func errorIsErrorInvalid(code string, target string, left string, options any) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Options:  options,
+		Output:   []string{replaceFirst(code, target, "Error.isError("+left+")")},
+		Errors:   []rule_tester.InvalidTestCaseError{expectedError(code, target)},
+	}
+}
+
+func primitiveInvalidOptions(code string, target string, left string, constructorName string, options any) rule_tester.InvalidTestCase {
+	typeName := strings.ToLower(constructorName)
+	err := expectedError(code, target)
+	err.Suggestions = []rule_tester.InvalidTestCaseSuggestion{{
+		MessageId: messageIDSwitchToTypeOf,
+		Output:    replaceFirst(code, target, "typeof "+left+" === '"+typeName+"'"),
+	}}
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Options:  options,
+		Errors:   []rule_tester.InvalidTestCaseError{err},
+	}
+}
+
+func expectedError(code string, target string) rule_tester.InvalidTestCaseError {
+	start := strings.Index(code, target)
+	if start < 0 {
+		panic(fmt.Sprintf("target %q not found in %q", target, code))
+	}
+	end := start + len(target)
+	line, column := lineColumnForOffset(code, start)
+	endLine, endColumn := lineColumnForOffset(code, end)
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageIDNoInstanceofBuiltins,
+		Message:   messageNoInstanceofBuiltins,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func lineColumnForOffset(code string, offset int) (int, int) {
+	line := 1
+	column := 1
+	for i := 0; i < offset; i++ {
+		switch code[i] {
+		case '\n':
+			line++
+			column = 1
+		case '\r':
+			line++
+			column = 1
+			if i+1 < offset && code[i+1] == '\n' {
+				i++
+			}
+		default:
+			column++
+		}
+	}
+	return line, column
+}
+
+func replaceFirst(code string, target string, replacement string) string {
+	index := strings.Index(code, target)
+	if index < 0 {
+		panic(fmt.Sprintf("target %q not found in %q", target, code))
+	}
+	return code[:index] + replacement + code[index+len(target):]
+}
+
+func constructorNameFromTarget(target string) string {
+	index := strings.LastIndex(target, "instanceof")
+	if index < 0 {
+		panic(fmt.Sprintf("instanceof not found in %q", target))
+	}
+	right := strings.TrimSpace(target[index+len("instanceof"):])
+	right = strings.Trim(right, "()")
+	return strings.TrimSpace(right)
+}
+
+func leftFromTarget(target string) string {
+	index := strings.LastIndex(target, "instanceof")
+	if index < 0 {
+		panic(fmt.Sprintf("instanceof not found in %q", target))
+	}
+	return strings.TrimSpace(target[:index])
+}
+
+func complexArrayCase() string {
+	return lines(
+		"(",
+		"\t// comment",
+		"\t((",
+		"\t\t// comment",
+		"\t\t(",
+		"\t\t\t// comment",
+		"\t\t\tfoo",
+		"\t\t\t// comment",
+		"\t\t)",
+		"\t\t// comment",
+		"\t))",
+		"\t// comment",
+		")",
+		"// comment before instanceof\r      instanceof",
+		"",
+		"// comment after instanceof",
+		"",
+		"(",
+		"\t// comment",
+		"",
+		"\t(",
+		"",
+		"\t\t// comment",
+		"",
+		"\t\tArray",
+		"",
+		"\t\t// comment",
+		"\t)",
+		"",
+		"\t\t// comment",
+		")",
+		"",
+		"\t// comment",
+	)
+}
+
+func complexArrayTarget() string {
+	code := complexArrayCase()
+	return strings.TrimSuffix(code, "\n\n\t// comment")
+}
+
+func complexArrayOutput() string {
+	left := lines(
+		"(",
+		"\t// comment",
+		"\t((",
+		"\t\t// comment",
+		"\t\t(",
+		"\t\t\t// comment",
+		"\t\t\tfoo",
+		"\t\t\t// comment",
+		"\t\t)",
+		"\t\t// comment",
+		"\t))",
+		"\t// comment",
+		")",
+	)
+	return lines(
+		"Array.isArray("+left+")",
+		"// comment before instanceof\r",
+		"",
+		"// comment after instanceof",
+		"",
+		"\t// comment",
+		"",
+		"",
+		"\t\t// comment",
+		"",
+		"",
+		"\t\t// comment",
+		"",
+		"",
+		"\t\t// comment",
+		"",
+		"",
+		"\t// comment",
+	)
+}
+
+func lines(parts ...string) string {
+	return strings.Join(parts, "\n")
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -529,6 +529,7 @@ export default defineConfig({
     // eslint-plugin-unicorn
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',
+    './tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-static-only-class.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-thenable.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/no-instanceof-builtins.test.ts
@@ -1,0 +1,164 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const lines = (...parts: string[]) => parts.join('\n');
+const js = (code: string) => ({ code, filename: 'file.js' });
+const invalid = (code: string, options?: Record<string, unknown>) => ({
+  ...js(code),
+  ...(options ? { options: [options] } : {}),
+  errors: [
+    {
+      message:
+        'Avoid using `instanceof` for type checking as it can lead to unreliable results.',
+    },
+  ],
+});
+
+const looseStrategyInvalid = [
+  'foo instanceof String',
+  'foo instanceof Number',
+  'foo instanceof Boolean',
+  'foo instanceof BigInt',
+  'foo instanceof Symbol',
+  'foo instanceof Function',
+  'foo instanceof Array',
+];
+
+const strictStrategyInvalid = [
+  'foo instanceof Error',
+  'foo instanceof EvalError',
+  'foo instanceof RangeError',
+  'foo instanceof ReferenceError',
+  'foo instanceof SyntaxError',
+  'foo instanceof TypeError',
+  'foo instanceof URIError',
+  'foo instanceof AggregateError',
+  'foo instanceof SuppressedError',
+  'foo instanceof Map',
+  'foo instanceof Set',
+  'foo instanceof WeakMap',
+  'foo instanceof WeakRef',
+  'foo instanceof WeakSet',
+  'foo instanceof ArrayBuffer',
+  'foo instanceof Int8Array',
+  'foo instanceof Uint8Array',
+  'foo instanceof Uint8ClampedArray',
+  'foo instanceof Int16Array',
+  'foo instanceof Uint16Array',
+  'foo instanceof Int32Array',
+  'foo instanceof Uint32Array',
+  'foo instanceof Float16Array',
+  'foo instanceof Float32Array',
+  'foo instanceof Float64Array',
+  'foo instanceof BigInt64Array',
+  'foo instanceof BigUint64Array',
+  'foo instanceof Object',
+  'foo instanceof RegExp',
+  'foo instanceof Promise',
+  'foo instanceof Proxy',
+  'foo instanceof DataView',
+  'foo instanceof Date',
+  'foo instanceof SharedArrayBuffer',
+  'foo instanceof FinalizationRegistry',
+];
+
+ruleTester.run('no-instanceof-builtins', undefined as never, {
+  valid: [
+    js('fooLoose instanceof WebWorker'),
+    ...strictStrategyInvalid.map((code) => js(code.replace('foo', 'fooLoose'))),
+    {
+      ...js('fooExclude instanceof Function'),
+      options: [{ exclude: ['Function'] }],
+    },
+    {
+      ...js('fooExclude instanceof Array'),
+      options: [{ exclude: ['Array'] }],
+    },
+    {
+      ...js('fooExclude instanceof String'),
+      options: [{ exclude: ['String'] }],
+    },
+    js('Array.isArray(arr)'),
+    js('arr instanceof array'),
+    js("a instanceof 'array'"),
+    js('a instanceof ArrayA'),
+    js('a.x[2] instanceof foo()'),
+    js('Array.isArray([1,2,3]) === true'),
+    js('"arr instanceof Array"'),
+  ],
+  invalid: [
+    ...looseStrategyInvalid.map((code) => invalid(code)),
+    ...[...looseStrategyInvalid, ...strictStrategyInvalid].map((code) =>
+      invalid(code.replace('foo', 'fooStrict'), { strategy: 'strict' }),
+    ),
+    invalid('fooErr instanceof Error', {
+      useErrorIsError: true,
+      strategy: 'loose',
+    }),
+    invalid('(fooErr) instanceof (Error)', {
+      useErrorIsError: true,
+      strategy: 'loose',
+    }),
+    ...[
+      'err instanceof Error',
+      'err instanceof EvalError',
+      'err instanceof RangeError',
+      'err instanceof ReferenceError',
+      'err instanceof SyntaxError',
+      'err instanceof TypeError',
+      'err instanceof URIError',
+      'err instanceof AggregateError',
+      'err instanceof SuppressedError',
+    ].map((code) =>
+      invalid(code, { useErrorIsError: true, strategy: 'strict' }),
+    ),
+    invalid('fooInclude instanceof WebWorker', { include: ['WebWorker'] }),
+    invalid('fooInclude instanceof HTMLElement', { include: ['HTMLElement'] }),
+    invalid('arr instanceof Array'),
+    invalid('[] instanceof Array'),
+    invalid('[1,2,3] instanceof Array === true'),
+    invalid('fun.call(1, 2, 3) instanceof Array'),
+    invalid('obj.arr instanceof Array'),
+    invalid('foo.bar[2] instanceof Array'),
+    invalid('(0, array) instanceof Array'),
+    invalid('function foo(){return[]instanceof Array}'),
+    invalid(
+      lines(
+        '(',
+        '\t// comment',
+        '\t((',
+        '\t\t// comment',
+        '\t\t(',
+        '\t\t\t// comment',
+        '\t\t\tfoo',
+        '\t\t\t// comment',
+        '\t\t)',
+        '\t\t// comment',
+        '\t))',
+        '\t// comment',
+        ')',
+        '// comment before instanceof\r      instanceof',
+        '',
+        '// comment after instanceof',
+        '',
+        '(',
+        '\t// comment',
+        '',
+        '\t(',
+        '',
+        '\t\t// comment',
+        '',
+        '\t\tArray',
+        '',
+        '\t\t// comment',
+        '\t)',
+        '',
+        '\t\t// comment',
+        ')',
+        '',
+        '\t// comment',
+      ),
+    ),
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `unicorn/no-instanceof-builtins` rule to rslint.

The rule reports unreliable `instanceof` checks against built-in constructors and provides fixes or suggestions for supported cases such as `Array`, `Function`, primitive wrappers, and `Error.isError` when configured.

## Related Links

- Unicorn rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-instanceof-builtins.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/no-instanceof-builtins.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).