### PR TITLE
fix: align explicit config base with cwd

### DIFF
--- a/packages/rslint/src/utils/config-discovery.ts
+++ b/packages/rslint/src/utils/config-discovery.ts
@@ -76,15 +76,20 @@ export async function discoverConfigs(
   // Map: configPath -> configDirectory
   const configs = new Map<string, string>();
 
-  const addConfig = (configPath: string): void => {
+  const addConfig = (
+    configPath: string,
+    configDirectory = path.dirname(configPath),
+  ): void => {
     if (!configs.has(configPath)) {
-      configs.set(configPath, path.dirname(configPath));
+      configs.set(configPath, configDirectory);
     }
   };
 
   if (explicitConfig) {
     const resolved = path.resolve(cwd, explicitConfig);
-    addConfig(resolved);
+    // Explicit --config follows ESLint flat config semantics: files, ignores,
+    // and project patterns resolve from the invocation cwd.
+    addConfig(resolved, cwd);
     return configs;
   }
 

--- a/packages/rslint/tests/config-discovery.test.ts
+++ b/packages/rslint/tests/config-discovery.test.ts
@@ -34,19 +34,18 @@ describe('discoverConfigs', () => {
     }
   });
 
-  test('explicit config overrides discovery', async () => {
+  test('explicit config overrides discovery and uses cwd as configDirectory', async () => {
     const tmp = createTempDir();
-    const configFile = path.join(tmp, 'custom.config.js');
+    const cwd = path.join(tmp, 'project');
+    const configDir = path.join(tmp, 'wrapper');
+    const configFile = path.join(configDir, 'custom.config.js');
     try {
+      fs.mkdirSync(cwd);
+      fs.mkdirSync(configDir);
+      fs.writeFileSync(path.join(cwd, 'rslint.config.js'), 'export default []');
       fs.writeFileSync(configFile, 'export default []');
-      const result = await discoverConfigs(
-        ['/some/file.ts'],
-        ['/some/dir'],
-        tmp,
-        configFile,
-      );
-      expect(result.size).toBe(1);
-      expect([...result.keys()][0]).toBe(configFile);
+      const result = await discoverConfigs([], [], cwd, configFile);
+      expect([...result]).toEqual([[configFile, cwd]]);
     } finally {
       cleanup(tmp);
     }

--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -60,6 +60,10 @@ You can also specify a config file explicitly (overrides automatic discovery):
 rslint --config path/to/rslint.config.ts .
 ```
 
+For automatically discovered configs, relative `files`, `ignores`, and `languageOptions.parserOptions.project` patterns are resolved from the config file's directory.
+
+For a config supplied with `--config`, those patterns are resolved from the current working directory.
+
 To generate a default config, run:
 
 ```bash


### PR DESCRIPTION
## Summary

This PR aligns explicit `--config` handling with ESLint flat config behavior: automatically discovered configs keep resolving relative `files`, `ignores`, and `languageOptions.parserOptions.project` patterns from the config file directory, while configs supplied via `--config` resolve those patterns from the invocation cwd.

The change keeps normal config discovery unchanged, updates the explicit-config discovery test, and documents the base-path difference for users.

## Related Links

- https://eslint.org/docs/latest/use/configure/configuration-files#specify-files-and-ignores
- https://github.com/eslint/eslint/issues/15683
- https://github.com/eslint/eslint/pull/16149
- https://eslint.org/docs/latest/use/migrating-to-7.0.0#the-base-path-of-overrides-and-ignorepatterns-has-changed-when-using-the-configignore-path-options

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
