### PR TITLE
feat: port rule max-params

### DIFF
--- a/internal/plugins/typescript/rules/max_params/max_params.go
+++ b/internal/plugins/typescript/rules/max_params/max_params.go
@@ -2,7 +2,6 @@ package max_params
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -32,7 +31,7 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 	check := func(node *ast.Node) {
 		params := node.Parameters()
 		effective := len(params)
-		if !opts.countVoidThis && len(params) > 0 && isThisVoidParam(params[0]) {
+		if !opts.countVoidThis && utils.IsThisVoidParameter(ast.GetThisParameter(node)) {
 			effective--
 		}
 		if effective <= opts.max {
@@ -67,17 +66,6 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 	}
 }
 
-// isThisVoidParam reports whether `p` is a `this: void` parameter, which
-// the typescript-eslint rule strips from the parameter list before counting
-// (unless `countVoidThis: true`).
-func isThisVoidParam(p *ast.Node) bool {
-	if !ast.IsThisParameter(p) {
-		return false
-	}
-	t := p.Type()
-	return t != nil && t.Kind == ast.KindVoidKeyword
-}
-
 // parseOptions mirrors @typescript-eslint/max-params' schema: a single
 // optional object with `max`, `maximum`, and `countVoidThis`. Other shapes
 // (bare integer, integer-in-array) fall through to defaults — upstream
@@ -87,34 +75,15 @@ func isThisVoidParam(p *ast.Node) bool {
 // `option.maximum || option.max` follows JS truthy coercion: a present-but-
 // zero `maximum` falls through to `max`; a present-but-falsy value with no
 // fallback leaves `numParams = undefined` upstream, which makes every
-// `count > undefined` comparison false (effectively disabling the rule).
-// We model that case with MaxInt.
+// `count > undefined` comparison false. The shared legacy max helper models
+// that disabled state with MaxInt.
 func parseOptions(o any) ruleOptions {
 	out := ruleOptions{max: defaultMax}
 	m := utils.GetOptionsMap(o)
 	if m == nil {
 		return out
 	}
-	_, hasMaximum := m["maximum"]
-	_, hasMax := m["max"]
-	if hasMaximum || hasMax {
-		hasNum := false
-		if hasMaximum {
-			if n, ok := utils.CoerceInt(m["maximum"]); ok && n != 0 {
-				out.max = n
-				hasNum = true
-			}
-		}
-		if !hasNum && hasMax {
-			if n, ok := utils.CoerceInt(m["max"]); ok {
-				out.max = n
-				hasNum = true
-			}
-		}
-		if !hasNum {
-			out.max = math.MaxInt
-		}
-	}
+	out.max = utils.ResolveLegacyMaxOption(m, defaultMax)
 	if v, ok := m["countVoidThis"]; ok {
 		if b, ok := v.(bool); ok {
 			out.countVoidThis = b
@@ -122,4 +91,3 @@ func parseOptions(o any) ruleOptions {
 	}
 	return out
 }
-

--- a/internal/plugins/typescript/rules/unbound_method/unbound_method.go
+++ b/internal/plugins/typescript/rules/unbound_method/unbound_method.go
@@ -144,11 +144,9 @@ var supportedGlobalTypes = []string{
 }
 
 func checkMethod(valueDeclaration *ast.Node, ignoreStatic bool) ( /* dangerous */ bool /* firstParamIsThis */, bool) {
-	params := valueDeclaration.Parameters()
-
-	firstParamIsThis := len(params) > 0 && ast.IsParameterDeclaration(params[0]) && ast.IsIdentifier(params[0].Name()) && params[0].Name().Text() == "this"
-
-	thisArgIsVoid := firstParamIsThis && params[0].Type().Kind == ast.KindVoidKeyword
+	thisParam := ast.GetThisParameter(valueDeclaration)
+	firstParamIsThis := thisParam != nil
+	thisArgIsVoid := utils.IsThisVoidParameter(thisParam)
 
 	dangerous := !thisArgIsVoid && (!ignoreStatic || !utils.IncludesModifier(valueDeclaration, ast.KindStaticKeyword))
 

--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -18,6 +18,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/max_lines"
 	"github.com/web-infra-dev/rslint/internal/rules/max_lines_per_function"
 	"github.com/web-infra-dev/rslint/internal/rules/max_nested_callbacks"
+	"github.com/web-infra-dev/rslint/internal/rules/max_params"
 	"github.com/web-infra-dev/rslint/internal/rules/no_alert"
 	"github.com/web-infra-dev/rslint/internal/rules/no_async_promise_executor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_await_in_loop"
@@ -155,6 +156,7 @@ func GetAllRules() []rule.Rule {
 		max_lines.MaxLinesRule,
 		max_lines_per_function.MaxLinesPerFunctionRule,
 		max_nested_callbacks.MaxNestedCallbacksRule,
+		max_params.MaxParamsRule,
 		no_alert.NoAlertRule,
 		no_async_promise_executor.NoAsyncPromiseExecutorRule,
 		no_await_in_loop.NoAwaitInLoopRule,

--- a/internal/rules/complexity/complexity.go
+++ b/internal/rules/complexity/complexity.go
@@ -2,7 +2,6 @@ package complexity
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
@@ -80,7 +79,7 @@ var ComplexityRule = rule.Rule{
 			}
 			delete(counters, node)
 			if complexity > threshold {
-				name := utils.UpperCaseFirstASCII(getFunctionNameWithKind(node))
+				name := utils.UpperCaseFirstASCII(utils.GetFunctionNameWithKindCore(node))
 				loc := utils.GetFunctionHeadLoc(ctx.SourceFile, node)
 				ctx.ReportRange(loc, makeMessage(name, complexity, threshold))
 			}
@@ -243,184 +242,6 @@ func makeMessage(name string, complexity, threshold int) rule.RuleMessage {
 			name, complexity, threshold,
 		),
 	}
-}
-
-// getFunctionNameWithKind mirrors ESLint's astUtils.getFunctionNameWithKind
-// EXACTLY — used here in preference to utils.GetFunctionNameWithKind because
-// the shared helper resolves names through VariableDeclaration parents
-// (producing strings like "function 'func'" for `var func = function () {}`),
-// while ESLint's complexity rule expects the bare "function" form. Other
-// rslint rules accept the broader name resolution; the complexity rule's test
-// suite locks in ESLint's narrower behavior.
-func getFunctionNameWithKind(node *ast.Node) string {
-	// Constructor short-circuit (matches ESLint). A KindConstructor is always
-	// declared inside a class body in valid TS, so a single unconditional
-	// check covers every case.
-	if node.Kind == ast.KindConstructor {
-		return "constructor"
-	}
-
-	parent := node.Parent
-	if parent == nil {
-		return "function"
-	}
-
-	tokens := []string{}
-
-	// Modifier prefixes (static / private) — only meaningful on class
-	// members. ESLint reads them off MethodDefinition / PropertyDefinition.
-	// Object-method shorthand (`{ foo() {} }`) inherits the "method"
-	// classification but never carries static / private modifiers.
-	isClassMember := isDirectClassMember(node)
-	isClassFieldValue := isClassFieldInitializer(node)
-	if isClassMember || isClassFieldValue {
-		owner := node
-		if isClassFieldValue {
-			owner = parent
-		}
-		if ast.HasSyntacticModifier(owner, ast.ModifierFlagsStatic) {
-			tokens = append(tokens, "static")
-		}
-		if name := owner.Name(); name != nil && name.Kind == ast.KindPrivateIdentifier {
-			tokens = append(tokens, "private")
-		}
-	}
-
-	flags := ast.GetFunctionFlags(node)
-	if flags&ast.FunctionFlagsAsync != 0 {
-		tokens = append(tokens, "async")
-	}
-	if flags&ast.FunctionFlagsGenerator != 0 {
-		tokens = append(tokens, "generator")
-	}
-
-	// Function-kind word. `MethodDeclaration` covers both class methods and
-	// object-method shorthand (`{ foo() {} }`) in tsgo, so it always
-	// classifies as "method". Object methods written with the `key: value`
-	// form (`{ foo: function () {} }` or `{ foo: () => {} }`) reach this
-	// switch as a FunctionExpression / ArrowFunction whose parent is a
-	// PropertyAssignment — also classified as "method" to match ESLint.
-	switch {
-	case node.Kind == ast.KindGetAccessor:
-		tokens = append(tokens, "getter")
-	case node.Kind == ast.KindSetAccessor:
-		tokens = append(tokens, "setter")
-	case node.Kind == ast.KindMethodDeclaration:
-		tokens = append(tokens, "method")
-	case parent.Kind == ast.KindPropertyAssignment:
-		tokens = append(tokens, "method")
-	case isClassFieldValue:
-		tokens = append(tokens, "method")
-	case node.Kind == ast.KindArrowFunction:
-		tokens = append(tokens, "arrow", "function")
-	default:
-		tokens = append(tokens, "function")
-	}
-
-	// Name resolution. ESLint only reads the name from the property key
-	// when the parent is Property / MethodDefinition / PropertyDefinition,
-	// or from `node.id` for plain function declarations / expressions.
-	// Notably, it does NOT walk up to a VariableDeclaration to recover a
-	// variable binding name — `var f = function () {}` reports as
-	// "function" without the "f".
-	//
-	// Object-method shorthand (`{ foo() {} }`) lives in tsgo as a
-	// MethodDeclaration whose parent is the ObjectLiteralExpression itself
-	// (no intermediate Property node), so we read the name off the method
-	// declaration directly when the kind is MethodDeclaration.
-	switch {
-	case parent.Kind == ast.KindPropertyAssignment:
-		// `{ foo: function () {} }` / `{ foo: () => {} }` — name lives on
-		// the property assignment.
-		appendNameFromOwner(&tokens, parent, node)
-	case isClassFieldValue:
-		appendNameFromOwner(&tokens, parent, node)
-	case node.Kind == ast.KindMethodDeclaration ||
-		node.Kind == ast.KindGetAccessor ||
-		node.Kind == ast.KindSetAccessor:
-		// Class methods/accessors AND object-literal method shorthand /
-		// getter / setter — name lives on the node itself in tsgo (no
-		// intermediate Property node).
-		appendNameFromOwner(&tokens, node, node)
-	default:
-		if id := nodeIdentifier(node); id != "" {
-			tokens = append(tokens, fmt.Sprintf("'%s'", id))
-		}
-	}
-
-	return joinTokens(tokens)
-}
-
-// appendNameFromOwner mirrors ESLint's name-resolution preference order
-// inside getFunctionNameWithKind: prefer the property key (private identifier
-// → static-name → empty), and fall back to `node.id` only for nameless
-// FunctionExpressions on a Property.
-func appendNameFromOwner(tokens *[]string, owner *ast.Node, node *ast.Node) {
-	if name := owner.Name(); name != nil {
-		if name.Kind == ast.KindPrivateIdentifier {
-			*tokens = append(*tokens, fmt.Sprintf("'%s'", name.AsPrivateIdentifier().Text))
-			return
-		}
-		if s, ok := utils.GetStaticPropertyName(name); ok {
-			*tokens = append(*tokens, fmt.Sprintf("'%s'", s))
-			return
-		}
-	}
-	if id := nodeIdentifier(node); id != "" {
-		*tokens = append(*tokens, fmt.Sprintf("'%s'", id))
-	}
-}
-
-// nodeIdentifier returns the identifier on the function node itself
-// (`node.id` in ESTree), or the empty string when there is none.
-func nodeIdentifier(node *ast.Node) string {
-	switch node.Kind {
-	case ast.KindFunctionDeclaration:
-		if n := node.AsFunctionDeclaration().Name(); n != nil && n.Kind == ast.KindIdentifier {
-			return n.AsIdentifier().Text
-		}
-	case ast.KindFunctionExpression:
-		if n := node.AsFunctionExpression().Name(); n != nil && n.Kind == ast.KindIdentifier {
-			return n.AsIdentifier().Text
-		}
-	}
-	return ""
-}
-
-// isDirectClassMember reports whether the function-like node is a method /
-// accessor whose parent is the enclosing class (not its initializer).
-func isDirectClassMember(node *ast.Node) bool {
-	parent := node.Parent
-	if parent == nil {
-		return false
-	}
-	if parent.Kind != ast.KindClassDeclaration && parent.Kind != ast.KindClassExpression {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
-		return true
-	}
-	return false
-}
-
-// isClassFieldInitializer reports whether the function-like node is the
-// direct initializer of a class field (e.g. `class C { x = () => {} }`).
-// Mirrors ESLint's `parent.type === "PropertyDefinition" && parent.value === node`.
-func isClassFieldInitializer(node *ast.Node) bool {
-	parent := node.Parent
-	if parent == nil || parent.Kind != ast.KindPropertyDeclaration {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindArrowFunction, ast.KindFunctionExpression:
-		return parent.AsPropertyDeclaration().Initializer == node
-	}
-	return false
-}
-
-func joinTokens(tokens []string) string {
-	return strings.Join(tokens, " ")
 }
 
 // parseOptions extracts the threshold and modified-variant flag from the

--- a/internal/rules/max_depth/max_depth.go
+++ b/internal/rules/max_depth/max_depth.go
@@ -2,7 +2,6 @@ package max_depth
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -120,54 +119,9 @@ func buildTooDeeplyMessage(depth, maxDepth int) rule.RuleMessage {
 	}
 }
 
-// parseMaxDepth resolves the configured maximum depth, mirroring ESLint's
-// `option.maximum || option.max` coercion. The legacy `maximum` key is honored
-// only when truthy (matching JS coercion); otherwise `max` wins. When neither
-// key is present, the default is 4.
+// parseMaxDepth resolves the configured maximum depth. max-depth shares
+// ESLint's legacy `maximum || max` option behavior with several max-* rules.
 func parseMaxDepth(options any) int {
 	const defaultMax = 4
-	if options == nil {
-		return defaultMax
-	}
-	// Number form: `3` or `[3]`.
-	if arr, ok := options.([]interface{}); ok {
-		if len(arr) == 0 {
-			return defaultMax
-		}
-		if n, ok := utils.CoerceInt(arr[0]); ok {
-			return n
-		}
-	} else if n, ok := utils.CoerceInt(options); ok {
-		return n
-	}
-	// Object form: `{ max: 3 }` or `[{ max: 3 }]`. Use the shared extractor so
-	// both the array-wrapped (rule_tester / multi-element CLI) and bare-object
-	// (single-option CLI) shapes are handled uniformly.
-	m := utils.GetOptionsMap(options)
-	if m == nil {
-		return defaultMax
-	}
-	_, hasMaximum := m["maximum"]
-	_, hasMax := m["max"]
-	if !hasMaximum && !hasMax {
-		// Matches ESLint: when neither key is present, the option object is
-		// ignored and the default is used.
-		return defaultMax
-	}
-	if hasMaximum {
-		if v, ok := utils.CoerceInt(m["maximum"]); ok && v != 0 {
-			return v
-		}
-	}
-	if hasMax {
-		if v, ok := utils.CoerceInt(m["max"]); ok {
-			return v
-		}
-	}
-	// `option.maximum` is present but coerces to 0 / non-numeric, and
-	// `option.max` is absent or non-numeric: ESLint sets `maxDepth = undefined`
-	// here, which makes every `len > maxDepth` comparison false and effectively
-	// disables the check. MaxInt produces the same observable behavior.
-	return math.MaxInt
+	return utils.ResolveLegacyMaxOption(options, defaultMax)
 }
-

--- a/internal/rules/max_nested_callbacks/max_nested_callbacks.go
+++ b/internal/rules/max_nested_callbacks/max_nested_callbacks.go
@@ -2,7 +2,6 @@ package max_nested_callbacks
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -86,54 +85,9 @@ func buildExceedMessage(num, threshold int) rule.RuleMessage {
 	}
 }
 
-// parseThreshold resolves the configured maximum nesting depth, mirroring
-// ESLint's `option.maximum || option.max` coercion. The legacy `maximum` key
-// is honored only when truthy (matching JS coercion); otherwise `max` wins.
-// When neither key is present, the default is 10.
+// parseThreshold resolves the configured maximum nesting depth. This rule uses
+// the same legacy `maximum || max` option behavior as other max-* core rules.
 func parseThreshold(options any) int {
 	const defaultMax = 10
-	if options == nil {
-		return defaultMax
-	}
-	// Number form: `3` or `[3]`.
-	if arr, ok := options.([]interface{}); ok {
-		if len(arr) == 0 {
-			return defaultMax
-		}
-		if n, ok := utils.CoerceInt(arr[0]); ok {
-			return n
-		}
-	} else if n, ok := utils.CoerceInt(options); ok {
-		return n
-	}
-	// Object form: `{ max: 3 }` or `[{ max: 3 }]`. Use the shared extractor so
-	// both the array-wrapped (rule_tester / multi-element CLI) and bare-object
-	// (single-option CLI) shapes are handled uniformly.
-	m := utils.GetOptionsMap(options)
-	if m == nil {
-		return defaultMax
-	}
-	_, hasMaximum := m["maximum"]
-	_, hasMax := m["max"]
-	if !hasMaximum && !hasMax {
-		// Matches ESLint: when neither key is present, the option object is
-		// ignored and the default is used.
-		return defaultMax
-	}
-	if hasMaximum {
-		if v, ok := utils.CoerceInt(m["maximum"]); ok && v != 0 {
-			return v
-		}
-	}
-	if hasMax {
-		if v, ok := utils.CoerceInt(m["max"]); ok {
-			return v
-		}
-	}
-	// `option.maximum` is present but coerces to 0 / non-numeric, and
-	// `option.max` is absent or non-numeric: ESLint sets `THRESHOLD = undefined`
-	// here, which makes every `length > THRESHOLD` comparison false and
-	// effectively disables the check. MaxInt produces the same observable
-	// behavior.
-	return math.MaxInt
+	return utils.ResolveLegacyMaxOption(options, defaultMax)
 }

--- a/internal/rules/max_params/max_params.go
+++ b/internal/rules/max_params/max_params.go
@@ -1,0 +1,99 @@
+package max_params
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// MaxParamsRule enforces a maximum number of parameters in function definitions.
+// https://eslint.org/docs/latest/rules/max-params
+var MaxParamsRule = rule.Rule{
+	Name: "max-params",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		check := func(node *ast.Node) {
+			params := node.Parameters()
+			effective := len(params)
+			if thisParam := ast.GetThisParameter(node); thisParam != nil {
+				switch opts.countThis {
+				case countThisNever:
+					effective--
+				case countThisExceptVoid:
+					if utils.IsThisVoidParameter(thisParam) {
+						effective--
+					}
+				}
+			}
+			if effective <= opts.max {
+				return
+			}
+
+			name := utils.UpperCaseFirstASCII(utils.GetFunctionNameWithKindCore(node))
+			ctx.ReportRange(
+				utils.GetFunctionHeadLoc(ctx.SourceFile, node),
+				rule.RuleMessage{
+					Id: "exceed",
+					Description: fmt.Sprintf(
+						"%s has too many parameters (%d). Maximum allowed is %d.",
+						name, effective, opts.max,
+					),
+				},
+			)
+		}
+
+		// ESLint listens for FunctionExpression, which covers methods,
+		// constructors, getters, and setters through ESTree's wrapper nodes.
+		// tsgo represents those function-likes directly, so each kind is wired.
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration: check,
+			ast.KindFunctionExpression:  check,
+			ast.KindArrowFunction:       check,
+			ast.KindMethodDeclaration:   check,
+			ast.KindConstructor:         check,
+			ast.KindGetAccessor:         check,
+			ast.KindSetAccessor:         check,
+			ast.KindFunctionType:        check,
+		}
+	},
+}
+
+const (
+	defaultMax          = 3
+	countThisAlways     = "always"
+	countThisNever      = "never"
+	countThisExceptVoid = "except-void"
+)
+
+type ruleOptions struct {
+	max       int
+	countThis string
+}
+
+// parseOptions keeps max parsing in a shared helper; only countThis /
+// countVoidThis are specific to this rule.
+func parseOptions(options any) ruleOptions {
+	out := ruleOptions{
+		max:       utils.ResolveLegacyMaxOption(options, defaultMax),
+		countThis: countThisExceptVoid,
+	}
+	m := utils.GetOptionsMap(options)
+	if m == nil {
+		return out
+	}
+
+	if v, ok := m["countThis"].(string); ok && v != "" {
+		out.countThis = v
+	} else if v, ok := m["countVoidThis"]; ok {
+		if b, ok := v.(bool); ok && b {
+			out.countThis = countThisAlways
+		} else {
+			out.countThis = countThisExceptVoid
+		}
+	}
+
+	return out
+}

--- a/internal/rules/max_params/max_params.md
+++ b/internal/rules/max_params/max_params.md
@@ -1,0 +1,105 @@
+# max-params
+
+## Rule Details
+
+This rule enforces a maximum number of parameters allowed in function
+definitions.
+
+Examples of **incorrect** code for this rule with the default `{ "max": 3 }`
+option:
+
+```javascript
+function foo1(bar, baz, qux, qxx) {
+  doSomething();
+}
+
+let foo2 = (bar, baz, qux, qxx) => {
+  doSomething();
+};
+```
+
+Examples of **correct** code for this rule with the default `{ "max": 3 }`
+option:
+
+```javascript
+function foo1(bar, baz, qux) {
+  doSomething();
+}
+
+let foo2 = (bar, baz, qux) => {
+  doSomething();
+};
+```
+
+## Options
+
+This rule accepts a number (the maximum allowed) or an object with the
+following properties:
+
+- `max` (default `3`): the maximum number of parameters allowed.
+- `countThis` (default `"except-void"`): TypeScript-only handling for `this`
+  declarations. Use `"always"` to count `this`, `"never"` to ignore it, or
+  `"except-void"` to ignore only `this: void`.
+- `maximum`: deprecated alias for `max`. When both keys are present and
+  `maximum` is truthy, `maximum` wins (matching ESLint's
+  `option.maximum || option.max` coercion).
+- `countVoidThis`: deprecated alias for `countThis`. `true` maps to
+  `"always"` and `false` maps to `"except-void"`.
+
+### `max`
+
+Examples of **incorrect** code for this rule with `{ "max": 2 }`:
+
+```json
+{ "max-params": ["error", { "max": 2 }] }
+```
+
+```javascript
+function foo(bar, baz, qux) {
+  doSomething();
+}
+```
+
+Examples of **correct** code for this rule with `{ "max": 2 }`:
+
+```json
+{ "max-params": ["error", { "max": 2 }] }
+```
+
+```javascript
+function foo(bar, baz) {
+  doSomething();
+}
+```
+
+### `countThis`
+
+Examples of **correct** TypeScript code for this rule with
+`{ "max": 2, "countThis": "never" }`:
+
+```json
+{ "max-params": ["error", { "max": 2, "countThis": "never" }] }
+```
+
+```typescript
+function hasThis(this: unknown[], first: string, second: string) {
+  doSomething();
+}
+```
+
+Examples of **incorrect** TypeScript code for this rule with
+`{ "max": 2, "countThis": "always" }`:
+
+```json
+{ "max-params": ["error", { "max": 2, "countThis": "always" }] }
+```
+
+```typescript
+function hasThis(this: void, first: string, second: string) {
+  doSomething();
+}
+```
+
+## Original Documentation
+
+- [https://eslint.org/docs/latest/rules/max-params](https://eslint.org/docs/latest/rules/max-params)

--- a/internal/rules/max_params/max_params_extras_test.go
+++ b/internal/rules/max_params/max_params_extras_test.go
@@ -1,0 +1,302 @@
+package max_params
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestMaxParamsExtras locks in branches and edge shapes that the upstream test suite doesn't exercise.
+// Each case carries an inline comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future refactors can't silently regress them without breaking a named lock-in.
+func TestMaxParamsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&MaxParamsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: "async function f(a, b, c) {}"},
+			{Code: "function* f(a, b, c) {}"},
+			{Code: "async function* f(a, b, c) {}"},
+			{Code: "class C { static method(a, b, c) {} }"},
+			{Code: "class C { #method(a, b, c) {} }"},
+			{Code: "const C = class { method(a, b, c) {} };"},
+			{Code: "const obj = { method(a, b, c) {} };"},
+			{Code: "const obj = { get value() { return 1; } };"},
+			{Code: "class C { field = (a, b, c) => {}; }"},
+			{Code: "class C { static #field = (a, b, c) => {}; }"},
+			{Code: "const obj = { field: function(a, b, c) {} };"},
+			{Code: "const obj = { field: (a, b, c) => {} };"},
+
+			// ---- Dimension 4: access/key forms ----
+			{Code: "class C { 'method'(a, b, c) {} }"},
+			{Code: "class C { 0(a, b, c) {} }"},
+			{Code: "class C { ['method'](a, b, c) {} }"},
+			{Code: "class C { #method(a, b, c) {} }"},
+
+			// ---- Dimension 4: receiver/expression wrappers on inspected function nodes ----
+			{Code: "(function(a, b, c) {});"},
+			{Code: "((function(a, b, c) {}));"},
+			{Code: "const f = (function(a, b, c) {}) as Function;"},
+			{Code: "const f = (function(a, b, c) {}) satisfies Function;"},
+			{Code: "const f = (function(a, b, c) {})!;"},
+			// N/A: optional chaining applies to calls/member access, not function definitions.
+
+			// ---- Dimension 4: graceful degradation ----
+			{Code: "function f() {}"},
+			{Code: "function f(...args) {}"},
+			{Code: "function f({a, b}, [c]) {}"},
+			{Code: "function f(a = 1, b?: number, c?: number) {}"},
+			{Code: "abstract class C { abstract method(a, b, c): void; }"},
+			{Code: "interface I { method(a: number, b: number, c: number): void; }"},
+			{Code: "interface I { method(a: number, b: number, c: number, d: number): void; }"},
+			{Code: "interface I { (a: number, b: number, c: number, d: number): void; }"},
+			{Code: "interface I { new (a: number, b: number, c: number, d: number): object; }"},
+			{Code: "type Shape = { method(a: number, b: number, c: number, d: number): void };"},
+			{Code: "type Fn = <T, U>(a: T, b: U, c: string) => void;"},
+			{Code: "type Ctor = new (a: number, b: number, c: number, d: number) => object;"},
+			{Code: "declare namespace API { export function request(a: string, b: string, c: string): void; }"},
+			// N/A: object spread/rest do not appear in function parameter lists as standalone members.
+
+			// Locks in upstream parseOptions arm 1: numeric option sets max directly.
+			{Code: "function f(a, b, c, d) {}", Options: option(4)},
+			// Locks in upstream parseOptions arm 2: bare object shape from CLI uses max.
+			{Code: "function f(a, b, c, d) {}", Options: map[string]interface{}{"max": 4}},
+			// Locks in upstream parseOptions arm 2b: bare object shape from CLI uses maximum.
+			{Code: "function f(a, b, c, d) {}", Options: map[string]interface{}{"maximum": 4}},
+			// Locks in upstream parseOptions arm 3: maximum wins when truthy.
+			{Code: "function f(a, b, c, d) {}", Options: option(map[string]interface{}{"maximum": 4, "max": 1})},
+			// Locks in upstream parseOptions arm 4: maximum: 0 falls through to max.
+			{Code: "function f(a, b, c, d) {}", Options: option(map[string]interface{}{"maximum": 0, "max": 4})},
+			// Locks in upstream parseOptions arm 5: maximum: 0 with no max disables reports.
+			{Code: "function f(a, b, c, d, e) {}", Options: option(map[string]interface{}{"maximum": 0})},
+			// Locks in upstream countThis arm 1: "never" strips any this parameter.
+			{Code: "function f(this: Foo, a, b, c) {}", Options: option(map[string]interface{}{"max": 3, "countThis": "never"})},
+			// Locks in upstream countThis arm 2: "except-void" strips this: void.
+			{Code: "function f(this: void, a, b, c) {}", Options: option(map[string]interface{}{"max": 3, "countThis": "except-void"})},
+			// Locks in upstream countVoidThis arm 1: false maps to except-void.
+			{Code: "function f(this: void, a, b, c) {}", Options: option(map[string]interface{}{"max": 3, "countVoidThis": false})},
+
+			// ---- Real-user: eslint/eslint#20107 countThis never for typed this ----
+			{Code: "function doSomething(this: MyType, param1: unknown, param2: unknown): unknown {}", Options: option(map[string]interface{}{"max": 2, "countThis": "never"})},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: declaration/container forms ----
+			{
+				Code:   "async function f(a, b, c, d) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Async function 'f'", 4, 3), Line: 1, Column: 1}},
+			},
+			{
+				Code:   "function* f(a, b, c, d) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Generator function 'f'", 4, 3), Line: 1, Column: 1}},
+			},
+			{
+				Code:   "export default function(a, b, c, d) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function", 4, 3)}},
+			},
+			{
+				Code:   "const f = async <T>(a: T, b: T, c: T, d: T) => {};",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Async arrow function", 4, 3)}},
+			},
+			{
+				Code:   "class C { static #method(a, b, c, d) {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Static private method '#method'", 4, 3), Line: 1, Column: 11}},
+			},
+			{
+				Code:   "class C { field = (a, b, c, d) => {}; }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 11}},
+			},
+			{
+				Code:   "class C { static #field = (a, b, c, d) => {}; }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Static private method '#field'", 4, 3)}},
+			},
+			{
+				Code:   "const obj = { field: function(a, b, c, d) {} };",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method 'field'", 4, 3)}},
+			},
+			{
+				Code:   "const obj = { field: (a, b, c, d) => {} };",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method 'field'", 4, 3)}},
+			},
+			{
+				Code:   "const obj = { async method(a, b, c, d) {} };",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Async method 'method'", 4, 3)}},
+			},
+			{
+				Code:   "const obj = { *method(a, b, c, d) {} };",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Generator method 'method'", 4, 3)}},
+			},
+			{
+				Code:    "const obj = { set value(v) {} };",
+				Options: option(0),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Setter 'value'", 1, 0)}},
+			},
+
+			// ---- Dimension 4: access/key forms ----
+			{
+				Code:   "class C { 'method'(a, b, c, d) {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method 'method'", 4, 3), Line: 1, Column: 11}},
+			},
+			{
+				Code:   "class C { 0(a, b, c, d) {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method '0'", 4, 3), Line: 1, Column: 11}},
+			},
+			{
+				Code:   "class C { [name](a, b, c, d) {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Method", 4, 3), Line: 1, Column: 11}},
+			},
+
+			// ---- Dimension 4: receiver/expression wrappers on inspected function nodes ----
+			{
+				Code:   "((function(a, b, c, d) {}));",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function", 4, 3), Line: 1, Column: 3}},
+			},
+			{
+				Code:   "const f = (function(a, b, c, d) {}) as Function;",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 12}},
+			},
+			{
+				Code:   "const f = (function(a, b, c, d) {})!;",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 12}},
+			},
+
+			// ---- Dimension 4: nesting/traversal boundaries ----
+			{
+				Code: "function outer(a, b, c, d) { function inner(e, f, g, h) {} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: exceedMessage("Function 'outer'", 4, 3), Line: 1, Column: 1},
+					{MessageId: "exceed", Message: exceedMessage("Function 'inner'", 4, 3), Line: 1, Column: 30},
+				},
+			},
+			{
+				Code: "class Outer { method(a, b, c, d) { const inner = (e, f, g, h) => {}; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: exceedMessage("Method 'method'", 4, 3)},
+					{MessageId: "exceed", Message: exceedMessage("Arrow function", 4, 3)},
+				},
+			},
+			{
+				Code: "function outer(a, b, c) { class C { method(d, e, f, g) {} } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: exceedMessage("Method 'method'", 4, 3)},
+				},
+			},
+			{
+				Code: "class C { static { function f(a, b, c, d) {} } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: exceedMessage("Function 'f'", 4, 3)},
+				},
+			},
+
+			// ---- Dimension 4: graceful degradation ----
+			{
+				Code:    "function f(...args) {}",
+				Options: option(0),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'f'", 1, 0), Line: 1, Column: 1}},
+			},
+			{
+				Code:    "abstract class C { abstract method(a, b, c, d): void; }",
+				Options: option(3),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 20}},
+			},
+			{
+				Code:    "class C { set value(v) {} }",
+				Options: option(0),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Setter 'value'", 1, 0)}},
+			},
+			{
+				Code:    "class C { constructor(public a, private b, readonly c, d) {} }",
+				Options: option(3),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Constructor", 4, 3)}},
+			},
+			{
+				Code:    "type Fn = <T>(a: T, b: T, c: T, d: T) => void;",
+				Options: option(3),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function", 4, 3)}},
+			},
+			{
+				Code:    "interface I { field: (a: number, b: number, c: number, d: number) => void; }",
+				Options: option(3),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function", 4, 3)}},
+			},
+			{
+				Code:    "declare const handler: (event: Event, source: string, retry: boolean, meta: unknown) => void;",
+				Options: option(3),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function", 4, 3)}},
+			},
+			{
+				Code:    "declare namespace API { export function request(a: string, b: string, c: string, d: string): void; }",
+				Options: option(3),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'request'", 4, 3)}},
+			},
+			{
+				Code: "function overload(a: string, b: string, c: string, d: string): void;\n" +
+					"function overload(a: string, b: string, c: string, d: string) {}",
+				Options: option(3),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Message: exceedMessage("Function 'overload'", 4, 3)},
+					{MessageId: "exceed", Message: exceedMessage("Function 'overload'", 4, 3)},
+				},
+			},
+
+			// Locks in upstream parseOptions arm 6: empty object defaults to max=3.
+			{
+				Code:    "function f(a, b, c, d) {}",
+				Options: option(map[string]interface{}{}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'f'", 4, 3), Line: 1, Column: 1}},
+			},
+			// Locks in upstream countThis arm 3: "always" counts this: void.
+			{
+				Code:    "function f(this: void, a) {}",
+				Options: option(map[string]interface{}{"max": 1, "countThis": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'f'", 2, 1), Line: 1, Column: 1}},
+			},
+			// Locks in upstream countVoidThis arm 2: true maps to always.
+			{
+				Code:    "function f(this: void, a) {}",
+				Options: option(map[string]interface{}{"max": 1, "countVoidThis": true}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'f'", 2, 1), Line: 1, Column: 1}},
+			},
+			// Locks in upstream checkFunction arm 1: non-this first parameter with void type still counts.
+			{
+				Code:    "function f(value: void, a) {}",
+				Options: option(map[string]interface{}{"max": 1, "countThis": "except-void"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'f'", 2, 1), Line: 1, Column: 1}},
+			},
+			// Locks in upstream checkFunction arm 2: only an exact `this: void` is stripped.
+			{
+				Code:    "function f(this: undefined, a, b, c) {}",
+				Options: option(map[string]interface{}{"max": 3, "countThis": "except-void"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'f'", 4, 3), Line: 1, Column: 1}},
+			},
+			// Locks in upstream checkFunction arm 2: unions containing void still count.
+			{
+				Code:    "function f(this: void | undefined, a, b, c) {}",
+				Options: option(map[string]interface{}{"max": 3, "countThis": "except-void"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'f'", 4, 3), Line: 1, Column: 1}},
+			},
+
+			// ---- Real-user: eslint/eslint#798 RequireJS define callback is still a normal function expression ----
+			{
+				Code: `define([
+  'dependency1',
+  'dependency2',
+  'dependency3',
+  'dependency4'
+], function(d1, d2, d3, d4) {
+  use(d1, d2, d3, d4);
+});`,
+				Options: option(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function", 4, 3), Line: 6, Column: 4}},
+			},
+			// ---- Real-user: Express-style route callbacks are normal function expressions ----
+			{
+				Code:    `app.get("/users/:id", function routeHandler(req, res, next, logger) { res.end(); });`,
+				Options: option(map[string]interface{}{"max": 3}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'routeHandler'", 4, 3)}},
+			},
+		},
+	)
+}

--- a/internal/rules/max_params/max_params_upstream_test.go
+++ b/internal/rules/max_params/max_params_upstream_test.go
@@ -1,0 +1,251 @@
+package max_params
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestMaxParamsUpstream migrates the full valid/invalid suite from upstream eslint/tests/lib/rules/max-params.js 1:1.
+// Position assertions cover line/column for every invalid case. rslint-specific lock-in cases live in the max_params_extras_test.go file.
+func TestMaxParamsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&MaxParamsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- ESLint core valid ----
+			{Code: "function test(d, e, f) {}"},
+			{Code: "var test = function(a, b, c) {};", Options: option(3)},
+			{Code: "var test = (a, b, c) => {};", Options: option(3)},
+			{Code: "var test = function test(a, b, c) {};", Options: option(3)},
+
+			// ---- ESLint core valid: object property options ----
+			{Code: "var test = function(a, b, c) {};", Options: option(map[string]interface{}{"max": 3})},
+
+			// ---- TypeScript valid ----
+			{Code: "function foo() {}"},
+			{Code: "const foo = function () {};"},
+			{Code: "const foo = () => {};"},
+			{Code: "function foo(a) {}"},
+			{Code: `
+class Foo {
+  constructor(a) {}
+}
+			`},
+			{Code: `
+class Foo {
+  method(this: void, a, b, c) {}
+}
+			`},
+			{Code: `
+class Foo {
+  method(this: Foo, a, b) {}
+}
+			`},
+			{Code: "function foo(a, b, c, d) {}", Options: option(map[string]interface{}{"max": 4})},
+			{Code: "function foo(a, b, c, d) {}", Options: option(map[string]interface{}{"maximum": 4})},
+			{Code: `
+class Foo {
+  method(this: void) {}
+}
+			`, Options: option(map[string]interface{}{"max": 0})},
+			{Code: `
+class Foo {
+  method(this: void, a) {}
+}
+			`, Options: option(map[string]interface{}{"max": 1})},
+			{Code: `
+class Foo {
+  method(this: void, a) {}
+}
+			`, Options: option(map[string]interface{}{"countVoidThis": true, "max": 2})},
+			{Code: "function testD(this: void, a) {}", Options: option(map[string]interface{}{"max": 1})},
+			{Code: "function testD(this: void, a) {}", Options: option(map[string]interface{}{"countVoidThis": true, "max": 2})},
+			{Code: "const testE = function (this: void, a) {}", Options: option(map[string]interface{}{"max": 1})},
+			{Code: "const testE = function (this: void, a) {}", Options: option(map[string]interface{}{"countVoidThis": true, "max": 2})},
+			{Code: `
+declare function makeDate(m: number, d: number, y: number): Date;
+			`, Options: option(map[string]interface{}{"max": 3})},
+			{Code: `
+type sum = (a: number, b: number) => number;
+			`, Options: option(map[string]interface{}{"max": 2})},
+			{Code: "function foo(this: unknown[], a, b, c) {}", Options: option(map[string]interface{}{"max": 3, "countThis": "never"})},
+			{Code: "function foo(this: void, a, b, c) {}", Options: option(map[string]interface{}{"max": 3, "countThis": "except-void"})},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- ESLint core invalid ----
+			{
+				Code:    "function test(a, b, c) {}",
+				Options: option(2),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'test'", 3, 2), Line: 1, Column: 1, EndLine: 1, EndColumn: 14}},
+			},
+			{
+				Code:   "function test(a, b, c, d) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'test'", 4, 3), Line: 1, Column: 1, EndLine: 1, EndColumn: 14}},
+			},
+			{
+				Code:    "var test = function(a, b, c, d) {};",
+				Options: option(3),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function", 4, 3), Line: 1, Column: 12, EndLine: 1, EndColumn: 20}},
+			},
+			{
+				Code:    "var test = (a, b, c, d) => {};",
+				Options: option(3),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Arrow function", 4, 3), Line: 1, Column: 25, EndLine: 1, EndColumn: 27}},
+			},
+			{
+				Code:    "(function(a, b, c, d) {});",
+				Options: option(3),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function", 4, 3), Line: 1, Column: 2, EndLine: 1, EndColumn: 10}},
+			},
+			{
+				Code:    "var test = function test(a, b, c) {};",
+				Options: option(1),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'test'", 3, 1), Line: 1, Column: 12, EndLine: 1, EndColumn: 25}},
+			},
+
+			// ---- ESLint core invalid: object property options ----
+			{
+				Code:    "function test(a, b, c) {}",
+				Options: option(map[string]interface{}{"max": 2}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'test'", 3, 2), Line: 1, Column: 1, EndLine: 1, EndColumn: 14}},
+			},
+			{
+				Code:    "function test(a, b, c, d) {}",
+				Options: option(map[string]interface{}{}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'test'", 4, 3), Line: 1, Column: 1, EndLine: 1, EndColumn: 14}},
+			},
+			{
+				Code:    "function test(a) {}",
+				Options: option(map[string]interface{}{"max": 0}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Message: exceedMessage("Function 'test'", 1, 0), Line: 1, Column: 1, EndLine: 1, EndColumn: 14}},
+			},
+			{
+				Code: `function test(a, b, c) {
+              // Just to make it longer
+            }`,
+				Options: option(map[string]interface{}{"max": 2}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 14}},
+			},
+
+			// ---- TypeScript invalid ----
+			{
+				Code:   "function foo(a, b, c, d) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1}},
+			},
+			{
+				Code:   "const foo = function (a, b, c, d) {};",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 13}},
+			},
+			{
+				Code:   "const foo = (a, b, c, d) => {};",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 26}},
+			},
+			{
+				Code:    "const foo = a => {};",
+				Options: option(map[string]interface{}{"max": 0}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 15}},
+			},
+			{
+				Code: `
+class Foo {
+  method(this: void, a, b, c, d) {}
+}
+				`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 3}},
+			},
+			{
+				Code: `
+class Foo {
+  method(this: void, a) {}
+}
+				`,
+				Options: option(map[string]interface{}{"countVoidThis": true, "max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 3}},
+			},
+			{
+				Code: `
+class Foo {
+  method(this: void, a) {}
+}
+				`,
+				Options: option(map[string]interface{}{"countThis": "always", "max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 3}},
+			},
+			{
+				Code:    "function testD(this: void, a) {}",
+				Options: option(map[string]interface{}{"countVoidThis": true, "max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1}},
+			},
+			{
+				Code:    "function testD(this: void, a) {}",
+				Options: option(map[string]interface{}{"countThis": "always", "max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1}},
+			},
+			{
+				Code:    "const testE = function (this: void, a) {}",
+				Options: option(map[string]interface{}{"countThis": "always", "max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 15}},
+			},
+			{
+				Code:    "function testFunction(test: void, a: number) {}",
+				Options: option(map[string]interface{}{"countThis": "except-void", "max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1}},
+			},
+			{
+				Code:    "const testE = function (this: void, a) {}",
+				Options: option(map[string]interface{}{"countVoidThis": true, "max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 15}},
+			},
+			{
+				Code:    "function testFunction(test: void, a: number) {}",
+				Options: option(map[string]interface{}{"countVoidThis": false, "max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1}},
+			},
+			{
+				Code: `
+class Foo {
+  method(this: Foo, a, b, c) {}
+}
+				`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 3}},
+			},
+			{
+				Code: `
+declare function makeDate(m: number, d: number, y: number): Date;
+				`,
+				Options: option(map[string]interface{}{"max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 2, Column: 1}},
+			},
+			{
+				Code: `
+type sum = (a: number, b: number) => number;
+				`,
+				Options: option(map[string]interface{}{"max": 1}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 2, Column: 12}},
+			},
+			{
+				Code:    "function foo(this: unknown[], a, b, c) {}",
+				Options: option(map[string]interface{}{"max": 3, "countThis": "always"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1}},
+			},
+			{
+				Code:    "function foo(this: unknown[], a, b, c) {}",
+				Options: option(map[string]interface{}{"max": 3, "countThis": "except-void"}),
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1}},
+			},
+		},
+	)
+}
+
+func option(v any) []interface{} {
+	return []interface{}{v}
+}
+
+func exceedMessage(name string, count, maxAllowed int) string {
+	return fmt.Sprintf("%s has too many parameters (%d). Maximum allowed is %d.", name, count, maxAllowed)
+}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -377,6 +377,134 @@ func GetFunctionNameWithKind(node *ast.Node) string {
 	return strings.Join(tokens, " ")
 }
 
+// GetFunctionNameWithKindCore mirrors ESLint core's astUtils.getFunctionNameWithKind.
+// It intentionally does not walk from a function expression or arrow function
+// to an enclosing variable declaration when resolving names. Core rules such
+// as complexity and max-params rely on that narrower behavior for message text.
+func GetFunctionNameWithKindCore(node *ast.Node) string {
+	if node.Kind == ast.KindConstructor {
+		return "constructor"
+	}
+
+	parent := node.Parent
+	if parent == nil {
+		return "function"
+	}
+
+	tokens := []string{}
+
+	isClassMember := isCoreDirectClassMember(node)
+	isClassFieldValue := isCoreClassFieldInitializer(node)
+	if isClassMember || isClassFieldValue {
+		owner := node
+		if isClassFieldValue {
+			owner = parent
+		}
+		if ast.HasSyntacticModifier(owner, ast.ModifierFlagsStatic) {
+			tokens = append(tokens, "static")
+		}
+		if name := owner.Name(); name != nil && name.Kind == ast.KindPrivateIdentifier {
+			tokens = append(tokens, "private")
+		}
+	}
+
+	flags := ast.GetFunctionFlags(node)
+	if flags&ast.FunctionFlagsAsync != 0 {
+		tokens = append(tokens, "async")
+	}
+	if flags&ast.FunctionFlagsGenerator != 0 {
+		tokens = append(tokens, "generator")
+	}
+
+	switch {
+	case node.Kind == ast.KindGetAccessor:
+		tokens = append(tokens, "getter")
+	case node.Kind == ast.KindSetAccessor:
+		tokens = append(tokens, "setter")
+	case node.Kind == ast.KindMethodDeclaration:
+		tokens = append(tokens, "method")
+	case parent.Kind == ast.KindPropertyAssignment:
+		tokens = append(tokens, "method")
+	case isClassFieldValue:
+		tokens = append(tokens, "method")
+	case node.Kind == ast.KindArrowFunction:
+		tokens = append(tokens, "arrow", "function")
+	default:
+		tokens = append(tokens, "function")
+	}
+
+	switch {
+	case parent.Kind == ast.KindPropertyAssignment:
+		appendCoreFunctionNameFromOwner(&tokens, parent, node)
+	case isClassFieldValue:
+		appendCoreFunctionNameFromOwner(&tokens, parent, node)
+	case node.Kind == ast.KindMethodDeclaration ||
+		node.Kind == ast.KindGetAccessor ||
+		node.Kind == ast.KindSetAccessor:
+		appendCoreFunctionNameFromOwner(&tokens, node, node)
+	default:
+		if id := coreFunctionNodeIdentifier(node); id != "" {
+			tokens = append(tokens, fmt.Sprintf("'%s'", id))
+		}
+	}
+
+	return strings.Join(tokens, " ")
+}
+
+func appendCoreFunctionNameFromOwner(tokens *[]string, owner *ast.Node, node *ast.Node) {
+	if name := owner.Name(); name != nil {
+		if name.Kind == ast.KindPrivateIdentifier {
+			*tokens = append(*tokens, fmt.Sprintf("'%s'", name.AsPrivateIdentifier().Text))
+			return
+		}
+		if s, ok := GetStaticPropertyName(name); ok {
+			*tokens = append(*tokens, fmt.Sprintf("'%s'", s))
+			return
+		}
+	}
+	if id := coreFunctionNodeIdentifier(node); id != "" {
+		*tokens = append(*tokens, fmt.Sprintf("'%s'", id))
+	}
+}
+
+func coreFunctionNodeIdentifier(node *ast.Node) string {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		if n := node.AsFunctionDeclaration().Name(); n != nil && n.Kind == ast.KindIdentifier {
+			return n.AsIdentifier().Text
+		}
+	case ast.KindFunctionExpression:
+		if n := node.AsFunctionExpression().Name(); n != nil && n.Kind == ast.KindIdentifier {
+			return n.AsIdentifier().Text
+		}
+	}
+	return ""
+}
+
+func isCoreDirectClassMember(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil || (parent.Kind != ast.KindClassDeclaration && parent.Kind != ast.KindClassExpression) {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		return true
+	}
+	return false
+}
+
+func isCoreClassFieldInitializer(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil || parent.Kind != ast.KindPropertyDeclaration {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindArrowFunction, ast.KindFunctionExpression:
+		return parent.AsPropertyDeclaration().Initializer == node
+	}
+	return false
+}
+
 // getFunctionDisplayName resolves the user-visible name of a function-like
 // node — first by inspecting the node's own name, then by walking the parent
 // for variable / property / type binding sites that ESLint's `getName` covers.

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"iter"
+	"math"
 	"slices"
 	"strings"
 	"unicode"
@@ -295,6 +296,17 @@ func IncludesModifier(node interface{ Modifiers() *ast.ModifierList }, modifier 
 	})
 }
 
+// IsThisVoidParameter reports whether param is TypeScript's synthetic
+// `this: void` parameter. It delegates the `this` shape check to tsgo so
+// callers do not need to duplicate identifier/name assumptions.
+func IsThisVoidParameter(param *ast.Node) bool {
+	if param == nil || !ast.IsThisParameter(param) {
+		return false
+	}
+	t := param.Type()
+	return t != nil && t.Kind == ast.KindVoidKeyword
+}
+
 // Source: https://github.com/microsoft/typescript-go/blob/5652e65d5ae944375676d3955f9755e554576d41/internal/jsnum/string.go#L99
 func IsStrWhiteSpace(r rune) bool {
 	// This is different than stringutil.IsWhiteSpaceLike.
@@ -409,6 +421,49 @@ func GetOptionsMap(opts any) map[string]interface{} {
 	}
 
 	return optsMap
+}
+
+// ResolveLegacyMaxOption resolves ESLint's legacy maximum/max option shape.
+// It handles number forms (`3` / `[3]`) plus object forms (`{max: 3}` /
+// `[{maximum: 3}]`). `maximum` wins only when it coerces to a non-zero number;
+// otherwise `max` is used. If either key is present but neither yields a
+// numeric threshold, ESLint ends up comparing against `undefined`, which never
+// reports; MaxInt gives the same observable behavior in Go.
+func ResolveLegacyMaxOption(options any, defaultMax int) int {
+	if options == nil {
+		return defaultMax
+	}
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) == 0 {
+			return defaultMax
+		}
+		if n, ok := CoerceInt(arr[0]); ok {
+			return n
+		}
+	} else if n, ok := CoerceInt(options); ok {
+		return n
+	}
+
+	m := GetOptionsMap(options)
+	if m == nil {
+		return defaultMax
+	}
+	_, hasMaximum := m["maximum"]
+	_, hasMax := m["max"]
+	if !hasMaximum && !hasMax {
+		return defaultMax
+	}
+	if hasMaximum {
+		if n, ok := CoerceInt(m["maximum"]); ok && n != 0 {
+			return n
+		}
+	}
+	if hasMax {
+		if n, ok := CoerceInt(m["max"]); ok {
+			return n
+		}
+	}
+	return math.MaxInt
 }
 
 // CoerceInt converts a JSON-decoded numeric value to int. JSON numbers come in

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"math"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -142,6 +143,52 @@ func TestAccessExpressionStaticName(t *testing.T) {
 		if got != tt.want || ok != tt.wantOkay {
 			t.Errorf("%s: AccessExpressionStaticName() = (%q, %v), want (%q, %v)", tt.name, got, ok, tt.want, tt.wantOkay)
 		}
+	}
+}
+
+func TestResolveLegacyMaxOption(t *testing.T) {
+	tests := []struct {
+		name       string
+		options    any
+		defaultMax int
+		want       int
+	}{
+		{name: "nil uses default", defaultMax: 3, want: 3},
+		{name: "empty array uses default", options: []interface{}{}, defaultMax: 3, want: 3},
+		{name: "bare number", options: 4, defaultMax: 3, want: 4},
+		{name: "array number", options: []interface{}{float64(5)}, defaultMax: 3, want: 5},
+		{name: "bare max object", options: map[string]interface{}{"max": 6}, defaultMax: 3, want: 6},
+		{name: "array maximum object", options: []interface{}{map[string]interface{}{"maximum": 7, "max": 1}}, defaultMax: 3, want: 7},
+		{name: "zero maximum falls through to max", options: []interface{}{map[string]interface{}{"maximum": 0, "max": 8}}, defaultMax: 3, want: 8},
+		{name: "zero maximum without fallback disables", options: []interface{}{map[string]interface{}{"maximum": 0}}, defaultMax: 3, want: math.MaxInt},
+		{name: "nonnumeric max disables", options: map[string]interface{}{"max": "wide"}, defaultMax: 3, want: math.MaxInt},
+		{name: "object without max keys uses default", options: map[string]interface{}{"foo": 1}, defaultMax: 3, want: 3},
+	}
+
+	for _, tt := range tests {
+		if got := ResolveLegacyMaxOption(tt.options, tt.defaultMax); got != tt.want {
+			t.Errorf("%s: ResolveLegacyMaxOption() = %d, want %d", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestIsThisVoidParameter(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, "function f(this: void, value: void) {}\nfunction g(this: Foo) {}\n", core.ScriptKindTS)
+
+	if IsThisVoidParameter(nil) {
+		t.Fatal("IsThisVoidParameter(nil) = true, want false")
+	}
+	if got := IsThisVoidParameter(findNodeWithText(t, sourceFile, "this: void")); !got {
+		t.Fatal("IsThisVoidParameter(this: void) = false, want true")
+	}
+	if got := IsThisVoidParameter(findNodeWithText(t, sourceFile, "value: void")); got {
+		t.Fatal("IsThisVoidParameter(value: void) = true, want false")
+	}
+	if got := IsThisVoidParameter(findNodeWithText(t, sourceFile, "this: Foo")); got {
+		t.Fatal("IsThisVoidParameter(this: Foo) = true, want false")
 	}
 }
 

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -443,6 +443,7 @@ export default defineConfig({
     './tests/eslint/rules/max-lines.test.ts',
     './tests/eslint/rules/max-lines-per-function.test.ts',
     './tests/eslint/rules/max-nested-callbacks.test.ts',
+    './tests/eslint/rules/max-params.test.ts',
     './tests/eslint/rules/no-label-var.test.ts',
     './tests/eslint/rules/no-shadow.test.ts',
     './tests/eslint/rules/no-labels.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-params.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-params.test.ts.snap
@@ -1,0 +1,751 @@
+// Rstest Snapshot v1
+
+exports[`max-params > invalid 1`] = `
+{
+  "code": "function test(a, b, c) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'test' has too many parameters (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 2`] = `
+{
+  "code": "function test(a, b, c, d) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'test' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 3`] = `
+{
+  "code": "var test = function(a, b, c, d) {};",
+  "diagnostics": [
+    {
+      "message": "Function has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 4`] = `
+{
+  "code": "var test = (a, b, c, d) => {};",
+  "diagnostics": [
+    {
+      "message": "Arrow function has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 5`] = `
+{
+  "code": "(function(a, b, c, d) {});",
+  "diagnostics": [
+    {
+      "message": "Function has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 6`] = `
+{
+  "code": "var test = function test(a, b, c) {};",
+  "diagnostics": [
+    {
+      "message": "Function 'test' has too many parameters (3). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 7`] = `
+{
+  "code": "function test(a, b, c) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'test' has too many parameters (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 8`] = `
+{
+  "code": "function test(a, b, c, d) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'test' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 9`] = `
+{
+  "code": "function test(a) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'test' has too many parameters (1). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 10`] = `
+{
+  "code": "function test(a, b, c) {
+              // Just to make it longer
+            }",
+  "diagnostics": [
+    {
+      "message": "Function 'test' has too many parameters (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 11`] = `
+{
+  "code": "function foo(a, b, c, d) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 12`] = `
+{
+  "code": "const foo = function (a, b, c, d) {};",
+  "diagnostics": [
+    {
+      "message": "Function has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 13`] = `
+{
+  "code": "const foo = (a, b, c, d) => {};",
+  "diagnostics": [
+    {
+      "message": "Arrow function has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 14`] = `
+{
+  "code": "const foo = a => {};",
+  "diagnostics": [
+    {
+      "message": "Arrow function has too many parameters (1). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 15`] = `
+{
+  "code": "
+class Foo {
+  method(this: void, a, b, c, d) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Method 'method' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 16`] = `
+{
+  "code": "
+class Foo {
+  method(this: void, a) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Method 'method' has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 17`] = `
+{
+  "code": "
+class Foo {
+  method(this: void, a) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Method 'method' has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 18`] = `
+{
+  "code": "function testD(this: void, a) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'testD' has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 19`] = `
+{
+  "code": "function testD(this: void, a) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'testD' has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 20`] = `
+{
+  "code": "const testE = function (this: void, a) {}",
+  "diagnostics": [
+    {
+      "message": "Function has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 21`] = `
+{
+  "code": "function testFunction(test: void, a: number) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'testFunction' has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 22`] = `
+{
+  "code": "const testE = function (this: void, a) {}",
+  "diagnostics": [
+    {
+      "message": "Function has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 23`] = `
+{
+  "code": "function testFunction(test: void, a: number) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'testFunction' has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 24`] = `
+{
+  "code": "
+class Foo {
+  method(this: Foo, a, b, c) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Method 'method' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 25`] = `
+{
+  "code": "
+declare function makeDate(m: number, d: number, y: number): Date;
+      ",
+  "diagnostics": [
+    {
+      "message": "Function 'makeDate' has too many parameters (3). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 26`] = `
+{
+  "code": "
+type sum = (a: number, b: number) => number;
+      ",
+  "diagnostics": [
+    {
+      "message": "Function has too many parameters (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 27`] = `
+{
+  "code": "function foo(this: unknown[], a, b, c) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-params > invalid 28`] = `
+{
+  "code": "function foo(this: unknown[], a, b, c) {}",
+  "diagnostics": [
+    {
+      "message": "Function 'foo' has too many parameters (4). Maximum allowed is 3.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-params",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/max-params.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/max-params.test.ts
@@ -1,0 +1,260 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('max-params', {
+  valid: [
+    'function test(d, e, f) {}',
+    { code: 'var test = function(a, b, c) {};', options: [3] as any },
+    { code: 'var test = (a, b, c) => {};', options: [3] as any },
+    { code: 'var test = function test(a, b, c) {};', options: [3] as any },
+    {
+      code: 'var test = function(a, b, c) {};',
+      options: [{ max: 3 }] as any,
+    },
+
+    'function foo() {}',
+    'const foo = function () {};',
+    'const foo = () => {};',
+    'function foo(a) {}',
+    `
+class Foo {
+  constructor(a) {}
+}
+    `,
+    `
+class Foo {
+  method(this: void, a, b, c) {}
+}
+    `,
+    `
+class Foo {
+  method(this: Foo, a, b) {}
+}
+    `,
+    {
+      code: 'function foo(a, b, c, d) {}',
+      options: [{ max: 4 }] as any,
+    },
+    {
+      code: 'function foo(a, b, c, d) {}',
+      options: [{ maximum: 4 }] as any,
+    },
+    {
+      code: `
+class Foo {
+  method(this: void) {}
+}
+      `,
+      options: [{ max: 0 }] as any,
+    },
+    {
+      code: `
+class Foo {
+  method(this: void, a) {}
+}
+      `,
+      options: [{ max: 1 }] as any,
+    },
+    {
+      code: `
+class Foo {
+  method(this: void, a) {}
+}
+      `,
+      options: [{ countVoidThis: true, max: 2 }] as any,
+    },
+    {
+      code: 'function testD(this: void, a) {}',
+      options: [{ max: 1 }] as any,
+    },
+    {
+      code: 'function testD(this: void, a) {}',
+      options: [{ countVoidThis: true, max: 2 }] as any,
+    },
+    {
+      code: 'const testE = function (this: void, a) {}',
+      options: [{ max: 1 }] as any,
+    },
+    {
+      code: 'const testE = function (this: void, a) {}',
+      options: [{ countVoidThis: true, max: 2 }] as any,
+    },
+    {
+      code: `
+declare function makeDate(m: number, d: number, y: number): Date;
+      `,
+      options: [{ max: 3 }] as any,
+    },
+    {
+      code: `
+type sum = (a: number, b: number) => number;
+      `,
+      options: [{ max: 2 }] as any,
+    },
+    {
+      code: 'function foo(this: unknown[], a, b, c) {}',
+      options: [{ max: 3, countThis: 'never' }] as any,
+    },
+    {
+      code: 'function foo(this: void, a, b, c) {}',
+      options: [{ max: 3, countThis: 'except-void' }] as any,
+    },
+  ],
+  invalid: [
+    {
+      code: 'function test(a, b, c) {}',
+      options: [2] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 1 }],
+    },
+    {
+      code: 'function test(a, b, c, d) {}',
+      errors: [{ messageId: 'exceed', line: 1, column: 1 }],
+    },
+    {
+      code: 'var test = function(a, b, c, d) {};',
+      options: [3] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 12 }],
+    },
+    {
+      code: 'var test = (a, b, c, d) => {};',
+      options: [3] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 25 }],
+    },
+    {
+      code: '(function(a, b, c, d) {});',
+      options: [3] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 2 }],
+    },
+    {
+      code: 'var test = function test(a, b, c) {};',
+      options: [1] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 12 }],
+    },
+    {
+      code: 'function test(a, b, c) {}',
+      options: [{ max: 2 }] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 1 }],
+    },
+    {
+      code: 'function test(a, b, c, d) {}',
+      options: [{}] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 1 }],
+    },
+    {
+      code: 'function test(a) {}',
+      options: [{ max: 0 }] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 1 }],
+    },
+    {
+      code: `function test(a, b, c) {
+              // Just to make it longer
+            }`,
+      options: [{ max: 2 }] as any,
+      errors: [{ messageId: 'exceed', line: 1, column: 1 }],
+    },
+
+    { code: 'function foo(a, b, c, d) {}', errors: [{ messageId: 'exceed' }] },
+    {
+      code: 'const foo = function (a, b, c, d) {};',
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'const foo = (a, b, c, d) => {};',
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'const foo = a => {};',
+      options: [{ max: 0 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: `
+class Foo {
+  method(this: void, a, b, c, d) {}
+}
+      `,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: `
+class Foo {
+  method(this: void, a) {}
+}
+      `,
+      options: [{ countVoidThis: true, max: 1 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: `
+class Foo {
+  method(this: void, a) {}
+}
+      `,
+      options: [{ countThis: 'always', max: 1 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'function testD(this: void, a) {}',
+      options: [{ countVoidThis: true, max: 1 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'function testD(this: void, a) {}',
+      options: [{ countThis: 'always', max: 1 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'const testE = function (this: void, a) {}',
+      options: [{ countThis: 'always', max: 1 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'function testFunction(test: void, a: number) {}',
+      options: [{ countThis: 'except-void', max: 1 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'const testE = function (this: void, a) {}',
+      options: [{ countVoidThis: true, max: 1 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'function testFunction(test: void, a: number) {}',
+      options: [{ countVoidThis: false, max: 1 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: `
+class Foo {
+  method(this: Foo, a, b, c) {}
+}
+      `,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: `
+declare function makeDate(m: number, d: number, y: number): Date;
+      `,
+      options: [{ max: 1 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: `
+type sum = (a: number, b: number) => number;
+      `,
+      options: [{ max: 1 }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'function foo(this: unknown[], a, b, c) {}',
+      options: [{ max: 3, countThis: 'always' }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+    {
+      code: 'function foo(this: unknown[], a, b, c) {}',
+      options: [{ max: 3, countThis: 'except-void' }] as any,
+      errors: [{ messageId: 'exceed' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the ESLint core `max-params` rule to rslint.

- Add the Go implementation, documentation, upstream parity tests, and extra Go edge coverage for `max-params`.
- Register the rule and add JS rule-tester coverage/snapshots.
- Reuse shared helpers for function naming, function head ranges, legacy `maximum || max` option parsing, and `this: void` parameter handling.
- Add regression coverage for real rsbuild/rspack shapes such as object/class methods, function types, constructors, overloads, nested functions, and TypeScript `this` parameters.

## Related Links

- ESLint rule documentation: https://eslint.org/docs/latest/rules/max-params
- ESLint rule source: https://github.com/eslint/eslint/blob/main/lib/rules/max-params.js
- ESLint upstream tests: https://github.com/eslint/eslint/blob/main/tests/lib/rules/max-params.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Verification:

- `go test -count=1 ./internal/rules/max_params`
- `go test -count=1 ./internal/utils ./internal/rules/max_params ./internal/rules/max_depth ./internal/rules/max_nested_callbacks ./internal/plugins/typescript/rules/max_params ./internal/plugins/typescript/rules/unbound_method`
- `cd packages/rslint-test-tools && npx rstest run --testTimeout=10000 max-params`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint run --timeout=10m ./internal/plugins/typescript/rules/max_params ./internal/plugins/typescript/rules/unbound_method ./internal/rules ./internal/rules/complexity ./internal/rules/max_depth ./internal/rules/max_nested_callbacks ./internal/rules/max_params ./internal/utils`
- Built `packages/rslint` and verified `max-params` against local rsbuild/rspack repositories with full diagnostic validation.
