### PR TITLE
feat: port rule no-empty-function

### DIFF
--- a/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this.go
+++ b/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this.go
@@ -479,7 +479,7 @@ func classFieldFunctionDisplayName(field, node *ast.Node) string {
 		tokens = append(tokens, "generator")
 	}
 	tokens = append(tokens, "method")
-	if name := propertyDisplayName(keyNode); name != "" {
+	if name := utils.GetPropertyDisplayName(keyNode); name != "" {
 		tokens = append(tokens, fmt.Sprintf("'%s'", name))
 	}
 	return strings.Join(tokens, " ")
@@ -594,24 +594,4 @@ func firstOpenParenPos(sf *ast.SourceFile, start, end int) int {
 		s.Scan()
 	}
 	return -1
-}
-
-// propertyDisplayName resolves a property-name node to the string ESLint
-// would emit inside single quotes (or empty when the key is not statically
-// resolvable). Mirrors `GetStaticPropertyName` but also retains the leading
-// `#` of a PrivateIdentifier.
-func propertyDisplayName(name *ast.Node) string {
-	if name == nil {
-		return ""
-	}
-	if name.Kind == ast.KindIdentifier {
-		return name.AsIdentifier().Text
-	}
-	if name.Kind == ast.KindPrivateIdentifier {
-		return name.AsPrivateIdentifier().Text
-	}
-	if s, ok := utils.GetStaticPropertyName(name); ok {
-		return s
-	}
-	return ""
 }

--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -45,6 +45,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_else_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_character_class"
+	"github.com/web-infra-dev/rslint/internal/rules/no_empty_function"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_pattern"
 	"github.com/web-infra-dev/rslint/internal/rules/no_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_ex_assign"
@@ -181,6 +182,7 @@ func GetAllRules() []rule.Rule {
 		no_duplicate_imports.NoDuplicateImportsRule,
 		no_else_return.NoElseReturnRule,
 		no_empty.NoEmptyRule,
+		no_empty_function.NoEmptyFunctionRule,
 		no_empty_pattern.NoEmptyPatternRule,
 		no_eval.NoEvalRule,
 		no_ex_assign.NoExAssignRule,

--- a/internal/rules/no_empty_function/no_empty_function.go
+++ b/internal/rules/no_empty_function/no_empty_function.go
@@ -1,0 +1,294 @@
+package no_empty_function
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-empty-function
+var NoEmptyFunctionRule = rule.Rule{
+	Name: "no-empty-function",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		check := func(node *ast.Node) {
+			body := node.Body()
+			if body == nil || body.Kind != ast.KindBlock {
+				return
+			}
+			if len(body.Statements()) != 0 {
+				return
+			}
+			if utils.HasCommentInsideNode(ctx.SourceFile, body) {
+				return
+			}
+			if isAllowedEmptyFunction(node, opts) {
+				return
+			}
+
+			name := emptyFunctionDisplayName(node)
+			bodyRange := utils.TrimNodeTextRange(ctx.SourceFile, body)
+			message := rule.RuleMessage{
+				Id:          "unexpected",
+				Description: fmt.Sprintf("Unexpected empty %s.", name),
+				Data:        map[string]string{"name": name},
+			}
+			suggestionMessage := rule.RuleMessage{
+				Id:          "suggestComment",
+				Description: fmt.Sprintf("Add comment inside empty %s.", name),
+				Data:        map[string]string{"name": name},
+			}
+			ctx.ReportRangeWithSuggestions(bodyRange, message, rule.RuleSuggestion{
+				Message: suggestionMessage,
+				FixesArr: []rule.RuleFix{
+					rule.RuleFixReplaceRange(core.NewTextRange(bodyRange.Pos()+1, bodyRange.End()-1), " /* empty */ "),
+				},
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindArrowFunction:       check,
+			ast.KindConstructor:         check,
+			ast.KindFunctionDeclaration: check,
+			ast.KindFunctionExpression:  check,
+			ast.KindGetAccessor:         check,
+			ast.KindMethodDeclaration:   check,
+			ast.KindSetAccessor:         check,
+		}
+	},
+}
+
+type noEmptyFunctionOptions struct {
+	allow map[string]bool
+}
+
+func parseOptions(options any) noEmptyFunctionOptions {
+	result := noEmptyFunctionOptions{allow: map[string]bool{}}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return result
+	}
+
+	switch allow := optsMap["allow"].(type) {
+	case []interface{}:
+		for _, item := range allow {
+			if s, ok := item.(string); ok {
+				result.allow[s] = true
+			}
+		}
+	case []string:
+		for _, item := range allow {
+			result.allow[item] = true
+		}
+	}
+
+	return result
+}
+
+func isAllowedEmptyFunction(node *ast.Node, opts noEmptyFunctionOptions) bool {
+	kind := emptyFunctionKind(node)
+	if opts.allow[kind] {
+		return true
+	}
+
+	if kind == "constructors" {
+		if ast.HasSyntacticModifier(node, ast.ModifierFlagsPrivate) && opts.allow["privateConstructors"] {
+			return true
+		}
+		if ast.HasSyntacticModifier(node, ast.ModifierFlagsProtected) && opts.allow["protectedConstructors"] {
+			return true
+		}
+		if hasParameterProperty(node) {
+			return true
+		}
+	}
+
+	if isMethodOrAccessorKind(kind) {
+		if ast.HasDecorators(node) && opts.allow["decoratedFunctions"] {
+			return true
+		}
+		if ast.HasSyntacticModifier(node, ast.ModifierFlagsOverride) && opts.allow["overrideMethods"] {
+			return true
+		}
+	}
+
+	return false
+}
+
+func emptyFunctionKind(node *ast.Node) string {
+	var kind string
+	switch node.Kind {
+	case ast.KindArrowFunction:
+		return "arrowFunctions"
+	case ast.KindConstructor:
+		return "constructors"
+	case ast.KindGetAccessor:
+		kind = "getters"
+	case ast.KindSetAccessor:
+		kind = "setters"
+	case ast.KindMethodDeclaration:
+		kind = "methods"
+	default:
+		kind = "functions"
+	}
+
+	flags := ast.GetFunctionFlags(node)
+	switch {
+	case flags&ast.FunctionFlagsGenerator != 0:
+		return "generator" + utils.UpperCaseFirstASCII(kind)
+	case flags&ast.FunctionFlagsAsync != 0:
+		return "async" + utils.UpperCaseFirstASCII(kind)
+	default:
+		return kind
+	}
+}
+
+func isMethodOrAccessorKind(kind string) bool {
+	switch kind {
+	case "getters", "setters", "methods", "generatorMethods", "asyncMethods":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasParameterProperty(node *ast.Node) bool {
+	if node.Kind != ast.KindConstructor {
+		return false
+	}
+	for _, param := range node.Parameters() {
+		if ast.IsParameterPropertyDeclaration(param, node) {
+			return true
+		}
+	}
+	return false
+}
+
+// emptyFunctionDisplayName mirrors ESLint's getFunctionNameWithKind for this
+// rule's message. It intentionally does not recover outer variable names for
+// anonymous function expressions because upstream reports those as plain
+// "function" / "arrow function".
+func emptyFunctionDisplayName(node *ast.Node) string {
+	if node.Kind == ast.KindConstructor {
+		return "constructor"
+	}
+
+	tokens := make([]string, 0, 5)
+	parent := parentSkippingParens(node)
+
+	if isClassMemberFunction(node) {
+		if ast.HasSyntacticModifier(node, ast.ModifierFlagsStatic) {
+			tokens = append(tokens, "static")
+		}
+		if name := node.Name(); name != nil && name.Kind == ast.KindPrivateIdentifier {
+			tokens = append(tokens, "private")
+		}
+	} else if parent != nil && parent.Kind == ast.KindPropertyDeclaration && parent.Parent != nil && ast.IsClassLike(parent.Parent) {
+		if ast.HasSyntacticModifier(parent, ast.ModifierFlagsStatic) {
+			tokens = append(tokens, "static")
+		}
+		if name := parent.Name(); name != nil && name.Kind == ast.KindPrivateIdentifier {
+			tokens = append(tokens, "private")
+		}
+	}
+
+	flags := ast.GetFunctionFlags(node)
+	if flags&ast.FunctionFlagsAsync != 0 {
+		tokens = append(tokens, "async")
+	}
+	if flags&ast.FunctionFlagsGenerator != 0 {
+		tokens = append(tokens, "generator")
+	}
+
+	switch {
+	case node.Kind == ast.KindGetAccessor:
+		tokens = append(tokens, "getter")
+	case node.Kind == ast.KindSetAccessor:
+		tokens = append(tokens, "setter")
+	case node.Kind == ast.KindMethodDeclaration:
+		tokens = append(tokens, "method")
+	case parent != nil && parent.Kind == ast.KindPropertyAssignment:
+		tokens = append(tokens, "method")
+	case parent != nil && parent.Kind == ast.KindPropertyDeclaration && parent.Parent != nil && ast.IsClassLike(parent.Parent):
+		tokens = append(tokens, "method")
+	default:
+		if node.Kind == ast.KindArrowFunction {
+			tokens = append(tokens, "arrow")
+		}
+		tokens = append(tokens, "function")
+	}
+
+	if name := functionDisplayName(node); name != "" {
+		tokens = append(tokens, name)
+	}
+
+	return strings.Join(tokens, " ")
+}
+
+func parentSkippingParens(node *ast.Node) *ast.Node {
+	if node == nil || node.Parent == nil {
+		return nil
+	}
+	// tsgo keeps ParenthesizedExpression nodes that ESLint does not expose
+	// here, so recover the property/class-field container around `(fn)`.
+	return ast.WalkUpParenthesizedExpressions(node.Parent)
+}
+
+func isClassMemberFunction(node *ast.Node) bool {
+	return node != nil && node.Parent != nil && ast.IsClassLike(node.Parent) && ast.IsMethodOrAccessor(node)
+}
+
+func functionDisplayName(node *ast.Node) string {
+	if parent := parentSkippingParens(node); parent != nil {
+		switch parent.Kind {
+		case ast.KindPropertyAssignment, ast.KindPropertyDeclaration:
+			if name := memberDisplayName(parent.Name()); name != "" {
+				return name
+			}
+			if node.Kind == ast.KindFunctionExpression {
+				return ownFunctionDisplayName(node)
+			}
+			return ""
+		}
+	}
+
+	switch node.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		if display := memberDisplayName(node.Name()); display != "" {
+			return display
+		}
+		if node.Kind == ast.KindMethodDeclaration {
+			return ownFunctionDisplayName(node)
+		}
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression:
+		return ownFunctionDisplayName(node)
+	}
+
+	return ""
+}
+
+func memberDisplayName(name *ast.Node) string {
+	if name == nil {
+		return ""
+	}
+	if name.Kind == ast.KindPrivateIdentifier {
+		return utils.GetPropertyDisplayName(name)
+	}
+	if displayName := utils.GetPropertyDisplayName(name); displayName != "" {
+		return fmt.Sprintf("'%s'", displayName)
+	}
+	return ""
+}
+
+func ownFunctionDisplayName(node *ast.Node) string {
+	name := node.Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return fmt.Sprintf("'%s'", name.AsIdentifier().Text)
+}

--- a/internal/rules/no_empty_function/no_empty_function.md
+++ b/internal/rules/no_empty_function/no_empty_function.md
@@ -1,0 +1,93 @@
+# no-empty-function
+
+## Rule Details
+
+Disallow empty functions. Empty functions can hide incomplete refactors; add a
+comment to intentionally empty function bodies, or configure an allowed function
+kind.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function noop() {}
+
+const handler = () => {};
+
+class Service {
+  connect() {}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function noop() {
+  // intentionally empty
+}
+
+const handler = () => value;
+
+class Service {
+  connect() {
+    start();
+  }
+}
+```
+
+TypeScript parameter-property constructors are also allowed:
+
+```typescript
+class Store {
+  constructor(private readonly id: string) {}
+}
+```
+
+## Options
+
+- `allow`: An array of empty function kinds to permit. Default: `[]`.
+
+Allowed values:
+
+- `functions`
+- `arrowFunctions`
+- `generatorFunctions`
+- `methods`
+- `generatorMethods`
+- `getters`
+- `setters`
+- `constructors`
+- `asyncFunctions`
+- `asyncMethods`
+- `privateConstructors`
+- `protectedConstructors`
+- `decoratedFunctions`
+- `overrideMethods`
+
+Examples of **correct** code for this rule with `{ "allow": ["constructors"] }`:
+
+```json
+{ "no-empty-function": ["error", { "allow": ["constructors"] }] }
+```
+
+```javascript
+class Service {
+  constructor() {}
+}
+```
+
+Examples of **correct** code for this rule with `{ "allow": ["decoratedFunctions"] }`:
+
+```json
+{ "no-empty-function": ["error", { "allow": ["decoratedFunctions"] }] }
+```
+
+```typescript
+class Service {
+  @bound
+  handle() {}
+}
+```
+
+## Original Documentation
+
+- [ESLint: no-empty-function](https://eslint.org/docs/latest/rules/no-empty-function)

--- a/internal/rules/no_empty_function/no_empty_function_extras_test.go
+++ b/internal/rules/no_empty_function/no_empty_function_extras_test.go
@@ -1,0 +1,175 @@
+// TestNoEmptyFunctionExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+//
+// Dimension 4 walk (rows that don't apply to no-empty-function, with reasons):
+//   - N/A member receiver wrappers ((X).y, X!.y, X as T, X satisfies T, X?.y):
+//     the rule inspects function-like declarations and their block body, not a
+//     member receiver expression. Expression wrappers around function values
+//     are covered below because tsgo preserves those wrappers.
+//   - N/A element access forms (X['y'], X[`y`], X[0]): the rule does not
+//     inspect member expressions.
+//   - N/A autofix boundaries: the rule has suggestions only, not an autofix.
+package no_empty_function
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoEmptyFunctionExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEmptyFunctionRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: non-block arrow body is not an empty function ----
+			{Code: `const fn = () => value;`},
+
+			// ---- Dimension 4: expression wrappers around function values preserve allow matching ----
+			{Code: `const fn = ((() => {})) as Fn;`, Options: map[string]interface{}{"allow": []interface{}{"arrowFunctions"}}},
+			{Code: `const fn = (function named() {}) satisfies Fn;`, Options: map[string]interface{}{"allow": []interface{}{"functions"}}},
+			{Code: `const fn = (function named() {})!;`, Options: map[string]interface{}{"allow": []interface{}{"functions"}}},
+
+			// ---- Dimension 4: comments inside an otherwise empty body are allowed ----
+			{Code: `function f() { /* intentionally empty */ }`},
+			{Code: "const f = () => {\n  // intentionally empty\n};"},
+			{Code: `class C { method() { /* intentionally empty */ } }`},
+
+			// Locks in upstream reportIfEmpty() arm: non-empty body short-circuits before options.
+			{Code: `function f() { sideEffect(); }`},
+			{Code: `function f() { ; }`},
+			{Code: `function f() { "use strict"; }`},
+			{Code: `class C { method() { sideEffect(); } }`},
+
+			// Locks in upstream isAllowedEmptyFunction() constructors arm: TS parameter properties are allowed.
+			{Code: `class C { constructor(public value: string) {} }`},
+			{Code: `class C { constructor(private value: string) {} }`},
+			{Code: `class C { constructor(protected value: string) {} }`},
+			{Code: `class C { constructor(readonly value: string) {} }`},
+
+			// Locks in upstream isAllowedEmptyFunction() private/protected constructor arms.
+			{Code: `class C { private constructor() {} }`, Options: map[string]interface{}{"allow": []interface{}{"privateConstructors"}}},
+			{Code: `class C { protected constructor() {} }`, Options: map[string]interface{}{"allow": []interface{}{"protectedConstructors"}}},
+
+			// Locks in upstream isAllowedEmptyFunction() decoratedFunctions arm.
+			{Code: `class C { @Log("This is a contrived example.") blah(): void { } }`, Options: map[string]interface{}{"allow": []interface{}{"decoratedFunctions"}}},
+
+			// ---- Real-user: typescript-eslint#2838 decorated methods may be intentionally empty ----
+			{Code: `class C { @Log("This is a contrived example.") blah(): void {} }`, Options: map[string]interface{}{"allow": []interface{}{"decoratedFunctions"}}},
+
+			// ---- Real-user: typescript-eslint#2278 decorated private methods may be intentionally empty ----
+			{Code: `class C { @Emit("click") private onClick() {} }`, Options: map[string]interface{}{"allow": []interface{}{"decoratedFunctions"}}},
+
+			// Locks in upstream isAllowedEmptyFunction() overrideMethods arm.
+			{Code: `class C extends B { override method() {} }`, Options: map[string]interface{}{"allow": []interface{}{"overrideMethods"}}},
+			{Code: `class C extends B { static override async method() {} }`, Options: map[string]interface{}{"allow": []interface{}{"overrideMethods"}}},
+
+			// ---- Dimension 4: class-field arrows are named as methods but allowed by arrowFunctions ----
+			{Code: `class C { field = () => {} }`, Options: map[string]interface{}{"allow": []interface{}{"arrowFunctions"}}},
+			{Code: `class C { field = (() => {}) }`, Options: map[string]interface{}{"allow": []interface{}{"arrowFunctions"}}},
+
+			// Locks in upstream getKind() parent PropertyDefinition fallback: class-field function expressions are functions.
+			{Code: `class C { field = function named() {} }`, Options: map[string]interface{}{"allow": []interface{}{"functions"}}},
+			{Code: `class C { field = async function named() {} }`, Options: map[string]interface{}{"allow": []interface{}{"asyncFunctions"}}},
+
+			// Locks in upstream getKind() parent Property fallback: object property arrows/functions keep their function kind.
+			{Code: `const obj = { foo: () => {} };`, Options: map[string]interface{}{"allow": []interface{}{"arrowFunctions"}}},
+			{Code: `const obj = { foo: async function () {} };`, Options: map[string]interface{}{"allow": []interface{}{"asyncFunctions"}}},
+
+			// ---- Dimension 4: async generator functions take the generatorFunctions kind, matching upstream prefix priority ----
+			{Code: `async function* f() {}`, Options: map[string]interface{}{"allow": []interface{}{"generatorFunctions"}}},
+			{Code: `class C { async *m() {} }`, Options: map[string]interface{}{"allow": []interface{}{"generatorMethods"}}},
+
+			// Locks in option parsing for combined arrays and the typed []string branch.
+			{Code: `function f() {} const g = () => {}; class C { method() {} }`, Options: map[string]interface{}{"allow": []interface{}{"functions", "arrowFunctions", "methods"}}},
+			{Code: `function f() {}`, Options: map[string]interface{}{"allow": []string{"functions"}}},
+
+			// ---- Dimension 4: declaration/body-absent forms do not report or crash ----
+			{Code: `declare function f(): void;`},
+			{Code: `abstract class C { abstract method(): void }`},
+			{Code: `class C { method(): void; }`},
+			{Code: `class C {}`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: class-field arrow name comes from the property definition ----
+			generatedInvalidCase(`class C { field = () => {} }`, "method 'field'", map[string]interface{}{"allow": []interface{}{"methods"}}),
+			generatedInvalidCase(`class C { field = (() => {}) }`, "method 'field'", map[string]interface{}{"allow": []interface{}{"methods"}}),
+			generatedInvalidCase(`class C { field = ((function named() {})) }`, "method 'field'", nil),
+			generatedInvalidCase(`class C { field = function named() {} }`, "method 'field'", map[string]interface{}{"allow": []interface{}{"methods"}}),
+
+			// ---- Dimension 4: expression wrappers around function values do not hide empty bodies ----
+			generatedInvalidCase(`const fn = (() => {}) as Fn;`, "arrow function", nil),
+			generatedInvalidCase(`const fn = (function named() {}) satisfies Fn;`, "function 'named'", nil),
+			generatedInvalidCase(`const fn = (function named() {})!;`, "function 'named'", nil),
+
+			// ---- Dimension 4: private class-field arrow uses raw PrivateIdentifier name ----
+			generatedInvalidCase(`class C { static #field = () => {} }`, "static private method #field", nil),
+			generatedInvalidCase(`class C { static #field = (async () => {}) }`, "static private async method #field", nil),
+			generatedInvalidCase(`class C { "#field" = () => {} }`, "method '#field'", nil),
+			generatedInvalidCase(`class C { static #field() {} }`, "static private method #field", nil),
+			generatedInvalidCase(`class C { static async #field() {} }`, "static private async method #field", nil),
+
+			// ---- Dimension 4: string / numeric / computed-static / private / dynamic keys ----
+			generatedInvalidCase(`const obj = {"quoted"() {}};`, "method 'quoted'", nil),
+			generatedInvalidCase(`const obj = {0() {}};`, "method '0'", nil),
+			generatedInvalidCase(`const obj = { ["computed"]() {} };`, "method 'computed'", nil),
+			generatedInvalidCase("const obj = { [`computed`]() {} };", "method 'computed'", nil),
+			generatedInvalidCase(`class C { [0x10]() {} }`, "method '16'", nil),
+			generatedInvalidCase(`class C { [1n]() {} }`, "method '1'", nil),
+			generatedInvalidCase(`class C { ["computed"]() {} }`, "method 'computed'", nil),
+			generatedInvalidCase(`class C { #privateMethod() {} }`, "private method #privateMethod", nil),
+			generatedInvalidCase(`class C { [dynamicName]() {} }`, "method", nil),
+			generatedInvalidCase(`const obj = {foo: (function () {})};`, "method 'foo'", nil),
+			generatedInvalidCase(`const obj = {foo: (() => {})};`, "method 'foo'", nil),
+			generatedInvalidCase(`const obj = {[dynamicName]: (function () {})};`, "method", nil),
+
+			// Locks in upstream getKind() parent Property/PropertyDefinition fallbacks.
+			generatedInvalidCase(`const obj = { foo: () => {} };`, "method 'foo'", map[string]interface{}{"allow": []interface{}{"methods"}}),
+			generatedInvalidCase(`const obj = { foo: async function () {} };`, "async method 'foo'", map[string]interface{}{"allow": []interface{}{"asyncMethods"}}),
+
+			// ---- Dimension 4: same-kind nesting reports only the empty inner function ----
+			generatedInvalidCase(`function outer() { function inner() {} }`, "function 'inner'", nil),
+			generatedInvalidCase(`function outer() { const inner = (() => {}); }`, "arrow function", nil),
+			generatedInvalidCase(`class C { static { function nested() {} } }`, "function 'nested'", nil),
+			generatedInvalidCaseWithNames("class C {\n  method() {}\n  field = () => {}\n}\nconst obj = { nested: function named() {} };\n", "method 'method'", "method 'field'", "method 'nested'"),
+
+			// ---- Dimension 4: spread/rest shapes do not mask sibling empty functions ----
+			generatedInvalidCase(`const obj = { ...extra, method() {} };`, "method 'method'", nil),
+			generatedInvalidCase(`function f(...args) {}`, "function 'f'", nil),
+			generatedInvalidCase(`function f() /* outside body */ {}`, "function 'f'", nil),
+			locationCase("class C {\n  field = () => {\n  }\n}", "method 'field'", 2, 17, 3, 4, "class C {\n  field = () => { /* empty */ }\n}"),
+
+			// Locks in upstream isAllowedEmptyFunction() constructors arm: ESLint uses camelCase option names.
+			generatedInvalidCase(`class C { private constructor() {} }`, "constructor", map[string]interface{}{"allow": []interface{}{"private-constructors"}}),
+			generatedInvalidCase(`class C { protected constructor() {} }`, "constructor", map[string]interface{}{"allow": []interface{}{"protected-constructors"}}),
+
+			// Locks in upstream getKind() prefix priority: async generator is not allowed by asyncFunctions.
+			generatedInvalidCase(`async function* f() {}`, "async generator function 'f'", map[string]interface{}{"allow": []interface{}{"asyncFunctions"}}),
+			generatedInvalidCase(`class C { async *m() {} }`, "async generator method 'm'", map[string]interface{}{"allow": []interface{}{"asyncMethods"}}),
+
+			// Locks in option parsing for bare object, empty object, empty allow, and malformed allow values.
+			generatedInvalidCase(`const fn = () => {};`, "arrow function", map[string]interface{}{"allow": []interface{}{"functions"}}),
+			generatedInvalidCase(`function f() {}`, "function 'f'", map[string]interface{}{}),
+			generatedInvalidCase(`function f() {}`, "function 'f'", []interface{}{map[string]interface{}{}}),
+			generatedInvalidCase(`function f() {}`, "function 'f'", map[string]interface{}{"allow": []interface{}{}}),
+			generatedInvalidCase(`function f() {}`, "function 'f'", map[string]interface{}{"allow": "functions"}),
+			generatedInvalidCase(`function f() {}`, "function 'f'", map[string]interface{}{"allow": []interface{}{"unknown"}}),
+
+			// ---- Dimension 4: overload/body-absent declarations do not mask the implementation body ----
+			generatedInvalidCase(`function f(value: string): void; function f(value: number): void; function f(value: string | number) {}`, "function 'f'", nil),
+			generatedInvalidCase(`class C { method(value: string): void; method(value: number): void; method(value: string | number) {} }`, "method 'method'", nil),
+
+			// ---- Real-user: typescript-eslint#2278 still reports decorated methods without the option ----
+			generatedInvalidCase(`class C { @Emit("click") private onClick() {} }`, "method 'onClick'", nil),
+
+			// Locks in upstream isAllowedEmptyFunction() method/accessor-only arm: decorated/override fields stay function/arrow kinds.
+			generatedInvalidCase(`class C { @dec field = () => {} }`, "method 'field'", map[string]interface{}{"allow": []interface{}{"decoratedFunctions"}}),
+			generatedInvalidCase(`class C extends B { override field = () => {} }`, "method 'field'", map[string]interface{}{"allow": []interface{}{"overrideMethods"}}),
+		},
+	)
+}

--- a/internal/rules/no_empty_function/no_empty_function_upstream_test.go
+++ b/internal/rules/no_empty_function/no_empty_function_upstream_test.go
@@ -1,0 +1,349 @@
+// TestNoEmptyFunctionUpstream migrates the full valid/invalid suite from
+// upstream eslint/tests/lib/rules/no-empty-function.js 1:1. Position assertions
+// cover line/column/endLine/endColumn for every invalid case. rslint-specific
+// lock-in cases live in the no_empty_function_extras_test.go file.
+package no_empty_function
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+var allAllowOptions = []string{
+	"functions",
+	"arrowFunctions",
+	"generatorFunctions",
+	"methods",
+	"generatorMethods",
+	"getters",
+	"setters",
+	"constructors",
+	"asyncFunctions",
+	"asyncMethods",
+	"privateConstructors",
+	"protectedConstructors",
+	"decoratedFunctions",
+	"overrideMethods",
+}
+
+type upstreamSeed struct {
+	code  string
+	name  string
+	allow []string
+}
+
+func TestNoEmptyFunctionUpstream(t *testing.T) {
+	valid, invalid := upstreamCases(
+		[]rule_tester.ValidTestCase{{Code: "var foo = () => 0;"}},
+		[]rule_tester.InvalidTestCase{
+			locationCase("function foo() {}", "function 'foo'", 1, 16, 1, 18, "function foo() { /* empty */ }"),
+			locationCase("var foo = function () {\n}", "function", 1, 23, 2, 2, "var foo = function () { /* empty */ }"),
+			locationCase("var foo = () => { \n\n  }", "arrow function", 1, 17, 3, 4, "var foo = () => { /* empty */ }"),
+			locationCase("var obj = {\n\tfoo() {\n\t}\n}", "method 'foo'", 2, 8, 3, 3, "var obj = {\n\tfoo() { /* empty */ }\n}"),
+			locationCase("class A { foo() { } }", "method 'foo'", 1, 17, 1, 20, "class A { foo() { /* empty */ } }"),
+		},
+		upstreamJSSSeeds,
+	)
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEmptyFunctionRule,
+		valid,
+		invalid,
+	)
+}
+
+func TestNoEmptyFunctionUpstreamTypeScript(t *testing.T) {
+	valid, invalid := upstreamCases(
+		[]rule_tester.ValidTestCase{
+			{Code: "class A { constructor(public param: string) {} }"},
+			{Code: "class A { constructor(private param: string) {} }"},
+			{Code: "class A { constructor(protected param: string) {} }"},
+			{Code: "class A { constructor(readonly param: string) {} }"},
+		},
+		nil,
+		upstreamTSSeeds,
+	)
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEmptyFunctionRule,
+		valid,
+		invalid,
+	)
+}
+
+func upstreamCases(initialValid []rule_tester.ValidTestCase, initialInvalid []rule_tester.InvalidTestCase, seeds []upstreamSeed) ([]rule_tester.ValidTestCase, []rule_tester.InvalidTestCase) {
+	valid := append([]rule_tester.ValidTestCase{}, initialValid...)
+	invalid := append([]rule_tester.InvalidTestCase{}, initialInvalid...)
+
+	for _, seed := range seeds {
+		valid = append(valid,
+			rule_tester.ValidTestCase{Code: strings.Replace(seed.code, "{}", "{ bar(); }", 1)},
+			rule_tester.ValidTestCase{Code: strings.Replace(seed.code, "{}", "{ /* empty */ }", 1)},
+			rule_tester.ValidTestCase{Code: strings.Replace(seed.code, "{}", "{\n    // empty\n}", 1)},
+		)
+		for _, allow := range seed.allow {
+			valid = append(valid, rule_tester.ValidTestCase{
+				Code:    seed.code + " // allow: " + allow,
+				Options: allowOption(allow),
+			})
+		}
+
+		invalid = append(invalid, generatedInvalidCase(seed.code, seed.name, nil))
+		for _, allow := range allAllowOptions {
+			if containsString(seed.allow, allow) {
+				continue
+			}
+			code := seed.code + " // allow: " + allow
+			invalid = append(invalid, generatedInvalidCase(code, seed.name, allowOption(allow)))
+		}
+	}
+
+	return valid, invalid
+}
+
+func allowOption(allow string) []interface{} {
+	return []interface{}{map[string]interface{}{"allow": []interface{}{allow}}}
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
+func generatedInvalidCase(code string, name string, options any) rule_tester.InvalidTestCase {
+	tc := rule_tester.InvalidTestCase{
+		Code:    code,
+		Options: options,
+		Errors: []rule_tester.InvalidTestCaseError{
+			generatedInvalidError(code, name, 0),
+		},
+	}
+	return tc
+}
+
+func generatedInvalidCaseWithNames(code string, names ...string) rule_tester.InvalidTestCase {
+	errors := make([]rule_tester.InvalidTestCaseError, 0, len(names))
+	for i, name := range names {
+		errors = append(errors, generatedInvalidError(code, name, i))
+	}
+	return rule_tester.InvalidTestCase{
+		Code:   code,
+		Errors: errors,
+	}
+}
+
+func generatedInvalidError(code string, name string, occurrence int) rule_tester.InvalidTestCaseError {
+	start := nthIndex(code, "{}", occurrence)
+	if start < 0 {
+		panic("generated no-empty-function case must contain enough {} bodies: " + code)
+	}
+	line, column := lineColumnForOffset(code, start)
+	endLine, endColumn := lineColumnForOffset(code, start+2)
+	output := code[:start] + "{ /* empty */ }" + code[start+2:]
+	return emptyFunctionError(name, line, column, endLine, endColumn, output)
+}
+
+func nthIndex(s string, substr string, occurrence int) int {
+	if occurrence < 0 {
+		return -1
+	}
+	offset := 0
+	for i := 0; i <= occurrence; i++ {
+		idx := strings.Index(s[offset:], substr)
+		if idx < 0 {
+			return -1
+		}
+		if i == occurrence {
+			return offset + idx
+		}
+		offset += idx + len(substr)
+	}
+	return -1
+}
+
+func locationCase(code string, name string, line int, column int, endLine int, endColumn int, output string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code: code,
+		Errors: []rule_tester.InvalidTestCaseError{
+			emptyFunctionError(name, line, column, endLine, endColumn, output),
+		},
+	}
+}
+
+func emptyFunctionError(name string, line int, column int, endLine int, endColumn int, output string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "unexpected",
+		Message:   "Unexpected empty " + name + ".",
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+		Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+			{MessageId: "suggestComment", Output: output},
+		},
+	}
+}
+
+func lineColumnForOffset(code string, offset int) (int, int) {
+	line, column := 1, 1
+	for i, r := range code {
+		if i >= offset {
+			break
+		}
+		if r == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+	return line, column
+}
+
+var upstreamJSSSeeds = []upstreamSeed{
+	{code: `function foo() {}`, name: "function 'foo'", allow: []string{"functions"}},
+	{code: `var foo = function() {};`, name: "function", allow: []string{"functions"}},
+	{code: `var obj = {foo: function() {}};`, name: "method 'foo'", allow: []string{"functions"}},
+	{code: `var foo = () => {};`, name: "arrow function", allow: []string{"arrowFunctions"}},
+	{code: `function* foo() {}`, name: "generator function 'foo'", allow: []string{"generatorFunctions"}},
+	{code: `var foo = function*() {};`, name: "generator function", allow: []string{"generatorFunctions"}},
+	{code: `var obj = {foo: function*() {}};`, name: "generator method 'foo'", allow: []string{"generatorFunctions"}},
+	{code: `var obj = {foo() {}};`, name: "method 'foo'", allow: []string{"methods"}},
+	{code: `class A {foo() {}}`, name: "method 'foo'", allow: []string{"methods"}},
+	{code: `class A {static foo() {}}`, name: "static method 'foo'", allow: []string{"methods"}},
+	{code: `var A = class {foo() {}};`, name: "method 'foo'", allow: []string{"methods"}},
+	{code: `var A = class {static foo() {}};`, name: "static method 'foo'", allow: []string{"methods"}},
+	{code: `var obj = {*foo() {}};`, name: "generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `class A {*foo() {}}`, name: "generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `class A {static *foo() {}}`, name: "static generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `var A = class {*foo() {}};`, name: "generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `var A = class {static *foo() {}};`, name: "static generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `var obj = {get foo() {}};`, name: "getter 'foo'", allow: []string{"getters"}},
+	{code: `class A {get foo() {}}`, name: "getter 'foo'", allow: []string{"getters"}},
+	{code: `class A {static get foo() {}}`, name: "static getter 'foo'", allow: []string{"getters"}},
+	{code: `var A = class {get foo() {}};`, name: "getter 'foo'", allow: []string{"getters"}},
+	{code: `var A = class {static get foo() {}};`, name: "static getter 'foo'", allow: []string{"getters"}},
+	{code: `var obj = {set foo(value) {}};`, name: "setter 'foo'", allow: []string{"setters"}},
+	{code: `class A {set foo(value) {}}`, name: "setter 'foo'", allow: []string{"setters"}},
+	{code: `class A {static set foo(value) {}}`, name: "static setter 'foo'", allow: []string{"setters"}},
+	{code: `var A = class {set foo(value) {}};`, name: "setter 'foo'", allow: []string{"setters"}},
+	{code: `var A = class {static set foo(value) {}};`, name: "static setter 'foo'", allow: []string{"setters"}},
+	{code: `class A {constructor() {}}`, name: "constructor", allow: []string{"constructors"}},
+	{code: `var A = class {constructor() {}};`, name: "constructor", allow: []string{"constructors"}},
+	{code: `const foo = { async method() {} }`, name: "async method 'method'", allow: []string{"asyncMethods"}},
+	{code: `async function a(){}`, name: "async function 'a'", allow: []string{"asyncFunctions"}},
+	{code: `const foo = async function () {}`, name: "async function", allow: []string{"asyncFunctions"}},
+	{code: `class Foo { async bar() {} }`, name: "async method 'bar'", allow: []string{"asyncMethods"}},
+	{code: `const foo = async () => {};`, name: "async arrow function", allow: []string{"arrowFunctions"}},
+}
+
+var upstreamTSSeeds = []upstreamSeed{
+	{code: `function foo() {}`, name: "function 'foo'", allow: []string{"functions"}},
+	{code: `const foo = function(param: string) {};`, name: "function", allow: []string{"functions"}},
+	{code: `const obj = {foo: function(param: string) {}};`, name: "method 'foo'", allow: []string{"functions"}},
+	{code: `const foo = (param: string) => {};`, name: "arrow function", allow: []string{"arrowFunctions"}},
+	{code: `function* foo(param: string) {}`, name: "generator function 'foo'", allow: []string{"generatorFunctions"}},
+	{code: `const foo = function*(param: string) {};`, name: "generator function", allow: []string{"generatorFunctions"}},
+	{code: `const obj = {foo: function*(param: string) {}};`, name: "generator method 'foo'", allow: []string{"generatorFunctions"}},
+	{code: `const obj = {foo(param: string) {}};`, name: "method 'foo'", allow: []string{"methods"}},
+	{code: `class A { foo(param: string) {} }`, name: "method 'foo'", allow: []string{"methods"}},
+	{code: `class A { private foo() {} }`, name: "method 'foo'", allow: []string{"methods"}},
+	{code: `class A { protected foo() {} }`, name: "method 'foo'", allow: []string{"methods"}},
+	{code: `class A { static foo(param: string) {} }`, name: "static method 'foo'", allow: []string{"methods"}},
+	{code: `class A { private static foo() {} }`, name: "static method 'foo'", allow: []string{"methods"}},
+	{code: `class A { protected static foo() {} }`, name: "static method 'foo'", allow: []string{"methods"}},
+	{code: `const A = class {foo(param: string) {}};`, name: "method 'foo'", allow: []string{"methods"}},
+	{code: `const A = class {static foo(param: string) {}};`, name: "static method 'foo'", allow: []string{"methods"}},
+	{code: `const A = class {private static foo() {}};`, name: "static method 'foo'", allow: []string{"methods"}},
+	{code: `const A = class {protected static foo() {}};`, name: "static method 'foo'", allow: []string{"methods"}},
+	{code: `class B { @decorator() foo() {} }`, name: "method 'foo'", allow: []string{"methods", "decoratedFunctions"}},
+	{code: `const B = class { @decorator() foo() {} }`, name: "method 'foo'", allow: []string{"methods", "decoratedFunctions"}},
+	{code: `class B extends C { override foo() {} }`, name: "method 'foo'", allow: []string{"methods", "overrideMethods"}},
+	{code: `class B extends C { @decorator() override foo() {} }`, name: "method 'foo'", allow: []string{"methods", "decoratedFunctions", "overrideMethods"}},
+	{code: `const obj = {*foo(param: string) {}};`, name: "generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `class A { *foo(param: string) {} }`, name: "generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `class A {static *foo(param: string) {}}`, name: "static generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `class A {private static *foo() {}}`, name: "static generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `class A {protected static *foo() {}}`, name: "static generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `const A = class {*foo(param: string) {}};`, name: "generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `const A = class {static *foo(param: string) {}};`, name: "static generator method 'foo'", allow: []string{"generatorMethods"}},
+	{code: `const obj = {get foo(): string {}};`, name: "getter 'foo'", allow: []string{"getters"}},
+	{code: `class A {get foo(): string {}}`, name: "getter 'foo'", allow: []string{"getters"}},
+	{code: `class A {static get foo(): string {}}`, name: "static getter 'foo'", allow: []string{"getters"}},
+	{code: `const A = class {get foo(): string {}};`, name: "getter 'foo'", allow: []string{"getters"}},
+	{code: `const A = class {static get foo(): string {}};`, name: "static getter 'foo'", allow: []string{"getters"}},
+	{code: `class A {@decorator() get foo(): string {}}`, name: "getter 'foo'", allow: []string{"getters", "decoratedFunctions"}},
+	{code: `class A {@decorator() static get foo(): string {}}`, name: "static getter 'foo'", allow: []string{"getters", "decoratedFunctions"}},
+	{code: `const A = class {@decorator() get foo(): string {}};`, name: "getter 'foo'", allow: []string{"getters", "decoratedFunctions"}},
+	{code: `const A = class {@decorator() static get foo(): string {}};`, name: "static getter 'foo'", allow: []string{"getters", "decoratedFunctions"}},
+	{code: `class A extends B {override get foo(): string {}}`, name: "getter 'foo'", allow: []string{"getters", "overrideMethods"}},
+	{code: `class A extends B {static override get foo(): string {}}`, name: "static getter 'foo'", allow: []string{"getters", "overrideMethods"}},
+	{code: `const A = class extends B {override get foo(): string {}};`, name: "getter 'foo'", allow: []string{"getters", "overrideMethods"}},
+	{code: `const A = class extends B {static override get foo(): string {}};`, name: "static getter 'foo'", allow: []string{"getters", "overrideMethods"}},
+	{code: `const obj = {set foo(value: string) {}};`, name: "setter 'foo'", allow: []string{"setters"}},
+	{code: `class A {set foo(value: string) {}}`, name: "setter 'foo'", allow: []string{"setters"}},
+	{code: `class A {static set foo(value: string) {}}`, name: "static setter 'foo'", allow: []string{"setters"}},
+	{code: `const A = class {set foo(value: string) {}};`, name: "setter 'foo'", allow: []string{"setters"}},
+	{code: `const A = class {static set foo(value: string) {}};`, name: "static setter 'foo'", allow: []string{"setters"}},
+	{code: `class A {@decorator() set foo(value: string) {}}`, name: "setter 'foo'", allow: []string{"setters", "decoratedFunctions"}},
+	{code: `class A {@decorator() static set foo(value: string) {}}`, name: "static setter 'foo'", allow: []string{"setters", "decoratedFunctions"}},
+	{code: `const A = class {@decorator() set foo(value: string) {}};`, name: "setter 'foo'", allow: []string{"setters", "decoratedFunctions"}},
+	{code: `const A = class {@decorator() static set foo(value: string) {}};`, name: "static setter 'foo'", allow: []string{"setters", "decoratedFunctions"}},
+	{code: `class A extends B {override set foo(value: string) {}}`, name: "setter 'foo'", allow: []string{"setters", "overrideMethods"}},
+	{code: `class A extends B {static override set foo(value: string) {}}`, name: "static setter 'foo'", allow: []string{"setters", "overrideMethods"}},
+	{code: `const A = class extends B {override set foo(value: string) {}};`, name: "setter 'foo'", allow: []string{"setters", "overrideMethods"}},
+	{code: `const A = class extends B {static override set foo(value: string) {}};`, name: "static setter 'foo'", allow: []string{"setters", "overrideMethods"}},
+	{code: `class A { constructor(param: string) {} }`, name: "constructor", allow: []string{"constructors"}},
+	{code: `class B { private constructor() {} }`, name: "constructor", allow: []string{"constructors", "privateConstructors"}},
+	{code: `class B { protected constructor() {} }`, name: "constructor", allow: []string{"constructors", "protectedConstructors"}},
+	{code: `const A = class {constructor(param: string) {}};`, name: "constructor", allow: []string{"constructors"}},
+	{code: `const B = class { private constructor() {} }`, name: "constructor", allow: []string{"constructors", "privateConstructors"}},
+	{code: `const B = class { protected constructor() {} }`, name: "constructor", allow: []string{"constructors", "protectedConstructors"}},
+	{code: `const foo = { async method(param: string) {} }`, name: "async method 'method'", allow: []string{"asyncMethods"}},
+	{code: `async function a(param: string){}`, name: "async function 'a'", allow: []string{"asyncFunctions"}},
+	{code: `const foo = async function(param: string) {}`, name: "async function", allow: []string{"asyncFunctions"}},
+	{code: `class A { async foo(param: string) {} }`, name: "async method 'foo'", allow: []string{"asyncMethods"}},
+	{code: `class A { @decorator() async foo(param: string) {} }`, name: "async method 'foo'", allow: []string{"asyncMethods", "decoratedFunctions"}},
+	{code: `class A extends B { override async foo(param: string) {} }`, name: "async method 'foo'", allow: []string{"asyncMethods", "overrideMethods"}},
+	{code: `const foo = async (): Promise<void> => {};`, name: "async arrow function", allow: []string{"arrowFunctions"}},
+	{code: `class A { private constructor() {} }`, name: "constructor", allow: []string{"privateConstructors", "constructors"}},
+	{code: `const A = class { private constructor() {} };`, name: "constructor", allow: []string{"privateConstructors", "constructors"}},
+	{code: `class A { protected constructor() {} }`, name: "constructor", allow: []string{"protectedConstructors", "constructors"}},
+	{code: `const A = class { protected constructor() {} };`, name: "constructor", allow: []string{"protectedConstructors", "constructors"}},
+	{code: `class A { @decorator() foo() {} }`, name: "method 'foo'", allow: []string{"decoratedFunctions", "methods"}},
+	{code: `const A = class { @decorator() foo() {} }`, name: "method 'foo'", allow: []string{"decoratedFunctions", "methods"}},
+	{code: `class B {@decorator() get foo(): string {}}`, name: "getter 'foo'", allow: []string{"decoratedFunctions", "getters"}},
+	{code: `class B {@decorator() static get foo(): string {}}`, name: "static getter 'foo'", allow: []string{"decoratedFunctions", "getters"}},
+	{code: `const B = class {@decorator() get foo(): string {}};`, name: "getter 'foo'", allow: []string{"decoratedFunctions", "getters"}},
+	{code: `const B = class {@decorator() static get foo(): string {}};`, name: "static getter 'foo'", allow: []string{"decoratedFunctions", "getters"}},
+	{code: `class B {@decorator() set foo(value: string) {}}`, name: "setter 'foo'", allow: []string{"decoratedFunctions", "setters"}},
+	{code: `class B {@decorator() static set foo(value: string) {}}`, name: "static setter 'foo'", allow: []string{"decoratedFunctions", "setters"}},
+	{code: `const B = class {@decorator() set foo(value: string) {}};`, name: "setter 'foo'", allow: []string{"decoratedFunctions", "setters"}},
+	{code: `const B = class {@decorator() static set foo(value: string) {}};`, name: "static setter 'foo'", allow: []string{"decoratedFunctions", "setters"}},
+	{code: `class B { @decorator() async foo(param: string) {} }`, name: "async method 'foo'", allow: []string{"decoratedFunctions", "asyncMethods"}},
+	{code: `class A extends B { @decorator() override foo() {} }`, name: "method 'foo'", allow: []string{"decoratedFunctions", "methods", "overrideMethods"}},
+	{code: `class B extends C {override get foo(): string {}}`, name: "getter 'foo'", allow: []string{"overrideMethods", "getters"}},
+	{code: `class B extends C {static override get foo(): string {}}`, name: "static getter 'foo'", allow: []string{"overrideMethods", "getters"}},
+	{code: `const B = class extends C {override get foo(): string {}};`, name: "getter 'foo'", allow: []string{"overrideMethods", "getters"}},
+	{code: `const B = class extends C {static override get foo(): string {}};`, name: "static getter 'foo'", allow: []string{"overrideMethods", "getters"}},
+	{code: `class B extends C {override set foo(value: string) {}}`, name: "setter 'foo'", allow: []string{"overrideMethods", "setters"}},
+	{code: `class B extends C {static override set foo(value: string) {}}`, name: "static setter 'foo'", allow: []string{"overrideMethods", "setters"}},
+	{code: `const B = class extends C {override set foo(value: string) {}};`, name: "setter 'foo'", allow: []string{"overrideMethods", "setters"}},
+	{code: `const B = class extends C {static override set foo(value: string) {}};`, name: "static setter 'foo'", allow: []string{"overrideMethods", "setters"}},
+	{code: `class B extends C { override async foo(param: string) {} }`, name: "async method 'foo'", allow: []string{"overrideMethods", "asyncMethods"}},
+	{code: `class C extends D { @decorator() override foo() {} }`, name: "method 'foo'", allow: []string{"overrideMethods", "methods", "decoratedFunctions"}},
+	{code: `class A extends B { override foo() {} }`, name: "method 'foo'", allow: []string{"overrideMethods", "methods"}},
+}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1149,6 +1149,25 @@ func GetNameFromMember(sourceFile *ast.SourceFile, member *ast.Node) (string, Me
 	return sourceFile.Text()[r.Pos():r.End()], MemberNameTypeExpression
 }
 
+// GetPropertyDisplayName resolves a property-name node to the diagnostic name
+// ESLint emits for statically-known member keys. Private identifiers keep their
+// leading "#"; dynamic computed keys return "".
+func GetPropertyDisplayName(name *ast.Node) string {
+	if name == nil {
+		return ""
+	}
+	if name.Kind == ast.KindIdentifier {
+		return name.AsIdentifier().Text
+	}
+	if name.Kind == ast.KindPrivateIdentifier {
+		return name.AsPrivateIdentifier().Text
+	}
+	if s, ok := GetStaticPropertyName(name); ok {
+		return s
+	}
+	return ""
+}
+
 // GetPropertyInfo extracts the property node and formatted property name from a PropertyAccessExpression
 // or ElementAccessExpression. Returns the property node and a formatted string like ".propertyName" or "[index]".
 // Returns (nil, "") if the node is neither a property access nor an element access expression.

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -172,6 +172,40 @@ func TestResolveLegacyMaxOption(t *testing.T) {
 	}
 }
 
+func TestGetPropertyDisplayName(t *testing.T) {
+	source := "const obj = {\n" +
+		"  id() {},\n" +
+		"  \"quoted\"() {},\n" +
+		"  0() {},\n" +
+		"  [`computed`]() {},\n" +
+		"  [dynamic]() {},\n" +
+		"};\n" +
+		"class C { #private() {} }\n"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, source, core.ScriptKindTS)
+
+	tests := []struct {
+		name       string
+		memberText string
+		want       string
+	}{
+		{name: "identifier", memberText: "id() {}", want: "id"},
+		{name: "string literal", memberText: `"quoted"() {}`, want: "quoted"},
+		{name: "numeric literal", memberText: "0() {}", want: "0"},
+		{name: "static computed template", memberText: "[`computed`]() {}", want: "computed"},
+		{name: "dynamic computed", memberText: "[dynamic]() {}", want: ""},
+		{name: "private identifier", memberText: "#private() {}", want: "#private"},
+	}
+	for _, tt := range tests {
+		member := findNodeWithText(t, sourceFile, tt.memberText)
+		if got := GetPropertyDisplayName(member.Name()); got != tt.want {
+			t.Errorf("%s: GetPropertyDisplayName() = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestIsThisVoidParameter(t *testing.T) {
 	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
 		FileName: "/test.ts",

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -79,6 +79,7 @@ export default defineConfig({
     './tests/eslint/rules/no-duplicate-imports.test.ts',
     './tests/eslint/rules/no-else-return.test.ts',
     './tests/eslint/rules/no-empty.test.ts',
+    './tests/eslint/rules/no-empty-function.test.ts',
     './tests/eslint/rules/no-empty-pattern.test.ts',
     './tests/eslint/rules/no-eval.test.ts',
     './tests/eslint/rules/no-implicit-coercion.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-empty-function.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-empty-function.test.ts.snap
@@ -1,0 +1,3491 @@
+// Rstest Snapshot v1
+
+exports[`no-empty-function > invalid 1`] = `
+{
+  "code": "function foo() {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty function 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 2`] = `
+{
+  "code": "var foo = function () {
+}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 3`] = `
+{
+  "code": "var foo = () => {
+
+  }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty arrow function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 4`] = `
+{
+  "code": "var obj = {
+	foo() {
+	}
+}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 5`] = `
+{
+  "code": "class A { foo() { } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 6`] = `
+{
+  "code": "function foo() {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty function 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 7`] = `
+{
+  "code": "var foo = function() {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 8`] = `
+{
+  "code": "var obj = {foo: function() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 9`] = `
+{
+  "code": "var foo = () => {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty arrow function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 10`] = `
+{
+  "code": "function* foo() {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator function 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 11`] = `
+{
+  "code": "var foo = function*() {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 12`] = `
+{
+  "code": "var obj = {foo: function*() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 13`] = `
+{
+  "code": "var obj = {foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 14`] = `
+{
+  "code": "class A {foo() {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 15`] = `
+{
+  "code": "class A {static foo() {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 16`] = `
+{
+  "code": "var A = class {foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 17`] = `
+{
+  "code": "var A = class {static foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 18`] = `
+{
+  "code": "var obj = {*foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 19`] = `
+{
+  "code": "class A {*foo() {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 20`] = `
+{
+  "code": "class A {static *foo() {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 21`] = `
+{
+  "code": "var A = class {*foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 22`] = `
+{
+  "code": "var A = class {static *foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 23`] = `
+{
+  "code": "var obj = {get foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 24`] = `
+{
+  "code": "class A {get foo() {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 25`] = `
+{
+  "code": "class A {static get foo() {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 26`] = `
+{
+  "code": "var A = class {get foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 27`] = `
+{
+  "code": "var A = class {static get foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 28`] = `
+{
+  "code": "var obj = {set foo(value) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 29`] = `
+{
+  "code": "class A {set foo(value) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 30`] = `
+{
+  "code": "class A {static set foo(value) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 31`] = `
+{
+  "code": "var A = class {set foo(value) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 32`] = `
+{
+  "code": "var A = class {static set foo(value) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 33`] = `
+{
+  "code": "class A {constructor() {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 34`] = `
+{
+  "code": "var A = class {constructor() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 35`] = `
+{
+  "code": "const foo = { async method() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async method 'method'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 36`] = `
+{
+  "code": "async function a(){}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async function 'a'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 37`] = `
+{
+  "code": "const foo = async function () {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 38`] = `
+{
+  "code": "class Foo { async bar() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async method 'bar'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 39`] = `
+{
+  "code": "const foo = async () => {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async arrow function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 40`] = `
+{
+  "code": "function foo() {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty function 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 41`] = `
+{
+  "code": "const foo = function(param: string) {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 42`] = `
+{
+  "code": "const obj = {foo: function(param: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 43`] = `
+{
+  "code": "const foo = (param: string) => {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty arrow function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 44`] = `
+{
+  "code": "function* foo(param: string) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator function 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 45`] = `
+{
+  "code": "const foo = function*(param: string) {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 46`] = `
+{
+  "code": "const obj = {foo: function*(param: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 47`] = `
+{
+  "code": "const obj = {foo(param: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 48`] = `
+{
+  "code": "class A { foo(param: string) {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 49`] = `
+{
+  "code": "class A { private foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 50`] = `
+{
+  "code": "class A { protected foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 51`] = `
+{
+  "code": "class A { static foo(param: string) {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 52`] = `
+{
+  "code": "class A { private static foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 53`] = `
+{
+  "code": "class A { protected static foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 54`] = `
+{
+  "code": "const A = class {foo(param: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 55`] = `
+{
+  "code": "const A = class {static foo(param: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 56`] = `
+{
+  "code": "const A = class {private static foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 57`] = `
+{
+  "code": "const A = class {protected static foo() {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 58`] = `
+{
+  "code": "class B { @decorator() foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 59`] = `
+{
+  "code": "const B = class { @decorator() foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 60`] = `
+{
+  "code": "class B extends C { override foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 61`] = `
+{
+  "code": "class B extends C { @decorator() override foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 62`] = `
+{
+  "code": "const obj = {*foo(param: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 63`] = `
+{
+  "code": "class A { *foo(param: string) {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 64`] = `
+{
+  "code": "class A {static *foo(param: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 65`] = `
+{
+  "code": "class A {private static *foo() {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 66`] = `
+{
+  "code": "class A {protected static *foo() {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 67`] = `
+{
+  "code": "const A = class {*foo(param: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 68`] = `
+{
+  "code": "const A = class {static *foo(param: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static generator method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 69`] = `
+{
+  "code": "const obj = {get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 70`] = `
+{
+  "code": "class A {get foo(): string {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 71`] = `
+{
+  "code": "class A {static get foo(): string {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 72`] = `
+{
+  "code": "const A = class {get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 73`] = `
+{
+  "code": "const A = class {static get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 74`] = `
+{
+  "code": "class A {@decorator() get foo(): string {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 75`] = `
+{
+  "code": "class A {@decorator() static get foo(): string {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 76`] = `
+{
+  "code": "const A = class {@decorator() get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 77`] = `
+{
+  "code": "const A = class {@decorator() static get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 78`] = `
+{
+  "code": "class A extends B {override get foo(): string {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 79`] = `
+{
+  "code": "class A extends B {static override get foo(): string {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 80`] = `
+{
+  "code": "const A = class extends B {override get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 81`] = `
+{
+  "code": "const A = class extends B {static override get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 62,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 82`] = `
+{
+  "code": "const obj = {set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 83`] = `
+{
+  "code": "class A {set foo(value: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 84`] = `
+{
+  "code": "class A {static set foo(value: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 85`] = `
+{
+  "code": "const A = class {set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 86`] = `
+{
+  "code": "const A = class {static set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 87`] = `
+{
+  "code": "class A {@decorator() set foo(value: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 88`] = `
+{
+  "code": "class A {@decorator() static set foo(value: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 89`] = `
+{
+  "code": "const A = class {@decorator() set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 90`] = `
+{
+  "code": "const A = class {@decorator() static set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 61,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 91`] = `
+{
+  "code": "class A extends B {override set foo(value: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 52,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 92`] = `
+{
+  "code": "class A extends B {static override set foo(value: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 59,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 93`] = `
+{
+  "code": "const A = class extends B {override set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 94`] = `
+{
+  "code": "const A = class extends B {static override set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 67,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 95`] = `
+{
+  "code": "class A { constructor(param: string) {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 96`] = `
+{
+  "code": "class B { private constructor() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 97`] = `
+{
+  "code": "class B { protected constructor() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 98`] = `
+{
+  "code": "const A = class {constructor(param: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 99`] = `
+{
+  "code": "const B = class { private constructor() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 100`] = `
+{
+  "code": "const B = class { protected constructor() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 101`] = `
+{
+  "code": "const foo = { async method(param: string) {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async method 'method'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 102`] = `
+{
+  "code": "async function a(param: string){}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async function 'a'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 103`] = `
+{
+  "code": "const foo = async function(param: string) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 104`] = `
+{
+  "code": "class A { async foo(param: string) {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 105`] = `
+{
+  "code": "class A { @decorator() async foo(param: string) {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 106`] = `
+{
+  "code": "class A extends B { override async foo(param: string) {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 107`] = `
+{
+  "code": "const foo = async (): Promise<void> => {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async arrow function.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 108`] = `
+{
+  "code": "class A { private constructor() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 109`] = `
+{
+  "code": "const A = class { private constructor() {} };",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 110`] = `
+{
+  "code": "class A { protected constructor() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 111`] = `
+{
+  "code": "const A = class { protected constructor() {} };",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty constructor.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 112`] = `
+{
+  "code": "class A { @decorator() foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 113`] = `
+{
+  "code": "const A = class { @decorator() foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 114`] = `
+{
+  "code": "class B {@decorator() get foo(): string {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 115`] = `
+{
+  "code": "class B {@decorator() static get foo(): string {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 116`] = `
+{
+  "code": "const B = class {@decorator() get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 117`] = `
+{
+  "code": "const B = class {@decorator() static get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 118`] = `
+{
+  "code": "class B {@decorator() set foo(value: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 119`] = `
+{
+  "code": "class B {@decorator() static set foo(value: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 120`] = `
+{
+  "code": "const B = class {@decorator() set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 121`] = `
+{
+  "code": "const B = class {@decorator() static set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 61,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 122`] = `
+{
+  "code": "class B { @decorator() async foo(param: string) {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 123`] = `
+{
+  "code": "class A extends B { @decorator() override foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 124`] = `
+{
+  "code": "class B extends C {override get foo(): string {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 125`] = `
+{
+  "code": "class B extends C {static override get foo(): string {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 126`] = `
+{
+  "code": "const B = class extends C {override get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 127`] = `
+{
+  "code": "const B = class extends C {static override get foo(): string {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static getter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 62,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 128`] = `
+{
+  "code": "class B extends C {override set foo(value: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 52,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 129`] = `
+{
+  "code": "class B extends C {static override set foo(value: string) {}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 59,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 130`] = `
+{
+  "code": "const B = class extends C {override set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 131`] = `
+{
+  "code": "const B = class extends C {static override set foo(value: string) {}};",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static setter 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 67,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 132`] = `
+{
+  "code": "class B extends C { override async foo(param: string) {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty async method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 133`] = `
+{
+  "code": "class C extends D { @decorator() override foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-function > invalid 134`] = `
+{
+  "code": "class A extends B { override foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty method 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-function",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-empty-function.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-empty-function.test.ts
@@ -1,0 +1,418 @@
+import {
+  RuleTester,
+  type InvalidTestCase,
+  type ValidTestCase,
+} from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+interface Seed {
+  code: string;
+  allow: string[];
+}
+
+function lineColumnForOffset(code: string, offset: number) {
+  let line = 1;
+  let column = 1;
+  for (let i = 0; i < offset; i++) {
+    if (code[i] === '\n') {
+      line++;
+      column = 1;
+    } else {
+      column++;
+    }
+  }
+  return { line, column };
+}
+
+function invalidFromSeed(seed: Seed): InvalidTestCase {
+  const offset = seed.code.lastIndexOf('{}');
+  const { line, column } = lineColumnForOffset(seed.code, offset);
+  return {
+    code: seed.code,
+    errors: [{ messageId: 'unexpected', line, column }],
+  };
+}
+
+function validFromSeed(seed: Seed): ValidTestCase[] {
+  return [
+    seed.code.replace('{}', '{ bar(); }'),
+    seed.code.replace('{}', '{ /* empty */ }'),
+    seed.code.replace('{}', '{\n    // empty\n}'),
+    ...seed.allow.map((allow) => ({
+      code: `${seed.code} // allow: ${allow}`,
+      options: { allow: [allow] },
+    })),
+  ];
+}
+
+const upstreamSeeds: Seed[] = [
+  { code: 'function foo() {}', allow: ['functions'] },
+  { code: 'var foo = function() {};', allow: ['functions'] },
+  { code: 'var obj = {foo: function() {}};', allow: ['functions'] },
+  { code: 'var foo = () => {};', allow: ['arrowFunctions'] },
+  { code: 'function* foo() {}', allow: ['generatorFunctions'] },
+  { code: 'var foo = function*() {};', allow: ['generatorFunctions'] },
+  { code: 'var obj = {foo: function*() {}};', allow: ['generatorFunctions'] },
+  { code: 'var obj = {foo() {}};', allow: ['methods'] },
+  { code: 'class A {foo() {}}', allow: ['methods'] },
+  { code: 'class A {static foo() {}}', allow: ['methods'] },
+  { code: 'var A = class {foo() {}};', allow: ['methods'] },
+  { code: 'var A = class {static foo() {}};', allow: ['methods'] },
+  { code: 'var obj = {*foo() {}};', allow: ['generatorMethods'] },
+  { code: 'class A {*foo() {}}', allow: ['generatorMethods'] },
+  { code: 'class A {static *foo() {}}', allow: ['generatorMethods'] },
+  { code: 'var A = class {*foo() {}};', allow: ['generatorMethods'] },
+  { code: 'var A = class {static *foo() {}};', allow: ['generatorMethods'] },
+  { code: 'var obj = {get foo() {}};', allow: ['getters'] },
+  { code: 'class A {get foo() {}}', allow: ['getters'] },
+  { code: 'class A {static get foo() {}}', allow: ['getters'] },
+  { code: 'var A = class {get foo() {}};', allow: ['getters'] },
+  { code: 'var A = class {static get foo() {}};', allow: ['getters'] },
+  { code: 'var obj = {set foo(value) {}};', allow: ['setters'] },
+  { code: 'class A {set foo(value) {}}', allow: ['setters'] },
+  { code: 'class A {static set foo(value) {}}', allow: ['setters'] },
+  { code: 'var A = class {set foo(value) {}};', allow: ['setters'] },
+  { code: 'var A = class {static set foo(value) {}};', allow: ['setters'] },
+  { code: 'class A {constructor() {}}', allow: ['constructors'] },
+  { code: 'var A = class {constructor() {}};', allow: ['constructors'] },
+  { code: 'const foo = { async method() {} }', allow: ['asyncMethods'] },
+  { code: 'async function a(){}', allow: ['asyncFunctions'] },
+  { code: 'const foo = async function () {}', allow: ['asyncFunctions'] },
+  { code: 'class Foo { async bar() {} }', allow: ['asyncMethods'] },
+  { code: 'const foo = async () => {};', allow: ['arrowFunctions'] },
+  { code: 'function foo() {}', allow: ['functions'] },
+  { code: 'const foo = function(param: string) {};', allow: ['functions'] },
+  {
+    code: 'const obj = {foo: function(param: string) {}};',
+    allow: ['functions'],
+  },
+  { code: 'const foo = (param: string) => {};', allow: ['arrowFunctions'] },
+  { code: 'function* foo(param: string) {}', allow: ['generatorFunctions'] },
+  {
+    code: 'const foo = function*(param: string) {};',
+    allow: ['generatorFunctions'],
+  },
+  {
+    code: 'const obj = {foo: function*(param: string) {}};',
+    allow: ['generatorFunctions'],
+  },
+  { code: 'const obj = {foo(param: string) {}};', allow: ['methods'] },
+  { code: 'class A { foo(param: string) {} }', allow: ['methods'] },
+  { code: 'class A { private foo() {} }', allow: ['methods'] },
+  { code: 'class A { protected foo() {} }', allow: ['methods'] },
+  { code: 'class A { static foo(param: string) {} }', allow: ['methods'] },
+  { code: 'class A { private static foo() {} }', allow: ['methods'] },
+  { code: 'class A { protected static foo() {} }', allow: ['methods'] },
+  { code: 'const A = class {foo(param: string) {}};', allow: ['methods'] },
+  {
+    code: 'const A = class {static foo(param: string) {}};',
+    allow: ['methods'],
+  },
+  { code: 'const A = class {private static foo() {}};', allow: ['methods'] },
+  { code: 'const A = class {protected static foo() {}};', allow: ['methods'] },
+  {
+    code: 'class B { @decorator() foo() {} }',
+    allow: ['methods', 'decoratedFunctions'],
+  },
+  {
+    code: 'const B = class { @decorator() foo() {} }',
+    allow: ['methods', 'decoratedFunctions'],
+  },
+  {
+    code: 'class B extends C { override foo() {} }',
+    allow: ['methods', 'overrideMethods'],
+  },
+  {
+    code: 'class B extends C { @decorator() override foo() {} }',
+    allow: ['methods', 'decoratedFunctions', 'overrideMethods'],
+  },
+  {
+    code: 'const obj = {*foo(param: string) {}};',
+    allow: ['generatorMethods'],
+  },
+  { code: 'class A { *foo(param: string) {} }', allow: ['generatorMethods'] },
+  {
+    code: 'class A {static *foo(param: string) {}}',
+    allow: ['generatorMethods'],
+  },
+  { code: 'class A {private static *foo() {}}', allow: ['generatorMethods'] },
+  { code: 'class A {protected static *foo() {}}', allow: ['generatorMethods'] },
+  {
+    code: 'const A = class {*foo(param: string) {}};',
+    allow: ['generatorMethods'],
+  },
+  {
+    code: 'const A = class {static *foo(param: string) {}};',
+    allow: ['generatorMethods'],
+  },
+  { code: 'const obj = {get foo(): string {}};', allow: ['getters'] },
+  { code: 'class A {get foo(): string {}}', allow: ['getters'] },
+  { code: 'class A {static get foo(): string {}}', allow: ['getters'] },
+  { code: 'const A = class {get foo(): string {}};', allow: ['getters'] },
+  {
+    code: 'const A = class {static get foo(): string {}};',
+    allow: ['getters'],
+  },
+  {
+    code: 'class A {@decorator() get foo(): string {}}',
+    allow: ['getters', 'decoratedFunctions'],
+  },
+  {
+    code: 'class A {@decorator() static get foo(): string {}}',
+    allow: ['getters', 'decoratedFunctions'],
+  },
+  {
+    code: 'const A = class {@decorator() get foo(): string {}};',
+    allow: ['getters', 'decoratedFunctions'],
+  },
+  {
+    code: 'const A = class {@decorator() static get foo(): string {}};',
+    allow: ['getters', 'decoratedFunctions'],
+  },
+  {
+    code: 'class A extends B {override get foo(): string {}}',
+    allow: ['getters', 'overrideMethods'],
+  },
+  {
+    code: 'class A extends B {static override get foo(): string {}}',
+    allow: ['getters', 'overrideMethods'],
+  },
+  {
+    code: 'const A = class extends B {override get foo(): string {}};',
+    allow: ['getters', 'overrideMethods'],
+  },
+  {
+    code: 'const A = class extends B {static override get foo(): string {}};',
+    allow: ['getters', 'overrideMethods'],
+  },
+  { code: 'const obj = {set foo(value: string) {}};', allow: ['setters'] },
+  { code: 'class A {set foo(value: string) {}}', allow: ['setters'] },
+  { code: 'class A {static set foo(value: string) {}}', allow: ['setters'] },
+  { code: 'const A = class {set foo(value: string) {}};', allow: ['setters'] },
+  {
+    code: 'const A = class {static set foo(value: string) {}};',
+    allow: ['setters'],
+  },
+  {
+    code: 'class A {@decorator() set foo(value: string) {}}',
+    allow: ['setters', 'decoratedFunctions'],
+  },
+  {
+    code: 'class A {@decorator() static set foo(value: string) {}}',
+    allow: ['setters', 'decoratedFunctions'],
+  },
+  {
+    code: 'const A = class {@decorator() set foo(value: string) {}};',
+    allow: ['setters', 'decoratedFunctions'],
+  },
+  {
+    code: 'const A = class {@decorator() static set foo(value: string) {}};',
+    allow: ['setters', 'decoratedFunctions'],
+  },
+  {
+    code: 'class A extends B {override set foo(value: string) {}}',
+    allow: ['setters', 'overrideMethods'],
+  },
+  {
+    code: 'class A extends B {static override set foo(value: string) {}}',
+    allow: ['setters', 'overrideMethods'],
+  },
+  {
+    code: 'const A = class extends B {override set foo(value: string) {}};',
+    allow: ['setters', 'overrideMethods'],
+  },
+  {
+    code: 'const A = class extends B {static override set foo(value: string) {}};',
+    allow: ['setters', 'overrideMethods'],
+  },
+  {
+    code: 'class A { constructor(param: string) {} }',
+    allow: ['constructors'],
+  },
+  {
+    code: 'class B { private constructor() {} }',
+    allow: ['constructors', 'privateConstructors'],
+  },
+  {
+    code: 'class B { protected constructor() {} }',
+    allow: ['constructors', 'protectedConstructors'],
+  },
+  {
+    code: 'const A = class {constructor(param: string) {}};',
+    allow: ['constructors'],
+  },
+  {
+    code: 'const B = class { private constructor() {} }',
+    allow: ['constructors', 'privateConstructors'],
+  },
+  {
+    code: 'const B = class { protected constructor() {} }',
+    allow: ['constructors', 'protectedConstructors'],
+  },
+  {
+    code: 'const foo = { async method(param: string) {} }',
+    allow: ['asyncMethods'],
+  },
+  { code: 'async function a(param: string){}', allow: ['asyncFunctions'] },
+  {
+    code: 'const foo = async function(param: string) {}',
+    allow: ['asyncFunctions'],
+  },
+  { code: 'class A { async foo(param: string) {} }', allow: ['asyncMethods'] },
+  {
+    code: 'class A { @decorator() async foo(param: string) {} }',
+    allow: ['asyncMethods', 'decoratedFunctions'],
+  },
+  {
+    code: 'class A extends B { override async foo(param: string) {} }',
+    allow: ['asyncMethods', 'overrideMethods'],
+  },
+  {
+    code: 'const foo = async (): Promise<void> => {};',
+    allow: ['arrowFunctions'],
+  },
+  {
+    code: 'class A { private constructor() {} }',
+    allow: ['privateConstructors', 'constructors'],
+  },
+  {
+    code: 'const A = class { private constructor() {} };',
+    allow: ['privateConstructors', 'constructors'],
+  },
+  {
+    code: 'class A { protected constructor() {} }',
+    allow: ['protectedConstructors', 'constructors'],
+  },
+  {
+    code: 'const A = class { protected constructor() {} };',
+    allow: ['protectedConstructors', 'constructors'],
+  },
+  {
+    code: 'class A { @decorator() foo() {} }',
+    allow: ['decoratedFunctions', 'methods'],
+  },
+  {
+    code: 'const A = class { @decorator() foo() {} }',
+    allow: ['decoratedFunctions', 'methods'],
+  },
+  {
+    code: 'class B {@decorator() get foo(): string {}}',
+    allow: ['decoratedFunctions', 'getters'],
+  },
+  {
+    code: 'class B {@decorator() static get foo(): string {}}',
+    allow: ['decoratedFunctions', 'getters'],
+  },
+  {
+    code: 'const B = class {@decorator() get foo(): string {}};',
+    allow: ['decoratedFunctions', 'getters'],
+  },
+  {
+    code: 'const B = class {@decorator() static get foo(): string {}};',
+    allow: ['decoratedFunctions', 'getters'],
+  },
+  {
+    code: 'class B {@decorator() set foo(value: string) {}}',
+    allow: ['decoratedFunctions', 'setters'],
+  },
+  {
+    code: 'class B {@decorator() static set foo(value: string) {}}',
+    allow: ['decoratedFunctions', 'setters'],
+  },
+  {
+    code: 'const B = class {@decorator() set foo(value: string) {}};',
+    allow: ['decoratedFunctions', 'setters'],
+  },
+  {
+    code: 'const B = class {@decorator() static set foo(value: string) {}};',
+    allow: ['decoratedFunctions', 'setters'],
+  },
+  {
+    code: 'class B { @decorator() async foo(param: string) {} }',
+    allow: ['decoratedFunctions', 'asyncMethods'],
+  },
+  {
+    code: 'class A extends B { @decorator() override foo() {} }',
+    allow: ['decoratedFunctions', 'methods', 'overrideMethods'],
+  },
+  {
+    code: 'class B extends C {override get foo(): string {}}',
+    allow: ['overrideMethods', 'getters'],
+  },
+  {
+    code: 'class B extends C {static override get foo(): string {}}',
+    allow: ['overrideMethods', 'getters'],
+  },
+  {
+    code: 'const B = class extends C {override get foo(): string {}};',
+    allow: ['overrideMethods', 'getters'],
+  },
+  {
+    code: 'const B = class extends C {static override get foo(): string {}};',
+    allow: ['overrideMethods', 'getters'],
+  },
+  {
+    code: 'class B extends C {override set foo(value: string) {}}',
+    allow: ['overrideMethods', 'setters'],
+  },
+  {
+    code: 'class B extends C {static override set foo(value: string) {}}',
+    allow: ['overrideMethods', 'setters'],
+  },
+  {
+    code: 'const B = class extends C {override set foo(value: string) {}};',
+    allow: ['overrideMethods', 'setters'],
+  },
+  {
+    code: 'const B = class extends C {static override set foo(value: string) {}};',
+    allow: ['overrideMethods', 'setters'],
+  },
+  {
+    code: 'class B extends C { override async foo(param: string) {} }',
+    allow: ['overrideMethods', 'asyncMethods'],
+  },
+  {
+    code: 'class C extends D { @decorator() override foo() {} }',
+    allow: ['overrideMethods', 'methods', 'decoratedFunctions'],
+  },
+  {
+    code: 'class A extends B { override foo() {} }',
+    allow: ['overrideMethods', 'methods'],
+  },
+];
+
+const valid: ValidTestCase[] = [
+  'var foo = () => 0;',
+  'class A { constructor(public param: string) {} }',
+  'class A { constructor(private param: string) {} }',
+  'class A { constructor(protected param: string) {} }',
+  'class A { constructor(readonly param: string) {} }',
+  ...upstreamSeeds.flatMap(validFromSeed),
+];
+
+const invalid: InvalidTestCase[] = [
+  {
+    code: 'function foo() {}',
+    errors: [{ messageId: 'unexpected', line: 1, column: 16 }],
+  },
+  {
+    code: 'var foo = function () {\n}',
+    errors: [{ messageId: 'unexpected', line: 1, column: 23 }],
+  },
+  {
+    code: 'var foo = () => {\n\n  }',
+    errors: [{ messageId: 'unexpected', line: 1, column: 17 }],
+  },
+  {
+    code: 'var obj = {\n\tfoo() {\n\t}\n}',
+    errors: [{ messageId: 'unexpected', line: 2, column: 8 }],
+  },
+  {
+    code: 'class A { foo() { } }',
+    errors: [{ messageId: 'unexpected', line: 1, column: 17 }],
+  },
+  ...upstreamSeeds.map(invalidFromSeed),
+];
+
+ruleTester.run('no-empty-function', { valid, invalid });


### PR DESCRIPTION
## Summary

Port the `no-empty-function` rule from ESLint to rslint.

Adds the core rule implementation, upstream and extra Go coverage, JS integration coverage, documentation, registration, and shared property-name display helper reuse.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-empty-function
- ESLint source: https://github.com/eslint/eslint/blob/v10.6.0/lib/rules/no-empty-function.js
- ESLint tests: https://github.com/eslint/eslint/blob/v10.6.0/tests/lib/rules/no-empty-function.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
