### PR TITLE
feat: port rule no-empty-static-block

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -47,6 +47,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_character_class"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_function"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_pattern"
+	"github.com/web-infra-dev/rslint/internal/rules/no_empty_static_block"
 	"github.com/web-infra-dev/rslint/internal/rules/no_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_ex_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extend_native"
@@ -184,6 +185,7 @@ func GetAllRules() []rule.Rule {
 		no_empty.NoEmptyRule,
 		no_empty_function.NoEmptyFunctionRule,
 		no_empty_pattern.NoEmptyPatternRule,
+		no_empty_static_block.NoEmptyStaticBlockRule,
 		no_eval.NoEvalRule,
 		no_ex_assign.NoExAssignRule,
 		no_extend_native.NoExtendNativeRule,

--- a/internal/rules/no_else_return/no_else_return.go
+++ b/internal/rules/no_else_return/no_else_return.go
@@ -223,10 +223,8 @@ func buildFixes(ctx rule.RuleContext, elseNode *ast.Node) []rule.RuleFix {
 
 	fixedSource := utils.TrimmedNodeText(sf, elseNode)
 	if startToken.Text == "{" {
-		trimmed := utils.TrimNodeTextRange(sf, elseNode)
-		if trimmed.End()-trimmed.Pos() >= 2 {
-			fixedSource = text[trimmed.Pos()+1 : trimmed.End()-1]
-		}
+		innerRange := utils.BracedNodeInnerRange(sf, elseNode)
+		fixedSource = text[innerRange.Pos():innerRange.End()]
 	}
 
 	retainStart := enclosingFunctionStart(sf, elseNode)

--- a/internal/rules/no_empty_function/no_empty_function.go
+++ b/internal/rules/no_empty_function/no_empty_function.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -46,7 +45,7 @@ var NoEmptyFunctionRule = rule.Rule{
 			ctx.ReportRangeWithSuggestions(bodyRange, message, rule.RuleSuggestion{
 				Message: suggestionMessage,
 				FixesArr: []rule.RuleFix{
-					rule.RuleFixReplaceRange(core.NewTextRange(bodyRange.Pos()+1, bodyRange.End()-1), " /* empty */ "),
+					rule.RuleFixReplaceRange(utils.BracedNodeInnerRange(ctx.SourceFile, body), " /* empty */ "),
 				},
 			})
 		}

--- a/internal/rules/no_empty_static_block/no_empty_static_block.go
+++ b/internal/rules/no_empty_static_block/no_empty_static_block.go
@@ -1,0 +1,55 @@
+package no_empty_static_block
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-empty-static-block
+var NoEmptyStaticBlockRule = rule.Rule{
+	Name: "no-empty-static-block",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindClassStaticBlockDeclaration: func(node *ast.Node) {
+				staticBlock := node.AsClassStaticBlockDeclaration()
+				if staticBlock == nil || staticBlock.Body == nil {
+					return
+				}
+
+				body := staticBlock.Body
+				block := body.AsBlock()
+				if block == nil {
+					return
+				}
+				if block.Statements != nil && len(block.Statements.Nodes) != 0 {
+					return
+				}
+
+				if utils.HasCommentInsideNode(ctx.SourceFile, body) {
+					return
+				}
+
+				bodyRange := utils.TrimNodeTextRange(ctx.SourceFile, body)
+				ctx.ReportRangeWithSuggestions(bodyRange, unexpectedMessage(), rule.RuleSuggestion{
+					Message:  suggestCommentMessage(),
+					FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(utils.BracedNodeInnerRange(ctx.SourceFile, body), " /* empty */ ")},
+				})
+			},
+		}
+	},
+}
+
+func unexpectedMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpected",
+		Description: "Unexpected empty static block.",
+	}
+}
+
+func suggestCommentMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "suggestComment",
+		Description: "Add comment inside empty static block.",
+	}
+}

--- a/internal/rules/no_empty_static_block/no_empty_static_block.md
+++ b/internal/rules/no_empty_static_block/no_empty_static_block.md
@@ -1,0 +1,40 @@
+# no-empty-static-block
+
+## Rule Details
+
+Disallow empty class static blocks. Empty static blocks usually indicate that a
+refactor was left unfinished or that an intentional placeholder needs an
+explanatory comment.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+class Foo {
+  static {}
+}
+
+class Bar {
+  static {
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+class Foo {
+  static {
+    initialize();
+  }
+}
+
+class Bar {
+  static {
+    // intentionally empty
+  }
+}
+```
+
+## Original Documentation
+
+- [ESLint no-empty-static-block](https://eslint.org/docs/latest/rules/no-empty-static-block)

--- a/internal/rules/no_empty_static_block/no_empty_static_block_extras_test.go
+++ b/internal/rules/no_empty_static_block/no_empty_static_block_extras_test.go
@@ -1,0 +1,137 @@
+// TestNoEmptyStaticBlockExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// Dimension 4 walk (rows that don't apply to no-empty-static-block, with
+// reasons):
+//   - N/A receiver / expression wrappers ((X).y, X!.y, X as T, X satisfies T,
+//     X?.y, X?.()): the rule only inspects class static block declarations, not
+//     expression receivers.
+//   - N/A access / key forms (identifier, string, numeric, private, computed,
+//     element access): static blocks have no key.
+//   - N/A function container variants (function declaration/expression/arrow,
+//     methods, accessors, async/generator): the rule is specific to class static
+//     blocks.
+//   - N/A autofix boundaries: the rule has suggestions only, not an autofix.
+//   - N/A body-absent class member forms (overload signatures, abstract,
+//     declare): static blocks always have a body.
+package no_empty_static_block
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoEmptyStaticBlockExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEmptyStaticBlockRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: non-empty static block bodies do not report ----
+			{Code: `class Foo { static { ; } }`},
+			{Code: `class Foo { static { {} } }`},
+			{Code: `class Foo { static { label: ; } }`},
+
+			// ---- Dimension 4: comments inside otherwise empty static blocks are allowed ----
+			{Code: `class Foo { static { /* intentionally empty */ } }`},
+			{Code: "class Foo { static {\n  // intentionally empty\n} }"},
+			{Code: "class Foo { static {\n  /* intentionally empty */\n} }"},
+
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: `const Foo = class { static { foo(); } };`},
+			{Code: `export default class Foo { static { foo(); } }`, FileName: "file.ts"},
+			{Code: `class Foo extends Bar { static { super.name; } }`},
+			{Code: `const Foo = class extends Bar { static { this.name; } };`},
+			{Code: `class Foo { static value = 1; static { value; } }`},
+
+			// ---- Dimension 4: graceful degradation around empty class/member forms ----
+			{Code: `class Foo {}`},
+			{Code: `class Foo { ; ; }`},
+			{Code: `abstract class Foo { abstract method(): void }`},
+			{Code: `class Foo { static /* before */ { /* inside */ } }`},
+
+			// Locks in upstream StaticBlock() arm 1: body length > 0 short-circuits before comment checks.
+			{Code: `class Foo { static { doWork(); /* trailing */ } }`},
+			{Code: `class Foo { static { "use strict"; } }`},
+			{Code: `class Foo { static { (() => {}); } }`},
+			{Code: `class Foo { static { class Inner { static { /* ok */ } } } }`},
+			{Code: `class Foo { static { const Inner = class { static { /* ok */ } }; } }`},
+
+			// Locks in upstream StaticBlock() arm 2: comments before the closing brace make an empty block valid.
+			{Code: `class Foo { static { /* block comment before close */ } }`},
+			{Code: "class Foo { static {\n  // line comment before close\n} }"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: class expression static blocks are inspected ----
+			invalidStaticBlockCase(`const Foo = class { static {} };`, 1, 28, 1, 30, `const Foo = class { static { /* empty */ } };`),
+			invalidStaticBlockCase(`const Foo = class extends Bar { static {} };`, 1, 40, 1, 42, `const Foo = class extends Bar { static { /* empty */ } };`),
+
+			// ---- Dimension 4: nested static blocks each keep their own traversal boundary ----
+			{
+				Code: `class Outer { static { class Inner { static {} } } static {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					staticBlockError(1, 45, 1, 47, `class Outer { static { class Inner { static { /* empty */ } } } static {} }`),
+					staticBlockError(1, 59, 1, 61, `class Outer { static { class Inner { static {} } } static { /* empty */ } }`),
+				},
+			},
+			invalidStaticBlockCase(`class Outer { static { if (flag) { class Inner { static {} } } } }`, 1, 57, 1, 59, `class Outer { static { if (flag) { class Inner { static { /* empty */ } } } } }`),
+			invalidStaticBlockCase(`class Foo { static { const Inner = class { static {} }; } }`, 1, 51, 1, 53, `class Foo { static { const Inner = class { static { /* empty */ } }; } }`),
+
+			// ---- Dimension 4: multiple empty static blocks in one class each report ----
+			{
+				Code: `class Foo { static {} static { work(); } static {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					staticBlockError(1, 20, 1, 22, `class Foo { static { /* empty */ } static { work(); } static {} }`),
+					staticBlockError(1, 49, 1, 51, `class Foo { static {} static { work(); } static { /* empty */ } }`),
+				},
+			},
+
+			// ---- Dimension 4: comments outside the braces do not make the block non-empty ----
+			invalidStaticBlockCase(`class Foo { /* before */ static {} }`, 1, 33, 1, 35, `class Foo { /* before */ static { /* empty */ } }`),
+			invalidStaticBlockCase(`class Foo { static {} /* after */ }`, 1, 20, 1, 22, `class Foo { static { /* empty */ } /* after */ }`),
+			invalidStaticBlockCase("class Foo { static /* before */\n{} }", 2, 1, 2, 3, "class Foo { static /* before */\n{ /* empty */ } }"),
+
+			// ---- Real-user: eslint#16318 proposed multiline empty class static blocks ----
+			invalidStaticBlockCase("class Foo {\n  static {\n  }\n}", 2, 10, 3, 4, "class Foo {\n  static { /* empty */ }\n}"),
+
+			// ---- Real-user: eslint#20056 highlights only braces and suggests inserting a comment ----
+			invalidStaticBlockCase("class Foo {\n  static // setup hook intentionally blank while prototyping\n  {}\n}", 3, 3, 3, 5, "class Foo {\n  static // setup hook intentionally blank while prototyping\n  { /* empty */ }\n}"),
+
+			// Locks in upstream StaticBlock() arm 3: empty body + no comment reports.
+			invalidStaticBlockCase(`export default class Foo { static {} }`, 1, 35, 1, 37, `export default class Foo { static { /* empty */ } }`),
+			invalidStaticBlockCase(`export default class { static {} }`, 1, 31, 1, 33, `export default class { static { /* empty */ } }`),
+			invalidStaticBlockCase(`export class Foo { static {} }`, 1, 27, 1, 29, `export class Foo { static { /* empty */ } }`),
+			invalidStaticBlockCase(`class Foo extends Bar { static {} }`, 1, 32, 1, 34, `class Foo extends Bar { static { /* empty */ } }`),
+			invalidStaticBlockCase(`class Foo<T> { static {} }`, 1, 23, 1, 25, `class Foo<T> { static { /* empty */ } }`),
+			invalidStaticBlockCase(`const Foo = mixin(class { static {} });`, 1, 34, 1, 36, `const Foo = mixin(class { static { /* empty */ } });`),
+			invalidStaticBlockCase(`class Outer extends mixin(class { static {} }) {}`, 1, 42, 1, 44, `class Outer extends mixin(class { static { /* empty */ } }) {}`),
+			invalidStaticBlockCase(`class Outer { [class { static {} }]() {} }`, 1, 31, 1, 33, `class Outer { [class { static { /* empty */ } }]() {} }`),
+			invalidStaticBlockCase(`class Outer { static field = class { static {} }; }`, 1, 45, 1, 47, `class Outer { static field = class { static { /* empty */ } }; }`),
+			invalidStaticBlockCase(`class Foo { static { /* ok */ } static {} }`, 1, 40, 1, 42, `class Foo { static { /* ok */ } static { /* empty */ } }`),
+			invalidStaticBlockCase("class Foo { static\n{} }", 2, 1, 2, 3, "class Foo { static\n{ /* empty */ } }"),
+		},
+	)
+}
+
+func staticBlockError(line int, column int, endLine int, endColumn int, output string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "unexpected",
+		Message:   "Unexpected empty static block.",
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+		Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+			{
+				MessageId: "suggestComment",
+				Output:    output,
+			},
+		},
+	}
+}

--- a/internal/rules/no_empty_static_block/no_empty_static_block_upstream_test.go
+++ b/internal/rules/no_empty_static_block/no_empty_static_block_upstream_test.go
@@ -1,0 +1,60 @@
+// TestNoEmptyStaticBlockUpstream migrates the full valid/invalid suite from
+// upstream eslint/tests/lib/rules/no-empty-static-block.js 1:1. Position
+// assertions cover line/column/endLine/endColumn for every invalid case.
+// rslint-specific lock-in cases live in the no_empty_static_block_extras_test.go
+// file.
+package no_empty_static_block
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoEmptyStaticBlockUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEmptyStaticBlockRule,
+		[]rule_tester.ValidTestCase{
+			// ---- valid ----
+			{Code: `class Foo { static { bar(); } }`},
+			{Code: `class Foo { static { /* comments */ } }`},
+			{Code: "class Foo { static {\n// comment\n} }"},
+			{Code: `class Foo { static { bar(); } static { bar(); } }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- invalid ----
+			invalidStaticBlockCase(`class Foo { static {} }`, 1, 20, 1, 22, `class Foo { static { /* empty */ } }`),
+			invalidStaticBlockCase(`class Foo { static { } }`, 1, 20, 1, 23, `class Foo { static { /* empty */ } }`),
+			invalidStaticBlockCase("class Foo { static { \n\n } }", 1, 20, 3, 3, `class Foo { static { /* empty */ } }`),
+			invalidStaticBlockCase(`class Foo { static { bar(); } static {} }`, 1, 38, 1, 40, `class Foo { static { bar(); } static { /* empty */ } }`),
+			invalidStaticBlockCase("class Foo { static // comment\n {} }", 2, 2, 2, 4, "class Foo { static // comment\n { /* empty */ } }"),
+			invalidStaticBlockCase(`class Foo { static /* empty */ {} /* empty */ }`, 1, 32, 1, 34, `class Foo { static /* empty */ { /* empty */ } /* empty */ }`),
+		},
+	)
+}
+
+func invalidStaticBlockCase(code string, line int, column int, endLine int, endColumn int, output string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code: code,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{
+				MessageId: "unexpected",
+				Message:   "Unexpected empty static block.",
+				Line:      line,
+				Column:    column,
+				EndLine:   endLine,
+				EndColumn: endColumn,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{
+						MessageId: "suggestComment",
+						Output:    output,
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -18,6 +18,17 @@ func TrimNodeTextRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRang
 	return scanner.GetRangeOfTokenAtPosition(sourceFile, node.Pos()).WithEnd(node.End())
 }
 
+// BracedNodeInnerRange returns the span between a braced node's opening and
+// closing braces. Callers should pass Block-like nodes whose trimmed text starts
+// with "{" and ends with "}".
+func BracedNodeInnerRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	nodeRange := TrimNodeTextRange(sourceFile, node)
+	if nodeRange.End() <= nodeRange.Pos()+1 {
+		return core.NewTextRange(nodeRange.Pos(), nodeRange.Pos())
+	}
+	return core.NewTextRange(nodeRange.Pos()+1, nodeRange.End()-1)
+}
+
 // GetVarKeywordRange returns the range of the kind keyword (`var`/`let`/`const`/
 // `using` or `await` for `await using`) inside a VariableStatement or
 // VariableDeclarationList. For VariableStatement it skips the modifier list

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -84,6 +84,37 @@ func TestHasCommentInsideNode(t *testing.T) {
 	}
 }
 
+func TestBracedNodeInnerRange(t *testing.T) {
+	source := "class Foo { static {} }\n" +
+		"class Bar {\n" +
+		"  static {\n" +
+		"    \n" +
+		"  }\n" +
+		"}\n" +
+		"function work() { doWork(); }\n"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, source, core.ScriptKindTS)
+
+	tests := []struct {
+		name      string
+		blockText string
+		want      string
+	}{
+		{name: "empty one-line block", blockText: "{}", want: ""},
+		{name: "whitespace-only multiline block", blockText: "{\n    \n  }", want: "\n    \n  "},
+		{name: "non-empty function block", blockText: "{ doWork(); }", want: " doWork(); "},
+	}
+	for _, tt := range tests {
+		node := findNodeWithText(t, sourceFile, tt.blockText)
+		gotRange := BracedNodeInnerRange(sourceFile, node)
+		if got := sourceFile.Text()[gotRange.Pos():gotRange.End()]; got != tt.want {
+			t.Errorf("%s: BracedNodeInnerRange() text = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestGetStaticStringLiteralValue(t *testing.T) {
 	source := "const empty = \"\";\n" +
 		"const template = `raw`;\n" +

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -81,6 +81,7 @@ export default defineConfig({
     './tests/eslint/rules/no-empty.test.ts',
     './tests/eslint/rules/no-empty-function.test.ts',
     './tests/eslint/rules/no-empty-pattern.test.ts',
+    './tests/eslint/rules/no-empty-static-block.test.ts',
     './tests/eslint/rules/no-eval.test.ts',
     './tests/eslint/rules/no-implicit-coercion.test.ts',
     './tests/eslint/rules/no-implied-eval.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-empty-static-block.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-empty-static-block.test.ts.snap
@@ -1,0 +1,160 @@
+// Rstest Snapshot v1
+
+exports[`no-empty-static-block > invalid 1`] = `
+{
+  "code": "class Foo { static {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static block.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-static-block",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-static-block > invalid 2`] = `
+{
+  "code": "class Foo { static { } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static block.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-static-block",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-static-block > invalid 3`] = `
+{
+  "code": "class Foo { static { 
+
+ } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static block.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-static-block",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-static-block > invalid 4`] = `
+{
+  "code": "class Foo { static { bar(); } static {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static block.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-static-block",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-static-block > invalid 5`] = `
+{
+  "code": "class Foo { static // comment
+ {} }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static block.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 2,
+        },
+        "start": {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-empty-static-block",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-empty-static-block > invalid 6`] = `
+{
+  "code": "class Foo { static /* empty */ {} /* empty */ }",
+  "diagnostics": [
+    {
+      "message": "Unexpected empty static block.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-empty-static-block",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-empty-static-block.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-empty-static-block.test.ts
@@ -1,0 +1,86 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-empty-static-block', {
+  valid: [
+    'class Foo { static { bar(); } }',
+    'class Foo { static { /* comments */ } }',
+    'class Foo { static {\n// comment\n} }',
+    'class Foo { static { bar(); } static { bar(); } }',
+  ],
+  invalid: [
+    {
+      code: 'class Foo { static {} }',
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 1,
+          column: 20,
+          endLine: 1,
+          endColumn: 22,
+        },
+      ],
+    },
+    {
+      code: 'class Foo { static { } }',
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 1,
+          column: 20,
+          endLine: 1,
+          endColumn: 23,
+        },
+      ],
+    },
+    {
+      code: 'class Foo { static { \n\n } }',
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 1,
+          column: 20,
+          endLine: 3,
+          endColumn: 3,
+        },
+      ],
+    },
+    {
+      code: 'class Foo { static { bar(); } static {} }',
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 1,
+          column: 38,
+          endLine: 1,
+          endColumn: 40,
+        },
+      ],
+    },
+    {
+      code: 'class Foo { static // comment\n {} }',
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 2,
+          column: 2,
+          endLine: 2,
+          endColumn: 4,
+        },
+      ],
+    },
+    {
+      code: 'class Foo { static /* empty */ {} /* empty */ }',
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 1,
+          column: 32,
+          endLine: 1,
+          endColumn: 34,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port ESLint core `no-empty-static-block` to rslint.

- Adds the Go rule, upstream and extra edge-case coverage, documentation, JS integration tests, and preset registration.
- Adds `utils.BracedNodeInnerRange` and reuses it in existing empty-block-style rules to avoid duplicate range logic.
- Validated with `packages/rslint/bin/rslint.js` on local `rsbuild` and `rspack` checkouts; this rule reported no diagnostics in either repo, matching ESLint reference runs.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-empty-static-block
- ESLint source: https://github.com/eslint/eslint/blob/main/lib/rules/no-empty-static-block.js
- ESLint tests: https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-empty-static-block.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
