### PR TITLE
feat: port rule no-unassigned-vars

### DIFF
--- a/internal/plugins/typescript/rules/init_declarations/init_declarations.go
+++ b/internal/plugins/typescript/rules/init_declarations/init_declarations.go
@@ -99,19 +99,7 @@ func checkVariableDeclarationList(ctx rule.RuleContext, node *ast.Node, opts ini
 		return
 	}
 
-	// Skip `declare const|let|var ...;` (the modifier lives on the wrapping
-	// VariableStatement, not the DeclarationList).
-	if parent.Kind == ast.KindVariableStatement &&
-		ast.HasSyntacticModifier(parent, ast.ModifierFlagsAmbient) {
-		return
-	}
-
-	// Skip declarations contained in any ambient ModuleDeclaration ancestor
-	// (`declare namespace`, `declare module 'm'`, `declare global`). Upstream
-	// tracks this via TSModuleDeclaration enter/exit state; the ancestor walk
-	// is equivalent because `declare` propagates downward through nested
-	// non-declare namespaces in TS scoping.
-	if hasAmbientModuleAncestor(node) {
+	if utils.IsInAmbientContext(node) {
 		return
 	}
 
@@ -202,16 +190,4 @@ func isForLoopParent(parent *ast.Node) bool {
 		return true
 	}
 	return false
-}
-
-// hasAmbientModuleAncestor walks ancestor ModuleDeclarations looking for one
-// with a `declare` modifier. Equivalent to upstream's stateful
-// TSModuleDeclaration enter/exit tracking — `declare` propagates downward
-// through nested non-declare namespaces in TS scoping, so an ancestor walk
-// matches the same set of bindings.
-func hasAmbientModuleAncestor(node *ast.Node) bool {
-	return ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
-		return n.Kind == ast.KindModuleDeclaration &&
-			ast.HasSyntacticModifier(n, ast.ModifierFlagsAmbient)
-	}) != nil
 }

--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -101,6 +101,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_template_curly_in_string"
 	"github.com/web-infra-dev/rslint/internal/rules/no_this_before_super"
 	"github.com/web-infra-dev/rslint/internal/rules/no_throw_literal"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unassigned_vars"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef_init"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unexpected_multiline"
@@ -236,6 +237,7 @@ func GetAllRules() []rule.Rule {
 		no_unneeded_ternary.NoUnneededTernaryRule,
 		no_undef.NoUndefRule,
 		no_undef_init.NoUndefInitRule,
+		no_unassigned_vars.NoUnassignedVarsRule,
 		prefer_const.PreferConstRule,
 		prefer_exponentiation_operator.PreferExponentiationOperatorRule,
 		prefer_numeric_literals.PreferNumericLiteralsRule,

--- a/internal/rules/no_loop_func/no_loop_func.go
+++ b/internal/rules/no_loop_func/no_loop_func.go
@@ -19,12 +19,7 @@ func BuildUnsafeRefsMessage(varNames string) rule.RuleMessage {
 type RunState struct {
 	Ctx          rule.RuleContext
 	SkippedIIFEs map[*ast.Node]bool
-	// refIndex buckets every value-position identifier (and destructuring
-	// shorthand write target) in the source file by resolved symbol. Populated
-	// lazily on the first forEachReference call and reused for all subsequent
-	// lookups — amortizes what would otherwise be a full-file walk per symbol
-	// into a single pass per rule invocation.
-	refIndex map[*ast.Symbol][]*ast.Node
+	refIndex     *utils.ReferenceIndex
 }
 
 // NewRunState constructs a RunState ready for one source-file pass.
@@ -198,20 +193,8 @@ func (s *RunState) CollectThroughReferences(funcNode *ast.Node) []ReferenceEntry
 			return
 		}
 
-		if n.Kind == ast.KindIdentifier && isValueReferencePosition(n) {
-			// Shorthand property assignments dual-purpose the identifier as
-			// the property name AND a value reference to a same-named
-			// variable. GetSymbolAtLocation returns the property symbol;
-			// GetShorthandAssignmentValueSymbol returns the variable symbol.
-			// This applies in BOTH destructuring (`({port} = obj)`, where
-			// the variable is being written) and object literal value
-			// position (`f({port})`, where the variable is being read).
-			var sym *ast.Symbol
-			if n.Parent != nil && n.Parent.Kind == ast.KindShorthandPropertyAssignment {
-				sym = s.Ctx.TypeChecker.GetShorthandAssignmentValueSymbol(n.Parent)
-			} else {
-				sym = s.Ctx.TypeChecker.GetSymbolAtLocation(n)
-			}
+		if n.Kind == ast.KindIdentifier && !utils.IsNonReferenceIdentifier(n) {
+			sym := utils.GetReferenceSymbol(n, s.Ctx.TypeChecker)
 			if sym != nil && (sym.Flags&ast.SymbolFlagsValue) != 0 {
 				if !isSymbolDeclaredInside(sym, funcNode) {
 					refs = append(refs, ReferenceEntry{
@@ -233,62 +216,6 @@ func (s *RunState) CollectThroughReferences(funcNode *ast.Node) []ReferenceEntry
 		walk(root)
 	}
 	return refs
-}
-
-// isValueReferencePosition reports whether an Identifier node is used as a
-// value reference (readable or writable), as opposed to a property name,
-// object literal key, or member access right-hand side.
-func isValueReferencePosition(node *ast.Node) bool {
-	parent := node.Parent
-	if parent == nil {
-		return true
-	}
-	switch parent.Kind {
-	case ast.KindPropertyAccessExpression:
-		// foo.bar — `bar` is a property name, not a variable.
-		pa := parent.AsPropertyAccessExpression()
-		if pa != nil && pa.Name() == node {
-			return false
-		}
-	case ast.KindQualifiedName:
-		qn := parent.AsQualifiedName()
-		if qn != nil && qn.Right == node {
-			return false
-		}
-	case ast.KindMetaProperty:
-		return false
-	case ast.KindPropertyAssignment:
-		// { key: value } — the `key` side is a property name.
-		pa := parent.AsPropertyAssignment()
-		if pa != nil && pa.Name() == node {
-			return false
-		}
-	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor,
-		ast.KindPropertyDeclaration, ast.KindPropertySignature,
-		ast.KindMethodSignature, ast.KindEnumMember:
-		// Member/enum key position.
-		if parent.Name() == node {
-			return false
-		}
-	case ast.KindImportSpecifier:
-		is := parent.AsImportSpecifier()
-		if is != nil && is.PropertyName == node {
-			return false
-		}
-	case ast.KindExportSpecifier:
-		es := parent.AsExportSpecifier()
-		if es != nil && es.PropertyName == node {
-			return false
-		}
-	case ast.KindLabeledStatement:
-		if parent.Name() == node {
-			return false
-		}
-	case ast.KindBreakStatement, ast.KindContinueStatement:
-		// break/continue label — not a variable.
-		return false
-	}
-	return true
 }
 
 // isSymbolDeclaredInside reports whether any declaration of `sym` resolves to
@@ -324,20 +251,6 @@ func GetVarDeclListKind(declList *ast.Node) string {
 	return utils.GetVarDeclListKind(declList)
 }
 
-// enclosingVarDeclOfBindingElement walks up through nested BindingElement /
-// BindingPattern layers to the containing VariableDeclaration, or returns nil
-// if the binding does not ultimately belong to a VariableDeclaration.
-func enclosingVarDeclOfBindingElement(bindingElement *ast.Node) *ast.Node {
-	if bindingElement == nil || bindingElement.Kind != ast.KindBindingElement {
-		return nil
-	}
-	parent := ast.WalkUpBindingElementsAndPatterns(bindingElement)
-	if parent == nil || parent.Kind != ast.KindVariableDeclaration {
-		return nil
-	}
-	return parent
-}
-
 // isWriteRef reports whether an identifier participates in a write to its
 // variable. Extends utils.IsWriteReference with the cases ESLint's scope
 // manager marks as writes but we don't otherwise detect: the binding names of
@@ -345,64 +258,7 @@ func enclosingVarDeclOfBindingElement(bindingElement *ast.Node) *ast.Node {
 // by `for (var/let/const ... in/of ...)` iteration, and catch-clause
 // parameters (bound anew per thrown exception).
 func IsWriteRef(node *ast.Node) bool {
-	if utils.IsWriteReference(node) {
-		return true
-	}
-	if node == nil || node.Parent == nil {
-		return false
-	}
-	parent := node.Parent
-	switch parent.Kind {
-	case ast.KindVariableDeclaration:
-		varDecl := parent.AsVariableDeclaration()
-		if varDecl == nil || varDecl.Name() != node {
-			return false
-		}
-		return varDeclIntroducesWrite(parent)
-	case ast.KindBindingElement:
-		be := parent.AsBindingElement()
-		if be == nil || be.Name() != node {
-			return false
-		}
-		varDecl := enclosingVarDeclOfBindingElement(parent)
-		if varDecl == nil {
-			return false
-		}
-		return varDeclIntroducesWrite(varDecl)
-	}
-	return false
-}
-
-// varDeclIntroducesWrite reports whether a VariableDeclaration's binding is
-// written at its introduction: it has an initializer, is the target of a
-// for-in/for-of iteration, or is a catch-clause parameter.
-func varDeclIntroducesWrite(varDecl *ast.Node) bool {
-	vd := varDecl.AsVariableDeclaration()
-	if vd == nil {
-		return false
-	}
-	if vd.Initializer != nil {
-		return true
-	}
-	if isVarDeclInForInOrOf(varDecl) {
-		return true
-	}
-	// `catch (e) {...}` binds `e` per thrown exception.
-	return varDecl.Parent != nil && varDecl.Parent.Kind == ast.KindCatchClause
-}
-
-// isVarDeclInForInOrOf reports whether a VariableDeclaration sits directly
-// inside a for-in/for-of initializer.
-func isVarDeclInForInOrOf(varDecl *ast.Node) bool {
-	if varDecl == nil || varDecl.Parent == nil {
-		return false
-	}
-	declList := varDecl.Parent
-	if declList.Kind != ast.KindVariableDeclarationList || declList.Parent == nil {
-		return false
-	}
-	outer := declList.Parent
-	return outer.Kind == ast.KindForInStatement || outer.Kind == ast.KindForOfStatement
+	return utils.IsVariableWriteReference(node)
 }
 
 // isSafe reports whether a through-reference `ref` to a symbol `sym` is safe
@@ -468,70 +324,14 @@ func (s *RunState) isSafeCore(loopNode *ast.Node, ref ReferenceEntry) bool {
 // getDeclListForSymbolDecl returns the VariableDeclarationList associated with
 // a declaration node, or nil if the declaration is not a variable-like binding.
 func GetDeclListForSymbolDecl(decl *ast.Node) *ast.Node {
-	if decl == nil {
-		return nil
-	}
-	current := decl
-	for current != nil {
-		if current.Kind == ast.KindVariableDeclarationList {
-			return current
-		}
-		if current.Kind == ast.KindVariableDeclaration ||
-			current.Kind == ast.KindBindingElement ||
-			current.Kind == ast.KindObjectBindingPattern ||
-			current.Kind == ast.KindArrayBindingPattern {
-			current = current.Parent
-			continue
-		}
-		return nil
-	}
-	return nil
+	return utils.GetDeclListForSymbolDecl(decl)
 }
 
-// buildRefIndex performs a single pass over the source file and groups every
-// value-position identifier by its resolved symbol. ShorthandPropertyAssignment
-// nodes need special handling because TypeChecker.GetSymbolAtLocation resolves
-// the shorthand key to the property symbol, not the variable symbol — we use
-// GetShorthandAssignmentValueSymbol instead and key by the variable symbol.
-// This is needed BOTH for destructuring shorthand (which is a write) and for
-// object-literal shorthand (which is a read).
 func (s *RunState) buildRefIndex() {
 	if s.refIndex != nil {
 		return
 	}
-	s.refIndex = map[*ast.Symbol][]*ast.Node{}
-	tc := s.Ctx.TypeChecker
-	var walk func(n *ast.Node)
-	walk = func(n *ast.Node) {
-		if n == nil {
-			return
-		}
-		if n.Kind == ast.KindIdentifier && isValueReferencePosition(n) {
-			var sym *ast.Symbol
-			if n.Parent != nil && n.Parent.Kind == ast.KindShorthandPropertyAssignment {
-				sym = tc.GetShorthandAssignmentValueSymbol(n.Parent)
-			} else {
-				sym = tc.GetSymbolAtLocation(n)
-			}
-			if sym != nil {
-				s.refIndex[sym] = append(s.refIndex[sym], n)
-			}
-		} else if n.Kind == ast.KindShorthandPropertyAssignment && utils.IsInDestructuringAssignment(n) {
-			// Already handled above via the Identifier branch in most cases,
-			// but keep this explicit indexing for the destructuring write
-			// path where the parent walk may not visit the Identifier directly.
-			if sym := tc.GetShorthandAssignmentValueSymbol(n); sym != nil {
-				if nameNode := n.AsShorthandPropertyAssignment().Name(); nameNode != nil {
-					s.refIndex[sym] = append(s.refIndex[sym], nameNode)
-				}
-			}
-		}
-		n.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
-	}
-	walk(s.Ctx.SourceFile.AsNode())
+	s.refIndex = utils.NewReferenceIndex(s.Ctx.SourceFile, s.Ctx.TypeChecker)
 }
 
 // forEachReference invokes `cb` for every identifier node resolving to `sym`,
@@ -539,11 +339,7 @@ func (s *RunState) buildRefIndex() {
 // is built on first use via buildRefIndex so subsequent calls are O(refs).
 func (s *RunState) ForEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
 	s.buildRefIndex()
-	for _, node := range s.refIndex[sym] {
-		if cb(node) {
-			return
-		}
-	}
+	s.refIndex.ForEachReference(sym, cb)
 }
 
 // checkForLoops processes a function-like node: if it is inside a loop and

--- a/internal/rules/no_unassigned_vars/no_unassigned_vars.go
+++ b/internal/rules/no_unassigned_vars/no_unassigned_vars.go
@@ -1,0 +1,123 @@
+package no_unassigned_vars
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-unassigned-vars
+
+func messageUnassigned(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unassigned",
+		Description: fmt.Sprintf("'%s' is always 'undefined' because it's never assigned.", name),
+		Data: map[string]string{
+			"name": name,
+		},
+	}
+}
+
+type runState struct {
+	ctx  rule.RuleContext
+	refs *utils.ReferenceIndex
+}
+
+func (s *runState) checkVariableDeclarator(node *ast.Node) {
+	if s.shouldSkipDeclarator(node) {
+		return
+	}
+
+	nameNode := node.AsVariableDeclaration().Name()
+	sym := utils.GetVariableDeclarationSymbol(node, s.ctx.TypeChecker)
+	if sym == nil {
+		return
+	}
+
+	name := nameNode.AsIdentifier().Text
+	hasRead := false
+	hasWrite := false
+	s.refs.ForEachReference(sym, func(refNode *ast.Node) bool {
+		if utils.IsVariableWriteReference(refNode) {
+			hasWrite = true
+			return true
+		}
+		if isReadReference(refNode) {
+			hasRead = true
+		}
+		return false
+	})
+	if !hasWrite {
+		s.refs.ForEachReferenceByName(name, node, func(refNode *ast.Node) bool {
+			if utils.IsVariableWriteReference(refNode) {
+				hasWrite = true
+				return true
+			}
+			if isReadReference(refNode) {
+				hasRead = true
+			}
+			return false
+		})
+	}
+	if hasWrite || !hasRead {
+		return
+	}
+
+	s.ctx.ReportNode(node, messageUnassigned(name))
+}
+
+func (s *runState) shouldSkipDeclarator(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindVariableDeclaration {
+		return true
+	}
+	varDecl := node.AsVariableDeclaration()
+	if varDecl == nil || varDecl.Initializer != nil {
+		return true
+	}
+
+	nameNode := varDecl.Name()
+	if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+		return true
+	}
+
+	declList := node.Parent
+	kind := utils.GetVarDeclListKind(declList)
+	if kind != "var" && kind != "let" {
+		return true
+	}
+
+	if utils.IsInAmbientContext(node) {
+		return true
+	}
+
+	return false
+}
+
+func isReadReference(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if ast.IsPartOfTypeNode(node) || ast.IsPartOfTypeQuery(node) {
+		return false
+	}
+	return !utils.IsNonReferenceIdentifier(node)
+}
+
+var NoUnassignedVarsRule = rule.Rule{
+	Name:             "no-unassigned-vars",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		if ctx.TypeChecker == nil {
+			return rule.RuleListeners{}
+		}
+
+		s := &runState{
+			ctx:  ctx,
+			refs: utils.NewReferenceIndex(ctx.SourceFile, ctx.TypeChecker),
+		}
+
+		return rule.RuleListeners{ast.KindVariableDeclaration: s.checkVariableDeclarator}
+	},
+}

--- a/internal/rules/no_unassigned_vars/no_unassigned_vars.md
+++ b/internal/rules/no_unassigned_vars/no_unassigned_vars.md
@@ -1,0 +1,57 @@
+# no-unassigned-vars
+
+## Rule Details
+
+This rule reports `let` and `var` variables that are read but never assigned a
+value. These variables are always `undefined`, so reading them is usually a
+programming mistake.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+let status;
+if (status === "ready") {
+  console.log("Ready!");
+}
+
+let user;
+greet(user);
+
+function test() {
+  let error;
+  return error || "Unknown error";
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+let message = "hello";
+console.log(message);
+
+let user;
+user = getUser();
+console.log(user.name);
+
+let temp;
+```
+
+Examples of **correct** TypeScript code for this rule:
+
+```typescript
+declare let value: number | undefined;
+console.log(value);
+
+declare module "my-module" {
+  let value: string;
+  export = value;
+}
+```
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- [ESLint rule: no-unassigned-vars](https://eslint.org/docs/latest/rules/no-unassigned-vars)

--- a/internal/rules/no_unassigned_vars/no_unassigned_vars_extras_test.go
+++ b/internal/rules/no_unassigned_vars/no_unassigned_vars_extras_test.go
@@ -1,0 +1,308 @@
+package no_unassigned_vars
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUnassignedVarsExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / real-user shape it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+func TestNoUnassignedVarsExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnassignedVarsRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream shouldSkip arm 1: initializer means the variable is assigned.
+			{Code: `let assigned = undefined; log(assigned);`},
+			// Locks in upstream shouldSkip arm 2: non-Identifier binding patterns are ignored.
+			{Code: `let [item] = items; log(item);`},
+			// Locks in upstream shouldSkip arm 3: const declarations are ignored.
+			{Code: `const value = undefined; log(value);`},
+			// Locks in upstream reference loop arm 1: any write reference suppresses the report.
+			{Code: `let value; value = compute(); log(value);`},
+			// Locks in upstream reference loop arm 1: a later write suppresses an earlier read.
+			{Code: `let value; log(value); value = compute();`},
+			// Locks in upstream reference loop arm 1: writes inside nested functions still count as writes.
+			{Code: `let value; function init() { value = compute(); } log(value);`},
+			// Locks in upstream reference loop arm 1: update expressions are writes.
+			{Code: `let value; value++; log(value);`},
+			// Locks in upstream reference loop arm 1: compound assignments are writes.
+			{Code: `let value; value += 1; log(value);`},
+			// Locks in upstream reference loop arm 1: logical assignments are writes.
+			{Code: `let value; value ||= compute(); log(value);`},
+			// Locks in upstream no-read arm: no overlap with no-unused-vars.
+			{Code: `let unread;`},
+			// Locks in upstream declaration.declare arm: ambient variables are declarations, not unassigned locals.
+			{Code: `declare let ambient: string; log(ambient);`},
+			// Locks in upstream insideDeclareModule arm: nested namespace contents stay ambient.
+			{Code: `declare namespace Lib { namespace Nested { let value: string; export { value }; } }`},
+			// Locks in type-only reference filtering: type queries do not read the runtime variable.
+			{Code: `let value; type Alias = typeof value;`},
+			// Locks in type-only export filtering: export type specifiers are not runtime reads.
+			{Code: `let value; export type { value };`},
+			// Locks in re-export filtering: re-export specifiers do not read same-named locals.
+			{Code: `let value; export { value } from "mod";`},
+
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: `for (let item of items) { log(item); }`},
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: `for (var key in object) { log(key); }`},
+			// ---- Dimension 4: assignment target forms ----
+			{Code: `let value; [value] = items; log(value);`},
+			// ---- Dimension 4: assignment target forms ----
+			{Code: `let value; ({ value } = object); log(value);`},
+			// ---- Dimension 4: assignment target forms ----
+			{Code: `let value; ({ nested: { value } } = object); log(value);`},
+			// ---- Dimension 4: assignment target forms ----
+			{Code: `let rest; ({ ...rest } = object); log(rest);`},
+			// ---- Dimension 4: assignment target forms ----
+			{Code: `let tail; [, ...tail] = items; log(tail);`},
+			// ---- Dimension 4: assignment target forms ----
+			{Code: `let value; ({ value = fallback } = object); log(value);`},
+			// ---- Dimension 4: assignment target forms ----
+			{Code: `let value; for (value of items) { } log(value);`},
+			// ---- Dimension 4: assignment target forms ----
+			{Code: `let value; for (value in object) { } log(value);`},
+			// ---- Dimension 4: parenthesized assignment targets ----
+			{Code: `let value; ((value)) = compute(); log(value);`},
+			// ---- Dimension 4: nesting/traversal boundary ----
+			{Code: `let outer; function f() { let outer = 1; return outer; } outer = 2; log(outer);`},
+			// ---- Dimension 4: nesting/traversal boundary ----
+			{Code: `let status;
+const f = function status() {
+  log(status);
+};`},
+			// ---- Dimension 4: nesting/traversal boundary ----
+			{Code: `let status;
+function f() {
+  if (condition) {
+    var status = "ready";
+  }
+  log(status);
+}`},
+			// ---- Real-user: callback ref writes before later reads ----
+			{Code: `let input; const ref = (element: HTMLInputElement) => { input = element; }; mount(ref); log(input);`},
+			// ---- Real-user: ambient global augmentation remains declaration-only ----
+			{Code: `declare global { namespace App { let value: string; export { value }; } }`},
+			// N/A: autofix boundaries do not apply; no-unassigned-vars has no autofix.
+			// N/A: overload, abstract, and declare members do not create var/let declarators.
+		},
+		[]rule_tester.InvalidTestCase{
+			// Locks in upstream report arm: read with zero writes reports exact message text.
+			{
+				Code: `let value; log(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			// Locks in upstream reference loop arm 2: declaration-only references are not reads.
+			{
+				Code: `let value; export { value };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			// Locks in export local alias arm: exported local specifiers are runtime reads.
+			{
+				Code: `let value; export { value as alias };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			// Locks in reference identity: a catch binding shadows instead of writing the outer variable.
+			{
+				Code: `let error; try {} catch (error) {} log(error);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("error", 1, 5, 1, 10),
+				},
+			},
+			// Locks in reference identity: block-scoped shadowing does not write the outer variable.
+			{
+				Code: `let value; { let value = 1; log(value); } log(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			// Locks in reference identity: a hoisted var in a nested function shadows the outer variable.
+			{
+				Code: `let status;
+function f() {
+  if (condition) {
+    var status;
+  }
+  log(status);
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("status", 4, 9, 4, 15),
+				},
+			},
+			// ---- Dimension 4: parenthesized read wrappers ----
+			{
+				Code: `let value; log(((value)));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			// ---- Dimension 4: TS type-expression wrappers ----
+			{
+				Code: `let value: string | undefined; log((value as any)!.trim());`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 30),
+				},
+			},
+			// ---- Dimension 4: optional chain reads ----
+			{
+				Code: `let config; config?.enabled;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("config", 1, 5, 1, 11),
+				},
+			},
+			// ---- Dimension 4: optional chain reads ----
+			{
+				Code: `let fn; fn?.();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("fn", 1, 5, 1, 7),
+				},
+			},
+			// ---- Dimension 4: element access reads ----
+			{
+				Code: `let obj; obj["x"] = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("obj", 1, 5, 1, 8),
+				},
+			},
+			// ---- Dimension 4: computed property key reads ----
+			{
+				Code: `let key; const obj = { [key]: 1 };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("key", 1, 5, 1, 8),
+				},
+			},
+			// ---- Dimension 4: computed class keys ----
+			{
+				Code: `let key; class C { [key]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("key", 1, 5, 1, 8),
+				},
+			},
+			// ---- Dimension 4: shorthand property reads ----
+			{
+				Code: `let obj; consume({ obj });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("obj", 1, 5, 1, 8),
+				},
+			},
+			// ---- Dimension 4: multi-line position in a function container ----
+			{
+				Code: `function load() {
+	let options: { debug?: boolean };
+	return options?.debug;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("options", 2, 6, 2, 34),
+				},
+			},
+			// ---- Dimension 4: nesting/traversal boundary ----
+			{
+				Code: `let outer; function f() { return () => outer; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("outer", 1, 5, 1, 10),
+				},
+			},
+			// ---- Dimension 4: class static block reads ----
+			{
+				Code: `let value; class C { static { value; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			// ---- Dimension 4: class heritage reads ----
+			{
+				Code: `let Base; class Derived extends Base {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("Base", 1, 5, 1, 9),
+				},
+			},
+			// ---- Dimension 4: class field initializer reads ----
+			{
+				Code: `let value; class C { field = value; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			// ---- Dimension 4: enum initializer reads ----
+			{
+				Code: `let value; enum E { A = value }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			// ---- Dimension 4: tagged template reads ----
+			{
+				Code: "let tag; tag`value`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("tag", 1, 5, 1, 8),
+				},
+			},
+			// ---- Dimension 4: export default expression reads ----
+			{
+				Code: `let value; export default value;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			// ---- Dimension 4: TS satisfies expression reads ----
+			{
+				Code: `let value; value satisfies string;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			// ---- Dimension 4: TSX expression reads ----
+			{
+				Code: `declare namespace JSX { interface IntrinsicElements { div: any } }
+let value;
+const element = <div data-value={value} />;`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 2, 5, 2, 10),
+				},
+			},
+			// ---- Real-user: eslint/eslint#12497 property writes read the receiver but do not assign it ----
+			{
+				Code: `var obj; obj.x = 1; obj.y = 2;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("obj", 1, 5, 1, 8),
+				},
+			},
+			// ---- Real-user: eslint/eslint#12497 assigned siblings do not hide an unassigned variable ----
+			{
+				Code: `let a, b, c; if (something) { a = 0; b = false; } else { a = 1; b = true; } f(a, b, c);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("c", 1, 11, 1, 12),
+				},
+			},
+			// ---- Real-user: eslint/eslint#20169 SolidJS refs are reads unless the variable is written ----
+			{
+				Code: `declare function onMount(cb: () => void): void;
+declare namespace JSX { interface IntrinsicElements { input: any } }
+export function Input() {
+	let inputRef: HTMLInputElement | undefined;
+	onMount(() => inputRef?.select());
+	return <input ref={inputRef} />;
+}`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("inputRef", 4, 6, 4, 44),
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_unassigned_vars/no_unassigned_vars_upstream_test.go
+++ b/internal/rules/no_unassigned_vars/no_unassigned_vars_upstream_test.go
@@ -1,0 +1,161 @@
+package no_unassigned_vars
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUnassignedVarsUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/no-unassigned-vars.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in the
+// no_unassigned_vars_extras_test.go file.
+func TestNoUnassignedVarsUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnassignedVarsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- upstream docs valid: JavaScript ----
+			{Code: `let message = "hello"; console.log(message);`},
+			{Code: `let user; user = getUser(); console.log(user.name);`},
+			{Code: `let count; count = 1; count++;`},
+			{Code: `let temp;`},
+			{Code: `let error; if (somethingWentWrong) { error = "Something went wrong"; } console.log(error);`},
+			{Code: `let item; for (item of items) { process(item); }`},
+			{Code: `let config; function setup() { config = { debug: true }; } setup(); console.log(config);`},
+			{Code: `let one = undefined; if (one === two) { }`},
+
+			// ---- upstream valid: JavaScript ----
+			{Code: `let x;`},
+			{Code: `var x;`},
+			{Code: `const x = undefined; log(x);`},
+			{Code: `let y = undefined; log(y);`},
+			{Code: `var y = undefined; log(y);`},
+			{Code: `let a = x, b = y; log(a, b);`},
+			{Code: `var a = x, b = y; log(a, b);`},
+			{Code: `const foo = (two) => { let one; if (one !== two) one = two; }`},
+
+			// ---- upstream valid: TypeScript ----
+			{Code: `let z: number | undefined = undefined; log(z);`},
+			{Code: `declare let c: string | undefined; log(c);`},
+			{Code: `
+const foo = (two: string): void => {
+	let one: string | undefined;
+	if (one !== two) {
+		one = two;
+	}
+}`},
+			{Code: `
+declare module 'module' {
+	import type { T } from 'module';
+	let x: T;
+	export = x;
+}`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- upstream docs invalid: JavaScript ----
+			{
+				Code: `let status; if (status === "ready") { console.log("Ready!"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("status", 1, 5, 1, 11),
+				},
+			},
+			// ---- upstream docs invalid: TypeScript ----
+			{
+				Code: `let value: number | undefined; console.log(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 30),
+				},
+			},
+
+			// ---- upstream invalid: JavaScript ----
+			{
+				Code: `let x; let a = x, b; log(x, a, b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("x", 1, 5, 1, 6),
+					unassignedError("b", 1, 19, 1, 20),
+				},
+			},
+			{
+				Code: `const foo = (two) => { let one; if (one === two) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("one", 1, 28, 1, 31),
+				},
+			},
+			{
+				Code: `let user; greet(user);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("user", 1, 5, 1, 9),
+				},
+			},
+			{
+				Code: `function test() { let error; return error || 'Unknown error'; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("error", 1, 23, 1, 28),
+				},
+			},
+			{
+				Code: `let options; const { debug } = options || {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("options", 1, 5, 1, 12),
+				},
+			},
+			{
+				Code: `let flag; while (!flag) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("flag", 1, 5, 1, 9),
+				},
+			},
+			{
+				Code: `let config; function init() { return config?.enabled; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("config", 1, 5, 1, 11),
+				},
+			},
+
+			// ---- upstream invalid: TypeScript ----
+			{
+				Code: `let x: number; log(x);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("x", 1, 5, 1, 14),
+				},
+			},
+			{
+				Code: `let x: number | undefined; log(x);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("x", 1, 5, 1, 26),
+				},
+			},
+			{
+				Code: `const foo = (two: string): void => { let one: string | undefined; if (one === two) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("one", 1, 42, 1, 65),
+				},
+			},
+			{
+				Code: `declare module 'module' {
+	let x: string;
+}
+let y: string;
+console.log(y);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("y", 4, 5, 4, 14),
+				},
+			},
+		},
+	)
+}
+
+func unassignedError(name string, line int, column int, endLine int, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "unassigned",
+		Message:   messageUnassigned(name).Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -123,10 +123,19 @@ func IsNonReferenceIdentifier(node *ast.Node) bool {
 		return true
 	}
 
-	// Re-export specifiers: export { x } from 'mod'
-	// All identifiers are source module names, not local references.
-	if parent.Kind == ast.KindExportSpecifier && isReExportSpecifier(parent) {
-		return true
+	// export { local as exported }: only `local` can read a runtime value.
+	if parent.Kind == ast.KindExportSpecifier {
+		if ast.IsTypeOnlyImportOrExportDeclaration(parent) || isReExportSpecifier(parent) {
+			return true
+		}
+		es := parent.AsExportSpecifier()
+		if es == nil {
+			return false
+		}
+		if es.PropertyName != nil {
+			return es.PropertyName != node
+		}
+		return es.Name() != node
 	}
 
 	// ast.IsDeclarationName covers: variable, function, class, parameter,
@@ -134,10 +143,6 @@ func IsNonReferenceIdentifier(node *ast.Node) bool {
 	if ast.IsDeclarationName(node) {
 		// ShorthandPropertyAssignment { x } — x IS a reference to the variable.
 		if parent.Kind == ast.KindShorthandPropertyAssignment {
-			return false
-		}
-		// export { x } (no rename, local) — x IS a reference to the local/global variable.
-		if parent.Kind == ast.KindExportSpecifier && parent.AsExportSpecifier().PropertyName == nil {
 			return false
 		}
 		return true
@@ -167,6 +172,13 @@ func IsNonReferenceIdentifier(node *ast.Node) bool {
 	}
 
 	return false
+}
+
+// IsInAmbientContext reports whether node was parsed inside an ambient
+// context. TypeScript-Go propagates this through declaration files and
+// `declare` contexts via NodeFlagsAmbient.
+func IsInAmbientContext(node *ast.Node) bool {
+	return node != nil && node.Flags&ast.NodeFlagsAmbient != 0
 }
 
 // CouldBeError reports whether a node could plausibly evaluate to an Error

--- a/internal/utils/reference_index.go
+++ b/internal/utils/reference_index.go
@@ -1,0 +1,186 @@
+package utils
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+)
+
+// ReferenceIndex wraps TypeScript-Go's per-symbol reference lookup and keeps a
+// small name index only for checker edge cases where symbol identity differs
+// from ESLint scope-manager's local variable identity.
+type ReferenceIndex struct {
+	sourceFile  *ast.SourceFile
+	typeChecker *checker.Checker
+	refsByName  map[string][]*ast.Node
+}
+
+func NewReferenceIndex(sourceFile *ast.SourceFile, typeChecker *checker.Checker) *ReferenceIndex {
+	return &ReferenceIndex{
+		sourceFile:  sourceFile,
+		typeChecker: typeChecker,
+	}
+}
+
+// GetVariableDeclarationSymbol returns the declared variable symbol for a
+// VariableDeclaration. The declaration node's symbol is the closest match to
+// ESLint's getDeclaredVariables(); GetSymbolAtLocation is only a fallback for
+// older checker states where the declaration symbol was not attached.
+func GetVariableDeclarationSymbol(varDecl *ast.Node, typeChecker *checker.Checker) *ast.Symbol {
+	if varDecl == nil {
+		return nil
+	}
+	if sym := varDecl.Symbol(); sym != nil {
+		return sym
+	}
+	vd := varDecl.AsVariableDeclaration()
+	if vd == nil || vd.Name() == nil || typeChecker == nil {
+		return nil
+	}
+	return typeChecker.GetSymbolAtLocation(vd.Name())
+}
+
+// ForEachReference invokes cb for every identifier node resolving to sym, in
+// source order. It returns early when cb returns true.
+func (i *ReferenceIndex) ForEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
+	if i == nil || i.sourceFile == nil || i.typeChecker == nil || sym == nil {
+		return
+	}
+	for _, node := range i.typeChecker.GetReferencesToSymbolInFile(i.sourceFile, sym) {
+		if cb(node) {
+			return
+		}
+	}
+}
+
+// ForEachReferenceByName invokes cb for identifier references with the given
+// text that are not shadowed between the reference site and boundary. This is
+// a fallback for TypeScript checker cases where a local declaration collides
+// with a lib/global symbol and symbol identity no longer matches ESLint's
+// scope-manager variable identity.
+func (i *ReferenceIndex) ForEachReferenceByName(name string, boundary *ast.Node, cb func(*ast.Node) bool) {
+	if i == nil || name == "" {
+		return
+	}
+	i.buildNameIndex()
+	for _, node := range i.refsByName[name] {
+		if boundary != nil && IsNameShadowedBetween(node, boundary, name) {
+			continue
+		}
+		if cb(node) {
+			return
+		}
+	}
+}
+
+func (i *ReferenceIndex) buildNameIndex() {
+	if i.refsByName != nil {
+		return
+	}
+	i.refsByName = map[string][]*ast.Node{}
+	if i.sourceFile == nil {
+		return
+	}
+
+	var walk func(*ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		if n.Kind == ast.KindIdentifier && !IsNonReferenceIdentifier(n) {
+			i.refsByName[n.Text()] = append(i.refsByName[n.Text()], n)
+		} else if n.Kind == ast.KindShorthandPropertyAssignment && IsInDestructuringAssignment(n) {
+			// Keep destructuring shorthand writes indexed even if a future tsgo
+			// traversal skips the child identifier for shorthand nodes.
+			if name := n.AsShorthandPropertyAssignment().Name(); name != nil {
+				i.refsByName[name.Text()] = append(i.refsByName[name.Text()], name)
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(i.sourceFile.AsNode())
+}
+
+// IsVariableWriteReference reports whether an identifier writes to its
+// variable. It extends IsWriteReference with writes introduced by variable
+// declarations with initializers, for-in/for-of declarations, and catch
+// bindings, matching ESLint scope-manager write-reference semantics.
+func IsVariableWriteReference(node *ast.Node) bool {
+	if IsWriteReference(node) {
+		return true
+	}
+	if node == nil || node.Parent == nil {
+		return false
+	}
+	parent := node.Parent
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		varDecl := parent.AsVariableDeclaration()
+		return varDecl != nil && varDecl.Name() == node && VariableDeclarationIntroducesWrite(parent)
+	case ast.KindBindingElement:
+		be := parent.AsBindingElement()
+		if be == nil || be.Name() != node {
+			return false
+		}
+		return ast.IsWriteAccessForReference(node) ||
+			VariableDeclarationIntroducesWrite(EnclosingVariableDeclarationOfBindingElement(parent))
+	}
+	return false
+}
+
+// VariableDeclarationIntroducesWrite reports whether a VariableDeclaration's
+// binding is written at introduction.
+func VariableDeclarationIntroducesWrite(varDecl *ast.Node) bool {
+	if varDecl == nil || varDecl.Kind != ast.KindVariableDeclaration {
+		return false
+	}
+	return ast.IsWriteAccessForReference(varDecl.Name()) || IsVarDeclInForInOrOf(varDecl)
+}
+
+// IsVarDeclInForInOrOf reports whether a VariableDeclaration sits directly
+// inside a for-in/for-of initializer.
+func IsVarDeclInForInOrOf(varDecl *ast.Node) bool {
+	if varDecl == nil || varDecl.Parent == nil {
+		return false
+	}
+	declList := varDecl.Parent
+	if declList.Kind != ast.KindVariableDeclarationList || declList.Parent == nil {
+		return false
+	}
+	outer := declList.Parent
+	return outer.Kind == ast.KindForInStatement || outer.Kind == ast.KindForOfStatement
+}
+
+// EnclosingVariableDeclarationOfBindingElement walks through nested
+// BindingElement / BindingPattern layers to the containing VariableDeclaration.
+func EnclosingVariableDeclarationOfBindingElement(bindingElement *ast.Node) *ast.Node {
+	if bindingElement == nil || bindingElement.Kind != ast.KindBindingElement {
+		return nil
+	}
+	parent := ast.WalkUpBindingElementsAndPatterns(bindingElement)
+	if parent == nil || parent.Kind != ast.KindVariableDeclaration {
+		return nil
+	}
+	return parent
+}
+
+// GetDeclListForSymbolDecl returns the VariableDeclarationList associated with
+// a declaration node, or nil if the declaration is not a variable-like binding.
+func GetDeclListForSymbolDecl(decl *ast.Node) *ast.Node {
+	for current := decl; current != nil; {
+		if current.Kind == ast.KindVariableDeclarationList {
+			return current
+		}
+		if current.Kind == ast.KindVariableDeclaration ||
+			current.Kind == ast.KindBindingElement ||
+			current.Kind == ast.KindObjectBindingPattern ||
+			current.Kind == ast.KindArrayBindingPattern {
+			current = current.Parent
+			continue
+		}
+		return nil
+	}
+	return nil
+}

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -10,6 +10,7 @@ import (
 //
 // Scopes examined:
 //   - Function-like parameter lists (covers all 7 function-like kinds).
+//   - Function expression names and hoisted `var` declarations in function bodies.
 //   - Block-scoped declarations (var/let/const/function/class inside a Block).
 //   - Catch-clause variable bindings (including destructured patterns).
 //   - For-statement `let`/`const` init (scoped to the loop).
@@ -24,6 +25,14 @@ func IsNameShadowedBetween(node *ast.Node, boundary *ast.Node, name string) bool
 	for current := node.Parent; current != nil && current != boundary; current = current.Parent {
 		if ast.IsFunctionLikeDeclaration(current) {
 			if HasShadowingParameter(current, name) {
+				return true
+			}
+			if current.Kind == ast.KindFunctionDeclaration || current.Kind == ast.KindFunctionExpression {
+				if n := current.Name(); n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+					return true
+				}
+			}
+			if body := current.Body(); body != nil && HasHoistedVarDeclaration(body, name) {
 				return true
 			}
 		}
@@ -64,10 +73,9 @@ func IsNameShadowedBetween(node *ast.Node, boundary *ast.Node, name string) bool
 }
 
 // GetReferenceSymbol returns the variable symbol for the given identifier.
-// When the identifier is the key of a shorthand property assignment in a
-// destructuring pattern (e.g., `({foo} = bar)`), it returns the value-binding
-// symbol rather than the property symbol that `GetSymbolAtLocation` would
-// otherwise produce.
+// When the identifier is a shorthand property name or a local export specifier
+// name, it returns the local value-binding symbol rather than the property or
+// export symbol that `GetSymbolAtLocation` would otherwise produce.
 func GetReferenceSymbol(node *ast.Node, typeChecker *checker.Checker) *ast.Symbol {
 	if node == nil || typeChecker == nil {
 		return nil
@@ -77,6 +85,19 @@ func GetReferenceSymbol(node *ast.Node, typeChecker *checker.Checker) *ast.Symbo
 		shorthand := parent.AsShorthandPropertyAssignment()
 		if shorthand != nil && shorthand.Name() == node {
 			if symbol := typeChecker.GetShorthandAssignmentValueSymbol(parent); symbol != nil {
+				return symbol
+			}
+		}
+	}
+	if parent != nil && parent.Kind == ast.KindExportSpecifier &&
+		!ast.IsTypeOnlyImportOrExportDeclaration(parent) &&
+		!isReExportSpecifier(parent) {
+		spec := parent.AsExportSpecifier()
+		isLocalName := spec != nil &&
+			((spec.PropertyName != nil && spec.PropertyName == node) ||
+				(spec.PropertyName == nil && spec.Name() == node))
+		if isLocalName {
+			if symbol := typeChecker.GetExportSpecifierLocalTargetSymbol(parent); symbol != nil {
 				return symbol
 			}
 		}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -111,6 +111,7 @@ export default defineConfig({
     './tests/eslint/rules/no-self-assign.test.ts',
     './tests/eslint/rules/no-undef.test.ts',
     './tests/eslint/rules/no-undef-init.test.ts',
+    './tests/eslint/rules/no-unassigned-vars.test.ts',
     './tests/eslint/rules/no-var.test.ts',
     './tests/eslint/rules/one-var.test.ts',
     './tests/eslint/rules/prefer-arrow-callback.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unassigned-vars.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unassigned-vars.test.ts.snap
@@ -1,0 +1,358 @@
+// Rstest Snapshot v1
+
+exports[`no-unassigned-vars > invalid 1`] = `
+{
+  "code": "let status; if (status === "ready") { console.log("Ready!"); }",
+  "diagnostics": [
+    {
+      "message": "'status' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 2`] = `
+{
+  "code": "let value: number | undefined; console.log(value);",
+  "diagnostics": [
+    {
+      "message": "'value' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 3`] = `
+{
+  "code": "let x; let a = x, b; log(x, a, b);",
+  "diagnostics": [
+    {
+      "message": "'x' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+    {
+      "message": "'b' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 4`] = `
+{
+  "code": "const foo = (two) => { let one; if (one === two) {} }",
+  "diagnostics": [
+    {
+      "message": "'one' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 5`] = `
+{
+  "code": "let user; greet(user);",
+  "diagnostics": [
+    {
+      "message": "'user' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 6`] = `
+{
+  "code": "function test() { let error; return error || 'Unknown error'; }",
+  "diagnostics": [
+    {
+      "message": "'error' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 7`] = `
+{
+  "code": "let options; const { debug } = options || {};",
+  "diagnostics": [
+    {
+      "message": "'options' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 8`] = `
+{
+  "code": "let flag; while (!flag) { }",
+  "diagnostics": [
+    {
+      "message": "'flag' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 9`] = `
+{
+  "code": "let config; function init() { return config?.enabled; }",
+  "diagnostics": [
+    {
+      "message": "'config' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 10`] = `
+{
+  "code": "let x: number; log(x);",
+  "diagnostics": [
+    {
+      "message": "'x' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 11`] = `
+{
+  "code": "let x: number | undefined; log(x);",
+  "diagnostics": [
+    {
+      "message": "'x' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 12`] = `
+{
+  "code": "const foo = (two: string): void => { let one: string | undefined; if (one === two) {} }",
+  "diagnostics": [
+    {
+      "message": "'one' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unassigned-vars > invalid 13`] = `
+{
+  "code": "declare module 'module' {
+  let x: string;
+}
+let y: string;
+console.log(y);",
+  "diagnostics": [
+    {
+      "message": "'y' is always 'undefined' because it's never assigned.",
+      "messageId": "unassigned",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-unassigned-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unassigned-vars.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unassigned-vars.test.ts
@@ -1,0 +1,102 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unassigned-vars', {
+  valid: [
+    'let message = "hello"; console.log(message);',
+    'let user; user = getUser(); console.log(user.name);',
+    'let count; count = 1; count++;',
+    'let temp;',
+    'let error; if (somethingWentWrong) { error = "Something went wrong"; } console.log(error);',
+    'let item; for (item of items) { process(item); }',
+    'let config; function setup() { config = { debug: true }; } setup(); console.log(config);',
+    'let one = undefined; if (one === two) { }',
+
+    'let x;',
+    'var x;',
+    'const x = undefined; log(x);',
+    'let y = undefined; log(y);',
+    'var y = undefined; log(y);',
+    'let a = x, b = y; log(a, b);',
+    'var a = x, b = y; log(a, b);',
+    'const foo = (two) => { let one; if (one !== two) one = two; }',
+
+    'let z: number | undefined = undefined; log(z);',
+    'declare let c: string | undefined; log(c);',
+    `
+const foo = (two: string): void => {
+  let one: string | undefined;
+  if (one !== two) {
+    one = two;
+  }
+}`,
+    `
+declare module 'module' {
+  import type { T } from 'module';
+  let x: T;
+  export = x;
+}`,
+  ],
+  invalid: [
+    {
+      code: 'let status; if (status === "ready") { console.log("Ready!"); }',
+      errors: [{ messageId: 'unassigned', line: 1, column: 5 }],
+    },
+    {
+      code: 'let value: number | undefined; console.log(value);',
+      errors: [{ messageId: 'unassigned', line: 1, column: 5 }],
+    },
+    {
+      code: 'let x; let a = x, b; log(x, a, b);',
+      errors: [
+        { messageId: 'unassigned', line: 1, column: 5 },
+        { messageId: 'unassigned', line: 1, column: 19 },
+      ],
+    },
+    {
+      code: 'const foo = (two) => { let one; if (one === two) {} }',
+      errors: [{ messageId: 'unassigned', line: 1, column: 28 }],
+    },
+    {
+      code: 'let user; greet(user);',
+      errors: [{ messageId: 'unassigned', line: 1, column: 5 }],
+    },
+    {
+      code: "function test() { let error; return error || 'Unknown error'; }",
+      errors: [{ messageId: 'unassigned', line: 1, column: 23 }],
+    },
+    {
+      code: 'let options; const { debug } = options || {};',
+      errors: [{ messageId: 'unassigned', line: 1, column: 5 }],
+    },
+    {
+      code: 'let flag; while (!flag) { }',
+      errors: [{ messageId: 'unassigned', line: 1, column: 5 }],
+    },
+    {
+      code: 'let config; function init() { return config?.enabled; }',
+      errors: [{ messageId: 'unassigned', line: 1, column: 5 }],
+    },
+    {
+      code: 'let x: number; log(x);',
+      errors: [{ messageId: 'unassigned', line: 1, column: 5 }],
+    },
+    {
+      code: 'let x: number | undefined; log(x);',
+      errors: [{ messageId: 'unassigned', line: 1, column: 5 }],
+    },
+    {
+      code: 'const foo = (two: string): void => { let one: string | undefined; if (one === two) {} }',
+      errors: [{ messageId: 'unassigned', line: 1, column: 42 }],
+    },
+    {
+      code: `declare module 'module' {
+  let x: string;
+}
+let y: string;
+console.log(y);`,
+      errors: [{ messageId: 'unassigned', line: 4, column: 5 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port ESLint core `no-unassigned-vars` to rslint.

This adds the Go rule implementation, documentation, rule registration, upstream compatibility coverage, extra edge-case coverage, and JS compatibility snapshots.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-unassigned-vars
- ESLint source: https://github.com/eslint/eslint/blob/main/lib/rules/no-unassigned-vars.js
- ESLint tests: https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-unassigned-vars.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
