### PR TITLE
feat: port rule no-unused-expressions

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -111,6 +111,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unused_expressions"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unused_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_backreference"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_call"
@@ -267,6 +268,7 @@ func GetAllRules() []rule.Rule {
 		no_unreachable.NoUnreachableRule,
 		require_atomic_updates.RequireAtomicUpdatesRule,
 		object_shorthand.ObjectShorthandRule,
+		no_unused_expressions.NoUnusedExpressionsRule,
 		no_unused_labels.NoUnusedLabelsRule,
 		one_var.OneVarRule,
 		prefer_arrow_callback.PreferArrowCallbackRule,

--- a/internal/rules/no_unused_expressions/no_unused_expressions.go
+++ b/internal/rules/no_unused_expressions/no_unused_expressions.go
@@ -6,37 +6,33 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-func unusedExpressionMessage() rule.RuleMessage {
+func messageUnusedExpression() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unusedExpression",
 		Description: "Expected an assignment or function call and instead saw an expression.",
 	}
 }
 
-// https://typescript-eslint.io/rules/no-unused-expressions
-var NoUnusedExpressionsRule = rule.CreateRule(rule.Rule{
+// https://eslint.org/docs/latest/rules/no-unused-expressions
+var NoUnusedExpressionsRule = rule.Rule{
 	Name: "no-unused-expressions",
 	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
 		opts := utils.ParseNoUnusedExpressionOptions(rawOptions)
 
 		return rule.RuleListeners{
 			ast.KindExpressionStatement: func(node *ast.Node) {
-				exprStmt := node.AsExpressionStatement()
-				if exprStmt == nil || exprStmt.Expression == nil {
-					return
-				}
-				expr := exprStmt.Expression
-
-				if !utils.IsDisallowedUnusedExpression(expr, opts) {
+				stmt := node.AsExpressionStatement()
+				if stmt == nil || stmt.Expression == nil {
 					return
 				}
 
-				if utils.IsDirectivePrologueStatementIncludingClassStaticBlocks(node) {
+				if utils.IsDirectivePrologueStatement(node) {
 					return
 				}
-
-				ctx.ReportNode(node, unusedExpressionMessage())
+				if utils.IsDisallowedUnusedExpression(stmt.Expression, opts) {
+					ctx.ReportNode(node, messageUnusedExpression())
+				}
 			},
 		}
 	},
-})
+}

--- a/internal/rules/no_unused_expressions/no_unused_expressions.md
+++ b/internal/rules/no_unused_expressions/no_unused_expressions.md
@@ -1,0 +1,91 @@
+# no-unused-expressions
+
+## Rule Details
+
+Disallow expression statements that do not affect program state.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+0;
+
+a;
+
+foo.bar;
+
+a ? b() : c;
+
+tag`template`;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+a = b;
+
+new Foo();
+
+foo();
+
+delete foo.bar;
+
+void foo();
+```
+
+## Options
+
+This rule has an object option:
+
+- `allowShortCircuit` (default: `false`): allow short-circuit expressions when
+  the right-hand side has an accepted side effect.
+- `allowTernary` (default: `false`): allow ternary expressions when both
+  branches have accepted side effects.
+- `allowTaggedTemplates` (default: `false`): allow tagged template expression
+  statements.
+- `enforceForJSX` (default: `false`): report unused JSX expression statements.
+- `ignoreDirectives` (default: `false`): accepted for ESLint config
+  compatibility; directive prologues are always allowed in rslint.
+
+Examples of **correct** code for this rule with `{ "allowShortCircuit": true }`:
+
+```json
+{ "no-unused-expressions": ["error", { "allowShortCircuit": true }] }
+```
+
+```javascript
+condition && doSomething();
+```
+
+Examples of **correct** code for this rule with `{ "allowTernary": true }`:
+
+```json
+{ "no-unused-expressions": ["error", { "allowTernary": true }] }
+```
+
+```javascript
+condition ? doSomething() : doSomethingElse();
+```
+
+Examples of **correct** code for this rule with `{ "allowTaggedTemplates": true }`:
+
+```json
+{ "no-unused-expressions": ["error", { "allowTaggedTemplates": true }] }
+```
+
+```javascript
+tag`template`;
+```
+
+Examples of **incorrect** code for this rule with `{ "enforceForJSX": true }`:
+
+```json
+{ "no-unused-expressions": ["error", { "enforceForJSX": true }] }
+```
+
+```jsx
+<div />;
+```
+
+## Original Documentation
+
+- [ESLint: no-unused-expressions](https://eslint.org/docs/latest/rules/no-unused-expressions)

--- a/internal/rules/no_unused_expressions/no_unused_expressions_extras_test.go
+++ b/internal/rules/no_unused_expressions/no_unused_expressions_extras_test.go
@@ -1,0 +1,177 @@
+// TestNoUnusedExpressionsExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+package no_unused_expressions
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedExpressionsExtras(t *testing.T) {
+	allowShortCircuit := map[string]interface{}{"allowShortCircuit": true}
+	allowShortCircuitAndTernary := map[string]interface{}{"allowShortCircuit": true, "allowTernary": true}
+	allowShortCircuitArray := []interface{}{map[string]interface{}{"allowShortCircuit": true}}
+	allowTernaryArray := []interface{}{map[string]interface{}{"allowTernary": true}}
+	allowTaggedTemplates := map[string]interface{}{"allowTaggedTemplates": true}
+	enforceForJSX := map[string]interface{}{"enforceForJSX": true}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedExpressionsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: parenthesized side-effecting expression ----
+			{Code: "((foo()));"},
+			// ---- Dimension 4: parenthesized assignment expression ----
+			{Code: "((foo = bar));"},
+			// ---- Dimension 4: nested TS wrappers around a side-effecting call ----
+			{Code: "((foo() as any)!);"},
+			// ---- Dimension 4: TS `satisfies` wrapper ----
+			// Locks in upstream Checker default: the core rule does not list
+			// TSSatisfiesExpression, so it stays in the unknown/allowed bucket.
+			{Code: "foo satisfies string;"},
+			// ---- Dimension 4: optional-chain call is side-effecting ----
+			{Code: "foo?.();"},
+			// ---- Dimension 4: declaration/container forms are not expression statements ----
+			{Code: "class C { field = foo; static other = bar; }"},
+			// ---- Dimension 4: graceful degradation - rest binding pattern ----
+			{Code: "const { ...rest } = obj;"},
+			// ---- Dimension 4: graceful degradation - overload and declare body-absent forms ----
+			{Code: "declare class C { overload(value: string): void; overload(value: number): void; }"},
+			// ---- Real-user: eslint/eslint#7632 tagged template APIs are allowed when configured ----
+			{Code: "injectGlobal`body { color: red; }`;", Options: allowTaggedTemplates},
+			// ---- Real-user: eslint/eslint#12822 optional method call is side-effecting ----
+			{Code: "foo?.bar();"},
+			// ---- Real-user: eslint/eslint#13666 nullish coalescing with call on the right ----
+			{Code: "foo ?? list.push(foo);", Options: allowShortCircuit},
+			// Locks in upstream LogicalExpression arm: array-wrapped options use the same JSON path as JS tests.
+			{Code: "foo && foo();", Options: allowShortCircuitArray},
+			// Locks in upstream ConditionalExpression arm: array-wrapped allowTernary accepts both side-effecting branches.
+			{Code: "foo ? bar() : baz();", Options: allowTernaryArray},
+			// Locks in recursive unwrapping under allowed short-circuit right-hand sides.
+			{Code: "foo && ((bar = baz) as any);", Options: allowShortCircuit},
+			// Locks in recursive unwrapping under allowed ternary branches.
+			{Code: "foo ? (bar() as any) : (baz()!);", Options: allowTernaryArray},
+			// Locks in nested short-circuit + ternary recursion where every terminal branch has side effects.
+			{Code: "foo && (bar ? baz() : qux());", Options: allowShortCircuitAndTernary},
+			// Locks in upstream UnaryExpression branch: void/delete are accepted side effects.
+			{Code: "foo ? void bar() : delete baz.qux;", Options: allowTernaryArray},
+			// Locks in upstream LogicalExpression recursion through a void expression.
+			{Code: "ready && void task();", Options: allowShortCircuit},
+			// Locks in upstream UnaryExpression/update distinction: prefix update has side effects.
+			{Code: "++i;"},
+			// Locks in upstream AssignmentExpression unknown/allowed branch.
+			{Code: "foo += 1;"},
+			// Locks in upstream AssignmentExpression branch for logical assignment.
+			{Code: "foo ||= bar;"},
+			// Locks in the other logical assignment operators covered by ast.IsAssignmentOperator.
+			{Code: "foo &&= bar;"},
+			{Code: "foo ??= bar;"},
+			// Locks in nested TS wrappers around satisfies: ESLint leaves TSSatisfiesExpression unknown/allowed.
+			{Code: "(foo satisfies string) as any;"},
+			// ---- Real-user: optional callback invocation is side-effecting ----
+			{Code: "onDone?.(result);"},
+			// ---- Real-user: styled-components tagged template APIs are allowed when configured ----
+			{Code: "styled.div`color: red;`;", Options: allowTaggedTemplates},
+			// N/A: autofix boundaries - this rule does not provide fixes.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized unused expression ----
+			invalidUnusedExpression("((foo));", "((foo));"),
+			// ---- Dimension 4: TS non-null assertion wrapper ----
+			invalidUnusedExpression("foo!;", "foo!;"),
+			// ---- Dimension 4: TS `as` type-expression wrapper ----
+			invalidUnusedExpression("(foo as any);", "(foo as any);"),
+			// ---- Dimension 4: TS type assertion wrapper ----
+			invalidUnusedExpression("<any>foo;", "<any>foo;"),
+			// ---- Dimension 4: nested TS wrappers around an unused expression ----
+			invalidUnusedExpression("((foo as any)!);", "((foo as any)!);"),
+			// ---- Dimension 4: type assertion around comma expression remains unused ----
+			invalidUnusedExpression("<any>(foo(), bar);", "<any>(foo(), bar);"),
+			// ---- Dimension 4: optional-chain member expression ----
+			invalidUnusedExpression("foo?.bar;", "foo?.bar;"),
+			// ---- Dimension 4: optional-chain member through nested TS wrappers ----
+			invalidUnusedExpression("((foo?.bar as any)!);", "((foo?.bar as any)!);"),
+			// ---- Dimension 4: element access string-literal key ----
+			invalidUnusedExpression("foo['bar'];", "foo['bar'];"),
+			// ---- Dimension 4: element access template-literal key ----
+			invalidUnusedExpression("foo[`bar`];", "foo[`bar`];"),
+			// ---- Dimension 4: element access numeric-literal key ----
+			invalidUnusedExpression("foo[0];", "foo[0];"),
+			// ---- Dimension 4: element access symbol key ----
+			invalidUnusedExpression("foo[Symbol.iterator];", "foo[Symbol.iterator];"),
+			// ---- Dimension 4: private identifier member expression ----
+			invalidUnusedExpression("class C { #x; m() { this.#x; } }", "this.#x;"),
+			// ---- Dimension 4: declaration/container form - class expression statement ----
+			invalidUnusedExpression("(class {});", "(class {});"),
+			// ---- Dimension 4: declaration/container form - function expression statement ----
+			invalidUnusedExpression("(function () {});", "(function () {});"),
+			// ---- Dimension 4: same-kind nesting/traversal boundary ----
+			invalidUnusedExpression("function outer() { function inner() { foo; } }", "foo;"),
+			// ---- Dimension 4: non-function block has no directive prologue ----
+			invalidUnusedExpression("if (foo) { 'bar'; }", "'bar';"),
+			// ---- Dimension 4: parenthesized string literal is not a directive prologue ----
+			invalidUnusedExpression("(\"use strict\");", "(\"use strict\");"),
+			// ---- Dimension 4: nested non-function block has no directive prologue after a real directive ----
+			invalidUnusedExpression("function outer() { 'directive'; { 'not directive'; } }", "'not directive';"),
+			// ---- Dimension 4: graceful degradation - object spread inside object literal ----
+			invalidUnusedExpression("({ ...obj });", "({ ...obj });"),
+			// ---- Dimension 4: graceful degradation - array spread inside array literal ----
+			invalidUnusedExpression("[...items];", "[...items];"),
+			// ---- Dimension 4: JSX expression statement with enforceForJSX through TS `as` wrapper ----
+			invalidUnusedExpressionWithOptionsTsx("<div /> as any;", "<div /> as any;", enforceForJSX),
+			// ---- Dimension 4: JSX fragment through TS wrapper with enforceForJSX ----
+			invalidUnusedExpressionWithOptionsTsx("<></> as any;", "<></> as any;", enforceForJSX),
+			// ---- Real-user: eslint/eslint#2102 / #14213 Chai getter chain remains an unused member expression ----
+			invalidUnusedExpression("expect(value).to.be.true;", "expect(value).to.be.true;"),
+			// ---- Real-user: Chai should-style property assertion remains an unused member expression ----
+			invalidUnusedExpression("value.should.be.ok;", "value.should.be.ok;"),
+			// Locks in upstream Checker.isDisallowed default path: call expressions are allowed, but member expressions are not.
+			invalidUnusedExpression("expect(value).to.be;", "expect(value).to.be;"),
+			// Locks in upstream LogicalExpression arm 1: no allowShortCircuit means always disallowed.
+			invalidUnusedExpression("foo && bar();", "foo && bar();"),
+			// Locks in upstream LogicalExpression arm 2: allowShortCircuit recurses into the right side.
+			invalidUnusedExpressionWithOptions("foo && bar;", "foo && bar;", allowShortCircuit),
+			// Locks in upstream LogicalExpression arm 2 for nullish coalescing.
+			invalidUnusedExpressionWithOptions("foo ?? bar;", "foo ?? bar;", allowShortCircuit),
+			// Locks in recursive TS wrapper unwrapping inside allowed short-circuit right-hand sides.
+			invalidUnusedExpressionWithOptions("foo && ((bar as any)!);", "foo && ((bar as any)!);", allowShortCircuit),
+			// Locks in upstream SequenceExpression branch under allowed short-circuit recursion.
+			invalidUnusedExpressionWithOptions("foo && (bar(), baz());", "foo && (bar(), baz());", allowShortCircuit),
+			// Locks in upstream ConditionalExpression arm 1: no allowTernary means always disallowed.
+			invalidUnusedExpression("foo ? bar() : baz();", "foo ? bar() : baz();"),
+			// Locks in upstream ConditionalExpression arm 2: consequent disallowed.
+			invalidUnusedExpressionWithOptions("foo ? bar : baz();", "foo ? bar : baz();", map[string]interface{}{"allowTernary": true}),
+			// Locks in upstream ConditionalExpression arm 2: alternate disallowed.
+			invalidUnusedExpressionWithOptions("foo ? bar() : baz;", "foo ? bar() : baz;", map[string]interface{}{"allowTernary": true}),
+			// Locks in nested short-circuit + ternary recursion when a terminal branch is unused.
+			invalidUnusedExpressionWithOptions("foo && (bar ? baz() : qux);", "foo && (bar ? baz() : qux);", allowShortCircuitAndTernary),
+			// Locks in ternary recursion through a valid short-circuit branch and an invalid alternate.
+			invalidUnusedExpressionWithOptions("foo ? (bar && baz()) : qux;", "foo ? (bar && baz()) : qux;", allowShortCircuitAndTernary),
+			// Locks in upstream SequenceExpression branch: comma expressions are disallowed even when the right side calls.
+			invalidUnusedExpression("foo(), bar();", "foo(), bar();"),
+			// Locks in upstream BinaryExpression branch for `in`.
+			invalidUnusedExpression("\"key\" in object;", "\"key\" in object;"),
+			// Locks in upstream BinaryExpression branch for `instanceof`.
+			invalidUnusedExpression("value instanceof Type;", "value instanceof Type;"),
+			// Locks in upstream TaggedTemplateExpression branch: disallowed by default.
+			invalidUnusedExpression("injectGlobal`body { color: red; }`;", "injectGlobal`body { color: red; }`;"),
+			// Locks in real-user styled-components tagged templates when allowTaggedTemplates is false.
+			invalidUnusedExpression("styled.div`color: red;`;", "styled.div`color: red;`;"),
+			// Locks in upstream UnaryExpression branch: typeof is disallowed.
+			invalidUnusedExpression("typeof foo;", "typeof foo;"),
+			// Locks in upstream UnaryExpression branch for other prefix operators without side effects.
+			invalidUnusedExpression("~flags;", "~flags;"),
+			// Locks in upstream MetaProperty branch.
+			invalidUnusedExpression("function f() { new.target; }", "new.target;"),
+			// Locks in upstream ThisExpression branch.
+			invalidUnusedExpression("function f() { this; }", "this;"),
+		},
+	)
+}

--- a/internal/rules/no_unused_expressions/no_unused_expressions_upstream_test.go
+++ b/internal/rules/no_unused_expressions/no_unused_expressions_upstream_test.go
@@ -1,0 +1,224 @@
+// TestNoUnusedExpressionsUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/no-unused-expressions.js 1:1. Position assertions
+// cover line/column for every invalid case. rslint-specific lock-in cases live
+// in the no_unused_expressions_extras_test.go file.
+package no_unused_expressions
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const unusedExpressionMessage = "Expected an assignment or function call and instead saw an expression."
+
+func TestNoUnusedExpressionsUpstream(t *testing.T) {
+	allowShortCircuit := map[string]interface{}{"allowShortCircuit": true}
+	allowTernary := map[string]interface{}{"allowTernary": true}
+	allowShortCircuitAndTernary := map[string]interface{}{"allowShortCircuit": true, "allowTernary": true}
+	allowTaggedTemplates := map[string]interface{}{"allowTaggedTemplates": true}
+	disallowTaggedTemplates := map[string]interface{}{"allowTaggedTemplates": false}
+	enforceForJSX := map[string]interface{}{"enforceForJSX": true}
+	ignoreDirectives := map[string]interface{}{"ignoreDirectives": true}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedExpressionsRule,
+		[]rule_tester.ValidTestCase{
+			// ---- upstream valid ----
+			{Code: "function f(){}"},
+			{Code: "a = b"},
+			{Code: "new a"},
+			{Code: "{}"},
+			{Code: "f(); g()"},
+			{Code: "i++"},
+			{Code: "a()"},
+			{Code: "a && a()", Options: allowShortCircuit},
+			{Code: "a() || (b = c)", Options: allowShortCircuit},
+			{Code: "a ? b() : c()", Options: allowTernary},
+			{Code: "a ? b() || (c = d) : e()", Options: allowShortCircuitAndTernary},
+			{Code: "delete foo.bar"},
+			{Code: "void new C"},
+			{Code: "\"use strict\";"},
+			{Code: "\"directive one\"; \"directive two\"; f();"},
+			{Code: "function foo() {\"use strict\"; return true; }"},
+			{Code: "var foo = () => {\"use strict\"; return true; }"},
+			{Code: "function foo() {\"directive one\"; \"directive two\"; f(); }"},
+			{Code: "function foo() { var foo = \"use strict\"; return true; }"},
+			{Code: "function* foo(){ yield 0; }"},
+			{Code: "async function foo() { await 5; }"},
+			{Code: "async function foo() { await foo.bar; }"},
+			{Code: "async function foo() { bar && await baz; }", Options: allowShortCircuit},
+			{Code: "async function foo() { foo ? await bar : await baz; }", Options: allowTernary},
+			{Code: "tag`tagged template literal`", Options: allowTaggedTemplates},
+			{Code: "shouldNotBeAffectedByAllowTemplateTagsOption()", Options: allowTaggedTemplates},
+			{Code: "import(\"foo\")"},
+			{Code: "func?.(\"foo\")"},
+			{Code: "obj?.foo(\"bar\")"},
+			// ---- upstream valid: JSX ----
+			{Code: "<div />", Tsx: true},
+			{Code: "<></>", Tsx: true},
+			{Code: "var partial = <div />", Tsx: true},
+			{Code: "var partial = <div />", Options: enforceForJSX, Tsx: true},
+			{Code: "var partial = <></>", Options: enforceForJSX, Tsx: true},
+			// ---- upstream valid: ignoreDirectives option ----
+			{Code: "\"use strict\";", Options: ignoreDirectives},
+			{Code: "\"directive one\"; \"directive two\"; f();", Options: ignoreDirectives},
+			{Code: "function foo() {\"use strict\"; return true; }", Options: ignoreDirectives},
+			{Code: "function foo() {\"directive one\"; \"directive two\"; f(); }", Options: ignoreDirectives},
+			// ---- upstream valid: TypeScript-specific ----
+			{Code: "test.age?.toLocaleString();"},
+			{Code: "let a = (a?.b).c;"},
+			{Code: "let b = a?.['b'];"},
+			{Code: "let c = one[2]?.[3][4];"},
+			{Code: "one[2]?.[3][4]?.();"},
+			{Code: "a?.['b']?.c();"},
+			{Code: "module Foo {\n  'use strict';\n}"},
+			{Code: "namespace Foo {\n  'use strict';\n\n  export class Foo {}\n  export class Bar {}\n}"},
+			{Code: "function foo() {\n  'use strict';\n\n  return null;\n}"},
+			{Code: "import('./foo');"},
+			{Code: "import('./foo').then(() => {});"},
+			{Code: "class Foo<T> {}\nnew Foo<string>();"},
+			{Code: "foo && foo?.();", Options: allowShortCircuit},
+			{Code: "foo && import('./foo');", Options: allowShortCircuit},
+			{Code: "foo ? import('./foo') : import('./bar');", Options: allowTernary},
+			{Code: "<div/> as any", Tsx: true},
+			{Code: "foo && foo()!;", Options: allowShortCircuit},
+			{
+				Code:    "declare const foo: Function | undefined;\n<any>(foo && foo()!)",
+				Options: allowShortCircuit,
+			},
+			{Code: "(Foo && Foo())<string, number>;", Options: allowShortCircuit},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- upstream invalid ----
+			invalidUnusedExpression("0", "0"),
+			invalidUnusedExpression("a", "a"),
+			invalidUnusedExpression("f(), 0", "f(), 0"),
+			invalidUnusedExpression("{0}", "0"),
+			invalidUnusedExpression("[]", "[]"),
+			invalidUnusedExpression("a && b();", "a && b();"),
+			invalidUnusedExpression("a() || false", "a() || false"),
+			invalidUnusedExpression("a || (b = c)", "a || (b = c)"),
+			invalidUnusedExpression("a ? b() || (c = d) : e", "a ? b() || (c = d) : e"),
+			invalidUnusedExpression("`untagged template literal`", "`untagged template literal`"),
+			invalidUnusedExpression("tag`tagged template literal`", "tag`tagged template literal`"),
+			invalidUnusedExpressionWithOptions("a && b()", "a && b()", allowTernary),
+			invalidUnusedExpressionWithOptions("a ? b() : c()", "a ? b() : c()", allowShortCircuit),
+			invalidUnusedExpressionWithOptions("a || b", "a || b", allowShortCircuit),
+			invalidUnusedExpressionWithOptions("a() && b", "a() && b", allowShortCircuit),
+			invalidUnusedExpressionWithOptions("a ? b : 0", "a ? b : 0", allowTernary),
+			invalidUnusedExpressionWithOptions("a ? b : c()", "a ? b : c()", allowTernary),
+			invalidUnusedExpression("foo.bar;", "foo.bar;"),
+			invalidUnusedExpression("!a", "!a"),
+			invalidUnusedExpression("+a", "+a"),
+			invalidUnusedExpression("\"directive one\"; f(); \"directive two\";", "\"directive two\";"),
+			invalidUnusedExpression("function foo() {\"directive one\"; f(); \"directive two\"; }", "\"directive two\";"),
+			invalidUnusedExpression("if (0) { \"not a directive\"; f(); }", "\"not a directive\";"),
+			invalidUnusedExpression("function foo() { var foo = true; \"use strict\"; }", "\"use strict\";"),
+			invalidUnusedExpression("var foo = () => { var foo = true; \"use strict\"; }", "\"use strict\";"),
+			invalidUnusedExpressionWithOptions("`untagged template literal`", "`untagged template literal`", allowTaggedTemplates),
+			invalidUnusedExpressionWithOptions("`untagged template literal`", "`untagged template literal`", disallowTaggedTemplates),
+			invalidUnusedExpressionWithOptions("tag`tagged template literal`", "tag`tagged template literal`", disallowTaggedTemplates),
+			// ---- upstream invalid: optional chaining ----
+			invalidUnusedExpression("obj?.foo", "obj?.foo"),
+			invalidUnusedExpression("obj?.foo.bar", "obj?.foo.bar"),
+			invalidUnusedExpression("obj?.foo().bar", "obj?.foo().bar"),
+			// ---- upstream invalid: JSX ----
+			invalidUnusedExpressionWithOptionsTsx("<div />", "<div />", enforceForJSX),
+			invalidUnusedExpressionWithOptionsTsx("<></>", "<></>", enforceForJSX),
+			// ---- upstream invalid: class static blocks do not have directive prologues ----
+			invalidUnusedExpression("class C { static { 'use strict'; } }", "'use strict';"),
+			{
+				Code: "class C { static {\n'foo'\n'bar'\n} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					unusedExpressionErrorAt("class C { static {\n'foo'\n'bar'\n} }", "'foo'"),
+					unusedExpressionErrorAt("class C { static {\n'foo'\n'bar'\n} }", "'bar'"),
+				},
+			},
+			invalidUnusedExpressionWithOptions("foo;", "foo;", ignoreDirectives),
+			// SKIP: rslint does not support ESLint's ecmaVersion: 3 parser mode,
+			// where string literals are not represented as directive prologues.
+			{Code: "\"use strict\";", Skip: true},
+			// SKIP: rslint does not support ESLint's ecmaVersion: 3 parser mode.
+			{Code: "\"directive one\"; \"directive two\"; f();", Skip: true},
+			// SKIP: rslint does not support ESLint's ecmaVersion: 3 parser mode.
+			{Code: "function foo() {\"use strict\"; return true; }", Skip: true},
+			// SKIP: rslint does not support ESLint's ecmaVersion: 3 parser mode.
+			{Code: "function foo() {\"directive one\"; \"directive two\"; f(); }", Skip: true},
+			// ---- upstream invalid: TypeScript-specific ----
+			invalidUnusedExpression("\n  if (0) 0;\n", "0;"),
+			invalidUnusedExpression("\n  f(0), {};\n", "f(0), {};"),
+			invalidUnusedExpression("\n  a, b();\n", "a, b();"),
+			invalidUnusedExpression("\n  a() &&\n\tfunction namedFunctionInExpressionContext() {\n\t  f();\n\t};\n", "a() &&"),
+			invalidUnusedExpression("\n  a?.b;\n", "a?.b;"),
+			invalidUnusedExpression("\n  (a?.b).c;\n", "(a?.b).c;"),
+			invalidUnusedExpression("\n  a?.['b'];\n", "a?.['b'];"),
+			invalidUnusedExpression("\n  (a?.['b']).c;\n", "(a?.['b']).c;"),
+			invalidUnusedExpression("\n  a?.b()?.c;\n", "a?.b()?.c;"),
+			invalidUnusedExpression("\n  (a?.b()).c;\n", "(a?.b()).c;"),
+			invalidUnusedExpression("\n  one[2]?.[3][4];\n", "one[2]?.[3][4];"),
+			invalidUnusedExpression("\n  one.two?.three.four;\n", "one.two?.three.four;"),
+			invalidUnusedExpression("module Foo {\n  const foo = true;\n  'use strict';\n}", "'use strict';"),
+			invalidUnusedExpression("namespace Foo {\n  export class Foo {}\n  export class Bar {}\n\n  'use strict';\n}", "'use strict';"),
+			invalidUnusedExpression("function foo() {\n  const foo = true;\n\n  'use strict';\n}", "'use strict';"),
+			invalidUnusedExpressionWithOptions("foo && foo?.bar;", "foo && foo?.bar;", allowShortCircuit),
+			invalidUnusedExpressionWithOptions("foo ? foo?.bar : bar.baz;", "foo ? foo?.bar : bar.baz;", allowTernary),
+			invalidUnusedExpression("\n  class Foo<T> {}\n  Foo<string>;\n", "Foo<string>;"),
+			invalidUnusedExpression("Map<string, string>;", "Map<string, string>;"),
+			invalidUnusedExpression("\n  declare const foo: number | undefined;\n  foo;\n", "foo;"),
+			invalidUnusedExpression("\n  declare const foo: number | undefined;\n  foo as any;\n", "foo as any;"),
+			invalidUnusedExpression("\n  declare const foo: number | undefined;\n  <any>foo;\n", "<any>foo;"),
+			invalidUnusedExpression("\n  declare const foo: number | undefined;\n  foo!;\n", "foo!;"),
+		},
+	)
+}
+
+func invalidUnusedExpression(code string, snippet string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code: code,
+		Errors: []rule_tester.InvalidTestCaseError{
+			unusedExpressionErrorAt(code, snippet),
+		},
+	}
+}
+
+func invalidUnusedExpressionWithOptions(code string, snippet string, options any) rule_tester.InvalidTestCase {
+	tc := invalidUnusedExpression(code, snippet)
+	tc.Options = options
+	return tc
+}
+
+func invalidUnusedExpressionWithOptionsTsx(code string, snippet string, options any) rule_tester.InvalidTestCase {
+	tc := invalidUnusedExpressionWithOptions(code, snippet, options)
+	tc.Tsx = true
+	return tc
+}
+
+func unusedExpressionErrorAt(code string, snippet string) rule_tester.InvalidTestCaseError {
+	line, column := lineColumnForSnippet(code, snippet)
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "unusedExpression",
+		Message:   unusedExpressionMessage,
+		Line:      line,
+		Column:    column,
+	}
+}
+
+func lineColumnForSnippet(code string, snippet string) (int, int) {
+	index := strings.Index(code, snippet)
+	if index < 0 {
+		panic("snippet not found: " + snippet)
+	}
+	before := code[:index]
+	line := strings.Count(before, "\n") + 1
+	lastNewline := strings.LastIndex(before, "\n")
+	if lastNewline < 0 {
+		return line, len(before) + 1
+	}
+	return line, len(before[lastNewline+1:]) + 1
+}

--- a/internal/utils/no_unused_expressions.go
+++ b/internal/utils/no_unused_expressions.go
@@ -1,0 +1,179 @@
+package utils
+
+import "github.com/microsoft/typescript-go/shim/ast"
+
+// NoUnusedExpressionOptions contains the expression-shape switches shared by
+// ESLint core and typescript-eslint's no-unused-expressions rules.
+type NoUnusedExpressionOptions struct {
+	AllowShortCircuit    bool
+	AllowTernary         bool
+	AllowTaggedTemplates bool
+	EnforceForJSX        bool
+}
+
+// ParseNoUnusedExpressionOptions reads the shared ESLint-compatible options.
+// ignoreDirectives only affects ESLint's legacy ecmaVersion: 3 mode, which
+// rslint does not expose; directive prologues are always skipped.
+func ParseNoUnusedExpressionOptions(raw any) NoUnusedExpressionOptions {
+	opts := NoUnusedExpressionOptions{}
+	optsMap := GetOptionsMap(raw)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowShortCircuit"].(bool); ok {
+		opts.AllowShortCircuit = v
+	}
+	if v, ok := optsMap["allowTernary"].(bool); ok {
+		opts.AllowTernary = v
+	}
+	if v, ok := optsMap["allowTaggedTemplates"].(bool); ok {
+		opts.AllowTaggedTemplates = v
+	}
+	if v, ok := optsMap["enforceForJSX"].(bool); ok {
+		opts.EnforceForJSX = v
+	}
+	return opts
+}
+
+// IsDisallowedUnusedExpression mirrors the no-unused-expressions checker:
+// true means the expression has no accepted side effect and should be reported.
+// This is rule semantics, not a general-purpose purity predicate.
+func IsDisallowedUnusedExpression(node *ast.Node, opts NoUnusedExpressionOptions) bool {
+	node = ast.SkipOuterExpressions(
+		node,
+		ast.OEKParentheses|ast.OEKTypeAssertions|ast.OEKNonNullAssertions,
+	)
+	if node == nil {
+		return false
+	}
+
+	switch node.Kind {
+	case ast.KindArrayLiteralExpression,
+		ast.KindArrowFunction,
+		ast.KindClassExpression,
+		ast.KindFalseKeyword,
+		ast.KindFunctionExpression,
+		ast.KindIdentifier,
+		ast.KindMetaProperty,
+		ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindNullKeyword,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindObjectLiteralExpression,
+		ast.KindPropertyAccessExpression,
+		ast.KindElementAccessExpression,
+		ast.KindRegularExpressionLiteral,
+		ast.KindStringLiteral,
+		ast.KindSuperKeyword,
+		ast.KindTemplateExpression,
+		ast.KindThisKeyword,
+		ast.KindTrueKeyword,
+		ast.KindTypeOfExpression:
+		return true
+
+	case ast.KindJsxElement, ast.KindJsxFragment, ast.KindJsxSelfClosingElement:
+		return opts.EnforceForJSX
+
+	case ast.KindTaggedTemplateExpression:
+		return !opts.AllowTaggedTemplates
+
+	case ast.KindConditionalExpression:
+		if !opts.AllowTernary {
+			return true
+		}
+		cond := node.AsConditionalExpression()
+		return cond == nil ||
+			IsDisallowedUnusedExpression(cond.WhenTrue, opts) ||
+			IsDisallowedUnusedExpression(cond.WhenFalse, opts)
+
+	case ast.KindBinaryExpression:
+		bin := node.AsBinaryExpression()
+		if bin == nil || bin.OperatorToken == nil {
+			return false
+		}
+		opKind := bin.OperatorToken.Kind
+		if ast.IsLogicalOrCoalescingBinaryOperator(opKind) {
+			if opts.AllowShortCircuit {
+				return IsDisallowedUnusedExpression(bin.Right, opts)
+			}
+			return true
+		}
+		if opKind == ast.KindCommaToken {
+			return true
+		}
+		return !ast.IsAssignmentOperator(opKind)
+
+	case ast.KindPrefixUnaryExpression:
+		prefix := node.AsPrefixUnaryExpression()
+		return prefix != nil && !isUpdateOperator(prefix.Operator)
+
+	case ast.KindExpressionWithTypeArguments:
+		return IsDisallowedUnusedExpression(node.Expression(), opts)
+
+	case ast.KindAwaitExpression,
+		ast.KindCallExpression,
+		ast.KindDeleteExpression,
+		ast.KindNewExpression,
+		ast.KindPostfixUnaryExpression,
+		ast.KindVoidExpression,
+		ast.KindYieldExpression:
+		return false
+
+	// The current ESLint rule does not list TSSatisfiesExpression, so the
+	// tsgo equivalent stays in the unknown/allowed bucket.
+	default:
+		return false
+	}
+}
+
+func isUpdateOperator(kind ast.Kind) bool {
+	return kind == ast.KindPlusPlusToken || kind == ast.KindMinusMinusToken
+}
+
+// IsDirectivePrologueStatement reports whether node is a leading string-literal
+// expression statement in a Program, function body, or TS module block.
+func IsDirectivePrologueStatement(node *ast.Node) bool {
+	return isDirectivePrologueStatement(node, false)
+}
+
+// IsDirectivePrologueStatementIncludingClassStaticBlocks matches the
+// @typescript-eslint/parser static-block behavior used by its extension rule.
+func IsDirectivePrologueStatementIncludingClassStaticBlocks(node *ast.Node) bool {
+	return isDirectivePrologueStatement(node, true)
+}
+
+func isDirectivePrologueStatement(node *ast.Node, includeClassStaticBlocks bool) bool {
+	if node == nil || !ast.IsPrologueDirective(node) {
+		return false
+	}
+	parent := node.Parent
+	if parent == nil || !isDirectivePrologueContainer(parent, includeClassStaticBlocks) {
+		return false
+	}
+	for _, stmt := range parent.Statements() {
+		if stmt == node {
+			return true
+		}
+		if !ast.IsPrologueDirective(stmt) {
+			return false
+		}
+	}
+	return false
+}
+
+func isDirectivePrologueContainer(node *ast.Node, includeClassStaticBlocks bool) bool {
+	switch node.Kind {
+	case ast.KindSourceFile, ast.KindModuleBlock:
+		return true
+	case ast.KindBlock:
+		if node.Parent == nil {
+			return false
+		}
+		if includeClassStaticBlocks {
+			return ast.IsFunctionLikeOrClassStaticBlockDeclaration(node.Parent)
+		}
+		return ast.IsFunctionLike(node.Parent)
+	default:
+		return false
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -450,6 +450,7 @@ export default defineConfig({
     './tests/eslint/rules/no-label-var.test.ts',
     './tests/eslint/rules/no-shadow.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
+    './tests/eslint/rules/no-unused-expressions.test.ts',
     './tests/eslint/rules/no-unused-labels.test.ts',
     './tests/eslint/rules/no-lone-blocks.test.ts',
     './tests/eslint/rules/no-loop-func.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unused-expressions.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unused-expressions.test.ts.snap
@@ -1,0 +1,1555 @@
+// Rstest Snapshot v1
+
+exports[`no-unused-expressions > invalid 1`] = `
+{
+  "code": "0",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 2`] = `
+{
+  "code": "a",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 3`] = `
+{
+  "code": "f(), 0",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 4`] = `
+{
+  "code": "{0}",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 5`] = `
+{
+  "code": "[]",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 6`] = `
+{
+  "code": "a && b();",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 7`] = `
+{
+  "code": "a() || false",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 8`] = `
+{
+  "code": "a || (b = c)",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 9`] = `
+{
+  "code": "a ? b() || (c = d) : e",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 10`] = `
+{
+  "code": "\`untagged template literal\`",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 11`] = `
+{
+  "code": "tag\`tagged template literal\`",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 12`] = `
+{
+  "code": "a && b()",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 13`] = `
+{
+  "code": "a ? b() : c()",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 14`] = `
+{
+  "code": "a || b",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 15`] = `
+{
+  "code": "a() && b",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 16`] = `
+{
+  "code": "a ? b : 0",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 17`] = `
+{
+  "code": "a ? b : c()",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 18`] = `
+{
+  "code": "foo.bar;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 19`] = `
+{
+  "code": "!a",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 20`] = `
+{
+  "code": "+a",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 21`] = `
+{
+  "code": ""directive one"; f(); "directive two";",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 22`] = `
+{
+  "code": "function foo() {"directive one"; f(); "directive two"; }",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 23`] = `
+{
+  "code": "if (0) { "not a directive"; f(); }",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 24`] = `
+{
+  "code": "function foo() { var foo = true; "use strict"; }",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 25`] = `
+{
+  "code": "var foo = () => { var foo = true; "use strict"; }",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 26`] = `
+{
+  "code": "\`untagged template literal\`",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 27`] = `
+{
+  "code": "\`untagged template literal\`",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 28`] = `
+{
+  "code": "tag\`tagged template literal\`",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 29`] = `
+{
+  "code": "obj?.foo",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 30`] = `
+{
+  "code": "obj?.foo.bar",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 31`] = `
+{
+  "code": "obj?.foo().bar",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 32`] = `
+{
+  "code": "class C { static { 'use strict'; } }",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 33`] = `
+{
+  "code": "class C { static {
+'foo'
+'bar'
+} }",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 34`] = `
+{
+  "code": "foo;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 35`] = `
+{
+  "code": "
+  if (0) 0;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 36`] = `
+{
+  "code": "
+  f(0), {};
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 37`] = `
+{
+  "code": "
+  a, b();
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 38`] = `
+{
+  "code": "
+  a() &&
+	function namedFunctionInExpressionContext() {
+	  f();
+	};
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 39`] = `
+{
+  "code": "
+  a?.b;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 40`] = `
+{
+  "code": "
+  (a?.b).c;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 41`] = `
+{
+  "code": "
+  a?.['b'];
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 42`] = `
+{
+  "code": "
+  (a?.['b']).c;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 43`] = `
+{
+  "code": "
+  a?.b()?.c;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 44`] = `
+{
+  "code": "
+  (a?.b()).c;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 45`] = `
+{
+  "code": "
+  one[2]?.[3][4];
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 46`] = `
+{
+  "code": "
+  one.two?.three.four;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 47`] = `
+{
+  "code": "module Foo {
+  const foo = true;
+  'use strict';
+}",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 48`] = `
+{
+  "code": "namespace Foo {
+  export class Foo {}
+  export class Bar {}
+
+  'use strict';
+}",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 49`] = `
+{
+  "code": "function foo() {
+  const foo = true;
+
+  'use strict';
+}",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 50`] = `
+{
+  "code": "foo && foo?.bar;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 51`] = `
+{
+  "code": "foo ? foo?.bar : bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 52`] = `
+{
+  "code": "
+  class Foo<T> {}
+  Foo<string>;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 53`] = `
+{
+  "code": "Map<string, string>;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 54`] = `
+{
+  "code": "
+  declare const foo: number | undefined;
+  foo;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 55`] = `
+{
+  "code": "
+  declare const foo: number | undefined;
+  foo as any;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 56`] = `
+{
+  "code": "
+  declare const foo: number | undefined;
+  <any>foo;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 57`] = `
+{
+  "code": "
+  declare const foo: number | undefined;
+  foo!;
+",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unused-expressions.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unused-expressions.test.ts
@@ -1,0 +1,307 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unused-expressions', {
+  valid: [
+    'function f(){}',
+    'a = b',
+    'new a',
+    '{}',
+    'f(); g()',
+    'i++',
+    'a()',
+    { code: 'a && a()', options: [{ allowShortCircuit: true }] as any },
+    {
+      code: 'a() || (b = c)',
+      options: [{ allowShortCircuit: true }] as any,
+    },
+    { code: 'a ? b() : c()', options: [{ allowTernary: true }] as any },
+    {
+      code: 'a ? b() || (c = d) : e()',
+      options: [{ allowShortCircuit: true, allowTernary: true }] as any,
+    },
+    'delete foo.bar',
+    'void new C',
+    '"use strict";',
+    '"directive one"; "directive two"; f();',
+    'function foo() {"use strict"; return true; }',
+    'var foo = () => {"use strict"; return true; }',
+    'function foo() {"directive one"; "directive two"; f(); }',
+    'function foo() { var foo = "use strict"; return true; }',
+    'function* foo(){ yield 0; }',
+    'async function foo() { await 5; }',
+    'async function foo() { await foo.bar; }',
+    {
+      code: 'async function foo() { bar && await baz; }',
+      options: [{ allowShortCircuit: true }] as any,
+    },
+    {
+      code: 'async function foo() { foo ? await bar : await baz; }',
+      options: [{ allowTernary: true }] as any,
+    },
+    {
+      code: 'tag`tagged template literal`',
+      options: [{ allowTaggedTemplates: true }] as any,
+    },
+    {
+      code: 'shouldNotBeAffectedByAllowTemplateTagsOption()',
+      options: [{ allowTaggedTemplates: true }] as any,
+    },
+    'import("foo")',
+    'func?.("foo")',
+    'obj?.foo("bar")',
+
+    // JSX upstream cases live in Go tests because this JS harness uses virtual.ts.
+
+    { code: '"use strict";', options: [{ ignoreDirectives: true }] as any },
+    {
+      code: '"directive one"; "directive two"; f();',
+      options: [{ ignoreDirectives: true }] as any,
+    },
+    {
+      code: 'function foo() {"use strict"; return true; }',
+      options: [{ ignoreDirectives: true }] as any,
+    },
+    {
+      code: 'function foo() {"directive one"; "directive two"; f(); }',
+      options: [{ ignoreDirectives: true }] as any,
+    },
+
+    'test.age?.toLocaleString();',
+    'let a = (a?.b).c;',
+    "let b = a?.['b'];",
+    'let c = one[2]?.[3][4];',
+    'one[2]?.[3][4]?.();',
+    "a?.['b']?.c();",
+    "module Foo {\n  'use strict';\n}",
+    "namespace Foo {\n  'use strict';\n\n  export class Foo {}\n  export class Bar {}\n}",
+    "function foo() {\n  'use strict';\n\n  return null;\n}",
+    "import('./foo');",
+    "import('./foo').then(() => {});",
+    'class Foo<T> {}\nnew Foo<string>();',
+    {
+      code: 'foo && foo?.();',
+      options: [{ allowShortCircuit: true }] as any,
+    },
+    {
+      code: "foo && import('./foo');",
+      options: [{ allowShortCircuit: true }] as any,
+    },
+    {
+      code: "foo ? import('./foo') : import('./bar');",
+      options: [{ allowTernary: true }] as any,
+    },
+    {
+      code: 'foo && foo()!;',
+      options: [{ allowShortCircuit: true }] as any,
+    },
+    {
+      code: 'declare const foo: Function | undefined;\n<any>(foo && foo()!)',
+      options: [{ allowShortCircuit: true }] as any,
+    },
+    {
+      code: '(Foo && Foo())<string, number>;',
+      options: [{ allowShortCircuit: true }] as any,
+    },
+  ],
+  invalid: [
+    { code: '0', errors: [{ messageId: 'unusedExpression' }] },
+    { code: 'a', errors: [{ messageId: 'unusedExpression' }] },
+    { code: 'f(), 0', errors: [{ messageId: 'unusedExpression' }] },
+    { code: '{0}', errors: [{ messageId: 'unusedExpression' }] },
+    { code: '[]', errors: [{ messageId: 'unusedExpression' }] },
+    { code: 'a && b();', errors: [{ messageId: 'unusedExpression' }] },
+    { code: 'a() || false', errors: [{ messageId: 'unusedExpression' }] },
+    { code: 'a || (b = c)', errors: [{ messageId: 'unusedExpression' }] },
+    {
+      code: 'a ? b() || (c = d) : e',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '`untagged template literal`',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'tag`tagged template literal`',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'a && b()',
+      options: [{ allowTernary: true }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'a ? b() : c()',
+      options: [{ allowShortCircuit: true }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'a || b',
+      options: [{ allowShortCircuit: true }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'a() && b',
+      options: [{ allowShortCircuit: true }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'a ? b : 0',
+      options: [{ allowTernary: true }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'a ? b : c()',
+      options: [{ allowTernary: true }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    { code: 'foo.bar;', errors: [{ messageId: 'unusedExpression' }] },
+    { code: '!a', errors: [{ messageId: 'unusedExpression' }] },
+    { code: '+a', errors: [{ messageId: 'unusedExpression' }] },
+    {
+      code: '"directive one"; f(); "directive two";',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'function foo() {"directive one"; f(); "directive two"; }',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'if (0) { "not a directive"; f(); }',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'function foo() { var foo = true; "use strict"; }',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'var foo = () => { var foo = true; "use strict"; }',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '`untagged template literal`',
+      options: [{ allowTaggedTemplates: true }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '`untagged template literal`',
+      options: [{ allowTaggedTemplates: false }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'tag`tagged template literal`',
+      options: [{ allowTaggedTemplates: false }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    { code: 'obj?.foo', errors: [{ messageId: 'unusedExpression' }] },
+    { code: 'obj?.foo.bar', errors: [{ messageId: 'unusedExpression' }] },
+    { code: 'obj?.foo().bar', errors: [{ messageId: 'unusedExpression' }] },
+
+    // JSX upstream invalid cases live in Go tests.
+
+    {
+      code: "class C { static { 'use strict'; } }",
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: "class C { static {\n'foo'\n'bar'\n} }",
+      errors: [
+        { messageId: 'unusedExpression' },
+        { messageId: 'unusedExpression' },
+      ],
+    },
+    {
+      code: 'foo;',
+      options: [{ ignoreDirectives: true }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    // SKIP: rslint's JS harness does not expose ESLint's ecmaVersion: 3 mode.
+    { code: '"use strict";', skip: true, errors: [] },
+    // SKIP: rslint's JS harness does not expose ESLint's ecmaVersion: 3 mode.
+    { code: '"directive one"; "directive two"; f();', skip: true, errors: [] },
+    // SKIP: rslint's JS harness does not expose ESLint's ecmaVersion: 3 mode.
+    {
+      code: 'function foo() {"use strict"; return true; }',
+      skip: true,
+      errors: [],
+    },
+    // SKIP: rslint's JS harness does not expose ESLint's ecmaVersion: 3 mode.
+    {
+      code: 'function foo() {"directive one"; "directive two"; f(); }',
+      skip: true,
+      errors: [],
+    },
+
+    { code: '\n  if (0) 0;\n', errors: [{ messageId: 'unusedExpression' }] },
+    { code: '\n  f(0), {};\n', errors: [{ messageId: 'unusedExpression' }] },
+    { code: '\n  a, b();\n', errors: [{ messageId: 'unusedExpression' }] },
+    {
+      code: '\n  a() &&\n\tfunction namedFunctionInExpressionContext() {\n\t  f();\n\t};\n',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    { code: '\n  a?.b;\n', errors: [{ messageId: 'unusedExpression' }] },
+    { code: '\n  (a?.b).c;\n', errors: [{ messageId: 'unusedExpression' }] },
+    { code: "\n  a?.['b'];\n", errors: [{ messageId: 'unusedExpression' }] },
+    {
+      code: "\n  (a?.['b']).c;\n",
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    { code: '\n  a?.b()?.c;\n', errors: [{ messageId: 'unusedExpression' }] },
+    { code: '\n  (a?.b()).c;\n', errors: [{ messageId: 'unusedExpression' }] },
+    {
+      code: '\n  one[2]?.[3][4];\n',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '\n  one.two?.three.four;\n',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: "module Foo {\n  const foo = true;\n  'use strict';\n}",
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: "namespace Foo {\n  export class Foo {}\n  export class Bar {}\n\n  'use strict';\n}",
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: "function foo() {\n  const foo = true;\n\n  'use strict';\n}",
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'foo && foo?.bar;',
+      options: [{ allowShortCircuit: true }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'foo ? foo?.bar : bar.baz;',
+      options: [{ allowTernary: true }] as any,
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '\n  class Foo<T> {}\n  Foo<string>;\n',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'Map<string, string>;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '\n  declare const foo: number | undefined;\n  foo;\n',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '\n  declare const foo: number | undefined;\n  foo as any;\n',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '\n  declare const foo: number | undefined;\n  <any>foo;\n',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '\n  declare const foo: number | undefined;\n  foo!;\n',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-unused-expressions` ESLint core rule to rslint.

The rule reports expression statements that have no effect, with ESLint-compatible handling for `allowShortCircuit`, `allowTernary`, `allowTaggedTemplates`, and `enforceForJSX`.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-unused-expressions
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-unused-expressions.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).