### PR TITLE
feat: port rule no-unused-private-class-members

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -113,6 +113,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unused_expressions"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unused_labels"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unused_private_class_members"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_backreference"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_call"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
@@ -270,6 +271,7 @@ func GetAllRules() []rule.Rule {
 		object_shorthand.ObjectShorthandRule,
 		no_unused_expressions.NoUnusedExpressionsRule,
 		no_unused_labels.NoUnusedLabelsRule,
+		no_unused_private_class_members.NoUnusedPrivateClassMembersRule,
 		one_var.OneVarRule,
 		prefer_arrow_callback.PreferArrowCallbackRule,
 		no_dupe_else_if.NoDupeElseIfRule,

--- a/internal/rules/no_unused_private_class_members/no_unused_private_class_members.go
+++ b/internal/rules/no_unused_private_class_members/no_unused_private_class_members.go
@@ -1,0 +1,532 @@
+package no_unused_private_class_members
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type privateMember struct {
+	declNode     *ast.Node
+	nameNode     *ast.Node
+	name         string
+	hasReference bool
+	isAccessor   bool
+	isUsed       bool
+}
+
+type classMembers struct {
+	classNode *ast.Node
+	members   map[string]*privateMember
+	order     []string
+}
+
+type sourceItem struct {
+	start     int
+	end       int
+	text      string
+	isComment bool
+}
+
+var NoUnusedPrivateClassMembersRule = rule.Rule{
+	Name: "no-unused-private-class-members",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		var stack []*classMembers
+		var sourceItems []sourceItem
+
+		getSourceItems := func() []sourceItem {
+			if sourceItems == nil {
+				sourceItems = collectSourceItems(ctx.SourceFile)
+			}
+			return sourceItems
+		}
+
+		pushClass := func(node *ast.Node) {
+			stack = append(stack, collectPrivateMembers(node))
+		}
+
+		popClass := func(_ *ast.Node) {
+			if len(stack) == 0 {
+				return
+			}
+			current := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			reportUnusedMembers(ctx, current, getSourceItems())
+		}
+
+		handlePrivateIdentifier := func(node *ast.Node) {
+			if isPrivateMemberDeclarationName(node) {
+				return
+			}
+
+			member := findTrackedPrivateMember(stack, node)
+			if member == nil || member.isUsed {
+				return
+			}
+
+			member.hasReference = true
+			if member.isAccessor {
+				member.isUsed = true
+				return
+			}
+
+			if parent := node.Parent; parent != nil && parent.Kind == ast.KindPropertyAccessExpression {
+				if isWriteOnlyAccess(parent) {
+					return
+				}
+			}
+
+			member.isUsed = true
+		}
+
+		var scanComputedKey func(node *ast.Node)
+		scanComputedKey = func(node *ast.Node) {
+			if node == nil {
+				return
+			}
+			if node.Kind == ast.KindPrivateIdentifier {
+				handlePrivateIdentifier(node)
+			}
+			node.ForEachChild(func(child *ast.Node) bool {
+				scanComputedKey(child)
+				return false
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindClassDeclaration:                      pushClass,
+			rule.ListenerOnExit(ast.KindClassDeclaration): popClass,
+			ast.KindClassExpression:                       pushClass,
+			rule.ListenerOnExit(ast.KindClassExpression):  popClass,
+			ast.KindPrivateIdentifier:                     handlePrivateIdentifier,
+			ast.KindPropertyAssignment: func(node *ast.Node) {
+				property := node.AsPropertyAssignment()
+				if property == nil {
+					return
+				}
+				name := property.Name()
+				if name == nil || name.Kind != ast.KindComputedPropertyName {
+					return
+				}
+				parent := node.Parent
+				if parent == nil || parent.Kind != ast.KindObjectLiteralExpression || !ast.IsAssignmentTarget(parent) {
+					return
+				}
+				// The generic PrivateIdentifier listener can miss computed keys in
+				// destructuring assignment patterns, so scan that key explicitly.
+				scanComputedKey(name)
+			},
+		}
+	},
+}
+
+func collectPrivateMembers(classNode *ast.Node) *classMembers {
+	result := &classMembers{
+		classNode: classNode,
+		members:   map[string]*privateMember{},
+	}
+
+	for _, memberNode := range classNode.Members() {
+		switch memberNode.Kind {
+		case ast.KindPropertyDeclaration,
+			ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor:
+			nameNode := memberNode.Name()
+			if nameNode == nil || nameNode.Kind != ast.KindPrivateIdentifier {
+				continue
+			}
+			name := nameNode.AsPrivateIdentifier().Text
+			if _, exists := result.members[name]; !exists {
+				result.order = append(result.order, name)
+			}
+			result.members[name] = &privateMember{
+				declNode:   memberNode,
+				nameNode:   nameNode,
+				name:       name,
+				isAccessor: memberNode.Kind == ast.KindGetAccessor || memberNode.Kind == ast.KindSetAccessor,
+			}
+		}
+	}
+
+	return result
+}
+
+func isPrivateMemberDeclarationName(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindPropertyDeclaration,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		return parent.Name() == node
+	default:
+		return false
+	}
+}
+
+func findTrackedPrivateMember(stack []*classMembers, node *ast.Node) *privateMember {
+	name := node.AsPrivateIdentifier().Text
+	for i := len(stack) - 1; i >= 0; i-- {
+		if member, ok := stack[i].members[name]; ok {
+			return member
+		}
+	}
+	return nil
+}
+
+func isWriteOnlyAccess(memberExpr *ast.Node) bool {
+	target := ast.GetAssignmentTarget(memberExpr)
+	if target == nil {
+		return false
+	}
+
+	switch target.Kind {
+	case ast.KindBinaryExpression:
+		binary := target.AsBinaryExpression()
+		if binary == nil || binary.OperatorToken == nil {
+			return false
+		}
+		if binary.OperatorToken.Kind == ast.KindEqualsToken {
+			return true
+		}
+		return isExpressionStatementParent(target.Parent)
+	case ast.KindPrefixUnaryExpression, ast.KindPostfixUnaryExpression:
+		return isExpressionStatementParent(target.Parent)
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		return true
+	default:
+		return false
+	}
+}
+
+func isExpressionStatementParent(parent *ast.Node) bool {
+	parent = ast.WalkUpParenthesizedExpressions(parent)
+	return parent != nil && parent.Kind == ast.KindExpressionStatement
+}
+
+func reportUnusedMembers(ctx rule.RuleContext, classInfo *classMembers, items []sourceItem) {
+	for _, name := range classInfo.order {
+		member := classInfo.members[name]
+		if member == nil || member.isUsed {
+			continue
+		}
+
+		message := unusedPrivateClassMemberMessage(member.name)
+		if member.hasReference {
+			ctx.ReportNode(member.nameNode, message)
+			continue
+		}
+
+		fixes := []rule.RuleFix{
+			rule.RuleFixReplaceRange(memberRemovalRange(ctx.SourceFile, member.declNode, items), ""),
+		}
+		if token, ok := semicolonInsertionToken(ctx.SourceFile, classInfo.classNode, member.declNode, items); ok {
+			fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(token.end, token.end), ";"))
+		}
+
+		ctx.ReportNodeWithSuggestions(member.nameNode, message, rule.RuleSuggestion{
+			Message:  removeUnusedPrivateClassMemberMessage(member.name),
+			FixesArr: fixes,
+		})
+	}
+}
+
+func unusedPrivateClassMemberMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unusedPrivateClassMember",
+		Description: fmt.Sprintf("'%s' is defined but never used.", name),
+		Data:        map[string]string{"classMemberName": name},
+	}
+}
+
+func removeUnusedPrivateClassMemberMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "removeUnusedPrivateClassMember",
+		Description: fmt.Sprintf("Remove unused private class member '%s'.", name),
+		Data:        map[string]string{"classMemberName": name},
+	}
+}
+
+func memberRemovalRange(sourceFile *ast.SourceFile, memberNode *ast.Node, items []sourceItem) core.TextRange {
+	// Suggestions follow ESLint's comment-sensitive member removal behavior:
+	// remove attached leading/trailing comments, but preserve unrelated comments
+	// and neighboring members that share a line.
+	memberTextRange := utils.TrimNodeTextRange(sourceFile, memberNode)
+	memberItem := sourceItem{start: memberTextRange.Pos(), end: memberNode.End()}
+	leadingComments := leadingCommentsForMember(sourceFile, memberItem, items)
+	trailingComments := trailingCommentsForMember(sourceFile, memberItem, items)
+	shouldRemoveLeadingComments := len(leadingComments) > 0 && !sharesLineWithAnotherToken(sourceFile, memberItem, items)
+	lastItemToRemove := memberItem
+	if len(trailingComments) > 0 {
+		lastItemToRemove = trailingComments[len(trailingComments)-1]
+	}
+
+	previousToken, hasPreviousToken := itemBefore(items, memberItem.start, false)
+	nextToken, hasNextToken := itemAfter(items, lastItemToRemove.end, true)
+	nextTokenStartsOnNewLine := hasNextToken && itemStartLine(sourceFile, nextToken) > itemEndLine(sourceFile, lastItemToRemove)
+	shouldRemoveOwnLine := !shouldRemoveLeadingComments &&
+		startsOnOwnLine(sourceFile, memberItem, items) &&
+		nextTokenStartsOnNewLine
+
+	start := memberItem.start
+	end := lastItemToRemove.end
+
+	switch {
+	case shouldRemoveLeadingComments:
+		if nextTokenStartsOnNewLine {
+			start = lineStartIndex(sourceFile.Text(), leadingComments[0].start)
+			end = lineStartIndex(sourceFile.Text(), nextToken.start)
+		} else {
+			start = leadingComments[0].start
+			end = nextToken.start
+		}
+	case shouldRemoveOwnLine:
+		start = lineStartIndex(sourceFile.Text(), memberItem.start)
+		end = lineStartIndex(sourceFile.Text(), nextToken.start)
+	case hasPreviousToken && itemEndLine(sourceFile, previousToken) == itemStartLine(sourceFile, memberItem):
+		start = previousToken.end
+	case hasNextToken && itemStartLine(sourceFile, nextToken) == itemEndLine(sourceFile, lastItemToRemove):
+		end = nextToken.start
+	}
+
+	return core.NewTextRange(start, end)
+}
+
+func leadingCommentsForMember(sourceFile *ast.SourceFile, member sourceItem, items []sourceItem) []sourceItem {
+	previousToken, hasPreviousToken := itemBefore(items, member.start, false)
+	startAfter := 0
+	if hasPreviousToken {
+		startAfter = previousToken.end
+	}
+
+	commentsBefore := make([]sourceItem, 0)
+	for _, item := range items {
+		if !item.isComment {
+			continue
+		}
+		if item.start >= startAfter && item.end <= member.start {
+			commentsBefore = append(commentsBefore, item)
+		}
+	}
+
+	lastNonLeadingComment := -1
+	for i, comment := range commentsBefore {
+		next := member
+		if i < len(commentsBefore)-1 {
+			next = commentsBefore[i+1]
+		}
+		if !startsOnOwnLine(sourceFile, comment, items) || itemStartLine(sourceFile, next)-itemEndLine(sourceFile, comment) > 1 {
+			lastNonLeadingComment = i
+		}
+	}
+
+	return commentsBefore[lastNonLeadingComment+1:]
+}
+
+func trailingCommentsForMember(sourceFile *ast.SourceFile, member sourceItem, items []sourceItem) []sourceItem {
+	if sharesLineWithAnotherToken(sourceFile, member, items) {
+		return nil
+	}
+
+	nextToken, hasNextToken := itemAfter(items, member.end, false)
+	endBefore := len(sourceFile.Text())
+	if hasNextToken {
+		endBefore = nextToken.start
+	}
+
+	trailingComments := make([]sourceItem, 0)
+	for _, item := range items {
+		if !item.isComment {
+			continue
+		}
+		if item.start >= member.end && item.end <= endBefore && itemStartLine(sourceFile, item) == itemEndLine(sourceFile, member) {
+			trailingComments = append(trailingComments, item)
+		}
+	}
+	return trailingComments
+}
+
+func sharesLineWithAnotherToken(sourceFile *ast.SourceFile, member sourceItem, items []sourceItem) bool {
+	previousToken, hasPreviousToken := itemBefore(items, member.start, false)
+	nextToken, hasNextToken := itemAfter(items, member.end, false)
+	return (hasPreviousToken && itemEndLine(sourceFile, previousToken) == itemStartLine(sourceFile, member)) ||
+		(hasNextToken && itemStartLine(sourceFile, nextToken) == itemEndLine(sourceFile, member))
+}
+
+func startsOnOwnLine(sourceFile *ast.SourceFile, item sourceItem, items []sourceItem) bool {
+	previous, ok := itemBefore(items, item.start, true)
+	return !ok || itemEndLine(sourceFile, previous) != itemStartLine(sourceFile, item)
+}
+
+func semicolonInsertionToken(sourceFile *ast.SourceFile, classNode *ast.Node, memberNode *ast.Node, items []sourceItem) (sourceItem, bool) {
+	// If removing this member lets the previous field initializer continue into
+	// the next member (`[`, `*`, `in`, or `instanceof`), insert a semicolon.
+	nextToken, hasNextToken := itemAfter(items, memberNode.End(), false)
+	if !hasNextToken || !canContinueExpressionInClassBody(nextToken) {
+		return sourceItem{}, false
+	}
+
+	memberStart := utils.TrimNodeTextRange(sourceFile, memberNode).Pos()
+	previousToken, hasPreviousToken := itemBefore(items, memberStart, false)
+	if !hasPreviousToken || isSemicolonSafePreviousToken(previousToken) {
+		return sourceItem{}, false
+	}
+
+	members := classNode.Members()
+	memberIndex := -1
+	for i, member := range members {
+		if member == memberNode {
+			memberIndex = i
+			break
+		}
+	}
+	if memberIndex <= 0 {
+		return sourceItem{}, false
+	}
+
+	previousMember := members[memberIndex-1]
+	if !ast.IsPropertyDeclaration(previousMember) {
+		return sourceItem{}, false
+	}
+	previousProperty := previousMember.AsPropertyDeclaration()
+	if previousProperty == nil || previousProperty.Initializer == nil {
+		return sourceItem{}, false
+	}
+
+	text := sourceFile.Text()
+	i := previousMember.End() - 1
+	for i > previousMember.Pos() && isASCIIWhitespace(text[i]) {
+		i--
+	}
+	if i >= 0 && text[i] == ';' {
+		return sourceItem{}, false
+	}
+
+	initializer := previousProperty.Initializer
+	if initializer.Kind == ast.KindPostfixUnaryExpression {
+		return sourceItem{}, false
+	}
+	if initializer.Kind == ast.KindArrowFunction {
+		if arrow := initializer.AsArrowFunction(); arrow != nil && arrow.Body != nil && arrow.Body.Kind == ast.KindBlock {
+			return sourceItem{}, false
+		}
+	}
+
+	return previousToken, true
+}
+
+func canContinueExpressionInClassBody(token sourceItem) bool {
+	return token.text == "[" || token.text == "*" || token.text == "in" || token.text == "instanceof"
+}
+
+func isSemicolonSafePreviousToken(token sourceItem) bool {
+	switch token.text {
+	case ":", ";", "{", "=>", "++", "--":
+		return true
+	default:
+		return false
+	}
+}
+
+func collectSourceItems(sourceFile *ast.SourceFile) []sourceItem {
+	text := sourceFile.Text()
+	items := make([]sourceItem, 0)
+
+	scan := scanner.GetScannerForSourceFile(sourceFile, 0)
+	for scan.Token() != ast.KindEndOfFile {
+		start := scan.TokenStart()
+		end := scan.TokenEnd()
+		if start < end {
+			items = append(items, sourceItem{
+				start: start,
+				end:   end,
+				text:  text[start:end],
+			})
+		}
+		scan.Scan()
+	}
+
+	seenComments := map[[2]int]bool{}
+	utils.ForEachComment(sourceFile.AsNode(), func(comment *ast.CommentRange) {
+		key := [2]int{comment.Pos(), comment.End()}
+		if seenComments[key] {
+			return
+		}
+		seenComments[key] = true
+		items = append(items, sourceItem{
+			start:     comment.Pos(),
+			end:       comment.End(),
+			text:      text[comment.Pos():comment.End()],
+			isComment: true,
+		})
+	}, sourceFile)
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].start != items[j].start {
+			return items[i].start < items[j].start
+		}
+		if items[i].end != items[j].end {
+			return items[i].end < items[j].end
+		}
+		return !items[i].isComment && items[j].isComment
+	})
+
+	return items
+}
+
+func itemBefore(items []sourceItem, pos int, includeComments bool) (sourceItem, bool) {
+	var previous sourceItem
+	found := false
+	for _, item := range items {
+		if item.start >= pos {
+			break
+		}
+		if item.end <= pos && (includeComments || !item.isComment) {
+			previous = item
+			found = true
+		}
+	}
+	return previous, found
+}
+
+func itemAfter(items []sourceItem, pos int, includeComments bool) (sourceItem, bool) {
+	for _, item := range items {
+		if item.start >= pos && (includeComments || !item.isComment) {
+			return item, true
+		}
+	}
+	return sourceItem{}, false
+}
+
+func itemStartLine(sourceFile *ast.SourceFile, item sourceItem) int {
+	line, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(sourceFile, item.start)
+	return line
+}
+
+func itemEndLine(sourceFile *ast.SourceFile, item sourceItem) int {
+	line, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(sourceFile, item.end)
+	return line
+}
+
+func lineStartIndex(text string, pos int) int {
+	if pos > len(text) {
+		pos = len(text)
+	}
+	for pos > 0 && text[pos-1] != '\n' && text[pos-1] != '\r' {
+		pos--
+	}
+	return pos
+}
+
+func isASCIIWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}

--- a/internal/rules/no_unused_private_class_members/no_unused_private_class_members.md
+++ b/internal/rules/no_unused_private_class_members/no_unused_private_class_members.md
@@ -1,0 +1,72 @@
+# no-unused-private-class-members
+
+## Rule Details
+
+This rule reports private class members that are declared but never used.
+
+A private field or method is considered unused if its value is never read. A
+private accessor is considered unused if it is never accessed, either for a read
+or a write.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+class A {
+    #unusedMember = 5;
+}
+
+class B {
+    #usedOnlyInWrite = 5;
+    method() {
+        this.#usedOnlyInWrite = 42;
+    }
+}
+
+class C {
+    #usedOnlyToUpdateItself = 5;
+    method() {
+        this.#usedOnlyToUpdateItself++;
+    }
+}
+
+class D {
+    #unusedMethod() {}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+class A {
+    #usedMember = 42;
+    method() {
+        return this.#usedMember;
+    }
+}
+
+class B {
+    #usedMethod() {
+        return 42;
+    }
+    anotherMethod() {
+        return this.#usedMethod();
+    }
+}
+
+class C {
+    get #usedAccessor() {}
+    set #usedAccessor(value) {}
+
+    method() {
+        this.#usedAccessor = 42;
+    }
+}
+```
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- [ESLint no-unused-private-class-members](https://eslint.org/docs/latest/rules/no-unused-private-class-members)

--- a/internal/rules/no_unused_private_class_members/no_unused_private_class_members_extras_test.go
+++ b/internal/rules/no_unused_private_class_members/no_unused_private_class_members_extras_test.go
@@ -1,0 +1,421 @@
+// TestNoUnusedPrivateClassMembersExtras locks in branches and edge shapes that
+// the upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// Dimension 4 walk (rows that don't apply to no-unused-private-class-members,
+// with reasons):
+//   - N/A element access forms (`this['#x']`, `this[expr]`): JavaScript
+//     hash-private members can only be accessed through `.#x` or `#x in obj`.
+//   - N/A optional chaining (`obj?.#x`): ECMAScript private identifiers do not
+//     have an optional chaining form.
+//   - N/A numeric/string/computed declaration keys: the core rule only tracks
+//     `PrivateIdentifier` keys, not static public keys that happen to spell
+//     `#x`.
+//   - N/A autofix boundaries: upstream exposes a suggestion, not an autofix.
+//   - N/A overload signatures / abstract / declare members: those are
+//     TypeScript-only forms and are outside the core ESLint rule's declaration
+//     surface.
+package no_unused_private_class_members
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedPrivateClassMembersExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedPrivateClassMembersRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: parenthesized receiver ----
+			{Code: `
+class C {
+    #x;
+    method() {
+        return (this).#x;
+    }
+}`},
+			{Code: `
+class C {
+    #x;
+    method() {
+        return ((this)).#x;
+    }
+}`},
+
+			// ---- Dimension 4: receiver wrapped in TypeScript expression forms ----
+			{Code: `
+class C {
+    #x;
+    method() {
+        return (this as C).#x;
+    }
+}`},
+			{Code: `
+class C {
+    #x;
+    method() {
+        return (this satisfies C).#x;
+    }
+}`},
+			{Code: `
+class C {
+    #x;
+    method() {
+        return (<C>this).#x;
+    }
+}`},
+			{Code: `
+class C {
+    #x;
+    method() {
+        return this!.#x;
+    }
+}`},
+
+			// ---- Dimension 4: declaration/container forms ----
+			{Code: `
+const C = class {
+    #x;
+    method() {
+        return this.#x;
+    }
+};`},
+			{Code: `
+class C {
+    static #x;
+    static {
+        this.#x;
+    }
+}`},
+			{Code: `
+class C {
+    method() {
+        return this.#x;
+    }
+    #x;
+}`},
+			{Code: `
+class C {
+    #x;
+    reader = () => this.#x;
+}`},
+			{Code: `
+class C {
+    static #x;
+    method() {
+        return C.#x;
+    }
+}`},
+
+			// ---- Dimension 4: async / generator method bodies ----
+			{Code: `
+class C {
+    #x;
+    async method() {
+        return this.#x;
+    }
+}`},
+			{Code: `
+class C {
+    #x;
+    *method() {
+        yield this.#x;
+    }
+}`},
+
+			// ---- Dimension 4: nesting boundaries ----
+			{Code: `
+class Outer {
+    #outer;
+    method() {
+        class Inner {
+            #inner;
+            method() {
+                return this.#inner;
+            }
+        }
+        return this.#outer;
+    }
+}`},
+
+			// ---- Dimension 4: private names are lexically visible in nested bodies ----
+			{Code: `
+class Outer {
+    #x;
+    method(obj) {
+        return class Inner {
+            check() {
+                return #x in obj;
+            }
+        };
+    }
+}`},
+			{Code: `
+class C {
+    #x;
+    method() {
+        return function() {
+            return this.#x;
+        };
+    }
+}`},
+
+			// ---- Dimension 4: private-in expression counts as a read ----
+			// Locks in upstream PrivateIdentifier() arm: non-member-expression
+			// private identifiers are references, not declarations.
+			{Code: `
+class C {
+    #x;
+    method(obj) {
+        return #x in obj;
+    }
+}`},
+
+			// ---- Dimension 4: expression-valued writes count as reads ----
+			{Code: `
+class C {
+    #x;
+    method() {
+        return this.#x += 1;
+    }
+}`},
+			{Code: `
+class C {
+    #x;
+    method() {
+        return this.#x++;
+    }
+}`},
+			{Code: `
+class C {
+    #x;
+    method() {
+        return this.#x ||= fallback;
+    }
+}`},
+			{Code: `
+class C {
+    #x;
+    method() {
+        this.#x = this.#x + 1;
+    }
+}`},
+
+			// ---- tsgo AST quirk: nested destructuring computed keys are reads ----
+			{Code: `
+class C {
+    #key;
+    method() {
+        ({ nested: { [this.#key]: value } } = source);
+    }
+}`},
+
+			// ---- Real-user: TS private modifier request stays outside core ----
+			{Code: `
+class C {
+    private value = 1;
+}`},
+			{Code: `
+class C {
+    private value = 1;
+    method() {
+        this.value = 2;
+    }
+}`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: class expressions are inspected ----
+			invalidUnusedPrivateCase(
+				`const C = class { #x; };`,
+				unusedPrivateError("#x", 1, 19, 1, 21, `const C = class { };`),
+			),
+
+			// ---- Dimension 4: public keys that spell "#x" don't satisfy private #x ----
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    "#x"() {
+        return 1;
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7, `class C {
+    "#x"() {
+        return 1;
+    }
+}`),
+			),
+
+			// ---- Real-user: write-only update from the original rule proposal ----
+			// Locks in upstream isWriteOnlyAssignment()/UpdateExpression arm.
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    method() {
+        this.#x++;
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7),
+			),
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    method() {
+        (++this.#x);
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7),
+			),
+
+			// ---- Real-user: suggestion preserves ASI before a keyword-named member ----
+			// Locks in upstream getSemicolonInsertionToken() branch for `in`.
+			invalidUnusedPrivateCase(
+				`class C {
+    foo = 1
+    #unused
+    in = 2
+}`,
+				unusedPrivateError("#unused", 3, 5, 3, 12, `class C {
+    foo = 1;
+    in = 2
+}`),
+			),
+
+			// Locks in upstream PrivateIdentifier() branch: nested class shadowing
+			// means the inner #x read does not mark the outer #x as used.
+			invalidUnusedPrivateCase(
+				`class Outer {
+    #x;
+    method() {
+        return class Inner {
+            #x;
+            method() {
+                return this.#x;
+            }
+        };
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7, `class Outer {
+    method() {
+        return class Inner {
+            #x;
+            method() {
+                return this.#x;
+            }
+        };
+    }
+}`),
+			),
+
+			// Locks in lexical private-name lookup for `#x in obj`: an inner
+			// class declaration shadows the outer private name.
+			invalidUnusedPrivateCase(
+				`class Outer {
+    #x;
+    method(obj) {
+        return class Inner {
+            #x;
+            check() {
+                return #x in obj;
+            }
+        };
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7, `class Outer {
+    method(obj) {
+        return class Inner {
+            #x;
+            check() {
+                return #x in obj;
+            }
+        };
+    }
+}`),
+			),
+
+			// Locks in upstream isWriteOnlyAssignment() branch: compound
+			// assignment used as a bare statement is still write-only.
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    method() {
+        this.#x += 1;
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7),
+			),
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    method() {
+        this.#x ||= fallback;
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7),
+			),
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    method() {
+        this.#x = (this.#x = 1);
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7),
+			),
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    method() {
+        ((this as C)).#x = 1;
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7),
+			),
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    method() {
+        this!.#x = 1;
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7),
+			),
+
+			// Locks in upstream destructuring branch: property values in an
+			// assignment pattern are writes, while computed keys are reads.
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    method() {
+        ({ value: this.#x } = source);
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7),
+			),
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    method() {
+        ({ nested: { value: this.#x } } = source);
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7),
+			),
+			invalidUnusedPrivateCase(
+				`class C {
+    #x;
+    method() {
+        ({ nested: [...this.#x] } = source);
+    }
+}`,
+				unusedPrivateError("#x", 2, 5, 2, 7),
+			),
+		},
+	)
+}

--- a/internal/rules/no_unused_private_class_members/no_unused_private_class_members_upstream_test.go
+++ b/internal/rules/no_unused_private_class_members/no_unused_private_class_members_upstream_test.go
@@ -1,0 +1,640 @@
+// TestNoUnusedPrivateClassMembersUpstream migrates the full valid/invalid suite from
+// upstream eslint/tests/lib/rules/no-unused-private-class-members.js 1:1.
+// Position assertions cover line/column/endLine/endColumn for every invalid
+// case. rslint-specific lock-in cases live in the
+// no_unused_private_class_members_extras_test.go file.
+package no_unused_private_class_members
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedPrivateClassMembersUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedPrivateClassMembersRule,
+		[]rule_tester.ValidTestCase{
+			// ---- valid ----
+			{Code: `class Foo {}`},
+			{Code: `class Foo {
+    publicMember = 42;
+}`},
+			{Code: `class Foo {
+    #usedMember = 42;
+    method() {
+        return this.#usedMember;
+    }
+}`},
+			{Code: `class Foo {
+    #usedMember = 42;
+    anotherMember = this.#usedMember;
+}`},
+			{Code: `class Foo {
+    #usedMember = 42;
+    foo() {
+        anotherMember = this.#usedMember;
+    }
+}`},
+			{Code: `class C {
+    #usedMember;
+
+    foo() {
+        bar(this.#usedMember += 1);
+    }
+}`},
+			{Code: `class Foo {
+    #usedMember = 42;
+    method() {
+        return someGlobalMethod(this.#usedMember);
+    }
+}`},
+			{Code: `class C {
+    #usedInOuterClass;
+
+    foo() {
+        return class {};
+    }
+
+    bar() {
+        return this.#usedInOuterClass;
+    }
+}`},
+			{Code: `class Foo {
+    #usedInForInLoop;
+    method() {
+        for (const bar in this.#usedInForInLoop) {
+
+        }
+    }
+}`},
+			{Code: `class Foo {
+    #usedInForOfLoop;
+    method() {
+        for (const bar of this.#usedInForOfLoop) {
+
+        }
+    }
+}`},
+			{Code: `class Foo {
+    #usedInAssignmentPattern;
+    method() {
+        [bar = 1] = this.#usedInAssignmentPattern;
+    }
+}`},
+			{Code: `class Foo {
+    #usedInArrayPattern;
+    method() {
+        [bar] = this.#usedInArrayPattern;
+    }
+}`},
+			{Code: `class Foo {
+    #usedInAssignmentPattern;
+    method() {
+        [bar] = this.#usedInAssignmentPattern;
+    }
+}`},
+			{Code: `class C {
+    #usedInObjectAssignment;
+
+    method() {
+        ({ [this.#usedInObjectAssignment]: a } = foo);
+    }
+}`},
+			{Code: `class C {
+    set #accessorWithSetterFirst(value) {
+        doSomething(value);
+    }
+    get #accessorWithSetterFirst() {
+        return something();
+    }
+    method() {
+        this.#accessorWithSetterFirst += 1;
+    }
+}`},
+			{Code: `class Foo {
+    set #accessorUsedInMemberAccess(value) {}
+
+    method(a) {
+        [this.#accessorUsedInMemberAccess] = a;
+    }
+}`},
+			{Code: `class C {
+    get #accessorWithGetterFirst() {
+        return something();
+    }
+    set #accessorWithGetterFirst(value) {
+        doSomething(value);
+    }
+    method() {
+        this.#accessorWithGetterFirst += 1;
+    }
+}`},
+			{Code: `class C {
+    #usedInInnerClass;
+
+    method(a) {
+        return class {
+            foo = a.#usedInInnerClass;
+        }
+    }
+}`},
+
+			// ---- Method definitions ----
+			{Code: `class Foo {
+    #usedMethod() {
+        return 42;
+    }
+    anotherMethod() {
+        return this.#usedMethod();
+    }
+}`},
+			{Code: `class C {
+    set #x(value) {
+        doSomething(value);
+    }
+
+    foo() {
+        this.#x = 1;
+    }
+}`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- invalid ----
+			invalidUnusedPrivateCase(`class Foo {
+    #unusedMember = 5;
+}`,
+				unusedPrivateError("#unusedMember", 2, 5, 2, 18, `class Foo {
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    /** docs */
+    #unusedMember = 1;
+}`,
+				unusedPrivateError("#unusedMember", 3, 5, 3, 18, `class Foo {
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    // remove me
+    #unusedMember = 1;
+}`,
+				unusedPrivateError("#unusedMember", 3, 5, 3, 18, `class Foo {
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    /* remove */ #unusedMember = 1;
+}`,
+				unusedPrivateError("#unusedMember", 2, 18, 2, 31, `class Foo {
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    /* keep */ #unusedMember = 1; foo = 1
+}`,
+				unusedPrivateError("#unusedMember", 2, 16, 2, 29, `class Foo {
+    /* keep */ foo = 1
+}`),
+			),
+			invalidUnusedPrivateCase(`class C {
+    #unused1; /* keep */ foo;
+}`,
+				unusedPrivateError("#unused1", 2, 5, 2, 13, `class C {
+    /* keep */ foo;
+}`),
+			),
+			invalidUnusedPrivateCase(`class C {
+    bar; #unused2; // keep
+}`,
+				unusedPrivateError("#unused2", 2, 10, 2, 18, `class C {
+    bar; // keep
+}`),
+			),
+			invalidUnusedPrivateCase(`class C {
+    // comment
+    #unused; foo;
+}`,
+				unusedPrivateError("#unused", 3, 5, 3, 12, `class C {
+    // comment
+    foo;
+}`),
+			),
+			invalidUnusedPrivateCase(`class C {
+    // comment
+    #unused; /*
+    */ foo;
+}`,
+				unusedPrivateError("#unused", 3, 5, 3, 12, `class C {
+    foo;
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    #unusedMember = 1; // trailing
+}`,
+				unusedPrivateError("#unusedMember", 2, 5, 2, 18, `class Foo {
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    foo = 1; /*
+    */ #unusedMember = 1;
+}`,
+				unusedPrivateError("#unusedMember", 3, 8, 3, 21, `class Foo {
+    foo = 1; /*
+    */ 
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    foo = 1; // keep this
+    #unusedMember = 1;
+}`,
+				unusedPrivateError("#unusedMember", 3, 5, 3, 18, `class Foo {
+    foo = 1; // keep this
+}`),
+			),
+			invalidUnusedPrivateCase(`class First {}
+class Second {
+    #unusedMemberInSecondClass = 5;
+}`,
+				unusedPrivateError("#unusedMemberInSecondClass", 3, 5, 3, 31, `class First {}
+class Second {
+}`),
+			),
+			invalidUnusedPrivateCase(`class First {
+    #unusedMemberInFirstClass = 5;
+}
+class Second {}`,
+				unusedPrivateError("#unusedMemberInFirstClass", 2, 5, 2, 30, `class First {
+}
+class Second {}`),
+			),
+			invalidUnusedPrivateCase(`class First {
+    #firstUnusedMemberInSameClass = 5;
+    #secondUnusedMemberInSameClass = 5;
+}`,
+				unusedPrivateError("#firstUnusedMemberInSameClass", 2, 5, 2, 34, `class First {
+    #secondUnusedMemberInSameClass = 5;
+}`),
+				unusedPrivateError("#secondUnusedMemberInSameClass", 3, 5, 3, 35, `class First {
+    #firstUnusedMemberInSameClass = 5;
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    #usedOnlyInWrite = 5;
+    method() {
+        this.#usedOnlyInWrite = 42;
+    }
+}`,
+				unusedPrivateError("#usedOnlyInWrite", 2, 5, 2, 21),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    #usedOnlyInWriteStatement = 5;
+    method() {
+        this.#usedOnlyInWriteStatement += 42;
+    }
+}`,
+				unusedPrivateError("#usedOnlyInWriteStatement", 2, 5, 2, 30),
+			),
+			invalidUnusedPrivateCase(`class C {
+    #usedOnlyInIncrement;
+
+    foo() {
+        this.#usedOnlyInIncrement++;
+    }
+}`,
+				unusedPrivateError("#usedOnlyInIncrement", 2, 5, 2, 25),
+			),
+			invalidUnusedPrivateCase(`class C {
+    #unusedInOuterClass;
+
+    foo() {
+        return class {
+            #unusedInOuterClass;
+
+            bar() {
+                return this.#unusedInOuterClass;
+            }
+        };
+    }
+}`,
+				unusedPrivateError("#unusedInOuterClass", 2, 5, 2, 24, `class C {
+    foo() {
+        return class {
+            #unusedInOuterClass;
+
+            bar() {
+                return this.#unusedInOuterClass;
+            }
+        };
+    }
+}`),
+			),
+			invalidUnusedPrivateCase(`class C {
+    #unusedOnlyInSecondNestedClass;
+
+    foo() {
+        return class {
+            #unusedOnlyInSecondNestedClass;
+
+            bar() {
+                return this.#unusedOnlyInSecondNestedClass;
+            }
+        };
+    }
+
+    baz() {
+        return this.#unusedOnlyInSecondNestedClass;
+    }
+
+    bar() {
+        return class {
+            #unusedOnlyInSecondNestedClass;
+        }
+    }
+}`,
+				unusedPrivateError("#unusedOnlyInSecondNestedClass", 20, 13, 20, 43, `class C {
+    #unusedOnlyInSecondNestedClass;
+
+    foo() {
+        return class {
+            #unusedOnlyInSecondNestedClass;
+
+            bar() {
+                return this.#unusedOnlyInSecondNestedClass;
+            }
+        };
+    }
+
+    baz() {
+        return this.#unusedOnlyInSecondNestedClass;
+    }
+
+    bar() {
+        return class {
+        }
+    }
+}`),
+			),
+
+			// ---- Unused method definitions ----
+			invalidUnusedPrivateCase(`class Foo {
+    #unusedMethod() {}
+}`,
+				unusedPrivateError("#unusedMethod", 2, 5, 2, 18, `class Foo {
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    #unusedMethod() {}
+    #usedMethod() {
+        return 42;
+    }
+    publicMethod() {
+        return this.#usedMethod();
+    }
+}`,
+				unusedPrivateError("#unusedMethod", 2, 5, 2, 18, `class Foo {
+    #usedMethod() {
+        return 42;
+    }
+    publicMethod() {
+        return this.#usedMethod();
+    }
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    set #unusedSetter(value) {}
+}`,
+				unusedPrivateError("#unusedSetter", 2, 9, 2, 22, `class Foo {
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    get #unusedAccessor() {
+        return 1;
+    }
+    set #unusedAccessor(value) {}
+}`,
+				unusedPrivateError("#unusedAccessor", 5, 9, 5, 24, `class Foo {
+    get #unusedAccessor() {
+        return 1;
+    }
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    #unusedForInLoop;
+    method() {
+        for (this.#unusedForInLoop in bar) {
+
+        }
+    }
+}`,
+				unusedPrivateError("#unusedForInLoop", 2, 5, 2, 21),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    #unusedForOfLoop;
+    method() {
+        for (this.#unusedForOfLoop of bar) {
+
+        }
+    }
+}`,
+				unusedPrivateError("#unusedForOfLoop", 2, 5, 2, 21),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    #unusedInDestructuring;
+    method() {
+        ({ x: this.#unusedInDestructuring } = bar);
+    }
+}`,
+				unusedPrivateError("#unusedInDestructuring", 2, 5, 2, 27),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    #unusedInRestPattern;
+    method() {
+        [...this.#unusedInRestPattern] = bar;
+    }
+}`,
+				unusedPrivateError("#unusedInRestPattern", 2, 5, 2, 25),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    #unusedInAssignmentPattern;
+    method() {
+        [this.#unusedInAssignmentPattern = 1] = bar;
+    }
+}`,
+				unusedPrivateError("#unusedInAssignmentPattern", 2, 5, 2, 31),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    #unusedInAssignmentPattern;
+    method() {
+        [this.#unusedInAssignmentPattern] = bar;
+    }
+}`,
+				unusedPrivateError("#unusedInAssignmentPattern", 2, 5, 2, 31),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    foo = 1
+    #unusedMethod() {}
+    [0]() {}
+}`,
+				unusedPrivateError("#unusedMethod", 3, 5, 3, 18, `class Foo {
+    foo = 1;
+    [0]() {}
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    foo = 1
+    #unusedMethod() {}
+    *generator() {}
+}`,
+				unusedPrivateError("#unusedMethod", 3, 5, 3, 18, `class Foo {
+    foo = 1;
+    *generator() {}
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    foo = 1
+    #unusedMethod() {}
+    in = 2
+}`,
+				unusedPrivateError("#unusedMethod", 3, 5, 3, 18, `class Foo {
+    foo = 1;
+    in = 2
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    foo = 1
+    #unused
+    instanceof() {}
+}`,
+				unusedPrivateError("#unused", 3, 5, 3, 12, `class Foo {
+    foo = 1;
+    instanceof() {}
+}`),
+			),
+			invalidUnusedPrivateCase(`class C {
+    foo = () => {}
+    #unused
+    [bar]
+}`,
+				unusedPrivateError("#unused", 3, 5, 3, 12, `class C {
+    foo = () => {}
+    [bar]
+}`),
+			),
+			invalidUnusedPrivateCase(`class C {
+    foo
+    #unused
+    [bar]
+}`,
+				unusedPrivateError("#unused", 3, 5, 3, 12, `class C {
+    foo
+    [bar]
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    foo = 1
+    /** docs */
+    #unusedMethod() {}
+    [0]() {}
+}`,
+				unusedPrivateError("#unusedMethod", 4, 5, 4, 18, `class Foo {
+    foo = 1;
+    [0]() {}
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    // keep
+
+    /** remove */
+    #unusedMember = 1;
+}`,
+				unusedPrivateError("#unusedMember", 5, 5, 5, 18, `class Foo {
+    // keep
+
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    // keep one
+    // keep two
+
+    /** remove */
+    #unusedMember = 1;
+}`,
+				unusedPrivateError("#unusedMember", 6, 5, 6, 18, `class Foo {
+    // keep one
+    // keep two
+
+}`),
+			),
+			invalidUnusedPrivateCase(`class Foo {
+    // maybe unrelated
+
+    #unusedMember = 1;
+}`,
+				unusedPrivateError("#unusedMember", 4, 5, 4, 18, `class Foo {
+    // maybe unrelated
+
+}`),
+			),
+			invalidUnusedPrivateCase(`class C {
+    #usedOnlyInTheSecondInnerClass;
+
+    method(a) {
+        return class {
+            #usedOnlyInTheSecondInnerClass;
+
+            method2(b) {
+                foo = b.#usedOnlyInTheSecondInnerClass;
+            }
+
+            method3(b) {
+                foo = b.#usedOnlyInTheSecondInnerClass;
+            }
+        }
+    }
+}`,
+				unusedPrivateError("#usedOnlyInTheSecondInnerClass", 2, 5, 2, 35, `class C {
+    method(a) {
+        return class {
+            #usedOnlyInTheSecondInnerClass;
+
+            method2(b) {
+                foo = b.#usedOnlyInTheSecondInnerClass;
+            }
+
+            method3(b) {
+                foo = b.#usedOnlyInTheSecondInnerClass;
+            }
+        }
+    }
+}`),
+			),
+		},
+	)
+}
+
+func invalidUnusedPrivateCase(code string, errors ...rule_tester.InvalidTestCaseError) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code:   code,
+		Errors: errors,
+	}
+}
+
+func unusedPrivateError(name string, line int, column int, endLine int, endColumn int, suggestionOutput ...string) rule_tester.InvalidTestCaseError {
+	err := rule_tester.InvalidTestCaseError{
+		MessageId: "unusedPrivateClassMember",
+		Message:   fmt.Sprintf("'%s' is defined but never used.", name),
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+	if len(suggestionOutput) > 0 {
+		err.Suggestions = []rule_tester.InvalidTestCaseSuggestion{
+			{MessageId: "removeUnusedPrivateClassMember", Output: suggestionOutput[0]},
+		}
+	}
+	return err
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -112,6 +112,7 @@ export default defineConfig({
     './tests/eslint/rules/no-undef.test.ts',
     './tests/eslint/rules/no-undef-init.test.ts',
     './tests/eslint/rules/no-unassigned-vars.test.ts',
+    './tests/eslint/rules/no-unused-private-class-members.test.ts',
     './tests/eslint/rules/no-var.test.ts',
     './tests/eslint/rules/one-var.test.ts',
     './tests/eslint/rules/prefer-arrow-callback.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unused-private-class-members.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unused-private-class-members.test.ts.snap
@@ -1,0 +1,1283 @@
+// Rstest Snapshot v1
+
+exports[`no-unused-private-class-members > invalid 1`] = `
+{
+  "code": "class Foo {
+    #unusedMember = 5;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 2`] = `
+{
+  "code": "class Foo {
+    /** docs */
+    #unusedMember = 1;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 3`] = `
+{
+  "code": "class Foo {
+    // remove me
+    #unusedMember = 1;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 4`] = `
+{
+  "code": "class Foo {
+    /* remove */ #unusedMember = 1;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 2,
+        },
+        "start": {
+          "column": 18,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 5`] = `
+{
+  "code": "class Foo {
+    /* keep */ #unusedMember = 1; foo = 1
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 6`] = `
+{
+  "code": "class C {
+    #unused1; /* keep */ foo;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unused1' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 7`] = `
+{
+  "code": "class C {
+    bar; #unused2; // keep
+}",
+  "diagnostics": [
+    {
+      "message": "'#unused2' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 8`] = `
+{
+  "code": "class C {
+    // comment
+    #unused; foo;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unused' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 9`] = `
+{
+  "code": "class C {
+    // comment
+    #unused; /*
+    */ foo;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unused' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 10`] = `
+{
+  "code": "class Foo {
+    #unusedMember = 1; // trailing
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 11`] = `
+{
+  "code": "class Foo {
+    foo = 1; /*
+    */ #unusedMember = 1;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 12`] = `
+{
+  "code": "class Foo {
+    foo = 1; // keep this
+    #unusedMember = 1;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 13`] = `
+{
+  "code": "class First {}
+class Second {
+    #unusedMemberInSecondClass = 5;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMemberInSecondClass' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 14`] = `
+{
+  "code": "class First {
+    #unusedMemberInFirstClass = 5;
+}
+class Second {}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMemberInFirstClass' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 15`] = `
+{
+  "code": "class First {
+    #firstUnusedMemberInSameClass = 5;
+    #secondUnusedMemberInSameClass = 5;
+}",
+  "diagnostics": [
+    {
+      "message": "'#firstUnusedMemberInSameClass' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+    {
+      "message": "'#secondUnusedMemberInSameClass' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 16`] = `
+{
+  "code": "class Foo {
+    #usedOnlyInWrite = 5;
+    method() {
+        this.#usedOnlyInWrite = 42;
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#usedOnlyInWrite' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 17`] = `
+{
+  "code": "class Foo {
+    #usedOnlyInWriteStatement = 5;
+    method() {
+        this.#usedOnlyInWriteStatement += 42;
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#usedOnlyInWriteStatement' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 18`] = `
+{
+  "code": "class C {
+    #usedOnlyInIncrement;
+
+    foo() {
+        this.#usedOnlyInIncrement++;
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#usedOnlyInIncrement' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 19`] = `
+{
+  "code": "class C {
+    #unusedInOuterClass;
+
+    foo() {
+        return class {
+            #unusedInOuterClass;
+
+            bar() {
+                return this.#unusedInOuterClass;
+            }
+        };
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedInOuterClass' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 20`] = `
+{
+  "code": "class C {
+    #unusedOnlyInSecondNestedClass;
+
+    foo() {
+        return class {
+            #unusedOnlyInSecondNestedClass;
+
+            bar() {
+                return this.#unusedOnlyInSecondNestedClass;
+            }
+        };
+    }
+
+    baz() {
+        return this.#unusedOnlyInSecondNestedClass;
+    }
+
+    bar() {
+        return class {
+            #unusedOnlyInSecondNestedClass;
+        }
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedOnlyInSecondNestedClass' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 20,
+        },
+        "start": {
+          "column": 13,
+          "line": 20,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 21`] = `
+{
+  "code": "class Foo {
+    #unusedMethod() {}
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMethod' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 22`] = `
+{
+  "code": "class Foo {
+    #unusedMethod() {}
+    #usedMethod() {
+        return 42;
+    }
+    publicMethod() {
+        return this.#usedMethod();
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMethod' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 23`] = `
+{
+  "code": "class Foo {
+    set #unusedSetter(value) {}
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedSetter' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 2,
+        },
+        "start": {
+          "column": 9,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 24`] = `
+{
+  "code": "class Foo {
+    get #unusedAccessor() {
+        return 1;
+    }
+    set #unusedAccessor(value) {}
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedAccessor' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 5,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 25`] = `
+{
+  "code": "class Foo {
+    #unusedForInLoop;
+    method() {
+        for (this.#unusedForInLoop in bar) {
+
+        }
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedForInLoop' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 26`] = `
+{
+  "code": "class Foo {
+    #unusedForOfLoop;
+    method() {
+        for (this.#unusedForOfLoop of bar) {
+
+        }
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedForOfLoop' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 27`] = `
+{
+  "code": "class Foo {
+    #unusedInDestructuring;
+    method() {
+        ({ x: this.#unusedInDestructuring } = bar);
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedInDestructuring' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 28`] = `
+{
+  "code": "class Foo {
+    #unusedInRestPattern;
+    method() {
+        [...this.#unusedInRestPattern] = bar;
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedInRestPattern' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 29`] = `
+{
+  "code": "class Foo {
+    #unusedInAssignmentPattern;
+    method() {
+        [this.#unusedInAssignmentPattern = 1] = bar;
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedInAssignmentPattern' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 30`] = `
+{
+  "code": "class Foo {
+    #unusedInAssignmentPattern;
+    method() {
+        [this.#unusedInAssignmentPattern] = bar;
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedInAssignmentPattern' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 31`] = `
+{
+  "code": "class Foo {
+    foo = 1
+    #unusedMethod() {}
+    [0]() {}
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMethod' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 32`] = `
+{
+  "code": "class Foo {
+    foo = 1
+    #unusedMethod() {}
+    *generator() {}
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMethod' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 33`] = `
+{
+  "code": "class Foo {
+    foo = 1
+    #unusedMethod() {}
+    in = 2
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMethod' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 34`] = `
+{
+  "code": "class Foo {
+    foo = 1
+    #unused
+    instanceof() {}
+}",
+  "diagnostics": [
+    {
+      "message": "'#unused' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 35`] = `
+{
+  "code": "class C {
+    foo = () => {}
+    #unused
+    [bar]
+}",
+  "diagnostics": [
+    {
+      "message": "'#unused' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 36`] = `
+{
+  "code": "class C {
+    foo
+    #unused
+    [bar]
+}",
+  "diagnostics": [
+    {
+      "message": "'#unused' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 37`] = `
+{
+  "code": "class Foo {
+    foo = 1
+    /** docs */
+    #unusedMethod() {}
+    [0]() {}
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMethod' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 38`] = `
+{
+  "code": "class Foo {
+    // keep
+
+    /** remove */
+    #unusedMember = 1;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 39`] = `
+{
+  "code": "class Foo {
+    // keep one
+    // keep two
+
+    /** remove */
+    #unusedMember = 1;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 40`] = `
+{
+  "code": "class Foo {
+    // maybe unrelated
+
+    #unusedMember = 1;
+}",
+  "diagnostics": [
+    {
+      "message": "'#unusedMember' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-private-class-members > invalid 41`] = `
+{
+  "code": "class C {
+    #usedOnlyInTheSecondInnerClass;
+
+    method(a) {
+        return class {
+            #usedOnlyInTheSecondInnerClass;
+
+            method2(b) {
+                foo = b.#usedOnlyInTheSecondInnerClass;
+            }
+
+            method3(b) {
+                foo = b.#usedOnlyInTheSecondInnerClass;
+            }
+        }
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "'#usedOnlyInTheSecondInnerClass' is defined but never used.",
+      "messageId": "unusedPrivateClassMember",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-unused-private-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unused-private-class-members.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unused-private-class-members.test.ts
@@ -1,0 +1,529 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unused-private-class-members', {
+  valid: [
+    'class Foo {}',
+    'class Foo {\n    publicMember = 42;\n}',
+    'class Foo {\n    #usedMember = 42;\n    method() {\n        return this.#usedMember;\n    }\n}',
+    'class Foo {\n    #usedMember = 42;\n    anotherMember = this.#usedMember;\n}',
+    'class Foo {\n    #usedMember = 42;\n    foo() {\n        anotherMember = this.#usedMember;\n    }\n}',
+    'class C {\n    #usedMember;\n\n    foo() {\n        bar(this.#usedMember += 1);\n    }\n}',
+    'class Foo {\n    #usedMember = 42;\n    method() {\n        return someGlobalMethod(this.#usedMember);\n    }\n}',
+    'class C {\n    #usedInOuterClass;\n\n    foo() {\n        return class {};\n    }\n\n    bar() {\n        return this.#usedInOuterClass;\n    }\n}',
+    'class Foo {\n    #usedInForInLoop;\n    method() {\n        for (const bar in this.#usedInForInLoop) {\n\n        }\n    }\n}',
+    'class Foo {\n    #usedInForOfLoop;\n    method() {\n        for (const bar of this.#usedInForOfLoop) {\n\n        }\n    }\n}',
+    'class Foo {\n    #usedInAssignmentPattern;\n    method() {\n        [bar = 1] = this.#usedInAssignmentPattern;\n    }\n}',
+    'class Foo {\n    #usedInArrayPattern;\n    method() {\n        [bar] = this.#usedInArrayPattern;\n    }\n}',
+    'class Foo {\n    #usedInAssignmentPattern;\n    method() {\n        [bar] = this.#usedInAssignmentPattern;\n    }\n}',
+    'class C {\n    #usedInObjectAssignment;\n\n    method() {\n        ({ [this.#usedInObjectAssignment]: a } = foo);\n    }\n}',
+    'class C {\n    set #accessorWithSetterFirst(value) {\n        doSomething(value);\n    }\n    get #accessorWithSetterFirst() {\n        return something();\n    }\n    method() {\n        this.#accessorWithSetterFirst += 1;\n    }\n}',
+    'class Foo {\n    set #accessorUsedInMemberAccess(value) {}\n\n    method(a) {\n        [this.#accessorUsedInMemberAccess] = a;\n    }\n}',
+    'class C {\n    get #accessorWithGetterFirst() {\n        return something();\n    }\n    set #accessorWithGetterFirst(value) {\n        doSomething(value);\n    }\n    method() {\n        this.#accessorWithGetterFirst += 1;\n    }\n}',
+    'class C {\n    #usedInInnerClass;\n\n    method(a) {\n        return class {\n            foo = a.#usedInInnerClass;\n        }\n    }\n}',
+    'class Foo {\n    #usedMethod() {\n        return 42;\n    }\n    anotherMethod() {\n        return this.#usedMethod();\n    }\n}',
+    'class C {\n    set #x(value) {\n        doSomething(value);\n    }\n\n    foo() {\n        this.#x = 1;\n    }\n}',
+  ],
+  invalid: [
+    {
+      code: 'class Foo {\n    #unusedMember = 5;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    /** docs */\n    #unusedMember = 1;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    // remove me\n    #unusedMember = 1;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    /* remove */ #unusedMember = 1;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 18,
+          endLine: 2,
+          endColumn: 31,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    /* keep */ #unusedMember = 1; foo = 1\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 16,
+          endLine: 2,
+          endColumn: 29,
+        },
+      ],
+    },
+    {
+      code: 'class C {\n    #unused1; /* keep */ foo;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: 'class C {\n    bar; #unused2; // keep\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 10,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class C {\n    // comment\n    #unused; foo;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 12,
+        },
+      ],
+    },
+    {
+      code: 'class C {\n    // comment\n    #unused; /*\n    */ foo;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 12,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #unusedMember = 1; // trailing\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    foo = 1; /*\n    */ #unusedMember = 1;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 8,
+          endLine: 3,
+          endColumn: 21,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    foo = 1; // keep this\n    #unusedMember = 1;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class First {}\nclass Second {\n    #unusedMemberInSecondClass = 5;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 31,
+        },
+      ],
+    },
+    {
+      code: 'class First {\n    #unusedMemberInFirstClass = 5;\n}\nclass Second {}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 30,
+        },
+      ],
+    },
+    {
+      code: 'class First {\n    #firstUnusedMemberInSameClass = 5;\n    #secondUnusedMemberInSameClass = 5;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 34,
+        },
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 35,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #usedOnlyInWrite = 5;\n    method() {\n        this.#usedOnlyInWrite = 42;\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 21,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #usedOnlyInWriteStatement = 5;\n    method() {\n        this.#usedOnlyInWriteStatement += 42;\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 30,
+        },
+      ],
+    },
+    {
+      code: 'class C {\n    #usedOnlyInIncrement;\n\n    foo() {\n        this.#usedOnlyInIncrement++;\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: 'class C {\n    #unusedInOuterClass;\n\n    foo() {\n        return class {\n            #unusedInOuterClass;\n\n            bar() {\n                return this.#unusedInOuterClass;\n            }\n        };\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 24,
+        },
+      ],
+    },
+    {
+      code: 'class C {\n    #unusedOnlyInSecondNestedClass;\n\n    foo() {\n        return class {\n            #unusedOnlyInSecondNestedClass;\n\n            bar() {\n                return this.#unusedOnlyInSecondNestedClass;\n            }\n        };\n    }\n\n    baz() {\n        return this.#unusedOnlyInSecondNestedClass;\n    }\n\n    bar() {\n        return class {\n            #unusedOnlyInSecondNestedClass;\n        }\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 20,
+          column: 13,
+          endLine: 20,
+          endColumn: 43,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #unusedMethod() {}\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #unusedMethod() {}\n    #usedMethod() {\n        return 42;\n    }\n    publicMethod() {\n        return this.#usedMethod();\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    set #unusedSetter(value) {}\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 9,
+          endLine: 2,
+          endColumn: 22,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    get #unusedAccessor() {\n        return 1;\n    }\n    set #unusedAccessor(value) {}\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 5,
+          column: 9,
+          endLine: 5,
+          endColumn: 24,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #unusedForInLoop;\n    method() {\n        for (this.#unusedForInLoop in bar) {\n\n        }\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 21,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #unusedForOfLoop;\n    method() {\n        for (this.#unusedForOfLoop of bar) {\n\n        }\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 21,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #unusedInDestructuring;\n    method() {\n        ({ x: this.#unusedInDestructuring } = bar);\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 27,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #unusedInRestPattern;\n    method() {\n        [...this.#unusedInRestPattern] = bar;\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #unusedInAssignmentPattern;\n    method() {\n        [this.#unusedInAssignmentPattern = 1] = bar;\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 31,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    #unusedInAssignmentPattern;\n    method() {\n        [this.#unusedInAssignmentPattern] = bar;\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 31,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    foo = 1\n    #unusedMethod() {}\n    [0]() {}\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    foo = 1\n    #unusedMethod() {}\n    *generator() {}\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    foo = 1\n    #unusedMethod() {}\n    in = 2\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    foo = 1\n    #unused\n    instanceof() {}\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 12,
+        },
+      ],
+    },
+    {
+      code: 'class C {\n    foo = () => {}\n    #unused\n    [bar]\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 12,
+        },
+      ],
+    },
+    {
+      code: 'class C {\n    foo\n    #unused\n    [bar]\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 3,
+          column: 5,
+          endLine: 3,
+          endColumn: 12,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    foo = 1\n    /** docs */\n    #unusedMethod() {}\n    [0]() {}\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 4,
+          column: 5,
+          endLine: 4,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    // keep\n\n    /** remove */\n    #unusedMember = 1;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 5,
+          column: 5,
+          endLine: 5,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    // keep one\n    // keep two\n\n    /** remove */\n    #unusedMember = 1;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 6,
+          column: 5,
+          endLine: 6,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class Foo {\n    // maybe unrelated\n\n    #unusedMember = 1;\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 4,
+          column: 5,
+          endLine: 4,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: 'class C {\n    #usedOnlyInTheSecondInnerClass;\n\n    method(a) {\n        return class {\n            #usedOnlyInTheSecondInnerClass;\n\n            method2(b) {\n                foo = b.#usedOnlyInTheSecondInnerClass;\n            }\n\n            method3(b) {\n                foo = b.#usedOnlyInTheSecondInnerClass;\n            }\n        }\n    }\n}',
+      errors: [
+        {
+          messageId: 'unusedPrivateClassMember',
+          line: 2,
+          column: 5,
+          endLine: 2,
+          endColumn: 35,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-unused-private-class-members` rule from ESLint to rslint.

This rule reports unused JavaScript private class fields, methods, getters, and setters, including write-only private fields while preserving accessor write semantics.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-unused-private-class-members
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-unused-private-class-members.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
