### PR TITLE
feat: port rule require-await

### DIFF
--- a/internal/plugins/typescript/rules/require_await/require_await.go
+++ b/internal/plugins/typescript/rules/require_await/require_await.go
@@ -43,8 +43,7 @@ var RequireAwaitRule = rule.CreateRule(rule.Rule{
 				upper:         currentScope,
 			}
 
-			body := node.Body()
-			if body != nil && (!ast.IsBlock(body) || len(body.AsBlock().Statements.Nodes) > 0) {
+			if utils.HasNonEmptyFunctionBody(node) {
 				currentScope.functionFlags = ast.GetFunctionFlags(node)
 			}
 		}

--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -137,6 +137,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_template"
 	"github.com/web-infra-dev/rslint/internal/rules/radix"
 	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
+	"github.com/web-infra-dev/rslint/internal/rules/require_await"
 	"github.com/web-infra-dev/rslint/internal/rules/require_yield"
 	"github.com/web-infra-dev/rslint/internal/rules/strict"
 	"github.com/web-infra-dev/rslint/internal/rules/symbol_description"
@@ -283,6 +284,7 @@ func GetAllRules() []rule.Rule {
 		no_useless_rename.NoUselessRenameRule,
 		no_useless_constructor.NoUselessConstructorRule,
 		no_prototype_builtins.NoPrototypeBuiltinsRule,
+		require_await.RequireAwaitRule,
 		require_yield.RequireYieldRule,
 		symbol_description.SymbolDescriptionRule,
 		no_unexpected_multiline.NoUnexpectedMultilineRule,

--- a/internal/rules/no_useless_constructor/no_useless_constructor.go
+++ b/internal/rules/no_useless_constructor/no_useless_constructor.go
@@ -3,7 +3,6 @@ package no_useless_constructor
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
-	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -181,16 +180,10 @@ func reportRange(ctx rule.RuleContext, node *ast.Node, constructor *ast.Construc
 		if p > start && text[p-1] == '(' {
 			p--
 		}
-		for p > start && isAsciiSpace(text[p-1]) {
-			p--
-		}
+		p = utils.SkipTrailingWhitespace(text, start, p)
 		end = p
 	}
 	return core.NewTextRange(start, end)
-}
-
-func isAsciiSpace(b byte) bool {
-	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
 // needsLeadingSemicolon reports whether removing `node` outright would cause
@@ -207,56 +200,17 @@ func isAsciiSpace(b byte) bool {
 // or a stray `;` (SemicolonClassElement) all shift the first token away from
 // `[` and therefore are safe.
 func needsLeadingSemicolon(sf *ast.SourceFile, classNode *ast.Node, node *ast.Node) bool {
-	text := sf.Text()
-	nextTokPos := scanner.SkipTrivia(text, node.End())
-	if nextTokPos >= len(text) || text[nextTokPos] != '[' {
+	nextToken, ok := utils.TokenAtOrAfter(sf, node.End())
+	if !ok || nextToken.Kind != ast.KindOpenBracketToken {
 		return false
 	}
-	members := classNode.Members()
-	idx := -1
-	for i, m := range members {
-		if m == node {
-			idx = i
-			break
-		}
-	}
-	if idx <= 0 {
-		return false
-	}
-	prev := members[idx-1]
-	// Only a PropertyDeclaration's initializer can greedily consume the next
-	// `[...]`. Method / accessor / constructor / static-block / index-signature
-	// all terminate at their own boundary, so the class body parser resumes
-	// cleanly for the next member regardless of the final character.
-	if !ast.IsPropertyDeclaration(prev) {
-		return false
-	}
-	i := prev.End() - 1
-	for i > prev.Pos() && isAsciiSpace(text[i]) {
-		i--
-	}
-	if text[i] == ';' {
-		return false
-	}
-	pd := prev.AsPropertyDeclaration()
-	if pd != nil && pd.Initializer != nil {
-		init := pd.Initializer
-		// Postfix `++`/`--` are restricted productions — ASI always fires
-		// after them. Mirrors ESLint's PUNCTUATORS allowlist.
-		if init.Kind == ast.KindPostfixUnaryExpression {
-			return false
-		}
-		// Arrow functions with a block body terminate at their own `}`, so
-		// the following `[...]` cannot member-access into them. Mirrors
-		// ESLint's needsPrecedingSemicolon (the `}` → ObjectExpression /
-		// function-expr / class-expr branches explicitly exclude arrows).
-		if init.Kind == ast.KindArrowFunction {
-			if arrow := init.AsArrowFunction(); arrow != nil && arrow.Body != nil && arrow.Body.Kind == ast.KindBlock {
-				return false
-			}
-		}
-	}
-	return true
+	return utils.NeedsClassMemberLeadingSemicolon(
+		sf,
+		classNode,
+		node,
+		nextToken,
+		utils.ClassMemberLeadingSemicolonOptions{IncludePropertiesWithoutInitializers: true},
+	)
 }
 
 var NoUselessConstructorRule = rule.Rule{

--- a/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator.go
+++ b/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator.go
@@ -283,22 +283,6 @@ func parenthesizeIfShould(text string, shouldParenthesize bool) string {
 	return text
 }
 
-func isStartOfExpressionStatement(sf *ast.SourceFile, node *ast.Node) bool {
-	nodeStart := utils.TrimNodeTextRange(sf, node).Pos()
-	for current := node.Parent; current != nil; current = current.Parent {
-		if current.Kind == ast.KindParenthesizedExpression {
-			return false
-		}
-		if current.Kind == ast.KindExpressionStatement {
-			return nodeStart == utils.TrimNodeTextRange(sf, current).Pos()
-		}
-		if !ast.IsExpression(current) {
-			return false
-		}
-	}
-	return false
-}
-
 func firstTokenKind(sf *ast.SourceFile, node *ast.Node) ast.Kind {
 	node = unparenthesized(node)
 	if node == nil {
@@ -387,26 +371,6 @@ func nextAdjacentTokenText(sf *ast.SourceFile, pos int) (string, bool) {
 	return text[pos:end], true
 }
 
-func needsPrecedingSemicolon(sf *ast.SourceFile, node *ast.Node) bool {
-	nodeStart := utils.TrimNodeTextRange(sf, node).Pos()
-
-	scan := scanner.GetScannerForSourceFile(sf, 0)
-	prevKind := ast.KindUnknown
-	for scan.Token() != ast.KindEndOfFile && scan.TokenStart() < nodeStart {
-		prevKind = scan.Token()
-		scan.Scan()
-	}
-	if prevKind == ast.KindUnknown || scan.TokenStart() != nodeStart || !scan.HasPrecedingLineBreak() {
-		return false
-	}
-
-	switch prevKind {
-	case ast.KindSemicolonToken, ast.KindCloseBraceToken:
-		return false
-	}
-	return true
-}
-
 func buildFix(sf *ast.SourceFile, node *ast.Node) *rule.RuleFix {
 	call := node.AsCallExpression()
 	if call == nil || call.Arguments == nil {
@@ -431,7 +395,7 @@ func buildFix(sf *ast.SourceFile, node *ast.Node) *rule.RuleFix {
 	exponentText := expressionText(sf, exponent)
 	shouldParenthesizeBase := doesBaseNeedParens(base)
 	shouldParenthesizeExponent := doesExponentNeedParens(exponent)
-	isStart := isStartOfExpressionStatement(sf, node)
+	isStart := utils.IsStartOfExpressionStatement(sf, node)
 	shouldParenthesizeAll := doesExponentiationExpressionNeedParens(node)
 
 	if !shouldParenthesizeAll && !shouldParenthesizeBase && isStart && isBaseStartThatNeedsWholeParens(sf, base) {
@@ -463,7 +427,7 @@ func buildFix(sf *ast.SourceFile, node *ast.Node) *rule.RuleFix {
 	exponentReplacement := parenthesizeIfShould(exponentText, shouldParenthesizeExponent)
 	replacement := parenthesizeIfShould(baseReplacement+"**"+exponentReplacement, shouldParenthesizeAll)
 
-	if prefix == "" && isStart && len(replacement) > 0 && continuationChars[replacement[0]] && needsPrecedingSemicolon(sf, node) {
+	if prefix == "" && isStart && len(replacement) > 0 && continuationChars[replacement[0]] && utils.NeedsPrecedingSemicolon(sf, node) {
 		prefix = ";"
 	}
 

--- a/internal/rules/require_await/require_await.go
+++ b/internal/rules/require_await/require_await.go
@@ -1,0 +1,169 @@
+package require_await
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildMissingAwaitMessage(node *ast.Node) rule.RuleMessage {
+	name := utils.UpperCaseFirstASCII(utils.GetFunctionNameWithKindCore(node))
+	return rule.RuleMessage{
+		Id:          "missingAwait",
+		Description: name + " has no 'await' expression.",
+		Data:        map[string]string{"name": name},
+	}
+}
+
+func buildRemoveAsyncMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "removeAsync",
+		Description: "Remove 'async'.",
+	}
+}
+
+type scopeFrame struct {
+	node     *ast.Node
+	hasAwait bool
+}
+
+type asyncKeywordInfo struct {
+	tokenRange  core.TextRange
+	removeRange core.TextRange
+}
+
+func findAsyncKeyword(sourceFile *ast.SourceFile, node *ast.Node) (asyncKeywordInfo, bool) {
+	mods := node.Modifiers()
+	if mods == nil {
+		return asyncKeywordInfo{}, false
+	}
+	for _, mod := range mods.Nodes {
+		if mod == nil || mod.Kind != ast.KindAsyncKeyword {
+			continue
+		}
+		tokenRange := utils.TrimNodeTextRange(sourceFile, mod)
+		removeEnd := utils.SkipLeadingWhitespace(sourceFile.Text(), tokenRange.End(), len(sourceFile.Text()))
+		return asyncKeywordInfo{
+			tokenRange:  tokenRange,
+			removeRange: core.NewTextRange(tokenRange.Pos(), removeEnd),
+		}, true
+	}
+	return asyncKeywordInfo{}, false
+}
+
+func shouldReplaceAsyncWithSemicolon(sourceFile *ast.SourceFile, node *ast.Node, asyncInfo asyncKeywordInfo) bool {
+	nextToken, ok := utils.TokenAtOrAfter(sourceFile, asyncInfo.tokenRange.End())
+	if !ok {
+		return false
+	}
+
+	if nextToken.Kind == ast.KindOpenParenToken &&
+		utils.IsStartOfExpressionStatement(sourceFile, node) &&
+		utils.NeedsPrecedingSemicolon(sourceFile, node) {
+		return true
+	}
+
+	if node.Kind != ast.KindMethodDeclaration {
+		return false
+	}
+	return utils.NeedsClassMemberLeadingSemicolon(
+		sourceFile,
+		ast.GetContainingClass(node),
+		node,
+		nextToken,
+		utils.ClassMemberLeadingSemicolonOptions{},
+	)
+}
+
+func reportMissingAwait(ctx rule.RuleContext, node *ast.Node) {
+	asyncInfo, ok := findAsyncKeyword(ctx.SourceFile, node)
+	if !ok {
+		ctx.ReportRange(utils.GetFunctionHeadLoc(ctx.SourceFile, node), buildMissingAwaitMessage(node))
+		return
+	}
+
+	replacement := ""
+	if shouldReplaceAsyncWithSemicolon(ctx.SourceFile, node, asyncInfo) {
+		replacement = ";"
+	}
+
+	ctx.ReportRangeWithSuggestions(
+		utils.GetFunctionHeadLoc(ctx.SourceFile, node),
+		buildMissingAwaitMessage(node),
+		rule.RuleSuggestion{
+			Message:  buildRemoveAsyncMessage(),
+			FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(asyncInfo.removeRange, replacement)},
+		},
+	)
+}
+
+// https://eslint.org/docs/latest/rules/require-await
+var RequireAwaitRule = rule.Rule{
+	Name: "require-await",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		stack := make([]scopeFrame, 0, 8)
+
+		enterFunction := func(node *ast.Node) {
+			stack = append(stack, scopeFrame{node: node})
+		}
+
+		exitFunction := func(node *ast.Node) {
+			n := len(stack)
+			if n == 0 {
+				return
+			}
+			top := stack[n-1]
+			stack = stack[:n-1]
+
+			flags := ast.GetFunctionFlags(node)
+			if flags&ast.FunctionFlagsAsync == 0 ||
+				flags&ast.FunctionFlagsGenerator != 0 ||
+				top.hasAwait ||
+				!utils.HasNonEmptyFunctionBody(node) {
+				return
+			}
+
+			reportMissingAwait(ctx, node)
+		}
+
+		markAwaitAt := func(node *ast.Node) {
+			for i := len(stack) - 1; i >= 0; i-- {
+				bp, be, ok := utils.BodyLikeRange(stack[i].node)
+				if !ok {
+					continue
+				}
+				if node.Pos() >= bp && node.End() <= be {
+					stack[i].hasAwait = true
+					return
+				}
+			}
+		}
+
+		listeners := rule.RuleListeners{
+			ast.KindAwaitExpression: markAwaitAt,
+			ast.KindForOfStatement: func(node *ast.Node) {
+				if node.AsForInOrOfStatement().AwaitModifier != nil {
+					markAwaitAt(node)
+				}
+			},
+			ast.KindVariableDeclarationList: func(node *ast.Node) {
+				if ast.IsVarAwaitUsing(node) {
+					markAwaitAt(node)
+				}
+			},
+		}
+
+		for _, kind := range []ast.Kind{
+			ast.KindFunctionDeclaration,
+			ast.KindFunctionExpression,
+			ast.KindMethodDeclaration,
+			ast.KindArrowFunction,
+		} {
+			listeners[kind] = enterFunction
+			listeners[rule.ListenerOnExit(kind)] = exitFunction
+		}
+
+		return listeners
+	},
+}

--- a/internal/rules/require_await/require_await.md
+++ b/internal/rules/require_await/require_await.md
@@ -1,0 +1,49 @@
+# require-await
+
+## Rule Details
+
+This rule warns on async functions that have no `await` expression.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+async function foo() {
+  doSomething();
+}
+
+bar(async () => {
+  doSomething();
+});
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+async function foo() {
+  await doSomething();
+}
+
+bar(async () => {
+  await doSomething();
+});
+
+function baz() {
+  doSomething();
+}
+
+bar(() => {
+  doSomething();
+});
+
+async function noop() {}
+```
+
+Async generator functions are ignored by this rule.
+
+## When Not To Use It
+
+If you don't want to warn on async functions that have no `await` expression, then it's safe to disable this rule.
+
+## Original Documentation
+
+- [ESLint require-await](https://eslint.org/docs/latest/rules/require-await)

--- a/internal/rules/require_await/require_await_extras_test.go
+++ b/internal/rules/require_await/require_await_extras_test.go
@@ -1,0 +1,312 @@
+package require_await
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestRequireAwaitExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+func TestRequireAwaitExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RequireAwaitRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: async generator container forms ----
+			// ---- Real-user: eslint/eslint#12459 async generators can delegate without await ----
+			{Code: `class Stream { async *read() { yield* anotherAsyncGenerator(); } }`},
+			{Code: `const makeStream = async function* () { yield* anotherAsyncGenerator(); };`},
+
+			// ---- Dimension 4: empty function body forms ----
+			// Locks in upstream exitFunction() arm 4: empty async functions are ignored.
+			{Code: `class A { async method() {} field = async () => {}; }`},
+			{Code: `async function onlyComment() { /* no executable statements */ }`},
+
+			// ---- Dimension 4: await in computed keys belongs to the enclosing function ----
+			// Locks in upstream AwaitExpression listener: computed class keys are outside the method body.
+			{Code: `async function outer() { class C { [await key()]() {} } }`},
+			{Code: `async function outer() { class C { async [await key()]() { await work(); } } }`},
+			{Code: `async function outer() { const obj = { [await key()]() {} }; }`},
+			{Code: `async function outer() { class C { [await key()] = value; } }`},
+
+			// ---- Dimension 4: for-await and await-using branch lock-ins ----
+			// Locks in upstream ForOfStatement arm: only awaited for-of marks the function.
+			{Code: `const run = async () => { for await (const item of items) consume(item); };`},
+			// Locks in upstream VariableDeclaration arm: await using marks the function.
+			{Code: `const run = async () => { await using resource = getResource(); resource.use(); };`},
+
+			// ---- Dimension 4: declaration forms without bodies ----
+			// N/A: ESLint core does not parse TS overloads, but rslint should not report body-absent declarations.
+			{Code: `declare function load(): Promise<void>;`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized async arrow expression ----
+			{
+				Code: `const f = (async () => { return 1; });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 1, 21, `const f = (() => { return 1; });`),
+				},
+			},
+
+			// ---- Dimension 4: TS type-parameter wrapper on arrow function ----
+			{
+				Code: `const f = async <T>(value: T) => value;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 1, 31, `const f = <T>(value: T) => value;`),
+				},
+			},
+			{
+				Code: `const f = async <T extends PromiseLike<number>>(value: T) => value;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 1, 59, `const f = <T extends PromiseLike<number>>(value: T) => value;`),
+				},
+			},
+
+			// ---- Dimension 4: class field arrow/function expression forms ----
+			{
+				Code: `class A { field = async () => value; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method 'field' has no 'await' expression.", 1, 11, `class A { field = () => value; }`),
+				},
+			},
+			{
+				Code: `class A { field = async function work() { return value; }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method 'field' has no 'await' expression.", 1, 11, `class A { field = function work() { return value; }; }`),
+				},
+			},
+			{
+				Code: `class A { [key] = async () => value; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 1, 11, `class A { [key] = () => value; }`),
+				},
+			},
+
+			// ---- Dimension 4: same-kind nesting boundary ----
+			// Locks in upstream enterFunction()/exitFunction() stack behavior: inner await does not satisfy outer.
+			{
+				Code: `async function outer() { async function inner() { await work(); } return inner; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'outer' has no 'await' expression.", 1, 1, `function outer() { async function inner() { await work(); } return inner; }`),
+				},
+			},
+			// Locks in upstream enterFunction()/exitFunction() stack behavior: outer await does not satisfy inner.
+			{
+				Code: `async function outer() { await setup(); return async () => result; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 1, 57, `async function outer() { await setup(); return () => result; }`),
+				},
+			},
+			{
+				Code: `async function outer() { await setup(); function middle() { return async () => value; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 1, 77, `async function outer() { await setup(); function middle() { return () => value; } }`),
+				},
+			},
+			// Locks in upstream enterFunction()/exitFunction() stack behavior: await in an async method does not satisfy the outer function.
+			{
+				Code: `async function outer() { class C { async method() { await work(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'outer' has no 'await' expression.", 1, 1, `function outer() { class C { async method() { await work(); } } }`),
+				},
+			},
+			// Locks in upstream ForOfStatement arm: an awaited for-of in an inner async function does not satisfy the outer function.
+			{
+				Code: `async function outer() { async function inner() { for await (const item of items) consume(item); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'outer' has no 'await' expression.", 1, 1, `function outer() { async function inner() { for await (const item of items) consume(item); } }`),
+				},
+			},
+			// Locks in upstream VariableDeclaration arm: await-using in an inner async function does not satisfy the outer function.
+			{
+				Code: `async function outer() { async function inner() { await using resource = getResource(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'outer' has no 'await' expression.", 1, 1, `function outer() { async function inner() { await using resource = getResource(); } }`),
+				},
+			},
+
+			// ---- Dimension 4: for-of without await and using without await do not satisfy the rule ----
+			// Locks in upstream ForOfStatement arm: non-await for-of is ignored.
+			{
+				Code: `async function run() { for (const item of items) consume(item); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'run' has no 'await' expression.", 1, 1, `function run() { for (const item of items) consume(item); }`),
+				},
+			},
+			// Locks in upstream VariableDeclaration arm: plain using is ignored.
+			{
+				Code: `async function run() { using resource = getResource(); resource.use(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'run' has no 'await' expression.", 1, 1, `function run() { using resource = getResource(); resource.use(); }`),
+				},
+			},
+
+			// ---- Real-user: eslint/eslint#10829 returning another promise is still reported ----
+			{
+				Code: `async function fetchJSON() { return fetch(url).then(r => r.json()); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'fetchJSON' has no 'await' expression.", 1, 1, `function fetchJSON() { return fetch(url).then(r => r.json()); }`),
+				},
+			},
+
+			// ---- Real-user: eslint/eslint#10000 throw-only async functions are still reported ----
+			{
+				Code: `async function fail() { throw new Error("Failure!"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'fail' has no 'await' expression.", 1, 1, `function fail() { throw new Error("Failure!"); }`),
+				},
+			},
+			// ---- Real-user: async APIs often return promises directly; core require-await still reports them ----
+			{
+				Code: `export default async function loadUser(id) { return api.users.get(id); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'loadUser' has no 'await' expression.", 1, 16, `export default function loadUser(id) { return api.users.get(id); }`),
+				},
+			},
+			{
+				Code: `const handler = async /* preserve */ (event) => ({ statusCode: 200, body: event.body });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 1, 46, `const handler = /* preserve */ (event) => ({ statusCode: 200, body: event.body });`),
+				},
+			},
+			{
+				Code: `export default async () => ({ ok: true });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 1, 25, `export default () => ({ ok: true });`),
+				},
+			},
+
+			// ---- Dimension 4: computed keys are outside the async method body ----
+			// The await in the computed key satisfies the outer function, not the method.
+			{
+				Code: `async function outer() { class C { async [await key()]() { return 1; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 1, 36, `async function outer() { class C { [await key()]() { return 1; } } }`),
+				},
+			},
+			{
+				Code: `const obj = { async [name]() { return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 1, 15, `const obj = { [name]() { return 1; } };`),
+				},
+			},
+			{
+				Code: `async function outer() { class C { [await key()] = async () => value; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 1, 36, `async function outer() { class C { [await key()] = () => value; } }`),
+				},
+			},
+
+			// ---- Branch lock-in: class-body semicolon after object-literal field initializer ----
+			// Locks in upstream exitFunction() suggestion arm: class member continuation after `async`.
+			{
+				Code: `class A {
+    field = {}
+    async [name]() { return value; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 3, 5, `class A {
+    field = {}
+    ;[name]() { return value; }
+}`),
+				},
+			},
+			{
+				Code: `class A {
+    field = 0
+    async /* keep */ [name]() { return value; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 3, 5, `class A {
+    field = 0
+    ;/* keep */ [name]() { return value; }
+}`),
+				},
+			},
+			{
+				Code: `class A {
+    field
+    async in(){ return value; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method 'in' has no 'await' expression.", 3, 5, `class A {
+    field
+    in(){ return value; }
+}`),
+				},
+			},
+			{
+				Code: `class A {
+    field: string
+    async [name]() { return value; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 3, 5, `class A {
+    field: string
+    ;[name]() { return value; }
+}`),
+				},
+			},
+			{
+				Code: `class A {
+    field = 0
+    async instanceof(){ return value; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method 'instanceof' has no 'await' expression.", 3, 5, `class A {
+    field = 0
+    ;instanceof(){ return value; }
+}`),
+				},
+			},
+			{
+				Code: `const C = class {
+    field = class {}
+    async [name]() { return value; }
+};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 3, 5, `const C = class {
+    field = class {}
+    ;[name]() { return value; }
+};`),
+				},
+			},
+			{
+				Code: `class A {
+    field = () => {}
+    async [name]() { return value; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 3, 5, `class A {
+    field = () => {}
+    [name]() { return value; }
+}`),
+				},
+			},
+			{
+				Code: `class A {
+    field = value++
+    async [name]() { return value; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 3, 5, `class A {
+    field = value++
+    [name]() { return value; }
+}`),
+				},
+			},
+			{
+				Code: `class A { static async #secret() { return value; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Static private async method '#secret' has no 'await' expression.", 1, 11, `class A { static #secret() { return value; } }`),
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/require_await/require_await_upstream_test.go
+++ b/internal/rules/require_await/require_await_upstream_test.go
@@ -1,0 +1,229 @@
+package require_await
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func missingAwaitError(message string, line int, column int, output string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "missingAwait",
+		Message:   message,
+		Line:      line,
+		Column:    column,
+		Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+			{
+				MessageId: "removeAsync",
+				Output:    output,
+			},
+		},
+	}
+}
+
+// TestRequireAwaitUpstream migrates the full valid/invalid suite from upstream
+// tests/lib/rules/require-await.js 1:1. Position assertions cover line/column
+// for every invalid case. rslint-specific lock-in cases live in the
+// require_await_extras_test.go file.
+func TestRequireAwaitUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RequireAwaitRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `async function foo() { await doSomething() }`},
+			{Code: `(async function() { await doSomething() })`},
+			{Code: `async () => { await doSomething() }`},
+			{Code: `async () => await doSomething()`},
+			{Code: `({ async foo() { await doSomething() } })`},
+			{Code: `class A { async foo() { await doSomething() } }`},
+			{Code: `(class { async foo() { await doSomething() } })`},
+			{Code: `async function foo() { await (async () => { await doSomething() }) }`},
+
+			// ---- empty functions are ok. ----
+			{Code: `async function foo() {}`},
+			{Code: `async () => {}`},
+
+			// ---- normal functions are ok. ----
+			{Code: `function foo() { doSomething() }`},
+
+			// ---- for-await-of ----
+			{Code: `async function foo() { for await (x of xs); }`},
+
+			// ---- global await ----
+			{Code: `await foo()`},
+			{Code: `
+for await (let num of asyncIterable) {
+    console.log(num);
+}
+`},
+
+			{Code: `async function* run() { yield * anotherAsyncGenerator() }`},
+			{Code: `
+async function* run() {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    yield 'Hello';
+    console.log('World');
+}
+`},
+			{Code: `async function* run() { }`},
+			{Code: `const foo = async function *(){}`},
+			{Code: `const foo = async function *(){ console.log("bar") }`},
+			{Code: `async function* run() { console.log("bar") }`},
+			{Code: `await using resource = getResource();`},
+			{Code: `async function run() { await using resource = getResource(); }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `async function foo() { doSomething() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'foo' has no 'await' expression.", 1, 1, `function foo() { doSomething() }`),
+				},
+			},
+			{
+				Code: `(async function() { doSomething() })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function has no 'await' expression.", 1, 2, `(function() { doSomething() })`),
+				},
+			},
+			{
+				Code: `async () => { doSomething() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 1, 10, `() => { doSomething() }`),
+				},
+			},
+			{
+				Code: `async () => doSomething()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 1, 10, `() => doSomething()`),
+				},
+			},
+			{
+				Code: `({ async foo() { doSomething() } })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method 'foo' has no 'await' expression.", 1, 4, `({ foo() { doSomething() } })`),
+				},
+			},
+			{
+				Code: `class A { async foo() { doSomething() } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method 'foo' has no 'await' expression.", 1, 11, `class A { foo() { doSomething() } }`),
+				},
+			},
+			{
+				Code: `(class { async foo() { doSomething() } })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method 'foo' has no 'await' expression.", 1, 10, `(class { foo() { doSomething() } })`),
+				},
+			},
+			{
+				Code: `(class { async ''() { doSomething() } })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method '' has no 'await' expression.", 1, 10, `(class { ''() { doSomething() } })`),
+				},
+			},
+			{
+				Code: `async function foo() { async () => { await doSomething() } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'foo' has no 'await' expression.", 1, 1, `function foo() { async () => { await doSomething() } }`),
+				},
+			},
+			{
+				Code: `async function foo() { await (async () => { doSomething() }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 1, 40, `async function foo() { await (() => { doSomething() }) }`),
+				},
+			},
+			{
+				Code: `const obj = { async: async function foo() { bar(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method 'async' has no 'await' expression.", 1, 15, `const obj = { async: function foo() { bar(); } }`),
+				},
+			},
+			{
+				Code: `async    /* test */ function foo() { doSomething() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'foo' has no 'await' expression.", 1, 1, `/* test */ function foo() { doSomething() }`),
+				},
+			},
+			{
+				Code: `class A {
+    a = 0
+    async [b](){ return 0; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 3, 5, `class A {
+    a = 0
+    ;[b](){ return 0; }
+}`),
+				},
+			},
+			{
+				Code: `class A {
+    a
+    async [b](){ return 0; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 3, 5, `class A {
+    a
+    [b](){ return 0; }
+}`),
+				},
+			},
+			{
+				Code: `class A {
+    a = 0
+    async in(){ return 0; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method 'in' has no 'await' expression.", 3, 5, `class A {
+    a = 0
+    ;in(){ return 0; }
+}`),
+				},
+			},
+			{
+				Code: `const obj = {
+    foo,
+    async in(){ return 0; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method 'in' has no 'await' expression.", 3, 5, `const obj = {
+    foo,
+    in(){ return 0; }
+}`),
+				},
+			},
+			{
+				Code: `foo
+    async () => { return 0; }
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async arrow function has no 'await' expression.", 2, 14, `foo
+    ;() => { return 0; }
+`),
+				},
+			},
+			{
+				Code: `class A {
+    foo() {}
+    async [bar] () { baz; }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async method has no 'await' expression.", 3, 5, `class A {
+    foo() {}
+    [bar] () { baz; }
+}`),
+				},
+			},
+			{
+				Code: `async function run() { using resource = getResource(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					missingAwaitError("Async function 'run' has no 'await' expression.", 1, 1, `function run() { using resource = getResource(); }`),
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/require_yield/require_yield.go
+++ b/internal/rules/require_yield/require_yield.go
@@ -17,68 +17,6 @@ func isGenerator(node *ast.Node) bool {
 	return ast.GetFunctionFlags(node)&ast.FunctionFlagsGenerator != 0
 }
 
-func hasNonEmptyBody(node *ast.Node) bool {
-	body := node.Body()
-	if body == nil || body.Kind != ast.KindBlock {
-		return false
-	}
-	block := body.AsBlock()
-	if block == nil || block.Statements == nil {
-		return false
-	}
-	return len(block.Statements.Nodes) > 0
-}
-
-// bodyLikeRange returns the [pos, end) of the "execution scope" of a
-// scope-bearing node. Yield expressions whose position falls inside this
-// range are attributed to this scope; yields outside it (e.g. in a
-// computed property key or a decorator expression) pass through to an
-// outer scope.
-//
-// Required because tsgo performs error-recovery parsing: an illegally
-// placed `yield` (e.g. inside a non-generator function body or in a
-// parameter default value of a non-generator) still produces a
-// KindYieldExpression AST node. Without position-aware attribution, such
-// a yield would bubble up to the nearest enclosing generator on the
-// stack and cause a false negative.
-//
-// For function-like nodes the scope starts at the parameter list, so
-// that yield in parameter default values is attributed here rather than
-// leaking to an outer generator.
-func bodyLikeRange(node *ast.Node) (int, int, bool) {
-	switch node.Kind {
-	case ast.KindFunctionDeclaration,
-		ast.KindFunctionExpression,
-		ast.KindMethodDeclaration,
-		ast.KindArrowFunction,
-		ast.KindGetAccessor,
-		ast.KindSetAccessor,
-		ast.KindConstructor:
-		body := node.Body()
-		if body == nil {
-			return 0, 0, false
-		}
-		pos := body.Pos()
-		if params := node.ParameterList(); params != nil {
-			pos = params.Loc.Pos()
-		}
-		return pos, body.End(), true
-	case ast.KindPropertyDeclaration:
-		init := node.AsPropertyDeclaration().Initializer
-		if init == nil {
-			return 0, 0, false
-		}
-		return init.Pos(), init.End(), true
-	case ast.KindClassStaticBlockDeclaration:
-		body := node.AsClassStaticBlockDeclaration().Body
-		if body == nil {
-			return 0, 0, false
-		}
-		return body.Pos(), body.End(), true
-	}
-	return 0, 0, false
-}
-
 type stackFrame struct {
 	node  *ast.Node
 	count int
@@ -108,7 +46,7 @@ var RequireYieldRule = rule.Rule{
 				top.node.Kind == ast.KindClassStaticBlockDeclaration {
 				return
 			}
-			if isGenerator(top.node) && top.count == 0 && hasNonEmptyBody(top.node) {
+			if isGenerator(top.node) && top.count == 0 && utils.HasNonEmptyFunctionBody(top.node) {
 				ctx.ReportRange(
 					utils.GetFunctionHeadLoc(ctx.SourceFile, top.node),
 					buildMissingYieldMessage(),
@@ -118,7 +56,7 @@ var RequireYieldRule = rule.Rule{
 
 		countYield := func(node *ast.Node) {
 			for i := len(stack) - 1; i >= 0; i-- {
-				bp, be, ok := bodyLikeRange(stack[i].node)
+				bp, be, ok := utils.BodyLikeRange(stack[i].node)
 				if !ok {
 					continue
 				}

--- a/internal/utils/class_member_semicolon.go
+++ b/internal/utils/class_member_semicolon.go
@@ -1,0 +1,91 @@
+package utils
+
+import "github.com/microsoft/typescript-go/shim/ast"
+
+// ClassMemberLeadingSemicolonOptions controls how
+// NeedsClassMemberLeadingSemicolon treats class fields without initializers.
+type ClassMemberLeadingSemicolonOptions struct {
+	// IncludePropertiesWithoutInitializers also treats plain fields like `foo`
+	// as hazards. Type-only fields like `foo: string` are always considered
+	// because the trailing type can merge with a following computed member.
+	IncludePropertiesWithoutInitializers bool
+}
+
+// NeedsClassMemberLeadingSemicolon reports whether an edit that removes or
+// rewrites member would leave nextToken at the start of a class member in a
+// position where the previous property declaration could consume it as part of
+// its initializer or type.
+func NeedsClassMemberLeadingSemicolon(
+	sourceFile *ast.SourceFile,
+	classNode *ast.Node,
+	member *ast.Node,
+	nextToken SourceToken,
+	options ClassMemberLeadingSemicolonOptions,
+) bool {
+	if sourceFile == nil || classNode == nil || member == nil {
+		return false
+	}
+	if classNode.Kind != ast.KindClassDeclaration && classNode.Kind != ast.KindClassExpression {
+		return false
+	}
+	if !canClassMemberTokenContinueExpression(nextToken) {
+		return false
+	}
+
+	members := classNode.Members()
+	idx := -1
+	for i, m := range members {
+		if m == member {
+			idx = i
+			break
+		}
+	}
+	if idx <= 0 {
+		return false
+	}
+
+	prev := members[idx-1]
+	if !ast.IsPropertyDeclaration(prev) || classPropertyEndsWithSemicolon(sourceFile, prev) {
+		return false
+	}
+
+	prop := prev.AsPropertyDeclaration()
+	if prop == nil {
+		return false
+	}
+	if prop.Initializer == nil {
+		return options.IncludePropertiesWithoutInitializers || prop.Type != nil
+	}
+
+	init := prop.Initializer
+	// Postfix ++/-- are restricted productions, so ASI fires before the next
+	// class member token and no explicit semicolon is needed.
+	if init.Kind == ast.KindPostfixUnaryExpression {
+		return false
+	}
+	// Arrow functions with block bodies terminate at their own `}`; a following
+	// `[`/`in`/`instanceof`/`*` cannot become a member access on the initializer.
+	if init.Kind == ast.KindArrowFunction {
+		if body := init.Body(); body != nil && body.Kind == ast.KindBlock {
+			return false
+		}
+	}
+	return true
+}
+
+func canClassMemberTokenContinueExpression(token SourceToken) bool {
+	switch token.Kind {
+	case ast.KindOpenBracketToken, ast.KindAsteriskToken, ast.KindInKeyword, ast.KindInstanceOfKeyword:
+		return true
+	case ast.KindIdentifier:
+		return token.Text == "in" || token.Text == "instanceof"
+	default:
+		return false
+	}
+}
+
+func classPropertyEndsWithSemicolon(sourceFile *ast.SourceFile, node *ast.Node) bool {
+	text := sourceFile.Text()
+	end := SkipTrailingWhitespace(text, node.Pos(), node.End())
+	return end > node.Pos() && end <= len(text) && text[end-1] == ';'
+}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -275,6 +275,99 @@ func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRan
 	return TrimNodeTextRange(sourceFile, node)
 }
 
+// BodyLikeRange returns the [pos, end) execution span for function-like and
+// implicit scope-bearing nodes. Expressions in computed keys or decorators sit
+// outside this span, so callers can attribute await/yield-like nodes to the
+// enclosing runtime scope instead of the declaration they decorate.
+func BodyLikeRange(node *ast.Node) (int, int, bool) {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression,
+		ast.KindMethodDeclaration,
+		ast.KindArrowFunction,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor,
+		ast.KindConstructor:
+		body := node.Body()
+		if body == nil {
+			return 0, 0, false
+		}
+		pos := body.Pos()
+		if params := node.ParameterList(); params != nil {
+			pos = params.Loc.Pos()
+		}
+		return pos, body.End(), true
+	case ast.KindPropertyDeclaration:
+		init := node.AsPropertyDeclaration().Initializer
+		if init == nil {
+			return 0, 0, false
+		}
+		return init.Pos(), init.End(), true
+	case ast.KindClassStaticBlockDeclaration:
+		body := node.AsClassStaticBlockDeclaration().Body
+		if body == nil {
+			return 0, 0, false
+		}
+		return body.Pos(), body.End(), true
+	}
+	return 0, 0, false
+}
+
+// HasNonEmptyFunctionBody reports whether a function-like node has executable
+// body content. Expression-bodied arrows count as non-empty; empty blocks and
+// body-less declarations do not.
+func HasNonEmptyFunctionBody(node *ast.Node) bool {
+	body := node.Body()
+	if body == nil {
+		return false
+	}
+	if body.Kind != ast.KindBlock {
+		return true
+	}
+	block := body.AsBlock()
+	return block != nil && block.Statements != nil && len(block.Statements.Nodes) > 0
+}
+
+// IsStartOfExpressionStatement reports whether node starts an ancestor
+// ExpressionStatement without crossing a ParenthesizedExpression.
+func IsStartOfExpressionStatement(sourceFile *ast.SourceFile, node *ast.Node) bool {
+	nodeStart := TrimNodeTextRange(sourceFile, node).Pos()
+	for current := node.Parent; current != nil; current = current.Parent {
+		if current.Kind == ast.KindParenthesizedExpression {
+			return false
+		}
+		if current.Kind == ast.KindExpressionStatement {
+			return nodeStart == TrimNodeTextRange(sourceFile, current).Pos()
+		}
+		if !ast.IsExpression(current) {
+			return false
+		}
+	}
+	return false
+}
+
+// NeedsPrecedingSemicolon mirrors ESLint's common ASI check for fixes that
+// make an expression-starter token begin a statement on a new line.
+func NeedsPrecedingSemicolon(sourceFile *ast.SourceFile, node *ast.Node) bool {
+	nodeStart := TrimNodeTextRange(sourceFile, node).Pos()
+
+	scan := scanner.GetScannerForSourceFile(sourceFile, 0)
+	prevKind := ast.KindUnknown
+	for scan.Token() != ast.KindEndOfFile && scan.TokenStart() < nodeStart {
+		prevKind = scan.Token()
+		scan.Scan()
+	}
+	if prevKind == ast.KindUnknown || scan.TokenStart() != nodeStart || !scan.HasPrecedingLineBreak() {
+		return false
+	}
+
+	switch prevKind {
+	case ast.KindSemicolonToken, ast.KindCloseBraceToken:
+		return false
+	}
+	return true
+}
+
 // GetFunctionNameWithKind mirrors ESLint's astUtils.getFunctionNameWithKind.
 // It produces a human-readable description of the function used in diagnostic
 // messages (e.g., `"function 'foo'"`, `"static private method '#bar'"`,

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -475,6 +475,7 @@ export default defineConfig({
     './tests/eslint/rules/prefer-promise-reject-errors.test.ts',
     './tests/eslint/rules/radix.test.ts',
     './tests/eslint/rules/require-atomic-updates.test.ts',
+    './tests/eslint/rules/require-await.test.ts',
     './tests/eslint/rules/require-yield.test.ts',
     './tests/eslint/rules/symbol-description.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-await.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-await.test.ts.snap
@@ -1,0 +1,512 @@
+// Rstest Snapshot v1
+
+exports[`require-await > invalid 1`] = `
+{
+  "code": "async function foo() { doSomething() }",
+  "diagnostics": [
+    {
+      "message": "Async function 'foo' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 2`] = `
+{
+  "code": "(async function() { doSomething() })",
+  "diagnostics": [
+    {
+      "message": "Async function has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 3`] = `
+{
+  "code": "async () => { doSomething() }",
+  "diagnostics": [
+    {
+      "message": "Async arrow function has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 4`] = `
+{
+  "code": "async () => doSomething()",
+  "diagnostics": [
+    {
+      "message": "Async arrow function has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 5`] = `
+{
+  "code": "({ async foo() { doSomething() } })",
+  "diagnostics": [
+    {
+      "message": "Async method 'foo' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 6`] = `
+{
+  "code": "class A { async foo() { doSomething() } }",
+  "diagnostics": [
+    {
+      "message": "Async method 'foo' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 7`] = `
+{
+  "code": "(class { async foo() { doSomething() } })",
+  "diagnostics": [
+    {
+      "message": "Async method 'foo' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 8`] = `
+{
+  "code": "(class { async ''() { doSomething() } })",
+  "diagnostics": [
+    {
+      "message": "Async method '' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 9`] = `
+{
+  "code": "async function foo() { async () => { await doSomething() } }",
+  "diagnostics": [
+    {
+      "message": "Async function 'foo' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 10`] = `
+{
+  "code": "async function foo() { await (async () => { doSomething() }) }",
+  "diagnostics": [
+    {
+      "message": "Async arrow function has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 11`] = `
+{
+  "code": "const obj = { async: async function foo() { bar(); } }",
+  "diagnostics": [
+    {
+      "message": "Async method 'async' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 12`] = `
+{
+  "code": "async    /* test */ function foo() { doSomething() }",
+  "diagnostics": [
+    {
+      "message": "Async function 'foo' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 13`] = `
+{
+  "code": "class A {
+    a = 0
+    async [b](){ return 0; }
+}",
+  "diagnostics": [
+    {
+      "message": "Async method has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 14`] = `
+{
+  "code": "class A {
+    a
+    async [b](){ return 0; }
+}",
+  "diagnostics": [
+    {
+      "message": "Async method has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 15`] = `
+{
+  "code": "class A {
+    a = 0
+    async in(){ return 0; }
+}",
+  "diagnostics": [
+    {
+      "message": "Async method 'in' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 16`] = `
+{
+  "code": "const obj = {
+    foo,
+    async in(){ return 0; }
+}",
+  "diagnostics": [
+    {
+      "message": "Async method 'in' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 17`] = `
+{
+  "code": "foo
+    async () => { return 0; }
+",
+  "diagnostics": [
+    {
+      "message": "Async arrow function has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 18`] = `
+{
+  "code": "class A {
+    foo() {}
+    async [bar] () { baz; }
+}",
+  "diagnostics": [
+    {
+      "message": "Async method has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-await > invalid 19`] = `
+{
+  "code": "async function run() { using resource = getResource(); }",
+  "diagnostics": [
+    {
+      "message": "Async function 'run' has no 'await' expression.",
+      "messageId": "missingAwait",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-await",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/require-await.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/require-await.test.ts
@@ -1,0 +1,135 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('require-await', {
+  valid: [
+    `async function foo() { await doSomething() }`,
+    `(async function() { await doSomething() })`,
+    `async () => { await doSomething() }`,
+    `async () => await doSomething()`,
+    `({ async foo() { await doSomething() } })`,
+    `class A { async foo() { await doSomething() } }`,
+    `(class { async foo() { await doSomething() } })`,
+    `async function foo() { await (async () => { await doSomething() }) }`,
+    `async function foo() {}`,
+    `async () => {}`,
+    `function foo() { doSomething() }`,
+    `async function foo() { for await (x of xs); }`,
+    `await foo()`,
+    `
+for await (let num of asyncIterable) {
+    console.log(num);
+}
+`,
+    `async function* run() { yield * anotherAsyncGenerator() }`,
+    `
+async function* run() {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    yield 'Hello';
+    console.log('World');
+}
+`,
+    `async function* run() { }`,
+    `const foo = async function *(){}`,
+    `const foo = async function *(){ console.log("bar") }`,
+    `async function* run() { console.log("bar") }`,
+    `await using resource = getResource();`,
+    `async function run() { await using resource = getResource(); }`,
+  ],
+  invalid: [
+    {
+      code: `async function foo() { doSomething() }`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `(async function() { doSomething() })`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `async () => { doSomething() }`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `async () => doSomething()`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `({ async foo() { doSomething() } })`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `class A { async foo() { doSomething() } }`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `(class { async foo() { doSomething() } })`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `(class { async ''() { doSomething() } })`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `async function foo() { async () => { await doSomething() } }`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `async function foo() { await (async () => { doSomething() }) }`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `const obj = { async: async function foo() { bar(); } }`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `async    /* test */ function foo() { doSomething() }`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `class A {
+    a = 0
+    async [b](){ return 0; }
+}`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `class A {
+    a
+    async [b](){ return 0; }
+}`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `class A {
+    a = 0
+    async in(){ return 0; }
+}`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `const obj = {
+    foo,
+    async in(){ return 0; }
+}`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `foo
+    async () => { return 0; }
+`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `class A {
+    foo() {}
+    async [bar] () { baz; }
+}`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+    {
+      code: `async function run() { using resource = getResource(); }`,
+      errors: [{ messageId: 'missingAwait' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `require-await` rule from ESLint core to rslint.

- Add the core rule implementation, documentation, Go upstream/extras coverage, and JS snapshot coverage.
- Reuse shared helpers for async function-like handling and TypeScript-ESLint style utility behavior across related rules.
- Validate the rule on rsbuild and rspack real repositories with per-diagnostic audit.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/require-await
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/require-await.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).