### PR TITLE
feat: port rule react/forward-ref-uses-ref

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_elements"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_foreign_prop_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forbid_prop_types"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forward_ref_uses_ref"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_boolean_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_closing_bracket_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_closing_tag_location"
@@ -88,6 +89,7 @@ func GetAllRules() []rule.Rule {
 		forbid_elements.ForbidElementsRule,
 		forbid_foreign_prop_types.ForbidForeignPropTypesRule,
 		forbid_prop_types.ForbidPropTypesRule,
+		forward_ref_uses_ref.ForwardRefUsesRefRule,
 		jsx_boolean_value.JsxBooleanValueRule,
 		jsx_closing_bracket_location.JsxClosingBracketLocationRule,
 		jsx_closing_tag_location.JsxClosingTagLocationRule,

--- a/internal/plugins/react/rules/forward_ref_uses_ref/forward_ref_uses_ref.go
+++ b/internal/plugins/react/rules/forward_ref_uses_ref/forward_ref_uses_ref.go
@@ -1,0 +1,125 @@
+package forward_ref_uses_ref
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const missingRefParameterText = "forwardRef is used with this component but no ref parameter is set"
+
+func missingRefParameterMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "missingRefParameter",
+		Description: missingRefParameterText,
+	}
+}
+
+func addRefParameterMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "addRefParameter",
+		Description: "Add a ref parameter",
+	}
+}
+
+func removeForwardRefMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "removeForwardRef",
+		Description: "Remove forwardRef wrapper",
+	}
+}
+
+func isForwardRefIdentifier(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipParentheses(node)
+	return node != nil && node.Kind == ast.KindIdentifier && node.AsIdentifier().Text == "forwardRef"
+}
+
+// isForwardRefCall mirrors upstream's narrow textual callee check:
+// `forwardRef(...)` or any member call whose property is named `forwardRef`.
+// It deliberately ignores imports, the object name, and the argument position,
+// so `Other.forwardRef(fn)` and `forwardRef(Component, fn)` match too. Only
+// parentheses are transparent; TS-only wrappers stay visible to match upstream.
+func isForwardRefCall(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+	if isForwardRefIdentifier(callee) {
+		return true
+	}
+	if callee == nil || callee.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	name := callee.AsPropertyAccessExpression().Name()
+	return isForwardRefIdentifier(name)
+}
+
+func parentForwardRefCall(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	parent := node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parent = parent.Parent
+	}
+	if !isForwardRefCall(parent) {
+		return nil
+	}
+	return parent
+}
+
+func addRefParameterSuggestion(ctx rule.RuleContext, fn *ast.Node, param *ast.Node) rule.RuleSuggestion {
+	fixes := []rule.RuleFix{}
+	if utils.IsParenlessArrowFunction(fn) {
+		fixes = append(fixes, rule.RuleFixInsertBefore(ctx.SourceFile, param, "("))
+		fixes = append(fixes, rule.RuleFixInsertAfter(param, ", ref)"))
+	} else {
+		fixes = append(fixes, rule.RuleFixInsertAfter(param, ", ref"))
+	}
+	return rule.RuleSuggestion{
+		Message:  addRefParameterMessage(),
+		FixesArr: fixes,
+	}
+}
+
+func removeForwardRefSuggestion(ctx rule.RuleContext, call *ast.Node, fn *ast.Node) rule.RuleSuggestion {
+	return rule.RuleSuggestion{
+		Message: removeForwardRefMessage(),
+		FixesArr: []rule.RuleFix{
+			rule.RuleFixReplace(ctx.SourceFile, call, utils.TrimmedNodeText(ctx.SourceFile, fn)),
+		},
+	}
+}
+
+// https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forward-ref-uses-ref.md
+var ForwardRefUsesRefRule = rule.Rule{
+	Name: "react/forward-ref-uses-ref",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		checkFunction := func(node *ast.Node) {
+			call := parentForwardRefCall(node)
+			if call == nil {
+				return
+			}
+			params := reactutil.FunctionParameters(node)
+			if len(params) != 1 {
+				return
+			}
+			param := params[0]
+			ctx.ReportNodeWithSuggestions(
+				node,
+				missingRefParameterMessage(),
+				addRefParameterSuggestion(ctx, node, param),
+				removeForwardRefSuggestion(ctx, call, node),
+			)
+		}
+
+		return rule.RuleListeners{
+			ast.KindArrowFunction:      checkFunction,
+			ast.KindFunctionExpression: checkFunction,
+		}
+	},
+}

--- a/internal/plugins/react/rules/forward_ref_uses_ref/forward_ref_uses_ref.md
+++ b/internal/plugins/react/rules/forward_ref_uses_ref/forward_ref_uses_ref.md
@@ -1,0 +1,40 @@
+# forward-ref-uses-ref
+
+Require all `forwardRef` components to include a `ref` parameter.
+
+## Rule Details
+
+Components wrapped with `forwardRef` receive props as the first parameter and the forwarded ref as the second parameter. This rule reports `forwardRef` callbacks that only declare the props parameter.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+const Button = forwardRef((props) => <button {...props} />);
+```
+
+```jsx
+const Button = React.forwardRef(function Button(props) {
+  return <button {...props} />;
+});
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+const Button = forwardRef((props, ref) => <button ref={ref} {...props} />);
+```
+
+```jsx
+function Button(props) {
+  return <button {...props} />;
+}
+```
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forward-ref-uses-ref.md
+- https://react.dev/reference/react/forwardRef

--- a/internal/plugins/react/rules/forward_ref_uses_ref/forward_ref_uses_ref_extras_test.go
+++ b/internal/plugins/react/rules/forward_ref_uses_ref/forward_ref_uses_ref_extras_test.go
@@ -1,0 +1,243 @@
+package forward_ref_uses_ref
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestForwardRefUsesRefExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+func TestForwardRefUsesRefExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ForwardRefUsesRefRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: parameter-count boundary ----
+		{Code: `forwardRef(() => null);`, Tsx: true},
+		{Code: `forwardRef((props, ref, extra) => null);`, Tsx: true},
+		{Code: `forwardRef((props, ...ref) => null);`, Tsx: true},
+
+		// ---- Dimension 4: parenthesized callee and callback with a valid ref ----
+		{Code: `(React.forwardRef)(((props, ref) => null));`, Tsx: true},
+
+		// ---- Dimension 4: TS wrappers are upstream-opaque ----
+		{Code: `forwardRef(((props) => null) as any);`, Tsx: true},
+		{Code: `forwardRef(((props) => null)!);`, Tsx: true},
+		{Code: `forwardRef(((props) => null) satisfies any);`, Tsx: true},
+		{Code: `(React.forwardRef as any)((props) => null);`, Tsx: true},
+		{Code: `forwardRef(((props, ref) => null) as any);`, Tsx: true},
+		{Code: `(React.forwardRef as any)((props, ref) => null);`, Tsx: true},
+
+		// ---- Dimension 4: computed property access is not a forwardRef property identifier ----
+		{Code: `React["forwardRef"]((props) => null);`, Tsx: true},
+		{Code: "React[`forwardRef`]((props) => null);", Tsx: true},
+
+		// ---- Dimension 4: graceful degradation for empty and non-function arguments ----
+		{Code: `forwardRef();`, Tsx: true},
+		{Code: `forwardRef(Component);`, Tsx: true},
+		{Code: `forwardReference((props) => null);`, Tsx: true},
+		{Code: `React.forwardRef2((props) => null);`, Tsx: true},
+		{Code: `React.forwardRef.call(null, (props) => null);`, Tsx: true},
+		{Code: `React.forwardRef.apply(null, [(props) => null]);`, Tsx: true},
+
+		// ---- Real-user: #3684 shadcn/ui typed React.forwardRef with destructured props ----
+		{
+			Code: `const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    const id = React.useId();
+    return <div className={className} ref={ref} {...props}>{id}</div>;
+  }
+);`,
+			Tsx: true,
+		},
+
+		// ---- Real-user: #3524 React.memo + typed React.forwardRef nesting ----
+		{
+			Code: `const LazyImage = React.memo<Props>(
+  React.forwardRef<Image, Props>(
+    ({ foo }, ref) => {
+      console.log("foo", foo);
+      return <Image ref={ref} />;
+    }
+  )
+);`,
+			Tsx: true,
+		},
+
+		// ---- Real-user: #3738 shadcn/ui default argument under forwardRef ----
+		{
+			Code: `const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a"> & { asChild?: boolean }
+>(({ asChild = false, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : "a";
+  return <Comp ref={ref} className={className} {...props} />;
+});`,
+			Tsx: true,
+		},
+
+		// ---- Real-user: #2172 export default React.forwardRef sibling wrapper shape ----
+		{
+			Code: `export default React.forwardRef((props, ref) => <StoreListItem {...props} forwardRef={ref} />);`,
+			Tsx:  true,
+		},
+
+		// N/A: Object/class property key forms do not apply; this rule only
+		// inspects call callees and function parameters.
+		// N/A: Class declaration / class expression containers do not apply;
+		// upstream only listens for function and arrow expressions.
+		// N/A: Body-absent overload / abstract / declare members do not apply;
+		// the inspected callbacks are expression nodes with parameter lists.
+	}, []rule_tester.InvalidTestCase{
+		// ---- Real-user: #3158 original missing-ref request ----
+		{
+			Code: `const Button = forwardRef(props => <button {...props} />);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 27,
+				`const Button = forwardRef((props, ref) => <button {...props} />);`,
+				`const Button = props => <button {...props} />;`)},
+			Tsx: true,
+		},
+
+		// ---- Dimension 4: nested wrapper chain ----
+		{
+			Code: `React.memo(React.forwardRef((props) => null));`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 29,
+				`React.memo(React.forwardRef((props, ref) => null));`,
+				`React.memo((props) => null);`)},
+			Tsx: true,
+		},
+
+		// ---- Dimension 4: parenthesized callee ----
+		// Locks in upstream isForwardRefCall() arm 1: Identifier callee.
+		{
+			Code: `(forwardRef)((props) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 14,
+				`(forwardRef)((props, ref) => null);`,
+				`(props) => null;`)},
+			Tsx: true,
+		},
+
+		// ---- Dimension 4: optional bare call ----
+		{
+			Code: `forwardRef?.((props) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 14,
+				`forwardRef?.((props, ref) => null);`,
+				`(props) => null;`)},
+			Tsx: true,
+		},
+		{
+			Code: `forwardRef?.(props => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 14,
+				`forwardRef?.((props, ref) => null);`,
+				`props => null;`)},
+			Tsx: true,
+		},
+
+		// ---- Dimension 4: optional member expression ----
+		// Locks in upstream isForwardRefCall() arm 2: MemberExpression property.
+		{
+			Code: `React?.forwardRef((props) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 19,
+				`React?.forwardRef((props, ref) => null);`,
+				`(props) => null;`)},
+			Tsx: true,
+		},
+		{
+			Code: `React.forwardRef?.(props => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 20,
+				`React.forwardRef?.((props, ref) => null);`,
+				`props => null;`)},
+			Tsx: true,
+		},
+		{
+			Code: `React.forwardRef?.((props) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 20,
+				`React.forwardRef?.((props, ref) => null);`,
+				`(props) => null;`)},
+			Tsx: true,
+		},
+
+		// ---- Dimension 4: parenthesized callback parent ----
+		{
+			Code: `forwardRef((((props) => null)));`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 14,
+				`forwardRef((((props, ref) => null)));`,
+				`(props) => null;`)},
+			Tsx: true,
+		},
+
+		// Locks in upstream isForwardRefCall() arm 2: object name is ignored.
+		{
+			Code: `Other.forwardRef((props) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 18,
+				`Other.forwardRef((props, ref) => null);`,
+				`(props) => null;`)},
+			Tsx: true,
+		},
+
+		// ---- Dimension 4: typed generic forwardRef call ----
+		{
+			Code: `React.forwardRef<HTMLDivElement, Props>((props: Props) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 41,
+				`React.forwardRef<HTMLDivElement, Props>((props: Props, ref) => null);`,
+				`(props: Props) => null;`)},
+			Tsx: true,
+		},
+
+		// ---- Dimension 4: parameter forms ----
+		{
+			Code: `forwardRef(({ className, ...props }) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 12,
+				`forwardRef(({ className, ...props }, ref) => null);`,
+				`({ className, ...props }) => null;`)},
+			Tsx: true,
+		},
+		{
+			Code: `forwardRef((props = {}) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 12,
+				`forwardRef((props = {}, ref) => null);`,
+				`(props = {}) => null;`)},
+			Tsx: true,
+		},
+		{
+			Code: `forwardRef((props /* keep */) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 12,
+				`forwardRef((props, ref /* keep */) => null);`,
+				`(props /* keep */) => null;`)},
+			Tsx: true,
+		},
+		{
+			Code: `forwardRef((...props) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 12,
+				`forwardRef((...props, ref) => null);`,
+				`(...props) => null;`)},
+			Tsx: true,
+		},
+		{
+			Code: `forwardRef(async props => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 12,
+				`forwardRef(async (props, ref) => null);`,
+				`async props => null;`)},
+			Tsx: true,
+		},
+		{
+			Code: `forwardRef(function* Component(props) { return null; });`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 12,
+				`forwardRef(function* Component(props, ref) { return null; });`,
+				`function* Component(props) { return null; };`)},
+			Tsx: true,
+		},
+
+		// Locks in upstream listener shape: direct function argument position is
+		// not checked, only the parent CallExpression callee.
+		{
+			Code: `forwardRef(Component, (props) => null);`,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(1, 23,
+				`forwardRef(Component, (props, ref) => null);`,
+				`(props) => null;`)},
+			Tsx: true,
+		},
+	})
+}

--- a/internal/plugins/react/rules/forward_ref_uses_ref/forward_ref_uses_ref_upstream_test.go
+++ b/internal/plugins/react/rules/forward_ref_uses_ref/forward_ref_uses_ref_upstream_test.go
@@ -1,0 +1,197 @@
+package forward_ref_uses_ref
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestForwardRefUsesRefUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/forward-ref-uses-ref.js 1:1. Position assertions
+// cover line/column for every invalid case. rslint-specific lock-in cases live
+// in the forward_ref_uses_ref_extras_test.go file.
+func TestForwardRefUsesRefUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ForwardRefUsesRefRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{Code: `
+        import { forwardRef } from 'react'
+        forwardRef((props, ref) => {
+          return null;
+        });
+      `, Tsx: true},
+		{Code: `
+        import { forwardRef } from 'react'
+        forwardRef((props, ref) => null);
+      `, Tsx: true},
+		{Code: `
+        import { forwardRef } from 'react'
+        forwardRef(function (props, ref) {
+          return null;
+        });
+      `, Tsx: true},
+		{Code: `
+        import { forwardRef } from 'react'
+        forwardRef(function Component(props, ref) {
+          return null;
+        });
+      `, Tsx: true},
+		{Code: `
+        import * as React from 'react'
+        React.forwardRef((props, ref) => {
+          return null;
+        });
+      `, Tsx: true},
+		{Code: `
+        import * as React from 'react'
+        React.forwardRef((props, ref) => null);
+      `, Tsx: true},
+		{Code: `
+        import * as React from 'react'
+        React.forwardRef(function (props, ref) {
+          return null;
+        });
+      `, Tsx: true},
+		{Code: `
+        import * as React from 'react'
+        React.forwardRef(function Component(props, ref) {
+          return null;
+        });
+      `, Tsx: true},
+		{Code: `
+        import * as React from 'react'
+        function Component(props) {
+          return null;
+        };
+      `, Tsx: true},
+		{Code: `
+        import * as React from 'react'
+        (props) => null;
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code: `
+        import { forwardRef } from 'react'
+        forwardRef((props) => {
+          return null;
+        });
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(3, 20,
+				`
+        import { forwardRef } from 'react'
+        forwardRef((props, ref) => {
+          return null;
+        });
+      `,
+				`
+        import { forwardRef } from 'react'
+        (props) => {
+          return null;
+        };
+      `)},
+			Tsx: true,
+		},
+		{
+			Code: `
+        import { forwardRef } from 'react'
+        forwardRef(props => {
+          return null;
+        });
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(3, 20,
+				`
+        import { forwardRef } from 'react'
+        forwardRef((props, ref) => {
+          return null;
+        });
+      `,
+				`
+        import { forwardRef } from 'react'
+        props => {
+          return null;
+        };
+      `)},
+			Tsx: true,
+		},
+		{
+			Code: `
+        import * as React from 'react'
+        React.forwardRef((props) => null);
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(3, 26,
+				`
+        import * as React from 'react'
+        React.forwardRef((props, ref) => null);
+      `,
+				`
+        import * as React from 'react'
+        (props) => null;
+      `)},
+			Tsx: true,
+		},
+		{
+			Code: `
+        import { forwardRef } from 'react'
+        const Component = forwardRef(function (props) {
+          return null;
+        });
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(3, 38,
+				`
+        import { forwardRef } from 'react'
+        const Component = forwardRef(function (props, ref) {
+          return null;
+        });
+      `,
+				`
+        import { forwardRef } from 'react'
+        const Component = function (props) {
+          return null;
+        };
+      `)},
+			Tsx: true,
+		},
+		{
+			Code: `
+        import * as React from 'react'
+        React.forwardRef(function Component(props) {
+          return null;
+        });
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{missingRefError(3, 26,
+				`
+        import * as React from 'react'
+        React.forwardRef(function Component(props, ref) {
+          return null;
+        });
+      `,
+				`
+        import * as React from 'react'
+        function Component(props) {
+          return null;
+        };
+      `)},
+			Tsx: true,
+		},
+	})
+}
+
+func missingRefError(line int, column int, addOutput string, removeOutput string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "missingRefParameter",
+		Message:   missingRefParameterText,
+		Line:      line,
+		Column:    column,
+		Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+			{
+				MessageId: "addRefParameter",
+				Output:    addOutput,
+			},
+			{
+				MessageId: "removeForwardRef",
+				Output:    removeOutput,
+			},
+		},
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -143,6 +143,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/forbid-elements.test.ts',
     './tests/eslint-plugin-react/rules/forbid-foreign-prop-types.test.ts',
     './tests/eslint-plugin-react/rules/forbid-prop-types.test.ts',
+    './tests/eslint-plugin-react/rules/forward-ref-uses-ref.test.ts',
     './tests/eslint-plugin-react/rules/jsx-child-element-spacing.test.ts',
     './tests/eslint-plugin-react/rules/self-closing-comp.test.ts',
     './tests/eslint-plugin-react/rules/void-dom-elements-no-children.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/forward-ref-uses-ref.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/forward-ref-uses-ref.test.ts
@@ -1,0 +1,130 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const message =
+  'forwardRef is used with this component but no ref parameter is set';
+
+ruleTester.run('forward-ref-uses-ref', {} as never, {
+  valid: [
+    {
+      code: `
+        import { forwardRef } from 'react'
+        forwardRef((props, ref) => {
+          return null;
+        });
+      `,
+    },
+    {
+      code: `
+        import { forwardRef } from 'react'
+        forwardRef((props, ref) => null);
+      `,
+    },
+    {
+      code: `
+        import { forwardRef } from 'react'
+        forwardRef(function (props, ref) {
+          return null;
+        });
+      `,
+    },
+    {
+      code: `
+        import { forwardRef } from 'react'
+        forwardRef(function Component(props, ref) {
+          return null;
+        });
+      `,
+    },
+    {
+      code: `
+        import * as React from 'react'
+        React.forwardRef((props, ref) => {
+          return null;
+        });
+      `,
+    },
+    {
+      code: `
+        import * as React from 'react'
+        React.forwardRef((props, ref) => null);
+      `,
+    },
+    {
+      code: `
+        import * as React from 'react'
+        React.forwardRef(function (props, ref) {
+          return null;
+        });
+      `,
+    },
+    {
+      code: `
+        import * as React from 'react'
+        React.forwardRef(function Component(props, ref) {
+          return null;
+        });
+      `,
+    },
+    {
+      code: `
+        import * as React from 'react'
+        function Component(props) {
+          return null;
+        };
+      `,
+    },
+    {
+      code: `
+        import * as React from 'react'
+        (props) => null;
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { forwardRef } from 'react'
+        forwardRef((props) => {
+          return null;
+        });
+      `,
+      errors: [{ message }],
+    },
+    {
+      code: `
+        import { forwardRef } from 'react'
+        forwardRef(props => {
+          return null;
+        });
+      `,
+      errors: [{ message }],
+    },
+    {
+      code: `
+        import * as React from 'react'
+        React.forwardRef((props) => null);
+      `,
+      errors: [{ message }],
+    },
+    {
+      code: `
+        import { forwardRef } from 'react'
+        const Component = forwardRef(function (props) {
+          return null;
+        });
+      `,
+      errors: [{ message }],
+    },
+    {
+      code: `
+        import * as React from 'react'
+        React.forwardRef(function Component(props) {
+          return null;
+        });
+      `,
+      errors: [{ message }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/forward-ref-uses-ref` rule from `eslint-plugin-react` to rslint.

The rule reports React `forwardRef` callbacks that accept props but do not declare the `ref` parameter, and provides suggestions to add the ref parameter or remove the `forwardRef` wrapper.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forward-ref-uses-ref.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/forward-ref-uses-ref.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
