### PR TITLE
feat: port rule import/default

### DIFF
--- a/internal/plugins/import/all.go
+++ b/internal/plugins/import/all.go
@@ -1,6 +1,7 @@
 package import_plugin
 
 import (
+	default_rule "github.com/web-infra-dev/rslint/internal/plugins/import/rules/default"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/first"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/newline_after_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_duplicates"
@@ -12,6 +13,7 @@ import (
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
+		default_rule.DefaultRule,
 		first.FirstRule,
 		newline_after_import.NewlineAfterImportRule,
 		no_duplicates.NoDuplicatesRule,

--- a/internal/plugins/import/fixtures/bar.ts
+++ b/internal/plugins/import/fixtures/bar.ts
@@ -1,0 +1,3 @@
+export default function bar() {}
+
+export const foo = 1;

--- a/internal/plugins/import/fixtures/broken-trampoline.ts
+++ b/internal/plugins/import/fixtures/broken-trampoline.ts
@@ -1,0 +1,1 @@
+export { default } from './named-exports';

--- a/internal/plugins/import/fixtures/common.js
+++ b/internal/plugins/import/fixtures/common.js
@@ -1,0 +1,8 @@
+module.exports = {
+  a: 1,
+  b: 2,
+};
+
+var c = 3;
+
+exports.d = c;

--- a/internal/plugins/import/fixtures/common.ts
+++ b/internal/plugins/import/fixtures/common.ts
@@ -1,0 +1,1 @@
+module.exports = function common() {};

--- a/internal/plugins/import/fixtures/cycle-default-a.ts
+++ b/internal/plugins/import/fixtures/cycle-default-a.ts
@@ -1,0 +1,1 @@
+export { default } from './cycle-default-b';

--- a/internal/plugins/import/fixtures/cycle-default-b.ts
+++ b/internal/plugins/import/fixtures/cycle-default-b.ts
@@ -1,0 +1,1 @@
+export { default } from './cycle-default-a';

--- a/internal/plugins/import/fixtures/cycle-with-local-default-a.ts
+++ b/internal/plugins/import/fixtures/cycle-with-local-default-a.ts
@@ -1,0 +1,2 @@
+export default 1;
+export { default as again } from './cycle-with-local-default-b';

--- a/internal/plugins/import/fixtures/cycle-with-local-default-b.ts
+++ b/internal/plugins/import/fixtures/cycle-with-local-default-b.ts
@@ -1,0 +1,1 @@
+export { again as default } from './cycle-with-local-default-a';

--- a/internal/plugins/import/fixtures/default-class.ts
+++ b/internal/plugins/import/fixtures/default-class.ts
@@ -1,0 +1,1 @@
+export default class CoolClass {}

--- a/internal/plugins/import/fixtures/default-export-from-ignored.js
+++ b/internal/plugins/import/fixtures/default-export-from-ignored.js
@@ -1,0 +1,1 @@
+export { foo as default } from './common.js';

--- a/internal/plugins/import/fixtures/default-export-from-named.ts
+++ b/internal/plugins/import/fixtures/default-export-from-named.ts
@@ -1,0 +1,1 @@
+export { foo as default } from './named-exports';

--- a/internal/plugins/import/fixtures/default-export-from.ts
+++ b/internal/plugins/import/fixtures/default-export-from.ts
@@ -1,0 +1,1 @@
+export { default } from './default-export';

--- a/internal/plugins/import/fixtures/default-export.ts
+++ b/internal/plugins/import/fixtures/default-export.ts
@@ -1,0 +1,3 @@
+export default function foo() {}
+
+export const baz = 1;

--- a/internal/plugins/import/fixtures/destructured-exports.ts
+++ b/internal/plugins/import/fixtures/destructured-exports.ts
@@ -1,0 +1,1 @@
+export const { renamed } = { renamed: 1 };

--- a/internal/plugins/import/fixtures/ignored-missing-default.ts
+++ b/internal/plugins/import/fixtures/ignored-missing-default.ts
@@ -1,0 +1,1 @@
+export const onlyNamed = 1;

--- a/internal/plugins/import/fixtures/jsx/App.tsx
+++ b/internal/plugins/import/fixtures/jsx/App.tsx
@@ -1,0 +1,3 @@
+export default function App() {
+  return null;
+}

--- a/internal/plugins/import/fixtures/jsx/FooES7.js
+++ b/internal/plugins/import/fixtures/jsx/FooES7.js
@@ -1,0 +1,17 @@
+// see issue #36
+
+// Foo.jsx
+class Foo {
+  // ES7 static members
+  static bar = true;
+}
+
+export default Foo;
+
+export class Bar {
+  static baz = false;
+
+  render() {
+    let { a, ...rest } = { a: 1, b: 2, c: 3 };
+  }
+}

--- a/internal/plugins/import/fixtures/jsx/MyCoolComponent.jsx
+++ b/internal/plugins/import/fixtures/jsx/MyCoolComponent.jsx
@@ -1,0 +1,3 @@
+export default function MyCoolComponent() {
+  return null;
+}

--- a/internal/plugins/import/fixtures/mixed-exports.ts
+++ b/internal/plugins/import/fixtures/mixed-exports.ts
@@ -1,0 +1,3 @@
+export default function foo() {}
+
+export const bar = 1;

--- a/internal/plugins/import/fixtures/multi-star-reexport.ts
+++ b/internal/plugins/import/fixtures/multi-star-reexport.ts
@@ -1,0 +1,2 @@
+export * from './named-exports';
+export * from './default-export';

--- a/internal/plugins/import/fixtures/named-default-export.ts
+++ b/internal/plugins/import/fixtures/named-default-export.ts
@@ -1,0 +1,3 @@
+const foo = 1;
+
+export { foo as default };

--- a/internal/plugins/import/fixtures/named-exports.ts
+++ b/internal/plugins/import/fixtures/named-exports.ts
@@ -1,0 +1,3 @@
+export const a = 1;
+export const bar = 2;
+export const foo = 3;

--- a/internal/plugins/import/fixtures/namespace-default.ts
+++ b/internal/plugins/import/fixtures/namespace-default.ts
@@ -1,0 +1,1 @@
+export * as default from './default-export';

--- a/internal/plugins/import/fixtures/re-export.ts
+++ b/internal/plugins/import/fixtures/re-export.ts
@@ -1,0 +1,1 @@
+export * from './default-export';

--- a/internal/plugins/import/fixtures/redux.ts
+++ b/internal/plugins/import/fixtures/redux.ts
@@ -1,0 +1,3 @@
+const connectedApp = {};
+
+export default connectedApp;

--- a/internal/plugins/import/fixtures/reexport-missing-as-default.ts
+++ b/internal/plugins/import/fixtures/reexport-missing-as-default.ts
@@ -1,0 +1,1 @@
+export { missing as default } from './named-exports';

--- a/internal/plugins/import/fixtures/reexport-unresolved-as-default.ts
+++ b/internal/plugins/import/fixtures/reexport-unresolved-as-default.ts
@@ -1,0 +1,1 @@
+export { missing as default } from './does-not-exist';

--- a/internal/plugins/import/fixtures/trampoline.ts
+++ b/internal/plugins/import/fixtures/trampoline.ts
@@ -1,0 +1,1 @@
+export { default } from './default-export';

--- a/internal/plugins/import/fixtures/tsconfig.allow-js.json
+++ b/internal/plugins/import/fixtures/tsconfig.allow-js.json
@@ -1,13 +1,12 @@
 {
   "compilerOptions": {
     "jsx": "preserve",
-    "target": "es5",
+    "target": "esnext",
     "module": "commonjs",
     "strict": true,
-    "esModuleInterop": false,
-    "lib": ["es2015", "es2017", "esnext"],
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
     "allowJs": true,
     "experimentalDecorators": true
-  },
-  "include": ["files/**/*", "fixtures/**/*"]
+  }
 }

--- a/internal/plugins/import/fixtures/tsconfig.no-interop.json
+++ b/internal/plugins/import/fixtures/tsconfig.no-interop.json
@@ -1,13 +1,11 @@
 {
   "compilerOptions": {
     "jsx": "preserve",
-    "target": "es5",
+    "target": "esnext",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": false,
-    "lib": ["es2015", "es2017", "esnext"],
-    "allowJs": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
     "experimentalDecorators": true
-  },
-  "include": ["files/**/*", "fixtures/**/*"]
+  }
 }

--- a/internal/plugins/import/fixtures/typescript-default.ts
+++ b/internal/plugins/import/fixtures/typescript-default.ts
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/internal/plugins/import/fixtures/typescript-export-as-default-namespace/index.d.ts
+++ b/internal/plugins/import/fixtures/typescript-export-as-default-namespace/index.d.ts
@@ -1,0 +1,3 @@
+export as namespace Foo;
+
+export function bar(): void;

--- a/internal/plugins/import/fixtures/typescript-export-assign-default-namespace/index.d.ts
+++ b/internal/plugins/import/fixtures/typescript-export-assign-default-namespace/index.d.ts
@@ -1,0 +1,3 @@
+export = FooBar;
+
+declare namespace FooBar {}

--- a/internal/plugins/import/fixtures/typescript-export-assign-default-reexport.ts
+++ b/internal/plugins/import/fixtures/typescript-export-assign-default-reexport.ts
@@ -1,0 +1,3 @@
+import { getFoo } from './typescript';
+
+export = getFoo;

--- a/internal/plugins/import/fixtures/typescript-export-assign-default.ts
+++ b/internal/plugins/import/fixtures/typescript-export-assign-default.ts
@@ -1,0 +1,3 @@
+const foo = 1;
+
+export = foo;

--- a/internal/plugins/import/fixtures/typescript-export-assign-function.ts
+++ b/internal/plugins/import/fixtures/typescript-export-assign-function.ts
@@ -1,0 +1,3 @@
+function foo() {}
+
+export = foo;

--- a/internal/plugins/import/fixtures/typescript-export-assign-local.ts
+++ b/internal/plugins/import/fixtures/typescript-export-assign-local.ts
@@ -1,0 +1,3 @@
+const local = 1;
+
+export = local;

--- a/internal/plugins/import/fixtures/typescript-export-assign-mixed.d.ts
+++ b/internal/plugins/import/fixtures/typescript-export-assign-mixed.d.ts
@@ -1,0 +1,11 @@
+export = foobar;
+
+declare function foobar(): void;
+declare namespace foobar {
+  type MyType = string;
+  enum MyEnum {
+    Foo,
+    Bar,
+    Baz,
+  }
+}

--- a/internal/plugins/import/fixtures/typescript-export-assign-property.ts
+++ b/internal/plugins/import/fixtures/typescript-export-assign-property.ts
@@ -1,0 +1,3 @@
+const AnalyticsNode = { Analytics: {} };
+
+export = AnalyticsNode.Analytics;

--- a/internal/plugins/import/fixtures/typescript-export-react-test-renderer/index.d.ts
+++ b/internal/plugins/import/fixtures/typescript-export-react-test-renderer/index.d.ts
@@ -1,0 +1,11 @@
+export {};
+
+export interface ReactTestRendererJSON {
+  type: string;
+  props: { [propName: string]: any };
+  children: null | ReactTestRendererNode[];
+}
+
+export type ReactTestRendererNode = ReactTestRendererJSON | string;
+
+export function create(nextElement: any, options?: any): any;

--- a/internal/plugins/import/fixtures/typescript-extended-config/index.d.ts
+++ b/internal/plugins/import/fixtures/typescript-extended-config/index.d.ts
@@ -1,0 +1,3 @@
+export = FooBar;
+
+declare namespace FooBar {}

--- a/internal/plugins/import/fixtures/typescript.ts
+++ b/internal/plugins/import/fixtures/typescript.ts
@@ -1,0 +1,15 @@
+export type MyType = string;
+
+export enum MyEnum {
+  Foo,
+  Bar,
+  Baz,
+}
+
+export function getFoo(): MyType {
+  return 'foo';
+}
+
+export namespace MyNamespace {
+  export function namespaceFunction() {}
+}

--- a/internal/plugins/import/rules/default/default.go
+++ b/internal/plugins/import/rules/default/default.go
@@ -1,0 +1,45 @@
+package default_rule
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	import_utils "github.com/web-infra-dev/rslint/internal/plugins/import/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// DefaultRule ensures a default export is present when a module is imported
+// through a default import.
+//
+// See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/default.js
+var DefaultRule = rule.Rule{
+	Name: "import/default",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		checkDefault := func(node *ast.Node) {
+			importDecl := node.AsImportDeclaration()
+			if importDecl.ImportClause == nil {
+				return
+			}
+
+			defaultSpecifier := importDecl.ImportClause.AsImportClause().Name()
+			if defaultSpecifier == nil {
+				return
+			}
+
+			hasDefault, ok := import_utils.HasDefaultExport(ctx, importDecl.ModuleSpecifier)
+			if !ok || hasDefault {
+				return
+			}
+
+			ctx.ReportNode(defaultSpecifier, rule.RuleMessage{
+				Id:          "noDefault",
+				Description: fmt.Sprintf("No default export found in imported module %q.", importDecl.ModuleSpecifier.Text()),
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindImportDeclaration:   checkDefault,
+			ast.KindJSImportDeclaration: checkDefault,
+		}
+	},
+}

--- a/internal/plugins/import/rules/default/default.md
+++ b/internal/plugins/import/rules/default/default.md
@@ -1,0 +1,31 @@
+# default
+
+## Rule Details
+
+This rule reports a default import when the imported module does not provide a default export.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+// ./bar.js
+export const bar = 1;
+
+// ./foo.js
+import bar from "./bar";
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+// ./bar.js
+export default 1;
+
+// ./foo.js
+import bar from "./bar";
+```
+
+Modules that cannot be resolved, are ignored, or are not ES modules are not reported by this rule.
+
+## Original Documentation
+
+- [eslint-plugin-import/default](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md)

--- a/internal/plugins/import/rules/default/default_extras_test.go
+++ b/internal/plugins/import/rules/default/default_extras_test.go
@@ -1,0 +1,152 @@
+package default_rule_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	default_rule "github.com/web-infra-dev/rslint/internal/plugins/import/rules/default"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	rslint_utils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// TestDefaultExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the
+// specific branch / Dimension 4 row it covers, so future refactors can't
+// silently regress them without breaking a named lock-in.
+func TestDefaultExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&default_rule.DefaultRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: declaration forms, side-effect import has no default specifier ----
+			{Code: `import "./named-exports";`},
+			// ---- Dimension 4: declaration forms, namespace import has no default specifier ----
+			{Code: `import * as ns from "./named-exports";`},
+			// ---- Dimension 4: declaration forms, named import has no default specifier ----
+			{Code: `import { foo } from "./named-exports";`},
+			// ---- Dimension 4: access/key forms N/A, import declarations have no receiver/key expression ----
+			// ---- Dimension 4: receiver/expression wrappers N/A, default import specifiers cannot be parenthesized ----
+			// ---- Dimension 4: nesting/traversal boundaries N/A, ES imports are module-level declarations ----
+			// ---- Dimension 4: graceful degradation, unresolved module returns no export map ----
+			{Code: `import missing from "./does-not-exist";`},
+			// Locks in upstream checkDefault branch 1: defaultSpecifier is absent.
+			{Code: `import { default as namedDefault } from "./named-exports";`},
+			// Locks in upstream checkDefault branch 2: ExportMapBuilder.get returns null for non-ES modules.
+			{Code: `import common from "./common";`},
+			// Locks in upstream checkDefault branch 4: exports.get("default") is present.
+			{Code: `import value from "./namespace-default";`},
+			// ---- Real-user: #54 named export re-exported as default ----
+			{Code: `import foo from "./named-default-export";`},
+			// ---- Real-user: #545 default re-export from another module ----
+			{Code: `import foo from "./default-export-from";`},
+			// ---- Dimension 4: explicit unresolved default re-export is not reported ----
+			{Code: `import foo from "./reexport-unresolved-as-default";`},
+			// ---- Dimension 4: re-export cycle with a local default terminates as valid ----
+			{Code: `import foo from "./cycle-with-local-default-a";`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: declaration forms, default import plus named imports still checks the default specifier ----
+			{
+				Code:     `import missing, { foo } from "./named-exports";`,
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: noDefaultFromNamedExports, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// ---- Dimension 4: declaration forms, type-only default import still has a default specifier ----
+			{
+				Code:     `import type Missing from "./named-exports";`,
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: noDefaultFromNamedExports, Line: 1, Column: 13, EndLine: 1, EndColumn: 20},
+				},
+			},
+			// ---- Dimension 4: diagnostic position on multiline import declaration ----
+			{
+				Code:     "import\n  baz\nfrom \"./named-exports\";",
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: noDefaultFromNamedExports, Line: 2, Column: 3, EndLine: 2, EndColumn: 6},
+				},
+			},
+			// Locks in upstream checkDefault branch 3: exports.get("default") is undefined.
+			{
+				Code:     `import missing from "./named-exports";`,
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: noDefaultFromNamedExports, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// ---- Real-user: #328 star exports do not include default ----
+			{
+				Code: `import barDefault from "./re-export";`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: `No default export found in imported module "./re-export".`, Line: 1, Column: 8, EndLine: 1, EndColumn: 18},
+				},
+			},
+			// ---- Dimension 4: explicit default re-export checks the remote local name ----
+			{
+				Code: `import missing from "./reexport-missing-as-default";`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: `No default export found in imported module "./reexport-missing-as-default".`, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// ---- Dimension 4: re-export cycle without a local default terminates as missing ----
+			{
+				Code: `import cycle from "./cycle-default-a";`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: `No default export found in imported module "./cycle-default-a".`, Line: 1, Column: 8, EndLine: 1, EndColumn: 13},
+				},
+			},
+		},
+	)
+}
+
+func TestDefaultSkippedBabelReExportSyntaxIsNotParsedByTsgo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code string
+	}{
+		{name: "default re-export", code: `export bar from "./bar"`},
+		{name: "default plus named re-export", code: `export bar, { foo } from "./bar"`},
+		{name: "default plus namespace re-export", code: `export bar, * as names from "./bar"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rootDir := fixtures.GetRootDir()
+			fileName := "file.ts"
+			fs := rslint_utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), tc.code)
+			host := rslint_utils.CreateCompilerHost(rootDir, fs)
+			_, err := rslint_utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+			if err == nil {
+				t.Fatalf("expected tsgo parse error for %q", tc.code)
+			}
+			var syntacticError *rslint_utils.SyntacticError
+			if !errors.As(err, &syntacticError) {
+				t.Fatalf("expected *utils.SyntacticError for %q, got %T: %v", tc.code, err, err)
+			}
+		})
+	}
+}
+
+func TestDefaultSkippedFooES7ParseErrorIsParsedByTsgo(t *testing.T) {
+	t.Parallel()
+
+	rootDir := fixtures.GetRootDir()
+	fileName := "foo-es7-consumer.ts"
+	code := `import Foo from "./jsx/FooES7.js";`
+	fs := rslint_utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := rslint_utils.CreateCompilerHost(rootDir, fs)
+	if _, err := rslint_utils.CreateProgram(true, fs, rootDir, "tsconfig.allow-js.json", host); err != nil {
+		t.Fatalf("expected tsgo to parse upstream FooES7.js fixture, got %T: %v", err, err)
+	}
+}

--- a/internal/plugins/import/rules/default/default_upstream_test.go
+++ b/internal/plugins/import/rules/default/default_upstream_test.go
@@ -1,0 +1,203 @@
+package default_rule_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	default_rule "github.com/web-infra-dev/rslint/internal/plugins/import/rules/default"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const noDefaultFromNamedExports = `No default export found in imported module "./named-exports".`
+
+// TestDefaultUpstream migrates the valid/invalid suite from upstream
+// tests/src/rules/default.js 1:1 where tsgo supports the syntax and framework
+// hooks. Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in default_extras_test.go.
+func TestDefaultUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&default_rule.DefaultRule,
+		[]rule_tester.ValidTestCase{
+			// ---- upstream valid: no default specifier ----
+			{Code: `import "./malformed.js"`},
+			{Code: `import { foo } from "./default-export";`},
+			{Code: `export {a} from "./named-exports"`},
+
+			// ---- upstream valid: unresolved / non-ES modules return no export map ----
+			{Code: `import foo from "./empty-folder";`},
+			{Code: `import crypto from "crypto";`},
+			{Code: `import common from "./common";`},
+
+			// ---- upstream valid: direct default exports ----
+			{Code: `import foo from "./default-export";`},
+			{Code: `import foo from "./mixed-exports";`},
+			{Code: `import bar from "./default-export";`},
+			{Code: `import CoolClass from "./default-class";`},
+			{Code: `import bar, { baz } from "./default-export";`},
+			{Code: `import connectedApp from "./redux"`},
+			{Code: `import MyCoolComponent from "./jsx/MyCoolComponent.jsx"`, TSConfig: "tsconfig.allow-js.json"},
+			{Code: `import App from "./jsx/App"`, TSConfig: "tsconfig.allow-js.json"},
+			{Code: `import Foo from './jsx/FooES7.js';`, TSConfig: "tsconfig.allow-js.json"},
+
+			// ---- upstream valid: default is exported under the name default ----
+			{Code: `import foo from "./named-default-export"`},
+
+			// ---- upstream valid: default re-export chains ----
+			{Code: `import twofer from "./trampoline"`},
+			{Code: `import bar from "./default-export-from";`},
+			{Code: `import bar from "./default-export-from-named";`},
+
+			// ---- upstream valid: TypeScript export assignment forms ----
+			{Code: `import foobar from "./typescript-default"`},
+			{Code: `import foobar from "./typescript-export-assign-default"`},
+			{Code: `import foobar from "./typescript-export-assign-function"`},
+			{Code: `import foobar from "./typescript-export-assign-mixed"`},
+			{Code: `import foobar from "./typescript-export-assign-default-reexport"`},
+			{Code: `import foobar from "./typescript-export-assign-property"`},
+
+			// ---- upstream valid: named default re-export is not this rule's default specifier branch ----
+			{Code: `export { default as bar } from "./bar"`},
+			{Code: `export { default as bar, foo } from "./bar"`},
+			{Code: `export { "default" as bar } from "./bar"`},
+
+			// SKIP: rslint does not parse Babel's default re-export proposal `export foo from`.
+			{Code: `export bar from "./bar"`, Skip: true},
+			// SKIP: rslint does not parse Babel's default re-export proposal `export foo, { bar } from`.
+			{Code: `export bar, { foo } from "./bar"`, Skip: true},
+			// SKIP: rslint does not parse Babel's default re-export proposal `export foo, * as ns from`.
+			{Code: `export bar, * as names from "./bar"`, Skip: true},
+			{Code: `import bar from './default-export-from-ignored.js';`, Settings: map[string]interface{}{"import/ignore": []interface{}{"common"}}, TSConfig: "tsconfig.allow-js.json"},
+			// SKIP: rslint does not parse Babel's default re-export proposal `export foo from`.
+			{Code: `export bar from './default-export-from-ignored.js';`, Skip: true},
+			{Code: `import React from "./typescript-export-assign-default-namespace"`},
+			{Code: `import Foo from "./typescript-export-as-default-namespace"`},
+			{Code: `import Foo from "./typescript-export-react-test-renderer"`},
+			{Code: `import Foo from "./typescript-extended-config"`},
+			// SKIP: upstream only runs this case on case-insensitive filesystems.
+			{Code: `import foo from "./jsx/MyUncoolComponent.jsx"`, Skip: true},
+
+			// ---- upstream valid: SYNTAX_CASES parser smoke cases with no default-import diagnostics ----
+			{Code: `for (let { foo, bar } of baz) {}`},
+			{Code: `for (let [ foo, bar ] of baz) {}`},
+			{Code: `const { x, y } = bar`},
+			{Code: `const { x, y, ...z } = bar`},
+			{Code: `let x; export { x }`},
+			{Code: `let x; export { x as y }`},
+			{Code: `export const x = null`},
+			{Code: `export var x = null`},
+			{Code: `export let x = null`},
+			{Code: `export default x`},
+			{Code: `export default class x {}`},
+			{Code: `import json from "./data.json"`},
+			{Code: `import foo from "./foobar.json";`},
+			{Code: `import foo from "./foobar";`},
+			{Code: `import { foo } from "./issue-370-commonjs-namespace/bar"`},
+			{Code: `export * from "./issue-370-commonjs-namespace/bar"`},
+			{Code: `import * as a from "./commonjs-namespace/a"; a.b`},
+			{Code: `import { foo } from "./ignore.invalid.extension"`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// SKIP: upstream's default parser rejects class fields in FooES7.js; tsgo parses that fixture.
+			{
+				Code: `import Foo from './jsx/FooES7.js';`,
+				Skip: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault"},
+				},
+			},
+			{
+				Code:     `import baz from "./named-exports";`,
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noDefault",
+						Message:   noDefaultFromNamedExports,
+						Line:      1,
+						Column:    8,
+						EndLine:   1,
+						EndColumn: 11,
+					},
+				},
+			},
+			// SKIP: rslint does not parse Babel's default re-export proposal `export foo from`.
+			{
+				Code: `export baz from "./named-exports"`,
+				Skip: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault"},
+				},
+			},
+			// SKIP: rslint does not parse Babel's default re-export proposal `export foo, { bar } from`.
+			{
+				Code: `export baz, { bar } from "./named-exports"`,
+				Skip: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault"},
+				},
+			},
+			// SKIP: rslint does not parse Babel's default re-export proposal `export foo, * as ns from`.
+			{
+				Code: `export baz, * as names from "./named-exports"`,
+				Skip: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault"},
+				},
+			},
+			{
+				Code:     `import twofer from "./broken-trampoline"`,
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: `No default export found in imported module "./broken-trampoline".`, Line: 1, Column: 8, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `import barDefault from "./re-export"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: `No default export found in imported module "./re-export".`, Line: 1, Column: 8, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:     `import foobar from "./typescript"`,
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: `No default export found in imported module "./typescript".`, Line: 1, Column: 8, EndLine: 1, EndColumn: 14},
+				},
+			},
+			// SKIP: upstream only runs this case on case-insensitive filesystems.
+			{
+				Code: `import bar from "./Named-Exports"`,
+				Skip: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault"},
+				},
+			},
+			// Upstream invalid branch without parserOptions.tsconfigRootDir.
+			{
+				Code:     `import React from "./typescript-export-assign-default-namespace"`,
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: `No default export found in imported module "./typescript-export-assign-default-namespace".`, Line: 1, Column: 8, EndLine: 1, EndColumn: 13},
+				},
+			},
+			// Upstream invalid branch without parserOptions.tsconfigRootDir.
+			{
+				Code:     `import FooBar from "./typescript-export-as-default-namespace"`,
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: `No default export found in imported module "./typescript-export-as-default-namespace".`, Line: 1, Column: 8, EndLine: 1, EndColumn: 14},
+				},
+			},
+			// Upstream invalid branch with tsconfigRootDir pointing at a config without compiler options.
+			{
+				Code:     `import Foo from "./typescript-export-as-default-namespace"`,
+				TSConfig: "tsconfig.no-interop.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDefault", Message: `No default export found in imported module "./typescript-export-as-default-namespace".`, Line: 1, Column: 8, EndLine: 1, EndColumn: 11},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/import/utils/export_map.go
+++ b/internal/plugins/import/utils/export_map.go
@@ -1,0 +1,415 @@
+package utils
+
+import (
+	"regexp"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	rslint_utils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const defaultExportName = "default"
+
+// HasDefaultExport resolves moduleSpecifier from ctx.SourceFile and reports
+// whether the resolved module has a statically visible default export. The
+// second result is false when no export map is available, matching
+// eslint-plugin-import's "imports == null" branch.
+func HasDefaultExport(ctx rule.RuleContext, moduleSpecifier *ast.Node) (bool, bool) {
+	return HasExport(ctx, moduleSpecifier, defaultExportName)
+}
+
+// HasExport resolves moduleSpecifier from ctx.SourceFile and reports whether
+// the resolved module statically exports exportName. The second result is false
+// when the target is unresolved or is not an ES module.
+func HasExport(ctx rule.RuleContext, moduleSpecifier *ast.Node, exportName string) (bool, bool) {
+	if ctx.Program == nil || ctx.SourceFile == nil || moduleSpecifier == nil || !ast.IsStringLiteralLike(moduleSpecifier) {
+		return false, false
+	}
+	return hasExport(ctx, ctx.SourceFile, moduleSpecifier, exportName, make(map[exportKey]bool))
+}
+
+type exportKey struct {
+	fileName string
+	name     string
+}
+
+func hasExport(ctx rule.RuleContext, origin *ast.SourceFile, moduleSpecifier *ast.Node, exportName string, seen map[exportKey]bool) (bool, bool) {
+	resolved := ctx.Program.GetResolvedModuleFromModuleSpecifier(origin, moduleSpecifier)
+	if resolved == nil || resolved.ResolvedFileName == "" {
+		return false, false
+	}
+
+	sourceFile := ctx.Program.GetSourceFileForResolvedModule(resolved.ResolvedFileName)
+	if sourceFile == nil {
+		return false, false
+	}
+	if IsImportPathIgnored(ctx.Settings, sourceFile.FileName()) {
+		return false, false
+	}
+
+	return sourceFileHasExport(ctx, sourceFile, exportName, seen)
+}
+
+// IsImportPathIgnored matches eslint-plugin-import's shared `import/ignore`
+// setting for resolved import target paths.
+func IsImportPathIgnored(settings map[string]interface{}, fileName string) bool {
+	if settings == nil {
+		return false
+	}
+
+	rawPatterns, ok := settings["import/ignore"]
+	if !ok {
+		return false
+	}
+
+	var patterns []string
+	switch typed := rawPatterns.(type) {
+	case []string:
+		patterns = typed
+	case []interface{}:
+		for _, item := range typed {
+			if pattern, ok := item.(string); ok {
+				patterns = append(patterns, pattern)
+			}
+		}
+	}
+
+	for _, pattern := range patterns {
+		re, err := regexp.Compile(pattern)
+		if err == nil && re.MatchString(fileName) {
+			return true
+		}
+	}
+	return false
+}
+
+func sourceFileHasExport(ctx rule.RuleContext, sourceFile *ast.SourceFile, exportName string, seen map[exportKey]bool) (bool, bool) {
+	if sourceFile == nil || !ast.IsExternalModule(sourceFile) {
+		return false, false
+	}
+
+	key := exportKey{fileName: sourceFile.FileName(), name: exportName}
+	if seen[key] {
+		return false, true
+	}
+	seen[key] = true
+	defer delete(seen, key)
+
+	statements := sourceFile.Statements
+	if statements == nil {
+		return false, true
+	}
+
+	for _, stmt := range statements.Nodes {
+		if stmt == nil {
+			continue
+		}
+
+		if exportedDeclarationHasName(stmt, exportName) {
+			return true, true
+		}
+
+		switch stmt.Kind {
+		case ast.KindExportAssignment:
+			if exportName == defaultExportName && exportAssignmentHasDefault(ctx, sourceFile, stmt.AsExportAssignment()) {
+				return true, true
+			}
+		case ast.KindNamespaceExportDeclaration:
+			if exportName == defaultExportName && compilerOptionsESModuleInterop(ctx) {
+				return true, true
+			}
+		case ast.KindExportDeclaration:
+			found, done := exportDeclarationHasName(ctx, sourceFile, stmt.AsExportDeclaration(), exportName, seen)
+			if done {
+				return found, true
+			}
+		}
+	}
+
+	if exportName == defaultExportName && compilerOptionsESModuleInterop(ctx) && sourceFileHasDirectNamespaceExport(sourceFile) {
+		return true, true
+	}
+
+	return false, true
+}
+
+func exportedDeclarationHasName(stmt *ast.Node, exportName string) bool {
+	if !ast.HasSyntacticModifier(stmt, ast.ModifierFlagsExport) {
+		return false
+	}
+
+	if ast.HasSyntacticModifier(stmt, ast.ModifierFlagsDefault) {
+		return exportName == defaultExportName
+	}
+
+	switch stmt.Kind {
+	case ast.KindVariableStatement:
+		return variableStatementDeclaresName(stmt, exportName)
+	case ast.KindFunctionDeclaration,
+		ast.KindClassDeclaration,
+		ast.KindInterfaceDeclaration,
+		ast.KindTypeAliasDeclaration,
+		ast.KindEnumDeclaration,
+		ast.KindModuleDeclaration:
+		name := stmt.Name()
+		return name != nil && moduleExportNameMatches(name, exportName)
+	}
+
+	return false
+}
+
+func exportAssignmentHasDefault(ctx rule.RuleContext, sourceFile *ast.SourceFile, exportAssignment *ast.ExportAssignment) bool {
+	if exportAssignment == nil {
+		return false
+	}
+	if !exportAssignment.IsExportEquals {
+		return true
+	}
+
+	// Match eslint-plugin-import's TypeScript export-assignment visitor:
+	// `export = namespace` gets a synthetic default only under esModuleInterop,
+	// while non-namespace local declarations and re-export-like expressions do.
+	name, ok := exportAssignmentReferencedName(exportAssignment.Expression)
+	if !ok {
+		return true
+	}
+	kind, ok := sourceFileExportAssignmentLocalDeclarationKind(sourceFile, name)
+	if !ok {
+		return true
+	}
+	if kind != exportAssignmentLocalDeclarationModule {
+		return true
+	}
+	return compilerOptionsESModuleInterop(ctx)
+}
+
+// The tsgo shim exposes CompilerOptions fields but not GetESModuleInterop.
+func compilerOptionsESModuleInterop(ctx rule.RuleContext) bool {
+	if ctx.Program == nil || ctx.Program.Options() == nil {
+		return false
+	}
+	options := ctx.Program.Options()
+	if options.ESModuleInterop != core.TSUnknown {
+		return options.ESModuleInterop == core.TSTrue
+	}
+	switch options.Module {
+	case core.ModuleKindNode16, core.ModuleKindNodeNext, core.ModuleKindPreserve:
+		return true
+	default:
+		return false
+	}
+}
+
+func exportAssignmentReferencedName(expr *ast.Node) (string, bool) {
+	expr = ast.SkipParentheses(expr)
+	if expr == nil {
+		return "", false
+	}
+	switch expr.Kind {
+	case ast.KindIdentifier:
+		return expr.AsIdentifier().Text, true
+	case ast.KindFunctionExpression, ast.KindClassExpression:
+		name := expr.Name()
+		if name != nil {
+			return name.Text(), true
+		}
+	}
+	return "", false
+}
+
+type exportAssignmentLocalDeclarationKind int
+
+const (
+	exportAssignmentLocalDeclarationOther exportAssignmentLocalDeclarationKind = iota
+	exportAssignmentLocalDeclarationModule
+)
+
+func sourceFileExportAssignmentLocalDeclarationKind(sourceFile *ast.SourceFile, name string) (exportAssignmentLocalDeclarationKind, bool) {
+	if sourceFile == nil || sourceFile.Statements == nil {
+		return exportAssignmentLocalDeclarationOther, false
+	}
+	for _, stmt := range sourceFile.Statements.Nodes {
+		if stmt == nil {
+			continue
+		}
+
+		switch stmt.Kind {
+		case ast.KindVariableStatement:
+			if variableStatementDeclaresName(stmt, name) {
+				return exportAssignmentLocalDeclarationOther, true
+			}
+		case ast.KindFunctionDeclaration:
+			if ast.HasSyntacticModifier(stmt, ast.ModifierFlagsAmbient) && declarationHasName(stmt, name) {
+				return exportAssignmentLocalDeclarationOther, true
+			}
+		case ast.KindClassDeclaration,
+			ast.KindInterfaceDeclaration,
+			ast.KindTypeAliasDeclaration,
+			ast.KindEnumDeclaration:
+			if declarationHasName(stmt, name) {
+				return exportAssignmentLocalDeclarationOther, true
+			}
+		case ast.KindModuleDeclaration:
+			if declarationHasName(stmt, name) {
+				return exportAssignmentLocalDeclarationModule, true
+			}
+		}
+	}
+	return exportAssignmentLocalDeclarationOther, false
+}
+
+func declarationHasName(stmt *ast.Node, name string) bool {
+	declName := stmt.Name()
+	return declName != nil && moduleExportNameMatches(declName, name)
+}
+
+func variableStatementDeclaresName(stmt *ast.Node, name string) bool {
+	declList := stmt.AsVariableStatement().DeclarationList
+	if declList == nil || !ast.IsVariableDeclarationList(declList) {
+		return false
+	}
+	for _, decl := range declList.AsVariableDeclarationList().Declarations.Nodes {
+		if decl == nil || !ast.IsVariableDeclaration(decl) {
+			continue
+		}
+		matched := false
+		rslint_utils.CollectBindingNames(decl.AsVariableDeclaration().Name(), func(_ *ast.Node, bindingName string) {
+			if bindingName == name {
+				matched = true
+			}
+		})
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+func sourceFileHasDirectNamespaceExport(sourceFile *ast.SourceFile) bool {
+	if sourceFile == nil || sourceFile.Statements == nil {
+		return false
+	}
+	for _, stmt := range sourceFile.Statements.Nodes {
+		if stmt == nil {
+			continue
+		}
+		if exportedDeclarationAddsNamespaceExport(stmt) {
+			return true
+		}
+		if stmt.Kind == ast.KindExportDeclaration && exportDeclarationAddsNamespaceExport(stmt.AsExportDeclaration()) {
+			return true
+		}
+	}
+	return false
+}
+
+func exportedDeclarationAddsNamespaceExport(stmt *ast.Node) bool {
+	if !ast.HasSyntacticModifier(stmt, ast.ModifierFlagsExport) {
+		return false
+	}
+	switch stmt.Kind {
+	case ast.KindVariableStatement,
+		ast.KindFunctionDeclaration,
+		ast.KindClassDeclaration,
+		ast.KindInterfaceDeclaration,
+		ast.KindTypeAliasDeclaration,
+		ast.KindEnumDeclaration,
+		ast.KindModuleDeclaration:
+		return true
+	}
+	return false
+}
+
+func exportDeclarationAddsNamespaceExport(exportDecl *ast.ExportDeclaration) bool {
+	if exportDecl == nil || exportDecl.ModuleSpecifier != nil || exportDecl.ExportClause == nil {
+		return false
+	}
+	switch exportDecl.ExportClause.Kind {
+	case ast.KindNamedExports:
+		namedExports := exportDecl.ExportClause.AsNamedExports()
+		return namedExports.Elements != nil && len(namedExports.Elements.Nodes) > 0
+	case ast.KindNamespaceExport:
+		return true
+	}
+	return false
+}
+
+func exportDeclarationHasName(ctx rule.RuleContext, sourceFile *ast.SourceFile, exportDecl *ast.ExportDeclaration, exportName string, seen map[exportKey]bool) (bool, bool) {
+	if exportDecl == nil {
+		return false, false
+	}
+
+	if exportDecl.ExportClause == nil {
+		if exportDecl.ModuleSpecifier == nil || exportName == defaultExportName {
+			return false, false
+		}
+		found, ok := hasExport(ctx, sourceFile, exportDecl.ModuleSpecifier, exportName, seen)
+		if !ok {
+			return true, true
+		}
+		return found, found
+	}
+
+	switch exportDecl.ExportClause.Kind {
+	case ast.KindNamedExports:
+		namedExports := exportDecl.ExportClause.AsNamedExports()
+		if namedExports.Elements == nil {
+			return false, false
+		}
+		for _, spec := range namedExports.Elements.Nodes {
+			if spec == nil || spec.Kind != ast.KindExportSpecifier {
+				continue
+			}
+
+			exportSpec := spec.AsExportSpecifier()
+			if !moduleExportNameMatches(exportSpec.Name(), exportName) {
+				continue
+			}
+
+			if exportDecl.ModuleSpecifier == nil {
+				return true, true
+			}
+
+			sourceName := exportSpec.PropertyName
+			if sourceName == nil {
+				sourceName = exportSpec.Name()
+			}
+
+			localName, ok := moduleExportName(sourceName)
+			if !ok {
+				return false, true
+			}
+
+			hasName, ok := hasExport(ctx, sourceFile, exportDecl.ModuleSpecifier, localName, seen)
+			if !ok {
+				return true, true
+			}
+			return hasName, hasName
+		}
+	case ast.KindNamespaceExport:
+		namespaceExport := exportDecl.ExportClause.AsNamespaceExport()
+		matched := moduleExportNameMatches(namespaceExport.Name(), exportName)
+		return matched, matched
+	}
+
+	return false, false
+}
+
+func moduleExportName(node *ast.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	return rslint_utils.GetStaticPropertyName(node)
+}
+
+func moduleExportNameMatches(node *ast.Node, exportName string) bool {
+	if node == nil {
+		return false
+	}
+	if exportName == defaultExportName {
+		return ast.ModuleExportNameIsDefault(node)
+	}
+	name, ok := moduleExportName(node)
+	return ok && name == exportName
+}

--- a/internal/plugins/import/utils/export_map_test.go
+++ b/internal/plugins/import/utils/export_map_test.go
@@ -1,0 +1,461 @@
+package utils_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	import_utils "github.com/web-infra-dev/rslint/internal/plugins/import/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	rslint_utils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestHasExport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		source     string
+		exportName string
+		wantFound  bool
+		wantOK     bool
+	}{
+		{
+			name:       "direct named export",
+			source:     "./named-exports",
+			exportName: "foo",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "direct TypeScript type export",
+			source:     "./typescript",
+			exportName: "MyType",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "direct TypeScript namespace export",
+			source:     "./typescript",
+			exportName: "MyNamespace",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "star export includes named exports",
+			source:     "./re-export",
+			exportName: "baz",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "multiple star exports continue after a miss",
+			source:     "./multi-star-reexport",
+			exportName: "baz",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "star export does not include default",
+			source:     "./re-export",
+			exportName: "default",
+			wantFound:  false,
+			wantOK:     true,
+		},
+		{
+			name:       "explicit default re-export resolves deeply",
+			source:     "./default-export-from",
+			exportName: "default",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "TypeScript export assignment re-export is default-visible",
+			source:     "./typescript-export-assign-default-reexport",
+			exportName: "default",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "TypeScript export assignment property expression is default-visible",
+			source:     "./typescript-export-assign-property",
+			exportName: "default",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "explicit re-export validates remote local name",
+			source:     "./reexport-missing-as-default",
+			exportName: "default",
+			wantFound:  false,
+			wantOK:     true,
+		},
+		{
+			name:       "explicit unresolved re-export is treated as present",
+			source:     "./reexport-unresolved-as-default",
+			exportName: "default",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "namespace export as default",
+			source:     "./namespace-default",
+			exportName: "default",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "commonjs target has no export map",
+			source:     "./common",
+			exportName: "default",
+			wantFound:  false,
+			wantOK:     false,
+		},
+		{
+			name:       "cycle without local default terminates",
+			source:     "./cycle-default-a",
+			exportName: "default",
+			wantFound:  false,
+			wantOK:     true,
+		},
+		{
+			name:       "cycle with local default wins before dependency walk",
+			source:     "./cycle-with-local-default-a",
+			exportName: "default",
+			wantFound:  true,
+			wantOK:     true,
+		},
+		{
+			name:       "exported destructuring binding",
+			source:     "./destructured-exports",
+			exportName: "renamed",
+			wantFound:  true,
+			wantOK:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, specifier := contextForImport(t, tc.source)
+			gotFound, gotOK := import_utils.HasExport(ctx, specifier, tc.exportName)
+			if gotFound != tc.wantFound || gotOK != tc.wantOK {
+				t.Fatalf("HasExport(%q, %q) = (%v, %v), want (%v, %v)", tc.source, tc.exportName, gotFound, gotOK, tc.wantFound, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestHasDefaultExportRespectsESModuleInterop(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		source            string
+		esModuleInterop   core.Tristate
+		wantDefaultExport bool
+	}{
+		{
+			name:              "named TypeScript exports synthesize default when enabled",
+			source:            "./typescript",
+			esModuleInterop:   core.TSTrue,
+			wantDefaultExport: true,
+		},
+		{
+			name:              "named TypeScript exports do not synthesize default when disabled",
+			source:            "./typescript",
+			esModuleInterop:   core.TSFalse,
+			wantDefaultExport: false,
+		},
+		{
+			name:              "export equals namespace synthesizes default when enabled",
+			source:            "./typescript-export-assign-default-namespace",
+			esModuleInterop:   core.TSTrue,
+			wantDefaultExport: true,
+		},
+		{
+			name:              "export equals namespace does not synthesize default when disabled",
+			source:            "./typescript-export-assign-default-namespace",
+			esModuleInterop:   core.TSFalse,
+			wantDefaultExport: false,
+		},
+		{
+			name:              "export equals local variable is default-visible when disabled",
+			source:            "./typescript-export-assign-local",
+			esModuleInterop:   core.TSFalse,
+			wantDefaultExport: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, specifier := contextForImportWithCompilerOptions(t, tc.source, &core.CompilerOptions{
+				ESModuleInterop: tc.esModuleInterop,
+			})
+			gotDefaultExport, gotOK := import_utils.HasDefaultExport(ctx, specifier)
+			if gotDefaultExport != tc.wantDefaultExport || !gotOK {
+				t.Fatalf("HasDefaultExport with esModuleInterop=%v = (%v, %v), want (%v, true)", tc.esModuleInterop, gotDefaultExport, gotOK, tc.wantDefaultExport)
+			}
+		})
+	}
+}
+
+func TestHasExportRespectsImportIgnore(t *testing.T) {
+	t.Parallel()
+
+	ctx, specifier := contextForImport(t, "./ignored-missing-default")
+	ctx.Settings = map[string]interface{}{
+		"import/ignore": []interface{}{"ignored-missing-default"},
+	}
+
+	gotDefaultExport, gotOK := import_utils.HasDefaultExport(ctx, specifier)
+	if gotDefaultExport || gotOK {
+		t.Fatalf("HasDefaultExport for ignored import = (%v, %v), want (false, false)", gotDefaultExport, gotOK)
+	}
+}
+
+func TestIsImportPathIgnored(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		settings map[string]interface{}
+		fileName string
+		want     bool
+	}{
+		{
+			name:     "array of interface strings matches as regexp",
+			settings: map[string]interface{}{"import/ignore": []interface{}{"ignored-missing-default"}},
+			fileName: "/repo/ignored-missing-default.ts",
+			want:     true,
+		},
+		{
+			name:     "array of strings matches as regexp",
+			settings: map[string]interface{}{"import/ignore": []string{`\.css$`}},
+			fileName: "/repo/styles.css",
+			want:     true,
+		},
+		{
+			name:     "non-string entries and invalid regexps are ignored",
+			settings: map[string]interface{}{"import/ignore": []interface{}{123, "["}},
+			fileName: "/repo/ignored-missing-default.ts",
+			want:     false,
+		},
+		{
+			name:     "missing setting does not ignore",
+			settings: map[string]interface{}{},
+			fileName: "/repo/ignored-missing-default.ts",
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := import_utils.IsImportPathIgnored(tc.settings, tc.fileName)
+			if got != tc.want {
+				t.Fatalf("IsImportPathIgnored() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHasDefaultExportFollowsHostCaseSensitivity(t *testing.T) {
+	t.Parallel()
+
+	rootDir := fixtures.GetRootDir()
+	consumerPath := tspath.ResolvePath(rootDir, "case-consumer.ts")
+	actualTargetPath := tspath.ResolvePath(rootDir, "case-target.ts")
+	virtualFiles := map[string]string{
+		consumerPath:     `import value from "./Case-Target";`,
+		actualTargetPath: `export const named = 1;`,
+	}
+
+	tests := []struct {
+		name        string
+		fs          vfs.FS
+		wantFound   bool
+		wantOK      bool
+		wantResolve bool
+	}{
+		{
+			name:        "case-sensitive host leaves mismatched import unresolved",
+			fs:          rslint_utils.NewOverlayVFS(bundled.WrapFS(osvfs.FS()), virtualFiles),
+			wantFound:   false,
+			wantOK:      false,
+			wantResolve: false,
+		},
+		{
+			name:        "case-insensitive host resolves then checks exports",
+			fs:          newCaseInsensitiveOverlayFS(virtualFiles),
+			wantFound:   false,
+			wantOK:      true,
+			wantResolve: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, specifier := contextForImportWithFS(t, tc.fs, consumerPath)
+			resolved := ctx.Program.GetResolvedModuleFromModuleSpecifier(ctx.SourceFile, specifier)
+			if (resolved != nil && resolved.ResolvedFileName != "") != tc.wantResolve {
+				t.Fatalf("resolved = %#v, want resolved %v", resolved, tc.wantResolve)
+			}
+
+			gotFound, gotOK := import_utils.HasDefaultExport(ctx, specifier)
+			if gotFound != tc.wantFound || gotOK != tc.wantOK {
+				t.Fatalf("HasDefaultExport() = (%v, %v), want (%v, %v)", gotFound, gotOK, tc.wantFound, tc.wantOK)
+			}
+		})
+	}
+}
+
+type caseInsensitiveOverlayFS struct {
+	vfs.FS
+	virtualFiles map[string]string
+}
+
+func newCaseInsensitiveOverlayFS(virtualFiles map[string]string) vfs.FS {
+	base := rslint_utils.NewOverlayVFS(bundled.WrapFS(osvfs.FS()), virtualFiles)
+	return &caseInsensitiveOverlayFS{
+		FS:           base,
+		virtualFiles: virtualFiles,
+	}
+}
+
+func (fsys *caseInsensitiveOverlayFS) UseCaseSensitiveFileNames() bool {
+	return false
+}
+
+func (fsys *caseInsensitiveOverlayFS) FileExists(path string) bool {
+	if _, ok := fsys.findVirtualPath(path); ok {
+		return true
+	}
+	return fsys.FS.FileExists(path)
+}
+
+func (fsys *caseInsensitiveOverlayFS) ReadFile(path string) (contents string, ok bool) {
+	if actualPath, ok := fsys.findVirtualPath(path); ok {
+		return fsys.virtualFiles[actualPath], true
+	}
+	return fsys.FS.ReadFile(path)
+}
+
+func (fsys *caseInsensitiveOverlayFS) Stat(path string) vfs.FileInfo {
+	if actualPath, ok := fsys.findVirtualPath(path); ok {
+		return fsys.FS.Stat(actualPath)
+	}
+	return fsys.FS.Stat(path)
+}
+
+func (fsys *caseInsensitiveOverlayFS) Realpath(path string) string {
+	if actualPath, ok := fsys.findVirtualPath(path); ok {
+		return actualPath
+	}
+	return fsys.FS.Realpath(path)
+}
+
+func (fsys *caseInsensitiveOverlayFS) findVirtualPath(path string) (string, bool) {
+	for virtualPath := range fsys.virtualFiles {
+		if strings.EqualFold(virtualPath, path) {
+			return virtualPath, true
+		}
+	}
+	return "", false
+}
+
+func contextForImport(t *testing.T, source string) (rule.RuleContext, *ast.Node) {
+	t.Helper()
+
+	rootDir := fixtures.GetRootDir()
+	fileName := "file.ts"
+	code := `import value from "` + source + `";`
+	fs := rslint_utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := rslint_utils.CreateCompilerHost(rootDir, fs)
+	program, err := rslint_utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("CreateProgram: %v", err)
+	}
+
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) == 0 {
+		t.Fatal("test source file was not parsed")
+	}
+	importDecl := sourceFile.Statements.Nodes[0].AsImportDeclaration()
+	if importDecl == nil || importDecl.ModuleSpecifier == nil {
+		t.Fatal("test import declaration was not parsed")
+	}
+
+	return rule.RuleContext{
+		Program:    program,
+		SourceFile: sourceFile,
+	}, importDecl.ModuleSpecifier
+}
+
+func contextForImportWithFS(t *testing.T, fs vfs.FS, filePath string) (rule.RuleContext, *ast.Node) {
+	t.Helper()
+
+	host := rslint_utils.CreateCompilerHost(fixtures.GetRootDir(), fs)
+	program, err := rslint_utils.CreateProgramFromOptions(true, &core.CompilerOptions{
+		ESModuleInterop: core.TSFalse,
+		Module:          core.ModuleKindCommonJS,
+	}, []string{filePath}, host)
+	if err != nil {
+		t.Fatalf("CreateProgramFromOptions: %v", err)
+	}
+
+	sourceFile := program.GetSourceFile(filePath)
+	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) == 0 {
+		t.Fatal("test source file was not parsed")
+	}
+	importDecl := sourceFile.Statements.Nodes[0].AsImportDeclaration()
+	if importDecl == nil || importDecl.ModuleSpecifier == nil {
+		t.Fatal("test import declaration was not parsed")
+	}
+
+	return rule.RuleContext{
+		Program:    program,
+		SourceFile: sourceFile,
+	}, importDecl.ModuleSpecifier
+}
+
+func contextForImportWithCompilerOptions(t *testing.T, source string, options *core.CompilerOptions) (rule.RuleContext, *ast.Node) {
+	t.Helper()
+
+	rootDir := fixtures.GetRootDir()
+	fileName := "file.ts"
+	filePath := tspath.ResolvePath(rootDir, fileName)
+	code := `import value from "` + source + `";`
+	fs := rslint_utils.NewOverlayVFSForFile(filePath, code)
+	host := rslint_utils.CreateCompilerHost(rootDir, fs)
+	program, err := rslint_utils.CreateProgramFromOptions(true, options, []string{filePath}, host)
+	if err != nil {
+		t.Fatalf("CreateProgramFromOptions: %v", err)
+	}
+
+	sourceFile := program.GetSourceFile(filePath)
+	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) == 0 {
+		t.Fatal("test source file was not parsed")
+	}
+	importDecl := sourceFile.Statements.Nodes[0].AsImportDeclaration()
+	if importDecl == nil || importDecl.ModuleSpecifier == nil {
+		t.Fatal("test import declaration was not parsed")
+	}
+
+	return rule.RuleContext{
+		Program:    program,
+		SourceFile: sourceFile,
+	}, importDecl.ModuleSpecifier
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -126,6 +126,7 @@ export default defineConfig({
     './tests/eslint/rules/no-useless-computed-key.test.ts',
     './tests/eslint/rules/no-useless-concat.test.ts',
     // eslint-plugin-import
+    './tests/eslint-plugin-import/rules/default.test.ts',
     './tests/eslint-plugin-import/rules/first.test.ts',
     './tests/eslint-plugin-import/rules/newline-after-import.test.ts',
     './tests/eslint-plugin-import/rules/no-duplicates.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/bar.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/bar.ts
@@ -1,0 +1,3 @@
+export default function bar() {}
+
+export const foo = 1;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/broken-trampoline.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/broken-trampoline.ts
@@ -1,0 +1,1 @@
+export { default } from './named-exports';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/common.js
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/common.js
@@ -1,0 +1,8 @@
+module.exports = {
+  a: 1,
+  b: 2,
+};
+
+var c = 3;
+
+exports.d = c;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/common.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/common.ts
@@ -1,0 +1,1 @@
+module.exports = function common() {};

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/default-class.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/default-class.ts
@@ -1,0 +1,1 @@
+export default class CoolClass {}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/default-export-from-ignored.js
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/default-export-from-ignored.js
@@ -1,0 +1,1 @@
+export { foo as default } from './common.js';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/default-export-from-named.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/default-export-from-named.ts
@@ -1,0 +1,1 @@
+export { foo as default } from './named-exports';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/default-export-from.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/default-export-from.ts
@@ -1,0 +1,1 @@
+export { default } from './default-export';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/default-export.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/default-export.ts
@@ -1,0 +1,3 @@
+export default function foo() {}
+
+export const baz = 1;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/jsx/App.tsx
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/jsx/App.tsx
@@ -1,0 +1,3 @@
+export default function App() {
+  return null;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/jsx/FooES7.js
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/jsx/FooES7.js
@@ -1,0 +1,17 @@
+// see issue #36
+
+// Foo.jsx
+class Foo {
+  // ES7 static members
+  static bar = true;
+}
+
+export default Foo;
+
+export class Bar {
+  static baz = false;
+
+  render() {
+    let { a, ...rest } = { a: 1, b: 2, c: 3 };
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/jsx/MyCoolComponent.jsx
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/jsx/MyCoolComponent.jsx
@@ -1,0 +1,3 @@
+export default function MyCoolComponent() {
+  return null;
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/mixed-exports.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/mixed-exports.ts
@@ -1,0 +1,3 @@
+export default function foo() {}
+
+export const bar = 1;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/named-default-export.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/named-default-export.ts
@@ -1,0 +1,3 @@
+const foo = 1;
+
+export { foo as default };

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/named-exports.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/named-exports.ts
@@ -1,0 +1,3 @@
+export const a = 1;
+export const bar = 2;
+export const foo = 3;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/re-export.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/re-export.ts
@@ -1,0 +1,1 @@
+export * from './default-export';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/redux.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/redux.ts
@@ -1,0 +1,3 @@
+const connectedApp = {};
+
+export default connectedApp;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/trampoline.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/trampoline.ts
@@ -1,0 +1,1 @@
+export { default } from './default-export';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-default.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-default.ts
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-export-assign-default-reexport.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-export-assign-default-reexport.ts
@@ -1,0 +1,3 @@
+import { getFoo } from './typescript';
+
+export = getFoo;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-export-assign-default.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-export-assign-default.ts
@@ -1,0 +1,3 @@
+const foo = 1;
+
+export = foo;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-export-assign-function.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-export-assign-function.ts
@@ -1,0 +1,3 @@
+function foo() {}
+
+export = foo;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-export-assign-mixed.d.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-export-assign-mixed.d.ts
@@ -1,0 +1,11 @@
+export = foobar;
+
+declare function foobar(): void;
+declare namespace foobar {
+  type MyType = string;
+  enum MyEnum {
+    Foo,
+    Bar,
+    Baz,
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-export-assign-property.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript-export-assign-property.ts
@@ -1,0 +1,3 @@
+const AnalyticsNode = { Analytics: {} };
+
+export = AnalyticsNode.Analytics;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/default-rule/typescript.ts
@@ -1,0 +1,15 @@
+export type MyType = string;
+
+export enum MyEnum {
+  Foo,
+  Bar,
+  Baz,
+}
+
+export function getFoo(): MyType {
+  return 'foo';
+}
+
+export namespace MyNamespace {
+  export function namespaceFunction() {}
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rules/default.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rules/default.test.ts
@@ -1,0 +1,244 @@
+import { test, testFixturePath } from '../utils.js';
+
+import { RuleTester } from '../rule-tester.js';
+
+const ruleTester = new RuleTester();
+// Rslint-Modified: we don't require rules
+// const rule = require('rules/default')
+const rule = null as never;
+// Rslint-Modified end
+
+ruleTester.run('default', rule, {
+  valid: [
+    test({
+      code: 'import "./malformed.js"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foo from "./empty-folder";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import { foo } from "./default-export";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foo from "./default-export";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foo from "./mixed-exports";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import bar from "./default-export";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import CoolClass from "./default-class";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import bar, { baz } from "./default-export";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import crypto from "crypto";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import common from "./common";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'export { default as bar } from "./bar"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'export { default as bar, foo } from "./bar"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'export {a} from "./named-exports"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import twofer from "./trampoline"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foo from "./named-default-export"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import connectedApp from "./redux"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import MyCoolComponent from "./jsx/MyCoolComponent.jsx"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import App from "./jsx/App"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: "import Foo from './jsx/FooES7.js';",
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import bar from "./default-export-from";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import bar from "./default-export-from-named";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: "import bar from './default-export-from-ignored.js';",
+      filename: testFixturePath('./default-rule/consumer.ts'),
+      settings: { 'import/ignore': ['common'] },
+    }),
+    test({
+      code: 'export { "default" as bar } from "./bar"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foobar from "./typescript-default"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foobar from "./typescript-export-assign-default"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foobar from "./typescript-export-assign-function"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foobar from "./typescript-export-assign-mixed"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foobar from "./typescript-export-assign-default-reexport"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foobar from "./typescript-export-assign-property"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'for (let { foo, bar } of baz) {}',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'for (let [ foo, bar ] of baz) {}',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'const { x, y } = bar',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'const { x, y, ...z } = bar',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'let x; export { x }',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'let x; export { x as y }',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'export const x = null',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'export var x = null',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'export let x = null',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'export default x',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'export default class x {}',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import json from "./data.json"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foo from "./foobar.json";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import foo from "./foobar";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import { foo } from "./issue-370-commonjs-namespace/bar"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'export * from "./issue-370-commonjs-namespace/bar"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import * as a from "./commonjs-namespace/a"; a.b',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+    test({
+      code: 'import { foo } from "./ignore.invalid.extension"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+    }),
+  ],
+
+  invalid: [
+    test({
+      code: 'import baz from "./named-exports";',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./named-exports".',
+        },
+      ],
+    }),
+    test({
+      code: 'import twofer from "./broken-trampoline"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+      errors: [
+        {
+          message:
+            'No default export found in imported module "./broken-trampoline".',
+        },
+      ],
+    }),
+    test({
+      code: 'import barDefault from "./re-export"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+      errors: [
+        {
+          message: 'No default export found in imported module "./re-export".',
+        },
+      ],
+    }),
+    test({
+      code: 'import foobar from "./typescript"',
+      filename: testFixturePath('./default-rule/consumer.ts'),
+      errors: [
+        {
+          message: 'No default export found in imported module "./typescript".',
+        },
+      ],
+    }),
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/utils.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/utils.ts
@@ -11,3 +11,7 @@ export function test<T extends ValidTestCase | InvalidTestCase>(t: T): T {
 export function testFilePath(relativePath: string): string {
   return path.join(import.meta.dirname, 'files', relativePath);
 }
+
+export function testFixturePath(relativePath: string): string {
+  return path.join(import.meta.dirname, 'fixtures', relativePath);
+}

--- a/packages/rslint-test-tools/tsconfig.spec.json
+++ b/packages/rslint-test-tools/tsconfig.spec.json
@@ -5,6 +5,6 @@
     "moduleResolution": "bundler",
     "module": "preserve"
   },
-  "exclude": ["./tests/typescript-eslint/fixtures/"],
+  "exclude": ["./tests/**/fixtures/**"],
   "references": []
 }


### PR DESCRIPTION
## Summary

Port the `import/default` rule from eslint-plugin-import to rslint.

This adds the native Go rule, shared import export-map helpers, documentation, Go test coverage, and JS integration coverage for default-import validation.

## Related Links

- ESLint rule: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/default.md
- Source code: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/default.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
