### PR TITLE
feat: port rule react/jsx-fragments

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -18,6 +18,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_equals_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_filename_extension"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_first_prop_new_line"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_fragments"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_handler_names"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_indent"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_indent_props"
@@ -96,6 +97,7 @@ func GetAllRules() []rule.Rule {
 		jsx_equals_spacing.JsxEqualsSpacingRule,
 		jsx_filename_extension.JsxFilenameExtensionRule,
 		jsx_first_prop_new_line.JsxFirstPropNewLineRule,
+		jsx_fragments.JsxFragmentsRule,
 		jsx_handler_names.JsxHandlerNamesRule,
 		jsx_indent.JsxIndentRule,
 		jsx_indent_props.JsxIndentPropsRule,

--- a/internal/plugins/react/rules/jsx_fragments/jsx_fragments.go
+++ b/internal/plugins/react/rules/jsx_fragments/jsx_fragments.go
@@ -1,0 +1,369 @@
+package jsx_fragments
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	modeSyntax  = "syntax"
+	modeElement = "element"
+)
+
+var JsxFragmentsRule = rule.Rule{
+	Name: "react/jsx-fragments",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		mode := parseMode(rawOptions)
+		reactPragma := reactutil.GetReactPragma(ctx.Settings)
+		fragmentPragma := reactutil.GetReactFragmentPragma(ctx.Settings)
+		openFragLong := "<" + reactPragma + "." + fragmentPragma + ">"
+		closeFragLong := "</" + reactPragma + "." + fragmentPragma + ">"
+		matcher := newFragmentMatcher(ctx, reactPragma, fragmentPragma)
+
+		reportOnReactVersion := func(node *ast.Node) bool {
+			if !reactutil.ReactVersionLessThan(ctx.Settings, 16, 2, 0) {
+				return false
+			}
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id: "fragmentsNotSupported",
+				Description: "Fragments are only supported starting from React v16.2. " +
+					"Please disable the `react/jsx-fragments` rule in `eslint` settings or upgrade your version of React.",
+			})
+			return true
+		}
+
+		preferPragmaMsg := func() rule.RuleMessage {
+			return rule.RuleMessage{
+				Id:          "preferPragma",
+				Description: "Prefer " + reactPragma + "." + fragmentPragma + " over fragment shorthand",
+				Data: map[string]string{
+					"react":    reactPragma,
+					"fragment": fragmentPragma,
+				},
+			}
+		}
+
+		preferFragmentMsg := func() rule.RuleMessage {
+			return rule.RuleMessage{
+				Id:          "preferFragment",
+				Description: "Prefer fragment shorthand over " + reactPragma + "." + fragmentPragma,
+				Data: map[string]string{
+					"react":    reactPragma,
+					"fragment": fragmentPragma,
+				},
+			}
+		}
+
+		checkFragment := func(node *ast.Node) {
+			if reportOnReactVersion(node) {
+				return
+			}
+			if mode != modeElement {
+				return
+			}
+			fragment := node.AsJsxFragment()
+			if fragment.OpeningFragment == nil || fragment.ClosingFragment == nil {
+				ctx.ReportNode(node, preferPragmaMsg())
+				return
+			}
+			ctx.ReportNodeWithFixes(node, preferPragmaMsg(),
+				rule.RuleFixReplace(ctx.SourceFile, fragment.OpeningFragment, openFragLong),
+				rule.RuleFixReplace(ctx.SourceFile, fragment.ClosingFragment, closeFragLong),
+			)
+		}
+
+		checkStandardElement := func(node *ast.Node) {
+			opening := openingElement(node)
+			if opening == nil || !matcher.isReactFragment(opening) {
+				return
+			}
+			if reportOnReactVersion(node) {
+				return
+			}
+			if mode != modeSyntax || len(reactutil.GetJsxElementAttributes(opening)) > 0 {
+				return
+			}
+			fixes := fixesToShort(ctx.SourceFile, node)
+			if len(fixes) == 0 {
+				ctx.ReportNode(node, preferFragmentMsg())
+				return
+			}
+			ctx.ReportNodeWithFixes(node, preferFragmentMsg(), fixes...)
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxFragment:           checkFragment,
+			ast.KindJsxElement:            checkStandardElement,
+			ast.KindJsxSelfClosingElement: checkStandardElement,
+		}
+	},
+}
+
+func parseMode(raw any) string {
+	options := rule.NormalizeOptions(raw)
+	if len(options) == 0 {
+		return modeSyntax
+	}
+	if mode, ok := options[0].(string); ok && (mode == modeSyntax || mode == modeElement) {
+		return mode
+	}
+	return modeSyntax
+}
+
+func openingElement(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case ast.KindJsxElement:
+		return node.AsJsxElement().OpeningElement
+	case ast.KindJsxSelfClosingElement:
+		return node
+	default:
+		return nil
+	}
+}
+
+func fixesToShort(sourceFile *ast.SourceFile, node *ast.Node) []rule.RuleFix {
+	switch node.Kind {
+	case ast.KindJsxElement:
+		element := node.AsJsxElement()
+		if element.OpeningElement == nil || element.ClosingElement == nil {
+			return nil
+		}
+		return []rule.RuleFix{
+			rule.RuleFixReplace(sourceFile, element.OpeningElement, "<>"),
+			rule.RuleFixReplace(sourceFile, element.ClosingElement, "</>"),
+		}
+	case ast.KindJsxSelfClosingElement:
+		return []rule.RuleFix{
+			rule.RuleFixReplace(sourceFile, node, "<></>"),
+		}
+	default:
+		return nil
+	}
+}
+
+type fragmentMatcher struct {
+	ctx            rule.RuleContext
+	reactPragma    string
+	fragmentPragma string
+	fragmentNames  map[string]bool
+}
+
+func newFragmentMatcher(ctx rule.RuleContext, reactPragma, fragmentPragma string) fragmentMatcher {
+	m := fragmentMatcher{
+		ctx:            ctx,
+		reactPragma:    reactPragma,
+		fragmentPragma: fragmentPragma,
+		fragmentNames:  map[string]bool{reactPragma + "." + fragmentPragma: true},
+	}
+	// Mirrors upstream's file-level `fragmentNames` set. It deliberately
+	// tracks import aliases by text and not by scope, so a later shadowing
+	// binding with the same JSX tag name still matches the import path.
+	if ctx.SourceFile != nil {
+		m.collectImportFragmentNames(ctx.SourceFile.AsNode())
+	}
+	return m
+}
+
+func (m fragmentMatcher) isReactFragment(opening *ast.Node) bool {
+	elementName := reactutil.GetJsxElementTypeString(opening)
+	if m.fragmentNames[elementName] {
+		return true
+	}
+
+	// The fallback mirrors upstream's `refersToReactFragment` branch for bare
+	// JSX identifiers whose variable initializer points at the React fragment.
+	tagName := reactutil.GetJsxTagName(opening)
+	if tagName == nil || tagName.Kind != ast.KindIdentifier {
+		return false
+	}
+	return m.refersToReactFragment(tagName, tagName.AsIdentifier().Text)
+}
+
+func (m fragmentMatcher) collectImportFragmentNames(root *ast.Node) {
+	var visit func(*ast.Node)
+	visit = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node.Kind == ast.KindImportDeclaration {
+			m.collectImportDeclaration(node)
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return false
+		})
+	}
+	visit(root)
+}
+
+func (m fragmentMatcher) collectImportDeclaration(node *ast.Node) {
+	decl := node.AsImportDeclaration()
+	if decl.ModuleSpecifier == nil ||
+		decl.ModuleSpecifier.Kind != ast.KindStringLiteral ||
+		decl.ModuleSpecifier.AsStringLiteral().Text != "react" ||
+		decl.ImportClause == nil {
+		return
+	}
+	importClause := decl.ImportClause.AsImportClause()
+	if importClause.NamedBindings == nil || importClause.NamedBindings.Kind != ast.KindNamedImports {
+		return
+	}
+	namedImports := importClause.NamedBindings.AsNamedImports()
+	if namedImports.Elements == nil {
+		return
+	}
+	for _, specNode := range namedImports.Elements.Nodes {
+		spec := specNode.AsImportSpecifier()
+		imported := spec.Name()
+		if spec.PropertyName != nil {
+			imported = spec.PropertyName
+		}
+		if imported == nil || imported.Kind != ast.KindIdentifier || imported.AsIdentifier().Text != m.fragmentPragma {
+			continue
+		}
+		local := spec.Name()
+		if local != nil && local.Kind == ast.KindIdentifier {
+			m.fragmentNames[local.AsIdentifier().Text] = true
+		}
+	}
+}
+
+func (m fragmentMatcher) refersToReactFragment(ident *ast.Node, name string) bool {
+	if ident == nil || name == "" {
+		return false
+	}
+	if m.ctx.TypeChecker != nil {
+		if decl := declarationForIdentifier(utils.GetReferenceSymbol(ident, m.ctx.TypeChecker)); decl != nil {
+			return m.declarationRefersToReactFragment(decl)
+		}
+	}
+	if m.ctx.SourceFile == nil {
+		return false
+	}
+	return m.syntaxDeclarationRefersToReactFragment(m.ctx.SourceFile.AsNode(), name)
+}
+
+func declarationForIdentifier(symbol *ast.Symbol) *ast.Node {
+	if symbol == nil {
+		return nil
+	}
+	if symbol.ValueDeclaration != nil {
+		return symbol.ValueDeclaration
+	}
+	if len(symbol.Declarations) > 0 {
+		return symbol.Declarations[0]
+	}
+	return nil
+}
+
+func (m fragmentMatcher) declarationRefersToReactFragment(decl *ast.Node) bool {
+	switch decl.Kind {
+	case ast.KindVariableDeclaration:
+		return m.initializerRefersToReactFragment(decl.AsVariableDeclaration().Initializer)
+	case ast.KindBindingElement:
+		root := ast.GetRootDeclaration(decl)
+		if root == nil || root.Kind != ast.KindVariableDeclaration {
+			return false
+		}
+		return m.initializerRefersToReactFragment(root.AsVariableDeclaration().Initializer)
+	default:
+		return false
+	}
+}
+
+func (m fragmentMatcher) syntaxDeclarationRefersToReactFragment(root *ast.Node, name string) bool {
+	var found bool
+	var visit func(*ast.Node)
+	visit = func(node *ast.Node) {
+		if found || node == nil {
+			return
+		}
+		if node.Kind == ast.KindVariableDeclaration && variableDeclarationBindsName(node, name) {
+			found = m.initializerRefersToReactFragment(node.AsVariableDeclaration().Initializer)
+			if found {
+				return
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return found
+		})
+	}
+	visit(root)
+	return found
+}
+
+func variableDeclarationBindsName(node *ast.Node, name string) bool {
+	declName := node.AsVariableDeclaration().Name()
+	if declName == nil {
+		return false
+	}
+	found := false
+	utils.CollectBindingNames(declName, func(_ *ast.Node, bindingName string) {
+		if bindingName == name {
+			found = true
+		}
+	})
+	return found
+}
+
+func (m fragmentMatcher) initializerRefersToReactFragment(init *ast.Node) bool {
+	init = ast.SkipParentheses(init)
+	if init == nil {
+		return false
+	}
+
+	if ast.IsOptionalChain(init) {
+		return false
+	}
+
+	if init.Kind == ast.KindIdentifier && init.AsIdentifier().Text == m.reactPragma {
+		return true
+	}
+
+	// Match only `<pragma>.<fragment>`, not `require('react').Fragment` or an
+	// arbitrary pragma member. Only parentheses are transparent here; upstream
+	// does not unwrap TS-only expression wrappers like `as`, `satisfies`, or `!`.
+	if init.Kind == ast.KindPropertyAccessExpression {
+		access := init.AsPropertyAccessExpression()
+		property := access.Name()
+		object := ast.SkipParentheses(access.Expression)
+		if object != nil &&
+			object.Kind == ast.KindIdentifier &&
+			object.AsIdentifier().Text == m.reactPragma &&
+			property != nil &&
+			property.Kind == ast.KindIdentifier &&
+			property.AsIdentifier().Text == m.fragmentPragma {
+			return true
+		}
+	}
+
+	return isRequireReactCall(init)
+}
+
+func isRequireReactCall(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	if ast.IsOptionalChain(node) {
+		return false
+	}
+	call := node.AsCallExpression()
+	callee := ast.SkipParentheses(call.Expression)
+	if callee == nil || callee.Kind != ast.KindIdentifier || callee.AsIdentifier().Text != "require" {
+		return false
+	}
+	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+		return false
+	}
+	// Do not use ast.IsRequireCall here: upstream only checks the first
+	// argument and therefore accepts unusual calls like require('react', x).
+	arg := ast.SkipParentheses(call.Arguments.Nodes[0])
+	return arg != nil && arg.Kind == ast.KindStringLiteral && arg.AsStringLiteral().Text == "react"
+}

--- a/internal/plugins/react/rules/jsx_fragments/jsx_fragments.md
+++ b/internal/plugins/react/rules/jsx_fragments/jsx_fragments.md
@@ -1,0 +1,61 @@
+# jsx-fragments
+
+Enforce shorthand or standard form for React fragments.
+
+## Rule Details
+
+In JSX, a React fragment can be written as either
+`<React.Fragment>...</React.Fragment>` or as shorthand `<>...</>`.
+
+Examples of **incorrect** code for this rule in the default `syntax` mode:
+
+```jsx
+<React.Fragment>
+  <Foo />
+</React.Fragment>;
+```
+
+Examples of **correct** code for this rule in the default `syntax` mode:
+
+```jsx
+<>
+  <Foo />
+</>;
+```
+
+```jsx
+<React.Fragment key="key">
+  <Foo />
+</React.Fragment>;
+```
+
+## Rule Options
+
+The first option is `"syntax"` (default) or `"element"`.
+
+Examples of **incorrect** code for this rule with `"element"`:
+
+```json
+{ "react/jsx-fragments": ["error", "element"] }
+```
+
+```jsx
+<>
+  <Foo />
+</>;
+```
+
+Examples of **correct** code for this rule with `"element"`:
+
+```jsx
+<React.Fragment>
+  <Foo />
+</React.Fragment>;
+```
+
+Support for fragments was added in React v16.2, so the rule reports either form
+when an older React version is specified in shared settings.
+
+## Original Documentation
+
+- [react/jsx-fragments](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md)

--- a/internal/plugins/react/rules/jsx_fragments/jsx_fragments_extras_test.go
+++ b/internal/plugins/react/rules/jsx_fragments/jsx_fragments_extras_test.go
@@ -1,0 +1,363 @@
+package jsx_fragments
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestJsxFragmentsExtras locks in behavior not covered by the upstream suite:
+// nested JSX, multiple fragments in one file, fragment-like lookalikes,
+// declaration resolution, binding patterns, and tsgo-specific AST shapes.
+func TestJsxFragmentsExtras(t *testing.T) {
+	settings := reactSettings("16.2", "Act", "Frag")
+	settingsOld := reactSettings("16.1", "Act", "Frag")
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxFragmentsRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 3: attributes suppress shorthand conversion ----
+		{Code: `<Act.Frag {...props}><Foo /></Act.Frag>`, Tsx: true, Settings: settings},
+		{Code: `<Act.Frag key={key} />`, Tsx: true, Settings: settings},
+
+		// ---- Dimension 4: access / key forms that are not React fragments ----
+		{Code: `<Act.Other><Foo /></Act.Other>`, Tsx: true, Settings: settings},
+		{Code: `<Other.Frag><Foo /></Other.Frag>`, Tsx: true, Settings: settings},
+		{Code: `<act.Frag><Foo /></act.Frag>`, Tsx: true, Settings: settings},
+		{Code: `<ns:Frag><Foo /></ns:Frag>`, Tsx: true, Settings: settings},
+		{Code: "const Frag = Act.Other;\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+		{Code: "const Frag = require('react').Frag;\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+
+		// ---- Dimension 4: import source and imported-name forms ----
+		{Code: "import { Other as Frag } from 'react';\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+		{Code: "import { Frag } from 'not-react';\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+		{Code: "import { Fragment } from 'react';\n<Fragment><Foo /></Fragment>;", Tsx: true, Settings: settings},
+
+		// ---- Dimension 2: local shadowing boundary ----
+		{
+			Code: "const Frag = Act.Frag;\nfunction render(Frag) { return <Frag><Foo /></Frag>; }",
+			Tsx:  true, Settings: settings,
+		},
+
+		// ---- Dimension 4: TS-only expression wrappers stay opaque ----
+		{Code: "const Frag = Other.Frag as any;\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+		{Code: "const Frag = Act.Frag as any;\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+		{Code: "const Frag = Act.Frag satisfies unknown;\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+		{Code: "const Frag = Act.Frag!;\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+		{Code: "const Frag = require('react') as any;\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+		{Code: "const Frag = require('react' as any);\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+
+		// ---- Dimension 4: optional-chain initializers stay opaque ----
+		{Code: "const Frag = Act?.Frag;\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+		{Code: "const Frag = require?.('react');\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+
+		// ---- Dimension 4: dynamic initializers should not crash or report ----
+		{Code: "const { Frag } = require(moduleName);\n<Frag><Foo /></Frag>;", Tsx: true, Settings: settings},
+
+		// ---- Dimension 4: empty children with attributes remain valid ----
+		{Code: `<Act.Frag key="key"></Act.Frag>`, Tsx: true, Settings: settings},
+
+		// N/A: Receiver optional chains do not apply to JSX tag names.
+		// N/A: Computed JSX tag names are not legal TSX syntax.
+		// N/A: Private identifiers do not apply to JSX tag names.
+		// N/A: Function/class container forms are not target nodes for this rule.
+		// N/A: Autofix side-effect suppression is not needed; fixes only replace tag tokens.
+	}, []rule_tester.InvalidTestCase{
+		// ---- Config: bare string option shape ----
+		{
+			Code:     `<><Foo /></>`,
+			Output:   []string{`<Act.Frag><Foo /></Act.Frag>`},
+			Tsx:      true,
+			Options:  modeElement,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferPragma", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 2: nested shorthand fragment in JSX expression ----
+		{
+			Code:     `<Box child={<><Foo /></>} />`,
+			Output:   []string{`<Box child={<Act.Frag><Foo /></Act.Frag>} />`},
+			Tsx:      true,
+			Options:  modeElement,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferPragma", Line: 1, Column: 13},
+			},
+		},
+
+		// ---- Dimension 2: nested shorthand fragments converge over repeated fixes ----
+		{
+			Code: "<>\n  <>\n    <Foo />\n  </>\n</>",
+			Output: []string{
+				"<Act.Frag>\n  <>\n    <Foo />\n  </>\n</Act.Frag>",
+				"<Act.Frag>\n  <Act.Frag>\n    <Foo />\n  </Act.Frag>\n</Act.Frag>",
+			},
+			Tsx:      true,
+			Options:  modeElement,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferPragma", Line: 1, Column: 1},
+				{MessageId: "preferPragma", Line: 2, Column: 3},
+			},
+		},
+
+		// ---- Branch: React version gate runs before syntax-mode attribute suppression ----
+		{
+			Code:     `<Act.Frag key="key"><Foo /></Act.Frag>`,
+			Tsx:      true,
+			Settings: settingsOld,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "fragmentsNotSupported", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 2: nested standard fragment inside another JSX container ----
+		{
+			Code:     `<Box><Act.Frag><Foo /></Act.Frag></Box>`,
+			Output:   []string{`<Box><><Foo /></></Box>`},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- Dimension 3: multi-line fixer preserves children and comments ----
+		{
+			Code:     "<Act.Frag>\n  {/* keep */}\n  <Foo />\n</Act.Frag>",
+			Output:   []string{"<>\n  {/* keep */}\n  <Foo />\n</>"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Dimension 2: multiple standard fragments in one file ----
+		{
+			Code:     `const x = [<Act.Frag />, <Act.Frag><Foo /></Act.Frag>];`,
+			Output:   []string{`const x = [<></>, <><Foo /></>];`},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 1, Column: 12},
+				{MessageId: "preferFragment", Line: 1, Column: 26},
+			},
+		},
+
+		// ---- Dimension 4: parenthesized initializer matching ----
+		{
+			Code:     "const Frag = (Act.Frag);\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const Frag = (Act.Frag);\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code:     "const Frag = (Act).Frag;\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const Frag = (Act).Frag;\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code:     "const Frag = (require)('react');\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const Frag = (require)('react');\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code:     "const Frag = require(('react'));\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const Frag = require(('react'));\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// Locks in upstream JSXFragment arm 1: default syntax mode does not report shorthand.
+		// The invalid counterpart here uses element mode to prove the branch boundary.
+		{
+			Code:     `<></>`,
+			Output:   []string{`<Act.Frag></Act.Frag>`},
+			Tsx:      true,
+			Options:  []interface{}{modeElement},
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferPragma", Line: 1, Column: 1},
+			},
+		},
+
+		// Locks in upstream getFixerToShort() arm 1: paired JSXElement.
+		{
+			Code:     `<Act.Frag></Act.Frag>`,
+			Output:   []string{`<></>`},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 1, Column: 1},
+			},
+		},
+
+		// Locks in upstream getFixerToShort() arm 2: self-closing JSXElement.
+		{
+			Code:     `<Act.Frag/>`,
+			Output:   []string{`<></>`},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 1, Column: 1},
+			},
+		},
+
+		// Locks in upstream ImportDeclaration arm: renamed import local is tracked.
+		{
+			Code:     "import { Frag as LocalFrag } from 'react';\n<LocalFrag><Foo /></LocalFrag>;",
+			Output:   []string{"import { Frag as LocalFrag } from 'react';\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// Locks in upstream ImportDeclaration arm: import aliases are tracked by text, not shadow-aware scope.
+		{
+			Code:     "import { Frag } from 'react';\nfunction render(Frag) { return <Frag><Foo /></Frag>; }",
+			Output:   []string{"import { Frag } from 'react';\nfunction render(Frag) { return <><Foo /></>; }"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 32},
+			},
+		},
+
+		// Locks in upstream Program:exit behavior: a later variable declaration still resolves.
+		{
+			Code:     "<Frag><Foo /></Frag>;\nconst Frag = Act.Frag;",
+			Output:   []string{"<><Foo /></>;\nconst Frag = Act.Frag;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 1, Column: 1},
+			},
+		},
+
+		// Locks in upstream refersToReactFragment() arm 1: variable init is the pragma identifier.
+		{
+			Code:     "const Frag = Act;\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const Frag = Act;\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// Locks in upstream refersToReactFragment() arm 1 with nested object binding.
+		{
+			Code:     "const { nested: { Frag } } = Act;\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const { nested: { Frag } } = Act;\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// Locks in upstream refersToReactFragment() arm 1 with array binding.
+		{
+			Code:     "const [Frag] = Act;\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const [Frag] = Act;\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// Locks in upstream refersToReactFragment() arm 2: variable init is pragma.fragment.
+		{
+			Code:     "const Frag = Act.Frag;\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const Frag = Act.Frag;\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// Locks in upstream refersToReactFragment() arm 3: variable init is require('react').
+		{
+			Code:     "const Frag = require('react');\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const Frag = require('react');\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// Locks in upstream refersToReactFragment() arm 3: only the first require argument is inspected.
+		{
+			Code:     "const Frag = require('react', extra);\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const Frag = require('react', extra);\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// Locks in upstream destructuring quirk: property name is not checked once init is the pragma.
+		{
+			Code:     "const { Other: Frag } = Act;\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const { Other: Frag } = Act;\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// Locks in upstream destructuring quirk: member init is accepted for a binding element.
+		{
+			Code:     "const { Other: Frag } = Act.Frag;\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const { Other: Frag } = Act.Frag;\n<><Foo /></>;"},
+			Tsx:      true,
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// ---- Real-user: #2420 asks about enforcing bare <Fragment>; current rule treats imported Fragment as standard-form fragment ----
+		{
+			Code:   "import { Fragment } from 'react';\n<Fragment><Foo /></Fragment>;",
+			Output: []string{"import { Fragment } from 'react';\n<><Foo /></>;"},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+
+		// ---- Real-user: #1661 proposed const Fragment = React.Fragment as a supported standard form ----
+		{
+			Code:   "const Fragment = React.Fragment;\n<Fragment><Foo /></Fragment>;",
+			Output: []string{"const Fragment = React.Fragment;\n<><Foo /></>;"},
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/jsx_fragments/jsx_fragments_upstream_test.go
+++ b/internal/plugins/react/rules/jsx_fragments/jsx_fragments_upstream_test.go
@@ -1,0 +1,196 @@
+package jsx_fragments
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestJsxFragmentsUpstream migrates the full valid/invalid suite from upstream
+// tests/lib/rules/jsx-fragments.js 1:1. Position assertions cover line/column
+// for every invalid case. rslint-specific lock-in cases live in the
+// jsx_fragments_extras_test.go file.
+func TestJsxFragmentsUpstream(t *testing.T) {
+	settings := reactSettings("16.2", "Act", "Frag")
+	settingsOld := reactSettings("16.1", "Act", "Frag")
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxFragmentsRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{Code: `<><Foo /></>`, Tsx: true, Settings: settings},
+		{Code: `<Act.Frag><Foo /></Act.Frag>`, Tsx: true, Options: []interface{}{modeElement}, Settings: settings},
+		{Code: `<Act.Frag />`, Tsx: true, Options: []interface{}{modeElement}, Settings: settings},
+		{
+			Code:     "import Act, { Frag as F } from 'react';\n<F><Foo /></F>;",
+			Tsx:      true,
+			Options:  []interface{}{modeElement},
+			Settings: settings,
+		},
+		{
+			Code:     "const F = Act.Frag;\n<F><Foo /></F>;",
+			Tsx:      true,
+			Options:  []interface{}{modeElement},
+			Settings: settings,
+		},
+		{
+			Code:     "const { Frag } = Act;\n<Frag><Foo /></Frag>;",
+			Tsx:      true,
+			Options:  []interface{}{modeElement},
+			Settings: settings,
+		},
+		{
+			Code:     "const { Frag } = require('react');\n<Frag><Foo /></Frag>;",
+			Tsx:      true,
+			Options:  []interface{}{modeElement},
+			Settings: settings,
+		},
+		{Code: `<Act.Frag key="key"><Foo /></Act.Frag>`, Tsx: true, Options: []interface{}{modeSyntax}, Settings: settings},
+		{Code: `<Act.Frag key="key" />`, Tsx: true, Options: []interface{}{modeSyntax}, Settings: settings},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code:     `<><Foo /></>`,
+			Tsx:      true,
+			Settings: settingsOld,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "fragmentsNotSupported", Message: fragmentsNotSupportedDescription, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:     `<Act.Frag><Foo /></Act.Frag>`,
+			Tsx:      true,
+			Settings: settingsOld,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "fragmentsNotSupported", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:     `<Act.Frag />`,
+			Tsx:      true,
+			Settings: settingsOld,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "fragmentsNotSupported", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:     `<><Foo /></>`,
+			Output:   []string{`<Act.Frag><Foo /></Act.Frag>`},
+			Tsx:      true,
+			Options:  []interface{}{modeElement},
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferPragma", Message: preferPragmaDescription("Act", "Frag"), Line: 1, Column: 1},
+			},
+		},
+		{
+			// SKIP: rslint uses one parser and has opening/closing fragment
+			// nodes, so upstream's old TypeScript-parser no-fix variant does
+			// not apply.
+			Code:     `<><Foo /></>`,
+			Skip:     true,
+			Tsx:      true,
+			Options:  []interface{}{modeElement},
+			Settings: settings,
+		},
+		{
+			Code:     `<Act.Frag><Foo /></Act.Frag>`,
+			Output:   []string{`<><Foo /></>`},
+			Tsx:      true,
+			Options:  []interface{}{modeSyntax},
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Message: preferFragmentDescription("Act", "Frag"), Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:     `<Act.Frag />`,
+			Output:   []string{`<></>`},
+			Tsx:      true,
+			Options:  []interface{}{modeSyntax},
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:     "import Act, { Frag as F } from 'react';\n<F />;",
+			Output:   []string{"import Act, { Frag as F } from 'react';\n<></>;"},
+			Tsx:      true,
+			Options:  []interface{}{modeSyntax},
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code:     "import Act, { Frag as F } from 'react';\n<F><Foo /></F>;",
+			Output:   []string{"import Act, { Frag as F } from 'react';\n<><Foo /></>;"},
+			Tsx:      true,
+			Options:  []interface{}{modeSyntax},
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code:     "import Act, { Frag } from 'react';\n<Frag><Foo /></Frag>;",
+			Output:   []string{"import Act, { Frag } from 'react';\n<><Foo /></>;"},
+			Tsx:      true,
+			Options:  []interface{}{modeSyntax},
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code:     "const F = Act.Frag;\n<F><Foo /></F>;",
+			Output:   []string{"const F = Act.Frag;\n<><Foo /></>;"},
+			Tsx:      true,
+			Options:  []interface{}{modeSyntax},
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code:     "const { Frag } = Act;\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const { Frag } = Act;\n<><Foo /></>;"},
+			Tsx:      true,
+			Options:  []interface{}{modeSyntax},
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code:     "const { Frag } = require('react');\n<Frag><Foo /></Frag>;",
+			Output:   []string{"const { Frag } = require('react');\n<><Foo /></>;"},
+			Tsx:      true,
+			Options:  []interface{}{modeSyntax},
+			Settings: settings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferFragment", Line: 2, Column: 1},
+			},
+		},
+	})
+}
+
+const fragmentsNotSupportedDescription = "Fragments are only supported starting from React v16.2. Please disable the `react/jsx-fragments` rule in `eslint` settings or upgrade your version of React."
+
+func reactSettings(version, pragma, fragment string) map[string]interface{} {
+	return map[string]interface{}{
+		"react": map[string]interface{}{
+			"version":  version,
+			"pragma":   pragma,
+			"fragment": fragment,
+		},
+	}
+}
+
+func preferPragmaDescription(react, fragment string) string {
+	return "Prefer " + react + "." + fragment + " over fragment shorthand"
+}
+
+func preferFragmentDescription(react, fragment string) string {
+	return "Prefer fragment shorthand over " + react + "." + fragment
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -153,6 +153,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-equals-spacing.test.ts',
     './tests/eslint-plugin-react/rules/jsx-filename-extension.test.ts',
     './tests/eslint-plugin-react/rules/jsx-first-prop-new-line.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-fragments.test.ts',
     './tests/eslint-plugin-react/rules/jsx-handler-names.test.ts',
     './tests/eslint-plugin-react/rules/jsx-indent.test.ts',
     './tests/eslint-plugin-react/rules/jsx-indent-props.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-fragments.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-fragments.test.ts
@@ -1,0 +1,169 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const settings = {
+  react: {
+    version: '16.2',
+    pragma: 'Act',
+    fragment: 'Frag',
+  },
+};
+
+const settingsOld = {
+  react: {
+    version: '16.1',
+    pragma: 'Act',
+    fragment: 'Frag',
+  },
+};
+
+ruleTester.run('jsx-fragments', {} as never, {
+  valid: [
+    {
+      code: '<><Foo /></>',
+      settings,
+    },
+    {
+      code: '<Act.Frag><Foo /></Act.Frag>',
+      options: ['element'],
+      settings,
+    },
+    {
+      code: '<Act.Frag />',
+      options: ['element'],
+      settings,
+    },
+    {
+      code: `
+        import Act, { Frag as F } from 'react';
+        <F><Foo /></F>;
+      `,
+      options: ['element'],
+      settings,
+    },
+    {
+      code: `
+        const F = Act.Frag;
+        <F><Foo /></F>;
+      `,
+      options: ['element'],
+      settings,
+    },
+    {
+      code: `
+        const { Frag } = Act;
+        <Frag><Foo /></Frag>;
+      `,
+      options: ['element'],
+      settings,
+    },
+    {
+      code: `
+        const { Frag } = require('react');
+        <Frag><Foo /></Frag>;
+      `,
+      options: ['element'],
+      settings,
+    },
+    {
+      code: '<Act.Frag key="key"><Foo /></Act.Frag>',
+      options: ['syntax'],
+      settings,
+    },
+    {
+      code: '<Act.Frag key="key" />',
+      options: ['syntax'],
+      settings,
+    },
+  ],
+  invalid: [
+    {
+      code: '<><Foo /></>',
+      settings: settingsOld,
+      errors: [{ messageId: 'fragmentsNotSupported' }],
+    },
+    {
+      code: '<Act.Frag><Foo /></Act.Frag>',
+      settings: settingsOld,
+      errors: [{ messageId: 'fragmentsNotSupported' }],
+    },
+    {
+      code: '<Act.Frag />',
+      settings: settingsOld,
+      errors: [{ messageId: 'fragmentsNotSupported' }],
+    },
+    {
+      code: '<><Foo /></>',
+      options: ['element'],
+      settings,
+      errors: [{ messageId: 'preferPragma' }],
+    },
+    {
+      code: '<Act.Frag><Foo /></Act.Frag>',
+      options: ['syntax'],
+      settings,
+      errors: [{ messageId: 'preferFragment' }],
+    },
+    {
+      code: '<Act.Frag />',
+      options: ['syntax'],
+      settings,
+      errors: [{ messageId: 'preferFragment' }],
+    },
+    {
+      code: `
+        import Act, { Frag as F } from 'react';
+        <F />;
+      `,
+      options: ['syntax'],
+      settings,
+      errors: [{ messageId: 'preferFragment' }],
+    },
+    {
+      code: `
+        import Act, { Frag as F } from 'react';
+        <F><Foo /></F>;
+      `,
+      options: ['syntax'],
+      settings,
+      errors: [{ messageId: 'preferFragment' }],
+    },
+    {
+      code: `
+        import Act, { Frag } from 'react';
+        <Frag><Foo /></Frag>;
+      `,
+      options: ['syntax'],
+      settings,
+      errors: [{ messageId: 'preferFragment' }],
+    },
+    {
+      code: `
+        const F = Act.Frag;
+        <F><Foo /></F>;
+      `,
+      options: ['syntax'],
+      settings,
+      errors: [{ messageId: 'preferFragment' }],
+    },
+    {
+      code: `
+        const { Frag } = Act;
+        <Frag><Foo /></Frag>;
+      `,
+      options: ['syntax'],
+      settings,
+      errors: [{ messageId: 'preferFragment' }],
+    },
+    {
+      code: `
+        const { Frag } = require('react');
+        <Frag><Foo /></Frag>;
+      `,
+      options: ['syntax'],
+      settings,
+      errors: [{ messageId: 'preferFragment' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/jsx-fragments` rule from eslint-plugin-react to rslint.

The rule enforces shorthand or standard-form React fragments, supports `syntax` and `element` modes, preserves the React version gate, and includes autofixes for both directions.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-fragments.js
- Upstream tests: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/tests/lib/rules/jsx-fragments.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
