### PR TITLE
feat: port rule react-hooks/component-hook-factories

### DIFF
--- a/internal/plugins/jest/rules/valid_title/valid_title.go
+++ b/internal/plugins/jest/rules/valid_title/valid_title.go
@@ -14,8 +14,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-const jsRegexOpts = regexp2.ECMAScript | regexp2.Unicode
-
 type matcherEntry struct {
 	re *regexp2.Regexp
 	// customText non-empty ⇒ use mustMatchCustom / mustNotMatchCustom
@@ -71,19 +69,11 @@ func boolFromMap(m map[string]interface{}, key string, def bool) bool {
 }
 
 func compileRE2(pat string) (*regexp2.Regexp, error) {
-	re, err := regexp2.Compile(pat, jsRegexOpts)
+	re, err := utils.CompileRegexp2(pat, utils.JSUnicodeRegexOptions)
 	if err != nil {
 		return nil, err
 	}
 	return re, nil
-}
-
-func matchRE2(re *regexp2.Regexp, s string) bool {
-	if re == nil {
-		return false
-	}
-	m, err := re.FindStringMatch(s)
-	return err == nil && m != nil
 }
 
 func compileMatcherPatterns(raw interface{}, optionPath string) (matchersByFn, []invalidPattern) {
@@ -514,13 +504,13 @@ var ValidTitleRule = rule.Rule{
 
 				fnKey := trimFXPrefix(jestFn.Name)
 
-				if me := matcherFor(fnKey, co.mustNotMatch); matchRE2(me.re, title) {
+				if me := matcherFor(fnKey, co.mustNotMatch); utils.Regexp2MatchString(me.re, title) {
 					buildMustNotReport(ctx, arg, unprefixedName, me)
 					return
 				}
 
 				me := matcherFor(fnKey, co.mustMatch)
-				if me.re != nil && !matchRE2(me.re, title) {
+				if me.re != nil && !utils.Regexp2MatchString(me.re, title) {
 					buildMustMatchReport(ctx, arg, unprefixedName, me)
 				}
 			},

--- a/internal/plugins/promise/rules/param_names/param_names.go
+++ b/internal/plugins/promise/rules/param_names/param_names.go
@@ -3,7 +3,6 @@ package param_names
 import (
 	"fmt"
 
-	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -82,12 +81,6 @@ func paramName(param *ast.Node) string {
 	return name.AsIdentifier().Text
 }
 
-// regexMatch wraps regexp2.MatchString, discarding the timeout error.
-func regexMatch(re *regexp2.Regexp, s string) bool {
-	matched, _ := re.MatchString(s)
-	return matched
-}
-
 var ParamNamesRule = rule.Rule{
 	Name: "promise/param-names",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
@@ -95,12 +88,11 @@ var ParamNamesRule = rule.Rule{
 		// ECMAScript + Unicode flags mirror ESLint's `new RegExp(pattern, 'u')`
 		// so user patterns using lookaround, backreferences, or `\p{...}` work
 		// identically to the original rule (Go's standard `regexp` / RE2 does not).
-		const reOpts = regexp2.ECMAScript | regexp2.Unicode
-		resolveRe, err := regexp2.Compile(opts.ResolvePattern, reOpts)
+		resolveRe, err := utils.CompileRegexp2(opts.ResolvePattern, utils.JSUnicodeRegexOptions)
 		if err != nil {
 			return rule.RuleListeners{}
 		}
-		rejectRe, err := regexp2.Compile(opts.RejectPattern, reOpts)
+		rejectRe, err := utils.CompileRegexp2(opts.RejectPattern, utils.JSUnicodeRegexOptions)
 		if err != nil {
 			return rule.RuleListeners{}
 		}
@@ -132,11 +124,11 @@ var ParamNamesRule = rule.Rule{
 					return
 				}
 
-				if resolveName := paramName(params[0]); resolveName != "" && !regexMatch(resolveRe, resolveName) {
+				if resolveName := paramName(params[0]); resolveName != "" && !utils.Regexp2MatchString(resolveRe, resolveName) {
 					ctx.ReportNode(params[0], buildResolveParamNamesMessage(opts.ResolvePattern))
 				}
 				if len(params) >= 2 {
-					if rejectName := paramName(params[1]); rejectName != "" && !regexMatch(rejectRe, rejectName) {
+					if rejectName := paramName(params[1]); rejectName != "" && !utils.Regexp2MatchString(rejectRe, rejectName) {
 						ctx.ReportNode(params[1], buildRejectParamNamesMessage(opts.RejectPattern))
 					}
 				}

--- a/internal/plugins/react_hooks/all.go
+++ b/internal/plugins/react_hooks/all.go
@@ -1,6 +1,7 @@
 package react_hooks
 
 import (
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/component_hook_factories"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/exhaustive_deps"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/rules_of_hooks"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -10,5 +11,6 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		rules_of_hooks.RulesOfHooksRule,
 		exhaustive_deps.ExhaustiveDepsRule,
+		component_hook_factories.ComponentHookFactoriesRule,
 	}
 }

--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -9,16 +9,29 @@
 // (and third) copy of every predicate.
 //
 // Naming convention follows the rest of the codebase: predicates
-// start with `Is*`, getters with `Get*`. The package never imports
-// `internal/utils/` — the rules consume `internal/utils/` separately
-// and pass values through.
+// start with `Is*`, getters with `Get*`. General AST helpers stay in
+// `internal/utils`; this package composes them where they already exist.
 package react_hooksutil
 
 import (
 	"regexp"
+	"strings"
 
+	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+type CompilerReactFunctionType string
+
+const (
+	CompilerReactFunctionComponent CompilerReactFunctionType = "Component"
+	CompilerReactFunctionHook      CompilerReactFunctionType = "Hook"
+)
+
+type CompilerFunctionOptions struct {
+	HookPattern *regexp2.Regexp
+}
 
 // hookNameTailRegex matches the suffix part of a hook identifier:
 // after the leading `use`, the next character must be uppercase Latin
@@ -39,6 +52,13 @@ var effectNameRegex = regexp.MustCompile(`Effect($|[^a-z])`)
 // `useFoo` / `use1` (`use` followed by uppercase letter or digit).
 func IsHookName(s string) bool {
 	return s == "use" || hookNameTailRegex.MatchString(s)
+}
+
+// IsCompilerHookName reports whether `s` follows the React Compiler
+// hook-like naming convention. Unlike rules-of-hooks, the compiler lint
+// predicates do not treat the bare `use` identifier as a custom hook name.
+func IsCompilerHookName(s string) bool {
+	return hookNameTailRegex.MatchString(s)
 }
 
 // IsComponentNameStr reports whether `s` looks like a React component
@@ -136,6 +156,200 @@ func IsHookCallee(node *ast.Node) bool {
 	return false
 }
 
+// IsCompilerHookCallee is the React Compiler variant of IsHookCallee:
+// it accepts `useFoo` / `Namespace.useFoo`, but not the bare `use`.
+func IsCompilerHookCallee(node *ast.Node, hookPattern *regexp2.Regexp) bool {
+	if node == nil {
+		return false
+	}
+	isHookName := func(name string) bool {
+		if hookPattern != nil {
+			return utils.Regexp2MatchString(hookPattern, name)
+		}
+		return IsCompilerHookName(name)
+	}
+	n := ast.SkipParentheses(node)
+	switch n.Kind {
+	case ast.KindIdentifier:
+		return isHookName(n.AsIdentifier().Text)
+	case ast.KindPropertyAccessExpression:
+		pae := n.AsPropertyAccessExpression()
+		prop := pae.Name()
+		if prop == nil || prop.Kind != ast.KindIdentifier || !isHookName(prop.AsIdentifier().Text) {
+			return false
+		}
+		obj := ast.SkipParentheses(pae.Expression)
+		return obj != nil && obj.Kind == ast.KindIdentifier && IsComponentNameStr(obj.AsIdentifier().Text)
+	}
+	return false
+}
+
+// IsCompilerFunctionKind reports whether `node` is one of the function
+// syntaxes that React Compiler's Factories diagnostic traverses:
+// FunctionDeclaration, FunctionExpression, or ArrowFunctionExpression.
+func IsCompilerFunctionKind(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return ast.IsFunctionDeclaration(node) || ast.IsFunctionExpressionOrArrowFunction(node)
+}
+
+// GetCompilerReactFunctionType mirrors the React Compiler classifier used by
+// the Factories diagnostic: a PascalCase function is a component only when it
+// directly creates JSX or calls a hook, has component-like parameters, and does
+// not return obviously non-ReactNode values; a hook-like function must directly
+// create JSX or call a hook; memo/forwardRef callbacks are components.
+func GetCompilerReactFunctionType(fn *ast.Node, opts CompilerFunctionOptions) CompilerReactFunctionType {
+	name := GetFunctionName(fn)
+	if name != nil && name.Kind == ast.KindIdentifier && IsComponentNameStr(name.AsIdentifier().Text) {
+		if CallsHooksOrCreatesJsx(fn, opts.HookPattern) &&
+			IsValidCompilerComponentParams(fn) &&
+			!ReturnsCompilerNonNode(fn) {
+			return CompilerReactFunctionComponent
+		}
+		return ""
+	}
+	if name != nil && IsCompilerHookCallee(name, opts.HookPattern) {
+		if CallsHooksOrCreatesJsx(fn, opts.HookPattern) {
+			return CompilerReactFunctionHook
+		}
+		return ""
+	}
+	if ast.IsFunctionExpressionOrArrowFunction(fn) {
+		if IsForwardRefOrMemoCallback(fn, "forwardRef") || IsForwardRefOrMemoCallback(fn, "memo") {
+			if CallsHooksOrCreatesJsx(fn, opts.HookPattern) {
+				return CompilerReactFunctionComponent
+			}
+		}
+	}
+	return ""
+}
+
+// CallsHooksOrCreatesJsx reports whether `fn` directly creates JSX or directly
+// calls a compiler hook. Nested function bodies are skipped, matching React
+// Compiler's traversal boundary.
+func CallsHooksOrCreatesJsx(fn *ast.Node, hookPattern *regexp2.Regexp) bool {
+	found := false
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil || found {
+			return
+		}
+		if node != fn && IsCompilerFunctionKind(node) {
+			return
+		}
+		if ast.IsJsxElement(node) || ast.IsJsxSelfClosingElement(node) || ast.IsJsxFragment(node) {
+			found = true
+			return
+		}
+		if ast.IsCallExpression(node) {
+			if IsCompilerHookCallee(node.AsCallExpression().Expression, hookPattern) {
+				found = true
+				return
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return found
+		})
+	}
+	walk(fn)
+	return found
+}
+
+// IsValidCompilerComponentParams mirrors React Compiler's
+// isValidComponentParams helper.
+func IsValidCompilerComponentParams(fn *ast.Node) bool {
+	params := fn.Parameters()
+	if len(params) == 0 {
+		return true
+	}
+	if len(params) > 2 || !isValidCompilerPropsAnnotation(params[0]) {
+		return false
+	}
+	if len(params) == 1 {
+		return !utils.IsRestParameterDeclaration(params[0])
+	}
+	secondName := params[1].AsParameterDeclaration().Name()
+	if secondName == nil || secondName.Kind != ast.KindIdentifier {
+		return false
+	}
+	name := secondName.AsIdentifier().Text
+	return strings.Contains(name, "ref") || strings.Contains(name, "Ref")
+}
+
+func isValidCompilerPropsAnnotation(param *ast.Node) bool {
+	if param == nil || !ast.IsParameterDeclaration(param) {
+		return false
+	}
+	typ := ast.GetTypeAnnotationNode(param)
+	if typ == nil {
+		return true
+	}
+	switch typ.Kind {
+	case ast.KindArrayType, ast.KindBigIntKeyword, ast.KindBooleanKeyword,
+		ast.KindConstructorType, ast.KindFunctionType, ast.KindLiteralType,
+		ast.KindNeverKeyword, ast.KindNumberKeyword, ast.KindStringKeyword,
+		ast.KindSymbolKeyword, ast.KindTupleType:
+		return false
+	}
+	return true
+}
+
+// ReturnsCompilerNonNode mirrors React Compiler's returnsNonNode helper.
+func ReturnsCompilerNonNode(fn *ast.Node) bool {
+	returnsNonNode := false
+	if ast.IsArrowFunction(fn) {
+		body := fn.AsArrowFunction().Body
+		if body != nil && body.Kind != ast.KindBlock {
+			returnsNonNode = IsCompilerNonNode(body)
+		}
+	}
+
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node != fn && IsCompilerFunctionKind(node) {
+			return
+		}
+		if isCompilerObjectMethod(node) {
+			return
+		}
+		if node.Kind == ast.KindReturnStatement {
+			returnsNonNode = IsCompilerNonNode(node.AsReturnStatement().Expression)
+			return
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(fn)
+	return returnsNonNode
+}
+
+func isCompilerObjectMethod(node *ast.Node) bool {
+	return node != nil && ast.IsObjectLiteralMethod(node)
+}
+
+// IsCompilerNonNode mirrors React Compiler's isNonNode helper for returns
+// whose value is definitely not a React node.
+func IsCompilerNonNode(node *ast.Node) bool {
+	if node == nil {
+		return true
+	}
+	n := ast.SkipParentheses(node)
+	if ast.IsObjectLiteralExpression(n) ||
+		ast.IsFunctionExpressionOrArrowFunction(n) ||
+		ast.IsClassExpression(n) ||
+		ast.IsNewExpression(n) {
+		return true
+	}
+	return ast.IsBigIntLiteral(n)
+}
+
 // IsFunctionLikeContainer reports whether `node` is one of the
 // function-like kinds the upstream rules treat as a "code path"
 // boundary.
@@ -227,7 +441,7 @@ func GetFunctionName(fn *ast.Node) *ast.Node {
 		}
 		// fall through to anonymous handling
 	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
-		if fn.Parent != nil && fn.Parent.Kind == ast.KindObjectLiteralExpression {
+		if fn.Parent != nil && ast.IsObjectLiteralExpression(fn.Parent) {
 			return fn.Name()
 		}
 		return nil
@@ -308,11 +522,11 @@ func IsClassMember(fn *ast.Node) bool {
 	p := fn.Parent
 	switch fn.Kind {
 	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
-		return p.Kind == ast.KindClassDeclaration || p.Kind == ast.KindClassExpression
+		return ast.IsClassLike(p)
 	case ast.KindArrowFunction, ast.KindFunctionExpression:
 		if p.Kind == ast.KindPropertyDeclaration {
 			gp := p.Parent
-			if gp != nil && (gp.Kind == ast.KindClassDeclaration || gp.Kind == ast.KindClassExpression) {
+			if gp != nil && ast.IsClassLike(gp) {
 				return true
 			}
 		}

--- a/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories.go
+++ b/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories.go
@@ -1,0 +1,145 @@
+package component_hook_factories
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dlclark/regexp2"
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type componentHookFactoriesOptions struct {
+	hookPattern *regexp2.Regexp
+}
+
+// ComponentHookFactoriesRule is the rslint port of upstream
+// `react-hooks/component-hook-factories`.
+//
+// The original rule is produced by React Compiler diagnostics. This port keeps
+// the Factories category local to rslint: flag functions that dynamically
+// create a nested React component or Hook instead of defining it at module
+// scope.
+var ComponentHookFactoriesRule = rule.Rule{
+	Name: "react-hooks/component-hook-factories",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		check := func(node *ast.Node) {
+			validateNoDynamicallyCreatedComponentsOrHooks(ctx, node, opts)
+		}
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration: check,
+			ast.KindFunctionExpression:  check,
+			ast.KindArrowFunction:       check,
+		}
+	},
+}
+
+func parseOptions(raw any) componentHookFactoriesOptions {
+	optsMap := utils.GetOptionsMap(raw)
+	if optsMap == nil {
+		return componentHookFactoriesOptions{}
+	}
+	environment, ok := optsMap["environment"].(map[string]interface{})
+	if !ok {
+		return componentHookFactoriesOptions{}
+	}
+	pattern, ok := environment["hookPattern"].(string)
+	if !ok || pattern == "" {
+		return componentHookFactoriesOptions{}
+	}
+	compiled, err := utils.CompileRegexp2(pattern, utils.JSRegexOptions)
+	if err != nil {
+		return componentHookFactoriesOptions{}
+	}
+	return componentHookFactoriesOptions{hookPattern: compiled}
+}
+
+func validateNoDynamicallyCreatedComponentsOrHooks(ctx rule.RuleContext, fn *ast.Node, opts componentHookFactoriesOptions) {
+	if isInsideClass(fn) {
+		return
+	}
+	parentNameNode := react_hooksutil.GetFunctionName(fn)
+	parentName := functionDisplayName(parentNameNode)
+	if parentName == "" {
+		parentName = "<anonymous>"
+	}
+	reportNode := parentNameNode
+	if reportNode == nil {
+		reportNode = fn
+	}
+
+	walkDirectChildren(fn, func(nestedFn *ast.Node) {
+		nestedType := react_hooksutil.GetCompilerReactFunctionType(nestedFn, react_hooksutil.CompilerFunctionOptions{
+			HookPattern: opts.hookPattern,
+		})
+		if nestedType == "" {
+			return
+		}
+		nestedName := functionDisplayName(react_hooksutil.GetFunctionName(nestedFn))
+		if nestedName == "" {
+			nestedName = "<anonymous>"
+		}
+		ctx.ReportNode(reportNode, buildDynamicFactoryMessage(parentName, nestedName, string(nestedType)))
+	})
+}
+
+func isInsideClass(node *ast.Node) bool {
+	for parent := node.Parent; parent != nil; parent = parent.Parent {
+		if ast.IsClassLike(parent) {
+			return true
+		}
+		if ast.IsSourceFile(parent) {
+			return false
+		}
+	}
+	return false
+}
+
+func walkDirectChildren(root *ast.Node, visitFunction func(*ast.Node)) {
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node != root && react_hooksutil.IsCompilerFunctionKind(node) {
+			visitFunction(node)
+			return
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(root)
+}
+
+func functionDisplayName(name *ast.Node) string {
+	if name == nil {
+		return ""
+	}
+	name = ast.SkipParentheses(name)
+	if ast.IsIdentifier(name) {
+		return name.AsIdentifier().Text
+	}
+	return ""
+}
+
+func buildDynamicFactoryMessage(parentName, nestedName, nestedType string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "componentHookFactory",
+		Description: fmt.Sprintf(
+			"Components and hooks cannot be created dynamically. The function `%s` appears to be a React %s, but it's defined inside `%s`. Components and Hooks should always be declared at module scope.",
+			nestedName,
+			strings.ToLower(nestedType),
+			parentName,
+		),
+		Data: map[string]string{
+			"nestedName": nestedName,
+			"nestedType": nestedType,
+			"parentName": parentName,
+		},
+	}
+}

--- a/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories.md
+++ b/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories.md
@@ -1,0 +1,80 @@
+# component-hook-factories
+
+## Rule Details
+
+Validates against higher order functions defining nested components or hooks.
+Components and hooks should be defined at the module level.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function createComponent(defaultValue) {
+  return function Component() {
+    return <span>{defaultValue}</span>;
+  };
+}
+
+function Parent() {
+  function Child() {
+    return <div />;
+  }
+
+  return <Child />;
+}
+
+function createCustomHook(endpoint) {
+  return function useData() {
+    return useMemo(() => endpoint, [endpoint]);
+  };
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function Component({ defaultValue }) {
+  return <span>{defaultValue}</span>;
+}
+
+function useData(endpoint) {
+  return useMemo(() => endpoint, [endpoint]);
+}
+
+function Button({ color, children }) {
+  return <button style={{ backgroundColor: color }}>{children}</button>;
+}
+```
+
+## Options
+
+```json
+{
+  "react-hooks/component-hook-factories": [
+    "error",
+    {
+      "environment": {
+        "hookPattern": "^signal[A-Z]"
+      }
+    }
+  ]
+}
+```
+
+- `environment.hookPattern`: A JavaScript regular expression pattern for
+  custom Hook names. Function names that match this pattern are treated as
+  Hooks when the rule classifies nested factories. When omitted or invalid,
+  the rule falls back to React's default Hook naming convention.
+
+Examples of **incorrect** code for this rule with `{ "environment": { "hookPattern": "^signal[A-Z]" } }`:
+
+```javascript
+function createSignalHook(source) {
+  return function signalValue() {
+    return signalRead(source);
+  };
+}
+```
+
+## Original Documentation
+
+- [react.dev — component-hook-factories](https://react.dev/reference/eslint-plugin-react-hooks/lints/component-hook-factories)

--- a/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories_extras_test.go
+++ b/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories_extras_test.go
@@ -1,0 +1,449 @@
+package component_hook_factories
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestComponentHookFactoriesExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Dimension 4: declaration/container forms — lowercase factory output is not a component/hook ----
+		{Code: `
+function makeRenderer(value: string) {
+  return function renderValue() {
+    return <span>{value}</span>;
+  };
+}
+		`, Tsx: true},
+		// ---- Dimension 4: receiver/expression wrappers — bare use() is not a compiler hook name ----
+		{Code: `
+function makeUse() {
+  return function use() {
+    return use(resource);
+  };
+}
+		`, Tsx: true},
+		// ---- Dimension 4: access/key forms — computed object method is not one of upstream's visited function nodes ----
+		{Code: `
+function FactoryBag() {
+  const bag = {
+    ['Component']() {
+      return <div />;
+    },
+  };
+  return bag;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: graceful degradation — body-absent declarations do not crash ----
+		{Code: `
+declare function createDeclaredComponent(): () => JSX.Element;
+
+abstract class BaseFactory {
+  abstract createComponent(): () => JSX.Element;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: component param validation — primitive props annotation is not component-like upstream ----
+		{Code: `
+function createStringComponent() {
+  return function Component(props: string) {
+    return <div>{props}</div>;
+  };
+}
+		`, Tsx: true},
+		// ---- Dimension 4: component return validation — returning a function is not ReactNode-like upstream ----
+		{Code: `
+function createFunctionReturningComponent() {
+  return function Component() {
+    return function helper() {};
+  };
+}
+		`, Tsx: true},
+		// ---- Real-user: helper factory that returns a lowercase render callback ----
+		{Code: `
+export function makeCellRenderer(format: (value: string) => string) {
+  return function renderCell(value: string) {
+    return <td>{format(value)}</td>;
+  };
+}
+		`, Tsx: true},
+		// ---- Real-user: module-level memo/forwardRef callbacks are accepted ----
+		{Code: `
+const Button = memo(function ButtonImpl(props) {
+  return <button {...props} />;
+});
+
+const Input = forwardRef((props, ref) => {
+  return <input ref={ref} {...props} />;
+});
+		`, Tsx: true},
+		// ---- Branch lock-in: nested function bodies are skipped when classifying the returned function ----
+		{Code: `
+function makeWrapper() {
+  return function Component() {
+    function helper() {
+      return useState();
+    }
+    return helper;
+  };
+}
+		`, Tsx: true},
+		// ---- Branch lock-in: return with no argument is definitely non-ReactNode-like upstream ----
+		{Code: `
+function makeEmptyComponent() {
+  return function Component() {
+    return;
+  };
+}
+		`, Tsx: true},
+		// ---- Branch lock-in: object, class, new, and function returns are not ReactNode-like upstream ----
+		{Code: `
+function makeNonNodeComponents() {
+  const A = function Component() {
+    return {};
+  };
+  const B = function Component() {
+    return class Inner {};
+  };
+  const C = function Component() {
+    return new Thing();
+  };
+  const D = function Component() {
+    return () => null;
+  };
+  return [A, B, C, D];
+}
+		`, Tsx: true},
+		// ---- Branch lock-in: computed hook member calls are not compiler hook callees ----
+		{Code: `
+function makeComputedHook() {
+  return function useComputed() {
+    return Hooks['useThing']();
+  };
+}
+		`, Tsx: true},
+		// ---- Branch lock-in: malformed hookPattern is ignored like upstream option parsing ----
+		{
+			Code: `
+function createSignalHook(source) {
+  return function signalValue() {
+    return signalRead(source);
+  };
+}
+			`,
+			Tsx:     true,
+			Options: map[string]interface{}{"environment": map[string]interface{}{"hookPattern": "["}},
+		},
+		// ---- Dimension 4: class declarations/expressions are skipped by the React Compiler traversal ----
+		{Code: `
+class Holder {
+  make = () => {
+    return function Component() {
+      return <div />;
+    };
+  };
+
+  method() {
+    function Child() {
+      return <span />;
+    }
+    return Child;
+  }
+}
+		`, Tsx: true},
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: function declaration factory ----
+		{
+			Code: `
+function createFeatureFlaggedComponent(flag: boolean) {
+  return function Feature() {
+    return flag ? <Enabled /> : <Disabled />;
+  };
+}
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Dimension 4: arrow factory assigned to a variable ----
+		{
+			Code: `
+const createComponent = (defaultValue: string) => {
+  return function Component() {
+    return <span>{defaultValue}</span>;
+  };
+};
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Dimension 4: async and generator factory containers ----
+		{
+			Code: `
+async function createAsyncComponent(load: () => Promise<string>) {
+  const value = await load();
+  return function Component() {
+    return <span>{value}</span>;
+  };
+}
+
+function* createHookGenerator() {
+  yield function useGenerated() {
+    return useState();
+  };
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentHookFactory"},
+				{MessageId: "componentHookFactory"},
+			},
+		},
+		// ---- Dimension 4: TS wrappers around produced components/hooks ----
+		{
+			Code: `
+type ComponentFactory = () => () => JSX.Element;
+const createWrappedComponent = (() => {
+  return ((function Component() {
+    return <div />;
+  }) as () => JSX.Element)!;
+}) satisfies ComponentFactory;
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Dimension 4: optional chain and element access near factories ----
+		{
+			Code: `
+function makeFactory(registry: any) {
+  const Base = registry?.['Component'];
+  return function Component() {
+    return Base ? <Base /> : null;
+  };
+}
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Branch lock-in: component can be inferred from a direct hook call without JSX ----
+		{
+			Code: `
+function makeHookOnlyComponent() {
+  return function Component() {
+    useState();
+    return null;
+  };
+}
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Branch lock-in: namespaced compiler hook callees are recognized ----
+		{
+			Code: `
+function makeNamespacedHook() {
+  return function useNamespaced() {
+    return React.useState(0)[0];
+  };
+}
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Branch lock-in: JSX fragments classify nested components ----
+		{
+			Code: `
+function makeFragmentComponent() {
+  return function FragmentComponent() {
+    return <></>;
+  };
+}
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// Locks in upstream validateNoDynamicallyCreatedComponentsOrHooks(): non-Identifier parent names print as <anonymous>.
+		{
+			Code: `
+registry.create = function () {
+  return function Component() {
+    return <div />;
+  };
+};
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "componentHookFactory",
+				Message:   "Components and hooks cannot be created dynamically. The function `Component` appears to be a React component, but it's defined inside `<anonymous>`. Components and Hooks should always be declared at module scope.",
+			}},
+		},
+		// ---- Dimension 4: JSX callback nesting reports at the callback boundary, not the outer component ----
+		{
+			Code: `
+function Parent({items}: {items: string[]}) {
+  return (
+    <>
+      {items.map(item => {
+        function Child() {
+          return <span>{item}</span>;
+        }
+        return <Child />;
+      })}
+    </>
+  );
+}
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Dimension 4: object literal property function factory ----
+		{
+			Code: `
+const factories = {
+  createComponent: function () {
+    return function Component() {
+      return <div />;
+    };
+  },
+};
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Dimension 4: assignments and destructuring defaults ----
+		{
+			Code: `
+let makeComponent;
+makeComponent = () => function Component() {
+  return <div />;
+};
+
+const {
+  makeHook = () => function useGenerated() {
+    return useReducer(reducer, 0);
+  },
+} = registry;
+void makeHook;
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentHookFactory"},
+				{MessageId: "componentHookFactory"},
+			},
+		},
+		// ---- Dimension 4: rest binding and empty patterns are accepted around the reported factory ----
+		{
+			Code: `
+function createFromRest(...rest: Array<() => string>) {
+  const [] = rest;
+  const [, value = 'fallback'] = rest;
+  return function Component() {
+    return <span>{value}</span>;
+  };
+}
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Dimension 4: memo and forwardRef callbacks created dynamically ----
+		{
+			Code: `
+function createWrapped(kind) {
+  const Memoed = memo(function MemoedComponent() {
+    return <div>{kind}</div>;
+  });
+  const Forwarded = forwardRef((props, ref) => {
+    return <input ref={ref} {...props} />;
+  });
+  return [Memoed, Forwarded];
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentHookFactory"},
+				{MessageId: "componentHookFactory"},
+			},
+		},
+		// ---- Dimension 4: custom hookPattern option ----
+		{
+			Code: `
+function createSignalHook(source) {
+  return function signalValue() {
+    return signalRead(source);
+  };
+}
+			`,
+			Tsx:     true,
+			Options: map[string]interface{}{"environment": map[string]interface{}{"hookPattern": "(?=signal)signal[A-Z]"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Branch lock-in: array-wrapped hookPattern option matches context.options shape ----
+		{
+			Code: `
+function createTrackedHook(source) {
+  return function trackValue() {
+    return trackRead(source);
+  };
+}
+			`,
+			Tsx:     true,
+			Options: []interface{}{map[string]interface{}{"environment": map[string]interface{}{"hookPattern": "^track[A-Z]"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Real-user: library helper that returns an endpoint hook ----
+		{
+			Code: `
+export const makeUseEndpoint = (endpoint: string) => {
+  return function useEndpoint() {
+    return useQuery(endpoint);
+  };
+};
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+		// ---- Branch lock-in: same outer component can dynamically create both component and hook ----
+		{
+			Code: `
+function Component() {
+  function Nested() {
+    return <div />;
+  }
+  const useNested = () => useState();
+  return <Nested data={useNested()} />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentHookFactory"},
+				{MessageId: "componentHookFactory"},
+			},
+		},
+		// Locks in upstream returnsNonNode() arm: ObjectMethod bodies are skipped.
+		{
+			Code: `
+function makeComponentWithUnreachableObjectMethod() {
+  return function Component() {
+    return <div />;
+    const helpers = {
+      render() {
+        return {};
+      },
+    };
+    return helpers;
+  };
+}
+			`,
+			Tsx:    true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
+		},
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ComponentHookFactoriesRule,
+		valid,
+		invalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories_upstream_test.go
+++ b/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories_upstream_test.go
@@ -1,0 +1,144 @@
+package component_hook_factories
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestComponentHookFactoriesUpstream(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- React docs: module-level component example is accepted ----
+		{Code: `
+function Component({ defaultValue }) {
+  return <span>{defaultValue}</span>;
+}
+		`, Tsx: true},
+		// ---- React docs: module-level hook example is accepted ----
+		{Code: `
+function useData(endpoint) {
+  return useMemo(() => endpoint, [endpoint]);
+}
+		`, Tsx: true},
+		// ---- React docs: troubleshooting replacement example is accepted ----
+		{Code: `
+function Button({color, children}) {
+  return (
+    <button style={{backgroundColor: color}}>
+      {children}
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <>
+      <Button color="red">Red</Button>
+      <Button color="blue">Blue</Button>
+    </>
+  );
+}
+		`, Tsx: true},
+		// ---- Upstream compiler heuristic: PascalCase alone is not enough ----
+		{Code: `
+function createComponent(defaultValue) {
+  return function Component() {
+    return null;
+  };
+}
+		`, Tsx: true},
+		// ---- Upstream compiler heuristic: hook name alone is not enough ----
+		{Code: `
+function createCustomHook(endpoint) {
+  return function useData() {
+    return endpoint;
+  };
+}
+		`, Tsx: true},
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- React docs: factory function creating components ----
+		{
+			Code: `
+function createComponent(defaultValue) {
+  return function Component() {
+    return <span>{defaultValue}</span>;
+  };
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "componentHookFactory",
+				Message:   "Components and hooks cannot be created dynamically. The function `Component` appears to be a React component, but it's defined inside `createComponent`. Components and Hooks should always be declared at module scope.",
+				Line:      2,
+				Column:    10,
+				EndLine:   2,
+				EndColumn: 25,
+			}},
+		},
+		// ---- React docs: component defined inside component ----
+		{
+			Code: `
+function Parent() {
+  function Child() {
+    return <div />;
+  }
+  return <Child />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "componentHookFactory",
+				Line:      2,
+				Column:    10,
+			}},
+		},
+		// ---- React docs: hook factory function ----
+		{
+			Code: `
+function createCustomHook(endpoint) {
+  return function useData() {
+    return useMemo(() => endpoint, [endpoint]);
+  };
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "componentHookFactory",
+				Line:      2,
+				Column:    10,
+			}},
+		},
+		// ---- React docs: dynamic button factory troubleshooting example ----
+		{
+			Code: `
+function makeButton(color) {
+  return function Button({children}) {
+    return (
+      <button style={{backgroundColor: color}}>
+        {children}
+      </button>
+    );
+  };
+}
+
+const RedButton = makeButton('red');
+const BlueButton = makeButton('blue');
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "componentHookFactory",
+				Line:      2,
+				Column:    10,
+			}},
+		},
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ComponentHookFactoriesRule,
+		valid,
+		invalid,
+	)
+}

--- a/internal/rules/no_restricted_imports/no_restricted_imports.go
+++ b/internal/rules/no_restricted_imports/no_restricted_imports.go
@@ -729,8 +729,7 @@ func reportNameForPath(ctx *rule.RuleContext, node *ast.Node, specifiers []speci
 
 func isRestrictedPattern(importSource string, group *restrictedPatternGroup) bool {
 	if group.regexMatcher != nil {
-		matched, _ := group.regexMatcher.MatchString(importSource)
-		return matched
+		return utils.Regexp2MatchString(group.regexMatcher, importSource)
 	}
 	if group.matcher != nil {
 		return group.matcher.ignores(importSource)
@@ -772,7 +771,7 @@ func reportPathForPatterns(
 
 		// Check restricted import names (by name list or regex pattern)
 		if (len(group.importNames) > 0 && slices.Contains(group.importNames, e.name)) ||
-			(group.importNamePattern != nil && regexp2Match(group.importNamePattern, e.name)) {
+			(group.importNamePattern != nil && utils.Regexp2MatchString(group.importNamePattern, e.name)) {
 			reportSpecifiersForPattern(ctx, node, e.specifiers, group, e.name, importSource,
 				"patternAndImportName", "patternAndImportNameWithCustomMessage",
 				fmt.Sprintf("'%s' import from '%s' is restricted from being used by a pattern.", e.name, importSource))
@@ -783,7 +782,7 @@ func reportPathForPatterns(
 				"allowedImportName", "allowedImportNameWithCustomMessage",
 				fmt.Sprintf("'%s' import from '%s' is restricted because only %s %s allowed.",
 					e.name, importSource, formatEnglishList(group.allowImportNames), isOrAre(group.allowImportNames)))
-		} else if group.allowImportNamePattern != nil && !regexp2Match(group.allowImportNamePattern, e.name) {
+		} else if group.allowImportNamePattern != nil && !utils.Regexp2MatchString(group.allowImportNamePattern, e.name) {
 			reportSpecifiersForPattern(ctx, node, e.specifiers, group, e.name, importSource,
 				"allowedImportNamePattern", "allowedImportNamePatternWithCustomMessage",
 				fmt.Sprintf("'%s' import from '%s' is restricted because only imports that match the pattern '%s' are allowed from '%s'.",
@@ -957,12 +956,6 @@ func formatEnglishList(names []string) string {
 // jsRegexString formats a regex pattern in JavaScript RegExp.toString() notation: /pattern/u.
 func jsRegexString(re *regexp2.Regexp) string {
 	return "/" + re.String() + "/u"
-}
-
-// regexp2Match wraps regexp2.MatchString, discarding the error (timeout).
-func regexp2Match(re *regexp2.Regexp, s string) bool {
-	matched, _ := re.MatchString(s)
-	return matched
 }
 
 func isOrAre(names []string) string {

--- a/internal/utils/regexp2.go
+++ b/internal/utils/regexp2.go
@@ -1,0 +1,29 @@
+package utils
+
+import "github.com/dlclark/regexp2"
+
+const (
+	// JSRegexOptions enables regexp2's ECMAScript mode for JavaScript RegExp
+	// patterns that do not pass explicit flags.
+	JSRegexOptions regexp2.RegexOptions = regexp2.ECMAScript
+	// JSUnicodeRegexOptions mirrors `new RegExp(pattern, "u")`.
+	JSUnicodeRegexOptions regexp2.RegexOptions = regexp2.ECMAScript | regexp2.Unicode
+)
+
+// CompileRegexp2 compiles a regexp2 pattern with the caller's exact options.
+// Use JSRegexOptions / JSUnicodeRegexOptions for ESLint rule options that model
+// JavaScript RegExp patterns.
+func CompileRegexp2(pattern string, options regexp2.RegexOptions) (*regexp2.Regexp, error) {
+	return regexp2.Compile(pattern, options)
+}
+
+// Regexp2MatchString reports whether re matches s. regexp2 only returns an
+// error for runtime failures such as timeouts, which lint rules treat as no
+// match instead of reporting a diagnostic.
+func Regexp2MatchString(re *regexp2.Regexp, s string) bool {
+	if re == nil {
+		return false
+	}
+	matched, err := re.MatchString(s)
+	return err == nil && matched
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -210,6 +210,7 @@ export default defineConfig({
     // eslint-plugin-react-hooks
     './tests/eslint-plugin-react-hooks/rules/rules-of-hooks.test.ts',
     './tests/eslint-plugin-react-hooks/rules/exhaustive-deps.test.ts',
+    './tests/eslint-plugin-react-hooks/rules/component-hook-factories.test.ts',
 
     // eslint-plugin-jsx-a11y
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/component-hook-factories.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/component-hook-factories.test.ts
@@ -1,0 +1,116 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('component-hook-factories', {} as never, {
+  valid: [
+    {
+      code: `
+        function Component({ defaultValue }) {
+          return <span>{defaultValue}</span>;
+        }
+      `,
+    },
+    {
+      code: `
+        function useData(endpoint) {
+          return useState(endpoint)[0];
+        }
+      `,
+    },
+    {
+      code: `
+        function Button({color, children}) {
+          return (
+            <button style={{backgroundColor: color}}>
+              {children}
+            </button>
+          );
+        }
+
+        function App() {
+          return (
+            <>
+              <Button color="red">Red</Button>
+              <Button color="blue">Blue</Button>
+            </>
+          );
+        }
+      `,
+    },
+    {
+      code: `
+        function createComponent(defaultValue) {
+          return function Component() {
+            return null;
+          };
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function createComponent(defaultValue) {
+          return function Component() {
+            return <span>{defaultValue}</span>;
+          };
+        }
+      `,
+      errors: [
+        {
+          message:
+            "Components and hooks cannot be created dynamically. The function `Component` appears to be a React component, but it's defined inside `createComponent`. Components and Hooks should always be declared at module scope.",
+        },
+      ],
+    },
+    {
+      code: `
+        function Parent() {
+          function Child() {
+            return <div />;
+          }
+          return <Child />;
+        }
+      `,
+      errors: [
+        {
+          message:
+            "Components and hooks cannot be created dynamically. The function `Child` appears to be a React component, but it's defined inside `Parent`. Components and Hooks should always be declared at module scope.",
+        },
+      ],
+    },
+    {
+      code: `
+        function createCustomHook(endpoint) {
+          return function useData() {
+            return useState(endpoint)[0];
+          };
+        }
+      `,
+      errors: [
+        {
+          message:
+            "Components and hooks cannot be created dynamically. The function `useData` appears to be a React hook, but it's defined inside `createCustomHook`. Components and Hooks should always be declared at module scope.",
+        },
+      ],
+    },
+    {
+      code: `
+        function makeButton(color) {
+          return function Button({children}) {
+            return (
+              <button style={{backgroundColor: color}}>
+                {children}
+              </button>
+            );
+          };
+        }
+
+        const RedButton = makeButton('red');
+        const BlueButton = makeButton('blue');
+      `,
+      errors: 1,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react-hooks/component-hook-factories` rule with React Compiler `Factories` diagnostic semantics.

The rule reports functions that dynamically create nested React components or Hooks instead of defining them at module scope. Shared React Compiler-style function classification helpers live in `react_hooksutil` so other React Hooks rules can reuse the same hook/component detection logic.

Validation covered upstream docs cases, additional branch lock-ins, nested traversal boundaries, component parameter/return classification, `environment.hookPattern`, and real-user factory shapes. I also ran the built `packages/rslint/bin/rslint.js` against local `rsbuild` and `rspack` with this rule explicitly enabled; full scans produced 0 `react-hooks/component-hook-factories` diagnostics in both repos, and a temporary fixture in each repo produced the expected single diagnostic to confirm the rule was actually active.

## Related Links

- https://react.dev/reference/eslint-plugin-react-hooks/lints/component-hook-factories
- https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/CHANGELOG.md

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).