### PR TITLE
feat: port rule react/jsx-props-no-spread-multi

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -31,6 +31,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_undef"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_pascal_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_props_no_multi_spaces"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_props_no_spread_multi"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_react"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
@@ -110,6 +111,7 @@ func GetAllRules() []rule.Rule {
 		jsx_no_undef.JsxNoUndefRule,
 		jsx_pascal_case.JsxPascalCaseRule,
 		jsx_props_no_multi_spaces.JsxPropsNoMultiSpacesRule,
+		jsx_props_no_spread_multi.JsxPropsNoSpreadMultiRule,
 		jsx_uses_react.JsxUsesReactRule,
 		jsx_uses_vars.JsxUsesVarsRule,
 		jsx_wrap_multilines.JsxWrapMultilinesRule,

--- a/internal/plugins/react/rules/jsx_props_no_spread_multi/jsx_props_no_spread_multi.go
+++ b/internal/plugins/react/rules/jsx_props_no_spread_multi/jsx_props_no_spread_multi.go
@@ -1,0 +1,51 @@
+package jsx_props_no_spread_multi
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// JsxPropsNoSpreadMultiRule disallows spreading the same identifier multiple
+// times in one JSX opening element.
+var JsxPropsNoSpreadMultiRule = rule.Rule{
+	Name: "react/jsx-props-no-spread-multi",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		check := func(node *ast.Node) {
+			attrs := reactutil.GetJsxElementAttributes(node)
+			if len(attrs) == 0 {
+				return
+			}
+
+			seen := map[string]struct{}{}
+			for _, attr := range attrs {
+				if !ast.IsJsxSpreadAttribute(attr) {
+					continue
+				}
+				expr := attr.AsJsxSpreadAttribute().Expression
+				// ESTree flattens parentheses, so `{...(props)}` still reaches
+				// upstream as an Identifier. TS-specific wrappers (`as`, `!`,
+				// `satisfies`) stay opaque because upstream sees distinct nodes.
+				if expr != nil {
+					expr = ast.SkipParentheses(expr)
+				}
+				if !ast.IsIdentifier(expr) {
+					continue
+				}
+				name := expr.AsIdentifier().Text
+				if _, ok := seen[name]; ok {
+					ctx.ReportNode(attr, rule.RuleMessage{
+						Id:          "noMultiSpreading",
+						Description: "Spreading the same expression multiple times is forbidden",
+					})
+				}
+				seen[name] = struct{}{}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/react/rules/jsx_props_no_spread_multi/jsx_props_no_spread_multi.md
+++ b/internal/plugins/react/rules/jsx_props_no_spread_multi/jsx_props_no_spread_multi.md
@@ -1,0 +1,26 @@
+# jsx-props-no-spread-multi
+
+## Rule Details
+
+Disallow spreading the same JSX props identifier multiple times in one element.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<App {...props} myAttr="1" {...props} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<App myAttr="1" {...props} />
+<App {...props} myAttr="1" />
+```
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- [react/jsx-props-no-spread-multi](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spread-multi.md)

--- a/internal/plugins/react/rules/jsx_props_no_spread_multi/jsx_props_no_spread_multi_extras_test.go
+++ b/internal/plugins/react/rules/jsx_props_no_spread_multi/jsx_props_no_spread_multi_extras_test.go
@@ -1,0 +1,228 @@
+// TestJsxPropsNoSpreadMultiExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// Dimension 4 rows that don't apply to this rule (it inspects JSX spread
+// attribute expressions only):
+//   - N/A: JSX attribute names, object/class keys, PrivateIdentifier, and
+//     element access as a member key; the rule never reads prop names or keys.
+//   - N/A: class / function declaration & container forms; the rule targets
+//     JSX opening elements only.
+//   - N/A: ancestor scope walks (getThisContainer / FindEnclosingScope); none
+//     performed.
+//   - N/A: RestElement in a binding pattern; JSX spread attributes are the
+//     only spread/rest form inspected.
+package jsx_props_no_spread_multi
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxPropsNoSpreadMultiExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxPropsNoSpreadMultiRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: TS expression wrappers do NOT match upstream's direct Identifier check ----
+		{Code: `<App {...props!} {...props} />`, Tsx: true},
+		{Code: `<App {...(props as any)} {...props} />`, Tsx: true},
+		{Code: `type Props = {}; const props = {}; <App {...(props satisfies Props)} {...props} />`, Tsx: true},
+
+		// ---- Dimension 4: non-Identifier spread expressions are ignored ----
+		{Code: `<App {...this.props} {...this.props} />`, Tsx: true},
+		{Code: `<App {...props.foo} {...props.foo} />`, Tsx: true},
+		{Code: `<App {...props["foo"]} {...props["foo"]} />`, Tsx: true},
+		{Code: `<App {...props[foo]} {...props[foo]} />`, Tsx: true},
+		{Code: `<App {...getProps()} {...getProps()} />`, Tsx: true},
+		{Code: `<App {...{ props }} {...{ props }} />`, Tsx: true},
+		{Code: `<App {...props?.bag} {...props?.bag} />`, Tsx: true},
+		{Code: `<App {...(props?.bag)} {...(props?.bag)} />`, Tsx: true},
+
+		// ---- Dimension 4: graceful degradation with empty / non-spread attributes ----
+		{Code: `<App />`, Tsx: true},
+		{Code: `<App attr="x" />`, Tsx: true},
+		{Code: `<App {...props} attr="x" />`, Tsx: true},
+		{Code: `<App {...props} {...other} />`, Tsx: true},
+
+		// ---- Dimension 2: per-element tracking does not bleed across nested elements ----
+		{Code: `<Outer {...props}><Inner {...props} /></Outer>`, Tsx: true},
+		{Code: `<><App {...props} /><App {...props} /></>`, Tsx: true},
+
+		// ---- Dimension 4: identifier names are case-sensitive ----
+		{Code: `<App {...props} {...Props} />`, Tsx: true},
+
+		// ---- Real-user: issue #3962 "When Not To Use It" dynamic expression shape ----
+		{Code: `<App {...buildProps()} {...buildProps()} />`, Tsx: true},
+		// ---- Real-user: PR #3724 explicitly limits the rule to identifier prop bags ----
+		{Code: `<App {...props.common} {...props.common} />`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: parenthesized identifiers match because ESTree flattens parens ----
+		{
+			Code: `<App {...(props)} {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 19),
+			},
+		},
+		{
+			Code: `<App {...((props))} {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 21),
+			},
+		},
+		// Locks in upstream filter arm: ignored TS wrappers do not reset identifier tracking.
+		{
+			Code: `<App {...props} {...(props as any)} {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 37),
+			},
+		},
+		// Locks in upstream filter arm: parenthesized identifier duplicates report before later direct duplicates.
+		{
+			Code: `<App {...props} {...(props)} {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 17),
+				noMultiSpreadingError(1, 30),
+			},
+		},
+		// Locks in upstream JSXOpeningElement listener arm: non-self-closing elements are checked.
+		{
+			Code: `<App {...props} {...props}></App>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noMultiSpreading", Message: noMultiSpreadingMessage, Line: 1, Column: 17, EndLine: 1, EndColumn: 27},
+			},
+		},
+		// Locks in upstream JSXOpeningElement listener arm: self-closing elements are checked.
+		{
+			Code: `<App {...props} {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 17),
+			},
+		},
+		// ---- Dimension 4: tag-name forms do not affect spread tracking ----
+		{
+			Code: `type Props = {}; <App<Props> {...props} {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 41),
+			},
+		},
+		{
+			Code: `<UI.Button {...props} {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 23),
+			},
+		},
+		{
+			Code: `<svg:path {...props} {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 22),
+			},
+		},
+		// Locks in upstream filter arm: ordinary JSX attributes do not reset duplicate tracking.
+		{
+			Code: `<App {...props} attr="x" {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 26),
+			},
+		},
+		// Locks in upstream Set branch: duplicate tracking is per identifier name.
+		{
+			Code: `<App {...a} {...b} {...a} {...b} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 20),
+				noMultiSpreadingError(1, 27),
+			},
+		},
+		// Locks in upstream forEach branch: every duplicate after the first reports.
+		{
+			Code: `<App {...a} {...a} {...a} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 13),
+				noMultiSpreadingError(1, 20),
+			},
+		},
+		// Locks in upstream branch ordering: duplicates are reported in attribute order.
+		{
+			Code: `<App {...a} {...b} {...a} {...a} {...b} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 20),
+				noMultiSpreadingError(1, 27),
+				noMultiSpreadingError(1, 34),
+			},
+		},
+		// ---- Dimension 2: nested duplicate reports only on the inner element ----
+		{
+			Code: `<Outer {...props}><Inner {...props} {...props} /></Outer>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 37),
+			},
+		},
+		// ---- Dimension 2: nested elements maintain independent duplicate sets ----
+		{
+			Code: `<Outer {...props} {...props}><Inner {...props} {...props} /></Outer>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 19),
+				noMultiSpreadingError(1, 48),
+			},
+		},
+		// ---- Real-user: PR #3724 duplicated prop bag around an overriding prop ----
+		{
+			Code: `<Button {...props} disabled {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 29),
+			},
+		},
+		// ---- Real-user: PR #3724 duplicate prop bags around explicit overrides ----
+		{
+			Code: `<FormField {...fieldProps} disabled={isDisabled} {...fieldProps} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 50),
+			},
+		},
+		{
+			Code: `<Route {...routeProps} element={<Page />} {...routeProps} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 43),
+			},
+		},
+		// ---- Dimension 4: comments and trivia between attributes do not affect tracking ----
+		{
+			Code: `<App {...props} /* keep override */ {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 37),
+			},
+		},
+		// ---- Dimension 4: multi-line position uses the second duplicate spread ----
+		{
+			Code: `<App
+  {...props}
+  attr="x"
+  {...props}
+/>`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noMultiSpreading", Message: noMultiSpreadingMessage, Line: 4, Column: 3, EndLine: 4, EndColumn: 13},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/jsx_props_no_spread_multi/jsx_props_no_spread_multi_upstream_test.go
+++ b/internal/plugins/react/rules/jsx_props_no_spread_multi/jsx_props_no_spread_multi_upstream_test.go
@@ -1,0 +1,54 @@
+// TestJsxPropsNoSpreadMultiUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/jsx-props-no-spread-multi.js 1:1. Position
+// assertions cover line/column for every invalid case. rslint-specific lock-in
+// cases live in the jsx_props_no_spread_multi_extras_test.go file.
+package jsx_props_no_spread_multi
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const noMultiSpreadingMessage = "Spreading the same expression multiple times is forbidden"
+
+func noMultiSpreadingError(line, column int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "noMultiSpreading",
+		Line:      line,
+		Column:    column,
+	}
+}
+
+func TestJsxPropsNoSpreadMultiUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxPropsNoSpreadMultiRule, []rule_tester.ValidTestCase{
+		// ---- valid ----
+		{Code: `const a = {}; <App {...a} />`, Tsx: true},
+		{Code: `const a = {}; const b = {}; <App {...a} {...b} />`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- invalid ----
+		{
+			Code: `const props = {}; <App {...props} {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 35),
+			},
+		},
+		{
+			Code: `const props = {}; <div {...props} a="a" {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 41),
+			},
+		},
+		{
+			Code: `const props = {}; <div {...props} {...props} {...props} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				noMultiSpreadingError(1, 35),
+				noMultiSpreadingError(1, 46),
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -170,6 +170,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-no-undef.test.ts',
     './tests/eslint-plugin-react/rules/jsx-pascal-case.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-props-no-spread-multi.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-bracket-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-curly-brace-presence.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-props-no-spread-multi.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-props-no-spread-multi.test.ts
@@ -1,0 +1,59 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-props-no-spread-multi', {} as never, {
+  valid: [
+    {
+      code: `
+        const a = {};
+        <App {...a} />
+      `,
+    },
+    {
+      code: `
+        const a = {};
+        const b = {};
+        <App {...a} {...b} />
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const props = {};
+        <App {...props} {...props} />
+      `,
+      errors: [
+        {
+          message: 'Spreading the same expression multiple times is forbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const props = {};
+        <div {...props} a="a" {...props} />
+      `,
+      errors: [
+        {
+          message: 'Spreading the same expression multiple times is forbidden',
+        },
+      ],
+    },
+    {
+      code: `
+        const props = {};
+        <div {...props} {...props} {...props} />
+      `,
+      errors: [
+        {
+          message: 'Spreading the same expression multiple times is forbidden',
+        },
+        {
+          message: 'Spreading the same expression multiple times is forbidden',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port `react/jsx-props-no-spread-multi` from `eslint-plugin-react` to rslint.

Adds the Go rule implementation, upstream and extra Go coverage, JS integration coverage, documentation, and React plugin registration.

Verification completed:

- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m ./internal/plugins/react ./internal/plugins/react/rules/jsx_props_no_spread_multi`
- Real-repo parity check against the upstream rule on rsbuild and rspack target files

## Related Links

- ESLint rule docs: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spread-multi.md
- ESLint rule source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-props-no-spread-multi.js
- ESLint rule tests: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/tests/lib/rules/jsx-props-no-spread-multi.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
