### PR TITLE
feat(core): expose runCLI JS API

### DIFF
--- a/packages/rslint/bin/rslint.js
+++ b/packages/rslint/bin/rslint.js
@@ -1,44 +1,8 @@
 #!/usr/bin/env node
-import { createRequire } from 'node:module';
-import os from 'node:os';
-
-const require = createRequire(import.meta.url);
-const startTime = Date.now();
-
-function getBinPath() {
-  // The Go binary lives in the @rslint/native-{tuple} platform package, reached
-  // via its `./bin` export. Resolution is identical in dev and prod: `pnpm build`
-  // drops the host binary into npm/rslint/{tuple}/, and npm installs only the
-  // subpackage matching the host os/cpu/libc. On linux we just try gnu then musl
-  // and use whichever resolved - no libc sniffing (Go binaries are static, the
-  // gnu/musl distinction doesn't matter to them).
-  const arch = os.arch();
-  const tuples =
-    process.platform === 'linux'
-      ? [`linux-${arch}-gnu`, `linux-${arch}-musl`]
-      : process.platform === 'win32'
-        ? [`win32-${arch}-msvc`]
-        : [`${process.platform}-${arch}`];
-  for (const tuple of tuples) {
-    try {
-      return require.resolve(`@rslint/native-${tuple}/bin`);
-    } catch {}
-  }
-  throw new Error(
-    `rslint: no native binary for ${process.platform}-${arch} ` +
-      `(looked for @rslint/native-{${tuples.join(',')}})`,
-  );
-}
 
 async function main() {
-  const binPath = getBinPath();
-  const { run } = await import('../dist/cli.js');
-  const exitCode = await run(binPath, process.argv.slice(2), startTime);
-  // process.exit() would tear down before async-buffered stdout writes (pipes,
-  // Windows TTYs) flush, truncating the lint tail. Setting exitCode lets the
-  // event loop drain naturally; run()'s cleanup guarantees nothing keeps it
-  // alive.
-  process.exitCode = exitCode;
+  const { runCLI } = await import('../dist/cli.js');
+  await runCLI();
 }
 
 main().catch((err) => {

--- a/packages/rslint/src/cli/cli.ts
+++ b/packages/rslint/src/cli/cli.ts
@@ -11,6 +11,11 @@ import {
   filterConfigsByParentIgnores,
   type ConfigEntry,
 } from '../utils/config-discovery.js';
+import { resolveRslintBinary } from '../internal/resolve-binary.js';
+
+export type RunCLIOptions = {
+  argv?: string[];
+};
 
 /**
  * Load multiple JS/TS configs and run them through the Go binary over IPC.
@@ -158,4 +163,13 @@ export async function run(
     : goArgs;
   const { runEngine } = await import('./engine.js');
   return runEngine({ binPath, goArgs: jsonGoArgs, configs: [], cwd });
+}
+
+export async function runCLI({
+  argv = process.argv,
+}: RunCLIOptions = {}): Promise<void> {
+  const startTime = Date.now();
+  const exitCode = await run(resolveRslintBinary(), argv.slice(2), startTime);
+  // Let stdout/stderr flush naturally instead of terminating the process.
+  process.exitCode = exitCode;
 }

--- a/packages/rslint/src/cli/cli.ts
+++ b/packages/rslint/src/cli/cli.ts
@@ -14,6 +14,10 @@ import {
 import { resolveRslintBinary } from '../internal/resolve-binary.js';
 
 export type RunCLIOptions = {
+  /**
+   * The command-line arguments to parse, matching the shape of Node.js `process.argv`
+   * @default process.argv
+   */
   argv?: string[];
 };
 

--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -17,12 +17,13 @@ export {
 } from './config/presets/index.js';
 
 // The ESLint v10-aligned programmatic Node.js API (issue #1106). This `Rslint`
-// class is the only linting surface exported from the package root; alongside
-// it the root exports just the config-authoring helpers (`defineConfig` /
-// `globalIgnores`) and the plugin presets. The low-level engine (the `lint`
-// convenience, `RSLintService`, and the Node backend) lives on internal
-// subpaths — `@rslint/core/internal` and `@rslint/core/service` — not on the
-// public root. (The browser/web-worker backend lives in `@rslint/wasm`.)
+// class and the `runCLI` wrapper are the only linting surfaces exported from
+// the package root; alongside them the root exports just the config-authoring
+// helpers (`defineConfig` / `globalIgnores`) and the plugin presets. The
+// low-level engine (the `lint` convenience, `RSLintService`, and the Node
+// backend) lives on internal subpaths — `@rslint/core/internal` and
+// `@rslint/core/service` — not on the public root. (The browser/web-worker
+// backend lives in `@rslint/wasm`.)
 export { Rslint } from './api/rslint.js';
 export type {
   RslintOptions,
@@ -31,3 +32,5 @@ export type {
   LintSuggestion,
   LintMessageFix,
 } from './api/rslint.js';
+export { runCLI } from './cli/cli.js';
+export type { RunCLIOptions } from './cli/cli.js';

--- a/packages/rslint/src/internal/node.ts
+++ b/packages/rslint/src/internal/node.ts
@@ -1,7 +1,7 @@
 import { spawn, ChildProcess } from 'child_process';
 import { Socket } from 'node:net';
-import { createRequire } from 'node:module';
 import { RSLintService } from '../service/service.js';
+import { resolveRslintBinary } from './resolve-binary.js';
 import type {
   RslintServiceInterface,
   RSlintOptions,
@@ -10,35 +10,6 @@ import type {
   LintOptions,
   LintResponse,
 } from '../types.js';
-
-const require = createRequire(import.meta.url);
-
-/**
- * Resolve the rslint Go binary from the matching `@rslint/native-<tuple>`
- * platform package (its `./bin` export) — the same resolution the CLI launcher
- * (`bin/rslint.js`) uses. Linux tries gnu then musl (Go is statically linked,
- * so the libc split is irrelevant to it).
- */
-function resolveRslintBinary(): string {
-  const arch = process.arch;
-  const tuples =
-    process.platform === 'linux'
-      ? [`linux-${arch}-gnu`, `linux-${arch}-musl`]
-      : process.platform === 'win32'
-        ? [`win32-${arch}-msvc`]
-        : [`${process.platform}-${arch}`];
-  for (const tuple of tuples) {
-    try {
-      return require.resolve(`@rslint/native-${tuple}/bin`);
-    } catch {
-      // not installed for this tuple; try the next
-    }
-  }
-  throw new Error(
-    `rslint: no native binary for ${process.platform}-${arch} ` +
-      `(looked for @rslint/native-{${tuples.join(',')}})`,
-  );
-}
 
 /**
  * Node.js implementation of RslintService using child processes

--- a/packages/rslint/src/internal/resolve-binary.ts
+++ b/packages/rslint/src/internal/resolve-binary.ts
@@ -1,0 +1,26 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export function resolveRslintBinary(): string {
+  const arch = process.arch;
+  const tuples =
+    process.platform === 'linux'
+      ? [`linux-${arch}-gnu`, `linux-${arch}-musl`]
+      : process.platform === 'win32'
+        ? [`win32-${arch}-msvc`]
+        : [`${process.platform}-${arch}`];
+
+  for (const tuple of tuples) {
+    try {
+      return require.resolve(`@rslint/native-${tuple}/bin`);
+    } catch {
+      // Try the next supported tuple.
+    }
+  }
+
+  throw new Error(
+    `rslint: no native binary for ${process.platform}-${arch} ` +
+      `(looked for @rslint/native-{${tuples.join(',')}})`,
+  );
+}

--- a/packages/rslint/tests/run-cli.test.ts
+++ b/packages/rslint/tests/run-cli.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from '@rstest/core';
+import { runCLI } from '../src/index.js';
+
+describe('runCLI', () => {
+  test('is exported from the package root', () => {
+    expect(typeof runCLI).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

This PR exposes `runCLI({ argv })` from `@rslint/core` so wrapper CLIs can delegate to Rslint without spawning the bin wrapper. It reuses the existing CLI `run` path, sets `process.exitCode` instead of returning an exit code, and shares native binary resolution with the Node service. No `-c` short config flag support is added.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).