### PR TITLE
feat: port rule react-hooks/error-boundaries

### DIFF
--- a/internal/plugins/react_hooks/all.go
+++ b/internal/plugins/react_hooks/all.go
@@ -2,6 +2,7 @@ package react_hooks
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/component_hook_factories"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/error_boundaries"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/exhaustive_deps"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/rules_of_hooks"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -12,5 +13,6 @@ func GetAllRules() []rule.Rule {
 		rules_of_hooks.RulesOfHooksRule,
 		exhaustive_deps.ExhaustiveDepsRule,
 		component_hook_factories.ComponentHookFactoriesRule,
+		error_boundaries.ErrorBoundariesRule,
 	}
 }

--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -496,19 +496,49 @@ func GetFunctionName(fn *ast.Node) *ast.Node {
 	return nil
 }
 
+// GetForwardRefOrMemoCallbackCall returns the CallExpression when `fn` is the
+// immediate argument of a call whose callee is `<name>` or `React.<name>`.
+// Parenthesized callback expressions are transparent: `memo((() => null))` is
+// the same callback shape as `memo(() => null)`.
+func GetForwardRefOrMemoCallbackCall(fn *ast.Node, name string) *ast.Node {
+	if fn == nil {
+		return nil
+	}
+	child := fn
+	p := fn.Parent
+	for p != nil && p.Kind == ast.KindParenthesizedExpression {
+		child = p
+		p = p.Parent
+	}
+	if p == nil || p.Kind != ast.KindCallExpression {
+		return nil
+	}
+	call := p.AsCallExpression()
+	if call.Arguments == nil {
+		return nil
+	}
+	isArg := false
+	for _, arg := range call.Arguments.Nodes {
+		if arg == child {
+			isArg = true
+			break
+		}
+	}
+	if !isArg {
+		return nil
+	}
+	callee := ast.SkipParentheses(call.Expression)
+	if !IsReactCalleeNamed(callee, name) {
+		return nil
+	}
+	return p
+}
+
 // IsForwardRefOrMemoCallback reports whether `fn` is the immediate
 // argument of a CallExpression whose callee is `<name>` or
 // `React.<name>`.
 func IsForwardRefOrMemoCallback(fn *ast.Node, name string) bool {
-	if fn == nil || fn.Parent == nil {
-		return false
-	}
-	p := fn.Parent
-	if p.Kind != ast.KindCallExpression {
-		return false
-	}
-	callee := ast.SkipParentheses(p.AsCallExpression().Expression)
-	return IsReactCalleeNamed(callee, name)
+	return GetForwardRefOrMemoCallbackCall(fn, name) != nil
 }
 
 // IsClassMember reports whether `fn` is a member of a class — either

--- a/internal/plugins/react_hooks/rules/error_boundaries/error_boundaries.go
+++ b/internal/plugins/react_hooks/rules/error_boundaries/error_boundaries.go
@@ -1,0 +1,240 @@
+package error_boundaries
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const errorBoundariesMessage = "Error: Avoid constructing JSX within try/catch\n\n" +
+	"React does not immediately render components when JSX is rendered, so any errors from this component will not be caught by the try/catch. " +
+	"To catch errors in rendering a given component, wrap that component in an error boundary. " +
+	"(https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)."
+
+// ErrorBoundariesRule is the rslint port of upstream
+// `react-hooks/error-boundaries`.
+var ErrorBoundariesRule = rule.Rule{
+	Name: "react-hooks/error-boundaries",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		if !mayContainReactCode(ctx.SourceFile) {
+			return rule.RuleListeners{}
+		}
+		check := func(node *ast.Node) {
+			fn := react_hooksutil.FindEnclosingFunction(node)
+			if fn == nil || !isCompilerLintFunction(fn) {
+				return
+			}
+			if jsxIsInsideTryBlock(node, fn) {
+				ctx.ReportNode(node, rule.RuleMessage{Description: errorBoundariesMessage})
+			}
+		}
+		return rule.RuleListeners{
+			ast.KindJsxElement:            check,
+			ast.KindJsxSelfClosingElement: check,
+			ast.KindJsxFragment:           check,
+		}
+	},
+}
+
+func mayContainReactCode(sf *ast.SourceFile) bool {
+	if sf == nil || sf.Statements == nil {
+		return false
+	}
+	for _, stmt := range sf.Statements.Nodes {
+		if checkTopLevelNode(stmt) {
+			return true
+		}
+	}
+	return false
+}
+
+func checkTopLevelNode(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		if isGeneratorFunction(node) {
+			return false
+		}
+		if name := node.Name(); isReactComponentOrHookName(name) {
+			return true
+		}
+		return node.Name() == nil && ast.HasSyntacticModifier(node, ast.ModifierFlagsDefault)
+	case ast.KindVariableStatement:
+		vs := node.AsVariableStatement()
+		if vs.DeclarationList == nil {
+			return false
+		}
+		decls := vs.DeclarationList.AsVariableDeclarationList().Declarations
+		if decls == nil {
+			return false
+		}
+		for _, decl := range decls.Nodes {
+			if topLevelVariableDeclMayContainReactCode(decl) {
+				return true
+			}
+		}
+	case ast.KindExportAssignment:
+		ea := node.AsExportAssignment()
+		if ea.IsExportEquals || ea.Expression == nil {
+			return false
+		}
+		expr := ast.SkipParentheses(ea.Expression)
+		return isFunctionExpressionLike(expr)
+	}
+	return false
+}
+
+func topLevelVariableDeclMayContainReactCode(decl *ast.Node) bool {
+	if decl == nil || decl.Kind != ast.KindVariableDeclaration {
+		return false
+	}
+	vd := decl.AsVariableDeclaration()
+	if !isReactComponentOrHookName(vd.Name()) || vd.Initializer == nil {
+		return false
+	}
+	return isFunctionExpressionLike(ast.SkipParentheses(vd.Initializer))
+}
+
+func isReactComponentOrHookName(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindIdentifier {
+		return false
+	}
+	name := node.AsIdentifier().Text
+	return react_hooksutil.IsComponentNameStr(name) || isCompilerHookNameStr(name)
+}
+
+func isHookNameNode(node *ast.Node) bool {
+	return node != nil && node.Kind == ast.KindIdentifier && isCompilerHookNameStr(node.AsIdentifier().Text)
+}
+
+func isComponentNameNode(node *ast.Node) bool {
+	return node != nil && node.Kind == ast.KindIdentifier && react_hooksutil.IsComponentNameStr(node.AsIdentifier().Text)
+}
+
+func isCompilerHookNameStr(name string) bool {
+	return name != "use" && react_hooksutil.IsHookName(name)
+}
+
+func isFunctionExpressionLike(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindFunctionExpression && node.AsFunctionExpression().AsteriskToken != nil {
+		return false
+	}
+	return node.Kind == ast.KindFunctionExpression || node.Kind == ast.KindArrowFunction
+}
+
+func isCompilerLintFunction(fn *ast.Node) bool {
+	if fn == nil {
+		return false
+	}
+	if isGeneratorFunction(fn) {
+		return false
+	}
+	// Keep this narrower than react_hooksutil.IsComponentOrHookFn: the
+	// compiler-backed lint pre-pass only checks top-level components, any hook,
+	// and memo/forwardRef callbacks once the file may contain React code.
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		name := fn.Name()
+		if isHookNameNode(name) {
+			return true
+		}
+		return isComponentNameNode(name) && isTopLevelStatement(fn)
+	case ast.KindFunctionExpression, ast.KindArrowFunction:
+		if name, topLevel := variableNameForFunction(fn); name != nil {
+			if isHookNameNode(name) {
+				return true
+			}
+			return topLevel && isComponentNameNode(name)
+		}
+		return isMemoOrForwardRefCallback(fn)
+	}
+	return false
+}
+
+func variableNameForFunction(fn *ast.Node) (*ast.Node, bool) {
+	child, parent := walkUpParens(fn)
+	if parent == nil || parent.Kind != ast.KindVariableDeclaration {
+		return nil, false
+	}
+	vd := parent.AsVariableDeclaration()
+	if vd.Initializer != child {
+		return nil, false
+	}
+	return vd.Name(), isTopLevelVariableDeclaration(parent)
+}
+
+func isMemoOrForwardRefCallback(fn *ast.Node) bool {
+	call := react_hooksutil.GetForwardRefOrMemoCallbackCall(fn, "memo")
+	if call == nil {
+		call = react_hooksutil.GetForwardRefOrMemoCallbackCall(fn, "forwardRef")
+	}
+	return call != nil && !callOrCalleeIsOptionalChain(call)
+}
+
+func callOrCalleeIsOptionalChain(callNode *ast.Node) bool {
+	if ast.IsOptionalChain(callNode) {
+		return true
+	}
+	call := callNode.AsCallExpression()
+	callee := ast.SkipParentheses(call.Expression)
+	return callee != nil && ast.IsOptionalChain(callee)
+}
+
+func isGeneratorFunction(fn *ast.Node) bool {
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		return fn.AsFunctionDeclaration().AsteriskToken != nil
+	case ast.KindFunctionExpression:
+		return fn.AsFunctionExpression().AsteriskToken != nil
+	}
+	return false
+}
+
+func walkUpParens(node *ast.Node) (*ast.Node, *ast.Node) {
+	child := node
+	parent := node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		child = parent
+		parent = parent.Parent
+	}
+	return child, parent
+}
+
+func isTopLevelVariableDeclaration(decl *ast.Node) bool {
+	if decl == nil || decl.Parent == nil || decl.Parent.Parent == nil {
+		return false
+	}
+	return decl.Parent.Kind == ast.KindVariableDeclarationList &&
+		decl.Parent.Parent.Kind == ast.KindVariableStatement &&
+		isTopLevelStatement(decl.Parent.Parent)
+}
+
+func isTopLevelStatement(node *ast.Node) bool {
+	return node != nil && node.Parent != nil && node.Parent.Kind == ast.KindSourceFile
+}
+
+func jsxIsInsideTryBlock(node *ast.Node, fn *ast.Node) bool {
+	insideTryBlock := false
+	child := node
+	for parent := node.Parent; parent != nil && parent != fn; parent = parent.Parent {
+		if react_hooksutil.IsFunctionLikeContainer(parent) {
+			return false
+		}
+		if parent.Kind == ast.KindTryStatement {
+			tryStmt := parent.AsTryStatement()
+			if tryStmt.FinallyBlock != nil && tryStmt.FinallyBlock.AsNode() == child {
+				return false
+			}
+			if tryStmt.TryBlock != nil && tryStmt.TryBlock.AsNode() == child {
+				insideTryBlock = true
+			}
+		}
+		child = parent
+	}
+	return insideTryBlock
+}

--- a/internal/plugins/react_hooks/rules/error_boundaries/error_boundaries.md
+++ b/internal/plugins/react_hooks/rules/error_boundaries/error_boundaries.md
@@ -1,0 +1,74 @@
+# error-boundaries
+
+Validates usage of Error Boundaries instead of `try` / `catch` for errors in
+child components.
+
+## Rule Details
+
+`try` / `catch` blocks cannot catch errors that happen later during React's
+rendering process. JSX only describes UI to render later, so render errors from
+that child tree should be handled by an Error Boundary.
+
+This rule follows React Compiler's lint target selection: it checks top-level
+React components, custom Hooks, nested custom Hooks, and `memo` / `forwardRef`
+callbacks once the file contains React code. JSX in the `catch` or `finally`
+block of the same `try` statement is not reported.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function Parent() {
+  try {
+    return <ChildComponent />;
+  } catch (error) {
+    return <div>Error occurred</div>;
+  }
+}
+```
+
+```javascript
+function Parent() {
+  try {
+    let child;
+    try {
+      child = getChild();
+    } catch {
+      return <ChildComponent value={child} />;
+    }
+  } catch {
+    return null;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function Parent() {
+  return (
+    <ErrorBoundary>
+      <ChildComponent />
+    </ErrorBoundary>
+  );
+}
+```
+
+```javascript
+function Parent() {
+  try {
+    doSomething();
+  } catch (error) {
+    return <div>Error occurred</div>;
+  }
+}
+```
+
+## Differences from ESLint
+
+- Files that use Flow component or hook syntax are not analyzed because rslint
+  does not parse those declarations.
+
+## Original Documentation
+
+- [react.dev - error-boundaries](https://react.dev/reference/eslint-plugin-react-hooks/lints/error-boundaries)
+- [Source code](https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoJSXInTryStatement.ts)

--- a/internal/plugins/react_hooks/rules/error_boundaries/error_boundaries_extras_test.go
+++ b/internal/plugins/react_hooks/rules/error_boundaries/error_boundaries_extras_test.go
@@ -1,0 +1,308 @@
+package error_boundaries
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestErrorBoundariesExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / compiler heuristic it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+
+var errorBoundariesExtrasValid = []rule_tester.ValidTestCase{
+	// N/A: receiver / member-access wrappers are not inspected by this rule.
+	// N/A: property key forms are not inspected by this rule.
+	// N/A: autofix boundaries do not apply because the rule has no fixes.
+	// ---- Dimension 4: anonymous default exports enable the file pre-pass but are not lint functions. ----
+	{Code: `export default () => { try { return <Child />; } catch { return null; } }`, Tsx: true},
+	// ---- Dimension 4: TS wrappers around function initializers are not peeled by the compiler pre-pass. ----
+	{Code: `const Component = (() => { try { return <Child />; } catch { return null; } }) as React.FC;`, Tsx: true},
+	{Code: `const Component = (() => { try { return <Child />; } catch { return null; } })!;`, Tsx: true},
+	// ---- Dimension 4: nested function boundary inside try must not inherit the outer try. ----
+	{Code: `function Component(){ try { const render = () => <Child />; return render; } catch { return null; } }`, Tsx: true},
+	{Code: `function Component(){ try { function useInner(){ return <Child />; } return useInner; } catch { return null; } }`, Tsx: true},
+	{Code: `function Component(){ try { foo(); } catch { try { foo(); } catch { return <Child />; } } }`, Tsx: true},
+	// ---- Dimension 4: nested PascalCase component declarations are not compiler lint functions. ----
+	{Code: `function Component(){ function Inner(){ try { return <Child />; } catch { return null; } } return <Inner />; }`, Tsx: true},
+	// ---- Dimension 4: object/class method containers are not compiler lint functions. ----
+	{Code: `function Sentinel(){ return null; } const obj = { Component(){ try { return <Child />; } catch { return null; } } };`, Tsx: true},
+	{Code: `function Sentinel(){ return null; } class C { Component(){ try { return <Child />; } catch { return null; } } }`, Tsx: true},
+	{Code: `function Sentinel(){ return null; } const obj = { Component: () => { try { return <Child />; } catch { return null; } } };`, Tsx: true},
+	{Code: `function Sentinel(){ return null; } class C { Component = () => { try { return <Child />; } catch { return null; } } }`, Tsx: true},
+	// ---- Dimension 4: assignment-created function names are not compiler lint functions. ----
+	{Code: `function Sentinel(){ return null; } Component = () => { try { return <Child />; } catch { return null; } };`, Tsx: true},
+	// ---- Dimension 4: memo callback alone is skipped by upstream's file heuristic. ----
+	{Code: `const C = React.memo(function(){ try { return <Child />; } catch { return null; } });`, Tsx: true},
+	// ---- Dimension 4: optional-chain wrappers are not compiler lint functions. ----
+	{Code: `function Sentinel(){ return null; } React.memo?.(function(){ try { return <Child />; } catch { return null; } });`, Tsx: true},
+	{Code: `function Sentinel(){ return null; } React?.memo(function(){ try { return <Child />; } catch { return null; } });`, Tsx: true},
+	// ---- Dimension 4: element-access wrapper names are not accepted. ----
+	{Code: `function Sentinel(){ return null; } React["memo"](function(){ try { return <Child />; } catch { return null; } });`, Tsx: true},
+	// ---- Dimension 4: generator functions are skipped by the compiler lint target selection. ----
+	{Code: `function* Component(){ try { yield <Child />; } catch { return null; } }`, Tsx: true},
+	{Code: `const Component = function*(){ try { yield <Child />; } catch { return null; } };`, Tsx: true},
+	{Code: `function Sentinel(){ return null; } React.memo(function*(){ try { yield <Child />; } catch { return null; } });`, Tsx: true},
+	// ---- Dimension 4: JSX in finally is ignored, even under an outer try. ----
+	{Code: `function Component(){ try { foo(); } finally { return <Child />; } }`, Tsx: true},
+	{Code: `function Component(){ try { try { foo(); } finally { return <Child />; } } catch { return null; } }`, Tsx: true},
+	{Code: `function Component(){ try { foo(); } finally { try { return <Child />; } catch { return null; } } }`, Tsx: true},
+	// ---- Real-user: facebook/react#31237 local bare `use` is not a custom Hook target. ----
+	{Code: `function use(){ try { return <Child />; } catch { return null; } }`, Tsx: true},
+	// ---- Real-user: facebook/react#31446 component names follow upstream's ASCII PascalCase predicate. ----
+	{Code: `function ÄndraVärde(){ try { return <Child />; } catch { return null; } }`, Tsx: true},
+	// ---- Dimension 4: empty graceful-degradation forms. ----
+	{Code: `function Component(){ try {} catch {} return null; }`, Tsx: true},
+	{Code: `function Component(){ try { return null; } finally {} }`, Tsx: true},
+	// ---- Real-user: facebook/react#34131 try/finally shape does not emit error-boundaries. ----
+	{Code: `function Component(){ let el; try { el = null; } finally { console.log(el); } return el; }`, Tsx: true},
+}
+
+var errorBoundariesExtrasInvalid = []rule_tester.InvalidTestCase{
+	// ---- Dimension 4: parenthesized JSX expression in a try block. ----
+	{
+		Code: `function Component(){ try { return (<Child />); } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 37, EndLine: 1, EndColumn: 46},
+		},
+	},
+	// ---- Dimension 4: TS type-expression wrapper around JSX in a try block. ----
+	{
+		Code: `function Component(){ try { return <Child /> as React.ReactNode; } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 36, EndLine: 1, EndColumn: 45},
+		},
+	},
+	// ---- Dimension 4: TS satisfies wrapper around JSX in a try block. ----
+	{
+		Code: `function Component(){ try { return <Child /> satisfies React.ReactNode; } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 36, EndLine: 1, EndColumn: 45},
+		},
+	},
+	// ---- Dimension 4: top-level component variable declaration. ----
+	{
+		Code: `const Component = () => { try { return <Child />; } catch { return null; } };`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 40, EndLine: 1, EndColumn: 49},
+		},
+	},
+	{
+		Code: `export const Component = () => { try { return <Child />; } catch { return null; } };`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 47, EndLine: 1, EndColumn: 56},
+		},
+	},
+	{
+		Code: `const Component: React.FC = () => { try { return <Child />; } catch { return null; } };`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 50, EndLine: 1, EndColumn: 59},
+		},
+	},
+	// ---- Dimension 4: async functions are still compiler lint functions. ----
+	{
+		Code: `async function Component(){ try { return <Child />; } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 42, EndLine: 1, EndColumn: 51},
+		},
+	},
+	{
+		Code: `const Component = async () => { try { return <Child />; } catch { return null; } };`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 46, EndLine: 1, EndColumn: 55},
+		},
+	},
+	// ---- Dimension 4: hook declarations are lint functions even when nested. ----
+	{
+		Code: `function Component(){ function useInner(){ try { return <Child />; } catch { return null; } } return null; }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 57, EndLine: 1, EndColumn: 66},
+		},
+	},
+	{
+		Code: `function Component(){ const useInner = () => { try { return <Child />; } catch { return null; } }; return null; }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 61, EndLine: 1, EndColumn: 70},
+		},
+	},
+	{
+		Code: `function use1(){ try { return <Child />; } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 31, EndLine: 1, EndColumn: 40},
+		},
+	},
+	// ---- Dimension 4: memo / forwardRef callbacks report once the file heuristic is enabled. ----
+	{
+		Code: `function Sentinel(){ return null; } const C = React.memo(function(){ try { return <Child />; } catch { return null; } });`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 83, EndLine: 1, EndColumn: 92},
+		},
+	},
+	{
+		Code: `function Sentinel(){ return null; } const C = React.forwardRef((props, ref) => { try { return <Child />; } catch { return null; } });`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 95, EndLine: 1, EndColumn: 104},
+		},
+	},
+	{
+		Code: `function Sentinel(){ return null; } React.memo(function(){ try { return <Child />; } catch { return null; } });`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 73, EndLine: 1, EndColumn: 82},
+		},
+	},
+	{
+		Code: `function Sentinel(){ return null; } (React.memo)(function(){ try { return <Child />; } catch { return null; } });`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 75, EndLine: 1, EndColumn: 84},
+		},
+	},
+	{
+		Code: `function Sentinel(){ return null; } foo(forwardRef((props, ref) => { try { return <Child />; } catch { return null; } }));`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 83, EndLine: 1, EndColumn: 92},
+		},
+	},
+	{
+		Code: `function Sentinel(){ return null; } const obj = { x: React.memo((function helper(){ try { return <Child />; } catch { return null; } })) };`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 98, EndLine: 1, EndColumn: 107},
+		},
+	},
+	{
+		Code: `function Sentinel(){ return null; } const C = React.memo(React.forwardRef((props, ref) => { try { return <Child />; } catch { return null; } }));`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 106, EndLine: 1, EndColumn: 115},
+		},
+	},
+	{
+		Code: `function Sentinel(){ return null; } function outer(){ const c = React.memo(function(){ try { return <Child />; } catch { return null; } }); }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 101, EndLine: 1, EndColumn: 110},
+		},
+	},
+	// ---- Dimension 4: normal control-flow nesting under a try block still reports. ----
+	{
+		Code: `function Component(){ try { if (ok) { return <Child />; } return null; } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 46, EndLine: 1, EndColumn: 55},
+		},
+	},
+	{
+		Code: `function Component(){ try { foo(); } catch { try { return <Child />; } catch { return null; } } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 59, EndLine: 1, EndColumn: 68},
+		},
+	},
+	// ---- Dimension 4: multi-line diagnostics preserve upstream report ranges. ----
+	{
+		Code: `function Component() {
+  try {
+    if (ok) {
+      return (
+        <Child />
+      );
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 5, Column: 9, EndLine: 5, EndColumn: 18},
+		},
+	},
+	{
+		Code: `function Component() {
+  try {
+    return (
+      <A>
+        <B />
+      </A>
+    );
+  } catch {
+    return null;
+  }
+}`,
+		Tsx: true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 4, Column: 7, EndLine: 6, EndColumn: 11},
+			{Line: 5, Column: 9, EndLine: 5, EndColumn: 14},
+		},
+	},
+	// ---- Dimension 4: nested JSX reports both parent and child JSX constructions. ----
+	{
+		Code: `function Component(){ try { return <A><B /></A>; } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 36, EndLine: 1, EndColumn: 48},
+			{Line: 1, Column: 39, EndLine: 1, EndColumn: 44},
+		},
+	},
+	// ---- Real-user: facebook/react#16026 component try/catch around hook result and JSX. ----
+	{
+		Code: `export function Things(){ try { const data = useThings(); return <Content>{!data ? <Loading /> : <ThingsList things={data} />}</Content>; } catch { return <Content><ThingsList roles={[]} /></Content>; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 66, EndLine: 1, EndColumn: 137},
+			{Line: 1, Column: 84, EndLine: 1, EndColumn: 95},
+			{Line: 1, Column: 98, EndLine: 1, EndColumn: 126},
+		},
+	},
+	// Locks in upstream validateNoJSXInTryStatement arm 1: active try with JsxExpression.
+	{
+		Code: `function Component(){ try { const child = <Child />; return child; } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 43, EndLine: 1, EndColumn: 52},
+		},
+	},
+	// Locks in upstream validateNoJSXInTryStatement arm 2: active try with JsxFragment.
+	{
+		Code: `function Component(){ try { const child = <>x</>; return child; } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 43, EndLine: 1, EndColumn: 49},
+		},
+	},
+	// Locks in upstream validateNoJSXInTryStatement arm 3: catch handler exits the inner try only.
+	{
+		Code: `function Component(){ try { try { foo(); } catch { return <Child />; } } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 59, EndLine: 1, EndColumn: 68},
+		},
+	},
+}
+
+func TestErrorBoundariesExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ErrorBoundariesRule,
+		errorBoundariesExtrasValid,
+		errorBoundariesExtrasInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/error_boundaries/error_boundaries_upstream_test.go
+++ b/internal/plugins/react_hooks/rules/error_boundaries/error_boundaries_upstream_test.go
@@ -1,0 +1,71 @@
+package error_boundaries
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestErrorBoundariesUpstream migrates the full valid/invalid suite available
+// from upstream React Compiler fixtures for validateNoJSXInTryStatement 1:1.
+// Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in error_boundaries_extras_test.go.
+
+var errorBoundariesUpstreamValid = []rule_tester.ValidTestCase{
+	// ---- Upstream docs: ErrorBoundary wrapper is the intended pattern. ----
+	{Code: `function Parent(){ return <ErrorBoundary><ChildComponent /></ErrorBoundary>; }`, Tsx: true},
+	// ---- Upstream docs: catch JSX is allowed when not nested in an outer try. ----
+	{Code: `function Parent(){ try { doSomething(); } catch { return <div>Error occurred</div>; } }`, Tsx: true},
+	// ---- Upstream compiler: lowercase utility functions are skipped. ----
+	{Code: `function helper(){ try { return <Child />; } catch { return null; } }`, Tsx: true},
+	// ---- Upstream compiler: module-level try/catch is skipped. ----
+	{Code: `try { const el = <Child />; } catch {}`, Tsx: true},
+	// ---- Upstream compiler TODO fixture: finally does not emit this lint category. ----
+	{Code: `function Component(){ try { foo(); } finally { return <Child />; } }`, Tsx: true},
+	// ---- Upstream docs: use() in try/catch is handled by rules-of-hooks, not this rule. ----
+	{Code: `function Component({promise}){ try { const data = use(promise); return <div>{data}</div>; } catch { return null; } }`, Tsx: true, Skip: true},
+}
+
+var errorBoundariesUpstreamInvalid = []rule_tester.InvalidTestCase{
+	// ---- Upstream docs: JSX returned directly from a try block. ----
+	{
+		Code: `function Parent(){ try { return <ChildComponent />; } catch (error) { return <div>Error occurred</div>; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Message: errorBoundariesMessage, Line: 1, Column: 33, EndLine: 1, EndColumn: 51},
+		},
+	},
+	// ---- Upstream fixture: invalid-jsx-in-try-with-catch.js. ----
+	{
+		Code: `function Component(){ let el; try { el = <div />; } catch { return null; } return el; }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 42, EndLine: 1, EndColumn: 49},
+		},
+	},
+	// ---- Upstream fixture: invalid-jsx-in-catch-in-outer-try-with-catch.js. ----
+	{
+		Code: `function Component(props){ let el; try { let value; try { value = identity(props.foo); } catch { el = <div value={value} />; } } catch { return null; } return el; }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 103, EndLine: 1, EndColumn: 124},
+		},
+	},
+	// ---- Upstream compiler: fragments are JsxFragment diagnostics. ----
+	{
+		Code: `function Component(){ try { return <>x</>; } catch { return null; } }`,
+		Tsx:  true,
+		Errors: []rule_tester.InvalidTestCaseError{
+			{Line: 1, Column: 36, EndLine: 1, EndColumn: 42},
+		},
+	},
+}
+
+func TestErrorBoundariesUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &ErrorBoundariesRule,
+		errorBoundariesUpstreamValid,
+		errorBoundariesUpstreamInvalid,
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -212,6 +212,7 @@ export default defineConfig({
     './tests/eslint-plugin-react-hooks/rules/rules-of-hooks.test.ts',
     './tests/eslint-plugin-react-hooks/rules/exhaustive-deps.test.ts',
     './tests/eslint-plugin-react-hooks/rules/component-hook-factories.test.ts',
+    './tests/eslint-plugin-react-hooks/rules/error-boundaries.test.ts',
 
     // eslint-plugin-jsx-a11y
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/error-boundaries.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/error-boundaries.test.ts
@@ -1,0 +1,108 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+const errorBoundariesMessage =
+  'Error: Avoid constructing JSX within try/catch\n\n' +
+  'React does not immediately render components when JSX is rendered, so any errors from this component will not be caught by the try/catch. ' +
+  'To catch errors in rendering a given component, wrap that component in an error boundary. ' +
+  '(https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary).';
+
+ruleTester.run('error-boundaries', {} as never, {
+  valid: [
+    {
+      code: `
+        function Parent() {
+          return <ErrorBoundary><ChildComponent /></ErrorBoundary>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Parent() {
+          try {
+            doSomething();
+          } catch {
+            return <div>Error occurred</div>;
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        function helper() {
+          try {
+            return <Child />;
+          } catch {
+            return null;
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        try {
+          const el = <Child />;
+        } catch {}
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function Parent() {
+          try {
+            return <ChildComponent />;
+          } catch (error) {
+            return <div>Error occurred</div>;
+          }
+        }
+      `,
+      errors: [{ message: errorBoundariesMessage }],
+    },
+    {
+      code: `
+        function Component() {
+          let el;
+          try {
+            el = <div />;
+          } catch {
+            return null;
+          }
+          return el;
+        }
+      `,
+      errors: [{ message: errorBoundariesMessage }],
+    },
+    {
+      code: `
+        function Component(props) {
+          let el;
+          try {
+            let value;
+            try {
+              value = identity(props.foo);
+            } catch {
+              el = <div value={value} />;
+            }
+          } catch {
+            return null;
+          }
+          return el;
+        }
+      `,
+      errors: [{ message: errorBoundariesMessage }],
+    },
+    {
+      code: `
+        function Component() {
+          try {
+            return <>x</>;
+          } catch {
+            return null;
+          }
+        }
+      `,
+      errors: [{ message: errorBoundariesMessage }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -600,3 +600,5 @@ ruleopts
 anyfunc
 errrr
 supa
+Ändra
+Värde


### PR DESCRIPTION
## Summary

Port the `react-hooks/error-boundaries` rule from `eslint-plugin-react-hooks` to rslint.

This rule reports JSX constructed inside `try` blocks where render-time errors should instead be handled by Error Boundaries.

## Related Links

- Documentation: https://react.dev/reference/eslint-plugin-react-hooks/lints/error-boundaries
- Source code: https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateNoJSXInTryStatement.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).