### PR TITLE
fix: align no-promise-in-callback edge cases

### DIFF
--- a/internal/plugins/promise/rules/no_promise_in_callback/no_promise_in_callback.go
+++ b/internal/plugins/promise/rules/no_promise_in_callback/no_promise_in_callback.go
@@ -34,7 +34,33 @@ func messageAvoidPromiseInCallback() rule.RuleMessage {
 
 func isReturnExpression(node *ast.Node) bool {
 	current := ast.WalkUpParenthesizedExpressions(node.Parent)
-	return current != nil && current.Kind == ast.KindReturnStatement
+	return current != nil && current.Kind == ast.KindReturnStatement && !hasOptionalChain(node)
+}
+
+func hasOptionalChain(node *ast.Node) bool {
+	node = ast.SkipOuterExpressions(node, skipTransparent)
+	if node == nil {
+		return false
+	}
+	if ast.IsOptionalChain(node) {
+		return true
+	}
+	switch node.Kind {
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		return call != nil && hasOptionalChain(call.Expression)
+	case ast.KindPropertyAccessExpression:
+		access := node.AsPropertyAccessExpression()
+		return access != nil && hasOptionalChain(access.Expression)
+	case ast.KindElementAccessExpression:
+		access := node.AsElementAccessExpression()
+		return access != nil && hasOptionalChain(access.Expression)
+	case ast.KindNonNullExpression:
+		expression := node.AsNonNullExpression()
+		return expression != nil && hasOptionalChain(expression.Expression)
+	default:
+		return false
+	}
 }
 
 func isPromiseCallback(node *ast.Node) bool {
@@ -51,6 +77,9 @@ func firstParameterName(node *ast.Node) string {
 	}
 	param := node.Parameters()[0]
 	if param == nil || !ast.IsParameterDeclaration(param) {
+		return ""
+	}
+	if param.Parent != nil && ast.IsParameterPropertyDeclaration(param, param.Parent) {
 		return ""
 	}
 	decl := param.AsParameterDeclaration()

--- a/internal/plugins/promise/rules/no_promise_in_callback/no_promise_in_callback_extras_test.go
+++ b/internal/plugins/promise/rules/no_promise_in_callback/no_promise_in_callback_extras_test.go
@@ -61,6 +61,9 @@ func TestNoPromiseInCallbackExtras(t *testing.T) {
 			{Code: `class X { onError(reason) { audit().catch(log) } }`},
 			// A getter takes no parameters, so it is never an err/error callback.
 			{Code: `class X { get value() { return p.then(a) } }`},
+
+			// ---- TypeScript ESTree parity: TSParameterProperty is not a plain param ----
+			{Code: `class X { constructor(public err: unknown) { Promise.resolve(err) } }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Branch lock-in: err/error as first parameter are callbacks ----
@@ -114,6 +117,14 @@ func TestNoPromiseInCallbackExtras(t *testing.T) {
 			// ---- Dimension 4: optional chain promise-like call ----
 			{
 				Code:   `a(function(err) { doThing()?.then(a) })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidPromiseInCallback", Message: avoidPromiseInCallbackMessage, Line: 1}},
+			},
+			{
+				Code:   `a(function(err) { return doThing()?.then(a) })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidPromiseInCallback", Message: avoidPromiseInCallbackMessage, Line: 1}},
+			},
+			{
+				Code:   `a(function(err) { return Promise?.resolve(err) })`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidPromiseInCallback", Message: avoidPromiseInCallbackMessage, Line: 1}},
 			},
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/no-promise-in-callback.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/no-promise-in-callback.test.ts
@@ -37,6 +37,9 @@ ruleTester.run('no-promise-in-callback', {} as never, {
     // (which take no params) are never err/error callbacks
     { code: 'const o = { onError(e) { Promise.resolve(e) } }' },
     { code: 'class X { get value() { return p.then(a) } }' },
+    {
+      code: 'class X { constructor(public err: unknown) { Promise.resolve(err) } }',
+    },
 
     {
       code: `
@@ -95,6 +98,14 @@ ruleTester.run('no-promise-in-callback', {} as never, {
     },
     {
       code: 'let x = (err) => doThingWith(err).then(a)',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'a(function(err) { return doThing()?.then(a) })',
+      errors: [{ message: errorMessage }],
+    },
+    {
+      code: 'a(function(err) { return Promise?.resolve(err) })',
       errors: [{ message: errorMessage }],
     },
 


### PR DESCRIPTION
## Summary

Fix `promise/no-promise-in-callback` parity for two upstream edge cases.

| Case | Upstream ESLint | rslint after fix |
| --- | ---: | ---: |
| `return doThing().then(a)` | 0 errors | 0 errors |
| `return doThing()?.then(a)` | 1 error | 1 error |
| `return Promise?.resolve(err)` | 1 error | 1 error |
| `constructor(public err) { Promise.resolve(err) }` | 0 errors | 0 errors |

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).