### PR TITLE
perf(core): enable Node.js compile cache

### DIFF
--- a/packages/rslint/bin/rslint.js
+++ b/packages/rslint/bin/rslint.js
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
+import nodeModule from 'node:module';
+
+// Enable on-disk code caching for modules loaded by Node.js.
+// Available in Node.js >= 22.8.0.
+const { enableCompileCache } = nodeModule;
+if (enableCompileCache) {
+  try {
+    enableCompileCache();
+  } catch {
+    // Ignore cache setup errors; the CLI should still run normally.
+  }
+}
 
 async function main() {
   const { runCLI } = await import('../dist/cli.js');

--- a/packages/rslint/src/eslint-plugin/worker-pool.ts
+++ b/packages/rslint/src/eslint-plugin/worker-pool.ts
@@ -36,6 +36,8 @@
 import { Worker, type WorkerOptions } from 'node:worker_threads';
 import { fileURLToPath } from 'node:url';
 import { StringDecoder } from 'node:string_decoder';
+import path from 'node:path';
+import nodeModule from 'node:module';
 
 import { CancelFlagPool } from './cancel-flag.js';
 import type {
@@ -174,6 +176,54 @@ const resolveWorkerFile = (): string =>
  * see the native-abort note on `terminateWorker`.
  */
 const WORKER_EXIT_GRACE_MS = 5_000;
+
+let nodeCompileCacheDir: string | undefined;
+let nodeCompileCacheDirResolved = false;
+
+/**
+ * Give worker threads the same Node compile cache as the host process.
+ * Workers need NODE_COMPILE_CACHE before their entry module loads, otherwise
+ * the large bundled lint-worker.js has already been compiled too early to
+ * cache.
+ */
+function getNodeCompileCacheDir(): string | undefined {
+  if (nodeCompileCacheDirResolved) {
+    return nodeCompileCacheDir;
+  }
+  nodeCompileCacheDirResolved = true;
+
+  if (process.env.NODE_DISABLE_COMPILE_CACHE) {
+    return undefined;
+  }
+
+  if (process.env.NODE_COMPILE_CACHE) {
+    nodeCompileCacheDir = process.env.NODE_COMPILE_CACHE;
+    return nodeCompileCacheDir;
+  }
+
+  const { enableCompileCache, getCompileCacheDir } = nodeModule;
+  if (!enableCompileCache || !getCompileCacheDir) {
+    return undefined;
+  }
+
+  try {
+    enableCompileCache();
+    const cacheDirectory = getCompileCacheDir();
+    nodeCompileCacheDir = cacheDirectory
+      ? path.dirname(cacheDirectory)
+      : undefined;
+    return nodeCompileCacheDir;
+  } catch {
+    return undefined;
+  }
+}
+
+function workerEnvWithCompileCache(): NodeJS.ProcessEnv | undefined {
+  const directory = getNodeCompileCacheDir();
+  return directory
+    ? { ...process.env, NODE_COMPILE_CACHE: directory }
+    : undefined;
+}
 
 /**
  * Terminate a worker, closing its piped stdout/stderr FIRST.
@@ -683,6 +733,7 @@ export class WorkerPool {
           cancelSab: this.cancelPool.sharedBuffer,
           configs: this.opts.configs,
         },
+        env: workerEnvWithCompileCache(),
         // Capture worker stdout/stderr instead of letting them inherit
         // the parent's. Native console behavior inside plugin code is
         // preserved (plugins still call the unpatched `console.log`),


### PR DESCRIPTION
## Summary

This PR enables Node's on-disk compile cache in the JS launcher and passes `NODE_COMPILE_CACHE` into ESLint-plugin worker threads before their entry module loads.

This lets the main CLI/config-loader path and the large bundled `lint-worker.js` reuse warm bytecode while gracefully falling back when the API is unavailable or disabled.

## Performance

Benchmarked with Node v24.14.0:

| Scenario | No compile cache | Warm compile cache | Median delta |
| --- | ---: | ---: | ---: |
| CLI module load | 30.70ms | 28.82ms | -1.88ms (-6.1%) |
| Project `rslint.config.ts` load | 48.25ms | 30.55ms | -17.71ms (-36.7%) |
| ESLint-plugin worker entry load | 20.11ms | 19.48ms | -0.63ms (-3.1%) |

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).