### PR TITLE
fix: make no-tsconfig projects respect global ignores and .gitignore

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -154,8 +154,9 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	// (the JS side resolves any multi-config merge into one entry list).
 	// The --api path never runs the type-check phase (RunLinterOptions.TypeCheck
 	// stays false), so there is no per-program type-check skip mask to build.
-	programs, typeInfoFiles, _ := buildProgramsWithGapFallback(
+	programs, typeInfoFiles, _, rslintConfig, _ := buildProgramsWithGapFallback(
 		programs, nil, rslintConfig, configDirectory, fs, allowedFiles, nil, parseCache, false,
+		len(tsConfigs) > 0, nil,
 	)
 
 	// Collect diagnostics and source files

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -33,7 +33,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
-	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
@@ -743,25 +742,38 @@ func collectAllowFileWarnings(
 
 	var out []allowFileWarning
 	for _, f := range allowFiles {
-		if _, inProgram := programFiles[f]; !inProgram {
-			out = append(out, allowFileWarning{Path: f, Kind: allowFileNotInProgram})
-			continue
-		}
-		// File is in a Program — check if config would assign rules
-		var merged *rslintconfig.MergedConfig
+		var cfgDir string
+		var cfg rslintconfig.RslintConfig
 		if configMap != nil {
 			dir := tspath.GetDirectoryPath(f)
 			cached, ok := dirConfigCache[dir]
 			if !ok {
-				cfgDir, cfg := rslintconfig.FindNearestConfig(f, configMap)
-				cached = &cachedConfig{cfgDir: cfgDir, cfg: cfg}
+				d, c := rslintconfig.FindNearestConfig(f, configMap)
+				cached = &cachedConfig{cfgDir: d, cfg: c}
 				dirConfigCache[dir] = cached
 			}
-			if cached.cfg != nil {
-				merged = cached.cfg.GetConfigForFile(f, cached.cfgDir)
-			}
+			cfgDir, cfg = cached.cfgDir, cached.cfg
 		} else {
-			merged = rslintConfig.GetConfigForFile(f, currentDirectory)
+			cfgDir, cfg = currentDirectory, rslintConfig
+		}
+
+		// Check ignore status first, independent of program membership: a
+		// gitignored/config-ignored file never enters a Program (correctly —
+		// see DiscoverGapFiles/the no-tsconfig fallback), so "not in program"
+		// would otherwise misreport it as merely absent rather than ignored.
+		if cfg != nil && cfg.IsFileIgnored(f, cfgDir) {
+			out = append(out, allowFileWarning{Path: f, Kind: allowFileIgnored})
+			continue
+		}
+		if _, inProgram := programFiles[f]; !inProgram {
+			out = append(out, allowFileWarning{Path: f, Kind: allowFileNotInProgram})
+			continue
+		}
+		// File is in a Program and not globally ignored — check if any entry's
+		// `files` pattern actually assigns it rules.
+		var merged *rslintconfig.MergedConfig
+		if cfg != nil {
+			merged = cfg.GetConfigForFile(f, cfgDir)
 		}
 		if merged == nil {
 			out = append(out, allowFileWarning{Path: f, Kind: allowFileIgnored})
@@ -1011,6 +1023,13 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// programConfigDirs tracks which configDir each program belongs to (parallel to programs).
 	// Used for ownership-based file deduplication in multi-config mode.
 	var programConfigDirs []string
+	// hasTsConfig / hasTsConfigByDir record whether ResolveTsConfigPaths found a
+	// tsconfig for the (single) config / each configDir in multi-config mode.
+	// Fed to buildProgramsWithGapFallback, which uses it to decide whether gap-file
+	// discovery is a no-op (tsconfig found, no `files` field) or must walk the
+	// directory (no tsconfig, or a `files` field restricts scope).
+	var hasTsConfig bool
+	var hasTsConfigByDir map[string]bool
 
 	if configStdin {
 		// Read config JSON from stdin (sent by JS config loader).
@@ -1037,119 +1056,47 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			configMap = payload.ConfigMap
 			originalConfigDir = payload.OriginalConfigDir
 
-			// Inject .gitignore patterns as global ignores for each config.
-			// Each config independently reads its own .gitignore tree:
-			// ReadGitignoreAsGlobs walks UP (ancestor inheritance) and DOWN
-			// (nested .gitignore) from each configDir. Sibling configs are
-			// fully isolated — they never share gitignore patterns.
-			//
-			// Config ignores are passed so that directories which are
-			// directory-level blocked (e.g. **/tests/**) are pruned during
-			// the .gitignore scan. This is safe because isDirAbsolutelyBlocked is
-			// the same predicate used by the linter — blocked dirs' files
-			// are never linted, so their .gitignore patterns are irrelevant.
-			//
-			// Concurrency:
-			//   - When singleThreaded is set, both stages run sequentially in
-			//     the main goroutine (no goroutines spawned at all).
-			//   - Otherwise, gitignore reads run in parallel across configs
-			//     (independent FS reads via cachedvfs, which is concurrent-
-			//     safe). createProgramsForConfig still runs serially in the
-			//     main goroutine — typescript-go's API is invoked one config
-			//     at a time. The two stages overlap: gitignore goroutines
-			//     run alongside the createPrograms loop.
-			//
-			// configMap is NOT mutated by gitignore goroutines; results are
-			// collected via channel and merged in the main goroutine after
-			// the createPrograms loop, so the createPrograms loop sees the
-			// pre-augmentation entries (createProgramsForConfig only reads
-			// languageOptions.parserOptions.project — Ignores entries are
-			// no-ops for it; verified in LoadTsConfigsFromRslintConfig).
-			// Read each config's gitignore on the shared WorkGroup (honoring
-			// --singleThreaded). In the parallel path these overlap with the
-			// serial createProgramsForConfig loop below; that is safe because
-			// createProgramsForConfig only reads parserOptions.project, never
-			// Ignores, so observing the pre-augmentation configMap is fine.
-			// Results are merged after the loop — DiscoverGapFiles needs them.
-			type giResult struct {
-				configDir string
-				globs     []string
-			}
-			var (
-				giResults []giResult
-				giMu      sync.Mutex
-			)
-			giWG := core.NewWorkGroup(singleThreaded)
-			for configDir, entries := range configMap {
-				configIgnores := rslintconfig.ExtractConfigIgnores(entries)
-				giWG.Queue(func() {
-					if globs := rslintconfig.ReadGitignoreAsGlobs(configDir, fs, configIgnores); len(globs) > 0 {
-						giMu.Lock()
-						giResults = append(giResults, giResult{configDir, globs})
-						giMu.Unlock()
-					}
-				})
-			}
-
+			// .gitignore reading is no longer a separate pass here: each
+			// configDir's .gitignore tree is read inline by the walk inside
+			// DiscoverGapFiles (via buildProgramsWithGapFallback), which runs
+			// after programs are built. hasTsConfigByDir records, per
+			// configDir, whether a tsconfig was found — that's what lets
+			// DiscoverGapFiles decide whether it needs to walk at all.
 			seenTsConfigs := make(map[string]struct{})
+			hasTsConfigByDir = make(map[string]bool, len(configMap))
 
 			for configDir, entries := range configMap {
-				progs, exitCode := createProgramsForConfig(configDir, entries, singleThreaded, fs, seenTsConfigs, parseCache)
+				progs, dirHasTsConfig, exitCode := createProgramsForConfig(configDir, entries, singleThreaded, fs, seenTsConfigs, parseCache)
 				if exitCode != 0 {
 					return exitCode
 				}
+				hasTsConfigByDir[configDir] = dirHasTsConfig
 				for range progs {
 					programConfigDirs = append(programConfigDirs, configDir)
 				}
 				programs = append(programs, progs...)
-			}
-
-			// Join the gitignore reads and merge into configMap. Must complete
-			// before DiscoverGapFiles, which relies on the augmented configMap.
-			giWG.RunAndWait()
-			for _, r := range giResults {
-				configMap[r.configDir] = append(
-					rslintconfig.RslintConfig{{Ignores: r.globs}},
-					configMap[r.configDir]...,
-				)
 			}
 		} else {
 			// Legacy single-config format
 			rslintConfig = payload.SingleConfig
 			currentDirectory = payload.SingleConfigDir
 
-			// Inject .gitignore patterns as global ignores. Run gitignore
-			// reading in parallel with createProgramsForConfig — they're
-			// independent (createProgramsForConfig only reads
-			// languageOptions.parserOptions.project, not Ignores).
-			var (
-				progs    []*compiler.Program
-				exitCode int
-			)
-			rslintConfig, progs, exitCode = parallelGitignoreAndPrograms(
-				rslintConfig, currentDirectory, fs, singleThreaded, nil, parseCache,
-			)
+			progs, dirHasTsConfig, exitCode := createProgramsForConfig(currentDirectory, rslintConfig, singleThreaded, fs, nil, parseCache)
 			if exitCode != 0 {
 				return exitCode
 			}
+			hasTsConfig = dirHasTsConfig
 			programs = append(programs, progs...)
 		}
 	} else {
 		// Load configuration from file (JSON config path, isJSConfig stays false)
 		rslintConfig, _, currentDirectory = rslintconfig.LoadConfigurationWithFallback(config, currentDirectory, fs)
 
-		// Inject .gitignore patterns as global ignores. Run gitignore reading
-		// in parallel with createProgramsForConfig (see comment above).
-		var (
-			progs    []*compiler.Program
-			exitCode int
-		)
-		rslintConfig, progs, exitCode = parallelGitignoreAndPrograms(
-			rslintConfig, currentDirectory, fs, singleThreaded, nil, parseCache,
-		)
+		progs, dirHasTsConfig, exitCode := createProgramsForConfig(currentDirectory, rslintConfig, singleThreaded, fs, nil, parseCache)
 		if exitCode != 0 {
 			return exitCode
 		}
+		hasTsConfig = dirHasTsConfig
 		programs = append(programs, progs...)
 	}
 
@@ -1197,8 +1144,11 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// resolve gap files, the fallback Program, and the type-info set (the
 	// type-aware gate's only input) identically. cwd == currentDirectory here
 	// (see above), so passing currentDirectory preserves prior behavior.
-	programs, typeInfoFiles, capturedGapFiles := buildProgramsWithGapFallback(
+	var capturedGapFiles []string
+	var typeInfoFiles map[string]struct{}
+	programs, typeInfoFiles, capturedGapFiles, rslintConfig, configMap = buildProgramsWithGapFallback(
 		programs, configMap, rslintConfig, currentDirectory, fs, allowFiles, allowDirs, parseCache, singleThreaded,
+		hasTsConfig, hasTsConfigByDir,
 	)
 
 	// Initial build (including the gap fallback) is complete: evict cache
@@ -1216,14 +1166,14 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		if configMap != nil {
 			seen := make(map[string]struct{})
 			for configDir, entries := range configMap {
-				progs, exitCode := createProgramsForConfig(configDir, entries, singleThreaded, fs, seen, parseCache)
+				progs, _, exitCode := createProgramsForConfig(configDir, entries, singleThreaded, fs, seen, parseCache)
 				if exitCode != 0 {
 					return nil, fmt.Errorf("failed to create programs for %s", configDir)
 				}
 				baseProgs = append(baseProgs, progs...)
 			}
 		} else {
-			progs, exitCode := createProgramsForConfig(currentDirectory, rslintConfig, singleThreaded, fs, nil, parseCache)
+			progs, _, exitCode := createProgramsForConfig(currentDirectory, rslintConfig, singleThreaded, fs, nil, parseCache)
 			if exitCode != 0 {
 				return nil, errors.New("failed to create programs")
 			}

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -9,74 +9,17 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
-	"github.com/microsoft/typescript-go/shim/vfs/vfsmatch"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// parallelGitignoreAndPrograms runs ReadGitignoreAsGlobs and createProgramsForConfig
-// for a single rslint config (single-config and legacy JSON paths).
-//
-// When singleThreaded is true, both run sequentially in the calling goroutine
-// — honoring the user's --singleThreaded flag (no concurrency at all).
-// Otherwise the two are dispatched as parallel goroutines: they have no data
-// dependency, since createProgramsForConfig only reads
-// entry.LanguageOptions.ParserOptions.Project (see
-// LoadTsConfigsFromRslintConfig), never entry.Ignores. Calling it before vs.
-// after gitignore globs are prepended is equivalent for TS Program creation.
-//
-// The returned config is the gitignore-augmented config (gitignore globs
-// prepended when non-empty), suitable for downstream DiscoverGapFiles /
-// GetConfigForFile.
-//
-// Returns: (augmentedConfig, programs, exitCode). On non-zero exitCode,
-// augmentedConfig and programs may be nil/partial — caller should propagate
-// exitCode without using them.
-func parallelGitignoreAndPrograms(
-	rslintConfig rslintconfig.RslintConfig,
-	configDir string,
-	fsys vfs.FS,
-	singleThreaded bool,
-	seenTsConfigs map[string]struct{},
-	parseCache *utils.ParseCache,
-) (rslintconfig.RslintConfig, []*compiler.Program, int) {
-	configIgnores := rslintconfig.ExtractConfigIgnores(rslintConfig)
-
-	var (
-		gitGlobs []string
-		progs    []*compiler.Program
-		exitCode int
-	)
-	// gitignore reading and program creation are independent
-	// (createProgramsForConfig only reads parserOptions.project, never Ignores),
-	// so run them on the shared WorkGroup — which honors --singleThreaded the
-	// same way the lint and type-check phases do.
-	wg := core.NewWorkGroup(singleThreaded)
-	wg.Queue(func() {
-		gitGlobs = rslintconfig.ReadGitignoreAsGlobs(configDir, fsys, configIgnores)
-	})
-	wg.Queue(func() {
-		progs, exitCode = createProgramsForConfig(configDir, rslintConfig, singleThreaded, fsys, seenTsConfigs, parseCache)
-	})
-	wg.RunAndWait()
-
-	if exitCode != 0 {
-		return rslintConfig, nil, exitCode
-	}
-	if len(gitGlobs) > 0 {
-		rslintConfig = append(
-			rslintconfig.RslintConfig{{Ignores: gitGlobs}},
-			rslintConfig...,
-		)
-	}
-	return rslintConfig, progs, 0
-}
-
 // createProgramsForConfig creates TypeScript programs for a single config entry.
-// It handles tsconfig extraction, auto-detection, deduplication, and the no-tsconfig fallback.
+// It handles tsconfig extraction, auto-detection, and deduplication.
 // seenTsConfigs is used for cross-config tsconfig deduplication (pass nil to skip).
-// Returns the created programs or an error exit code (> 0).
+// Returns the created programs, whether a tsconfig was found for this config
+// (see DiscoverGapFiles — this gates whether gap-file discovery is a no-op),
+// and an error exit code (> 0).
 func createProgramsForConfig(
 	configDir string,
 	entries rslintconfig.RslintConfig,
@@ -84,68 +27,55 @@ func createProgramsForConfig(
 	fsys vfs.FS,
 	seenTsConfigs map[string]struct{},
 	parseCache *utils.ParseCache,
-) ([]*compiler.Program, int) {
+) ([]*compiler.Program, bool, int) {
 	tsConfigs, err := rslintconfig.ResolveTsConfigPaths(entries, configDir, fsys)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return nil, 1
+		return nil, false, 1
+	}
+
+	if len(tsConfigs) == 0 {
+		// No tsconfig for this config directory: buildProgramsWithGapFallback's
+		// DiscoverGapFiles call (with hasTsConfig=false) is responsible for
+		// walking configDir and building the fallback Program — there is no
+		// separate "no tsconfig" scan here anymore.
+		return nil, false, 0
 	}
 
 	var programs []*compiler.Program
 	host := utils.WithParseCache(utils.CreateCompilerHost(configDir, fsys), parseCache)
 
-	if len(tsConfigs) > 0 {
-		for _, tc := range tsConfigs {
-			// Cross-config deduplication
-			if seenTsConfigs != nil {
-				normalized := tspath.NormalizePath(tc)
-				if _, exists := seenTsConfigs[normalized]; exists {
-					continue
-				}
-				seenTsConfigs[normalized] = struct{}{}
+	for _, tc := range tsConfigs {
+		// Cross-config deduplication
+		if seenTsConfigs != nil {
+			normalized := tspath.NormalizePath(tc)
+			if _, exists := seenTsConfigs[normalized]; exists {
+				continue
 			}
+			seenTsConfigs[normalized] = struct{}{}
+		}
 
-			program, err := utils.CreateProgram(singleThreaded, fsys, configDir, tc, host)
-			if err != nil {
-				w := bufio.NewWriter(os.Stderr)
-				if !reportSyntacticErrors(err, w, tspath.ComparePathsOptions{
-					CurrentDirectory:          configDir,
-					UseCaseSensitiveFileNames: host.FS().UseCaseSensitiveFileNames(),
-				}) {
-					fmt.Fprintf(os.Stderr, "error creating TS program: %v", err)
-				}
-				return nil, 1
+		program, err := utils.CreateProgram(singleThreaded, fsys, configDir, tc, host)
+		if err != nil {
+			w := bufio.NewWriter(os.Stderr)
+			if !reportSyntacticErrors(err, w, tspath.ComparePathsOptions{
+				CurrentDirectory:          configDir,
+				UseCaseSensitiveFileNames: host.FS().UseCaseSensitiveFileNames(),
+			}) {
+				fmt.Fprintf(os.Stderr, "error creating TS program: %v", err)
 			}
-			programs = append(programs, program)
+			return nil, true, 1
 		}
-	} else {
-		// No tsconfig fallback: scan directory for pure JS projects
-		sourceExts := []string{".ts", ".tsx", ".js", ".jsx", ".mts", ".mjs"}
-		excludes := utils.DefaultExcludeDirNames
-		includes := []string{"**/*"}
-		rootFiles := vfsmatch.ReadDirectory(fsys, configDir, configDir, sourceExts, excludes, includes, vfsmatch.UnlimitedDepth)
-		if len(rootFiles) > 0 {
-			program, err := utils.CreateProgramFromOptions(singleThreaded, &core.CompilerOptions{AllowJs: core.TSTrue}, rootFiles, host)
-			if err != nil {
-				w := bufio.NewWriter(os.Stderr)
-				if !reportSyntacticErrors(err, w, tspath.ComparePathsOptions{
-					CurrentDirectory:          configDir,
-					UseCaseSensitiveFileNames: host.FS().UseCaseSensitiveFileNames(),
-				}) {
-					fmt.Fprintf(os.Stderr, "error creating program: %v", err)
-				}
-				return nil, 1
-			}
-			programs = append(programs, program)
-		}
+		programs = append(programs, program)
 	}
 
-	return programs, 0
+	return programs, true, 0
 }
 
 // createFallbackProgram creates a Program for "gap" files — files matched by
-// config `files` patterns but not included in any tsconfig. Uses minimal
-// compiler options sufficient for AST parsing (no type checking).
+// config `files` patterns but not included in any tsconfig, or every source
+// file in a project with no tsconfig at all. Uses minimal compiler options
+// sufficient for AST parsing (no type checking).
 func createFallbackProgram(
 	gapFiles []string,
 	singleThreaded bool,
@@ -171,14 +101,16 @@ func createFallbackProgram(
 
 // buildProgramsWithGapFallback discovers "gap" files — files matched by config
 // `files` patterns (or explicitly requested and matched by config) but absent
-// from every tsconfig Program — and appends one AST-only fallback Program for
-// them. It returns the (possibly extended) program slice, the type-info file
-// set, and the gap files retained for --fix rebuilds.
+// from every tsconfig Program, or every source file in a tsconfig-less
+// project — and appends one AST-only fallback Program for them. It returns
+// the (possibly extended) program slice, the type-info file set, the gap
+// files retained for --fix rebuilds, and the rslintConfig/configMap updated
+// with any .gitignore-derived global ignores discovered while walking.
 //
-// The appended fallback Program (like the no-tsconfig directory-scan Program)
-// carries synthesized CompilerOptions with no ConfigFilePath, which is how
-// buildTypeCheckSkipMask later recognizes and excludes it from the CLI
-// --type-check phase — no index needs to be threaded out of here.
+// The appended fallback Program carries synthesized CompilerOptions with no
+// ConfigFilePath, which is how buildTypeCheckSkipMask later recognizes and
+// excludes it from the CLI --type-check phase — no index needs to be
+// threaded out of here.
 //
 // The type-info set is captured from the tsconfig Programs BEFORE the fallback
 // is appended, so fallback files are deliberately absent from it. That absence
@@ -191,7 +123,16 @@ func createFallbackProgram(
 //
 // configMap is non-nil only in the multi-config (stdin) path; the --api and
 // single-config paths pass nil and resolve against rslintConfig +
-// currentDirectory.
+// currentDirectory. hasTsConfig / hasTsConfigByDir mirror that split: exactly
+// one of them is consulted, matching which of rslintConfig/configMap is live.
+//
+// Callers MUST use the returned rslintConfig/configMap (not their pre-call
+// values) for anything downstream — buildFileFilters, RunLinter, and any
+// --fix rebuild — so that files excluded by a discovered .gitignore rule
+// (even ones already inside a tsconfig Program) are correctly filtered out
+// of lint results. The .gitignore-derived entry is prepended (not appended)
+// to preserve existing negation precedence: gitignore rules first, user
+// config `ignores` after, so a user's `!` can override a gitignore rule.
 func buildProgramsWithGapFallback(
 	programs []*compiler.Program,
 	configMap map[string]rslintconfig.RslintConfig,
@@ -202,17 +143,51 @@ func buildProgramsWithGapFallback(
 	allowDirs []string,
 	parseCache *utils.ParseCache,
 	singleThreaded bool,
-) ([]*compiler.Program, map[string]struct{}, []string) {
-	var typeInfoFiles map[string]struct{}
-	var capturedGapFiles []string
-
+	hasTsConfig bool,
+	hasTsConfigByDir map[string]bool,
+) (
+	resultPrograms []*compiler.Program,
+	typeInfoFiles map[string]struct{},
+	capturedGapFiles []string,
+	updatedRslintConfig rslintconfig.RslintConfig,
+	updatedConfigMap map[string]rslintconfig.RslintConfig,
+) {
 	programFiles := utils.CollectProgramFiles(programs, fs, singleThreaded)
 
 	var gapFiles []string
 	if configMap != nil {
-		gapFiles = rslintconfig.DiscoverGapFilesMultiConfig(configMap, fs, programFiles, allowFiles, allowDirs, singleThreaded)
+		var gitignoreGlobsByDir map[string][]string
+		gapFiles, gitignoreGlobsByDir = rslintconfig.DiscoverGapFilesMultiConfig(
+			configMap, fs, programFiles, allowFiles, allowDirs, singleThreaded, hasTsConfigByDir,
+		)
+		if len(gitignoreGlobsByDir) > 0 {
+			updatedConfigMap = make(map[string]rslintconfig.RslintConfig, len(configMap))
+			for dir, cfg := range configMap {
+				updatedConfigMap[dir] = cfg
+			}
+			for dir, globs := range gitignoreGlobsByDir {
+				updatedConfigMap[dir] = append(
+					rslintconfig.RslintConfig{{Ignores: globs}},
+					updatedConfigMap[dir]...,
+				)
+			}
+		} else {
+			updatedConfigMap = configMap
+		}
+		updatedRslintConfig = rslintConfig
 	} else {
-		gapFiles = rslintconfig.DiscoverGapFiles(rslintConfig, currentDirectory, fs, programFiles, allowFiles, allowDirs, singleThreaded)
+		var gitignoreGlobs []string
+		gapFiles, gitignoreGlobs = rslintconfig.DiscoverGapFiles(
+			rslintConfig, currentDirectory, fs, programFiles, allowFiles, allowDirs, singleThreaded, hasTsConfig,
+		)
+		if len(gitignoreGlobs) > 0 {
+			updatedRslintConfig = append(
+				rslintconfig.RslintConfig{{Ignores: gitignoreGlobs}},
+				rslintConfig...,
+			)
+		} else {
+			updatedRslintConfig = rslintConfig
+		}
 	}
 
 	// Explicit file args bypass config `files` patterns (ESLint behavior):
@@ -233,13 +208,13 @@ func buildProgramsWithGapFallback(
 			}
 			// Check if config would assign any rules to this file.
 			var merged *rslintconfig.MergedConfig
-			if configMap != nil {
-				cfgDir, cfg := rslintconfig.FindNearestConfig(nf, configMap)
+			if updatedConfigMap != nil {
+				cfgDir, cfg := rslintconfig.FindNearestConfig(nf, updatedConfigMap)
 				if cfg != nil {
 					merged = cfg.GetConfigForFile(nf, cfgDir)
 				}
 			} else {
-				merged = rslintConfig.GetConfigForFile(nf, currentDirectory)
+				merged = updatedRslintConfig.GetConfigForFile(nf, currentDirectory)
 			}
 			if merged != nil {
 				gapFiles = append(gapFiles, nf)
@@ -261,7 +236,7 @@ func buildProgramsWithGapFallback(
 		}
 	}
 
-	return programs, typeInfoFiles, capturedGapFiles
+	return programs, typeInfoFiles, capturedGapFiles, updatedRslintConfig, updatedConfigMap
 }
 
 // buildFileOwnerMap determines which config directory "owns" each file across
@@ -362,22 +337,16 @@ func toFileFilters(in []func(string) bool) []linter.FileFilter {
 // buildTypeCheckSkipMask returns a parallel-to-programs []bool marking which
 // programs must be excluded from the type-check phase. A program is skipped
 // when it was NOT built from a real tsconfig on disk — i.e. its CompilerOptions
-// carry no ConfigFilePath. That covers both synthetic-options program kinds:
-//
-//   - the no-tsconfig directory-scan Program (createProgramsForConfig's else
-//     branch), built with default options for a config directory that has no
-//     tsconfig; and
-//   - the gap-file fallback Program (createFallbackProgram).
-//
-// Their options are synthesized, not the user's tsconfig, so semantic
-// diagnostics there are unreliable and must not be surfaced. Concretely, the
-// scan program sets neither Target nor Lib, so its default lib can lack modern
-// globals like Symbol.asyncDispose and emit spurious diagnostics against
-// typings pulled in from node_modules. This mirrors the type-checking boundary:
-// only Programs backed by parserOptions.project or the auto-detected
-// tsconfig.json participate in program-level --type-check diagnostics. Programs
-// built via utils.CreateProgram -> GetParsedCommandLineOfConfigFile carry a
-// non-empty ConfigFilePath.
+// carry no ConfigFilePath. That is the gap-file fallback Program
+// (createFallbackProgram): its options are synthesized, not the user's
+// tsconfig, so semantic diagnostics there are unreliable and must not be
+// surfaced. Concretely, it sets neither Target nor Lib beyond ESNext defaults,
+// so it can lack modern globals or emit spurious diagnostics against typings
+// pulled in from node_modules. This mirrors the type-checking boundary: only
+// Programs backed by parserOptions.project or the auto-detected tsconfig.json
+// participate in program-level --type-check diagnostics. Programs built via
+// utils.CreateProgram -> GetParsedCommandLineOfConfigFile carry a non-empty
+// ConfigFilePath.
 //
 // Returns nil when every program is tsconfig-backed, so callers don't allocate
 // an all-false slice. Deriving from the programs keeps the CLI initial build

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -76,17 +76,29 @@ export default [{ files: ['**/*.ts'], rules: {} }] satisfies Bad;
 	})
 
 	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	programs, exitCode := createProgramsForConfig(
+	parseCache := utils.NewParseCache()
+	cfg := rslintconfig.RslintConfig{{Files: []string{"**/*.ts"}}}
+	programs, hasTsConfig, exitCode := createProgramsForConfig(
 		dir,
-		rslintconfig.RslintConfig{{Files: []string{"**/*.ts"}}},
+		cfg,
 		true,
 		fs,
 		nil,
-		utils.NewParseCache(),
+		parseCache,
 	)
 	if exitCode != 0 {
 		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
 	}
+	if hasTsConfig {
+		t.Fatalf("expected no tsconfig to be found")
+	}
+	if len(programs) != 0 {
+		t.Fatalf("expected no programs before gap fallback, got %d", len(programs))
+	}
+
+	programs, _, _, _, _ = buildProgramsWithGapFallback(
+		programs, nil, cfg, dir, fs, nil, nil, parseCache, true, hasTsConfig, nil,
+	)
 	if len(programs) != 1 {
 		t.Fatalf("expected one synthesized fallback program, got %d", len(programs))
 	}
@@ -125,7 +137,7 @@ export const value: Bad | null = null;
 	})
 
 	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	programs, exitCode := createProgramsForConfig(
+	programs, hasTsConfig, exitCode := createProgramsForConfig(
 		dir,
 		rslintconfig.RslintConfig{{
 			Files: []string{"**/*.ts"},
@@ -142,6 +154,9 @@ export const value: Bad | null = null;
 	)
 	if exitCode != 0 {
 		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	}
+	if !hasTsConfig {
+		t.Fatalf("expected tsconfig to be found")
 	}
 	if len(programs) != 1 {
 		t.Fatalf("expected one tsconfig-backed program, got %d", len(programs))
@@ -191,7 +206,7 @@ export const value: Bad | null = null;
 			},
 		},
 	}}
-	programs, exitCode := createProgramsForConfig(
+	programs, hasTsConfig, exitCode := createProgramsForConfig(
 		dir,
 		cfg,
 		true,
@@ -202,6 +217,9 @@ export const value: Bad | null = null;
 	if exitCode != 0 {
 		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
 	}
+	if !hasTsConfig {
+		t.Fatalf("expected tsconfig to be found")
+	}
 	if len(programs) != 1 {
 		t.Fatalf("expected one tsconfig-backed program before gap fallback, got %d", len(programs))
 	}
@@ -209,7 +227,7 @@ export const value: Bad | null = null;
 		t.Fatalf("expected tsconfig-backed program to participate in type-check, got %v", skip)
 	}
 
-	programs, typeInfoFiles, gapFiles := buildProgramsWithGapFallback(
+	programs, typeInfoFiles, gapFiles, _, _ := buildProgramsWithGapFallback(
 		programs,
 		nil,
 		cfg,
@@ -219,6 +237,8 @@ export const value: Bad | null = null;
 		nil,
 		parseCache,
 		true,
+		hasTsConfig,
+		nil,
 	)
 	if len(programs) != 2 {
 		t.Fatalf("expected the gap fallback program to be appended, got %d programs", len(programs))

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -14,44 +14,204 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// defaultExcludeDirs is a set of directory names always excluded from walking.
-var defaultExcludeDirs = func() map[string]struct{} {
-	m := make(map[string]struct{}, len(utils.DefaultExcludeDirNames))
-	for _, name := range utils.DefaultExcludeDirNames {
-		m[name] = struct{}{}
-	}
-	return m
-}()
+// sourceFileExtensions are the extensions walkDir treats as lintable source
+// files. Mirrors the extension list historically used for the no-tsconfig
+// directory scan (cmd/rslint/programs.go).
+var sourceFileExtensions = []string{".ts", ".tsx", ".js", ".jsx", ".mts", ".mjs"}
 
-// DiscoverGapFiles scans the filesystem for "gap files" — files that match a config
-// entry's `files` pattern but are not in any tsconfig Program. These files get a
-// fallback Program (AST-only, no type info) and only run non-type-aware rules.
+func hasSourceExtension(name string) bool {
+	for _, ext := range sourceFileExtensions {
+		if strings.HasSuffix(name, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// walkJob is one unit of work for walkDir's worker pool: a directory to read,
+// plus the gitignore-derived ignore chain inherited from ancestors (grows as
+// nested .gitignore files are found) and the combined ignores/negation-reach
+// ready for use (chain ++ staticIgnores, cached — see walkDir's doc comment
+// on why gitignore patterns must stay ordered before staticIgnores).
+type walkJob struct {
+	path    string
+	chain   []IgnorePattern
+	ignores []IgnorePattern
+	neg     negReach
+}
+
+// walkDir does a single top-down traversal of cwd, returning:
+//   - every file not excluded by gitignoreSeed, any .gitignore found during
+//     the walk, or staticIgnores (no extension filtering here —
+//     DiscoverGapFiles applies that itself, only for the no-`files`-field
+//     case; when a config entry sets `files`, the pattern itself is the only
+//     filter, matching pre-existing behavior for e.g. `files: ["**/*"]`).
+//     ".git" is the only hard-coded directory skip; everything else,
+//     including node_modules, is controlled by ignore patterns the caller
+//     folds into staticIgnores (see utils.DefaultIgnoreDirGlobs).
+//   - every .gitignore-derived glob pattern discovered during the walk
+//     (flat, in top-down discovery order), for callers that need to fold them
+//     into a config's global ignores for consumers outside this walk (e.g.
+//     GetConfigForFile on a file that is already in a tsconfig Program).
+//     Patterns already present in gitignoreSeed are NOT re-returned.
+//
+// gitignoreSeed and staticIgnores are kept as two separate inputs — rather
+// than one flat pre-merged list — because they must stay in a fixed relative
+// order that a single "seed, then append newly found .gitignore" list can't
+// guarantee: gitignore-derived patterns (ancestor + seed + anything found
+// during the walk) must ALWAYS be evaluated before staticIgnores (the user's
+// own config `ignores`, e.g. `!dist/keep.ts`), so a user's `!` can override a
+// gitignore rule regardless of whether that rule came from an ancestor
+// .gitignore (known upfront) or one discovered mid-walk. Every job carries
+// `chain` (the gitignore patterns accumulated root-to-here) separately from
+// the cached `ignores = chain ++ staticIgnores`; only chain growth (a new
+// .gitignore found in that directory) triggers recomputing `ignores`/`neg`.
+//
+// A .gitignore found in a directory applies to that directory and everything
+// beneath it: its rules are appended after the inherited chain (so a nested
+// `!` can override an ancestor .gitignore's rule — sequential evaluation,
+// later wins) and threaded down to child jobs. Directories without their own
+// .gitignore just pass their inherited chain/ignores/negReach to children
+// unchanged (no recomputation).
+//
+// Symlinked subdirectories are skipped (vfsAdapter with followSymlinks=false),
+// matching ESLint v10's flat-config walker semantics.
+func walkDir(
+	cwd string,
+	fsys vfs.FS,
+	gitignoreSeed []IgnorePattern,
+	staticIgnores []IgnorePattern,
+	singleThreaded bool,
+) (files []string, gitignoreGlobs []string) {
+	normalizedCwd := normalizeGlobPath(cwd)
+	fsAdapter := &vfsAdapter{vfs: fsys, root: normalizedCwd}
+
+	var filesMu, globsMu sync.Mutex
+
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 2 {
+		workers = 2
+	}
+	if singleThreaded {
+		workers = 1
+	}
+
+	combine := func(chain []IgnorePattern) ([]IgnorePattern, negReach) {
+		combined := make([]IgnorePattern, 0, len(chain)+len(staticIgnores))
+		combined = append(combined, chain...)
+		combined = append(combined, staticIgnores...)
+		return combined, buildNegReach(combined)
+	}
+
+	work := func(job walkJob) []walkJob {
+		f, err := fsAdapter.Open(job.path)
+		if err != nil {
+			return nil
+		}
+		rdf, ok := f.(fs.ReadDirFile)
+		if !ok {
+			f.Close()
+			return nil
+		}
+		entries, _ := rdf.ReadDir(-1)
+		f.Close()
+
+		chain := job.chain
+		ignores := job.ignores
+		neg := job.neg
+
+		for _, e := range entries {
+			if e.IsDir() || e.Name() != ".gitignore" {
+				continue
+			}
+			dirAbsPath := normalizedCwd
+			if job.path != "." {
+				dirAbsPath = normalizedCwd + "/" + job.path
+			}
+			content, ok := fsys.ReadFile(dirAbsPath + "/.gitignore")
+			if !ok {
+				break
+			}
+			relDir := ""
+			if job.path != "." {
+				relDir = job.path
+			}
+			localGlobs := convertGitignoreToGlobs(content, relDir)
+			if len(localGlobs) == 0 {
+				break
+			}
+			globsMu.Lock()
+			gitignoreGlobs = append(gitignoreGlobs, localGlobs...)
+			globsMu.Unlock()
+
+			newChain := make([]IgnorePattern, len(chain), len(chain)+len(localGlobs))
+			copy(newChain, chain)
+			chain = append(newChain, ParseIgnorePatterns(localGlobs)...)
+			ignores, neg = combine(chain)
+			break
+		}
+
+		var childJobs []walkJob
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() {
+				if name == ".git" {
+					continue
+				}
+				childPath := path.Join(job.path, name)
+				if canPruneDir(childPath, ignores, neg) {
+					continue
+				}
+				childJobs = append(childJobs, walkJob{path: childPath, chain: chain, ignores: ignores, neg: neg})
+				continue
+			}
+			walkPath := path.Join(job.path, name)
+			fullPath := tspath.NormalizePath(path.Join(normalizedCwd, walkPath))
+			if isFileIgnored(fullPath, ignores, cwd) {
+				continue
+			}
+			filesMu.Lock()
+			files = append(files, fullPath)
+			filesMu.Unlock()
+		}
+		return childJobs
+	}
+
+	rootIgnores, rootNeg := combine(gitignoreSeed)
+	pool := newWalkPool[walkJob](workers)
+	pool.submitMany([]walkJob{{path: ".", chain: gitignoreSeed, ignores: rootIgnores, neg: rootNeg}})
+	pool.run(work)
+
+	sort.Strings(files)
+	return files, gitignoreGlobs
+}
+
+// DiscoverGapFiles discovers files that should get a fallback (AST-only, no
+// type info) Program: they are not already covered by any tsconfig-backed
+// Program, but the linter would still assign them rules.
+//
+// Two scenarios trigger this:
+//   - hasTsConfig is false: there is no tsconfig at all for configDir (a pure
+//     JS/TS project). Every ts/js file under configDir not already in
+//     programFiles is a gap file — a whole-directory fallback Program takes
+//     the place of the old ad-hoc "no tsconfig" directory scan.
+//   - a config entry sets `files`: files matching those patterns but absent
+//     from every tsconfig Program are gaps, even when a tsconfig exists.
+//
+// When hasTsConfig is true and no entry sets `files`, the tsconfig's own
+// `include`/`exclude` resolution is authoritative and this function is a
+// no-op (nil, nil) — legacy behavior.
 //
 // Files pass through these filters:
-//  1. Match at least one config entry's `files` pattern
-//  2. Not in global ignores (directory-level and file-level)
+//  1. Match at least one config entry's `files` pattern (skipped when no
+//     entry sets `files` — legacy semantics: applies to everything)
+//  2. Not in global ignores or any .gitignore (enforced inside walkDir)
 //  3. Not already in programFiles (existing tsconfig Programs)
 //  4. Pass GetConfigForFile (would actually receive lint rules)
 //
-// Walking model:
-//   - A bounded worker pool (see walkPool) traverses the directory tree.
-//     Total live goroutines at any moment is at most `workers`.
-//   - Default workers = max(2, GOMAXPROCS); singleThreaded forces workers=1
-//     for fully serial traversal (a knob users rely on for debugging,
-//     reproducibility, and constrained environments).
-//   - The vfsAdapter is constructed with followSymlinks=false, so symlinked
-//     subdirectories are skipped entirely. This matches ESLint v10's
-//     flat-config file walker, which uses @humanfs/node and recurses only
-//     when Dirent.isDirectory() is true (Node returns false for symlinks).
-//     It also avoids the otherwise scheduling-dependent "first writer wins"
-//     non-determinism a parallel walker would introduce.
-//
-// When allowFiles/allowDirs are provided (CLI args), only files within scope.
-//
-// Returns:
-//   - nil: no config entry has a `files` field → caller uses legacy tsconfig-only behavior
-//   - []: `files` present but no gaps found
-//   - [...]: gap files to create a fallback Program for (sorted lexically)
+// Returns the gap files (sorted, deduplicated) and every .gitignore-derived
+// glob pattern relevant to configDir (ancestor + discovered during the walk),
+// for the caller to fold into the config's global ignores.
 func DiscoverGapFiles(
 	config RslintConfig,
 	configDir string,
@@ -60,9 +220,9 @@ func DiscoverGapFiles(
 	allowFiles []string,
 	allowDirs []string,
 	singleThreaded bool,
-) []string {
-	// 1. Collect global ignore patterns and files patterns from config entries.
-	globalIgnores := ExtractConfigIgnores(config)
+	hasTsConfig bool,
+) (gapFiles []string, gitignoreGlobs []string) {
+	configIgnores := ExtractConfigIgnores(config)
 
 	var allFilesPatterns []string
 	hasFilesField := false
@@ -73,15 +233,14 @@ func DiscoverGapFiles(
 		}
 	}
 
-	// No entry has files → backward compat, signal caller to skip new logic.
-	if !hasFilesField {
-		return nil
+	// tsconfig found and no entry restricts scope via `files` → legacy
+	// behavior, tsconfig `include`/`exclude` is authoritative.
+	if hasTsConfig && !hasFilesField {
+		return nil, nil
 	}
 
-	// Deduplicate patterns.
 	allFilesPatterns = deduplicate(allFilesPatterns)
 
-	// Build allowFiles set for fast lookup.
 	var allowFileSet map[string]struct{}
 	if allowFiles != nil {
 		allowFileSet = make(map[string]struct{}, len(allowFiles))
@@ -90,97 +249,109 @@ func DiscoverGapFiles(
 		}
 	}
 
-	// 2. Prepend default directory ignores so they are always active
-	// regardless of user config.
-	globalIgnores = append(ParseIgnorePatterns(utils.DefaultIgnoreDirGlobs()), globalIgnores...)
+	// staticIgnores (default dir excludes + the user's own config `ignores`)
+	// must always be evaluated AFTER gitignore-derived patterns, so a user's
+	// `!` can override a gitignore rule regardless of where that rule came
+	// from. See walkDir's doc comment for why these stay as two separate
+	// lists instead of one pre-merged seed.
+	staticIgnores := append(ParseIgnorePatterns(utils.DefaultIgnoreDirGlobs()), configIgnores...)
 
-	// Use non-nil empty slice to distinguish "files field present, no gaps"
-	// from "no files field" (nil).
-	gapFiles := []string{}
+	normalizedConfigDirForGitignore := normalizeGlobPath(configDir)
+	ancestorGlobs := collectAncestorGitignoreGlobs(normalizedConfigDirForGitignore, fsys)
+	gitignoreSeed := ParseIgnorePatterns(ancestorGlobs)
+
+	result := []string{}
 
 	// Fast path: when only specific files are provided (e.g., lint-staged),
-	// check each file directly instead of walking the entire filesystem.
+	// check each file directly instead of walking the entire filesystem. This
+	// path skips walkDir entirely, so it wouldn't otherwise see any
+	// .gitignore at all — read configDir's own .gitignore directly (one
+	// extra file read, not a tree walk) so the common case (a single
+	// top-level .gitignore) still works. Nested .gitignore files in
+	// subdirectories under configDir are NOT discovered by this path — that
+	// would require a walk, defeating the point of the fast path.
 	if allowFileSet != nil && allowDirs == nil {
-		for f := range allowFileSet {
-			if _, exists := programFiles[f]; exists {
-				continue
+		ownGlobs, _ := fsys.ReadFile(normalizedConfigDirForGitignore + "/.gitignore")
+		fastGitignore := gitignoreSeed
+		rootGlobs := ancestorGlobs
+		if ownGlobs != "" {
+			converted := convertGitignoreToGlobs(ownGlobs, "")
+			if len(converted) > 0 {
+				fastGitignore = append(append([]IgnorePattern{}, gitignoreSeed...), ParseIgnorePatterns(converted)...)
+				rootGlobs = append(append([]string{}, ancestorGlobs...), converted...)
 			}
-			if isFileIgnored(f, globalIgnores, configDir) {
+		}
+		fastIgnores := append(append([]IgnorePattern{}, fastGitignore...), staticIgnores...)
+		for f := range allowFileSet {
+			// See the same check in the walk path below for why this only
+			// applies when hasTsConfig is true.
+			if hasTsConfig {
+				if _, exists := programFiles[f]; exists {
+					continue
+				}
+			}
+			if isFileIgnored(f, fastIgnores, configDir) {
 				continue
 			}
 			if config.GetConfigForFile(f, configDir) == nil {
 				continue
 			}
-			gapFiles = append(gapFiles, f)
+			result = append(result, f)
 		}
-		gapFiles = deduplicate(gapFiles)
-		// Map iteration order is non-deterministic; sort to match the walker
-		// path and keep output stable across runs.
-		sort.Strings(gapFiles)
-		return gapFiles
+		result = deduplicate(result)
+		sort.Strings(result)
+		return result, rootGlobs
 	}
 
-	// 3. Walk the tree with a bounded worker pool. Goroutine count is capped
-	// at `workers`; symlinks are skipped (see vfsAdapter doc) so the result
-	// set is deterministic regardless of scheduling.
-	normalizedConfigDir := normalizeGlobPath(configDir)
-	fsAdapter := &vfsAdapter{vfs: fsys, root: normalizedConfigDir}
+	walked, discoveredGlobs := walkDir(configDir, fsys, gitignoreSeed, staticIgnores, singleThreaded)
 
-	// Normalize patterns relative to configDir for matching.
+	normalizedConfigDir := normalizeGlobPath(configDir)
 	relativePatterns := make([]string, len(allFilesPatterns))
 	for i, pattern := range allFilesPatterns {
 		normalizedPattern := normalizeGlobPath(tspath.ResolvePath(configDir, pattern))
 		relativePatterns[i] = strings.TrimPrefix(normalizedPattern, normalizedConfigDir+"/")
 	}
 
-	var (
-		gapMu     sync.Mutex
-		seen      sync.Map // map[string]struct{} — file dedupe
-		dirIgnore sync.Map // map[string]bool — pattern check cache, write-once per path
-	)
-
-	// Precompute negation reaches once. canPruneDir uses them to prune gitignore
-	// file-level directories (e.g. target/ → **/target/**/*) without ever
-	// skipping a directory a `!` pattern could re-include.
-	neg := buildNegReach(globalIgnores)
-
-	// Defer the parallelism limit to GOMAXPROCS (Go's standard knob; aligned
-	// with container CGroup CPU limits). Lower bound of 2 keeps the walker
-	// useful on single-core CI runners. singleThreaded overrides to 1 for
-	// fully serial traversal — a knob users depend on for reproducibility,
-	// debugging, and constrained environments.
-	workers := runtime.GOMAXPROCS(0)
-	if workers < 2 {
-		workers = 2
-	}
-	if singleThreaded {
-		workers = 1
-	}
-
-	processFile := func(walkPath string) {
-		// 1. pattern match
-		matched := false
-		for _, pattern := range relativePatterns {
-			if ok, _ := doublestar.Match(pattern, walkPath); ok {
-				matched = true
-				break
+	for _, fullPath := range walked {
+		// 1. pattern match (skipped when no entry sets `files`: legacy
+		// semantics treat that as "applies to everything" — but only to
+		// ts/js source files, matching the old no-tsconfig directory scan
+		// this case replaces; a `files` pattern like "**/*" is itself the
+		// only filter when one is present, so e.g. .md/.json files stay
+		// discoverable there).
+		if hasFilesField {
+			relPath := strings.TrimPrefix(fullPath, normalizedConfigDir+"/")
+			matched := false
+			for _, pattern := range relativePatterns {
+				if ok, _ := doublestar.Match(pattern, relPath); ok {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		} else if !hasSourceExtension(fullPath) {
+			continue
+		}
+		// 2. already in tsconfig Programs. Only applies when THIS configDir
+		// has its own tsconfig: programFiles is a cross-config set, and an
+		// ancestor config's broader tsconfig `include` can already cover a
+		// file that structurally belongs to a nested config with no
+		// tsconfig of its own (e.g. a monorepo root tsconfig with
+		// `include: ["**/*.ts"]` sweeping up every package). Excluding it
+		// here would mean it never gets the nested config's own rules at
+		// all. Instead, when hasTsConfig is false, always treat it as a gap
+		// file for this config — the existing nearest-config ownership
+		// resolution (buildFileOwnerMap/buildFileFilters) is what decides
+		// which program's rules actually apply per file, exactly as it did
+		// for the old no-tsconfig whole-directory scan Program.
+		if hasTsConfig {
+			if _, exists := programFiles[fullPath]; exists {
+				continue
 			}
 		}
-		if !matched {
-			return
-		}
-
-		fullPath := tspath.NormalizePath(path.Join(normalizedConfigDir, walkPath))
-
-		// 2. already in tsconfig Programs
-		if _, exists := programFiles[fullPath]; exists {
-			return
-		}
-		// 3. file-level global ignores
-		if isFileIgnored(fullPath, globalIgnores, configDir) {
-			return
-		}
-		// 4. CLI scope
+		// 3. CLI scope
 		if allowFileSet != nil || allowDirs != nil {
 			inScope := false
 			if allowFileSet != nil {
@@ -197,82 +368,34 @@ func DiscoverGapFiles(
 				}
 			}
 			if !inScope {
-				return
+				continue
 			}
 		}
-		// 5. final config check
+		// 4. final config check
 		if config.GetConfigForFile(fullPath, configDir) == nil {
-			return
+			continue
 		}
-		// 6. dedupe + append
-		if _, loaded := seen.LoadOrStore(fullPath, struct{}{}); loaded {
-			return
-		}
-		gapMu.Lock()
-		gapFiles = append(gapFiles, fullPath)
-		gapMu.Unlock()
+		result = append(result, fullPath)
 	}
 
-	work := func(walkPath string) []string {
-		f, err := fsAdapter.Open(walkPath)
-		if err != nil {
-			return nil
-		}
-		rdf, ok := f.(fs.ReadDirFile)
-		if !ok {
-			f.Close()
-			return nil
-		}
-		entries, _ := rdf.ReadDir(-1)
-		f.Close()
+	result = deduplicate(result)
+	sort.Strings(result)
 
-		var childDirs []string
-		for _, e := range entries {
-			name := e.Name()
-			if e.IsDir() {
-				if _, excluded := defaultExcludeDirs[name]; excluded {
-					continue
-				}
-				childPath := path.Join(walkPath, name)
-				if cached, ok := dirIgnore.Load(childPath); ok {
-					blocked, _ := cached.(bool) // dirIgnore only stores bool (set by Store below)
-					if blocked {
-						continue
-					}
-				} else {
-					// canPruneDir unifies both directory-prune cases: absolute
-					// blocks (dir/**, bare names) and negation-aware file-level
-					// gitignore covers (dir/**/*). Sound — prunes only when every
-					// descendant file would be ignored by isFileIgnored.
-					blocked := canPruneDir(childPath, globalIgnores, neg)
-					dirIgnore.Store(childPath, blocked)
-					if blocked {
-						continue
-					}
-				}
-				childDirs = append(childDirs, childPath)
-			} else {
-				processFile(path.Join(walkPath, name))
-			}
-		}
-		return childDirs
-	}
+	allGlobs := make([]string, 0, len(ancestorGlobs)+len(discoveredGlobs))
+	allGlobs = append(allGlobs, ancestorGlobs...)
+	allGlobs = append(allGlobs, discoveredGlobs...)
 
-	pool := newWalkPool(workers)
-	pool.submitMany([]string{"."})
-	pool.run(work)
-
-	sort.Strings(gapFiles)
-	return gapFiles
+	return result, allGlobs
 }
 
 // DiscoverGapFilesMultiConfig runs DiscoverGapFiles for each config in a
-// monorepo config map and returns the union of all gap files.
+// monorepo config map and returns the union of all gap files, plus the
+// .gitignore-derived globs discovered per configDir (kept separate per dir —
+// a child config's own .gitignore must not leak into its siblings or parent).
 //
-// Configs are processed serially. Each DiscoverGapFiles invocation already
-// uses an internal worker pool, so the total live goroutine count is bounded
-// by the worker pool size, not by `len(configMap) × workers`. Cross-config
-// parallelism can be added later if benchmarks justify it.
+// hasTsConfigByDir carries, per configDir, whether a tsconfig was found for
+// that config (see DiscoverGapFiles). A missing entry defaults to false
+// (walks that configDir), which is the safe default.
 func DiscoverGapFilesMultiConfig(
 	configMap map[string]RslintConfig,
 	fsys vfs.FS,
@@ -280,33 +403,44 @@ func DiscoverGapFilesMultiConfig(
 	allowFiles []string,
 	allowDirs []string,
 	singleThreaded bool,
-) []string {
+	hasTsConfigByDir map[string]bool,
+) (gapFiles []string, gitignoreGlobsByDir map[string][]string) {
 	if len(configMap) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	seen := make(map[string]struct{})
 	var allGapFiles []string
+	globsByDir := make(map[string][]string, len(configMap))
 	for configDir, cfg := range configMap {
-		gapFiles := DiscoverGapFiles(cfg, configDir, fsys, programFiles, allowFiles, allowDirs, singleThreaded)
-		for _, f := range gapFiles {
+		dirGapFiles, dirGlobs := DiscoverGapFiles(
+			cfg, configDir, fsys, programFiles, allowFiles, allowDirs, singleThreaded, hasTsConfigByDir[configDir],
+		)
+		for _, f := range dirGapFiles {
 			if _, exists := seen[f]; !exists {
 				seen[f] = struct{}{}
 				allGapFiles = append(allGapFiles, f)
 			}
 		}
+		if len(dirGlobs) > 0 {
+			globsByDir[configDir] = dirGlobs
+		}
 	}
 
-	if len(allGapFiles) == 0 {
-		return nil
+	if len(allGapFiles) > 0 {
+		sort.Strings(allGapFiles)
+	} else {
+		allGapFiles = nil
 	}
-	sort.Strings(allGapFiles)
-	return allGapFiles
+	if len(globsByDir) == 0 {
+		globsByDir = nil
+	}
+	return allGapFiles, globsByDir
 }
 
 // walkPool is a fixed-size worker pool with an unbounded internal LIFO queue,
-// used by DiscoverGapFiles to walk directory trees with a bounded number of
-// live goroutines. Properties:
+// used by walkDir to walk directory trees with a bounded number of live
+// goroutines. Properties:
 //
 //   - At most `workers` goroutines exist concurrently.
 //   - submitMany never blocks (queue grows as needed; total memory ~ peak
@@ -316,84 +450,86 @@ func DiscoverGapFilesMultiConfig(
 //     idle and the queue is empty.
 //
 // workers=1 degenerates to an effectively serial DFS-style traversal (LIFO
-// pops the most recently submitted dir); the only goroutine is the worker
+// pops the most recently submitted item); the only goroutine is the worker
 // itself. This is what --singleThreaded relies on.
-type walkPool struct {
+type walkPool[T any] struct {
 	mu      sync.Mutex
 	cond    *sync.Cond
-	queue   []string
+	queue   []T
 	idle    int
 	workers int
 	done    bool
 }
 
-func newWalkPool(workers int) *walkPool {
+func newWalkPool[T any](workers int) *walkPool[T] {
 	if workers < 1 {
 		workers = 1
 	}
-	p := &walkPool{workers: workers}
+	p := &walkPool[T]{workers: workers}
 	p.cond = sync.NewCond(&p.mu)
 	return p
 }
 
-// submitMany appends dirs to the queue and wakes idle workers. Safe to call
+// submitMany appends items to the queue and wakes idle workers. Safe to call
 // from any goroutine.
-func (p *walkPool) submitMany(dirs []string) {
-	if len(dirs) == 0 {
+func (p *walkPool[T]) submitMany(items []T) {
+	if len(items) == 0 {
 		return
 	}
 	p.mu.Lock()
-	p.queue = append(p.queue, dirs...)
+	p.queue = append(p.queue, items...)
 	p.mu.Unlock()
-	if len(dirs) == 1 {
+	if len(items) == 1 {
 		p.cond.Signal()
 	} else {
 		p.cond.Broadcast()
 	}
 }
 
-// take pops a job from the queue, blocking if empty. Returns ("", false)
+// take pops a job from the queue, blocking if empty. Returns (zero, false)
 // only when the queue is empty AND every worker is simultaneously idle —
 // which means no more work will ever appear.
-func (p *walkPool) take() (string, bool) {
+func (p *walkPool[T]) take() (T, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	for {
 		if len(p.queue) > 0 {
 			n := len(p.queue) - 1
-			dir := p.queue[n]
+			item := p.queue[n]
 			p.queue = p.queue[:n]
-			return dir, true
+			return item, true
 		}
 		p.idle++
 		if p.idle == p.workers {
 			p.done = true
 			p.cond.Broadcast()
-			return "", false
+			var zero T
+			return zero, false
 		}
 		p.cond.Wait()
 		if p.done {
-			return "", false
+			var zero T
+			return zero, false
 		}
 		p.idle--
 	}
 }
 
-// run drives the worker pool. Each worker pulls jobs and calls work(dir),
-// which returns the child directories to enqueue. Returns when all reachable
-// work is processed.
+// run drives the worker pool. Each worker pulls jobs and calls work(item),
+// which returns the child jobs to enqueue. Returns when all reachable work
+// is processed.
 //
 // When workers == 1, runs the loop on the calling goroutine directly — no
 // goroutines are spawned at all. This is what --singleThreaded relies on:
 // callers can rely on the Go side spawning no extra goroutines.
-func (p *walkPool) run(work func(string) []string) {
+func (p *walkPool[T]) run(work func(T) []T) {
 	if p.workers == 1 {
 		for {
-			dir, ok := p.take()
+			item, ok := p.take()
 			if !ok {
 				return
 			}
-			p.submitMany(work(dir))
+			p.submitMany(work(item))
 		}
 	}
 	var wg sync.WaitGroup
@@ -402,11 +538,11 @@ func (p *walkPool) run(work func(string) []string) {
 		go func() {
 			defer wg.Done()
 			for {
-				dir, ok := p.take()
+				item, ok := p.take()
 				if !ok {
 					return
 				}
-				p.submitMany(work(dir))
+				p.submitMany(work(item))
 			}
 		}()
 	}

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // sourceFileExtensions are the extensions walkDir treats as lintable source
@@ -47,8 +46,8 @@ type walkJob struct {
 //     case; when a config entry sets `files`, the pattern itself is the only
 //     filter, matching pre-existing behavior for e.g. `files: ["**/*"]`).
 //     ".git" is the only hard-coded directory skip; everything else,
-//     including node_modules, is controlled by ignore patterns the caller
-//     folds into staticIgnores (see utils.DefaultIgnoreDirGlobs).
+//     including node_modules, is only excluded if matched by a .gitignore
+//     or the user's own config `ignores` — there is no built-in default.
 //   - every .gitignore-derived glob pattern discovered during the walk
 //     (flat, in top-down discovery order), for callers that need to fold them
 //     into a config's global ignores for consumers outside this walk (e.g.
@@ -186,6 +185,49 @@ func walkDir(
 	return files, gitignoreGlobs
 }
 
+// collectNestedGitignoreChain reads the .gitignore files, if any, in each
+// directory strictly between configDir (exclusive — the caller reads
+// configDir's own .gitignore separately) and the directory containing
+// filePath (inclusive), in root-to-leaf order. This mirrors the order walkDir
+// would encounter them while descending, so a deeper .gitignore's rules are
+// appended after — and can override — a shallower one's.
+//
+// Returns the chain as parsed IgnorePatterns (ready to combine with other
+// ignore sources) and as raw glob strings (for folding into the config's
+// global ignores, matching what walkDir returns for the directories it
+// visits).
+func collectNestedGitignoreChain(filePath, configDir string, fsys vfs.FS) (chain []IgnorePattern, globs []string) {
+	normalizedConfigDir := normalizeGlobPath(configDir)
+	fileDir := path.Dir(normalizeGlobPath(filePath))
+	if fileDir == normalizedConfigDir || !tspath.StartsWithDirectory(fileDir, normalizedConfigDir, true) {
+		return nil, nil
+	}
+
+	rel := strings.TrimPrefix(fileDir, normalizedConfigDir+"/")
+	var segments []string
+	for rel != "" && rel != "." {
+		segments = append(segments, rel)
+		rel = path.Dir(rel)
+	}
+	for i, j := 0, len(segments)-1; i < j; i, j = i+1, j-1 {
+		segments[i], segments[j] = segments[j], segments[i]
+	}
+
+	for _, seg := range segments {
+		content, ok := fsys.ReadFile(normalizedConfigDir + "/" + seg + "/.gitignore")
+		if !ok {
+			continue
+		}
+		localGlobs := convertGitignoreToGlobs(content, seg)
+		if len(localGlobs) == 0 {
+			continue
+		}
+		globs = append(globs, localGlobs...)
+		chain = append(chain, ParseIgnorePatterns(localGlobs)...)
+	}
+	return chain, globs
+}
+
 // DiscoverGapFiles discovers files that should get a fallback (AST-only, no
 // type info) Program: they are not already covered by any tsconfig-backed
 // Program, but the linter would still assign them rules.
@@ -249,12 +291,12 @@ func DiscoverGapFiles(
 		}
 	}
 
-	// staticIgnores (default dir excludes + the user's own config `ignores`)
-	// must always be evaluated AFTER gitignore-derived patterns, so a user's
-	// `!` can override a gitignore rule regardless of where that rule came
-	// from. See walkDir's doc comment for why these stay as two separate
-	// lists instead of one pre-merged seed.
-	staticIgnores := append(ParseIgnorePatterns(utils.DefaultIgnoreDirGlobs()), configIgnores...)
+	// staticIgnores (the user's own config `ignores`) must always be
+	// evaluated AFTER gitignore-derived patterns, so a user's `!` can
+	// override a gitignore rule regardless of where that rule came from. See
+	// walkDir's doc comment for why these stay as two separate lists instead
+	// of one pre-merged seed.
+	staticIgnores := configIgnores
 
 	normalizedConfigDirForGitignore := normalizeGlobPath(configDir)
 	ancestorGlobs := collectAncestorGitignoreGlobs(normalizedConfigDirForGitignore, fsys)
@@ -267,9 +309,11 @@ func DiscoverGapFiles(
 	// path skips walkDir entirely, so it wouldn't otherwise see any
 	// .gitignore at all — read configDir's own .gitignore directly (one
 	// extra file read, not a tree walk) so the common case (a single
-	// top-level .gitignore) still works. Nested .gitignore files in
-	// subdirectories under configDir are NOT discovered by this path — that
-	// would require a walk, defeating the point of the fast path.
+	// top-level .gitignore) still works. For a file nested under configDir,
+	// the .gitignore files in directories between configDir and the file are
+	// also read directly (one read per intervening directory, not a walk of
+	// the whole tree) via collectNestedGitignoreChain, so an explicitly-passed
+	// nested file is still correctly reported as ignored.
 	if allowFileSet != nil && allowDirs == nil {
 		ownGlobs, _ := fsys.ReadFile(normalizedConfigDirForGitignore + "/.gitignore")
 		fastGitignore := gitignoreSeed
@@ -281,7 +325,7 @@ func DiscoverGapFiles(
 				rootGlobs = append(append([]string{}, ancestorGlobs...), converted...)
 			}
 		}
-		fastIgnores := append(append([]IgnorePattern{}, fastGitignore...), staticIgnores...)
+		seenNestedGlobs := make(map[string]struct{})
 		for f := range allowFileSet {
 			// See the same check in the walk path below for why this only
 			// applies when hasTsConfig is true.
@@ -290,6 +334,15 @@ func DiscoverGapFiles(
 					continue
 				}
 			}
+			nestedChain, nestedGlobs := collectNestedGitignoreChain(f, configDir, fsys)
+			for _, g := range nestedGlobs {
+				if _, exists := seenNestedGlobs[g]; !exists {
+					seenNestedGlobs[g] = struct{}{}
+					rootGlobs = append(rootGlobs, g)
+				}
+			}
+			fastIgnores := append(append([]IgnorePattern{}, fastGitignore...), nestedChain...)
+			fastIgnores = append(fastIgnores, staticIgnores...)
 			if isFileIgnored(f, fastIgnores, configDir) {
 				continue
 			}

--- a/internal/config/file_discovery_dir_prune_test.go
+++ b/internal/config/file_discovery_dir_prune_test.go
@@ -41,7 +41,7 @@ func TestDiscoverGapFiles_PrunesGitignoreFileLevelDir(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 
 	// target/ must NOT be entered.
 	for _, dir := range spy.snapshotAccessedDirs() {
@@ -68,7 +68,7 @@ func TestDiscoverGapFiles_NegationReincludeFullPath(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 	dirs := spy.snapshotAccessedDirs()
 
 	// Top-level target NOT entered; the re-included sub/path/target IS entered.
@@ -99,7 +99,7 @@ func TestDiscoverGapFiles_NegationReincludeChildNotOverPruned(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 
 	// Must reach target/keep.
 	assert.Assert(t, dirAccessed(spy.snapshotAccessedDirs(), "target/keep"), "target/keep must be walked")
@@ -124,7 +124,7 @@ func TestDiscoverGapFiles_UnrootedNegationConservative(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 
 	assert.Assert(t, dirAccessed(spy.snapshotAccessedDirs(), "build"), "build must be walked (unrooted negation)")
 
@@ -147,7 +147,7 @@ func TestDiscoverGapFiles_DirLevelVsFileLevel(t *testing.T) {
 			{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 		}
 		spy := &spyFS{FS: osvfs.FS()}
-		gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+		gapFiles, _ := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 		for _, d := range spy.snapshotAccessedDirs() {
 			if strings.Contains(d, "dist") {
 				t.Errorf("dir-level dist must be absolutely pruned, entered: %s", d)
@@ -168,7 +168,7 @@ func TestDiscoverGapFiles_DirLevelVsFileLevel(t *testing.T) {
 			{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 		}
 		spy := &spyFS{FS: osvfs.FS()}
-		gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+		gapFiles, _ := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 		assert.Assert(t, dirAccessed(spy.snapshotAccessedDirs(), "dist"), "file-level dist must be walked for negation")
 		gapSet := toSet(gapFiles)
 		assert.Assert(t, gapSet[paths["dist/keep.ts"]], "file-level ! re-includes keep.ts")
@@ -190,20 +190,22 @@ func TestDiscoverGapFiles_GitignoreTargetPrunedE2E(t *testing.T) {
 	config := RslintConfig{
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 	}
-	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ExtractConfigIgnores(config))
-	if len(gitGlobs) > 0 {
-		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
-	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, dir, spy, map[string]struct{}{}, nil, nil, false)
+	gapFiles, gitignoreGlobs := DiscoverGapFiles(config, dir, spy, map[string]struct{}{}, nil, nil, false, true)
 
 	// The actual optimization: target/ must NOT be entered.
 	assert.Assert(t, !dirAccessed(spy.snapshotAccessedDirs(), "target"), "target should be pruned via gitignore")
 	// gap-file set unchanged.
 	assert.Equal(t, len(gapFiles), 1, "got %v", gapFiles)
 	assert.Assert(t, toSet(gapFiles)[tspath.NormalizePath(dir+"/src/index.ts")])
-	// Linter consistency: target files return nil.
+
+	// Linter consistency: once the discovered .gitignore globs are folded into
+	// the config's global ignores (as buildProgramsWithGapFallback does),
+	// target files return nil.
+	if len(gitignoreGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitignoreGlobs}}, config...)
+	}
 	assert.Assert(t, config.GetConfigForFile(tspath.NormalizePath(dir+"/target/a.ts"), dir) == nil)
 }
 
@@ -223,18 +225,18 @@ func TestDiscoverGapFiles_NestedGitignoreNegationE2E(t *testing.T) {
 	config := RslintConfig{
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 	}
-	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ExtractConfigIgnores(config))
-	if len(gitGlobs) > 0 {
-		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
-	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, dir, spy, map[string]struct{}{}, nil, nil, false)
+	gapFiles, gitignoreGlobs := DiscoverGapFiles(config, dir, spy, map[string]struct{}{}, nil, nil, false, true)
 	gapSet := toSet(gapFiles)
 
 	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/src/a.ts")])
 	// Re-included nested build must be walked + discovered.
 	assert.Assert(t, dirAccessed(spy.snapshotAccessedDirs(), "build"), "sub/build must be walked")
+
+	if len(gitignoreGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitignoreGlobs}}, config...)
+	}
 	if !gapSet[tspath.NormalizePath(dir+"/sub/build/keep.ts")] {
 		// Consistency cross-check: linter must agree it is lintable.
 		mc := config.GetConfigForFile(tspath.NormalizePath(dir+"/sub/build/keep.ts"), dir)
@@ -319,7 +321,7 @@ func TestDiscoverGapFiles_PruningPreservesGapFiles(t *testing.T) {
 			}
 			sort.Strings(oracle)
 
-			got := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+			got, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false, true)
 			sort.Strings(got)
 
 			assert.DeepEqual(t, got, oracle)
@@ -345,7 +347,7 @@ func TestDiscoverGapFiles_PerEntryNegationDoesNotResurrect(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 	gapSet := toSet(gapFiles)
 
 	assert.Assert(t, gapSet[paths["src/a.ts"]])
@@ -369,8 +371,8 @@ func TestDiscoverGapFiles_PruneSingleThreadedEquivalence(t *testing.T) {
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 	}
 
-	par := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
-	seq := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, true)
+	par, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false, true)
+	seq, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, true, true)
 	sort.Strings(par)
 	sort.Strings(seq)
 	assert.DeepEqual(t, par, seq)

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -54,7 +54,7 @@ func TestDiscoverGapFiles_Basic(t *testing.T) {
 		paths["src/a.ts"]: {},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil, "should not be nil when config has files")
 	assert.Equal(t, len(gapFiles), 1)
@@ -78,7 +78,7 @@ func TestDiscoverGapFiles_GlobalIgnoresExclude(t *testing.T) {
 		paths["src/a.ts"]: {},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	// scripts/b.ts should be excluded by global ignores
 	assert.Assert(t, gapFiles != nil)
@@ -101,7 +101,7 @@ func TestDiscoverGapFiles_ProgramFilesSkipped(t *testing.T) {
 		paths["src/b.ts"]: {},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil)
 	assert.Equal(t, len(gapFiles), 0)
@@ -126,7 +126,7 @@ func TestDiscoverGapFiles_GetConfigForFilePreFilter(t *testing.T) {
 		paths["src/a.ts"]: {},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	// test/b.ts matches **/*.ts but is excluded by entry-level ignores →
 	// GetConfigForFile returns nil → not a gap file
@@ -144,7 +144,7 @@ func TestDiscoverGapFiles_NoFilesField_ReturnsNil(t *testing.T) {
 		{Rules: Rules{"test-rule": "error"}},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false, true)
 
 	// Should return nil (backward compat signal)
 	assert.Assert(t, gapFiles == nil, "should return nil when no entry has files field")
@@ -165,7 +165,7 @@ func TestDiscoverGapFiles_AllowDirsScope(t *testing.T) {
 
 	// Only allow scripts/ directory
 	scriptsDir := tspath.NormalizePath(filepath.Join(configDir, "scripts"))
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, []string{scriptsDir}, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, []string{scriptsDir}, false, true)
 
 	assert.Assert(t, gapFiles != nil)
 	assert.Equal(t, len(gapFiles), 1)
@@ -187,7 +187,7 @@ func TestDiscoverGapFiles_MultipleFilesPatterns(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil)
 	sort.Strings(gapFiles)
@@ -214,7 +214,7 @@ func TestDiscoverGapFiles_JsFilesNotDiscoveredWithoutPattern(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil)
 	// b.js should NOT be discovered because no entry has files: ['**/*.js']
@@ -235,9 +235,9 @@ func TestDiscoverGapFiles_AllowFilesScope(t *testing.T) {
 	programFiles := map[string]struct{}{}
 
 	// Only allow scripts/b.ts via allowFiles
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles,
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles,
 		[]string{paths["scripts/b.ts"]}, nil,
-		false,
+		false, true,
 	)
 
 	assert.Assert(t, gapFiles != nil)
@@ -259,7 +259,7 @@ func TestDiscoverGapFiles_AllExtensionsDiscoveredByPattern(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil)
 	// All files matching the pattern should be discovered (no extension filter)
@@ -285,7 +285,8 @@ func TestDiscoverGapFilesMultiConfig(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFilesMultiConfig(configMap, osvfs.FS(), programFiles, nil, nil, false)
+	hasTsConfigByDir := map[string]bool{configDir1: true, configDir2: true}
+	gapFiles, _ := DiscoverGapFilesMultiConfig(configMap, osvfs.FS(), programFiles, nil, nil, false, hasTsConfigByDir)
 
 	assert.Assert(t, gapFiles != nil)
 	assert.Equal(t, len(gapFiles), 2)
@@ -310,7 +311,7 @@ func TestDiscoverGapFiles_EmptyFilesArray(t *testing.T) {
 		{Files: []string{}, Rules: Rules{"test-rule": "error"}},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false, true)
 
 	// Empty files array has no patterns to match → same as no files field → nil (legacy mode)
 	assert.Assert(t, gapFiles == nil, "should return nil for empty files array")
@@ -328,7 +329,7 @@ func TestDiscoverGapFiles_FilesButNoRules(t *testing.T) {
 		{Files: []string{"**/*.ts"}},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false, true)
 
 	// GetConfigForFile returns non-nil (entry matched), so the file IS a gap file.
 	// The linter will subsequently skip it because it has no rules, but that's
@@ -353,7 +354,7 @@ func TestDiscoverGapFiles_DirIgnoreBlocksTraversal(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil)
 	// build/ entirely blocked — neither keep.ts nor other.ts discovered
@@ -387,7 +388,7 @@ func TestDiscoverGapFiles_FileIgnoreAllowsNegation(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil)
 
@@ -422,7 +423,7 @@ func TestDiscoverGapFiles_WildcardMiddleDirIgnoreBlocks(t *testing.T) {
 	}
 
 	programFiles := map[string]struct{}{}
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	gapSet := make(map[string]struct{})
 	for _, f := range gapFiles {
@@ -453,7 +454,7 @@ func TestDiscoverGapFiles_CrossEntryDirIgnoreAndNegation(t *testing.T) {
 	}
 
 	programFiles := map[string]struct{}{}
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	for _, f := range gapFiles {
 		if f == paths["build/keep.ts"] || f == paths["build/other.ts"] {
@@ -476,7 +477,7 @@ func TestDiscoverGapFiles_DoubleStarDirIgnoreBlocksNested(t *testing.T) {
 
 	programFiles := map[string]struct{}{}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil)
 	for _, f := range gapFiles {
@@ -499,7 +500,7 @@ func TestDiscoverGapFiles_DefaultExcludesNodeModules(t *testing.T) {
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil)
 	for _, f := range gapFiles {
@@ -527,7 +528,7 @@ func TestDiscoverGapFiles_DefaultExcludesGitDir(t *testing.T) {
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil)
 	for _, f := range gapFiles {
@@ -581,7 +582,7 @@ func TestDiscoverGapFiles_PrunesNodeModulesAtWalkLevel(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 
 	for _, dir := range spy.snapshotAccessedDirs() {
 		if strings.Contains(dir, "node_modules") {
@@ -601,7 +602,7 @@ func TestDiscoverGapFiles_PrunesGitDirAtWalkLevel(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 
 	for _, dir := range spy.snapshotAccessedDirs() {
 		if strings.Contains(dir, ".git") {
@@ -623,7 +624,7 @@ func TestDiscoverGapFiles_PrunesUserIgnoredDirAtWalkLevel(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 
 	for _, dir := range spy.snapshotAccessedDirs() {
 		if strings.Contains(dir, "vendor") {
@@ -645,7 +646,7 @@ func TestDiscoverGapFiles_PrunesNestedIgnoredDirButEntersParent(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 
 	// build/ should be entered (not blocked)
 	buildEntered := false
@@ -683,7 +684,7 @@ func TestDiscoverGapFiles_EntersNonExcludedDirs(t *testing.T) {
 	}
 
 	spy := &spyFS{FS: osvfs.FS()}
-	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
 
 	// src/ and lib/ should be entered
 	srcEntered := false
@@ -718,23 +719,22 @@ func TestDiscoverGapFiles_EntersNonExcludedDirs(t *testing.T) {
 // GetConfigForFile also returns nil for any file in that dir.
 // =============================================================================
 
-// e2eSetup creates a fixture, runs ReadGitignoreAsGlobs + config injection + DiscoverGapFiles,
-// and returns gap files + the final config (for GetConfigForFile verification).
+// e2eSetup creates a fixture, runs DiscoverGapFiles (which reads .gitignore
+// inline as part of its walk), folds the discovered .gitignore globs into
+// config the same way buildProgramsWithGapFallback does, and returns gap
+// files + the final config (for GetConfigForFile verification).
 func e2eSetup(t *testing.T, files map[string]string, config RslintConfig, programFiles map[string]struct{}) (string, []string, RslintConfig) {
 	t.Helper()
 	dir := setupGitignoreFixture(t, files)
-
-	configIgnores := ExtractConfigIgnores(config)
-	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
-	if len(gitGlobs) > 0 {
-		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
-	}
 
 	if programFiles == nil {
 		programFiles = map[string]struct{}{}
 	}
 
-	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, gitignoreGlobs := DiscoverGapFiles(config, dir, osvfs.FS(), programFiles, nil, nil, false, true)
+	if len(gitignoreGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitignoreGlobs}}, config...)
+	}
 	return dir, gapFiles, config
 }
 
@@ -799,10 +799,9 @@ func TestE2E_NestedGitignoreAffectsProgramFiles(t *testing.T) {
 	indexPath := tspath.NormalizePath(dir + "/packages/foo/src/index.ts")
 	genPathFull := tspath.NormalizePath(dir + "/packages/foo/src/generated/api.ts")
 
-	configIgnores := ExtractConfigIgnores(config)
-	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
-	if len(gitGlobs) > 0 {
-		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
+	_, gitignoreGlobs := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, nil, nil, false, true)
+	if len(gitignoreGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitignoreGlobs}}, config...)
 	}
 
 	// generated/api.ts is in programFiles but gitignored.
@@ -925,13 +924,7 @@ func TestE2E_ProgramFilesExcluded(t *testing.T) {
 		indexPath: {},
 	}
 
-	configIgnores := ExtractConfigIgnores(config)
-	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
-	if len(gitGlobs) > 0 {
-		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
-	}
-
-	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), programFiles, nil, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, dir, osvfs.FS(), programFiles, nil, nil, false, true)
 	gapSet := toSet(gapFiles)
 
 	// index.ts in program → NOT a gap file
@@ -988,12 +981,6 @@ func TestE2E_ConfigIgnoredDirInProgram(t *testing.T) {
 	dir := setupGitignoreFixture(t, files)
 	testFile := tspath.NormalizePath(dir + "/tests/helpers/setup.ts")
 
-	configIgnores := ExtractConfigIgnores(config)
-	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
-	if len(gitGlobs) > 0 {
-		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
-	}
-
 	// Even though setup.ts is in programFiles, GetConfigForFile should return nil
 	// because tests/ is directory-blocked by config ignores.
 	mc := config.GetConfigForFile(testFile, dir)
@@ -1039,15 +1026,10 @@ func TestE2E_AllowDirsWithConfigIgnores(t *testing.T) {
 	}
 
 	dir := setupGitignoreFixture(t, files)
-	configIgnores := ExtractConfigIgnores(config)
-	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
-	if len(gitGlobs) > 0 {
-		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
-	}
 
 	// Only allow packages/foo/
 	fooDir := tspath.NormalizePath(dir + "/packages/foo")
-	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, nil, []string{fooDir}, false)
+	gapFiles, _ := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, nil, []string{fooDir}, false, true)
 	gapSet := toSet(gapFiles)
 
 	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/packages/foo/src/a.ts")], "packages/foo/src/a.ts should be discovered (in allowDirs)")
@@ -1069,17 +1051,12 @@ func TestE2E_AllowFilesWithGitignore(t *testing.T) {
 	}
 
 	dir := setupGitignoreFixture(t, files)
-	configIgnores := ExtractConfigIgnores(config)
-	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
-	if len(gitGlobs) > 0 {
-		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
-	}
 
 	srcFile := tspath.NormalizePath(dir + "/src/index.ts")
 	distFile := tspath.NormalizePath(dir + "/dist/bundle.ts")
 
 	// Simulate lint-staged passing both files explicitly.
-	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, []string{srcFile, distFile}, nil, false)
+	gapFiles, _ := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, []string{srcFile, distFile}, nil, false, true)
 	gapSet := toSet(gapFiles)
 
 	assert.Assert(t, gapSet[srcFile], "src/index.ts should be discovered (explicit allowFile)")
@@ -1125,8 +1102,8 @@ func TestDiscoverGapFiles_SkipsSymlinkedDirs(t *testing.T) {
 	}
 
 	for _, single := range []bool{false, true} {
-		gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(),
-			map[string]struct{}{}, nil, nil, single)
+		gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(),
+			map[string]struct{}{}, nil, nil, single, true)
 		assert.Equal(t, len(gapFiles), 1, "singleThreaded=%v: only the real path should produce a gap file", single)
 		realPath := tspath.NormalizePath(filepath.Join(realDir, "in_real.ts"))
 		assert.Equal(t, gapFiles[0], realPath, "singleThreaded=%v: gap file should be the canonical realpath", single)
@@ -1150,10 +1127,10 @@ func TestDiscoverGapFiles_SingleThreadedEquivalence(t *testing.T) {
 		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},
 	}
 
-	parallelGaps := DiscoverGapFiles(config, configDir, osvfs.FS(),
-		map[string]struct{}{}, nil, nil, false)
-	serialGaps := DiscoverGapFiles(config, configDir, osvfs.FS(),
-		map[string]struct{}{}, nil, nil, true)
+	parallelGaps, _ := DiscoverGapFiles(config, configDir, osvfs.FS(),
+		map[string]struct{}{}, nil, nil, false, true)
+	serialGaps, _ := DiscoverGapFiles(config, configDir, osvfs.FS(),
+		map[string]struct{}{}, nil, nil, true, true)
 
 	// Both already sorted by DiscoverGapFiles; equality is exact.
 	assert.Equal(t, len(parallelGaps), len(serialGaps), "must produce same count")
@@ -1183,8 +1160,8 @@ func TestDiscoverGapFiles_AllowFilesFastPathSorted(t *testing.T) {
 	// Run multiple times to give Go's randomized map iteration a chance to
 	// surface non-determinism if the sort is missing.
 	for i := range 8 {
-		got := DiscoverGapFiles(config, configDir, osvfs.FS(),
-			map[string]struct{}{}, allow, nil, false)
+		got, _ := DiscoverGapFiles(config, configDir, osvfs.FS(),
+			map[string]struct{}{}, allow, nil, false, true)
 		assert.Equal(t, len(got), len(expected), "run %d: count mismatch", i)
 		for j := range expected {
 			assert.Equal(t, got[j], expected[j], "run %d, idx %d: not in lexical order", i, j)
@@ -1205,7 +1182,7 @@ func TestWalkPool_BoundsConcurrency(t *testing.T) {
 		maxDepth = 3 // 3^3 = 27 leaves per root × 200 roots ≈ thousands of jobs
 	)
 
-	pool := newWalkPool(workers)
+	pool := newWalkPool[string](workers)
 	// Seed with `dirCount` independent root jobs so the queue has enough
 	// fan-out to actually exercise concurrency.
 	roots := make([]string, dirCount)
@@ -1263,7 +1240,7 @@ func TestWalkPool_BoundsConcurrency(t *testing.T) {
 // We assert by checking the caller goroutine ID is the only one observed
 // inside the work function via runtime.Stack.
 func TestWalkPool_SingleWorkerNoGoroutine(t *testing.T) {
-	pool := newWalkPool(1)
+	pool := newWalkPool[string](1)
 	pool.submitMany([]string{"a", "b", "c"})
 
 	caller := goroutineID()

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -487,15 +487,16 @@ func TestDiscoverGapFiles_DoubleStarDirIgnoreBlocksNested(t *testing.T) {
 	}
 }
 
-// --- Default excludes (node_modules, .git) ---
+// --- Default excludes (.git only — node_modules has no built-in default) ---
 
-func TestDiscoverGapFiles_DefaultExcludesNodeModules(t *testing.T) {
+func TestDiscoverGapFiles_NodeModulesHasNoDefaultExclusion(t *testing.T) {
 	configDir, paths := setupDiscoveryFixture(t, []string{
 		"src/index.ts",
 		"node_modules/pkg/index.ts",
 	})
 
-	// No global ignores at all — defaults should still exclude node_modules
+	// No global ignores and no .gitignore — node_modules has no hard-coded
+	// default exclusion, so it is discovered like any other directory.
 	config := RslintConfig{
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 	}
@@ -503,19 +504,13 @@ func TestDiscoverGapFiles_DefaultExcludesNodeModules(t *testing.T) {
 	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false, true)
 
 	assert.Assert(t, gapFiles != nil)
-	for _, f := range gapFiles {
-		if f == paths["node_modules/pkg/index.ts"] {
-			t.Error("node_modules should be excluded by default even without user ignores")
-		}
-	}
-	// src/index.ts should still be discovered
 	found := false
 	for _, f := range gapFiles {
-		if f == paths["src/index.ts"] {
+		if f == paths["node_modules/pkg/index.ts"] {
 			found = true
 		}
 	}
-	assert.Assert(t, found, "src/index.ts should be discovered")
+	assert.Assert(t, found, "node_modules/pkg/index.ts should be discovered absent a default exclusion")
 }
 
 func TestDiscoverGapFiles_DefaultExcludesGitDir(t *testing.T) {
@@ -541,8 +536,8 @@ func TestDiscoverGapFiles_DefaultExcludesGitDir(t *testing.T) {
 // --- Directory pruning verification (spy vfs) ---
 // These tests verify that WalkDir actually skips excluded directories at the
 // walk level (fs.SkipDir), not just filters files after entering them.
-// This is critical for performance: entering node_modules with 10,000+ files
-// is the difference between <100ms and 7s.
+// This is critical for performance: entering a large ignored directory with
+// 10,000+ files is the difference between <100ms and 7s.
 
 // spyFS wraps a vfs.FS and records which directories had their contents listed.
 // GetAccessibleEntries is called by vfsAdapter.ReadDir only when the walker
@@ -570,7 +565,7 @@ func (s *spyFS) snapshotAccessedDirs() []string {
 	return out
 }
 
-func TestDiscoverGapFiles_PrunesNodeModulesAtWalkLevel(t *testing.T) {
+func TestDiscoverGapFiles_EntersNodeModulesAtWalkLevelAbsentIgnore(t *testing.T) {
 	configDir, _ := setupDiscoveryFixture(t, []string{
 		"src/index.ts",
 		"node_modules/pkg/index.ts",
@@ -578,6 +573,30 @@ func TestDiscoverGapFiles_PrunesNodeModulesAtWalkLevel(t *testing.T) {
 	})
 
 	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	spy := &spyFS{FS: osvfs.FS()}
+	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, false, true)
+
+	entered := false
+	for _, dir := range spy.snapshotAccessedDirs() {
+		if strings.Contains(dir, "node_modules") {
+			entered = true
+		}
+	}
+	assert.Assert(t, entered, "node_modules should be walked absent a default exclusion or .gitignore/config ignore")
+}
+
+func TestDiscoverGapFiles_PrunesNodeModulesAtWalkLevelWhenIgnored(t *testing.T) {
+	configDir, _ := setupDiscoveryFixture(t, []string{
+		"src/index.ts",
+		"node_modules/pkg/index.ts",
+		"node_modules/pkg/nested/deep.ts",
+	})
+
+	config := RslintConfig{
+		{Ignores: []string{"node_modules/**"}},
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 	}
 
@@ -1167,6 +1186,36 @@ func TestDiscoverGapFiles_AllowFilesFastPathSorted(t *testing.T) {
 			assert.Equal(t, got[j], expected[j], "run %d, idx %d: not in lexical order", i, j)
 		}
 	}
+}
+
+func TestDiscoverGapFiles_AllowFilesFastPathRespectsNestedGitignore(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"sub/ignored.ts",
+		"sub/kept.ts",
+	})
+	if err := os.WriteFile(filepath.Join(configDir, "sub", ".gitignore"), []byte("ignored.ts\n"), 0644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},
+	}
+	programFiles := map[string]struct{}{}
+
+	// An explicitly-passed file (e.g. lint-staged) under a subdirectory whose
+	// own .gitignore ignores it must not be treated as a gap file, even
+	// though the fast path skips the full walkDir traversal.
+	gapFiles, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles,
+		[]string{paths["sub/ignored.ts"]}, nil, false, false)
+	assert.Equal(t, len(gapFiles), 0)
+
+	// A sibling file not matched by that nested .gitignore is still
+	// discovered.
+	gapFiles, _ = DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles,
+		[]string{paths["sub/kept.ts"]}, nil, false, false)
+	assert.Assert(t, gapFiles != nil)
+	assert.Equal(t, len(gapFiles), 1)
+	assert.Equal(t, gapFiles[0], paths["sub/kept.ts"])
 }
 
 // walkPool must hold concurrent execution of `work` to at most `workers`

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -6,46 +6,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/vfs"
 )
 
-// ReadGitignoreAsGlobs reads .gitignore files relevant to configDir and
-// converts their patterns to rslint glob format suitable for use as global
-// ignore patterns.
-//
-// It collects patterns from two sources:
-//  1. Ancestor .gitignore files: walks UP from configDir to filesystem root,
-//     collecting .gitignore patterns at each level. This implements gitignore
-//     inheritance (root .gitignore affects all subdirectories).
-//  2. Descendant .gitignore files: walks DOWN from configDir, collecting
-//     nested .gitignore with directory-scoped prefixes.
-//
-// configIgnores are the user-configured global ignore patterns (from config
-// entries with only ignores), already parsed. Directories that are
-// directory-level blocked by these patterns are skipped during the descendant
-// scan — their .gitignore files are not collected because files in those
-// directories will never be linted (isDirAbsolutelyBlocked guarantees this).
-//
-// Returns nil if no .gitignore files are found.
-func ReadGitignoreAsGlobs(configDir string, fsys vfs.FS, configIgnores []IgnorePattern) []string {
-	if fsys == nil {
-		return nil
-	}
-	normalizedRoot := normalizeGlobPath(configDir)
-	var allGlobs []string
-
-	// Phase 1: collect ancestor .gitignore files (walk UP).
-	// Ancestor patterns apply globally (no path prefix needed since they
-	// are above configDir and affect everything below).
-	ancestorGlobs := collectAncestorGitignoreGlobs(normalizedRoot, fsys)
-	allGlobs = append(allGlobs, ancestorGlobs...)
-
-	// Phase 2: collect descendant .gitignore files (walk DOWN from configDir).
-	collectGitignoreGlobs(normalizedRoot, "", fsys, &allGlobs, configIgnores)
-
-	if len(allGlobs) == 0 {
-		return nil
-	}
-	return allGlobs
-}
-
 // ExtractConfigIgnores collects global ignore patterns from config entries and
 // parses them once into structured form. These are patterns from entries that
 // have only ignores (no files/rules/etc.), representing user-configured
@@ -104,91 +64,6 @@ func parentDir(dir string) string {
 		return ""
 	}
 	return dir[:idx]
-}
-
-// collectGitignoreGlobs recursively scans for .gitignore files and converts
-// their patterns to globs. Already-converted patterns from parent .gitignore
-// are used to prune directories during scanning (avoids entering e.g. target/
-// with thousands of subdirectories).
-//
-// configIgnores provides additional directory-level pruning from the user's
-// lint config. If isDirAbsolutelyBlocked returns true for a directory against
-// these patterns, the directory is skipped. This is safe because
-// isDirAbsolutelyBlocked is the same predicate used by the linter's
-// GetConfigForFile (via isDirBlockedByIgnores) — if a directory is blocked
-// here, its files will never be linted, so collecting its .gitignore is
-// unnecessary.
-func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string, configIgnores []IgnorePattern) {
-	gitignorePath := absDir + "/.gitignore"
-	if content, ok := fsys.ReadFile(gitignorePath); ok {
-		localGlobs := convertGitignoreToGlobs(content, relDir)
-		*result = append(*result, localGlobs...)
-	}
-
-	entries := fsys.GetAccessibleEntries(absDir)
-	for _, dir := range entries.Directories {
-		if _, excluded := defaultExcludeDirs[dir]; excluded {
-			continue
-		}
-
-		childRel := dir
-		if relDir != "" {
-			childRel = relDir + "/" + dir
-		}
-
-		// Prune directories that are directory-level blocked by config ignores.
-		// isDirAbsolutelyBlocked is the same predicate the linter uses in
-		// GetConfigForFile → isDirBlockedByIgnores. If it returns true here,
-		// the linter will also return nil for any file in this directory,
-		// meaning files here are never linted. Therefore their .gitignore
-		// patterns are irrelevant and we can safely skip collecting them.
-		// Checked first because configIgnores is typically a short list (a few
-		// user-defined patterns), whereas *result grows as we collect more
-		// .gitignore patterns — checking configIgnores first avoids a linear
-		// scan of the longer list for directories blocked by config.
-		if len(configIgnores) > 0 && isDirAbsolutelyBlocked(childRel, configIgnores) {
-			continue
-		}
-
-		// Prune directories already matched by collected gitignore patterns.
-		// This is a scan-local heuristic over the growing glob set (sequential
-		// `!` handling); the gap-file walk independently re-validates soundness
-		// via canPruneDir, so this stays a fast string-set match. Critical for
-		// performance: without it, scanning rspack enters target/ (6,277 Rust
-		// build dirs, 0 .ts files).
-		if isDirIgnoredByGlobs(*result, childRel) {
-			continue
-		}
-
-		childAbs := absDir + "/" + dir
-		collectGitignoreGlobs(childAbs, childRel, fsys, result, configIgnores)
-	}
-}
-
-// isDirIgnoredByGlobs reports whether relDir is ignored by the collected
-// gitignore globs (sequential `!` evaluation, later overrides earlier). It is
-// scan-local: a fast string-set match used only to prune which nested
-// .gitignore files get collected, NOT a soundness predicate. The gap-file walk
-// re-derives directory pruning from the structured patterns via canPruneDir, so
-// for the patterns that ARE collected the walk stays sound regardless. The one
-// behavior this skips is a `!` re-include inside an already-ignored directory's
-// nested .gitignore — which matches git's own rule that a file cannot be
-// re-included once a parent directory is excluded. This logic is unchanged by
-// the IgnorePattern refactor.
-func isDirIgnoredByGlobs(globs []string, relDir string) bool {
-	ignored := false
-	for _, pattern := range globs {
-		if strings.HasPrefix(pattern, "!") {
-			if matchGlob(pattern[1:], relDir) || matchGlob(pattern[1:], relDir+"/x") {
-				ignored = false
-			}
-		} else {
-			if matchGlob(pattern, relDir) || matchGlob(pattern, relDir+"/x") {
-				ignored = true
-			}
-		}
-	}
-	return ignored
 }
 
 // convertGitignoreToGlobs converts .gitignore file content into rslint glob

--- a/internal/config/gitignore_test.go
+++ b/internal/config/gitignore_test.go
@@ -38,6 +38,22 @@ func setupGitignoreFixture(t *testing.T, files map[string]string) string {
 	return tspath.NormalizePath(tmpDir)
 }
 
+// readGitignoreGlobsForTest replicates the old standalone ReadGitignoreAsGlobs
+// entry point (deleted — .gitignore reading is now inline inside walkDir's
+// single traversal) for tests that want to assert on the discovered glob set
+// or on which directories a .gitignore-aware walk enters. singleThreaded is
+// forced so results are deterministic and safe with unsynchronized spy FS
+// implementations in this file.
+func readGitignoreGlobsForTest(dir string, fsys vfs.FS, configIgnores []IgnorePattern) []string {
+	ancestorGlobs := collectAncestorGitignoreGlobs(normalizeGlobPath(dir), fsys)
+	gitignoreSeed := ParseIgnorePatterns(ancestorGlobs)
+	_, discovered := walkDir(dir, fsys, gitignoreSeed, configIgnores, true)
+	if len(ancestorGlobs) == 0 && len(discovered) == 0 {
+		return nil
+	}
+	return append(append([]string{}, ancestorGlobs...), discovered...)
+}
+
 // --- Pattern conversion tests ---
 
 func TestConvertGitignoreToGlobs_DirectoryPattern(t *testing.T) {
@@ -132,7 +148,7 @@ func TestReadGitignoreAsGlobs_RootOnly(t *testing.T) {
 		".gitignore": "dist/\n*.log\n",
 		"src/a.ts":   "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 	assert.Equal(t, len(globs), 2, "got: %v", globs)
 
 	hasDistGlob := false
@@ -153,7 +169,7 @@ func TestReadGitignoreAsGlobs_NoGitignore(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		"src/a.ts": "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 	assert.Assert(t, globs == nil, "should return nil when no .gitignore")
 }
 
@@ -163,7 +179,7 @@ func TestReadGitignoreAsGlobs_Nested(t *testing.T) {
 		"packages/app/.gitignore": "tmp/\n",
 		"src/a.ts":                "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 
 	hasDistGlob := false
 	hasTmpGlob := false
@@ -185,7 +201,7 @@ func TestReadGitignoreAsGlobs_NestedNegation(t *testing.T) {
 		"packages/app/.gitignore": "!dist/\n",
 		"src/a.ts":                "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 
 	hasDistGlob := false
 	hasNegation := false
@@ -209,7 +225,7 @@ func TestReadGitignoreAsGlobs_PrunesGitignoredDirs(t *testing.T) {
 		"src/a.ts":                      "x",
 		"target/deep/nested/.gitignore": "# should not be read\nfoo\n",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 
 	// Positive: root .gitignore should be read
 	assert.Assert(t, len(globs) >= 1, "should have at least root target/ glob")
@@ -228,7 +244,7 @@ func TestReadGitignoreAsGlobs_SkipsNodeModules(t *testing.T) {
 		"node_modules/pkg/.gitignore": "# should not be read\n",
 		"src/a.ts":                    "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 
 	// Only root .gitignore should be read
 	assert.Equal(t, len(globs), 1)
@@ -252,7 +268,7 @@ func TestReadGitignoreAsGlobs_ThreeLevelNested(t *testing.T) {
 		"packages/app/sub/.gitignore": "cache/\n",
 		"src/a.ts":                    "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 
 	hasRoot := false
 	hasApp := false
@@ -337,7 +353,7 @@ func TestReadGitignoreAsGlobs_AncestorInheritance(t *testing.T) {
 		"packages/app/src/a.ts": "x",
 	})
 	childDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
-	globs := ReadGitignoreAsGlobs(childDir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(childDir, osvfs.FS(), nil)
 
 	hasDistGlob := false
 	for _, g := range globs {
@@ -356,7 +372,7 @@ func TestReadGitignoreAsGlobs_AncestorPlusOwn(t *testing.T) {
 		"packages/app/src/a.ts":   "x",
 	})
 	childDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
-	globs := ReadGitignoreAsGlobs(childDir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(childDir, osvfs.FS(), nil)
 
 	hasDist := false
 	hasTmp := false
@@ -383,7 +399,7 @@ func TestReadGitignoreAsGlobs_SiblingIsolation(t *testing.T) {
 		"packages/lib/src/b.ts":   "x",
 	})
 	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
-	appGlobs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+	appGlobs := readGitignoreGlobsForTest(appDir, osvfs.FS(), nil)
 
 	for _, g := range appGlobs {
 		if strings.Contains(g, "cache") {
@@ -412,7 +428,7 @@ func TestReadGitignoreAsGlobs_DeepAncestor(t *testing.T) {
 		"packages/app/sub/src/a.ts": "x",
 	})
 	deepDir := tspath.NormalizePath(filepath.Join(dir, "packages/app/sub"))
-	globs := ReadGitignoreAsGlobs(deepDir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(deepDir, osvfs.FS(), nil)
 
 	hasDist := false
 	for _, g := range globs {
@@ -432,7 +448,7 @@ func TestReadGitignoreAsGlobs_MultipleAncestors(t *testing.T) {
 		"packages/app/src/a.ts": "x",
 	})
 	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
-	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(appDir, osvfs.FS(), nil)
 
 	hasDist := false
 	hasVendor := false
@@ -457,7 +473,7 @@ func TestReadGitignoreAsGlobs_AncestorNegationOverride(t *testing.T) {
 		"packages/app/src/a.ts": "x",
 	})
 	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
-	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(appDir, osvfs.FS(), nil)
 
 	hasDist := false
 	hasNegation := false
@@ -478,7 +494,7 @@ func TestReadGitignoreAsGlobs_EmptyFile(t *testing.T) {
 		".gitignore": "",
 		"src/a.ts":   "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 	assert.Assert(t, globs == nil, "empty .gitignore → no globs")
 }
 
@@ -487,7 +503,7 @@ func TestReadGitignoreAsGlobs_OnlyComments(t *testing.T) {
 		".gitignore": "# just a comment\n# another\n",
 		"src/a.ts":   "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 	assert.Assert(t, globs == nil, "comments-only .gitignore → no globs")
 }
 
@@ -521,7 +537,7 @@ func TestReadGitignoreAsGlobs_ConfigIgnoresPrunesDir(t *testing.T) {
 		"tests/unit/a.test.ts":  "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**"}))
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**"}))
 	gs := globSet(globs)
 
 	// Exactly 1 glob: root .gitignore "dist/" → "**/dist/**/*"
@@ -530,20 +546,31 @@ func TestReadGitignoreAsGlobs_ConfigIgnoresPrunesDir(t *testing.T) {
 }
 
 // A2: file-level config ignore (**/tests/**/*) does NOT prune tests/.gitignore.
-func TestReadGitignoreAsGlobs_FileLevelConfigIgnoreDoesNotPrune(t *testing.T) {
+// The unified walk (walkDir) uses a single sound pruning predicate
+// (canPruneDir) for both config ignores and gitignore patterns: a directory
+// covered by a file-level ignore pattern with no reachable `!` negation is
+// pruned outright, since every file beneath it would be excluded by
+// isFileIgnored regardless — pruning it changes nothing observable, it just
+// also means its nested .gitignore isn't read. That's a deliberate
+// simplification over the old two-tier pruning policy (which kept walking
+// file-level-covered dirs purely to keep collecting now-redundant gitignore
+// globs from inside them).
+func TestReadGitignoreAsGlobs_FileLevelConfigIgnorePrunesInUnifiedWalk(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":       "dist/\n",
 		"tests/.gitignore": "snapshots/\n",
 		"tests/a.test.ts":  "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**/*"}))
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**/*"}))
 	gs := globSet(globs)
 
-	// 2 globs: root dist + tests snapshots (file-level ignore doesn't prune dirs)
-	assert.Equal(t, len(globs), 2, "should have 2 globs, got: %v", globs)
+	// Only root dist/ is collected: tests/ is pruned by the file-level config
+	// ignore before its .gitignore is ever read. Every file under tests/ is
+	// excluded by that same config ignore anyway, so the missing
+	// tests/**/snapshots/**/* pattern has no observable effect.
+	assert.Equal(t, len(globs), 1, "should have 1 glob, got: %v", globs)
 	assert.Assert(t, gs["**/dist/**/*"], "root dist")
-	assert.Assert(t, gs["tests/**/snapshots/**/*"], "tests snapshots should be collected")
 }
 
 // A3: dir-level + negation — isDirAbsolutelyBlocked skips negation → still prunes.
@@ -554,7 +581,7 @@ func TestReadGitignoreAsGlobs_NegationInConfigIgnoreStillPrunes(t *testing.T) {
 		"tests/e2e/a.ts":       "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**", "!tests/e2e/**"}))
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**", "!tests/e2e/**"}))
 
 	// Exactly 1 glob: root dist. tests/e2e/.gitignore NOT collected.
 	assert.Equal(t, len(globs), 1, "should have exactly 1 glob, got: %v", globs)
@@ -571,7 +598,7 @@ func TestReadGitignoreAsGlobs_SiblingDirPreservesGitignore(t *testing.T) {
 		"tests/a.test.ts":         "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**"}))
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**"}))
 	gs := globSet(globs)
 
 	// Exactly 2 globs: root dist + packages/foo tmp. tests/ pruned.
@@ -587,7 +614,7 @@ func TestReadGitignoreAsGlobs_NilConfigIgnores(t *testing.T) {
 		"tests/.gitignore": "snapshots/\n",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 	gs := globSet(globs)
 
 	assert.Equal(t, len(globs), 2, "should have 2 globs (both collected), got: %v", globs)
@@ -607,7 +634,7 @@ func TestReadGitignoreAsGlobs_DeepNestedConfigIgnore(t *testing.T) {
 		"src/a.ts":                     "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/vendor/**"}))
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/vendor/**"}))
 	gs := globSet(globs)
 
 	// Exactly 2 globs: root *.log + src generated. All 3 vendor .gitignore pruned.
@@ -628,7 +655,7 @@ func TestReadGitignoreAsGlobs_WildcardConfigIgnoreSkipsNested(t *testing.T) {
 		"packages/rspack/src/index.ts": "x",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"crates/**"}))
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), ParseIgnorePatterns([]string{"crates/**"}))
 	gs := globSet(globs)
 
 	// Exactly 2: root dist + packages/rspack tmp. Both crates/ .gitignore pruned.
@@ -644,7 +671,7 @@ func TestReadGitignoreAsGlobs_EmptyConfigIgnores(t *testing.T) {
 		"tests/.gitignore": "snapshots/\n",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{}))
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), ParseIgnorePatterns([]string{}))
 	gs := globSet(globs)
 
 	assert.Equal(t, len(globs), 2, "empty slice = no pruning, got: %v", globs)
@@ -660,7 +687,7 @@ func TestReadGitignoreAsGlobs_ExactPathConfigIgnore(t *testing.T) {
 		"build/tools/.gitignore":  "tmp/\n",
 	})
 
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"build/output/**"}))
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), ParseIgnorePatterns([]string{"build/output/**"}))
 	gs := globSet(globs)
 
 	// 2 globs: root dist + build/tools tmp. build/output cache pruned.
@@ -719,7 +746,7 @@ func TestReadGitignoreAsGlobs_BareConfigIgnorePattern(t *testing.T) {
 
 	// Bare "tests" — no trailing /**. isDirAbsolutelyBlocked("tests", ["tests"]) should
 	// match via matchGlob("tests", "tests") → true → blocked.
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"tests"}))
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), ParseIgnorePatterns([]string{"tests"}))
 	gs := globSet(globs)
 
 	// 2 globs: root *.log + src/generated. tests/ pruned by bare "tests" pattern.
@@ -747,7 +774,7 @@ func TestReadGitignoreAsGlobs_OverlappingGitignoreAndConfigIgnore(t *testing.T) 
 	// dist/ is in both .gitignore and config ignores.
 	// build/ is only in .gitignore.
 	configIgnores := ParseIgnorePatterns([]string{"**/dist/**"})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), configIgnores)
 	gs := globSet(globs)
 
 	// dist/ pruned by CONFIG IGNORE (isDirAbsolutelyBlocked runs first → **/dist/** matches).
@@ -760,7 +787,7 @@ func TestReadGitignoreAsGlobs_OverlappingGitignoreAndConfigIgnore(t *testing.T) 
 	assert.Assert(t, gs["src/**/generated/**/*"], "src generated")
 
 	// Compare: without config ignores, result should be identical (gitignore already prunes both).
-	globsNoConfig := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globsNoConfig := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 	assert.Equal(t, len(globsNoConfig), len(globs), "overlapping config ignore should not change result vs nil configIgnores")
 }
 
@@ -778,7 +805,7 @@ func TestReadGitignoreAsGlobs_RegressionWithVsWithout(t *testing.T) {
 	})
 
 	// WITHOUT configIgnores: all 4 .gitignore files collected → 4 patterns.
-	globsWithout := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	globsWithout := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 	gsWithout := globSet(globsWithout)
 	assert.Equal(t, len(globsWithout), 4, "without configIgnores should collect all 4 patterns, got: %v", globsWithout)
 	assert.Assert(t, gsWithout["**/dist/**/*"])
@@ -787,7 +814,7 @@ func TestReadGitignoreAsGlobs_RegressionWithVsWithout(t *testing.T) {
 	assert.Assert(t, gsWithout["tests/unit/**/coverage/**/*"])
 
 	// WITH configIgnores: tests/ pruned → only 2 patterns (root + src).
-	globsWith := ReadGitignoreAsGlobs(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**"}))
+	globsWith := readGitignoreGlobsForTest(dir, osvfs.FS(), ParseIgnorePatterns([]string{"**/tests/**"}))
 	gsWith := globSet(globsWith)
 	assert.Equal(t, len(globsWith), 2, "with configIgnores should collect 2 patterns (tests/ pruned), got: %v", globsWith)
 	assert.Assert(t, gsWith["**/dist/**/*"])
@@ -813,7 +840,7 @@ func TestReadGitignoreAsGlobs_ConfigIgnoreSkipsWalkLevel(t *testing.T) {
 	})
 
 	spy := &gitignoreSpyFS{FS: osvfs.FS()}
-	globs := ReadGitignoreAsGlobs(dir, spy, ParseIgnorePatterns([]string{"**/tests/**"}))
+	globs := readGitignoreGlobsForTest(dir, spy, ParseIgnorePatterns([]string{"**/tests/**"}))
 
 	// Output correctness: only root + src patterns.
 	assert.Equal(t, len(globs), 2, "got: %v", globs)
@@ -856,12 +883,12 @@ func TestReadGitignoreAsGlobs_ConfigIgnoreReducesWalkCount(t *testing.T) {
 
 	// Without configIgnores: walks everything including tests/ subtree.
 	spyWithout := &gitignoreSpyFS{FS: osvfs.FS()}
-	ReadGitignoreAsGlobs(dir, spyWithout, nil)
+	readGitignoreGlobsForTest(dir, spyWithout, nil)
 	countWithout := len(spyWithout.accessedDirs)
 
 	// With configIgnores: skips tests/ subtree.
 	spyWith := &gitignoreSpyFS{FS: osvfs.FS()}
-	ReadGitignoreAsGlobs(dir, spyWith, ParseIgnorePatterns([]string{"**/tests/**"}))
+	readGitignoreGlobsForTest(dir, spyWith, ParseIgnorePatterns([]string{"**/tests/**"}))
 	countWith := len(spyWith.accessedDirs)
 
 	// With configIgnores should access FEWER directories.

--- a/internal/config/gitignore_test.go
+++ b/internal/config/gitignore_test.go
@@ -238,17 +238,41 @@ func TestReadGitignoreAsGlobs_PrunesGitignoredDirs(t *testing.T) {
 	}
 }
 
-func TestReadGitignoreAsGlobs_SkipsNodeModules(t *testing.T) {
+func TestReadGitignoreAsGlobs_NodeModulesHasNoBuiltInDefault(t *testing.T) {
+	// There is no hard-coded default exclusion for node_modules — it is only
+	// skipped when a .gitignore (or config `ignores`) says so, exactly like
+	// any other directory.
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                  "dist/\n",
-		"node_modules/pkg/.gitignore": "# should not be read\n",
+		"node_modules/pkg/.gitignore": "should-be-read\n",
 		"src/a.ts":                    "x",
 	})
 	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
 
-	// Only root .gitignore should be read
-	assert.Equal(t, len(globs), 1)
-	assert.Equal(t, globs[0], "**/dist/**/*")
+	found := false
+	for _, g := range globs {
+		if strings.Contains(g, "should-be-read") {
+			found = true
+		}
+	}
+	assert.Assert(t, found, "node_modules/pkg/.gitignore should be read absent a default exclusion, got: %v", globs)
+}
+
+func TestReadGitignoreAsGlobs_NodeModulesExcludedWhenGitignored(t *testing.T) {
+	// The common real-world case: node_modules/ is itself listed in
+	// .gitignore, so it is pruned like any other gitignored directory.
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                  "node_modules/\ndist/\n",
+		"node_modules/pkg/.gitignore": "should-not-be-read\n",
+		"src/a.ts":                    "x",
+	})
+	globs := readGitignoreGlobsForTest(dir, osvfs.FS(), nil)
+
+	for _, g := range globs {
+		if strings.Contains(g, "should-not-be-read") {
+			t.Errorf("node_modules should be pruned once gitignored, but its nested .gitignore was read: %s", g)
+		}
+	}
 }
 
 // --- Scope isolation tests ---

--- a/internal/config/ignore_pattern_realworld_test.go
+++ b/internal/config/ignore_pattern_realworld_test.go
@@ -267,7 +267,7 @@ func TestRealWorld_DiscoverGapFiles_MatchesLinterOracle(t *testing.T) {
 	}
 	sort.Strings(oracle)
 
-	got := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+	got, _ := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false, true)
 	sort.Strings(got)
 
 	// Walker must equal the linter oracle exactly (no over-prune, no over-include).

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -381,22 +381,6 @@ func LineContentEnd(text string, nextLineStart int) int {
 // Used by RunLinterInProgram to skip files during program source file iteration.
 var ExcludePaths = []string{"/node_modules/", "bundled:"}
 
-// DefaultExcludeDirNames contains directory names that are always excluded
-// from file scanning. This is the single source of truth for default directory
-// exclusions, used by DiscoverGapFiles and the no-tsconfig fallback.
-// Aligned with JS-side SCAN_EXCLUDE_DIRS: new Set(['node_modules', '.git']).
-var DefaultExcludeDirNames = []string{"node_modules", ".git"}
-
-// DefaultIgnoreDirGlobs returns glob patterns derived from DefaultExcludeDirNames,
-// suitable for use with ignore pattern matching (e.g., DiscoverGapFiles).
-func DefaultIgnoreDirGlobs() []string {
-	globs := make([]string, len(DefaultExcludeDirNames))
-	for i, name := range DefaultExcludeDirNames {
-		globs[i] = name + "/**"
-	}
-	return globs
-}
-
 func Must[T any](v T, err error) T {
 	if err != nil {
 		panic(err)

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -281,37 +281,6 @@ func findNodeWithText(t *testing.T, sourceFile *ast.SourceFile, text string) *as
 	return found
 }
 
-func TestDefaultIgnoreDirGlobs(t *testing.T) {
-	globs := DefaultIgnoreDirGlobs()
-
-	if len(globs) != len(DefaultExcludeDirNames) {
-		t.Fatalf("Expected %d globs, got %d", len(DefaultExcludeDirNames), len(globs))
-	}
-
-	for i, name := range DefaultExcludeDirNames {
-		expected := name + "/**"
-		if globs[i] != expected {
-			t.Errorf("Expected glob %q for dir %q, got %q", expected, name, globs[i])
-		}
-	}
-}
-
-func TestDefaultExcludeDirNames_ContainsExpected(t *testing.T) {
-	expected := map[string]bool{"node_modules": false, ".git": false}
-
-	for _, name := range DefaultExcludeDirNames {
-		if _, ok := expected[name]; ok {
-			expected[name] = true
-		}
-	}
-
-	for name, found := range expected {
-		if !found {
-			t.Errorf("Expected %q in DefaultExcludeDirNames", name)
-		}
-	}
-}
-
 func TestNaturalCompare(t *testing.T) {
 	tests := []struct {
 		a, b string

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -231,6 +231,7 @@ ldflags
 ldquo
 libsyncrpc
 lifecycles
+lintable
 lintedfile
 listitem
 llms


### PR DESCRIPTION
## Summary

Projects without a `tsconfig.json` used to scan files with an ad-hoc directory walk that ignored `{ ignores: [...] }` config entries and `.gitignore` entirely — files users explicitly excluded were silently linted anyway.

**Fix:** that fallback walk is removed. No-tsconfig projects now go through `DiscoverGapFiles`/`walkDir`, the same discovery pipeline already used when a tsconfig only partially covers a project's files — which does honor `ignores` and `.gitignore`, and only walks the tree once instead of twice.

Fixing this surfaced a few related bugs, also fixed here:
- `.gitignore`-derived ignores were sometimes evaluated after config `ignores`, so a config's `!` negation could lose to a `.gitignore` rule depending on discovery order. `.gitignore` patterns are now always evaluated first, so negations always win.
- A nested config with no tsconfig of its own could have its files wrongly excluded just because an *ancestor* config's tsconfig `include` already covered them. File discovery for it now proceeds normally, and existing nearest-config resolution decides ownership.
- `rslint <file>` on an explicitly-passed file that's gitignored/ignored reported "was not found in the project" instead of "is ignored".
- `--allowFiles` (lint-staged style) missed `.gitignore` files in directories between the config root and a nested explicit file, so those files could be wrongly linted.
- `node_modules` is no longer hardcoded-skipped; it's excluded only via `.gitignore`/`ignores`, like any other directory (in practice invisible for most repos, since `node_modules/` is almost always itself gitignored).

**Behavior now:** no-tsconfig projects respect `{ ignores: [...] }` and `.gitignore` the same way tsconfig projects do, and explicitly-passed ignored files are reported as ignored instead of linted or misreported.

## Related Links

Fixes #1164

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
