### PR TITLE
feat(cli): support -c config alias

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -617,7 +617,7 @@ Usage:
 
 Options:
   --init                Initialize a default config in the current directory.
-  --config PATH         Which rslint config file to use.
+  -c, --config PATH     Which rslint config file to use.
   --format FORMAT       Output format: default | jsonline | github | gitlab
   --fix                 Automatically fix problems
   --type-check          Enable TypeScript type checking
@@ -832,6 +832,7 @@ func parseLintFlags(argv []string) (args lintArgs, help bool, fatalExitCode int)
 
 	fs.StringVar(&args.Format, "format", "default", "output format")
 	fs.StringVar(&args.Config, "config", "", "which rslint config to use")
+	fs.StringVar(&args.Config, "c", "", "which rslint config to use")
 	fs.BoolVar(&args.ConfigStdin, "config-stdin", false, "read config from stdin (used internally by JS config loader)")
 	fs.BoolVar(&args.Init, "init", false, "initialize a default config in the current directory")
 	fs.BoolVar(&args.Fix, "fix", false, "automatically fix problems")

--- a/packages/rslint/src/utils/args.ts
+++ b/packages/rslint/src/utils/args.ts
@@ -12,7 +12,7 @@ export function parseArgs(argv: string[]) {
     strict: false,
     tokens: true,
     options: {
-      config: { type: 'string' },
+      config: { type: 'string', short: 'c' },
       init: { type: 'boolean' },
       // Detected so the JS host can size the ESLint-plugin worker pool to a
       // single worker. NOT skipped below, so it still forwards to Go in

--- a/packages/rslint/tests/args.test.ts
+++ b/packages/rslint/tests/args.test.ts
@@ -243,6 +243,15 @@ describe('parseArgs positionals', () => {
     expect(result.positionals).toEqual(['src/a.ts']);
   });
 
+  test('-c is parsed as --config and excluded from rest', () => {
+    const result = parseArgs(['-c', 'custom.js', 'src/a.ts']);
+    expect(result.config).toBe('custom.js');
+    expect(result.rest).not.toContain('-c');
+    expect(result.rest).not.toContain('custom.js');
+    expect(result.rest).toContain('src/a.ts');
+    expect(result.positionals).toEqual(['src/a.ts']);
+  });
+
   test('--start-time is excluded from rest', () => {
     const result = parseArgs(['--start-time', '1234567890', 'src/a.ts']);
     expect(result.rest).not.toContain('--start-time');

--- a/website/docs/en/guide/cli.md
+++ b/website/docs/en/guide/cli.md
@@ -8,19 +8,19 @@ rslint [options] [files/directories...]
 
 ## Options
 
-| Flag                 | Description                                                                                    |
-| -------------------- | ---------------------------------------------------------------------------------------------- |
-| `--init`             | Generate a default config file, or migrate an existing JSON config to JS/TS                    |
-| `--config <path>`    | Specify which config file to use                                                               |
-| `--fix`              | Automatically fix problems                                                                     |
-| `--type-check`       | Enable TypeScript semantic type checking ([details](/guide/type-checking))                     |
-| `--format <format>`  | Output format: `default`, `jsonline`, `github`, or `gitlab` ([details](/guide/output-formats)) |
-| `--quiet`            | Report errors only, suppress warnings                                                          |
-| `--max-warnings <n>` | Exit with error if warning count exceeds this number                                           |
-| `--rule <rule>`      | Override a rule's severity or options (repeatable, see [details](#rule-overrides))             |
-| `--no-color`         | Disable colored output ([details](/guide/environment-variables))                               |
-| `--force-color`      | Force colored output ([details](/guide/environment-variables))                                 |
-| `--help`, `-h`       | Show help information                                                                          |
+| Flag                  | Description                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------- |
+| `--init`              | Generate a default config file, or migrate an existing JSON config to JS/TS                    |
+| `-c, --config <path>` | Specify which config file to use                                                               |
+| `--fix`               | Automatically fix problems                                                                     |
+| `--type-check`        | Enable TypeScript semantic type checking ([details](/guide/type-checking))                     |
+| `--format <format>`   | Output format: `default`, `jsonline`, `github`, or `gitlab` ([details](/guide/output-formats)) |
+| `--quiet`             | Report errors only, suppress warnings                                                          |
+| `--max-warnings <n>`  | Exit with error if warning count exceeds this number                                           |
+| `--rule <rule>`       | Override a rule's severity or options (repeatable, see [details](#rule-overrides))             |
+| `--no-color`          | Disable colored output ([details](/guide/environment-variables))                               |
+| `--force-color`       | Force colored output ([details](/guide/environment-variables))                                 |
+| `--help`, `-h`        | Show help information                                                                          |
 
 ## File and Directory Arguments
 
@@ -59,10 +59,11 @@ rslint packages/foo/
 rslint packages/foo/src/a.ts packages/bar/src/b.ts
 ```
 
-Use `--config` to override automatic config discovery:
+Use `--config` or `-c` to override automatic config discovery:
 
 ```bash
 rslint --config custom.config.ts src/
+rslint -c custom.config.ts src/
 ```
 
 ## Rule Overrides


### PR DESCRIPTION
## Summary

This PR adds the ESLint-compatible `-c` alias for `--config` across the Node wrapper and the Go CLI fallback, so migrated scripts can use the short config flag. It also updates the CLI docs and covers wrapper parsing in the args tests.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
