### PR TITLE
feat: port rule import/no-cycle

### DIFF
--- a/internal/plugins/import/all.go
+++ b/internal/plugins/import/all.go
@@ -5,6 +5,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/first"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/namespace"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/newline_after_import"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_cycle"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_duplicates"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_mutable_exports"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_self_import"
@@ -18,6 +19,7 @@ func GetAllRules() []rule.Rule {
 		first.FirstRule,
 		namespace.NamespaceRule,
 		newline_after_import.NewlineAfterImportRule,
+		no_cycle.NoCycleRule,
 		no_duplicates.NoDuplicatesRule,
 		no_mutable_exports.NoMutableExportsRule,
 		no_self_import.NoSelfImportRule,

--- a/internal/plugins/import/fixtures/no-cycle/alias-b.ts
+++ b/internal/plugins/import/fixtures/no-cycle/alias-b.ts
@@ -1,0 +1,3 @@
+import { aliasA } from '@cycles/alias-a';
+
+export const aliasB = aliasA;

--- a/internal/plugins/import/fixtures/no-cycle/amd-depth-one.ts
+++ b/internal/plugins/import/fixtures/no-cycle/amd-depth-one.ts
@@ -1,0 +1,3 @@
+define(['../file'], () => ({}));
+
+export const amd = 1;

--- a/internal/plugins/import/fixtures/no-cycle/barrel-real-config.ts
+++ b/internal/plugins/import/fixtures/no-cycle/barrel-real-config.ts
@@ -1,0 +1,2 @@
+export type { RealEntry } from '../barrel-real-entry';
+export const config = 1;

--- a/internal/plugins/import/fixtures/no-cycle/barrel-real-runtime.ts
+++ b/internal/plugins/import/fixtures/no-cycle/barrel-real-runtime.ts
@@ -1,0 +1,4 @@
+import { config } from './barrel-real-config';
+
+export { config };
+export const run = config;

--- a/internal/plugins/import/fixtures/no-cycle/barrel-real.ts
+++ b/internal/plugins/import/fixtures/no-cycle/barrel-real.ts
@@ -1,0 +1,2 @@
+export type { RealEntry } from '../barrel-real-entry';
+export { run } from './barrel-real-runtime';

--- a/internal/plugins/import/fixtures/no-cycle/commonjs-depth-one.ts
+++ b/internal/plugins/import/fixtures/no-cycle/commonjs-depth-one.ts
@@ -1,0 +1,3 @@
+const root = require('../file');
+
+export const common = root;

--- a/internal/plugins/import/fixtures/no-cycle/depth-one-dynamic.ts
+++ b/internal/plugins/import/fixtures/no-cycle/depth-one-dynamic.ts
@@ -1,0 +1,2 @@
+export const dynamicDepthOne = () =>
+  import('../file').then(({ rootValue }) => rootValue);

--- a/internal/plugins/import/fixtures/no-cycle/depth-one.ts
+++ b/internal/plugins/import/fixtures/no-cycle/depth-one.ts
@@ -1,0 +1,3 @@
+import { rootValue } from '../file';
+
+export const depthOne = rootValue;

--- a/internal/plugins/import/fixtures/no-cycle/depth-three-indirect.ts
+++ b/internal/plugins/import/fixtures/no-cycle/depth-three-indirect.ts
@@ -1,0 +1,3 @@
+import './depth-two';
+
+export const depthThreeIndirect = 'side effects';

--- a/internal/plugins/import/fixtures/no-cycle/depth-three-star.ts
+++ b/internal/plugins/import/fixtures/no-cycle/depth-three-star.ts
@@ -1,0 +1,3 @@
+import * as two from './depth-two';
+
+export { two };

--- a/internal/plugins/import/fixtures/no-cycle/depth-three.ts
+++ b/internal/plugins/import/fixtures/no-cycle/depth-three.ts
@@ -1,0 +1,3 @@
+import { depthTwo } from './depth-two';
+
+export const depthThree = depthTwo;

--- a/internal/plugins/import/fixtures/no-cycle/depth-two.ts
+++ b/internal/plugins/import/fixtures/no-cycle/depth-two.ts
@@ -1,0 +1,3 @@
+import { depthOne } from './depth-one';
+
+export const depthTwo = depthOne;

--- a/internal/plugins/import/fixtures/no-cycle/dynamic-depth-one.ts
+++ b/internal/plugins/import/fixtures/no-cycle/dynamic-depth-one.ts
@@ -1,0 +1,3 @@
+export function loadRoot() {
+  return import('../file');
+}

--- a/internal/plugins/import/fixtures/no-cycle/dynamic-middle.ts
+++ b/internal/plugins/import/fixtures/no-cycle/dynamic-middle.ts
@@ -1,0 +1,3 @@
+export function loadDepthOne() {
+  return import('./depth-one');
+}

--- a/internal/plugins/import/fixtures/no-cycle/external-depth-two.ts
+++ b/internal/plugins/import/fixtures/no-cycle/external-depth-two.ts
@@ -1,0 +1,3 @@
+import { externalDepthOne } from './external/depth-one';
+
+export const externalDepthTwo = externalDepthOne;

--- a/internal/plugins/import/fixtures/no-cycle/external/depth-one.ts
+++ b/internal/plugins/import/fixtures/no-cycle/external/depth-one.ts
@@ -1,0 +1,3 @@
+import { rootValue } from '../../file';
+
+export const externalDepthOne = rootValue;

--- a/internal/plugins/import/fixtures/no-cycle/ignore/index.ts
+++ b/internal/plugins/import/fixtures/no-cycle/ignore/index.ts
@@ -1,0 +1,3 @@
+import { rootValue } from '../../file';
+
+export const ignoredValue = rootValue;

--- a/internal/plugins/import/fixtures/no-cycle/independent-b.ts
+++ b/internal/plugins/import/fixtures/no-cycle/independent-b.ts
@@ -1,0 +1,3 @@
+import { rootValue } from '../file';
+
+export const independent = 'b';

--- a/internal/plugins/import/fixtures/no-cycle/inline-type-only.ts
+++ b/internal/plugins/import/fixtures/no-cycle/inline-type-only.ts
@@ -1,0 +1,4 @@
+import { type RootType } from '../file';
+
+export type InlineTypeOnly = RootType;
+export const inlineTypeOnly = 1;

--- a/internal/plugins/import/fixtures/no-cycle/inline-type-reexport.ts
+++ b/internal/plugins/import/fixtures/no-cycle/inline-type-reexport.ts
@@ -1,0 +1,1 @@
+export { type RootType } from '../file';

--- a/internal/plugins/import/fixtures/no-cycle/intermediate-ignore.ts
+++ b/internal/plugins/import/fixtures/no-cycle/intermediate-ignore.ts
@@ -1,0 +1,3 @@
+import { ignoredValue } from './ignore';
+
+export const intermediateIgnoredValue = ignoredValue;

--- a/internal/plugins/import/fixtures/no-cycle/mixed-inline-type-reexport.ts
+++ b/internal/plugins/import/fixtures/no-cycle/mixed-inline-type-reexport.ts
@@ -1,0 +1,3 @@
+export { type RootType, rootValue } from '../file';
+
+export const mixedInlineReexport = rootValue;

--- a/internal/plugins/import/fixtures/no-cycle/mixed-type.ts
+++ b/internal/plugins/import/fixtures/no-cycle/mixed-type.ts
@@ -1,0 +1,4 @@
+import { rootValue, type RootType } from '../file';
+
+export type MixedType = RootType;
+export const mixed = rootValue;

--- a/internal/plugins/import/fixtures/no-cycle/no-cycle.ts
+++ b/internal/plugins/import/fixtures/no-cycle/no-cycle.ts
@@ -1,0 +1,1 @@
+export const noCycle = 1;

--- a/internal/plugins/import/fixtures/no-cycle/reexport-depth-one.ts
+++ b/internal/plugins/import/fixtures/no-cycle/reexport-depth-one.ts
@@ -1,0 +1,1 @@
+export { rootValue } from '../file';

--- a/internal/plugins/import/fixtures/no-cycle/reexport-type-only.ts
+++ b/internal/plugins/import/fixtures/no-cycle/reexport-type-only.ts
@@ -1,0 +1,1 @@
+export type { RootType } from '../file';

--- a/internal/plugins/import/fixtures/no-cycle/type-only.ts
+++ b/internal/plugins/import/fixtures/no-cycle/type-only.ts
@@ -1,0 +1,4 @@
+import type { RootType } from '../file';
+
+export type TypeOnly = RootType;
+export const typeOnly = 1;

--- a/internal/plugins/import/fixtures/no-cycle/unrelated-dynamic.ts
+++ b/internal/plugins/import/fixtures/no-cycle/unrelated-dynamic.ts
@@ -1,0 +1,5 @@
+import { depthOne } from './depth-one';
+
+import('./no-cycle');
+
+export const unrelatedDynamic = depthOne;

--- a/internal/plugins/import/fixtures/tsconfig.no-cycle-paths.json
+++ b/internal/plugins/import/fixtures/tsconfig.no-cycle-paths.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@cycles/*": ["no-cycle/*"]
+    },
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
+    "experimentalDecorators": true
+  },
+  "include": ["**/*"]
+}

--- a/internal/plugins/import/rules/no_cycle/no_cycle.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle.go
@@ -1,0 +1,279 @@
+package no_cycle
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	import_utils "github.com/web-infra-dev/rslint/internal/plugins/import/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	rslint_utils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const unlimitedDepth = int(^uint(0) >> 1)
+
+type ruleOptions struct {
+	maxDepth                           int
+	ignoreExternal                     bool
+	allowUnsafeDynamicCyclicDependency bool
+	moduleReferences                   import_utils.ModuleReferenceOptions
+}
+
+type routeStep struct {
+	value string
+	line  int
+}
+
+type queuedModule struct {
+	sourceFile *ast.SourceFile
+	route      []routeStep
+}
+
+// NoCycleRule forbids dependency paths that resolve back to the linted module.
+//
+// See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-cycle.js
+var NoCycleRule = rule.Rule{
+	Name: "import/no-cycle",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		checkSourceFile(ctx, opts)
+		return rule.RuleListeners{}
+	},
+}
+
+func parseOptions(options any) ruleOptions {
+	opts := ruleOptions{
+		maxDepth: unlimitedDepth,
+		moduleReferences: import_utils.ModuleReferenceOptions{
+			ESModule: true,
+		},
+	}
+
+	optsMap := rslint_utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+
+	if maxDepth, ok := parseMaxDepth(optsMap["maxDepth"]); ok {
+		opts.maxDepth = maxDepth
+	}
+	if ignoreExternal, ok := optsMap["ignoreExternal"].(bool); ok {
+		opts.ignoreExternal = ignoreExternal
+	}
+	if allow, ok := optsMap["allowUnsafeDynamicCyclicDependency"].(bool); ok {
+		opts.allowUnsafeDynamicCyclicDependency = allow
+	}
+	if commonJS, ok := optsMap["commonjs"].(bool); ok {
+		opts.moduleReferences.CommonJS = commonJS
+	}
+	if amd, ok := optsMap["amd"].(bool); ok {
+		opts.moduleReferences.AMD = amd
+	}
+	if esmodule, ok := optsMap["esmodule"].(bool); ok {
+		opts.moduleReferences.ESModule = esmodule
+	}
+
+	return opts
+}
+
+func parseMaxDepth(raw any) (int, bool) {
+	switch value := raw.(type) {
+	case nil:
+		return 0, false
+	case int:
+		return normalizeDepth(value)
+	case int64:
+		return normalizeDepth(int(value))
+	case float64:
+		if math.IsInf(value, 1) {
+			return unlimitedDepth, true
+		}
+		if math.Trunc(value) != value {
+			return 0, false
+		}
+		return normalizeDepth(int(value))
+	case float32:
+		if math.IsInf(float64(value), 1) {
+			return unlimitedDepth, true
+		}
+		if math.Trunc(float64(value)) != float64(value) {
+			return 0, false
+		}
+		return normalizeDepth(int(value))
+	case json.Number:
+		if i, err := value.Int64(); err == nil {
+			return normalizeDepth(int(i))
+		}
+		if f, err := value.Float64(); err == nil {
+			return normalizeDepth(int(f))
+		}
+	case string:
+		if value == "∞" {
+			return unlimitedDepth, true
+		}
+	}
+	return 0, false
+}
+
+func normalizeDepth(depth int) (int, bool) {
+	if depth < 1 {
+		return 0, false
+	}
+	return depth, true
+}
+
+func checkSourceFile(ctx rule.RuleContext, opts ruleOptions) {
+	if ctx.SourceFile == nil || ctx.Program == nil {
+		return
+	}
+
+	myPath := ctx.SourceFile.FileName()
+	if myPath == "" || myPath == "<text>" {
+		return
+	}
+
+	traversed := make(map[string]bool)
+	for _, ref := range import_utils.CollectModuleReferences(ctx, ctx.SourceFile, opts.moduleReferences) {
+		checkReference(ctx, opts, myPath, traversed, ref)
+	}
+}
+
+func checkReference(ctx rule.RuleContext, opts ruleOptions, myPath string, traversed map[string]bool, ref import_utils.ModuleReference) {
+	if ref.OnlyTypes || ref.Target == nil || shouldIgnoreExternal(ctx, opts, ref) {
+		return
+	}
+
+	if opts.allowUnsafeDynamicCyclicDependency && ref.Dynamic {
+		return
+	}
+
+	if moduleReferencePath(ref) == myPath {
+		return
+	}
+
+	route, ok := detectCycle(ctx, opts, myPath, traversed, ref.Target)
+	if !ok {
+		return
+	}
+
+	reportNode := ref.Importer
+	if reportNode == nil {
+		reportNode = ref.Source
+	}
+	ctx.ReportNode(reportNode, messageCycle(route))
+}
+
+func detectCycle(ctx rule.RuleContext, opts ruleOptions, myPath string, traversed map[string]bool, start *ast.SourceFile) ([]routeStep, bool) {
+	queue := []queuedModule{{sourceFile: start}}
+	if traversed == nil {
+		traversed = make(map[string]bool)
+	}
+
+	for len(queue) > 0 {
+		next := queue[0]
+		queue = queue[1:]
+		if next.sourceFile == nil {
+			continue
+		}
+
+		sourcePath := next.sourceFile.FileName()
+		if traversed[sourcePath] {
+			continue
+		}
+		traversed[sourcePath] = true
+
+		for _, ref := range referencesToTraverse(ctx, opts, import_utils.CollectModuleReferences(ctx, next.sourceFile, opts.moduleReferences)) {
+			targetPath := moduleReferencePath(ref)
+			if targetPath == "" || traversed[targetPath] {
+				continue
+			}
+			if targetPath == myPath {
+				return next.route, true
+			}
+			if ref.Target != nil && len(next.route)+1 < opts.maxDepth {
+				queue = append(queue, queuedModule{
+					sourceFile: ref.Target,
+					route:      appendRoute(next.route, ref),
+				})
+			}
+		}
+	}
+
+	return nil, false
+}
+
+func referencesToTraverse(ctx rule.RuleContext, opts ruleOptions, refs []import_utils.ModuleReference) []import_utils.ModuleReference {
+	filtered := make([]import_utils.ModuleReference, 0, len(refs))
+	dynamicPaths := make(map[string]bool)
+	for _, ref := range refs {
+		if ref.OnlyTypes || ref.Target == nil || shouldIgnoreExternal(ctx, opts, ref) {
+			continue
+		}
+		if opts.allowUnsafeDynamicCyclicDependency && ref.Dynamic {
+			dynamicPaths[moduleReferencePath(ref)] = true
+		}
+		filtered = append(filtered, ref)
+	}
+
+	if len(dynamicPaths) == 0 {
+		return filtered
+	}
+
+	traversable := filtered[:0]
+	for _, ref := range filtered {
+		if !dynamicPaths[moduleReferencePath(ref)] {
+			traversable = append(traversable, ref)
+		}
+	}
+	return traversable
+}
+
+func appendRoute(route []routeStep, ref import_utils.ModuleReference) []routeStep {
+	next := make([]routeStep, 0, len(route)+1)
+	next = append(next, route...)
+	next = append(next, routeStep{
+		value: ref.Specifier,
+		line:  sourceLine(ref),
+	})
+	return next
+}
+
+func sourceLine(ref import_utils.ModuleReference) int {
+	if ref.SourceFile == nil || ref.Source == nil {
+		return 1
+	}
+	line, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(ref.SourceFile, ref.Source.Pos())
+	return line + 1
+}
+
+func messageCycle(route []routeStep) rule.RuleMessage {
+	description := "Dependency cycle detected."
+	if len(route) > 0 {
+		parts := make([]string, 0, len(route))
+		for _, step := range route {
+			parts = append(parts, fmt.Sprintf("%s:%d", step.value, step.line))
+		}
+		description = "Dependency cycle via " + strings.Join(parts, "=>")
+	}
+	return rule.RuleMessage{
+		Id:          "cycle",
+		Description: description,
+	}
+}
+
+func moduleReferencePath(ref import_utils.ModuleReference) string {
+	if ref.Target != nil {
+		return ref.Target.FileName()
+	}
+	return ref.ResolvedPath
+}
+
+func shouldIgnoreExternal(ctx rule.RuleContext, opts ruleOptions, ref import_utils.ModuleReference) bool {
+	if !opts.ignoreExternal {
+		return false
+	}
+	return import_utils.IsExternalModulePath(ctx.Settings, ref.Specifier, moduleReferencePath(ref))
+}

--- a/internal/plugins/import/rules/no_cycle/no_cycle.md
+++ b/internal/plugins/import/rules/no_cycle/no_cycle.md
@@ -1,0 +1,86 @@
+# no-cycle
+
+## Rule Details
+
+Ensures that an imported module does not have a resolvable dependency path back
+to the linted module.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+// dep-b.js
+import "./dep-a.js";
+
+// dep-a.js
+import "./dep-b.js";
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+// dep-b.js
+export const value = 1;
+
+// dep-a.js
+import { value } from "./dep-b.js";
+```
+
+This rule does not report direct self imports. Use `import/no-self-import` for
+that case.
+
+Type-only imports are ignored because they have no runtime effect. Named
+type-only re-exports still participate in the dependency graph, matching
+`eslint-plugin-import`.
+
+## Options
+
+### `maxDepth`
+
+Limits how far the rule traverses the dependency graph. The value must be a
+positive integer or `"∞"`.
+
+```json
+{ "import/no-cycle": ["error", { "maxDepth": 1 }] }
+```
+
+### `commonjs`
+
+Checks `require()` calls in addition to ES module imports.
+
+```json
+{ "import/no-cycle": ["error", { "commonjs": true }] }
+```
+
+### `amd`
+
+Checks AMD `require([...])` and `define([...])` dependencies.
+
+```json
+{ "import/no-cycle": ["error", { "amd": true }] }
+```
+
+### `ignoreExternal`
+
+Skips modules treated as external, such as modules under `node_modules`.
+
+```json
+{ "import/no-cycle": ["error", { "ignoreExternal": true }] }
+```
+
+### `allowUnsafeDynamicCyclicDependency`
+
+Allows a cycle when at least one dependency in the cycle is imported with
+dynamic `import()`.
+
+```json
+{
+  "import/no-cycle": [
+    "error",
+    { "allowUnsafeDynamicCyclicDependency": true }
+  ]
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-import/no-cycle](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md)

--- a/internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go
@@ -1,0 +1,214 @@
+package no_cycle_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_cycle"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoCycleExtras locks in branches, real-user shapes, and tsgo AST edge
+// cases that the upstream test suite doesn't exercise. Upstream-migrated cases
+// live in no_cycle_upstream_test.go.
+func TestNoCycleExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_cycle.NoCycleRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: empty and non-string call arguments are not module edges ----
+			{Code: `const name = "./no-cycle/depth-one"; import(name); require(); define([name]); ` + rootExports, Options: map[string]interface{}{"commonjs": true, "amd": true}},
+
+			// ---- Dimension 4: object keys are ordinary string literals, not module source literals ----
+			{Code: `const keyed = { "./no-cycle/depth-one": true, ["./no-cycle/depth-two"]: false }; ` + rootExports},
+
+			// ---- Dimension 4: string literals inside declarations are not module source literals ----
+			{Code: `class Local { method() { return "./no-cycle/depth-one"; } } ` + rootExports},
+
+			// ---- Dimension 4: `export type * from` stays type-only and does not form a graph edge ----
+			{Code: `export type * from "./no-cycle/reexport-type-only"; ` + rootExports},
+
+			// ---- Dimension 4: CommonJS require() must have exactly one argument to be a module edge ----
+			{Code: `const common = require("./no-cycle/commonjs-depth-one", "extra"); ` + rootExports, Options: map[string]interface{}{"commonjs": true}},
+
+			// ---- Real-user: #2265 dynamic import cycles are permitted when explicitly allowed ----
+			{Code: `const lazy = () => import("./no-cycle/dynamic-depth-one"); ` + rootExports, Options: map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true}},
+
+			// ---- Real-user: #1647 ignoreExternal skips external folders reached through a relative intermediate ----
+			{Code: `import { externalDepthTwo } from "./no-cycle/external-depth-two"; export const rootValue = externalDepthTwo; export type RootType = string;`, Options: map[string]interface{}{"ignoreExternal": true}, Settings: map[string]interface{}{"import/external-module-folders": []interface{}{"no-cycle/external"}}},
+
+			// Locks in upstream checkSourceValue() arm 1: unresolved imports return without reporting.
+			{Code: `import missing from "./no-cycle/does-not-exist"; ` + rootExports},
+
+			// Locks in upstream checkSourceValue() arm 2: direct self imports are delegated to import/no-self-import.
+			{Code: `import { rootValue as self } from "./file"; ` + rootExports},
+
+			// Locks in upstream checkSourceValue() arm 3: import type declarations are ignored.
+			{Code: `import type { RootType as LocalType } from "./no-cycle/type-only"; ` + rootExports},
+
+			// Locks in upstream detectCycle() maxDepth branch: depth-three is beyond maxDepth 2.
+			{Code: `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`, Options: []interface{}{map[string]interface{}{"maxDepth": 2}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized CommonJS source literals still resolve ----
+			{
+				Code:    `const common = require(("./no-cycle/commonjs-depth-one")); ` + rootExports,
+				Options: map[string]interface{}{"commonjs": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "cycle", Message: messageDetected, Line: 1, Column: 16},
+				},
+			},
+
+			// ---- Dimension 4: require() inside nested code still contributes a graph edge ----
+			{
+				Code:    `function load() { return require("./no-cycle/commonjs-depth-one"); } ` + rootExports,
+				Options: map[string]interface{}{"commonjs": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "cycle", Message: messageDetected, Line: 1},
+				},
+			},
+
+			// ---- Dimension 4: dynamic import calls are checked by default ----
+			{
+				Code: `import("./no-cycle/dynamic-depth-one"); ` + rootExports,
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageDetected),
+				},
+			},
+			{
+				Code: `import(("./no-cycle/dynamic-depth-one")); ` + rootExports,
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageDetected),
+				},
+			},
+
+			// ---- Real-user: #1554 TS path aliases still participate in cycle detection ----
+			{
+				Code:     `import { aliasB } from "@cycles/alias-b"; export const aliasA = aliasB;`,
+				FileName: "no-cycle/alias-a.ts",
+				TSConfig: "tsconfig.no-cycle-paths.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageDetected),
+				},
+			},
+
+			// ---- Real-user: #3147 side-effect-only imports participate in indirect cycle detection ----
+			{
+				Code: `import "./no-cycle/depth-three-indirect"; ` + rootExports,
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageViaTwoOne),
+				},
+			},
+
+			// Graph-level cycles report even when exports are independent.
+			{
+				Code: `import { independent } from "./no-cycle/independent-b"; export const rootValue = independent; export type RootType = string;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageDetected),
+				},
+			},
+
+			// Locks in upstream detectCycle() arm 1: route strings include intermediate source and line.
+			{
+				Code: `import { depthTwo } from "./no-cycle/depth-two"; export const rootValue = depthTwo; export type RootType = string;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageViaDepthOne),
+				},
+			},
+
+			// Locks in upstream detectCycle() arm 2: maxDepth "∞" is treated as unlimited.
+			{
+				Code:    `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`,
+				Options: map[string]interface{}{"maxDepth": "∞"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageViaTwoOne),
+				},
+			},
+			{
+				Code:    `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`,
+				Options: map[string]interface{}{"maxDepth": "2"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageViaTwoOne),
+				},
+			},
+			{
+				Code:    `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`,
+				Options: map[string]interface{}{"maxDepth": 2.5},
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageViaTwoOne),
+				},
+			},
+
+			// Locks in upstream detectCycle() dynamic arm: allowUnsafeDynamicCyclicDependency only skips the dynamic path, not unrelated static cycles.
+			{
+				Code:    `import { unrelatedDynamic } from "./no-cycle/unrelated-dynamic"; export const rootValue = unrelatedDynamic; export type RootType = string;`,
+				Options: map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageViaDepthOne),
+				},
+			},
+
+			// Locks in upstream ignoreModule() arm: ignoreExternal=false keeps external-folder paths in the graph.
+			{
+				Code:     `import { externalDepthTwo } from "./no-cycle/external-depth-two"; export const rootValue = externalDepthTwo; export type RootType = string;`,
+				Settings: map[string]interface{}{"import/external-module-folders": []interface{}{"no-cycle/external"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError("Dependency cycle via ./external/depth-one:1"),
+				},
+			},
+
+			// Locks in upstream checkSourceValue() arm 4: mixed type/value imports are runtime edges.
+			{
+				Code: `import { mixed } from "./no-cycle/mixed-type"; export const rootValue = mixed; export type RootType = string;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageDetected),
+				},
+			},
+
+			// Inline type specifiers do not make a mixed value re-export type-only.
+			{
+				Code: `import { mixedInlineReexport } from "./no-cycle/mixed-inline-type-reexport"; export const rootValue = mixedInlineReexport; export type RootType = string;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageDetected),
+				},
+			},
+
+			// ---- Dimension 4: named type re-exports match upstream export-map dependency edges ----
+			{
+				Code: `export type { RootType } from "./no-cycle/reexport-type-only"; ` + rootExports,
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageDetected),
+				},
+			},
+			{
+				Code: `import "./no-cycle/inline-type-reexport"; ` + rootExports,
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageDetected),
+				},
+			},
+
+			// ---- Real-user: rspack-style barrel reports each cyclic import and keeps route text aligned ----
+			{
+				Code: `import * as realBarrel from "./no-cycle/barrel-real";
+import { run } from "./no-cycle/barrel-real-runtime";
+export type RealEntry = string;
+export const realValue = realBarrel.run || run;`,
+				FileName: "barrel-real-entry.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "cycle", Message: messageDetected, Line: 1, Column: 1},
+					{MessageId: "cycle", Message: "Dependency cycle via ./barrel-real-config:1", Line: 2, Column: 1},
+				},
+			},
+
+			// Upstream keeps one traversal set per linted file, so duplicate imports of the same cyclic target report once.
+			{
+				Code: `import { depthOne } from "./no-cycle/depth-one"; import { depthOne as again } from "./no-cycle/depth-one"; export const rootValue = depthOne || again; export type RootType = string;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					cycleError(messageDetected),
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/import/rules/no_cycle/no_cycle_upstream_test.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle_upstream_test.go
@@ -1,0 +1,357 @@
+package no_cycle_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_cycle"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	rootExports        = `export const rootValue = 1; export type RootType = string;`
+	messageDetected    = "Dependency cycle detected."
+	messageViaDepthOne = "Dependency cycle via ./depth-one:1"
+	messageViaTwoOne   = "Dependency cycle via ./depth-two:1=>./depth-one:1"
+)
+
+// TestNoCycleUpstream migrates the full supported valid/invalid suite from
+// upstream tests/src/rules/no-cycle.js 1:1 by semantic group. Unsupported
+// parser/resolver framework cases stay present as skipped cases. Position
+// assertions cover line/column for every invalid case. rslint-specific lock-in
+// cases live in no_cycle_extras_test.go.
+func TestNoCycleUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_cycle.NoCycleRule,
+		withDisableSccValid(noCycleUpstreamValidCases()),
+		withDisableSccInvalid(noCycleUpstreamInvalidCases()),
+	)
+}
+
+func noCycleUpstreamValidCases() []rule_tester.ValidTestCase {
+	return []rule_tester.ValidTestCase{
+		// ---- upstream valid: this rule does not report self imports or unresolved imports ----
+		{Code: `import { rootValue as other } from "./file"; ` + rootExports},
+		{Code: `import foo from "./foo.js"; ` + rootExports},
+
+		// ---- upstream valid: unresolved and external modules are no-unresolved territory ----
+		{Code: `import _ from "lodash"; ` + rootExports},
+		{Code: `import foo from "@scope/foo"; ` + rootExports},
+		{Code: `import { noCycle } from "./no-cycle/no-cycle"; export const rootValue = noCycle; export type RootType = string;`},
+
+		// ---- upstream valid: commonjs and amd are off by default ----
+		{Code: `var _ = require("lodash"); ` + rootExports},
+		{Code: `var find = require("lodash.find"); ` + rootExports},
+		{Code: `var foo = require("./foo"); ` + rootExports},
+		{Code: `var foo = require("../foo"); ` + rootExports},
+		{Code: `var foo = require("foo"); ` + rootExports},
+		{Code: `var foo = require("./"); ` + rootExports},
+		{Code: `var foo = require("@scope/foo"); ` + rootExports},
+		{Code: `var bar = require("./bar/index"); ` + rootExports},
+		{Code: `var bar = require("./bar"); ` + rootExports},
+		{Code: `const common = require("./no-cycle/commonjs-depth-one"); ` + rootExports},
+		{Code: `define(["./no-cycle/amd-depth-one"], () => ({})); ` + rootExports},
+
+		// SKIP: rule_tester always maps test files into the fixture VFS, so it cannot produce ESLint's literal "<text>" physical filename.
+		{Code: `var bar = require("./bar");`, FileName: "<text>", Skip: true},
+		// SKIP: rslint Go rule tests do not use upstream's webpack resolver settings.
+		{Code: `import { foo } from "cycles/external/depth-one";`, Options: []interface{}{map[string]interface{}{"ignoreExternal": true}}, Skip: true},
+		// SKIP: rslint Go rule tests do not use upstream's webpack resolver settings.
+		{Code: `import { foo } from "./external-depth-two";`, Options: []interface{}{map[string]interface{}{"ignoreExternal": true}}, Skip: true},
+
+		// ---- upstream valid: maxDepth limits traversal beyond direct cycles ----
+		{Code: `import { depthTwo } from "./no-cycle/depth-two"; export const rootValue = depthTwo; export type RootType = string;`, Options: []interface{}{map[string]interface{}{"maxDepth": 1}}},
+		{Code: `import { depthOne, depthTwo } from "./no-cycle/depth-two"; export const rootValue = depthOne || depthTwo; export type RootType = string;`, Options: []interface{}{map[string]interface{}{"maxDepth": 1}}},
+		{Code: `import("./no-cycle/depth-two").then(({ depthTwo }) => depthTwo); ` + rootExports, Options: []interface{}{map[string]interface{}{"maxDepth": 1}}},
+		{Code: `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`, Options: map[string]interface{}{"maxDepth": 2}},
+
+		// ---- upstream valid: type-only imports do not form runtime cycles ----
+		{Code: `import type { RootType as LocalType } from "./no-cycle/type-only"; ` + rootExports},
+		{Code: `import type { RootType as LocalType, TypeOnly } from "./no-cycle/type-only"; ` + rootExports},
+		{Code: `import { typeOnly } from "./no-cycle/type-only"; export const rootValue = typeOnly; export type RootType = string;`},
+		{Code: `import { inlineTypeOnly } from "./no-cycle/inline-type-only"; export const rootValue = inlineTypeOnly; export type RootType = string;`},
+
+		// ---- upstream valid: dynamic cycle allowed by option (#2265) ----
+		{Code: `function bar(){ return import("./no-cycle/depth-one"); } ` + rootExports, Options: []interface{}{map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true}}},
+		{Code: `import { dynamicDepthOne } from "./no-cycle/depth-one-dynamic"; export const rootValue = dynamicDepthOne; export type RootType = string;`, Options: []interface{}{map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true}}},
+		{Code: `import { loadRoot } from "./no-cycle/dynamic-depth-one"; export const rootValue = loadRoot; export type RootType = string;`, Options: map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true}},
+		{Code: `import { loadDepthOne } from "./no-cycle/dynamic-middle"; export const rootValue = loadDepthOne; export type RootType = string;`, Options: []interface{}{map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true}}},
+
+		// ---- upstream valid: ignoreExternal skips external-looking specifiers ----
+		{Code: `import { anything } from "external-package"; ` + rootExports, Options: map[string]interface{}{"ignoreExternal": true}},
+
+		// ---- upstream valid: esmodule=false disables import/export source checks ----
+		{Code: `import { depthOne } from "./no-cycle/depth-one"; export const rootValue = depthOne; export type RootType = string;`, Options: map[string]interface{}{"esmodule": false}},
+
+		// SKIP: rslint does not parse Flow import type/typeof syntax with the Babel parser.
+		{Code: `import { bar } from "./flow-types"`, Skip: true},
+		// SKIP: rslint does not parse Flow import type/typeof syntax with the Babel parser.
+		{Code: `import { bar } from "./flow-types-only-importing-type"`, Skip: true},
+		// SKIP: rslint does not parse Flow import type/typeof syntax with the Babel parser.
+		{Code: `import { bar } from "./flow-types-only-importing-multiple-types"`, Skip: true},
+		// SKIP: rslint does not parse Flow `import typeof`.
+		{Code: `import { bar } from "./flow-typeof"`, Skip: true},
+	}
+}
+
+func noCycleUpstreamInvalidCases() []rule_tester.InvalidTestCase {
+	return []rule_tester.InvalidTestCase{
+		// SKIP: rslint does not parse Flow import type syntax with the Babel parser.
+		{Code: `import { bar } from "./flow-types-some-type-imports"`, Skip: true, Errors: []rule_tester.InvalidTestCaseError{cycleError(messageDetected)}},
+		// SKIP: rslint Go rule tests do not use upstream's webpack resolver settings.
+		{Code: `import { foo } from "cycles/external/depth-one"`, Skip: true, Errors: []rule_tester.InvalidTestCaseError{cycleError(messageDetected)}},
+		// SKIP: rslint Go rule tests do not use upstream's webpack resolver settings.
+		{Code: `import { foo } from "./external-depth-two"`, Skip: true, Errors: []rule_tester.InvalidTestCaseError{cycleError("Dependency cycle via cycles/external/depth-one:1")}},
+
+		// ---- upstream invalid: direct ES module cycle ----
+		{
+			Code: `import { depthOne } from "./no-cycle/depth-one"; export const rootValue = depthOne; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+		{
+			Code:    `import { depthOne } from "./no-cycle/depth-one"; export const rootValue = depthOne; export type RootType = string;`,
+			Options: []interface{}{map[string]interface{}{}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+		{
+			Code:    `import { depthOne } from "./no-cycle/depth-one"; export const rootValue = depthOne; export type RootType = string;`,
+			Options: map[string]interface{}{"maxDepth": 1},
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+		{
+			Code:    `import { depthOne } from "./no-cycle/depth-one"; export const rootValue = depthOne; export type RootType = string;`,
+			Options: []interface{}{map[string]interface{}{"maxDepth": 1}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+
+		// ---- upstream invalid: CommonJS and AMD sources when enabled ----
+		{
+			Code:    `const { common } = require("./no-cycle/commonjs-depth-one"); ` + rootExports,
+			Options: []interface{}{map[string]interface{}{"commonjs": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "cycle", Message: messageDetected, Line: 1, Column: 20},
+			},
+		},
+		{
+			Code:    `require(["./no-cycle/amd-depth-one"], d1 => {}); ` + rootExports,
+			Options: []interface{}{map[string]interface{}{"amd": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+		{
+			Code:    `define(["./no-cycle/amd-depth-one"], d1 => {}); ` + rootExports,
+			Options: []interface{}{map[string]interface{}{"amd": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+
+		// ---- upstream invalid: re-export cycles are import graph edges ----
+		{
+			Code: `import { rootValue as reexported } from "./no-cycle/reexport-depth-one"; export const rootValue = reexported; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+
+		// ---- upstream invalid: dependency path route is reported ----
+		{
+			Code: `import { depthTwo } from "./no-cycle/depth-two"; export const rootValue = depthTwo; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageViaDepthOne),
+			},
+		},
+		{
+			Code:    `import { depthTwo } from "./no-cycle/depth-two"; export const rootValue = depthTwo; export type RootType = string;`,
+			Options: []interface{}{map[string]interface{}{"maxDepth": 2}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageViaDepthOne),
+			},
+		},
+		{
+			Code:    `const { depthTwo } = require("./no-cycle/depth-two"); export const rootValue = depthTwo; export type RootType = string;`,
+			Options: []interface{}{map[string]interface{}{"commonjs": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "cycle", Message: messageViaDepthOne, Line: 1, Column: 22},
+			},
+		},
+		{
+			Code: `import { two } from "./no-cycle/depth-three-star"; export const rootValue = two.depthTwo; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageViaTwoOne),
+			},
+		},
+		{
+			Code: `import one, { two, three } from "./no-cycle/depth-three-star"; export const rootValue = one || two || three; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageViaTwoOne),
+			},
+		},
+		{
+			Code: `import { depthThreeIndirect } from "./no-cycle/depth-three-indirect"; export const rootValue = depthThreeIndirect; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageViaTwoOne),
+			},
+		},
+		{
+			Code: `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageViaTwoOne),
+			},
+		},
+		{
+			Code:    `import { depthTwo } from "./no-cycle/depth-two"; export const rootValue = depthTwo; export type RootType = string;`,
+			Options: []interface{}{map[string]interface{}{"maxDepth": math.Inf(1)}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageViaDepthOne),
+			},
+		},
+		{
+			Code:    `import { depthTwo } from "./no-cycle/depth-two"; export const rootValue = depthTwo; export type RootType = string;`,
+			Options: map[string]interface{}{"maxDepth": "∞"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageViaDepthOne),
+			},
+		},
+
+		// ---- upstream invalid: dynamic cycles are reported by default ----
+		{
+			Code: `import("./no-cycle/depth-three-star"); ` + rootExports,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageViaTwoOne),
+			},
+		},
+		{
+			Code: `import("./no-cycle/depth-three-indirect"); ` + rootExports,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageViaTwoOne),
+			},
+		},
+		{
+			Code: `function bar(){ return import("./no-cycle/depth-one"); } ` + rootExports,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "cycle", Message: messageDetected, Line: 1, Column: 24},
+			},
+		},
+		{
+			Code: `import { dynamicDepthOne } from "./no-cycle/depth-one-dynamic"; export const rootValue = dynamicDepthOne; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+		{
+			Code:    `import { depthOne } from "./no-cycle/depth-one"; export const rootValue = depthOne; export type RootType = string;`,
+			Options: []interface{}{map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+
+		// ---- upstream invalid: mixed value/type imports remain runtime imports ----
+		{
+			Code: `import { mixed } from "./no-cycle/mixed-type"; export const rootValue = mixed; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+		// ---- upstream invalid: named type re-exports still participate in the export-map dependency graph ----
+		{
+			Code: `import "./no-cycle/reexport-type-only"; ` + rootExports,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+		// SKIP: rslint does not parse Flow import type syntax with the Babel parser.
+		{Code: `import { bar } from "./flow-types-depth-one"`, Skip: true, Errors: []rule_tester.InvalidTestCaseError{cycleError("Dependency cycle via ./flow-types-depth-two:4=>./es6/depth-one:1")}},
+
+		// ---- upstream invalid: disabled nested rule config does not remove graph edges ----
+		{
+			Code: `import { intermediateIgnoredValue } from "./no-cycle/intermediate-ignore"; export const rootValue = intermediateIgnoredValue; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError("Dependency cycle via ./ignore:1"),
+			},
+		},
+		{
+			Code: `import { ignoredValue } from "./no-cycle/ignore"; export const rootValue = ignoredValue; export type RootType = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				cycleError(messageDetected),
+			},
+		},
+	}
+}
+
+func withDisableSccValid(cases []rule_tester.ValidTestCase) []rule_tester.ValidTestCase {
+	withVariants := make([]rule_tester.ValidTestCase, 0, len(cases)*2)
+	for _, testCase := range cases {
+		withVariants = append(withVariants, testCase)
+		variant := testCase
+		variant.Code += ` // disableScc=true`
+		variant.Options = withOption(testCase.Options, "disableScc", true)
+		withVariants = append(withVariants, variant)
+	}
+	return withVariants
+}
+
+func withDisableSccInvalid(cases []rule_tester.InvalidTestCase) []rule_tester.InvalidTestCase {
+	withVariants := make([]rule_tester.InvalidTestCase, 0, len(cases)*2)
+	for _, testCase := range cases {
+		withVariants = append(withVariants, testCase)
+		variant := testCase
+		variant.Code += ` // disableScc=true`
+		variant.Options = withOption(testCase.Options, "disableScc", true)
+		withVariants = append(withVariants, variant)
+	}
+	return withVariants
+}
+
+func withOption(options any, name string, value any) any {
+	switch typed := options.(type) {
+	case nil:
+		return map[string]interface{}{name: value}
+	case map[string]interface{}:
+		next := make(map[string]interface{}, len(typed)+1)
+		for key, item := range typed {
+			next[key] = item
+		}
+		next[name] = value
+		return next
+	case []interface{}:
+		if len(typed) == 0 {
+			return []interface{}{map[string]interface{}{name: value}}
+		}
+		if first, ok := typed[0].(map[string]interface{}); ok {
+			nextFirst := make(map[string]interface{}, len(first)+1)
+			for key, item := range first {
+				nextFirst[key] = item
+			}
+			nextFirst[name] = value
+			next := append([]interface{}{}, typed...)
+			next[0] = nextFirst
+			return next
+		}
+	}
+
+	return map[string]interface{}{name: value}
+}
+
+func cycleError(message string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "cycle",
+		Message:   message,
+		Line:      1,
+		Column:    1,
+	}
+}

--- a/internal/plugins/import/utils/export_map.go
+++ b/internal/plugins/import/utils/export_map.go
@@ -122,13 +122,8 @@ type exportKey struct {
 }
 
 func hasExport(ctx rule.RuleContext, origin *ast.SourceFile, moduleSpecifier *ast.Node, exportName string, seen map[exportKey]bool) (bool, bool) {
-	resolved := ctx.Program.GetResolvedModuleFromModuleSpecifier(origin, moduleSpecifier)
-	if resolved == nil || resolved.ResolvedFileName == "" {
-		return false, false
-	}
-
-	sourceFile := ctx.Program.GetSourceFileForResolvedModule(resolved.ResolvedFileName)
-	if sourceFile == nil {
+	_, sourceFile, ok := ResolveSourceFileFromSourceFile(ctx, origin, moduleSpecifier)
+	if !ok {
 		return false, false
 	}
 	if IsImportPathIgnored(ctx.Settings, sourceFile.FileName()) {
@@ -143,13 +138,8 @@ func getExportMap(ctx rule.RuleContext, origin *ast.SourceFile, moduleSpecifier 
 		return nil, false
 	}
 
-	resolved := ctx.Program.GetResolvedModuleFromModuleSpecifier(origin, moduleSpecifier)
-	if resolved == nil || resolved.ResolvedFileName == "" {
-		return nil, false
-	}
-
-	sourceFile := ctx.Program.GetSourceFileForResolvedModule(resolved.ResolvedFileName)
-	if sourceFile == nil {
+	_, sourceFile, ok := ResolveSourceFileFromSourceFile(ctx, origin, moduleSpecifier)
+	if !ok {
 		return nil, false
 	}
 	if IsImportPathIgnored(ctx.Settings, sourceFile.FileName()) {

--- a/internal/plugins/import/utils/external.go
+++ b/internal/plugins/import/utils/external.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+)
+
+// ExternalModuleFolders returns eslint-plugin-import's configured external
+// module folders, defaulting to node_modules.
+func ExternalModuleFolders(settings map[string]interface{}) []string {
+	folders := []string{"node_modules"}
+	if settings == nil {
+		return folders
+	}
+
+	raw, ok := settings["import/external-module-folders"]
+	if !ok {
+		return folders
+	}
+
+	switch typed := raw.(type) {
+	case []string:
+		return append([]string{}, typed...)
+	case []interface{}:
+		result := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if folder, ok := item.(string); ok && folder != "" {
+				result = append(result, folder)
+			}
+		}
+		if len(result) > 0 {
+			return result
+		}
+	}
+
+	return folders
+}
+
+// IsExternalModulePath reports whether a resolved path or unresolved bare
+// specifier should be treated as external by eslint-plugin-import rules.
+func IsExternalModulePath(settings map[string]interface{}, specifier string, resolvedPath string) bool {
+	for _, folder := range ExternalModuleFolders(settings) {
+		if pathContainsSegment(resolvedPath, folder) {
+			return true
+		}
+	}
+	return specifier != "" && !tspath.IsExternalModuleNameRelative(specifier) && resolvedPath == ""
+}
+
+func pathContainsSegment(fileName string, segment string) bool {
+	if fileName == "" || segment == "" {
+		return false
+	}
+	normalizedFileName := "/" + strings.Trim(tspath.NormalizePath(fileName), "/") + "/"
+	normalizedSegment := strings.Trim(tspath.NormalizeSlashes(segment), "/")
+	return strings.Contains(normalizedFileName, "/"+normalizedSegment+"/")
+}

--- a/internal/plugins/import/utils/external_test.go
+++ b/internal/plugins/import/utils/external_test.go
@@ -1,0 +1,65 @@
+package utils_test
+
+import (
+	"testing"
+
+	import_utils "github.com/web-infra-dev/rslint/internal/plugins/import/utils"
+)
+
+func TestIsExternalModulePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		settings     map[string]interface{}
+		specifier    string
+		resolvedPath string
+		want         bool
+	}{
+		{
+			name:         "resolved node_modules path",
+			specifier:    "external-package",
+			resolvedPath: "/repo/node_modules/external-package/index.d.ts",
+			want:         true,
+		},
+		{
+			name:      "unresolved bare specifier",
+			specifier: "external-package",
+			want:      true,
+		},
+		{
+			name:      "unresolved relative specifier",
+			specifier: "./local",
+			want:      false,
+		},
+		{
+			name:      "unresolved absolute path",
+			specifier: "/repo/src/local.ts",
+			want:      false,
+		},
+		{
+			name:         "ts path alias resolved inside project",
+			specifier:    "@cycles/alias-b",
+			resolvedPath: "/repo/src/no-cycle/alias-b.ts",
+			want:         false,
+		},
+		{
+			name:         "custom external module folder",
+			settings:     map[string]interface{}{"import/external-module-folders": []interface{}{"vendor"}},
+			specifier:    "@vendor/pkg",
+			resolvedPath: "/repo/vendor/pkg/index.ts",
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := import_utils.IsExternalModulePath(tt.settings, tt.specifier, tt.resolvedPath)
+			if got != tt.want {
+				t.Fatalf("IsExternalModulePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/plugins/import/utils/module_refs.go
+++ b/internal/plugins/import/utils/module_refs.go
@@ -1,0 +1,174 @@
+package utils
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type ModuleReferenceOptions struct {
+	ESModule bool
+	CommonJS bool
+	AMD      bool
+}
+
+type ModuleReference struct {
+	Source       *ast.Node
+	Importer     *ast.Node
+	SourceFile   *ast.SourceFile
+	Target       *ast.SourceFile
+	ResolvedPath string
+	Specifier    string
+	Dynamic      bool
+	OnlyTypes    bool
+}
+
+func CollectModuleReferences(ctx rule.RuleContext, sourceFile *ast.SourceFile, options ModuleReferenceOptions) []ModuleReference {
+	if ctx.Program == nil || sourceFile == nil {
+		return nil
+	}
+
+	var refs []ModuleReference
+	visitDescendants(sourceFile.AsNode(), func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+
+		switch node.Kind {
+		case ast.KindImportDeclaration, ast.KindJSImportDeclaration:
+			if !options.ESModule {
+				return
+			}
+			importDecl := node.AsImportDeclaration()
+			addModuleReference(ctx, sourceFile, &refs, importDecl.ModuleSpecifier, node, false, importDeclarationOnlyImportsTypes(importDecl))
+		case ast.KindExportDeclaration:
+			if !options.ESModule {
+				return
+			}
+			exportDecl := node.AsExportDeclaration()
+			// tsgo matches eslint-plugin-import here: only `export type * from`
+			// is exclusively type-only; named type re-exports still stay graph edges.
+			addModuleReference(ctx, sourceFile, &refs, exportDecl.ModuleSpecifier, node, false, ast.IsTypeOnlyImportOrExportDeclaration(node))
+		case ast.KindCallExpression:
+			collectCallModuleReferences(ctx, sourceFile, &refs, node.AsCallExpression(), options)
+		}
+	})
+
+	return refs
+}
+
+func collectCallModuleReferences(ctx rule.RuleContext, sourceFile *ast.SourceFile, refs *[]ModuleReference, call *ast.CallExpression, options ModuleReferenceOptions) {
+	if call == nil {
+		return
+	}
+
+	callee := ast.SkipParentheses(call.Expression)
+	if callee == nil {
+		return
+	}
+
+	if options.ESModule && callee.Kind == ast.KindImportKeyword {
+		if len(call.Arguments.Nodes) == 0 {
+			return
+		}
+		addModuleReference(ctx, sourceFile, refs, ast.SkipParentheses(call.Arguments.Nodes[0]), call.AsNode(), true, false)
+		return
+	}
+
+	if callee.Kind != ast.KindIdentifier {
+		return
+	}
+
+	calleeName := callee.AsIdentifier().Text
+	if options.CommonJS && ast.IsRequireCall(call.AsNode(), false) {
+		arg := ast.SkipParentheses(call.Arguments.Nodes[0])
+		if arg != nil && ast.IsStringLiteralLike(arg) {
+			addModuleReference(ctx, sourceFile, refs, arg, call.AsNode(), false, false)
+		}
+		return
+	}
+
+	if options.AMD && (calleeName == "require" || calleeName == "define") {
+		if len(call.Arguments.Nodes) == 0 {
+			return
+		}
+		arg := ast.SkipParentheses(call.Arguments.Nodes[0])
+		if arg == nil || arg.Kind != ast.KindArrayLiteralExpression {
+			return
+		}
+		for _, element := range arg.AsArrayLiteralExpression().Elements.Nodes {
+			element = ast.SkipParentheses(element)
+			if element == nil || !ast.IsStringLiteralLike(element) {
+				continue
+			}
+			addModuleReference(ctx, sourceFile, refs, element, call.AsNode(), false, false)
+		}
+	}
+}
+
+func addModuleReference(ctx rule.RuleContext, sourceFile *ast.SourceFile, refs *[]ModuleReference, source *ast.Node, importer *ast.Node, dynamic bool, onlyTypes bool) {
+	if source == nil {
+		return
+	}
+	source = ast.SkipParentheses(source)
+	if source == nil || !ast.IsStringLiteralLike(source) {
+		return
+	}
+
+	ref := ModuleReference{
+		Source:     source,
+		Importer:   importer,
+		SourceFile: sourceFile,
+		Specifier:  source.Text(),
+		Dynamic:    dynamic,
+		OnlyTypes:  onlyTypes,
+	}
+
+	ref.ResolvedPath, ref.Target, _ = ResolveModuleReferenceFromSourceFile(ctx, sourceFile, source)
+	if ref.Target != nil && IsImportPathIgnored(ctx.Settings, ref.Target.FileName()) {
+		return
+	}
+
+	*refs = append(*refs, ref)
+}
+
+func importDeclarationOnlyImportsTypes(importDecl *ast.ImportDeclaration) bool {
+	if importDecl == nil || importDecl.ImportClause == nil {
+		return false
+	}
+
+	importClause := importDecl.ImportClause
+	if importClause.IsTypeOnly() {
+		return true
+	}
+
+	clause := importClause.AsImportClause()
+	if clause == nil || clause.Name() != nil || clause.NamedBindings == nil {
+		return false
+	}
+
+	if clause.NamedBindings.Kind != ast.KindNamedImports {
+		return false
+	}
+	namedImports := clause.NamedBindings.AsNamedImports()
+	if namedImports == nil || namedImports.Elements == nil || len(namedImports.Elements.Nodes) == 0 {
+		return false
+	}
+
+	for _, specifier := range namedImports.Elements.Nodes {
+		if specifier == nil || specifier.Kind != ast.KindImportSpecifier || !ast.IsTypeOnlyImportDeclaration(specifier) {
+			return false
+		}
+	}
+	return true
+}
+
+func visitDescendants(node *ast.Node, visit func(*ast.Node)) {
+	if node == nil {
+		return
+	}
+	visit(node)
+	node.ForEachChild(func(child *ast.Node) bool {
+		visitDescendants(child, visit)
+		return false
+	})
+}

--- a/internal/plugins/import/utils/resolve.go
+++ b/internal/plugins/import/utils/resolve.go
@@ -2,16 +2,119 @@ package utils
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
 
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 func Resolve(moduleSpecifier *ast.StringLiteralLike, ctx rule.RuleContext) (string, bool) {
-	module := ctx.Program.GetResolvedModuleFromModuleSpecifier(ctx.SourceFile, moduleSpecifier)
+	return ResolveFromSourceFile(ctx, ctx.SourceFile, moduleSpecifier)
+}
 
-	if module != nil {
+// ResolveFromSourceFile resolves a module specifier using TypeScript's cached
+// resolution result for the provided origin file.
+func ResolveFromSourceFile(ctx rule.RuleContext, sourceFile *ast.SourceFile, moduleSpecifier *ast.StringLiteralLike) (string, bool) {
+	if ctx.Program == nil || sourceFile == nil || moduleSpecifier == nil || !ast.IsStringLiteralLike(moduleSpecifier) {
+		return "", false
+	}
+
+	module := ctx.Program.GetResolvedModuleFromModuleSpecifier(sourceFile, moduleSpecifier)
+	if module != nil && module.ResolvedFileName != "" {
 		return module.ResolvedFileName, true
 	}
 
 	return "", false
+}
+
+// ResolveSourceFileFromSourceFile resolves a module specifier and returns the
+// source file TypeScript associated with the resolved path.
+func ResolveSourceFileFromSourceFile(ctx rule.RuleContext, sourceFile *ast.SourceFile, moduleSpecifier *ast.StringLiteralLike) (string, *ast.SourceFile, bool) {
+	resolvedPath, ok := ResolveFromSourceFile(ctx, sourceFile, moduleSpecifier)
+	if !ok {
+		return "", nil, false
+	}
+
+	target := ctx.Program.GetSourceFileForResolvedModule(resolvedPath)
+	if target == nil {
+		return "", nil, false
+	}
+	return resolvedPath, target, true
+}
+
+// ResolveModuleReferenceFromSourceFile resolves lint graph edges. It first uses
+// TypeScript resolution, then falls back to already-loaded relative source files
+// for extension-substitution cases eslint-plugin-import still treats as edges.
+func ResolveModuleReferenceFromSourceFile(ctx rule.RuleContext, sourceFile *ast.SourceFile, moduleSpecifier *ast.StringLiteralLike) (string, *ast.SourceFile, bool) {
+	if ctx.Program == nil || sourceFile == nil || moduleSpecifier == nil || !ast.IsStringLiteralLike(moduleSpecifier) {
+		return "", nil, false
+	}
+
+	if resolvedPath, target, ok := ResolveSourceFileFromSourceFile(ctx, sourceFile, moduleSpecifier); ok {
+		return resolvedPath, target, true
+	}
+
+	specifier := moduleSpecifier.Text()
+	if specifier == "" || !tspath.IsExternalModuleNameRelative(specifier) {
+		return "", nil, false
+	}
+
+	basePath := specifier
+	if tspath.PathIsAbsolute(basePath) {
+		basePath = tspath.NormalizePath(basePath)
+	} else {
+		basePath = tspath.ResolvePath(tspath.GetDirectoryPath(sourceFile.FileName()), specifier)
+	}
+
+	for _, candidate := range moduleResolutionFallbackCandidates(basePath) {
+		if target := ctx.Program.GetSourceFile(candidate); target != nil {
+			return target.FileName(), target, true
+		}
+	}
+
+	return "", nil, false
+}
+
+func moduleResolutionFallbackCandidates(basePath string) []string {
+	ext := tspath.TryGetExtensionFromPath(basePath)
+	if ext != "" {
+		candidates := []string{basePath}
+		withoutExt := tspath.RemoveFileExtension(basePath)
+		switch ext {
+		case tspath.ExtensionJs:
+			candidates = append(candidates, withoutExt+tspath.ExtensionTs, withoutExt+tspath.ExtensionTsx, withoutExt+tspath.ExtensionDts)
+		case tspath.ExtensionJsx:
+			candidates = append(candidates, withoutExt+tspath.ExtensionTsx, withoutExt+tspath.ExtensionTs, withoutExt+tspath.ExtensionDts)
+		case tspath.ExtensionMjs:
+			candidates = append(candidates, withoutExt+tspath.ExtensionMts, withoutExt+tspath.ExtensionDmts, withoutExt+tspath.ExtensionTs)
+		case tspath.ExtensionCjs:
+			candidates = append(candidates, withoutExt+tspath.ExtensionCts, withoutExt+tspath.ExtensionDcts, withoutExt+tspath.ExtensionTs)
+		}
+		return candidates
+	}
+
+	return []string{
+		basePath,
+		basePath + tspath.ExtensionTs,
+		basePath + tspath.ExtensionTsx,
+		basePath + tspath.ExtensionMts,
+		basePath + tspath.ExtensionCts,
+		basePath + tspath.ExtensionJs,
+		basePath + tspath.ExtensionJsx,
+		basePath + tspath.ExtensionMjs,
+		basePath + tspath.ExtensionCjs,
+		basePath + tspath.ExtensionDts,
+		basePath + tspath.ExtensionDmts,
+		basePath + tspath.ExtensionDcts,
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionTs),
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionTsx),
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionMts),
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionCts),
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionJs),
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionJsx),
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionMjs),
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionCjs),
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionDts),
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionDmts),
+		tspath.CombinePaths(basePath, "index"+tspath.ExtensionDcts),
+	}
 }

--- a/internal/plugins/import/utils/resolve_test.go
+++ b/internal/plugins/import/utils/resolve_test.go
@@ -1,0 +1,39 @@
+package utils_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	import_utils "github.com/web-infra-dev/rslint/internal/plugins/import/utils"
+)
+
+func TestResolveSourceFileFromSourceFile(t *testing.T) {
+	t.Parallel()
+
+	ctx, specifier := contextForImport(t, "./bar")
+
+	resolvedPath, target, ok := import_utils.ResolveSourceFileFromSourceFile(ctx, ctx.SourceFile, specifier)
+	if !ok {
+		t.Fatal("ResolveSourceFileFromSourceFile() did not resolve ./bar")
+	}
+	if target == nil {
+		t.Fatal("ResolveSourceFileFromSourceFile() returned nil target")
+	}
+	if got := tspath.NormalizeSlashes(resolvedPath); !strings.HasSuffix(got, "/bar.ts") {
+		t.Fatalf("resolvedPath = %q, want suffix /bar.ts", resolvedPath)
+	}
+	if target.FileName() != resolvedPath {
+		t.Fatalf("target.FileName() = %q, want %q", target.FileName(), resolvedPath)
+	}
+}
+
+func TestResolveModuleReferenceFromSourceFileInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	ctx, _ := contextForImport(t, "./bar")
+
+	if resolvedPath, target, ok := import_utils.ResolveModuleReferenceFromSourceFile(ctx, ctx.SourceFile, nil); ok || resolvedPath != "" || target != nil {
+		t.Fatalf("ResolveModuleReferenceFromSourceFile(nil) = (%q, %#v, %v), want empty result", resolvedPath, target, ok)
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -130,6 +130,7 @@ export default defineConfig({
     './tests/eslint-plugin-import/rules/first.test.ts',
     './tests/eslint-plugin-import/rules/namespace.test.ts',
     './tests/eslint-plugin-import/rules/newline-after-import.test.ts',
+    './tests/eslint-plugin-import/rules/no-cycle.test.ts',
     './tests/eslint-plugin-import/rules/no-duplicates.test.ts',
     './tests/eslint-plugin-import/rules/no-self-import.test.ts',
     './tests/eslint-plugin-import/rules/no-mutable-exports.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/amd-depth-one.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/amd-depth-one.ts
@@ -1,0 +1,3 @@
+define(['./consumer'], () => ({}));
+
+export const amd = 1;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/commonjs-depth-one.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/commonjs-depth-one.ts
@@ -1,0 +1,3 @@
+const root = require('./consumer');
+
+export const common = root;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/consumer.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/consumer.ts
@@ -1,0 +1,2 @@
+export const rootValue = 1;
+export type RootType = string;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-one-dynamic.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-one-dynamic.ts
@@ -1,0 +1,2 @@
+export const dynamicDepthOne = () =>
+  import('./consumer').then(({ rootValue }) => rootValue);

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-one.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-one.ts
@@ -1,0 +1,3 @@
+import { rootValue } from './consumer';
+
+export const depthOne = rootValue;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-three-indirect.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-three-indirect.ts
@@ -1,0 +1,3 @@
+import './depth-two';
+
+export const depthThreeIndirect = 'side effects';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-three-star.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-three-star.ts
@@ -1,0 +1,3 @@
+import * as two from './depth-two';
+
+export { two };

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-three.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-three.ts
@@ -1,0 +1,3 @@
+import { depthTwo } from './depth-two';
+
+export const depthThree = depthTwo;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-two.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/depth-two.ts
@@ -1,0 +1,3 @@
+import { depthOne } from './depth-one';
+
+export const depthTwo = depthOne;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/dynamic-depth-one.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/dynamic-depth-one.ts
@@ -1,0 +1,3 @@
+export function loadRoot() {
+  return import('./consumer');
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/inline-type-only.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/inline-type-only.ts
@@ -1,0 +1,4 @@
+import { type RootType } from './consumer';
+
+export type InlineTypeOnly = RootType;
+export const inlineTypeOnly = 1;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/no-cycle.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/no-cycle.ts
@@ -1,0 +1,1 @@
+export const noCycle = 1;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/reexport-depth-one.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/reexport-depth-one.ts
@@ -1,0 +1,1 @@
+export { rootValue } from './consumer';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/reexport-type-only.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/reexport-type-only.ts
@@ -1,0 +1,1 @@
+export type { RootType } from './consumer';

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/type-only.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/fixtures/no-cycle-rule/type-only.ts
@@ -1,0 +1,4 @@
+import type { RootType } from './consumer';
+
+export type TypeOnly = RootType;
+export const typeOnly = 1;

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rules/no-cycle.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rules/no-cycle.test.ts
@@ -1,0 +1,284 @@
+import { test, testFixturePath } from '../utils.js';
+
+import { RuleTester } from '../rule-tester.js';
+
+const ruleTester = new RuleTester();
+// Rslint-Modified: we don't require rules
+// const rule = require('rules/no-cycle')
+const rule = null as never;
+// Rslint-Modified end
+
+const filename = testFixturePath('./no-cycle-rule/consumer.ts');
+const rootExports =
+  'export const rootValue = 1; export type RootType = string;';
+
+const errorDetected = {
+  message: 'Dependency cycle detected.',
+};
+
+const errorViaDepthOne = {
+  message: 'Dependency cycle via ./depth-one:1',
+};
+
+const errorViaTwoOne = {
+  message: 'Dependency cycle via ./depth-two:1=>./depth-one:1',
+};
+
+const valid = [
+  test({
+    code: `import { rootValue as other } from "./consumer"; ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `import foo from "./foo.js"; ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `import _ from "lodash"; ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `import foo from "@scope/foo"; ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: 'import { noCycle } from "./no-cycle"; export const rootValue = noCycle; export type RootType = string;',
+    filename,
+  }),
+  test({
+    code: `var _ = require("lodash"); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `var find = require("lodash.find"); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `var foo = require("./foo"); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `var foo = require("../foo"); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `var foo = require("foo"); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `var foo = require("./"); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `var foo = require("@scope/foo"); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `var bar = require("./bar/index"); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `var bar = require("./bar"); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `const common = require("./commonjs-depth-one"); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: `define(["./amd-depth-one"], () => ({})); ${rootExports}`,
+    filename,
+  }),
+  test({
+    code: 'import { depthTwo } from "./depth-two"; export const rootValue = depthTwo; export type RootType = string;',
+    filename,
+    options: [{ maxDepth: 1 }],
+  }),
+  test({
+    code: 'import { depthOne, depthTwo } from "./depth-two"; export const rootValue = depthOne || depthTwo; export type RootType = string;',
+    filename,
+    options: [{ maxDepth: 1 }],
+  }),
+  test({
+    code: `import("./depth-two").then(({ depthTwo }) => depthTwo); ${rootExports}`,
+    filename,
+    options: [{ maxDepth: 1 }],
+  }),
+  test({
+    code: 'import type { RootType as LocalType } from "./type-only"; export const rootValue = 1; export type RootType = string;',
+    filename,
+  }),
+  test({
+    code: 'import type { RootType as LocalType, TypeOnly } from "./type-only"; export const rootValue = 1; export type RootType = string;',
+    filename,
+  }),
+  test({
+    code: 'import { typeOnly } from "./type-only"; export const rootValue = typeOnly; export type RootType = string;',
+    filename,
+  }),
+  test({
+    code: 'import { inlineTypeOnly } from "./inline-type-only"; export const rootValue = inlineTypeOnly; export type RootType = string;',
+    filename,
+  }),
+  test({
+    code: `function bar(){ return import("./depth-one"); } ${rootExports}`,
+    filename,
+    options: [{ allowUnsafeDynamicCyclicDependency: true }],
+  }),
+  test({
+    code: 'import { dynamicDepthOne } from "./depth-one-dynamic"; export const rootValue = dynamicDepthOne; export type RootType = string;',
+    filename,
+    options: [{ allowUnsafeDynamicCyclicDependency: true }],
+  }),
+  test({
+    code: 'import { loadRoot } from "./dynamic-depth-one"; export const rootValue = loadRoot; export type RootType = string;',
+    filename,
+    options: [{ allowUnsafeDynamicCyclicDependency: true }],
+  }),
+  test({
+    code: 'import { depthOne } from "./depth-one"; export const rootValue = depthOne; export type RootType = string;',
+    filename,
+    options: [{ esmodule: false }],
+  }),
+];
+
+const invalid = [
+  test({
+    code: 'import { depthOne } from "./depth-one"; export const rootValue = depthOne; export type RootType = string;',
+    filename,
+    errors: [errorDetected],
+  }),
+  test({
+    code: 'import { depthOne } from "./depth-one"; export const rootValue = depthOne; export type RootType = string;',
+    filename,
+    options: [{}],
+    errors: [errorDetected],
+  }),
+  test({
+    code: 'import { depthOne } from "./depth-one"; export const rootValue = depthOne; export type RootType = string;',
+    filename,
+    options: [{ maxDepth: 1 }],
+    errors: [errorDetected],
+  }),
+  test({
+    code: `const { common } = require("./commonjs-depth-one"); ${rootExports}`,
+    filename,
+    options: [{ commonjs: true }],
+    errors: [errorDetected],
+  }),
+  test({
+    code: `require(["./amd-depth-one"], d1 => {}); ${rootExports}`,
+    filename,
+    options: [{ amd: true }],
+    errors: [errorDetected],
+  }),
+  test({
+    code: `define(["./amd-depth-one"], d1 => {}); ${rootExports}`,
+    filename,
+    options: [{ amd: true }],
+    errors: [errorDetected],
+  }),
+  test({
+    code: 'import { rootValue as reexported } from "./reexport-depth-one"; export const rootValue = reexported; export type RootType = string;',
+    filename,
+    errors: [errorDetected],
+  }),
+  test({
+    code: 'import { depthTwo } from "./depth-two"; export const rootValue = depthTwo; export type RootType = string;',
+    filename,
+    errors: [errorViaDepthOne],
+  }),
+  test({
+    code: 'import { depthTwo } from "./depth-two"; export const rootValue = depthTwo; export type RootType = string;',
+    filename,
+    options: [{ maxDepth: 2 }],
+    errors: [errorViaDepthOne],
+  }),
+  test({
+    code: 'const { depthTwo } = require("./depth-two"); export const rootValue = depthTwo; export type RootType = string;',
+    filename,
+    options: [{ commonjs: true }],
+    errors: [errorViaDepthOne],
+  }),
+  test({
+    code: 'import { two } from "./depth-three-star"; export const rootValue = two.depthTwo; export type RootType = string;',
+    filename,
+    errors: [errorViaTwoOne],
+  }),
+  test({
+    code: 'import one, { two, three } from "./depth-three-star"; export const rootValue = one || two || three; export type RootType = string;',
+    filename,
+    errors: [errorViaTwoOne],
+  }),
+  test({
+    code: 'import { depthThreeIndirect } from "./depth-three-indirect"; export const rootValue = depthThreeIndirect; export type RootType = string;',
+    filename,
+    errors: [errorViaTwoOne],
+  }),
+  test({
+    code: 'import { depthThree } from "./depth-three"; export const rootValue = depthThree; export type RootType = string;',
+    filename,
+    errors: [errorViaTwoOne],
+  }),
+  test({
+    code: 'import { depthTwo } from "./depth-two"; export const rootValue = depthTwo; export type RootType = string;',
+    filename,
+    options: [{ maxDepth: Infinity }],
+    errors: [errorViaDepthOne],
+  }),
+  test({
+    code: 'import { depthTwo } from "./depth-two"; export const rootValue = depthTwo; export type RootType = string;',
+    filename,
+    options: [{ maxDepth: '∞' }],
+    errors: [errorViaDepthOne],
+  }),
+  test({
+    code: `import("./depth-three-star"); ${rootExports}`,
+    filename,
+    errors: [errorViaTwoOne],
+  }),
+  test({
+    code: `import("./depth-three-indirect"); ${rootExports}`,
+    filename,
+    errors: [errorViaTwoOne],
+  }),
+  test({
+    code: `function bar(){ return import("./depth-one"); } ${rootExports}`,
+    filename,
+    errors: [errorDetected],
+  }),
+  test({
+    code: 'import { dynamicDepthOne } from "./depth-one-dynamic"; export const rootValue = dynamicDepthOne; export type RootType = string;',
+    filename,
+    errors: [errorDetected],
+  }),
+  test({
+    code: 'import { depthOne } from "./depth-one"; export const rootValue = depthOne; export type RootType = string;',
+    filename,
+    options: [{ allowUnsafeDynamicCyclicDependency: true }],
+    errors: [errorDetected],
+  }),
+  test({
+    code: `import "./reexport-type-only"; ${rootExports}`,
+    filename,
+    errors: [errorDetected],
+  }),
+];
+
+function withDisableScc<
+  T extends { code: string; options?: Record<string, unknown>[] },
+>(cases: T[]): T[] {
+  return cases.flatMap((item) => [
+    item,
+    {
+      ...item,
+      code: `${item.code} // disableScc=true`,
+      options: [{ ...(item.options?.[0] ?? {}), disableScc: true }],
+    },
+  ]);
+}
+
+ruleTester.run('no-cycle', rule, {
+  valid: withDisableScc(valid),
+  invalid: withDisableScc(invalid),
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -602,3 +602,5 @@ errrr
 supa
 Ändra
 Värde
+Dmts
+Dcts


### PR DESCRIPTION
## Summary

Port the `import/no-cycle` rule from `eslint-plugin-import` to rslint.

The implementation detects resolvable dependency paths that cycle back to the linted module, with support for `maxDepth`, `commonjs`, `amd`, `ignoreExternal`, `allowUnsafeDynamicCyclicDependency`, and TypeScript resolver edge cases.

## Related Links

- ESLint rule: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md
- Source code: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-cycle.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).