### PR TITLE
feat: port rule react-hooks/globals

### DIFF
--- a/internal/plugins/react_hooks/all.go
+++ b/internal/plugins/react_hooks/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/component_hook_factories"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/error_boundaries"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/exhaustive_deps"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/globals"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/rules_of_hooks"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -14,5 +15,6 @@ func GetAllRules() []rule.Rule {
 		exhaustive_deps.ExhaustiveDepsRule,
 		component_hook_factories.ComponentHookFactoriesRule,
 		error_boundaries.ErrorBoundariesRule,
+		globals.GlobalsRule,
 	}
 }

--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -350,19 +350,10 @@ func IsCompilerNonNode(node *ast.Node) bool {
 	return ast.IsBigIntLiteral(n)
 }
 
-// IsFunctionLikeContainer reports whether `node` is one of the
-// function-like kinds the upstream rules treat as a "code path"
-// boundary.
+// IsFunctionLikeContainer keeps the react-hooks shared API while delegating to
+// the repository-wide function-scope boundary helper.
 func IsFunctionLikeContainer(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
-		ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
-		return true
-	}
-	return false
+	return utils.IsFunctionLikeContainer(node)
 }
 
 // FindEnclosingFunction walks up from `node` and returns the nearest
@@ -496,11 +487,11 @@ func GetFunctionName(fn *ast.Node) *ast.Node {
 	return nil
 }
 
-// GetForwardRefOrMemoCallbackCall returns the CallExpression when `fn` is the
-// immediate argument of a call whose callee is `<name>` or `React.<name>`.
+// GetReactCallbackCall returns the CallExpression when `fn` is the immediate
+// argument of a call whose callee is `<name>` or `React.<name>`.
 // Parenthesized callback expressions are transparent: `memo((() => null))` is
 // the same callback shape as `memo(() => null)`.
-func GetForwardRefOrMemoCallbackCall(fn *ast.Node, name string) *ast.Node {
+func GetReactCallbackCall(fn *ast.Node, name string) *ast.Node {
 	if fn == nil {
 		return nil
 	}
@@ -532,6 +523,12 @@ func GetForwardRefOrMemoCallbackCall(fn *ast.Node, name string) *ast.Node {
 		return nil
 	}
 	return p
+}
+
+// GetForwardRefOrMemoCallbackCall is kept for existing callers that only check
+// React's `memo` / `forwardRef` callback shapes.
+func GetForwardRefOrMemoCallbackCall(fn *ast.Node, name string) *ast.Node {
+	return GetReactCallbackCall(fn, name)
 }
 
 // IsForwardRefOrMemoCallback reports whether `fn` is the immediate

--- a/internal/plugins/react_hooks/rules/globals/globals.go
+++ b/internal/plugins/react_hooks/rules/globals/globals.go
@@ -1,0 +1,488 @@
+package globals
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	globalReassignmentReason = "Cannot reassign variables declared outside of the component/hook"
+)
+
+type activeFunctionKind int
+
+const (
+	activeFunctionNone activeFunctionKind = iota
+	activeFunctionRoot
+	activeFunctionRenderCallback
+	activeFunctionHelper
+)
+
+type globalsState struct {
+	activeFunctions map[*ast.Node]activeFunctionKind
+}
+
+// GlobalsRule is the rslint port of upstream `react-hooks/globals`.
+var GlobalsRule = rule.Rule{
+	Name: "react-hooks/globals",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		state := &globalsState{
+			activeFunctions: make(map[*ast.Node]activeFunctionKind),
+		}
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				state.checkAssignment(ctx, node)
+			},
+		}
+	},
+}
+
+func (state *globalsState) checkAssignment(ctx rule.RuleContext, node *ast.Node) {
+	if node == nil || !ast.IsAssignmentExpression(node, false) {
+		return
+	}
+	binary := node.AsBinaryExpression()
+	if binary == nil || binary.OperatorToken == nil {
+		return
+	}
+	if ast.IsLogicalOrCoalescingAssignmentExpression(node) {
+		return
+	}
+	if utils.IsDefaultValueInDestructuringAssignment(node) {
+		return
+	}
+	targets := collectAssignmentTargets(binary.Left)
+	for _, target := range targets {
+		fn := react_hooksutil.FindEnclosingFunction(target.node)
+		if fn == nil || state.activeFunctionKind(fn) == activeFunctionNone {
+			continue
+		}
+		if state.isLocalToFunction(fn, target.node, target.name) {
+			continue
+		}
+		reportNode := target.node
+		if binary.OperatorToken.Kind != ast.KindEqualsToken {
+			// Upstream reports compound assignments over the whole assignment
+			// expression, while plain assignments point at the written binding.
+			reportNode = node
+		}
+		ctx.ReportNode(reportNode, buildGlobalReassignmentMessage(target.name))
+	}
+}
+
+func buildGlobalReassignmentMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "globalReassignment",
+		Description: fmt.Sprintf(
+			"Error: %s\n\nVariable `%s` is declared outside of the component/hook. Reassigning this value during render is a form of side effect, which can cause unpredictable behavior depending on when the component happens to re-render. If this variable is used in rendering, use useState instead. Otherwise, consider updating it in an effect. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render).",
+			globalReassignmentReason,
+			name,
+		),
+		Data: map[string]string{
+			"name": name,
+		},
+	}
+}
+
+type assignmentTarget struct {
+	node *ast.Node
+	name string
+}
+
+func collectAssignmentTargets(node *ast.Node) []assignmentTarget {
+	var targets []assignmentTarget
+	collectAssignmentTargetsInto(node, &targets)
+	return targets
+}
+
+func collectAssignmentTargetsInto(node *ast.Node, targets *[]assignmentTarget) {
+	if node == nil {
+		return
+	}
+	node = ast.SkipParentheses(node)
+	switch node.Kind {
+	case ast.KindIdentifier:
+		name := node.AsIdentifier().Text
+		if name != "" {
+			*targets = append(*targets, assignmentTarget{node: node, name: name})
+		}
+	case ast.KindObjectLiteralExpression:
+		obj := node.AsObjectLiteralExpression()
+		if obj == nil || obj.Properties == nil {
+			return
+		}
+		for _, prop := range obj.Properties.Nodes {
+			switch prop.Kind {
+			case ast.KindShorthandPropertyAssignment:
+				shorthand := prop.AsShorthandPropertyAssignment()
+				name := prop.Name()
+				if shorthand != nil && shorthand.ObjectAssignmentInitializer != nil && name != nil && name.Kind == ast.KindIdentifier {
+					*targets = append(*targets, assignmentTarget{node: prop, name: name.AsIdentifier().Text})
+					continue
+				}
+				collectAssignmentTargetsInto(name, targets)
+			case ast.KindPropertyAssignment:
+				assignment := prop.AsPropertyAssignment()
+				if assignment != nil {
+					collectAssignmentTargetsInto(assignment.Initializer, targets)
+				}
+			case ast.KindSpreadAssignment:
+				prop.ForEachChild(func(child *ast.Node) bool {
+					collectAssignmentTargetsInto(child, targets)
+					return false
+				})
+			}
+		}
+	case ast.KindArrayLiteralExpression:
+		node.ForEachChild(func(child *ast.Node) bool {
+			collectAssignmentTargetsInto(child, targets)
+			return false
+		})
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
+			left := ast.SkipParentheses(binary.Left)
+			if left != nil && left.Kind == ast.KindIdentifier {
+				name := left.AsIdentifier().Text
+				if name != "" {
+					*targets = append(*targets, assignmentTarget{node: node, name: name})
+				}
+				return
+			}
+			collectAssignmentTargetsInto(left, targets)
+		}
+	case ast.KindSpreadElement:
+		node.ForEachChild(func(child *ast.Node) bool {
+			collectAssignmentTargetsInto(child, targets)
+			return false
+		})
+	}
+}
+
+func (state *globalsState) activeFunctionKind(fn *ast.Node) activeFunctionKind {
+	if fn == nil {
+		return activeFunctionNone
+	}
+	if kind, ok := state.activeFunctions[fn]; ok {
+		return kind
+	}
+
+	kind := activeFunctionNone
+	if !isNonRenderCallback(fn) {
+		parentFn := react_hooksutil.FindEnclosingFunction(fn)
+		if parentFn == nil {
+			if isCompilerRenderFunction(fn) {
+				kind = activeFunctionRoot
+			}
+		} else {
+			parentKind := state.activeFunctionKind(parentFn)
+			if parentKind == activeFunctionRoot || parentKind == activeFunctionRenderCallback {
+				switch {
+				case isUseMemoCallback(fn):
+					kind = activeFunctionRenderCallback
+				case isImmediatelyCalled(fn):
+					kind = activeFunctionHelper
+				case state.isObjectHelperCalled(fn, parentFn):
+					kind = activeFunctionHelper
+				case state.isDirectlyCalledByName(fn, parentFn):
+					kind = activeFunctionHelper
+				case state.isReferencedAsJsxChild(fn, parentFn):
+					kind = activeFunctionHelper
+				case functionReturnsJsx(fn) && state.isPassedAsJsxProp(fn, parentFn):
+					kind = activeFunctionHelper
+				}
+			}
+		}
+	}
+
+	state.activeFunctions[fn] = kind
+	return kind
+}
+
+func isCompilerRenderFunction(fn *ast.Node) bool {
+	return react_hooksutil.GetCompilerReactFunctionType(fn, react_hooksutil.CompilerFunctionOptions{}) != ""
+}
+
+func isNonRenderCallback(fn *ast.Node) bool {
+	return isCallbackArgumentOf(fn, "useEffect", "useLayoutEffect", "useInsertionEffect", "useCallback")
+}
+
+func isUseMemoCallback(fn *ast.Node) bool {
+	return isCallbackArgumentOf(fn, "useMemo")
+}
+
+func isCallbackArgumentOf(fn *ast.Node, names ...string) bool {
+	for _, name := range names {
+		if react_hooksutil.GetReactCallbackCall(fn, name) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func isImmediatelyCalled(fn *ast.Node) bool {
+	return ast.GetImmediatelyInvokedFunctionExpression(fn) != nil
+}
+
+func (state *globalsState) isObjectHelperCalled(fn *ast.Node, parentFn *ast.Node) bool {
+	name := objectLiteralRootBindingName(fn)
+	if name == "" {
+		return false
+	}
+	found := false
+	walkRenderParentBody(parentFn, func(node *ast.Node) bool {
+		if node.Kind != ast.KindCallExpression {
+			return false
+		}
+		call := node.AsCallExpression()
+		if memberExpressionRootIdentifier(call.Expression) == name {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+func objectLiteralRootBindingName(fn *ast.Node) string {
+	child := fn
+	for parent := fn.Parent; parent != nil; parent = parent.Parent {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression:
+			child = parent
+		case ast.KindPropertyAssignment:
+			assignment := parent.AsPropertyAssignment()
+			if assignment == nil || assignment.Initializer != child {
+				return ""
+			}
+			child = parent
+		case ast.KindObjectLiteralExpression:
+			child = parent
+		case ast.KindVariableDeclaration:
+			decl := parent.AsVariableDeclaration()
+			if decl == nil || decl.Initializer != child {
+				return ""
+			}
+			return identifierName(parent.Name())
+		case ast.KindBinaryExpression:
+			binary := parent.AsBinaryExpression()
+			if binary == nil || binary.OperatorToken == nil || binary.OperatorToken.Kind != ast.KindEqualsToken || binary.Right != child {
+				return ""
+			}
+			return identifierName(ast.SkipParentheses(binary.Left))
+		default:
+			return ""
+		}
+	}
+	return ""
+}
+
+func memberExpressionRootIdentifier(node *ast.Node) string {
+	node = ast.SkipParentheses(node)
+	if node == nil || !ast.IsAccessExpression(node) {
+		return ""
+	}
+	for node != nil && ast.IsAccessExpression(node) {
+		node = utils.AccessExpressionObject(node)
+		node = ast.SkipParentheses(node)
+	}
+	if node != nil && node.Kind == ast.KindIdentifier {
+		return node.AsIdentifier().Text
+	}
+	return ""
+}
+
+func identifierName(node *ast.Node) string {
+	if node == nil || node.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return node.AsIdentifier().Text
+}
+
+func (state *globalsState) isDirectlyCalledByName(fn *ast.Node, parentFn *ast.Node) bool {
+	name := functionIdentifierName(fn)
+	if name == "" {
+		return false
+	}
+	found := false
+	walkRenderParentBody(parentFn, func(node *ast.Node) bool {
+		if node.Kind != ast.KindCallExpression {
+			return false
+		}
+		call := node.AsCallExpression()
+		callee := ast.SkipParentheses(call.Expression)
+		if callee != nil && callee.Kind == ast.KindIdentifier && callee.AsIdentifier().Text == name {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+func (state *globalsState) isReferencedAsJsxChild(fn *ast.Node, parentFn *ast.Node) bool {
+	name := functionIdentifierName(fn)
+	if name == "" {
+		return false
+	}
+	found := false
+	walkRenderParentBody(parentFn, func(node *ast.Node) bool {
+		if node.Kind != ast.KindJsxExpression {
+			return false
+		}
+		if node.Parent != nil && ast.IsJsxAttributeLike(node.Parent) {
+			return false
+		}
+		expr := ast.SkipParentheses(node.AsJsxExpression().Expression)
+		if expr != nil && expr.Kind == ast.KindIdentifier && expr.AsIdentifier().Text == name {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+func (state *globalsState) isPassedAsJsxProp(fn *ast.Node, parentFn *ast.Node) bool {
+	name := functionIdentifierName(fn)
+	if name == "" {
+		return false
+	}
+	found := false
+	walkRenderParentBody(parentFn, func(node *ast.Node) bool {
+		if node.Kind != ast.KindJsxExpression || node.Parent == nil || !ast.IsJsxAttributeLike(node.Parent) {
+			return false
+		}
+		expr := ast.SkipParentheses(node.AsJsxExpression().Expression)
+		if expr != nil && expr.Kind == ast.KindIdentifier && expr.AsIdentifier().Text == name {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+func functionIdentifierName(fn *ast.Node) string {
+	name := react_hooksutil.GetFunctionName(fn)
+	if name == nil {
+		return ""
+	}
+	name = ast.SkipParentheses(name)
+	if name.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return name.AsIdentifier().Text
+}
+
+func walkRenderParentBody(fn *ast.Node, visit func(*ast.Node) bool) {
+	body := react_hooksutil.GetFunctionBody(fn)
+	if body == nil {
+		return
+	}
+	var walk func(*ast.Node) bool
+	walk = func(node *ast.Node) bool {
+		if node == nil {
+			return false
+		}
+		if node != body && utils.IsFunctionLikeContainer(node) {
+			return false
+		}
+		if visit(node) {
+			return true
+		}
+		stop := false
+		node.ForEachChild(func(child *ast.Node) bool {
+			if walk(child) {
+				stop = true
+				return true
+			}
+			return false
+		})
+		return stop
+	}
+	walk(body)
+}
+
+func functionReturnsJsx(fn *ast.Node) bool {
+	body := react_hooksutil.GetFunctionBody(fn)
+	if body == nil {
+		return false
+	}
+	if body.Kind != ast.KindBlock {
+		return containsJsx(body)
+	}
+	found := false
+	var walk func(*ast.Node) bool
+	walk = func(node *ast.Node) bool {
+		if node == nil {
+			return false
+		}
+		if node != body && utils.IsFunctionLikeContainer(node) {
+			return false
+		}
+		if node.Kind == ast.KindReturnStatement {
+			ret := node.AsReturnStatement()
+			if ret != nil && ret.Expression != nil && containsJsx(ret.Expression) {
+				found = true
+				return true
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			return walk(child)
+		})
+		return found
+	}
+	walk(body)
+	return found
+}
+
+func containsJsx(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	found := false
+	var walk func(*ast.Node) bool
+	walk = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		switch n.Kind {
+		case ast.KindJsxElement, ast.KindJsxSelfClosingElement, ast.KindJsxFragment:
+			found = true
+			return true
+		}
+		if n != node && utils.IsFunctionLikeContainer(n) {
+			return false
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			return walk(child)
+		})
+		return found
+	}
+	walk(node)
+	return found
+}
+
+func (state *globalsState) isLocalToFunction(fn *ast.Node, target *ast.Node, name string) bool {
+	if fn == nil || target == nil || name == "" {
+		return false
+	}
+	if fn.Kind == ast.KindFunctionExpression {
+		if fnName := fn.Name(); fnName != nil && fnName.Kind == ast.KindIdentifier && fnName.AsIdentifier().Text == name {
+			return true
+		}
+	}
+	if utils.HasShadowingParameter(fn, name) {
+		return true
+	}
+	body := react_hooksutil.GetFunctionBody(fn)
+	if body != nil && utils.HasHoistedVarDeclaration(body, name) {
+		return true
+	}
+	return utils.IsNameShadowedBetween(target, fn, name)
+}

--- a/internal/plugins/react_hooks/rules/globals/globals.md
+++ b/internal/plugins/react_hooks/rules/globals/globals.md
@@ -1,0 +1,70 @@
+# globals
+
+Prevents assignments to variables that are declared outside a React component
+or Hook while React is rendering.
+
+## Rule Details
+
+Validates against reassigning variables declared outside of a component or Hook
+during render.
+
+The rule checks assignments in the component or Hook body and in helper
+functions that are called during render, such as direct helper calls,
+`useMemo` callbacks, JSX children, and render-prop helpers that return JSX.
+Event handlers, effect callbacks, and `useCallback` callbacks are not render
+execution for this rule.
+
+Property writes such as `window.location.href = value` are not reported by this
+rule; those mutations are handled by React's immutability lint.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+let moduleLocal;
+
+function Component() {
+  moduleLocal = true;
+  return <div />;
+}
+```
+
+```javascript
+function Component() {
+  const update = () => {
+    someGlobal = true;
+  };
+
+  update();
+  return <div />;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function Component() {
+  let local;
+  local = true;
+  return <div />;
+}
+```
+
+```javascript
+function Component() {
+  const onClick = () => {
+    someGlobal = true;
+  };
+
+  return <button onClick={onClick} />;
+}
+```
+
+## Differences from ESLint
+
+- Files that use Flow component or hook syntax are not analyzed because rslint
+  does not parse those declarations.
+
+## Original Documentation
+
+- [react.dev - globals](https://react.dev/reference/eslint-plugin-react-hooks/lints/globals)
+- [Source code](https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts)

--- a/internal/plugins/react_hooks/rules/globals/globals_extras_test.go
+++ b/internal/plugins/react_hooks/rules/globals/globals_extras_test.go
@@ -1,0 +1,515 @@
+package globals
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestGlobalsExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the
+// specific branch / Dimension 4 row it covers, so future refactors can't
+// silently regress them without breaking a named lock-in.
+
+func globalsError(name string, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "globalReassignment",
+		Message:   buildGlobalReassignmentMessage(name).Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func TestGlobalsExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Dimension 4: parenthesized property mutation remains outside globals. ----
+		{Code: `
+function Component() {
+  (window).location.href = "/";
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: element access mutation remains outside globals. ----
+		{Code: `
+function Component() {
+  window["location"] = {};
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: empty destructuring target degrades gracefully. ----
+		{Code: `
+function Component(props) {
+  [] = props.items;
+  ({}) = props;
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Scope: same-block lexical bindings are local, even before declaration. ----
+		{Code: `
+function Component() {
+  someGlobal = true;
+  let someGlobal;
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Scope: nested block lexical bindings are local to assignments in that block. ----
+		{Code: `
+function Component() {
+  {
+    let someGlobal;
+    someGlobal = true;
+  }
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Scope: var declarations hoist from nested blocks to the component body. ----
+		{Code: `
+function Component() {
+  someGlobal = true;
+  if (cond) {
+    var someGlobal;
+  }
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Scope: named function expression's own name is local to its body. ----
+		{Code: `
+const wrapper = function Foo() {
+  Foo = true;
+  return <div />;
+};
+		`, Tsx: true},
+		// ---- Scope: destructured parameters are local to the component body. ----
+		{Code: `
+function Component({someGlobal}) {
+  someGlobal = true;
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: update expressions are intentionally unmatched. ----
+		{Code: `
+function Component() {
+  ((someGlobal))++;
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Official ESLint: logical assignment operators are not reported by globals. ----
+		{Code: `
+function Component() {
+  a ||= true;
+  b &&= true;
+  c ??= true;
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Official ESLint with @typescript-eslint/parser: TS wrappers are not globals targets. ----
+		{Code: `
+type Flag = boolean;
+function Component() {
+  (someGlobal as any) = true;
+  someOtherGlobal! = true;
+  (thirdGlobal satisfies Flag) = true;
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: map callbacks are not render helpers for this rule. ----
+		{Code: `
+function Component({items}) {
+  return items.map(item => {
+    someGlobal = true;
+    return <div key={item} />;
+  });
+}
+		`, Tsx: true},
+		// ---- Real-user: facebook/react#34776 event handler global property write is not globals. ----
+		{Code: `
+function Link({isHashLink, to}) {
+  const go = () => {
+    if (isHashLink) {
+      window.location.hash = to;
+    }
+  };
+  return <button onClick={go} />;
+}
+		`, Tsx: true},
+		// ---- Real-user: facebook/react#31630 effect helper may write outside render. ----
+		{Code: `
+function Component() {
+  useEffect(() => {
+    writeAfterRender();
+  });
+  function writeAfterRender() {
+    someGlobal = true;
+  }
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Real-user: facebook/react#31544 process property writes in callbacks are not globals. ----
+		{Code: `
+function Component() {
+  const cb = useCallback(() => {
+    process.exitCode = 1;
+  }, []);
+  return <button onClick={cb} />;
+}
+		`, Tsx: true},
+		// Locks in upstream active helper arm: helpers do not activate second-level helpers.
+		{Code: `
+function Component() {
+  function foo() {
+    function bar() {
+      someGlobal = true;
+    }
+    bar();
+  }
+  foo();
+  return <div />;
+}
+		`, Tsx: true},
+		// Locks in upstream non-render callback arm: helpers inside useCallback stay inactive.
+		{Code: `
+function Component() {
+  const cb = useCallback(() => {
+    const helper = () => {
+      someGlobal = true;
+    };
+    helper();
+  });
+  return <div onClick={cb} />;
+}
+		`, Tsx: true},
+		// Locks in upstream object-literal helper arm: unrelated member calls do not activate local functions.
+		{Code: `
+function Component() {
+  const foo = () => {
+    someGlobal = true;
+  };
+  other.foo();
+  return <div />;
+}
+		`, Tsx: true},
+		// Locks in upstream non-render callback arm for React.useCallback namespace calls.
+		{Code: `
+function Component() {
+  React.useCallback(() => {
+    someGlobal = true;
+  }, []);
+  return <div />;
+}
+		`, Tsx: true},
+		// N/A: private keys, computed property names, class members, and overload
+		// signatures are not assignment targets for react-hooks/globals.
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: parenthesized identifier assignment target. ----
+		{
+			Code: `
+function Component() {
+  (someGlobal) = true;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 3, 4, 3, 14),
+			},
+		},
+		// ---- Dimension 4: array destructuring assignment target. ----
+		{
+			Code: `
+function Component(props) {
+  [x] = props.items;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("x", 3, 4, 3, 5),
+			},
+		},
+		// ---- Dimension 4: object destructuring alias assignment target. ----
+		{
+			Code: `
+function Component(props) {
+  ({value: x} = props);
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("x", 3, 12, 3, 13),
+			},
+		},
+		// ---- Dimension 4: nested destructuring targets include defaults and rest elements. ----
+		{
+			Code: `
+function Component(props) {
+  ({items: [first = fallback, ...rest], meta: {value}} = props);
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("first", 3, 13, 3, 29),
+				globalsError("rest", 3, 34, 3, 38),
+				globalsError("value", 3, 48, 3, 53),
+			},
+		},
+		// ---- Dimension 4: object destructuring defaults report the default assignment range. ----
+		{
+			Code: `
+function Component(props) {
+  ({x = 1, y: z = 2} = props);
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("x", 3, 5, 3, 10),
+				globalsError("z", 3, 15, 3, 20),
+			},
+		},
+		// ---- Dimension 4: compound assignment reports the full assignment expression. ----
+		{
+			Code: `
+function Component() {
+  x += 1;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("x", 3, 3, 3, 9),
+			},
+		},
+		// ---- Official ESLint: chained plain assignments report each written binding. ----
+		{
+			Code: `
+function Component() {
+  a = b = true;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("a", 3, 3, 3, 4),
+				globalsError("b", 3, 7, 3, 8),
+			},
+		},
+		// ---- Scope: sibling block lexical declarations do not make a name local here. ----
+		{
+			Code: `
+function Component() {
+  someGlobal = true;
+  { let someGlobal; }
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 3, 3, 3, 13),
+			},
+		},
+		// ---- Scope: function declaration names belong to the outer scope. ----
+		{
+			Code: `
+function Component() {
+  Component = true;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("Component", 3, 3, 3, 12),
+			},
+		},
+		// ---- Scope: component variables are declared outside the render body. ----
+		{
+			Code: `
+const Component = () => {
+  Component = true;
+  return <div />;
+};
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("Component", 3, 3, 3, 12),
+			},
+		},
+		// ---- Dimension 4: IIFE runs during render. ----
+		{
+			Code: `
+function Component() {
+  (() => {
+    someGlobal = true;
+  })();
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 4, 5, 4, 15),
+			},
+		},
+		// Locks in upstream JSX prop render-helper arm: returning JSX makes a prop callback render-time.
+		{
+			Code: `
+function Component() {
+  const renderItem = item => {
+    someGlobal = true;
+    return <Item item={item} />;
+  };
+  return <ItemList renderItem={renderItem} />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 4, 5, 4, 15),
+			},
+		},
+		// Locks in upstream compiler root arm: hook call makes a hook-like function render-time.
+		{
+			Code: `
+function useFoo(props) {
+  useState();
+  x = props;
+  return {x};
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("x", 4, 3, 4, 4),
+			},
+		},
+		// Locks in upstream useMemo callback arm: direct helper inside useMemo is checked.
+		{
+			Code: `
+function Component() {
+  useMemo(() => {
+    const helper = () => {
+      someGlobal = true;
+    };
+    helper();
+    return 1;
+  });
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 5, 7, 5, 17),
+			},
+		},
+		// Locks in upstream object-literal helper arm: called object helpers run during render.
+		{
+			Code: `
+function Component() {
+  const helpers = {
+    foo: () => {
+      someGlobal = true;
+    },
+  };
+  helpers.foo();
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 5, 7, 5, 17),
+			},
+		},
+		// Locks in upstream object-literal helper arm: any member call of the object is conservative.
+		{
+			Code: `
+function Component() {
+  const helpers = {
+    foo: () => {
+      someGlobal = true;
+    },
+  };
+  helpers.bar();
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 5, 7, 5, 17),
+			},
+		},
+		// Locks in upstream object-literal helper arm: nested helper objects still attach to the root binding.
+		{
+			Code: `
+function Component() {
+  const helpers = {
+    nested: {
+      foo: () => {
+        someGlobal = true;
+      },
+    },
+  };
+  helpers.nested.foo();
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 6, 9, 6, 19),
+			},
+		},
+		// Locks in upstream useMemo callback arm for React.useMemo namespace calls.
+		{
+			Code: `
+function Component() {
+  React.useMemo(() => {
+    someGlobal = true;
+    return 1;
+  }, []);
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 4, 5, 4, 15),
+			},
+		},
+		// Locks in upstream compiler root arm: React.memo callbacks are components.
+		{
+			Code: `
+export default React.memo(function Component() {
+  someGlobal = true;
+  return <div />;
+});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 3, 3, 3, 13),
+			},
+		},
+		// Locks in upstream JSX prop render-helper arm with conditional JSX returns.
+		{
+			Code: `
+function Component() {
+  const renderItem = item => {
+    someGlobal = true;
+    return item ? <Item item={item} /> : null;
+  };
+  return <ItemList renderItem={renderItem} />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				globalsError("someGlobal", 4, 5, 4, 15),
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &GlobalsRule,
+		valid,
+		invalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/globals/globals_upstream_test.go
+++ b/internal/plugins/react_hooks/rules/globals/globals_upstream_test.go
@@ -1,0 +1,264 @@
+package globals
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestGlobalsUpstream migrates the react-hooks/globals cases from upstream
+// React Compiler fixtures and official ESLint behavior 1:1. Position
+// assertions cover line/column for every invalid case. rslint-specific
+// lock-in cases live in globals_extras_test.go.
+
+func upstreamGlobalsError(name string, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "globalReassignment",
+		Message:   buildGlobalReassignmentMessage(name).Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func TestGlobalsUpstream(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Upstream fixture: allow-reassignment-to-global-function-jsx-prop.js. ----
+		{Code: `
+function Component() {
+  const onClick = () => {
+    someUnknownGlobal = true;
+    moduleLocal = true;
+  };
+  return <div onClick={onClick} />;
+}
+		`, Tsx: true},
+		// ---- Upstream fixture: globals-Boolean.js. ----
+		{Code: `
+function Component(props) {
+  const x = {};
+  const y = Boolean(x);
+  return [x, y];
+}
+		`, Tsx: true},
+		// ---- Upstream fixture: globals-Number.js. ----
+		{Code: `
+function Component(props) {
+  const x = {};
+  const y = Number(x);
+  return [x, y];
+}
+		`, Tsx: true},
+		// ---- Upstream fixture: globals-String.js. ----
+		{Code: `
+function Component(props) {
+  const x = {};
+  const y = String(x);
+  return [x, y];
+}
+		`, Tsx: true},
+		// ---- Upstream fixture: globals-dont-resolve-local-useState.js. ----
+		{Code: `
+import {useState as _useState, useCallback, useEffect} from 'react';
+
+function useState(value) {
+  const [state, setState] = _useState(value);
+  return [state, setState];
+}
+
+function Component() {
+  const [state, setState] = useState('hello');
+
+  return <div onClick={() => setState('goodbye')}>{state}</div>;
+}
+		`, Tsx: true},
+		// ---- Official ESLint: PascalCase without JSX or hook call is skipped. ----
+		{Code: `
+function Component() {
+  someUnknownGlobal = true;
+  return null;
+}
+		`, Tsx: true},
+		// ---- Official ESLint: local bindings can be reassigned. ----
+		{Code: `
+function Component() {
+  let moduleLocal;
+  moduleLocal = true;
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Official ESLint: parameters are local to the component. ----
+		{Code: `
+function Component(moduleLocal) {
+  moduleLocal = true;
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Official ESLint: property writes are handled by react-hooks/immutability, not globals. ----
+		{Code: `
+function Component() {
+  window.location.href = "/";
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Official ESLint: event callbacks do not run during render. ----
+		{Code: `
+function Component() {
+  const onClick = () => {
+    someGlobal = true;
+  };
+  return <button onClick={onClick} />;
+}
+		`, Tsx: true},
+		// ---- Official ESLint: effect callbacks do not run during render. ----
+		{Code: `
+function Component() {
+  useEffect(() => {
+    someGlobal = true;
+  });
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Official ESLint: useCallback callbacks do not run during render. ----
+		{Code: `
+function Component() {
+  useCallback(() => {
+    someGlobal = true;
+  });
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Official ESLint: update expressions are not reported by globals. ----
+		{Code: `
+function Component() {
+  someGlobal++;
+  ++otherGlobal;
+  return <div />;
+}
+		`, Tsx: true},
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- Upstream fixture: error.reassignment-to-global.js, adapted with JSX render marker. ----
+		{
+			Code: `
+function Component() {
+  someUnknownGlobal = true;
+  moduleLocal = true;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamGlobalsError("someUnknownGlobal", 3, 3, 3, 20),
+				upstreamGlobalsError("moduleLocal", 4, 3, 4, 14),
+			},
+		},
+		// ---- Upstream fixture: new-mutability/error.reassignment-to-global.js, adapted with JSX render marker. ----
+		{
+			Code: `
+// @enableNewMutationAliasingModel
+function Component() {
+  someUnknownGlobal = true;
+  moduleLocal = true;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamGlobalsError("someUnknownGlobal", 4, 3, 4, 20),
+				upstreamGlobalsError("moduleLocal", 5, 3, 5, 14),
+			},
+		},
+		// ---- Official ESLint: top-level module bindings are still outside the component. ----
+		{
+			Code: `
+let moduleLocal;
+function Component() {
+  moduleLocal = true;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamGlobalsError("moduleLocal", 4, 3, 4, 14),
+			},
+		},
+		// ---- Upstream fixture: error.reassignment-to-global-indirect.js, adapted with JSX render marker. ----
+		{
+			Code: `
+function Component() {
+  const foo = () => {
+    someUnknownGlobal = true;
+    moduleLocal = true;
+  };
+  foo();
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamGlobalsError("someUnknownGlobal", 4, 5, 4, 22),
+				upstreamGlobalsError("moduleLocal", 5, 5, 5, 16),
+			},
+		},
+		// ---- Upstream fixture: new-mutability/error.reassignment-to-global-indirect.js, adapted with JSX render marker. ----
+		{
+			Code: `
+// @enableNewMutationAliasingModel
+function Component() {
+  const foo = () => {
+    someUnknownGlobal = true;
+    moduleLocal = true;
+  };
+  foo();
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamGlobalsError("someUnknownGlobal", 5, 5, 5, 22),
+				upstreamGlobalsError("moduleLocal", 6, 5, 6, 16),
+			},
+		},
+		// ---- Upstream fixture: error.assign-global-in-jsx-children.js. ----
+		{
+			Code: `
+function Component() {
+  const foo = () => {
+    someGlobal = true;
+  };
+  return <Foo>{foo}</Foo>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamGlobalsError("someGlobal", 4, 5, 4, 15),
+			},
+		},
+		// ---- Official ESLint: useMemo callbacks run during render. ----
+		{
+			Code: `
+function Component() {
+  useMemo(() => {
+    someGlobal = true;
+    return 1;
+  });
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamGlobalsError("someGlobal", 4, 5, 4, 15),
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &GlobalsRule,
+		valid,
+		invalid,
+	)
+}

--- a/internal/rules/prefer_const/prefer_const.go
+++ b/internal/rules/prefer_const/prefer_const.go
@@ -852,7 +852,7 @@ func isStandaloneAssignment(identNode *ast.Node) bool {
 
 	// GetAssignmentTarget may return a default value's BinaryExpression
 	// (e.g. [x = 5] returns x=5, not [x=5]=[1]). If so, find the outer destructuring.
-	if target.Kind == ast.KindBinaryExpression && isDefaultValueInDestructuring(target) {
+	if utils.IsDefaultValueInDestructuringAssignment(target) {
 		target = ast.FindAncestor(target.Parent, func(n *ast.Node) bool {
 			return ast.IsDestructuringAssignment(n)
 		})
@@ -867,29 +867,4 @@ func isStandaloneAssignment(identNode *ast.Node) bool {
 		parent = parent.Parent
 	}
 	return parent != nil && parent.Kind == ast.KindExpressionStatement
-}
-
-// isDefaultValueInDestructuring checks if a BinaryExpression(=) node is a default
-// value inside a destructuring assignment target (e.g., x = 5 in [x = 5] = [1]
-// or val: x = 5 in ({val: x = 5} = {val: 1})).
-func isDefaultValueInDestructuring(node *ast.Node) bool {
-	parent := node.Parent
-	if parent == nil {
-		return false
-	}
-	switch parent.Kind {
-	case ast.KindArrayLiteralExpression:
-		// [x = 5] — default in array destructuring target
-		return utils.IsInDestructuringAssignment(parent)
-	case ast.KindPropertyAssignment:
-		// {val: x = 5} — default in object destructuring rename
-		pa := parent.AsPropertyAssignment()
-		if pa != nil && pa.Initializer == node {
-			return utils.IsInDestructuringAssignment(parent)
-		}
-	case ast.KindSpreadElement:
-		// [...x = 5] — unlikely but handle for completeness
-		return utils.IsInDestructuringAssignment(parent)
-	}
-	return false
 }

--- a/internal/utils/write_reference.go
+++ b/internal/utils/write_reference.go
@@ -96,7 +96,6 @@ func IsWriteReference(node *ast.Node) bool {
 		// ...x in object destructuring assignment context
 		return IsInDestructuringAssignment(parent)
 
-
 	case ast.KindForInStatement, ast.KindForOfStatement:
 		// for (x in obj) / for (x of arr) — x is a write target
 		stmt := parent.AsForInOrOfStatement()
@@ -192,4 +191,38 @@ func IsInDestructuringAssignment(node *ast.Node) bool {
 		current = current.Parent
 	}
 	return false
+}
+
+// IsDefaultValueInDestructuringAssignment checks whether node is a
+// BinaryExpression(=) used as a default value inside a destructuring assignment
+// target, such as `x = 5` in `[x = 5] = values` or `y = 5` in
+// `({x: y = 5} = value)`.
+func IsDefaultValueInDestructuringAssignment(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	binary := node.AsBinaryExpression()
+	if binary == nil || binary.OperatorToken == nil || binary.OperatorToken.Kind != ast.KindEqualsToken {
+		return false
+	}
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindArrayLiteralExpression:
+		return isArrayOrObjectDestructuringAssignmentPattern(parent)
+	case ast.KindPropertyAssignment:
+		assignment := parent.AsPropertyAssignment()
+		return assignment != nil &&
+			assignment.Initializer == node &&
+			isArrayOrObjectDestructuringAssignmentPattern(parent.Parent)
+	case ast.KindSpreadElement:
+		return isArrayOrObjectDestructuringAssignmentPattern(parent.Parent)
+	}
+	return false
+}
+
+func isArrayOrObjectDestructuringAssignmentPattern(node *ast.Node) bool {
+	return node != nil && ast.IsArrayLiteralOrObjectLiteralDestructuringPattern(node)
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -214,6 +214,7 @@ export default defineConfig({
     './tests/eslint-plugin-react-hooks/rules/exhaustive-deps.test.ts',
     './tests/eslint-plugin-react-hooks/rules/component-hook-factories.test.ts',
     './tests/eslint-plugin-react-hooks/rules/error-boundaries.test.ts',
+    './tests/eslint-plugin-react-hooks/rules/globals.test.ts',
 
     // eslint-plugin-jsx-a11y
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/globals.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/globals.test.ts
@@ -1,0 +1,232 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const globalMessage = (name: string) =>
+  `Error: Cannot reassign variables declared outside of the component/hook\n\nVariable \`${name}\` is declared outside of the component/hook. Reassigning this value during render is a form of side effect, which can cause unpredictable behavior depending on when the component happens to re-render. If this variable is used in rendering, use useState instead. Otherwise, consider updating it in an effect. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render).`;
+
+ruleTester.run('globals', {} as never, {
+  valid: [
+    {
+      code: `
+        function Component() {
+          const onClick = () => {
+            someUnknownGlobal = true;
+            moduleLocal = true;
+          };
+          return <div onClick={onClick} />;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component(props) {
+          const x = {};
+          const y = Boolean(x);
+          return [x, y];
+        }
+      `,
+    },
+    {
+      code: `
+        function Component(props) {
+          const x = {};
+          const y = Number(x);
+          return [x, y];
+        }
+      `,
+    },
+    {
+      code: `
+        function Component(props) {
+          const x = {};
+          const y = String(x);
+          return [x, y];
+        }
+      `,
+    },
+    {
+      code: `
+        import {useState as _useState, useCallback, useEffect} from 'react';
+
+        function useState(value) {
+          const [state, setState] = _useState(value);
+          return [state, setState];
+        }
+
+        function Component() {
+          const [state, setState] = useState('hello');
+
+          return <div onClick={() => setState('goodbye')}>{state}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          someUnknownGlobal = true;
+          return null;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          let moduleLocal;
+          moduleLocal = true;
+          return <div />;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component(moduleLocal) {
+          moduleLocal = true;
+          return <div />;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          window.location.href = "/";
+          return <div />;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          const onClick = () => {
+            someGlobal = true;
+          };
+          return <button onClick={onClick} />;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          useEffect(() => {
+            someGlobal = true;
+          });
+          return <div />;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          useCallback(() => {
+            someGlobal = true;
+          }, []);
+          return <div />;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          someGlobal++;
+          ++otherGlobal;
+          return <div />;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function Component() {
+          someUnknownGlobal = true;
+          moduleLocal = true;
+          return <div />;
+        }
+      `,
+      errors: [
+        { message: globalMessage('someUnknownGlobal') },
+        { message: globalMessage('moduleLocal') },
+      ],
+    },
+    {
+      code: `
+        // @enableNewMutationAliasingModel
+        function Component() {
+          someUnknownGlobal = true;
+          moduleLocal = true;
+          return <div />;
+        }
+      `,
+      errors: [
+        { message: globalMessage('someUnknownGlobal') },
+        { message: globalMessage('moduleLocal') },
+      ],
+    },
+    {
+      code: `
+        let moduleLocal;
+        function Component() {
+          moduleLocal = true;
+          return <div />;
+        }
+      `,
+      errors: [{ message: globalMessage('moduleLocal') }],
+    },
+    {
+      code: `
+        function Component() {
+          const foo = () => {
+            someUnknownGlobal = true;
+            moduleLocal = true;
+          };
+          foo();
+          return <div />;
+        }
+      `,
+      errors: [
+        { message: globalMessage('someUnknownGlobal') },
+        { message: globalMessage('moduleLocal') },
+      ],
+    },
+    {
+      code: `
+        // @enableNewMutationAliasingModel
+        function Component() {
+          const foo = () => {
+            someUnknownGlobal = true;
+            moduleLocal = true;
+          };
+          foo();
+          return <div />;
+        }
+      `,
+      errors: [
+        { message: globalMessage('someUnknownGlobal') },
+        { message: globalMessage('moduleLocal') },
+      ],
+    },
+    {
+      code: `
+        function Component() {
+          const foo = () => {
+            someGlobal = true;
+          };
+          return <Foo>{foo}</Foo>;
+        }
+      `,
+      errors: [{ message: globalMessage('someGlobal') }],
+    },
+    {
+      code: `
+        function Component() {
+          useMemo(() => {
+            someGlobal = true;
+            return 1;
+          }, []);
+          return <div />;
+        }
+      `,
+      errors: [{ message: globalMessage('someGlobal') }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port `react-hooks/globals` to rslint.

This adds the Go rule implementation, registration, docs, upstream fixture coverage, additional Go edge/branch coverage, and the JS integration test for the compiled CLI path.

## Related Links

- React docs: https://react.dev/reference/eslint-plugin-react-hooks/lints/globals
- Source code: https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Inference/InferMutationAliasingEffects.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
