### PR TITLE
feat: port rule import/no-default-export

### DIFF
--- a/internal/plugins/import/all.go
+++ b/internal/plugins/import/all.go
@@ -6,6 +6,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/namespace"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/newline_after_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_cycle"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_default_export"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_duplicates"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_mutable_exports"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_self_import"
@@ -20,6 +21,7 @@ func GetAllRules() []rule.Rule {
 		namespace.NamespaceRule,
 		newline_after_import.NewlineAfterImportRule,
 		no_cycle.NoCycleRule,
+		no_default_export.NoDefaultExportRule,
 		no_duplicates.NoDuplicatesRule,
 		no_mutable_exports.NoMutableExportsRule,
 		no_self_import.NoSelfImportRule,

--- a/internal/plugins/import/rules/no_default_export/no_default_export.go
+++ b/internal/plugins/import/rules/no_default_export/no_default_export.go
@@ -1,0 +1,147 @@
+package no_default_export
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func preferNamedMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferNamed",
+		Description: "Prefer named exports.",
+	}
+}
+
+func noAliasDefaultMessage(local string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "noAliasDefault",
+		Description: fmt.Sprintf(
+			"Do not alias `%s` as `default`. Just export `%s` itself instead.",
+			local,
+			local,
+		),
+	}
+}
+
+// See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-default-export.js
+var NoDefaultExportRule = rule.Rule{
+	Name: "import/no-default-export",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		reportDefaultExport := func(node *ast.Node) {
+			ctx.ReportRange(defaultKeywordRange(ctx.SourceFile, node), preferNamedMessage())
+		}
+
+		checkExportDeclaration := func(node *ast.Node) {
+			exportDecl := node.AsExportDeclaration()
+			if exportDecl == nil ||
+				exportDecl.ExportClause == nil ||
+				exportDecl.ExportClause.Kind != ast.KindNamedExports {
+				return
+			}
+
+			namedExports := exportDecl.ExportClause.AsNamedExports()
+			if namedExports == nil || namedExports.Elements == nil {
+				return
+			}
+
+			reportRange := tokenAfterExportKeywordRange(ctx.SourceFile, node)
+			for _, specifierNode := range namedExports.Elements.Nodes {
+				specifier := specifierNode.AsExportSpecifier()
+				if specifier == nil || !ast.ModuleExportNameIsDefault(specifier.Name()) {
+					continue
+				}
+
+				local := specifier.PropertyName
+				if local == nil {
+					local = specifier.Name()
+				}
+				ctx.ReportRange(reportRange, noAliasDefaultMessage(localNameForMessage(local)))
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindExportAssignment: func(node *ast.Node) {
+				exportAssignment := node.AsExportAssignment()
+				if exportAssignment == nil || exportAssignment.IsExportEquals {
+					return
+				}
+				reportDefaultExport(node)
+			},
+			ast.KindFunctionDeclaration: func(node *ast.Node) {
+				if isDefaultExportedDeclaration(node) {
+					reportDefaultExport(node)
+				}
+			},
+			ast.KindClassDeclaration: func(node *ast.Node) {
+				if isDefaultExportedDeclaration(node) {
+					reportDefaultExport(node)
+				}
+			},
+			ast.KindInterfaceDeclaration: func(node *ast.Node) {
+				if isDefaultExportedDeclaration(node) {
+					reportDefaultExport(node)
+				}
+			},
+			ast.KindEnumDeclaration: func(node *ast.Node) {
+				if isDefaultExportedDeclaration(node) {
+					reportDefaultExport(node)
+				}
+			},
+			ast.KindExportDeclaration: checkExportDeclaration,
+		}
+	},
+}
+
+func isDefaultExportedDeclaration(node *ast.Node) bool {
+	flags := node.ModifierFlags()
+	return flags&ast.ModifierFlagsExport != 0 && flags&ast.ModifierFlagsDefault != 0
+}
+
+func localNameForMessage(node *ast.Node) string {
+	if node != nil && (ast.IsIdentifier(node) || node.Kind == ast.KindDefaultKeyword) {
+		return node.Text()
+	}
+	return "undefined"
+}
+
+func defaultKeywordRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	token, ok := tokenAfterExportKeyword(sourceFile, node)
+	if ok && token.Kind == ast.KindDefaultKeyword {
+		return token.Range()
+	}
+
+	return utils.TrimNodeTextRange(sourceFile, node)
+}
+
+func tokenAfterExportKeywordRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	token, ok := tokenAfterExportKeyword(sourceFile, node)
+	if ok {
+		return token.Range()
+	}
+
+	return utils.TrimNodeTextRange(sourceFile, node)
+}
+
+// tokenAfterExportKeyword returns the first non-trivia token after a leading
+// `export` keyword. Upstream reports named default aliases on that token.
+func tokenAfterExportKeyword(sourceFile *ast.SourceFile, node *ast.Node) (utils.SourceToken, bool) {
+	if sourceFile == nil || node == nil {
+		return utils.SourceToken{}, false
+	}
+
+	exportToken, ok := utils.TokenAtOrAfter(sourceFile, node.Pos())
+	if !ok || exportToken.Start >= node.End() || exportToken.Kind != ast.KindExportKeyword {
+		return utils.SourceToken{}, false
+	}
+
+	next, ok := utils.TokenAtOrAfter(sourceFile, exportToken.End)
+	if !ok || next.Start >= node.End() {
+		return utils.SourceToken{}, false
+	}
+
+	return next, true
+}

--- a/internal/plugins/import/rules/no_default_export/no_default_export.md
+++ b/internal/plugins/import/rules/no_default_export/no_default_export.md
@@ -1,0 +1,29 @@
+# no-default-export
+
+## Rule Details
+
+Forbids default exports and default re-exports. Use named exports instead.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+export default function foo() {}
+
+const foo = "foo";
+export { foo as default };
+
+export { default } from "./foo";
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+export function foo() {}
+
+const foo = "foo";
+export { foo };
+```
+
+## Original Documentation
+
+https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md

--- a/internal/plugins/import/rules/no_default_export/no_default_export_extras_test.go
+++ b/internal/plugins/import/rules/no_default_export/no_default_export_extras_test.go
@@ -1,0 +1,283 @@
+package no_default_export_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_default_export"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	rslint_utils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// TestNoDefaultExportExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+func TestNoDefaultExportExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_default_export.NoDefaultExportRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: declaration forms, named function export is allowed ----
+			{Code: `export function foo() {}`},
+			// ---- Dimension 4: declaration forms, named class export is allowed ----
+			{Code: `export class Foo {}`},
+			// ---- Dimension 4: declaration forms, named interface/type exports are allowed ----
+			{Code: `export interface Foo {}`},
+			{Code: `export type Foo = string`},
+			{Code: `export enum Foo { A }`},
+			// ---- Dimension 4: access/key forms, non-default string export name is allowed ----
+			{Code: `const foo = 1; export { foo as "foo-bar" }`},
+			// ---- Dimension 4: access/key forms, re-exported default under a named export is allowed ----
+			{Code: `export { default as foo } from "./foo"`},
+			// ---- Dimension 4: access/key forms, namespace and star exports are allowed ----
+			{Code: `export * from "./foo"`},
+			{Code: `export * as ns from "./foo"`},
+			// ---- Dimension 4: receiver/expression wrappers N/A, export declarations have no receiver ----
+			// ---- Dimension 4: computed keys N/A, module export names are identifier/string literal only ----
+			// ---- Dimension 4: nesting/traversal boundaries, named exports inside ambient module are allowed ----
+			{Code: `declare module "pkg" { export const foo: string }`},
+			{Code: `namespace N { export const foo = 1 }`},
+			{Code: `declare module "pkg" { export { foo } from "foo" }`},
+			// ---- Dimension 4: graceful degradation, empty named export has no default specifier ----
+			{Code: `export {}`},
+			// ---- Dimension 4: graceful degradation, export equals is not a default export ----
+			{Code: `const foo = 1; export = foo`},
+			// Locks in upstream create() arm 1: CommonJS assignments are ignored.
+			{Code: `module.exports = { foo: 1 }`},
+			// Locks in upstream ExportNamedDeclaration arm 1: exported name is not default.
+			{Code: `const foo = 1; export { foo as bar }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: receiver/expression wrappers, parenthesized default expression still reports ----
+			{
+				Code: `const foo = 1; export default (foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 23, EndLine: 1, EndColumn: 30},
+				},
+			},
+			// ---- Dimension 4: receiver/expression wrappers, TS non-null expression still reports ----
+			{
+				Code: `const foo = 1; export default foo!`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 23, EndLine: 1, EndColumn: 30},
+				},
+			},
+			// ---- Dimension 4: receiver/expression wrappers, TS assertion expression still reports ----
+			{
+				Code: `const foo = 1; export default foo as string`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 23, EndLine: 1, EndColumn: 30},
+				},
+			},
+			// ---- Dimension 4: receiver/expression wrappers, TS satisfies expression still reports ----
+			{
+				Code: `const foo = "x"; export default foo satisfies string`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 25, EndLine: 1, EndColumn: 32},
+				},
+			},
+			// ---- Dimension 4: declaration forms, default interface export reports ----
+			{
+				Code: `export default interface Foo {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// ---- Dimension 4: declaration forms, default abstract class export reports ----
+			{
+				Code: `export default abstract class Foo {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// ---- Dimension 4: declaration forms, async generator default function reports ----
+			{
+				Code: `export default async function* foo() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// ---- Dimension 4: declaration forms, multiline default export reports at default ----
+			{
+				Code: "export\n  default class Foo {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 2, Column: 3, EndLine: 2, EndColumn: 10},
+				},
+			},
+			// ---- Dimension 4: declaration forms, leading comments before export are ignored for report location ----
+			{
+				Code: `/* leading */ export default function foo() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// ---- Dimension 4: declaration forms, comments between export and default are transparent ----
+			{
+				Code: `export /* comment */ default function foo() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// ---- Dimension 4: access/key forms, string-literal default export name reports ----
+			{
+				Code: `const foo = 1; export { foo as "default" }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAliasDefault", Message: noAliasDefaultMessage, Line: 1, Column: 23, EndLine: 1, EndColumn: 24},
+				},
+			},
+			// ---- Dimension 4: access/key forms, string-literal local name is preserved in alias message ----
+			{
+				Code: `export { "foo" as default } from "foo"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAliasDefault", Message: noAliasUndefinedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+			// ---- Dimension 4: access/key forms, string-literal default shorthand matches upstream local.name output ----
+			{
+				Code: `export { "default" } from "foo"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAliasDefault", Message: noAliasUndefinedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				},
+			},
+			// ---- Dimension 4: access/key forms, comments after export are ignored for named export location ----
+			{
+				Code: "const foo = 1;\nexport\n/* comment */\n{ foo as default }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAliasDefault", Message: noAliasDefaultMessage, Line: 4, Column: 1, EndLine: 4, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: access/key forms, shorthand default re-export reports ----
+			// ---- Real-user: import-js/eslint-plugin-import#3209 default re-exports are reported upstream ----
+			{
+				Code: `export { default } from "foo"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noAliasDefault",
+						Message:   noAliasDefaultDefaultMessage,
+						Line:      1,
+						Column:    8,
+						EndLine:   1,
+						EndColumn: 9,
+					},
+				},
+			},
+			// ---- Dimension 4: access/key forms, type-only default alias reports like upstream's generic specifier walk ----
+			{
+				Code: `type Foo = string; export type { Foo as default }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noAliasDefault",
+						Message:   "Do not alias `Foo` as `default`. Just export `Foo` itself instead.",
+						Line:      1,
+						Column:    27,
+						EndLine:   1,
+						EndColumn: 31,
+					},
+				},
+			},
+			// ---- Dimension 4: nesting/traversal boundaries, ambient module default export still reports ----
+			{
+				Code: `declare module "pkg" { export default Foo }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 31, EndLine: 1, EndColumn: 38},
+				},
+			},
+			// ---- Dimension 4: nesting/traversal boundaries, namespace default export reports ----
+			{
+				Code: `namespace N { export default Foo }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// ---- Dimension 4: nesting/traversal boundaries, nested namespace default export reports ----
+			{
+				Code: `namespace A { namespace B { export default Foo } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 36, EndLine: 1, EndColumn: 43},
+				},
+			},
+			// ---- Dimension 4: nesting/traversal boundaries, ambient module default re-export still reports ----
+			{
+				Code: `declare module "pkg" { export { default } from "foo" }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noAliasDefault",
+						Message:   noAliasDefaultDefaultMessage,
+						Line:      1,
+						Column:    31,
+						EndLine:   1,
+						EndColumn: 32,
+					},
+				},
+			},
+			// ---- Dimension 4: nesting/traversal boundaries, nested namespace alias default reports ----
+			{
+				Code: `namespace A { namespace B { export { foo as default } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAliasDefault", Message: noAliasDefaultMessage, Line: 1, Column: 36, EndLine: 1, EndColumn: 37},
+				},
+			},
+			// Locks in upstream ExportDefaultDeclaration arm: report direct default exports.
+			// ---- Real-user: import-js/eslint-plugin-import#889 proposed direct default export bad case ----
+			{
+				Code: `export default function foo() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// Locks in upstream ExportNamedDeclaration arm 2: ExportSpecifier exported as default uses alias message.
+			// ---- Real-user: import-js/eslint-plugin-import#889 proposed alias default bad case ----
+			{
+				Code: `function foo() {}; export {foo as default}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAliasDefault", Message: noAliasDefaultMessage, Line: 1, Column: 27, EndLine: 1, EndColumn: 28},
+				},
+			},
+			// Locks in upstream ExportNamedDeclaration filter: only exported default names are reported.
+			{
+				Code: `let foo, bar; export { foo as default, bar }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAliasDefault", Message: noAliasDefaultMessage, Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+		},
+	)
+}
+
+func TestNoDefaultExportSkippedBabelReExportSyntaxIsNotParsedByTsgo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code string
+	}{
+		{name: "default re-export", code: `export foo from "foo.js"`},
+		{name: "default plus named re-export", code: `export Memory, { MemoryValue } from './Memory'`},
+		{name: "default from shorthand", code: `export default from "foo.js"`},
+		{name: "default enum export", code: `export default enum Foo { A }`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rootDir := fixtures.GetRootDir()
+			fileName := "file.ts"
+			fs := rslint_utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), tc.code)
+			host := rslint_utils.CreateCompilerHost(rootDir, fs)
+			_, err := rslint_utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+			if err == nil {
+				t.Fatalf("expected tsgo parse error for %q", tc.code)
+			}
+			var syntacticError *rslint_utils.SyntacticError
+			if !errors.As(err, &syntacticError) {
+				t.Fatalf("expected *utils.SyntacticError for %q, got %T: %v", tc.code, err, err)
+			}
+		})
+	}
+}

--- a/internal/plugins/import/rules/no_default_export/no_default_export_upstream_test.go
+++ b/internal/plugins/import/rules/no_default_export/no_default_export_upstream_test.go
@@ -1,0 +1,116 @@
+package no_default_export_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_default_export"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	preferNamedMessage           = "Prefer named exports."
+	noAliasDefaultMessage        = "Do not alias `foo` as `default`. Just export `foo` itself instead."
+	noAliasUndefinedMessage      = "Do not alias `undefined` as `default`. Just export `undefined` itself instead."
+	noAliasDefaultDefaultMessage = "Do not alias `default` as `default`. Just export `default` itself instead."
+)
+
+// TestNoDefaultExportUpstream migrates the full valid/invalid suite from
+// upstream tests/src/rules/no-default-export.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// no_default_export_extras_test.go.
+func TestNoDefaultExportUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_default_export.NoDefaultExportRule,
+		[]rule_tester.ValidTestCase{
+			// ---- upstream valid: CommonJS is not an ES default export ----
+			{Code: `module.exports = function foo() {}`},
+			{Code: `module.exports = function foo() {}`},
+
+			// ---- upstream valid: named exports ----
+			{Code: "export const foo = 'foo';\nexport const bar = 'bar';"},
+			{Code: "export const foo = 'foo';\nexport function bar() {};"},
+			{Code: `export const foo = 'foo';`},
+			{Code: "const foo = 'foo';\nexport { foo };"},
+			{Code: `let foo, bar; export { foo, bar }`},
+			{Code: `export const { foo, bar } = item;`},
+			{Code: `export const { foo, bar: baz } = item;`},
+			{Code: `export const { foo: { bar, baz } } = item;`},
+			{Code: "let item;\nexport const foo = item;\nexport { item };"},
+			{Code: `export * from './foo';`},
+			{Code: `export const { foo } = { foo: "bar" };`},
+			{Code: `export const { foo: { bar } } = { foo: { bar: "baz" } };`},
+			{Code: `export { a, b } from "foo.js"`},
+
+			// ---- upstream valid: no exports at all ----
+			{Code: `import * as foo from './foo';`},
+			{Code: `import foo from './foo';`},
+			{Code: `import {default as foo} from './foo';`},
+
+			// ---- upstream valid: type exports and unsupported Babel proposal syntax ----
+			{Code: `export type UserId = number;`},
+			// SKIP: rslint does not parse Babel's default re-export proposal `export foo from`.
+			{Code: `export foo from "foo.js"`, Skip: true},
+			// SKIP: rslint does not parse Babel's default re-export proposal `export foo, { bar } from`.
+			{Code: `export Memory, { MemoryValue } from './Memory'`, Skip: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- upstream invalid: direct default exports ----
+			{
+				Code: `export default function bar() {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code: "export const foo = 'foo';\nexport default bar;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 2, Column: 8, EndLine: 2, EndColumn: 15},
+				},
+			},
+			{
+				Code: `export default class Bar {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code: `export default function() {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code: `export default class {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed", Message: preferNamedMessage, Line: 1, Column: 8, EndLine: 1, EndColumn: 15},
+				},
+			},
+
+			// ---- upstream invalid: aliasing a local export as default ----
+			{
+				Code: `let foo; export { foo as default }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAliasDefault", Message: noAliasDefaultMessage, Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+			// SKIP: rslint does not parse Babel's default re-export proposal `export default from`.
+			{
+				Code: `export default from "foo.js"`,
+				Skip: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferNamed"},
+				},
+			},
+			{
+				Code: `let foo; export { foo as "default" }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noAliasDefault", Message: noAliasDefaultMessage, Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/tokens.go
+++ b/internal/utils/tokens.go
@@ -5,6 +5,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 )
 
@@ -13,6 +14,11 @@ type SourceToken struct {
 	Kind       ast.Kind
 	Start, End int
 	Text       string
+}
+
+// Range returns the token's source span.
+func (t SourceToken) Range() core.TextRange {
+	return core.NewTextRange(t.Start, t.End)
 }
 
 // TokensOfNode returns all parser tokens contained in node, in source order.

--- a/internal/utils/tokens_test.go
+++ b/internal/utils/tokens_test.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+func TestSourceTokenRange(t *testing.T) {
+	token := SourceToken{Kind: ast.KindIdentifier, Start: 3, End: 8, Text: "value"}
+	r := token.Range()
+	if r.Pos() != token.Start || r.End() != token.End {
+		t.Fatalf("Range() = [%d,%d), want [%d,%d)", r.Pos(), r.End(), token.Start, token.End)
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -131,6 +131,7 @@ export default defineConfig({
     './tests/eslint-plugin-import/rules/namespace.test.ts',
     './tests/eslint-plugin-import/rules/newline-after-import.test.ts',
     './tests/eslint-plugin-import/rules/no-cycle.test.ts',
+    './tests/eslint-plugin-import/rules/no-default-export.test.ts',
     './tests/eslint-plugin-import/rules/no-duplicates.test.ts',
     './tests/eslint-plugin-import/rules/no-self-import.test.ts',
     './tests/eslint-plugin-import/rules/no-mutable-exports.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rules/no-default-export.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rules/no-default-export.test.ts
@@ -1,0 +1,91 @@
+import { test } from '../utils.js';
+
+import { RuleTester } from '../rule-tester.js';
+
+const ruleTester = new RuleTester();
+
+const preferNamed = 'Prefer named exports.';
+const noAliasDefault =
+  'Do not alias `foo` as `default`. Just export `foo` itself instead.';
+
+ruleTester.run('no-default-export', null as never, {
+  valid: [
+    test({ code: 'module.exports = function foo() {}' }),
+    test({ code: 'module.exports = function foo() {}' }),
+    test({
+      code: `
+        export const foo = 'foo';
+        export const bar = 'bar';
+      `,
+    }),
+    test({
+      code: `
+        export const foo = 'foo';
+        export function bar() {};
+      `,
+    }),
+    test({ code: "export const foo = 'foo';" }),
+    test({
+      code: `
+        const foo = 'foo';
+        export { foo };
+      `,
+    }),
+    test({ code: 'let foo, bar; export { foo, bar }' }),
+    test({ code: 'export const { foo, bar } = item;' }),
+    test({ code: 'export const { foo, bar: baz } = item;' }),
+    test({ code: 'export const { foo: { bar, baz } } = item;' }),
+    test({
+      code: `
+        let item;
+        export const foo = item;
+        export { item };
+      `,
+    }),
+    test({ code: "export * from './foo';" }),
+    test({ code: 'export const { foo } = { foo: "bar" };' }),
+    test({
+      code: 'export const { foo: { bar } } = { foo: { bar: "baz" } };',
+    }),
+    test({ code: 'export { a, b } from "foo.js"' }),
+
+    // no exports at all
+    test({ code: "import * as foo from './foo';" }),
+    test({ code: "import foo from './foo';" }),
+    test({ code: "import {default as foo} from './foo';" }),
+
+    test({ code: 'export type UserId = number;' }),
+  ],
+  invalid: [
+    test({
+      code: 'export default function bar() {};',
+      errors: [{ message: preferNamed }],
+    }),
+    test({
+      code: `
+        export const foo = 'foo';
+        export default bar;`,
+      errors: [{ message: preferNamed }],
+    }),
+    test({
+      code: 'export default class Bar {};',
+      errors: [{ message: preferNamed }],
+    }),
+    test({
+      code: 'export default function() {};',
+      errors: [{ message: preferNamed }],
+    }),
+    test({
+      code: 'export default class {};',
+      errors: [{ message: preferNamed }],
+    }),
+    test({
+      code: 'let foo; export { foo as default }',
+      errors: [{ message: noAliasDefault }],
+    }),
+    test({
+      code: 'let foo; export { foo as "default" }',
+      errors: [{ message: noAliasDefault }],
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `import/no-default-export` rule from eslint-plugin-import to rslint.

This adds the Go rule implementation, upstream and extra coverage, rule documentation, JS registration coverage, and import plugin registration.

## Related Links

- Rule docs: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-default-export.md
- Source code: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-default-export.js
- Upstream tests: https://github.com/import-js/eslint-plugin-import/blob/main/tests/src/rules/no-default-export.js

## Verification

- [x] `pnpm -w run check-spell`
- [x] `pnpm format:check`
- [x] Scoped Go lint for changed Go packages with `golangci-lint run --new-from-rev=origin/main --timeout=10m`
- [x] `go test -count=1 ./internal/utils ./internal/plugins/import ./internal/plugins/import/rules/no_default_export`
- [x] `cd packages/rslint && pnpm build:bin`
- [x] `cd packages/rslint-test-tools && npx rstest run --testTimeout=10000 no-default-export`
- [x] Sanity checked rsbuild/rspack configs without `import` plugin do not enable `import/no-default-export` via `--rule`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
