### PR TITLE
feat: port rule react-hooks/immutability

### DIFF
--- a/internal/plugins/react_hooks/all.go
+++ b/internal/plugins/react_hooks/all.go
@@ -5,6 +5,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/error_boundaries"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/exhaustive_deps"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/globals"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/immutability"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/rules_of_hooks"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -16,5 +17,6 @@ func GetAllRules() []rule.Rule {
 		component_hook_factories.ComponentHookFactoriesRule,
 		error_boundaries.ErrorBoundariesRule,
 		globals.GlobalsRule,
+		immutability.ImmutabilityRule,
 	}
 }

--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -183,6 +183,31 @@ func IsCompilerFunctionKind(node *ast.Node) bool {
 	return ast.IsFunctionDeclaration(node) || ast.IsFunctionExpressionOrArrowFunction(node)
 }
 
+// AccessChainRootIdentifier returns the identifier at the root of an access
+// chain like `value.x.y` or `(value as T)["x"]`.
+func AccessChainRootIdentifier(node *ast.Node) *ast.Node {
+	node = utils.SkipAssertionsAndParens(node)
+	for node != nil && ast.IsAccessExpression(node) {
+		node = utils.SkipAssertionsAndParens(utils.AccessExpressionObject(node))
+	}
+	if node != nil && node.Kind == ast.KindIdentifier {
+		return node
+	}
+	return nil
+}
+
+// ContainsNode reports whether `descendant` is inside `ancestor` in the same
+// source file.
+func ContainsNode(ancestor, descendant *ast.Node) bool {
+	if ancestor == nil || descendant == nil {
+		return false
+	}
+	if descendant.Pos() < ancestor.Pos() || descendant.End() > ancestor.End() {
+		return false
+	}
+	return ast.GetSourceFileOfNode(ancestor) == ast.GetSourceFileOfNode(descendant)
+}
+
 // GetCompilerReactFunctionType mirrors the React Compiler classifier used by
 // the Factories diagnostic: a PascalCase function is a component only when it
 // directly creates JSX or calls a hook, has component-like parameters, and does

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
@@ -117,13 +117,7 @@ func stripAsExpression(node *ast.Node) *ast.Node {
 // check runs only after the cheap position comparison so we don't pay the
 // parent-chain walk on the common "obviously outside" path.
 func containsNode(ancestor, descendant *ast.Node) bool {
-	if ancestor == nil || descendant == nil {
-		return false
-	}
-	if descendant.Pos() < ancestor.Pos() || descendant.End() > ancestor.End() {
-		return false
-	}
-	return ast.GetSourceFileOfNode(ancestor) == ast.GetSourceFileOfNode(descendant)
+	return react_hooksutil.ContainsNode(ancestor, descendant)
 }
 
 // nodeText returns the trimmed source text for `node`.

--- a/internal/plugins/react_hooks/rules/globals/globals.go
+++ b/internal/plugins/react_hooks/rules/globals/globals.go
@@ -239,7 +239,8 @@ func (state *globalsState) isObjectHelperCalled(fn *ast.Node, parentFn *ast.Node
 			return false
 		}
 		call := node.AsCallExpression()
-		if memberExpressionRootIdentifier(call.Expression) == name {
+		root := react_hooksutil.AccessChainRootIdentifier(call.Expression)
+		if root != nil && root.AsIdentifier().Text == name {
 			found = true
 			return true
 		}
@@ -277,21 +278,6 @@ func objectLiteralRootBindingName(fn *ast.Node) string {
 		default:
 			return ""
 		}
-	}
-	return ""
-}
-
-func memberExpressionRootIdentifier(node *ast.Node) string {
-	node = ast.SkipParentheses(node)
-	if node == nil || !ast.IsAccessExpression(node) {
-		return ""
-	}
-	for node != nil && ast.IsAccessExpression(node) {
-		node = utils.AccessExpressionObject(node)
-		node = ast.SkipParentheses(node)
-	}
-	if node != nil && node.Kind == ast.KindIdentifier {
-		return node.AsIdentifier().Text
 	}
 	return ""
 }

--- a/internal/plugins/react_hooks/rules/immutability/immutability.go
+++ b/internal/plugins/react_hooks/rules/immutability/immutability.go
@@ -1,0 +1,802 @@
+package immutability
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	immutabilityReason = "This value cannot be modified"
+)
+
+type immutableKind int
+
+const (
+	immutablePropsOrHookArgs immutableKind = iota
+	immutableUseState
+	immutableUseReducer
+	immutableHookReturn
+	immutableFrozenHookArgument
+	immutableJSXValue
+)
+
+type immutableInfo struct {
+	kind     immutableKind
+	hookName string
+}
+
+type immutabilityState struct {
+	checked map[*ast.Node]bool
+}
+
+type immutabilityScope struct {
+	ctx  rule.RuleContext
+	root *ast.Node
+
+	symbols map[*ast.Symbol]immutableInfo
+	names   map[string]immutableInfo
+	reports map[*ast.Node]bool
+}
+
+type mutationTarget struct {
+	node *ast.Node
+	info immutableInfo
+}
+
+// ImmutabilityRule is the rslint port of upstream
+// `react-hooks/immutability`.
+//
+// The upstream rule is emitted from React Compiler diagnostics. This port keeps
+// the user-facing lint contract local to rslint: React-like functions treat
+// component props, hook arguments, hook return values, and values passed to
+// hooks as immutable, then report later direct writes and known mutating method
+// calls.
+var ImmutabilityRule = rule.Rule{
+	Name: "react-hooks/immutability",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		state := &immutabilityState{checked: map[*ast.Node]bool{}}
+		check := func(node *ast.Node) {
+			state.checkFunction(ctx, node)
+		}
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration: check,
+			ast.KindFunctionExpression:  check,
+			ast.KindArrowFunction:       check,
+		}
+	},
+}
+
+func (state *immutabilityState) checkFunction(ctx rule.RuleContext, fn *ast.Node) {
+	if fn == nil || state.checked[fn] {
+		return
+	}
+	state.checked[fn] = true
+
+	fnTyp := getImmutabilityFunctionType(fn)
+	if fnTyp == "" {
+		return
+	}
+
+	scope := &immutabilityScope{
+		ctx:     ctx,
+		root:    fn,
+		symbols: map[*ast.Symbol]immutableInfo{},
+		names:   map[string]immutableInfo{},
+		reports: map[*ast.Node]bool{},
+	}
+	scope.seedParameters()
+	scope.scan(fn)
+}
+
+func getImmutabilityFunctionType(fn *ast.Node) react_hooksutil.CompilerReactFunctionType {
+	if fn == nil || react_hooksutil.IsClassMember(fn) {
+		return ""
+	}
+	name := react_hooksutil.GetFunctionName(fn)
+	if name != nil {
+		n := utils.SkipAssertionsAndParens(name)
+		switch {
+		case n != nil && n.Kind == ast.KindIdentifier:
+			text := n.AsIdentifier().Text
+			if react_hooksutil.IsComponentNameStr(text) && react_hooksutil.CallsHooksOrCreatesJsx(fn) {
+				return react_hooksutil.CompilerReactFunctionComponent
+			}
+			if react_hooksutil.IsCompilerHookName(text) {
+				return react_hooksutil.CompilerReactFunctionHook
+			}
+		case n != nil && react_hooksutil.IsCompilerHookCallee(n):
+			return react_hooksutil.CompilerReactFunctionHook
+		}
+	}
+	if isDefaultExportedAnonymousFunction(fn) && react_hooksutil.CallsHooksOrCreatesJsx(fn) {
+		return react_hooksutil.CompilerReactFunctionComponent
+	}
+	if ast.IsFunctionExpressionOrArrowFunction(fn) {
+		if react_hooksutil.IsForwardRefOrMemoCallback(fn, "forwardRef") ||
+			react_hooksutil.IsForwardRefOrMemoCallback(fn, "memo") {
+			return react_hooksutil.CompilerReactFunctionComponent
+		}
+	}
+	return ""
+}
+
+func isDefaultExportedAnonymousFunction(fn *ast.Node) bool {
+	if fn == nil || react_hooksutil.GetFunctionName(fn) != nil {
+		return false
+	}
+	if fn.Kind == ast.KindFunctionDeclaration {
+		return ast.GetCombinedModifierFlags(fn)&ast.ModifierFlagsDefault != 0
+	}
+	child := fn
+	for parent := fn.Parent; parent != nil; parent = parent.Parent {
+		if parent.Kind == ast.KindParenthesizedExpression {
+			child = parent
+			continue
+		}
+		if parent.Kind != ast.KindExportAssignment {
+			return false
+		}
+		assignment := parent.AsExportAssignment()
+		return assignment != nil && !assignment.IsExportEquals && assignment.Expression == child
+	}
+	return false
+}
+
+func (scope *immutabilityScope) seedParameters() {
+	info := immutableInfo{kind: immutablePropsOrHookArgs}
+	for _, param := range scope.root.Parameters() {
+		if param == nil {
+			continue
+		}
+		scope.addBinding(param.Name(), info)
+	}
+}
+
+func (scope *immutabilityScope) scan(node *ast.Node) {
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case ast.KindVariableDeclaration:
+		scope.processVariableDeclaration(node)
+	case ast.KindBinaryExpression:
+		scope.checkAssignment(node)
+	case ast.KindPrefixUnaryExpression:
+		scope.checkPrefixUpdate(node)
+	case ast.KindPostfixUnaryExpression:
+		scope.checkPostfixUpdate(node)
+	case ast.KindDeleteExpression:
+		scope.checkDelete(node)
+	case ast.KindCallExpression:
+		scope.checkMutatingCall(node)
+		scope.freezeHookArguments(node)
+		scope.freezeCreateElementArguments(node)
+	case ast.KindJsxExpression:
+		scope.freezeJSXExpression(node)
+	case ast.KindJsxSpreadAttribute:
+		scope.freezeJSXSpreadAttribute(node)
+	}
+
+	node.ForEachChild(func(child *ast.Node) bool {
+		scope.scan(child)
+		return false
+	})
+}
+
+func (scope *immutabilityScope) processVariableDeclaration(node *ast.Node) {
+	if isForInOrOfVariableDeclaration(node) {
+		return
+	}
+	decl := node.AsVariableDeclaration()
+	if decl == nil || decl.Initializer == nil {
+		return
+	}
+	init := utils.SkipAssertionsAndParens(decl.Initializer)
+	if init == nil {
+		return
+	}
+	if hookName, ok := hookCallName(init); ok {
+		scope.addHookReturnBinding(decl.Name(), hookName)
+		return
+	}
+	if info, ok := scope.infoForExpression(init); ok {
+		scope.addBinding(decl.Name(), info)
+	}
+}
+
+func isForInOrOfVariableDeclaration(node *ast.Node) bool {
+	return node != nil &&
+		node.Kind == ast.KindVariableDeclaration &&
+		node.Parent != nil &&
+		node.Parent.Kind == ast.KindVariableDeclarationList &&
+		node.Parent.Parent != nil &&
+		ast.IsForInOrOfStatement(node.Parent.Parent)
+}
+
+func (scope *immutabilityScope) addHookReturnBinding(name *ast.Node, hookName string) {
+	switch hookName {
+	case "useState":
+		scope.addFirstArrayBinding(name, immutableInfo{kind: immutableUseState, hookName: hookName})
+	case "useReducer":
+		scope.addFirstArrayBinding(name, immutableInfo{kind: immutableUseReducer, hookName: hookName})
+	case "useOptimistic":
+		scope.addFirstArrayBinding(name, immutableInfo{kind: immutableHookReturn, hookName: hookName})
+	case "useRef":
+		return
+	default:
+		scope.addBinding(name, immutableInfo{kind: immutableHookReturn, hookName: hookName})
+	}
+}
+
+func (scope *immutabilityScope) addHookReturnAssignmentBinding(name *ast.Node, hookName string) {
+	switch hookName {
+	case "useState":
+		scope.addFirstArrayAssignmentBinding(name, immutableInfo{kind: immutableUseState, hookName: hookName})
+	case "useReducer":
+		scope.addFirstArrayAssignmentBinding(name, immutableInfo{kind: immutableUseReducer, hookName: hookName})
+	case "useOptimistic":
+		scope.addFirstArrayAssignmentBinding(name, immutableInfo{kind: immutableHookReturn, hookName: hookName})
+	case "useRef":
+		return
+	default:
+		scope.addAssignmentBinding(name, immutableInfo{kind: immutableHookReturn, hookName: hookName})
+	}
+}
+
+func (scope *immutabilityScope) addFirstArrayBinding(name *ast.Node, info immutableInfo) {
+	if name == nil {
+		return
+	}
+	if name.Kind != ast.KindArrayBindingPattern {
+		scope.addBinding(name, info)
+		return
+	}
+	found := false
+	name.ForEachChild(func(child *ast.Node) bool {
+		if found {
+			return true
+		}
+		if child == nil || child.Kind != ast.KindBindingElement {
+			return false
+		}
+		binding := child.AsBindingElement()
+		if binding == nil || binding.Name() == nil {
+			return false
+		}
+		scope.addBinding(binding.Name(), info)
+		found = true
+		return true
+	})
+}
+
+func (scope *immutabilityScope) addFirstArrayAssignmentBinding(name *ast.Node, info immutableInfo) {
+	name = utils.SkipAssertionsAndParens(name)
+	if name == nil {
+		return
+	}
+	if name.Kind != ast.KindArrayLiteralExpression {
+		scope.addAssignmentBinding(name, info)
+		return
+	}
+	found := false
+	name.ForEachChild(func(child *ast.Node) bool {
+		if found {
+			return true
+		}
+		if child == nil || child.Kind == ast.KindOmittedExpression {
+			return false
+		}
+		scope.addAssignmentBinding(child, info)
+		found = true
+		return true
+	})
+}
+
+func (scope *immutabilityScope) addBinding(nameNode *ast.Node, info immutableInfo) {
+	utils.CollectBindingNames(nameNode, func(ident *ast.Node, name string) {
+		if ident == nil || name == "" {
+			return
+		}
+		if scope.ctx.TypeChecker != nil {
+			if sym := scope.ctx.TypeChecker.GetSymbolAtLocation(ident); sym != nil {
+				scope.addSymbol(sym, info)
+				return
+			}
+		}
+		if _, exists := scope.names[name]; !exists {
+			scope.names[name] = info
+		}
+	})
+}
+
+func (scope *immutabilityScope) addSymbol(sym *ast.Symbol, info immutableInfo) {
+	if sym != nil {
+		if _, exists := scope.symbols[sym]; exists {
+			return
+		}
+		scope.symbols[sym] = info
+	}
+}
+
+func (scope *immutabilityScope) infoForExpression(node *ast.Node) (immutableInfo, bool) {
+	root := react_hooksutil.AccessChainRootIdentifier(node)
+	if root == nil {
+		return immutableInfo{}, false
+	}
+	return scope.infoForIdentifier(root)
+}
+
+func (scope *immutabilityScope) infoForIdentifier(id *ast.Node) (immutableInfo, bool) {
+	if id == nil || id.Kind != ast.KindIdentifier {
+		return immutableInfo{}, false
+	}
+	if scope.ctx.TypeChecker != nil {
+		if sym := utils.GetReferenceSymbol(id, scope.ctx.TypeChecker); sym != nil {
+			info, ok := scope.symbols[sym]
+			return info, ok
+		}
+	}
+	if info, ok := scope.names[id.AsIdentifier().Text]; ok {
+		return info, true
+	}
+	return immutableInfo{}, false
+}
+
+func (scope *immutabilityScope) checkAssignment(node *ast.Node) {
+	if !ast.IsAssignmentExpression(node, false) || utils.IsDefaultValueInDestructuringAssignment(node) {
+		return
+	}
+	binary := node.AsBinaryExpression()
+	if binary == nil || binary.OperatorToken == nil {
+		return
+	}
+	targets := scope.collectMutationTargets(binary.Left)
+	if binary.OperatorToken.Kind == ast.KindEqualsToken && isBareIdentifierTarget(binary.Left) {
+		// `x = value` rebinds a local slot; it does not mutate the value that
+		// `x` previously pointed at. Property writes and compound assignments
+		// are still reported through the normal mutation-target path.
+		targets = nil
+	}
+	for _, target := range targets {
+		scope.report(target)
+	}
+	if binary.OperatorToken.Kind == ast.KindEqualsToken {
+		if len(targets) == 0 {
+			if hookName, ok := hookCallName(binary.Right); ok {
+				scope.addHookReturnAssignmentBinding(binary.Left, hookName)
+			} else if info, ok := scope.infoForExpression(binary.Right); ok {
+				scope.addAssignmentBinding(binary.Left, info)
+			}
+		}
+	}
+}
+
+func isBareIdentifierTarget(node *ast.Node) bool {
+	node = utils.SkipAssertionsAndParens(node)
+	return node != nil && node.Kind == ast.KindIdentifier
+}
+
+func (scope *immutabilityScope) checkPrefixUpdate(node *ast.Node) {
+	prefix := node.AsPrefixUnaryExpression()
+	if prefix == nil || (prefix.Operator != ast.KindPlusPlusToken && prefix.Operator != ast.KindMinusMinusToken) {
+		return
+	}
+	for _, target := range scope.collectMutationTargets(prefix.Operand) {
+		scope.report(target)
+	}
+}
+
+func (scope *immutabilityScope) checkPostfixUpdate(node *ast.Node) {
+	postfix := node.AsPostfixUnaryExpression()
+	if postfix == nil || (postfix.Operator != ast.KindPlusPlusToken && postfix.Operator != ast.KindMinusMinusToken) {
+		return
+	}
+	for _, target := range scope.collectMutationTargets(postfix.Operand) {
+		scope.report(target)
+	}
+}
+
+func (scope *immutabilityScope) checkDelete(node *ast.Node) {
+	del := node.AsDeleteExpression()
+	if del == nil {
+		return
+	}
+	for _, target := range scope.collectMutationTargets(del.Expression) {
+		scope.report(target)
+	}
+}
+
+func (scope *immutabilityScope) checkMutatingCall(node *ast.Node) {
+	call := node.AsCallExpression()
+	if call == nil {
+		return
+	}
+	callee := utils.SkipAssertionsAndParens(call.Expression)
+	if callee == nil {
+		return
+	}
+	if utils.IsSpecificMemberAccess(callee, "Object", "assign") && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+		for _, target := range scope.collectMutationTargets(call.Arguments.Nodes[0]) {
+			if isMutatingCallReportable(target.info) {
+				scope.report(target)
+			}
+		}
+		return
+	}
+	if ast.IsAccessExpression(callee) {
+		name, ok := utils.AccessExpressionStaticName(callee)
+		if ok && isKnownMutatingMethod(name) {
+			receiver := utils.AccessExpressionObject(callee)
+			for _, target := range scope.collectMutationTargets(receiver) {
+				if isMutatingCallReportable(target.info) {
+					scope.report(target)
+				}
+			}
+		}
+		return
+	}
+}
+
+func (scope *immutabilityScope) freezeHookArguments(node *ast.Node) {
+	call := node.AsCallExpression()
+	if call == nil || call.Arguments == nil {
+		return
+	}
+	if _, ok := hookCallName(node); !ok {
+		return
+	}
+	info := immutableInfo{kind: immutableFrozenHookArgument}
+	for _, arg := range call.Arguments.Nodes {
+		if arg == nil {
+			continue
+		}
+		if id := react_hooksutil.AccessChainRootIdentifier(arg); id != nil {
+			if sym := scope.symbolForIdentifier(id); sym != nil {
+				scope.addSymbol(sym, info)
+			}
+		}
+		if react_hooksutil.IsCompilerFunctionKind(utils.SkipAssertionsAndParens(arg)) {
+			scope.freezeCapturedValues(arg, info)
+		}
+	}
+}
+
+func (scope *immutabilityScope) freezeCreateElementArguments(node *ast.Node) {
+	call := node.AsCallExpression()
+	if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) < 2 {
+		return
+	}
+	callee := utils.SkipAssertionsAndParens(call.Expression)
+	if !isCreateElementCallee(callee) {
+		return
+	}
+	info := immutableInfo{kind: immutableJSXValue}
+	for i, arg := range call.Arguments.Nodes {
+		if i == 0 {
+			continue
+		}
+		scope.freezeExpressionReferences(arg, info)
+	}
+}
+
+func (scope *immutabilityScope) freezeJSXExpression(node *ast.Node) {
+	expr := node.AsJsxExpression()
+	if expr == nil {
+		return
+	}
+	scope.freezeExpressionReferences(expr.Expression, immutableInfo{kind: immutableJSXValue})
+}
+
+func (scope *immutabilityScope) freezeJSXSpreadAttribute(node *ast.Node) {
+	attr := node.AsJsxSpreadAttribute()
+	if attr == nil {
+		return
+	}
+	scope.freezeExpressionReferences(attr.Expression, immutableInfo{kind: immutableJSXValue})
+}
+
+func (scope *immutabilityScope) freezeExpressionReferences(node *ast.Node, info immutableInfo) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return
+	}
+	if react_hooksutil.IsCompilerFunctionKind(node) {
+		// Function bodies are separate execution points. Hook callbacks get
+		// their captured values frozen through freezeCapturedValues.
+		return
+	}
+	if id := react_hooksutil.AccessChainRootIdentifier(node); id != nil && !utils.IsNonReferenceIdentifier(id) {
+		scope.freezeIdentifier(id, info)
+		if ast.IsAccessExpression(node) {
+			return
+		}
+	}
+	node.ForEachChild(func(child *ast.Node) bool {
+		scope.freezeExpressionReferences(child, info)
+		return false
+	})
+}
+
+func isCreateElementCallee(callee *ast.Node) bool {
+	if utils.IsSpecificMemberAccess(callee, "React", "createElement") {
+		return true
+	}
+	return callee != nil && callee.Kind == ast.KindIdentifier && callee.AsIdentifier().Text == "createElement"
+}
+
+func (scope *immutabilityScope) freezeIdentifier(id *ast.Node, info immutableInfo) {
+	if id == nil || id.Kind != ast.KindIdentifier || scope.ctx.TypeChecker == nil {
+		return
+	}
+	sym := utils.GetReferenceSymbol(id, scope.ctx.TypeChecker)
+	if sym == nil || !scope.symbolDeclaredInRootFunction(sym) {
+		return
+	}
+	scope.addSymbol(sym, info)
+}
+
+func (scope *immutabilityScope) freezeCapturedValues(fn *ast.Node, info immutableInfo) {
+	fn = utils.SkipAssertionsAndParens(fn)
+	if fn == nil || !react_hooksutil.IsCompilerFunctionKind(fn) {
+		return
+	}
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node != fn && react_hooksutil.IsCompilerFunctionKind(node) {
+			return
+		}
+		if node.Kind == ast.KindIdentifier && !utils.IsNonReferenceIdentifier(node) {
+			if sym := scope.symbolForIdentifier(node); sym != nil && scope.symbolBelongsToRoot(sym, fn) {
+				scope.addSymbol(sym, info)
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(fn)
+}
+
+func (scope *immutabilityScope) symbolForIdentifier(id *ast.Node) *ast.Symbol {
+	if id == nil || id.Kind != ast.KindIdentifier || scope.ctx.TypeChecker == nil {
+		return nil
+	}
+	return utils.GetReferenceSymbol(id, scope.ctx.TypeChecker)
+}
+
+func (scope *immutabilityScope) symbolDeclaredInRootFunction(sym *ast.Symbol) bool {
+	if sym == nil {
+		return false
+	}
+	for _, decl := range sym.Declarations {
+		if decl == nil || ast.GetSourceFileOfNode(decl) != scope.ctx.SourceFile {
+			continue
+		}
+		if react_hooksutil.ContainsNode(scope.root, decl) && react_hooksutil.FindEnclosingFunction(decl) == scope.root {
+			return true
+		}
+	}
+	return false
+}
+
+func (scope *immutabilityScope) symbolBelongsToRoot(sym *ast.Symbol, callback *ast.Node) bool {
+	if sym == nil {
+		return false
+	}
+	for _, decl := range sym.Declarations {
+		if decl == nil || ast.GetSourceFileOfNode(decl) != scope.ctx.SourceFile {
+			continue
+		}
+		if react_hooksutil.ContainsNode(scope.root, decl) && !react_hooksutil.ContainsNode(callback, decl) {
+			return true
+		}
+	}
+	return false
+}
+
+func (scope *immutabilityScope) collectMutationTargets(node *ast.Node) []mutationTarget {
+	var targets []mutationTarget
+	var collect func(*ast.Node)
+	collect = func(cur *ast.Node) {
+		cur = utils.SkipAssertionsAndParens(cur)
+		if cur == nil {
+			return
+		}
+		if id := react_hooksutil.AccessChainRootIdentifier(cur); id != nil {
+			if info, ok := scope.infoForIdentifier(id); ok {
+				targets = append(targets, mutationTarget{node: id, info: info})
+				return
+			}
+		}
+		switch cur.Kind {
+		case ast.KindObjectLiteralExpression, ast.KindArrayLiteralExpression:
+			cur.ForEachChild(func(child *ast.Node) bool {
+				collect(child)
+				return false
+			})
+		case ast.KindPropertyAssignment:
+			assignment := cur.AsPropertyAssignment()
+			if assignment != nil {
+				collect(assignment.Initializer)
+			}
+		case ast.KindShorthandPropertyAssignment:
+			name := cur.Name()
+			if name != nil {
+				collect(name)
+			}
+			shorthand := cur.AsShorthandPropertyAssignment()
+			if shorthand != nil {
+				collect(shorthand.ObjectAssignmentInitializer)
+			}
+		case ast.KindSpreadAssignment, ast.KindSpreadElement:
+			cur.ForEachChild(func(child *ast.Node) bool {
+				collect(child)
+				return false
+			})
+		case ast.KindBinaryExpression:
+			binary := cur.AsBinaryExpression()
+			if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
+				collect(binary.Left)
+			}
+		}
+	}
+	collect(node)
+	return targets
+}
+
+func (scope *immutabilityScope) addAssignmentBinding(node *ast.Node, info immutableInfo) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindVariableDeclarationList:
+		list := node.AsVariableDeclarationList()
+		if list == nil || list.Declarations == nil {
+			return
+		}
+		for _, decl := range list.Declarations.Nodes {
+			if decl != nil && decl.Kind == ast.KindVariableDeclaration {
+				scope.addBinding(decl.Name(), info)
+			}
+		}
+	case ast.KindIdentifier, ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
+		scope.addBinding(node, info)
+	case ast.KindObjectLiteralExpression:
+		obj := node.AsObjectLiteralExpression()
+		if obj == nil || obj.Properties == nil {
+			return
+		}
+		for _, prop := range obj.Properties.Nodes {
+			switch prop.Kind {
+			case ast.KindShorthandPropertyAssignment:
+				scope.addBinding(prop.Name(), info)
+				shorthand := prop.AsShorthandPropertyAssignment()
+				if shorthand != nil {
+					scope.addAssignmentBinding(shorthand.ObjectAssignmentInitializer, info)
+				}
+			case ast.KindPropertyAssignment:
+				assignment := prop.AsPropertyAssignment()
+				if assignment != nil {
+					scope.addAssignmentBinding(assignment.Initializer, info)
+				}
+			case ast.KindSpreadAssignment:
+				prop.ForEachChild(func(child *ast.Node) bool {
+					scope.addAssignmentBinding(child, info)
+					return false
+				})
+			}
+		}
+	case ast.KindArrayLiteralExpression:
+		node.ForEachChild(func(child *ast.Node) bool {
+			scope.addAssignmentBinding(child, info)
+			return false
+		})
+	case ast.KindSpreadElement:
+		node.ForEachChild(func(child *ast.Node) bool {
+			scope.addAssignmentBinding(child, info)
+			return false
+		})
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
+			scope.addAssignmentBinding(binary.Left, info)
+		}
+	}
+}
+
+func (scope *immutabilityScope) report(target mutationTarget) {
+	if target.node == nil || scope.reports[target.node] {
+		return
+	}
+	scope.reports[target.node] = true
+	scope.ctx.ReportNode(target.node, buildImmutabilityMessage(target.info))
+}
+
+func buildImmutabilityMessage(info immutableInfo) rule.RuleMessage {
+	description := ""
+	switch info.kind {
+	case immutablePropsOrHookArgs:
+		description = "Modifying component props or hook arguments is not allowed. Consider using a local variable instead."
+	case immutableUseState:
+		description = "Modifying a value returned from 'useState()', which should not be modified directly. Use the setter function to update instead."
+	case immutableUseReducer:
+		description = "Modifying a value returned from 'useReducer()', which should not be modified directly. Use the dispatch function to update instead."
+	case immutableHookReturn:
+		if info.hookName != "" {
+			description = fmt.Sprintf("Modifying a value returned from '%s()' is not allowed.", info.hookName)
+			if info.hookName == "useContext" {
+				description += "."
+			}
+		} else {
+			description = "Modifying a value returned from a hook is not allowed. Consider moving the modification into the hook where the value is constructed."
+		}
+	case immutableFrozenHookArgument:
+		description = "Modifying a value previously passed as an argument to a hook is not allowed. Consider moving the modification before calling the hook."
+	case immutableJSXValue:
+		description = "Modifying a value used previously in JSX is not allowed. Consider moving the modification before the JSX."
+	}
+	return rule.RuleMessage{
+		Id:          "immutableMutation",
+		Description: fmt.Sprintf("Error: %s\n\n%s", immutabilityReason, description),
+	}
+}
+
+func hookCallName(node *ast.Node) (string, bool) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return "", false
+	}
+	callee := utils.SkipAssertionsAndParens(node.AsCallExpression().Expression)
+	if !react_hooksutil.IsCompilerHookCallee(callee) {
+		return "", false
+	}
+	name := hookCalleeName(callee)
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+func hookCalleeName(callee *ast.Node) string {
+	callee = utils.SkipAssertionsAndParens(callee)
+	if callee == nil {
+		return ""
+	}
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		return callee.AsIdentifier().Text
+	case ast.KindPropertyAccessExpression:
+		name := callee.AsPropertyAccessExpression().Name()
+		if name != nil && name.Kind == ast.KindIdentifier {
+			return name.AsIdentifier().Text
+		}
+	}
+	return ""
+}
+
+func isKnownMutatingMethod(name string) bool {
+	switch name {
+	case "clear", "delete", "pop", "push", "set":
+		return true
+	}
+	return false
+}
+
+func isMutatingCallReportable(info immutableInfo) bool {
+	switch info.kind {
+	case immutableFrozenHookArgument, immutableJSXValue:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/plugins/react_hooks/rules/immutability/immutability.md
+++ b/internal/plugins/react_hooks/rules/immutability/immutability.md
@@ -1,0 +1,64 @@
+# immutability
+
+## Rule Details
+
+Validates against mutating component props, hook arguments, state values, hook
+return values, values that have already been passed to hooks, and local values
+that have already been used to create JSX.
+
+React treats props and state as immutable snapshots. Mutating them directly can
+leave React with the same object or array reference, so React has no reliable
+signal that the UI needs to update.
+
+The rule reports direct assignments, update/delete expressions, and known
+mutating calls such as `push`, `sort`, `splice`, and `Object.assign` when their
+target is an immutable value or an alias derived from one.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function Component() {
+  const [items, setItems] = useState([1, 2, 3]);
+
+  const addItem = () => {
+    items.push(4);
+    setItems(items);
+  };
+}
+```
+
+```javascript
+function Component({ user }) {
+  user.name = "Alice";
+  return <div>{user.name}</div>;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function Component() {
+  const [items, setItems] = useState([1, 2, 3]);
+
+  const addItem = () => {
+    setItems([...items, 4]);
+  };
+}
+```
+
+```javascript
+function Component({ user, setUser }) {
+  setUser({ ...user, name: "Alice" });
+  return <div>{user.name}</div>;
+}
+```
+
+## Differences from ESLint
+
+- Files that use Flow component or hook syntax are not analyzed because rslint
+  does not parse those declarations.
+
+## Original Documentation
+
+- [react.dev - immutability](https://react.dev/reference/eslint-plugin-react-hooks/lints/immutability)
+- [Source code](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/shared/ReactCompiler.ts)

--- a/internal/plugins/react_hooks/rules/immutability/immutability_extras_test.go
+++ b/internal/plugins/react_hooks/rules/immutability/immutability_extras_test.go
@@ -1,0 +1,527 @@
+package immutability
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestImmutabilityExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / React Compiler fixture shape it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+
+func immutabilityError(info immutableInfo, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "immutableMutation",
+		Message:   buildImmutabilityMessage(info).Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func TestImmutabilityExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Official docs: create a new array instead of mutating state. ----
+		{Code: `
+function Component() {
+  const [items, setItems] = useState([1, 2, 3]);
+  const addItem = () => {
+    setItems([...items, 4]);
+  };
+}
+		`, Tsx: true},
+		// ---- Official docs: create a new object instead of mutating state. ----
+		{Code: `
+function Component() {
+  const [user, setUser] = useState({name: 'Alice'});
+  const updateName = () => {
+    setUser({...user, name: 'Bob'});
+  };
+}
+		`, Tsx: true},
+		// ---- Branch lock-in: mutation before a hook call freezes the value is allowed. ----
+		{Code: `
+function Component({a}) {
+  const x = {a};
+  x.y = true;
+  useFreeze(x);
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: lowercase non-React function remains outside the lint target. ----
+		{Code: `
+function helper(arg) {
+  (arg).value = 1;
+  arg.items.push(1);
+}
+		`, Tsx: true},
+		// ---- Dimension 4: useRef return values are mutable and intentionally unmatched. ----
+		{Code: `
+function Component() {
+  const ref = useRef(null);
+  ref.current = document.body;
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Branch lock-in: state setters from tuple position 2 are not immutable state. ----
+		{Code: `
+function Component() {
+  const [state, setState] = useState({value: 0});
+  setState.extra = true;
+  return <div>{state.value}</div>;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: parameter shadowing inside nested callbacks does not fall back to name matching. ----
+		{Code: `
+function Component() {
+  const [state] = useState({value: 0});
+  const handler = (state) => {
+    state.value = 1;
+  };
+  return <button onClick={handler} />;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: local shadowing in nested helpers does not mutate the outer state binding. ----
+		{Code: `
+function Component() {
+  const [state] = useState({value: 0});
+  function update() {
+    const state = {value: 0};
+    state.value = 1;
+  }
+  update();
+  return <div>{state.value}</div>;
+}
+		`, Tsx: true},
+		// ---- Upstream parity: PascalCase helpers without JSX or hook calls are not components. ----
+		{Code: `
+const D = <T, P extends keyof T>(obj: T, prop: P, value: T[P]) => {
+  if (obj[prop] === undefined) {
+    obj[prop] = value;
+  }
+};
+		`, Tsx: true},
+		// ---- Upstream parity: component props report property writes, not mutating method calls. ----
+		{Code: `
+function Component({list}) {
+  list.sort();
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Upstream parity: state mutating methods are not emitted by the official rule. ----
+		{Code: `
+function Component() {
+  const [items, setItems] = useState([1, 2, 3]);
+  items.push(4);
+  setItems(items.sort());
+  Object.assign(items, [5]);
+  return <div />;
+}
+		`, Tsx: true},
+		// ---- Upstream parity: custom hook return values report property writes, not Object.assign. ----
+		{Code: `
+function Component() {
+  const location = useLocation();
+  return Object.assign(location, {query: new URLSearchParams(location.search)});
+}
+		`, Tsx: true},
+		// ---- Upstream parity: non-use helper returns are mutable values. ----
+		{Code: `
+function Component() {
+  const value = signalData({x: 1});
+  value.x = 2;
+  return <div />;
+}
+		`, Tsx: true},
+		{Code: `
+function signalThing(arg) {
+  arg.value = 1;
+}
+		`, Tsx: true},
+		// N/A: private property names and class members are not React Compiler
+		// render-function inputs for this rule. Flow component/hook syntax is
+		// covered as skipped upstream cases because tsgo does not parse it.
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- Official docs: Object property assignment. ----
+		{
+			Code: `
+function Component() {
+  const [user, setUser] = useState({name: 'Alice'});
+  const updateName = () => {
+    user.name = 'Bob';
+    setUser(user);
+  };
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableUseState, hookName: "useState"}, 5, 5, 5, 9),
+			},
+		},
+		// ---- Official docs: nested object mutation. ----
+		{
+			Code: `
+function UserProfile() {
+  const [user, setUser] = useState({
+    name: 'Alice',
+    settings: {theme: 'light', notifications: true},
+  });
+  const toggleTheme = () => {
+    user.settings.theme = 'dark';
+    setUser(user);
+  };
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableUseState, hookName: "useState"}, 8, 5, 8, 9),
+			},
+		},
+		// ---- React Compiler fixture: error.modify-state-2 alias of state property. ----
+		{
+			Code: `
+function Foo() {
+  const [state, setState] = useState({foo: {bar: 3}});
+  const foo = state.foo;
+  foo.bar = 1;
+  return state;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableUseState, hookName: "useState"}, 5, 3, 5, 6),
+			},
+		},
+		// ---- React Compiler fixture: error.modify-useReducer-state. ----
+		{
+			Code: `
+function Foo() {
+  let [state, dispatch] = useReducer(reducer, {foo: 1});
+  state.foo = 1;
+  return state;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableUseReducer, hookName: "useReducer"}, 4, 3, 4, 8),
+			},
+		},
+		// ---- React Compiler fixture: error.mutate-props. ----
+		{
+			Code: `
+function Foo(props) {
+  props.test = 1;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 3, 3, 8),
+			},
+		},
+		// ---- React Compiler fixture: error.mutate-hook-argument. ----
+		{
+			Code: `
+function useHook(a, b) {
+  b.test = 1;
+  a.test = 2;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 3, 3, 4),
+				immutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 4, 3, 4, 4),
+			},
+		},
+		// ---- React Compiler fixture: error.invalid-mutate-context. ----
+		{
+			Code: `
+function Component(props) {
+  const context = useContext(FooContext);
+  context.value = props.value;
+  return context.value;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableHookReturn, hookName: "useContext"}, 4, 3, 4, 10),
+			},
+		},
+		// ---- Real-user: facebook/react#35157 direct state property mutation from docs-shaped repro. ----
+		{
+			Code: `
+function Component() {
+  const [user, setUser] = useState({name: 'Alice'});
+  user.name = 'Bob';
+  return <div>{user.name}</div>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableUseState, hookName: "useState"}, 4, 3, 4, 7),
+			},
+		},
+		// ---- Real-user: reddit react-hooks immutability with useRef-style frozen argument. ----
+		{
+			Code: `
+function Component({isPlaying}) {
+  const box = {isPlaying};
+  useSomeHook(box);
+  box.isPlaying = false;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableFrozenHookArgument}, 5, 3, 5, 6),
+			},
+		},
+		// ---- Dimension 4: parenthesized receiver and TS assertion wrappers. ----
+		{
+			Code: `
+function Component() {
+  const [state, setState] = useState({value: 0});
+  ((state as any)).value = 1;
+  (state!).value = 2;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableUseState, hookName: "useState"}, 4, 5, 4, 10),
+				immutabilityError(immutableInfo{kind: immutableUseState, hookName: "useState"}, 5, 4, 5, 9),
+			},
+		},
+		// ---- Dimension 4: JSX-frozen values report the mutating method set covered upstream. ----
+		{
+			Code: `
+function Component() {
+  const items = [];
+  const map = new Map();
+  const element = <Child items={items} map={map} />;
+  items["push"](4);
+  items.pop();
+  map.set("value", 1);
+  map.delete("value");
+  map.clear();
+  return element;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableJSXValue}, 6, 3, 6, 8),
+				immutabilityError(immutableInfo{kind: immutableJSXValue}, 7, 3, 7, 8),
+				immutabilityError(immutableInfo{kind: immutableJSXValue}, 8, 3, 8, 6),
+				immutabilityError(immutableInfo{kind: immutableJSXValue}, 9, 3, 9, 6),
+				immutabilityError(immutableInfo{kind: immutableJSXValue}, 10, 3, 10, 6),
+			},
+		},
+		// ---- Dimension 4: nested object destructuring aliases remain immutable. ----
+		{
+			Code: `
+function Component() {
+  const [user] = useState({settings: {theme: {dark: false}}});
+  const {settings: {theme}} = user;
+  theme.dark = true;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableUseState, hookName: "useState"}, 5, 3, 5, 8),
+			},
+		},
+		// ---- Dimension 4: nested array destructuring aliases remain immutable. ----
+		{
+			Code: `
+function Component() {
+  const [items] = useState([[{done: false}]]);
+  const [[first]] = items;
+  first.done = true;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableUseState, hookName: "useState"}, 5, 3, 5, 8),
+			},
+		},
+		// ---- Dimension 4: update and delete expressions. ----
+		{
+			Code: `
+function Component({props}) {
+  props.count++;
+  delete props.value;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 3, 3, 8),
+				immutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 4, 10, 4, 15),
+			},
+		},
+		// ---- Dimension 4: destructuring assignment target degrades through object patterns. ----
+		{
+			Code: `
+function Component(props) {
+  ({value: props.value} = other);
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 12, 3, 17),
+			},
+		},
+		// Locks in upstream hook-call freeze arm: values passed to hook calls become immutable afterwards.
+		{
+			Code: `
+function Component({a}) {
+  const x = {a};
+  useFreeze(x);
+  x.y = true;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableFrozenHookArgument}, 5, 3, 5, 4),
+			},
+		},
+		// Locks in upstream transitive callback freeze arm: hook callback captures a later-mutated local.
+		{
+			Code: `
+function Component({count}) {
+  const x = {value: 0};
+  const cb = useIdentity(() => {
+    console.log(x.value, count);
+  });
+  x.value += count;
+  return <div>{cb}</div>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableFrozenHookArgument}, 7, 3, 7, 4),
+			},
+		},
+		// ---- React Compiler fixture: error.invalid-mutate-after-freeze JSX freezes local values. ----
+		{
+			Code: `
+function Component(props) {
+  let x = [];
+  let _ = <Component x={x} />;
+  x.push(props.p2);
+  return <div>{_}</div>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableJSXValue}, 5, 3, 5, 4),
+			},
+		},
+		// ---- Dimension 4: JSX spread attributes freeze their referenced object. ----
+		{
+			Code: `
+function Component() {
+  const childProps = {};
+  const element = <Child {...childProps} />;
+  childProps.id = 1;
+  return element;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableJSXValue}, 5, 3, 5, 13),
+			},
+		},
+		// ---- React Compiler fixture: createElement-freeze freezes props after React.createElement. ----
+		{
+			Code: `
+function Component() {
+  const childProps = {style: {}};
+  const element = React.createElement('div', childProps, ['hello']);
+  childProps.style.width = 1;
+  return <>{element}</>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableJSXValue}, 5, 3, 5, 13),
+			},
+		},
+		// ---- React Compiler fixture: error.invalid-mutate-phi-which-could-be-frozen assignment alias. ----
+		{
+			Code: `
+function Component(props) {
+  const frozen = useHook();
+  let x;
+  if (props.cond) {
+    x = frozen;
+  } else {
+    x = {};
+  }
+  x.property = true;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableHookReturn, hookName: "useHook"}, 10, 3, 10, 4),
+			},
+		},
+		// ---- Branch lock-in: hook return assignment through destructuring propagates immutability. ----
+		{
+			Code: `
+function Component() {
+  let alias;
+  ({value: alias} = useThing());
+  alias.current = 1;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutableHookReturn, hookName: "useThing"}, 5, 3, 5, 8),
+			},
+		},
+		// ---- Branch lock-in: anonymous default-exported JSX functions are React components. ----
+		{
+			Code: `
+export default function(props) {
+  props.value = 1;
+  return <div />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 3, 3, 8),
+			},
+		},
+		// ---- Dimension 4: nested component scopes still enforce their own props. ----
+		{
+			Code: `
+function Parent() {
+  function Child(props) {
+    props.value = 1;
+    return <span />;
+  }
+  return <Child value={1} />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				immutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 4, 5, 4, 10),
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ImmutabilityRule, valid, invalid)
+}

--- a/internal/plugins/react_hooks/rules/immutability/immutability_upstream_test.go
+++ b/internal/plugins/react_hooks/rules/immutability/immutability_upstream_test.go
@@ -1,0 +1,227 @@
+package immutability
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestImmutabilityUpstream migrates the react-hooks/immutability cases from
+// upstream packages/eslint-plugin-react-hooks/__tests__/ReactCompilerRuleTypescript-test.ts
+// and ReactCompilerRuleFlow-test.ts 1:1. Position assertions cover line/column
+// for every invalid case. rslint-specific lock-in cases live in the
+// immutability_extras_test.go file.
+
+func upstreamImmutabilityError(info immutableInfo, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "immutableMutation",
+		Message:   buildImmutabilityMessage(info).Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func TestImmutabilityUpstream(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- ReactCompilerRuleTypescript: Basic example. ----
+		{Code: `
+function Button(props) {
+  return null;
+}
+		`, FileName: "test.tsx", Tsx: true},
+		// ---- ReactCompilerRuleTypescript: Repro for hooks as normal values. ----
+		{Code: `
+function Button(props) {
+  const scrollView = React.useRef<ScrollView>(null);
+  return <Button thing={scrollView} />;
+}
+		`, FileName: "test.tsx", Tsx: true},
+		// ---- ReactCompilerRuleTypescript: [Heuristic] skips files with only lowercase utility functions. ----
+		{Code: `
+function helper(obj) {
+  obj.key = 'value';
+  return obj;
+}
+		`, FileName: "utils.ts"},
+		// ---- ReactCompilerRuleTypescript: [Heuristic] skips lowercase arrow functions even with mutations. ----
+		{Code: `
+const processData = (input) => {
+  input.modified = true;
+  return input;
+};
+		`, FileName: "helpers.ts"},
+		// ---- ReactCompilerRuleFlow: lowercase utility functions are skipped. ----
+		{Code: `
+function helper(obj) {
+  obj.key = 'value';
+  return obj;
+}
+		`, Skip: true}, // SKIP: rslint does not parse Flow-only React Compiler test files with hermes-eslint.
+		// ---- ReactCompilerRuleFlow: lowercase arrow functions are skipped. ----
+		{Code: `
+const processData = (input) => {
+  input.modified = true;
+  return input;
+};
+		`, Skip: true}, // SKIP: rslint does not parse Flow-only React Compiler test files with hermes-eslint.
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- ReactCompilerRuleTypescript: Mutating useState value. ----
+		{
+			Code: `
+import { useState } from 'react';
+function Component(props) {
+  const x: ` + "`foo${1}`" + ` = 'foo1';
+  const [state, setState] = useState({a: 0});
+  state.a = 1;
+  return <div>{props.foo}</div>;
+}
+			`,
+			FileName: "test.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamImmutabilityError(immutableInfo{kind: immutableUseState, hookName: "useState"}, 6, 3, 6, 8),
+			},
+		},
+		// ---- ReactCompilerRuleTypescript: PascalCase function declaration detects prop mutation. ----
+		{
+			Code: `
+function MyComponent({a}) {
+  a.key = 'value';
+  return <div />;
+}
+			`,
+			FileName: "component.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamImmutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 3, 3, 4),
+			},
+		},
+		// ---- ReactCompilerRuleTypescript: PascalCase arrow function detects prop mutation. ----
+		{
+			Code: `
+const MyComponent = ({a}) => {
+  a.key = 'value';
+  return <div />;
+};
+			`,
+			FileName: "component.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamImmutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 3, 3, 4),
+			},
+		},
+		// ---- ReactCompilerRuleTypescript: PascalCase function expression detects prop mutation. ----
+		{
+			Code: `
+const MyComponent = function({a}) {
+  a.key = 'value';
+  return <div />;
+};
+			`,
+			FileName: "component.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamImmutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 3, 3, 4),
+			},
+		},
+		// ---- ReactCompilerRuleTypescript: exported function declaration detects prop mutation. ----
+		{
+			Code: `
+export function MyComponent({a}) {
+  a.key = 'value';
+  return <div />;
+}
+			`,
+			FileName: "component.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamImmutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 3, 3, 4),
+			},
+		},
+		// ---- ReactCompilerRuleTypescript: exported arrow function detects prop mutation. ----
+		{
+			Code: `
+export const MyComponent = ({a}) => {
+  a.key = 'value';
+  return <div />;
+};
+			`,
+			FileName: "component.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamImmutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 3, 3, 4),
+			},
+		},
+		// ---- ReactCompilerRuleTypescript: default exported function detects prop mutation. ----
+		{
+			Code: `
+export default function MyComponent({a}) {
+  a.key = 'value';
+  return <div />;
+}
+			`,
+			FileName: "component.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				upstreamImmutabilityError(immutableInfo{kind: immutablePropsOrHookArgs}, 3, 3, 3, 4),
+			},
+		},
+		// ---- ReactCompilerRuleFlow: Flow component declaration detects prop mutation. ----
+		{
+			Code: `
+component MyComponent(a: {key: string}) {
+  a.key = 'value';
+  return <div />;
+}
+			`,
+			Skip: true, // SKIP: rslint does not parse Flow component declarations.
+		},
+		// ---- ReactCompilerRuleFlow: exported Flow component declaration detects prop mutation. ----
+		{
+			Code: `
+export component MyComponent(a: {key: string}) {
+  a.key = 'value';
+  return <div />;
+}
+			`,
+			Skip: true, // SKIP: rslint does not parse Flow component declarations.
+		},
+		// ---- ReactCompilerRuleFlow: default exported Flow component declaration detects prop mutation. ----
+		{
+			Code: `
+export default component MyComponent(a: {key: string}) {
+  a.key = 'value';
+  return <div />;
+}
+			`,
+			Skip: true, // SKIP: rslint does not parse Flow component declarations.
+		},
+		// ---- ReactCompilerRuleFlow: Flow hook declaration detects argument mutation. ----
+		{
+			Code: `
+hook useMyHook(a: {key: string}) {
+  a.key = 'value';
+  return a;
+}
+			`,
+			Skip: true, // SKIP: rslint does not parse Flow hook declarations.
+		},
+		// ---- ReactCompilerRuleFlow: exported Flow hook declaration detects argument mutation. ----
+		{
+			Code: `
+export hook useMyHook(a: {key: string}) {
+  a.key = 'value';
+  return a;
+}
+			`,
+			Skip: true, // SKIP: rslint does not parse Flow hook declarations.
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ImmutabilityRule, valid, invalid)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -216,6 +216,7 @@ export default defineConfig({
     './tests/eslint-plugin-react-hooks/rules/component-hook-factories.test.ts',
     './tests/eslint-plugin-react-hooks/rules/error-boundaries.test.ts',
     './tests/eslint-plugin-react-hooks/rules/globals.test.ts',
+    './tests/eslint-plugin-react-hooks/rules/immutability.test.ts',
 
     // eslint-plugin-jsx-a11y
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/immutability.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/immutability.test.ts
@@ -1,0 +1,118 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const immutableMessage = (description: string) =>
+  `Error: This value cannot be modified\n\n${description}`;
+
+const stateMessage = immutableMessage(
+  "Modifying a value returned from 'useState()', which should not be modified directly. Use the setter function to update instead.",
+);
+
+const propsMessage = immutableMessage(
+  'Modifying component props or hook arguments is not allowed. Consider using a local variable instead.',
+);
+
+ruleTester.run('immutability', {} as never, {
+  valid: [
+    {
+      code: `
+        function Button(props) {
+          return null;
+        }
+      `,
+    },
+    {
+      code: `
+        function Button(props) {
+          const scrollView = React.useRef<ScrollView>(null);
+          return <Button thing={scrollView} />;
+        }
+      `,
+    },
+    {
+      code: `
+        function helper(obj) {
+          obj.key = 'value';
+          return obj;
+        }
+      `,
+    },
+    {
+      code: `
+        const processData = (input) => {
+          input.modified = true;
+          return input;
+        };
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { useState } from 'react';
+        function Component(props) {
+          const x: \`foo\${1}\` = 'foo1';
+          const [state, setState] = useState({a: 0});
+          state.a = 1;
+          return <div>{props.foo}</div>;
+        }
+      `,
+      errors: [{ message: stateMessage }],
+    },
+    {
+      code: `
+        function MyComponent({a}) {
+          a.key = 'value';
+          return <div />;
+        }
+      `,
+      errors: [{ message: propsMessage }],
+    },
+    {
+      code: `
+        const MyComponent = ({a}) => {
+          a.key = 'value';
+          return <div />;
+        };
+      `,
+      errors: [{ message: propsMessage }],
+    },
+    {
+      code: `
+        const MyComponent = function({a}) {
+          a.key = 'value';
+          return <div />;
+        };
+      `,
+      errors: [{ message: propsMessage }],
+    },
+    {
+      code: `
+        export function MyComponent({a}) {
+          a.key = 'value';
+          return <div />;
+        }
+      `,
+      errors: [{ message: propsMessage }],
+    },
+    {
+      code: `
+        export const MyComponent = ({a}) => {
+          a.key = 'value';
+          return <div />;
+        };
+      `,
+      errors: [{ message: propsMessage }],
+    },
+    {
+      code: `
+        export default function MyComponent({a}) {
+          a.key = 'value';
+          return <div />;
+        }
+      `,
+      errors: [{ message: propsMessage }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react-hooks/immutability` rule from `eslint-plugin-react-hooks` to rslint.

The rule reports direct mutations of immutable React values such as component props, hook arguments, hook return values, values used in JSX, and values passed to hooks. The Go implementation includes upstream parity cases plus extra lock-in coverage for nested and real-repo shapes.

## Related Links

- Rule docs: https://react.dev/reference/eslint-plugin-react-hooks/lints/immutability
- Source code: https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
