### PR TITLE
fix: align react hooks rule options

### DIFF
--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -17,7 +17,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -28,10 +27,6 @@ const (
 	CompilerReactFunctionComponent CompilerReactFunctionType = "Component"
 	CompilerReactFunctionHook      CompilerReactFunctionType = "Hook"
 )
-
-type CompilerFunctionOptions struct {
-	HookPattern *regexp2.Regexp
-}
 
 // hookNameTailRegex matches the suffix part of a hook identifier:
 // after the leading `use`, the next character must be uppercase Latin
@@ -158,24 +153,18 @@ func IsHookCallee(node *ast.Node) bool {
 
 // IsCompilerHookCallee is the React Compiler variant of IsHookCallee:
 // it accepts `useFoo` / `Namespace.useFoo`, but not the bare `use`.
-func IsCompilerHookCallee(node *ast.Node, hookPattern *regexp2.Regexp) bool {
+func IsCompilerHookCallee(node *ast.Node) bool {
 	if node == nil {
 		return false
-	}
-	isHookName := func(name string) bool {
-		if hookPattern != nil {
-			return utils.Regexp2MatchString(hookPattern, name)
-		}
-		return IsCompilerHookName(name)
 	}
 	n := ast.SkipParentheses(node)
 	switch n.Kind {
 	case ast.KindIdentifier:
-		return isHookName(n.AsIdentifier().Text)
+		return IsCompilerHookName(n.AsIdentifier().Text)
 	case ast.KindPropertyAccessExpression:
 		pae := n.AsPropertyAccessExpression()
 		prop := pae.Name()
-		if prop == nil || prop.Kind != ast.KindIdentifier || !isHookName(prop.AsIdentifier().Text) {
+		if prop == nil || prop.Kind != ast.KindIdentifier || !IsCompilerHookName(prop.AsIdentifier().Text) {
 			return false
 		}
 		obj := ast.SkipParentheses(pae.Expression)
@@ -199,25 +188,25 @@ func IsCompilerFunctionKind(node *ast.Node) bool {
 // directly creates JSX or calls a hook, has component-like parameters, and does
 // not return obviously non-ReactNode values; a hook-like function must directly
 // create JSX or call a hook; memo/forwardRef callbacks are components.
-func GetCompilerReactFunctionType(fn *ast.Node, opts CompilerFunctionOptions) CompilerReactFunctionType {
+func GetCompilerReactFunctionType(fn *ast.Node) CompilerReactFunctionType {
 	name := GetFunctionName(fn)
 	if name != nil && name.Kind == ast.KindIdentifier && IsComponentNameStr(name.AsIdentifier().Text) {
-		if CallsHooksOrCreatesJsx(fn, opts.HookPattern) &&
+		if CallsHooksOrCreatesJsx(fn) &&
 			IsValidCompilerComponentParams(fn) &&
 			!ReturnsCompilerNonNode(fn) {
 			return CompilerReactFunctionComponent
 		}
 		return ""
 	}
-	if name != nil && IsCompilerHookCallee(name, opts.HookPattern) {
-		if CallsHooksOrCreatesJsx(fn, opts.HookPattern) {
+	if name != nil && IsCompilerHookCallee(name) {
+		if CallsHooksOrCreatesJsx(fn) {
 			return CompilerReactFunctionHook
 		}
 		return ""
 	}
 	if ast.IsFunctionExpressionOrArrowFunction(fn) {
 		if IsForwardRefOrMemoCallback(fn, "forwardRef") || IsForwardRefOrMemoCallback(fn, "memo") {
-			if CallsHooksOrCreatesJsx(fn, opts.HookPattern) {
+			if CallsHooksOrCreatesJsx(fn) {
 				return CompilerReactFunctionComponent
 			}
 		}
@@ -228,7 +217,7 @@ func GetCompilerReactFunctionType(fn *ast.Node, opts CompilerFunctionOptions) Co
 // CallsHooksOrCreatesJsx reports whether `fn` directly creates JSX or directly
 // calls a compiler hook. Nested function bodies are skipped, matching React
 // Compiler's traversal boundary.
-func CallsHooksOrCreatesJsx(fn *ast.Node, hookPattern *regexp2.Regexp) bool {
+func CallsHooksOrCreatesJsx(fn *ast.Node) bool {
 	found := false
 	var walk func(*ast.Node)
 	walk = func(node *ast.Node) {
@@ -243,7 +232,7 @@ func CallsHooksOrCreatesJsx(fn *ast.Node, hookPattern *regexp2.Regexp) bool {
 			return
 		}
 		if ast.IsCallExpression(node) {
-			if IsCompilerHookCallee(node.AsCallExpression().Expression, hookPattern) {
+			if IsCompilerHookCallee(node.AsCallExpression().Expression) {
 				found = true
 				return
 			}

--- a/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories.go
+++ b/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories.go
@@ -4,16 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
-
-type componentHookFactoriesOptions struct {
-	hookPattern *regexp2.Regexp
-}
 
 // ComponentHookFactoriesRule is the rslint port of upstream
 // `react-hooks/component-hook-factories`.
@@ -25,9 +19,8 @@ type componentHookFactoriesOptions struct {
 var ComponentHookFactoriesRule = rule.Rule{
 	Name: "react-hooks/component-hook-factories",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
-		opts := parseOptions(options)
 		check := func(node *ast.Node) {
-			validateNoDynamicallyCreatedComponentsOrHooks(ctx, node, opts)
+			validateNoDynamicallyCreatedComponentsOrHooks(ctx, node)
 		}
 		return rule.RuleListeners{
 			ast.KindFunctionDeclaration: check,
@@ -37,27 +30,7 @@ var ComponentHookFactoriesRule = rule.Rule{
 	},
 }
 
-func parseOptions(raw any) componentHookFactoriesOptions {
-	optsMap := utils.GetOptionsMap(raw)
-	if optsMap == nil {
-		return componentHookFactoriesOptions{}
-	}
-	environment, ok := optsMap["environment"].(map[string]interface{})
-	if !ok {
-		return componentHookFactoriesOptions{}
-	}
-	pattern, ok := environment["hookPattern"].(string)
-	if !ok || pattern == "" {
-		return componentHookFactoriesOptions{}
-	}
-	compiled, err := utils.CompileRegexp2(pattern, utils.JSRegexOptions)
-	if err != nil {
-		return componentHookFactoriesOptions{}
-	}
-	return componentHookFactoriesOptions{hookPattern: compiled}
-}
-
-func validateNoDynamicallyCreatedComponentsOrHooks(ctx rule.RuleContext, fn *ast.Node, opts componentHookFactoriesOptions) {
+func validateNoDynamicallyCreatedComponentsOrHooks(ctx rule.RuleContext, fn *ast.Node) {
 	if isInsideClass(fn) {
 		return
 	}
@@ -72,9 +45,7 @@ func validateNoDynamicallyCreatedComponentsOrHooks(ctx rule.RuleContext, fn *ast
 	}
 
 	walkDirectChildren(fn, func(nestedFn *ast.Node) {
-		nestedType := react_hooksutil.GetCompilerReactFunctionType(nestedFn, react_hooksutil.CompilerFunctionOptions{
-			HookPattern: opts.hookPattern,
-		})
+		nestedType := react_hooksutil.GetCompilerReactFunctionType(nestedFn)
 		if nestedType == "" {
 			return
 		}

--- a/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories.md
+++ b/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories.md
@@ -45,36 +45,6 @@ function Button({ color, children }) {
 }
 ```
 
-## Options
-
-```json
-{
-  "react-hooks/component-hook-factories": [
-    "error",
-    {
-      "environment": {
-        "hookPattern": "^signal[A-Z]"
-      }
-    }
-  ]
-}
-```
-
-- `environment.hookPattern`: A JavaScript regular expression pattern for
-  custom Hook names. Function names that match this pattern are treated as
-  Hooks when the rule classifies nested factories. When omitted or invalid,
-  the rule falls back to React's default Hook naming convention.
-
-Examples of **incorrect** code for this rule with `{ "environment": { "hookPattern": "^signal[A-Z]" } }`:
-
-```javascript
-function createSignalHook(source) {
-  return function signalValue() {
-    return signalRead(source);
-  };
-}
-```
-
 ## Original Documentation
 
 - [react.dev — component-hook-factories](https://react.dev/reference/eslint-plugin-react-hooks/lints/component-hook-factories)

--- a/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories_extras_test.go
+++ b/internal/plugins/react_hooks/rules/component_hook_factories/component_hook_factories_extras_test.go
@@ -123,18 +123,14 @@ function makeComputedHook() {
   };
 }
 		`, Tsx: true},
-		// ---- Branch lock-in: malformed hookPattern is ignored like upstream option parsing ----
-		{
-			Code: `
+		// ---- Upstream parity: non-use factory names are not custom Hooks. ----
+		{Code: `
 function createSignalHook(source) {
   return function signalValue() {
     return signalRead(source);
   };
 }
-			`,
-			Tsx:     true,
-			Options: map[string]interface{}{"environment": map[string]interface{}{"hookPattern": "["}},
-		},
+		`, Tsx: true},
 		// ---- Dimension 4: class declarations/expressions are skipped by the React Compiler traversal ----
 		{Code: `
 class Holder {
@@ -365,32 +361,6 @@ function createWrapped(kind) {
 				{MessageId: "componentHookFactory"},
 				{MessageId: "componentHookFactory"},
 			},
-		},
-		// ---- Dimension 4: custom hookPattern option ----
-		{
-			Code: `
-function createSignalHook(source) {
-  return function signalValue() {
-    return signalRead(source);
-  };
-}
-			`,
-			Tsx:     true,
-			Options: map[string]interface{}{"environment": map[string]interface{}{"hookPattern": "(?=signal)signal[A-Z]"}},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
-		},
-		// ---- Branch lock-in: array-wrapped hookPattern option matches context.options shape ----
-		{
-			Code: `
-function createTrackedHook(source) {
-  return function trackValue() {
-    return trackRead(source);
-  };
-}
-			`,
-			Tsx:     true,
-			Options: []interface{}{map[string]interface{}{"environment": map[string]interface{}{"hookPattern": "^track[A-Z]"}}},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "componentHookFactory"}},
 		},
 		// ---- Real-user: library helper that returns an endpoint hook ----
 		{

--- a/internal/plugins/react_hooks/rules/globals/globals.go
+++ b/internal/plugins/react_hooks/rules/globals/globals.go
@@ -204,7 +204,7 @@ func (state *globalsState) activeFunctionKind(fn *ast.Node) activeFunctionKind {
 }
 
 func isCompilerRenderFunction(fn *ast.Node) bool {
-	return react_hooksutil.GetCompilerReactFunctionType(fn, react_hooksutil.CompilerFunctionOptions{}) != ""
+	return react_hooksutil.GetCompilerReactFunctionType(fn) != ""
 }
 
 func isNonRenderCallback(fn *ast.Node) bool {


### PR DESCRIPTION
## Summary

Remove unsupported `environment.hookPattern` handling from the existing `react-hooks/component-hook-factories` port.

Upstream `eslint-plugin-react-hooks@7.1.1` exposes no options for `component-hook-factories` (`meta.schema` is `[]`), and ESLint rejects `{ environment: { hookPattern } }` during config validation. Keep `rules-of-hooks` and `exhaustive-deps` options/settings unchanged because their corresponding upstream fields exist.

## Related Links

- react-hooks component-hook-factories docs: https://react.dev/reference/eslint-plugin-react-hooks/lints/component-hook-factories
- Source package: https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks

## Verification

- `go test -count=1 ./internal/plugins/react_hooks/react_hooksutil ./internal/plugins/react_hooks/rules/component_hook_factories ./internal/plugins/react_hooks/rules/globals ./internal/plugins/react_hooks`
- `pnpm exec rstest tests/eslint-plugin-react-hooks/rules/component-hook-factories.test.ts --testTimeout=10000`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m` on packages containing changed Go files

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
