### PR TITLE
feat: port rule react-hooks/incompatible-library

### DIFF
--- a/internal/plugins/react_hooks/all.go
+++ b/internal/plugins/react_hooks/all.go
@@ -6,6 +6,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/exhaustive_deps"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/globals"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/immutability"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/incompatible_library"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/rules_of_hooks"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -18,5 +19,6 @@ func GetAllRules() []rule.Rule {
 		error_boundaries.ErrorBoundariesRule,
 		globals.GlobalsRule,
 		immutability.ImmutabilityRule,
+		incompatible_library.IncompatibleLibraryRule,
 	}
 }

--- a/internal/plugins/react_hooks/rules/incompatible_library/incompatible_library.go
+++ b/internal/plugins/react_hooks/rules/incompatible_library/incompatible_library.go
@@ -1,0 +1,748 @@
+package incompatible_library
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const incompatibleLibraryDescription = "This API returns functions which cannot be memoized without leading to stale UI. " +
+	"To prevent this, by default React Compiler will skip memoizing this component/hook. " +
+	"However, you may see issues if values from this API are passed to other components/hooks that are memoized."
+
+const (
+	reactHookFormWatchMessage = "React Hook Form's `useForm()` API returns a `watch()` function which cannot be memoized safely."
+	tanStackTableMessage      = "TanStack Table's `useReactTable()` API returns functions that cannot be memoized safely"
+	tanStackVirtualMessage    = "TanStack Virtual's `useVirtualizer()` API returns functions that cannot be memoized safely"
+)
+
+type bindingKind int
+
+const (
+	bindingUnknown bindingKind = iota
+	bindingReactHookFormNamespace
+	bindingTanStackTableNamespace
+	bindingTanStackVirtualNamespace
+	bindingUseForm
+	bindingFormReturn
+	bindingWatch
+	bindingUseReactTable
+	bindingUseVirtualizer
+)
+
+type lexicalScope map[string]bindingKind
+
+type incompatibleLibraryState struct {
+	ctx    rule.RuleContext
+	scopes []lexicalScope
+}
+
+// IncompatibleLibraryRule is the rslint port of upstream
+// `react-hooks/incompatible-library`.
+//
+// Upstream emits this rule from React Compiler's IncompatibleLibrary
+// diagnostic category. This port keeps the published built-in module model
+// local to rslint: React Hook Form's `useForm().watch`, TanStack Table's
+// `useReactTable`, and TanStack Virtual's `useVirtualizer`.
+var IncompatibleLibraryRule = rule.Rule{
+	Name: "react-hooks/incompatible-library",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		state := &incompatibleLibraryState{ctx: ctx}
+		state.pushScope()
+		return rule.RuleListeners{
+			ast.KindImportDeclaration:   state.processImportDeclaration,
+			ast.KindFunctionDeclaration: state.enterFunctionDeclaration,
+			ast.KindFunctionExpression:  state.enterFunctionExpression,
+			ast.KindArrowFunction:       state.enterFunctionExpression,
+			ast.KindBlock:               state.enterBlock,
+			ast.KindModuleBlock:         state.enterBlock,
+			ast.KindCatchClause:         state.enterCatchClause,
+			ast.KindVariableDeclaration: state.processVariableDeclaration,
+			ast.KindBinaryExpression:    state.processBinaryExpression,
+			ast.KindCallExpression:      state.processCallExpression,
+
+			rule.ListenerOnExit(ast.KindFunctionDeclaration): func(node *ast.Node) { state.popScope() },
+			rule.ListenerOnExit(ast.KindFunctionExpression):  func(node *ast.Node) { state.popScope() },
+			rule.ListenerOnExit(ast.KindArrowFunction):       func(node *ast.Node) { state.popScope() },
+			rule.ListenerOnExit(ast.KindBlock):               func(node *ast.Node) { state.popScope() },
+			rule.ListenerOnExit(ast.KindModuleBlock):         func(node *ast.Node) { state.popScope() },
+			rule.ListenerOnExit(ast.KindCatchClause):         func(node *ast.Node) { state.popScope() },
+		}
+	},
+}
+
+func (state *incompatibleLibraryState) processImportDeclaration(node *ast.Node) {
+	if ast.IsTypeOnlyImportDeclaration(node) {
+		return
+	}
+	decl := node.AsImportDeclaration()
+	if decl == nil || decl.ImportClause == nil {
+		return
+	}
+	moduleName, ok := utils.GetStaticStringLiteralValue(utils.SkipAssertionsAndParens(decl.ModuleSpecifier))
+	if !ok {
+		return
+	}
+	clause := decl.ImportClause.AsImportClause()
+	if clause == nil {
+		return
+	}
+	if clause.Name() != nil {
+		state.declareNode(clause.Name(), bindingUnknown)
+	}
+	if clause.NamedBindings == nil {
+		return
+	}
+	switch clause.NamedBindings.Kind {
+	case ast.KindNamespaceImport:
+		state.processNamespaceImport(moduleName, clause.NamedBindings)
+	case ast.KindNamedImports:
+		state.processNamedImports(moduleName, clause.NamedBindings)
+	}
+}
+
+func (state *incompatibleLibraryState) processNamespaceImport(moduleName string, node *ast.Node) {
+	namespace := node.AsNamespaceImport()
+	if namespace == nil || namespace.Name() == nil {
+		return
+	}
+	switch moduleName {
+	case "react-hook-form":
+		state.declareNode(namespace.Name(), bindingReactHookFormNamespace)
+	case "@tanstack/react-table":
+		state.declareNode(namespace.Name(), bindingTanStackTableNamespace)
+	case "@tanstack/react-virtual":
+		state.declareNode(namespace.Name(), bindingTanStackVirtualNamespace)
+	default:
+		state.declareNode(namespace.Name(), bindingUnknown)
+	}
+}
+
+func (state *incompatibleLibraryState) processNamedImports(moduleName string, node *ast.Node) {
+	named := node.AsNamedImports()
+	if named == nil || named.Elements == nil {
+		return
+	}
+	for _, elem := range named.Elements.Nodes {
+		spec := elem.AsImportSpecifier()
+		if spec == nil || spec.Name() == nil || spec.IsTypeOnly {
+			continue
+		}
+		importedName := importSpecifierImportedName(spec)
+		localName := spec.Name()
+		switch {
+		case moduleName == "react-hook-form" && importedName == "useForm":
+			state.declareNode(localName, bindingUseForm)
+		case moduleName == "@tanstack/react-table" && importedName == "useReactTable":
+			state.declareNode(localName, bindingUseReactTable)
+		case moduleName == "@tanstack/react-virtual" && importedName == "useVirtualizer":
+			state.declareNode(localName, bindingUseVirtualizer)
+		default:
+			state.declareNode(localName, bindingUnknown)
+		}
+	}
+}
+
+func (state *incompatibleLibraryState) enterFunctionDeclaration(node *ast.Node) {
+	if name := node.Name(); name != nil {
+		state.declareNode(name, bindingUnknown)
+	}
+	state.pushScope()
+	if name := node.Name(); name != nil {
+		state.declareNode(name, bindingUnknown)
+	}
+	state.declareParameters(node)
+	state.predeclareHoistedVarNames(node.Body())
+}
+
+func (state *incompatibleLibraryState) enterFunctionExpression(node *ast.Node) {
+	state.pushScope()
+	if name := node.Name(); name != nil {
+		state.declareNode(name, bindingUnknown)
+	}
+	state.declareParameters(node)
+	state.predeclareHoistedVarNames(node.Body())
+}
+
+func (state *incompatibleLibraryState) enterBlock(node *ast.Node) {
+	state.pushScope()
+	state.predeclareBlockDeclarations(node)
+}
+
+func (state *incompatibleLibraryState) enterCatchClause(node *ast.Node) {
+	state.pushScope()
+	catchClause := node.AsCatchClause()
+	if catchClause == nil || catchClause.VariableDeclaration == nil {
+		return
+	}
+	decl := catchClause.VariableDeclaration.AsVariableDeclaration()
+	if decl != nil {
+		state.declareBindingName(decl.Name(), bindingUnknown)
+	}
+}
+
+func (state *incompatibleLibraryState) processVariableDeclaration(node *ast.Node) {
+	decl := node.AsVariableDeclaration()
+	if decl == nil {
+		return
+	}
+	name := decl.Name()
+	if name == nil {
+		return
+	}
+	initKind := state.expressionBindingKind(decl.Initializer)
+	if initKind != bindingUnknown && !isInsideIncompatibleLibraryTarget(node) {
+		state.declareBindingName(name, bindingUnknown)
+		return
+	}
+	if initKind == bindingFormReturn {
+		state.declareFormReturnBinding(name)
+		return
+	}
+	if initKind == bindingReactHookFormNamespace || initKind == bindingTanStackTableNamespace || initKind == bindingTanStackVirtualNamespace {
+		state.declareModuleObjectPattern(name, initKind)
+		return
+	}
+	state.declareBindingName(name, initKind)
+}
+
+func (state *incompatibleLibraryState) processBinaryExpression(node *ast.Node) {
+	if !ast.IsAssignmentExpression(node, false) {
+		return
+	}
+	binary := node.AsBinaryExpression()
+	if binary == nil || binary.OperatorToken == nil || binary.OperatorToken.Kind != ast.KindEqualsToken {
+		return
+	}
+	rightKind := state.expressionBindingKind(binary.Right)
+	if rightKind != bindingUnknown && !isInsideIncompatibleLibraryTarget(node) {
+		state.assignBindingName(binary.Left, bindingUnknown)
+		return
+	}
+	switch rightKind {
+	case bindingFormReturn:
+		state.assignFormReturnBinding(binary.Left)
+	case bindingReactHookFormNamespace, bindingTanStackTableNamespace, bindingTanStackVirtualNamespace:
+		state.assignModuleObjectPattern(binary.Left, rightKind)
+	default:
+		state.assignBindingName(binary.Left, rightKind)
+	}
+}
+
+func (state *incompatibleLibraryState) processCallExpression(node *ast.Node) {
+	call := node.AsCallExpression()
+	if call == nil || call.Expression == nil {
+		return
+	}
+	if !isInsideIncompatibleLibraryTarget(node) {
+		return
+	}
+	callee := utils.SkipAssertionsAndParens(call.Expression)
+	kind, reportNode := state.calleeBindingKindAndReportNode(callee)
+	switch kind {
+	case bindingUseReactTable:
+		state.report(reportNode, tanStackTableMessage)
+	case bindingUseVirtualizer:
+		state.report(reportNode, tanStackVirtualMessage)
+	case bindingWatch:
+		state.report(reportNode, reactHookFormWatchMessage)
+	}
+}
+
+// This diagnostic runs only inside functions selected as React Compiler roots.
+// Nested callbacks inside those roots are checked, but a top-level memo or
+// forwardRef callback is not a root for this rule in upstream.
+func isInsideIncompatibleLibraryTarget(node *ast.Node) bool {
+	for fn := react_hooksutil.FindEnclosingFunction(node); fn != nil; fn = react_hooksutil.FindEnclosingFunction(fn) {
+		if isIncompatibleLibraryRootFunction(fn) {
+			return true
+		}
+	}
+	return false
+}
+
+func isIncompatibleLibraryRootFunction(fn *ast.Node) bool {
+	if fn == nil || isImmediateCallArgument(fn) {
+		return false
+	}
+	name := react_hooksutil.GetFunctionName(fn)
+	if name != nil && name.Kind == ast.KindIdentifier && react_hooksutil.IsComponentNameStr(name.AsIdentifier().Text) {
+		return react_hooksutil.CallsHooksOrCreatesJsx(fn) &&
+			react_hooksutil.IsValidCompilerComponentParams(fn) &&
+			!react_hooksutil.ReturnsCompilerNonNode(fn)
+	}
+	if name != nil && react_hooksutil.IsCompilerHookCallee(name) {
+		return react_hooksutil.CallsHooksOrCreatesJsx(fn)
+	}
+	return false
+}
+
+func isImmediateCallArgument(fn *ast.Node) bool {
+	child := fn
+	parent := fn.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		child = parent
+		parent = parent.Parent
+	}
+	if parent == nil || parent.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := parent.AsCallExpression()
+	if call == nil || call.Arguments == nil {
+		return false
+	}
+	for _, arg := range call.Arguments.Nodes {
+		if arg == child {
+			return true
+		}
+	}
+	return false
+}
+
+func (state *incompatibleLibraryState) declareParameters(fn *ast.Node) {
+	for _, param := range fn.Parameters() {
+		if param == nil {
+			continue
+		}
+		state.declareBindingName(param.Name(), bindingUnknown)
+	}
+}
+
+func (state *incompatibleLibraryState) predeclareBlockDeclarations(block *ast.Node) {
+	var statements []*ast.Node
+	switch block.Kind {
+	case ast.KindBlock:
+		if b := block.AsBlock(); b != nil && b.Statements != nil {
+			statements = b.Statements.Nodes
+		}
+	case ast.KindModuleBlock:
+		if b := block.AsModuleBlock(); b != nil && b.Statements != nil {
+			statements = b.Statements.Nodes
+		}
+	}
+	for _, stmt := range statements {
+		state.predeclareStatement(stmt)
+	}
+}
+
+func (state *incompatibleLibraryState) predeclareStatement(stmt *ast.Node) {
+	if stmt == nil {
+		return
+	}
+	switch stmt.Kind {
+	case ast.KindVariableStatement:
+		varStmt := stmt.AsVariableStatement()
+		if varStmt == nil || varStmt.DeclarationList == nil {
+			return
+		}
+		state.declareVarListBindings(varStmt.DeclarationList)
+	case ast.KindFunctionDeclaration, ast.KindClassDeclaration, ast.KindEnumDeclaration, ast.KindModuleDeclaration:
+		if name := stmt.Name(); name != nil && name.Kind == ast.KindIdentifier {
+			state.declareNode(name, bindingUnknown)
+		}
+	}
+}
+
+func (state *incompatibleLibraryState) predeclareHoistedVarNames(root *ast.Node) {
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node != root && ast.IsFunctionLikeOrClassStaticBlockDeclaration(node) {
+			return
+		}
+		switch node.Kind {
+		case ast.KindVariableStatement:
+			varStmt := node.AsVariableStatement()
+			if varStmt != nil && varStmt.DeclarationList != nil && utils.IsVarKeyword(varStmt.DeclarationList) {
+				state.declareVarListBindings(varStmt.DeclarationList)
+			}
+		case ast.KindForStatement:
+			forStmt := node.AsForStatement()
+			if forStmt != nil && forStmt.Initializer != nil &&
+				forStmt.Initializer.Kind == ast.KindVariableDeclarationList &&
+				utils.IsVarKeyword(forStmt.Initializer) {
+				state.declareVarListBindings(forStmt.Initializer)
+			}
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			stmt := node.AsForInOrOfStatement()
+			if stmt != nil && stmt.Initializer != nil &&
+				stmt.Initializer.Kind == ast.KindVariableDeclarationList &&
+				utils.IsVarKeyword(stmt.Initializer) {
+				state.declareVarListBindings(stmt.Initializer)
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(root)
+}
+
+func (state *incompatibleLibraryState) declareVarListBindings(node *ast.Node) {
+	declList := node.AsVariableDeclarationList()
+	if declList == nil || declList.Declarations == nil {
+		return
+	}
+	for _, decl := range declList.Declarations.Nodes {
+		if decl != nil && decl.Kind == ast.KindVariableDeclaration {
+			state.declareBindingName(decl.AsVariableDeclaration().Name(), bindingUnknown)
+		}
+	}
+}
+
+func (state *incompatibleLibraryState) declareFormReturnBinding(name *ast.Node) {
+	if name == nil {
+		return
+	}
+	if name.Kind == ast.KindIdentifier {
+		state.declareNode(name, bindingFormReturn)
+		return
+	}
+	if name.Kind == ast.KindObjectBindingPattern {
+		state.declareObjectPattern(name, func(prop string) bindingKind {
+			if prop == "watch" {
+				return bindingWatch
+			}
+			return bindingUnknown
+		})
+		return
+	}
+	state.declareBindingName(name, bindingUnknown)
+}
+
+func (state *incompatibleLibraryState) assignFormReturnBinding(name *ast.Node) {
+	if name == nil {
+		return
+	}
+	name = utils.SkipAssertionsAndParens(name)
+	if name.Kind == ast.KindIdentifier {
+		state.assignNode(name, bindingFormReturn)
+		return
+	}
+	if name.Kind == ast.KindObjectLiteralExpression {
+		state.assignObjectPattern(name, func(prop string) bindingKind {
+			if prop == "watch" {
+				return bindingWatch
+			}
+			return bindingUnknown
+		})
+		return
+	}
+	state.assignBindingName(name, bindingUnknown)
+}
+
+func (state *incompatibleLibraryState) declareModuleObjectPattern(name *ast.Node, moduleKind bindingKind) {
+	if name == nil {
+		return
+	}
+	if name.Kind == ast.KindIdentifier {
+		state.declareNode(name, moduleKind)
+		return
+	}
+	if name.Kind == ast.KindObjectBindingPattern {
+		state.declareObjectPattern(name, func(prop string) bindingKind {
+			switch moduleKind {
+			case bindingReactHookFormNamespace:
+				if prop == "useForm" {
+					return bindingUseForm
+				}
+			case bindingTanStackTableNamespace:
+				if prop == "useReactTable" {
+					return bindingUseReactTable
+				}
+			case bindingTanStackVirtualNamespace:
+				if prop == "useVirtualizer" {
+					return bindingUseVirtualizer
+				}
+			}
+			return bindingUnknown
+		})
+		return
+	}
+	state.declareBindingName(name, bindingUnknown)
+}
+
+func (state *incompatibleLibraryState) assignModuleObjectPattern(name *ast.Node, moduleKind bindingKind) {
+	if name == nil {
+		return
+	}
+	name = utils.SkipAssertionsAndParens(name)
+	if name.Kind == ast.KindIdentifier {
+		state.assignNode(name, moduleKind)
+		return
+	}
+	if name.Kind == ast.KindObjectLiteralExpression {
+		state.assignObjectPattern(name, func(prop string) bindingKind {
+			switch moduleKind {
+			case bindingReactHookFormNamespace:
+				if prop == "useForm" {
+					return bindingUseForm
+				}
+			case bindingTanStackTableNamespace:
+				if prop == "useReactTable" {
+					return bindingUseReactTable
+				}
+			case bindingTanStackVirtualNamespace:
+				if prop == "useVirtualizer" {
+					return bindingUseVirtualizer
+				}
+			}
+			return bindingUnknown
+		})
+		return
+	}
+	state.assignBindingName(name, bindingUnknown)
+}
+
+func (state *incompatibleLibraryState) declareBindingName(name *ast.Node, kind bindingKind) {
+	if name == nil {
+		return
+	}
+	switch name.Kind {
+	case ast.KindIdentifier:
+		state.declareNode(name, kind)
+	case ast.KindObjectBindingPattern:
+		state.declareObjectPattern(name, func(string) bindingKind { return kind })
+	case ast.KindArrayBindingPattern:
+		name.ForEachChild(func(child *ast.Node) bool {
+			if child.Kind == ast.KindBindingElement {
+				state.declareBindingName(child.AsBindingElement().Name(), kind)
+			}
+			return false
+		})
+	}
+}
+
+func (state *incompatibleLibraryState) assignBindingName(name *ast.Node, kind bindingKind) {
+	if name == nil {
+		return
+	}
+	name = utils.SkipAssertionsAndParens(name)
+	switch name.Kind {
+	case ast.KindIdentifier:
+		state.assignNode(name, kind)
+	case ast.KindObjectLiteralExpression:
+		state.assignObjectPattern(name, func(string) bindingKind { return kind })
+	case ast.KindArrayLiteralExpression:
+		name.ForEachChild(func(child *ast.Node) bool {
+			if child.Kind != ast.KindSpreadElement {
+				state.assignBindingName(child, kind)
+			}
+			return false
+		})
+	}
+}
+
+func (state *incompatibleLibraryState) declareObjectPattern(pattern *ast.Node, kindForProperty func(string) bindingKind) {
+	pattern.ForEachChild(func(child *ast.Node) bool {
+		if child.Kind != ast.KindBindingElement {
+			return false
+		}
+		binding := child.AsBindingElement()
+		if binding == nil {
+			return false
+		}
+		propName := bindingElementPropertyName(child)
+		childKind := kindForProperty(propName)
+		if childKind != bindingUnknown && binding.Name() != nil && binding.Name().Kind != ast.KindIdentifier {
+			state.declareBindingName(binding.Name(), bindingUnknown)
+			return false
+		}
+		state.declareBindingName(binding.Name(), childKind)
+		return false
+	})
+}
+
+func (state *incompatibleLibraryState) assignObjectPattern(pattern *ast.Node, kindForProperty func(string) bindingKind) {
+	pattern.ForEachChild(func(child *ast.Node) bool {
+		switch child.Kind {
+		case ast.KindPropertyAssignment:
+			prop := child.AsPropertyAssignment()
+			if prop == nil {
+				return false
+			}
+			childKind := kindForProperty(bindingElementPropertyName(child))
+			if childKind != bindingUnknown && prop.Initializer != nil && prop.Initializer.Kind != ast.KindIdentifier {
+				state.assignBindingName(prop.Initializer, bindingUnknown)
+				return false
+			}
+			state.assignBindingName(prop.Initializer, childKind)
+		case ast.KindShorthandPropertyAssignment:
+			name := child.Name()
+			if name != nil {
+				state.assignBindingName(name, kindForProperty(name.Text()))
+			}
+		case ast.KindSpreadAssignment:
+			if name := child.Name(); name != nil {
+				state.assignBindingName(name, bindingUnknown)
+			}
+		}
+		return false
+	})
+}
+
+func (state *incompatibleLibraryState) expressionBindingKind(expr *ast.Node) bindingKind {
+	expr = utils.SkipAssertionsAndParens(expr)
+	if expr == nil {
+		return bindingUnknown
+	}
+	switch expr.Kind {
+	case ast.KindIdentifier:
+		return state.lookup(expr.AsIdentifier().Text)
+	case ast.KindCallExpression:
+		if state.expressionBindingKind(expr.AsCallExpression().Expression) == bindingUseForm {
+			return bindingFormReturn
+		}
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		return state.accessExpressionBindingKind(expr)
+	}
+	return bindingUnknown
+}
+
+func (state *incompatibleLibraryState) calleeBindingKindAndReportNode(callee *ast.Node) (bindingKind, *ast.Node) {
+	kind := state.expressionBindingKind(callee)
+	if kind == bindingUnknown {
+		return kind, callee
+	}
+	if ast.IsAccessExpression(callee) {
+		if receiver := reportableAccessReceiver(callee); receiver != nil {
+			return kind, receiver
+		}
+	}
+	return kind, callee
+}
+
+// Upstream reports member-call diagnostics on the receiver expression:
+// `form.watch()` reports `form`, and `(Table).useReactTable()` reports `Table`.
+func reportableAccessReceiver(expr *ast.Node) *ast.Node {
+	object := utils.AccessExpressionObject(expr)
+	for object != nil {
+		object = ast.SkipParentheses(object)
+		if object == nil || object.Kind != ast.KindNonNullExpression {
+			return object
+		}
+		object = object.AsNonNullExpression().Expression
+	}
+	return expr
+}
+
+func (state *incompatibleLibraryState) accessExpressionBindingKind(expr *ast.Node) bindingKind {
+	propName, ok := utils.AccessExpressionStaticName(expr)
+	if !ok {
+		return bindingUnknown
+	}
+	object := utils.SkipAssertionsAndParens(utils.AccessExpressionObject(expr))
+	objectKind := state.expressionBindingKind(object)
+	switch objectKind {
+	case bindingReactHookFormNamespace:
+		if propName == "useForm" {
+			return bindingUseForm
+		}
+	case bindingTanStackTableNamespace:
+		if propName == "useReactTable" {
+			return bindingUseReactTable
+		}
+	case bindingTanStackVirtualNamespace:
+		if propName == "useVirtualizer" {
+			return bindingUseVirtualizer
+		}
+	case bindingFormReturn:
+		if propName == "watch" {
+			return bindingWatch
+		}
+	}
+	return bindingUnknown
+}
+
+func (state *incompatibleLibraryState) report(node *ast.Node, detail string) {
+	if node == nil {
+		return
+	}
+	state.ctx.ReportNode(node, buildIncompatibleLibraryMessage(detail))
+}
+
+func buildIncompatibleLibraryMessage(detail string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "incompatibleLibrary",
+		Description: fmt.Sprintf(
+			"Compilation Skipped: Use of incompatible library\n\n%s\n\n%s",
+			incompatibleLibraryDescription,
+			detail,
+		),
+		Data: map[string]string{"detail": detail},
+	}
+}
+
+func (state *incompatibleLibraryState) pushScope() {
+	state.scopes = append(state.scopes, lexicalScope{})
+}
+
+func (state *incompatibleLibraryState) popScope() {
+	state.scopes = state.scopes[:len(state.scopes)-1]
+}
+
+func (state *incompatibleLibraryState) declareNode(node *ast.Node, kind bindingKind) {
+	if node == nil || node.Kind != ast.KindIdentifier || len(state.scopes) == 0 {
+		return
+	}
+	state.scopes[len(state.scopes)-1][node.AsIdentifier().Text] = kind
+}
+
+func (state *incompatibleLibraryState) assignNode(node *ast.Node, kind bindingKind) {
+	if node == nil || node.Kind != ast.KindIdentifier {
+		return
+	}
+	name := node.AsIdentifier().Text
+	for i := len(state.scopes) - 1; i >= 0; i-- {
+		if _, ok := state.scopes[i][name]; ok {
+			state.scopes[i][name] = kind
+			return
+		}
+	}
+	state.declareNode(node, kind)
+}
+
+func (state *incompatibleLibraryState) lookup(name string) bindingKind {
+	for i := len(state.scopes) - 1; i >= 0; i-- {
+		if kind, ok := state.scopes[i][name]; ok {
+			return kind
+		}
+	}
+	return bindingUnknown
+}
+
+func importSpecifierImportedName(spec *ast.ImportSpecifier) string {
+	if spec.PropertyName != nil {
+		return moduleExportNameText(spec.PropertyName)
+	}
+	if spec.Name() != nil {
+		return spec.Name().Text()
+	}
+	return ""
+}
+
+func moduleExportNameText(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindIdentifier, ast.KindStringLiteral:
+		return node.Text()
+	}
+	return ""
+}
+
+func bindingElementPropertyName(node *ast.Node) string {
+	if propertyName := ast.TryGetPropertyNameOfBindingOrAssignmentElement(node); propertyName != nil {
+		if prop, ok := utils.GetStaticPropertyName(propertyName); ok {
+			return prop
+		}
+	}
+	return ""
+}

--- a/internal/plugins/react_hooks/rules/incompatible_library/incompatible_library.md
+++ b/internal/plugins/react_hooks/rules/incompatible_library/incompatible_library.md
@@ -1,0 +1,55 @@
+# incompatible-library
+
+## Rule Details
+
+Validates against usage of libraries with APIs that are incompatible with memoization, including React Compiler's automatic memoization.
+
+This rule currently reports known incompatible APIs from React Hook Form,
+TanStack Table, and TanStack Virtual.
+
+Like the upstream rule, it reports usage inside React Compiler target
+components and hooks. Top-level module code and non-component helpers are
+ignored.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+import { useForm } from "react-hook-form";
+
+function Form() {
+  const { watch } = useForm();
+  const name = watch("name");
+  return <div>{name}</div>;
+}
+```
+
+```javascript
+import { useReactTable } from "@tanstack/react-table";
+
+function Table({ data, columns }) {
+  const table = useReactTable({ data, columns });
+  return <Grid table={table} />;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+import { useForm } from "react-hook-form";
+
+function Form() {
+  const { register } = useForm();
+  return <input {...register("name")} />;
+}
+```
+
+```javascript
+function Component() {
+  return <div />;
+}
+```
+
+## Original Documentation
+
+- [react.dev - incompatible-library](https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library)
+- [Source code](https://github.com/facebook/react/blob/1ddff43c41147b880c22eb363e07aade5a71c5d9/compiler/packages/babel-plugin-react-compiler/src/HIR/DefaultModuleTypeProvider.ts)

--- a/internal/plugins/react_hooks/rules/incompatible_library/incompatible_library_extras_test.go
+++ b/internal/plugins/react_hooks/rules/incompatible_library/incompatible_library_extras_test.go
@@ -1,0 +1,431 @@
+package incompatible_library
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestIncompatibleLibraryExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+func TestIncompatibleLibraryExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Dimension 4: access/key forms; non-watch react-hook-form member is not incompatible. ----
+		{Code: `
+import * as RHF from 'react-hook-form';
+function Form() {
+  const form = RHF.useForm();
+  form.register('name');
+  return <form />;
+}
+		`, FileName: "form.tsx", Tsx: true},
+		// ---- Dimension 4: declaration/container forms; a locally shadowed import alias is not reported. ----
+		{Code: `
+import { useReactTable } from '@tanstack/react-table';
+function Table(useReactTable) {
+  const table = useReactTable();
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: access/key forms; dynamic property names are not treated as known incompatible APIs. ----
+		{Code: `
+import { useForm } from 'react-hook-form';
+function Form(name) {
+  const form = useForm();
+  const value = form[name]('field');
+  return <div>{value}</div>;
+}
+		`, FileName: "form.tsx", Tsx: true},
+		// ---- Real-user: TanStack Table issue #5141 stable options discussion; local non-imported hook name is ignored. ----
+		{Code: `
+function Table({ data, columns }) {
+  const useReactTable = (config) => config;
+  const table = useReactTable({ data, columns });
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Real-user: React issue #33057; non-hook table helpers are not reported. ----
+		{Code: `
+import { flexRender } from '@tanstack/react-table';
+function Table({ cell }) {
+  return <td>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: nesting/traversal boundaries; later function declarations shadow imports for the whole block. ----
+		{Code: `
+import { useReactTable } from '@tanstack/react-table';
+function Table({ data, columns }) {
+  const table = useReactTable({ data, columns });
+  function useReactTable(config) {
+    return config;
+  }
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: nesting/traversal boundaries; var declarations hoist from nested blocks. ----
+		{Code: `
+import { useReactTable } from '@tanstack/react-table';
+function Table({ data, columns, condition }) {
+  const table = useReactTable({ data, columns });
+  if (condition) {
+    var useReactTable = (config) => config;
+  }
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: declaration/container forms; default imports do not imply named incompatible exports. ----
+		{Code: `
+import useReactTable from '@tanstack/react-table';
+function Table({ data, columns }) {
+  const table = useReactTable({ data, columns });
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: declaration/container forms; CommonJS require is not a source tracked by upstream. ----
+		{Code: `
+const TableLib = require('@tanstack/react-table');
+function Table({ data, columns }) {
+  const table = TableLib.useReactTable({ data, columns });
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: access/key forms; TypeScript import-equals mirrors upstream's non-reporting behavior. ----
+		{Code: `
+import TableLib = require('@tanstack/react-table');
+function Table({ data, columns }) {
+  const table = TableLib.useReactTable({ data, columns });
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: declaration/container forms; top-level uses are outside React Compiler targets. ----
+		{Code: `
+import { useForm } from 'react-hook-form';
+const form = useForm();
+form.watch('name');
+		`, FileName: "form.tsx", Tsx: true},
+		// ---- Dimension 4: nesting/traversal boundaries; top-level derived form bindings do not flow into components. ----
+		{Code: `
+import { useForm } from 'react-hook-form';
+const form = useForm();
+function Form() {
+  return <div>{form.watch('name')}</div>;
+}
+		`, FileName: "form.tsx", Tsx: true},
+		// ---- Dimension 4: nesting/traversal boundaries; top-level aliases do not flow into components. ----
+		{Code: `
+import { useReactTable } from '@tanstack/react-table';
+const createTable = useReactTable;
+function Table({ data, columns }) {
+  const table = createTable({ data, columns });
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: nesting/traversal boundaries; top-level namespace destructuring does not flow into components. ----
+		{Code: `
+import * as TableLib from '@tanstack/react-table';
+const { useReactTable } = TableLib;
+function Table({ data, columns }) {
+  const table = useReactTable({ data, columns });
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: nesting/traversal boundaries; top-level callbacks are outside compiler roots. ----
+		{Code: `
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+const form = useForm();
+const name = useMemo(() => form.watch('name'), [form]);
+		`, FileName: "form.tsx", Tsx: true},
+		// ---- Dimension 4: declaration/container forms; lowercase functions are not compiler roots even when returning JSX. ----
+		{Code: `
+import { useReactTable } from '@tanstack/react-table';
+function table({ data, columns }) {
+  const table = useReactTable({ data, columns });
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: declaration/container forms; top-level memo callbacks are not roots for this diagnostic. ----
+		{Code: `
+import { memo } from 'react';
+import { useReactTable } from '@tanstack/react-table';
+const Table = memo(function Table({ data, columns }) {
+  const table = useReactTable({ data, columns });
+  return <Grid table={table} />;
+});
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: declaration/container forms; aliased incompatible calls do not make a PascalCase null-returning function a root. ----
+		{Code: `
+import { useReactTable as createTable } from '@tanstack/react-table';
+function Table({ data, columns }) {
+  const table = createTable({ data, columns });
+  return null;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- Dimension 4: declaration/container forms; nested destructuring from watch does not preserve function identity. ----
+		{Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const { watch: { current } } = useForm();
+  return <div>{current()}</div>;
+}
+		`, FileName: "form.tsx", Tsx: true},
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: receiver wrappers; parenthesized namespace receiver is transparent. ----
+		// Locks in upstream defaultModuleTypeProvider arm 2: @tanstack/react-table namespace import.
+		{
+			Code: `
+import * as TableLib from '@tanstack/react-table';
+function Table({ data, columns }) {
+  const table = (TableLib).useReactTable({ data, columns });
+  return <Grid table={table} />;
+}
+			`,
+			FileName: "table.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(tanStackTableMessage, 4, 18, 4, 26),
+			},
+		},
+		// ---- Dimension 4: declaration/container forms; namespace destructuring inside a compiler root is tracked. ----
+		// Locks in upstream defaultModuleTypeProvider arm 2 through local destructuring.
+		{
+			Code: `
+import * as TableLib from '@tanstack/react-table';
+function Table({ data, columns }) {
+  const { useReactTable } = TableLib;
+  const table = useReactTable({ data, columns });
+  return <Grid table={table} />;
+}
+			`,
+			FileName: "table.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(tanStackTableMessage, 5, 17, 5, 30),
+			},
+		},
+		// ---- Dimension 4: receiver wrappers; TS assertions on the useForm return value are transparent. ----
+		// Locks in upstream defaultModuleTypeProvider arm 1: react-hook-form watch return property.
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const form = useForm();
+  const value = (form as any).watch('name');
+  return <div>{value}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 5, 18, 5, 29),
+			},
+		},
+		// ---- Dimension 4: receiver wrappers; TS non-null assertions are transparent for report ranges. ----
+		// Locks in upstream report location for TSNonNullExpression receivers.
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const form = useForm();
+  return <div>{form!.watch('name')}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 5, 16, 5, 20),
+			},
+		},
+		// ---- Dimension 4: access/key forms; string-literal element access matches the static watch property. ----
+		// Locks in upstream signature.knownIncompatible branch: known incompatible function property.
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const form = useForm();
+  const value = form['watch']('name');
+  return <div>{value}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 5, 17, 5, 21),
+			},
+		},
+		// ---- Dimension 4: access/key forms; no-substitution template keys match static watch. ----
+		// Locks in upstream signature.knownIncompatible branch for template-literal element access.
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const form = useForm();
+  const value = form[` + "`watch`" + `]('name');
+  return <div>{value}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 5, 17, 5, 21),
+			},
+		},
+		// ---- Dimension 4: declaration/container forms; renamed destructuring tracks the watch binding. ----
+		// Locks in upstream hook-return property arm: destructured incompatible function.
+		{
+			Code: `
+import { useForm as useHookForm } from 'react-hook-form';
+function Form() {
+  const { watch: observe } = useHookForm();
+  return <div>{observe('name')}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 5, 16, 5, 23),
+			},
+		},
+		// ---- Real-user: TanStack Table issue #5141; useReactTable is reported at the call site. ----
+		{
+			Code: `
+import { useReactTable as createTable } from '@tanstack/react-table';
+function Table({ data, columns }) {
+  const table = createTable({ data, columns, getCoreRowModel: () => null });
+  return <Grid table={table} />;
+}
+			`,
+			FileName: "table.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(tanStackTableMessage, 4, 17, 4, 28),
+			},
+		},
+		// ---- Real-user: React issue #33057; the exact incompatible table hook is skipped by the compiler. ----
+		{
+			Code: `
+import { useReactTable } from '@tanstack/react-table';
+function Table({ data, columns }) {
+  const table = useReactTable({ data, columns, state: {} });
+  return <Grid table={table} />;
+}
+			`,
+			FileName: "table.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(tanStackTableMessage, 4, 17, 4, 30),
+			},
+		},
+		// ---- Dimension 4: declaration/container forms; assignment updates an existing form binding. ----
+		// Locks in upstream hook-return property arm through assignment instead of declaration.
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  let form;
+  form = useForm();
+  return <div>{form.watch('name')}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 6, 16, 6, 20),
+			},
+		},
+		// ---- Dimension 4: declaration/container forms; object destructuring assignment tracks watch. ----
+		// Locks in upstream hook-return property arm for assignment patterns.
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  let watch;
+  ({ watch } = useForm());
+  return <div>{watch('name')}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 6, 16, 6, 21),
+			},
+		},
+		// ---- Dimension 4: declaration/container forms; assigned aliases keep imported hook identity. ----
+		// Locks in upstream defaultModuleTypeProvider arm 2 through alias assignment.
+		{
+			Code: `
+import { useReactTable } from '@tanstack/react-table';
+function Table({ data, columns }) {
+  let createTable;
+  createTable = useReactTable;
+  const table = createTable({ data, columns });
+  return <Grid table={table} />;
+}
+			`,
+			FileName: "table.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(tanStackTableMessage, 6, 17, 6, 28),
+			},
+		},
+		// ---- Dimension 4: receiver wrappers; direct useForm().watch reports the useForm() receiver. ----
+		// Locks in upstream signature.knownIncompatible branch report location for call-expression receivers.
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  return <div>{useForm().watch('name')}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 4, 16, 4, 25),
+			},
+		},
+		// ---- Dimension 4: nesting/traversal boundaries; nested callbacks inside compiler roots are still checked. ----
+		// Locks in upstream compiler target traversal through nested function bodies.
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const form = useForm();
+  const getName = () => form.watch('name');
+  return <div>{getName()}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 5, 25, 5, 29),
+			},
+		},
+		// ---- Dimension 4: optional chain; optional calls still use the same incompatible API. ----
+		// Locks in upstream signature.knownIncompatible branch when tsgo marks the call optional.
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const form = useForm();
+  return <div>{form.watch?.('name')}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 5, 16, 5, 20),
+			},
+		},
+	}
+
+	// N/A: PrivateIdentifier, numeric keys, class members, overload signatures,
+	// abstract/declare members, and autofix boundaries do not apply because the
+	// rule only checks imported call expressions and the static `watch` property.
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &IncompatibleLibraryRule, valid, invalid)
+}

--- a/internal/plugins/react_hooks/rules/incompatible_library/incompatible_library_upstream_test.go
+++ b/internal/plugins/react_hooks/rules/incompatible_library/incompatible_library_upstream_test.go
@@ -1,0 +1,153 @@
+package incompatible_library
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestIncompatibleLibraryUpstream migrates the public React Compiler
+// IncompatibleLibrary module model from upstream
+// compiler/packages/babel-plugin-react-compiler/src/HIR/DefaultModuleTypeProvider.ts
+// 1:1. Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in the incompatible_library_extras_test.go file.
+func TestIncompatibleLibraryUpstream(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- DefaultModuleTypeProvider: react-hook-form useForm itself is allowed. ----
+		{Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const form = useForm();
+  return <form />;
+}
+		`, FileName: "form.tsx", Tsx: true},
+		// ---- DefaultModuleTypeProvider: react-hook-form non-watch properties are allowed. ----
+		{Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const { register } = useForm();
+  return <input {...register('name')} />;
+}
+		`, FileName: "form.tsx", Tsx: true},
+		// ---- DefaultModuleTypeProvider: unknown libraries are ignored. ----
+		{Code: `
+import { useReactTable } from '@example/react-table';
+function Table() {
+  const table = useReactTable();
+  return <Grid table={table} />;
+}
+		`, FileName: "table.tsx", Tsx: true},
+		// ---- react.dev docs: useWatch is the memoization-compatible React Hook Form API. ----
+		{Code: `
+import { useWatch } from 'react-hook-form';
+function Form() {
+  const name = useWatch({ name: 'name' });
+  return <div>{name}</div>;
+}
+		`, FileName: "form.tsx", Tsx: true},
+		// ---- react.dev docs pitfall: MobX observer is not detected by this rule yet. ----
+		{Code: `
+import { observer } from 'mobx-react-lite';
+const TodoView = observer(function TodoView({ todo }) {
+  return <div>{todo.title}</div>;
+});
+		`, FileName: "todo.tsx", Tsx: true},
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- DefaultModuleTypeProvider: react-hook-form useForm().watch property. ----
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const form = useForm();
+  const name = form.watch('name');
+  return <div>{name}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 5, 16, 5, 20),
+			},
+		},
+		// ---- DefaultModuleTypeProvider: react-hook-form destructured watch function. ----
+		{
+			Code: `
+import { useForm } from 'react-hook-form';
+function Form() {
+  const { watch } = useForm();
+  const name = watch('name');
+  return <div>{name}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 5, 16, 5, 21),
+			},
+		},
+		// ---- react.dev docs: react-hook-form watch inside useMemo is incompatible. ----
+		{
+			Code: `
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+function Form() {
+  const { watch } = useForm();
+  const name = useMemo(() => watch('name'), [watch]);
+  return <div>{name}</div>;
+}
+			`,
+			FileName: "form.tsx",
+			Tsx:      true,
+			Options:  map[string]interface{}{},
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(reactHookFormWatchMessage, 6, 30, 6, 35),
+			},
+		},
+		// ---- react.dev docs: @tanstack/react-table useReactTable hook. ----
+		{
+			Code: `
+import { useReactTable, getCoreRowModel } from '@tanstack/react-table';
+function Table({ data, columns }) {
+  const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+  return <Grid table={table} />;
+}
+			`,
+			FileName: "table.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(tanStackTableMessage, 4, 17, 4, 30),
+			},
+		},
+		// ---- DefaultModuleTypeProvider: @tanstack/react-virtual useVirtualizer hook. ----
+		{
+			Code: `
+import { useVirtualizer } from '@tanstack/react-virtual';
+function List({ count }) {
+  const virtualizer = useVirtualizer({ count });
+  return <Grid virtualizer={virtualizer} />;
+}
+			`,
+			FileName: "list.tsx",
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				incompatibleLibraryError(tanStackVirtualMessage, 4, 23, 4, 37),
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &IncompatibleLibraryRule, valid, invalid)
+}
+
+func incompatibleLibraryError(detail string, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "incompatibleLibrary",
+		Message:   buildIncompatibleLibraryMessage(detail).Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -217,6 +217,7 @@ export default defineConfig({
     './tests/eslint-plugin-react-hooks/rules/error-boundaries.test.ts',
     './tests/eslint-plugin-react-hooks/rules/globals.test.ts',
     './tests/eslint-plugin-react-hooks/rules/immutability.test.ts',
+    './tests/eslint-plugin-react-hooks/rules/incompatible-library.test.ts',
 
     // eslint-plugin-jsx-a11y
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/incompatible-library.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/incompatible-library.test.ts
@@ -1,0 +1,132 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const incompatibleMessage = (detail: string) =>
+  `Compilation Skipped: Use of incompatible library\n\n` +
+  `This API returns functions which cannot be memoized without leading to stale UI. ` +
+  `To prevent this, by default React Compiler will skip memoizing this component/hook. ` +
+  `However, you may see issues if values from this API are passed to other components/hooks that are memoized.\n\n` +
+  detail;
+
+const reactHookFormWatchMessage = incompatibleMessage(
+  "React Hook Form's `useForm()` API returns a `watch()` function which cannot be memoized safely.",
+);
+
+const tanStackTableMessage = incompatibleMessage(
+  "TanStack Table's `useReactTable()` API returns functions that cannot be memoized safely",
+);
+
+const tanStackVirtualMessage = incompatibleMessage(
+  "TanStack Virtual's `useVirtualizer()` API returns functions that cannot be memoized safely",
+);
+
+ruleTester.run('incompatible-library', {} as never, {
+  valid: [
+    {
+      code: `
+        import { useForm } from 'react-hook-form';
+        function Form() {
+          const form = useForm();
+          return <form />;
+        }
+      `,
+    },
+    {
+      code: `
+        import { useForm } from 'react-hook-form';
+        function Form() {
+          const { register } = useForm();
+          return <input {...register('name')} />;
+        }
+      `,
+    },
+    {
+      code: `
+        import { useReactTable } from '@example/react-table';
+        function Table() {
+          const table = useReactTable();
+          return <Grid table={table} />;
+        }
+      `,
+    },
+    {
+      code: `
+        import { useWatch } from 'react-hook-form';
+        function Form() {
+          const name = useWatch({ name: 'name' });
+          return <div>{name}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        import { observer } from 'mobx-react-lite';
+        const TodoView = observer(function TodoView({ todo }) {
+          return <div>{todo.title}</div>;
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { useForm } from 'react-hook-form';
+        function Form() {
+          const form = useForm();
+          const name = form.watch('name');
+          return <div>{name}</div>;
+        }
+      `,
+      options: [{}],
+      errors: [{ message: reactHookFormWatchMessage }],
+    },
+    {
+      code: `
+        import { useForm } from 'react-hook-form';
+        function Form() {
+          const { watch } = useForm();
+          const name = watch('name');
+          return <div>{name}</div>;
+        }
+      `,
+      errors: [{ message: reactHookFormWatchMessage }],
+    },
+    {
+      code: `
+        import { useMemo } from 'react';
+        import { useForm } from 'react-hook-form';
+        function Form() {
+          const { watch } = useForm();
+          const name = useMemo(() => watch('name'), [watch]);
+          return <div>{name}</div>;
+        }
+      `,
+      errors: [{ message: reactHookFormWatchMessage }],
+    },
+    {
+      code: `
+        import { useReactTable, getCoreRowModel } from '@tanstack/react-table';
+        function Table({ data, columns }) {
+          const table = useReactTable({
+            data,
+            columns,
+            getCoreRowModel: getCoreRowModel(),
+          });
+          return <Grid table={table} />;
+        }
+      `,
+      errors: [{ message: tanStackTableMessage }],
+    },
+    {
+      code: `
+        import { useVirtualizer } from '@tanstack/react-virtual';
+        function List({ count }) {
+          const virtualizer = useVirtualizer({ count });
+          return <Grid virtualizer={virtualizer} />;
+        }
+      `,
+      errors: [{ message: tanStackVirtualMessage }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -604,3 +604,5 @@ supa
 Värde
 Dmts
 Dcts
+tanstack
+predeclare


### PR DESCRIPTION
## Summary

Port the `react-hooks/incompatible-library` rule to rslint.

The rule reports known React Compiler-incompatible library APIs from React Hook Form, TanStack Table, and TanStack Virtual when they are used inside compiler target components and hooks.

## Related Links

- react.dev rule docs: https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library
- React source: https://github.com/facebook/react/blob/1ddff43c41147b880c22eb363e07aade5a71c5d9/compiler/packages/babel-plugin-react-compiler/src/HIR/DefaultModuleTypeProvider.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
