### PR TITLE
fix: align lint target discovery with files config

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -180,7 +180,7 @@ The current parsing and linting pipeline is built on top of ts-go `Program` and 
 ### Detailed Pipeline Steps
 
 1. **Source Text Loading**: Files come from the real filesystem, an overlay VFS, or LSP document overlays.
-2. **Program Construction**: CLI/API build `Program` objects directly; LSP uses ts-go `project.Session`.
+2. **Program Construction**: CLI/API build `Program` objects directly. LSP reuses matching projects from ts-go `project.Session`; a declared custom tsconfig that project service has not loaded is built on demand against an isolated editor overlay.
 3. **Lexical + Syntax Parsing**: ts-go tokenizes and parses source files into TypeScript-native AST nodes.
 4. **Semantic Analysis**: When needed, the linter acquires a `TypeChecker` from the `Program`.
 5. **Rule Registration**: Enabled rules register listeners keyed by AST kind.
@@ -195,6 +195,7 @@ The parser and program builder are tolerant enough to support editor and fallbac
 
 - ts-go can continue producing ASTs after syntax errors
 - LSP delays lint on rapid edits to avoid repeated work on broken intermediate text
+- lint rules and community-plugin dispatch are suppressed for malformed lint targets; syntax diagnostics remain authoritative
 - CLI/API create tsconfig-backed Programs leniently so plain lint can decide
   syntax diagnostics from the final lint target set instead of failing during
   broad tsconfig construction
@@ -420,14 +421,14 @@ JSON config files (`rslint.json`, `rslint.jsonc`) are deprecated and will be rem
 
 Each entry in the config array supports:
 
-| Field             | Type                | Description                                                                                     |
-| ----------------- | ------------------- | ----------------------------------------------------------------------------------------------- |
-| `files`           | `string[]`          | Non-empty glob patterns this entry applies to; omit to use rslint's default lintable extensions |
-| `ignores`         | `string[]`          | Glob patterns excluded by this entry                                                            |
-| `languageOptions` | `object`            | Parser options such as `project` and `projectService`                                           |
-| `rules`           | `Record<string, …>` | Rule level or `[level, options]`                                                                |
-| `plugins`         | `string[]`          | Plugin declarations used for plugin gating                                                      |
-| `settings`        | `Record<string, …>` | Shared settings available in `RuleContext`                                                      |
+| Field             | Type                     | Description                                                                          |
+| ----------------- | ------------------------ | ------------------------------------------------------------------------------------ |
+| `files`           | `(string \| string[])[]` | Non-empty selector list; top-level selectors are ORed and nested selectors are ANDed |
+| `ignores`         | `string[]`               | Glob patterns excluded by this entry                                                 |
+| `languageOptions` | `object`                 | Parser options such as `project` and `projectService`                                |
+| `rules`           | `Record<string, …>`      | Rule level or `[level, options]`                                                     |
+| `plugins`         | `string[]`               | Plugin declarations used for plugin gating                                           |
+| `settings`        | `Record<string, …>`      | Shared settings available in `RuleContext`                                           |
 
 ### Configuration Loading
 
@@ -451,12 +452,12 @@ The loading flow differs by config type:
 
 Config merging follows flat-config-style semantics in `GetConfigForFile()`:
 
-1. global-ignore-only entries apply first
-2. `files` patterns decide which entries match; an explicit `files: []` is invalid
-3. `ignores` can remove files from an otherwise matching entry
+1. entries containing only `ignores` and an optional `name` form the global-ignore set
+2. the implicit default extension baseline plus explicit `files` selectors defines the config selector union; top-level selectors are ORed, patterns in a nested selector are ANDed, and an explicit `files: []` is invalid
+3. entries without `files` cascade across that selector union, while entry-level `ignores` prevent only that entry from contributing configuration
 4. later rule values override earlier rule values
 5. later settings override earlier settings by key
-6. `languageOptions.parserOptions` are merged field-by-field
+6. `languageOptions.parserOptions` are merged field-by-field and `languageOptions.globals` are merged by global name
 
 In multi-config mode, `FindNearestConfig()` is used before `GetConfigForFile()` so that each file is merged against the nearest config directory.
 
@@ -464,9 +465,11 @@ Additional current behaviors:
 
 - `.gitignore` is injected into CLI configs as a global-ignore entry
 - plugin rules are gated by declared plugins for JS/TS configs
-- lint target selection is independent from TypeScript `Program` membership: CLI/API targets are filtered by `files`, global ignores, and `.gitignore`; omitted `files` entries contribute rslint's default lintable extensions (`.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, `.cts`)
-- files passed explicitly on the CLI/API can still appear as 0-rule lint results even if they do not match any config `files` pattern
-- selected files outside all tsconfig-backed Programs become gap files and receive an AST-only fallback Program
+- lint target selection is independent from TypeScript `Program` membership: rslint always starts with `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, and `.cts`, then unions explicit config `files`; global ignores and `.gitignore` remove targets, while entry-level ignores do not
+- files passed explicitly on the CLI/API can still appear as 0-rule lint results when no config entry contributes rules; selected files are parsed and can report syntax diagnostics in that state
+- each selected file is governed by its nearest config and can bind only to a tsconfig declared by that config; the first declared project containing the file wins
+- canonical tsconfigs are built once while retaining every config association, and selected files outside the governing config's Programs receive an AST-only fallback Program
+- `--type-check` runs over every real tsconfig Program and is not constrained by lint targets, config `files`/`ignores`, `.gitignore`, or CLI file/directory arguments; synthetic fallback Programs never participate
 
 ### Inline Directives
 
@@ -498,13 +501,13 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
    - `--lsp`: starts the LSP server
    - `--api`: starts the IPC API server
    - default: runs direct CLI linting
-4. **Program Creation**: Go builds one or more tsconfig-backed Programs from configured or auto-detected tsconfigs
-5. **Lint Target Selection**: Go resolves the lint target set from CLI/API targets, config `files`, default lintable extensions, global ignores, and `.gitignore`
-6. **Program Binding**: selected files are bound to existing Programs when possible; selected files outside every tsconfig-backed Program, including projects with no tsconfig, are parsed through an AST-only fallback Program
+4. **Program Registry**: Go builds each canonical configured or auto-detected tsconfig once and records every governing-config association plus declaration order
+5. **Lint Target Plan**: independently, Go resolves a stable target set from CLI/API scope, the implicit default baseline, explicit config `files`, global ignores, and `.gitignore`
+6. **Program Binding**: each target is bound to the first containing Program declared by its governing config; unbound targets, including projects with no tsconfig, are parsed through an AST-only fallback Program
 7. **Rule Resolution**: `getRulesForFile` resolves enabled rules per selected file, filtering type-aware rules off no-type-info gap files
-8. **Rule Execution**: `RunLinter()` schedules per-Program work over the exact target plan; the unexported `runLintRulesInProgram()` does the actual per-file traversal. When `--type-check` is enabled, a second program-level pass runs after Phase 1 and aggregates `tsc --noEmit`-aligned diagnostics through the internal `collectNoEmitDiagnostics()` helper
+8. **Rule Execution**: `RunLinter()` schedules per-Program work over the exact target plan; the unexported `runLintRulesInProgram()` does the actual per-file traversal. When `--type-check` is enabled, a separate program-wide pass over real tsconfig Programs aggregates `tsc --noEmit`-aligned diagnostics through `collectNoEmitDiagnostics()`
 9. **Result Aggregation**: diagnostics are sent through one run-scoped diagnostics channel and collected at the CLI layer
-10. **Fix Passes**: when enabled, fixes are applied and Programs can be rebuilt for another pass without changing the original target set
+10. **Fix Passes**: when enabled, fixes are applied, real Programs are rebuilt, and the stable target plan is rebound; target membership stays fixed while a file may move between a real Program and fallback as its import graph changes
 11. **Output Formatting**: default, JSON line, and GitHub workflow formats are supported
 12. **Exit Code**: depends on diagnostics, warnings, and fix outcomes
 
@@ -519,12 +522,12 @@ which is the user-facing escape hatch for serial / reproducible execution.
 
 2. **gitignore reading ‖ Program creation** (in `cmd/rslint/cmd.go`)
    - `ReadGitignoreAsGlobs` walks `.gitignore` for each config; it is independent
-     of `createProgramsForConfig` (which only reads
+     of Program registry construction (which only reads
      `languageOptions.parserOptions.project`, never `Ignores`). The two are
      dispatched as parallel goroutines per config.
    - In multi-config mode, gitignore reads also fan out across configs in
-     parallel; `createProgramsForConfig` invocations run serially across configs
-     (typescript-go's API is invoked one config at a time).
+     parallel; canonical Programs are constructed serially in stable config and
+     project order (typescript-go's API is invoked one Program at a time).
    - `--singleThreaded` runs both stages sequentially — no goroutines spawned.
 
 3. **Lint-target directory walker** (`internal/config/file_discovery.go`)
@@ -542,14 +545,14 @@ true})` reports the dirent type without following symlinks, so
      scheduling-dependent non-determinism that a parallel walker would
      otherwise introduce.
 
-4. **Multi-config target discovery** (`DiscoverLintFilesMultiConfig`)
-   - Iterates `configMap` serially, calling `DiscoverLintFiles` once per config.
+4. **Multi-config target discovery** (`DiscoverLintTargetsMultiConfig`)
+   - Uses a config-directory index to assign explicit files and directory ownership before calling per-config discovery.
    - Each call is itself bounded by its own worker pool, so total live
      goroutines remain bounded by `workers`, not `len(configMap) × workers`.
 
 Other invariants:
 
-- Target discovery and Program binding deduplicate selected files across configs before `RunLinter` runs.
+- Target discovery canonicalizes and deduplicates selected files before binding; aliases governed by different configs are rejected instead of choosing an owner by scan order.
 - LSP uses a different orchestration model and keeps session access on its
   main dispatch loop.
 
@@ -736,13 +739,15 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 │            │                                                                 │
 │            ▼                                                                 │
 │  Config Load / Normalize / Merge                                             │
-│            │                                                                 │
-│            ▼                                                                 │
-│  Create tsconfig-backed Programs                                             │
-│            │                                                                 │
-│            ├───────────────► Discover Gap Files ───────► Fallback Program    │
-│            │                                                                 │
-│            ▼                                                                 │
+│            ├──────────────────────────┐                                      │
+│            ▼                          ▼                                      │
+│  Canonical Program Registry      Stable Lint Target Plan                     │
+│  (tsconfig + config/order)       (scope + selectors + ignores)               │
+│            └──────────────┬───────────┘                                      │
+│                           ▼                                                  │
+│  Bind by Governing Config / Project Order ─────► AST-only Fallback Program   │
+│                           │                                                  │
+│                           ▼                                                  │
 │  Resolve Enabled Rules Per File                                              │
 │            │                                                                 │
 │            ▼                                                                 │
@@ -754,6 +759,7 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 │            ▼                                                                 │
 │  RuleDiagnostic / Fix / Suggestion Collection                                │
 │            │                                                                 │
+│            ├───────────────► Program-wide Type Check (real tsconfigs only)    │
 │            ├───────────────► CLI formatter / exit code                       │
 │            └───────────────► API structured response                         │
 │                                                                              │
@@ -805,15 +811,16 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 - **Config Entry**: One flat-config object whose `files`, `ignores`, `settings`, and `rules` participate in per-file config merging
 - **ConfiguredRule**: Rule implementation plus resolved severity, settings, options, and type-info requirement
 - **Diagnostic**: A lint finding reported by a rule or by TypeScript semantic diagnostics
-- **Fallback Program**: Extra AST-only `Program` created from selected lint targets that are not covered by any tsconfig-backed Program; fallback files are intentionally non-type-aware
+- **Fallback Program**: Extra AST-only `Program` created from selected lint targets that are not covered by a tsconfig Program associated with their governing config; fallback files are intentionally non-type-aware
 - **Flat Config**: ESLint-style array-based configuration model used by rslint to merge rule settings per file
-- **Gap File**: A selected lint target that is not present in any tsconfig-backed Program
+- **Gap File**: A selected lint target that is not present in any tsconfig Program declared by its governing config
 - **Inspector**: Auxiliary backend path that returns node, type, symbol, signature, and flow information for Playground inspection
 - **IPC API**: Length-prefixed JSON message protocol exposed by `cmd/rslint --api` for Node and WASM clients
 - **Listener**: Callback registered by a rule for an AST kind or synthetic listener kind
 - **Nearest Config**: In multi-config mode, the deepest config directory that owns a file
 - **Node Kind**: Enumerated AST kind value used by ts-go and by the listener dispatcher to identify node types
 - **Program**: ts-go compilation context, usually tied to a tsconfig or fallback root-file set
+- **Program Registry**: Run-scoped set of canonical tsconfig Programs plus the governing configs and project declaration order associated with each Program
 - **project.Session**: ts-go project manager used by LSP for inferred/configured projects and overlays
 - **Rule Context**: Runtime environment through which a rule reads file/program/checker state and reports findings
 - **RuleFix**: Text edit represented as a range plus replacement text; fixes are merged and applied after diagnostics are collected

--- a/architecture.md
+++ b/architecture.md
@@ -35,7 +35,7 @@ Rslint is a high-performance JavaScript and TypeScript linter, designed as a dro
 
 ### Non-Goals
 
-- **100% ESLint Plugin Compatibility**: Focus on core rules, not every community plugin
+- **Complete Third-Party Plugin Compatibility**: The Node worker supports third-party ESLint plugins on a best-effort API surface, not every parser, processor, or ESLint runtime API
 - **Runtime Performance Optimization**: Optimized for build-time linting, not runtime performance
 - **Custom Parser Support**: Standardized on TypeScript parser through typescript-go
 
@@ -180,7 +180,7 @@ The current parsing and linting pipeline is built on top of ts-go `Program` and 
 ### Detailed Pipeline Steps
 
 1. **Source Text Loading**: Files come from the real filesystem, an overlay VFS, or LSP document overlays.
-2. **Program Construction**: CLI/API build `Program` objects directly. LSP reuses matching projects from ts-go `project.Session`; a declared custom tsconfig that project service has not loaded is built on demand against an isolated editor overlay.
+2. **Program Construction**: Plain CLI/API lint resolves its effective targets first and builds `Program` objects only for governing configs that own a selected target. Program-wide type-check modes build every configured project. LSP reuses matching projects from ts-go `project.Session`; a declared custom tsconfig that project service has not loaded is built on demand against an isolated editor overlay.
 3. **Lexical + Syntax Parsing**: ts-go tokenizes and parses source files into TypeScript-native AST nodes.
 4. **Semantic Analysis**: When needed, the linter acquires a `TypeChecker` from the `Program`.
 5. **Rule Registration**: Enabled rules register listeners keyed by AST kind.
@@ -195,14 +195,15 @@ The parser and program builder are tolerant enough to support editor and fallbac
 
 - ts-go can continue producing ASTs after syntax errors
 - LSP delays lint on rapid edits to avoid repeated work on broken intermediate text
-- lint rules and community-plugin dispatch are suppressed for malformed lint targets; syntax diagnostics remain authoritative
+- lint rules and third-party plugin dispatch are suppressed for malformed lint targets; syntax diagnostics remain authoritative
 - CLI/API create tsconfig-backed Programs leniently so plain lint can decide
   syntax diagnostics from the final lint target set instead of failing during
   broad tsconfig construction
 - `--type-check` and `--type-check-only` still surface TypeScript syntactic and
   semantic diagnostics from the tsconfig-backed Program boundary
-- fallback Programs for selected files outside tsconfig coverage are AST-only
-  and intentionally skipped by the type-check phase
+- fallback Programs for selected files outside tsconfig coverage are not
+  project-backed, do not enable type-aware rules, and are intentionally skipped
+  by the type-check phase
 
 ## 5. Abstract Syntax Tree (AST)
 
@@ -283,7 +284,10 @@ The linter parses `/* global */` comments once per file before rules run.
 `ConfigGlobals` preserves the effective `languageOptions.globals` source,
 `InlineGlobals` preserves ordered comment name ranges, and `Globals` is the
 resolved map after inline settings override configuration. Rules consume this
-context data instead of scanning comments independently.
+context data instead of scanning comments independently. Configured access
+aliases are normalized consistently: writable and read-only aliases declare a
+name, `null` is read-only, and only `"off"` disables it. The Node plugin scope separately
+preserves writable versus read-only access for ESLint-compatible scope APIs.
 
 ### Listener Registration
 
@@ -367,7 +371,7 @@ Rslint supports two configuration formats following ESLint flat config semantics
 
 #### JS/TS Configuration (Recommended)
 
-JS/TS config files (`rslint.config.ts`, `rslint.config.js`, `rslint.config.mjs`, `rslint.config.mts`) are the recommended approach. They support preset composition via `defineConfig()`:
+JS/TS config files (`rslint.config.js`, `rslint.config.mjs`, `rslint.config.cjs`, `rslint.config.ts`, `rslint.config.mts`, `rslint.config.cts`) are the recommended approach. They support preset composition via `defineConfig()`:
 
 ```typescript
 import { defineConfig, ts } from '@rslint/core';
@@ -421,14 +425,14 @@ JSON config files (`rslint.json`, `rslint.jsonc`) are deprecated and will be rem
 
 Each entry in the config array supports:
 
-| Field             | Type                     | Description                                                                          |
-| ----------------- | ------------------------ | ------------------------------------------------------------------------------------ |
-| `files`           | `(string \| string[])[]` | Non-empty selector list; top-level selectors are ORed and nested selectors are ANDed |
-| `ignores`         | `string[]`               | Glob patterns excluded by this entry                                                 |
-| `languageOptions` | `object`                 | Parser options such as `project` and `projectService`                                |
-| `rules`           | `Record<string, …>`      | Rule level or `[level, options]`                                                     |
-| `plugins`         | `string[]`               | Plugin declarations used for plugin gating                                           |
-| `settings`        | `Record<string, …>`      | Shared settings available in `RuleContext`                                           |
+| Field             | Type                                       | Description                                                                          |
+| ----------------- | ------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `files`           | `(string \| string[])[]`                   | Non-empty selector list; top-level selectors are ORed and nested selectors are ANDed |
+| `ignores`         | `string[]`                                 | Glob patterns excluded by this entry                                                 |
+| `languageOptions` | `object`                                   | Parser options such as `project` and `projectService`                                |
+| `rules`           | `Record<string, …>`                        | Rule level or `[level, options]`                                                     |
+| `plugins`         | `string[] \| Record<string, ESLintPlugin>` | Native plugin declarations or third-party plugin instances                           |
+| `settings`        | `Record<string, …>`                        | Shared settings available in `RuleContext`                                           |
 
 ### Configuration Loading
 
@@ -437,10 +441,10 @@ The loading flow differs by config type:
 **JS/TS config**:
 
 1. `packages/rslint/src/cli/cli.ts` discovers one or more config files
-2. each config is loaded and normalized on the Node side
-3. the Node wrapper sends the normalized config list to Go in the IPC `init` payload
+2. each config is loaded and normalized on the Node side; live third-party plugin objects remain in a Node-side host while their prefixes and rule metadata are extracted
+3. the Node wrapper sends the normalized config list, explicit-file ownership scopes, and third-party rule metadata to Go in the IPC `init` payload
 4. Go parses either a multi-config payload or a legacy single-config payload shape
-5. nearest-config lookup is used later to decide target ownership and rule selection
+5. Go builds a `ConfigOwnerResolver` over those already-loaded objects to route each runtime target; it does not discover or evaluate JS/TS config files
 
 **JSON config**:
 
@@ -453,23 +457,35 @@ The loading flow differs by config type:
 Config merging follows flat-config-style semantics in `GetConfigForFile()`:
 
 1. entries containing only `ignores` and an optional `name` form the global-ignore set
-2. the implicit default extension baseline plus explicit `files` selectors defines the config selector union; top-level selectors are ORed, patterns in a nested selector are ANDed, and an explicit `files: []` is invalid
-3. entries without `files` cascade across that selector union, while entry-level `ignores` prevent only that entry from contributing configuration
-4. later rule values override earlier rule values
-5. later settings override earlier settings by key
-6. `languageOptions.parserOptions` are merged field-by-field and `languageOptions.globals` are merged by global name
+2. the implicit default extension baseline plus effective explicit `files` selectors defines the config selector union; an entry's `ignores` prevents its selector from extending that union, top-level selectors are ORed, nested patterns are ANDed, and an explicit `files: []` is invalid
+3. entries without `files` cascade across that selector union, while entry-level `ignores` prevent only that entry from contributing configuration to an otherwise selected file
+4. later rule values override earlier values; a severity-only override retains earlier rule options
+5. settings and language options recursively merge ordinary objects, while later arrays and scalar values replace earlier values
 
-In multi-config mode, `FindNearestConfig()` is used before `GetConfigForFile()` so that each file is merged against the nearest config directory.
+In multi-config mode, `ConfigOwnerResolver.Resolve()` selects the governing
+object before `GetConfigForFile()` merges its entries. This is runtime routing
+over the catalog supplied by Node, not config-file parsing or discovery.
+Ownership lookup never compares depth across lexical and physical path spaces:
+the nearest exact lexical config wins, a native case alias is accepted only
+after filesystem identity verification, and realpath ancestry is consulted only
+when no lexical owner exists. Directory-walk handoff boundaries are likewise
+built only from the lexical config hierarchy. Canonical paths remain file and
+Program identities, not a second config inheritance tree. CLI target discovery,
+the IPC API, and LSP all use this ordering.
 
 Additional current behaviors:
 
 - `.gitignore` is injected into CLI configs as a global-ignore entry
-- plugin rules are gated by declared plugins for JS/TS configs
-- lint target selection is independent from TypeScript `Program` membership: rslint always starts with `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, and `.cts`, then unions explicit config `files`; global ignores and `.gitignore` remove targets, while entry-level ignores do not
+- the VS Code extension preserves last-good JS configs during reloads; a newly
+  unavailable config with no usable JS ancestor contributes an empty boundary,
+  preventing legacy JSON fallback only in that authored config subtree
+- native and third-party plugin rules are gated by their normalized prefixes for JS/TS configs; third-party rules use Go registry placeholders and execute in the Node plugin worker
+- lint target selection is independent from TypeScript `Program` membership: rslint always starts with `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, and `.cts`, then unions effective explicit config `files`; global ignores and `.gitignore` remove targets, while an entry-level ignore prevents only its own selector/config contribution
 - files passed explicitly on the CLI/API can still appear as 0-rule lint results when no config entry contributes rules; selected files are parsed and can report syntax diagnostics in that state
 - each selected file is governed by its nearest config and can bind only to a tsconfig declared by that config; the first declared project containing the file wins
-- canonical tsconfigs are built once while retaining every config association, and selected files outside the governing config's Programs receive an AST-only fallback Program
-- `--type-check` runs over every real tsconfig Program and is not constrained by lint targets, config `files`/`ignores`, `.gitignore`, or CLI file/directory arguments; synthetic fallback Programs never participate
+- `files`/`ignores` matching uses the stable target path in the governing config's path space; a Program source alias is used only to locate the AST and type information, so moving a target into or out of a tsconfig cannot change its rule configuration
+- each normalized declared tsconfig path is built once within a Go lint invocation while retaining every config association; file-symlink declarations remain distinct because TypeScript resolves relative paths from the declared location. Selected files outside the governing config's Programs receive a non-project-backed fallback Program, and targets whose names collide under a case-insensitive ts-go path key are partitioned across fallback Programs so distinct physical files remain distinct
+- `--type-check` and `--type-check-only` run over every real tsconfig Program and are not constrained by lint targets, config `files`/`ignores`, `.gitignore`, or CLI file/directory arguments; synthetic fallback Programs never participate. `--type-check-only` skips lint-target and `.gitignore` discovery entirely.
 
 ### Inline Directives
 
@@ -501,10 +517,10 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
    - `--lsp`: starts the LSP server
    - `--api`: starts the IPC API server
    - default: runs direct CLI linting
-4. **Program Registry**: Go builds each canonical configured or auto-detected tsconfig once and records every governing-config association plus declaration order
-5. **Lint Target Plan**: independently, Go resolves a stable target set from CLI/API scope, the implicit default baseline, explicit config `files`, global ignores, and `.gitignore`
-6. **Program Binding**: each target is bound to the first containing Program declared by its governing config; unbound targets, including projects with no tsconfig, are parsed through an AST-only fallback Program
-7. **Rule Resolution**: `getRulesForFile` resolves enabled rules per selected file, filtering type-aware rules off no-type-info gap files
+4. **Lint Target Plan**: Go resolves a stable target set from CLI/API scope, the implicit default baseline, explicit config `files`, global ignores, and `.gitignore`
+5. **Program Registry**: plain lint builds each normalized tsconfig path declared by an active governing config once; `--type-check` and `--type-check-only` instead retain every configured project. Shared declared paths preserve each active config association and declaration order.
+6. **Program Binding**: each target is bound by exact canonical filesystem identity to the first containing Program declared by its governing config; unbound targets, including projects with no tsconfig, are parsed through a non-project-backed fallback Program
+7. **Rule Resolution**: `getRulesForFile` resolves enabled rules from the stable lint-target path, never the Program source alias, and filters type-aware rules off no-type-info gap files
 8. **Rule Execution**: `RunLinter()` schedules per-Program work over the exact target plan; the unexported `runLintRulesInProgram()` does the actual per-file traversal. When `--type-check` is enabled, a separate program-wide pass over real tsconfig Programs aggregates `tsc --noEmit`-aligned diagnostics through `collectNoEmitDiagnostics()`
 9. **Result Aggregation**: diagnostics are sent through one run-scoped diagnostics channel and collected at the CLI layer
 10. **Fix Passes**: when enabled, fixes are applied, real Programs are rebuilt, and the stable target plan is rebound; target membership stays fixed while a file may move between a real Program and fallback as its import graph changes
@@ -520,53 +536,81 @@ which is the user-facing escape hatch for serial / reproducible execution.
    - Schedules per-Program lint work; runs rules in parallel within a Program.
    - `--singleThreaded` collapses the work group to serial execution.
 
-2. **gitignore reading ‖ Program creation** (in `cmd/rslint/cmd.go`)
-   - `ReadGitignoreAsGlobs` walks `.gitignore` for each config; it is independent
-     of Program registry construction (which only reads
-     `languageOptions.parserOptions.project`, never `Ignores`). The two are
-     dispatched as parallel goroutines per config.
+2. **gitignore reading and Program creation** (in `cmd/rslint/cmd.go`)
+   - Plain lint completes `ReadGitignoreAsGlobs` before target discovery, then
+     constructs Programs only for configs represented in the target plan.
+   - `--type-check` constructs every configured Program independently from
+     gitignore discovery. `--type-check-only` constructs the same Program set
+     without reading gitignore state because it has no lint-target phase.
    - In multi-config mode, gitignore reads also fan out across configs in
-     parallel; canonical Programs are constructed serially in stable config and
-     project order (typescript-go's API is invoked one Program at a time).
+     parallel; configured Programs are constructed serially in stable config
+     and project order (typescript-go's API is invoked one Program at a time).
    - `--singleThreaded` runs both stages sequentially — no goroutines spawned.
 
 3. **Lint-target directory walker** (`internal/config/file_discovery.go`)
-   - `DiscoverLintFiles` uses a fixed-size worker pool (`walkPool`) that walks
-     the directory tree. Live goroutine count is capped at `workers`, not the
-     number of directories.
+   - `DiscoverLintTargets` uses a fixed-size worker pool (`walkPool`) that
+     walks the directory tree. `DiscoverLintFiles` is the path-only
+     compatibility wrapper. Live goroutine count is capped at `workers`, not
+     the number of directories.
    - Default `workers = max(2, GOMAXPROCS)`; `--singleThreaded` forces
      `workers = 1`, which degenerates into a fully serial DFS-style traversal.
    - The walker is built on a `vfsAdapter` with `followSymlinks = false`:
-     symlinked subdirectories are skipped. This matches ESLint v10's
+     nested symlinked subdirectories are skipped. An explicitly requested
+     directory alias is resolved once and used as a bounded scan root. This
+     matches ESLint v10's
      flat-config file walker, which uses `@humanfs/node` and recurses only
-     when `Dirent.isDirectory()` is true (Node's `readdir({withFileTypes:
-true})` reports the dirent type without following symlinks, so
-     `Dirent.isDirectory()` is false for symlinks). The skip also eliminates
+     when `Dirent.isDirectory()` is true. Node's
+     `readdir({ withFileTypes: true })` reports the dirent type without
+     following symlinks, so
+     `Dirent.isDirectory()` is false for symlinks. The skip also eliminates
      scheduling-dependent non-determinism that a parallel walker would
      otherwise introduce.
 
 4. **Multi-config target discovery** (`DiscoverLintTargetsMultiConfig`)
-   - Uses a config-directory index to assign explicit files and directory ownership before calling per-config discovery.
+   - Uses host-provided scopes for explicit-file ownership. Explicit files not
+     assigned by a host are routed through the config-directory index before
+     per-config discovery.
    - Each call is itself bounded by its own worker pool, so total live
      goroutines remain bounded by `workers`, not `len(configMap) × workers`.
 
 Other invariants:
 
-- Target discovery canonicalizes and deduplicates selected files before binding; aliases governed by different configs are rejected instead of choosing an owner by scan order.
-- LSP uses a different orchestration model and keeps session access on its
-  main dispatch loop.
+- Target discovery returns both the caller-visible lexical path and a canonical
+  identity hint. A regular directory walk derives the canonical path from the
+  canonical config root without a per-file realpath call. Explicit directory
+  aliases are resolved once and their descendants inherit the corresponding
+  physical path; explicit files and file symlinks are resolved individually.
+  Canonical identities use exact comparison, and aliases governed by different
+  configs are rejected instead of choosing an owner by scan order.
+- The Node CLI keeps explicit targets in the caller's lexical path space for
+  config ownership. It consults physical ancestry only when lexical discovery
+  finds no config, and loads an ancestor only after a nearer explicit-file
+  config fails.
+- Go applies the same strict lexical-first ordering to the already-loaded config
+  catalog. A physically deeper config loaded for another target cannot replace
+  an existing lexical owner; physical ancestry is only a fallback for paths
+  with no lexical config.
+- `Rslint.lintFiles()` applies the same rule before creating a third-party
+  plugin host or sending API requests. Its realpath memo is bounded to one API
+  call and is not a persistent cache. Canonical target paths resolved during
+  that plan are sent with the request so Go does not repeat the same realpath
+  work.
+- LSP uses a different orchestration model and keeps session access on its main
+  dispatch loop. It shares the exact/canonical Program source lookup used by
+  CLI/API binding, including file-symlink aliases and case-folded lookup
+  validation.
 
 #### `--singleThreaded` semantics
 
 `--singleThreaded` is honored in every parallelism point above:
 
-| Point                          | Effect when set                                               |
-| ------------------------------ | ------------------------------------------------------------- |
-| Linter work group              | Collapsed to serial via `core.NewWorkGroup(true)`.            |
-| gitignore ‖ Program creation   | Both stages run sequentially in the main goroutine.           |
-| Multi-config gitignore fan-out | Replaced by a sequential for-loop.                            |
-| Lint-target walker workers     | Forced to 1 (single goroutine, no concurrency).               |
-| Multi-config target discovery  | Already serial across configs; inner walker also forced to 1. |
+| Point                          | Effect when set                                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Linter work group              | Collapsed to serial via `core.NewWorkGroup(true)`.                                                       |
+| gitignore / Program creation   | Plain lint performs target discovery before Program creation; type-check mode runs both stages serially. |
+| Multi-config gitignore fan-out | Replaced by a sequential for-loop.                                                                       |
+| Lint-target walker workers     | Forced to 1 (single goroutine, no concurrency).                                                          |
+| Multi-config target discovery  | Already serial across configs; inner walker also forced to 1.                                            |
 
 End result: with `--singleThreaded`, the Go side spawns no goroutines beyond
 those typescript-go itself creates for syntactic / semantic work.
@@ -596,7 +640,8 @@ those typescript-go itself creates for syntactic / semantic work.
 - **LSP Session Reuse**: `internal/lsp` builds a shared ts-go `project.Session`, so configured projects, inferred projects, and overlay document state are reused across requests
 - **Parse Cache in LSP**: the LSP server passes a shared `project.ParseCache` into the session to avoid re-parsing from scratch on every change
 - **Debounced Re-linting**: `refreshCh` and `debounceCh` collapse bursts of file changes and session refreshes onto the main dispatch loop
-- **CLI/API Are Mostly Fresh Runs**: CLI and one-shot API requests generally rebuild `Program` state per run; there is no repository-local rule-result cache or persistent incremental lint cache in the main CLI path today
+- **CLI/API Are Mostly Fresh Runs**: CLI and one-shot API requests generally rebuild `Program` state per run; there is no repository-local rule-result cache or persistent incremental lint cache in the main CLI path today. JavaScript API path canonicalization is also scoped to one `lintFiles()` call.
+- **Run-Scoped Parse Reuse**: CLI Program rebuilds within one invocation share a parse cache, primarily for multi-pass fixing. The cache is discarded with the run and is neither repository-persistent nor shared across lint requests.
 - **Bounded Multi-Pass Fixing**: `--fix` and LSP `fixAll` intentionally rerun lint after applying edits, but cap the cascade at `maxFixPasses = 10`
 
 ### Memory Management
@@ -612,26 +657,25 @@ those typescript-go itself creates for syntactic / semantic work.
 
 ### Plugin Architecture
 
-Today, plugin support is built-in rather than dynamically loading arbitrary third-party ESLint plugins at runtime.
+Plugin execution has two paths:
 
-The repository currently ships internal support for:
+- native plugins are compiled into the Go binary and execute through the shared listener traversal
+- third-party ESLint plugin objects are loaded from JS/TS config on the Node side; Go registers routing placeholders for their rules and sends per-file batches back to the Node plugin worker over reverse IPC
 
-- TypeScript plugin rules
-- React rules
-- Jest rules
-- Import plugin rules
+JSON config supports only native plugin names because it cannot represent live JavaScript plugin objects. The repository currently ships native implementations for TypeScript ESLint, Import, Jest, JSX accessibility, Promise, React, React Hooks, and Unicorn rule namespaces.
 
 ### Rule Extension Points
 
 - **Core Rules**: add a package under `internal/rules/<rule_name>/` and append the rule var to `internal/rules/all.go`'s `GetAllRules()` slice
-- **Plugin Rules**: add a package under `internal/plugins/<plugin>/rules/<rule_name>/` and append the rule var to `internal/plugins/<plugin>/all.go`'s `GetAllRules()` slice
+- **Native Plugin Rules**: add a package under `internal/plugins/<plugin>/rules/<rule_name>/` and append the rule var to `internal/plugins/<plugin>/all.go`'s `GetAllRules()` slice
+- **Third-Party Plugin Rules**: import a plugin object in JS/TS config and mount it under an object-form `plugins` prefix; no Go rule registration is required
 - **Rule Options**: each rule receives parsed options through `Run(ctx, options)`
 - **Custom Listener Shapes**: rules can listen on standard kinds and synthetic pattern/exit kinds
 
 ### Integration Points
 
 - **Language Server**: `internal/lsp` exposes diagnostics and code actions
-- **JavaScript API**: `packages/rslint` talks to `cmd/rslint --api`
+- **JavaScript API**: `packages/rslint` talks to `cmd/rslint --api` through the versioned `2.0.0` protocol; the handshake negotiates reverse `pluginLint` support before third-party rules run
 - **WASM Playground**: `packages/rslint-wasm` runs the API server in a browser worker
 - **Rust Client**: `crates/tsgo-client` consumes `cmd/tsgo`
 
@@ -739,13 +783,17 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 │            │                                                                 │
 │            ▼                                                                 │
 │  Config Load / Normalize / Merge                                             │
-│            ├──────────────────────────┐                                      │
-│            ▼                          ▼                                      │
-│  Canonical Program Registry      Stable Lint Target Plan                     │
-│  (tsconfig + config/order)       (scope + selectors + ignores)               │
-│            └──────────────┬───────────┘                                      │
-│                           ▼                                                  │
-│  Bind by Governing Config / Project Order ─────► AST-only Fallback Program   │
+│            │                                                                 │
+│            ▼                                                                 │
+│  Stable Lint Target Plan (scope + selectors + ignores; skipped by            │
+│  type-check-only)                                                            │
+│            │                                                                 │
+│            ▼                                                                 │
+│  Canonical Program Registry                                                  │
+│  (active governing configs for plain lint; all configs for type-check)       │
+│            │                                                                 │
+│            ▼                                                                 │
+│  Bind by Governing Config / Project Order ─────► Non-project Fallback        │
 │                           │                                                  │
 │                           ▼                                                  │
 │  Resolve Enabled Rules Per File                                              │
@@ -811,16 +859,16 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 - **Config Entry**: One flat-config object whose `files`, `ignores`, `settings`, and `rules` participate in per-file config merging
 - **ConfiguredRule**: Rule implementation plus resolved severity, settings, options, and type-info requirement
 - **Diagnostic**: A lint finding reported by a rule or by TypeScript semantic diagnostics
-- **Fallback Program**: Extra AST-only `Program` created from selected lint targets that are not covered by a tsconfig Program associated with their governing config; fallback files are intentionally non-type-aware
+- **Fallback Program**: Extra non-project-backed `Program` created from selected lint targets that are not covered by a tsconfig Program associated with their governing config; fallback files do not enable type-aware rules or participate in program-wide type-check
 - **Flat Config**: ESLint-style array-based configuration model used by rslint to merge rule settings per file
 - **Gap File**: A selected lint target that is not present in any tsconfig Program declared by its governing config
 - **Inspector**: Auxiliary backend path that returns node, type, symbol, signature, and flow information for Playground inspection
-- **IPC API**: Length-prefixed JSON message protocol exposed by `cmd/rslint --api` for Node and WASM clients
+- **IPC API**: Length-prefixed JSON message protocol exposed by `cmd/rslint --api` for Node and WASM clients; config path resolution and third-party plugin routing use separate keys when API overrides rebase relative patterns
 - **Listener**: Callback registered by a rule for an AST kind or synthetic listener kind
 - **Nearest Config**: In multi-config mode, the deepest config directory that owns a file
 - **Node Kind**: Enumerated AST kind value used by ts-go and by the listener dispatcher to identify node types
 - **Program**: ts-go compilation context, usually tied to a tsconfig or fallback root-file set
-- **Program Registry**: Run-scoped set of canonical tsconfig Programs plus the governing configs and project declaration order associated with each Program
+- **Program Registry**: Run-scoped set of Programs keyed by normalized declared tsconfig path, plus the governing configs and project declaration order associated with each Program
 - **project.Session**: ts-go project manager used by LSP for inferred/configured projects and overlays
 - **Rule Context**: Runtime environment through which a rule reads file/program/checker state and reports findings
 - **RuleFix**: Text edit represented as a range plus replacement text; fixes are merged and applied after diagnostics are collected

--- a/architecture.md
+++ b/architecture.md
@@ -437,8 +437,8 @@ The loading flow differs by config type:
 
 1. `packages/rslint/src/cli/cli.ts` discovers one or more config files
 2. each config is loaded and normalized on the Node side
-3. the Node wrapper sends a stdin payload to the Go binary via `--config-stdin`
-4. Go parses either a multi-config payload or a legacy single-config payload
+3. the Node wrapper sends the normalized config list to Go in the IPC `init` payload
+4. Go parses either a multi-config payload or a legacy single-config payload shape
 5. nearest-config lookup is used later to decide target ownership and rule selection
 
 **JSON config**:
@@ -490,9 +490,9 @@ rslint [options] [files...]
 
 The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cli/cli.ts`) and the Go binary (`cmd/rslint/`).
 
-1. **Node.js Wrapper**: parses args, discovers JS/TS configs, and decides whether to use `--config-stdin`
+1. **Node.js Wrapper**: parses args, discovers JS/TS configs, and decides whether Go should load JSON config itself
 2. **Config Path Selection**:
-   - JS/TS configs are normalized in Node and piped to Go
+   - JS/TS configs are normalized in Node and sent to Go in the IPC `init` payload
    - JSON configs are loaded directly by Go
 3. **Mode Selection**:
    - `--lsp`: starts the LSP server
@@ -807,7 +807,7 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 - **Diagnostic**: A lint finding reported by a rule or by TypeScript semantic diagnostics
 - **Fallback Program**: Extra AST-only `Program` created from selected lint targets that are not covered by any tsconfig-backed Program; fallback files are intentionally non-type-aware
 - **Flat Config**: ESLint-style array-based configuration model used by rslint to merge rule settings per file
-- **Gap File**: A file matched by config but not present in any tsconfig-backed Program
+- **Gap File**: A selected lint target that is not present in any tsconfig-backed Program
 - **Inspector**: Auxiliary backend path that returns node, type, symbol, signature, and flow information for Playground inspection
 - **IPC API**: Length-prefixed JSON message protocol exposed by `cmd/rslint --api` for Node and WASM clients
 - **Listener**: Callback registered by a rule for an AST kind or synthetic listener kind

--- a/architecture.md
+++ b/architecture.md
@@ -195,8 +195,13 @@ The parser and program builder are tolerant enough to support editor and fallbac
 
 - ts-go can continue producing ASTs after syntax errors
 - LSP delays lint on rapid edits to avoid repeated work on broken intermediate text
-- fallback Programs for gap files are created leniently so parse failures there do not fail the whole run
-- CLI reports syntax diagnostics separately when program creation fails in the strict tsconfig-backed path
+- CLI/API create tsconfig-backed Programs leniently so plain lint can decide
+  syntax diagnostics from the final lint target set instead of failing during
+  broad tsconfig construction
+- `--type-check` and `--type-check-only` still surface TypeScript syntactic and
+  semantic diagnostics from the tsconfig-backed Program boundary
+- fallback Programs for selected files outside tsconfig coverage are AST-only
+  and intentionally skipped by the type-check phase
 
 ## 5. Abstract Syntax Tree (AST)
 
@@ -493,9 +498,9 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
    - `--lsp`: starts the LSP server
    - `--api`: starts the IPC API server
    - default: runs direct CLI linting
-4. **Program Creation**: Go builds one or more tsconfig-backed Programs, plus optional no-tsconfig Programs for projects without tsconfig coverage
+4. **Program Creation**: Go builds one or more tsconfig-backed Programs from configured or auto-detected tsconfigs
 5. **Lint Target Selection**: Go resolves the lint target set from CLI/API targets, config `files`, default lintable extensions, global ignores, and `.gitignore`
-6. **Program Binding**: selected files are bound to existing Programs when possible; selected files outside every Program are parsed through an AST-only fallback Program
+6. **Program Binding**: selected files are bound to existing Programs when possible; selected files outside every tsconfig-backed Program, including projects with no tsconfig, are parsed through an AST-only fallback Program
 7. **Rule Resolution**: `getRulesForFile` resolves enabled rules per selected file, filtering type-aware rules off no-type-info gap files
 8. **Rule Execution**: `RunLinter()` schedules per-Program work over the exact target plan; the unexported `runLintRulesInProgram()` does the actual per-file traversal. When `--type-check` is enabled, a second program-level pass runs after Phase 1 and aggregates `tsc --noEmit`-aligned diagnostics through the internal `collectNoEmitDiagnostics()` helper
 9. **Result Aggregation**: diagnostics are sent through one run-scoped diagnostics channel and collected at the CLI layer
@@ -800,7 +805,7 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 - **Config Entry**: One flat-config object whose `files`, `ignores`, `settings`, and `rules` participate in per-file config merging
 - **ConfiguredRule**: Rule implementation plus resolved severity, settings, options, and type-info requirement
 - **Diagnostic**: A lint finding reported by a rule or by TypeScript semantic diagnostics
-- **Fallback Program**: Extra `Program` created for no-tsconfig projects or for gap files; gap-file fallbacks are intentionally non-type-aware
+- **Fallback Program**: Extra AST-only `Program` created from selected lint targets that are not covered by any tsconfig-backed Program; fallback files are intentionally non-type-aware
 - **Flat Config**: ESLint-style array-based configuration model used by rslint to merge rule settings per file
 - **Gap File**: A file matched by config but not present in any tsconfig-backed Program
 - **Inspector**: Auxiliary backend path that returns node, type, symbol, signature, and flow information for Playground inspection

--- a/architecture.md
+++ b/architecture.md
@@ -415,14 +415,14 @@ JSON config files (`rslint.json`, `rslint.jsonc`) are deprecated and will be rem
 
 Each entry in the config array supports:
 
-| Field             | Type                | Description                                           |
-| ----------------- | ------------------- | ----------------------------------------------------- |
-| `files`           | `string[]`          | Glob patterns this entry applies to                   |
-| `ignores`         | `string[]`          | Glob patterns excluded by this entry                  |
-| `languageOptions` | `object`            | Parser options such as `project` and `projectService` |
-| `rules`           | `Record<string, …>` | Rule level or `[level, options]`                      |
-| `plugins`         | `string[]`          | Plugin declarations used for plugin gating            |
-| `settings`        | `Record<string, …>` | Shared settings available in `RuleContext`            |
+| Field             | Type                | Description                                                                                     |
+| ----------------- | ------------------- | ----------------------------------------------------------------------------------------------- |
+| `files`           | `string[]`          | Non-empty glob patterns this entry applies to; omit to use rslint's default lintable extensions |
+| `ignores`         | `string[]`          | Glob patterns excluded by this entry                                                            |
+| `languageOptions` | `object`            | Parser options such as `project` and `projectService`                                           |
+| `rules`           | `Record<string, …>` | Rule level or `[level, options]`                                                                |
+| `plugins`         | `string[]`          | Plugin declarations used for plugin gating                                                      |
+| `settings`        | `Record<string, …>` | Shared settings available in `RuleContext`                                                      |
 
 ### Configuration Loading
 
@@ -434,7 +434,7 @@ The loading flow differs by config type:
 2. each config is loaded and normalized on the Node side
 3. the Node wrapper sends a stdin payload to the Go binary via `--config-stdin`
 4. Go parses either a multi-config payload or a legacy single-config payload
-5. nearest-config lookup is used later to decide file ownership and rule selection
+5. nearest-config lookup is used later to decide target ownership and rule selection
 
 **JSON config**:
 
@@ -447,7 +447,7 @@ The loading flow differs by config type:
 Config merging follows flat-config-style semantics in `GetConfigForFile()`:
 
 1. global-ignore-only entries apply first
-2. `files` patterns decide which entries match
+2. `files` patterns decide which entries match; an explicit `files: []` is invalid
 3. `ignores` can remove files from an otherwise matching entry
 4. later rule values override earlier rule values
 5. later settings override earlier settings by key
@@ -459,8 +459,9 @@ Additional current behaviors:
 
 - `.gitignore` is injected into CLI configs as a global-ignore entry
 - plugin rules are gated by declared plugins for JS/TS configs
-- files passed explicitly on the CLI can still be linted even if they do not match a config `files` pattern, if merged config still assigns them rules
-- files outside all tsconfig-backed Programs can become gap files and receive an AST-only fallback Program
+- lint target selection is independent from TypeScript `Program` membership: CLI/API targets are filtered by `files`, global ignores, and `.gitignore`; omitted `files` entries contribute rslint's default lintable extensions (`.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, `.cts`)
+- files passed explicitly on the CLI/API can still appear as 0-rule lint results even if they do not match any config `files` pattern
+- selected files outside all tsconfig-backed Programs become gap files and receive an AST-only fallback Program
 
 ### Inline Directives
 
@@ -492,14 +493,15 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
    - `--lsp`: starts the LSP server
    - `--api`: starts the IPC API server
    - default: runs direct CLI linting
-4. **Program Creation**: Go builds one or more tsconfig-backed Programs, plus optional no-tsconfig or gap-file fallback Programs
-5. **Ownership Filtering**: multi-config mode computes nearest-config ownership so files are linted once
-6. **Rule Resolution**: `getRulesForFile` resolves enabled rules per file
-7. **Rule Execution**: `RunLinter()` schedules per-Program work; the unexported `runLintRulesInProgram()` does the actual per-file traversal. When `--type-check` is enabled, a second program-level pass runs after Phase 1 and aggregates `tsc --noEmit`-aligned diagnostics through the internal `collectNoEmitDiagnostics()` helper
-8. **Result Aggregation**: diagnostics are sent through one run-scoped diagnostics channel and collected at the CLI layer
-9. **Fix Passes**: when enabled, fixes are applied and Programs can be rebuilt for another pass
-10. **Output Formatting**: default, JSON line, and GitHub workflow formats are supported
-11. **Exit Code**: depends on diagnostics, warnings, and fix outcomes
+4. **Program Creation**: Go builds one or more tsconfig-backed Programs, plus optional no-tsconfig Programs for projects without tsconfig coverage
+5. **Lint Target Selection**: Go resolves the lint target set from CLI/API targets, config `files`, default lintable extensions, global ignores, and `.gitignore`
+6. **Program Binding**: selected files are bound to existing Programs when possible; selected files outside every Program are parsed through an AST-only fallback Program
+7. **Rule Resolution**: `getRulesForFile` resolves enabled rules per selected file, filtering type-aware rules off no-type-info gap files
+8. **Rule Execution**: `RunLinter()` schedules per-Program work over the exact target plan; the unexported `runLintRulesInProgram()` does the actual per-file traversal. When `--type-check` is enabled, a second program-level pass runs after Phase 1 and aggregates `tsc --noEmit`-aligned diagnostics through the internal `collectNoEmitDiagnostics()` helper
+9. **Result Aggregation**: diagnostics are sent through one run-scoped diagnostics channel and collected at the CLI layer
+10. **Fix Passes**: when enabled, fixes are applied and Programs can be rebuilt for another pass without changing the original target set
+11. **Output Formatting**: default, JSON line, and GitHub workflow formats are supported
+12. **Exit Code**: depends on diagnostics, warnings, and fix outcomes
 
 ### Concurrency Model
 
@@ -520,8 +522,8 @@ which is the user-facing escape hatch for serial / reproducible execution.
      (typescript-go's API is invoked one config at a time).
    - `--singleThreaded` runs both stages sequentially — no goroutines spawned.
 
-3. **Gap-file directory walker** (`internal/config/file_discovery.go`)
-   - `DiscoverGapFiles` uses a fixed-size worker pool (`walkPool`) that walks
+3. **Lint-target directory walker** (`internal/config/file_discovery.go`)
+   - `DiscoverLintFiles` uses a fixed-size worker pool (`walkPool`) that walks
      the directory tree. Live goroutine count is capped at `workers`, not the
      number of directories.
    - Default `workers = max(2, GOMAXPROCS)`; `--singleThreaded` forces
@@ -535,14 +537,14 @@ true})` reports the dirent type without following symlinks, so
      scheduling-dependent non-determinism that a parallel walker would
      otherwise introduce.
 
-4. **Multi-config gap discovery** (`DiscoverGapFilesMultiConfig`)
-   - Iterates `configMap` serially, calling `DiscoverGapFiles` once per config.
+4. **Multi-config target discovery** (`DiscoverLintFilesMultiConfig`)
+   - Iterates `configMap` serially, calling `DiscoverLintFiles` once per config.
    - Each call is itself bounded by its own worker pool, so total live
      goroutines remain bounded by `workers`, not `len(configMap) × workers`.
 
 Other invariants:
 
-- File-ownership filtering avoids duplicate work in multi-config mode.
+- Target discovery and Program binding deduplicate selected files across configs before `RunLinter` runs.
 - LSP uses a different orchestration model and keeps session access on its
   main dispatch loop.
 
@@ -555,8 +557,8 @@ Other invariants:
 | Linter work group              | Collapsed to serial via `core.NewWorkGroup(true)`.            |
 | gitignore ‖ Program creation   | Both stages run sequentially in the main goroutine.           |
 | Multi-config gitignore fan-out | Replaced by a sequential for-loop.                            |
-| Gap-file walker workers        | Forced to 1 (single goroutine, no concurrency).               |
-| Multi-config gap discovery     | Already serial across configs; inner walker also forced to 1. |
+| Lint-target walker workers     | Forced to 1 (single goroutine, no concurrency).               |
+| Multi-config target discovery  | Already serial across configs; inner walker also forced to 1. |
 
 End result: with `--singleThreaded`, the Go side spawns no goroutines beyond
 those typescript-go itself creates for syntactic / semantic work.
@@ -568,7 +570,7 @@ those typescript-go itself creates for syntactic / semantic work.
 - **Direct ts-go Data Model**: rslint operates on ts-go `Program`, AST, and `TypeChecker` objects directly instead of converting through a second AST representation
 - **Program-Level Parallelism**: `RunLinter` queues work per `Program` through `core.NewWorkGroup`; `--singleThreaded` forces the same flow to run serially
 - **Single-Walk Rule Dispatch**: each file is traversed once, with rules registering listeners up front and sharing the same AST walk
-- **Early Filtering**: skip paths, allowFiles/allowDirs, nearest-config ownership filters, and gap-file type filtering reduce work before listeners run
+- **Early Filtering**: exact lint target plans, skip paths, global-ignore filters, and gap-file type filtering reduce work before listeners run
 
 ### Performance Optimizations
 

--- a/architecture.md
+++ b/architecture.md
@@ -180,7 +180,7 @@ The current parsing and linting pipeline is built on top of ts-go `Program` and 
 ### Detailed Pipeline Steps
 
 1. **Source Text Loading**: Files come from the real filesystem, an overlay VFS, or LSP document overlays.
-2. **Program Construction**: Plain CLI/API lint resolves its effective targets first and builds `Program` objects only for governing configs that own a selected target. Program-wide type-check modes build every configured project. LSP reuses matching projects from ts-go `project.Session`; a declared custom tsconfig that project service has not loaded is built on demand against an isolated editor overlay.
+2. **Program Construction**: Plain CLI/API lint resolves its effective targets first and builds `Program` objects only for governing configs that own a selected target. Program-wide type-check modes build every project declared by the effective loaded config catalog. LSP reuses matching projects from ts-go `project.Session`; a declared custom tsconfig that project service has not loaded is built on demand against an isolated editor overlay.
 3. **Lexical + Syntax Parsing**: ts-go tokenizes and parses source files into TypeScript-native AST nodes.
 4. **Semantic Analysis**: When needed, the linter acquires a `TypeChecker` from the `Program`.
 5. **Rule Registration**: Enabled rules register listeners keyed by AST kind.
@@ -371,7 +371,7 @@ Rslint supports two configuration formats following ESLint flat config semantics
 
 #### JS/TS Configuration (Recommended)
 
-JS/TS config files (`rslint.config.js`, `rslint.config.mjs`, `rslint.config.cjs`, `rslint.config.ts`, `rslint.config.mts`, `rslint.config.cts`) are the recommended approach. They support preset composition via `defineConfig()`:
+Rslint automatically discovers `rslint.config.js`, `rslint.config.mjs`, `rslint.config.ts`, and `rslint.config.mts`. Explicit configuration paths also support `.cjs` and `.cts` files through CLI `--config` and API `overrideConfigFile`. JS/TS config files support preset composition via `defineConfig()`:
 
 ```typescript
 import { defineConfig, ts } from '@rslint/core';
@@ -438,13 +438,20 @@ Each entry in the config array supports:
 
 The loading flow differs by config type:
 
-**JS/TS config**:
+**CLI JS/TS config**:
 
 1. `packages/rslint/src/cli/cli.ts` discovers one or more config files
 2. each config is loaded and normalized on the Node side; live third-party plugin objects remain in a Node-side host while their prefixes and rule metadata are extracted
 3. the Node wrapper sends the normalized config list, explicit-file ownership scopes, and third-party rule metadata to Go in the IPC `init` payload
 4. Go parses either a multi-config payload or a legacy single-config payload shape
 5. Go builds a `ConfigOwnerResolver` over those already-loaded objects to route each runtime target; it does not discover or evaluate JS/TS config files
+
+The JavaScript API performs config discovery and lexical-first ownership
+routing in `Rslint.lintFiles()`, groups selected files by resolved config, and
+sends one normalized single-config request per group to Go `--api`. LSP receives
+an already-loaded config catalog from the VS Code extension and routes that
+catalog in Go. No Go integration discovers, parses, or evaluates JS/TS config
+source.
 
 **JSON config**:
 
@@ -462,30 +469,35 @@ Config merging follows flat-config-style semantics in `GetConfigForFile()`:
 4. later rule values override earlier values; a severity-only override retains earlier rule options
 5. settings and language options recursively merge ordinary objects, while later arrays and scalar values replace earlier values
 
-In multi-config mode, `ConfigOwnerResolver.Resolve()` selects the governing
-object before `GetConfigForFile()` merges its entries. This is runtime routing
-over the catalog supplied by Node, not config-file parsing or discovery.
+CLI multi-config mode and LSP use `ConfigOwnerResolver.Resolve()` to select the
+governing object before `GetConfigForFile()` merges its entries. This is runtime
+routing over a catalog supplied by Node, not config-file parsing or discovery.
+The JavaScript API applies equivalent lexical-first routing in Node, groups
+files by resolved config, and sends single-config IPC lint requests. The
+low-level Go IPC handler does not route a multi-config catalog.
+
 Ownership lookup never compares depth across lexical and physical path spaces:
 the nearest exact lexical config wins, a native case alias is accepted only
 after filesystem identity verification, and realpath ancestry is consulted only
 when no lexical owner exists. Directory-walk handoff boundaries are likewise
 built only from the lexical config hierarchy. Canonical paths remain file and
-Program identities, not a second config inheritance tree. CLI target discovery,
-the IPC API, and LSP all use this ordering.
+Program identities, not a second config inheritance tree.
 
 Additional current behaviors:
 
-- `.gitignore` is injected into CLI configs as a global-ignore entry
+- `.gitignore` is injected into CLI and IPC API configs as a global-ignore
+  entry; LSP `.gitignore` integration remains a separate follow-up
 - the VS Code extension preserves last-good JS configs during reloads; a newly
   unavailable config with no usable JS ancestor contributes an empty boundary,
   preventing legacy JSON fallback only in that authored config subtree
 - native and third-party plugin rules are gated by their normalized prefixes for JS/TS configs; third-party rules use Go registry placeholders and execute in the Node plugin worker
-- lint target selection is independent from TypeScript `Program` membership: rslint always starts with `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, and `.cts`, then unions effective explicit config `files`; global ignores and `.gitignore` remove targets, while an entry-level ignore prevents only its own selector/config contribution
-- files passed explicitly on the CLI/API can still appear as 0-rule lint results when no config entry contributes rules; selected files are parsed and can report syntax diagnostics in that state
-- each selected file is governed by its nearest config and can bind only to a tsconfig declared by that config; the first declared project containing the file wins
+- CLI/API lint target selection is independent from TypeScript `Program` membership and considers only rslint-supported script extensions. The `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, and `.cts` default baseline is always selected; explicit config `files` contributes candidates only within the supported set. Global ignores and `.gitignore` remove targets, while an entry-level ignore prevents only its own selector/config contribution
+- selected CLI/API targets can still appear as 0-rule lint results when no config entry contributes rules; this applies to default-baseline directory discovery and explicit supported files, and syntax diagnostics remain available in that state
+- under automatic discovery, each selected file is governed by its nearest loadable config; explicit config modes use the selected config directly. In either mode, a target can bind only to a tsconfig declared by its governing config, and the first declared project containing the file wins
 - `files`/`ignores` matching uses the stable target path in the governing config's path space; a Program source alias is used only to locate the AST and type information, so moving a target into or out of a tsconfig cannot change its rule configuration
-- each normalized declared tsconfig path is built once within a Go lint invocation while retaining every config association; file-symlink declarations remain distinct because TypeScript resolves relative paths from the declared location. Selected files outside the governing config's Programs receive a non-project-backed fallback Program, and targets whose names collide under a case-insensitive ts-go path key are partitioned across fallback Programs so distinct physical files remain distinct
-- `--type-check` and `--type-check-only` run over every real tsconfig Program and are not constrained by lint targets, config `files`/`ignores`, `.gitignore`, or CLI file/directory arguments; synthetic fallback Programs never participate. `--type-check-only` skips lint-target and `.gitignore` discovery entirely.
+- within each Program-registry build, normalized declared tsconfig paths are deduplicated across config associations; CLI fix passes create a new registry build. File-symlink declarations remain distinct because TypeScript resolves relative paths from the declared location. Selected files outside the governing config's Programs receive a non-project-backed fallback Program, and targets whose names collide under a case-insensitive ts-go path key are partitioned across fallback Programs so distinct physical files remain distinct
+- `--type-check` and `--type-check-only` build every real tsconfig declared by the effective loaded config catalog. Once that catalog is established, program-wide checking is not filtered by lint targets, config `files`/`ignores`, `.gitignore`, or CLI file/directory arguments; synthetic fallback Programs never participate. `--type-check-only` skips lint-target and `.gitignore` discovery entirely.
+- for LSP, an open supported script is a per-file target independent of Program membership. Global config ignores, default-excluded paths, and unavailable config boundaries suppress native rules, plugin rules, and fixes; an available zero-rule config still parses the target and can report syntax diagnostics. LSP does not yet apply `.gitignore`
 
 ### Inline Directives
 
@@ -518,36 +530,43 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
    - `--api`: starts the IPC API server
    - default: runs direct CLI linting
 4. **Lint Target Plan**: Go resolves a stable target set from CLI/API scope, the implicit default baseline, explicit config `files`, global ignores, and `.gitignore`
-5. **Program Registry**: plain lint builds each normalized tsconfig path declared by an active governing config once; `--type-check` and `--type-check-only` instead retain every configured project. Shared declared paths preserve each active config association and declaration order.
-6. **Program Binding**: each target is bound by exact canonical filesystem identity to the first containing Program declared by its governing config; unbound targets, including projects with no tsconfig, are parsed through a non-project-backed fallback Program
+5. **Program Registry**: plain lint builds each normalized tsconfig path declared by an active governing config once; `--type-check` and `--type-check-only` instead retain every project declared by the effective loaded config catalog. Shared declared paths preserve each active config association and declaration order.
+6. **Program Binding**: each target is bound by exact lexical or canonical filesystem identity to the first containing Program declared by its governing config; unbound targets, including projects with no tsconfig, are parsed through a non-project-backed fallback Program
 7. **Rule Resolution**: `getRulesForFile` resolves enabled rules from the stable lint-target path, never the Program source alias, and filters type-aware rules off no-type-info gap files
 8. **Rule Execution**: `RunLinter()` schedules per-Program work over the exact target plan; the unexported `runLintRulesInProgram()` does the actual per-file traversal. When `--type-check` is enabled, a separate program-wide pass over real tsconfig Programs aggregates `tsc --noEmit`-aligned diagnostics through `collectNoEmitDiagnostics()`
 9. **Result Aggregation**: diagnostics are sent through one run-scoped diagnostics channel and collected at the CLI layer
-10. **Fix Passes**: when enabled, fixes are applied, real Programs are rebuilt, and the stable target plan is rebound; target membership stays fixed while a file may move between a real Program and fallback as its import graph changes
+10. **Fix Passes**: CLI multi-pass `--fix` applies fixes, rebuilds real Programs, and rebinds the unchanged target plan after each pass; a file may move between a real Program and fallback as its import graph changes
 11. **Output Formatting**: default, JSON line, and GitHub workflow formats are supported
 12. **Exit Code**: depends on diagnostics, warnings, and fix outcomes
 
 ### Concurrency Model
 
-The Go side has four parallelism points; each one honors `--singleThreaded`,
-which is the user-facing escape hatch for serial / reproducible execution.
+The main Go workload work groups and pools below honor `--singleThreaded`.
+The flag serializes these workload stages, but IPC transport, diagnostic
+collection, and plugin dispatch may still use infrastructure goroutines.
 
 1. **Linter work group** (`RunLinter()` via `core.NewWorkGroup`)
    - Schedules per-Program lint work; runs rules in parallel within a Program.
    - `--singleThreaded` collapses the work group to serial execution.
 
-2. **gitignore reading and Program creation** (in `cmd/rslint/cmd.go`)
+2. **Type-check work group** (`runTypeCheckAcrossPrograms`)
+   - Schedules diagnostics for real tsconfig Programs and merges results in
+     stable Program order.
+   - `--singleThreaded` computes Program diagnostics serially.
+
+3. **gitignore reading and Program creation** (in `cmd/rslint/cmd.go`)
    - Plain lint completes `ReadGitignoreAsGlobs` before target discovery, then
      constructs Programs only for configs represented in the target plan.
-   - `--type-check` constructs every configured Program independently from
-     gitignore discovery. `--type-check-only` constructs the same Program set
-     without reading gitignore state because it has no lint-target phase.
+   - `--type-check` constructs every Program from the effective config catalog
+     independently from gitignore discovery. `--type-check-only` constructs the
+     same Program set without reading gitignore state because it has no
+     lint-target phase.
    - In multi-config mode, gitignore reads also fan out across configs in
      parallel; configured Programs are constructed serially in stable config
      and project order (typescript-go's API is invoked one Program at a time).
-   - `--singleThreaded` runs both stages sequentially — no goroutines spawned.
+   - `--singleThreaded` executes these workload tasks serially.
 
-3. **Lint-target directory walker** (`internal/config/file_discovery.go`)
+4. **Lint-target directory walker** (`internal/config/file_discovery.go`)
    - `DiscoverLintTargets` uses a fixed-size worker pool (`walkPool`) that
      walks the directory tree. `DiscoverLintFiles` is the path-only
      compatibility wrapper. Live goroutine count is capped at `workers`, not
@@ -566,12 +585,13 @@ which is the user-facing escape hatch for serial / reproducible execution.
      scheduling-dependent non-determinism that a parallel walker would
      otherwise introduce.
 
-4. **Multi-config target discovery** (`DiscoverLintTargetsMultiConfig`)
-   - Uses host-provided scopes for explicit-file ownership. Explicit files not
-     assigned by a host are routed through the config-directory index before
-     per-config discovery.
-   - Each call is itself bounded by its own worker pool, so total live
-     goroutines remain bounded by `workers`, not `len(configMap) × workers`.
+5. **Program source identity index** (`bindLintTargetPlan`)
+   - Direct lexical Program lookups remain synchronous. If one misses, the
+     binder resolves each unique Program source path once and builds a
+     binding-pass canonical identity index. CLI fix passes rebuild it when they
+     rebind the target plan.
+   - Independent realpath lookups use `core.NewWorkGroup`; `--singleThreaded`
+     runs the same work serially.
 
 Other invariants:
 
@@ -582,10 +602,13 @@ Other invariants:
   physical path; explicit files and file symlinks are resolved individually.
   Canonical identities use exact comparison, and aliases governed by different
   configs are rejected instead of choosing an owner by scan order.
+- Multi-config target discovery processes config roots in stable order. It uses
+  host-provided scopes for explicit-file ownership and invokes the bounded
+  lint-target walker for each config.
 - The Node CLI keeps explicit targets in the caller's lexical path space for
   config ownership. It consults physical ancestry only when lexical discovery
-  finds no config, and loads an ancestor only after a nearer explicit-file
-  config fails.
+  finds no config, and loads an ancestor only after a nearer explicit file or
+  directory config fails.
 - Go applies the same strict lexical-first ordering to the already-loaded config
   catalog. A physically deeper config loaded for another target cannot replace
   an existing lexical owner; physical ancestry is only a fallback for paths
@@ -596,24 +619,24 @@ Other invariants:
   that plan are sent with the request so Go does not repeat the same realpath
   work.
 - LSP uses a different orchestration model and keeps session access on its main
-  dispatch loop. It shares the exact/canonical Program source lookup used by
-  CLI/API binding, including file-symlink aliases and case-folded lookup
-  validation.
+  dispatch loop. Its Program-source lookup follows the same exact lexical and
+  canonical filesystem identity rules as CLI/API binding, including
+  file-symlink aliases and rejection of case-folded nonidentical paths.
 
 #### `--singleThreaded` semantics
 
 `--singleThreaded` is honored in every parallelism point above:
 
-| Point                          | Effect when set                                                                                          |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| Linter work group              | Collapsed to serial via `core.NewWorkGroup(true)`.                                                       |
-| gitignore / Program creation   | Plain lint performs target discovery before Program creation; type-check mode runs both stages serially. |
-| Multi-config gitignore fan-out | Replaced by a sequential for-loop.                                                                       |
-| Lint-target walker workers     | Forced to 1 (single goroutine, no concurrency).                                                          |
-| Multi-config target discovery  | Already serial across configs; inner walker also forced to 1.                                            |
+| Point                            | Effect when set                                                                             |
+| -------------------------------- | ------------------------------------------------------------------------------------------- |
+| Linter work group                | Collapsed to serial via `core.NewWorkGroup(true)`.                                          |
+| Type-check work group            | Program diagnostics are computed serially via `core.NewWorkGroup(true)`.                    |
+| Gitignore / Program construction | Gitignore tasks execute serially; Program construction remains serial and does not overlap. |
+| Lint-target walker workers       | Forced to 1 (single goroutine, no concurrency).                                             |
+| Program source identity index    | Canonical source paths are resolved serially through `core.NewWorkGroup(true)`.             |
 
-End result: with `--singleThreaded`, the Go side spawns no goroutines beyond
-those typescript-go itself creates for syntactic / semantic work.
+These workload stages run serially with `--singleThreaded`; infrastructure
+goroutines remain outside that guarantee.
 
 ## 10. Performance & Memory Considerations
 
@@ -782,21 +805,34 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 │  JS/TS Configs or JSON Configs                                               │
 │            │                                                                 │
 │            ▼                                                                 │
-│  Config Load / Normalize / Merge                                             │
+│  Config Load / Normalize / Catalog                                           │
+│            │                                                                 │
+│            ├───────────────► CLI --type-check-only                           │
+│            │                          │                                       │
+│            │                          ▼                                       │
+│            │                 Effective-catalog Program Registry              │
+│            │                          │                                       │
+│            │                          ▼                                       │
+│            │                 Program-wide Type Check                         │
+│            │                 (real tsconfigs)                                │
+│            │                          │                                       │
+│            │                          ▼                                       │
+│            │                 CLI formatter / exit code                       │
+│            │                                                                 │
+│            └───────────────► Lint path (CLI / API)                           │
+│                                       │                                      │
+│                                       ▼                                      │
+│  Stable Lint Target Plan (scope + selectors + ignores)                       │
 │            │                                                                 │
 │            ▼                                                                 │
-│  Stable Lint Target Plan (scope + selectors + ignores; skipped by            │
-│  type-check-only)                                                            │
-│            │                                                                 │
-│            ▼                                                                 │
-│  Canonical Program Registry                                                  │
-│  (active governing configs for plain lint; all configs for type-check)       │
+│  Run-scoped Program Registry                                                 │
+│  (active governing configs; effective catalog for CLI --type-check)          │
 │            │                                                                 │
 │            ▼                                                                 │
 │  Bind by Governing Config / Project Order ─────► Non-project Fallback        │
 │                           │                                                  │
 │                           ▼                                                  │
-│  Resolve Enabled Rules Per File                                              │
+│  Resolve / Merge Config and Enabled Rules Per File                           │
 │            │                                                                 │
 │            ▼                                                                 │
 │  Run Rule Initializers -> Register Listeners                                 │
@@ -807,7 +843,8 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 │            ▼                                                                 │
 │  RuleDiagnostic / Fix / Suggestion Collection                                │
 │            │                                                                 │
-│            ├───────────────► Program-wide Type Check (real tsconfigs only)    │
+│            ├───────────────► CLI --type-check: Program-wide Type Check       │
+│            │                    (real tsconfigs)                              │
 │            ├───────────────► CLI formatter / exit code                       │
 │            └───────────────► API structured response                         │
 │                                                                              │
@@ -865,7 +902,7 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 - **Inspector**: Auxiliary backend path that returns node, type, symbol, signature, and flow information for Playground inspection
 - **IPC API**: Length-prefixed JSON message protocol exposed by `cmd/rslint --api` for Node and WASM clients; config path resolution and third-party plugin routing use separate keys when API overrides rebase relative patterns
 - **Listener**: Callback registered by a rule for an AST kind or synthetic listener kind
-- **Nearest Config**: In multi-config mode, the deepest config directory that owns a file
+- **Nearest Config**: In multi-config mode, the governing config selected by lexical-first ownership resolution
 - **Node Kind**: Enumerated AST kind value used by ts-go and by the listener dispatcher to identify node types
 - **Program**: ts-go compilation context, usually tied to a tsconfig or fallback root-file set
 - **Program Registry**: Run-scoped set of Programs keyed by normalized declared tsconfig path, plus the governing configs and project declaration order associated with each Program

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	api "github.com/web-infra-dev/rslint/internal/api"
@@ -87,17 +88,16 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		}
 	}
 	// Apply file contents if provided
+	var fileContents map[string]string
 	if len(req.FileContents) > 0 {
 		if allowedFiles == nil {
 			allowedFiles = make([]string, 0, len(req.FileContents))
 		}
-		fileContents := make(map[string]string, len(req.FileContents))
+		fileContents = make(map[string]string, len(req.FileContents))
 		for k, v := range req.FileContents {
 			normalizedPath := addAllowedFile(k)
 			fileContents[normalizedPath] = v
 		}
-		fs = utils.NewOverlayVFS(fs, fileContents)
-
 	}
 
 	// Initialize rule registry with all available rules
@@ -121,6 +121,10 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		configDirectory = currentDirectory
 	}
 	configDirectory = tspath.NormalizePath(configDirectory)
+	if len(fileContents) > 0 {
+		addEquivalentFileContentPaths(fileContents, configDirectory, currentDirectory, fs)
+		fs = utils.NewOverlayVFS(fs, fileContents)
+	}
 	var gitignoreGlobs []string
 	if len(allowedFiles) > 0 {
 		gitignoreGlobs = rslintconfig.ReadGitignoreAsGlobsForFiles(configDirectory, fs, allowedFiles)
@@ -166,10 +170,10 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	// list).
 	// The --api path never runs the type-check phase (RunLinterOptions.TypeCheck
 	// stays false), so there is no per-program type-check skip mask to build.
-	programs, typeInfoFiles, _, _, targetsByProgram := buildProgramsWithLintTargets(
+	programs, typeInfoFiles, _, _, targetsByProgram, configPathBySourcePath := buildProgramsWithLintTargets(
 		programs, nil, rslintConfig, configDirectory, nil, nil, fs, allowedFiles, nil, parseCache, false,
 	)
-	fileConfigResolver := rslintconfig.NewFileConfigResolver(rslintConfig, configDirectory, true)
+	fileConfigResolver := newLintConfigResolver(nil, rslintConfig, configDirectory, true, typeInfoFiles, configPathBySourcePath)
 
 	// Collect diagnostics and source files
 	var diagnostics []api.Diagnostic
@@ -337,7 +341,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 			// so a rule carrying a plugin prefix runs only when its plugin is
 			// declared in the config's `plugins` — matching CLI and ESLint
 			// semantics (a rule whose plugin is not declared is skipped).
-			return fileConfigResolver.ActiveRulesForFile(sourceFile.FileName(), typeInfoFiles)
+			return fileConfigResolver.ActiveRulesForFile(sourceFile.FileName())
 		},
 		OnDiagnostic: diagnosticCollector,
 	})
@@ -433,6 +437,56 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		response.EncodedSourceFiles = encodedSourceFiles
 	}
 	return response, nil
+}
+
+func addEquivalentFileContentPaths(fileContents map[string]string, configDirectory string, currentDirectory string, fs vfs.FS) {
+	if len(fileContents) == 0 || fs == nil {
+		return
+	}
+
+	type fileContentEntry struct {
+		path    string
+		content string
+	}
+	entries := make([]fileContentEntry, 0, len(fileContents))
+	for filePath, content := range fileContents {
+		entries = append(entries, fileContentEntry{path: filePath, content: content})
+	}
+
+	comparePathOptions := tspath.ComparePathsOptions{
+		CurrentDirectory:          currentDirectory,
+		UseCaseSensitiveFileNames: fs.UseCaseSensitiveFileNames(),
+	}
+	addAlias := func(alias string, content string) {
+		if alias == "" {
+			return
+		}
+		if _, exists := fileContents[alias]; exists {
+			return
+		}
+		fileContents[alias] = content
+	}
+	addDirectoryAlias := func(fromDir string, toDir string, filePath string, content string) {
+		if fromDir == "" || toDir == "" || !tspath.ContainsPath(fromDir, filePath, comparePathOptions) {
+			return
+		}
+		relativePath := tspath.GetRelativePathFromDirectory(fromDir, filePath, comparePathOptions)
+		if relativePath == "" {
+			return
+		}
+		addAlias(tspath.ResolvePath(toDir, relativePath), content)
+	}
+
+	realConfigDirectory := fs.Realpath(configDirectory)
+	for _, entry := range entries {
+		if realPath := fs.Realpath(entry.path); realPath != "" && realPath != entry.path {
+			addAlias(realPath, entry.content)
+		}
+		if realConfigDirectory != "" && tspath.ComparePaths(configDirectory, realConfigDirectory, comparePathOptions) != 0 {
+			addDirectoryAlias(configDirectory, realConfigDirectory, entry.path, entry.content)
+			addDirectoryAlias(realConfigDirectory, configDirectory, entry.path, entry.content)
+		}
+	}
 }
 
 // HandleGetAstInfo handles get AST info requests in IPC mode

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -151,7 +151,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	// Create programs from all tsconfig files found in rslint config
 	programs := []*compiler.Program{}
 	for _, configFileName := range tsConfigs {
-		program, err := utils.CreateProgram(false, fs, configDirectory, configFileName, host)
+		program, err := utils.CreateProgramLenient(false, fs, configDirectory, configFileName, host)
 		if err != nil {
 			return nil, fmt.Errorf("error creating TS program for %s: %w", configFileName, err)
 		}
@@ -192,6 +192,14 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	diagnosticCollector := func(d rule.RuleDiagnostic) {
 		diagnosticsLock.Lock()
 		defer diagnosticsLock.Unlock()
+		if d.SourceFile != nil {
+			sourceFilesLock.Lock()
+			filePath := tspath.ConvertToRelativePath(d.FilePath, comparePathOptions)
+			if sf, ok := d.SourceFile.(*ast.SourceFile); ok {
+				sourceFiles[filePath] = sf
+			}
+			sourceFilesLock.Unlock()
+		}
 
 		diagnosticStart := d.Range.Pos()
 		diagnosticEnd := d.Range.End()
@@ -291,6 +299,12 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	// rules through GetActiveRulesForFile. --api takes one resolved config
 	// (single-config mode), so configMap / programConfigDirs are nil.
 	fileFilters := buildFileFilters(programs, nil, nil, rslintConfig, configDirectory)
+	shouldReportLintSyntax := func(filePath string) bool {
+		return rslintConfig.GetConfigForFile(filePath, configDirectory) != nil
+	}
+	for _, diagnostic := range collectTargetSyntacticDiagnostics(programs, targetsByProgram, nil, false, false, shouldReportLintSyntax) {
+		diagnosticCollector(diagnostic)
+	}
 
 	// Run linter
 	lintResult, err := linter.RunLinter(linter.RunLinterOptions{

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -169,6 +169,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	programs, typeInfoFiles, _, _, targetsByProgram := buildProgramsWithLintTargets(
 		programs, nil, rslintConfig, configDirectory, nil, nil, fs, allowedFiles, nil, parseCache, false,
 	)
+	fileConfigResolver := rslintconfig.NewFileConfigResolver(rslintConfig, configDirectory, true)
 
 	// Collect diagnostics and source files
 	var diagnostics []api.Diagnostic
@@ -297,7 +298,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	// explicit file excluded by the only matching entry is still a lint result,
 	// but runs zero rules through GetActiveRulesForFile.
 	shouldReportLintSyntax := func(filePath string) bool {
-		return rslintConfig.GetConfigForFile(filePath, configDirectory) != nil
+		return fileConfigResolver.ConfigForFile(filePath) != nil
 	}
 	for _, diagnostic := range collectTargetSyntacticDiagnostics(programs, targetsByProgram, nil, false, false, shouldReportLintSyntax) {
 		diagnosticCollector(diagnostic)
@@ -336,7 +337,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 			// so a rule carrying a plugin prefix runs only when its plugin is
 			// declared in the config's `plugins` — matching CLI and ESLint
 			// semantics (a rule whose plugin is not declared is skipped).
-			return rslintconfig.GlobalRuleRegistry.GetActiveRulesForFile(rslintConfig, sourceFile.FileName(), configDirectory, true, typeInfoFiles)
+			return fileConfigResolver.ActiveRulesForFile(sourceFile.FileName(), typeInfoFiles)
 		},
 		OnDiagnostic: diagnosticCollector,
 	})

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -43,6 +43,31 @@ var astInfoProgramCache = &programCache{}
 
 // HandleLint handles lint requests in IPC mode
 func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) {
+	return h.handleLint(context.Background(), req, nil)
+}
+
+// HandleLintWithContext enables reverse pluginLint requests when IPCHandler is
+// hosted by the bidirectional API service. HandleLint remains available for
+// direct/legacy callers that do not need community plugin execution.
+func (h *IPCHandler) HandleLintWithContext(ctx context.Context, req api.LintRequest, requester api.Requester) (*api.LintResponse, error) {
+	var dispatch linter.EslintPluginDispatcher
+	if requester != nil {
+		dispatch = func(reqCtx context.Context, pluginReq linter.EslintPluginLintRequest) (*linter.EslintPluginLintResult, error) {
+			msg, err := requester.SendRequest(reqCtx, api.KindPluginLint, pluginReq)
+			if err != nil {
+				return nil, err
+			}
+			var result linter.EslintPluginLintResult
+			if err := msg.Decode(&result); err != nil {
+				return nil, fmt.Errorf("decode pluginLint result: %w", err)
+			}
+			return &result, nil
+		}
+	}
+	return h.handleLint(ctx, req, dispatch)
+}
+
+func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispatch linter.EslintPluginDispatcher) (*api.LintResponse, error) {
 
 	// Resolve the working directory WITHOUT os.Chdir: this is a long-lived,
 	// reused --api process, so mutating the process-global cwd would leak
@@ -95,13 +120,35 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		}
 		fileContents = make(map[string]string, len(req.FileContents))
 		for k, v := range req.FileContents {
-			normalizedPath := addAllowedFile(k)
+			normalizedPath := resolveRequestPath(k)
+			// Preserve the low-level IPC contract: when Files is omitted,
+			// FileContents supplies the in-memory target set. When Files is
+			// present, FileContents is overlay-only dependency/config data and
+			// must not widen the explicit lint target set.
+			if req.Files == nil {
+				addAllowedFile(normalizedPath)
+			}
 			fileContents[normalizedPath] = v
 		}
 	}
 
 	// Initialize rule registry with all available rules
 	rslintconfig.RegisterAllRules()
+	var requestPluginRules map[string]struct{}
+	if len(req.EslintPlugins) > 0 {
+		entries := make([]rslintconfig.EslintPluginEntry, 0, len(req.EslintPlugins))
+		requestPluginRules = make(map[string]struct{})
+		for _, plugin := range req.EslintPlugins {
+			entries = append(entries, rslintconfig.EslintPluginEntry{
+				Prefix:    plugin.Prefix,
+				RuleNames: plugin.RuleNames,
+			})
+			for _, ruleName := range plugin.RuleNames {
+				requestPluginRules[plugin.Prefix+"/"+ruleName] = struct{}{}
+			}
+		}
+		rslintconfig.RegisterEslintPluginRules(entries)
+	}
 
 	// Config is the JS-resolved final config object (serialized RslintConfig).
 	// --api never reads config from disk or auto-discovers — the JS side does
@@ -126,7 +173,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		fs = utils.NewOverlayVFS(fs, fileContents)
 	}
 	var gitignoreGlobs []string
-	if len(allowedFiles) > 0 {
+	if allowedFiles != nil {
 		gitignoreGlobs = rslintconfig.ReadGitignoreAsGlobsForFiles(configDirectory, fs, allowedFiles)
 	} else {
 		gitignoreGlobs = rslintconfig.ReadGitignoreAsGlobs(configDirectory, fs, rslintconfig.ExtractConfigIgnores(rslintConfig))
@@ -134,32 +181,17 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	if len(gitignoreGlobs) > 0 {
 		rslintConfig = append(rslintconfig.RslintConfig{{Ignores: gitignoreGlobs}}, rslintConfig...)
 	}
-	tsConfigs, err := rslintconfig.ResolveTsConfigPaths(rslintConfig, configDirectory, fs)
-	if err != nil {
-		return nil, fmt.Errorf("error resolving tsconfig: %w", err)
-	}
-
-	// Create compiler host with a request-scoped parse cache: the tsconfig
-	// loop below builds one Program per tsconfig on this host, and shared
-	// dependencies (lib/node_modules d.ts, cross-package sources) parse once.
+	// Build unique tsconfig Programs with a request-scoped parse cache.
 	// The cache dies with this request — no RetainOnly sweep here, and none
-	// may be added inside the tsConfigs loop (a mid-build eviction boundary
-	// buys nothing per I7 and complicates reasoning).
+	// may be added during Program construction.
 	parseCache := utils.NewParseCache()
-	host := utils.WithParseCache(utils.CreateCompilerHost(configDirectory, fs), parseCache)
-	comparePathOptions := tspath.ComparePathsOptions{
-		CurrentDirectory:          host.GetCurrentDirectory(),
-		UseCaseSensitiveFileNames: host.FS().UseCaseSensitiveFileNames(),
+	programSet, err := createProgramSetForConfig(configDirectory, rslintConfig, false, fs, parseCache)
+	if err != nil {
+		return nil, err
 	}
-
-	// Create programs from all tsconfig files found in rslint config
-	programs := []*compiler.Program{}
-	for _, configFileName := range tsConfigs {
-		program, err := utils.CreateProgramLenient(false, fs, configDirectory, configFileName, host)
-		if err != nil {
-			return nil, fmt.Errorf("error creating TS program for %s: %w", configFileName, err)
-		}
-		programs = append(programs, program)
+	comparePathOptions := tspath.ComparePathsOptions{
+		CurrentDirectory:          configDirectory,
+		UseCaseSensitiveFileNames: fs.UseCaseSensitiveFileNames(),
 	}
 
 	// Resolve the exact lint target set, bind targets to existing Programs, and
@@ -170,10 +202,37 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	// list).
 	// The --api path never runs the type-check phase (RunLinterOptions.TypeCheck
 	// stays false), so there is no per-program type-check skip mask to build.
-	programs, typeInfoFiles, _, _, targetsByProgram, configPathBySourcePath := buildProgramsWithLintTargets(
-		programs, nil, rslintConfig, configDirectory, nil, nil, fs, allowedFiles, nil, parseCache, false,
-	)
-	fileConfigResolver := newLintConfigResolver(nil, rslintConfig, configDirectory, true, typeInfoFiles, configPathBySourcePath)
+	targetPlan, err := resolveLintTargetPlan(nil, rslintConfig, configDirectory, nil, fs, allowedFiles, nil, false)
+	if err != nil {
+		return nil, fmt.Errorf("resolve lint targets: %w", err)
+	}
+	binding, err := bindLintTargetPlan(programSet, targetPlan, configDirectory, fs, parseCache, false)
+	if err != nil {
+		return nil, err
+	}
+	programs := binding.Programs
+	typeInfoFiles := binding.TypeInfoFiles
+	targetsByProgram := binding.TargetsByProgram
+	targetPathBySourcePath := binding.TargetPathBySourcePath
+	fileConfigResolver := newLintConfigResolver(lintConfigResolverOptions{
+		Config:                     rslintConfig,
+		CurrentDirectory:           configDirectory,
+		EnforcePlugins:             true,
+		TypeInfoFiles:              typeInfoFiles,
+		TargetPathBySourcePath:     targetPathBySourcePath,
+		ConfigPathBySourcePath:     binding.ConfigPathBySourcePath,
+		OwnerConfigDirBySourcePath: binding.OwnerConfigDirBySourcePath,
+		FS:                         fs,
+	})
+	targetPathForSourcePath := func(sourcePath string) string {
+		if targetPath := targetPathBySourcePath[sourcePath]; targetPath != "" {
+			return targetPath
+		}
+		return sourcePath
+	}
+	responsePathForSourcePath := func(sourcePath string) string {
+		return tspath.ConvertToRelativePath(targetPathForSourcePath(sourcePath), comparePathOptions)
+	}
 
 	// Collect diagnostics and source files
 	var diagnostics []api.Diagnostic
@@ -199,7 +258,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		defer diagnosticsLock.Unlock()
 		if d.SourceFile != nil {
 			sourceFilesLock.Lock()
-			filePath := tspath.ConvertToRelativePath(d.FilePath, comparePathOptions)
+			filePath := responsePathForSourcePath(d.FilePath)
 			if sf, ok := d.SourceFile.(*ast.SourceFile); ok {
 				sourceFiles[filePath] = sf
 			}
@@ -216,7 +275,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 			RuleName:  d.RuleName,
 			MessageId: d.Message.Id,
 			Message:   d.Message.Description,
-			FilePath:  tspath.ConvertToRelativePath(d.FilePath, comparePathOptions),
+			FilePath:  responsePathForSourcePath(d.FilePath),
 			Range: api.Range{
 				Start: api.Position{
 					Line:   startLine + 1, // Convert to 1-based indexing
@@ -291,25 +350,23 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		}
 
 		// Retain the original diagnostic (byte-offset fixes + SourceFile) for the
-		// in-band fix pass, grouped by absolute file path.
+		// in-band fix pass, grouped by the caller-visible target path.
 		if req.Fix && hasFix {
-			diagnosticsByFile[d.FilePath] = append(diagnosticsByFile[d.FilePath], d)
+			targetPath := targetPathForSourcePath(d.FilePath)
+			diagnosticsByFile[targetPath] = append(diagnosticsByFile[targetPath], d)
 		}
 	}
 
-	// Target discovery already excluded default paths, global ignores, and
-	// .gitignore entries. Entry-level ignores are not target exclusions: an
-	// explicit file excluded by the only matching entry is still a lint result,
-	// but runs zero rules through GetActiveRulesForFile.
-	shouldReportLintSyntax := func(filePath string) bool {
-		return fileConfigResolver.ConfigForFile(filePath) != nil
-	}
-	for _, diagnostic := range collectTargetSyntacticDiagnostics(programs, targetsByProgram, nil, false, false, shouldReportLintSyntax) {
+	// Every selected target is parsed even when no config entry contributes
+	// rules. Global ignores were already removed during target discovery.
+	syntaxDiagnostics, syntaxErrorFiles := collectTargetSyntacticDiagnostics(programs, targetsByProgram, nil, false, false)
+	for _, diagnostic := range syntaxDiagnostics {
 		diagnosticCollector(diagnostic)
 	}
 
-	// Run linter
-	lintResult, err := linter.RunLinter(linter.RunLinterOptions{
+	// Build one run descriptor shared by native lint and plugin target
+	// collection, keeping both paths on the exact same file/rule selection.
+	runOpts := linter.RunLinterOptions{
 		Programs:       programs,
 		SingleThreaded: false, // Don't use single-threaded mode for IPC
 		Scope:          linter.FileScope{Files: allowedFiles},
@@ -318,11 +375,12 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		// a nil TypeChecker to rules running on files outside this set (gap /
 		// fallback files), so a non-type-aware rule with optional TypeChecker
 		// usage degrades gracefully. nil ⇒ no fallback ⇒ no gap distinction.
-		TypeInfoFiles: typeInfoFiles,
+		TypeInfoFiles:    typeInfoFiles,
+		SyntaxErrorFiles: syntaxErrorFiles,
 		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 			// Track source file for encoding
 			sourceFilesLock.Lock()
-			filePath := tspath.ConvertToRelativePath(sourceFile.FileName(), comparePathOptions)
+			filePath := responsePathForSourcePath(sourceFile.FileName())
 			sourceFiles[filePath] = sourceFile
 			sourceFilesLock.Unlock()
 
@@ -341,12 +399,83 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 			// so a rule carrying a plugin prefix runs only when its plugin is
 			// declared in the config's `plugins` — matching CLI and ESLint
 			// semantics (a rule whose plugin is not declared is skipped).
-			return fileConfigResolver.ActiveRulesForFile(sourceFile.FileName())
+			activeRules := fileConfigResolver.ActiveRulesForFile(sourceFile.FileName())
+			// Plugin placeholders live in the process-global registry. Restrict
+			// them to this request's metadata so a long-lived API process cannot
+			// leak a plugin registered by an earlier lint into a later request.
+			for i, configuredRule := range activeRules {
+				if !configuredRule.IsEslintPluginRule {
+					continue
+				}
+				if _, ok := requestPluginRules[configuredRule.Name]; ok {
+					continue
+				}
+				filtered := make([]linter.ConfiguredRule, 0, len(activeRules)-1)
+				filtered = append(filtered, activeRules[:i]...)
+				for _, remainingRule := range activeRules[i+1:] {
+					if !remainingRule.IsEslintPluginRule {
+						filtered = append(filtered, remainingRule)
+						continue
+					}
+					if _, ok := requestPluginRules[remainingRule.Name]; ok {
+						filtered = append(filtered, remainingRule)
+					}
+				}
+				return filtered
+			}
+			return activeRules
 		},
 		OnDiagnostic: diagnosticCollector,
-	})
+	}
+
+	// Metadata is the feature gate: without it there is no plugin target walk,
+	// goroutine, or reverse request. With metadata, dispatch starts before the
+	// native pass and runs in parallel, matching the CLI pipeline.
+	var pluginCh <-chan []rule.RuleDiagnostic
+	var cancelPlugin context.CancelFunc
+	if len(req.EslintPlugins) > 0 {
+		wireConfigDirectory := req.ConfigDirectory
+		if wireConfigDirectory == "" {
+			wireConfigDirectory = configDirectory
+		}
+		pluginInputs := buildPluginFileInputs(runOpts, pluginConfigResolver{
+			lintResolver: fileConfigResolver,
+			originalConfigDir: map[string]string{
+				configDirectory: wireConfigDirectory,
+			},
+		})
+		for i := range pluginInputs {
+			// Programmatic lint supports in-memory overlays. Always send the exact
+			// parsed source frame instead of asking the host to re-read disk.
+			if pluginInputs[i].SourceFile != nil {
+				text := pluginInputs[i].SourceFile.Text()
+				pluginInputs[i].Text = &text
+			}
+		}
+		if len(pluginInputs) > 0 {
+			pluginCtx := ctx
+			pluginCtx, cancelPlugin = context.WithCancel(pluginCtx)
+			if dispatch == nil {
+				dispatch = func(context.Context, linter.EslintPluginLintRequest) (*linter.EslintPluginLintResult, error) {
+					return nil, errors.New("bidirectional pluginLint transport is unavailable")
+				}
+			}
+			pluginCh = dispatchPluginLintAsync(pluginCtx, dispatch, pluginInputs, req.Fix, pluginSuggestionsMode(req.Fix))
+		}
+	}
+	if cancelPlugin != nil {
+		defer cancelPlugin()
+	}
+
+	// Run native rules while community plugin batches execute in the host.
+	lintResult, err := linter.RunLinter(runOpts)
 	if err != nil {
 		return nil, fmt.Errorf("error running linter: %w", err)
+	}
+	if pluginCh != nil {
+		for _, diagnostic := range <-pluginCh {
+			diagnosticCollector(diagnostic)
+		}
 	}
 
 	if diagnostics == nil {
@@ -359,10 +488,6 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	// worker, so under a STABLE sort this key is already fully
 	// deterministic. Keep this comparator in sync with the CLI one in
 	// cmd.go (same policy over rule.RuleDiagnostic).
-	// Known pre-existing exception: a file rooted by two tsconfigs at once
-	// is linted by both programs (duplicate diagnostics with
-	// scheduling-dependent interleaving) — neither introduced nor fixed
-	// here.
 	sort.SliceStable(diagnostics, func(i, j int) bool {
 		a, b := diagnostics[i], diagnostics[j]
 		if a.FilePath != b.FilePath {
@@ -396,9 +521,11 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 
 	// The files actually linted (target discovery already excluded global
 	// ignores and gitignore entries). sourceFiles was populated by
-	// GetRulesForFile for every linted file under its program-canonical
-	// relative path — the same path space as Diagnostic.FilePath — so the JS
-	// side can seed one result per entry. Sorted for a deterministic response.
+	// GetRulesForFile for every linted file under its caller-visible target
+	// path, relative to configDirectory. This keeps
+	// Diagnostic.FilePath, LintedFiles, Output, and EncodedSourceFiles in one path
+	// space even when a Program represents a requested symlink target by a
+	// different source-file path. Sorted for a deterministic response.
 	lintedFiles := make([]string, 0, len(sourceFiles))
 	for filePath := range sourceFiles {
 		lintedFiles = append(lintedFiles, filePath)
@@ -412,10 +539,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		WarningCount:        warningsCount,
 		FixableErrorCount:   fixableErrorsCount,
 		FixableWarningCount: fixableWarningsCount,
-		// FileCount mirrors len(LintedFiles) (unique linted files), not
-		// RunLinter's per-program visit count which double-counts a file rooted
-		// by two tsconfig programs — keeping it consistent with LintedFiles and
-		// the ESLint per-file result shape.
+		// FileCount mirrors the unique caller-visible LintedFiles result set.
 		FileCount:   len(lintedFiles),
 		RuleCount:   len(lintResult.ExecutedRules),
 		LintedFiles: lintedFiles,

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -292,13 +292,10 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		}
 	}
 
-	// Exclude global ignores from the lint scope (and therefore from FileCount
-	// and the LintedFiles list built below), matching the CLI (cmd.go).
-	// Entry-level ignores are not global target exclusions: an explicit file
-	// excluded by the only matching entry is still a lint result, but runs zero
-	// rules through GetActiveRulesForFile. --api takes one resolved config
-	// (single-config mode), so configMap / programConfigDirs are nil.
-	fileFilters := buildFileFilters(programs, nil, nil, rslintConfig, configDirectory)
+	// Target discovery already excluded default paths, global ignores, and
+	// .gitignore entries. Entry-level ignores are not target exclusions: an
+	// explicit file excluded by the only matching entry is still a lint result,
+	// but runs zero rules through GetActiveRulesForFile.
 	shouldReportLintSyntax := func(filePath string) bool {
 		return rslintConfig.GetConfigForFile(filePath, configDirectory) != nil
 	}
@@ -308,11 +305,10 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 
 	// Run linter
 	lintResult, err := linter.RunLinter(linter.RunLinterOptions{
-		Programs:         programs,
-		SingleThreaded:   false, // Don't use single-threaded mode for IPC
-		Scope:            linter.FileScope{Files: allowedFiles},
-		PerProgramFilter: toFileFilters(fileFilters),
-		TargetFiles:      targetsByProgram,
+		Programs:       programs,
+		SingleThreaded: false, // Don't use single-threaded mode for IPC
+		Scope:          linter.FileScope{Files: allowedFiles},
+		TargetFiles:    targetsByProgram,
 		// Defense-in-depth alongside the GetRulesForFile gate: RunLinter passes
 		// a nil TypeChecker to rules running on files outside this set (gap /
 		// fallback files), so a non-type-aware rule with optional TypeChecker
@@ -393,11 +389,11 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		}
 	}
 
-	// The files actually linted (config ignores already excluded by the
-	// PerProgramFilter above). sourceFiles was populated by GetRulesForFile for
-	// every linted file under its program-canonical relative path — the same
-	// path space as Diagnostic.FilePath — so the JS side can seed one result per
-	// entry. Sorted for a deterministic response.
+	// The files actually linted (target discovery already excluded global
+	// ignores and gitignore entries). sourceFiles was populated by
+	// GetRulesForFile for every linted file under its program-canonical
+	// relative path — the same path space as Diagnostic.FilePath — so the JS
+	// side can seed one result per entry. Sorted for a deterministic response.
 	lintedFiles := make([]string, 0, len(sourceFiles))
 	for filePath := range sourceFiles {
 		lintedFiles = append(lintedFiles, filePath)

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -112,12 +112,24 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		if err := json.Unmarshal(req.Config, &rslintConfig); err != nil {
 			return nil, fmt.Errorf("invalid config: %w", err)
 		}
+		if err := rslintconfig.ValidateConfig(rslintConfig); err != nil {
+			return nil, fmt.Errorf("invalid config: %w", err)
+		}
 	}
 	configDirectory := req.ConfigDirectory
 	if configDirectory == "" {
 		configDirectory = currentDirectory
 	}
 	configDirectory = tspath.NormalizePath(configDirectory)
+	var gitignoreGlobs []string
+	if len(allowedFiles) > 0 {
+		gitignoreGlobs = rslintconfig.ReadGitignoreAsGlobsForFiles(configDirectory, fs, allowedFiles)
+	} else {
+		gitignoreGlobs = rslintconfig.ReadGitignoreAsGlobs(configDirectory, fs, rslintconfig.ExtractConfigIgnores(rslintConfig))
+	}
+	if len(gitignoreGlobs) > 0 {
+		rslintConfig = append(rslintconfig.RslintConfig{{Ignores: gitignoreGlobs}}, rslintConfig...)
+	}
 	tsConfigs, err := rslintconfig.ResolveTsConfigPaths(rslintConfig, configDirectory, fs)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving tsconfig: %w", err)
@@ -146,16 +158,16 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		programs = append(programs, program)
 	}
 
-	// Discover "gap" files — requested/matched files absent from every tsconfig
-	// Program (the typical lintText/lintFiles in-memory file) — and append an
-	// AST-only fallback Program for them, plus the type-info set that gates
-	// type-aware rules off no-type-info files. Identical to the CLI via the
-	// shared helper. configMap is nil: the --api path is always single-config
-	// (the JS side resolves any multi-config merge into one entry list).
+	// Resolve the exact lint target set, bind targets to existing Programs, and
+	// append an AST-only fallback Program for selected files absent from every
+	// Program (the typical lintText/lintFiles in-memory file). Identical to the
+	// CLI via the shared helper. configMap is nil: the --api path is always
+	// single-config (the JS side resolves any multi-config merge into one entry
+	// list).
 	// The --api path never runs the type-check phase (RunLinterOptions.TypeCheck
 	// stays false), so there is no per-program type-check skip mask to build.
-	programs, typeInfoFiles, _ := buildProgramsWithGapFallback(
-		programs, nil, rslintConfig, configDirectory, fs, allowedFiles, nil, parseCache, false,
+	programs, typeInfoFiles, _, _, targetsByProgram := buildProgramsWithLintTargets(
+		programs, nil, rslintConfig, configDirectory, nil, nil, fs, allowedFiles, nil, parseCache, false,
 	)
 
 	// Collect diagnostics and source files
@@ -272,13 +284,12 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		}
 	}
 
-	// Exclude config-ignored files from the lint scope (and therefore from
-	// FileCount and the LintedFiles list built below), matching the CLI
-	// (cmd.go). Without this an ignored file the caller passed would still be
-	// linted — its rules are gated off so it produces no diagnostics, but it
-	// would inflate the count and seed a phantom empty result on the JS side.
-	// --api takes one resolved config (single-config mode), so configMap /
-	// programConfigDirs are nil.
+	// Exclude global ignores from the lint scope (and therefore from FileCount
+	// and the LintedFiles list built below), matching the CLI (cmd.go).
+	// Entry-level ignores are not global target exclusions: an explicit file
+	// excluded by the only matching entry is still a lint result, but runs zero
+	// rules through GetActiveRulesForFile. --api takes one resolved config
+	// (single-config mode), so configMap / programConfigDirs are nil.
 	fileFilters := buildFileFilters(programs, nil, nil, rslintConfig, configDirectory)
 
 	// Run linter
@@ -287,6 +298,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		SingleThreaded:   false, // Don't use single-threaded mode for IPC
 		Scope:            linter.FileScope{Files: allowedFiles},
 		PerProgramFilter: toFileFilters(fileFilters),
+		TargetFiles:      targetsByProgram,
 		// Defense-in-depth alongside the GetRulesForFile gate: RunLinter passes
 		// a nil TypeChecker to rules running on files outside this set (gap /
 		// fallback files), so a non-type-aware rule with optional TypeChecker

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -29,6 +29,18 @@ import (
 // IPCHandler implements the ipc.Handler interface
 type IPCHandler struct{}
 
+type canonicalPathVFS struct {
+	vfs.FS
+	canonicalPaths map[string]string
+}
+
+func (fs *canonicalPathVFS) Realpath(filePath string) string {
+	if canonicalPath := fs.canonicalPaths[exactFilesystemPathID(filePath)]; canonicalPath != "" {
+		return canonicalPath
+	}
+	return fs.FS.Realpath(filePath)
+}
+
 // programCache holds a cached Program instance for AST info requests
 type programCache struct {
 	mu              sync.RWMutex
@@ -94,6 +106,16 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 			return tspath.NormalizePath(filePath)
 		}
 		return tspath.ResolvePath(currentDirectory, filePath)
+	}
+	if len(req.CanonicalFiles) > 0 && len(req.CanonicalFiles) != len(req.Files) {
+		return nil, errors.New("canonicalFiles must be parallel to files")
+	}
+	canonicalPaths := make(map[string]string, len(req.CanonicalFiles))
+	for index, canonicalPath := range req.CanonicalFiles {
+		filePath := resolveRequestPath(req.Files[index])
+		canonicalPath = resolveRequestPath(canonicalPath)
+		canonicalPaths[exactFilesystemPathID(filePath)] = canonicalPath
+		canonicalPaths[exactFilesystemPathID(canonicalPath)] = canonicalPath
 	}
 
 	addAllowedFile := func(filePath string) string {
@@ -172,6 +194,9 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 		addEquivalentFileContentPaths(fileContents, configDirectory, currentDirectory, fs)
 		fs = utils.NewOverlayVFS(fs, fileContents)
 	}
+	if len(canonicalPaths) > 0 {
+		fs = &canonicalPathVFS{FS: fs, canonicalPaths: canonicalPaths}
+	}
 	var gitignoreGlobs []string
 	if allowedFiles != nil {
 		gitignoreGlobs = rslintconfig.ReadGitignoreAsGlobsForFiles(configDirectory, fs, allowedFiles)
@@ -181,21 +206,13 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	if len(gitignoreGlobs) > 0 {
 		rslintConfig = append(rslintconfig.RslintConfig{{Ignores: gitignoreGlobs}}, rslintConfig...)
 	}
-	// Build unique tsconfig Programs with a request-scoped parse cache.
-	// The cache dies with this request — no RetainOnly sweep here, and none
-	// may be added during Program construction.
-	parseCache := utils.NewParseCache()
-	programSet, err := createProgramSetForConfig(configDirectory, rslintConfig, false, fs, parseCache)
-	if err != nil {
-		return nil, err
-	}
 	comparePathOptions := tspath.ComparePathsOptions{
 		CurrentDirectory:          configDirectory,
-		UseCaseSensitiveFileNames: fs.UseCaseSensitiveFileNames(),
+		UseCaseSensitiveFileNames: true,
 	}
 
 	// Resolve the exact lint target set, bind targets to existing Programs, and
-	// append an AST-only fallback Program for selected files absent from every
+	// append a non-project-backed fallback Program for selected files absent from every
 	// Program (the typical lintText/lintFiles in-memory file). Identical to the
 	// CLI via the shared helper. configMap is nil: the --api path is always
 	// single-config (the JS side resolves any multi-config merge into one entry
@@ -205,6 +222,17 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	targetPlan, err := resolveLintTargetPlan(nil, rslintConfig, configDirectory, nil, fs, allowedFiles, nil, false)
 	if err != nil {
 		return nil, fmt.Errorf("resolve lint targets: %w", err)
+	}
+	// A plain API lint only needs type information when at least one target is
+	// selected. Resolve the target plan before project paths so an ignored or
+	// empty request cannot fail on an inactive project declaration.
+	parseCache := utils.NewParseCache()
+	var programSet lintProgramSet
+	if len(targetPlan.Targets) > 0 {
+		programSet, err = createProgramSetForConfig(configDirectory, rslintConfig, false, fs, parseCache)
+		if err != nil {
+			return nil, err
+		}
 	}
 	binding, err := bindLintTargetPlan(programSet, targetPlan, configDirectory, fs, parseCache, false)
 	if err != nil {
@@ -219,9 +247,9 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 		CurrentDirectory:           configDirectory,
 		EnforcePlugins:             true,
 		TypeInfoFiles:              typeInfoFiles,
-		TargetPathBySourcePath:     targetPathBySourcePath,
 		ConfigPathBySourcePath:     binding.ConfigPathBySourcePath,
 		OwnerConfigDirBySourcePath: binding.OwnerConfigDirBySourcePath,
+		SourceMappingsCanonical:    true,
 		FS:                         fs,
 	})
 	targetPathForSourcePath := func(sourcePath string) string {
@@ -371,10 +399,8 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 		SingleThreaded: false, // Don't use single-threaded mode for IPC
 		Scope:          linter.FileScope{Files: allowedFiles},
 		TargetFiles:    targetsByProgram,
-		// Defense-in-depth alongside the GetRulesForFile gate: RunLinter passes
-		// a nil TypeChecker to rules running on files outside this set (gap /
-		// fallback files), so a non-type-aware rule with optional TypeChecker
-		// usage degrades gracefully. nil ⇒ no fallback ⇒ no gap distinction.
+		// RunLinter repeats the RequiresTypeInfo eligibility check for files
+		// outside this set and withholds the project TypeChecker from them.
 		TypeInfoFiles:    typeInfoFiles,
 		SyntaxErrorFiles: syntaxErrorFiles,
 		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
@@ -387,8 +413,7 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 			// GetActiveRulesForFile applies the type-aware gate: when
 			// typeInfoFiles is non-nil and this file is not in it (a gap /
 			// fallback file with no type information), type-aware rules are
-			// filtered out — the only guard against a type-aware rule
-			// dereferencing a nil TypeChecker and crashing the process.
+			// filtered out. RunLinter repeats this check at the execution boundary.
 			// typeInfoFiles==nil ⇒ no fallback ⇒ every linted file has type
 			// info ⇒ nothing to filter. Rules come solely from the resolved
 			// config object (config.rules); --api has no separate rule-options
@@ -434,7 +459,10 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	var pluginCh <-chan []rule.RuleDiagnostic
 	var cancelPlugin context.CancelFunc
 	if len(req.EslintPlugins) > 0 {
-		wireConfigDirectory := req.ConfigDirectory
+		wireConfigDirectory := req.PluginConfigDirectory
+		if wireConfigDirectory == "" {
+			wireConfigDirectory = req.ConfigDirectory
+		}
 		if wireConfigDirectory == "" {
 			wireConfigDirectory = configDirectory
 		}
@@ -579,7 +607,7 @@ func addEquivalentFileContentPaths(fileContents map[string]string, configDirecto
 
 	comparePathOptions := tspath.ComparePathsOptions{
 		CurrentDirectory:          currentDirectory,
-		UseCaseSensitiveFileNames: fs.UseCaseSensitiveFileNames(),
+		UseCaseSensitiveFileNames: true,
 	}
 	addAlias := func(alias string, content string) {
 		if alias == "" {

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	api "github.com/web-infra-dev/rslint/internal/api"
+	"github.com/web-infra-dev/rslint/internal/ipc"
+	"github.com/web-infra-dev/rslint/internal/linter"
 )
 
 func TestHandleLint_DefaultsToLintAllFiles(t *testing.T) {
@@ -151,10 +156,9 @@ func TestHandleLint_AllIgnored_EmptyLintedFiles(t *testing.T) {
 	}
 }
 
-// A file rooted by two tsconfig programs is linted (and diagnosed) by both, so
-// RunLinter's per-program LintedFileCount counts it twice; FileCount must mirror
-// len(LintedFiles) (deduped by canonical path) and report it once.
-func TestHandleLint_FileCountDeduplicatesAcrossPrograms(t *testing.T) {
+// When multiple declared projects contain a target, the first project owns the
+// lint pass and the API reports one caller-visible result.
+func TestHandleLint_FirstContainingProgramReportsFileOnce(t *testing.T) {
 	dir := t.TempDir()
 
 	write := func(name, content string) {
@@ -267,7 +271,7 @@ func TestHandleLint_ExplicitFileOutsideFilesIsCountedWithNoRules(t *testing.T) {
 	}
 }
 
-func TestHandleLint_ExplicitMalformedFileOutsideFilesSuppressesSyntaxDiagnostic(t *testing.T) {
+func TestHandleLint_ExplicitMalformedFileOutsideFilesReportsSyntaxDiagnostic(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "explicit.js")
 	if err := os.WriteFile(target, []byte("const = ;\n"), 0o644); err != nil {
@@ -292,11 +296,116 @@ func TestHandleLint_ExplicitMalformedFileOutsideFilesSuppressesSyntaxDiagnostic(
 	if response.FileCount != 1 {
 		t.Fatalf("explicit files-scope miss should still count as one lint result, got %d", response.FileCount)
 	}
-	if len(response.Diagnostics) != 0 {
-		t.Fatalf("expected no syntax or rule diagnostics because no config entry matches the file, got %+v", response.Diagnostics)
+	if len(response.Diagnostics) != 1 || response.Diagnostics[0].RuleName != "TypeScript(TS1134)" {
+		t.Fatalf("expected the selected zero-rule target to report TS1134, got %+v", response.Diagnostics)
 	}
 	if response.RuleCount != 0 {
 		t.Fatalf("expected no executed rules, got %d", response.RuleCount)
+	}
+}
+
+func TestHandleLint_MalformedFileDoesNotRunRules(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "explicit.js")
+	if err := os.WriteFile(target, []byte("debugger;\nconst = ;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	response, err := (&IPCHandler{}).HandleLint(api.LintRequest{
+		Config:           json.RawMessage(`[{"rules":{"no-debugger":"error"}}]`),
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 1 {
+		t.Fatalf("malformed target should still count as one linted file, got %d", response.FileCount)
+	}
+	if len(response.Diagnostics) != 1 || response.Diagnostics[0].RuleName != "TypeScript(TS1134)" {
+		t.Fatalf("expected only TS1134 and no rule diagnostics, got %+v", response.Diagnostics)
+	}
+	if response.RuleCount != 0 {
+		t.Fatalf("malformed target must not execute rules, got %d", response.RuleCount)
+	}
+}
+
+func TestHandleLint_FileContentsDependenciesDoNotWidenExplicitTargets(t *testing.T) {
+	dir := t.TempDir()
+	writeProgramTestFiles(t, dir, map[string]string{
+		"target.ts":     "import './dependency';\ndebugger;\n",
+		"dependency.ts": "export const clean = true;\n",
+		"tsconfig.json": `{"include":["*.ts"]}`,
+	})
+	target := filepath.Join(dir, "target.ts")
+	dependency := filepath.Join(dir, "dependency.ts")
+	config := json.RawMessage(`[{
+		"languageOptions": { "parserOptions": { "project": ["./tsconfig.json"] } },
+		"rules": { "no-debugger": "error" }
+	}]`)
+
+	response, err := (&IPCHandler{}).HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+		FileContents: map[string]string{
+			dependency: "debugger;\n",
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 1 || len(response.LintedFiles) != 1 || response.LintedFiles[0] != "target.ts" {
+		t.Fatalf("overlay dependency must not widen explicit targets: count=%d files=%v", response.FileCount, response.LintedFiles)
+	}
+	if len(response.Diagnostics) != 1 || response.Diagnostics[0].FilePath != "target.ts" || response.Diagnostics[0].RuleName != "no-debugger" {
+		t.Fatalf("expected only target.ts no-debugger diagnostic, got %+v", response.Diagnostics)
+	}
+}
+
+func TestHandleLint_FilesPresenceControlsWhetherFileContentsAreTargets(t *testing.T) {
+	dir := t.TempDir()
+	virtualFile := filepath.Join(dir, "virtual.ts")
+	config := json.RawMessage(`[{"rules":{"no-debugger":"error"}}]`)
+
+	tests := []struct {
+		name            string
+		files           []string
+		wantFileCount   int
+		wantDiagnostics int
+	}{
+		{
+			name:            "files omitted",
+			files:           nil,
+			wantFileCount:   1,
+			wantDiagnostics: 1,
+		},
+		{
+			name:            "files explicitly empty",
+			files:           []string{},
+			wantFileCount:   0,
+			wantDiagnostics: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := (&IPCHandler{}).HandleLint(api.LintRequest{
+				Config:           config,
+				ConfigDirectory:  dir,
+				WorkingDirectory: dir,
+				Files:            tt.files,
+				FileContents:     map[string]string{virtualFile: "debugger;\n"},
+			})
+			if err != nil {
+				t.Fatalf("HandleLint returned error: %v", err)
+			}
+			if response.FileCount != tt.wantFileCount || len(response.Diagnostics) != tt.wantDiagnostics {
+				t.Fatalf("got fileCount=%d diagnostics=%d, want fileCount=%d diagnostics=%d", response.FileCount, len(response.Diagnostics), tt.wantFileCount, tt.wantDiagnostics)
+			}
+		})
 	}
 }
 
@@ -663,11 +772,12 @@ func TestHandleLint_FileContentsKeepTypeInfoWhenProgramUsesSymlinkSource(t *test
 
 	handler := &IPCHandler{}
 	response, err := handler.HandleLint(api.LintRequest{
-		Config:           config,
-		ConfigDirectory:  linkDir,
-		WorkingDirectory: linkDir,
-		Files:            []string{realTarget},
-		FileContents:     map[string]string{realTarget: "let b: any = 10;\nb.c = 20;\n"},
+		Config:                    config,
+		ConfigDirectory:           linkDir,
+		WorkingDirectory:          linkDir,
+		Files:                     []string{realTarget},
+		FileContents:              map[string]string{realTarget: "let b: any = 10;\nb.c = 20;\n"},
+		IncludeEncodedSourceFiles: true,
 	})
 	if err != nil {
 		t.Fatalf("HandleLint returned error: %v", err)
@@ -678,11 +788,24 @@ func TestHandleLint_FileContentsKeepTypeInfoWhenProgramUsesSymlinkSource(t *test
 	if got := response.Diagnostics[0].RuleName; got != "@typescript-eslint/no-unsafe-member-access" {
 		t.Fatalf("expected no-unsafe-member-access diagnostic from typed overlay content, got %q", got)
 	}
+	expectedPath, err := filepath.Rel(linkDir, realTarget)
+	if err != nil {
+		t.Fatalf("relative target path: %v", err)
+	}
+	expectedPath = filepath.ToSlash(expectedPath)
+	if len(response.LintedFiles) != 1 || response.LintedFiles[0] != expectedPath {
+		t.Fatalf("expected requested target path %q in LintedFiles, got %v", expectedPath, response.LintedFiles)
+	}
+	if response.Diagnostics[0].FilePath != expectedPath {
+		t.Fatalf("expected requested target path %q in diagnostic, got %q", expectedPath, response.Diagnostics[0].FilePath)
+	}
+	if _, ok := response.EncodedSourceFiles[expectedPath]; !ok {
+		t.Fatalf("expected requested target path %q in encoded source files, got keys %v", expectedPath, response.EncodedSourceFiles)
+	}
 }
 
-// scenario b (in-memory file命门): a requested file outside every tsconfig
-// Program (a "gap" file) must still be linted by non-type-aware rules via the
-// fallback Program — it must NOT be silently skipped with 0 diagnostics.
+// An in-memory target outside every tsconfig Program must still run
+// non-type-aware rules through the fallback Program.
 func TestHandleLint_GapFile_NonTypeAwareRuleRuns(t *testing.T) {
 	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "packages", "rslint", "fixtures"))
 	if err != nil {
@@ -724,10 +847,8 @@ func TestHandleLint_GapFile_NonTypeAwareRuleRuns(t *testing.T) {
 	}
 }
 
-// scenario a (the唯一防线): a type-aware rule on a gap file (no type info) must
-// be filtered out by the gate, NOT run against a nil TypeChecker (which would
-// SIGSEGV the whole process). Reaching the assertions means no crash; the rule
-// must have produced no diagnostic.
+// A type-aware rule on a gap file must be filtered before execution. Running
+// it with a nil TypeChecker would crash the process.
 func TestHandleLint_GapFile_TypeAwareRuleGatedOff(t *testing.T) {
 	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "packages", "rslint", "fixtures"))
 	if err != nil {
@@ -1058,5 +1179,178 @@ func TestHandleLint_FixRangeIsUTF16(t *testing.T) {
 	}
 	if got := resp.Diagnostics[0].Fixes[0].StartPos; got != 9 {
 		t.Fatalf("expected fix StartPos 9 (UTF-16 offset, not byte 11), got %d", got)
+	}
+}
+
+type apiRequesterFunc func(context.Context, ipc.MessageKind, any) (*ipc.Message, error)
+
+func (f apiRequesterFunc) SendRequest(ctx context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error) {
+	return f(ctx, kind, payload)
+}
+
+func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "input.js")
+	const source = "const bad = 1;\n"
+	config := json.RawMessage(`[{
+		"plugins": ["community"],
+		"rules": { "community/rename": ["error", { "replacement": "good" }] }
+	}]`)
+
+	var calls atomic.Int32
+	requester := apiRequesterFunc(func(_ context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error) {
+		calls.Add(1)
+		if kind != api.KindPluginLint {
+			t.Fatalf("expected pluginLint reverse request, got %q", kind)
+		}
+		req, ok := payload.(linter.EslintPluginLintRequest)
+		if !ok {
+			t.Fatalf("unexpected pluginLint payload type %T", payload)
+		}
+		if !req.Fix || req.SuggestionsMode != linter.SuggestionsModeEager {
+			t.Fatalf("unexpected fix settings: fix=%v suggestions=%q", req.Fix, req.SuggestionsMode)
+		}
+		if len(req.Files) != 1 || req.Files[0].Text == nil || *req.Files[0].Text != source {
+			t.Fatalf("plugin request must carry the exact overlay text, got %+v", req.Files)
+		}
+		if req.Files[0].ConfigKey != dir {
+			t.Fatalf("expected configKey %q, got %q", dir, req.Files[0].ConfigKey)
+		}
+		ruleConfig, ok := req.Rules["community/rename"]
+		if !ok || len(ruleConfig.Options) != 1 {
+			t.Fatalf("missing normalized plugin rule options: %+v", req.Rules)
+		}
+
+		result := linter.EslintPluginLintResult{Results: []linter.EslintPluginFileResult{{
+			FilePath: req.Files[0].Path,
+			Diagnostics: []linter.EslintPluginDiagnostic{{
+				RuleName:  "community/rename",
+				MessageId: "rename",
+				Message:   "rename bad",
+				StartPos:  6,
+				EndPos:    9,
+				Fixes: []linter.EslintPluginFix{{
+					Range: [2]int{6, 9},
+					Text:  "good",
+				}},
+			}},
+		}}}
+		return ipc.NewMessage(ipc.KindResponse, 1, result)
+	})
+
+	response, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+		FileContents:     map[string]string{target: source},
+		EslintPlugins: []api.EslintPluginEntry{{
+			Prefix:    "community",
+			RuleNames: []string{"rename"},
+		}},
+		Fix: true,
+	}, requester)
+	if err != nil {
+		t.Fatalf("HandleLintWithContext returned error: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("expected one pluginLint request, got %d", calls.Load())
+	}
+	if len(response.Diagnostics) != 1 {
+		t.Fatalf("expected one plugin diagnostic, got %+v", response.Diagnostics)
+	}
+	diagnostic := response.Diagnostics[0]
+	if diagnostic.RuleName != "community/rename" || diagnostic.MessageId != "rename" || diagnostic.FilePath != "input.js" {
+		t.Fatalf("unexpected plugin diagnostic: %+v", diagnostic)
+	}
+	if diagnostic.Range.Start.Line != 1 || diagnostic.Range.Start.Column != 7 ||
+		diagnostic.Range.End.Line != 1 || diagnostic.Range.End.Column != 10 {
+		t.Fatalf("unexpected plugin diagnostic range: %+v", diagnostic.Range)
+	}
+	if len(diagnostic.Fixes) != 1 || diagnostic.Fixes[0].StartPos != 6 || diagnostic.Fixes[0].EndPos != 9 {
+		t.Fatalf("unexpected plugin fix: %+v", diagnostic.Fixes)
+	}
+	if response.ErrorCount != 1 || response.FixableErrorCount != 1 || response.RuleCount != 1 {
+		t.Fatalf("unexpected plugin counts: errors=%d fixable=%d rules=%d", response.ErrorCount, response.FixableErrorCount, response.RuleCount)
+	}
+	if got := response.Output["input.js"]; got != "const good = 1;\n" {
+		t.Fatalf("expected plugin fix in Output, got %q", got)
+	}
+}
+
+func TestHandleLint_EslintPluginSyntaxErrorSkipsDispatch(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "broken.js")
+	var calls atomic.Int32
+	requester := apiRequesterFunc(func(context.Context, ipc.MessageKind, any) (*ipc.Message, error) {
+		calls.Add(1)
+		return nil, errors.New("plugin dispatcher must not be called for a syntax error")
+	})
+
+	response, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
+		Config:           json.RawMessage(`[{"plugins":["syntax-plugin"],"rules":{"syntax-plugin/rule":"error"}}]`),
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+		FileContents:     map[string]string{target: "const = ;\n"},
+		EslintPlugins: []api.EslintPluginEntry{{
+			Prefix:    "syntax-plugin",
+			RuleNames: []string{"rule"},
+		}},
+	}, requester)
+	if err != nil {
+		t.Fatalf("HandleLintWithContext returned error: %v", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("syntax-error file issued %d pluginLint requests", calls.Load())
+	}
+	if len(response.Diagnostics) != 1 || !strings.HasPrefix(response.Diagnostics[0].RuleName, "TypeScript(TS") {
+		t.Fatalf("expected only the syntax diagnostic, got %+v", response.Diagnostics)
+	}
+	if response.RuleCount != 0 {
+		t.Fatalf("syntax-error file must execute no rules, got %d", response.RuleCount)
+	}
+}
+
+func TestHandleLint_NoEslintPluginMetadataDoesNotDispatchStalePlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "input.js")
+	const source = "const value = 1;\n"
+	config := json.RawMessage(`[{"plugins":["request-plugin"],"rules":{"request-plugin/rule":"error"}}]`)
+	var calls atomic.Int32
+	requester := apiRequesterFunc(func(_ context.Context, _ ipc.MessageKind, payload any) (*ipc.Message, error) {
+		calls.Add(1)
+		req := payload.(linter.EslintPluginLintRequest)
+		return ipc.NewMessage(ipc.KindResponse, 1, linter.EslintPluginLintResult{Results: []linter.EslintPluginFileResult{{
+			FilePath: req.Files[0].Path,
+		}}})
+	})
+	handler := &IPCHandler{}
+	baseRequest := api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+		FileContents:     map[string]string{target: source},
+	}
+
+	withMetadata := baseRequest
+	withMetadata.EslintPlugins = []api.EslintPluginEntry{{Prefix: "request-plugin", RuleNames: []string{"rule"}}}
+	if _, err := handler.HandleLintWithContext(context.Background(), withMetadata, requester); err != nil {
+		t.Fatalf("register plugin placeholder: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("expected initial plugin dispatch, got %d", calls.Load())
+	}
+
+	response, err := handler.HandleLintWithContext(context.Background(), baseRequest, requester)
+	if err != nil {
+		t.Fatalf("lint without metadata: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("request without metadata unexpectedly dispatched pluginLint; calls=%d", calls.Load())
+	}
+	if response.RuleCount != 0 || len(response.Diagnostics) != 0 {
+		t.Fatalf("stale placeholder leaked into metadata-free request: rules=%d diagnostics=%+v", response.RuleCount, response.Diagnostics)
 	}
 }

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -267,6 +267,39 @@ func TestHandleLint_ExplicitFileOutsideFilesIsCountedWithNoRules(t *testing.T) {
 	}
 }
 
+func TestHandleLint_ExplicitMalformedFileOutsideFilesSuppressesSyntaxDiagnostic(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "explicit.js")
+	if err := os.WriteFile(target, []byte("const = ;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	config := json.RawMessage(`[{
+		"files": ["**/*.ts"],
+		"rules": { "no-debugger": "error" }
+	}]`)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 1 {
+		t.Fatalf("explicit files-scope miss should still count as one lint result, got %d", response.FileCount)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("expected no syntax or rule diagnostics because no config entry matches the file, got %+v", response.Diagnostics)
+	}
+	if response.RuleCount != 0 {
+		t.Fatalf("expected no executed rules, got %d", response.RuleCount)
+	}
+}
+
 func TestHandleLint_ExplicitFileEntryIgnoredIsCountedWithNoRules(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "ignored.js")

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -635,6 +635,51 @@ func TestHandleLint_NoConfigEnablesNoRules(t *testing.T) {
 	}
 }
 
+func TestHandleLint_FileContentsKeepTypeInfoWhenProgramUsesSymlinkSource(t *testing.T) {
+	realDir := t.TempDir()
+	linkDir := filepath.Join(filepath.Dir(realDir), filepath.Base(realDir)+"-link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	defer os.Remove(linkDir)
+
+	srcDir := filepath.Join(realDir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "a.ts"), []byte("const clean = 1;\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "tsconfig.json"), []byte(`{"include":["src/a.ts"]}`), 0o644); err != nil {
+		t.Fatalf("write tsconfig: %v", err)
+	}
+
+	config := json.RawMessage(`[{
+		"languageOptions": { "parserOptions": { "project": ["./tsconfig.json"] } },
+		"plugins": ["@typescript-eslint"],
+		"rules": { "@typescript-eslint/no-unsafe-member-access": "error" }
+	}]`)
+	realTarget := filepath.Join(realDir, "src", "a.ts")
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  linkDir,
+		WorkingDirectory: linkDir,
+		Files:            []string{realTarget},
+		FileContents:     map[string]string{realTarget: "let b: any = 10;\nb.c = 20;\n"},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if len(response.Diagnostics) != 1 {
+		t.Fatalf("expected one type-aware overlay diagnostic, got %d: %+v", len(response.Diagnostics), response.Diagnostics)
+	}
+	if got := response.Diagnostics[0].RuleName; got != "@typescript-eslint/no-unsafe-member-access" {
+		t.Fatalf("expected no-unsafe-member-access diagnostic from typed overlay content, got %q", got)
+	}
+}
+
 // scenario b (in-memory file命门): a requested file outside every tsconfig
 // Program (a "gap" file) must still be linted by non-type-aware rules via the
 // fallback Program — it must NOT be silently skipped with 0 diagnostics.

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -231,6 +231,354 @@ func TestHandleLint_ExplicitFilesRestrictsScope(t *testing.T) {
 	}
 }
 
+func TestHandleLint_ExplicitFileOutsideFilesIsCountedWithNoRules(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "explicit.js")
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	config := json.RawMessage(`[{
+		"files": ["**/*.ts"],
+		"rules": { "no-debugger": "error" }
+	}]`)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 1 {
+		t.Fatalf("explicit files-scope miss should still count as one lint result, got %d", response.FileCount)
+	}
+	if len(response.LintedFiles) != 1 || response.LintedFiles[0] != "explicit.js" {
+		t.Fatalf("expected explicit.js in LintedFiles, got %v", response.LintedFiles)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics because no rules match the file, got %+v", response.Diagnostics)
+	}
+	if response.RuleCount != 0 {
+		t.Fatalf("expected no executed rules, got %d", response.RuleCount)
+	}
+}
+
+func TestHandleLint_ExplicitFileEntryIgnoredIsCountedWithNoRules(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "ignored.js")
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	config := json.RawMessage(`[{
+		"files": ["**/*.js"],
+		"ignores": ["ignored.js"],
+		"rules": { "no-debugger": "error" }
+	}]`)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 1 {
+		t.Fatalf("entry-level ignores should not remove an explicit file from the result set, got FileCount=%d", response.FileCount)
+	}
+	if len(response.LintedFiles) != 1 || response.LintedFiles[0] != "ignored.js" {
+		t.Fatalf("expected ignored.js in LintedFiles, got %v", response.LintedFiles)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics because entry-level ignores leave no matching rules, got %+v", response.Diagnostics)
+	}
+	if response.RuleCount != 0 {
+		t.Fatalf("expected no executed rules, got %d", response.RuleCount)
+	}
+}
+
+func TestHandleLint_ExplicitFileGloballyIgnoredIsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "ignored.js")
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	config := json.RawMessage(`[
+		{ "ignores": ["ignored.js"] },
+		{ "files": ["**/*.js"], "rules": { "no-debugger": "error" } }
+	]`)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 0 {
+		t.Fatalf("globally ignored explicit files should be skipped, got FileCount=%d", response.FileCount)
+	}
+	if len(response.LintedFiles) != 0 {
+		t.Fatalf("globally ignored file must not be in LintedFiles, got %v", response.LintedFiles)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics for globally ignored file, got %+v", response.Diagnostics)
+	}
+}
+
+func TestHandleLint_ExplicitFileGitignoredIsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "ignored.js")
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("ignored.js\n"), 0o644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+	config := json.RawMessage(`[
+		{ "files": ["**/*.js"], "rules": { "no-debugger": "error" } }
+	]`)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 0 {
+		t.Fatalf("gitignored explicit files should be skipped, got FileCount=%d", response.FileCount)
+	}
+	if len(response.LintedFiles) != 0 {
+		t.Fatalf("gitignored file must not be in LintedFiles, got %v", response.LintedFiles)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics for gitignored file, got %+v", response.Diagnostics)
+	}
+}
+
+func TestHandleLint_GitignoredParentBlocksNestedNegation(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "ignored", "src", "file.js")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("ignored/\n"), 0o644); err != nil {
+		t.Fatalf("write root .gitignore: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ignored", ".gitignore"), []byte("!src/file.js\n"), 0o644); err != nil {
+		t.Fatalf("write nested .gitignore: %v", err)
+	}
+	config := json.RawMessage(`[
+		{ "files": ["**/*.js"], "rules": { "no-debugger": "error" } }
+	]`)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 0 {
+		t.Fatalf("parent-gitignored explicit file should stay skipped despite nested negation, got FileCount=%d", response.FileCount)
+	}
+	if len(response.LintedFiles) != 0 {
+		t.Fatalf("parent-gitignored file must not be in LintedFiles, got %v", response.LintedFiles)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics for parent-gitignored file, got %+v", response.Diagnostics)
+	}
+}
+
+func TestHandleLint_AncestorGitignoredConfigRootBlocksOwnNegation(t *testing.T) {
+	dir := t.TempDir()
+	appDir := filepath.Join(dir, "packages", "app")
+	target := filepath.Join(appDir, "src", "file.js")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("packages/\n"), 0o644); err != nil {
+		t.Fatalf("write root .gitignore: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, ".gitignore"), []byte("!src/file.js\n"), 0o644); err != nil {
+		t.Fatalf("write app .gitignore: %v", err)
+	}
+	config := json.RawMessage(`[
+		{ "files": ["**/*.js"], "rules": { "no-debugger": "error" } }
+	]`)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  appDir,
+		WorkingDirectory: appDir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 0 {
+		t.Fatalf("ancestor-gitignored config root should stay skipped despite own negation, got FileCount=%d", response.FileCount)
+	}
+	if len(response.LintedFiles) != 0 {
+		t.Fatalf("ancestor-gitignored file must not be in LintedFiles, got %v", response.LintedFiles)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics for ancestor-gitignored file, got %+v", response.Diagnostics)
+	}
+}
+
+func TestHandleLint_AncestorGitignoredIntermediateBlocksNegation(t *testing.T) {
+	dir := t.TempDir()
+	appDir := filepath.Join(dir, "packages", "app")
+	target := filepath.Join(appDir, "src", "file.js")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("packages/\n"), 0o644); err != nil {
+		t.Fatalf("write root .gitignore: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "packages", ".gitignore"), []byte("!app/src/file.js\n"), 0o644); err != nil {
+		t.Fatalf("write packages .gitignore: %v", err)
+	}
+	config := json.RawMessage(`[
+		{ "files": ["**/*.js"], "rules": { "no-debugger": "error" } }
+	]`)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  appDir,
+		WorkingDirectory: appDir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 0 {
+		t.Fatalf("ancestor-gitignored intermediate dir should stay skipped despite its negation, got FileCount=%d", response.FileCount)
+	}
+	if len(response.LintedFiles) != 0 {
+		t.Fatalf("ancestor-gitignored file must not be in LintedFiles, got %v", response.LintedFiles)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics for ancestor-gitignored file, got %+v", response.Diagnostics)
+	}
+}
+
+func TestHandleLint_AncestorChildWildcardReadsIntermediateGitignore(t *testing.T) {
+	dir := t.TempDir()
+	appDir := filepath.Join(dir, "packages", "app")
+	target := filepath.Join(appDir, "src", "generated", "file.js")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("packages/*\n!packages/app/\n"), 0o644); err != nil {
+		t.Fatalf("write root .gitignore: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "packages", ".gitignore"), []byte("app/src/generated/\n"), 0o644); err != nil {
+		t.Fatalf("write packages .gitignore: %v", err)
+	}
+	config := json.RawMessage(`[
+		{ "files": ["**/*.js"], "rules": { "no-debugger": "error" } }
+	]`)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  appDir,
+		WorkingDirectory: appDir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+	if response.FileCount != 0 {
+		t.Fatalf("intermediate .gitignore should skip generated explicit file, got FileCount=%d", response.FileCount)
+	}
+	if len(response.LintedFiles) != 0 {
+		t.Fatalf("gitignored generated file must not be in LintedFiles, got %v", response.LintedFiles)
+	}
+	if len(response.Diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics for gitignored generated file, got %+v", response.Diagnostics)
+	}
+}
+
+func TestHandleLint_NoFilesEntryScansDefaultExtensions(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"a.jsx":      "debugger;\n",
+		"b.cjs":      "debugger;\n",
+		"c.cts":      "debugger;\n",
+		"styles.css": "debugger;\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	config := json.RawMessage(`[{
+		"rules": { "no-debugger": "error" }
+	}]`)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+
+	expectedFiles := []string{"a.jsx", "b.cjs", "c.cts"}
+	if strings.Join(response.LintedFiles, ",") != strings.Join(expectedFiles, ",") {
+		t.Fatalf("expected default lint files %v, got %v", expectedFiles, response.LintedFiles)
+	}
+	if response.FileCount != len(expectedFiles) {
+		t.Fatalf("expected FileCount=%d, got %d", len(expectedFiles), response.FileCount)
+	}
+	if len(response.Diagnostics) != len(expectedFiles) {
+		t.Fatalf("expected one no-debugger diagnostic per default file, got %d: %+v", len(response.Diagnostics), response.Diagnostics)
+	}
+	for _, diagnostic := range response.Diagnostics {
+		if diagnostic.FilePath == "styles.css" {
+			t.Fatalf("unsupported css file must not be linted, diagnostics=%+v", response.Diagnostics)
+		}
+	}
+}
+
 func TestHandleLint_NoConfigEnablesNoRules(t *testing.T) {
 	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "packages", "rslint", "fixtures"))
 	if err != nil {
@@ -262,9 +610,9 @@ func TestHandleLint_GapFile_NonTypeAwareRuleRuns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve fixtures dir: %v", err)
 	}
-	// Non-empty `files` activates gap discovery; the tsconfig only covers
-	// src/, so a file at the fixtures root is a gap file. array-type is a
-	// non-type-aware (syntactic) rule, so it must still run on the fallback.
+	// The tsconfig only covers src/, so a selected file at the fixtures root is
+	// bound to the AST-only fallback. array-type is a non-type-aware
+	// (syntactic) rule, so it must still run there.
 	config := json.RawMessage(`[{
 		"files": ["**/*.ts"],
 		"languageOptions": { "parserOptions": { "project": ["./tsconfig.json"] } },
@@ -366,6 +714,26 @@ func TestHandleLint_MalformedConfigReturnsError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected an error for a malformed (non-array) config")
+	}
+}
+
+func TestHandleLint_RejectsEmptyFilesArrayConfig(t *testing.T) {
+	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "packages", "rslint", "fixtures"))
+	if err != nil {
+		t.Fatalf("resolve fixtures dir: %v", err)
+	}
+
+	handler := &IPCHandler{}
+	_, err = handler.HandleLint(api.LintRequest{
+		Config:           json.RawMessage(`[{"files":[],"rules":{"no-console":"error"}}]`),
+		ConfigDirectory:  fixturesDir,
+		WorkingDirectory: fixturesDir,
+	})
+	if err == nil {
+		t.Fatal("expected an error for empty files array")
+	}
+	if !strings.Contains(err.Error(), `key "files": expected value to be a non-empty array`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -10,10 +10,46 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	api "github.com/web-infra-dev/rslint/internal/api"
 	"github.com/web-infra-dev/rslint/internal/ipc"
 	"github.com/web-infra-dev/rslint/internal/linter"
 )
+
+type canonicalPathBaseFS struct {
+	vfs.FS
+	realpathCalls atomic.Int32
+}
+
+func (fs *canonicalPathBaseFS) Realpath(filePath string) string {
+	fs.realpathCalls.Add(1)
+	return fs.FS.Realpath(filePath)
+}
+
+func TestCanonicalPathVFS_UsesRequestHintBeforeBaseFilesystem(t *testing.T) {
+	base := &canonicalPathBaseFS{FS: osvfs.FS()}
+	fsys := &canonicalPathVFS{
+		FS:             base,
+		canonicalPaths: map[string]string{exactFilesystemPathID("/lexical/a.ts"): "/physical/a.ts"},
+	}
+	if got := fsys.Realpath("/lexical/a.ts"); got != "/physical/a.ts" {
+		t.Fatalf("Realpath returned %q, want request hint", got)
+	}
+	if calls := base.realpathCalls.Load(); calls != 0 {
+		t.Fatalf("request hint must avoid base realpath, got %d calls", calls)
+	}
+}
+
+func TestHandleLint_RejectsMismatchedCanonicalFiles(t *testing.T) {
+	_, err := (&IPCHandler{}).HandleLint(api.LintRequest{
+		Files:          []string{"a.ts"},
+		CanonicalFiles: []string{"a.ts", "b.ts"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "canonicalFiles must be parallel to files") {
+		t.Fatalf("expected canonicalFiles length error, got %v", err)
+	}
+}
 
 func TestHandleLint_DefaultsToLintAllFiles(t *testing.T) {
 	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "packages", "rslint", "fixtures"))
@@ -153,6 +189,56 @@ func TestHandleLint_AllIgnored_EmptyLintedFiles(t *testing.T) {
 	}
 	if len(response.Diagnostics) != 0 {
 		t.Fatalf("expected zero diagnostics, got %d", len(response.Diagnostics))
+	}
+}
+
+func TestHandleLint_AllIgnoredDoesNotResolveInactiveProject(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "ignored.ts")
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	config := json.RawMessage(`[
+		{ "ignores": ["ignored.ts"] },
+		{
+			"languageOptions": { "parserOptions": { "project": ["./missing.json"] } },
+			"rules": { "no-debugger": "error" }
+		}
+	]`)
+
+	response, err := (&IPCHandler{}).HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+	})
+	if err != nil {
+		t.Fatalf("an inactive project must not fail plain API lint: %v", err)
+	}
+	if response.FileCount != 0 || len(response.LintedFiles) != 0 {
+		t.Fatalf("ignored request should lint no files: %+v", response)
+	}
+}
+
+func TestHandleLint_SelectedTargetResolvesGoverningProject(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "selected.ts")
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	config := json.RawMessage(`[{
+		"languageOptions": { "parserOptions": { "project": ["./missing.json"] } },
+		"rules": { "no-debugger": "error" }
+	}]`)
+
+	_, err := (&IPCHandler{}).HandleLint(api.LintRequest{
+		Config:           config,
+		ConfigDirectory:  dir,
+		WorkingDirectory: dir,
+		Files:            []string{target},
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing.json") {
+		t.Fatalf("selected target must resolve its governing project, got %v", err)
 	}
 }
 
@@ -812,7 +898,7 @@ func TestHandleLint_GapFile_NonTypeAwareRuleRuns(t *testing.T) {
 		t.Fatalf("resolve fixtures dir: %v", err)
 	}
 	// The tsconfig only covers src/, so a selected file at the fixtures root is
-	// bound to the AST-only fallback. array-type is a non-type-aware
+	// bound to the non-project-backed fallback. array-type is a non-type-aware
 	// (syntactic) rule, so it must still run there.
 	config := json.RawMessage(`[{
 		"files": ["**/*.ts"],
@@ -1190,6 +1276,7 @@ func (f apiRequesterFunc) SendRequest(ctx context.Context, kind ipc.MessageKind,
 
 func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
 	dir := t.TempDir()
+	pluginConfigDirectory := filepath.Join(dir, "authored-config")
 	target := filepath.Join(dir, "input.js")
 	const source = "const bad = 1;\n"
 	config := json.RawMessage(`[{
@@ -1213,8 +1300,8 @@ func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
 		if len(req.Files) != 1 || req.Files[0].Text == nil || *req.Files[0].Text != source {
 			t.Fatalf("plugin request must carry the exact overlay text, got %+v", req.Files)
 		}
-		if req.Files[0].ConfigKey != dir {
-			t.Fatalf("expected configKey %q, got %q", dir, req.Files[0].ConfigKey)
+		if req.Files[0].ConfigKey != pluginConfigDirectory {
+			t.Fatalf("expected configKey %q, got %q", pluginConfigDirectory, req.Files[0].ConfigKey)
 		}
 		ruleConfig, ok := req.Rules["community/rename"]
 		if !ok || len(ruleConfig.Options) != 1 {
@@ -1239,11 +1326,12 @@ func TestHandleLint_EslintPluginDiagnosticAndFix(t *testing.T) {
 	})
 
 	response, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
-		Config:           config,
-		ConfigDirectory:  dir,
-		WorkingDirectory: dir,
-		Files:            []string{target},
-		FileContents:     map[string]string{target: source},
+		Config:                config,
+		ConfigDirectory:       dir,
+		PluginConfigDirectory: pluginConfigDirectory,
+		WorkingDirectory:      dir,
+		Files:                 []string{target},
+		FileContents:          map[string]string{target: source},
 		EslintPlugins: []api.EslintPluginEntry{{
 			Prefix:    "community",
 			RuleNames: []string{"rename"},

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -18,6 +18,7 @@ import (
 	"runtime/pprof"
 	"runtime/trace"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -32,10 +33,10 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
-	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
@@ -640,11 +641,131 @@ func groupDiagsByFile(diags []rule.RuleDiagnostic) map[string][]rule.RuleDiagnos
 	return m
 }
 
+// remapDiagnosticTargetPaths keeps diagnostics in the caller's target path
+// space when a TypeScript Program represents that target by another lexical or
+// canonical source-file path. SourceFile remains unchanged because ranges and
+// fixes are defined against its text; FilePath controls display and disk writes.
+func remapDiagnosticTargetPaths(diags []rule.RuleDiagnostic, targetPathBySourcePath map[string]string, filesystems ...vfs.FS) {
+	if len(targetPathBySourcePath) == 0 {
+		return
+	}
+	var fsys vfs.FS
+	if len(filesystems) > 0 {
+		fsys = filesystems[0]
+	}
+	for i := range diags {
+		targetPath := targetPathBySourcePath[diags[i].FilePath]
+		if targetPath == "" {
+			targetPath = targetPathBySourcePath[filesystemPathID(diags[i].FilePath, fsys)]
+		}
+		if targetPath != "" {
+			diags[i].FilePath = targetPath
+		}
+	}
+}
+
+type typeScriptDiagnosticDedupeKey struct {
+	path     string
+	ruleName string
+	pos      int
+	end      int
+	message  string
+}
+
+// deduplicateTypeScriptDiagnostics joins the lint-target syntax path and the
+// program-wide type-check path. A file governed by a config without a tsconfig
+// can be parsed by the fallback Program while also belonging to another
+// config's real Program; --type-check legitimately visits both, but the same
+// TypeScript diagnostic must be reported once.
+func deduplicateTypeScriptDiagnostics(
+	diags []rule.RuleDiagnostic,
+	fsys vfs.FS,
+	preferredCallerTargets ...map[string]string,
+) []rule.RuleDiagnostic {
+	if len(diags) == 0 {
+		return diags
+	}
+	var callerTargetByCanonicalPath map[string]string
+	if len(preferredCallerTargets) > 0 {
+		callerTargetByCanonicalPath = preferredCallerTargets[0]
+	}
+	if len(diags) == 1 {
+		if strings.HasPrefix(diags[0].RuleName, "TypeScript(TS") {
+			canonicalID := canonicalFilesystemPathID(diags[0].FilePath, fsys)
+			if callerTarget := callerTargetByCanonicalPath[canonicalID]; callerTarget != "" {
+				diags[0].FilePath = callerTarget
+			}
+		}
+		return diags
+	}
+	bestIndex := make(map[typeScriptDiagnosticDedupeKey]int)
+	keys := make([]typeScriptDiagnosticDedupeKey, len(diags))
+	for i, diagnostic := range diags {
+		if !strings.HasPrefix(diagnostic.RuleName, "TypeScript(TS") {
+			continue
+		}
+		key := typeScriptDiagnosticDedupeKey{
+			path:     canonicalFilesystemPathID(diagnostic.FilePath, fsys),
+			ruleName: diagnostic.RuleName,
+			pos:      diagnostic.Range.Pos(),
+			end:      diagnostic.Range.End(),
+			message:  diagnostic.Message.Description,
+		}
+		keys[i] = key
+		current, exists := bestIndex[key]
+		if !exists || preferTypeScriptDiagnostic(diagnostic, diags[current], callerTargetByCanonicalPath[key.path], fsys) {
+			bestIndex[key] = i
+		}
+	}
+
+	result := diags[:0]
+	for i, diagnostic := range diags {
+		if !strings.HasPrefix(diagnostic.RuleName, "TypeScript(TS") {
+			result = append(result, diagnostic)
+			continue
+		}
+		key := keys[i]
+		if bestIndex[key] != i {
+			continue
+		}
+		if callerTarget := callerTargetByCanonicalPath[key.path]; callerTarget != "" {
+			diagnostic.FilePath = callerTarget
+		}
+		result = append(result, diagnostic)
+	}
+	return result
+}
+
+func preferTypeScriptDiagnostic(candidate rule.RuleDiagnostic, current rule.RuleDiagnostic, callerTarget string, fsys vfs.FS) bool {
+	if callerTarget != "" {
+		candidateIsCaller := filesystemPathID(candidate.FilePath, fsys) == filesystemPathID(callerTarget, fsys)
+		currentIsCaller := filesystemPathID(current.FilePath, fsys) == filesystemPathID(callerTarget, fsys)
+		if candidateIsCaller != currentIsCaller {
+			return candidateIsCaller
+		}
+	}
+	candidatePath := tspath.NormalizePath(candidate.FilePath)
+	currentPath := tspath.NormalizePath(current.FilePath)
+	if candidatePath != currentPath {
+		return candidatePath < currentPath
+	}
+	return false
+}
+
 // applyFixPass applies auto-fixes for all files in diagnosticsByFile,
-// writes fixed content to disk, and returns the number of issues fixed.
-func applyFixPass(diagnosticsByFile map[string][]rule.RuleDiagnostic) int {
+// writes fixed content to disk, and returns the number of issues fixed. Write
+// failures are returned after all independent files have been attempted.
+func applyFixPass(diagnosticsByFile map[string][]rule.RuleDiagnostic) (int, error) {
 	fixed := 0
-	for fileName, fileDiagnostics := range diagnosticsByFile {
+	fileNames := make([]string, 0, len(diagnosticsByFile))
+	for fileName := range diagnosticsByFile {
+		fileNames = append(fileNames, fileName)
+	}
+	sort.Strings(fileNames)
+
+	var writeErrors []error
+	for _, fileName := range fileNames {
+		fileDiagnostics := diagnosticsByFile[fileName]
 		var diagnosticsWithFixes []rule.RuleDiagnostic
 		for _, d := range fileDiagnostics {
 			if len(d.Fixes()) > 0 {
@@ -661,13 +782,13 @@ func applyFixPass(diagnosticsByFile map[string][]rule.RuleDiagnostic) int {
 		if wasFixed {
 			err := os.WriteFile(fileName, []byte(fixedContent), 0644)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "error writing fixed file %s: %v\n", fileName, err)
+				writeErrors = append(writeErrors, fmt.Errorf("write fixed file %q: %w", fileName, err))
 			} else {
 				fixed += len(diagnosticsWithFixes) - len(unapplied)
 			}
 		}
 	}
-	return fixed
+	return fixed, errors.Join(writeErrors...)
 }
 
 // allowFileWarningKind categorizes why a CLI-specified file won't have lint
@@ -718,11 +839,11 @@ func formatAllowFileWarning(w allowFileWarning, opts tspath.ComparePathsOptions)
 // constrained by `files`/`ignores`").
 func collectAllowFileWarnings(
 	allowFiles []string,
-	programs []*compiler.Program,
 	configMap map[string]rslintconfig.RslintConfig,
 	rslintConfig rslintconfig.RslintConfig,
 	currentDirectory string,
 	useCaseSensitive bool,
+	filesystems ...vfs.FS,
 ) []allowFileWarning {
 	if len(allowFiles) == 0 {
 		return nil
@@ -735,6 +856,10 @@ func collectAllowFileWarnings(
 		cfg    rslintconfig.RslintConfig
 	}
 	dirConfigCache := make(map[string]*cachedConfig)
+	var fsys vfs.FS
+	if len(filesystems) > 0 {
+		fsys = filesystems[0]
+	}
 
 	var out []allowFileWarning
 	for _, f := range allowFiles {
@@ -742,11 +867,21 @@ func collectAllowFileWarnings(
 		var cfg rslintconfig.RslintConfig
 		if configMap != nil {
 			dir := tspath.GetDirectoryPath(f)
-			cached, ok := dirConfigCache[dir]
+			cacheKey := dir
+			if fsys != nil {
+				cacheKey = filesystemPathID(dir, fsys)
+			}
+			cached, ok := dirConfigCache[cacheKey]
 			if !ok {
-				foundDir, foundCfg := rslintconfig.FindNearestConfig(f, configMap)
+				var foundDir string
+				var foundCfg rslintconfig.RslintConfig
+				if fsys != nil {
+					foundDir, foundCfg = rslintconfig.FindNearestConfigWithFS(f, configMap, fsys)
+				} else {
+					foundDir, foundCfg = rslintconfig.FindNearestConfigWithCaseSensitivity(f, configMap, useCaseSensitive)
+				}
 				cached = &cachedConfig{cfgDir: foundDir, cfg: foundCfg}
-				dirConfigCache[dir] = cached
+				dirConfigCache[cacheKey] = cached
 			}
 			cfgDir = cached.cfgDir
 			cfg = cached.cfg
@@ -754,8 +889,19 @@ func collectAllowFileWarnings(
 			cfgDir = currentDirectory
 			cfg = rslintConfig
 		}
-		if rslintconfig.IsDefaultExcludedPath(f, cfgDir, useCaseSensitive) ||
-			(cfg != nil && cfg.IsFileIgnored(f, cfgDir)) {
+		matchFile := f
+		matchDir := cfgDir
+		if fsys != nil && cfgDir != "" {
+			canonicalPath := authoritativeFilesystemPath(f, fsys)
+			matchFile = configPathForBoundSource(f, resolvedLintTarget{
+				Path:           tspath.NormalizePath(f),
+				CanonicalPath:  canonicalPath,
+				OwnerConfigDir: cfgDir,
+			}, fsys)
+			matchDir = authoritativeFilesystemPath(cfgDir, fsys)
+		}
+		if rslintconfig.IsDefaultExcludedPath(matchFile, matchDir, useCaseSensitive) ||
+			(cfg != nil && cfg.IsFileIgnored(matchFile, matchDir)) {
 			out = append(out, allowFileWarning{Path: f, Kind: allowFileIgnored})
 			continue
 		}
@@ -1019,11 +1165,9 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	var originalConfigDir map[string]string
 	var configTargetFiles map[string][]string
 
-	programs := []*compiler.Program{}
-	// programConfigDirs tracks which configDir each program belongs to (parallel to programs).
-	// Used when binding duplicate selected targets to the Program associated
-	// with the nearest config in multi-config mode.
-	var programConfigDirs []string
+	// Real tsconfig-backed Programs are built independently from lint targets.
+	// Shared tsconfigs are deduplicated while retaining every config association.
+	var realProgramSet lintProgramSet
 
 	if configStdin {
 		// Read config JSON from stdin (sent by JS config loader).
@@ -1039,7 +1183,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			return 1
 		}
 
-		payload, parseErr := parseConfigPayload(data)
+		payload, parseErr := parseConfigPayload(data, fs)
 		if parseErr != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", parseErr)
 			return 1
@@ -1065,10 +1209,10 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			//
 			// configMap is NOT mutated by gitignore goroutines; results are
 			// collected via channel and merged in the main goroutine after
-			// the createPrograms loop, so the createPrograms loop sees the
-			// pre-augmentation entries (createProgramsForConfig only reads
-			// languageOptions.parserOptions.project — Ignores entries are
-			// no-ops for it; verified in LoadTsConfigsFromRslintConfig).
+			// Program registry construction. Program construction sees the
+			// pre-augmentation entries and reads only
+			// languageOptions.parserOptions.project, so ignore entries are
+			// irrelevant to it.
 			type giResult struct {
 				configDir string
 				globs     []string
@@ -1089,17 +1233,10 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				})
 			}
 
-			seenTsConfigs := make(map[string]struct{})
-
-			for configDir, entries := range configMap {
-				progs, exitCode := createProgramsForConfig(configDir, entries, singleThreaded, fs, seenTsConfigs, parseCache)
-				if exitCode != 0 {
-					return exitCode
-				}
-				for range progs {
-					programConfigDirs = append(programConfigDirs, configDir)
-				}
-				programs = append(programs, progs...)
+			realProgramSet, err = createProgramSetForConfigs(configMap, singleThreaded, fs, parseCache)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				return 1
 			}
 
 			// Join the gitignore reads and merge into configMap. Must complete
@@ -1117,20 +1254,16 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			currentDirectory = payload.SingleConfigDir
 
 			// Inject .gitignore patterns as global ignores. Run gitignore
-			// reading in parallel with createProgramsForConfig — they're
-			// independent (createProgramsForConfig only reads
+			// reading in parallel with Program registry construction. They are
+			// independent because Program construction only reads
 			// languageOptions.parserOptions.project, not Ignores).
-			var (
-				progs    []*compiler.Program
-				exitCode int
+			rslintConfig, realProgramSet, err = parallelGitignoreAndPrograms(
+				rslintConfig, currentDirectory, fs, singleThreaded, parseCache,
 			)
-			rslintConfig, progs, exitCode = parallelGitignoreAndPrograms(
-				rslintConfig, currentDirectory, fs, singleThreaded, nil, parseCache,
-			)
-			if exitCode != 0 {
-				return exitCode
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				return 1
 			}
-			programs = append(programs, progs...)
 		}
 	} else {
 		// Load configuration from file (JSON config path, isJSConfig stays false)
@@ -1143,18 +1276,14 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		}
 
 		// Inject .gitignore patterns as global ignores. Run gitignore reading
-		// in parallel with createProgramsForConfig (see comment above).
-		var (
-			progs    []*compiler.Program
-			exitCode int
+		// in parallel with Program registry construction (see above).
+		rslintConfig, realProgramSet, err = parallelGitignoreAndPrograms(
+			rslintConfig, currentDirectory, fs, singleThreaded, parseCache,
 		)
-		rslintConfig, progs, exitCode = parallelGitignoreAndPrograms(
-			rslintConfig, currentDirectory, fs, singleThreaded, nil, parseCache,
-		)
-		if exitCode != 0 {
-			return exitCode
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
 		}
-		programs = append(programs, progs...)
 	}
 
 	targetConfigMap := cloneConfigMap(configMap)
@@ -1199,23 +1328,44 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	}
 
 	// --- Lint target discovery and fallback Program binding ---
-	// Resolve the exact lint target set independently from Program membership,
-	// then bind selected files to existing Programs or an AST-only fallback
-	// Program. Shared with the --api path via buildProgramsWithLintTargets, so
-	// target discovery, fallback creation, and type-aware gating stay aligned.
-	programs, typeInfoFiles, capturedGapFiles, targetFiles, targetsByProgram, configPathBySourcePath := buildProgramsWithLintTargets(
-		programs,
-		targetConfigMap,
-		targetRslintConfig,
-		currentDirectory,
-		programConfigDirs,
-		configTargetFiles,
-		fs,
-		allowFiles,
-		allowDirs,
-		parseCache,
-		singleThreaded,
+	programs := realProgramSet.Programs
+	var (
+		targetPlan                 lintTargetPlan
+		typeInfoFiles              map[string]struct{}
+		targetsByProgram           [][]string
+		targetPathBySourcePath     map[string]string
+		configPathBySourcePath     map[string]string
+		ownerConfigDirBySourcePath map[string]string
 	)
+	// --type-check-only is program-wide and pays no lint-target discovery,
+	// fallback, config-resolution, or Program-binding cost.
+	if !typeCheckOnly {
+		targetPlan, err = resolveLintTargetPlan(
+			targetConfigMap,
+			targetRslintConfig,
+			currentDirectory,
+			configTargetFiles,
+			fs,
+			allowFiles,
+			allowDirs,
+			singleThreaded,
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		binding, err := bindLintTargetPlan(realProgramSet, targetPlan, currentDirectory, fs, parseCache, singleThreaded)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		programs = binding.Programs
+		typeInfoFiles = binding.TypeInfoFiles
+		targetsByProgram = binding.TargetsByProgram
+		targetPathBySourcePath = binding.TargetPathBySourcePath
+		configPathBySourcePath = binding.ConfigPathBySourcePath
+		ownerConfigDirBySourcePath = binding.OwnerConfigDirBySourcePath
+	}
 
 	// Initial build (including any fallback) is complete: evict cache
 	// entries for files that ended up in no program — build-time dedup
@@ -1223,42 +1373,21 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// ParseCache.RetainOnly (I7).
 	parseCache.RetainOnly(programs)
 
-	// createPrograms rebuilds programs (needed for multi-pass --fix re-linting).
-	// The fallback is appended last, but callers no longer need its
-	// index: buildTypeCheckSkipMask reads each program's ConfigFilePath to decide
-	// what to exclude from type-check.
-	createPrograms := func() ([]*compiler.Program, []string, error) {
-		var baseProgs []*compiler.Program
-		var baseProgramConfigDirs []string
+	// Rebuild real Programs and bind the original stable target plan again on
+	// every fix pass. A target can move between a tsconfig Program and fallback
+	// when fixes change the import graph.
+	createPrograms := func() (lintTargetBinding, error) {
+		var rebuilt lintProgramSet
+		var err error
 		if configMap != nil {
-			seen := make(map[string]struct{})
-			for configDir, entries := range configMap {
-				progs, exitCode := createProgramsForConfig(configDir, entries, singleThreaded, fs, seen, parseCache)
-				if exitCode != 0 {
-					return nil, nil, fmt.Errorf("failed to create programs for %s", configDir)
-				}
-				for range progs {
-					baseProgramConfigDirs = append(baseProgramConfigDirs, configDir)
-				}
-				baseProgs = append(baseProgs, progs...)
-			}
+			rebuilt, err = createProgramSetForConfigs(configMap, singleThreaded, fs, parseCache)
 		} else {
-			progs, exitCode := createProgramsForConfig(currentDirectory, rslintConfig, singleThreaded, fs, nil, parseCache)
-			if exitCode != 0 {
-				return nil, nil, errors.New("failed to create programs")
-			}
-			baseProgs = append(baseProgs, progs...)
+			rebuilt, err = createProgramSetForConfig(currentDirectory, rslintConfig, singleThreaded, fs, parseCache)
 		}
-
-		// Rebuild fallback Program for gap files (content may have changed after fixes).
-		if len(capturedGapFiles) > 0 {
-			fallback, _ := createFallbackProgram(capturedGapFiles, singleThreaded, cwd, fs, parseCache)
-			if fallback != nil {
-				baseProgs = append(baseProgs, fallback)
-			}
+		if err != nil {
+			return lintTargetBinding{}, err
 		}
-
-		return baseProgs, baseProgramConfigDirs, nil
+		return bindLintTargetPlan(rebuilt, targetPlan, currentDirectory, fs, parseCache, singleThreaded)
 	}
 
 	// Phase 1: Collect all diagnostics (no printing yet).
@@ -1279,14 +1408,17 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	}()
 
 	enforcePlugins := configStdin // JS/TS configs loaded via stdin require plugin declarations
-	fileConfigResolver := newLintConfigResolver(
-		configMap,
-		rslintConfig,
-		currentDirectory,
-		enforcePlugins,
-		typeInfoFiles,
-		configPathBySourcePath,
-	)
+	fileConfigResolver := newLintConfigResolver(lintConfigResolverOptions{
+		ConfigMap:                  configMap,
+		Config:                     rslintConfig,
+		CurrentDirectory:           currentDirectory,
+		EnforcePlugins:             enforcePlugins,
+		TypeInfoFiles:              typeInfoFiles,
+		TargetPathBySourcePath:     targetPathBySourcePath,
+		ConfigPathBySourcePath:     configPathBySourcePath,
+		OwnerConfigDirBySourcePath: ownerConfigDirBySourcePath,
+		FS:                         fs,
+	})
 	getRulesForFile := func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 		return fileConfigResolver.ActiveRulesForFile(sourceFile.FileName())
 	}
@@ -1294,10 +1426,6 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// Target discovery already excluded default paths, global ignores, and
 	// .gitignore entries. Target ownership and deduplication were already
 	// resolved in targetsByProgram.
-	shouldReportLintSyntax := func(filePath string) bool {
-		return fileConfigResolver.ConfigForFile(filePath) != nil
-	}
-
 	// Programs not backed by a real tsconfig are excluded from --type-check:
 	// their CompilerOptions are synthesized defaults, not the user's tsconfig,
 	// so semantic diagnostics there would be unreliable. This includes the
@@ -1305,14 +1433,14 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// for projects with no tsconfig at all, honoring the "Gap files" contract
 	// in website/docs/en/guide/type-checking.md.
 	skipTypeCheck := buildTypeCheckSkipMask(programs)
-	for _, diagnostic := range collectTargetSyntacticDiagnostics(
+	syntaxDiagnostics, syntaxErrorFiles := collectTargetSyntacticDiagnostics(
 		programs,
 		targetsByProgram,
 		skipTypeCheck,
 		typeCheck,
 		typeCheckOnly,
-		shouldReportLintSyntax,
-	) {
+	)
+	for _, diagnostic := range syntaxDiagnostics {
 		diagnosticsChan <- diagnostic
 	}
 
@@ -1331,6 +1459,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		TargetFiles:           targetsByProgram,
 		GetRulesForFile:       rulesForFile,
 		TypeInfoFiles:         typeInfoFiles,
+		SyntaxErrorFiles:      syntaxErrorFiles,
 		TypeCheck:             typeCheck,
 		SkipTypeCheckPrograms: skipTypeCheck,
 		OnDiagnostic: func(d rule.RuleDiagnostic) {
@@ -1370,6 +1499,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	if pluginCh != nil {
 		allDiags = append(allDiags, (<-pluginCh)...)
 	}
+	remapDiagnosticTargetPaths(allDiags, targetPathBySourcePath, fs)
 
 	// Emit per-file warnings for CLI-specified files that won't be linted.
 	// Distinguishes "not found in project" vs "ignored by pattern", aligned
@@ -1377,7 +1507,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// these are lint-phase concepts and would mislead users about Phase 2
 	// (which runs program-wide regardless of CLI scope and rslint ignores).
 	if !typeCheckOnly {
-		warnings := collectAllowFileWarnings(allowFiles, programs, configMap, rslintConfig, currentDirectory, fs.UseCaseSensitiveFileNames())
+		warnings := collectAllowFileWarnings(allowFiles, configMap, rslintConfig, currentDirectory, fs.UseCaseSensitiveFileNames(), fs)
 		for _, w := range warnings {
 			fmt.Fprintln(os.Stderr, formatAllowFileWarning(w, comparePathOptions))
 		}
@@ -1394,14 +1524,25 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	const maxFixPasses = 10
 	if fix && len(allDiags) > 0 {
 		diagnosticsByFile := groupDiagsByFile(allDiags)
-		fixedCount += applyFixPass(diagnosticsByFile)
+		passFixed, fixErr := applyFixPass(diagnosticsByFile)
+		if fixErr != nil {
+			fmt.Fprintf(os.Stderr, "error applying fixes: %v\n", fixErr)
+			return 1
+		}
+		fixedCount += passFixed
 
 		// Re-lint → fix → re-lint → fix → ... until stable or maxFixPasses.
 		// Skip if nothing was fixed in the first pass (no need to re-lint).
-		for pass := 1; pass < maxFixPasses && fixedCount > 0; pass++ {
-			newPrograms, newProgramConfigDirs, err := createPrograms()
-			if err != nil || len(newPrograms) == 0 {
-				break
+		for pass := 1; pass <= maxFixPasses && fixedCount > 0; pass++ {
+			newBinding, err := createPrograms()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error rebuilding Programs after fixes: %v\n", err)
+				return 1
+			}
+			newPrograms := newBinding.Programs
+			if len(newPrograms) == 0 {
+				fmt.Fprintln(os.Stderr, "error rebuilding Programs after fixes: no Program returned")
+				return 1
 			}
 
 			// Evict cache entries no longer referenced by any live program:
@@ -1412,19 +1553,22 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// keeping their entries costs nothing (deletion-only, I7).
 			parseCache.RetainOnly(append(slices.Clone(newPrograms), programs...))
 
-			// Re-lint: collect remaining diagnostics.
-			fixProgramIndex := buildProgramFileIndex(newPrograms, fs, singleThreaded)
-			fixTargetsByProgram, fixConfigPathBySourcePath := assignLintTargetsToPrograms(newPrograms, targetConfigMap, newProgramConfigDirs, targetFiles, fixProgramIndex, fs)
+			// Re-lint using the fresh binding derived from the stable target plan.
+			fixTargetsByProgram := newBinding.TargetsByProgram
+			fixTargetPathBySourcePath := newBinding.TargetPathBySourcePath
 			fixSkipMask := buildTypeCheckSkipMask(newPrograms)
-			fixTypeInfoFiles := buildTypeInfoFilesForPrograms(newPrograms, fixSkipMask, fs, singleThreaded)
-			fixConfigResolver := newLintConfigResolver(
-				configMap,
-				rslintConfig,
-				currentDirectory,
-				enforcePlugins,
-				fixTypeInfoFiles,
-				fixConfigPathBySourcePath,
-			)
+			fixTypeInfoFiles := newBinding.TypeInfoFiles
+			fixConfigResolver := newLintConfigResolver(lintConfigResolverOptions{
+				ConfigMap:                  configMap,
+				Config:                     rslintConfig,
+				CurrentDirectory:           currentDirectory,
+				EnforcePlugins:             enforcePlugins,
+				TypeInfoFiles:              fixTypeInfoFiles,
+				TargetPathBySourcePath:     fixTargetPathBySourcePath,
+				ConfigPathBySourcePath:     newBinding.ConfigPathBySourcePath,
+				OwnerConfigDirBySourcePath: newBinding.OwnerConfigDirBySourcePath,
+				FS:                         fs,
+			})
 			fixGetRulesForFile := func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 				return fixConfigResolver.ActiveRulesForFile(sourceFile.FileName())
 			}
@@ -1432,18 +1576,15 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			if !typeCheckOnly {
 				fixRulesForFile = fixGetRulesForFile
 			}
-			fixShouldReportLintSyntax := func(filePath string) bool {
-				return fixConfigResolver.ConfigForFile(filePath) != nil
-			}
 			var passDiags []rule.RuleDiagnostic
-			passDiags = append(passDiags, collectTargetSyntacticDiagnostics(
+			fixSyntaxDiagnostics, fixSyntaxErrorFiles := collectTargetSyntacticDiagnostics(
 				newPrograms,
 				fixTargetsByProgram,
 				fixSkipMask,
 				typeCheck,
 				typeCheckOnly,
-				fixShouldReportLintSyntax,
-			)...)
+			)
+			passDiags = append(passDiags, fixSyntaxDiagnostics...)
 			fixRunOpts := linter.RunLinterOptions{
 				Programs:              newPrograms,
 				SingleThreaded:        singleThreaded,
@@ -1451,6 +1592,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				TargetFiles:           fixTargetsByProgram,
 				GetRulesForFile:       fixRulesForFile,
 				TypeInfoFiles:         fixTypeInfoFiles,
+				SyntaxErrorFiles:      fixSyntaxErrorFiles,
 				TypeCheck:             typeCheck,
 				SkipTypeCheckPrograms: fixSkipMask,
 				OnDiagnostic: func(d rule.RuleDiagnostic) {
@@ -1470,7 +1612,15 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				})
 				fixPluginCh = dispatchPluginLintAsync(ctx, dispatch, fixPluginInputs, fix, pluginSuggestionsMode(fix))
 			}
-			passResult, _ := linter.RunLinter(fixRunOpts)
+			passResult, passErr := linter.RunLinter(fixRunOpts)
+			var fixPluginDiags []rule.RuleDiagnostic
+			if fixPluginCh != nil {
+				fixPluginDiags = <-fixPluginCh
+			}
+			if passErr != nil {
+				fmt.Fprintf(os.Stderr, "error running linter after fixes: %v\n", passErr)
+				return 1
+			}
 			if passResult != nil {
 				for name := range passResult.ExecutedRules {
 					lintResult.ExecutedRules[name] = struct{}{}
@@ -1478,20 +1628,31 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			}
 			// Merge this pass's plugin diagnostics before applying fixes so
 			// plugin fixes participate and plugin diagnostics survive.
-			if fixPluginCh != nil {
-				passDiags = append(passDiags, (<-fixPluginCh)...)
-			}
+			passDiags = append(passDiags, fixPluginDiags...)
+			remapDiagnosticTargetPaths(passDiags, fixTargetPathBySourcePath, fs)
 
 			// Replace allDiags with latest post-fix diagnostics.
 			allDiags = passDiags
+			if pass == maxFixPasses {
+				// The maximum number of write passes has already run (the initial
+				// pass plus maxFixPasses-1 loop passes). This extra pass is the
+				// required final verification of the bytes written by pass 10.
+				break
+			}
 
-			passFixed := applyFixPass(groupDiagsByFile(passDiags))
+			passFixed, fixErr := applyFixPass(groupDiagsByFile(passDiags))
+			if fixErr != nil {
+				fmt.Fprintf(os.Stderr, "error applying fixes: %v\n", fixErr)
+				return 1
+			}
 			if passFixed == 0 {
 				break // Stable — allDiags reflect final state
 			}
 			fixedCount += passFixed
 		}
 	}
+
+	allDiags = deduplicateTypeScriptDiagnostics(allDiags, fs, preferredCallerTargetPaths(targetPlan, fs))
 
 	// Diagnostics arrive in completion order — programs and, within a
 	// program, file shards run in parallel — so impose a deterministic
@@ -1502,10 +1663,6 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// a STABLE sort this key is already fully deterministic. Keep this
 	// comparator in sync with the --api one in api.go (same policy over
 	// api.Diagnostic).
-	// Known pre-existing exception: a file rooted by two tsconfigs at once
-	// is linted by both programs (duplicate diagnostics with
-	// scheduling-dependent interleaving) — neither introduced nor fixed
-	// here.
 	slices.SortStableFunc(allDiags, func(a, b rule.RuleDiagnostic) int {
 		if c := strings.Compare(a.FilePath, b.FilePath); c != 0 {
 			return c

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -656,7 +656,7 @@ func remapDiagnosticTargetPaths(diags []rule.RuleDiagnostic, targetPathBySourceP
 	for i := range diags {
 		targetPath := targetPathBySourcePath[diags[i].FilePath]
 		if targetPath == "" {
-			targetPath = targetPathBySourcePath[filesystemPathID(diags[i].FilePath, fsys)]
+			targetPath = targetPathBySourcePath[canonicalFilesystemPathID(diags[i].FilePath, fsys)]
 		}
 		if targetPath != "" {
 			diags[i].FilePath = targetPath
@@ -738,8 +738,8 @@ func deduplicateTypeScriptDiagnostics(
 
 func preferTypeScriptDiagnostic(candidate rule.RuleDiagnostic, current rule.RuleDiagnostic, callerTarget string, fsys vfs.FS) bool {
 	if callerTarget != "" {
-		candidateIsCaller := filesystemPathID(candidate.FilePath, fsys) == filesystemPathID(callerTarget, fsys)
-		currentIsCaller := filesystemPathID(current.FilePath, fsys) == filesystemPathID(callerTarget, fsys)
+		candidateIsCaller := exactFilesystemPathID(candidate.FilePath) == exactFilesystemPathID(callerTarget)
+		currentIsCaller := exactFilesystemPathID(current.FilePath) == exactFilesystemPathID(callerTarget)
 		if candidateIsCaller != currentIsCaller {
 			return candidateIsCaller
 		}
@@ -849,8 +849,8 @@ func collectAllowFileWarnings(
 		return nil
 	}
 
-	// Cache FindNearestConfig results by directory to avoid redundant lookups
-	// when many files are in the same directory (e.g., lint-staged).
+	// Reuse owner resolution by directory when many explicit files share a
+	// directory (for example, lint-staged invocations).
 	type cachedConfig struct {
 		cfgDir string
 		cfg    rslintconfig.RslintConfig
@@ -860,6 +860,10 @@ func collectAllowFileWarnings(
 	if len(filesystems) > 0 {
 		fsys = filesystems[0]
 	}
+	var configOwnerResolver *rslintconfig.ConfigOwnerResolver
+	if configMap != nil {
+		configOwnerResolver = rslintconfig.NewConfigOwnerResolver(configMap, fsys)
+	}
 
 	var out []allowFileWarning
 	for _, f := range allowFiles {
@@ -867,19 +871,12 @@ func collectAllowFileWarnings(
 		var cfg rslintconfig.RslintConfig
 		if configMap != nil {
 			dir := tspath.GetDirectoryPath(f)
-			cacheKey := dir
-			if fsys != nil {
-				cacheKey = filesystemPathID(dir, fsys)
-			}
+			cacheKey := exactFilesystemPathID(dir)
 			cached, ok := dirConfigCache[cacheKey]
 			if !ok {
 				var foundDir string
 				var foundCfg rslintconfig.RslintConfig
-				if fsys != nil {
-					foundDir, foundCfg = rslintconfig.FindNearestConfigWithFS(f, configMap, fsys)
-				} else {
-					foundDir, foundCfg = rslintconfig.FindNearestConfigWithCaseSensitivity(f, configMap, useCaseSensitive)
-				}
+				foundDir, foundCfg = configOwnerResolver.Resolve(f)
 				cached = &cachedConfig{cfgDir: foundDir, cfg: foundCfg}
 				dirConfigCache[cacheKey] = cached
 			}
@@ -893,7 +890,7 @@ func collectAllowFileWarnings(
 		matchDir := cfgDir
 		if fsys != nil && cfgDir != "" {
 			canonicalPath := authoritativeFilesystemPath(f, fsys)
-			matchFile = configPathForBoundSource(f, resolvedLintTarget{
+			matchFile = configPathForLintTarget(resolvedLintTarget{
 				Path:           tspath.NormalizePath(f),
 				CanonicalPath:  canonicalPath,
 				OwnerConfigDir: cfgDir,
@@ -1143,8 +1140,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
 
 	// Run-scoped parse cache shared by every Program built in this pipeline
-	// (initial build, gap fallback, --fix rebuilds). Created here and passed
-	// down explicitly — see utils.WithParseCache (I5: no package singleton).
+	// (initial build, gap fallback, --fix rebuilds). It is passed explicitly and
+	// discarded after the invocation; no package-level cache is involved.
 	parseCache := utils.NewParseCache()
 
 	// Initialize rule registry with all available rules
@@ -1163,11 +1160,14 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// round-trips raw (byte-matching the worker's plugin map key). nil outside
 	// multi-config mode (single-config / JSON configs never mount plugins).
 	var originalConfigDir map[string]string
-	var configTargetFiles map[string][]string
+	var configTargetScopes map[string]rslintconfig.LintDiscoveryScope
 
-	// Real tsconfig-backed Programs are built independently from lint targets.
-	// Shared tsconfigs are deduplicated while retaining every config association.
+	// Program-wide type checking builds every configured project. Plain linting
+	// waits for target discovery and builds only the projects owned by configs
+	// that govern at least one selected target.
 	var realProgramSet lintProgramSet
+	buildAllPrograms := typeCheck || typeCheckOnly
+	needsLintTargets := !typeCheckOnly
 
 	if configStdin {
 		// Read config JSON from stdin (sent by JS config loader).
@@ -1193,7 +1193,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// Multi-config format
 			configMap = payload.ConfigMap
 			originalConfigDir = payload.OriginalConfigDir
-			configTargetFiles = payload.ConfigTargetFiles
+			configTargetScopes = payload.ConfigTargetScopes
 
 			// Inject .gitignore patterns as global ignores for each config.
 			// Each config independently reads its own .gitignore tree:
@@ -1207,12 +1207,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// the same predicate used by the linter — blocked dirs' files
 			// are never linted, so their .gitignore patterns are irrelevant.
 			//
-			// configMap is NOT mutated by gitignore goroutines; results are
-			// collected via channel and merged in the main goroutine after
-			// Program registry construction. Program construction sees the
-			// pre-augmentation entries and reads only
-			// languageOptions.parserOptions.project, so ignore entries are
-			// irrelevant to it.
+			// configMap is not mutated by gitignore workers. Results are collected
+			// and merged on this goroutine before target discovery.
 			type giResult struct {
 				configDir string
 				globs     []string
@@ -1222,21 +1218,22 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				giMu      sync.Mutex
 			)
 			giWG := core.NewWorkGroup(singleThreaded)
-			for configDir, entries := range configMap {
-				configIgnores := rslintconfig.ExtractConfigIgnores(entries)
-				giWG.Queue(func() {
-					if globs := rslintconfig.ReadGitignoreAsGlobs(configDir, fs, configIgnores); len(globs) > 0 {
-						giMu.Lock()
-						giResults = append(giResults, giResult{configDir, globs})
-						giMu.Unlock()
-					}
-				})
+			if needsLintTargets {
+				for configDir, entries := range configMap {
+					configIgnores := rslintconfig.ExtractConfigIgnores(entries)
+					giWG.Queue(func() {
+						if globs := rslintconfig.ReadGitignoreAsGlobs(configDir, fs, configIgnores); len(globs) > 0 {
+							giMu.Lock()
+							giResults = append(giResults, giResult{configDir, globs})
+							giMu.Unlock()
+						}
+					})
+				}
 			}
 
-			realProgramSet, err = createProgramSetForConfigs(configMap, singleThreaded, fs, parseCache)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "error: %v\n", err)
-				return 1
+			var programErr error
+			if buildAllPrograms {
+				realProgramSet, programErr = createProgramSetForConfigs(configMap, singleThreaded, fs, parseCache)
 			}
 
 			// Join the gitignore reads and merge into configMap. Must complete
@@ -1248,18 +1245,24 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 					configMap[r.configDir]...,
 				)
 			}
+			if programErr != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", programErr)
+				return 1
+			}
 		} else {
 			// Legacy single-config format
 			rslintConfig = payload.SingleConfig
 			currentDirectory = payload.SingleConfigDir
 
-			// Inject .gitignore patterns as global ignores. Run gitignore
-			// reading in parallel with Program registry construction. They are
-			// independent because Program construction only reads
-			// languageOptions.parserOptions.project, not Ignores).
-			rslintConfig, realProgramSet, err = parallelGitignoreAndPrograms(
-				rslintConfig, currentDirectory, fs, singleThreaded, parseCache,
-			)
+			if typeCheckOnly {
+				realProgramSet, err = createProgramSetForConfig(currentDirectory, rslintConfig, singleThreaded, fs, parseCache)
+			} else if buildAllPrograms {
+				rslintConfig, realProgramSet, err = parallelGitignoreAndPrograms(
+					rslintConfig, currentDirectory, fs, singleThreaded, parseCache,
+				)
+			} else {
+				rslintConfig = configWithGitignore(rslintConfig, currentDirectory, fs)
+			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
 				return 1
@@ -1267,7 +1270,12 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		}
 	} else {
 		// Load configuration from file (JSON config path, isJSConfig stays false)
-		rslintConfig, _, currentDirectory = rslintconfig.LoadConfigurationWithFallback(config, currentDirectory, fs)
+		loader := rslintconfig.NewConfigLoader(fs, currentDirectory)
+		rslintConfig, currentDirectory, err = loader.LoadRslintConfiguration(config)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
 		if config != "" {
 			// Explicit --config follows flat-config invocation semantics: file,
 			// ignore, project, and implicit no-args target scope are rooted at
@@ -1275,11 +1283,15 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			currentDirectory = workingDirectory
 		}
 
-		// Inject .gitignore patterns as global ignores. Run gitignore reading
-		// in parallel with Program registry construction (see above).
-		rslintConfig, realProgramSet, err = parallelGitignoreAndPrograms(
-			rslintConfig, currentDirectory, fs, singleThreaded, parseCache,
-		)
+		if typeCheckOnly {
+			realProgramSet, err = createProgramSetForConfig(currentDirectory, rslintConfig, singleThreaded, fs, parseCache)
+		} else if buildAllPrograms {
+			rslintConfig, realProgramSet, err = parallelGitignoreAndPrograms(
+				rslintConfig, currentDirectory, fs, singleThreaded, parseCache,
+			)
+		} else {
+			rslintConfig = configWithGitignore(rslintConfig, currentDirectory, fs)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			return 1
@@ -1317,7 +1329,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 
 	comparePathOptions := tspath.ComparePathsOptions{
 		CurrentDirectory:          cwd,
-		UseCaseSensitiveFileNames: fs.UseCaseSensitiveFileNames(),
+		UseCaseSensitiveFileNames: true,
 	}
 
 	// No args → implicit CWD scoping (same as `rslint .`), matching ESLint.
@@ -1329,6 +1341,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 
 	// --- Lint target discovery and fallback Program binding ---
 	programs := realProgramSet.Programs
+	programConfigMap := configMap
+	buildSingleConfigPrograms := buildAllPrograms
 	var (
 		targetPlan                 lintTargetPlan
 		typeInfoFiles              map[string]struct{}
@@ -1344,7 +1358,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			targetConfigMap,
 			targetRslintConfig,
 			currentDirectory,
-			configTargetFiles,
+			configTargetScopes,
 			fs,
 			allowFiles,
 			allowDirs,
@@ -1353,6 +1367,19 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			return 1
+		}
+		if !buildAllPrograms {
+			if configMap != nil {
+				programConfigMap = configsForLintTargetPlan(configMap, targetPlan)
+				realProgramSet, err = createProgramSetForConfigs(programConfigMap, singleThreaded, fs, parseCache)
+			} else if len(targetPlan.Targets) > 0 {
+				buildSingleConfigPrograms = true
+				realProgramSet, err = createProgramSetForConfig(currentDirectory, rslintConfig, singleThreaded, fs, parseCache)
+			}
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				return 1
+			}
 		}
 		binding, err := bindLintTargetPlan(realProgramSet, targetPlan, currentDirectory, fs, parseCache, singleThreaded)
 		if err != nil {
@@ -1367,10 +1394,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		ownerConfigDirBySourcePath = binding.OwnerConfigDirBySourcePath
 	}
 
-	// Initial build (including any fallback) is complete: evict cache
-	// entries for files that ended up in no program — build-time dedup
-	// losers, parsed-then-dropped duplicates. Deletion-only, see
-	// ParseCache.RetainOnly (I7).
+	// Initial build (including any fallback) is complete. Evict entries for
+	// parsed files that ended up in no Program.
 	parseCache.RetainOnly(programs)
 
 	// Rebuild real Programs and bind the original stable target plan again on
@@ -1380,8 +1405,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		var rebuilt lintProgramSet
 		var err error
 		if configMap != nil {
-			rebuilt, err = createProgramSetForConfigs(configMap, singleThreaded, fs, parseCache)
-		} else {
+			rebuilt, err = createProgramSetForConfigs(programConfigMap, singleThreaded, fs, parseCache)
+		} else if buildSingleConfigPrograms {
 			rebuilt, err = createProgramSetForConfig(currentDirectory, rslintConfig, singleThreaded, fs, parseCache)
 		}
 		if err != nil {
@@ -1414,9 +1439,9 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		CurrentDirectory:           currentDirectory,
 		EnforcePlugins:             enforcePlugins,
 		TypeInfoFiles:              typeInfoFiles,
-		TargetPathBySourcePath:     targetPathBySourcePath,
 		ConfigPathBySourcePath:     configPathBySourcePath,
 		OwnerConfigDirBySourcePath: ownerConfigDirBySourcePath,
+		SourceMappingsCanonical:    true,
 		FS:                         fs,
 	})
 	getRulesForFile := func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
@@ -1429,7 +1454,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// Programs not backed by a real tsconfig are excluded from --type-check:
 	// their CompilerOptions are synthesized defaults, not the user's tsconfig,
 	// so semantic diagnostics there would be unreliable. This includes the
-	// AST-only fallback used for selected files outside tsconfig coverage and
+	// non-project-backed fallback used for selected files outside tsconfig coverage and
 	// for projects with no tsconfig at all, honoring the "Gap files" contract
 	// in website/docs/en/guide/type-checking.md.
 	skipTypeCheck := buildTypeCheckSkipMask(programs)
@@ -1550,7 +1575,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// losers. The live set is the union of this round's programs and
 			// the initial ones — the initial slice stays referenced until the
 			// end of this function, so its objects are alive regardless and
-			// keeping their entries costs nothing (deletion-only, I7).
+			// keeping their entries costs nothing because RetainOnly only deletes.
 			parseCache.RetainOnly(append(slices.Clone(newPrograms), programs...))
 
 			// Re-lint using the fresh binding derived from the stable target plan.
@@ -1564,9 +1589,9 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				CurrentDirectory:           currentDirectory,
 				EnforcePlugins:             enforcePlugins,
 				TypeInfoFiles:              fixTypeInfoFiles,
-				TargetPathBySourcePath:     fixTargetPathBySourcePath,
 				ConfigPathBySourcePath:     newBinding.ConfigPathBySourcePath,
 				OwnerConfigDirBySourcePath: newBinding.OwnerConfigDirBySourcePath,
+				SourceMappingsCanonical:    true,
 				FS:                         fs,
 			})
 			fixGetRulesForFile := func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
@@ -1652,7 +1677,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		}
 	}
 
-	allDiags = deduplicateTypeScriptDiagnostics(allDiags, fs, preferredCallerTargetPaths(targetPlan, fs))
+	allDiags = deduplicateTypeScriptDiagnostics(allDiags, fs, preferredCallerTargetPaths(targetPlan))
 
 	// Diagnostics arrive in completion order — programs and, within a
 	// program, file shards run in parallel — so impose a deterministic

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -677,7 +677,7 @@ func applyFixPass(diagnosticsByFile map[string][]rule.RuleDiagnostic) int {
 type allowFileWarningKind int
 
 const (
-	allowFileNotInProgram allowFileWarningKind = iota
+	allowFileNotFound allowFileWarningKind = iota
 	allowFileIgnored
 )
 
@@ -696,8 +696,8 @@ type allowFileWarning struct {
 func formatAllowFileWarning(w allowFileWarning, opts tspath.ComparePathsOptions) string {
 	rel := tspath.ConvertToRelativePath(w.Path, opts)
 	switch w.Kind {
-	case allowFileNotInProgram:
-		return fmt.Sprintf("warning: %s was not found in the project, skipping", rel)
+	case allowFileNotFound:
+		return fmt.Sprintf("warning: %s was not found, skipping", rel)
 	case allowFileIgnored:
 		return fmt.Sprintf("warning: %s is ignored because of a matching ignore pattern", rel)
 	}
@@ -705,10 +705,10 @@ func formatAllowFileWarning(w allowFileWarning, opts tspath.ComparePathsOptions)
 }
 
 // collectAllowFileWarnings explains, for each CLI-specified file in
-// allowFiles, why it won't be visited by Phase 1 (lint). A file lands in
-// the result if it is outside every Program, or if it is in some Program
-// but the nearest config's `ignores` patterns exclude it. Returns nil for
-// empty allowFiles.
+// allowFiles, why it won't be visited by Phase 1 (lint). Program membership
+// is deliberately not consulted: lint targets are resolved before type-info
+// binding, so a file outside every tsconfig can still be linted via fallback.
+// Returns nil for empty allowFiles.
 //
 // This is a Phase-1 concern only. In --type-check-only mode the lint phase
 // is skipped, so callers MUST gate emission on `!typeCheckOnly` — otherwise
@@ -726,12 +726,6 @@ func collectAllowFileWarnings(
 	if len(allowFiles) == 0 {
 		return nil
 	}
-	programFiles := make(map[string]struct{})
-	for _, prog := range programs {
-		for _, sf := range prog.GetSourceFiles() {
-			programFiles[sf.FileName()] = struct{}{}
-		}
-	}
 
 	// Cache FindNearestConfig results by directory to avoid redundant lookups
 	// when many files are in the same directory (e.g., lint-staged).
@@ -743,28 +737,30 @@ func collectAllowFileWarnings(
 
 	var out []allowFileWarning
 	for _, f := range allowFiles {
-		if _, inProgram := programFiles[f]; !inProgram {
-			out = append(out, allowFileWarning{Path: f, Kind: allowFileNotInProgram})
-			continue
-		}
-		// File is in a Program — check if config would assign rules
-		var merged *rslintconfig.MergedConfig
+		var cfgDir string
+		var cfg rslintconfig.RslintConfig
 		if configMap != nil {
 			dir := tspath.GetDirectoryPath(f)
 			cached, ok := dirConfigCache[dir]
 			if !ok {
-				cfgDir, cfg := rslintconfig.FindNearestConfig(f, configMap)
-				cached = &cachedConfig{cfgDir: cfgDir, cfg: cfg}
+				foundDir, foundCfg := rslintconfig.FindNearestConfig(f, configMap)
+				cached = &cachedConfig{cfgDir: foundDir, cfg: foundCfg}
 				dirConfigCache[dir] = cached
 			}
-			if cached.cfg != nil {
-				merged = cached.cfg.GetConfigForFile(f, cached.cfgDir)
-			}
+			cfgDir = cached.cfgDir
+			cfg = cached.cfg
 		} else {
-			merged = rslintConfig.GetConfigForFile(f, currentDirectory)
+			cfgDir = currentDirectory
+			cfg = rslintConfig
 		}
-		if merged == nil {
+		if cfg != nil && cfg.IsFileIgnored(f, cfgDir) {
 			out = append(out, allowFileWarning{Path: f, Kind: allowFileIgnored})
+			continue
+		}
+
+		if _, err := os.Stat(f); err != nil {
+			out = append(out, allowFileWarning{Path: f, Kind: allowFileNotFound})
+			continue
 		}
 	}
 	return out
@@ -804,6 +800,17 @@ func validateTypeCheckOnlyFlags(typeCheckOnly, fix bool, ruleFlags []string) (in
 		return 2, "error: --rule cannot be combined with --type-check-only (no lint rules run)"
 	}
 	return 0, ""
+}
+
+func cloneConfigMap(configMap map[string]rslintconfig.RslintConfig) map[string]rslintconfig.RslintConfig {
+	if configMap == nil {
+		return nil
+	}
+	cloned := make(map[string]rslintconfig.RslintConfig, len(configMap))
+	for dir, cfg := range configMap {
+		cloned[dir] = slices.Clone(cfg)
+	}
+	return cloned
 }
 
 // resolveStartTime returns the start time for timing output.
@@ -898,9 +905,9 @@ func parseLintFlags(argv []string) (args lintArgs, help bool, fatalExitCode int)
 	return args, help, 0
 }
 
-// executeLintPipeline runs the full lint flow (config load → program build
-// → gap-file fallback → lint → optional --fix loop → report) and returns
-// the process exit code. Shared by the IPC entry (runCLI) and the wasm
+// executeLintPipeline runs the full lint flow (config load → program build →
+// lint target plan/fallback binding → lint → optional --fix loop → report) and
+// returns the process exit code. Shared by the IPC entry (runCLI) and the wasm
 // native fallback.
 func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.EslintPluginDispatcher) int {
 	// Unpack into locals so the pipeline body below stays verbatim — only the
@@ -975,6 +982,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		return 1
 	}
 	currentDirectory = tspath.NormalizePath(currentDirectory)
+	workingDirectory := currentDirectory
 
 	if init {
 		if err := rslintconfig.InitDefaultConfig(currentDirectory); err != nil {
@@ -1007,10 +1015,12 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// round-trips raw (byte-matching the worker's plugin map key). nil outside
 	// multi-config mode (single-config / JSON configs never mount plugins).
 	var originalConfigDir map[string]string
+	var configTargetFiles map[string][]string
 
 	programs := []*compiler.Program{}
 	// programConfigDirs tracks which configDir each program belongs to (parallel to programs).
-	// Used for ownership-based file deduplication in multi-config mode.
+	// Used when binding duplicate selected targets to the Program associated
+	// with the nearest config in multi-config mode.
 	var programConfigDirs []string
 
 	if configStdin {
@@ -1037,6 +1047,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// Multi-config format
 			configMap = payload.ConfigMap
 			originalConfigDir = payload.OriginalConfigDir
+			configTargetFiles = payload.ConfigTargetFiles
 
 			// Inject .gitignore patterns as global ignores for each config.
 			// Each config independently reads its own .gitignore tree:
@@ -1071,7 +1082,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// serial createProgramsForConfig loop below; that is safe because
 			// createProgramsForConfig only reads parserOptions.project, never
 			// Ignores, so observing the pre-augmentation configMap is fine.
-			// Results are merged after the loop — DiscoverGapFiles needs them.
+			// Results are merged after the loop — target discovery needs them.
 			type giResult struct {
 				configDir string
 				globs     []string
@@ -1106,7 +1117,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			}
 
 			// Join the gitignore reads and merge into configMap. Must complete
-			// before DiscoverGapFiles, which relies on the augmented configMap.
+			// before target discovery, which relies on the augmented configMap.
 			giWG.RunAndWait()
 			for _, r := range giResults {
 				configMap[r.configDir] = append(
@@ -1138,6 +1149,12 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	} else {
 		// Load configuration from file (JSON config path, isJSConfig stays false)
 		rslintConfig, _, currentDirectory = rslintconfig.LoadConfigurationWithFallback(config, currentDirectory, fs)
+		if config != "" {
+			// Explicit --config follows flat-config invocation semantics: file,
+			// ignore, project, and implicit no-args target scope are rooted at
+			// the cwd where rslint was invoked, not the config file's directory.
+			currentDirectory = workingDirectory
+		}
 
 		// Inject .gitignore patterns as global ignores. Run gitignore reading
 		// in parallel with createProgramsForConfig (see comment above).
@@ -1154,7 +1171,13 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		programs = append(programs, progs...)
 	}
 
-	// Apply --rule CLI overrides by appending a synthetic ConfigEntry (no files = matches all).
+	targetConfigMap := cloneConfigMap(configMap)
+	targetRslintConfig := slices.Clone(rslintConfig)
+
+	// Apply --rule CLI overrides by appending a synthetic ConfigEntry. Target
+	// discovery below intentionally uses the pre-override config snapshots
+	// above, so --rule overlays already-selected lint targets without widening
+	// discovery by itself.
 	if len(ruleFlags) > 0 {
 		cliEntry, err := rslintconfig.BuildCLIRuleEntry(ruleFlags)
 		if err != nil {
@@ -1175,58 +1198,58 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// Use CWD for display paths (not any config directory).
 	// In multi-config mode, currentDirectory was never reassigned from os.Getwd(),
 	// so it already holds the normalized CWD.
-	cwd := currentDirectory
+	cwd := workingDirectory
 
 	comparePathOptions := tspath.ComparePathsOptions{
 		CurrentDirectory:          cwd,
 		UseCaseSensitiveFileNames: fs.UseCaseSensitiveFileNames(),
 	}
 
-	// No args → implicit CWD scoping (same as `rslint .`).
-	// Only applies to multi-config stdin path. In this mode, configs may include
-	// parent or nested configs, so Programs may contain files outside CWD.
-	// Without scoping, all those files would be linted unexpectedly.
-	if len(allowFiles) == 0 && len(allowDirs) == 0 && configStdin && configMap != nil {
+	// No args → implicit CWD scoping (same as `rslint .`), matching ESLint.
+	// This keeps an explicit --config outside the current directory from
+	// widening the scanned root to the config file's directory.
+	if len(allowFiles) == 0 && len(allowDirs) == 0 {
 		allowDirs = []string{cwd}
 	}
 
-	// --- Gap file discovery and fallback Program ---
-	// Discover files that match config `files` patterns but are not in any
-	// tsconfig Program. These "gap" files get a fallback Program (AST-only,
-	// no type info) and only run non-type-aware rules. Shared verbatim with
-	// the --api path (HandleLint) via buildProgramsWithGapFallback, so both
-	// resolve gap files, the fallback Program, and the type-info set (the
-	// type-aware gate's only input) identically. cwd == currentDirectory here
-	// (see above), so passing currentDirectory preserves prior behavior.
-	programs, typeInfoFiles, capturedGapFiles := buildProgramsWithGapFallback(
-		programs, configMap, rslintConfig, currentDirectory, fs, allowFiles, allowDirs, parseCache, singleThreaded,
+	// --- Lint target discovery and fallback Program binding ---
+	// Resolve the exact lint target set independently from Program membership,
+	// then bind selected files to existing Programs or an AST-only fallback
+	// Program. Shared with the --api path via buildProgramsWithLintTargets, so
+	// target discovery, fallback creation, and type-aware gating stay aligned.
+	programs, typeInfoFiles, capturedGapFiles, targetFiles, targetsByProgram := buildProgramsWithLintTargets(
+		programs, targetConfigMap, targetRslintConfig, currentDirectory, programConfigDirs, configTargetFiles, fs, allowFiles, allowDirs, parseCache, singleThreaded,
 	)
 
-	// Initial build (including the gap fallback) is complete: evict cache
+	// Initial build (including any fallback) is complete: evict cache
 	// entries for files that ended up in no program — build-time dedup
 	// losers, parsed-then-dropped duplicates. Deletion-only, see
 	// ParseCache.RetainOnly (I7).
 	parseCache.RetainOnly(programs)
 
 	// createPrograms rebuilds programs (needed for multi-pass --fix re-linting).
-	// The gap-file fallback is appended last, but callers no longer need its
+	// The fallback is appended last, but callers no longer need its
 	// index: buildTypeCheckSkipMask reads each program's ConfigFilePath to decide
 	// what to exclude from type-check.
-	createPrograms := func() ([]*compiler.Program, error) {
+	createPrograms := func() ([]*compiler.Program, []string, error) {
 		var baseProgs []*compiler.Program
+		var baseProgramConfigDirs []string
 		if configMap != nil {
 			seen := make(map[string]struct{})
 			for configDir, entries := range configMap {
 				progs, exitCode := createProgramsForConfig(configDir, entries, singleThreaded, fs, seen, parseCache)
 				if exitCode != 0 {
-					return nil, fmt.Errorf("failed to create programs for %s", configDir)
+					return nil, nil, fmt.Errorf("failed to create programs for %s", configDir)
+				}
+				for range progs {
+					baseProgramConfigDirs = append(baseProgramConfigDirs, configDir)
 				}
 				baseProgs = append(baseProgs, progs...)
 			}
 		} else {
 			progs, exitCode := createProgramsForConfig(currentDirectory, rslintConfig, singleThreaded, fs, nil, parseCache)
 			if exitCode != 0 {
-				return nil, errors.New("failed to create programs")
+				return nil, nil, errors.New("failed to create programs")
 			}
 			baseProgs = append(baseProgs, progs...)
 		}
@@ -1239,7 +1262,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			}
 		}
 
-		return baseProgs, nil
+		return baseProgs, baseProgramConfigDirs, nil
 	}
 
 	// Phase 1: Collect all diagnostics (no printing yet).
@@ -1272,9 +1295,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		return rslintconfig.GlobalRuleRegistry.GetActiveRulesForFile(rslintConfig, filePath, currentDirectory, enforcePlugins, typeInfoFiles)
 	}
 
-	// Build per-program file filters combining:
-	//   - multi-config ownership deduplication (ESLint v10 aligned)
-	//   - config `ignores` exclusion (applies to rules and counts)
+	// Build per-program file filters for global ignores. Target ownership and
+	// deduplication were already resolved in targetsByProgram.
 	fileFilters := buildFileFilters(programs, configMap, programConfigDirs, rslintConfig, currentDirectory)
 
 	// Programs not backed by a real tsconfig (the gap-file fallback AND the
@@ -1297,6 +1319,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		SingleThreaded:        singleThreaded,
 		Scope:                 linter.FileScope{Files: allowFiles, Dirs: allowDirs},
 		PerProgramFilter:      toFileFilters(fileFilters),
+		TargetFiles:           targetsByProgram,
 		GetRulesForFile:       rulesForFile,
 		TypeInfoFiles:         typeInfoFiles,
 		TypeCheck:             typeCheck,
@@ -1369,7 +1392,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		// Re-lint → fix → re-lint → fix → ... until stable or maxFixPasses.
 		// Skip if nothing was fixed in the first pass (no need to re-lint).
 		for pass := 1; pass < maxFixPasses && fixedCount > 0; pass++ {
-			newPrograms, err := createPrograms()
+			newPrograms, newProgramConfigDirs, err := createPrograms()
 			if err != nil || len(newPrograms) == 0 {
 				break
 			}
@@ -1383,8 +1406,9 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			parseCache.RetainOnly(append(slices.Clone(newPrograms), programs...))
 
 			// Re-lint: collect remaining diagnostics.
-			// Rebuild file filters for the new programs (ownership + ignores).
-			fixFileFilters := buildFileFilters(newPrograms, configMap, programConfigDirs, rslintConfig, currentDirectory)
+			// Rebuild global-ignore filters for the new programs.
+			fixFileFilters := buildFileFilters(newPrograms, configMap, newProgramConfigDirs, rslintConfig, currentDirectory)
+			fixTargetsByProgram := assignLintTargetsToPrograms(newPrograms, targetConfigMap, newProgramConfigDirs, targetFiles, fs)
 			fixSkipMask := buildTypeCheckSkipMask(newPrograms)
 			var passDiags []rule.RuleDiagnostic
 			fixRunOpts := linter.RunLinterOptions{
@@ -1392,6 +1416,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				SingleThreaded:        singleThreaded,
 				Scope:                 linter.FileScope{Files: allowFiles, Dirs: allowDirs},
 				PerProgramFilter:      toFileFilters(fixFileFilters),
+				TargetFiles:           fixTargetsByProgram,
 				GetRulesForFile:       getRulesForFile,
 				TypeInfoFiles:         typeInfoFiles,
 				TypeCheck:             typeCheck,

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -1203,7 +1203,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// then bind selected files to existing Programs or an AST-only fallback
 	// Program. Shared with the --api path via buildProgramsWithLintTargets, so
 	// target discovery, fallback creation, and type-aware gating stay aligned.
-	programs, typeInfoFiles, capturedGapFiles, targetFiles, targetsByProgram := buildProgramsWithLintTargets(
+	programs, typeInfoFiles, capturedGapFiles, targetFiles, targetsByProgram, configPathBySourcePath := buildProgramsWithLintTargets(
 		programs,
 		targetConfigMap,
 		targetRslintConfig,
@@ -1285,6 +1285,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		currentDirectory,
 		enforcePlugins,
 		typeInfoFiles,
+		configPathBySourcePath,
 	)
 	getRulesForFile := func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 		return fileConfigResolver.ActiveRulesForFile(sourceFile.FileName())
@@ -1413,8 +1414,27 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 
 			// Re-lint: collect remaining diagnostics.
 			fixProgramIndex := buildProgramFileIndex(newPrograms, fs, singleThreaded)
-			fixTargetsByProgram := assignLintTargetsToPrograms(newPrograms, targetConfigMap, newProgramConfigDirs, targetFiles, fixProgramIndex)
+			fixTargetsByProgram, fixConfigPathBySourcePath := assignLintTargetsToPrograms(newPrograms, targetConfigMap, newProgramConfigDirs, targetFiles, fixProgramIndex, fs)
 			fixSkipMask := buildTypeCheckSkipMask(newPrograms)
+			fixTypeInfoFiles := buildTypeInfoFilesForPrograms(newPrograms, fixSkipMask, fs, singleThreaded)
+			fixConfigResolver := newLintConfigResolver(
+				configMap,
+				rslintConfig,
+				currentDirectory,
+				enforcePlugins,
+				fixTypeInfoFiles,
+				fixConfigPathBySourcePath,
+			)
+			fixGetRulesForFile := func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+				return fixConfigResolver.ActiveRulesForFile(sourceFile.FileName())
+			}
+			var fixRulesForFile linter.RuleHandler
+			if !typeCheckOnly {
+				fixRulesForFile = fixGetRulesForFile
+			}
+			fixShouldReportLintSyntax := func(filePath string) bool {
+				return fixConfigResolver.ConfigForFile(filePath) != nil
+			}
 			var passDiags []rule.RuleDiagnostic
 			passDiags = append(passDiags, collectTargetSyntacticDiagnostics(
 				newPrograms,
@@ -1422,15 +1442,15 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				fixSkipMask,
 				typeCheck,
 				typeCheckOnly,
-				shouldReportLintSyntax,
+				fixShouldReportLintSyntax,
 			)...)
 			fixRunOpts := linter.RunLinterOptions{
 				Programs:              newPrograms,
 				SingleThreaded:        singleThreaded,
 				Scope:                 linter.FileScope{Files: allowFiles, Dirs: allowDirs},
 				TargetFiles:           fixTargetsByProgram,
-				GetRulesForFile:       getRulesForFile,
-				TypeInfoFiles:         typeInfoFiles,
+				GetRulesForFile:       fixRulesForFile,
+				TypeInfoFiles:         fixTypeInfoFiles,
 				TypeCheck:             typeCheck,
 				SkipTypeCheckPrograms: fixSkipMask,
 				OnDiagnostic: func(d rule.RuleDiagnostic) {
@@ -1444,7 +1464,10 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// plugin diagnostics from being lost when allDiags is replaced.
 			var fixPluginCh <-chan []rule.RuleDiagnostic
 			if hasEslintPlugins {
-				fixPluginInputs := buildPluginFileInputs(fixRunOpts, pluginResolver)
+				fixPluginInputs := buildPluginFileInputs(fixRunOpts, pluginConfigResolver{
+					lintResolver:      fixConfigResolver,
+					originalConfigDir: originalConfigDir,
+				})
 				fixPluginCh = dispatchPluginLintAsync(ctx, dispatch, fixPluginInputs, fix, pluginSuggestionsMode(fix))
 			}
 			passResult, _ := linter.RunLinter(fixRunOpts)

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -1291,9 +1291,9 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		return rslintconfig.GlobalRuleRegistry.GetActiveRulesForFile(rslintConfig, filePath, currentDirectory, enforcePlugins, typeInfoFiles)
 	}
 
-	// Build per-program file filters for global ignores. Target ownership and
-	// deduplication were already resolved in targetsByProgram.
-	fileFilters := buildFileFilters(programs, configMap, programConfigDirs, rslintConfig, currentDirectory)
+	// Target discovery already excluded default paths, global ignores, and
+	// .gitignore entries. Target ownership and deduplication were already
+	// resolved in targetsByProgram.
 	shouldReportLintSyntax := func(filePath string) bool {
 		if configMap != nil {
 			cfgDir, cfg := rslintconfig.FindNearestConfig(filePath, configMap)
@@ -1332,7 +1332,6 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		Programs:              programs,
 		SingleThreaded:        singleThreaded,
 		Scope:                 linter.FileScope{Files: allowFiles, Dirs: allowDirs},
-		PerProgramFilter:      toFileFilters(fileFilters),
 		TargetFiles:           targetsByProgram,
 		GetRulesForFile:       rulesForFile,
 		TypeInfoFiles:         typeInfoFiles,
@@ -1420,8 +1419,6 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			parseCache.RetainOnly(append(slices.Clone(newPrograms), programs...))
 
 			// Re-lint: collect remaining diagnostics.
-			// Rebuild global-ignore filters for the new programs.
-			fixFileFilters := buildFileFilters(newPrograms, configMap, newProgramConfigDirs, rslintConfig, currentDirectory)
 			fixTargetsByProgram := assignLintTargetsToPrograms(newPrograms, targetConfigMap, newProgramConfigDirs, targetFiles, fs)
 			fixSkipMask := buildTypeCheckSkipMask(newPrograms)
 			var passDiags []rule.RuleDiagnostic
@@ -1437,7 +1434,6 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				Programs:              newPrograms,
 				SingleThreaded:        singleThreaded,
 				Scope:                 linter.FileScope{Files: allowFiles, Dirs: allowDirs},
-				PerProgramFilter:      toFileFilters(fixFileFilters),
 				TargetFiles:           fixTargetsByProgram,
 				GetRulesForFile:       getRulesForFile,
 				TypeInfoFiles:         typeInfoFiles,

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -893,7 +893,7 @@ func parseLintFlags(argv []string) (args lintArgs, help bool, fatalExitCode int)
 			// config matching, dir scoping, and gitignore checks.
 			// Edge cases (e.g. user passes a symlink-resolved absolute path)
 			// are handled by isFileAllowed's os.SameFile fallback in linter.go
-			// and CollectProgramFiles's Realpath'd keys in create_program.go.
+			// and program file index realpath aliases during target binding.
 			normalized := tspath.NormalizePath(absPath)
 			info, statErr := os.Stat(absPath)
 			if statErr == nil && info.IsDir() {
@@ -1279,27 +1279,22 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	}()
 
 	enforcePlugins := configStdin // JS/TS configs loaded via stdin require plugin declarations
+	fileConfigResolver := newLintConfigResolver(
+		configMap,
+		rslintConfig,
+		currentDirectory,
+		enforcePlugins,
+		typeInfoFiles,
+	)
 	getRulesForFile := func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
-		filePath := sourceFile.FileName()
-		if configMap != nil {
-			cfgDir, cfg := rslintconfig.FindNearestConfig(filePath, configMap)
-			if cfg == nil {
-				return nil
-			}
-			return rslintconfig.GlobalRuleRegistry.GetActiveRulesForFile(cfg, filePath, cfgDir, enforcePlugins, typeInfoFiles)
-		}
-		return rslintconfig.GlobalRuleRegistry.GetActiveRulesForFile(rslintConfig, filePath, currentDirectory, enforcePlugins, typeInfoFiles)
+		return fileConfigResolver.ActiveRulesForFile(sourceFile.FileName())
 	}
 
 	// Target discovery already excluded default paths, global ignores, and
 	// .gitignore entries. Target ownership and deduplication were already
 	// resolved in targetsByProgram.
 	shouldReportLintSyntax := func(filePath string) bool {
-		if configMap != nil {
-			cfgDir, cfg := rslintconfig.FindNearestConfig(filePath, configMap)
-			return cfg != nil && cfg.GetConfigForFile(filePath, cfgDir) != nil
-		}
-		return rslintConfig.GetConfigForFile(filePath, currentDirectory) != nil
+		return fileConfigResolver.ConfigForFile(filePath) != nil
 	}
 
 	// Programs not backed by a real tsconfig are excluded from --type-check:
@@ -1349,10 +1344,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// feature.
 	hasEslintPlugins := len(args.EslintPlugins) > 0
 	pluginResolver := pluginConfigResolver{
-		configMap:         configMap,
+		lintResolver:      fileConfigResolver,
 		originalConfigDir: originalConfigDir,
-		rslintConfig:      rslintConfig,
-		currentDirectory:  currentDirectory,
 	}
 	var pluginCh <-chan []rule.RuleDiagnostic
 	if hasEslintPlugins {
@@ -1419,7 +1412,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			parseCache.RetainOnly(append(slices.Clone(newPrograms), programs...))
 
 			// Re-lint: collect remaining diagnostics.
-			fixTargetsByProgram := assignLintTargetsToPrograms(newPrograms, targetConfigMap, newProgramConfigDirs, targetFiles, fs)
+			fixProgramIndex := buildProgramFileIndex(newPrograms, fs, singleThreaded)
+			fixTargetsByProgram := assignLintTargetsToPrograms(newPrograms, targetConfigMap, newProgramConfigDirs, targetFiles, fixProgramIndex)
 			fixSkipMask := buildTypeCheckSkipMask(newPrograms)
 			var passDiags []rule.RuleDiagnostic
 			passDiags = append(passDiags, collectTargetSyntacticDiagnostics(

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -722,6 +722,7 @@ func collectAllowFileWarnings(
 	configMap map[string]rslintconfig.RslintConfig,
 	rslintConfig rslintconfig.RslintConfig,
 	currentDirectory string,
+	useCaseSensitive bool,
 ) []allowFileWarning {
 	if len(allowFiles) == 0 {
 		return nil
@@ -753,7 +754,8 @@ func collectAllowFileWarnings(
 			cfgDir = currentDirectory
 			cfg = rslintConfig
 		}
-		if cfg != nil && cfg.IsFileIgnored(f, cfgDir) {
+		if rslintconfig.IsDefaultExcludedPath(f, cfgDir, useCaseSensitive) ||
+			(cfg != nil && cfg.IsFileIgnored(f, cfgDir)) {
 			out = append(out, allowFileWarning{Path: f, Kind: allowFileIgnored})
 			continue
 		}
@@ -1061,28 +1063,12 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// the same predicate used by the linter — blocked dirs' files
 			// are never linted, so their .gitignore patterns are irrelevant.
 			//
-			// Concurrency:
-			//   - When singleThreaded is set, both stages run sequentially in
-			//     the main goroutine (no goroutines spawned at all).
-			//   - Otherwise, gitignore reads run in parallel across configs
-			//     (independent FS reads via cachedvfs, which is concurrent-
-			//     safe). createProgramsForConfig still runs serially in the
-			//     main goroutine — typescript-go's API is invoked one config
-			//     at a time. The two stages overlap: gitignore goroutines
-			//     run alongside the createPrograms loop.
-			//
 			// configMap is NOT mutated by gitignore goroutines; results are
 			// collected via channel and merged in the main goroutine after
 			// the createPrograms loop, so the createPrograms loop sees the
 			// pre-augmentation entries (createProgramsForConfig only reads
 			// languageOptions.parserOptions.project — Ignores entries are
 			// no-ops for it; verified in LoadTsConfigsFromRslintConfig).
-			// Read each config's gitignore on the shared WorkGroup (honoring
-			// --singleThreaded). In the parallel path these overlap with the
-			// serial createProgramsForConfig loop below; that is safe because
-			// createProgramsForConfig only reads parserOptions.project, never
-			// Ignores, so observing the pre-augmentation configMap is fine.
-			// Results are merged after the loop — target discovery needs them.
 			type giResult struct {
 				configDir string
 				globs     []string
@@ -1218,7 +1204,17 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// Program. Shared with the --api path via buildProgramsWithLintTargets, so
 	// target discovery, fallback creation, and type-aware gating stay aligned.
 	programs, typeInfoFiles, capturedGapFiles, targetFiles, targetsByProgram := buildProgramsWithLintTargets(
-		programs, targetConfigMap, targetRslintConfig, currentDirectory, programConfigDirs, configTargetFiles, fs, allowFiles, allowDirs, parseCache, singleThreaded,
+		programs,
+		targetConfigMap,
+		targetRslintConfig,
+		currentDirectory,
+		programConfigDirs,
+		configTargetFiles,
+		fs,
+		allowFiles,
+		allowDirs,
+		parseCache,
+		singleThreaded,
 	)
 
 	// Initial build (including any fallback) is complete: evict cache
@@ -1298,13 +1294,31 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// Build per-program file filters for global ignores. Target ownership and
 	// deduplication were already resolved in targetsByProgram.
 	fileFilters := buildFileFilters(programs, configMap, programConfigDirs, rslintConfig, currentDirectory)
+	shouldReportLintSyntax := func(filePath string) bool {
+		if configMap != nil {
+			cfgDir, cfg := rslintconfig.FindNearestConfig(filePath, configMap)
+			return cfg != nil && cfg.GetConfigForFile(filePath, cfgDir) != nil
+		}
+		return rslintConfig.GetConfigForFile(filePath, currentDirectory) != nil
+	}
 
-	// Programs not backed by a real tsconfig (the gap-file fallback AND the
-	// no-tsconfig directory-scan program) are excluded from --type-check: their
-	// CompilerOptions are synthesized defaults, not the user's tsconfig, so
-	// semantic diagnostics there would be unreliable. This honors the "Gap files"
-	// contract in website/docs/en/guide/type-checking.md.
+	// Programs not backed by a real tsconfig are excluded from --type-check:
+	// their CompilerOptions are synthesized defaults, not the user's tsconfig,
+	// so semantic diagnostics there would be unreliable. This includes the
+	// AST-only fallback used for selected files outside tsconfig coverage and
+	// for projects with no tsconfig at all, honoring the "Gap files" contract
+	// in website/docs/en/guide/type-checking.md.
 	skipTypeCheck := buildTypeCheckSkipMask(programs)
+	for _, diagnostic := range collectTargetSyntacticDiagnostics(
+		programs,
+		targetsByProgram,
+		skipTypeCheck,
+		typeCheck,
+		typeCheckOnly,
+		shouldReportLintSyntax,
+	) {
+		diagnosticsChan <- diagnostic
+	}
 
 	// In --type-check-only mode, skip the lint phase entirely by passing
 	// nil for GetRulesForFile. RunLinter's Phase 1 is gated on this being
@@ -1370,7 +1384,7 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// these are lint-phase concepts and would mislead users about Phase 2
 	// (which runs program-wide regardless of CLI scope and rslint ignores).
 	if !typeCheckOnly {
-		warnings := collectAllowFileWarnings(allowFiles, programs, configMap, rslintConfig, currentDirectory)
+		warnings := collectAllowFileWarnings(allowFiles, programs, configMap, rslintConfig, currentDirectory, fs.UseCaseSensitiveFileNames())
 		for _, w := range warnings {
 			fmt.Fprintln(os.Stderr, formatAllowFileWarning(w, comparePathOptions))
 		}
@@ -1411,6 +1425,14 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			fixTargetsByProgram := assignLintTargetsToPrograms(newPrograms, targetConfigMap, newProgramConfigDirs, targetFiles, fs)
 			fixSkipMask := buildTypeCheckSkipMask(newPrograms)
 			var passDiags []rule.RuleDiagnostic
+			passDiags = append(passDiags, collectTargetSyntacticDiagnostics(
+				newPrograms,
+				fixTargetsByProgram,
+				fixSkipMask,
+				typeCheck,
+				typeCheckOnly,
+				shouldReportLintSyntax,
+			)...)
 			fixRunOpts := linter.RunLinterOptions{
 				Programs:              newPrograms,
 				SingleThreaded:        singleThreaded,

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -31,18 +31,7 @@ import (
 func runLintPipelineForTest(t *testing.T, cwd string, args lintArgs) (int, string, string) {
 	t.Helper()
 
-	originalWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(cwd); err != nil {
-		t.Fatalf("chdir %s: %v", cwd, err)
-	}
-	defer func() {
-		if err := os.Chdir(originalWD); err != nil {
-			t.Fatalf("restore cwd: %v", err)
-		}
-	}()
+	t.Chdir(cwd)
 
 	stdoutR, stdoutW, err := os.Pipe()
 	if err != nil {

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,13 +17,67 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+func runLintPipelineForTest(t *testing.T, cwd string, args lintArgs) (int, string, string) {
+	t.Helper()
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("chdir %s: %v", cwd, err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	defer stdoutR.Close()
+	defer stderrR.Close()
+
+	originalStdout, originalStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = stdoutW, stderrW
+
+	code := executeLintPipeline(args, context.Background(), nil)
+
+	os.Stdout, os.Stderr = originalStdout, originalStderr
+	if err := stdoutW.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	if err := stderrW.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+
+	stdoutBytes, err := io.ReadAll(stdoutR)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	stderrBytes, err := io.ReadAll(stderrR)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	return code, string(stdoutBytes), string(stderrBytes)
+}
 
 // TestPrintDiagnosticUTF8 tests that printDiagnosticDefault correctly renders
 // UTF-8 characters (Chinese, Japanese, Korean, Emoji) in diagnostic output.
@@ -875,14 +931,14 @@ func TestShouldShortCircuitOutput_LintModeKeepsRunningOtherwise(t *testing.T) {
 // We test them separately so the policy (when to emit) and the wording
 // (what the message looks like) are pinned independently.
 
-func TestFormatAllowFileWarning_NotInProgram(t *testing.T) {
+func TestFormatAllowFileWarning_NotFound(t *testing.T) {
 	opts := tspath.ComparePathsOptions{CurrentDirectory: "/work", UseCaseSensitiveFileNames: true}
-	msg := formatAllowFileWarning(allowFileWarning{Path: "/work/missing.ts", Kind: allowFileNotInProgram}, opts)
+	msg := formatAllowFileWarning(allowFileWarning{Path: "/work/missing.ts", Kind: allowFileNotFound}, opts)
 	if !strings.Contains(msg, "missing.ts") {
 		t.Errorf("message should contain file name, got %q", msg)
 	}
-	if !strings.Contains(msg, "was not found in the project") {
-		t.Errorf("message should explain 'not in project', got %q", msg)
+	if !strings.Contains(msg, "was not found") {
+		t.Errorf("message should explain missing file, got %q", msg)
 	}
 	if !strings.Contains(msg, "skipping") {
 		t.Errorf("message should say 'skipping' (lint-side semantics), got %q", msg)
@@ -923,6 +979,231 @@ func TestCollectAllowFileWarnings_EmptyReturnsNil(t *testing.T) {
 	if got != nil {
 		t.Errorf("empty allowFiles (non-nil slice) should still produce nil, got %+v", got)
 	}
+}
+
+func TestCollectAllowFileWarnings_NoWarningForFilesScopeMiss(t *testing.T) {
+	program := createTestProgram(t, map[string]string{
+		"src/app.ts": "const value = 1;",
+	})
+	target := findProgramFileForTest(t, program, "src/app.ts")
+	configDir := tspath.GetDirectoryPath(tspath.GetDirectoryPath(target))
+
+	warnings := collectAllowFileWarnings(
+		[]string{target},
+		[]*compiler.Program{program},
+		nil,
+		rslintconfig.RslintConfig{
+			{Files: []string{"**/*.js"}, Rules: rslintconfig.Rules{"no-console": "error"}},
+		},
+		configDir,
+	)
+	if len(warnings) != 0 {
+		t.Fatalf("files scope miss should not emit warning, got %+v", warnings)
+	}
+}
+
+func TestCollectAllowFileWarnings_NoWarningForExistingFileOutsideProgram(t *testing.T) {
+	program := createTestProgram(t, map[string]string{
+		"src/app.ts": "const value = 1;",
+	})
+	target := filepath.Join(t.TempDir(), "outside.ts")
+	if err := os.WriteFile(target, []byte("const outside = 1;\n"), 0o644); err != nil {
+		t.Fatalf("write outside target: %v", err)
+	}
+	target = tspath.NormalizePath(target)
+
+	warnings := collectAllowFileWarnings(
+		[]string{target},
+		[]*compiler.Program{program},
+		nil,
+		rslintconfig.RslintConfig{
+			{Rules: rslintconfig.Rules{"no-console": "error"}},
+		},
+		tspath.GetDirectoryPath(target),
+	)
+	if len(warnings) != 0 {
+		t.Fatalf("existing files outside Program should be handled by fallback, got warnings %+v", warnings)
+	}
+}
+
+func TestCollectAllowFileWarnings_MissingFileWarns(t *testing.T) {
+	target := tspath.NormalizePath(filepath.Join(t.TempDir(), "missing.ts"))
+	warnings := collectAllowFileWarnings(
+		[]string{target},
+		nil,
+		nil,
+		rslintconfig.RslintConfig{
+			{Rules: rslintconfig.Rules{"no-console": "error"}},
+		},
+		tspath.GetDirectoryPath(target),
+	)
+	if len(warnings) != 1 {
+		t.Fatalf("expected one missing-file warning, got %+v", warnings)
+	}
+	if warnings[0].Kind != allowFileNotFound {
+		t.Fatalf("expected allowFileNotFound, got %+v", warnings[0])
+	}
+}
+
+func TestCollectAllowFileWarnings_GlobalIgnoreStillWarns(t *testing.T) {
+	program := createTestProgram(t, map[string]string{
+		"src/app.ts": "const value = 1;",
+	})
+	target := findProgramFileForTest(t, program, "src/app.ts")
+	configDir := tspath.GetDirectoryPath(tspath.GetDirectoryPath(target))
+
+	warnings := collectAllowFileWarnings(
+		[]string{target},
+		[]*compiler.Program{program},
+		nil,
+		rslintconfig.RslintConfig{
+			{Ignores: []string{"src/**"}},
+			{Rules: rslintconfig.Rules{"no-console": "error"}},
+		},
+		configDir,
+	)
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning, got %+v", warnings)
+	}
+	if warnings[0].Kind != allowFileIgnored {
+		t.Fatalf("expected allowFileIgnored, got %+v", warnings[0])
+	}
+}
+
+func TestCLIRuleOverlayDoesNotWidenTargetDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	write("a.ts", "debugger;\n")
+	write("b.js", "debugger;\n")
+
+	baseConfig := rslintconfig.RslintConfig{{
+		Files: []string{"**/*.ts"},
+		Rules: rslintconfig.Rules{"no-debugger": "off"},
+	}}
+	targetConfig := append(rslintconfig.RslintConfig(nil), baseConfig...)
+	cliEntry, err := rslintconfig.BuildCLIRuleEntry([]string{"no-debugger: error"})
+	if err != nil {
+		t.Fatalf("BuildCLIRuleEntry: %v", err)
+	}
+	activeConfig := append(append(rslintconfig.RslintConfig(nil), baseConfig...), *cliEntry)
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	parseCache := utils.NewParseCache()
+	programs, exitCode := createProgramsForConfig(dir, activeConfig, true, fs, nil, parseCache)
+	if exitCode != 0 {
+		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	}
+	programs, typeInfoFiles, _, targetFiles, targetsByProgram := buildProgramsWithLintTargets(
+		programs, nil, targetConfig, dir, nil, nil, fs, nil, []string{tspath.NormalizePath(dir)}, parseCache, true,
+	)
+	if len(targetFiles) != 1 || !strings.HasSuffix(targetFiles[0], "/a.ts") {
+		t.Fatalf("target discovery should stay TS-only despite --rule overlay, got %v", targetFiles)
+	}
+
+	rslintconfig.RegisterAllRules()
+	var diagnostics []rule.RuleDiagnostic
+	_, err = linter.RunLinter(linter.RunLinterOptions{
+		Programs:       programs,
+		SingleThreaded: true,
+		TargetFiles:    targetsByProgram,
+		TypeInfoFiles:  typeInfoFiles,
+		GetRulesForFile: func(sf *ast.SourceFile) []linter.ConfiguredRule {
+			return rslintconfig.GlobalRuleRegistry.GetActiveRulesForFile(activeConfig, sf.FileName(), dir, false, typeInfoFiles)
+		},
+		OnDiagnostic: func(d rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, d)
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	if len(diagnostics) != 1 {
+		t.Fatalf("expected one no-debugger diagnostic on a.ts only, got %+v", diagnostics)
+	}
+	if !strings.HasSuffix(diagnostics[0].FilePath, "/a.ts") {
+		t.Fatalf("expected diagnostic on a.ts, got %+v", diagnostics[0])
+	}
+}
+
+func TestCLIExplicitJSONConfigNoArgsScopesToInvocationCWD(t *testing.T) {
+	dir := t.TempDir()
+	childDir := filepath.Join(dir, "child")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+	write := func(base, name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(base, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	write(dir, "rslint.jsonc", `[{ "files": ["*.js"], "rules": { "no-debugger": "error" } }]`)
+	write(dir, "parent.js", "debugger;\n")
+	write(childDir, "child.js", "debugger;\n")
+
+	code, stdout, stderr := runLintPipelineForTest(t, childDir, lintArgs{
+		Config:         "../rslint.jsonc",
+		Format:         "jsonline",
+		NoColor:        true,
+		SingleThreaded: true,
+	})
+	if code != 1 {
+		t.Fatalf("expected no-debugger to fail on child.js, got code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, `"filePath":"child.js"`) {
+		t.Fatalf("expected child.js diagnostic relative to invocation cwd, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if strings.Contains(stdout, "parent.js") {
+		t.Fatalf("explicit --config must not widen no-args scope to config dir, stdout=%q", stdout)
+	}
+}
+
+func TestCLIExplicitFileOutsideFilesCountsWithNoRules(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "rslint.jsonc"), []byte(`[
+		{ "files": ["**/*.ts"], "rules": { "no-debugger": "error" } }
+	]`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	explicit := tspath.NormalizePath(filepath.Join(dir, "explicit.js"))
+	if err := os.WriteFile(explicit, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatalf("write explicit file: %v", err)
+	}
+
+	code, stdout, stderr := runLintPipelineForTest(t, dir, lintArgs{
+		Config:         "rslint.jsonc",
+		Format:         "default",
+		NoColor:        true,
+		SingleThreaded: true,
+		AllowFiles:     []string{explicit},
+	})
+	if code != 0 {
+		t.Fatalf("expected explicit files-scope miss to exit cleanly, got code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "linted 1 file with 0 rules") {
+		t.Fatalf("expected the explicit file to be counted with zero matching rules, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if strings.Contains(stdout, "no-debugger") {
+		t.Fatalf("files-scope miss must not run no-debugger, stdout=%q", stdout)
+	}
+}
+
+func findProgramFileForTest(t *testing.T, program *compiler.Program, suffix string) string {
+	t.Helper()
+	normalizedSuffix := strings.ReplaceAll(suffix, "\\", "/")
+	for _, sf := range program.GetSourceFiles() {
+		name := sf.FileName()
+		if strings.HasSuffix(name, normalizedSuffix) {
+			return name
+		}
+	}
+	t.Fatalf("program file with suffix %q not found", suffix)
+	return ""
 }
 
 // TestGitlabReportState_EmptyProducesEmptyArray verifies a run with no

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -960,11 +960,11 @@ func TestFormatAllowFileWarning_UnknownKindIsEmpty(t *testing.T) {
 func TestCollectAllowFileWarnings_EmptyReturnsNil(t *testing.T) {
 	// No allowFiles → no work, no warnings. Important so callers can rely
 	// on a non-nil result implying actual user-specified files.
-	got := collectAllowFileWarnings(nil, nil, nil, nil, "/work")
+	got := collectAllowFileWarnings(nil, nil, nil, nil, "/work", true)
 	if got != nil {
 		t.Errorf("empty allowFiles should produce nil, got %+v", got)
 	}
-	got = collectAllowFileWarnings([]string{}, nil, nil, nil, "/work")
+	got = collectAllowFileWarnings([]string{}, nil, nil, nil, "/work", true)
 	if got != nil {
 		t.Errorf("empty allowFiles (non-nil slice) should still produce nil, got %+v", got)
 	}
@@ -985,6 +985,7 @@ func TestCollectAllowFileWarnings_NoWarningForFilesScopeMiss(t *testing.T) {
 			{Files: []string{"**/*.js"}, Rules: rslintconfig.Rules{"no-console": "error"}},
 		},
 		configDir,
+		true,
 	)
 	if len(warnings) != 0 {
 		t.Fatalf("files scope miss should not emit warning, got %+v", warnings)
@@ -1009,6 +1010,7 @@ func TestCollectAllowFileWarnings_NoWarningForExistingFileOutsideProgram(t *test
 			{Rules: rslintconfig.Rules{"no-console": "error"}},
 		},
 		tspath.GetDirectoryPath(target),
+		true,
 	)
 	if len(warnings) != 0 {
 		t.Fatalf("existing files outside Program should be handled by fallback, got warnings %+v", warnings)
@@ -1025,6 +1027,7 @@ func TestCollectAllowFileWarnings_MissingFileWarns(t *testing.T) {
 			{Rules: rslintconfig.Rules{"no-console": "error"}},
 		},
 		tspath.GetDirectoryPath(target),
+		true,
 	)
 	if len(warnings) != 1 {
 		t.Fatalf("expected one missing-file warning, got %+v", warnings)
@@ -1050,6 +1053,35 @@ func TestCollectAllowFileWarnings_GlobalIgnoreStillWarns(t *testing.T) {
 			{Rules: rslintconfig.Rules{"no-console": "error"}},
 		},
 		configDir,
+		true,
+	)
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning, got %+v", warnings)
+	}
+	if warnings[0].Kind != allowFileIgnored {
+		t.Fatalf("expected allowFileIgnored, got %+v", warnings[0])
+	}
+}
+
+func TestCollectAllowFileWarnings_DefaultExcludedFileWarns(t *testing.T) {
+	dir := t.TempDir()
+	target := tspath.NormalizePath(filepath.Join(dir, "node_modules/pkg/a.ts"))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("const value = 1;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	warnings := collectAllowFileWarnings(
+		[]string{target},
+		nil,
+		nil,
+		rslintconfig.RslintConfig{
+			{Rules: rslintconfig.Rules{"no-console": "error"}},
+		},
+		tspath.NormalizePath(dir),
+		true,
 	)
 	if len(warnings) != 1 {
 		t.Fatalf("expected one warning, got %+v", warnings)
@@ -1179,6 +1211,64 @@ func TestCLIExplicitFileOutsideFilesCountsWithNoRules(t *testing.T) {
 	}
 	if strings.Contains(stdout, "no-debugger") {
 		t.Fatalf("files-scope miss must not run no-debugger, stdout=%q", stdout)
+	}
+}
+
+func TestCLIExplicitMalformedFileOutsideFilesSuppressesSyntaxDiagnostic(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "rslint.jsonc"), []byte(`[
+		{ "files": ["**/*.ts"], "rules": { "no-debugger": "error" } }
+	]`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	explicit := tspath.NormalizePath(filepath.Join(dir, "explicit.js"))
+	if err := os.WriteFile(explicit, []byte("const = ;\n"), 0o644); err != nil {
+		t.Fatalf("write explicit file: %v", err)
+	}
+
+	code, stdout, stderr := runLintPipelineForTest(t, dir, lintArgs{
+		Config:         "rslint.jsonc",
+		Format:         "default",
+		NoColor:        true,
+		SingleThreaded: true,
+		AllowFiles:     []string{explicit},
+	})
+	if code != 0 {
+		t.Fatalf("expected explicit files-scope miss to exit cleanly, got code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "linted 1 file with 0 rules") {
+		t.Fatalf("expected the explicit file to be counted with zero matching rules, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if strings.Contains(stdout, "TypeScript(") || strings.Contains(stderr, "TS1134") {
+		t.Fatalf("files-scope miss must not surface syntax diagnostics, stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestCLIExplicitMalformedFileWithRuleOverlayReportsSyntaxDiagnostic(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "rslint.jsonc"), []byte(`[
+		{ "files": ["**/*.ts"], "rules": {} }
+	]`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	explicit := tspath.NormalizePath(filepath.Join(dir, "explicit.js"))
+	if err := os.WriteFile(explicit, []byte("const = ;\n"), 0o644); err != nil {
+		t.Fatalf("write explicit file: %v", err)
+	}
+
+	code, stdout, stderr := runLintPipelineForTest(t, dir, lintArgs{
+		Config:         "rslint.jsonc",
+		Format:         "default",
+		NoColor:        true,
+		SingleThreaded: true,
+		AllowFiles:     []string{explicit},
+		RuleFlags:      []string{"no-debugger:error"},
+	})
+	if code != 1 {
+		t.Fatalf("expected syntax diagnostic to fail, got code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "TypeScript(TS") || !strings.Contains(stdout, "explicit.js") {
+		t.Fatalf("expected syntax diagnostic for explicit.js, stdout=%q stderr=%q", stdout, stderr)
 	}
 }
 

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -960,11 +961,11 @@ func TestFormatAllowFileWarning_UnknownKindIsEmpty(t *testing.T) {
 func TestCollectAllowFileWarnings_EmptyReturnsNil(t *testing.T) {
 	// No allowFiles → no work, no warnings. Important so callers can rely
 	// on a non-nil result implying actual user-specified files.
-	got := collectAllowFileWarnings(nil, nil, nil, nil, "/work", true)
+	got := collectAllowFileWarnings(nil, nil, nil, "/work", true)
 	if got != nil {
 		t.Errorf("empty allowFiles should produce nil, got %+v", got)
 	}
-	got = collectAllowFileWarnings([]string{}, nil, nil, nil, "/work", true)
+	got = collectAllowFileWarnings([]string{}, nil, nil, "/work", true)
 	if got != nil {
 		t.Errorf("empty allowFiles (non-nil slice) should still produce nil, got %+v", got)
 	}
@@ -979,7 +980,6 @@ func TestCollectAllowFileWarnings_NoWarningForFilesScopeMiss(t *testing.T) {
 
 	warnings := collectAllowFileWarnings(
 		[]string{target},
-		[]*compiler.Program{program},
 		nil,
 		rslintconfig.RslintConfig{
 			{Files: []string{"**/*.js"}, Rules: rslintconfig.Rules{"no-console": "error"}},
@@ -992,10 +992,7 @@ func TestCollectAllowFileWarnings_NoWarningForFilesScopeMiss(t *testing.T) {
 	}
 }
 
-func TestCollectAllowFileWarnings_NoWarningForExistingFileOutsideProgram(t *testing.T) {
-	program := createTestProgram(t, map[string]string{
-		"src/app.ts": "const value = 1;",
-	})
+func TestCollectAllowFileWarnings_NoWarningForExistingFile(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "outside.ts")
 	if err := os.WriteFile(target, []byte("const outside = 1;\n"), 0o644); err != nil {
 		t.Fatalf("write outside target: %v", err)
@@ -1004,7 +1001,6 @@ func TestCollectAllowFileWarnings_NoWarningForExistingFileOutsideProgram(t *test
 
 	warnings := collectAllowFileWarnings(
 		[]string{target},
-		[]*compiler.Program{program},
 		nil,
 		rslintconfig.RslintConfig{
 			{Rules: rslintconfig.Rules{"no-console": "error"}},
@@ -1013,7 +1009,7 @@ func TestCollectAllowFileWarnings_NoWarningForExistingFileOutsideProgram(t *test
 		true,
 	)
 	if len(warnings) != 0 {
-		t.Fatalf("existing files outside Program should be handled by fallback, got warnings %+v", warnings)
+		t.Fatalf("existing files should not produce warnings, got %+v", warnings)
 	}
 }
 
@@ -1021,7 +1017,6 @@ func TestCollectAllowFileWarnings_MissingFileWarns(t *testing.T) {
 	target := tspath.NormalizePath(filepath.Join(t.TempDir(), "missing.ts"))
 	warnings := collectAllowFileWarnings(
 		[]string{target},
-		nil,
 		nil,
 		rslintconfig.RslintConfig{
 			{Rules: rslintconfig.Rules{"no-console": "error"}},
@@ -1046,7 +1041,6 @@ func TestCollectAllowFileWarnings_GlobalIgnoreStillWarns(t *testing.T) {
 
 	warnings := collectAllowFileWarnings(
 		[]string{target},
-		[]*compiler.Program{program},
 		nil,
 		rslintconfig.RslintConfig{
 			{Ignores: []string{"src/**"}},
@@ -1076,7 +1070,6 @@ func TestCollectAllowFileWarnings_DefaultExcludedFileWarns(t *testing.T) {
 	warnings := collectAllowFileWarnings(
 		[]string{target},
 		nil,
-		nil,
 		rslintconfig.RslintConfig{
 			{Rules: rslintconfig.Rules{"no-console": "error"}},
 		},
@@ -1091,7 +1084,7 @@ func TestCollectAllowFileWarnings_DefaultExcludedFileWarns(t *testing.T) {
 	}
 }
 
-func TestCLIRuleOverlayDoesNotWidenTargetDiscovery(t *testing.T) {
+func TestCLIRuleOverlayDoesNotAlterTargetDiscovery(t *testing.T) {
 	dir := t.TempDir()
 	write := func(name, content string) {
 		t.Helper()
@@ -1115,15 +1108,27 @@ func TestCLIRuleOverlayDoesNotWidenTargetDiscovery(t *testing.T) {
 
 	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
 	parseCache := utils.NewParseCache()
-	programs, exitCode := createProgramsForConfig(dir, activeConfig, true, fs, nil, parseCache)
-	if exitCode != 0 {
-		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	programSet, err := createProgramSetForConfig(dir, activeConfig, true, fs, parseCache)
+	if err != nil {
+		t.Fatalf("createProgramSetForConfig: %v", err)
 	}
-	programs, typeInfoFiles, _, targetFiles, targetsByProgram, _ := buildProgramsWithLintTargets(
-		programs, nil, targetConfig, dir, nil, nil, fs, nil, []string{tspath.NormalizePath(dir)}, parseCache, true,
-	)
-	if len(targetFiles) != 1 || !strings.HasSuffix(targetFiles[0], "/a.ts") {
-		t.Fatalf("target discovery should stay TS-only despite --rule overlay, got %v", targetFiles)
+	targetPlan, err := resolveLintTargetPlan(nil, targetConfig, dir, nil, fs, nil, []string{tspath.NormalizePath(dir)}, true)
+	if err != nil {
+		t.Fatalf("resolveLintTargetPlan: %v", err)
+	}
+	binding, err := bindLintTargetPlan(programSet, targetPlan, dir, fs, parseCache, true)
+	if err != nil {
+		t.Fatalf("bindLintTargetPlan: %v", err)
+	}
+	programs := binding.Programs
+	typeInfoFiles := binding.TypeInfoFiles
+	targetsByProgram := binding.TargetsByProgram
+	targetFiles := make([]string, 0, len(targetPlan.Targets))
+	for _, target := range targetPlan.Targets {
+		targetFiles = append(targetFiles, target.Path)
+	}
+	if len(targetFiles) != 2 || !strings.HasSuffix(targetFiles[0], "/a.ts") || !strings.HasSuffix(targetFiles[1], "/b.js") {
+		t.Fatalf("target discovery should retain the default baseline despite --rule overlay, got %v", targetFiles)
 	}
 
 	rslintconfig.RegisterAllRules()
@@ -1143,11 +1148,13 @@ func TestCLIRuleOverlayDoesNotWidenTargetDiscovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunLinter: %v", err)
 	}
-	if len(diagnostics) != 1 {
-		t.Fatalf("expected one no-debugger diagnostic on a.ts only, got %+v", diagnostics)
+	if len(diagnostics) != 2 {
+		t.Fatalf("expected no-debugger diagnostics on both baseline targets, got %+v", diagnostics)
 	}
-	if !strings.HasSuffix(diagnostics[0].FilePath, "/a.ts") {
-		t.Fatalf("expected diagnostic on a.ts, got %+v", diagnostics[0])
+	diagnosticFiles := []string{diagnostics[0].FilePath, diagnostics[1].FilePath}
+	sort.Strings(diagnosticFiles)
+	if !strings.HasSuffix(diagnosticFiles[0], "/a.ts") || !strings.HasSuffix(diagnosticFiles[1], "/b.js") {
+		t.Fatalf("expected diagnostics on a.ts and b.js, got %+v", diagnostics)
 	}
 }
 
@@ -1214,7 +1221,7 @@ func TestCLIExplicitFileOutsideFilesCountsWithNoRules(t *testing.T) {
 	}
 }
 
-func TestCLIExplicitMalformedFileOutsideFilesSuppressesSyntaxDiagnostic(t *testing.T) {
+func TestCLIExplicitMalformedFileOutsideFilesReportsSyntaxDiagnostic(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "rslint.jsonc"), []byte(`[
 		{ "files": ["**/*.ts"], "rules": { "no-debugger": "error" } }
@@ -1222,7 +1229,7 @@ func TestCLIExplicitMalformedFileOutsideFilesSuppressesSyntaxDiagnostic(t *testi
 		t.Fatalf("write config: %v", err)
 	}
 	explicit := tspath.NormalizePath(filepath.Join(dir, "explicit.js"))
-	if err := os.WriteFile(explicit, []byte("const = ;\n"), 0o644); err != nil {
+	if err := os.WriteFile(explicit, []byte("debugger;\nconst = ;\n"), 0o644); err != nil {
 		t.Fatalf("write explicit file: %v", err)
 	}
 
@@ -1233,14 +1240,14 @@ func TestCLIExplicitMalformedFileOutsideFilesSuppressesSyntaxDiagnostic(t *testi
 		SingleThreaded: true,
 		AllowFiles:     []string{explicit},
 	})
-	if code != 0 {
-		t.Fatalf("expected explicit files-scope miss to exit cleanly, got code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	if code != 1 {
+		t.Fatalf("expected malformed explicit target to exit 1, got code=%d stdout=%q stderr=%q", code, stdout, stderr)
 	}
 	if !strings.Contains(stdout, "linted 1 file with 0 rules") {
 		t.Fatalf("expected the explicit file to be counted with zero matching rules, stdout=%q stderr=%q", stdout, stderr)
 	}
-	if strings.Contains(stdout, "TypeScript(") || strings.Contains(stderr, "TS1134") {
-		t.Fatalf("files-scope miss must not surface syntax diagnostics, stdout=%q stderr=%q", stdout, stderr)
+	if !strings.Contains(stdout, "TypeScript(TS1134)") {
+		t.Fatalf("selected zero-rule target must surface syntax diagnostics, stdout=%q stderr=%q", stdout, stderr)
 	}
 }
 
@@ -1269,6 +1276,9 @@ func TestCLIExplicitMalformedFileWithRuleOverlayReportsSyntaxDiagnostic(t *testi
 	}
 	if !strings.Contains(stdout, "TypeScript(TS") || !strings.Contains(stdout, "explicit.js") {
 		t.Fatalf("expected syntax diagnostic for explicit.js, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if strings.Contains(stdout, "no-debugger") {
+		t.Fatalf("rules must not run when parsing fails, stdout=%q stderr=%q", stdout, stderr)
 	}
 }
 
@@ -1391,5 +1401,119 @@ func TestGitlabFingerprint_CollisionsDeterministicallyDistinguished(t *testing.T
 	a2 := gitlabFingerprint(seen2, "f.ts", "rule", "msg", 1, 1, 1, 5)
 	if a != a2 {
 		t.Errorf("fingerprint should be deterministic, got %q then %q", a, a2)
+	}
+}
+
+func TestRemapDiagnosticTargetPaths(t *testing.T) {
+	diagnostics := []rule.RuleDiagnostic{
+		{FilePath: "/program/link.ts"},
+		{FilePath: "/program/unchanged.ts"},
+	}
+	remapDiagnosticTargetPaths(diagnostics, map[string]string{
+		"/program/link.ts": "/requested/real.ts",
+	})
+
+	if diagnostics[0].FilePath != "/requested/real.ts" {
+		t.Fatalf("expected requested target path, got %q", diagnostics[0].FilePath)
+	}
+	if diagnostics[1].FilePath != "/program/unchanged.ts" {
+		t.Fatalf("unexpected remap of unrelated diagnostic: %q", diagnostics[1].FilePath)
+	}
+}
+
+func TestDeduplicateTypeScriptDiagnosticsAcrossPathAliases(t *testing.T) {
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "real.ts")
+	aliasPath := filepath.Join(dir, "alias.ts")
+	if err := os.WriteFile(realPath, []byte("let value: = 1;\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realPath, aliasPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	base := rule.RuleDiagnostic{
+		RuleName: "TypeScript(TS1110)",
+		Range:    core.NewTextRange(11, 11),
+		Message:  rule.RuleMessage{Description: "Type expected."},
+	}
+	realDiagnostic := base
+	realDiagnostic.FilePath = realPath
+	aliasDiagnostic := base
+	aliasDiagnostic.FilePath = aliasPath
+	nonTypeScriptA := base
+	nonTypeScriptA.RuleName = "some-rule"
+	nonTypeScriptA.FilePath = realPath
+	nonTypeScriptB := nonTypeScriptA
+	nonTypeScriptB.FilePath = aliasPath
+
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	for name, diagnostics := range map[string][]rule.RuleDiagnostic{
+		"real-first":  {realDiagnostic, aliasDiagnostic, nonTypeScriptA, nonTypeScriptB},
+		"alias-first": {aliasDiagnostic, realDiagnostic, nonTypeScriptA, nonTypeScriptB},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := deduplicateTypeScriptDiagnostics(diagnostics, fsys)
+			if len(got) != 3 {
+				t.Fatalf("expected one TypeScript diagnostic and both rule diagnostics, got %d: %+v", len(got), got)
+			}
+			if got[0].FilePath != aliasPath {
+				t.Fatalf("expected deterministic lexical alias survivor %q, got %q", aliasPath, got[0].FilePath)
+			}
+		})
+	}
+}
+
+func TestDeduplicateTypeScriptDiagnosticsPrefersCallerTarget(t *testing.T) {
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "z-real.ts")
+	aliasPath := filepath.Join(dir, "a-alias.ts")
+	if err := os.WriteFile(realPath, []byte("let value: = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realPath, aliasPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	base := rule.RuleDiagnostic{
+		RuleName: "TypeScript(TS1110)",
+		Range:    core.NewTextRange(11, 11),
+		Message:  rule.RuleMessage{Description: "Type expected."},
+	}
+	realDiagnostic := base
+	realDiagnostic.FilePath = realPath
+	aliasDiagnostic := base
+	aliasDiagnostic.FilePath = aliasPath
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	preferred := map[string]string{canonicalFilesystemPathID(realPath, fsys): realPath}
+
+	got := deduplicateTypeScriptDiagnostics([]rule.RuleDiagnostic{aliasDiagnostic, realDiagnostic}, fsys, preferred)
+	if len(got) != 1 || got[0].FilePath != realPath {
+		t.Fatalf("expected caller-selected target %q to win over lexical alias, got %+v", realPath, got)
+	}
+	single := deduplicateTypeScriptDiagnostics([]rule.RuleDiagnostic{aliasDiagnostic}, fsys, preferred)
+	if single[0].FilePath != realPath {
+		t.Fatalf("expected a single aliased diagnostic to use caller target %q, got %+v", realPath, single)
+	}
+}
+
+func TestApplyFixPassReturnsWriteError(t *testing.T) {
+	diagnostic, _ := createTestDiagnostic(t, "a", 0, 1)
+	diagnostic.FixesPtr = &[]rule.RuleFix{{
+		Range: core.NewTextRange(0, 1),
+		Text:  "b",
+	}}
+	unwritablePath := t.TempDir()
+
+	fixed, err := applyFixPass(map[string][]rule.RuleDiagnostic{
+		unwritablePath: {diagnostic},
+	})
+	if err == nil {
+		t.Fatal("expected a write error")
+	}
+	if fixed != 0 {
+		t.Fatalf("failed write must not count as a fix, got %d", fixed)
+	}
+	if !strings.Contains(err.Error(), unwritablePath) {
+		t.Fatalf("write error must identify the target path, got %v", err)
 	}
 }

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -1084,6 +1084,46 @@ func TestCollectAllowFileWarnings_DefaultExcludedFileWarns(t *testing.T) {
 	}
 }
 
+func TestCollectAllowFileWarnings_KeepsLexicalConfigOwnersSeparate(t *testing.T) {
+	root := t.TempDir()
+	sharedDir := filepath.Join(root, "shared")
+	ownerA := filepath.Join(root, "a")
+	ownerB := filepath.Join(root, "b")
+	for _, dir := range []string{sharedDir, ownerA, ownerB} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(sharedDir, "index.ts"), []byte("export {};\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	for _, owner := range []string{ownerA, ownerB} {
+		if err := os.Symlink(sharedDir, filepath.Join(owner, "link")); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+	}
+
+	ownerA = tspath.NormalizePath(ownerA)
+	ownerB = tspath.NormalizePath(ownerB)
+	targetA := tspath.ResolvePath(ownerA, "link/index.ts")
+	targetB := tspath.ResolvePath(ownerB, "link/index.ts")
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	warnings := collectAllowFileWarnings(
+		[]string{targetA, targetB},
+		map[string]rslintconfig.RslintConfig{
+			ownerA: {{Ignores: []string{"link/**"}}},
+			ownerB: {{}},
+		},
+		nil,
+		root,
+		true,
+		fsys,
+	)
+	if len(warnings) != 1 || warnings[0].Path != targetA || warnings[0].Kind != allowFileIgnored {
+		t.Fatalf("expected only the target owned by config A to be ignored, got %+v", warnings)
+	}
+}
+
 func TestCLIRuleOverlayDoesNotAlterTargetDiscovery(t *testing.T) {
 	dir := t.TempDir()
 	write := func(name, content string) {
@@ -1155,6 +1195,46 @@ func TestCLIRuleOverlayDoesNotAlterTargetDiscovery(t *testing.T) {
 	sort.Strings(diagnosticFiles)
 	if !strings.HasSuffix(diagnosticFiles[0], "/a.ts") || !strings.HasSuffix(diagnosticFiles[1], "/b.js") {
 		t.Fatalf("expected diagnostics on a.ts and b.js, got %+v", diagnostics)
+	}
+}
+
+func TestPlainLintSkipsProjectResolutionWhenAllTargetsAreIgnored(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "rslint.json")
+	target := filepath.Join(dir, "ignored.ts")
+	if err := os.WriteFile(configPath, []byte(`[
+		{"ignores":["ignored.ts"]},
+		{
+			"languageOptions":{"parserOptions":{"project":["./missing.json"]}},
+			"rules":{"no-debugger":"error"}
+		}
+	]`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	// Deliberately malformed fixture: a global ignore removes it before Program
+	// creation and syntax diagnostics, rather than treating parse failure as an
+	// implicit ignore.
+	if err := os.WriteFile(target, []byte("const = ;\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	code, _, stderr := runLintPipelineForTest(t, dir, lintArgs{
+		Config:         configPath,
+		AllowFiles:     []string{tspath.NormalizePath(target)},
+		SingleThreaded: true,
+	})
+	if code != 0 {
+		t.Fatalf("plain lint resolved an inactive project: code=%d stderr=%s", code, stderr)
+	}
+
+	code, _, stderr = runLintPipelineForTest(t, dir, lintArgs{
+		Config:         configPath,
+		AllowFiles:     []string{tspath.NormalizePath(target)},
+		SingleThreaded: true,
+		TypeCheck:      true,
+	})
+	if code == 0 || !strings.Contains(stderr, "missing.json") {
+		t.Fatalf("type-check must resolve every configured project: code=%d stderr=%s", code, stderr)
 	}
 }
 
@@ -1502,10 +1582,10 @@ func TestApplyFixPassReturnsWriteError(t *testing.T) {
 		Range: core.NewTextRange(0, 1),
 		Text:  "b",
 	}}
-	unwritablePath := t.TempDir()
+	directoryPath := t.TempDir()
 
 	fixed, err := applyFixPass(map[string][]rule.RuleDiagnostic{
-		unwritablePath: {diagnostic},
+		directoryPath: {diagnostic},
 	})
 	if err == nil {
 		t.Fatal("expected a write error")
@@ -1513,7 +1593,7 @@ func TestApplyFixPassReturnsWriteError(t *testing.T) {
 	if fixed != 0 {
 		t.Fatalf("failed write must not count as a fix, got %d", fixed)
 	}
-	if !strings.Contains(err.Error(), unwritablePath) {
+	if !strings.Contains(err.Error(), directoryPath) {
 		t.Fatalf("write error must identify the target path, got %v", err)
 	}
 }

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -1119,7 +1119,7 @@ func TestCLIRuleOverlayDoesNotWidenTargetDiscovery(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
 	}
-	programs, typeInfoFiles, _, targetFiles, targetsByProgram := buildProgramsWithLintTargets(
+	programs, typeInfoFiles, _, targetFiles, targetsByProgram, _ := buildProgramsWithLintTargets(
 		programs, nil, targetConfig, dir, nil, nil, fs, nil, []string{tspath.NormalizePath(dir)}, parseCache, true,
 	)
 	if len(targetFiles) != 1 || !strings.HasSuffix(targetFiles[0], "/a.ts") {

--- a/cmd/rslint/eslint_plugin.go
+++ b/cmd/rslint/eslint_plugin.go
@@ -11,17 +11,13 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
-// pluginConfigResolver bundles everything needed to resolve, per file, the
-// eslint-plugin wire configKey + merged config. configMap/originalConfigDir are
-// the multi-config maps (normalized dir → entries, and normalized dir → the raw
-// dir the JS host sent); rslintConfig/currentDirectory are the single-config
-// fallback (which never mounts plugins). Bundling them keeps the normalized-vs-
-// raw two-map duality private to resolve().
+// pluginConfigResolver resolves the eslint-plugin wire configKey plus the
+// cached merged config for a file. lintResolver owns nearest-config selection;
+// originalConfigDir maps a normalized config dir back to the raw key the JS host
+// registered its worker pool under.
 type pluginConfigResolver struct {
-	configMap         map[string]rslintconfig.RslintConfig
+	lintResolver      *lintConfigResolver
 	originalConfigDir map[string]string
-	rslintConfig      rslintconfig.RslintConfig
-	currentDirectory  string
 }
 
 // resolve returns the worker wire configKey + merged config for filePath. Go
@@ -30,18 +26,18 @@ type pluginConfigResolver struct {
 // that is what the Node worker keys its plugin map on. POSIX / single-config
 // fall back to the normalized key, where raw == normalized.
 func (r pluginConfigResolver) resolve(filePath string) (wireKey string, merged *rslintconfig.MergedConfig) {
-	if r.configMap != nil {
-		cfgDir, cfg := rslintconfig.FindNearestConfig(filePath, r.configMap)
-		if cfg == nil {
-			return "", nil
-		}
-		wireKey = cfgDir
-		if raw, ok := r.originalConfigDir[cfgDir]; ok {
-			wireKey = raw
-		}
-		return wireKey, cfg.GetConfigForFile(filePath, cfgDir)
+	if r.lintResolver == nil {
+		return "", nil
 	}
-	return r.currentDirectory, r.rslintConfig.GetConfigForFile(filePath, r.currentDirectory)
+	cfgDir, resolver, ok := r.lintResolver.resolverForFile(filePath)
+	if !ok {
+		return "", nil
+	}
+	wireKey = cfgDir
+	if raw, ok := r.originalConfigDir[cfgDir]; ok {
+		wireKey = raw
+	}
+	return wireKey, resolver.ConfigForFile(filePath)
 }
 
 // buildPluginFileInputs collects, from RunLinter's lint targets, the files that

--- a/cmd/rslint/eslint_plugin.go
+++ b/cmd/rslint/eslint_plugin.go
@@ -12,17 +12,17 @@ import (
 )
 
 // pluginConfigResolver resolves the eslint-plugin wire configKey plus the
-// cached merged config for a file. lintResolver owns nearest-config selection;
-// originalConfigDir maps a normalized config dir back to the raw key the JS host
-// registered its worker pool under.
+// cached merged config for a file. lintResolver uses the target binding's
+// owning config when available; originalConfigDir maps a normalized config dir
+// back to the raw key the JS host registered its worker pool under.
 type pluginConfigResolver struct {
 	lintResolver      *lintConfigResolver
 	originalConfigDir map[string]string
 }
 
 // resolve returns the worker wire configKey + merged config for filePath. Go
-// matches the file against its NORMALIZED owning-config key (FindNearestConfig),
-// then echoes the RAW configDirectory the JS host sent as the wire configKey —
+// resolves the file against its normalized owning-config key, then echoes the
+// RAW configDirectory the JS host sent as the wire configKey —
 // that is what the Node worker keys its plugin map on. POSIX / single-config
 // fall back to the normalized key, where raw == normalized.
 func (r pluginConfigResolver) resolve(filePath string) (wireKey string, merged *rslintconfig.MergedConfig) {
@@ -30,7 +30,7 @@ func (r pluginConfigResolver) resolve(filePath string) (wireKey string, merged *
 		return "", nil
 	}
 	configPath := r.lintResolver.configPathFor(filePath)
-	cfgDir, resolver, ok := r.lintResolver.resolverForFile(configPath)
+	cfgDir, resolver, ok := r.lintResolver.resolverForFile(filePath, configPath)
 	if !ok {
 		return "", nil
 	}

--- a/cmd/rslint/eslint_plugin.go
+++ b/cmd/rslint/eslint_plugin.go
@@ -53,8 +53,8 @@ func buildPluginFileInputs(runOpts linter.RunLinterOptions, resolver pluginConfi
 	}
 	var inputs []linter.EslintPluginFileInput
 	for _, t := range targets {
-		// Short-circuit pure-native files before resolving their config (resolve
-		// re-runs GetConfigForFile), avoiding that cost across the whole repo.
+		// Pure-native files never need a plugin routing key or merged plugin maps.
+		// Skip that lookup before consulting the per-run config resolver.
 		if !hasEslintPluginRule(t.Rules) {
 			continue
 		}

--- a/cmd/rslint/eslint_plugin.go
+++ b/cmd/rslint/eslint_plugin.go
@@ -29,7 +29,8 @@ func (r pluginConfigResolver) resolve(filePath string) (wireKey string, merged *
 	if r.lintResolver == nil {
 		return "", nil
 	}
-	cfgDir, resolver, ok := r.lintResolver.resolverForFile(filePath)
+	configPath := r.lintResolver.configPathFor(filePath)
+	cfgDir, resolver, ok := r.lintResolver.resolverForFile(configPath)
 	if !ok {
 		return "", nil
 	}
@@ -37,7 +38,7 @@ func (r pluginConfigResolver) resolve(filePath string) (wireKey string, merged *
 	if raw, ok := r.originalConfigDir[cfgDir]; ok {
 		wireKey = raw
 	}
-	return wireKey, resolver.ConfigForFile(filePath)
+	return wireKey, resolver.ConfigForFile(configPath)
 }
 
 // buildPluginFileInputs collects, from RunLinter's lint targets, the files that

--- a/cmd/rslint/eslint_plugin_test.go
+++ b/cmd/rslint/eslint_plugin_test.go
@@ -200,10 +200,8 @@ func TestLintConfigResolver_UsesBoundOwnerForAliasedSource(t *testing.T) {
 		}},
 	}
 	sourcePath := "/repo/packages/app/a.ts"
-	targetPath := "/repo/link/a.ts"
 	resolver := newLintConfigResolver(lintConfigResolverOptions{
 		ConfigMap:                  configMap,
-		TargetPathBySourcePath:     map[string]string{sourcePath: targetPath},
 		OwnerConfigDirBySourcePath: map[string]string{sourcePath: "/repo"},
 	})
 
@@ -250,10 +248,10 @@ type caseInsensitiveResolverFS struct {
 
 func (f *caseInsensitiveResolverFS) UseCaseSensitiveFileNames() bool { return false }
 func (f *caseInsensitiveResolverFS) Realpath(filePath string) string {
-	return tspath.NormalizePath(filePath)
+	return strings.ToLower(tspath.NormalizePath(filePath))
 }
 
-func TestLintConfigResolver_SourceMappingsUseFilesystemCaseSemantics(t *testing.T) {
+func TestLintConfigResolver_SourceMappingsUseCanonicalFilesystemIdentity(t *testing.T) {
 	rslintconfig.RegisterAllRules()
 	fsys := &caseInsensitiveResolverFS{FS: osvfs.FS()}
 	sourcePath := "c:/repo/src/a.ts"
@@ -264,8 +262,7 @@ func TestLintConfigResolver_SourceMappingsUseFilesystemCaseSemantics(t *testing.
 				Rules: rslintconfig.Rules{"no-console": "error"},
 			}},
 		},
-		TargetPathBySourcePath: map[string]string{"C:/REPO/SRC/A.ts": "D:/caller/a.ts"},
-		ConfigPathBySourcePath: map[string]string{"C:/REPO/SRC/A.ts": "C:/Repo/src/a.ts"},
+		ConfigPathBySourcePath: map[string]string{"C:/REPO/SRC/A.ts": "c:/repo/src/a.ts"},
 		OwnerConfigDirBySourcePath: map[string]string{
 			"C:/REPO/SRC/A.ts": "c:/repo",
 		},

--- a/cmd/rslint/eslint_plugin_test.go
+++ b/cmd/rslint/eslint_plugin_test.go
@@ -28,7 +28,7 @@ func TestPluginConfigResolver_NormalizedMatchRawWireKey(t *testing.T) {
 
 	// Windows: file matches on the normalized key, wire key is the RAW string.
 	r := pluginConfigResolver{
-		lintResolver:      newLintConfigResolver(p.ConfigMap, nil, "", false, nil),
+		lintResolver:      newLintConfigResolver(p.ConfigMap, nil, "", false, nil, nil),
 		originalConfigDir: p.OriginalConfigDir,
 	}
 	wireKey, merged := r.resolve(norm + "/src/a.ts")
@@ -46,6 +46,7 @@ func TestPluginConfigResolver_NormalizedMatchRawWireKey(t *testing.T) {
 			nil,
 			"",
 			false,
+			nil,
 			nil,
 		),
 	}
@@ -120,7 +121,7 @@ func TestPluginConfigResolver_Branches(t *testing.T) {
 
 	// Multi-config, file under no config -> ("", nil).
 	r := pluginConfigResolver{
-		lintResolver:      newLintConfigResolver(p.ConfigMap, nil, "", false, nil),
+		lintResolver:      newLintConfigResolver(p.ConfigMap, nil, "", false, nil, nil),
 		originalConfigDir: p.OriginalConfigDir,
 	}
 	if wk, m := r.resolve("/elsewhere/a.ts"); wk != "" || m != nil {
@@ -129,7 +130,7 @@ func TestPluginConfigResolver_Branches(t *testing.T) {
 
 	// Single-config (configMap==nil): wireKey is currentDirectory; merged from rslintConfig.
 	single := pluginConfigResolver{
-		lintResolver: newLintConfigResolver(nil, p.ConfigMap["/proj"], "/proj", false, nil),
+		lintResolver: newLintConfigResolver(nil, p.ConfigMap["/proj"], "/proj", false, nil, nil),
 	}
 	if wk, m := single.resolve("/proj/a.ts"); wk != "/proj" || m == nil {
 		t.Errorf("single-config -> (currentDirectory, merged), got (%q, nil=%v)", wk, m == nil)
@@ -155,7 +156,7 @@ func TestLintConfigResolver_NearestConfigAndTypeInfoGate(t *testing.T) {
 	typeInfoFiles := map[string]struct{}{
 		"/repo/packages/app/src/typed.ts": {},
 	}
-	resolver := newLintConfigResolver(configMap, nil, "", false, typeInfoFiles)
+	resolver := newLintConfigResolver(configMap, nil, "", false, typeInfoFiles, nil)
 
 	gapRules := configuredRuleNameSet(resolver.ActiveRulesForFile("/repo/packages/app/src/gap.ts"))
 	if gapRules["@typescript-eslint/require-await"] {
@@ -180,6 +181,39 @@ func TestLintConfigResolver_NearestConfigAndTypeInfoGate(t *testing.T) {
 
 	if rules := resolver.ActiveRulesForFile("/outside/a.ts"); len(rules) != 0 {
 		t.Fatalf("expected file outside every config to have no rules, got %v", rules)
+	}
+}
+
+func TestLintConfigResolver_UsesConfigPathAliasForRulesAndGlobals(t *testing.T) {
+	rslintconfig.RegisterAllRules()
+
+	cfg := rslintconfig.RslintConfig{{
+		Files: []string{"src/**/*.ts"},
+		LanguageOptions: &rslintconfig.LanguageOptions{Raw: map[string]any{
+			"globals": map[string]any{
+				"aliasedGlobal": "readonly",
+			},
+		}},
+		Rules: rslintconfig.Rules{"no-console": "error"},
+	}}
+	resolver := newLintConfigResolver(
+		nil,
+		cfg,
+		"/repo",
+		false,
+		map[string]struct{}{"/outside/real-a.ts": {}},
+		map[string]string{"/outside/real-a.ts": "/repo/src/a.ts"},
+	)
+
+	rules := resolver.ActiveRulesForFile("/outside/real-a.ts")
+	if len(rules) != 1 || rules[0].Name != "no-console" {
+		t.Fatalf("expected aliased source path to use config path rules, got %v", configuredRuleNameSet(rules))
+	}
+	if !rules[0].Globals["aliasedGlobal"] {
+		t.Fatalf("expected aliased source path to carry globals from config path")
+	}
+	if resolver.ConfigForFile("/outside/real-a.ts") == nil {
+		t.Fatalf("expected aliased source path to resolve merged config")
 	}
 }
 

--- a/cmd/rslint/eslint_plugin_test.go
+++ b/cmd/rslint/eslint_plugin_test.go
@@ -27,7 +27,10 @@ func TestPluginConfigResolver_NormalizedMatchRawWireKey(t *testing.T) {
 	norm := tspath.NormalizePath(raw) // "C:/proj"
 
 	// Windows: file matches on the normalized key, wire key is the RAW string.
-	r := pluginConfigResolver{configMap: p.ConfigMap, originalConfigDir: p.OriginalConfigDir}
+	r := pluginConfigResolver{
+		lintResolver:      newLintConfigResolver(p.ConfigMap, nil, "", false, nil),
+		originalConfigDir: p.OriginalConfigDir,
+	}
 	wireKey, merged := r.resolve(norm + "/src/a.ts")
 	if wireKey != raw {
 		t.Errorf("wire configKey = %q, want RAW %q (not the normalized %q)", wireKey, raw, norm)
@@ -38,7 +41,13 @@ func TestPluginConfigResolver_NormalizedMatchRawWireKey(t *testing.T) {
 
 	// POSIX / no raw mapping: wireKey falls back to the (already-slash) key.
 	posix := pluginConfigResolver{
-		configMap: map[string]rslintconfig.RslintConfig{"/posix/proj": p.ConfigMap[norm]},
+		lintResolver: newLintConfigResolver(
+			map[string]rslintconfig.RslintConfig{"/posix/proj": p.ConfigMap[norm]},
+			nil,
+			"",
+			false,
+			nil,
+		),
 	}
 	if wk, m := posix.resolve("/posix/proj/a.ts"); wk != "/posix/proj" || m == nil {
 		t.Errorf("POSIX fallback: wireKey=%q merged-nil=%v, want /posix/proj + non-nil", wk, m == nil)
@@ -110,14 +119,74 @@ func TestPluginConfigResolver_Branches(t *testing.T) {
 	}
 
 	// Multi-config, file under no config -> ("", nil).
-	r := pluginConfigResolver{configMap: p.ConfigMap, originalConfigDir: p.OriginalConfigDir}
+	r := pluginConfigResolver{
+		lintResolver:      newLintConfigResolver(p.ConfigMap, nil, "", false, nil),
+		originalConfigDir: p.OriginalConfigDir,
+	}
 	if wk, m := r.resolve("/elsewhere/a.ts"); wk != "" || m != nil {
 		t.Errorf("no-match -> (\"\",nil), got (%q, nil=%v)", wk, m == nil)
 	}
 
 	// Single-config (configMap==nil): wireKey is currentDirectory; merged from rslintConfig.
-	single := pluginConfigResolver{rslintConfig: p.ConfigMap["/proj"], currentDirectory: "/proj"}
+	single := pluginConfigResolver{
+		lintResolver: newLintConfigResolver(nil, p.ConfigMap["/proj"], "/proj", false, nil),
+	}
 	if wk, m := single.resolve("/proj/a.ts"); wk != "/proj" || m == nil {
 		t.Errorf("single-config -> (currentDirectory, merged), got (%q, nil=%v)", wk, m == nil)
 	}
+}
+
+func TestLintConfigResolver_NearestConfigAndTypeInfoGate(t *testing.T) {
+	rslintconfig.RegisterAllRules()
+
+	configMap := map[string]rslintconfig.RslintConfig{
+		"/repo": {{
+			Files: []string{"**/*.ts"},
+			Rules: rslintconfig.Rules{"no-console": "error"},
+		}},
+		"/repo/packages/app": {{
+			Files: []string{"**/*.ts"},
+			Rules: rslintconfig.Rules{
+				"@typescript-eslint/require-await": "error",
+				"no-debugger":                      "error",
+			},
+		}},
+	}
+	typeInfoFiles := map[string]struct{}{
+		"/repo/packages/app/src/typed.ts": {},
+	}
+	resolver := newLintConfigResolver(configMap, nil, "", false, typeInfoFiles)
+
+	gapRules := configuredRuleNameSet(resolver.ActiveRulesForFile("/repo/packages/app/src/gap.ts"))
+	if gapRules["@typescript-eslint/require-await"] {
+		t.Fatal("expected type-aware app rule to be filtered for file without type info")
+	}
+	if !gapRules["no-debugger"] {
+		t.Fatal("expected nearest app config to enable no-debugger")
+	}
+	if gapRules["no-console"] {
+		t.Fatal("did not expect parent config rule for file owned by nearest app config")
+	}
+
+	typedRules := configuredRuleNameSet(resolver.ActiveRulesForFile("/repo/packages/app/src/typed.ts"))
+	if !typedRules["@typescript-eslint/require-await"] || !typedRules["no-debugger"] {
+		t.Fatalf("expected typed app file to keep both app rules, got %v", typedRules)
+	}
+
+	rootRules := configuredRuleNameSet(resolver.ActiveRulesForFile("/repo/root.ts"))
+	if !rootRules["no-console"] || rootRules["no-debugger"] {
+		t.Fatalf("expected root file to use root config only, got %v", rootRules)
+	}
+
+	if rules := resolver.ActiveRulesForFile("/outside/a.ts"); len(rules) != 0 {
+		t.Fatalf("expected file outside every config to have no rules, got %v", rules)
+	}
+}
+
+func configuredRuleNameSet(rules []linter.ConfiguredRule) map[string]bool {
+	names := make(map[string]bool, len(rules))
+	for _, r := range rules {
+		names[r.Name] = true
+	}
+	return names
 }

--- a/cmd/rslint/eslint_plugin_test.go
+++ b/cmd/rslint/eslint_plugin_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -28,7 +30,7 @@ func TestPluginConfigResolver_NormalizedMatchRawWireKey(t *testing.T) {
 
 	// Windows: file matches on the normalized key, wire key is the RAW string.
 	r := pluginConfigResolver{
-		lintResolver:      newLintConfigResolver(p.ConfigMap, nil, "", false, nil, nil),
+		lintResolver:      newLintConfigResolver(lintConfigResolverOptions{ConfigMap: p.ConfigMap}),
 		originalConfigDir: p.OriginalConfigDir,
 	}
 	wireKey, merged := r.resolve(norm + "/src/a.ts")
@@ -41,14 +43,9 @@ func TestPluginConfigResolver_NormalizedMatchRawWireKey(t *testing.T) {
 
 	// POSIX / no raw mapping: wireKey falls back to the (already-slash) key.
 	posix := pluginConfigResolver{
-		lintResolver: newLintConfigResolver(
-			map[string]rslintconfig.RslintConfig{"/posix/proj": p.ConfigMap[norm]},
-			nil,
-			"",
-			false,
-			nil,
-			nil,
-		),
+		lintResolver: newLintConfigResolver(lintConfigResolverOptions{
+			ConfigMap: map[string]rslintconfig.RslintConfig{"/posix/proj": p.ConfigMap[norm]},
+		}),
 	}
 	if wk, m := posix.resolve("/posix/proj/a.ts"); wk != "/posix/proj" || m == nil {
 		t.Errorf("POSIX fallback: wireKey=%q merged-nil=%v, want /posix/proj + non-nil", wk, m == nil)
@@ -121,7 +118,7 @@ func TestPluginConfigResolver_Branches(t *testing.T) {
 
 	// Multi-config, file under no config -> ("", nil).
 	r := pluginConfigResolver{
-		lintResolver:      newLintConfigResolver(p.ConfigMap, nil, "", false, nil, nil),
+		lintResolver:      newLintConfigResolver(lintConfigResolverOptions{ConfigMap: p.ConfigMap}),
 		originalConfigDir: p.OriginalConfigDir,
 	}
 	if wk, m := r.resolve("/elsewhere/a.ts"); wk != "" || m != nil {
@@ -130,7 +127,10 @@ func TestPluginConfigResolver_Branches(t *testing.T) {
 
 	// Single-config (configMap==nil): wireKey is currentDirectory; merged from rslintConfig.
 	single := pluginConfigResolver{
-		lintResolver: newLintConfigResolver(nil, p.ConfigMap["/proj"], "/proj", false, nil, nil),
+		lintResolver: newLintConfigResolver(lintConfigResolverOptions{
+			Config:           p.ConfigMap["/proj"],
+			CurrentDirectory: "/proj",
+		}),
 	}
 	if wk, m := single.resolve("/proj/a.ts"); wk != "/proj" || m == nil {
 		t.Errorf("single-config -> (currentDirectory, merged), got (%q, nil=%v)", wk, m == nil)
@@ -156,7 +156,10 @@ func TestLintConfigResolver_NearestConfigAndTypeInfoGate(t *testing.T) {
 	typeInfoFiles := map[string]struct{}{
 		"/repo/packages/app/src/typed.ts": {},
 	}
-	resolver := newLintConfigResolver(configMap, nil, "", false, typeInfoFiles, nil)
+	resolver := newLintConfigResolver(lintConfigResolverOptions{
+		ConfigMap:     configMap,
+		TypeInfoFiles: typeInfoFiles,
+	})
 
 	gapRules := configuredRuleNameSet(resolver.ActiveRulesForFile("/repo/packages/app/src/gap.ts"))
 	if gapRules["@typescript-eslint/require-await"] {
@@ -184,6 +187,32 @@ func TestLintConfigResolver_NearestConfigAndTypeInfoGate(t *testing.T) {
 	}
 }
 
+func TestLintConfigResolver_UsesBoundOwnerForAliasedSource(t *testing.T) {
+	rslintconfig.RegisterAllRules()
+
+	configMap := map[string]rslintconfig.RslintConfig{
+		"/repo": {{
+			Files: []string{"packages/app/*.ts"},
+			Rules: rslintconfig.Rules{"no-console": "error"},
+		}},
+		"/repo/packages/app": {{
+			Rules: rslintconfig.Rules{"no-debugger": "error"},
+		}},
+	}
+	sourcePath := "/repo/packages/app/a.ts"
+	targetPath := "/repo/link/a.ts"
+	resolver := newLintConfigResolver(lintConfigResolverOptions{
+		ConfigMap:                  configMap,
+		TargetPathBySourcePath:     map[string]string{sourcePath: targetPath},
+		OwnerConfigDirBySourcePath: map[string]string{sourcePath: "/repo"},
+	})
+
+	rules := configuredRuleNameSet(resolver.ActiveRulesForFile(sourcePath))
+	if !rules["no-console"] || rules["no-debugger"] {
+		t.Fatalf("expected the binding's root owner to win over source-path inference, got %v", rules)
+	}
+}
+
 func TestLintConfigResolver_UsesConfigPathAliasForRulesAndGlobals(t *testing.T) {
 	rslintconfig.RegisterAllRules()
 
@@ -196,14 +225,12 @@ func TestLintConfigResolver_UsesConfigPathAliasForRulesAndGlobals(t *testing.T) 
 		}},
 		Rules: rslintconfig.Rules{"no-console": "error"},
 	}}
-	resolver := newLintConfigResolver(
-		nil,
-		cfg,
-		"/repo",
-		false,
-		map[string]struct{}{"/outside/real-a.ts": {}},
-		map[string]string{"/outside/real-a.ts": "/repo/src/a.ts"},
-	)
+	resolver := newLintConfigResolver(lintConfigResolverOptions{
+		Config:                 cfg,
+		CurrentDirectory:       "/repo",
+		TypeInfoFiles:          map[string]struct{}{"/outside/real-a.ts": {}},
+		ConfigPathBySourcePath: map[string]string{"/outside/real-a.ts": "/repo/src/a.ts"},
+	})
 
 	rules := resolver.ActiveRulesForFile("/outside/real-a.ts")
 	if len(rules) != 1 || rules[0].Name != "no-console" {
@@ -214,6 +241,40 @@ func TestLintConfigResolver_UsesConfigPathAliasForRulesAndGlobals(t *testing.T) 
 	}
 	if resolver.ConfigForFile("/outside/real-a.ts") == nil {
 		t.Fatalf("expected aliased source path to resolve merged config")
+	}
+}
+
+type caseInsensitiveResolverFS struct {
+	vfs.FS
+}
+
+func (f *caseInsensitiveResolverFS) UseCaseSensitiveFileNames() bool { return false }
+func (f *caseInsensitiveResolverFS) Realpath(filePath string) string {
+	return tspath.NormalizePath(filePath)
+}
+
+func TestLintConfigResolver_SourceMappingsUseFilesystemCaseSemantics(t *testing.T) {
+	rslintconfig.RegisterAllRules()
+	fsys := &caseInsensitiveResolverFS{FS: osvfs.FS()}
+	sourcePath := "c:/repo/src/a.ts"
+	resolver := newLintConfigResolver(lintConfigResolverOptions{
+		ConfigMap: map[string]rslintconfig.RslintConfig{
+			"C:/Repo": {{
+				Files: []string{"src/**/*.ts"},
+				Rules: rslintconfig.Rules{"no-console": "error"},
+			}},
+		},
+		TargetPathBySourcePath: map[string]string{"C:/REPO/SRC/A.ts": "D:/caller/a.ts"},
+		ConfigPathBySourcePath: map[string]string{"C:/REPO/SRC/A.ts": "C:/Repo/src/a.ts"},
+		OwnerConfigDirBySourcePath: map[string]string{
+			"C:/REPO/SRC/A.ts": "c:/repo",
+		},
+		FS: fsys,
+	})
+
+	rules := resolver.ActiveRulesForFile(sourcePath)
+	if len(rules) != 1 || rules[0].Name != "no-console" {
+		t.Fatalf("expected case-equivalent source mapping to retain config rules, got %v", configuredRuleNameSet(rules))
 	}
 }
 

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -68,7 +68,7 @@ type initPayload struct {
 	// Re-marshaled byte-for-byte into the synthesized parseConfigPayload input
 	// so IPC init and the legacy stdin path share identical config semantics.
 	// Empty/nil means "no JS config — load JSON config from disk via
-	// LoadConfigurationWithFallback (ConfigStdin=false branch)".
+	// the JSON configuration loader (ConfigStdin=false branch)".
 	Configs []json.RawMessage `json:"configs,omitempty"`
 
 	// Runtime: out-of-band switches without a 1:1 user flag.

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -65,9 +65,9 @@ const (
 // is the wire contract — keep in sync with packages/rslint/src/engine.ts.
 type initPayload struct {
 	// Configs: array of `{configDirectory, entries}`-shaped JSON objects.
-	// Re-marshaled byte-for-byte into the synthesized stdin payload so
-	// parseConfigPayload (cmd.go) parses it identically to the legacy stdin
-	// path. Empty/nil means "no JS config — load JSON config from disk via
+	// Re-marshaled byte-for-byte into the synthesized parseConfigPayload input
+	// so IPC init and the legacy stdin path share identical config semantics.
+	// Empty/nil means "no JS config — load JSON config from disk via
 	// LoadConfigurationWithFallback (ConfigStdin=false branch)".
 	Configs []json.RawMessage `json:"configs,omitempty"`
 

--- a/cmd/rslint/lint_config_resolver.go
+++ b/cmd/rslint/lint_config_resolver.go
@@ -1,78 +1,143 @@
 package main
 
 import (
-	"sync"
+	"sort"
 
+	"github.com/microsoft/typescript-go/shim/vfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/linter"
 )
 
 type lintConfigResolver struct {
-	configMap              map[string]rslintconfig.RslintConfig
-	rslintConfig           rslintconfig.RslintConfig
-	currentDirectory       string
-	enforcePlugins         bool
-	typeInfoFiles          map[string]struct{}
-	configPathBySourcePath map[string]string
-
-	mu              sync.Mutex
-	singleResolver  *rslintconfig.FileConfigResolver
-	configResolvers map[string]*rslintconfig.FileConfigResolver
+	configMap                  map[string]rslintconfig.RslintConfig
+	currentDirectory           string
+	typeInfoFiles              map[string]struct{}
+	configPathBySourcePath     map[string]string
+	ownerConfigDirBySourcePath map[string]string
+	fsys                       vfs.FS
+	useCaseSensitive           bool
+	singleResolver             *rslintconfig.FileConfigResolver
+	configResolvers            map[string]*rslintconfig.FileConfigResolver
+	matchConfigMap             map[string]rslintconfig.RslintConfig
+	ownerByMatchConfigDir      map[string]string
 }
 
-func newLintConfigResolver(
-	configMap map[string]rslintconfig.RslintConfig,
-	rslintConfig rslintconfig.RslintConfig,
-	currentDirectory string,
-	enforcePlugins bool,
-	typeInfoFiles map[string]struct{},
-	configPathBySourcePath map[string]string,
-) *lintConfigResolver {
-	return &lintConfigResolver{
-		configMap:              configMap,
-		rslintConfig:           rslintConfig,
-		currentDirectory:       currentDirectory,
-		enforcePlugins:         enforcePlugins,
-		typeInfoFiles:          typeInfoFiles,
-		configPathBySourcePath: configPathBySourcePath,
-		configResolvers:        make(map[string]*rslintconfig.FileConfigResolver),
+type lintConfigResolverOptions struct {
+	ConfigMap        map[string]rslintconfig.RslintConfig
+	Config           rslintconfig.RslintConfig
+	CurrentDirectory string
+	EnforcePlugins   bool
+	TypeInfoFiles    map[string]struct{}
+	// TargetPathBySourcePath is a display/writeback mapping. Config resolution
+	// deliberately does not consult it.
+	TargetPathBySourcePath     map[string]string
+	ConfigPathBySourcePath     map[string]string
+	OwnerConfigDirBySourcePath map[string]string
+	FS                         vfs.FS
+}
+
+func newLintConfigResolver(opts lintConfigResolverOptions) *lintConfigResolver {
+	useCaseSensitive := true
+	if opts.FS != nil {
+		useCaseSensitive = opts.FS.UseCaseSensitiveFileNames()
 	}
-}
-
-func (r *lintConfigResolver) resolverForConfig(configDir string, cfg rslintconfig.RslintConfig) *rslintconfig.FileConfigResolver {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if resolver := r.configResolvers[configDir]; resolver != nil {
+	resolver := &lintConfigResolver{
+		configMap:                  opts.ConfigMap,
+		currentDirectory:           opts.CurrentDirectory,
+		typeInfoFiles:              opts.TypeInfoFiles,
+		configPathBySourcePath:     normalizeSourcePathMappings(opts.ConfigPathBySourcePath, opts.FS),
+		ownerConfigDirBySourcePath: normalizeSourcePathMappings(opts.OwnerConfigDirBySourcePath, opts.FS),
+		fsys:                       opts.FS,
+		useCaseSensitive:           useCaseSensitive,
+	}
+	if opts.ConfigMap == nil {
+		matchRoot := authoritativeFilesystemPath(opts.CurrentDirectory, opts.FS)
+		resolver.singleResolver = rslintconfig.NewFileConfigResolver(opts.Config, matchRoot, opts.EnforcePlugins)
 		return resolver
 	}
-	resolver := rslintconfig.NewFileConfigResolver(cfg, configDir, r.enforcePlugins)
-	r.configResolvers[configDir] = resolver
+	resolver.configResolvers = make(map[string]*rslintconfig.FileConfigResolver, len(opts.ConfigMap)*2)
+	resolver.matchConfigMap = make(map[string]rslintconfig.RslintConfig, len(opts.ConfigMap))
+	resolver.ownerByMatchConfigDir = make(map[string]string, len(opts.ConfigMap))
+	configDirs := make([]string, 0, len(opts.ConfigMap))
+	for configDir := range opts.ConfigMap {
+		configDirs = append(configDirs, configDir)
+	}
+	sort.Strings(configDirs)
+	for _, configDir := range configDirs {
+		cfg := opts.ConfigMap[configDir]
+		matchRoot := authoritativeFilesystemPath(configDir, opts.FS)
+		fileResolver := rslintconfig.NewFileConfigResolver(cfg, matchRoot, opts.EnforcePlugins)
+		resolver.configResolvers[configDir] = fileResolver
+		resolver.configResolvers[filesystemPathID(configDir, opts.FS)] = fileResolver
+		matchRootID := filesystemPathID(matchRoot, opts.FS)
+		if _, exists := resolver.ownerByMatchConfigDir[matchRootID]; !exists {
+			resolver.matchConfigMap[matchRoot] = cfg
+			resolver.ownerByMatchConfigDir[matchRootID] = configDir
+		}
+	}
 	return resolver
 }
 
-func (r *lintConfigResolver) resolverForFile(filePath string) (string, *rslintconfig.FileConfigResolver, bool) {
+func normalizeSourcePathMappings(mapping map[string]string, fsys vfs.FS) map[string]string {
+	if len(mapping) == 0 {
+		return mapping
+	}
+	normalized := make(map[string]string, len(mapping)*2)
+	for sourcePath, value := range mapping {
+		normalized[sourcePath] = value
+		normalized[filesystemPathID(sourcePath, fsys)] = value
+	}
+	return normalized
+}
+
+func (r *lintConfigResolver) pathMappingValue(mapping map[string]string, filePath string) string {
+	if len(mapping) == 0 {
+		return ""
+	}
+	if value := mapping[filePath]; value != "" {
+		return value
+	}
+	return mapping[filesystemPathID(filePath, r.fsys)]
+}
+
+func (r *lintConfigResolver) configResolver(configDir string) *rslintconfig.FileConfigResolver {
+	if resolver := r.configResolvers[configDir]; resolver != nil {
+		return resolver
+	}
+	return r.configResolvers[filesystemPathID(configDir, r.fsys)]
+}
+
+func (r *lintConfigResolver) resolverForFile(sourcePath string, configPath string) (string, *rslintconfig.FileConfigResolver, bool) {
 	if r.configMap != nil {
-		cfgDir, cfg := rslintconfig.FindNearestConfig(filePath, r.configMap)
+		ownerConfigDir := r.pathMappingValue(r.ownerConfigDirBySourcePath, sourcePath)
+		if ownerConfigDir != "" {
+			resolver := r.configResolver(ownerConfigDir)
+			return ownerConfigDir, resolver, resolver != nil
+		}
+
+		// Compatibility fallback for callers that do not provide a target binding
+		// (for example the legacy plugin protocol and focused resolver tests).
+		cfgDir, cfg := rslintconfig.FindNearestConfigWithCaseSensitivity(sourcePath, r.configMap, r.useCaseSensitive)
+		if cfg != nil {
+			resolver := r.configResolver(cfgDir)
+			return cfgDir, resolver, resolver != nil
+		}
+		matchDir, cfg := rslintconfig.FindNearestConfigWithCaseSensitivity(configPath, r.matchConfigMap, r.useCaseSensitive)
 		if cfg == nil {
 			return "", nil, false
 		}
-		return cfgDir, r.resolverForConfig(cfgDir, cfg), true
+		ownerConfigDir = r.ownerByMatchConfigDir[filesystemPathID(matchDir, r.fsys)]
+		resolver := r.configResolver(ownerConfigDir)
+		return ownerConfigDir, resolver, resolver != nil
 	}
-
-	r.mu.Lock()
-	if r.singleResolver == nil {
-		r.singleResolver = rslintconfig.NewFileConfigResolver(r.rslintConfig, r.currentDirectory, r.enforcePlugins)
-	}
-	resolver := r.singleResolver
-	r.mu.Unlock()
-	return r.currentDirectory, resolver, true
+	return r.currentDirectory, r.singleResolver, true
 }
 
 func (r *lintConfigResolver) configPathFor(filePath string) string {
 	if r == nil || len(r.configPathBySourcePath) == 0 {
 		return filePath
 	}
-	if configPath := r.configPathBySourcePath[filePath]; configPath != "" {
+	if configPath := r.pathMappingValue(r.configPathBySourcePath, filePath); configPath != "" {
 		return configPath
 	}
 	return filePath
@@ -80,7 +145,7 @@ func (r *lintConfigResolver) configPathFor(filePath string) string {
 
 func (r *lintConfigResolver) ConfigForFile(filePath string) *rslintconfig.MergedConfig {
 	configPath := r.configPathFor(filePath)
-	_, resolver, ok := r.resolverForFile(configPath)
+	_, resolver, ok := r.resolverForFile(filePath, configPath)
 	if !ok {
 		return nil
 	}
@@ -89,7 +154,7 @@ func (r *lintConfigResolver) ConfigForFile(filePath string) *rslintconfig.Merged
 
 func (r *lintConfigResolver) ActiveRulesForFile(filePath string) []linter.ConfiguredRule {
 	configPath := r.configPathFor(filePath)
-	_, resolver, ok := r.resolverForFile(configPath)
+	_, resolver, ok := r.resolverForFile(filePath, configPath)
 	if !ok {
 		return nil
 	}

--- a/cmd/rslint/lint_config_resolver.go
+++ b/cmd/rslint/lint_config_resolver.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"sync"
+
+	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
+	"github.com/web-infra-dev/rslint/internal/linter"
+)
+
+type lintConfigResolver struct {
+	configMap        map[string]rslintconfig.RslintConfig
+	rslintConfig     rslintconfig.RslintConfig
+	currentDirectory string
+	enforcePlugins   bool
+	typeInfoFiles    map[string]struct{}
+
+	mu              sync.Mutex
+	singleResolver  *rslintconfig.FileConfigResolver
+	configResolvers map[string]*rslintconfig.FileConfigResolver
+}
+
+func newLintConfigResolver(
+	configMap map[string]rslintconfig.RslintConfig,
+	rslintConfig rslintconfig.RslintConfig,
+	currentDirectory string,
+	enforcePlugins bool,
+	typeInfoFiles map[string]struct{},
+) *lintConfigResolver {
+	return &lintConfigResolver{
+		configMap:        configMap,
+		rslintConfig:     rslintConfig,
+		currentDirectory: currentDirectory,
+		enforcePlugins:   enforcePlugins,
+		typeInfoFiles:    typeInfoFiles,
+		configResolvers:  make(map[string]*rslintconfig.FileConfigResolver),
+	}
+}
+
+func (r *lintConfigResolver) resolverForConfig(configDir string, cfg rslintconfig.RslintConfig) *rslintconfig.FileConfigResolver {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if resolver := r.configResolvers[configDir]; resolver != nil {
+		return resolver
+	}
+	resolver := rslintconfig.NewFileConfigResolver(cfg, configDir, r.enforcePlugins)
+	r.configResolvers[configDir] = resolver
+	return resolver
+}
+
+func (r *lintConfigResolver) resolverForFile(filePath string) (string, *rslintconfig.FileConfigResolver, bool) {
+	if r.configMap != nil {
+		cfgDir, cfg := rslintconfig.FindNearestConfig(filePath, r.configMap)
+		if cfg == nil {
+			return "", nil, false
+		}
+		return cfgDir, r.resolverForConfig(cfgDir, cfg), true
+	}
+
+	r.mu.Lock()
+	if r.singleResolver == nil {
+		r.singleResolver = rslintconfig.NewFileConfigResolver(r.rslintConfig, r.currentDirectory, r.enforcePlugins)
+	}
+	resolver := r.singleResolver
+	r.mu.Unlock()
+	return r.currentDirectory, resolver, true
+}
+
+func (r *lintConfigResolver) ConfigForFile(filePath string) *rslintconfig.MergedConfig {
+	_, resolver, ok := r.resolverForFile(filePath)
+	if !ok {
+		return nil
+	}
+	return resolver.ConfigForFile(filePath)
+}
+
+func (r *lintConfigResolver) ActiveRulesForFile(filePath string) []linter.ConfiguredRule {
+	_, resolver, ok := r.resolverForFile(filePath)
+	if !ok {
+		return nil
+	}
+	return resolver.ActiveRulesForFile(filePath, r.typeInfoFiles)
+}

--- a/cmd/rslint/lint_config_resolver.go
+++ b/cmd/rslint/lint_config_resolver.go
@@ -15,40 +15,36 @@ type lintConfigResolver struct {
 	configPathBySourcePath     map[string]string
 	ownerConfigDirBySourcePath map[string]string
 	fsys                       vfs.FS
-	useCaseSensitive           bool
 	singleResolver             *rslintconfig.FileConfigResolver
 	configResolvers            map[string]*rslintconfig.FileConfigResolver
 	matchConfigMap             map[string]rslintconfig.RslintConfig
 	ownerByMatchConfigDir      map[string]string
+	configOwnerResolver        *rslintconfig.ConfigOwnerResolver
+	matchConfigOwnerResolver   *rslintconfig.ConfigOwnerResolver
 }
 
 type lintConfigResolverOptions struct {
-	ConfigMap        map[string]rslintconfig.RslintConfig
-	Config           rslintconfig.RslintConfig
-	CurrentDirectory string
-	EnforcePlugins   bool
-	TypeInfoFiles    map[string]struct{}
-	// TargetPathBySourcePath is a display/writeback mapping. Config resolution
-	// deliberately does not consult it.
-	TargetPathBySourcePath     map[string]string
+	ConfigMap                  map[string]rslintconfig.RslintConfig
+	Config                     rslintconfig.RslintConfig
+	CurrentDirectory           string
+	EnforcePlugins             bool
+	TypeInfoFiles              map[string]struct{}
 	ConfigPathBySourcePath     map[string]string
 	OwnerConfigDirBySourcePath map[string]string
-	FS                         vfs.FS
+	// SourceMappingsCanonical indicates that binding already supplied both
+	// lexical and canonical source keys, so normalization needs no filesystem IO.
+	SourceMappingsCanonical bool
+	FS                      vfs.FS
 }
 
 func newLintConfigResolver(opts lintConfigResolverOptions) *lintConfigResolver {
-	useCaseSensitive := true
-	if opts.FS != nil {
-		useCaseSensitive = opts.FS.UseCaseSensitiveFileNames()
-	}
 	resolver := &lintConfigResolver{
 		configMap:                  opts.ConfigMap,
 		currentDirectory:           opts.CurrentDirectory,
 		typeInfoFiles:              opts.TypeInfoFiles,
-		configPathBySourcePath:     normalizeSourcePathMappings(opts.ConfigPathBySourcePath, opts.FS),
-		ownerConfigDirBySourcePath: normalizeSourcePathMappings(opts.OwnerConfigDirBySourcePath, opts.FS),
+		configPathBySourcePath:     normalizeSourcePathMappings(opts.ConfigPathBySourcePath, opts.FS, opts.SourceMappingsCanonical),
+		ownerConfigDirBySourcePath: normalizeSourcePathMappings(opts.OwnerConfigDirBySourcePath, opts.FS, opts.SourceMappingsCanonical),
 		fsys:                       opts.FS,
-		useCaseSensitive:           useCaseSensitive,
 	}
 	if opts.ConfigMap == nil {
 		matchRoot := authoritativeFilesystemPath(opts.CurrentDirectory, opts.FS)
@@ -58,6 +54,7 @@ func newLintConfigResolver(opts lintConfigResolverOptions) *lintConfigResolver {
 	resolver.configResolvers = make(map[string]*rslintconfig.FileConfigResolver, len(opts.ConfigMap)*2)
 	resolver.matchConfigMap = make(map[string]rslintconfig.RslintConfig, len(opts.ConfigMap))
 	resolver.ownerByMatchConfigDir = make(map[string]string, len(opts.ConfigMap))
+	resolver.configOwnerResolver = rslintconfig.NewConfigOwnerResolver(opts.ConfigMap, opts.FS)
 	configDirs := make([]string, 0, len(opts.ConfigMap))
 	for configDir := range opts.ConfigMap {
 		configDirs = append(configDirs, configDir)
@@ -68,24 +65,28 @@ func newLintConfigResolver(opts lintConfigResolverOptions) *lintConfigResolver {
 		matchRoot := authoritativeFilesystemPath(configDir, opts.FS)
 		fileResolver := rslintconfig.NewFileConfigResolver(cfg, matchRoot, opts.EnforcePlugins)
 		resolver.configResolvers[configDir] = fileResolver
-		resolver.configResolvers[filesystemPathID(configDir, opts.FS)] = fileResolver
-		matchRootID := filesystemPathID(matchRoot, opts.FS)
+		resolver.configResolvers[canonicalFilesystemPathID(configDir, opts.FS)] = fileResolver
+		matchRootID := canonicalFilesystemPathID(matchRoot, opts.FS)
 		if _, exists := resolver.ownerByMatchConfigDir[matchRootID]; !exists {
 			resolver.matchConfigMap[matchRoot] = cfg
 			resolver.ownerByMatchConfigDir[matchRootID] = configDir
 		}
 	}
+	resolver.matchConfigOwnerResolver = rslintconfig.NewConfigOwnerResolver(resolver.matchConfigMap, opts.FS)
 	return resolver
 }
 
-func normalizeSourcePathMappings(mapping map[string]string, fsys vfs.FS) map[string]string {
+func normalizeSourcePathMappings(mapping map[string]string, fsys vfs.FS, canonicalKeysPresent bool) map[string]string {
 	if len(mapping) == 0 {
 		return mapping
 	}
 	normalized := make(map[string]string, len(mapping)*2)
 	for sourcePath, value := range mapping {
-		normalized[sourcePath] = value
-		normalized[filesystemPathID(sourcePath, fsys)] = value
+		normalizedPath := exactFilesystemPathID(sourcePath)
+		normalized[normalizedPath] = value
+		if !canonicalKeysPresent {
+			normalized[canonicalFilesystemPathID(normalizedPath, fsys)] = value
+		}
 	}
 	return normalized
 }
@@ -94,17 +95,17 @@ func (r *lintConfigResolver) pathMappingValue(mapping map[string]string, filePat
 	if len(mapping) == 0 {
 		return ""
 	}
-	if value := mapping[filePath]; value != "" {
+	if value := mapping[exactFilesystemPathID(filePath)]; value != "" {
 		return value
 	}
-	return mapping[filesystemPathID(filePath, r.fsys)]
+	return mapping[canonicalFilesystemPathID(filePath, r.fsys)]
 }
 
 func (r *lintConfigResolver) configResolver(configDir string) *rslintconfig.FileConfigResolver {
 	if resolver := r.configResolvers[configDir]; resolver != nil {
 		return resolver
 	}
-	return r.configResolvers[filesystemPathID(configDir, r.fsys)]
+	return r.configResolvers[canonicalFilesystemPathID(configDir, r.fsys)]
 }
 
 func (r *lintConfigResolver) resolverForFile(sourcePath string, configPath string) (string, *rslintconfig.FileConfigResolver, bool) {
@@ -117,16 +118,16 @@ func (r *lintConfigResolver) resolverForFile(sourcePath string, configPath strin
 
 		// Compatibility fallback for callers that do not provide a target binding
 		// (for example the legacy plugin protocol and focused resolver tests).
-		cfgDir, cfg := rslintconfig.FindNearestConfigWithCaseSensitivity(sourcePath, r.configMap, r.useCaseSensitive)
+		cfgDir, cfg := r.configOwnerResolver.Resolve(sourcePath)
 		if cfg != nil {
 			resolver := r.configResolver(cfgDir)
 			return cfgDir, resolver, resolver != nil
 		}
-		matchDir, cfg := rslintconfig.FindNearestConfigWithCaseSensitivity(configPath, r.matchConfigMap, r.useCaseSensitive)
+		matchDir, cfg := r.matchConfigOwnerResolver.Resolve(configPath)
 		if cfg == nil {
 			return "", nil, false
 		}
-		ownerConfigDir = r.ownerByMatchConfigDir[filesystemPathID(matchDir, r.fsys)]
+		ownerConfigDir = r.ownerByMatchConfigDir[canonicalFilesystemPathID(matchDir, r.fsys)]
 		resolver := r.configResolver(ownerConfigDir)
 		return ownerConfigDir, resolver, resolver != nil
 	}

--- a/cmd/rslint/lint_config_resolver.go
+++ b/cmd/rslint/lint_config_resolver.go
@@ -8,11 +8,12 @@ import (
 )
 
 type lintConfigResolver struct {
-	configMap        map[string]rslintconfig.RslintConfig
-	rslintConfig     rslintconfig.RslintConfig
-	currentDirectory string
-	enforcePlugins   bool
-	typeInfoFiles    map[string]struct{}
+	configMap              map[string]rslintconfig.RslintConfig
+	rslintConfig           rslintconfig.RslintConfig
+	currentDirectory       string
+	enforcePlugins         bool
+	typeInfoFiles          map[string]struct{}
+	configPathBySourcePath map[string]string
 
 	mu              sync.Mutex
 	singleResolver  *rslintconfig.FileConfigResolver
@@ -25,14 +26,16 @@ func newLintConfigResolver(
 	currentDirectory string,
 	enforcePlugins bool,
 	typeInfoFiles map[string]struct{},
+	configPathBySourcePath map[string]string,
 ) *lintConfigResolver {
 	return &lintConfigResolver{
-		configMap:        configMap,
-		rslintConfig:     rslintConfig,
-		currentDirectory: currentDirectory,
-		enforcePlugins:   enforcePlugins,
-		typeInfoFiles:    typeInfoFiles,
-		configResolvers:  make(map[string]*rslintconfig.FileConfigResolver),
+		configMap:              configMap,
+		rslintConfig:           rslintConfig,
+		currentDirectory:       currentDirectory,
+		enforcePlugins:         enforcePlugins,
+		typeInfoFiles:          typeInfoFiles,
+		configPathBySourcePath: configPathBySourcePath,
+		configResolvers:        make(map[string]*rslintconfig.FileConfigResolver),
 	}
 }
 
@@ -65,18 +68,38 @@ func (r *lintConfigResolver) resolverForFile(filePath string) (string, *rslintco
 	return r.currentDirectory, resolver, true
 }
 
+func (r *lintConfigResolver) configPathFor(filePath string) string {
+	if r == nil || len(r.configPathBySourcePath) == 0 {
+		return filePath
+	}
+	if configPath := r.configPathBySourcePath[filePath]; configPath != "" {
+		return configPath
+	}
+	return filePath
+}
+
 func (r *lintConfigResolver) ConfigForFile(filePath string) *rslintconfig.MergedConfig {
-	_, resolver, ok := r.resolverForFile(filePath)
+	configPath := r.configPathFor(filePath)
+	_, resolver, ok := r.resolverForFile(configPath)
 	if !ok {
 		return nil
 	}
-	return resolver.ConfigForFile(filePath)
+	return resolver.ConfigForFile(configPath)
 }
 
 func (r *lintConfigResolver) ActiveRulesForFile(filePath string) []linter.ConfiguredRule {
-	_, resolver, ok := r.resolverForFile(filePath)
+	configPath := r.configPathFor(filePath)
+	_, resolver, ok := r.resolverForFile(configPath)
 	if !ok {
 		return nil
 	}
-	return resolver.ActiveRulesForFile(filePath, r.typeInfoFiles)
+	activeRules, _ := resolver.EnabledRulesForFile(configPath)
+	if r.typeInfoFiles != nil {
+		if _, hasTypeInfo := r.typeInfoFiles[filePath]; !hasTypeInfo {
+			if _, hasTypeInfo = r.typeInfoFiles[configPath]; !hasTypeInfo {
+				activeRules = linter.FilterNonTypeAwareRules(activeRules)
+			}
+		}
+	}
+	return activeRules
 }

--- a/cmd/rslint/payload.go
+++ b/cmd/rslint/payload.go
@@ -14,6 +14,7 @@ type configPayloadEntry struct {
 	ConfigDirectory string                    `json:"configDirectory"`
 	Entries         rslintconfig.RslintConfig `json:"entries"`
 	TargetFiles     []string                  `json:"targetFiles,omitempty"`
+	ExplicitOnly    bool                      `json:"explicitOnly,omitempty"`
 }
 
 // parsedPayload is the result of parsing the serialized JS-config payload.
@@ -32,10 +33,10 @@ type parsedPayload struct {
 	// legacy single-config mode.
 	OriginalConfigDir map[string]string
 
-	// ConfigTargetFiles restricts a config to explicit target files when the JS
-	// host had to keep a nearest config that directory discovery would have
-	// skipped because of a parent global ignore.
-	ConfigTargetFiles map[string][]string
+	// ConfigTargetScopes carries explicit-file provenance established by the JS
+	// host. Go uses it to preserve lexical ownership and to keep configs that
+	// survived only for an explicit file out of directory discovery.
+	ConfigTargetScopes map[string]rslintconfig.LintDiscoveryScope
 
 	// singleConfig and singleConfigDir are set in legacy single-config mode.
 	SingleConfig    rslintconfig.RslintConfig
@@ -65,7 +66,7 @@ func parseConfigPayload(data []byte, filesystems ...vfs.FS) (*parsedPayload, err
 	if len(multiPayload.Configs) > 0 {
 		configMap := make(map[string]rslintconfig.RslintConfig, len(multiPayload.Configs))
 		originalConfigDir := make(map[string]string, len(multiPayload.Configs))
-		configTargetFiles := make(map[string][]string)
+		configTargetScopes := make(map[string]rslintconfig.LintDiscoveryScope)
 		configDirByPathID := make(map[string]string, len(multiPayload.Configs))
 		configDirByCanonicalID := make(map[string]string, len(multiPayload.Configs))
 		for _, cfg := range multiPayload.Configs {
@@ -77,10 +78,10 @@ func parseConfigPayload(data []byte, filesystems ...vfs.FS) (*parsedPayload, err
 			if len(configDir) > tspath.GetRootLength(configDir) {
 				configDir = tspath.RemoveTrailingDirectorySeparators(configDir)
 			}
-			pathID := filesystemPathID(configDir, fsys)
+			pathID := exactFilesystemPathID(configDir)
 			if previous, exists := configDirByPathID[pathID]; exists {
 				return nil, fmt.Errorf(
-					"duplicate config directories %q and %q are equivalent on this filesystem (normalized as %q)",
+					"duplicate config directories %q and %q normalize to the same path %q",
 					previous,
 					cfg.ConfigDirectory,
 					configDir,
@@ -105,7 +106,7 @@ func parseConfigPayload(data []byte, filesystems ...vfs.FS) (*parsedPayload, err
 			originalConfigDir[configDir] = cfg.ConfigDirectory
 			configDirByPathID[pathID] = cfg.ConfigDirectory
 			configDirByCanonicalID[canonicalID] = cfg.ConfigDirectory
-			if len(cfg.TargetFiles) > 0 {
+			if cfg.TargetFiles != nil || cfg.ExplicitOnly {
 				files := make([]string, 0, len(cfg.TargetFiles))
 				for _, file := range cfg.TargetFiles {
 					if tspath.PathIsAbsolute(file) {
@@ -114,14 +115,18 @@ func parseConfigPayload(data []byte, filesystems ...vfs.FS) (*parsedPayload, err
 						files = append(files, tspath.ResolvePath(configDir, file))
 					}
 				}
-				configTargetFiles[configDir] = files
+				scope := rslintconfig.LintDiscoveryScope{
+					Files:        files,
+					ExplicitOnly: cfg.ExplicitOnly,
+				}
+				configTargetScopes[configDir] = scope
 			}
 		}
 		return &parsedPayload{
-			ConfigMap:         configMap,
-			OriginalConfigDir: originalConfigDir,
-			ConfigTargetFiles: configTargetFiles,
-			IsMultiConfig:     true,
+			ConfigMap:          configMap,
+			OriginalConfigDir:  originalConfigDir,
+			ConfigTargetScopes: configTargetScopes,
+			IsMultiConfig:      true,
 		}, nil
 	}
 

--- a/cmd/rslint/payload.go
+++ b/cmd/rslint/payload.go
@@ -10,8 +10,9 @@ import (
 
 // configPayloadEntry represents a single config with its directory.
 type configPayloadEntry struct {
-	ConfigDirectory string                   `json:"configDirectory"`
+	ConfigDirectory string                    `json:"configDirectory"`
 	Entries         rslintconfig.RslintConfig `json:"entries"`
+	TargetFiles     []string                  `json:"targetFiles,omitempty"`
 }
 
 // parsedPayload is the result of parsing a config-stdin payload.
@@ -29,6 +30,11 @@ type parsedPayload struct {
 	// sides independently normalizing the path and having to agree. nil in
 	// legacy single-config mode.
 	OriginalConfigDir map[string]string
+
+	// ConfigTargetFiles restricts a config to explicit target files when the JS
+	// host had to keep a nearest config that directory discovery would have
+	// skipped because of a parent global ignore.
+	ConfigTargetFiles map[string][]string
 
 	// singleConfig and singleConfigDir are set in legacy single-config mode.
 	SingleConfig    rslintconfig.RslintConfig
@@ -53,18 +59,34 @@ func parseConfigPayload(data []byte) (*parsedPayload, error) {
 	if len(multiPayload.Configs) > 0 {
 		configMap := make(map[string]rslintconfig.RslintConfig, len(multiPayload.Configs))
 		originalConfigDir := make(map[string]string, len(multiPayload.Configs))
+		configTargetFiles := make(map[string][]string)
 		for _, cfg := range multiPayload.Configs {
 			// configMap is keyed by the normalized dir (Go matches normalized
 			// file paths against it); originalConfigDir recovers the raw string
 			// for the eslint-plugin wire configKey. Both are populated in this
 			// one loop from the same NormalizePath call, so they cannot disagree.
 			configDir := tspath.NormalizePath(cfg.ConfigDirectory)
+			if err := rslintconfig.ValidateConfig(cfg.Entries); err != nil {
+				return nil, fmt.Errorf("invalid config for %q: %w", cfg.ConfigDirectory, err)
+			}
 			configMap[configDir] = cfg.Entries
 			originalConfigDir[configDir] = cfg.ConfigDirectory
+			if len(cfg.TargetFiles) > 0 {
+				files := make([]string, 0, len(cfg.TargetFiles))
+				for _, file := range cfg.TargetFiles {
+					if tspath.PathIsAbsolute(file) {
+						files = append(files, tspath.NormalizePath(file))
+					} else {
+						files = append(files, tspath.ResolvePath(configDir, file))
+					}
+				}
+				configTargetFiles[configDir] = files
+			}
 		}
 		return &parsedPayload{
 			ConfigMap:         configMap,
 			OriginalConfigDir: originalConfigDir,
+			ConfigTargetFiles: configTargetFiles,
 			IsMultiConfig:     true,
 		}, nil
 	}
@@ -73,6 +95,9 @@ func parseConfigPayload(data []byte) (*parsedPayload, error) {
 	var singlePayload configPayloadEntry
 	if err := json.Unmarshal(data, &singlePayload); err != nil {
 		return nil, fmt.Errorf("error parsing config from stdin: %w", err)
+	}
+	if err := rslintconfig.ValidateConfig(singlePayload.Entries); err != nil {
+		return nil, fmt.Errorf("invalid config for %q: %w", singlePayload.ConfigDirectory, err)
 	}
 
 	return &parsedPayload{

--- a/cmd/rslint/payload.go
+++ b/cmd/rslint/payload.go
@@ -15,7 +15,7 @@ type configPayloadEntry struct {
 	TargetFiles     []string                  `json:"targetFiles,omitempty"`
 }
 
-// parsedPayload is the result of parsing a config-stdin payload.
+// parsedPayload is the result of parsing the serialized JS-config payload.
 type parsedPayload struct {
 	// configMap maps normalized configDirectory to config entries (multi-config mode).
 	// nil when using legacy single-config mode.
@@ -44,7 +44,7 @@ type parsedPayload struct {
 	IsMultiConfig bool
 }
 
-// parseConfigPayload parses the JSON payload from --config-stdin.
+// parseConfigPayload parses the serialized JS-config payload.
 // It supports both the new multi-config format ({ configs: [...] })
 // and the legacy single-config format ({ configDirectory, entries }).
 func parseConfigPayload(data []byte) (*parsedPayload, error) {

--- a/cmd/rslint/payload.go
+++ b/cmd/rslint/payload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 )
 
@@ -47,7 +48,12 @@ type parsedPayload struct {
 // parseConfigPayload parses the serialized JS-config payload.
 // It supports both the new multi-config format ({ configs: [...] })
 // and the legacy single-config format ({ configDirectory, entries }).
-func parseConfigPayload(data []byte) (*parsedPayload, error) {
+func parseConfigPayload(data []byte, filesystems ...vfs.FS) (*parsedPayload, error) {
+	var fsys vfs.FS
+	if len(filesystems) > 0 {
+		fsys = filesystems[0]
+	}
+
 	// Try multi-config format: { configs: [...] }
 	var multiPayload struct {
 		Configs []configPayloadEntry `json:"configs"`
@@ -60,17 +66,45 @@ func parseConfigPayload(data []byte) (*parsedPayload, error) {
 		configMap := make(map[string]rslintconfig.RslintConfig, len(multiPayload.Configs))
 		originalConfigDir := make(map[string]string, len(multiPayload.Configs))
 		configTargetFiles := make(map[string][]string)
+		configDirByPathID := make(map[string]string, len(multiPayload.Configs))
+		configDirByCanonicalID := make(map[string]string, len(multiPayload.Configs))
 		for _, cfg := range multiPayload.Configs {
 			// configMap is keyed by the normalized dir (Go matches normalized
 			// file paths against it); originalConfigDir recovers the raw string
 			// for the eslint-plugin wire configKey. Both are populated in this
 			// one loop from the same NormalizePath call, so they cannot disagree.
 			configDir := tspath.NormalizePath(cfg.ConfigDirectory)
+			if len(configDir) > tspath.GetRootLength(configDir) {
+				configDir = tspath.RemoveTrailingDirectorySeparators(configDir)
+			}
+			pathID := filesystemPathID(configDir, fsys)
+			if previous, exists := configDirByPathID[pathID]; exists {
+				return nil, fmt.Errorf(
+					"duplicate config directories %q and %q are equivalent on this filesystem (normalized as %q)",
+					previous,
+					cfg.ConfigDirectory,
+					configDir,
+				)
+			}
+			// Config roots are ownership boundaries. Two lexical roots for one
+			// physical directory cannot both own the same canonical target without
+			// order-dependent config loss, so reject them at ingress. This is one
+			// realpath per config, not per target.
+			canonicalID := canonicalFilesystemPathID(configDir, fsys)
+			if previous, exists := configDirByCanonicalID[canonicalID]; exists {
+				return nil, fmt.Errorf(
+					"duplicate config directories %q and %q resolve to the same filesystem location",
+					previous,
+					cfg.ConfigDirectory,
+				)
+			}
 			if err := rslintconfig.ValidateConfig(cfg.Entries); err != nil {
 				return nil, fmt.Errorf("invalid config for %q: %w", cfg.ConfigDirectory, err)
 			}
 			configMap[configDir] = cfg.Entries
 			originalConfigDir[configDir] = cfg.ConfigDirectory
+			configDirByPathID[pathID] = cfg.ConfigDirectory
+			configDirByCanonicalID[canonicalID] = cfg.ConfigDirectory
 			if len(cfg.TargetFiles) > 0 {
 				files := make([]string, 0, len(cfg.TargetFiles))
 				for _, file := range cfg.TargetFiles {

--- a/cmd/rslint/payload_test.go
+++ b/cmd/rslint/payload_test.go
@@ -89,7 +89,8 @@ func TestParseConfigPayload_MultiConfigTargetFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	targets := result.ConfigTargetFiles["/project/packages/foo"]
+	scope := result.ConfigTargetScopes["/project/packages/foo"]
+	targets := scope.Files
 	if len(targets) != 2 {
 		t.Fatalf("Expected 2 target files, got %v", targets)
 	}
@@ -98,6 +99,29 @@ func TestParseConfigPayload_MultiConfigTargetFiles(t *testing.T) {
 	}
 	if targets[1] != "/project/packages/foo/src/b.ts" {
 		t.Errorf("Expected relative target to resolve from config dir, got %q", targets[1])
+	}
+	if scope.ExplicitOnly {
+		t.Fatal("ordinary explicit ownership must preserve directory discovery")
+	}
+}
+
+func TestParseConfigPayload_ExplicitOnlyScope(t *testing.T) {
+	data := []byte(`{
+		"configs": [{
+			"configDirectory": "/project/packages/foo",
+			"entries": [{}],
+			"targetFiles": ["src/a.ts"],
+			"explicitOnly": true
+		}]
+	}`)
+
+	result, err := parseConfigPayload(data)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	scope := result.ConfigTargetScopes["/project/packages/foo"]
+	if !scope.ExplicitOnly {
+		t.Fatal("explicit-only scope must suppress directory discovery")
 	}
 }
 
@@ -239,7 +263,33 @@ type caseInsensitivePayloadFS struct {
 
 func (f *caseInsensitivePayloadFS) UseCaseSensitiveFileNames() bool { return false }
 func (f *caseInsensitivePayloadFS) Realpath(filePath string) string {
+	return strings.ToLower(tspath.NormalizePath(filePath))
+}
+
+type mixedCasePayloadFS struct {
+	vfs.FS
+}
+
+func (f *mixedCasePayloadFS) UseCaseSensitiveFileNames() bool { return false }
+func (f *mixedCasePayloadFS) Realpath(filePath string) string {
 	return tspath.NormalizePath(filePath)
+}
+
+func TestParseConfigPayload_PreservesDistinctCanonicalConfigDirs(t *testing.T) {
+	data := []byte(`{
+		"configs": [
+			{"configDirectory": "C:/Repo", "entries": []},
+			{"configDirectory": "c:/repo", "entries": []}
+		]
+	}`)
+
+	result, err := parseConfigPayload(data, &mixedCasePayloadFS{FS: osvfs.FS()})
+	if err != nil {
+		t.Fatalf("distinct physical paths must not be collapsed by a global case flag: %v", err)
+	}
+	if len(result.ConfigMap) != 2 {
+		t.Fatalf("expected both canonical config roots, got %v", keysOf(result.ConfigMap))
+	}
 }
 
 func TestParseConfigPayload_RejectsCaseEquivalentConfigDirs(t *testing.T) {
@@ -251,7 +301,7 @@ func TestParseConfigPayload_RejectsCaseEquivalentConfigDirs(t *testing.T) {
 	}`)
 
 	_, err := parseConfigPayload(data, &caseInsensitivePayloadFS{FS: osvfs.FS()})
-	if err == nil || !strings.Contains(err.Error(), "equivalent on this filesystem") {
+	if err == nil || !strings.Contains(err.Error(), "same filesystem location") {
 		t.Fatalf("expected case-equivalent config roots to be rejected, got %v", err)
 	}
 }

--- a/cmd/rslint/payload_test.go
+++ b/cmd/rslint/payload_test.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 )
 
 // TestParseConfigPayload_MultiConfig_OriginalConfigDirPreservesRaw pins the
@@ -213,28 +220,66 @@ func TestParseConfigPayload_ConfigDirNormalized(t *testing.T) {
 }
 
 func TestParseConfigPayload_DuplicateConfigDirs(t *testing.T) {
-	// Same configDirectory twice → last one wins (map semantics)
 	data := []byte(`{
 		"configs": [
 			{"configDirectory": "/project", "entries": [{"rules": {"rule-a": "error"}}]},
-			{"configDirectory": "/project", "entries": [{"rules": {"rule-b": "error"}}]}
+			{"configDirectory": "/project/./", "entries": [{"rules": {"rule-b": "error"}}]}
 		]
 	}`)
 
-	result, err := parseConfigPayload(data)
+	_, err := parseConfigPayload(data)
+	if err == nil || !strings.Contains(err.Error(), "duplicate config directories") {
+		t.Fatalf("expected duplicate normalized directories to be rejected, got %v", err)
+	}
+}
+
+type caseInsensitivePayloadFS struct {
+	vfs.FS
+}
+
+func (f *caseInsensitivePayloadFS) UseCaseSensitiveFileNames() bool { return false }
+func (f *caseInsensitivePayloadFS) Realpath(filePath string) string {
+	return tspath.NormalizePath(filePath)
+}
+
+func TestParseConfigPayload_RejectsCaseEquivalentConfigDirs(t *testing.T) {
+	data := []byte(`{
+		"configs": [
+			{"configDirectory": "C:/Repo", "entries": [{"rules": {"rule-a": "error"}}]},
+			{"configDirectory": "c:/repo", "entries": [{"rules": {"rule-b": "error"}}]}
+		]
+	}`)
+
+	_, err := parseConfigPayload(data, &caseInsensitivePayloadFS{FS: osvfs.FS()})
+	if err == nil || !strings.Contains(err.Error(), "equivalent on this filesystem") {
+		t.Fatalf("expected case-equivalent config roots to be rejected, got %v", err)
+	}
+}
+
+func TestParseConfigPayload_RejectsSymlinkEquivalentConfigDirs(t *testing.T) {
+	parent := t.TempDir()
+	realDir := filepath.Join(parent, "real")
+	aliasDir := filepath.Join(parent, "alias")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	payload, err := json.Marshal(map[string]any{
+		"configs": []any{
+			map[string]any{"configDirectory": realDir, "entries": []any{}},
+			map[string]any{"configDirectory": aliasDir, "entries": []any{}},
+		},
+	})
 	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+		t.Fatal(err)
 	}
-	if len(result.ConfigMap) != 1 {
-		t.Errorf("Expected 1 config (deduped), got %d", len(result.ConfigMap))
-	}
-	// Last entry should win
-	cfg := result.ConfigMap["/project"]
-	if cfg == nil {
-		t.Fatal("Expected config for /project")
-	}
-	if _, ok := cfg[0].Rules["rule-b"]; !ok {
-		t.Error("Expected last entry (rule-b) to win")
+
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	_, err = parseConfigPayload(payload, fsys)
+	if err == nil || !strings.Contains(err.Error(), "same filesystem location") {
+		t.Fatalf("expected symlink-equivalent config roots to be rejected, got %v", err)
 	}
 }
 

--- a/cmd/rslint/payload_test.go
+++ b/cmd/rslint/payload_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/tspath"
@@ -66,6 +67,33 @@ func TestParseConfigPayload_MultiConfig(t *testing.T) {
 	}
 }
 
+func TestParseConfigPayload_MultiConfigTargetFiles(t *testing.T) {
+	data := []byte(`{
+		"configs": [
+			{
+				"configDirectory": "/project/packages/foo",
+				"entries": [{"rules": {"no-console": "error"}}],
+				"targetFiles": ["/project/packages/foo/src/a.ts", "src/b.ts"]
+			}
+		]
+	}`)
+
+	result, err := parseConfigPayload(data)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	targets := result.ConfigTargetFiles["/project/packages/foo"]
+	if len(targets) != 2 {
+		t.Fatalf("Expected 2 target files, got %v", targets)
+	}
+	if targets[0] != "/project/packages/foo/src/a.ts" {
+		t.Errorf("Expected absolute target to be normalized, got %q", targets[0])
+	}
+	if targets[1] != "/project/packages/foo/src/b.ts" {
+		t.Errorf("Expected relative target to resolve from config dir, got %q", targets[1])
+	}
+}
+
 func TestParseConfigPayload_SingleConfig(t *testing.T) {
 	data := []byte(`{
 		"configDirectory": "/project/packages/foo",
@@ -87,6 +115,40 @@ func TestParseConfigPayload_SingleConfig(t *testing.T) {
 	}
 	if result.SingleConfig == nil {
 		t.Fatal("Expected non-nil singleConfig")
+	}
+}
+
+func TestParseConfigPayload_RejectsEmptyFilesArray(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "multi config",
+			data: []byte(`{
+				"configs": [
+					{"configDirectory": "/project", "entries": [{"files": [], "rules": {"no-console": "error"}}]}
+				]
+			}`),
+		},
+		{
+			name: "legacy single config",
+			data: []byte(`{
+				"configDirectory": "/project",
+				"entries": [{"files": [], "rules": {"no-console": "error"}}]
+			}`),
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseConfigPayload(tt.data)
+			if err == nil {
+				t.Fatal("expected parseConfigPayload to reject empty files array")
+			}
+			if !strings.Contains(err.Error(), `key "files": expected value to be a non-empty array`) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -183,7 +183,7 @@ func buildProgramsWithLintTargets(
 	var typeInfoFiles map[string]struct{}
 	var capturedGapFiles []string
 
-	programFiles := utils.CollectProgramFiles(programs, fs, singleThreaded)
+	programIndex := buildProgramFileIndex(programs, fs, singleThreaded)
 
 	var targetFiles []string
 	if configMap != nil {
@@ -194,7 +194,7 @@ func buildProgramsWithLintTargets(
 
 	gapFiles := make([]string, 0, len(targetFiles))
 	for _, target := range targetFiles {
-		if _, inProgram := programFiles[target]; !inProgram {
+		if _, inProgram := programIndex.files[target]; !inProgram {
 			gapFiles = append(gapFiles, target)
 		}
 	}
@@ -202,16 +202,17 @@ func buildProgramsWithLintTargets(
 	if len(gapFiles) > 0 {
 		// Build type-info set from existing (tsconfig) Programs BEFORE
 		// appending the fallback, so fallback files are NOT in this set.
-		typeInfoFiles = programFiles
+		typeInfoFiles = cloneStringSet(programIndex.files)
 		capturedGapFiles = gapFiles
 
 		fallback, _ := createFallbackProgram(gapFiles, singleThreaded, currentDirectory, fs, parseCache)
 		if fallback != nil {
+			addProgramToFileIndex(&programIndex, fallback, len(programs), fs, singleThreaded)
 			programs = append(programs, fallback)
 		}
 	}
 
-	targetsByProgram := assignLintTargetsToPrograms(programs, configMap, programConfigDirs, targetFiles, fs)
+	targetsByProgram := assignLintTargetsToPrograms(programs, configMap, programConfigDirs, targetFiles, programIndex)
 
 	return programs, typeInfoFiles, capturedGapFiles, targetFiles, targetsByProgram
 }
@@ -255,6 +256,96 @@ type programFileCandidate struct {
 	fileName     string
 }
 
+type programFileIndex struct {
+	files  map[string]struct{}
+	byPath map[string][]programFileCandidate
+}
+
+type indexedProgram struct {
+	program      *compiler.Program
+	programIndex int
+}
+
+func buildProgramFileIndex(programs []*compiler.Program, fs vfs.FS, singleThreaded bool) programFileIndex {
+	index := programFileIndex{
+		files:  make(map[string]struct{}),
+		byPath: make(map[string][]programFileCandidate),
+	}
+	indexedPrograms := make([]indexedProgram, 0, len(programs))
+	for i, program := range programs {
+		indexedPrograms = append(indexedPrograms, indexedProgram{
+			program:      program,
+			programIndex: i,
+		})
+	}
+	addProgramsToFileIndex(&index, indexedPrograms, fs, singleThreaded)
+	return index
+}
+
+func addProgramToFileIndex(index *programFileIndex, program *compiler.Program, programIndex int, fs vfs.FS, singleThreaded bool) {
+	addProgramsToFileIndex(index, []indexedProgram{{
+		program:      program,
+		programIndex: programIndex,
+	}}, fs, singleThreaded)
+}
+
+func addProgramsToFileIndex(index *programFileIndex, programs []indexedProgram, fs vfs.FS, singleThreaded bool) {
+	if len(programs) == 0 {
+		return
+	}
+
+	candidatesByName := make(map[string][]programFileCandidate)
+	names := make([]string, 0)
+	for _, entry := range programs {
+		if entry.program == nil {
+			continue
+		}
+		for _, sf := range entry.program.GetSourceFiles() {
+			name := sf.FileName()
+			candidate := programFileCandidate{programIndex: entry.programIndex, fileName: name}
+			index.files[name] = struct{}{}
+			index.byPath[name] = append(index.byPath[name], candidate)
+			if _, seen := candidatesByName[name]; !seen {
+				names = append(names, name)
+			}
+			candidatesByName[name] = append(candidatesByName[name], candidate)
+		}
+	}
+	if fs == nil || len(candidatesByName) == 0 {
+		return
+	}
+
+	resolved := make([]string, len(names))
+	wg := core.NewWorkGroup(singleThreaded)
+	for i := range names {
+		wg.Queue(func() {
+			if realPath := fs.Realpath(names[i]); realPath != "" && realPath != names[i] {
+				resolved[i] = realPath
+			}
+		})
+	}
+	wg.RunAndWait()
+
+	for i, realPath := range resolved {
+		if realPath == "" {
+			continue
+		}
+		index.files[realPath] = struct{}{}
+		index.byPath[realPath] = append(index.byPath[realPath], candidatesByName[names[i]]...)
+	}
+}
+
+func cloneStringSet(set map[string]struct{}) map[string]struct{} {
+	if set == nil {
+		return nil
+	}
+	cloned := make(map[string]struct{}, len(set))
+	for key := range set {
+		cloned[key] = struct{}{}
+	}
+	return cloned
+}
+
 // assignLintTargetsToPrograms binds resolved lint targets to exactly one
 // Program. It accepts imported non-root SourceFiles; ownership/dedup is driven
 // by the target plan, not by CommandLine().FileNames().
@@ -263,30 +354,16 @@ func assignLintTargetsToPrograms(
 	configMap map[string]rslintconfig.RslintConfig,
 	programConfigDirs []string,
 	targetFiles []string,
-	fs vfs.FS,
+	programIndex programFileIndex,
 ) [][]string {
 	targetsByProgram := make([][]string, len(programs))
 	if len(programs) == 0 || len(targetFiles) == 0 {
 		return targetsByProgram
 	}
 
-	byPath := make(map[string][]programFileCandidate)
-	for i, prog := range programs {
-		for _, sf := range prog.GetSourceFiles() {
-			name := sf.FileName()
-			candidate := programFileCandidate{programIndex: i, fileName: name}
-			byPath[name] = append(byPath[name], candidate)
-			if fs != nil {
-				if realPath := fs.Realpath(name); realPath != "" && realPath != name {
-					byPath[realPath] = append(byPath[realPath], candidate)
-				}
-			}
-		}
-	}
-
 	seenProgramFile := make([]map[string]struct{}, len(programs))
 	for _, target := range targetFiles {
-		candidates := byPath[target]
+		candidates := programIndex.byPath[target]
 		if len(candidates) == 0 {
 			continue
 		}

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
@@ -27,7 +28,7 @@ import (
 // after gitignore globs are prepended is equivalent for TS Program creation.
 //
 // The returned config is the gitignore-augmented config (gitignore globs
-// prepended when non-empty), suitable for downstream DiscoverGapFiles /
+// prepended when non-empty), suitable for downstream target discovery /
 // GetConfigForFile.
 //
 // Returns: (augmentedConfig, programs, exitCode). On non-zero exitCode,
@@ -120,7 +121,7 @@ func createProgramsForConfig(
 		}
 	} else {
 		// No tsconfig fallback: scan directory for pure JS projects
-		sourceExts := []string{".ts", ".tsx", ".js", ".jsx", ".mts", ".mjs"}
+		sourceExts := rslintconfig.DefaultLintFileExtensions
 		excludes := utils.DefaultExcludeDirNames
 		includes := []string{"**/*"}
 		rootFiles := vfsmatch.ReadDirectory(fsys, configDir, configDir, sourceExts, excludes, includes, vfsmatch.UnlimitedDepth)
@@ -143,9 +144,9 @@ func createProgramsForConfig(
 	return programs, 0
 }
 
-// createFallbackProgram creates a Program for "gap" files — files matched by
-// config `files` patterns but not included in any tsconfig. Uses minimal
-// compiler options sufficient for AST parsing (no type checking).
+// createFallbackProgram creates a Program for selected lint targets not
+// included in any existing Program. It uses minimal compiler options sufficient
+// for AST parsing (no type checking).
 func createFallbackProgram(
 	gapFiles []string,
 	singleThreaded bool,
@@ -169,11 +170,9 @@ func createFallbackProgram(
 	return program, 0
 }
 
-// buildProgramsWithGapFallback discovers "gap" files — files matched by config
-// `files` patterns (or explicitly requested and matched by config) but absent
-// from every tsconfig Program — and appends one AST-only fallback Program for
-// them. It returns the (possibly extended) program slice, the type-info file
-// set, and the gap files retained for --fix rebuilds.
+// buildProgramsWithLintTargets resolves the exact lint target set, appends an
+// AST-only fallback Program for selected files absent from every existing
+// Program, and returns the per-program target plan consumed by RunLinter.
 //
 // The appended fallback Program (like the no-tsconfig directory-scan Program)
 // carries synthesized CompilerOptions with no ConfigFilePath, which is how
@@ -186,108 +185,168 @@ func createFallbackProgram(
 // rules off files with no type information — the only guard against a
 // type-aware rule dereferencing a nil TypeChecker (which crashes the whole
 // process). Both the CLI (executeLintPipeline) and the --api path (HandleLint)
-// call this, so their gap / fallback / gate behavior is identical by
-// construction rather than by two parallel implementations kept in sync.
+// call this, so target discovery, fallback binding, and type-aware gating are
+// identical by construction rather than by two parallel implementations kept
+// in sync.
 //
 // configMap is non-nil only in the multi-config (stdin) path; the --api and
 // single-config paths pass nil and resolve against rslintConfig +
 // currentDirectory.
-func buildProgramsWithGapFallback(
+func buildProgramsWithLintTargets(
 	programs []*compiler.Program,
 	configMap map[string]rslintconfig.RslintConfig,
 	rslintConfig rslintconfig.RslintConfig,
 	currentDirectory string,
+	programConfigDirs []string,
+	configTargetFiles map[string][]string,
 	fs vfs.FS,
 	allowFiles []string,
 	allowDirs []string,
 	parseCache *utils.ParseCache,
 	singleThreaded bool,
-) ([]*compiler.Program, map[string]struct{}, []string) {
+) ([]*compiler.Program, map[string]struct{}, []string, []string, [][]string) {
 	var typeInfoFiles map[string]struct{}
 	var capturedGapFiles []string
 
 	programFiles := utils.CollectProgramFiles(programs, fs, singleThreaded)
 
-	var gapFiles []string
+	var targetFiles []string
 	if configMap != nil {
-		gapFiles = rslintconfig.DiscoverGapFilesMultiConfig(configMap, fs, programFiles, allowFiles, allowDirs, singleThreaded)
+		targetFiles = discoverLintFilesMultiConfig(configMap, configTargetFiles, fs, allowFiles, allowDirs, singleThreaded)
 	} else {
-		gapFiles = rslintconfig.DiscoverGapFiles(rslintConfig, currentDirectory, fs, programFiles, allowFiles, allowDirs, singleThreaded)
+		targetFiles = rslintconfig.DiscoverLintFiles(rslintConfig, currentDirectory, fs, allowFiles, allowDirs, singleThreaded)
 	}
 
-	// Explicit file args bypass config `files` patterns (ESLint behavior):
-	// if a file is explicitly requested, lint it even if no config entry has a
-	// matching `files` pattern — as long as the config would assign it rules.
-	if gapFiles != nil && len(allowFiles) > 0 {
-		gapSet := make(map[string]struct{}, len(gapFiles))
-		for _, f := range gapFiles {
-			gapSet[f] = struct{}{}
-		}
-		for _, f := range allowFiles {
-			nf := tspath.NormalizePath(f)
-			if _, inProgram := programFiles[nf]; inProgram {
-				continue
-			}
-			if _, alreadyGap := gapSet[nf]; alreadyGap {
-				continue
-			}
-			// Check if config would assign any rules to this file.
-			var merged *rslintconfig.MergedConfig
-			if configMap != nil {
-				cfgDir, cfg := rslintconfig.FindNearestConfig(nf, configMap)
-				if cfg != nil {
-					merged = cfg.GetConfigForFile(nf, cfgDir)
-				}
-			} else {
-				merged = rslintConfig.GetConfigForFile(nf, currentDirectory)
-			}
-			if merged != nil {
-				gapFiles = append(gapFiles, nf)
-			}
+	gapFiles := make([]string, 0, len(targetFiles))
+	for _, target := range targetFiles {
+		if _, inProgram := programFiles[target]; !inProgram {
+			gapFiles = append(gapFiles, target)
 		}
 	}
 
-	if gapFiles != nil {
+	if len(gapFiles) > 0 {
 		// Build type-info set from existing (tsconfig) Programs BEFORE
 		// appending the fallback, so fallback files are NOT in this set.
 		typeInfoFiles = utils.CollectProgramFiles(programs, fs, singleThreaded)
 		capturedGapFiles = gapFiles
 
-		if len(gapFiles) > 0 {
-			fallback, _ := createFallbackProgram(gapFiles, singleThreaded, currentDirectory, fs, parseCache)
-			if fallback != nil {
-				programs = append(programs, fallback)
-			}
+		fallback, _ := createFallbackProgram(gapFiles, singleThreaded, currentDirectory, fs, parseCache)
+		if fallback != nil {
+			programs = append(programs, fallback)
 		}
 	}
 
-	return programs, typeInfoFiles, capturedGapFiles
+	targetsByProgram := assignLintTargetsToPrograms(programs, configMap, programConfigDirs, targetFiles, fs)
+
+	return programs, typeInfoFiles, capturedGapFiles, targetFiles, targetsByProgram
 }
 
-// buildFileOwnerMap determines which config directory "owns" each file across
-// all programs. Ownership is based on nearest config lookup (deepest matching
-// configDirectory), aligning with ESLint v10's per-file config resolution.
-// This ensures each file is linted exactly once by the program belonging to
-// its nearest config.
-func buildFileOwnerMap(programs []*compiler.Program, configMap map[string]rslintconfig.RslintConfig) map[string]string {
-	fileOwner := make(map[string]string)
-	for _, prog := range programs {
+func discoverLintFilesMultiConfig(
+	configMap map[string]rslintconfig.RslintConfig,
+	configTargetFiles map[string][]string,
+	fs vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	singleThreaded bool,
+) []string {
+	if len(configTargetFiles) == 0 {
+		return rslintconfig.DiscoverLintFilesMultiConfig(configMap, fs, allowFiles, allowDirs, singleThreaded)
+	}
+
+	seen := make(map[string]struct{})
+	var allTargets []string
+	for configDir, cfg := range configMap {
+		configAllowFiles := allowFiles
+		configAllowDirs := allowDirs
+		if targetFiles, scoped := configTargetFiles[configDir]; scoped {
+			configAllowFiles = targetFiles
+			configAllowDirs = nil
+		}
+
+		targets := rslintconfig.DiscoverLintFiles(cfg, configDir, fs, configAllowFiles, configAllowDirs, singleThreaded)
+		for _, f := range targets {
+			ownerDir, _ := rslintconfig.FindNearestConfig(f, configMap)
+			if ownerDir != configDir {
+				continue
+			}
+			if _, exists := seen[f]; !exists {
+				seen[f] = struct{}{}
+				allTargets = append(allTargets, f)
+			}
+		}
+	}
+	sort.Strings(allTargets)
+	return allTargets
+}
+
+type programFileCandidate struct {
+	programIndex int
+	fileName     string
+}
+
+// assignLintTargetsToPrograms binds resolved lint targets to exactly one
+// Program. It accepts imported non-root SourceFiles; ownership/dedup is driven
+// by the target plan, not by CommandLine().FileNames().
+func assignLintTargetsToPrograms(
+	programs []*compiler.Program,
+	configMap map[string]rslintconfig.RslintConfig,
+	programConfigDirs []string,
+	targetFiles []string,
+	fs vfs.FS,
+) [][]string {
+	targetsByProgram := make([][]string, len(programs))
+	if len(programs) == 0 || len(targetFiles) == 0 {
+		return targetsByProgram
+	}
+
+	byPath := make(map[string][]programFileCandidate)
+	for i, prog := range programs {
 		for _, sf := range prog.GetSourceFiles() {
-			fn := sf.FileName()
-			if _, ok := fileOwner[fn]; !ok {
-				nearestDir, _ := rslintconfig.FindNearestConfig(fn, configMap)
-				fileOwner[fn] = nearestDir
+			name := sf.FileName()
+			candidate := programFileCandidate{programIndex: i, fileName: name}
+			byPath[name] = append(byPath[name], candidate)
+			if fs != nil {
+				if real := fs.Realpath(name); real != "" && real != name {
+					byPath[real] = append(byPath[real], candidate)
+				}
 			}
 		}
 	}
-	return fileOwner
+
+	seenProgramFile := make([]map[string]struct{}, len(programs))
+	for _, target := range targetFiles {
+		candidates := byPath[target]
+		if len(candidates) == 0 {
+			continue
+		}
+		chosen := candidates[0]
+		if configMap != nil && len(programConfigDirs) > 0 {
+			ownerDir, _ := rslintconfig.FindNearestConfig(target, configMap)
+			for _, candidate := range candidates {
+				if candidate.programIndex < len(programConfigDirs) && programConfigDirs[candidate.programIndex] == ownerDir {
+					chosen = candidate
+					break
+				}
+			}
+		}
+		if seenProgramFile[chosen.programIndex] == nil {
+			seenProgramFile[chosen.programIndex] = make(map[string]struct{})
+		}
+		if _, seen := seenProgramFile[chosen.programIndex][chosen.fileName]; seen {
+			continue
+		}
+		seenProgramFile[chosen.programIndex][chosen.fileName] = struct{}{}
+		targetsByProgram[chosen.programIndex] = append(targetsByProgram[chosen.programIndex], chosen.fileName)
+	}
+	for i := range targetsByProgram {
+		sort.Strings(targetsByProgram[i])
+	}
+	return targetsByProgram
 }
 
-// buildFileFilters returns per-program file filters combining two concerns:
-//   - multi-config ownership: a file is linted by the program belonging to its
-//     nearest config (only active when len(configMap) > 1)
-//   - config `ignores`: files matching the user's ignore patterns are excluded
-//     from lint rules and the linted-file count
+// buildFileFilters returns per-program file filters for config `ignores`.
+// Target ownership/deduplication is handled by DiscoverLintFilesMultiConfig and
+// assignLintTargetsToPrograms before RunLinter receives TargetFiles.
 //
 // These filters are consumed by RunLinter only in Phase 1 (lint). Phase 2
 // (type-check) does NOT consult them — type-check mirrors `tsgo --noEmit`
@@ -307,25 +366,9 @@ func buildFileFilters(
 	singleConfig rslintconfig.RslintConfig,
 	singleConfigDir string,
 ) []func(string) bool {
-	var fileOwner map[string]string
-	if len(configMap) > 1 {
-		fileOwner = buildFileOwnerMap(programs, configMap)
-	}
-
 	filters := make([]func(string) bool, len(programs))
 	for i := range programs {
-		var ownerDir string
-		if fileOwner != nil && i < len(programConfigDirs) {
-			ownerDir = programConfigDirs[i]
-		}
 		filters[i] = func(fileName string) bool {
-			// Ownership check: only when we have multiple configs AND this
-			// program is anchored to a configDir (gap fallback has "").
-			if fileOwner != nil && ownerDir != "" {
-				if owner, ok := fileOwner[fileName]; ok && owner != ownerDir {
-					return false
-				}
-			}
 			// Ignore check: resolve the config that governs this file and
 			// consult its global `ignores` patterns.
 			var cfg rslintconfig.RslintConfig

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -46,22 +46,6 @@ func canonicalFilesystemPathID(filePath string, fsys vfs.FS) string {
 	return exactFilesystemPathID(authoritativeFilesystemPath(filePath, fsys))
 }
 
-func relativePathUnderRoot(filePath string, root string, useCaseSensitive bool) (string, bool) {
-	filePath = tspath.NormalizePath(filePath)
-	root = tspath.NormalizePath(root)
-	compareOptions := tspath.ComparePathsOptions{
-		CurrentDirectory:          root,
-		UseCaseSensitiveFileNames: useCaseSensitive,
-	}
-	if tspath.ComparePaths(filePath, root, compareOptions) == 0 {
-		return "", true
-	}
-	if !tspath.StartsWithDirectory(filePath, root, useCaseSensitive) {
-		return "", false
-	}
-	return tspath.GetRelativePathFromDirectory(root, filePath, compareOptions), true
-}
-
 // configPathForLintTarget returns the target path used for files/ignores
 // matching. Program source names are deliberately excluded: adding or removing
 // a file from a TypeScript Program must not change its lint configuration.
@@ -375,108 +359,103 @@ type lintTargetBinding struct {
 	OwnerConfigDirBySourcePath map[string]string
 }
 
-func aliasPathUnderRoot(path string, canonicalRoot string, lexicalRoot string, useCaseSensitive bool) string {
-	if path == "" || canonicalRoot == "" || lexicalRoot == "" {
-		return ""
-	}
-	relative, ok := relativePathUnderRoot(path, canonicalRoot, useCaseSensitive)
-	if !ok {
-		return ""
-	}
-	return tspath.ResolvePath(lexicalRoot, relative)
-}
-
-type programTargetLookup struct {
-	program      *compiler.Program
-	fsys         vfs.FS
-	sourceLookup *utils.ProgramSourceLookup
-}
-
-func (lookup *programTargetLookup) programSources() *utils.ProgramSourceLookup {
-	if lookup.sourceLookup == nil {
-		lookup.sourceLookup = utils.NewProgramSourceLookup(lookup.program, lookup.fsys)
-	}
-	return lookup.sourceLookup
-}
-
-func (lookup *programTargetLookup) sourceFileForCandidate(candidate string, canonicalTarget string) *ast.SourceFile {
-	return lookup.programSources().SourceFileForCandidate(candidate, canonicalTarget)
-}
-
-func (lookup *programTargetLookup) canonicalSourceFile(canonicalPath string) *ast.SourceFile {
-	return lookup.programSources().CanonicalSourceFile(canonicalPath)
-}
-
-// sourceFileForTarget first performs bounded target-driven lookups. Only when
-// every lexical/root alias misses does it build one lazy canonical source index
-// for the Program, covering file-level symlinks without imposing graph-wide
-// realpath work on normal projects.
-func (lookup *programTargetLookup) sourceFileForTarget(target resolvedLintTarget) *ast.SourceFile {
-	program := lookup.program
-	fsys := lookup.fsys
-	if program == nil {
+func exactProgramSourceFile(program *compiler.Program, targetPath string) *ast.SourceFile {
+	if program == nil || targetPath == "" {
 		return nil
 	}
-	targetPath := tspath.NormalizePath(target.Path)
-	canonicalPath := ""
-	if target.CanonicalPath != "" {
-		canonicalPath = tspath.NormalizePath(target.CanonicalPath)
-	}
-	// Normal projects hit the lexical target exactly. Physical validation is
-	// only needed when GetSourceFile returns a differently spelled source.
-	if sourceFile := lookup.sourceFileForCandidate(targetPath, canonicalPath); sourceFile != nil {
-		return sourceFile
-	}
-	if canonicalPath != "" && canonicalPath != targetPath {
-		if sourceFile := lookup.sourceFileForCandidate(canonicalPath, canonicalPath); sourceFile != nil {
-			return sourceFile
-		}
-	}
-	// A physical source index can only resolve a spelling alias. When target
-	// planning found no lexical/canonical difference, the direct miss above is
-	// authoritative and indexing every Program source would add pure realpath IO.
-	if canonicalPath == "" || exactFilesystemPathID(canonicalPath) == exactFilesystemPathID(targetPath) {
+	targetPath = tspath.NormalizePath(targetPath)
+	sourceFile := program.GetSourceFile(targetPath)
+	if sourceFile == nil || exactFilesystemPathID(sourceFile.FileName()) != exactFilesystemPathID(targetPath) {
 		return nil
 	}
-	if fsys == nil {
+	return sourceFile
+}
+
+// programFileIndex joins lint targets to Program sources by exact physical
+// path. It resolves each unique source path once and retains Program membership
+// so project declaration order remains authoritative during lookup.
+type programFileIndex struct {
+	programs         []*compiler.Program
+	fsys             vfs.FS
+	singleThreaded   bool
+	built            bool
+	sourcesByProgram []map[string]*ast.SourceFile
+}
+
+func newProgramFileIndex(programs []*compiler.Program, fsys vfs.FS, singleThreaded bool) *programFileIndex {
+	return &programFileIndex{
+		programs:       programs,
+		fsys:           fsys,
+		singleThreaded: singleThreaded,
+	}
+}
+
+func (index *programFileIndex) sourceFile(programIndex int, canonicalTarget string) *ast.SourceFile {
+	if index == nil || index.fsys == nil || canonicalTarget == "" ||
+		programIndex < 0 || programIndex >= len(index.programs) {
 		return nil
 	}
+	if !index.built {
+		index.build()
+	}
+	return index.sourcesByProgram[programIndex][exactFilesystemPathID(canonicalTarget)]
+}
 
-	lookupAlias := func(candidate string) *ast.SourceFile {
-		if candidate == "" {
-			return nil
+type programSourceMembership struct {
+	programIndex int
+	sourceIndex  int
+	sourceFile   *ast.SourceFile
+}
+
+func (index *programFileIndex) build() {
+	index.built = true
+	index.sourcesByProgram = make([]map[string]*ast.SourceFile, len(index.programs))
+
+	sourceIndexByPath := make(map[string]int)
+	var sourcePaths []string
+	var memberships []programSourceMembership
+	for programIndex, program := range index.programs {
+		if program == nil {
+			continue
 		}
-		candidate = tspath.NormalizePath(candidate)
-		candidateID := exactFilesystemPathID(candidate)
-		if candidateID == exactFilesystemPathID(targetPath) ||
-			candidateID == exactFilesystemPathID(canonicalPath) {
-			return nil
+		for _, sourceFile := range program.GetSourceFiles() {
+			sourcePath := tspath.NormalizePath(sourceFile.FileName())
+			sourcePathID := exactFilesystemPathID(sourcePath)
+			sourceIndex, exists := sourceIndexByPath[sourcePathID]
+			if !exists {
+				sourceIndex = len(sourcePaths)
+				sourceIndexByPath[sourcePathID] = sourceIndex
+				sourcePaths = append(sourcePaths, sourcePath)
+			}
+			memberships = append(memberships, programSourceMembership{
+				programIndex: programIndex,
+				sourceIndex:  sourceIndex,
+				sourceFile:   sourceFile,
+			})
 		}
-		return lookup.sourceFileForCandidate(candidate, canonicalPath)
 	}
 
-	ownerRoot := tspath.NormalizePath(target.OwnerConfigDir)
-	ownerCanonical := ownerRoot
-	if realPath := fsys.Realpath(ownerRoot); realPath != "" {
-		ownerCanonical = tspath.NormalizePath(realPath)
+	canonicalIDs := make([]string, len(sourcePaths))
+	work := core.NewWorkGroup(index.singleThreaded)
+	for i := range sourcePaths {
+		work.Queue(func() {
+			canonicalIDs[i] = canonicalFilesystemPathID(sourcePaths[i], index.fsys)
+		})
 	}
-	ownerAlias := aliasPathUnderRoot(canonicalPath, ownerCanonical, ownerRoot, true)
-	if sourceFile := lookupAlias(ownerAlias); sourceFile != nil {
-		return sourceFile
-	}
+	work.RunAndWait()
 
-	programRoot := tspath.NormalizePath(program.GetCurrentDirectory())
-	programCanonical := programRoot
-	if realPath := fsys.Realpath(programRoot); realPath != "" {
-		programCanonical = tspath.NormalizePath(realPath)
-	}
-	programAlias := aliasPathUnderRoot(canonicalPath, programCanonical, programRoot, true)
-	if exactFilesystemPathID(programAlias) != exactFilesystemPathID(ownerAlias) {
-		if sourceFile := lookupAlias(programAlias); sourceFile != nil {
-			return sourceFile
+	for _, membership := range memberships {
+		sources := index.sourcesByProgram[membership.programIndex]
+		if sources == nil {
+			sources = make(map[string]*ast.SourceFile)
+			index.sourcesByProgram[membership.programIndex] = sources
+		}
+		canonicalID := canonicalIDs[membership.sourceIndex]
+		existing := sources[canonicalID]
+		if existing == nil || membership.sourceFile.FileName() < existing.FileName() {
+			sources[canonicalID] = membership.sourceFile
 		}
 	}
-	return lookup.canonicalSourceFile(canonicalPath)
 }
 
 func groupFallbackTargets(
@@ -552,10 +531,7 @@ func bindLintTargetPlan(
 
 	var gaps []resolvedLintTarget
 	programIndexesByConfig := make(map[string][]int)
-	programLookups := make([]programTargetLookup, len(set.Programs))
-	for i, program := range set.Programs {
-		programLookups[i] = programTargetLookup{program: program, fsys: fsys}
-	}
+	programFiles := newProgramFileIndex(set.Programs, fsys, singleThreaded)
 	for _, target := range plan.Targets {
 		programIndexes, cached := programIndexesByConfig[target.OwnerConfigDir]
 		if !cached {
@@ -564,7 +540,10 @@ func bindLintTargetPlan(
 		}
 		bound := false
 		for _, programIndex := range programIndexes {
-			sourceFile := programLookups[programIndex].sourceFileForTarget(target)
+			sourceFile := exactProgramSourceFile(set.Programs[programIndex], target.Path)
+			if sourceFile == nil {
+				sourceFile = programFiles.sourceFile(programIndex, target.CanonicalPath)
+			}
 			if sourceFile == nil {
 				continue
 			}
@@ -607,9 +586,8 @@ func bindLintTargetPlan(
 			fallbackIndex := len(binding.Programs)
 			binding.Programs = append(binding.Programs, fallback)
 			binding.TargetsByProgram = append(binding.TargetsByProgram, nil)
-			fallbackLookup := programTargetLookup{program: fallback, fsys: fsys}
 			for _, gap := range fallbackTargets {
-				sourceFile := fallbackLookup.sourceFileForTarget(gap)
+				sourceFile := exactProgramSourceFile(fallback, gap.Path)
 				if sourceFile == nil {
 					return lintTargetBinding{}, fmt.Errorf("fallback Program did not contain lint target %q", gap.Path)
 				}

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -16,8 +16,8 @@ import (
 )
 
 // programConfigOrders records which rslint configs declared one Program's
-// canonical tsconfig and the declaration order within each config. A shared
-// tsconfig has one Program instance but may have multiple config associations.
+// normalized tsconfig path and the declaration order within each config. A
+// shared path has one Program instance but may have multiple associations.
 type programConfigOrders map[string]int
 
 // lintProgramSet is the unique set of real tsconfig-backed Programs used by a
@@ -28,12 +28,8 @@ type lintProgramSet struct {
 	ConfigOrders []programConfigOrders
 }
 
-func filesystemPathID(filePath string, fsys vfs.FS) string {
-	useCaseSensitive := true
-	if fsys != nil {
-		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
-	}
-	return string(tspath.ToPath(tspath.NormalizePath(filePath), "", useCaseSensitive))
+func exactFilesystemPathID(filePath string) string {
+	return string(tspath.ToPath(tspath.NormalizePath(filePath), "", true))
 }
 
 func authoritativeFilesystemPath(filePath string, fsys vfs.FS) string {
@@ -47,7 +43,7 @@ func authoritativeFilesystemPath(filePath string, fsys vfs.FS) string {
 }
 
 func canonicalFilesystemPathID(filePath string, fsys vfs.FS) string {
-	return filesystemPathID(authoritativeFilesystemPath(filePath, fsys), fsys)
+	return exactFilesystemPathID(authoritativeFilesystemPath(filePath, fsys))
 }
 
 func relativePathUnderRoot(filePath string, root string, useCaseSensitive bool) (string, bool) {
@@ -66,44 +62,31 @@ func relativePathUnderRoot(filePath string, root string, useCaseSensitive bool) 
 	return tspath.GetRelativePathFromDirectory(root, filePath, compareOptions), true
 }
 
-// configPathForBoundSource returns the path used for files/ignores matching.
-// Program source aliases are authoritative over the caller's display path. The
-// result is rooted in the physical config directory so a symlinked config root
-// and its real path share one stable matching space.
-func configPathForBoundSource(sourcePath string, target resolvedLintTarget, fsys vfs.FS) string {
-	useCaseSensitive := true
-	if fsys != nil {
-		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
-	}
-	ownerRoot := tspath.NormalizePath(target.OwnerConfigDir)
-	authoritativeRoot := authoritativeFilesystemPath(ownerRoot, fsys)
-
-	if relative, ok := relativePathUnderRoot(sourcePath, ownerRoot, useCaseSensitive); ok {
-		return tspath.ResolvePath(authoritativeRoot, relative)
-	}
-	canonicalSource := authoritativeFilesystemPath(sourcePath, fsys)
-	if relative, ok := relativePathUnderRoot(canonicalSource, authoritativeRoot, useCaseSensitive); ok {
-		return tspath.ResolvePath(authoritativeRoot, relative)
-	}
-	if relative, ok := relativePathUnderRoot(target.Path, ownerRoot, useCaseSensitive); ok {
-		return tspath.ResolvePath(authoritativeRoot, relative)
-	}
-	if relative, ok := relativePathUnderRoot(target.CanonicalPath, authoritativeRoot, useCaseSensitive); ok {
-		return tspath.ResolvePath(authoritativeRoot, relative)
-	}
-	return tspath.NormalizePath(sourcePath)
+// configPathForLintTarget returns the target path used for files/ignores
+// matching. Program source names are deliberately excluded: adding or removing
+// a file from a TypeScript Program must not change its lint configuration.
+func configPathForLintTarget(target resolvedLintTarget, fsys vfs.FS) string {
+	matchPath, _ := rslintconfig.ResolveConfigPathSpaceWithCanonical(
+		target.Path,
+		target.CanonicalPath,
+		target.OwnerConfigDir,
+		fsys,
+	)
+	return matchPath
 }
 
-func storeSourcePathMapping(mapping map[string]string, sourcePath string, value string, fsys vfs.FS) {
+func storeSourcePathMapping(mapping map[string]string, sourcePath string, canonicalSourcePath string, value string) {
 	if mapping == nil {
 		return
 	}
 	normalizedSource := tspath.NormalizePath(sourcePath)
 	mapping[normalizedSource] = value
-	mapping[filesystemPathID(normalizedSource, fsys)] = value
+	if canonicalSourcePath != "" {
+		mapping[exactFilesystemPathID(canonicalSourcePath)] = value
+	}
 }
 
-// createProgramSetForConfigs builds each canonical tsconfig once while
+// createProgramSetForConfigs builds each normalized tsconfig path once while
 // retaining every config that declared it. Config roots are processed in a
 // stable order; target binding later uses the per-config project order rather
 // than map iteration or Program construction order.
@@ -133,7 +116,8 @@ func createProgramSetForConfigs(
 		}
 
 		for order, tsconfigPath := range tsConfigs {
-			tsconfigID := canonicalFilesystemPathID(tsconfigPath, fsys)
+			tsconfigPath = tspath.NormalizePath(tsconfigPath)
+			tsconfigID := exactFilesystemPathID(tsconfigPath)
 			if programIndex, ok := programByTsconfig[tsconfigID]; ok {
 				if _, alreadyAssociated := set.ConfigOrders[programIndex][configDir]; !alreadyAssociated {
 					set.ConfigOrders[programIndex][configDir] = order
@@ -141,10 +125,10 @@ func createProgramSetForConfigs(
 				continue
 			}
 
-			// Build shared Programs from the tsconfig's own directory so the
-			// result does not depend on which rslint config happened to declare
-			// the tsconfig first.
-			programCwd := tspath.GetDirectoryPath(tspath.NormalizePath(tsconfigPath))
+			// Relative paths in a tsconfig are resolved from the declared path,
+			// including when that path is a file symlink. This matches tsc/tsgo;
+			// realpath is only a source-identity fallback during target binding.
+			programCwd := tspath.GetDirectoryPath(tsconfigPath)
 			host := utils.WithParseCache(utils.CreateCompilerHost(programCwd, fsys), parseCache)
 			program, err := utils.CreateProgramLenient(singleThreaded, fsys, programCwd, tsconfigPath, host)
 			if err != nil {
@@ -228,6 +212,22 @@ func parallelGitignoreAndPrograms(
 	return rslintConfig, programs, nil
 }
 
+func configWithGitignore(
+	rslintConfig rslintconfig.RslintConfig,
+	configDir string,
+	fsys vfs.FS,
+) rslintconfig.RslintConfig {
+	gitGlobs := rslintconfig.ReadGitignoreAsGlobs(
+		configDir,
+		fsys,
+		rslintconfig.ExtractConfigIgnores(rslintConfig),
+	)
+	if len(gitGlobs) == 0 {
+		return rslintConfig
+	}
+	return append(rslintconfig.RslintConfig{{Ignores: gitGlobs}}, rslintConfig...)
+}
+
 // createFallbackProgram creates a Program for selected lint targets not
 // included in any existing Program. It uses minimal compiler options sufficient
 // for AST parsing (no type checking).
@@ -263,28 +263,53 @@ type lintTargetPlan struct {
 	Targets []resolvedLintTarget
 }
 
+func configsForLintTargetPlan(
+	configMap map[string]rslintconfig.RslintConfig,
+	plan lintTargetPlan,
+) map[string]rslintconfig.RslintConfig {
+	if len(configMap) == 0 || len(plan.Targets) == 0 {
+		return nil
+	}
+	active := make(map[string]rslintconfig.RslintConfig)
+	for _, target := range plan.Targets {
+		if entries, ok := configMap[target.OwnerConfigDir]; ok {
+			active[target.OwnerConfigDir] = entries
+		}
+	}
+	return active
+}
+
 func resolveLintTargetPlan(
 	configMap map[string]rslintconfig.RslintConfig,
 	rslintConfig rslintconfig.RslintConfig,
 	currentDirectory string,
-	configTargetFiles map[string][]string,
+	configTargetScopes map[string]rslintconfig.LintDiscoveryScope,
 	fsys vfs.FS,
 	allowFiles []string,
 	allowDirs []string,
 	singleThreaded bool,
 ) (lintTargetPlan, error) {
 	type targetWithOwner struct {
-		path  string
-		owner string
+		path          string
+		canonicalPath string
+		owner         string
 	}
 	var targetFiles []targetWithOwner
 	if configMap != nil {
-		for _, target := range discoverLintFilesMultiConfig(configMap, configTargetFiles, fsys, allowFiles, allowDirs, singleThreaded) {
-			targetFiles = append(targetFiles, targetWithOwner{path: target.Path, owner: target.ConfigDirectory})
+		for _, target := range discoverLintFilesMultiConfig(configMap, configTargetScopes, fsys, allowFiles, allowDirs, singleThreaded) {
+			targetFiles = append(targetFiles, targetWithOwner{
+				path:          target.Path,
+				canonicalPath: target.CanonicalPath,
+				owner:         target.ConfigDirectory,
+			})
 		}
 	} else {
-		for _, targetPath := range rslintconfig.DiscoverLintFiles(rslintConfig, currentDirectory, fsys, allowFiles, allowDirs, singleThreaded) {
-			targetFiles = append(targetFiles, targetWithOwner{path: targetPath, owner: currentDirectory})
+		for _, target := range rslintconfig.DiscoverLintTargets(rslintConfig, currentDirectory, fsys, allowFiles, allowDirs, singleThreaded) {
+			targetFiles = append(targetFiles, targetWithOwner{
+				path:          target.Path,
+				canonicalPath: target.CanonicalPath,
+				owner:         currentDirectory,
+			})
 		}
 	}
 
@@ -294,22 +319,22 @@ func resolveLintTargetPlan(
 		targetPath := discovered.path
 		ownerConfigDir := discovered.owner
 		canonicalPath := tspath.NormalizePath(targetPath)
-		if fsys != nil {
+		if discovered.canonicalPath != "" {
+			canonicalPath = tspath.NormalizePath(discovered.canonicalPath)
+		}
+		if discovered.canonicalPath == "" && fsys != nil {
 			if realPath := fsys.Realpath(canonicalPath); realPath != "" {
 				canonicalPath = tspath.NormalizePath(realPath)
 			}
 		}
-		canonicalKey := canonicalPath
-		if fsys != nil {
-			canonicalKey = string(tspath.ToPath(canonicalPath, "", fsys.UseCaseSensitiveFileNames()))
-		}
+		canonicalKey := exactFilesystemPathID(canonicalPath)
 		target := resolvedLintTarget{
 			Path:           tspath.NormalizePath(targetPath),
 			CanonicalPath:  canonicalPath,
 			OwnerConfigDir: tspath.NormalizePath(ownerConfigDir),
 		}
 		if existing, exists := seenCanonical[canonicalKey]; exists {
-			if filesystemPathID(existing.OwnerConfigDir, fsys) != filesystemPathID(target.OwnerConfigDir, fsys) {
+			if canonicalFilesystemPathID(existing.OwnerConfigDir, fsys) != canonicalFilesystemPathID(target.OwnerConfigDir, fsys) {
 				return lintTargetPlan{}, fmt.Errorf(
 					"lint target aliases %q and %q resolve to the same file but are governed by different configs %q and %q",
 					existing.Path,
@@ -326,13 +351,13 @@ func resolveLintTargetPlan(
 	return plan, nil
 }
 
-func preferredCallerTargetPaths(plan lintTargetPlan, fsys vfs.FS) map[string]string {
+func preferredCallerTargetPaths(plan lintTargetPlan) map[string]string {
 	if len(plan.Targets) == 0 {
 		return nil
 	}
 	preferred := make(map[string]string, len(plan.Targets))
 	for _, target := range plan.Targets {
-		canonicalID := canonicalFilesystemPathID(target.CanonicalPath, fsys)
+		canonicalID := exactFilesystemPathID(target.CanonicalPath)
 		if _, exists := preferred[canonicalID]; !exists {
 			preferred[canonicalID] = target.Path
 		}
@@ -362,28 +387,24 @@ func aliasPathUnderRoot(path string, canonicalRoot string, lexicalRoot string, u
 }
 
 type programTargetLookup struct {
-	program             *compiler.Program
-	fsys                vfs.FS
-	canonicalIndexBuilt bool
-	canonicalSources    map[string]*ast.SourceFile
+	program      *compiler.Program
+	fsys         vfs.FS
+	sourceLookup *utils.ProgramSourceLookup
+}
+
+func (lookup *programTargetLookup) programSources() *utils.ProgramSourceLookup {
+	if lookup.sourceLookup == nil {
+		lookup.sourceLookup = utils.NewProgramSourceLookup(lookup.program, lookup.fsys)
+	}
+	return lookup.sourceLookup
+}
+
+func (lookup *programTargetLookup) sourceFileForCandidate(candidate string, canonicalTarget string) *ast.SourceFile {
+	return lookup.programSources().SourceFileForCandidate(candidate, canonicalTarget)
 }
 
 func (lookup *programTargetLookup) canonicalSourceFile(canonicalPath string) *ast.SourceFile {
-	if lookup.fsys == nil || canonicalPath == "" {
-		return nil
-	}
-	if !lookup.canonicalIndexBuilt {
-		lookup.canonicalIndexBuilt = true
-		lookup.canonicalSources = make(map[string]*ast.SourceFile)
-		for _, sourceFile := range lookup.program.GetSourceFiles() {
-			canonicalID := canonicalFilesystemPathID(sourceFile.FileName(), lookup.fsys)
-			existing := lookup.canonicalSources[canonicalID]
-			if existing == nil || sourceFile.FileName() < existing.FileName() {
-				lookup.canonicalSources[canonicalID] = sourceFile
-			}
-		}
-	}
-	return lookup.canonicalSources[canonicalFilesystemPathID(canonicalPath, lookup.fsys)]
+	return lookup.programSources().CanonicalSourceFile(canonicalPath)
 }
 
 // sourceFileForTarget first performs bounded target-driven lookups. Only when
@@ -396,44 +417,42 @@ func (lookup *programTargetLookup) sourceFileForTarget(target resolvedLintTarget
 	if program == nil {
 		return nil
 	}
-	// Normal projects hit the lexical target immediately. Keep realpath work
-	// entirely off this hot path; aliases are only derived after both direct
-	// target forms miss.
 	targetPath := tspath.NormalizePath(target.Path)
-	if sourceFile := program.GetSourceFile(targetPath); sourceFile != nil {
-		return sourceFile
-	}
 	canonicalPath := ""
 	if target.CanonicalPath != "" {
 		canonicalPath = tspath.NormalizePath(target.CanonicalPath)
 	}
+	// Normal projects hit the lexical target exactly. Physical validation is
+	// only needed when GetSourceFile returns a differently spelled source.
+	if sourceFile := lookup.sourceFileForCandidate(targetPath, canonicalPath); sourceFile != nil {
+		return sourceFile
+	}
 	if canonicalPath != "" && canonicalPath != targetPath {
-		if sourceFile := program.GetSourceFile(canonicalPath); sourceFile != nil {
+		if sourceFile := lookup.sourceFileForCandidate(canonicalPath, canonicalPath); sourceFile != nil {
 			return sourceFile
 		}
+	}
+	// A physical source index can only resolve a spelling alias. When target
+	// planning found no lexical/canonical difference, the direct miss above is
+	// authoritative and indexing every Program source would add pure realpath IO.
+	if canonicalPath == "" || exactFilesystemPathID(canonicalPath) == exactFilesystemPathID(targetPath) {
+		return nil
 	}
 	if fsys == nil {
 		return nil
 	}
-	if canonicalPath == "" {
-		canonicalPath = targetPath
-	}
-	if canonicalPath == "" {
-		return nil
-	}
 
-	useCaseSensitive := program.UseCaseSensitiveFileNames()
 	lookupAlias := func(candidate string) *ast.SourceFile {
 		if candidate == "" {
 			return nil
 		}
 		candidate = tspath.NormalizePath(candidate)
-		compareOptions := tspath.ComparePathsOptions{UseCaseSensitiveFileNames: useCaseSensitive}
-		if tspath.ComparePaths(candidate, targetPath, compareOptions) == 0 ||
-			tspath.ComparePaths(candidate, canonicalPath, compareOptions) == 0 {
+		candidateID := exactFilesystemPathID(candidate)
+		if candidateID == exactFilesystemPathID(targetPath) ||
+			candidateID == exactFilesystemPathID(canonicalPath) {
 			return nil
 		}
-		return program.GetSourceFile(candidate)
+		return lookup.sourceFileForCandidate(candidate, canonicalPath)
 	}
 
 	ownerRoot := tspath.NormalizePath(target.OwnerConfigDir)
@@ -441,7 +460,7 @@ func (lookup *programTargetLookup) sourceFileForTarget(target resolvedLintTarget
 	if realPath := fsys.Realpath(ownerRoot); realPath != "" {
 		ownerCanonical = tspath.NormalizePath(realPath)
 	}
-	ownerAlias := aliasPathUnderRoot(canonicalPath, ownerCanonical, ownerRoot, useCaseSensitive)
+	ownerAlias := aliasPathUnderRoot(canonicalPath, ownerCanonical, ownerRoot, true)
 	if sourceFile := lookupAlias(ownerAlias); sourceFile != nil {
 		return sourceFile
 	}
@@ -451,14 +470,44 @@ func (lookup *programTargetLookup) sourceFileForTarget(target resolvedLintTarget
 	if realPath := fsys.Realpath(programRoot); realPath != "" {
 		programCanonical = tspath.NormalizePath(realPath)
 	}
-	programAlias := aliasPathUnderRoot(canonicalPath, programCanonical, programRoot, useCaseSensitive)
-	compareOptions := tspath.ComparePathsOptions{UseCaseSensitiveFileNames: useCaseSensitive}
-	if tspath.ComparePaths(programAlias, ownerAlias, compareOptions) != 0 {
+	programAlias := aliasPathUnderRoot(canonicalPath, programCanonical, programRoot, true)
+	if exactFilesystemPathID(programAlias) != exactFilesystemPathID(ownerAlias) {
 		if sourceFile := lookupAlias(programAlias); sourceFile != nil {
 			return sourceFile
 		}
 	}
 	return lookup.canonicalSourceFile(canonicalPath)
+}
+
+func groupFallbackTargets(
+	gaps []resolvedLintTarget,
+	currentDirectory string,
+	useCaseSensitive bool,
+) [][]resolvedLintTarget {
+	if len(gaps) == 0 {
+		return nil
+	}
+
+	groups := make([][]resolvedLintTarget, 0, 1)
+	keysByGroup := make([]map[tspath.Path]struct{}, 0, 1)
+	for _, gap := range gaps {
+		key := tspath.ToPath(gap.Path, currentDirectory, useCaseSensitive)
+		groupIndex := -1
+		for i, keys := range keysByGroup {
+			if _, exists := keys[key]; !exists {
+				groupIndex = i
+				break
+			}
+		}
+		if groupIndex == -1 {
+			groupIndex = len(groups)
+			groups = append(groups, nil)
+			keysByGroup = append(keysByGroup, make(map[tspath.Path]struct{}))
+		}
+		groups[groupIndex] = append(groups[groupIndex], gap)
+		keysByGroup[groupIndex][key] = struct{}{}
+	}
+	return groups
 }
 
 func orderedProgramIndexesForConfig(set lintProgramSet, configDir string) []int {
@@ -521,13 +570,13 @@ func bindLintTargetPlan(
 			}
 			sourcePath := sourceFile.FileName()
 			binding.TargetsByProgram[programIndex] = append(binding.TargetsByProgram[programIndex], sourcePath)
-			storeSourcePathMapping(binding.OwnerConfigDirBySourcePath, sourcePath, target.OwnerConfigDir, fsys)
-			storeSourcePathMapping(binding.ConfigPathBySourcePath, sourcePath, configPathForBoundSource(sourcePath, target, fsys), fsys)
+			storeSourcePathMapping(binding.OwnerConfigDirBySourcePath, sourcePath, target.CanonicalPath, target.OwnerConfigDir)
+			storeSourcePathMapping(binding.ConfigPathBySourcePath, sourcePath, target.CanonicalPath, configPathForLintTarget(target, fsys))
 			binding.TypeInfoFiles[sourcePath] = struct{}{}
 			binding.TypeInfoFiles[target.Path] = struct{}{}
 			binding.TypeInfoFiles[target.CanonicalPath] = struct{}{}
 			if tspath.NormalizePath(sourcePath) != target.Path {
-				storeSourcePathMapping(binding.TargetPathBySourcePath, sourcePath, target.Path, fsys)
+				storeSourcePathMapping(binding.TargetPathBySourcePath, sourcePath, target.CanonicalPath, target.Path)
 			}
 			bound = true
 			break
@@ -539,32 +588,38 @@ func bindLintTargetPlan(
 	}
 
 	if len(gaps) > 0 {
-		fallbackFiles := make([]string, 0, len(gaps))
-		for _, gap := range gaps {
-			fallbackFiles = append(fallbackFiles, gap.Path)
+		useCaseSensitive := true
+		if fsys != nil {
+			useCaseSensitive = fsys.UseCaseSensitiveFileNames()
 		}
-		fallback, err := createFallbackProgram(fallbackFiles, singleThreaded, currentDirectory, fsys, parseCache)
-		if err != nil {
-			return lintTargetBinding{}, err
-		}
-		if fallback == nil {
-			return lintTargetBinding{}, fmt.Errorf("create fallback Program for %d lint target(s): no Program returned", len(gaps))
-		}
-		fallbackIndex := len(binding.Programs)
-		binding.Programs = append(binding.Programs, fallback)
-		binding.TargetsByProgram = append(binding.TargetsByProgram, nil)
-		fallbackLookup := programTargetLookup{program: fallback, fsys: fsys}
-		for _, gap := range gaps {
-			sourceFile := fallbackLookup.sourceFileForTarget(gap)
-			if sourceFile == nil {
-				return lintTargetBinding{}, fmt.Errorf("fallback Program did not contain lint target %q", gap.Path)
+		for _, fallbackTargets := range groupFallbackTargets(gaps, currentDirectory, useCaseSensitive) {
+			fallbackFiles := make([]string, 0, len(fallbackTargets))
+			for _, gap := range fallbackTargets {
+				fallbackFiles = append(fallbackFiles, gap.Path)
 			}
-			sourcePath := sourceFile.FileName()
-			binding.TargetsByProgram[fallbackIndex] = append(binding.TargetsByProgram[fallbackIndex], sourcePath)
-			storeSourcePathMapping(binding.OwnerConfigDirBySourcePath, sourcePath, gap.OwnerConfigDir, fsys)
-			storeSourcePathMapping(binding.ConfigPathBySourcePath, sourcePath, configPathForBoundSource(sourcePath, gap, fsys), fsys)
-			if tspath.NormalizePath(sourcePath) != gap.Path {
-				storeSourcePathMapping(binding.TargetPathBySourcePath, sourcePath, gap.Path, fsys)
+			fallback, err := createFallbackProgram(fallbackFiles, singleThreaded, currentDirectory, fsys, parseCache)
+			if err != nil {
+				return lintTargetBinding{}, err
+			}
+			if fallback == nil {
+				return lintTargetBinding{}, fmt.Errorf("create fallback Program for %d lint target(s): no Program returned", len(fallbackTargets))
+			}
+			fallbackIndex := len(binding.Programs)
+			binding.Programs = append(binding.Programs, fallback)
+			binding.TargetsByProgram = append(binding.TargetsByProgram, nil)
+			fallbackLookup := programTargetLookup{program: fallback, fsys: fsys}
+			for _, gap := range fallbackTargets {
+				sourceFile := fallbackLookup.sourceFileForTarget(gap)
+				if sourceFile == nil {
+					return lintTargetBinding{}, fmt.Errorf("fallback Program did not contain lint target %q", gap.Path)
+				}
+				sourcePath := sourceFile.FileName()
+				binding.TargetsByProgram[fallbackIndex] = append(binding.TargetsByProgram[fallbackIndex], sourcePath)
+				storeSourcePathMapping(binding.OwnerConfigDirBySourcePath, sourcePath, gap.CanonicalPath, gap.OwnerConfigDir)
+				storeSourcePathMapping(binding.ConfigPathBySourcePath, sourcePath, gap.CanonicalPath, configPathForLintTarget(gap, fsys))
+				if tspath.NormalizePath(sourcePath) != gap.Path {
+					storeSourcePathMapping(binding.TargetPathBySourcePath, sourcePath, gap.CanonicalPath, gap.Path)
+				}
 			}
 		}
 	}
@@ -583,26 +638,19 @@ func bindLintTargetPlan(
 
 func discoverLintFilesMultiConfig(
 	configMap map[string]rslintconfig.RslintConfig,
-	configTargetFiles map[string][]string,
+	configTargetScopes map[string]rslintconfig.LintDiscoveryScope,
 	fs vfs.FS,
 	allowFiles []string,
 	allowDirs []string,
 	singleThreaded bool,
 ) []rslintconfig.DiscoveredLintTarget {
-	var scopes map[string]rslintconfig.LintDiscoveryScope
-	if len(configTargetFiles) > 0 {
-		scopes = make(map[string]rslintconfig.LintDiscoveryScope, len(configTargetFiles))
-		for configDir, targetFiles := range configTargetFiles {
-			scopes[configDir] = rslintconfig.LintDiscoveryScope{Files: targetFiles}
-		}
-	}
-	return rslintconfig.DiscoverLintTargetsMultiConfig(configMap, scopes, fs, allowFiles, allowDirs, singleThreaded)
+	return rslintconfig.DiscoverLintTargetsMultiConfig(configMap, configTargetScopes, fs, allowFiles, allowDirs, singleThreaded)
 }
 
 // buildTypeCheckSkipMask returns a parallel-to-programs []bool marking which
 // programs must be excluded from the type-check phase. A program is skipped
 // when it was NOT built from a real tsconfig on disk — i.e. its CompilerOptions
-// carry no ConfigFilePath. That covers the AST-only fallback Program used for
+// carry no ConfigFilePath. That covers the non-project-backed fallback Program used for
 // selected files absent from every tsconfig-backed Program, including projects
 // with no tsconfig at all.
 //
@@ -659,14 +707,8 @@ func collectTargetSyntacticDiagnostics(
 		if i >= len(targetsByProgram) || len(targetsByProgram[i]) == 0 {
 			continue
 		}
-
-		targets := make(map[string]struct{}, len(targetsByProgram[i]))
-		for _, target := range targetsByProgram[i] {
-			targets[target] = struct{}{}
-		}
-
 		ctx := context.Background()
-		for target := range targets {
+		for _, target := range targetsByProgram[i] {
 			file := program.GetSourceFile(target)
 			if file == nil {
 				continue

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -15,9 +15,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// programConfigOrders records which rslint configs declared one Program's
-// normalized tsconfig path and the declaration order within each config. A
-// shared path has one Program instance but may have multiple associations.
+// programConfigOrders maps normalized config-directory identities to the
+// declaration order of one Program's tsconfig in each config. A shared path
+// has one Program instance but may have multiple associations.
 type programConfigOrders map[string]int
 
 // lintProgramSet is the unique set of real tsconfig-backed Programs used by a
@@ -94,7 +94,9 @@ func createProgramSetForConfigs(
 	programByTsconfig := make(map[string]int)
 	for _, configDir := range configDirs {
 		entries := configMap[configDir]
-		tsConfigs, err := rslintconfig.ResolveTsConfigPaths(entries, configDir, fsys)
+		normalizedConfigDir := tspath.NormalizePath(configDir)
+		configDirID := exactFilesystemPathID(normalizedConfigDir)
+		tsConfigs, err := rslintconfig.ResolveTsConfigPaths(entries, normalizedConfigDir, fsys)
 		if err != nil {
 			return lintProgramSet{}, fmt.Errorf("resolve tsconfigs for %q: %w", configDir, err)
 		}
@@ -103,8 +105,8 @@ func createProgramSetForConfigs(
 			tsconfigPath = tspath.NormalizePath(tsconfigPath)
 			tsconfigID := exactFilesystemPathID(tsconfigPath)
 			if programIndex, ok := programByTsconfig[tsconfigID]; ok {
-				if _, alreadyAssociated := set.ConfigOrders[programIndex][configDir]; !alreadyAssociated {
-					set.ConfigOrders[programIndex][configDir] = order
+				if _, alreadyAssociated := set.ConfigOrders[programIndex][configDirID]; !alreadyAssociated {
+					set.ConfigOrders[programIndex][configDirID] = order
 				}
 				continue
 			}
@@ -121,7 +123,7 @@ func createProgramSetForConfigs(
 
 			programByTsconfig[tsconfigID] = len(set.Programs)
 			set.Programs = append(set.Programs, program)
-			set.ConfigOrders = append(set.ConfigOrders, programConfigOrders{configDir: order})
+			set.ConfigOrders = append(set.ConfigOrders, programConfigOrders{configDirID: order})
 		}
 	}
 
@@ -490,17 +492,18 @@ func groupFallbackTargets(
 }
 
 func orderedProgramIndexesForConfig(set lintProgramSet, configDir string) []int {
+	configDirID := exactFilesystemPathID(configDir)
 	indexes := make([]int, 0, len(set.Programs))
 	for i := range set.Programs {
 		if i < len(set.ConfigOrders) {
-			if _, ok := set.ConfigOrders[i][configDir]; ok {
+			if _, ok := set.ConfigOrders[i][configDirID]; ok {
 				indexes = append(indexes, i)
 			}
 		}
 	}
 	sort.SliceStable(indexes, func(i, j int) bool {
-		left := set.ConfigOrders[indexes[i]][configDir]
-		right := set.ConfigOrders[indexes[j]][configDir]
+		left := set.ConfigOrders[indexes[i]][configDirID]
+		right := set.ConfigOrders[indexes[j]][configDirID]
 		if left != right {
 			return left < right
 		}

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -3,9 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 
+	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
@@ -15,13 +15,173 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// parallelGitignoreAndPrograms runs ReadGitignoreAsGlobs and createProgramsForConfig
-// for a single rslint config (single-config and legacy JSON paths).
+// programConfigOrders records which rslint configs declared one Program's
+// canonical tsconfig and the declaration order within each config. A shared
+// tsconfig has one Program instance but may have multiple config associations.
+type programConfigOrders map[string]int
+
+// lintProgramSet is the unique set of real tsconfig-backed Programs used by a
+// lint run. ConfigOrders is parallel to Programs. Synthetic fallback Programs
+// are appended only while binding a lint target plan and have no config entry.
+type lintProgramSet struct {
+	Programs     []*compiler.Program
+	ConfigOrders []programConfigOrders
+}
+
+func filesystemPathID(filePath string, fsys vfs.FS) string {
+	useCaseSensitive := true
+	if fsys != nil {
+		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
+	}
+	return string(tspath.ToPath(tspath.NormalizePath(filePath), "", useCaseSensitive))
+}
+
+func authoritativeFilesystemPath(filePath string, fsys vfs.FS) string {
+	filePath = tspath.NormalizePath(filePath)
+	if fsys != nil {
+		if realPath := fsys.Realpath(filePath); realPath != "" {
+			return tspath.NormalizePath(realPath)
+		}
+	}
+	return filePath
+}
+
+func canonicalFilesystemPathID(filePath string, fsys vfs.FS) string {
+	return filesystemPathID(authoritativeFilesystemPath(filePath, fsys), fsys)
+}
+
+func relativePathUnderRoot(filePath string, root string, useCaseSensitive bool) (string, bool) {
+	filePath = tspath.NormalizePath(filePath)
+	root = tspath.NormalizePath(root)
+	compareOptions := tspath.ComparePathsOptions{
+		CurrentDirectory:          root,
+		UseCaseSensitiveFileNames: useCaseSensitive,
+	}
+	if tspath.ComparePaths(filePath, root, compareOptions) == 0 {
+		return "", true
+	}
+	if !tspath.StartsWithDirectory(filePath, root, useCaseSensitive) {
+		return "", false
+	}
+	return tspath.GetRelativePathFromDirectory(root, filePath, compareOptions), true
+}
+
+// configPathForBoundSource returns the path used for files/ignores matching.
+// Program source aliases are authoritative over the caller's display path. The
+// result is rooted in the physical config directory so a symlinked config root
+// and its real path share one stable matching space.
+func configPathForBoundSource(sourcePath string, target resolvedLintTarget, fsys vfs.FS) string {
+	useCaseSensitive := true
+	if fsys != nil {
+		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
+	}
+	ownerRoot := tspath.NormalizePath(target.OwnerConfigDir)
+	authoritativeRoot := authoritativeFilesystemPath(ownerRoot, fsys)
+
+	if relative, ok := relativePathUnderRoot(sourcePath, ownerRoot, useCaseSensitive); ok {
+		return tspath.ResolvePath(authoritativeRoot, relative)
+	}
+	canonicalSource := authoritativeFilesystemPath(sourcePath, fsys)
+	if relative, ok := relativePathUnderRoot(canonicalSource, authoritativeRoot, useCaseSensitive); ok {
+		return tspath.ResolvePath(authoritativeRoot, relative)
+	}
+	if relative, ok := relativePathUnderRoot(target.Path, ownerRoot, useCaseSensitive); ok {
+		return tspath.ResolvePath(authoritativeRoot, relative)
+	}
+	if relative, ok := relativePathUnderRoot(target.CanonicalPath, authoritativeRoot, useCaseSensitive); ok {
+		return tspath.ResolvePath(authoritativeRoot, relative)
+	}
+	return tspath.NormalizePath(sourcePath)
+}
+
+func storeSourcePathMapping(mapping map[string]string, sourcePath string, value string, fsys vfs.FS) {
+	if mapping == nil {
+		return
+	}
+	normalizedSource := tspath.NormalizePath(sourcePath)
+	mapping[normalizedSource] = value
+	mapping[filesystemPathID(normalizedSource, fsys)] = value
+}
+
+// createProgramSetForConfigs builds each canonical tsconfig once while
+// retaining every config that declared it. Config roots are processed in a
+// stable order; target binding later uses the per-config project order rather
+// than map iteration or Program construction order.
+func createProgramSetForConfigs(
+	configMap map[string]rslintconfig.RslintConfig,
+	singleThreaded bool,
+	fsys vfs.FS,
+	parseCache *utils.ParseCache,
+) (lintProgramSet, error) {
+	if len(configMap) == 0 {
+		return lintProgramSet{}, nil
+	}
+
+	configDirs := make([]string, 0, len(configMap))
+	for configDir := range configMap {
+		configDirs = append(configDirs, configDir)
+	}
+	sort.Strings(configDirs)
+
+	set := lintProgramSet{}
+	programByTsconfig := make(map[string]int)
+	for _, configDir := range configDirs {
+		entries := configMap[configDir]
+		tsConfigs, err := rslintconfig.ResolveTsConfigPaths(entries, configDir, fsys)
+		if err != nil {
+			return lintProgramSet{}, fmt.Errorf("resolve tsconfigs for %q: %w", configDir, err)
+		}
+
+		for order, tsconfigPath := range tsConfigs {
+			tsconfigID := canonicalFilesystemPathID(tsconfigPath, fsys)
+			if programIndex, ok := programByTsconfig[tsconfigID]; ok {
+				if _, alreadyAssociated := set.ConfigOrders[programIndex][configDir]; !alreadyAssociated {
+					set.ConfigOrders[programIndex][configDir] = order
+				}
+				continue
+			}
+
+			// Build shared Programs from the tsconfig's own directory so the
+			// result does not depend on which rslint config happened to declare
+			// the tsconfig first.
+			programCwd := tspath.GetDirectoryPath(tspath.NormalizePath(tsconfigPath))
+			host := utils.WithParseCache(utils.CreateCompilerHost(programCwd, fsys), parseCache)
+			program, err := utils.CreateProgramLenient(singleThreaded, fsys, programCwd, tsconfigPath, host)
+			if err != nil {
+				return lintProgramSet{}, fmt.Errorf("create TypeScript Program from %q: %w", tsconfigPath, err)
+			}
+
+			programByTsconfig[tsconfigID] = len(set.Programs)
+			set.Programs = append(set.Programs, program)
+			set.ConfigOrders = append(set.ConfigOrders, programConfigOrders{configDir: order})
+		}
+	}
+
+	return set, nil
+}
+
+func createProgramSetForConfig(
+	configDir string,
+	entries rslintconfig.RslintConfig,
+	singleThreaded bool,
+	fsys vfs.FS,
+	parseCache *utils.ParseCache,
+) (lintProgramSet, error) {
+	return createProgramSetForConfigs(
+		map[string]rslintconfig.RslintConfig{configDir: entries},
+		singleThreaded,
+		fsys,
+		parseCache,
+	)
+}
+
+// parallelGitignoreAndPrograms reads gitignore state and builds the Program
+// registry for a single rslint config (single-config and legacy JSON paths).
 //
 // When singleThreaded is true, both run sequentially in the calling goroutine
 // — honoring the user's --singleThreaded flag (no concurrency at all).
 // Otherwise the two are dispatched as parallel goroutines: they have no data
-// dependency, since createProgramsForConfig only reads
+// dependency, since Program creation only reads
 // entry.LanguageOptions.ParserOptions.Project (see
 // LoadTsConfigsFromRslintConfig), never entry.Ignores. Calling it before vs.
 // after gitignore globs are prepended is equivalent for TS Program creation.
@@ -29,27 +189,22 @@ import (
 // The returned config is the gitignore-augmented config (gitignore globs
 // prepended when non-empty), suitable for downstream target discovery /
 // GetConfigForFile.
-//
-// Returns: (augmentedConfig, programs, exitCode). On non-zero exitCode,
-// augmentedConfig and programs may be nil/partial — caller should propagate
-// exitCode without using them.
 func parallelGitignoreAndPrograms(
 	rslintConfig rslintconfig.RslintConfig,
 	configDir string,
 	fsys vfs.FS,
 	singleThreaded bool,
-	seenTsConfigs map[string]struct{},
 	parseCache *utils.ParseCache,
-) (rslintconfig.RslintConfig, []*compiler.Program, int) {
+) (rslintconfig.RslintConfig, lintProgramSet, error) {
 	configIgnores := rslintconfig.ExtractConfigIgnores(rslintConfig)
 
 	var (
-		gitGlobs []string
-		progs    []*compiler.Program
-		exitCode int
+		gitGlobs   []string
+		programs   lintProgramSet
+		programErr error
 	)
 	// gitignore reading and program creation are independent
-	// (createProgramsForConfig only reads parserOptions.project, never Ignores),
+	// (Program creation only reads parserOptions.project, never Ignores),
 	// so run them on the shared WorkGroup — which honors --singleThreaded the
 	// same way the lint and type-check phases do.
 	wg := core.NewWorkGroup(singleThreaded)
@@ -57,12 +212,12 @@ func parallelGitignoreAndPrograms(
 		gitGlobs = rslintconfig.ReadGitignoreAsGlobs(configDir, fsys, configIgnores)
 	})
 	wg.Queue(func() {
-		progs, exitCode = createProgramsForConfig(configDir, rslintConfig, singleThreaded, fsys, seenTsConfigs, parseCache)
+		programs, programErr = createProgramSetForConfig(configDir, rslintConfig, singleThreaded, fsys, parseCache)
 	})
 	wg.RunAndWait()
 
-	if exitCode != 0 {
-		return rslintConfig, nil, exitCode
+	if programErr != nil {
+		return rslintConfig, lintProgramSet{}, programErr
 	}
 	if len(gitGlobs) > 0 {
 		rslintConfig = append(
@@ -70,51 +225,7 @@ func parallelGitignoreAndPrograms(
 			rslintConfig...,
 		)
 	}
-	return rslintConfig, progs, 0
-}
-
-// createProgramsForConfig creates tsconfig-backed TypeScript programs for a
-// single config entry. Configs without a tsconfig deliberately return no
-// Program here; buildProgramsWithLintTargets later creates an AST-only fallback
-// from the final files-driven lint target set.
-// seenTsConfigs is used for cross-config tsconfig deduplication (pass nil to skip).
-// Returns the created programs or an error exit code (> 0).
-func createProgramsForConfig(
-	configDir string,
-	entries rslintconfig.RslintConfig,
-	singleThreaded bool,
-	fsys vfs.FS,
-	seenTsConfigs map[string]struct{},
-	parseCache *utils.ParseCache,
-) ([]*compiler.Program, int) {
-	tsConfigs, err := rslintconfig.ResolveTsConfigPaths(entries, configDir, fsys)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return nil, 1
-	}
-
-	var programs []*compiler.Program
-	host := utils.WithParseCache(utils.CreateCompilerHost(configDir, fsys), parseCache)
-
-	for _, tc := range tsConfigs {
-		// Cross-config deduplication
-		if seenTsConfigs != nil {
-			normalized := tspath.NormalizePath(tc)
-			if _, exists := seenTsConfigs[normalized]; exists {
-				continue
-			}
-			seenTsConfigs[normalized] = struct{}{}
-		}
-
-		program, err := utils.CreateProgramLenient(singleThreaded, fsys, configDir, tc, host)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error creating TS program: %v", err)
-			return nil, 1
-		}
-		programs = append(programs, program)
-	}
-
-	return programs, 0
+	return rslintConfig, programs, nil
 }
 
 // createFallbackProgram creates a Program for selected lint targets not
@@ -126,7 +237,7 @@ func createFallbackProgram(
 	configDir string,
 	fsys vfs.FS,
 	parseCache *utils.ParseCache,
-) (*compiler.Program, int) {
+) (*compiler.Program, error) {
 	host := utils.WithParseCache(utils.CreateCompilerHost(configDir, fsys), parseCache)
 	program, err := utils.CreateProgramFromOptionsLenient(singleThreaded, &core.CompilerOptions{
 		Target:    core.ScriptTargetESNext,
@@ -137,84 +248,337 @@ func createFallbackProgram(
 		NoResolve: core.TSTrue,
 	}, gapFiles, host)
 	if err != nil {
-		// Non-fatal: gap files failing to parse should not block the entire run.
-		// Log to stderr and skip.
-		fmt.Fprintf(os.Stderr, "warning: failed to create program for %d file(s) outside tsconfig: %v\n", len(gapFiles), err)
-		return nil, 0
+		return nil, fmt.Errorf("create fallback Program for %d lint target(s): %w", len(gapFiles), err)
 	}
-	return program, 0
+	return program, nil
 }
 
-// buildProgramsWithLintTargets resolves the exact lint target set, appends an
-// AST-only fallback Program for selected files absent from every existing
-// Program, and returns the per-program target plan consumed by RunLinter.
-//
-// The appended fallback Program carries synthesized CompilerOptions with no
-// ConfigFilePath, which is how buildTypeCheckSkipMask later recognizes and
-// excludes it from the CLI --type-check phase — no index needs to be threaded
-// out of here.
-//
-// The type-info set is captured from the tsconfig Programs BEFORE the fallback
-// is appended, so fallback files are deliberately absent from it. That absence
-// is exactly the signal GetActiveRulesForFile keys off to filter type-aware
-// rules off files with no type information — the only guard against a
-// type-aware rule dereferencing a nil TypeChecker (which crashes the whole
-// process). Both the CLI (executeLintPipeline) and the --api path (HandleLint)
-// call this, so target discovery, fallback binding, and type-aware gating are
-// identical by construction rather than by two parallel implementations kept
-// in sync.
-//
-// configMap is non-nil only in the multi-config (stdin) path; the --api and
-// single-config paths pass nil and resolve against rslintConfig +
-// currentDirectory.
-func buildProgramsWithLintTargets(
-	programs []*compiler.Program,
+type resolvedLintTarget struct {
+	Path           string
+	CanonicalPath  string
+	OwnerConfigDir string
+}
+
+type lintTargetPlan struct {
+	Targets []resolvedLintTarget
+}
+
+func resolveLintTargetPlan(
 	configMap map[string]rslintconfig.RslintConfig,
 	rslintConfig rslintconfig.RslintConfig,
 	currentDirectory string,
-	programConfigDirs []string,
 	configTargetFiles map[string][]string,
-	fs vfs.FS,
+	fsys vfs.FS,
 	allowFiles []string,
 	allowDirs []string,
+	singleThreaded bool,
+) (lintTargetPlan, error) {
+	type targetWithOwner struct {
+		path  string
+		owner string
+	}
+	var targetFiles []targetWithOwner
+	if configMap != nil {
+		for _, target := range discoverLintFilesMultiConfig(configMap, configTargetFiles, fsys, allowFiles, allowDirs, singleThreaded) {
+			targetFiles = append(targetFiles, targetWithOwner{path: target.Path, owner: target.ConfigDirectory})
+		}
+	} else {
+		for _, targetPath := range rslintconfig.DiscoverLintFiles(rslintConfig, currentDirectory, fsys, allowFiles, allowDirs, singleThreaded) {
+			targetFiles = append(targetFiles, targetWithOwner{path: targetPath, owner: currentDirectory})
+		}
+	}
+
+	plan := lintTargetPlan{Targets: make([]resolvedLintTarget, 0, len(targetFiles))}
+	seenCanonical := make(map[string]resolvedLintTarget, len(targetFiles))
+	for _, discovered := range targetFiles {
+		targetPath := discovered.path
+		ownerConfigDir := discovered.owner
+		canonicalPath := tspath.NormalizePath(targetPath)
+		if fsys != nil {
+			if realPath := fsys.Realpath(canonicalPath); realPath != "" {
+				canonicalPath = tspath.NormalizePath(realPath)
+			}
+		}
+		canonicalKey := canonicalPath
+		if fsys != nil {
+			canonicalKey = string(tspath.ToPath(canonicalPath, "", fsys.UseCaseSensitiveFileNames()))
+		}
+		target := resolvedLintTarget{
+			Path:           tspath.NormalizePath(targetPath),
+			CanonicalPath:  canonicalPath,
+			OwnerConfigDir: tspath.NormalizePath(ownerConfigDir),
+		}
+		if existing, exists := seenCanonical[canonicalKey]; exists {
+			if filesystemPathID(existing.OwnerConfigDir, fsys) != filesystemPathID(target.OwnerConfigDir, fsys) {
+				return lintTargetPlan{}, fmt.Errorf(
+					"lint target aliases %q and %q resolve to the same file but are governed by different configs %q and %q",
+					existing.Path,
+					target.Path,
+					existing.OwnerConfigDir,
+					target.OwnerConfigDir,
+				)
+			}
+			continue
+		}
+		seenCanonical[canonicalKey] = target
+		plan.Targets = append(plan.Targets, target)
+	}
+	return plan, nil
+}
+
+func preferredCallerTargetPaths(plan lintTargetPlan, fsys vfs.FS) map[string]string {
+	if len(plan.Targets) == 0 {
+		return nil
+	}
+	preferred := make(map[string]string, len(plan.Targets))
+	for _, target := range plan.Targets {
+		canonicalID := canonicalFilesystemPathID(target.CanonicalPath, fsys)
+		if _, exists := preferred[canonicalID]; !exists {
+			preferred[canonicalID] = target.Path
+		}
+	}
+	return preferred
+}
+
+type lintTargetBinding struct {
+	Programs                   []*compiler.Program
+	TypeInfoFiles              map[string]struct{}
+	GapFiles                   []string
+	TargetsByProgram           [][]string
+	TargetPathBySourcePath     map[string]string
+	ConfigPathBySourcePath     map[string]string
+	OwnerConfigDirBySourcePath map[string]string
+}
+
+func aliasPathUnderRoot(path string, canonicalRoot string, lexicalRoot string, useCaseSensitive bool) string {
+	if path == "" || canonicalRoot == "" || lexicalRoot == "" {
+		return ""
+	}
+	relative, ok := relativePathUnderRoot(path, canonicalRoot, useCaseSensitive)
+	if !ok {
+		return ""
+	}
+	return tspath.ResolvePath(lexicalRoot, relative)
+}
+
+type programTargetLookup struct {
+	program             *compiler.Program
+	fsys                vfs.FS
+	canonicalIndexBuilt bool
+	canonicalSources    map[string]*ast.SourceFile
+}
+
+func (lookup *programTargetLookup) canonicalSourceFile(canonicalPath string) *ast.SourceFile {
+	if lookup.fsys == nil || canonicalPath == "" {
+		return nil
+	}
+	if !lookup.canonicalIndexBuilt {
+		lookup.canonicalIndexBuilt = true
+		lookup.canonicalSources = make(map[string]*ast.SourceFile)
+		for _, sourceFile := range lookup.program.GetSourceFiles() {
+			canonicalID := canonicalFilesystemPathID(sourceFile.FileName(), lookup.fsys)
+			existing := lookup.canonicalSources[canonicalID]
+			if existing == nil || sourceFile.FileName() < existing.FileName() {
+				lookup.canonicalSources[canonicalID] = sourceFile
+			}
+		}
+	}
+	return lookup.canonicalSources[canonicalFilesystemPathID(canonicalPath, lookup.fsys)]
+}
+
+// sourceFileForTarget first performs bounded target-driven lookups. Only when
+// every lexical/root alias misses does it build one lazy canonical source index
+// for the Program, covering file-level symlinks without imposing graph-wide
+// realpath work on normal projects.
+func (lookup *programTargetLookup) sourceFileForTarget(target resolvedLintTarget) *ast.SourceFile {
+	program := lookup.program
+	fsys := lookup.fsys
+	if program == nil {
+		return nil
+	}
+	// Normal projects hit the lexical target immediately. Keep realpath work
+	// entirely off this hot path; aliases are only derived after both direct
+	// target forms miss.
+	targetPath := tspath.NormalizePath(target.Path)
+	if sourceFile := program.GetSourceFile(targetPath); sourceFile != nil {
+		return sourceFile
+	}
+	canonicalPath := ""
+	if target.CanonicalPath != "" {
+		canonicalPath = tspath.NormalizePath(target.CanonicalPath)
+	}
+	if canonicalPath != "" && canonicalPath != targetPath {
+		if sourceFile := program.GetSourceFile(canonicalPath); sourceFile != nil {
+			return sourceFile
+		}
+	}
+	if fsys == nil {
+		return nil
+	}
+	if canonicalPath == "" {
+		canonicalPath = targetPath
+	}
+	if canonicalPath == "" {
+		return nil
+	}
+
+	useCaseSensitive := program.UseCaseSensitiveFileNames()
+	lookupAlias := func(candidate string) *ast.SourceFile {
+		if candidate == "" {
+			return nil
+		}
+		candidate = tspath.NormalizePath(candidate)
+		compareOptions := tspath.ComparePathsOptions{UseCaseSensitiveFileNames: useCaseSensitive}
+		if tspath.ComparePaths(candidate, targetPath, compareOptions) == 0 ||
+			tspath.ComparePaths(candidate, canonicalPath, compareOptions) == 0 {
+			return nil
+		}
+		return program.GetSourceFile(candidate)
+	}
+
+	ownerRoot := tspath.NormalizePath(target.OwnerConfigDir)
+	ownerCanonical := ownerRoot
+	if realPath := fsys.Realpath(ownerRoot); realPath != "" {
+		ownerCanonical = tspath.NormalizePath(realPath)
+	}
+	ownerAlias := aliasPathUnderRoot(canonicalPath, ownerCanonical, ownerRoot, useCaseSensitive)
+	if sourceFile := lookupAlias(ownerAlias); sourceFile != nil {
+		return sourceFile
+	}
+
+	programRoot := tspath.NormalizePath(program.GetCurrentDirectory())
+	programCanonical := programRoot
+	if realPath := fsys.Realpath(programRoot); realPath != "" {
+		programCanonical = tspath.NormalizePath(realPath)
+	}
+	programAlias := aliasPathUnderRoot(canonicalPath, programCanonical, programRoot, useCaseSensitive)
+	compareOptions := tspath.ComparePathsOptions{UseCaseSensitiveFileNames: useCaseSensitive}
+	if tspath.ComparePaths(programAlias, ownerAlias, compareOptions) != 0 {
+		if sourceFile := lookupAlias(programAlias); sourceFile != nil {
+			return sourceFile
+		}
+	}
+	return lookup.canonicalSourceFile(canonicalPath)
+}
+
+func orderedProgramIndexesForConfig(set lintProgramSet, configDir string) []int {
+	indexes := make([]int, 0, len(set.Programs))
+	for i := range set.Programs {
+		if i < len(set.ConfigOrders) {
+			if _, ok := set.ConfigOrders[i][configDir]; ok {
+				indexes = append(indexes, i)
+			}
+		}
+	}
+	sort.SliceStable(indexes, func(i, j int) bool {
+		left := set.ConfigOrders[indexes[i]][configDir]
+		right := set.ConfigOrders[indexes[j]][configDir]
+		if left != right {
+			return left < right
+		}
+		return indexes[i] < indexes[j]
+	})
+	return indexes
+}
+
+// bindLintTargetPlan binds every stable target to a Program from its governing
+// config. Calling this for each fix pass recomputes gap status from the current
+// import graph instead of retaining an initial gap classification.
+func bindLintTargetPlan(
+	set lintProgramSet,
+	plan lintTargetPlan,
+	currentDirectory string,
+	fsys vfs.FS,
 	parseCache *utils.ParseCache,
 	singleThreaded bool,
-) ([]*compiler.Program, map[string]struct{}, []string, []string, [][]string, map[string]string) {
-	var typeInfoFiles map[string]struct{}
-	var capturedGapFiles []string
-
-	programIndex := buildProgramFileIndex(programs, fs, singleThreaded)
-
-	var targetFiles []string
-	if configMap != nil {
-		targetFiles = discoverLintFilesMultiConfig(configMap, configTargetFiles, fs, allowFiles, allowDirs, singleThreaded)
-	} else {
-		targetFiles = rslintconfig.DiscoverLintFiles(rslintConfig, currentDirectory, fs, allowFiles, allowDirs, singleThreaded)
+) (lintTargetBinding, error) {
+	binding := lintTargetBinding{
+		Programs:                   append([]*compiler.Program(nil), set.Programs...),
+		TargetsByProgram:           make([][]string, len(set.Programs)),
+		TypeInfoFiles:              make(map[string]struct{}),
+		TargetPathBySourcePath:     make(map[string]string),
+		ConfigPathBySourcePath:     make(map[string]string),
+		OwnerConfigDirBySourcePath: make(map[string]string),
 	}
 
-	gapFiles := make([]string, 0, len(targetFiles))
-	for _, target := range targetFiles {
-		if len(programIndex.candidatesFor(target, fs)) == 0 {
-			gapFiles = append(gapFiles, target)
+	var gaps []resolvedLintTarget
+	programIndexesByConfig := make(map[string][]int)
+	programLookups := make([]programTargetLookup, len(set.Programs))
+	for i, program := range set.Programs {
+		programLookups[i] = programTargetLookup{program: program, fsys: fsys}
+	}
+	for _, target := range plan.Targets {
+		programIndexes, cached := programIndexesByConfig[target.OwnerConfigDir]
+		if !cached {
+			programIndexes = orderedProgramIndexesForConfig(set, target.OwnerConfigDir)
+			programIndexesByConfig[target.OwnerConfigDir] = programIndexes
+		}
+		bound := false
+		for _, programIndex := range programIndexes {
+			sourceFile := programLookups[programIndex].sourceFileForTarget(target)
+			if sourceFile == nil {
+				continue
+			}
+			sourcePath := sourceFile.FileName()
+			binding.TargetsByProgram[programIndex] = append(binding.TargetsByProgram[programIndex], sourcePath)
+			storeSourcePathMapping(binding.OwnerConfigDirBySourcePath, sourcePath, target.OwnerConfigDir, fsys)
+			storeSourcePathMapping(binding.ConfigPathBySourcePath, sourcePath, configPathForBoundSource(sourcePath, target, fsys), fsys)
+			binding.TypeInfoFiles[sourcePath] = struct{}{}
+			binding.TypeInfoFiles[target.Path] = struct{}{}
+			binding.TypeInfoFiles[target.CanonicalPath] = struct{}{}
+			if tspath.NormalizePath(sourcePath) != target.Path {
+				storeSourcePathMapping(binding.TargetPathBySourcePath, sourcePath, target.Path, fsys)
+			}
+			bound = true
+			break
+		}
+		if !bound {
+			gaps = append(gaps, target)
+			binding.GapFiles = append(binding.GapFiles, target.Path)
 		}
 	}
 
-	if len(gapFiles) > 0 {
-		// Build type-info set from existing (tsconfig) Programs BEFORE
-		// appending the fallback, so fallback files are NOT in this set.
-		typeInfoFiles = cloneStringSet(programIndex.files)
-		capturedGapFiles = gapFiles
-
-		fallback, _ := createFallbackProgram(gapFiles, singleThreaded, currentDirectory, fs, parseCache)
-		if fallback != nil {
-			addProgramToFileIndex(&programIndex, fallback, len(programs), fs, singleThreaded)
-			programs = append(programs, fallback)
+	if len(gaps) > 0 {
+		fallbackFiles := make([]string, 0, len(gaps))
+		for _, gap := range gaps {
+			fallbackFiles = append(fallbackFiles, gap.Path)
+		}
+		fallback, err := createFallbackProgram(fallbackFiles, singleThreaded, currentDirectory, fsys, parseCache)
+		if err != nil {
+			return lintTargetBinding{}, err
+		}
+		if fallback == nil {
+			return lintTargetBinding{}, fmt.Errorf("create fallback Program for %d lint target(s): no Program returned", len(gaps))
+		}
+		fallbackIndex := len(binding.Programs)
+		binding.Programs = append(binding.Programs, fallback)
+		binding.TargetsByProgram = append(binding.TargetsByProgram, nil)
+		fallbackLookup := programTargetLookup{program: fallback, fsys: fsys}
+		for _, gap := range gaps {
+			sourceFile := fallbackLookup.sourceFileForTarget(gap)
+			if sourceFile == nil {
+				return lintTargetBinding{}, fmt.Errorf("fallback Program did not contain lint target %q", gap.Path)
+			}
+			sourcePath := sourceFile.FileName()
+			binding.TargetsByProgram[fallbackIndex] = append(binding.TargetsByProgram[fallbackIndex], sourcePath)
+			storeSourcePathMapping(binding.OwnerConfigDirBySourcePath, sourcePath, gap.OwnerConfigDir, fsys)
+			storeSourcePathMapping(binding.ConfigPathBySourcePath, sourcePath, configPathForBoundSource(sourcePath, gap, fsys), fsys)
+			if tspath.NormalizePath(sourcePath) != gap.Path {
+				storeSourcePathMapping(binding.TargetPathBySourcePath, sourcePath, gap.Path, fsys)
+			}
 		}
 	}
 
-	targetsByProgram, configPathBySourcePath := assignLintTargetsToPrograms(programs, configMap, programConfigDirs, targetFiles, programIndex, fs)
-
-	return programs, typeInfoFiles, capturedGapFiles, targetFiles, targetsByProgram, configPathBySourcePath
+	for i := range binding.TargetsByProgram {
+		sort.Strings(binding.TargetsByProgram[i])
+	}
+	if len(binding.GapFiles) == 0 {
+		binding.TypeInfoFiles = nil
+	}
+	if len(binding.TargetPathBySourcePath) == 0 {
+		binding.TargetPathBySourcePath = nil
+	}
+	return binding, nil
 }
 
 func discoverLintFilesMultiConfig(
@@ -224,220 +588,15 @@ func discoverLintFilesMultiConfig(
 	allowFiles []string,
 	allowDirs []string,
 	singleThreaded bool,
-) []string {
-	if len(configTargetFiles) == 0 {
-		return rslintconfig.DiscoverLintFilesMultiConfig(configMap, fs, allowFiles, allowDirs, singleThreaded)
-	}
-
-	seen := make(map[string]struct{})
-	var allTargets []string
-	for configDir := range configMap {
-		configAllowFiles := allowFiles
-		configAllowDirs := allowDirs
-		if targetFiles, scoped := configTargetFiles[configDir]; scoped {
-			configAllowFiles = targetFiles
-			configAllowDirs = nil
-		}
-
-		targets := rslintconfig.DiscoverLintFilesForConfigInMap(configMap, configDir, fs, configAllowFiles, configAllowDirs, singleThreaded)
-		for _, f := range targets {
-			if _, exists := seen[f]; !exists {
-				seen[f] = struct{}{}
-				allTargets = append(allTargets, f)
-			}
+) []rslintconfig.DiscoveredLintTarget {
+	var scopes map[string]rslintconfig.LintDiscoveryScope
+	if len(configTargetFiles) > 0 {
+		scopes = make(map[string]rslintconfig.LintDiscoveryScope, len(configTargetFiles))
+		for configDir, targetFiles := range configTargetFiles {
+			scopes[configDir] = rslintconfig.LintDiscoveryScope{Files: targetFiles}
 		}
 	}
-	sort.Strings(allTargets)
-	return allTargets
-}
-
-type programFileCandidate struct {
-	programIndex int
-	fileName     string
-}
-
-type programFileIndex struct {
-	files  map[string]struct{}
-	byPath map[string][]programFileCandidate
-}
-
-func (index programFileIndex) candidatesFor(path string, fs vfs.FS) []programFileCandidate {
-	if len(index.byPath) == 0 {
-		return nil
-	}
-	if candidates := index.byPath[path]; len(candidates) > 0 {
-		return candidates
-	}
-	if fs == nil {
-		return nil
-	}
-	realPath := fs.Realpath(path)
-	if realPath == "" || realPath == path {
-		return nil
-	}
-	return index.byPath[realPath]
-}
-
-type indexedProgram struct {
-	program      *compiler.Program
-	programIndex int
-}
-
-func buildProgramFileIndex(programs []*compiler.Program, fs vfs.FS, singleThreaded bool) programFileIndex {
-	index := programFileIndex{
-		files:  make(map[string]struct{}),
-		byPath: make(map[string][]programFileCandidate),
-	}
-	indexedPrograms := make([]indexedProgram, 0, len(programs))
-	for i, program := range programs {
-		indexedPrograms = append(indexedPrograms, indexedProgram{
-			program:      program,
-			programIndex: i,
-		})
-	}
-	addProgramsToFileIndex(&index, indexedPrograms, fs, singleThreaded)
-	return index
-}
-
-func addProgramToFileIndex(index *programFileIndex, program *compiler.Program, programIndex int, fs vfs.FS, singleThreaded bool) {
-	addProgramsToFileIndex(index, []indexedProgram{{
-		program:      program,
-		programIndex: programIndex,
-	}}, fs, singleThreaded)
-}
-
-func addProgramsToFileIndex(index *programFileIndex, programs []indexedProgram, fs vfs.FS, singleThreaded bool) {
-	if len(programs) == 0 {
-		return
-	}
-
-	candidatesByName := make(map[string][]programFileCandidate)
-	names := make([]string, 0)
-	for _, entry := range programs {
-		if entry.program == nil {
-			continue
-		}
-		for _, sf := range entry.program.GetSourceFiles() {
-			name := sf.FileName()
-			candidate := programFileCandidate{programIndex: entry.programIndex, fileName: name}
-			index.files[name] = struct{}{}
-			index.byPath[name] = append(index.byPath[name], candidate)
-			if _, seen := candidatesByName[name]; !seen {
-				names = append(names, name)
-			}
-			candidatesByName[name] = append(candidatesByName[name], candidate)
-		}
-	}
-	if fs == nil || len(candidatesByName) == 0 {
-		return
-	}
-
-	resolved := make([]string, len(names))
-	wg := core.NewWorkGroup(singleThreaded)
-	for i := range names {
-		wg.Queue(func() {
-			if realPath := fs.Realpath(names[i]); realPath != "" && realPath != names[i] {
-				resolved[i] = realPath
-			}
-		})
-	}
-	wg.RunAndWait()
-
-	for i, realPath := range resolved {
-		if realPath == "" {
-			continue
-		}
-		index.files[realPath] = struct{}{}
-		index.byPath[realPath] = append(index.byPath[realPath], candidatesByName[names[i]]...)
-	}
-}
-
-func cloneStringSet(set map[string]struct{}) map[string]struct{} {
-	if set == nil {
-		return nil
-	}
-	cloned := make(map[string]struct{}, len(set))
-	for key := range set {
-		cloned[key] = struct{}{}
-	}
-	return cloned
-}
-
-// assignLintTargetsToPrograms binds resolved lint targets to exactly one
-// Program. It accepts imported non-root SourceFiles; ownership/dedup is driven
-// by the target plan, not by CommandLine().FileNames().
-func assignLintTargetsToPrograms(
-	programs []*compiler.Program,
-	configMap map[string]rslintconfig.RslintConfig,
-	programConfigDirs []string,
-	targetFiles []string,
-	programIndex programFileIndex,
-	fs vfs.FS,
-) ([][]string, map[string]string) {
-	targetsByProgram := make([][]string, len(programs))
-	if len(programs) == 0 || len(targetFiles) == 0 {
-		return targetsByProgram, nil
-	}
-
-	seenProgramFile := make([]map[string]struct{}, len(programs))
-	configPathBySourcePath := make(map[string]string)
-	for _, target := range targetFiles {
-		candidates := programIndex.candidatesFor(target, fs)
-		if len(candidates) == 0 {
-			continue
-		}
-		chosen := candidates[0]
-		if configMap != nil && len(programConfigDirs) > 0 {
-			ownerDir, _ := rslintconfig.FindNearestConfig(target, configMap)
-			for _, candidate := range candidates {
-				if candidate.programIndex < len(programConfigDirs) && programConfigDirs[candidate.programIndex] == ownerDir {
-					chosen = candidate
-					break
-				}
-			}
-		}
-		if seenProgramFile[chosen.programIndex] == nil {
-			seenProgramFile[chosen.programIndex] = make(map[string]struct{})
-		}
-		if _, seen := seenProgramFile[chosen.programIndex][chosen.fileName]; seen {
-			continue
-		}
-		seenProgramFile[chosen.programIndex][chosen.fileName] = struct{}{}
-		targetsByProgram[chosen.programIndex] = append(targetsByProgram[chosen.programIndex], chosen.fileName)
-		if chosen.fileName != target {
-			configPathBySourcePath[chosen.fileName] = target
-		}
-	}
-	for i := range targetsByProgram {
-		sort.Strings(targetsByProgram[i])
-	}
-	if len(configPathBySourcePath) == 0 {
-		configPathBySourcePath = nil
-	}
-	return targetsByProgram, configPathBySourcePath
-}
-
-func buildTypeInfoFilesForPrograms(programs []*compiler.Program, skipTypeCheck []bool, fs vfs.FS, singleThreaded bool) map[string]struct{} {
-	if len(skipTypeCheck) == 0 {
-		return nil
-	}
-
-	index := programFileIndex{
-		files:  make(map[string]struct{}),
-		byPath: make(map[string][]programFileCandidate),
-	}
-	indexedPrograms := make([]indexedProgram, 0, len(programs))
-	for i, program := range programs {
-		if i < len(skipTypeCheck) && skipTypeCheck[i] {
-			continue
-		}
-		indexedPrograms = append(indexedPrograms, indexedProgram{
-			program:      program,
-			programIndex: i,
-		})
-	}
-	addProgramsToFileIndex(&index, indexedPrograms, fs, singleThreaded)
-	return index.files
+	return rslintconfig.DiscoverLintTargetsMultiConfig(configMap, scopes, fs, allowFiles, allowDirs, singleThreaded)
 }
 
 // buildTypeCheckSkipMask returns a parallel-to-programs []bool marking which
@@ -449,10 +608,10 @@ func buildTypeInfoFilesForPrograms(programs []*compiler.Program, skipTypeCheck [
 //
 // Their options are synthesized, not the user's tsconfig, so semantic
 // diagnostics there are unreliable and must not be surfaced. This mirrors the
-// type-checking boundary: only Programs backed by parserOptions.project or the auto-detected
-// tsconfig.json participate in program-level --type-check diagnostics. Programs
-// built via utils.CreateProgram -> GetParsedCommandLineOfConfigFile carry a
-// non-empty ConfigFilePath.
+// type-checking boundary: only Programs backed by parserOptions.project or the
+// auto-detected tsconfig.json participate in program-level --type-check
+// diagnostics. Programs built via utils.CreateProgram ->
+// GetParsedCommandLineOfConfigFile carry a non-empty ConfigFilePath.
 //
 // Returns nil when every program is tsconfig-backed, so callers don't allocate
 // an all-false slice. Deriving from the programs keeps the CLI initial build
@@ -484,23 +643,19 @@ func collectTargetSyntacticDiagnostics(
 	skipTypeCheck []bool,
 	typeCheck bool,
 	typeCheckOnly bool,
-	shouldReportForFile func(string) bool,
-) []rule.RuleDiagnostic {
+) ([]rule.RuleDiagnostic, map[string]struct{}) {
+	syntaxErrorFiles := make(map[string]struct{})
 	if len(programs) == 0 || len(targetsByProgram) == 0 {
-		return nil
+		return nil, syntaxErrorFiles
 	}
 
 	seen := make(map[syntacticDiagnosticKey]struct{})
 	var diagnostics []rule.RuleDiagnostic
 	for i, program := range programs {
 		// When --type-check runs, tsconfig-backed Programs surface syntactic
-		// diagnostics through the type-check phase. Synthetic Programs are
-		// skipped there, so plain lint still needs to report their target
-		// syntax errors. In --type-check-only, lint-phase diagnostics stay off.
+		// diagnostics through the type-check phase. We still inspect every target
+		// here so the lint-rule phase can skip malformed files, matching ESLint.
 		coveredByTypeCheck := typeCheck && (i >= len(skipTypeCheck) || !skipTypeCheck[i])
-		if coveredByTypeCheck || typeCheckOnly {
-			continue
-		}
 		if i >= len(targetsByProgram) || len(targetsByProgram[i]) == 0 {
 			continue
 		}
@@ -512,14 +667,15 @@ func collectTargetSyntacticDiagnostics(
 
 		ctx := context.Background()
 		for target := range targets {
-			if shouldReportForFile != nil && !shouldReportForFile(target) {
-				continue
-			}
 			file := program.GetSourceFile(target)
 			if file == nil {
 				continue
 			}
 			for _, diagnostic := range program.GetSyntacticDiagnostics(ctx, file) {
+				syntaxErrorFiles[file.FileName()] = struct{}{}
+				if coveredByTypeCheck || typeCheckOnly {
+					continue
+				}
 				loc := diagnostic.Loc()
 				key := syntacticDiagnosticKey{
 					path: file.FileName(),
@@ -543,5 +699,5 @@ func collectTargetSyntacticDiagnostics(
 			}
 		}
 	}
-	return diagnostics
+	return diagnostics, syntaxErrorFiles
 }

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -306,8 +306,8 @@ func assignLintTargetsToPrograms(
 			candidate := programFileCandidate{programIndex: i, fileName: name}
 			byPath[name] = append(byPath[name], candidate)
 			if fs != nil {
-				if real := fs.Realpath(name); real != "" && real != name {
-					byPath[real] = append(byPath[real], candidate)
+				if realPath := fs.Realpath(name); realPath != "" && realPath != name {
+					byPath[realPath] = append(byPath[realPath], candidate)
 				}
 			}
 		}

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -10,9 +10,9 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
-	"github.com/microsoft/typescript-go/shim/vfs/vfsmatch"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -74,8 +74,10 @@ func parallelGitignoreAndPrograms(
 	return rslintConfig, progs, 0
 }
 
-// createProgramsForConfig creates TypeScript programs for a single config entry.
-// It handles tsconfig extraction, auto-detection, deduplication, and the no-tsconfig fallback.
+// createProgramsForConfig creates tsconfig-backed TypeScript programs for a
+// single config entry. Configs without a tsconfig deliberately return no
+// Program here; buildProgramsWithLintTargets later creates an AST-only fallback
+// from the final files-driven lint target set.
 // seenTsConfigs is used for cross-config tsconfig deduplication (pass nil to skip).
 // Returns the created programs or an error exit code (> 0).
 func createProgramsForConfig(
@@ -95,50 +97,22 @@ func createProgramsForConfig(
 	var programs []*compiler.Program
 	host := utils.WithParseCache(utils.CreateCompilerHost(configDir, fsys), parseCache)
 
-	if len(tsConfigs) > 0 {
-		for _, tc := range tsConfigs {
-			// Cross-config deduplication
-			if seenTsConfigs != nil {
-				normalized := tspath.NormalizePath(tc)
-				if _, exists := seenTsConfigs[normalized]; exists {
-					continue
-				}
-				seenTsConfigs[normalized] = struct{}{}
+	for _, tc := range tsConfigs {
+		// Cross-config deduplication
+		if seenTsConfigs != nil {
+			normalized := tspath.NormalizePath(tc)
+			if _, exists := seenTsConfigs[normalized]; exists {
+				continue
 			}
+			seenTsConfigs[normalized] = struct{}{}
+		}
 
-			program, err := utils.CreateProgram(singleThreaded, fsys, configDir, tc, host)
-			if err != nil {
-				w := bufio.NewWriter(os.Stderr)
-				if !reportSyntacticErrors(err, w, tspath.ComparePathsOptions{
-					CurrentDirectory:          configDir,
-					UseCaseSensitiveFileNames: host.FS().UseCaseSensitiveFileNames(),
-				}) {
-					fmt.Fprintf(os.Stderr, "error creating TS program: %v", err)
-				}
-				return nil, 1
-			}
-			programs = append(programs, program)
+		program, err := utils.CreateProgramLenient(singleThreaded, fsys, configDir, tc, host)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error creating TS program: %v", err)
+			return nil, 1
 		}
-	} else {
-		// No tsconfig fallback: scan directory for pure JS projects
-		sourceExts := rslintconfig.DefaultLintFileExtensions
-		excludes := utils.DefaultExcludeDirNames
-		includes := []string{"**/*"}
-		rootFiles := vfsmatch.ReadDirectory(fsys, configDir, configDir, sourceExts, excludes, includes, vfsmatch.UnlimitedDepth)
-		if len(rootFiles) > 0 {
-			program, err := utils.CreateProgramFromOptions(singleThreaded, &core.CompilerOptions{AllowJs: core.TSTrue}, rootFiles, host)
-			if err != nil {
-				w := bufio.NewWriter(os.Stderr)
-				if !reportSyntacticErrors(err, w, tspath.ComparePathsOptions{
-					CurrentDirectory:          configDir,
-					UseCaseSensitiveFileNames: host.FS().UseCaseSensitiveFileNames(),
-				}) {
-					fmt.Fprintf(os.Stderr, "error creating program: %v", err)
-				}
-				return nil, 1
-			}
-			programs = append(programs, program)
-		}
+		programs = append(programs, program)
 	}
 
 	return programs, 0
@@ -156,10 +130,12 @@ func createFallbackProgram(
 ) (*compiler.Program, int) {
 	host := utils.WithParseCache(utils.CreateCompilerHost(configDir, fsys), parseCache)
 	program, err := utils.CreateProgramFromOptionsLenient(singleThreaded, &core.CompilerOptions{
-		Target:  core.ScriptTargetESNext,
-		Module:  core.ModuleKindESNext,
-		Jsx:     core.JsxEmitPreserve,
-		AllowJs: core.TSTrue,
+		Target:    core.ScriptTargetESNext,
+		Module:    core.ModuleKindESNext,
+		Jsx:       core.JsxEmitPreserve,
+		AllowJs:   core.TSTrue,
+		NoLib:     core.TSTrue,
+		NoResolve: core.TSTrue,
 	}, gapFiles, host)
 	if err != nil {
 		// Non-fatal: gap files failing to parse should not block the entire run.
@@ -174,10 +150,10 @@ func createFallbackProgram(
 // AST-only fallback Program for selected files absent from every existing
 // Program, and returns the per-program target plan consumed by RunLinter.
 //
-// The appended fallback Program (like the no-tsconfig directory-scan Program)
-// carries synthesized CompilerOptions with no ConfigFilePath, which is how
-// buildTypeCheckSkipMask later recognizes and excludes it from the CLI
-// --type-check phase — no index needs to be threaded out of here.
+// The appended fallback Program carries synthesized CompilerOptions with no
+// ConfigFilePath, which is how buildTypeCheckSkipMask later recognizes and
+// excludes it from the CLI --type-check phase — no index needs to be threaded
+// out of here.
 //
 // The type-info set is captured from the tsconfig Programs BEFORE the fallback
 // is appended, so fallback files are deliberately absent from it. That absence
@@ -227,7 +203,7 @@ func buildProgramsWithLintTargets(
 	if len(gapFiles) > 0 {
 		// Build type-info set from existing (tsconfig) Programs BEFORE
 		// appending the fallback, so fallback files are NOT in this set.
-		typeInfoFiles = utils.CollectProgramFiles(programs, fs, singleThreaded)
+		typeInfoFiles = programFiles
 		capturedGapFiles = gapFiles
 
 		fallback, _ := createFallbackProgram(gapFiles, singleThreaded, currentDirectory, fs, parseCache)
@@ -255,7 +231,7 @@ func discoverLintFilesMultiConfig(
 
 	seen := make(map[string]struct{})
 	var allTargets []string
-	for configDir, cfg := range configMap {
+	for configDir := range configMap {
 		configAllowFiles := allowFiles
 		configAllowDirs := allowDirs
 		if targetFiles, scoped := configTargetFiles[configDir]; scoped {
@@ -263,12 +239,8 @@ func discoverLintFilesMultiConfig(
 			configAllowDirs = nil
 		}
 
-		targets := rslintconfig.DiscoverLintFiles(cfg, configDir, fs, configAllowFiles, configAllowDirs, singleThreaded)
+		targets := rslintconfig.DiscoverLintFilesForConfigInMap(configMap, configDir, fs, configAllowFiles, configAllowDirs, singleThreaded)
 		for _, f := range targets {
-			ownerDir, _ := rslintconfig.FindNearestConfig(f, configMap)
-			if ownerDir != configDir {
-				continue
-			}
 			if _, exists := seen[f]; !exists {
 				seen[f] = struct{}{}
 				allTargets = append(allTargets, f)
@@ -405,19 +377,13 @@ func toFileFilters(in []func(string) bool) []linter.FileFilter {
 // buildTypeCheckSkipMask returns a parallel-to-programs []bool marking which
 // programs must be excluded from the type-check phase. A program is skipped
 // when it was NOT built from a real tsconfig on disk — i.e. its CompilerOptions
-// carry no ConfigFilePath. That covers both synthetic-options program kinds:
-//
-//   - the no-tsconfig directory-scan Program (createProgramsForConfig's else
-//     branch), built with default options for a config directory that has no
-//     tsconfig; and
-//   - the gap-file fallback Program (createFallbackProgram).
+// carry no ConfigFilePath. That covers the AST-only fallback Program used for
+// selected files absent from every tsconfig-backed Program, including projects
+// with no tsconfig at all.
 //
 // Their options are synthesized, not the user's tsconfig, so semantic
-// diagnostics there are unreliable and must not be surfaced. Concretely, the
-// scan program sets neither Target nor Lib, so its default lib can lack modern
-// globals like Symbol.asyncDispose and emit spurious diagnostics against
-// typings pulled in from node_modules. This mirrors the type-checking boundary:
-// only Programs backed by parserOptions.project or the auto-detected
+// diagnostics there are unreliable and must not be surfaced. This mirrors the
+// type-checking boundary: only Programs backed by parserOptions.project or the auto-detected
 // tsconfig.json participate in program-level --type-check diagnostics. Programs
 // built via utils.CreateProgram -> GetParsedCommandLineOfConfigFile carry a
 // non-empty ConfigFilePath.
@@ -437,4 +403,79 @@ func buildTypeCheckSkipMask(programs []*compiler.Program) []bool {
 		}
 	}
 	return mask
+}
+
+type syntacticDiagnosticKey struct {
+	path string
+	code int32
+	pos  int
+	end  int
+}
+
+func collectTargetSyntacticDiagnostics(
+	programs []*compiler.Program,
+	targetsByProgram [][]string,
+	skipTypeCheck []bool,
+	typeCheck bool,
+	typeCheckOnly bool,
+	shouldReportForFile func(string) bool,
+) []rule.RuleDiagnostic {
+	if len(programs) == 0 || len(targetsByProgram) == 0 {
+		return nil
+	}
+
+	seen := make(map[syntacticDiagnosticKey]struct{})
+	var diagnostics []rule.RuleDiagnostic
+	for i, program := range programs {
+		// When --type-check runs, tsconfig-backed Programs surface syntactic
+		// diagnostics through the type-check phase. Synthetic Programs are
+		// skipped there, so plain lint still needs to report their target
+		// syntax errors. In --type-check-only, lint-phase diagnostics stay off.
+		coveredByTypeCheck := typeCheck && (i >= len(skipTypeCheck) || !skipTypeCheck[i])
+		if coveredByTypeCheck || typeCheckOnly {
+			continue
+		}
+		if i >= len(targetsByProgram) || len(targetsByProgram[i]) == 0 {
+			continue
+		}
+
+		targets := make(map[string]struct{}, len(targetsByProgram[i]))
+		for _, target := range targetsByProgram[i] {
+			targets[target] = struct{}{}
+		}
+
+		ctx := context.Background()
+		for target := range targets {
+			if shouldReportForFile != nil && !shouldReportForFile(target) {
+				continue
+			}
+			file := program.GetSourceFile(target)
+			if file == nil {
+				continue
+			}
+			for _, diagnostic := range program.GetSyntacticDiagnostics(ctx, file) {
+				loc := diagnostic.Loc()
+				key := syntacticDiagnosticKey{
+					path: file.FileName(),
+					code: diagnostic.Code(),
+					pos:  loc.Pos(),
+					end:  loc.End(),
+				}
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				seen[key] = struct{}{}
+				diagnostics = append(diagnostics, rule.RuleDiagnostic{
+					RuleName:     fmt.Sprintf("TypeScript(TS%d)", diagnostic.Code()),
+					SourceFile:   file,
+					FilePath:     file.FileName(),
+					Range:        loc,
+					Message:      rule.RuleMessage{Description: diagnostic.String()},
+					Severity:     rule.SeverityError,
+					PreFormatted: true,
+				})
+			}
+		}
+	}
+	return diagnostics
 }

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -179,7 +179,7 @@ func buildProgramsWithLintTargets(
 	allowDirs []string,
 	parseCache *utils.ParseCache,
 	singleThreaded bool,
-) ([]*compiler.Program, map[string]struct{}, []string, []string, [][]string) {
+) ([]*compiler.Program, map[string]struct{}, []string, []string, [][]string, map[string]string) {
 	var typeInfoFiles map[string]struct{}
 	var capturedGapFiles []string
 
@@ -194,7 +194,7 @@ func buildProgramsWithLintTargets(
 
 	gapFiles := make([]string, 0, len(targetFiles))
 	for _, target := range targetFiles {
-		if _, inProgram := programIndex.files[target]; !inProgram {
+		if len(programIndex.candidatesFor(target, fs)) == 0 {
 			gapFiles = append(gapFiles, target)
 		}
 	}
@@ -212,9 +212,9 @@ func buildProgramsWithLintTargets(
 		}
 	}
 
-	targetsByProgram := assignLintTargetsToPrograms(programs, configMap, programConfigDirs, targetFiles, programIndex)
+	targetsByProgram, configPathBySourcePath := assignLintTargetsToPrograms(programs, configMap, programConfigDirs, targetFiles, programIndex, fs)
 
-	return programs, typeInfoFiles, capturedGapFiles, targetFiles, targetsByProgram
+	return programs, typeInfoFiles, capturedGapFiles, targetFiles, targetsByProgram, configPathBySourcePath
 }
 
 func discoverLintFilesMultiConfig(
@@ -259,6 +259,23 @@ type programFileCandidate struct {
 type programFileIndex struct {
 	files  map[string]struct{}
 	byPath map[string][]programFileCandidate
+}
+
+func (index programFileIndex) candidatesFor(path string, fs vfs.FS) []programFileCandidate {
+	if len(index.byPath) == 0 {
+		return nil
+	}
+	if candidates := index.byPath[path]; len(candidates) > 0 {
+		return candidates
+	}
+	if fs == nil {
+		return nil
+	}
+	realPath := fs.Realpath(path)
+	if realPath == "" || realPath == path {
+		return nil
+	}
+	return index.byPath[realPath]
 }
 
 type indexedProgram struct {
@@ -355,15 +372,17 @@ func assignLintTargetsToPrograms(
 	programConfigDirs []string,
 	targetFiles []string,
 	programIndex programFileIndex,
-) [][]string {
+	fs vfs.FS,
+) ([][]string, map[string]string) {
 	targetsByProgram := make([][]string, len(programs))
 	if len(programs) == 0 || len(targetFiles) == 0 {
-		return targetsByProgram
+		return targetsByProgram, nil
 	}
 
 	seenProgramFile := make([]map[string]struct{}, len(programs))
+	configPathBySourcePath := make(map[string]string)
 	for _, target := range targetFiles {
-		candidates := programIndex.byPath[target]
+		candidates := programIndex.candidatesFor(target, fs)
 		if len(candidates) == 0 {
 			continue
 		}
@@ -385,11 +404,40 @@ func assignLintTargetsToPrograms(
 		}
 		seenProgramFile[chosen.programIndex][chosen.fileName] = struct{}{}
 		targetsByProgram[chosen.programIndex] = append(targetsByProgram[chosen.programIndex], chosen.fileName)
+		if chosen.fileName != target {
+			configPathBySourcePath[chosen.fileName] = target
+		}
 	}
 	for i := range targetsByProgram {
 		sort.Strings(targetsByProgram[i])
 	}
-	return targetsByProgram
+	if len(configPathBySourcePath) == 0 {
+		configPathBySourcePath = nil
+	}
+	return targetsByProgram, configPathBySourcePath
+}
+
+func buildTypeInfoFilesForPrograms(programs []*compiler.Program, skipTypeCheck []bool, fs vfs.FS, singleThreaded bool) map[string]struct{} {
+	if len(skipTypeCheck) == 0 {
+		return nil
+	}
+
+	index := programFileIndex{
+		files:  make(map[string]struct{}),
+		byPath: make(map[string][]programFileCandidate),
+	}
+	indexedPrograms := make([]indexedProgram, 0, len(programs))
+	for i, program := range programs {
+		if i < len(skipTypeCheck) && skipTypeCheck[i] {
+			continue
+		}
+		indexedPrograms = append(indexedPrograms, indexedProgram{
+			program:      program,
+			programIndex: i,
+		})
+	}
+	addProgramsToFileIndex(&index, indexedPrograms, fs, singleThreaded)
+	return index.files
 }
 
 // buildTypeCheckSkipMask returns a parallel-to-programs []bool marking which

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -11,7 +11,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
-	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -314,64 +313,6 @@ func assignLintTargetsToPrograms(
 		sort.Strings(targetsByProgram[i])
 	}
 	return targetsByProgram
-}
-
-// buildFileFilters returns per-program file filters for config `ignores`.
-// Target ownership/deduplication is handled by DiscoverLintFilesMultiConfig and
-// assignLintTargetsToPrograms before RunLinter receives TargetFiles.
-//
-// These filters are consumed by RunLinter only in Phase 1 (lint). Phase 2
-// (type-check) does NOT consult them — type-check mirrors `tsgo --noEmit`
-// over the full tsconfig-determined program. See linter.go RunLinter doc
-// and website/docs/en/guide/type-checking.md for the contract.
-//
-// The returned slice is always len(programs). Entries are never nil — ignore
-// semantics must apply to every program in Phase 1, including the gap-file
-// fallback program.
-//
-// singleConfig / singleConfigDir are used when configMap is nil (single-config
-// mode). When configMap is non-nil, the per-file nearest config is looked up.
-func buildFileFilters(
-	programs []*compiler.Program,
-	configMap map[string]rslintconfig.RslintConfig,
-	programConfigDirs []string,
-	singleConfig rslintconfig.RslintConfig,
-	singleConfigDir string,
-) []func(string) bool {
-	filters := make([]func(string) bool, len(programs))
-	for i := range programs {
-		filters[i] = func(fileName string) bool {
-			// Ignore check: resolve the config that governs this file and
-			// consult its global `ignores` patterns.
-			var cfg rslintconfig.RslintConfig
-			var cwd string
-			if configMap != nil {
-				cwd, cfg = rslintconfig.FindNearestConfig(fileName, configMap)
-			} else {
-				cfg = singleConfig
-				cwd = singleConfigDir
-			}
-			if cfg != nil && cfg.IsFileIgnored(fileName, cwd) {
-				return false
-			}
-			return true
-		}
-	}
-	return filters
-}
-
-// toFileFilters converts the legacy `[]func(string) bool` per-program filter
-// slice (used by buildFileFilters) into linter.FileFilter typed entries. The
-// underlying functions are identical; this is purely a type adapter.
-func toFileFilters(in []func(string) bool) []linter.FileFilter {
-	if in == nil {
-		return nil
-	}
-	out := make([]linter.FileFilter, len(in))
-	for i, f := range in {
-		out[i] = f
-	}
-	return out
 }
 
 // buildTypeCheckSkipMask returns a parallel-to-programs []bool marking which

--- a/cmd/rslint/programs_gate_regression_test.go
+++ b/cmd/rslint/programs_gate_regression_test.go
@@ -1,12 +1,7 @@
 package main
 
 import (
-	"bytes"
-	"errors"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -21,66 +16,13 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// TestGate_BypassedTypeAwareRuleOnGapFile_Crashes is the REVERSE assertion that
-// nails the type-aware gate (GetActiveRulesForFile) as the *only* line of
-// defense for gap files.
-//
-// A gap file has no tsconfig coverage, so RunLinter passes its rules a nil
-// TypeChecker (linter.go: TypeInfoFiles is non-nil and does not contain it). A
-// RequiresTypeInfo rule dereferences that checker without a nil guard, so if
-// such a rule is ever allowed to run on a gap file — i.e. the gate is bypassed
-// — the whole process crashes (the rule runs in a worker goroutine with no
-// recover). The forward safety case is TestHandleLint_GapFile_TypeAwareRuleGatedOff.
-//
-// This runs the bypassed-gate scenario (rules taken from GetEnabledRules, which
-// does NOT gate, instead of GetActiveRulesForFile, which does) in a subprocess
-// and asserts it does NOT exit cleanly. If a future change makes a bypassed
-// gate "safe" (e.g. a nil-TypeChecker guard inside rules, or a second filtering
-// layer), this fails — forcing a deliberate re-examination of whether the gate
-// is still load-bearing.
-func TestGate_BypassedTypeAwareRuleOnGapFile_Crashes(t *testing.T) {
-	if os.Getenv("RSLINT_GATE_CRASH_CHILD") == "1" {
-		runBypassedGateScenario()
-		// Reaching here means the type-aware rule did NOT crash on the nil
-		// TypeChecker — exit 0 so the parent's "expected a crash" fails loudly.
-		os.Exit(0)
-	}
-
-	cmd := exec.Command(os.Args[0], "-test.run=^TestGate_BypassedTypeAwareRuleOnGapFile_Crashes$")
-	cmd.Env = append(os.Environ(), "RSLINT_GATE_CRASH_CHILD=1")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err == nil {
-		t.Fatalf("expected the bypassed-gate scenario to crash (nil TypeChecker dereference): "+
-			"the type-aware gate is the only thing preventing this crash and must not be "+
-			"silently neutralized by a second defense layer.\nchild stderr:\n%s", stderr.String())
-	}
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected the subprocess to terminate with a non-zero exit (crash), got %T: %v", err, err)
-	}
-	// Pin the crash to its CAUSE — a nil-TypeChecker dereference inside the
-	// type-aware rule — so an unrelated panic elsewhere cannot masquerade as a
-	// passing gate-regression. The Go runtime prints the nil-pointer signature
-	// and a stack frame in the rule package.
-	out := stderr.String()
-	if !strings.Contains(out, "nil pointer dereference") {
-		t.Fatalf("expected a nil-pointer-dereference crash signature, got child stderr:\n%s", out)
-	}
-	if !strings.Contains(out, "no_unsafe_member_access") {
-		t.Fatalf("expected the crash to originate in the type-aware rule (no_unsafe_member_access), got child stderr:\n%s", out)
-	}
-}
-
-// runBypassedGateScenario reproduces a gap-file lint with the type-aware gate
-// REMOVED: rules come from GetEnabledRules (no gate) instead of
-// GetActiveRulesForFile (gate), so a RequiresTypeInfo rule is handed to a file
-// that RunLinter gives a nil TypeChecker. This MUST crash; it exists only to be
-// driven by the subprocess above.
-func runBypassedGateScenario() {
-	tmpDir := tspath.NormalizePath(os.TempDir())
-	gapFile := tspath.NormalizePath(filepath.Join(tmpDir, "rslint-gate-crash-gap.ts"))
+// The config resolver normally filters RequiresTypeInfo rules for gap files.
+// RunLinter repeats that filter so a caller cannot accidentally execute one
+// against a fallback Program. Non-type-aware rules continue in the established
+// gap-file mode with no TypeChecker.
+func TestGate_LinterFiltersTypeAwareRuleOnGapFile(t *testing.T) {
+	tmpDir := tspath.NormalizePath(t.TempDir())
+	gapFile := tspath.NormalizePath(filepath.Join(tmpDir, "gap.ts"))
 
 	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
 	fs = utils.NewOverlayVFS(fs, map[string]string{gapFile: "let a: any = 10;\na.b = 20;\n"})
@@ -88,7 +30,7 @@ func runBypassedGateScenario() {
 	parseCache := utils.NewParseCache()
 	fallback, _ := createFallbackProgram([]string{gapFile}, false, tmpDir, fs, parseCache)
 	if fallback == nil {
-		return // could not build the program → cannot reproduce; parent fails
+		t.Fatal("could not create fallback Program")
 	}
 
 	rslintconfig.RegisterAllRules()
@@ -99,21 +41,24 @@ func runBypassedGateScenario() {
 			Plugins: []string{"@typescript-eslint"},
 		},
 	}
-	// GetEnabledRules is the NON-gated path: it returns the RequiresTypeInfo
-	// rule for the gap file unconditionally (GetActiveRulesForFile would have
-	// filtered it out via typeInfoFiles).
+	// Deliberately bypass the config resolver's type-info gate.
 	rules, _ := rslintconfig.GlobalRuleRegistry.GetEnabledRules(cfg, gapFile, tmpDir, false)
-
-	// TypeInfoFiles is non-nil and excludes the gap file, so RunLinter passes a
-	// nil TypeChecker for it — exactly the HandleLint setup, minus the gate.
-	typeInfoFiles := map[string]struct{}{tspath.NormalizePath(filepath.Join(tmpDir, "unrelated.ts")): {}}
-	_, _ = linter.RunLinter(linter.RunLinterOptions{
+	if len(rules) != 1 || rules[0].Name != "@typescript-eslint/no-unsafe-member-access" || !rules[0].RequiresTypeInfo {
+		t.Fatalf("fixture did not resolve the expected type-aware rule: %+v", rules)
+	}
+	result, err := linter.RunLinter(linter.RunLinterOptions{
 		Programs:      []*compiler.Program{fallback},
 		Scope:         linter.FileScope{Files: []string{gapFile}},
-		TypeInfoFiles: typeInfoFiles,
+		TypeInfoFiles: map[string]struct{}{},
 		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
 			return rules
 		},
 		OnDiagnostic: func(rule.RuleDiagnostic) {},
 	})
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	if _, ran := result.ExecutedRules["@typescript-eslint/no-unsafe-member-access"]; ran {
+		t.Fatal("type-aware rule bypassed the linter's gap-file eligibility filter")
+	}
 }

--- a/cmd/rslint/programs_test.go
+++ b/cmd/rslint/programs_test.go
@@ -4,13 +4,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/tspath"
-	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/linter"
@@ -170,73 +168,5 @@ func TestBuildProgramFileSet_RealpathKeyForSymlinks(t *testing.T) {
 			}
 		}
 		t.Errorf("Expected fileSet to contain resolved path %s", resolvedFilePath)
-	}
-}
-
-type realpathCountingFS struct {
-	vfs.FS
-
-	mu      sync.Mutex
-	aliases map[string]string
-	calls   map[string]int
-}
-
-func (fsys *realpathCountingFS) Realpath(path string) string {
-	fsys.mu.Lock()
-	fsys.calls[path]++
-	alias, ok := fsys.aliases[path]
-	fsys.mu.Unlock()
-	if ok {
-		return alias
-	}
-	return fsys.FS.Realpath(path)
-}
-
-func (fsys *realpathCountingFS) callCount(path string) int {
-	fsys.mu.Lock()
-	defer fsys.mu.Unlock()
-	return fsys.calls[path]
-}
-
-func TestBuildProgramFileIndex_DedupesRealpathAcrossPrograms(t *testing.T) {
-	program := createTestProgram(t, map[string]string{
-		"a.ts": "const a = 1;",
-	})
-
-	var target string
-	for _, sf := range program.GetSourceFiles() {
-		if strings.HasSuffix(sf.FileName(), "/a.ts") {
-			target = sf.FileName()
-			break
-		}
-	}
-	if target == "" {
-		t.Fatal("expected program to include a.ts")
-	}
-
-	realTarget := target + ".real"
-	fsys := &realpathCountingFS{
-		FS:      bundled.WrapFS(cachedvfs.From(osvfs.FS())),
-		aliases: map[string]string{target: realTarget},
-		calls:   make(map[string]int),
-	}
-
-	index := buildProgramFileIndex([]*compiler.Program{program, program}, fsys, true)
-
-	if got := fsys.callCount(target); got != 1 {
-		t.Fatalf("expected one realpath lookup for duplicate source path, got %d", got)
-	}
-	if _, ok := index.files[target]; !ok {
-		t.Fatalf("expected original path %q in program index", target)
-	}
-	if _, ok := index.files[realTarget]; !ok {
-		t.Fatalf("expected realpath alias %q in program index", realTarget)
-	}
-	candidates := index.byPath[realTarget]
-	if len(candidates) != 2 {
-		t.Fatalf("expected both program candidates for realpath alias, got %d", len(candidates))
-	}
-	if candidates[0].programIndex != 0 || candidates[1].programIndex != 1 {
-		t.Fatalf("expected candidates to preserve program order, got %#v", candidates)
 	}
 }

--- a/cmd/rslint/programs_test.go
+++ b/cmd/rslint/programs_test.go
@@ -4,11 +4,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/linter"
@@ -168,5 +170,73 @@ func TestBuildProgramFileSet_RealpathKeyForSymlinks(t *testing.T) {
 			}
 		}
 		t.Errorf("Expected fileSet to contain resolved path %s", resolvedFilePath)
+	}
+}
+
+type realpathCountingFS struct {
+	vfs.FS
+
+	mu      sync.Mutex
+	aliases map[string]string
+	calls   map[string]int
+}
+
+func (fsys *realpathCountingFS) Realpath(path string) string {
+	fsys.mu.Lock()
+	fsys.calls[path]++
+	alias, ok := fsys.aliases[path]
+	fsys.mu.Unlock()
+	if ok {
+		return alias
+	}
+	return fsys.FS.Realpath(path)
+}
+
+func (fsys *realpathCountingFS) callCount(path string) int {
+	fsys.mu.Lock()
+	defer fsys.mu.Unlock()
+	return fsys.calls[path]
+}
+
+func TestBuildProgramFileIndex_DedupesRealpathAcrossPrograms(t *testing.T) {
+	program := createTestProgram(t, map[string]string{
+		"a.ts": "const a = 1;",
+	})
+
+	var target string
+	for _, sf := range program.GetSourceFiles() {
+		if strings.HasSuffix(sf.FileName(), "/a.ts") {
+			target = sf.FileName()
+			break
+		}
+	}
+	if target == "" {
+		t.Fatal("expected program to include a.ts")
+	}
+
+	realTarget := target + ".real"
+	fsys := &realpathCountingFS{
+		FS:      bundled.WrapFS(cachedvfs.From(osvfs.FS())),
+		aliases: map[string]string{target: realTarget},
+		calls:   make(map[string]int),
+	}
+
+	index := buildProgramFileIndex([]*compiler.Program{program, program}, fsys, true)
+
+	if got := fsys.callCount(target); got != 1 {
+		t.Fatalf("expected one realpath lookup for duplicate source path, got %d", got)
+	}
+	if _, ok := index.files[target]; !ok {
+		t.Fatalf("expected original path %q in program index", target)
+	}
+	if _, ok := index.files[realTarget]; !ok {
+		t.Fatalf("expected realpath alias %q in program index", realTarget)
+	}
+	candidates := index.byPath[realTarget]
+	if len(candidates) != 2 {
+		t.Fatalf("expected both program candidates for realpath alias, got %d", len(candidates))
+	}
+	if candidates[0].programIndex != 0 || candidates[1].programIndex != 1 {
+		t.Fatalf("expected candidates to preserve program order, got %#v", candidates)
 	}
 }

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
@@ -209,11 +210,13 @@ export const value: Bad | null = null;
 		t.Fatalf("expected tsconfig-backed program to participate in type-check, got %v", skip)
 	}
 
-	programs, typeInfoFiles, gapFiles := buildProgramsWithGapFallback(
+	programs, typeInfoFiles, gapFiles, _, _ := buildProgramsWithLintTargets(
 		programs,
 		nil,
 		cfg,
 		dir,
+		nil,
+		nil,
 		fs,
 		nil,
 		nil,
@@ -240,5 +243,63 @@ export const value: Bad | null = null;
 
 	if diags := collectProgramTypeDiagnostics(t, programs, skip, typeInfoFiles); containsTSDiagnostic(diags, "TS2304") {
 		t.Fatalf("did not expect declaration diagnostics from a gap fallback program: %+v", diags)
+	}
+}
+
+func TestBuildProgramsWithLintTargets_BindsImportedNonRootFile(t *testing.T) {
+	dir := t.TempDir()
+	writeProgramTestFiles(t, dir, map[string]string{
+		"main.ts":       "import { value } from './lib';\nconsole.log(value);\n",
+		"lib.ts":        "export const value = 1;\n",
+		"tsconfig.json": `{"files": ["main.ts"], "compilerOptions": {"module": "ESNext"}}`,
+	})
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	parseCache := utils.NewParseCache()
+	cfg := rslintconfig.RslintConfig{{
+		Files: []string{"**/*.ts"},
+		LanguageOptions: &rslintconfig.LanguageOptions{
+			ParserOptions: &rslintconfig.ParserOptions{
+				Project: rslintconfig.ProjectPaths{"./tsconfig.json"},
+			},
+		},
+		Rules: rslintconfig.Rules{"no-debugger": "error"},
+	}}
+	programs, exitCode := createProgramsForConfig(dir, cfg, true, fs, nil, parseCache)
+	if exitCode != 0 {
+		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	}
+	if len(programs) != 1 {
+		t.Fatalf("expected one tsconfig-backed program, got %d", len(programs))
+	}
+
+	libPath := tspath.NormalizePath(filepath.Join(dir, "lib.ts"))
+	programs, typeInfoFiles, gapFiles, targetFiles, targetsByProgram := buildProgramsWithLintTargets(
+		programs,
+		nil,
+		cfg,
+		dir,
+		nil,
+		nil,
+		fs,
+		[]string{libPath},
+		nil,
+		parseCache,
+		true,
+	)
+	if len(programs) != 1 {
+		t.Fatalf("imported non-root target should reuse existing Program, got %d programs", len(programs))
+	}
+	if len(gapFiles) != 0 {
+		t.Fatalf("imported non-root target should not become a gap file, got %v", gapFiles)
+	}
+	if typeInfoFiles != nil {
+		t.Fatalf("no fallback appended, so typeInfoFiles should stay nil, got %v", typeInfoFiles)
+	}
+	if len(targetFiles) != 1 || targetFiles[0] != libPath {
+		t.Fatalf("expected lib.ts as the only target, got %v", targetFiles)
+	}
+	if len(targetsByProgram) != 1 || len(targetsByProgram[0]) != 1 || targetsByProgram[0][0] != libPath {
+		t.Fatalf("expected lib.ts bound to the tsconfig Program, got %v", targetsByProgram)
 	}
 }

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
@@ -66,6 +67,28 @@ func containsTSDiagnostic(diags []rule.RuleDiagnostic, code string) bool {
 	return false
 }
 
+func resolveAndBindTestTargets(
+	t *testing.T,
+	set lintProgramSet,
+	cfg rslintconfig.RslintConfig,
+	dir string,
+	fsys vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	parseCache *utils.ParseCache,
+) (lintTargetPlan, lintTargetBinding) {
+	t.Helper()
+	plan, err := resolveLintTargetPlan(nil, cfg, dir, nil, fsys, allowFiles, allowDirs, true)
+	if err != nil {
+		t.Fatalf("resolveLintTargetPlan: %v", err)
+	}
+	binding, err := bindLintTargetPlan(set, plan, dir, fsys, parseCache, true)
+	if err != nil {
+		t.Fatalf("bindLintTargetPlan: %v", err)
+	}
+	return plan, binding
+}
+
 func TestTypeCheck_SkipsNoTsconfigTargetFallbackProgram(t *testing.T) {
 	dir := t.TempDir()
 	writeProgramTestFiles(t, dir, map[string]string{
@@ -74,34 +97,33 @@ func TestTypeCheck_SkipsNoTsconfigTargetFallbackProgram(t *testing.T) {
 	})
 
 	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	programs, exitCode := createProgramsForConfig(
+	programSet, err := createProgramSetForConfig(
 		dir,
 		rslintconfig.RslintConfig{{Files: []string{"**/*.ts"}}},
 		true,
 		fs,
-		nil,
 		utils.NewParseCache(),
 	)
-	if exitCode != 0 {
-		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	if err != nil {
+		t.Fatalf("createProgramSetForConfig: %v", err)
 	}
-	if len(programs) != 0 {
-		t.Fatalf("expected no tsconfig-backed programs, got %d", len(programs))
+	if len(programSet.Programs) != 0 {
+		t.Fatalf("expected no tsconfig-backed programs, got %d", len(programSet.Programs))
 	}
 
-	programs, typeInfoFiles, gapFiles, _, _, _ := buildProgramsWithLintTargets(
-		programs,
-		nil,
+	_, binding := resolveAndBindTestTargets(
+		t,
+		programSet,
 		rslintconfig.RslintConfig{{Files: []string{"**/*.ts"}}},
 		dir,
-		nil,
-		nil,
 		fs,
 		nil,
 		nil,
 		utils.NewParseCache(),
-		true,
 	)
+	programs := binding.Programs
+	typeInfoFiles := binding.TypeInfoFiles
+	gapFiles := binding.GapFiles
 	if len(programs) != 1 {
 		t.Fatalf("expected one files-driven fallback program, got %d", len(programs))
 	}
@@ -143,7 +165,7 @@ export const value: Bad | null = null;
 	})
 
 	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	programs, exitCode := createProgramsForConfig(
+	programSet, err := createProgramSetForConfig(
 		dir,
 		rslintconfig.RslintConfig{{
 			Files: []string{"**/*.ts"},
@@ -155,12 +177,12 @@ export const value: Bad | null = null;
 		}},
 		true,
 		fs,
-		nil,
 		utils.NewParseCache(),
 	)
-	if exitCode != 0 {
-		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	if err != nil {
+		t.Fatalf("createProgramSetForConfig: %v", err)
 	}
+	programs := programSet.Programs
 	if len(programs) != 1 {
 		t.Fatalf("expected one tsconfig-backed program, got %d", len(programs))
 	}
@@ -209,37 +231,36 @@ export const value: Bad | null = null;
 			},
 		},
 	}}
-	programs, exitCode := createProgramsForConfig(
+	programSet, err := createProgramSetForConfig(
 		dir,
 		cfg,
 		true,
 		fs,
-		nil,
 		parseCache,
 	)
-	if exitCode != 0 {
-		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	if err != nil {
+		t.Fatalf("createProgramSetForConfig: %v", err)
 	}
-	if len(programs) != 1 {
-		t.Fatalf("expected one tsconfig-backed program before gap fallback, got %d", len(programs))
+	if len(programSet.Programs) != 1 {
+		t.Fatalf("expected one tsconfig-backed program before gap fallback, got %d", len(programSet.Programs))
 	}
-	if skip := buildTypeCheckSkipMask(programs); skip != nil {
+	if skip := buildTypeCheckSkipMask(programSet.Programs); skip != nil {
 		t.Fatalf("expected tsconfig-backed program to participate in type-check, got %v", skip)
 	}
 
-	programs, typeInfoFiles, gapFiles, _, _, _ := buildProgramsWithLintTargets(
-		programs,
-		nil,
+	_, binding := resolveAndBindTestTargets(
+		t,
+		programSet,
 		cfg,
 		dir,
-		nil,
-		nil,
 		fs,
 		nil,
 		nil,
 		parseCache,
-		true,
 	)
+	programs := binding.Programs
+	typeInfoFiles := binding.TypeInfoFiles
+	gapFiles := binding.GapFiles
 	if len(programs) != 2 {
 		t.Fatalf("expected the gap fallback program to be appended, got %d programs", len(programs))
 	}
@@ -285,28 +306,30 @@ func TestBuildProgramsWithLintTargets_BindsImportedNonRootFile(t *testing.T) {
 		},
 		Rules: rslintconfig.Rules{"no-debugger": "error"},
 	}}
-	programs, exitCode := createProgramsForConfig(dir, cfg, true, fs, nil, parseCache)
-	if exitCode != 0 {
-		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	programSet, err := createProgramSetForConfig(dir, cfg, true, fs, parseCache)
+	if err != nil {
+		t.Fatalf("createProgramSetForConfig: %v", err)
 	}
-	if len(programs) != 1 {
-		t.Fatalf("expected one tsconfig-backed program, got %d", len(programs))
+	if len(programSet.Programs) != 1 {
+		t.Fatalf("expected one tsconfig-backed program, got %d", len(programSet.Programs))
 	}
 
 	libPath := tspath.NormalizePath(filepath.Join(dir, "lib.ts"))
-	programs, typeInfoFiles, gapFiles, targetFiles, targetsByProgram, _ := buildProgramsWithLintTargets(
-		programs,
-		nil,
+	plan, binding := resolveAndBindTestTargets(
+		t,
+		programSet,
 		cfg,
 		dir,
-		nil,
-		nil,
 		fs,
 		[]string{libPath},
 		nil,
 		parseCache,
-		true,
 	)
+	programs := binding.Programs
+	typeInfoFiles := binding.TypeInfoFiles
+	gapFiles := binding.GapFiles
+	targetFiles := []string{plan.Targets[0].Path}
+	targetsByProgram := binding.TargetsByProgram
 	if len(programs) != 1 {
 		t.Fatalf("imported non-root target should reuse existing Program, got %d programs", len(programs))
 	}
@@ -351,10 +374,11 @@ func TestBuildProgramsWithLintTargets_BindsRealpathTargetToProgramSourceName(t *
 
 	linkDir = tspath.NormalizePath(linkDir)
 	realTarget := tspath.NormalizePath(filepath.Join(realDir, "src/a.ts"))
-	programs, exitCode := createProgramsForConfig(linkDir, cfg, true, fs, nil, parseCache)
-	if exitCode != 0 {
-		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	programSet, err := createProgramSetForConfig(linkDir, cfg, true, fs, parseCache)
+	if err != nil {
+		t.Fatalf("createProgramSetForConfig: %v", err)
 	}
+	programs := programSet.Programs
 	if len(programs) != 1 {
 		t.Fatalf("expected one tsconfig-backed program, got %d", len(programs))
 	}
@@ -373,19 +397,22 @@ func TestBuildProgramsWithLintTargets_BindsRealpathTargetToProgramSourceName(t *
 		t.Skip("compiler already canonicalized source file to realpath")
 	}
 
-	programs, typeInfoFiles, gapFiles, targetFiles, targetsByProgram, configPathBySourcePath := buildProgramsWithLintTargets(
-		programs,
-		nil,
+	plan, binding := resolveAndBindTestTargets(
+		t,
+		programSet,
 		cfg,
 		linkDir,
-		nil,
-		nil,
 		fs,
 		[]string{realTarget},
 		nil,
 		parseCache,
-		true,
 	)
+	programs = binding.Programs
+	typeInfoFiles := binding.TypeInfoFiles
+	gapFiles := binding.GapFiles
+	targetFiles := []string{plan.Targets[0].Path}
+	targetsByProgram := binding.TargetsByProgram
+	targetPathBySourcePath := binding.TargetPathBySourcePath
 	if len(programs) != 1 {
 		t.Fatalf("realpath target should reuse existing Program, got %d programs", len(programs))
 	}
@@ -401,7 +428,394 @@ func TestBuildProgramsWithLintTargets_BindsRealpathTargetToProgramSourceName(t *
 	if len(targetsByProgram) != 1 || len(targetsByProgram[0]) != 1 || targetsByProgram[0][0] != sourceName {
 		t.Fatalf("expected realpath target to bind back to source name %q, got %v", sourceName, targetsByProgram)
 	}
-	if configPathBySourcePath[sourceName] != realTarget {
-		t.Fatalf("expected source path %q to resolve config through target path %q, got %v", sourceName, realTarget, configPathBySourcePath)
+	if targetPathBySourcePath[sourceName] != realTarget {
+		t.Fatalf("expected source path %q to resolve config through target path %q, got %v", sourceName, realTarget, targetPathBySourcePath)
+	}
+}
+
+func TestBindLintTargetPlan_UsesPhysicalConfigSpaceForSymlinkedConfigRoot(t *testing.T) {
+	realDir := t.TempDir()
+	linkDir := filepath.Join(filepath.Dir(realDir), filepath.Base(realDir)+"-config-link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	defer os.Remove(linkDir)
+	writeProgramTestFiles(t, realDir, map[string]string{
+		"src/a.ts":      "debugger;\n",
+		"tsconfig.json": `{"include":["src/a.ts"]}`,
+	})
+
+	linkDir = tspath.NormalizePath(linkDir)
+	realTarget := tspath.NormalizePath(filepath.Join(realDir, "src/a.ts"))
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	cfg := rslintconfig.RslintConfig{{
+		Files: []string{"src/**/*.ts"},
+		LanguageOptions: &rslintconfig.LanguageOptions{ParserOptions: &rslintconfig.ParserOptions{
+			Project: rslintconfig.ProjectPaths{"./tsconfig.json"},
+		}},
+		Rules: rslintconfig.Rules{"no-debugger": "error"},
+	}}
+	set, err := createProgramSetForConfig(linkDir, cfg, true, fsys, utils.NewParseCache())
+	if err != nil || len(set.Programs) != 1 {
+		t.Fatalf("create Program through symlinked config root: err=%v programs=%d", err, len(set.Programs))
+	}
+	plan := lintTargetPlan{Targets: []resolvedLintTarget{testLintTarget(fsys, linkDir, realTarget)}}
+	binding, err := bindLintTargetPlan(set, plan, linkDir, fsys, utils.NewParseCache(), true)
+	if err != nil {
+		t.Fatalf("bindLintTargetPlan: %v", err)
+	}
+	if len(binding.TargetsByProgram) != 1 || len(binding.TargetsByProgram[0]) != 1 {
+		t.Fatalf("expected real target to bind to config Program, got %v", binding.TargetsByProgram)
+	}
+	sourcePath := binding.TargetsByProgram[0][0]
+	configPath := binding.ConfigPathBySourcePath[sourcePath]
+	if canonicalFilesystemPathID(configPath, fsys) != canonicalFilesystemPathID(realTarget, fsys) {
+		t.Fatalf("config path must stay in the physical config-root space: source=%q config=%q target=%q", sourcePath, configPath, realTarget)
+	}
+
+	rslintconfig.RegisterAllRules()
+	resolver := newLintConfigResolver(lintConfigResolverOptions{
+		Config:                     cfg,
+		CurrentDirectory:           linkDir,
+		TypeInfoFiles:              binding.TypeInfoFiles,
+		TargetPathBySourcePath:     binding.TargetPathBySourcePath,
+		ConfigPathBySourcePath:     binding.ConfigPathBySourcePath,
+		OwnerConfigDirBySourcePath: binding.OwnerConfigDirBySourcePath,
+		FS:                         fsys,
+	})
+	rules := resolver.ActiveRulesForFile(sourcePath)
+	if len(rules) != 1 || rules[0].Name != "no-debugger" {
+		t.Fatalf("expected files selector to match in physical config space, got %v", configuredRuleNameSet(rules))
+	}
+}
+
+func TestBindLintTargetPlan_BindsFileSymlinkOutsideProgramRoot(t *testing.T) {
+	sharedDir := t.TempDir()
+	writeProgramTestFiles(t, sharedDir, map[string]string{
+		"shared.ts": `export const value = 1;`,
+	})
+	repoDir := t.TempDir()
+	linkedPath := filepath.Join(repoDir, "linked.ts")
+	realTarget := filepath.Join(sharedDir, "shared.ts")
+	if err := os.Symlink(realTarget, linkedPath); err != nil {
+		t.Skipf("file symlink unavailable: %v", err)
+	}
+	writeProgramTestFiles(t, repoDir, map[string]string{
+		"tsconfig.json": `{"files":["linked.ts"]}`,
+	})
+
+	repoDir = tspath.NormalizePath(repoDir)
+	realTarget = tspath.NormalizePath(realTarget)
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	parseCache := utils.NewParseCache()
+	cfg := projectConfig("./tsconfig.json")
+	set, err := createProgramSetForConfig(repoDir, cfg, true, fsys, parseCache)
+	if err != nil || len(set.Programs) != 1 {
+		t.Fatalf("expected one Program for file-symlink fixture, err=%v programs=%d", err, len(set.Programs))
+	}
+	var sourceName string
+	for _, sourceFile := range set.Programs[0].GetSourceFiles() {
+		if strings.HasSuffix(sourceFile.FileName(), "/linked.ts") || sourceFile.FileName() == realTarget {
+			sourceName = sourceFile.FileName()
+			break
+		}
+	}
+	if sourceName == "" {
+		t.Fatal("expected Program to contain the symlinked source")
+	}
+	if sourceName == realTarget {
+		t.Skip("compiler canonicalized the file symlink before Program lookup")
+	}
+
+	plan := lintTargetPlan{Targets: []resolvedLintTarget{testLintTarget(fsys, repoDir, realTarget)}}
+	binding, err := bindLintTargetPlan(set, plan, repoDir, fsys, parseCache, true)
+	if err != nil {
+		t.Fatalf("bindLintTargetPlan: %v", err)
+	}
+	if len(binding.GapFiles) != 0 || len(binding.Programs) != 1 {
+		t.Fatalf("real target should bind through the Program's file symlink, gaps=%v programs=%d", binding.GapFiles, len(binding.Programs))
+	}
+	if len(binding.TargetsByProgram[0]) != 1 || binding.TargetsByProgram[0][0] != sourceName {
+		t.Fatalf("expected target to bind to Program source %q, got %v", sourceName, binding.TargetsByProgram)
+	}
+	if owner := binding.OwnerConfigDirBySourcePath[sourceName]; owner != repoDir {
+		t.Fatalf("expected bound source owner %q, got %q", repoDir, owner)
+	}
+}
+
+func testLintTarget(fsys vfs.FS, ownerDir string, filePath string) resolvedLintTarget {
+	filePath = tspath.NormalizePath(filePath)
+	canonicalPath := filePath
+	if realPath := fsys.Realpath(filePath); realPath != "" {
+		canonicalPath = tspath.NormalizePath(realPath)
+	}
+	return resolvedLintTarget{
+		Path:           filePath,
+		CanonicalPath:  canonicalPath,
+		OwnerConfigDir: tspath.NormalizePath(ownerDir),
+	}
+}
+
+func projectConfig(projects ...string) rslintconfig.RslintConfig {
+	return rslintconfig.RslintConfig{{
+		LanguageOptions: &rslintconfig.LanguageOptions{
+			ParserOptions: &rslintconfig.ParserOptions{
+				Project: rslintconfig.ProjectPaths(projects),
+			},
+		},
+	}}
+}
+
+func TestBindLintTargetPlan_DoesNotBorrowParentConfigProgram(t *testing.T) {
+	rootDir := t.TempDir()
+	childDir := filepath.Join(rootDir, "child")
+	writeProgramTestFiles(t, rootDir, map[string]string{
+		"tsconfig.json":   `{"include":["child/target.ts"]}`,
+		"child/target.ts": `export const value = 1;`,
+	})
+
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	parseCache := utils.NewParseCache()
+	configMap := map[string]rslintconfig.RslintConfig{
+		tspath.NormalizePath(rootDir):  projectConfig("./tsconfig.json"),
+		tspath.NormalizePath(childDir): rslintconfig.RslintConfig{{}},
+	}
+	set, err := createProgramSetForConfigs(configMap, true, fsys, parseCache)
+	if err != nil {
+		t.Fatalf("createProgramSetForConfigs: %v", err)
+	}
+	if len(set.Programs) != 1 {
+		t.Fatalf("expected only the root tsconfig Program, got %d", len(set.Programs))
+	}
+
+	targetPath := filepath.Join(childDir, "target.ts")
+	plan := lintTargetPlan{Targets: []resolvedLintTarget{testLintTarget(fsys, childDir, targetPath)}}
+	binding, err := bindLintTargetPlan(set, plan, rootDir, fsys, parseCache, true)
+	if err != nil {
+		t.Fatalf("bindLintTargetPlan: %v", err)
+	}
+
+	if len(binding.GapFiles) != 1 || binding.GapFiles[0] != tspath.NormalizePath(targetPath) {
+		t.Fatalf("child-owned target must use fallback instead of borrowing the parent Program: %v", binding.GapFiles)
+	}
+	if len(binding.Programs) != 2 || len(binding.TargetsByProgram[0]) != 0 || len(binding.TargetsByProgram[1]) != 1 {
+		t.Fatalf("expected target only in fallback Program, got targets=%v", binding.TargetsByProgram)
+	}
+	fallbackSource := binding.TargetsByProgram[1][0]
+	if owner := binding.OwnerConfigDirBySourcePath[fallbackSource]; owner != tspath.NormalizePath(childDir) {
+		t.Fatalf("expected fallback source owner %q, got %q", tspath.NormalizePath(childDir), owner)
+	}
+	if binding.TypeInfoFiles == nil || len(binding.TypeInfoFiles) != 0 {
+		t.Fatalf("expected an explicit empty type-info set for the child gap target, got %v", binding.TypeInfoFiles)
+	}
+}
+
+func TestTypeCheckDeduplicatesSyntaxFromGoverningFallbackAndParentProgram(t *testing.T) {
+	rootDir := t.TempDir()
+	childDir := filepath.Join(rootDir, "child")
+	writeProgramTestFiles(t, rootDir, map[string]string{
+		"tsconfig.json":   `{"include":["child/target.ts"]}`,
+		"child/target.ts": `let value: ;`,
+	})
+
+	rootDir = tspath.NormalizePath(rootDir)
+	childDir = tspath.NormalizePath(childDir)
+	configMap := map[string]rslintconfig.RslintConfig{
+		rootDir:  projectConfig("./tsconfig.json"),
+		childDir: rslintconfig.RslintConfig{{}},
+	}
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	parseCache := utils.NewParseCache()
+	set, err := createProgramSetForConfigs(configMap, true, fsys, parseCache)
+	if err != nil {
+		t.Fatalf("createProgramSetForConfigs: %v", err)
+	}
+	targetPath := tspath.NormalizePath(filepath.Join(childDir, "target.ts"))
+	plan := lintTargetPlan{Targets: []resolvedLintTarget{testLintTarget(fsys, childDir, targetPath)}}
+	binding, err := bindLintTargetPlan(set, plan, rootDir, fsys, parseCache, true)
+	if err != nil {
+		t.Fatalf("bindLintTargetPlan: %v", err)
+	}
+	if len(binding.GapFiles) != 1 {
+		t.Fatalf("child-owned target must remain on fallback, got gaps %v", binding.GapFiles)
+	}
+
+	skip := buildTypeCheckSkipMask(binding.Programs)
+	diagnostics, syntaxErrorFiles := collectTargetSyntacticDiagnostics(binding.Programs, binding.TargetsByProgram, skip, true, false)
+	if len(syntaxErrorFiles) != 1 {
+		t.Fatalf("expected one malformed lint target, got %v", syntaxErrorFiles)
+	}
+	diagnostics = append(diagnostics, collectProgramTypeDiagnostics(t, binding.Programs, skip, binding.TypeInfoFiles)...)
+	remapDiagnosticTargetPaths(diagnostics, binding.TargetPathBySourcePath)
+	if len(diagnostics) < 2 {
+		t.Fatalf("fixture must exercise both fallback syntax and parent Program type-check paths, got %+v", diagnostics)
+	}
+
+	diagnostics = deduplicateTypeScriptDiagnostics(diagnostics, fsys)
+	if len(diagnostics) != 1 || diagnostics[0].RuleName != "TypeScript(TS1110)" {
+		t.Fatalf("expected one TS1110 diagnostic after cross-phase dedupe, got %+v", diagnostics)
+	}
+}
+
+func TestCreateProgramSetForConfigs_DeduplicatesSharedTsconfigAndRetainsOwners(t *testing.T) {
+	rootDir := t.TempDir()
+	childDir := filepath.Join(rootDir, "child")
+	writeProgramTestFiles(t, rootDir, map[string]string{
+		"tsconfig.json": `{"include":["src/**/*.ts"]}`,
+		"src/a.ts":      `export const a = 1;`,
+	})
+	if err := os.MkdirAll(childDir, 0755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+
+	rootKey := tspath.NormalizePath(rootDir)
+	childKey := tspath.NormalizePath(childDir)
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	set, err := createProgramSetForConfigs(map[string]rslintconfig.RslintConfig{
+		rootKey:  projectConfig("./tsconfig.json"),
+		childKey: projectConfig("../tsconfig.json"),
+	}, true, fsys, utils.NewParseCache())
+	if err != nil {
+		t.Fatalf("createProgramSetForConfigs: %v", err)
+	}
+	if len(set.Programs) != 1 || len(set.ConfigOrders) != 1 {
+		t.Fatalf("shared tsconfig must produce one Program, got programs=%d orders=%d", len(set.Programs), len(set.ConfigOrders))
+	}
+	if order, ok := set.ConfigOrders[0][rootKey]; !ok || order != 0 {
+		t.Fatalf("missing root config association: %v", set.ConfigOrders[0])
+	}
+	if order, ok := set.ConfigOrders[0][childKey]; !ok || order != 0 {
+		t.Fatalf("missing child config association: %v", set.ConfigOrders[0])
+	}
+}
+
+func TestBindLintTargetPlan_UsesGoverningConfigProjectOrder(t *testing.T) {
+	dir := t.TempDir()
+	writeProgramTestFiles(t, dir, map[string]string{
+		"shared.ts":       `export const value = 1;`,
+		"tsconfig-a.json": `{"files":["shared.ts"]}`,
+		"tsconfig-b.json": `{"files":["shared.ts"]}`,
+	})
+
+	dir = tspath.NormalizePath(dir)
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	parseCache := utils.NewParseCache()
+	set, err := createProgramSetForConfig(
+		dir,
+		projectConfig("./tsconfig-a.json", "./tsconfig-b.json"),
+		true,
+		fsys,
+		parseCache,
+	)
+	if err != nil || len(set.Programs) != 2 {
+		t.Fatalf("expected two ordered Programs, err=%v programs=%d", err, len(set.Programs))
+	}
+
+	targetPath := filepath.Join(dir, "shared.ts")
+	plan := lintTargetPlan{Targets: []resolvedLintTarget{testLintTarget(fsys, dir, targetPath)}}
+	binding, err := bindLintTargetPlan(set, plan, dir, fsys, parseCache, true)
+	if err != nil {
+		t.Fatalf("bindLintTargetPlan: %v", err)
+	}
+	if len(binding.TargetsByProgram[0]) != 1 || len(binding.TargetsByProgram[1]) != 0 {
+		t.Fatalf("overlapping target must bind to the first declared project, got %v", binding.TargetsByProgram)
+	}
+}
+
+func TestBindLintTargetPlan_RecomputesProgramMembershipAfterImportGraphChange(t *testing.T) {
+	dir := t.TempDir()
+	writeProgramTestFiles(t, dir, map[string]string{
+		"main.ts":       `import "./extra";`,
+		"extra.ts":      `export const value = 1;`,
+		"tsconfig.json": `{"files":["main.ts"]}`,
+	})
+
+	dir = tspath.NormalizePath(dir)
+	config := projectConfig("./tsconfig.json")
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	parseCache := utils.NewParseCache()
+	set, err := createProgramSetForConfig(dir, config, true, fsys, parseCache)
+	if err != nil {
+		t.Fatalf("initial createProgramSetForConfig: %v", err)
+	}
+	plan := lintTargetPlan{Targets: []resolvedLintTarget{
+		testLintTarget(fsys, dir, filepath.Join(dir, "extra.ts")),
+	}}
+	initial, err := bindLintTargetPlan(set, plan, dir, fsys, parseCache, true)
+	if err != nil {
+		t.Fatalf("initial bindLintTargetPlan: %v", err)
+	}
+	if len(initial.GapFiles) != 0 || len(initial.Programs) != 1 || len(initial.TargetsByProgram[0]) != 1 {
+		t.Fatalf("imported target should initially use the real Program, got gaps=%v targets=%v", initial.GapFiles, initial.TargetsByProgram)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "main.ts"), []byte(`export const main = 1;`), 0644); err != nil {
+		t.Fatalf("rewrite main.ts: %v", err)
+	}
+	// Production fix passes reuse the run-scoped filesystem and parse caches.
+	// ParseCache keys include the exact source text hash, so rewritten content
+	// must still produce a fresh AST and updated import graph.
+	rebuilt, err := createProgramSetForConfig(dir, config, true, fsys, parseCache)
+	if err != nil {
+		t.Fatalf("rebuilt createProgramSetForConfig: %v", err)
+	}
+	afterFix, err := bindLintTargetPlan(rebuilt, plan, dir, fsys, parseCache, true)
+	if err != nil {
+		t.Fatalf("rebuilt bindLintTargetPlan: %v", err)
+	}
+	if len(afterFix.GapFiles) != 1 || len(afterFix.Programs) != 2 || len(afterFix.TargetsByProgram[1]) != 1 {
+		t.Fatalf("target must move to fallback after its importing edge is removed, got gaps=%v targets=%v", afterFix.GapFiles, afterFix.TargetsByProgram)
+	}
+}
+
+func TestResolveLintTargetPlan_RejectsCanonicalTargetWithDifferentOwners(t *testing.T) {
+	sharedDir := t.TempDir()
+	writeProgramTestFiles(t, sharedDir, map[string]string{
+		"target.ts": `export const value = 1;`,
+	})
+	ownersRoot := t.TempDir()
+	ownerA := filepath.Join(ownersRoot, "owner-a")
+	ownerB := filepath.Join(ownersRoot, "owner-b")
+	if err := os.MkdirAll(ownerA, 0755); err != nil {
+		t.Fatalf("mkdir owner A: %v", err)
+	}
+	if err := os.MkdirAll(ownerB, 0755); err != nil {
+		t.Fatalf("mkdir owner B: %v", err)
+	}
+	sharedTarget := filepath.Join(sharedDir, "target.ts")
+	targetA := filepath.Join(ownerA, "target.ts")
+	targetB := filepath.Join(ownerB, "target.ts")
+	if err := os.Symlink(sharedTarget, targetA); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.Symlink(sharedTarget, targetB); err != nil {
+		t.Skipf("second symlink unavailable: %v", err)
+	}
+
+	ownerA = tspath.NormalizePath(ownerA)
+	ownerB = tspath.NormalizePath(ownerB)
+	targetA = tspath.NormalizePath(targetA)
+	targetB = tspath.NormalizePath(targetB)
+	configMap := map[string]rslintconfig.RslintConfig{
+		ownerA: {{Rules: rslintconfig.Rules{"no-debugger": "error"}}},
+		ownerB: {{Rules: rslintconfig.Rules{"no-console": "error"}}},
+	}
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+
+	_, err := resolveLintTargetPlan(
+		configMap,
+		nil,
+		tspath.NormalizePath(ownersRoot),
+		nil,
+		fsys,
+		[]string{targetA, targetB},
+		nil,
+		true,
+	)
+	if err == nil {
+		t.Fatal("expected aliases governed by different configs to be rejected")
+	}
+	if !strings.Contains(err.Error(), "resolve to the same file") || !strings.Contains(err.Error(), ownerA) || !strings.Contains(err.Error(), ownerB) {
+		t.Fatalf("unexpected ownership conflict error: %v", err)
 	}
 }

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -339,6 +339,9 @@ func TestBuildProgramsWithLintTargets_BindsImportedNonRootFile(t *testing.T) {
 	if len(programSet.Programs) != 1 {
 		t.Fatalf("expected one tsconfig-backed program, got %d", len(programSet.Programs))
 	}
+	if _, ok := programSet.ConfigOrders[0][exactFilesystemPathID(dir)]; !ok {
+		t.Fatalf("config order was not keyed by normalized directory identity: %v", programSet.ConfigOrders[0])
+	}
 
 	libPath := tspath.NormalizePath(filepath.Join(dir, "lib.ts"))
 	plan, binding := resolveAndBindTestTargets(
@@ -371,6 +374,22 @@ func TestBuildProgramsWithLintTargets_BindsImportedNonRootFile(t *testing.T) {
 	if len(targetsByProgram) != 1 || len(targetsByProgram[0]) != 1 ||
 		canonicalFilesystemPathID(targetsByProgram[0][0], fs) != canonicalFilesystemPathID(libPath, fs) {
 		t.Fatalf("expected lib.ts bound to the tsconfig Program, got %v", targetsByProgram)
+	}
+}
+
+func TestOrderedProgramIndexesForConfig_NormalizesDirectorySeparators(t *testing.T) {
+	set := lintProgramSet{
+		Programs: []*compiler.Program{nil},
+		ConfigOrders: []programConfigOrders{{
+			exactFilesystemPathID(`C:\Repo`): 0,
+		}},
+	}
+	indexes := orderedProgramIndexesForConfig(set, "C:/Repo")
+	if len(indexes) != 1 || indexes[0] != 0 {
+		t.Fatalf("normalized config directory did not find its Program: %v", indexes)
+	}
+	if indexes := orderedProgramIndexesForConfig(set, "c:/repo"); len(indexes) != 0 {
+		t.Fatalf("config directory identity unexpectedly folded case: %v", indexes)
 	}
 }
 

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -5,10 +5,12 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
@@ -18,6 +20,26 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+type targetPlanRealpathCountingFS struct {
+	vfs.FS
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func (f *targetPlanRealpathCountingFS) Realpath(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	f.mu.Lock()
+	f.calls[filePath]++
+	f.mu.Unlock()
+	return f.FS.Realpath(filePath)
+}
+
+func (f *targetPlanRealpathCountingFS) callCount(filePath string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[tspath.NormalizePath(filePath)]
+}
 
 func writeProgramTestFiles(t *testing.T, dir string, files map[string]string) {
 	t.Helper()
@@ -137,7 +159,7 @@ func TestTypeCheck_SkipsNoTsconfigTargetFallbackProgram(t *testing.T) {
 		t.Fatalf("expected files-driven fallback program to have no ConfigFilePath, got %q", got)
 	}
 	if !programs[0].Options().NoLib.IsTrue() || !programs[0].Options().NoResolve.IsTrue() {
-		t.Fatalf("expected files-driven fallback to stay AST-only, got options %+v", programs[0].Options())
+		t.Fatalf("expected files-driven fallback to stay non-project-backed, got options %+v", programs[0].Options())
 	}
 	skip := buildTypeCheckSkipMask(programs)
 	if len(skip) != 1 || !skip[0] {
@@ -212,7 +234,7 @@ func TestTypeCheck_SkipsGapFallbackPrograms(t *testing.T) {
   "include": ["src/in-project.ts"]
 }
 `,
-		"src/in-project.ts": `export const ok = 1;
+		"src/in-project.ts": `export const bad: number = "oops";
 `,
 		"gap.ts": `import type { Bad } from './bad';
 export const value: Bad | null = null;
@@ -275,14 +297,18 @@ export const value: Bad | null = null;
 		t.Fatalf("expected gap fallback program to have no ConfigFilePath, got %q", got)
 	}
 	if !programs[1].Options().NoLib.IsTrue() || !programs[1].Options().NoResolve.IsTrue() {
-		t.Fatalf("expected gap fallback to stay AST-only, got options %+v", programs[1].Options())
+		t.Fatalf("expected gap fallback to stay non-project-backed, got options %+v", programs[1].Options())
 	}
 	skip := buildTypeCheckSkipMask(programs)
 	if len(skip) != 2 || skip[0] || !skip[1] {
 		t.Fatalf("expected only the gap fallback program to be skipped, got %v", skip)
 	}
 
-	if diags := collectProgramTypeDiagnostics(t, programs, skip, typeInfoFiles); containsTSDiagnostic(diags, "TS2304") {
+	diags := collectProgramTypeDiagnostics(t, programs, skip, typeInfoFiles)
+	if !containsTSDiagnostic(diags, "TS2322") {
+		t.Fatalf("expected the tsconfig-backed Program to retain semantic diagnostics: %+v", diags)
+	}
+	if containsTSDiagnostic(diags, "TS2304") {
 		t.Fatalf("did not expect declaration diagnostics from a gap fallback program: %+v", diags)
 	}
 }
@@ -342,7 +368,8 @@ func TestBuildProgramsWithLintTargets_BindsImportedNonRootFile(t *testing.T) {
 	if len(targetFiles) != 1 || targetFiles[0] != libPath {
 		t.Fatalf("expected lib.ts as the only target, got %v", targetFiles)
 	}
-	if len(targetsByProgram) != 1 || len(targetsByProgram[0]) != 1 || targetsByProgram[0][0] != libPath {
+	if len(targetsByProgram) != 1 || len(targetsByProgram[0]) != 1 ||
+		canonicalFilesystemPathID(targetsByProgram[0][0], fs) != canonicalFilesystemPathID(libPath, fs) {
 		t.Fatalf("expected lib.ts bound to the tsconfig Program, got %v", targetsByProgram)
 	}
 }
@@ -478,7 +505,6 @@ func TestBindLintTargetPlan_UsesPhysicalConfigSpaceForSymlinkedConfigRoot(t *tes
 		Config:                     cfg,
 		CurrentDirectory:           linkDir,
 		TypeInfoFiles:              binding.TypeInfoFiles,
-		TargetPathBySourcePath:     binding.TargetPathBySourcePath,
 		ConfigPathBySourcePath:     binding.ConfigPathBySourcePath,
 		OwnerConfigDirBySourcePath: binding.OwnerConfigDirBySourcePath,
 		FS:                         fsys,
@@ -486,6 +512,66 @@ func TestBindLintTargetPlan_UsesPhysicalConfigSpaceForSymlinkedConfigRoot(t *tes
 	rules := resolver.ActiveRulesForFile(sourcePath)
 	if len(rules) != 1 || rules[0].Name != "no-debugger" {
 		t.Fatalf("expected files selector to match in physical config space, got %v", configuredRuleNameSet(rules))
+	}
+}
+
+func TestBindLintTargetPlan_ConfigMatchingDoesNotDependOnProgramSourcePath(t *testing.T) {
+	rootDir := t.TempDir()
+	writeProgramTestFiles(t, rootDir, map[string]string{
+		"physical/index.ts": "console.log('value');\n",
+		"tsconfig.json":     `{"files":["physical/index.ts"]}`,
+	})
+	linkPath := filepath.Join(rootDir, "link.ts")
+	physicalPath := filepath.Join(rootDir, "physical/index.ts")
+	if err := os.Symlink(physicalPath, linkPath); err != nil {
+		t.Skipf("file symlink unavailable: %v", err)
+	}
+
+	rootDir = tspath.NormalizePath(rootDir)
+	linkPath = tspath.NormalizePath(linkPath)
+	physicalPath = tspath.NormalizePath(physicalPath)
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	cfg := rslintconfig.RslintConfig{{
+		Files: []string{"link.ts"},
+		LanguageOptions: &rslintconfig.LanguageOptions{ParserOptions: &rslintconfig.ParserOptions{
+			Project: rslintconfig.ProjectPaths{"./tsconfig.json"},
+		}},
+		Rules: rslintconfig.Rules{"no-console": "error"},
+	}}
+	set, err := createProgramSetForConfig(rootDir, cfg, true, fsys, utils.NewParseCache())
+	if err != nil || len(set.Programs) != 1 {
+		t.Fatalf("create Program: err=%v programs=%d", err, len(set.Programs))
+	}
+	plan := lintTargetPlan{Targets: []resolvedLintTarget{testLintTarget(fsys, rootDir, linkPath)}}
+	binding, err := bindLintTargetPlan(set, plan, rootDir, fsys, utils.NewParseCache(), true)
+	if err != nil {
+		t.Fatalf("bindLintTargetPlan: %v", err)
+	}
+	if len(binding.TargetsByProgram) != 1 || len(binding.TargetsByProgram[0]) != 1 {
+		t.Fatalf("expected lexical target to bind to the physical Program source, got %v", binding.TargetsByProgram)
+	}
+	sourcePath := binding.TargetsByProgram[0][0]
+	expectedSourcePath := authoritativeFilesystemPath(physicalPath, fsys)
+	if canonicalFilesystemPathID(sourcePath, fsys) != canonicalFilesystemPathID(expectedSourcePath, fsys) {
+		t.Fatalf("fixture must bind through physical Program source %q, got %q", expectedSourcePath, sourcePath)
+	}
+	expectedConfigPath := tspath.ResolvePath(authoritativeFilesystemPath(rootDir, fsys), "link.ts")
+	if configPath := binding.ConfigPathBySourcePath[sourcePath]; configPath != expectedConfigPath {
+		t.Fatalf("config matching must retain lexical target %q, got %q", expectedConfigPath, configPath)
+	}
+
+	rslintconfig.RegisterAllRules()
+	resolver := newLintConfigResolver(lintConfigResolverOptions{
+		Config:                     cfg,
+		CurrentDirectory:           rootDir,
+		TypeInfoFiles:              binding.TypeInfoFiles,
+		ConfigPathBySourcePath:     binding.ConfigPathBySourcePath,
+		OwnerConfigDirBySourcePath: binding.OwnerConfigDirBySourcePath,
+		FS:                         fsys,
+	})
+	rules := resolver.ActiveRulesForFile(sourcePath)
+	if len(rules) != 1 || rules[0].Name != "no-console" {
+		t.Fatalf("Program membership changed the lexical files match: %v", configuredRuleNameSet(rules))
 	}
 }
 
@@ -689,6 +775,56 @@ func TestCreateProgramSetForConfigs_DeduplicatesSharedTsconfigAndRetainsOwners(t
 	}
 }
 
+func TestCreateProgramSetForConfigs_PreservesSymlinkedTsconfigBase(t *testing.T) {
+	rootDir := t.TempDir()
+	realDir := filepath.Join(rootDir, "z-real")
+	aliasDir := filepath.Join(rootDir, "a-alias")
+	writeProgramTestFiles(t, realDir, map[string]string{
+		"tsconfig.json": `{"include":["src/**/*.ts"]}`,
+		"src/real.ts":   `export const source = "real";`,
+	})
+	writeProgramTestFiles(t, aliasDir, map[string]string{
+		"src/alias.ts": `export const source = "alias";`,
+	})
+	aliasConfig := filepath.Join(aliasDir, "tsconfig.json")
+	if err := os.Symlink(filepath.Join(realDir, "tsconfig.json"), aliasConfig); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	realDir = tspath.NormalizePath(realDir)
+	aliasDir = tspath.NormalizePath(aliasDir)
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	set, err := createProgramSetForConfigs(map[string]rslintconfig.RslintConfig{
+		aliasDir: projectConfig("./tsconfig.json"),
+		realDir:  projectConfig("./tsconfig.json"),
+	}, true, fsys, utils.NewParseCache())
+	if err != nil {
+		t.Fatalf("createProgramSetForConfigs: %v", err)
+	}
+	if len(set.Programs) != 2 {
+		t.Fatalf("distinct declared tsconfig paths must produce two Programs, got %d", len(set.Programs))
+	}
+	programByConfigPath := make(map[string]*compiler.Program, len(set.Programs))
+	for _, program := range set.Programs {
+		programByConfigPath[exactFilesystemPathID(program.Options().ConfigFilePath)] = program
+	}
+	aliasConfigPath := tspath.ResolvePath(aliasDir, "tsconfig.json")
+	realConfigPath := tspath.ResolvePath(realDir, "tsconfig.json")
+	aliasProgram := programByConfigPath[exactFilesystemPathID(aliasConfigPath)]
+	realProgram := programByConfigPath[exactFilesystemPathID(realConfigPath)]
+	if aliasProgram == nil || realProgram == nil {
+		t.Fatalf("missing lexical tsconfig Programs: %v", programByConfigPath)
+	}
+	aliasSource := tspath.ResolvePath(aliasDir, "src/alias.ts")
+	realSource := tspath.ResolvePath(realDir, "src/real.ts")
+	if aliasProgram.GetSourceFile(aliasSource) == nil || aliasProgram.GetSourceFile(realSource) != nil {
+		t.Fatalf("symlinked tsconfig must resolve includes from %q", aliasDir)
+	}
+	if realProgram.GetSourceFile(realSource) == nil || realProgram.GetSourceFile(aliasSource) != nil {
+		t.Fatalf("real tsconfig must resolve includes from %q", realDir)
+	}
+}
+
 func TestBindLintTargetPlan_UsesGoverningConfigProjectOrder(t *testing.T) {
 	dir := t.TempDir()
 	writeProgramTestFiles(t, dir, map[string]string{
@@ -768,6 +904,79 @@ func TestBindLintTargetPlan_RecomputesProgramMembershipAfterImportGraphChange(t 
 	}
 }
 
+func TestProgramTargetLookup_DirectMissWithoutAliasSkipsCanonicalIndex(t *testing.T) {
+	dir := t.TempDir()
+	writeProgramTestFiles(t, dir, map[string]string{
+		"inside.ts":     `export const inside = true;`,
+		"outside.ts":    `export const outside = true;`,
+		"tsconfig.json": `{"files":["inside.ts"]}`,
+	})
+	dir = tspath.NormalizePath(dir)
+	counter := &targetPlanRealpathCountingFS{FS: osvfs.FS(), calls: make(map[string]int)}
+	fsys := bundled.WrapFS(cachedvfs.From(counter))
+	set, err := createProgramSetForConfig(
+		dir,
+		projectConfig("./tsconfig.json"),
+		true,
+		fsys,
+		utils.NewParseCache(),
+	)
+	if err != nil || len(set.Programs) != 1 {
+		t.Fatalf("create Program: programs=%d err=%v", len(set.Programs), err)
+	}
+
+	counter.mu.Lock()
+	counter.calls = make(map[string]int)
+	counter.mu.Unlock()
+	targetPath := tspath.ResolvePath(dir, "outside.ts")
+	lookup := programTargetLookup{program: set.Programs[0], fsys: fsys}
+	if sourceFile := lookup.sourceFileForTarget(resolvedLintTarget{
+		Path:           targetPath,
+		CanonicalPath:  targetPath,
+		OwnerConfigDir: dir,
+	}); sourceFile != nil {
+		t.Fatalf("outside target unexpectedly resolved to %q", sourceFile.FileName())
+	}
+	counter.mu.Lock()
+	defer counter.mu.Unlock()
+	if len(counter.calls) != 0 {
+		t.Fatalf("ordinary Program miss performed realpath IO: %v", counter.calls)
+	}
+}
+
+func TestResolveLintTargetPlan_DirectoryWalkAvoidsPerTargetRealpath(t *testing.T) {
+	dir := t.TempDir()
+	writeProgramTestFiles(t, dir, map[string]string{
+		"src/a.ts": `export const a = 1;`,
+		"src/b.ts": `export const b = 2;`,
+	})
+	dir = tspath.NormalizePath(dir)
+	fileA := tspath.ResolvePath(dir, "src/a.ts")
+	fileB := tspath.ResolvePath(dir, "src/b.ts")
+	counter := &targetPlanRealpathCountingFS{FS: osvfs.FS(), calls: make(map[string]int)}
+	fsys := bundled.WrapFS(cachedvfs.From(counter))
+
+	plan, err := resolveLintTargetPlan(
+		nil,
+		rslintconfig.RslintConfig{{Rules: rslintconfig.Rules{"no-debugger": "error"}}},
+		dir,
+		nil,
+		fsys,
+		nil,
+		[]string{dir},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("resolveLintTargetPlan: %v", err)
+	}
+	if len(plan.Targets) != 2 {
+		t.Fatalf("targets = %v, want two files", plan.Targets)
+	}
+	if counter.callCount(fileA) != 0 || counter.callCount(fileB) != 0 {
+		t.Fatalf("regular targets performed realpath IO: a=%d b=%d", counter.callCount(fileA), counter.callCount(fileB))
+	}
+}
+
 func TestResolveLintTargetPlan_RejectsCanonicalTargetWithDifferentOwners(t *testing.T) {
 	sharedDir := t.TempDir()
 	writeProgramTestFiles(t, sharedDir, map[string]string{
@@ -817,5 +1026,209 @@ func TestResolveLintTargetPlan_RejectsCanonicalTargetWithDifferentOwners(t *test
 	}
 	if !strings.Contains(err.Error(), "resolve to the same file") || !strings.Contains(err.Error(), ownerA) || !strings.Contains(err.Error(), ownerB) {
 		t.Fatalf("unexpected ownership conflict error: %v", err)
+	}
+}
+
+func TestConfigsForLintTargetPlan_SelectsOnlyGoverningConfigs(t *testing.T) {
+	configMap := map[string]rslintconfig.RslintConfig{
+		"/repo/a": {{Rules: rslintconfig.Rules{"no-debugger": "error"}}},
+		"/repo/b": {{LanguageOptions: &rslintconfig.LanguageOptions{
+			ParserOptions: &rslintconfig.ParserOptions{Project: []string{"./missing.json"}},
+		}}},
+	}
+	active := configsForLintTargetPlan(configMap, lintTargetPlan{Targets: []resolvedLintTarget{{
+		Path:           "/repo/a/index.ts",
+		CanonicalPath:  "/repo/a/index.ts",
+		OwnerConfigDir: "/repo/a",
+	}}})
+	if len(active) != 1 || active["/repo/a"] == nil {
+		t.Fatalf("expected only the governing config, got %v", active)
+	}
+	if _, present := active["/repo/b"]; present {
+		t.Fatalf("inactive config unexpectedly selected: %v", active)
+	}
+}
+
+func TestPlainProgramSetSkipsInactiveConfigProjects(t *testing.T) {
+	root := t.TempDir()
+	activeDir := filepath.Join(root, "active")
+	inactiveDir := filepath.Join(root, "inactive")
+	writeProgramTestFiles(t, root, map[string]string{
+		"active/index.ts":      "export const value = 1;\n",
+		"active/tsconfig.json": `{"files":["index.ts"]}`,
+	})
+	if err := os.MkdirAll(inactiveDir, 0o755); err != nil {
+		t.Fatalf("mkdir inactive config: %v", err)
+	}
+	activeDir = tspath.NormalizePath(activeDir)
+	inactiveDir = tspath.NormalizePath(inactiveDir)
+	configMap := map[string]rslintconfig.RslintConfig{
+		activeDir:   projectConfig("./tsconfig.json"),
+		inactiveDir: projectConfig("./missing.json"),
+	}
+	plan := lintTargetPlan{Targets: []resolvedLintTarget{{
+		Path:           tspath.ResolvePath(activeDir, "index.ts"),
+		CanonicalPath:  tspath.ResolvePath(activeDir, "index.ts"),
+		OwnerConfigDir: activeDir,
+	}}}
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+
+	activeConfigMap := configsForLintTargetPlan(configMap, plan)
+	set, err := createProgramSetForConfigs(activeConfigMap, true, fsys, utils.NewParseCache())
+	if err != nil || len(set.Programs) != 1 {
+		t.Fatalf("plain lint should build only the active config Program: programs=%d err=%v", len(set.Programs), err)
+	}
+	if _, err := createProgramSetForConfigs(configMap, true, fsys, utils.NewParseCache()); err == nil || !strings.Contains(err.Error(), "missing.json") {
+		t.Fatalf("the all-project type-check scope must still reject the inactive missing project, got %v", err)
+	}
+}
+
+type canonicalIdentityTestFS struct {
+	vfs.FS
+	realPaths map[string]string
+}
+
+type exactCaseProgramFS struct {
+	vfs.FS
+	files map[string]string
+}
+
+func (fs *exactCaseProgramFS) UseCaseSensitiveFileNames() bool { return false }
+func (fs *exactCaseProgramFS) FileExists(filePath string) bool {
+	if _, ok := fs.files[tspath.NormalizePath(filePath)]; ok {
+		return true
+	}
+	return fs.FS.FileExists(filePath)
+}
+func (fs *exactCaseProgramFS) ReadFile(filePath string) (string, bool) {
+	if content, ok := fs.files[tspath.NormalizePath(filePath)]; ok {
+		return content, true
+	}
+	return fs.FS.ReadFile(filePath)
+}
+func (fs *exactCaseProgramFS) Realpath(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	if _, ok := fs.files[filePath]; ok {
+		return filePath
+	}
+	return fs.FS.Realpath(filePath)
+}
+
+func (fs *canonicalIdentityTestFS) UseCaseSensitiveFileNames() bool { return false }
+func (fs *canonicalIdentityTestFS) FileExists(string) bool          { return true }
+func (fs *canonicalIdentityTestFS) Realpath(filePath string) string {
+	if realPath := fs.realPaths[tspath.NormalizePath(filePath)]; realPath != "" {
+		return realPath
+	}
+	return tspath.NormalizePath(filePath)
+}
+
+func TestResolveLintTargetPlan_UsesCanonicalIdentityInsteadOfGlobalCaseFlag(t *testing.T) {
+	configDir := "C:/Repo"
+	upper := "C:/Repo/Src/A.ts"
+	lower := "c:/repo/src/a.ts"
+	config := rslintconfig.RslintConfig{{}}
+
+	t.Run("same canonical path is deduplicated", func(t *testing.T) {
+		fsys := &canonicalIdentityTestFS{
+			FS: osvfs.FS(),
+			realPaths: map[string]string{
+				upper: "C:/Repo/Src/A.ts",
+				lower: "C:/Repo/Src/A.ts",
+			},
+		}
+		plan, err := resolveLintTargetPlan(nil, config, configDir, nil, fsys, []string{upper, lower}, nil, true)
+		if err != nil || len(plan.Targets) != 1 {
+			t.Fatalf("same canonical target should be deduplicated: targets=%v err=%v", plan.Targets, err)
+		}
+	})
+
+	t.Run("distinct canonical paths remain distinct", func(t *testing.T) {
+		fsys := &canonicalIdentityTestFS{
+			FS: osvfs.FS(),
+			realPaths: map[string]string{
+				upper: upper,
+				lower: lower,
+			},
+		}
+		plan, err := resolveLintTargetPlan(nil, config, configDir, nil, fsys, []string{upper, lower}, nil, true)
+		if err != nil || len(plan.Targets) != 2 {
+			t.Fatalf("global case behavior must not merge distinct physical paths: targets=%v err=%v", plan.Targets, err)
+		}
+	})
+}
+
+func TestBindLintTargetPlan_RejectsCaseFoldedSourceWithDifferentCanonicalIdentity(t *testing.T) {
+	configDir := "/repo"
+	upper := "/repo/Source.ts"
+	lower := "/repo/source.ts"
+	fsys := &exactCaseProgramFS{
+		FS: osvfs.FS(),
+		files: map[string]string{
+			upper: "export const upper = 1;\n",
+			lower: "export const lower = 2;\n",
+		},
+	}
+	host := utils.CreateCompilerHost(configDir, fsys)
+	program, err := utils.CreateProgramFromOptionsLenient(true, &core.CompilerOptions{
+		NoLib:     core.TSTrue,
+		NoResolve: core.TSTrue,
+	}, []string{upper}, host)
+	if err != nil {
+		t.Fatalf("CreateProgramFromOptionsLenient: %v", err)
+	}
+	if source := program.GetSourceFile(lower); source == nil || source.FileName() != upper {
+		t.Fatalf("fixture must exercise case-folded Program lookup, got %v", source)
+	}
+
+	set := lintProgramSet{
+		Programs:     []*compiler.Program{program},
+		ConfigOrders: []programConfigOrders{{configDir: 0}},
+	}
+	plan := lintTargetPlan{Targets: []resolvedLintTarget{{
+		Path:           lower,
+		CanonicalPath:  lower,
+		OwnerConfigDir: configDir,
+	}}}
+	binding, err := bindLintTargetPlan(set, plan, configDir, fsys, utils.NewParseCache(), true)
+	if err != nil {
+		t.Fatalf("bindLintTargetPlan: %v", err)
+	}
+	if len(binding.Programs) != 2 || len(binding.TargetsByProgram[0]) != 0 {
+		t.Fatalf("lower-case target must not bind to the distinct upper-case source: %+v", binding.TargetsByProgram)
+	}
+	if got := binding.TargetsByProgram[1]; len(got) != 1 || got[0] != lower {
+		t.Fatalf("lower-case target must bind to its exact fallback source, got %v", got)
+	}
+}
+
+func TestBindLintTargetPlan_SplitsFallbackProgramsForCaseFoldedPathCollisions(t *testing.T) {
+	configDir := "/repo"
+	upper := "/repo/Source.ts"
+	lower := "/repo/source.ts"
+	fsys := &exactCaseProgramFS{
+		FS: osvfs.FS(),
+		files: map[string]string{
+			upper: "export const upper = 1;\n",
+			lower: "export const lower = 2;\n",
+		},
+	}
+	plan := lintTargetPlan{Targets: []resolvedLintTarget{
+		{Path: upper, CanonicalPath: upper, OwnerConfigDir: configDir},
+		{Path: lower, CanonicalPath: lower, OwnerConfigDir: configDir},
+	}}
+	binding, err := bindLintTargetPlan(lintProgramSet{}, plan, configDir, fsys, utils.NewParseCache(), true)
+	if err != nil {
+		t.Fatalf("bindLintTargetPlan: %v", err)
+	}
+	if len(binding.Programs) != 2 || len(binding.TargetsByProgram) != 2 {
+		t.Fatalf("case-folded root names require separate fallback Programs, got %d", len(binding.Programs))
+	}
+	bound := []string{binding.TargetsByProgram[0][0], binding.TargetsByProgram[1][0]}
+	slices.Sort(bound)
+	want := []string{upper, lower}
+	slices.Sort(want)
+	if !slices.Equal(bound, want) {
+		t.Fatalf("fallback Programs must preserve both exact source identities: got %v want %v", bound, want)
 	}
 }

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -323,3 +323,82 @@ func TestBuildProgramsWithLintTargets_BindsImportedNonRootFile(t *testing.T) {
 		t.Fatalf("expected lib.ts bound to the tsconfig Program, got %v", targetsByProgram)
 	}
 }
+
+func TestBuildProgramsWithLintTargets_BindsRealpathTargetToProgramSourceName(t *testing.T) {
+	realDir := t.TempDir()
+	linkDir := filepath.Join(filepath.Dir(realDir), filepath.Base(realDir)+"-link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	defer os.Remove(linkDir)
+
+	writeProgramTestFiles(t, realDir, map[string]string{
+		"src/a.ts":      "export const a = 1;\n",
+		"tsconfig.json": `{"include": ["src/a.ts"]}`,
+	})
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	parseCache := utils.NewParseCache()
+	cfg := rslintconfig.RslintConfig{{
+		Files: []string{"**/*.ts"},
+		LanguageOptions: &rslintconfig.LanguageOptions{
+			ParserOptions: &rslintconfig.ParserOptions{
+				Project: rslintconfig.ProjectPaths{"./tsconfig.json"},
+			},
+		},
+		Rules: rslintconfig.Rules{"no-debugger": "error"},
+	}}
+
+	linkDir = tspath.NormalizePath(linkDir)
+	realTarget := tspath.NormalizePath(filepath.Join(realDir, "src/a.ts"))
+	programs, exitCode := createProgramsForConfig(linkDir, cfg, true, fs, nil, parseCache)
+	if exitCode != 0 {
+		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+	}
+	if len(programs) != 1 {
+		t.Fatalf("expected one tsconfig-backed program, got %d", len(programs))
+	}
+
+	var sourceName string
+	for _, sf := range programs[0].GetSourceFiles() {
+		if strings.HasSuffix(sf.FileName(), "/src/a.ts") {
+			sourceName = sf.FileName()
+			break
+		}
+	}
+	if sourceName == "" {
+		t.Fatal("expected program to include src/a.ts")
+	}
+	if sourceName == realTarget {
+		t.Skip("compiler already canonicalized source file to realpath")
+	}
+
+	programs, typeInfoFiles, gapFiles, targetFiles, targetsByProgram := buildProgramsWithLintTargets(
+		programs,
+		nil,
+		cfg,
+		linkDir,
+		nil,
+		nil,
+		fs,
+		[]string{realTarget},
+		nil,
+		parseCache,
+		true,
+	)
+	if len(programs) != 1 {
+		t.Fatalf("realpath target should reuse existing Program, got %d programs", len(programs))
+	}
+	if len(gapFiles) != 0 {
+		t.Fatalf("realpath target should not become a gap file, got %v", gapFiles)
+	}
+	if typeInfoFiles != nil {
+		t.Fatalf("no fallback appended, so typeInfoFiles should stay nil, got %v", typeInfoFiles)
+	}
+	if len(targetFiles) != 1 || targetFiles[0] != realTarget {
+		t.Fatalf("expected realpath target as the only discovered target, got %v", targetFiles)
+	}
+	if len(targetsByProgram) != 1 || len(targetsByProgram[0]) != 1 || targetsByProgram[0][0] != sourceName {
+		t.Fatalf("expected realpath target to bind back to source name %q, got %v", sourceName, targetsByProgram)
+	}
+}

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -904,46 +904,6 @@ func TestBindLintTargetPlan_RecomputesProgramMembershipAfterImportGraphChange(t 
 	}
 }
 
-func TestProgramTargetLookup_DirectMissWithoutAliasSkipsCanonicalIndex(t *testing.T) {
-	dir := t.TempDir()
-	writeProgramTestFiles(t, dir, map[string]string{
-		"inside.ts":     `export const inside = true;`,
-		"outside.ts":    `export const outside = true;`,
-		"tsconfig.json": `{"files":["inside.ts"]}`,
-	})
-	dir = tspath.NormalizePath(dir)
-	counter := &targetPlanRealpathCountingFS{FS: osvfs.FS(), calls: make(map[string]int)}
-	fsys := bundled.WrapFS(cachedvfs.From(counter))
-	set, err := createProgramSetForConfig(
-		dir,
-		projectConfig("./tsconfig.json"),
-		true,
-		fsys,
-		utils.NewParseCache(),
-	)
-	if err != nil || len(set.Programs) != 1 {
-		t.Fatalf("create Program: programs=%d err=%v", len(set.Programs), err)
-	}
-
-	counter.mu.Lock()
-	counter.calls = make(map[string]int)
-	counter.mu.Unlock()
-	targetPath := tspath.ResolvePath(dir, "outside.ts")
-	lookup := programTargetLookup{program: set.Programs[0], fsys: fsys}
-	if sourceFile := lookup.sourceFileForTarget(resolvedLintTarget{
-		Path:           targetPath,
-		CanonicalPath:  targetPath,
-		OwnerConfigDir: dir,
-	}); sourceFile != nil {
-		t.Fatalf("outside target unexpectedly resolved to %q", sourceFile.FileName())
-	}
-	counter.mu.Lock()
-	defer counter.mu.Unlock()
-	if len(counter.calls) != 0 {
-		t.Fatalf("ordinary Program miss performed realpath IO: %v", counter.calls)
-	}
-}
-
 func TestResolveLintTargetPlan_DirectoryWalkAvoidsPerTargetRealpath(t *testing.T) {
 	dir := t.TempDir()
 	writeProgramTestFiles(t, dir, map[string]string{

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -89,7 +89,7 @@ func TestTypeCheck_SkipsNoTsconfigTargetFallbackProgram(t *testing.T) {
 		t.Fatalf("expected no tsconfig-backed programs, got %d", len(programs))
 	}
 
-	programs, typeInfoFiles, gapFiles, _, _ := buildProgramsWithLintTargets(
+	programs, typeInfoFiles, gapFiles, _, _, _ := buildProgramsWithLintTargets(
 		programs,
 		nil,
 		rslintconfig.RslintConfig{{Files: []string{"**/*.ts"}}},
@@ -227,7 +227,7 @@ export const value: Bad | null = null;
 		t.Fatalf("expected tsconfig-backed program to participate in type-check, got %v", skip)
 	}
 
-	programs, typeInfoFiles, gapFiles, _, _ := buildProgramsWithLintTargets(
+	programs, typeInfoFiles, gapFiles, _, _, _ := buildProgramsWithLintTargets(
 		programs,
 		nil,
 		cfg,
@@ -294,7 +294,7 @@ func TestBuildProgramsWithLintTargets_BindsImportedNonRootFile(t *testing.T) {
 	}
 
 	libPath := tspath.NormalizePath(filepath.Join(dir, "lib.ts"))
-	programs, typeInfoFiles, gapFiles, targetFiles, targetsByProgram := buildProgramsWithLintTargets(
+	programs, typeInfoFiles, gapFiles, targetFiles, targetsByProgram, _ := buildProgramsWithLintTargets(
 		programs,
 		nil,
 		cfg,
@@ -373,7 +373,7 @@ func TestBuildProgramsWithLintTargets_BindsRealpathTargetToProgramSourceName(t *
 		t.Skip("compiler already canonicalized source file to realpath")
 	}
 
-	programs, typeInfoFiles, gapFiles, targetFiles, targetsByProgram := buildProgramsWithLintTargets(
+	programs, typeInfoFiles, gapFiles, targetFiles, targetsByProgram, configPathBySourcePath := buildProgramsWithLintTargets(
 		programs,
 		nil,
 		cfg,
@@ -400,5 +400,8 @@ func TestBuildProgramsWithLintTargets_BindsRealpathTargetToProgramSourceName(t *
 	}
 	if len(targetsByProgram) != 1 || len(targetsByProgram[0]) != 1 || targetsByProgram[0][0] != sourceName {
 		t.Fatalf("expected realpath target to bind back to source name %q, got %v", sourceName, targetsByProgram)
+	}
+	if configPathBySourcePath[sourceName] != realTarget {
+		t.Fatalf("expected source path %q to resolve config through target path %q, got %v", sourceName, realTarget, configPathBySourcePath)
 	}
 }

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -66,13 +66,10 @@ func containsTSDiagnostic(diags []rule.RuleDiagnostic, code string) bool {
 	return false
 }
 
-func TestTypeCheck_SkipsNoTsconfigFallbackPrograms(t *testing.T) {
+func TestTypeCheck_SkipsNoTsconfigTargetFallbackProgram(t *testing.T) {
 	dir := t.TempDir()
 	writeProgramTestFiles(t, dir, map[string]string{
-		"rslint.config.ts": `import type { Bad } from './bad';
-export default [{ files: ['**/*.ts'], rules: {} }] satisfies Bad;
-`,
-		"bad.d.ts": `export type Bad = MissingGlobalType;
+		"bad.ts": `const bad: number = "oops";
 `,
 	})
 
@@ -88,25 +85,45 @@ export default [{ files: ['**/*.ts'], rules: {} }] satisfies Bad;
 	if exitCode != 0 {
 		t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
 	}
+	if len(programs) != 0 {
+		t.Fatalf("expected no tsconfig-backed programs, got %d", len(programs))
+	}
+
+	programs, typeInfoFiles, gapFiles, _, _ := buildProgramsWithLintTargets(
+		programs,
+		nil,
+		rslintconfig.RslintConfig{{Files: []string{"**/*.ts"}}},
+		dir,
+		nil,
+		nil,
+		fs,
+		nil,
+		nil,
+		utils.NewParseCache(),
+		true,
+	)
 	if len(programs) != 1 {
-		t.Fatalf("expected one synthesized fallback program, got %d", len(programs))
+		t.Fatalf("expected one files-driven fallback program, got %d", len(programs))
+	}
+	if len(gapFiles) == 0 {
+		t.Fatalf("expected files-driven fallback roots, got %v", gapFiles)
+	}
+	if typeInfoFiles == nil || len(typeInfoFiles) != 0 {
+		t.Fatalf("expected empty type-info set for no-tsconfig fallback, got %v", typeInfoFiles)
 	}
 	if got := programs[0].Options().ConfigFilePath; got != "" {
-		t.Fatalf("expected synthesized fallback program to have no ConfigFilePath, got %q", got)
+		t.Fatalf("expected files-driven fallback program to have no ConfigFilePath, got %q", got)
+	}
+	if !programs[0].Options().NoLib.IsTrue() || !programs[0].Options().NoResolve.IsTrue() {
+		t.Fatalf("expected files-driven fallback to stay AST-only, got options %+v", programs[0].Options())
 	}
 	skip := buildTypeCheckSkipMask(programs)
 	if len(skip) != 1 || !skip[0] {
 		t.Fatalf("expected no-tsconfig fallback program to be skipped for type-check, got %v", skip)
 	}
 
-	if diags := collectProgramTypeDiagnostics(t, programs, skip, nil); containsTSDiagnostic(diags, "TS2304") {
-		t.Fatalf("did not expect declaration diagnostics from a no-tsconfig fallback program: %+v", diags)
-	}
-
-	// Prove the fixture is capable of surfacing the bad declaration if the
-	// synthesized Program is not skipped. This pins the regression directly.
-	if diags := collectProgramTypeDiagnostics(t, programs, nil, nil); !containsTSDiagnostic(diags, "TS2304") {
-		t.Fatalf("expected TS2304 without the skip mask, got: %+v", diags)
+	if diags := collectProgramTypeDiagnostics(t, programs, skip, typeInfoFiles); containsTSDiagnostic(diags, "TS2322") {
+		t.Fatalf("did not expect semantic diagnostics from a no-tsconfig fallback program: %+v", diags)
 	}
 }
 
@@ -235,6 +252,9 @@ export const value: Bad | null = null;
 	}
 	if got := programs[1].Options().ConfigFilePath; got != "" {
 		t.Fatalf("expected gap fallback program to have no ConfigFilePath, got %q", got)
+	}
+	if !programs[1].Options().NoLib.IsTrue() || !programs[1].Options().NoResolve.IsTrue() {
+		t.Fatalf("expected gap fallback to stay AST-only, got options %+v", programs[1].Options())
 	}
 	skip := buildTypeCheckSkipMask(programs)
 	if len(skip) != 2 || skip[0] || !skip[1] {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,8 +1,6 @@
-// Package api is the single-direction programmatic IPC service used by
-// `--api` mode (consumed by packages/rslint-wasm and packages/rslint-api).
-// The peer (a Node parent or a wasm host) sends lint/getAstInfo
-// requests; this service answers them. It does NOT dispatch tasks back to
-// the peer — that bidirectional path is internal/ipc.Channel.
+// Package api is the programmatic IPC service used by `--api` mode (consumed
+// by packages/rslint-wasm and packages/rslint-api). Most requests flow from
+// the host to Go; lint may also dispatch plugin work back to a capable host.
 //
 // Framing is shared with internal/ipc (the single source of the
 // length-prefixed-JSON wire format); this package only owns the
@@ -10,13 +8,15 @@
 package api
 
 import (
-	"bufio"
+	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/microsoft/typescript-go/shim/api/encoder"
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -54,6 +54,8 @@ const (
 	KindLint ipc.MessageKind = "lint"
 	// KindGetAstInfo is sent from JS to Go to request AST info at a position.
 	KindGetAstInfo ipc.MessageKind = "getAstInfo"
+	// KindPluginLint is sent from Go to JS to run community ESLint plugin rules.
+	KindPluginLint ipc.MessageKind = "pluginLint"
 )
 
 // Version is the IPC protocol version.
@@ -85,12 +87,23 @@ type LintRequest struct {
 	ConfigDirectory  string            `json:"configDirectory,omitempty"`
 	WorkingDirectory string            `json:"workingDirectory,omitempty"`
 	FileContents     map[string]string `json:"fileContents,omitempty"` // Map of file paths to their contents for VFS
+	// EslintPlugins carries the names Go must register as Node-dispatched rule
+	// placeholders. The live plugin implementations remain in the JS host.
+	EslintPlugins []EslintPluginEntry `json:"eslintPlugins,omitempty"`
 	// Fix, when true, applies rule auto-fixes in-band and returns the fixed
 	// source per file in LintResponse.Output (ESLint's `fix: true`). The fix is
 	// computed but NOT written to disk — the JS side (Rslint.outputFixes) writes
-	// it. Remaining (unfixed) diagnostics are still reported.
+	// it. Diagnostics describe the original input; callers can lint Output again
+	// when they need post-fix diagnostics.
 	Fix                       bool `json:"fix,omitempty"`
 	IncludeEncodedSourceFiles bool `json:"includeEncodedSourceFiles,omitempty"` // Whether to include encoded source files in response
+}
+
+// EslintPluginEntry is the wire metadata for one object-form ESLint plugin.
+// Prefix is the config mount name; RuleNames are names relative to the prefix.
+type EslintPluginEntry struct {
+	Prefix    string   `json:"prefix"`
+	RuleNames []string `json:"ruleNames"`
 }
 type ByteArray []byte
 
@@ -108,11 +121,10 @@ type LintResponse struct {
 	FileCount           int `json:"fileCount"`
 	RuleCount           int `json:"ruleCount"`
 	// LintedFiles lists the files actually linted (config `ignores` excluded),
-	// each the program's canonical path relative to the config directory — the
-	// same path space as Diagnostic.FilePath. The JS side seeds one LintResult
-	// per entry, so a glob match the config ignores yields no phantom result,
-	// and a symlinked glob path can't duplicate a result. Present for lintFiles;
-	// lintText seeds from its own explicit path instead.
+	// using each caller-visible target path relative to the config directory.
+	// This is the same path space as Diagnostic.FilePath and Output. The JS side
+	// seeds one LintResult per entry, so ignored glob matches yield no phantom
+	// results. Present for lintFiles; lintText seeds its own explicit path.
 	//
 	// MUST NOT be omitempty: an all-ignored lint produces an empty (non-nil)
 	// slice that has to serialize as `[]`, distinct from an old binary that
@@ -175,125 +187,285 @@ type Handler interface {
 	HandleGetAstInfo(req GetAstInfoRequest) (*GetAstInfoResponse, error)
 }
 
-// Service manages the single-direction IPC communication for `--api` mode.
-// Framing is delegated to internal/ipc (the shared wire format).
+// Requester is the reverse-RPC capability exposed to a bidirectional lint
+// handler. ipc.Channel implements it directly.
+type Requester interface {
+	SendRequest(ctx context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error)
+}
+
+// BidirectionalHandler is an optional extension to Handler. Existing handlers
+// continue to receive HandleLint; handlers that implement this interface also
+// receive the request context and reverse-RPC transport.
+type BidirectionalHandler interface {
+	HandleLintWithContext(ctx context.Context, req LintRequest, requester Requester) (*LintResponse, error)
+}
+
+// Service manages bidirectional IPC communication for `--api` mode. Framing,
+// request multiplexing, and the continuously running read loop are delegated
+// to internal/ipc.Channel.
 type Service struct {
-	reader  *bufio.Reader
-	writer  io.Writer
 	handler Handler
-	writeMu sync.Mutex
+	channel *ipc.Channel
+	reader  *observedReader
+
+	// Preserve the old service's one-at-a-time inbound handling. Channel keeps
+	// reading while this lock is held, so reverse responses are still routed and
+	// a lint handler can synchronously await pluginLint without deadlocking.
+	handlerMu sync.Mutex
+
+	exitMu        sync.Mutex
+	exitRequestID int
+	exitRequested bool
+	exitAck       chan struct{}
+	exitAckOnce   sync.Once
 }
 
 // NewService creates a new IPC service
 func NewService(reader io.Reader, writer io.Writer, handler Handler) *Service {
-	return &Service{
-		reader:  bufio.NewReader(reader),
-		writer:  writer,
+	s := &Service{
 		handler: handler,
+		reader:  &observedReader{reader: reader},
+		exitAck: make(chan struct{}),
 	}
+	observedWriter := &frameObserverWriter{
+		writer:        writer,
+		remaining:     -1,
+		shouldCapture: s.exitHasBeenRequested,
+		onFrame:       s.observeOutboundFrame,
+	}
+	s.channel = ipc.NewChannel(s.reader, observedWriter)
+	s.channel.SetInboundHandler(s.handleInbound)
+	return s
 }
 
 // Start starts the IPC service
 func (s *Service) Start() error {
-	for {
-		msg, err := ipc.ReadFrame(s.reader)
+	s.channel.Start()
+	select {
+	case <-s.exitAck:
+		// The complete exit response frame has reached the underlying writer.
+		// Closing earlier can race Channel's asynchronous inbound handler and
+		// suppress the ack that legacy Node/browser clients await.
+		_ = s.channel.Close()
+		return nil
+	case <-s.channel.Done():
+		err := s.reader.Err()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return nil
-			}
 			return err
 		}
+		return errors.New("api: IPC transport closed unexpectedly")
+	}
+}
 
-		switch msg.Kind {
-		case ipc.KindHandshake:
-			s.handleHandshake(msg)
-		case KindLint:
-			s.handleLint(msg)
-		case KindGetAstInfo:
-			s.handleGetAstInfo(msg)
-		case ipc.KindExit:
-			s.handleExit(msg)
-			return nil
-		default:
-			s.sendError(msg.ID, fmt.Sprintf("unknown message kind: %s", msg.Kind))
+func (s *Service) handleInbound(ctx context.Context, msg *ipc.Message) (any, error) {
+	s.handlerMu.Lock()
+	defer s.handlerMu.Unlock()
+
+	switch msg.Kind {
+	case ipc.KindHandshake:
+		var req HandshakeRequest
+		if err := msg.Decode(&req); err != nil {
+			return nil, fmt.Errorf("failed to parse handshake request: %v", err)
+		}
+		return HandshakeResponse{Version: Version, OK: true}, nil
+
+	case KindLint:
+		var req LintRequest
+		if err := msg.Decode(&req); err != nil {
+			return nil, fmt.Errorf("failed to parse lint request: %v", err)
+		}
+		if handler, ok := s.handler.(BidirectionalHandler); ok {
+			return handler.HandleLintWithContext(ctx, req, s.channel)
+		}
+		return s.handler.HandleLint(req)
+
+	case KindGetAstInfo:
+		var req GetAstInfoRequest
+		if err := msg.Decode(&req); err != nil {
+			return nil, fmt.Errorf("failed to parse get ast info request: %v", err)
+		}
+		return s.handler.HandleGetAstInfo(req)
+
+	case ipc.KindExit:
+		s.exitMu.Lock()
+		if !s.exitRequested {
+			s.exitRequested = true
+			s.exitRequestID = msg.ID
+		}
+		s.exitMu.Unlock()
+		return nil, nil
+
+	default:
+		return nil, fmt.Errorf("unknown message kind: %s", msg.Kind)
+	}
+}
+
+func (s *Service) observeOutboundFrame(msg *ipc.Message) {
+	if msg.Kind != ipc.KindResponse && msg.Kind != ipc.KindError {
+		return
+	}
+	s.exitMu.Lock()
+	isExitAck := s.exitRequested && msg.ID == s.exitRequestID
+	s.exitMu.Unlock()
+	if isExitAck {
+		s.exitAckOnce.Do(func() { close(s.exitAck) })
+	}
+}
+
+func (s *Service) exitHasBeenRequested() bool {
+	s.exitMu.Lock()
+	defer s.exitMu.Unlock()
+	return s.exitRequested
+}
+
+// observedReader records the terminal read error so Service.Start can retain
+// the legacy clean-EOF behavior while Channel owns frame decoding. It tracks
+// only frame byte counts (never payload copies), allowing it to distinguish a
+// clean frame-boundary EOF from a truncated frame.
+type observedReader struct {
+	reader    io.Reader
+	mu        sync.Mutex
+	err       error
+	header    [4]byte
+	headerLen int
+	remaining uint32
+	inBody    bool
+}
+
+func (r *observedReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.mu.Lock()
+	r.observe(p[:n])
+	if err != nil {
+		if errors.Is(err, io.EOF) && (r.headerLen != 0 || r.inBody) {
+			r.err = io.ErrUnexpectedEOF
+		} else {
+			r.err = err
+		}
+	}
+	r.mu.Unlock()
+	return n, err
+}
+
+func (r *observedReader) observe(data []byte) {
+	for len(data) > 0 {
+		if !r.inBody {
+			n := min(4-r.headerLen, len(data))
+			copy(r.header[r.headerLen:], data[:n])
+			r.headerLen += n
+			data = data[n:]
+			if r.headerLen < 4 {
+				continue
+			}
+			r.remaining = binary.LittleEndian.Uint32(r.header[:])
+			r.headerLen = 0
+			if r.remaining == 0 {
+				continue
+			}
+			r.inBody = true
+		}
+
+		n := len(data)
+		if uint64(n) > uint64(r.remaining) {
+			n = int(r.remaining)
+		}
+		r.remaining -= uint32(n)
+		data = data[n:]
+		if r.remaining == 0 {
+			r.inBody = false
 		}
 	}
 }
 
-// handleHandshake handles handshake messages
-func (s *Service) handleHandshake(msg *ipc.Message) {
-	var req HandshakeRequest
-	if err := msg.Decode(&req); err != nil {
-		s.sendError(msg.ID, fmt.Sprintf("failed to parse handshake request: %v", err))
-		return
-	}
-
-	s.sendResponse(msg.ID, HandshakeResponse{
-		Version: Version,
-		OK:      true,
-	})
+func (r *observedReader) Err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
 }
 
-// Handle exit message
-func (s *Service) handleExit(msg *ipc.Message) {
-	s.sendResponse(msg.ID, nil)
+// frameObserverWriter observes complete outbound frames after their bytes have
+// been accepted by the real writer. It normally tracks lengths only; after an
+// exit request arrives it captures response bodies until the matching ack is
+// seen. Channel serializes all calls into it.
+type frameObserverWriter struct {
+	writer        io.Writer
+	shouldCapture func() bool
+	onFrame       func(*ipc.Message)
+	mu            sync.Mutex
+	header        [4]byte
+	headerLen     int
+	remaining     int
+	capture       bool
+	body          []byte
 }
 
-// handleLint handles lint messages
-func (s *Service) handleLint(msg *ipc.Message) {
-	var req LintRequest
-	if err := msg.Decode(&req); err != nil {
-		s.sendError(msg.ID, fmt.Sprintf("failed to parse lint request: %v", err))
-		return
+func (w *frameObserverWriter) Write(p []byte) (int, error) {
+	n, err := w.writer.Write(p)
+	if n != len(p) && err == nil {
+		err = io.ErrShortWrite
 	}
-	resp, err := s.handler.HandleLint(req)
-	if err != nil {
-		s.sendError(msg.ID, err.Error())
-		return
+	if n <= 0 {
+		return n, err
 	}
 
-	s.sendResponse(msg.ID, resp)
+	w.mu.Lock()
+	var completed []*ipc.Message
+	data := p[:n]
+	for len(data) > 0 {
+		if w.remaining < 0 {
+			headerBytes := min(4-w.headerLen, len(data))
+			copy(w.header[w.headerLen:], data[:headerBytes])
+			w.headerLen += headerBytes
+			data = data[headerBytes:]
+			if w.headerLen < 4 {
+				continue
+			}
+			w.remaining = int(binary.LittleEndian.Uint32(w.header[:]))
+			w.headerLen = 0
+			w.capture = w.shouldCapture()
+			if w.capture {
+				w.body = make([]byte, 0, w.remaining)
+			}
+		}
+
+		bodyBytes := min(w.remaining, len(data))
+		if w.capture {
+			w.body = append(w.body, data[:bodyBytes]...)
+		}
+		w.remaining -= bodyBytes
+		data = data[bodyBytes:]
+		if w.remaining == 0 {
+			if w.capture {
+				var msg ipc.Message
+				if json.Unmarshal(w.body, &msg) == nil {
+					completed = append(completed, &msg)
+				}
+			}
+			w.remaining = -1
+			w.capture = false
+			w.body = nil
+		}
+	}
+	w.mu.Unlock()
+
+	if err == nil {
+		for _, msg := range completed {
+			w.onFrame(msg)
+		}
+	}
+	return n, err
 }
 
-// handleGetAstInfo handles get AST info messages
-func (s *Service) handleGetAstInfo(msg *ipc.Message) {
-	var req GetAstInfoRequest
-	if err := msg.Decode(&req); err != nil {
-		s.sendError(msg.ID, fmt.Sprintf("failed to parse get ast info request: %v", err))
-		return
+// Preserve Channel's write-deadline support when the underlying writer is an
+// *os.File or net.Conn. Channel intentionally ignores unsupported deadlines.
+func (w *frameObserverWriter) SetWriteDeadline(deadline time.Time) error {
+	if writer, ok := w.writer.(interface{ SetWriteDeadline(time.Time) error }); ok {
+		return writer.SetWriteDeadline(deadline)
 	}
-
-	resp, err := s.handler.HandleGetAstInfo(req)
-	if err != nil {
-		s.sendError(msg.ID, err.Error())
-		return
-	}
-
-	s.sendResponse(msg.ID, resp)
-}
-
-// sendResponse sends a response message
-func (s *Service) sendResponse(id int, data interface{}) {
-	msg, err := ipc.NewMessage(ipc.KindResponse, id, data)
-	if err != nil {
-		s.sendError(id, fmt.Sprintf("failed to marshal response: %v", err))
-		return
-	}
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-	if err := ipc.WriteFrame(s.writer, msg); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to send response: %v\n", err)
-	}
-}
-
-// sendError sends an error message
-func (s *Service) sendError(id int, message string) {
-	msg, _ := ipc.NewMessage(ipc.KindError, id, ipc.ErrorResponseData{Message: message})
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-	if err := ipc.WriteFrame(s.writer, msg); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to send error: %v\n", err)
-	}
+	return nil
 }
 
 // IsIPCMode returns true if the process is in IPC mode

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -59,22 +59,30 @@ const (
 )
 
 // Version is the IPC protocol version.
-const Version = "1.0.0"
+const Version = "2.0.0"
+
+const CapabilityReversePluginLint = "reversePluginLint"
 
 // HandshakeRequest represents a handshake request
 type HandshakeRequest struct {
-	Version string `json:"version"`
+	Version      string   `json:"version"`
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // HandshakeResponse represents a handshake response
 type HandshakeResponse struct {
-	Version string `json:"version"`
-	OK      bool   `json:"ok"`
+	Version      string   `json:"version"`
+	OK           bool     `json:"ok"`
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // LintRequest represents a lint request from JS to Go
 type LintRequest struct {
 	Files []string `json:"files,omitempty"`
+	// CanonicalFiles is parallel to Files when the host already resolved physical
+	// identity. Go uses these paths for this request instead of repeating realpath
+	// calls; omitted by lower-level clients that have no pre-resolved identity.
+	CanonicalFiles []string `json:"canonicalFiles,omitempty"`
 	// Final resolved config — a serialized RslintConfig (RslintConfigEntry[]).
 	// The JS side does ALL of overrideConfig / config-file / auto-discovery /
 	// normalize and hands Go only this object; --api never reads config from
@@ -84,9 +92,13 @@ type LintRequest struct {
 	Config json.RawMessage `json:"config,omitempty"`
 	// Anchor directory for resolving the config's relative
 	// files / ignores / parserOptions.project. Defaults to the working dir.
-	ConfigDirectory  string            `json:"configDirectory,omitempty"`
-	WorkingDirectory string            `json:"workingDirectory,omitempty"`
-	FileContents     map[string]string `json:"fileContents,omitempty"` // Map of file paths to their contents for VFS
+	ConfigDirectory string `json:"configDirectory,omitempty"`
+	// PluginConfigDirectory is the opaque worker routing key for community
+	// plugins. It can differ from ConfigDirectory when overrideConfig rebases
+	// authored path patterns to the API cwd.
+	PluginConfigDirectory string            `json:"pluginConfigDirectory,omitempty"`
+	WorkingDirectory      string            `json:"workingDirectory,omitempty"`
+	FileContents          map[string]string `json:"fileContents,omitempty"` // Map of file paths to their contents for VFS
 	// EslintPlugins carries the names Go must register as Node-dispatched rule
 	// placeholders. The live plugin implementations remain in the JS host.
 	EslintPlugins []EslintPluginEntry `json:"eslintPlugins,omitempty"`
@@ -211,7 +223,9 @@ type Service struct {
 	// Preserve the old service's one-at-a-time inbound handling. Channel keeps
 	// reading while this lock is held, so reverse responses are still routed and
 	// a lint handler can synchronously await pluginLint without deadlocking.
-	handlerMu sync.Mutex
+	handlerMu        sync.Mutex
+	handshakeOK      bool
+	peerCapabilities map[string]struct{}
 
 	exitMu        sync.Mutex
 	exitRequestID int
@@ -268,24 +282,52 @@ func (s *Service) handleInbound(ctx context.Context, msg *ipc.Message) (any, err
 	case ipc.KindHandshake:
 		var req HandshakeRequest
 		if err := msg.Decode(&req); err != nil {
-			return nil, fmt.Errorf("failed to parse handshake request: %v", err)
+			return nil, fmt.Errorf("failed to parse handshake request: %w", err)
 		}
-		return HandshakeResponse{Version: Version, OK: true}, nil
+		s.handshakeOK = req.Version == Version
+		s.peerCapabilities = make(map[string]struct{}, len(req.Capabilities))
+		for _, capability := range req.Capabilities {
+			s.peerCapabilities[capability] = struct{}{}
+		}
+		var capabilities []string
+		if _, ok := s.handler.(BidirectionalHandler); ok {
+			capabilities = []string{CapabilityReversePluginLint}
+		}
+		return HandshakeResponse{
+			Version:      Version,
+			OK:           s.handshakeOK,
+			Capabilities: capabilities,
+		}, nil
 
 	case KindLint:
+		if !s.handshakeOK {
+			return nil, fmt.Errorf("API protocol handshake required (expected version %s)", Version)
+		}
 		var req LintRequest
 		if err := msg.Decode(&req); err != nil {
-			return nil, fmt.Errorf("failed to parse lint request: %v", err)
+			return nil, fmt.Errorf("failed to parse lint request: %w", err)
 		}
-		if handler, ok := s.handler.(BidirectionalHandler); ok {
+		handler, bidirectional := s.handler.(BidirectionalHandler)
+		if len(req.EslintPlugins) > 0 {
+			if !bidirectional {
+				return nil, errors.New("API handler does not support reversePluginLint requests")
+			}
+			if _, ok := s.peerCapabilities[CapabilityReversePluginLint]; !ok {
+				return nil, errors.New("API peer does not advertise reversePluginLint capability")
+			}
+		}
+		if bidirectional {
 			return handler.HandleLintWithContext(ctx, req, s.channel)
 		}
 		return s.handler.HandleLint(req)
 
 	case KindGetAstInfo:
+		if !s.handshakeOK {
+			return nil, fmt.Errorf("API protocol handshake required (expected version %s)", Version)
+		}
 		var req GetAstInfoRequest
 		if err := msg.Decode(&req); err != nil {
-			return nil, fmt.Errorf("failed to parse get ast info request: %v", err)
+			return nil, fmt.Errorf("failed to parse get ast info request: %w", err)
 		}
 		return s.handler.HandleGetAstInfo(req)
 
@@ -296,7 +338,7 @@ func (s *Service) handleInbound(ctx context.Context, msg *ipc.Message) (any, err
 			s.exitRequestID = msg.ID
 		}
 		s.exitMu.Unlock()
-		return nil, nil
+		return struct{}{}, nil
 
 	default:
 		return nil, fmt.Errorf("unknown message kind: %s", msg.Kind)
@@ -462,7 +504,9 @@ func (w *frameObserverWriter) Write(p []byte) (int, error) {
 // Preserve Channel's write-deadline support when the underlying writer is an
 // *os.File or net.Conn. Channel intentionally ignores unsupported deadlines.
 func (w *frameObserverWriter) SetWriteDeadline(deadline time.Time) error {
-	if writer, ok := w.writer.(interface{ SetWriteDeadline(time.Time) error }); ok {
+	if writer, ok := w.writer.(interface {
+		SetWriteDeadline(deadline time.Time) error
+	}); ok {
 		return writer.SetWriteDeadline(deadline)
 	}
 	return nil

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,257 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/web-infra-dev/rslint/internal/ipc"
+)
+
+type serviceTestHandler struct {
+	lintCalls atomic.Int32
+}
+
+func (h *serviceTestHandler) HandleLint(LintRequest) (*LintResponse, error) {
+	h.lintCalls.Add(1)
+	return &LintResponse{Diagnostics: []Diagnostic{}, LintedFiles: []string{}}, nil
+}
+
+func (h *serviceTestHandler) HandleGetAstInfo(GetAstInfoRequest) (*GetAstInfoResponse, error) {
+	return &GetAstInfoResponse{}, nil
+}
+
+type reverseServiceTestHandler struct {
+	serviceTestHandler
+	reverseCalls atomic.Int32
+	reverseErr   chan error
+	requests     chan LintRequest
+}
+
+func (h *reverseServiceTestHandler) HandleLintWithContext(ctx context.Context, req LintRequest, requester Requester) (*LintResponse, error) {
+	h.reverseCalls.Add(1)
+	if h.requests != nil {
+		h.requests <- req
+	}
+	msg, err := requester.SendRequest(ctx, KindPluginLint, struct {
+		Text string `json:"text"`
+	}{Text: "from-go"})
+	if h.reverseErr != nil {
+		h.reverseErr <- err
+	}
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Text string `json:"text"`
+	}
+	if err := msg.Decode(&result); err != nil {
+		return nil, err
+	}
+	return &LintResponse{
+		Diagnostics: []Diagnostic{{RuleName: "test", Message: result.Text}},
+		LintedFiles: []string{},
+	}, nil
+}
+
+type serviceChannelPair struct {
+	peer          *ipc.Channel
+	serviceDone   chan error
+	serviceClosed chan struct{}
+	peerToService *io.PipeWriter
+	serviceToPeer *io.PipeWriter
+	readers       []*io.PipeReader
+}
+
+func newServiceChannelPair(t *testing.T, handler Handler, peerHandler ipc.InboundHandler) *serviceChannelPair {
+	t.Helper()
+	peerToServiceR, peerToServiceW := io.Pipe()
+	serviceToPeerR, serviceToPeerW := io.Pipe()
+
+	service := NewService(peerToServiceR, serviceToPeerW, handler)
+	peer := ipc.NewChannel(serviceToPeerR, peerToServiceW)
+	if peerHandler != nil {
+		peer.SetInboundHandler(peerHandler)
+	}
+
+	done := make(chan error, 1)
+	closed := make(chan struct{})
+	go func() {
+		done <- service.Start()
+		close(closed)
+	}()
+	peer.Start()
+
+	pair := &serviceChannelPair{
+		peer:          peer,
+		serviceDone:   done,
+		serviceClosed: closed,
+		peerToService: peerToServiceW,
+		serviceToPeer: serviceToPeerW,
+		readers:       []*io.PipeReader{peerToServiceR, serviceToPeerR},
+	}
+	t.Cleanup(func() {
+		_ = peer.Close()
+		_ = peerToServiceW.Close()
+		_ = serviceToPeerW.Close()
+		for _, reader := range pair.readers {
+			_ = reader.Close()
+		}
+		select {
+		case <-closed:
+		case <-time.After(2 * time.Second):
+			t.Errorf("API service did not stop during cleanup")
+		}
+	})
+	return pair
+}
+
+func requestContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func TestService_BidirectionalLintKeepsReadLoopRunning(t *testing.T) {
+	handler := &reverseServiceTestHandler{requests: make(chan LintRequest, 1)}
+	pair := newServiceChannelPair(t, handler, func(_ context.Context, msg *ipc.Message) (any, error) {
+		if msg.Kind != KindPluginLint {
+			t.Fatalf("unexpected reverse request kind %q", msg.Kind)
+		}
+		var req struct {
+			Text string `json:"text"`
+		}
+		if err := msg.Decode(&req); err != nil {
+			return nil, err
+		}
+		return struct {
+			Text string `json:"text"`
+		}{Text: req.Text + "-and-back"}, nil
+	})
+
+	ctx := requestContext(t)
+	handshake, err := pair.peer.SendRequest(ctx, ipc.KindHandshake, HandshakeRequest{Version: Version})
+	if err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+	var handshakeResult HandshakeResponse
+	if err := handshake.Decode(&handshakeResult); err != nil {
+		t.Fatalf("decode handshake: %v", err)
+	}
+	if !handshakeResult.OK || handshakeResult.Version != Version {
+		t.Fatalf("unexpected handshake response: %+v", handshakeResult)
+	}
+
+	msg, err := pair.peer.SendRequest(ctx, KindLint, LintRequest{EslintPlugins: []EslintPluginEntry{{
+		Prefix:    "community",
+		RuleNames: []string{"rule"},
+	}}})
+	if err != nil {
+		t.Fatalf("lint request deadlocked or failed: %v", err)
+	}
+	var lintResult LintResponse
+	if err := msg.Decode(&lintResult); err != nil {
+		t.Fatalf("decode lint response: %v", err)
+	}
+	if handler.reverseCalls.Load() != 1 {
+		t.Fatalf("expected one context-aware lint call, got %d", handler.reverseCalls.Load())
+	}
+	received := <-handler.requests
+	if len(received.EslintPlugins) != 1 || received.EslintPlugins[0].Prefix != "community" ||
+		len(received.EslintPlugins[0].RuleNames) != 1 || received.EslintPlugins[0].RuleNames[0] != "rule" {
+		t.Fatalf("eslintPlugins metadata did not survive the wire: %+v", received.EslintPlugins)
+	}
+	if len(lintResult.Diagnostics) != 1 || lintResult.Diagnostics[0].Message != "from-go-and-back" {
+		t.Fatalf("unexpected reverse RPC result: %+v", lintResult.Diagnostics)
+	}
+
+	if _, err := pair.peer.SendRequest(ctx, KindGetAstInfo, GetAstInfoRequest{}); err != nil {
+		t.Fatalf("getAstInfo compatibility request: %v", err)
+	}
+	if _, err := pair.peer.SendRequest(ctx, ipc.KindExit, struct{}{}); err != nil {
+		t.Fatalf("exit request: %v", err)
+	}
+	select {
+	case err := <-pair.serviceDone:
+		if err != nil {
+			t.Fatalf("service exit: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("service did not stop after writing the exit acknowledgement")
+	}
+}
+
+func TestService_LegacyHandlerFallback(t *testing.T) {
+	handler := &serviceTestHandler{}
+	pair := newServiceChannelPair(t, handler, nil)
+	ctx := requestContext(t)
+
+	if _, err := pair.peer.SendRequest(ctx, KindLint, LintRequest{}); err != nil {
+		t.Fatalf("legacy lint handler: %v", err)
+	}
+	if handler.lintCalls.Load() != 1 {
+		t.Fatalf("expected legacy HandleLint once, got %d", handler.lintCalls.Load())
+	}
+	if _, err := pair.peer.SendRequest(ctx, ipc.KindExit, struct{}{}); err != nil {
+		t.Fatalf("exit request: %v", err)
+	}
+}
+
+func TestService_TransportShutdownCancelsReverseRequest(t *testing.T) {
+	reverseStarted := make(chan struct{})
+	handler := &reverseServiceTestHandler{reverseErr: make(chan error, 1)}
+	pair := newServiceChannelPair(t, handler, func(ctx context.Context, msg *ipc.Message) (any, error) {
+		if msg.Kind != KindPluginLint {
+			return nil, errors.New("unexpected reverse request")
+		}
+		close(reverseStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	ctx := requestContext(t)
+	go func() {
+		_, _ = pair.peer.SendRequest(ctx, KindLint, LintRequest{})
+	}()
+	select {
+	case <-reverseStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("service never issued reverse pluginLint request")
+	}
+
+	// Closing the host's write half gives the service a clean peer EOF while a
+	// reverse request is pending. Channel shutdown must wake SendRequest.
+	if err := pair.peerToService.Close(); err != nil {
+		t.Fatalf("close peer transport: %v", err)
+	}
+	select {
+	case err := <-handler.reverseErr:
+		if err == nil {
+			t.Fatal("expected reverse request to fail when the transport closes")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("reverse request remained blocked after transport shutdown")
+	}
+	select {
+	case err := <-pair.serviceDone:
+		if err != nil {
+			t.Fatalf("clean peer EOF should stop service without error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("service did not stop after peer EOF")
+	}
+}
+
+func TestService_TruncatedFrameIsNotCleanShutdown(t *testing.T) {
+	// Declares a 10-byte JSON body but supplies one byte before EOF.
+	reader := bytes.NewReader([]byte{10, 0, 0, 0, '{'})
+	err := NewService(reader, io.Discard, &serviceTestHandler{}).Start()
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected truncated frame error, got %v", err)
+	}
+}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -135,7 +136,10 @@ func TestService_BidirectionalLintKeepsReadLoopRunning(t *testing.T) {
 	})
 
 	ctx := requestContext(t)
-	handshake, err := pair.peer.SendRequest(ctx, ipc.KindHandshake, HandshakeRequest{Version: Version})
+	handshake, err := pair.peer.SendRequest(ctx, ipc.KindHandshake, HandshakeRequest{
+		Version:      Version,
+		Capabilities: []string{CapabilityReversePluginLint},
+	})
 	if err != nil {
 		t.Fatalf("handshake: %v", err)
 	}
@@ -145,6 +149,9 @@ func TestService_BidirectionalLintKeepsReadLoopRunning(t *testing.T) {
 	}
 	if !handshakeResult.OK || handshakeResult.Version != Version {
 		t.Fatalf("unexpected handshake response: %+v", handshakeResult)
+	}
+	if len(handshakeResult.Capabilities) != 1 || handshakeResult.Capabilities[0] != CapabilityReversePluginLint {
+		t.Fatalf("bidirectional handler did not advertise reverse lint: %+v", handshakeResult.Capabilities)
 	}
 
 	msg, err := pair.peer.SendRequest(ctx, KindLint, LintRequest{EslintPlugins: []EslintPluginEntry{{
@@ -190,6 +197,17 @@ func TestService_LegacyHandlerFallback(t *testing.T) {
 	handler := &serviceTestHandler{}
 	pair := newServiceChannelPair(t, handler, nil)
 	ctx := requestContext(t)
+	message, err := pair.peer.SendRequest(ctx, ipc.KindHandshake, HandshakeRequest{Version: Version})
+	if err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+	var response HandshakeResponse
+	if err := message.Decode(&response); err != nil {
+		t.Fatalf("decode handshake: %v", err)
+	}
+	if len(response.Capabilities) != 0 {
+		t.Fatalf("legacy handler advertised unsupported capabilities: %+v", response.Capabilities)
+	}
 
 	if _, err := pair.peer.SendRequest(ctx, KindLint, LintRequest{}); err != nil {
 		t.Fatalf("legacy lint handler: %v", err)
@@ -215,6 +233,12 @@ func TestService_TransportShutdownCancelsReverseRequest(t *testing.T) {
 	})
 
 	ctx := requestContext(t)
+	if _, err := pair.peer.SendRequest(ctx, ipc.KindHandshake, HandshakeRequest{
+		Version:      Version,
+		Capabilities: []string{CapabilityReversePluginLint},
+	}); err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
 	go func() {
 		_, _ = pair.peer.SendRequest(ctx, KindLint, LintRequest{})
 	}()
@@ -245,6 +269,68 @@ func TestService_TransportShutdownCancelsReverseRequest(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("service did not stop after peer EOF")
 	}
+}
+
+func TestService_RejectsProtocolMismatch(t *testing.T) {
+	handler := &serviceTestHandler{}
+	pair := newServiceChannelPair(t, handler, nil)
+	ctx := requestContext(t)
+
+	message, err := pair.peer.SendRequest(ctx, ipc.KindHandshake, HandshakeRequest{Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("handshake request: %v", err)
+	}
+	var response HandshakeResponse
+	if err := message.Decode(&response); err != nil {
+		t.Fatalf("decode handshake: %v", err)
+	}
+	if response.OK || response.Version != Version {
+		t.Fatalf("unexpected mismatch response: %+v", response)
+	}
+	if _, err := pair.peer.SendRequest(ctx, KindLint, LintRequest{}); err == nil {
+		t.Fatal("lint should be rejected after a mismatched handshake")
+	}
+	_, _ = pair.peer.SendRequest(ctx, ipc.KindExit, struct{}{})
+}
+
+func TestService_RequiresPeerCapabilityForPluginLint(t *testing.T) {
+	handler := &reverseServiceTestHandler{}
+	pair := newServiceChannelPair(t, handler, nil)
+	ctx := requestContext(t)
+
+	if _, err := pair.peer.SendRequest(ctx, ipc.KindHandshake, HandshakeRequest{Version: Version}); err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+	_, err := pair.peer.SendRequest(ctx, KindLint, LintRequest{
+		EslintPlugins: []EslintPluginEntry{{Prefix: "community", RuleNames: []string{"rule"}}},
+	})
+	if err == nil || !strings.Contains(err.Error(), CapabilityReversePluginLint) {
+		t.Fatalf("expected missing-capability error, got %v", err)
+	}
+	_, _ = pair.peer.SendRequest(ctx, ipc.KindExit, struct{}{})
+}
+
+func TestService_RejectsPluginMetadataForLegacyHandler(t *testing.T) {
+	handler := &serviceTestHandler{}
+	pair := newServiceChannelPair(t, handler, nil)
+	ctx := requestContext(t)
+
+	if _, err := pair.peer.SendRequest(ctx, ipc.KindHandshake, HandshakeRequest{
+		Version:      Version,
+		Capabilities: []string{CapabilityReversePluginLint},
+	}); err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+	_, err := pair.peer.SendRequest(ctx, KindLint, LintRequest{
+		EslintPlugins: []EslintPluginEntry{{Prefix: "community", RuleNames: []string{"rule"}}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "handler does not support reversePluginLint") {
+		t.Fatalf("expected unsupported-handler error, got %v", err)
+	}
+	if handler.lintCalls.Load() != 0 {
+		t.Fatalf("legacy HandleLint must not receive plugin metadata, got %d calls", handler.lintCalls.Load())
+	}
+	_, _ = pair.peer.SendRequest(ctx, ipc.KindExit, struct{}{})
 }
 
 func TestService_TruncatedFrameIsNotCleanShutdown(t *testing.T) {

--- a/internal/config/cli_rules.go
+++ b/internal/config/cli_rules.go
@@ -47,7 +47,9 @@ func ParseCLIRuleFlag(input string) (string, interface{}, error) {
 }
 
 // BuildCLIRuleEntry converts a list of --rule flag values into a synthetic
-// ConfigEntry with no Files field (matches all files). Returns nil if flags is empty.
+// ConfigEntry with no Files field. It overlays the already-selected lint
+// targets; target discovery remains owned by CLI/API target + files matching.
+// Returns nil if flags is empty.
 func BuildCLIRuleEntry(flags []string) (*ConfigEntry, error) {
 	if len(flags) == 0 {
 		return nil, nil //nolint:nilnil // no flags means no entry, not an error

--- a/internal/config/cli_rules_test.go
+++ b/internal/config/cli_rules_test.go
@@ -54,10 +54,10 @@ func TestParseCLIRuleFlag_WhitespaceVariations(t *testing.T) {
 		wantName string
 		wantVal  interface{}
 	}{
-		{"no-console:error", "no-console", "error"},           // no space after colon
-		{"no-console:  error", "no-console", "error"},         // multiple spaces after colon
-		{"  no-console  :  error  ", "no-console", "error"},   // leading/trailing spaces
-		{"no-console:\terror", "no-console", "error"},         // tab after colon
+		{"no-console:error", "no-console", "error"},                                                 // no space after colon
+		{"no-console:  error", "no-console", "error"},                                               // multiple spaces after colon
+		{"  no-console  :  error  ", "no-console", "error"},                                         // leading/trailing spaces
+		{"no-console:\terror", "no-console", "error"},                                               // tab after colon
 		{"@typescript-eslint/no-explicit-any:  warn", "@typescript-eslint/no-explicit-any", "warn"}, // plugin rule with extra space
 	}
 	for _, tt := range tests {
@@ -249,7 +249,7 @@ func TestBuildCLIRuleEntry_SingleRule(t *testing.T) {
 	entry, err := BuildCLIRuleEntry([]string{"no-console: error"})
 	assert.NilError(t, err)
 	assert.Assert(t, entry != nil)
-	assert.Assert(t, len(entry.Files) == 0, "should have no files (matches all)")
+	assert.Assert(t, entry.Files == nil, "should omit files and only overlay selected targets")
 	assert.Assert(t, len(entry.Ignores) == 0, "should have no ignores")
 	assert.Assert(t, len(entry.Plugins) == 0, "should have no plugins")
 	assert.Assert(t, entry.LanguageOptions == nil, "should have no language options")
@@ -497,14 +497,14 @@ func TestIntegration_CLIWithMultipleConfigEntries(t *testing.T) {
 	// .ts file: base + ts-specific + CLI
 	merged = config.GetConfigForFile("src/app.ts", "")
 	assert.Assert(t, merged != nil)
-	assert.Equal(t, merged.Rules["no-console"].Level, "error")  // CLI overrides ts-specific "warn"
-	assert.Equal(t, merged.Rules["no-debugger"].Level, "warn")  // CLI overrides base "error"
+	assert.Equal(t, merged.Rules["no-console"].Level, "error") // CLI overrides ts-specific "warn"
+	assert.Equal(t, merged.Rules["no-debugger"].Level, "warn") // CLI overrides base "error"
 
 	// .test.ts file: base + ts-specific + test-specific + CLI
 	merged = config.GetConfigForFile("src/app.test.ts", "")
 	assert.Assert(t, merged != nil)
-	assert.Equal(t, merged.Rules["no-console"].Level, "error")  // CLI overrides test-specific "off"
-	assert.Equal(t, merged.Rules["no-debugger"].Level, "warn")  // CLI overrides test-specific "off"
+	assert.Equal(t, merged.Rules["no-console"].Level, "error") // CLI overrides test-specific "off"
+	assert.Equal(t, merged.Rules["no-debugger"].Level, "warn") // CLI overrides test-specific "off"
 }
 
 func TestIntegration_CLIOnlyMatchesFilesMatchedByConfig(t *testing.T) {

--- a/internal/config/cli_rules_test.go
+++ b/internal/config/cli_rules_test.go
@@ -415,8 +415,9 @@ func TestIntegration_CLIArrayOverridesConfigString(t *testing.T) {
 	assert.Equal(t, allow[0], "warn")
 }
 
-func TestIntegration_CLIStringOverridesConfigArray(t *testing.T) {
-	// Config has array with options, CLI overrides with plain "off"
+func TestIntegration_CLISeverityOverrideRetainsConfigOptions(t *testing.T) {
+	// A severity-only override retains the earlier options, matching flat config
+	// cascading in ESLint.
 	config := RslintConfig{
 		{
 			Rules: Rules{"no-console": []interface{}{"error", map[string]interface{}{"allow": []interface{}{"warn"}}}},
@@ -430,7 +431,7 @@ func TestIntegration_CLIStringOverridesConfigArray(t *testing.T) {
 	merged := config.GetConfigForFile("src/app.ts", "")
 	assert.Assert(t, merged != nil)
 	assert.Equal(t, merged.Rules["no-console"].Level, "off")
-	assert.Assert(t, merged.Rules["no-console"].Options == nil)
+	assert.Equal(t, len(merged.Rules["no-console"].Options), 1)
 }
 
 func TestIntegration_CLIDoesNotAffectGloballyIgnoredFiles(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -78,7 +80,7 @@ func (entry *ConfigEntry) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if len(config) != 1 {
-		return fmt.Errorf("expected one config entry")
+		return errors.New("expected one config entry")
 	}
 	*entry = config[0]
 	return nil
@@ -132,6 +134,9 @@ func (config *RslintConfig) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(entryForDecode, &decoded); err != nil {
 			return err
 		}
+		if err := validateConfigRules(decoded.Rules); err != nil {
+			return fmt.Errorf("config entry at index %d: %w", index, err)
+		}
 		// Global-ignore semantics depend on object shape, not on whether a
 		// present field decodes to a non-nil Go value. Preserve the non-global
 		// shape of entries such as {ignores, rules: null} or entries carrying a
@@ -166,20 +171,34 @@ func decodeFilesSelectors(raw json.RawMessage, entryIndex int) ([]string, [][]st
 	files := make([]string, 0, len(selectors))
 	var groups [][]string
 	for selectorIndex, selector := range selectors {
-		var pattern string
-		if err := json.Unmarshal(selector, &pattern); err == nil {
-			files = append(files, pattern)
-			continue
+		var value any
+		if err := json.Unmarshal(selector, &value); err != nil {
+			return nil, nil, err
 		}
-		var group []string
-		if err := json.Unmarshal(selector, &group); err != nil || len(group) == 0 {
+		switch value := value.(type) {
+		case string:
+			files = append(files, value)
+		case []any:
+			group := make([]string, 0, len(value))
+			for _, item := range value {
+				pattern, ok := item.(string)
+				if !ok {
+					return nil, nil, fmt.Errorf(
+						"config entry at index %d: key \"files\": item at index %d must be a string or an array of strings",
+						entryIndex,
+						selectorIndex,
+					)
+				}
+				group = append(group, pattern)
+			}
+			groups = append(groups, group)
+		default:
 			return nil, nil, fmt.Errorf(
-				"config entry at index %d: key \"files\": item at index %d must be a string or a non-empty array of strings",
+				"config entry at index %d: key \"files\": item at index %d must be a string or an array of strings",
 				entryIndex,
 				selectorIndex,
 			)
 		}
-		groups = append(groups, group)
 	}
 	return files, groups, nil
 }
@@ -191,10 +210,60 @@ func ValidateConfig(config RslintConfig) error {
 		if (entry.Files != nil || entry.FilePatternGroups != nil) && len(entry.Files) == 0 && len(entry.FilePatternGroups) == 0 {
 			return fmt.Errorf("config entry at index %d: key \"files\": expected value to be a non-empty array", index)
 		}
-		for groupIndex, group := range entry.FilePatternGroups {
-			if len(group) == 0 {
-				return fmt.Errorf("config entry at index %d: key \"files\": AND group at index %d must be non-empty", index, groupIndex)
-			}
+		if err := validateConfigGlobals(entry.LanguageOptions); err != nil {
+			return fmt.Errorf("config entry at index %d: %w", index, err)
+		}
+		if err := validateConfigRules(entry.Rules); err != nil {
+			return fmt.Errorf("config entry at index %d: %w", index, err)
+		}
+	}
+	return nil
+}
+
+func validateConfigGlobals(languageOptions *LanguageOptions) error {
+	if languageOptions == nil || languageOptions.Raw == nil {
+		return nil
+	}
+	value, present := languageOptions.Raw["globals"]
+	if !present {
+		return nil
+	}
+	globals, ok := value.(map[string]any)
+	if !ok {
+		return errors.New("key \"languageOptions.globals\": expected an object")
+	}
+	for name, access := range globals {
+		if name != strings.TrimSpace(name) {
+			return fmt.Errorf("key \"languageOptions.globals\": global %q has leading or trailing whitespace", name)
+		}
+		if !isValidGlobalAccess(access) {
+			return fmt.Errorf(
+				"key \"languageOptions.globals\": global %q has invalid access %v; expected a boolean, null, \"true\", \"false\", \"readonly\", \"readable\", \"writable\", \"writeable\", or \"off\"",
+				name,
+				access,
+			)
+		}
+	}
+	return nil
+}
+
+func isValidGlobalAccess(value any) bool {
+	switch value := value.(type) {
+	case nil, bool:
+		return true
+	case string:
+		switch value {
+		case "true", "writable", "writeable", "false", "readonly", "readable", "off":
+			return true
+		}
+	}
+	return false
+}
+
+func validateConfigRules(rules Rules) error {
+	for name, value := range rules {
+		if _, _, err := parseRuleConfigValue(value); err != nil {
+			return fmt.Errorf("key \"rules\": rule %q: %w", name, err)
 		}
 	}
 	return nil
@@ -387,32 +456,99 @@ func NormalizePluginName(pluginName string) string {
 // parseArrayRuleConfig parses array-style rule configuration like ["error", {...options}]
 // Supports ESLint-compatible formats:
 // - ["off"] -> disabled rule
+// - [0] -> disabled rule
 // - ["error"] -> enabled rule with error severity
+// - [2] -> enabled rule with error severity
 // - ["warn"] -> enabled rule with warning severity
+// - [1] -> enabled rule with warning severity
 // - ["error", {...options}] -> enabled rule with error severity and options
 // - ["error", "both"] -> enabled rule with string option (e.g. no-inner-declarations)
 // - ["error", "both", {...options}] -> enabled rule with string + object options
 func parseArrayRuleConfig(ruleArray []interface{}) *RuleConfig {
-	if len(ruleArray) == 0 {
+	ruleConfig, _, err := parseRuleConfigValue(ruleArray)
+	if err != nil {
 		return nil
 	}
-
-	// First element should always be the severity level
-	level, ok := ruleArray[0].(string)
-	if !ok {
-		return nil
-	}
-
-	ruleConfig := &RuleConfig{Level: level}
-
-	// Remaining elements are rule options, kept as ESLint's context.options
-	// array form ([]any) — no bare-value collapsing. Every consumer of
-	// RuleConfig.Options can now assume []any uniformly.
-	if len(ruleArray) > 1 {
-		ruleConfig.Options = ruleArray[1:]
-	}
-
 	return ruleConfig
+}
+
+func parseRuleConfigValue(value any) (*RuleConfig, bool, error) {
+	if ruleArray, ok := value.([]interface{}); ok {
+		if len(ruleArray) == 0 {
+			return nil, false, errors.New("rule configuration array must contain a severity")
+		}
+		level, err := normalizeRuleSeverity(ruleArray[0])
+		if err != nil {
+			return nil, false, fmt.Errorf("invalid array severity at index 0: %w", err)
+		}
+		ruleConfig := &RuleConfig{Level: level}
+		if len(ruleArray) > 1 {
+			// Keep ESLint's context.options array form without collapsing a
+			// single positional option to a bare value.
+			ruleConfig.Options = ruleArray[1:]
+		}
+		return ruleConfig, len(ruleArray) > 1, nil
+	}
+
+	level, err := normalizeRuleSeverity(value)
+	if err != nil {
+		return nil, false, err
+	}
+	return &RuleConfig{Level: level}, false, nil
+}
+
+func normalizeRuleSeverity(value any) (string, error) {
+	if value == nil {
+		return "", invalidRuleSeverity(value)
+	}
+	if number, ok := value.(json.Number); ok {
+		numeric, err := number.Float64()
+		if err != nil {
+			return "", invalidRuleSeverity(value)
+		}
+		return normalizeNumericRuleSeverity(numeric, value)
+	}
+
+	severity := reflect.ValueOf(value)
+	switch severity.Kind() {
+	case reflect.String:
+		level := severity.String()
+		switch level {
+		case "off", "warn", "error":
+			return level, nil
+		default:
+			return "", invalidRuleSeverity(value)
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return normalizeNumericRuleSeverity(float64(severity.Int()), value)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return normalizeNumericRuleSeverity(float64(severity.Uint()), value)
+	case reflect.Float32, reflect.Float64:
+		return normalizeNumericRuleSeverity(severity.Float(), value)
+	}
+
+	return "", invalidRuleSeverity(value)
+}
+
+func normalizeNumericRuleSeverity(value float64, original any) (string, error) {
+	switch value {
+	case 0:
+		return "off", nil
+	case 1:
+		return "warn", nil
+	case 2:
+		return "error", nil
+	default:
+		return "", invalidRuleSeverity(original)
+	}
+}
+
+func invalidRuleSeverity(value any) error {
+	return fmt.Errorf(
+		"invalid severity %v (%T); expected \"off\", \"warn\", \"error\", 0, 1, or 2",
+		value,
+		value,
+	)
 }
 
 var registerOnce sync.Once
@@ -614,16 +750,19 @@ func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *Merged
 
 		entryMatched = true
 
-		// 4. Rules: shallow merge, later entries override earlier ones
+		// 4. Rules: later entries override earlier ones. When the later value
+		// changes only severity, ESLint retains the earlier rule options.
 		for ruleName, ruleValue := range entry.Rules {
-			switch v := ruleValue.(type) {
-			case string:
-				merged.Rules[ruleName] = &RuleConfig{Level: v}
-			case []interface{}:
-				if rc := parseArrayRuleConfig(v); rc != nil {
-					merged.Rules[ruleName] = rc
-				}
+			next, hasOptions, err := parseRuleConfigValue(ruleValue)
+			if err != nil {
+				// Config ingress validates rule values before merge. Keep this
+				// guard for callers that construct a config without validating it.
+				continue
 			}
+			if previous := merged.Rules[ruleName]; !hasOptions && previous != nil {
+				next.Options = append([]interface{}(nil), previous.Options...)
+			}
+			merged.Rules[ruleName] = next
 		}
 
 		// 5. Plugins: union from all matching entries (normalized to rule prefix form)
@@ -631,14 +770,13 @@ func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *Merged
 			merged.Plugins[NormalizePluginName(plugin)] = struct{}{}
 		}
 
-		// 6. Settings: shallow merge
+		// 6. Settings: recursively merge ordinary objects; arrays and scalar
+		// values are replaced by the later entry.
 		if entry.Settings != nil {
-			if merged.Settings == nil {
-				merged.Settings = make(Settings)
-			}
-			for k, v := range entry.Settings {
-				merged.Settings[k] = v
-			}
+			merged.Settings = Settings(deepMergeConfigObjects(
+				map[string]any(merged.Settings),
+				map[string]any(entry.Settings),
+			))
 		}
 
 		// 7. LanguageOptions: deep merge
@@ -675,7 +813,8 @@ func isFileMatchedByConfigEntry(filePath string, entry ConfigEntry, cwd string) 
 		return true
 	}
 	for _, group := range entry.FilePatternGroups {
-		matched := len(group) > 0
+		// ESLint treats an empty nested selector as a vacuously true AND group.
+		matched := true
 		for _, pattern := range group {
 			if !isSingleFilePatternMatched(filePath, pattern, cwd) {
 				matched = false
@@ -687,6 +826,52 @@ func isFileMatchedByConfigEntry(filePath string, entry ConfigEntry, cwd string) 
 		}
 	}
 	return false
+}
+
+func deepMergeConfigObjects(base map[string]any, override map[string]any) map[string]any {
+	merged := make(map[string]any, len(base)+len(override))
+	for key, value := range base {
+		merged[key] = cloneConfigValue(value)
+	}
+	for key, value := range override {
+		baseObject, baseIsObject := configObject(base[key])
+		overrideObject, overrideIsObject := configObject(value)
+		if baseIsObject && overrideIsObject {
+			merged[key] = deepMergeConfigObjects(baseObject, overrideObject)
+			continue
+		}
+		merged[key] = cloneConfigValue(value)
+	}
+	return merged
+}
+
+func configObject(value any) (map[string]any, bool) {
+	switch object := value.(type) {
+	case map[string]any:
+		return object, true
+	case Settings:
+		return map[string]any(object), true
+	default:
+		return nil, false
+	}
+}
+
+func cloneConfigValue(value any) any {
+	if object, ok := configObject(value); ok {
+		return deepMergeConfigObjects(nil, object)
+	}
+	switch values := value.(type) {
+	case []any:
+		cloned := make([]any, len(values))
+		for index, item := range values {
+			cloned[index] = cloneConfigValue(item)
+		}
+		return cloned
+	case []string:
+		return append([]string(nil), values...)
+	default:
+		return value
+	}
 }
 
 // isFileMatched checks if a file matches any of the given glob patterns
@@ -756,49 +941,21 @@ func mergeLanguageOptions(base, override *LanguageOptions) *LanguageOptions {
 			if override.ParserOptions.ProjectService != nil {
 				po.ProjectService = override.ParserOptions.ProjectService
 			}
-			if len(override.ParserOptions.Project) > 0 {
+			if override.ParserOptions.Project != nil {
 				po.Project = override.ParserOptions.Project
 			}
 			merged.ParserOptions = &po
 		}
 	}
-	// Shallow-merge the raw languageOptions map (override wins per key), except
-	// globals, which ESLint merges by global name. merged is a shallow copy of
-	// base, so build fresh maps rather than mutating either input.
-	if len(override.Raw) > 0 {
-		mergedRaw := make(map[string]any, len(base.Raw)+len(override.Raw))
-		for k, v := range base.Raw {
-			mergedRaw[k] = v
-		}
-		for k, v := range override.Raw {
-			mergedRaw[k] = v
-		}
-		if overrideGlobals, ok := override.Raw["globals"].(map[string]any); ok {
-			mergedGlobals := make(map[string]any, len(overrideGlobals))
-			if baseGlobals, ok := base.Raw["globals"].(map[string]any); ok {
-				for name, value := range baseGlobals {
-					mergedGlobals[name] = value
-				}
-			}
-			for name, value := range overrideGlobals {
-				mergedGlobals[name] = value
-			}
-			mergedRaw["globals"] = mergedGlobals
-		}
-		merged.Raw = mergedRaw
-	}
+	merged.Raw = deepMergeConfigObjects(base.Raw, override.Raw)
 	return &merged
 }
 
 // ExtractGlobals reads the effective `languageOptions.globals` for a merged
 // config and normalizes it to a simple "is this name declared" set.
 //
-// Matches ESLint's own normalizeConfigGlobal (lib/languages/js/source-code/
-// source-code.js): only the string `"off"` un-declares a global. Every other
-// accepted value — including boolean `false` and `null`, which both map to
-// `"readonly"` — still declares it. (`false` does NOT mean "off"; that's a
-// common mix-up since other ESLint config knobs use `false`/`"off"`
-// interchangeably, but globals don't.)
+// Writable and readonly aliases both declare the name. As in ESLint v10, null
+// normalizes to readonly; only the string "off" disables a declaration.
 func ExtractGlobals(langOpts *LanguageOptions) map[string]bool {
 	if langOpts == nil || langOpts.Raw == nil {
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,11 @@ type Settings map[string]interface{}
 // An omitted `files` field remains valid and means "use rslint's default
 // lintable extensions"; explicit null/empty arrays are invalid.
 func (config *RslintConfig) UnmarshalJSON(data []byte) error {
+	if strings.TrimSpace(string(data)) == "null" {
+		*config = nil
+		return nil
+	}
+
 	var rawEntries []json.RawMessage
 	if err := json.Unmarshal(data, &rawEntries); err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,12 +25,63 @@ type RslintConfig []ConfigEntry
 
 // ConfigEntry represents a single configuration entry in the config array
 type ConfigEntry struct {
-	Files           []string         `json:"files,omitempty"`
-	Ignores         []string         `json:"ignores,omitempty"`
-	LanguageOptions *LanguageOptions `json:"languageOptions,omitempty"`
-	Rules           Rules            `json:"rules"`
-	Plugins         []string         `json:"plugins,omitempty"`
-	Settings        Settings         `json:"settings,omitempty"`
+	Name string `json:"name,omitempty"`
+	// Files retains the established Go construction API for top-level OR
+	// patterns. FilePatternGroups stores nested arrays, each of which is an AND
+	// group. JSON encoding combines both fields back into one mixed `files`
+	// array.
+	Files             []string         `json:"files,omitempty"`
+	FilePatternGroups [][]string       `json:"-"`
+	Ignores           []string         `json:"ignores,omitempty"`
+	LanguageOptions   *LanguageOptions `json:"languageOptions,omitempty"`
+	Rules             Rules            `json:"rules"`
+	Plugins           []string         `json:"plugins,omitempty"`
+	Settings          Settings         `json:"settings,omitempty"`
+}
+
+func (entry ConfigEntry) MarshalJSON() ([]byte, error) {
+	type configEntryAlias ConfigEntry
+	if len(entry.FilePatternGroups) == 0 {
+		return json.Marshal(configEntryAlias(entry))
+	}
+
+	encoded, err := json.Marshal(configEntryAlias(entry))
+	if err != nil {
+		return nil, err
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &object); err != nil {
+		return nil, err
+	}
+	selectors := make([]any, 0, len(entry.Files)+len(entry.FilePatternGroups))
+	for _, pattern := range entry.Files {
+		selectors = append(selectors, pattern)
+	}
+	for _, group := range entry.FilePatternGroups {
+		selectors = append(selectors, group)
+	}
+	filesJSON, err := json.Marshal(selectors)
+	if err != nil {
+		return nil, err
+	}
+	object["files"] = filesJSON
+	return json.Marshal(object)
+}
+
+func (entry *ConfigEntry) UnmarshalJSON(data []byte) error {
+	wrapped := make([]byte, 0, len(data)+2)
+	wrapped = append(wrapped, '[')
+	wrapped = append(wrapped, data...)
+	wrapped = append(wrapped, ']')
+	var config RslintConfig
+	if err := config.UnmarshalJSON(wrapped); err != nil {
+		return err
+	}
+	if len(config) != 1 {
+		return fmt.Errorf("expected one config entry")
+	}
+	*entry = config[0]
+	return nil
 }
 
 // Settings represents shared settings accessible to rules
@@ -58,19 +109,43 @@ func (config *RslintConfig) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
+		var decoded configEntryAlias
+		entryForDecode := rawEntry
 		if rawFiles, ok := raw["files"]; ok {
-			var files []string
-			if err := json.Unmarshal(rawFiles, &files); err != nil {
-				return fmt.Errorf("config entry at index %d: key \"files\": expected value to be a non-empty array: %w", index, err)
+			files, groups, err := decodeFilesSelectors(rawFiles, index)
+			if err != nil {
+				return err
 			}
-			if len(files) == 0 {
-				return fmt.Errorf("config entry at index %d: key \"files\": expected value to be a non-empty array", index)
+			decoded.Files = files
+			decoded.FilePatternGroups = groups
+			withoutFiles := make(map[string]json.RawMessage, len(raw)-1)
+			for key, value := range raw {
+				if key != "files" {
+					withoutFiles[key] = value
+				}
+			}
+			entryForDecode, err = json.Marshal(withoutFiles)
+			if err != nil {
+				return err
 			}
 		}
-
-		var decoded configEntryAlias
-		if err := json.Unmarshal(rawEntry, &decoded); err != nil {
+		if err := json.Unmarshal(entryForDecode, &decoded); err != nil {
 			return err
+		}
+		// Global-ignore semantics depend on object shape, not on whether a
+		// present field decodes to a non-nil Go value. Preserve the non-global
+		// shape of entries such as {ignores, rules: null} or entries carrying a
+		// currently unsupported field. An empty Settings map is behaviorally
+		// neutral but remains non-nil for isGlobalIgnoreEntry.
+		hasNonGlobalKey := false
+		for key := range raw {
+			if key != "ignores" && key != "name" {
+				hasNonGlobalKey = true
+				break
+			}
+		}
+		if hasNonGlobalKey && decoded.Files == nil && decoded.FilePatternGroups == nil && decoded.Rules == nil && decoded.Plugins == nil && decoded.Settings == nil && decoded.LanguageOptions == nil {
+			decoded.Settings = Settings{}
 		}
 		entries = append(entries, ConfigEntry(decoded))
 	}
@@ -79,12 +154,47 @@ func (config *RslintConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func decodeFilesSelectors(raw json.RawMessage, entryIndex int) ([]string, [][]string, error) {
+	var selectors []json.RawMessage
+	if err := json.Unmarshal(raw, &selectors); err != nil || len(selectors) == 0 {
+		if err != nil {
+			return nil, nil, fmt.Errorf("config entry at index %d: key \"files\": expected value to be a non-empty array: %w", entryIndex, err)
+		}
+		return nil, nil, fmt.Errorf("config entry at index %d: key \"files\": expected value to be a non-empty array", entryIndex)
+	}
+
+	files := make([]string, 0, len(selectors))
+	var groups [][]string
+	for selectorIndex, selector := range selectors {
+		var pattern string
+		if err := json.Unmarshal(selector, &pattern); err == nil {
+			files = append(files, pattern)
+			continue
+		}
+		var group []string
+		if err := json.Unmarshal(selector, &group); err != nil || len(group) == 0 {
+			return nil, nil, fmt.Errorf(
+				"config entry at index %d: key \"files\": item at index %d must be a string or a non-empty array of strings",
+				entryIndex,
+				selectorIndex,
+			)
+		}
+		groups = append(groups, group)
+	}
+	return files, groups, nil
+}
+
 // ValidateConfig checks config invariants for configs constructed in Go. JSON
 // config ingress rejects explicit null/empty `files` during unmarshaling.
 func ValidateConfig(config RslintConfig) error {
 	for index, entry := range config {
-		if entry.Files != nil && len(entry.Files) == 0 {
+		if (entry.Files != nil || entry.FilePatternGroups != nil) && len(entry.Files) == 0 && len(entry.FilePatternGroups) == 0 {
 			return fmt.Errorf("config entry at index %d: key \"files\": expected value to be a non-empty array", index)
+		}
+		for groupIndex, group := range entry.FilePatternGroups {
+			if len(group) == 0 {
+				return fmt.Errorf("config entry at index %d: key \"files\": AND group at index %d must be non-empty", index, groupIndex)
+			}
 		}
 	}
 	return nil
@@ -427,8 +537,9 @@ type MergedConfig struct {
 // IsFileIgnored reports whether filePath is excluded by the config's global
 // `ignores` patterns. It is distinct from GetConfigForFile returning nil,
 // which also covers "no entry matched this file" — callers that need ESLint's
-// "ignores hides the file from the linter entirely" semantics (including
-// type-check diagnostics and file counts) should use this method.
+// "ignores removes the file from lint target discovery" semantics should use
+// this method. Program-wide type-check diagnostics are intentionally governed
+// by tsconfig membership instead.
 func (config RslintConfig) IsFileIgnored(filePath string, cwd string) bool {
 	patterns := ExtractConfigIgnores(config)
 	if len(patterns) == 0 {
@@ -438,8 +549,10 @@ func (config RslintConfig) IsFileIgnored(filePath string, cwd string) bool {
 		isFileIgnored(filePath, patterns, cwd)
 }
 
-// GetConfigForFile computes the merged configuration for a file following ESLint flat config semantics.
-// Returns nil if the file is globally ignored or no entry matches (should not be linted).
+// GetConfigForFile computes the merged configuration for a selected file
+// following ESLint flat config semantics. It returns nil when the file is
+// globally ignored, outside the config's implicit/explicit selector union, or
+// no entry contributes configuration.
 //
 // Global ignore evaluation happens in two phases:
 //  1. Directory-level (isDirBlockedByIgnores): patterns like dir/** block entire directories.
@@ -471,6 +584,14 @@ func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *Merged
 		}
 	}
 
+	// A CLI/API explicit target can bypass config `files` for parsing, but it
+	// must not make unscoped entries apply to a path the config itself never
+	// selected. Conversely, an explicit selector makes unscoped entries apply
+	// to that file, as in ESLint flat config cascading.
+	if !isFileSelectedByConfig(config, filePath, cwd) {
+		return nil
+	}
+
 	// Track whether any non-global entry matched this file
 	entryMatched := false
 
@@ -480,7 +601,7 @@ func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *Merged
 		}
 
 		// 2. files matching
-		if len(entry.Files) > 0 && !isFileMatched(filePath, entry.Files, cwd) {
+		if hasFileSelectors(entry) && !isFileMatchedByConfigEntry(filePath, entry, cwd) {
 			continue
 		}
 
@@ -532,19 +653,66 @@ func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *Merged
 	return merged
 }
 
-// isGlobalIgnoreEntry returns true if the entry is a global ignore entry
-// (has only ignores, no other fields).
+// isGlobalIgnoreEntry returns true if the entry has only ignores and an
+// optional name. Empty config objects are still present and make ignores local
+// to the entry, matching ESLint flat config semantics.
 func isGlobalIgnoreEntry(entry ConfigEntry) bool {
 	return entry.Files == nil &&
-		len(entry.Rules) == 0 &&
-		len(entry.Plugins) == 0 &&
+		entry.FilePatternGroups == nil &&
+		entry.Rules == nil &&
+		entry.Plugins == nil &&
 		entry.Settings == nil &&
 		entry.LanguageOptions == nil &&
 		len(entry.Ignores) > 0
 }
 
+func hasFileSelectors(entry ConfigEntry) bool {
+	return len(entry.Files) > 0 || len(entry.FilePatternGroups) > 0
+}
+
+func isFileMatchedByConfigEntry(filePath string, entry ConfigEntry, cwd string) bool {
+	if isFileMatched(filePath, entry.Files, cwd) {
+		return true
+	}
+	for _, group := range entry.FilePatternGroups {
+		matched := len(group) > 0
+		for _, pattern := range group {
+			if !isSingleFilePatternMatched(filePath, pattern, cwd) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
 // isFileMatched checks if a file matches any of the given glob patterns
 func isFileMatched(filePath string, patterns []string, cwd string) bool {
+	for _, pattern := range patterns {
+		if isSingleFilePatternMatched(filePath, pattern, cwd) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSingleFilePatternMatched(filePath string, pattern string, cwd string) bool {
+	negated := false
+	for strings.HasPrefix(pattern, "!") {
+		negated = !negated
+		pattern = strings.TrimPrefix(pattern, "!")
+	}
+	matched := isPositiveFilePatternMatched(filePath, pattern, cwd)
+	if negated {
+		return !matched
+	}
+	return matched
+}
+
+func isPositiveFilePatternMatched(filePath string, pattern string, cwd string) bool {
 	var normalizedPath string
 	if cwd != "" {
 		normalizedPath = normalizePath(filePath, cwd)
@@ -552,22 +720,20 @@ func isFileMatched(filePath string, patterns []string, cwd string) bool {
 		normalizedPath = filePath
 	}
 
-	for _, pattern := range patterns {
-		normalizedPattern := normalizePattern(pattern)
+	normalizedPattern := normalizePattern(pattern)
 
-		if matched, err := doublestar.Match(normalizedPattern, normalizedPath); err == nil && matched {
+	if matched, err := doublestar.Match(normalizedPattern, normalizedPath); err == nil && matched {
+		return true
+	}
+	if normalizedPath != filePath {
+		if matched, err := doublestar.Match(normalizedPattern, filePath); err == nil && matched {
 			return true
 		}
-		if normalizedPath != filePath {
-			if matched, err := doublestar.Match(normalizedPattern, filePath); err == nil && matched {
-				return true
-			}
-		}
-		unixPath := strings.ReplaceAll(normalizedPath, "\\", "/")
-		if unixPath != normalizedPath {
-			if matched, err := doublestar.Match(normalizedPattern, unixPath); err == nil && matched {
-				return true
-			}
+	}
+	unixPath := strings.ReplaceAll(normalizedPath, "\\", "/")
+	if unixPath != normalizedPath {
+		if matched, err := doublestar.Match(normalizedPattern, unixPath); err == nil && matched {
+			return true
 		}
 	}
 	return false
@@ -596,11 +762,9 @@ func mergeLanguageOptions(base, override *LanguageOptions) *LanguageOptions {
 			merged.ParserOptions = &po
 		}
 	}
-	// Shallow-merge the raw languageOptions map (override wins per key). This is
-	// intentionally shallow, NOT ESLint's recursive flat-config deepMerge of
-	// nested parserOptions/globals — matching that merge fidelity is a separate
-	// concern from wiring eslintPlugins and is out of scope here. merged is a
-	// shallow copy of base, so build a fresh map rather than mutating base.Raw.
+	// Shallow-merge the raw languageOptions map (override wins per key), except
+	// globals, which ESLint merges by global name. merged is a shallow copy of
+	// base, so build fresh maps rather than mutating either input.
 	if len(override.Raw) > 0 {
 		mergedRaw := make(map[string]any, len(base.Raw)+len(override.Raw))
 		for k, v := range base.Raw {
@@ -609,14 +773,25 @@ func mergeLanguageOptions(base, override *LanguageOptions) *LanguageOptions {
 		for k, v := range override.Raw {
 			mergedRaw[k] = v
 		}
+		if overrideGlobals, ok := override.Raw["globals"].(map[string]any); ok {
+			mergedGlobals := make(map[string]any, len(overrideGlobals))
+			if baseGlobals, ok := base.Raw["globals"].(map[string]any); ok {
+				for name, value := range baseGlobals {
+					mergedGlobals[name] = value
+				}
+			}
+			for name, value := range overrideGlobals {
+				mergedGlobals[name] = value
+			}
+			mergedRaw["globals"] = mergedGlobals
+		}
 		merged.Raw = mergedRaw
 	}
 	return &merged
 }
 
 // ExtractGlobals reads the effective `languageOptions.globals` for a merged
-// config (the buggy shallow-merged Raw map — see mergeLanguageOptions) and
-// normalizes it to a simple "is this name declared" set.
+// config and normalizes it to a simple "is this name declared" set.
 //
 // Matches ESLint's own normalizeConfigGlobal (lib/languages/js/source-code/
 // source-code.js): only the string `"off"` un-declares a global. Every other

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,40 +31,54 @@ type ConfigEntry struct {
 	Rules           Rules            `json:"rules"`
 	Plugins         []string         `json:"plugins,omitempty"`
 	Settings        Settings         `json:"settings,omitempty"`
-
-	filesPresent bool
 }
 
 // Settings represents shared settings accessible to rules
 type Settings map[string]interface{}
 
-// UnmarshalJSON records whether the `files` key was present so validation can
-// distinguish an omitted field from an explicit null/empty array.
-func (entry *ConfigEntry) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON rejects invalid explicit `files` values at the config boundary.
+// An omitted `files` field remains valid and means "use rslint's default
+// lintable extensions"; explicit null/empty arrays are invalid.
+func (config *RslintConfig) UnmarshalJSON(data []byte) error {
+	var rawEntries []json.RawMessage
+	if err := json.Unmarshal(data, &rawEntries); err != nil {
+		return err
+	}
+
 	type configEntryAlias ConfigEntry
+	entries := make(RslintConfig, 0, len(rawEntries))
+	for index, rawEntry := range rawEntries {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(rawEntry, &raw); err != nil {
+			return err
+		}
 
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
+		if rawFiles, ok := raw["files"]; ok {
+			var files []string
+			if err := json.Unmarshal(rawFiles, &files); err != nil {
+				return fmt.Errorf("config entry at index %d: key \"files\": expected value to be a non-empty array: %w", index, err)
+			}
+			if len(files) == 0 {
+				return fmt.Errorf("config entry at index %d: key \"files\": expected value to be a non-empty array", index)
+			}
+		}
+
+		var decoded configEntryAlias
+		if err := json.Unmarshal(rawEntry, &decoded); err != nil {
+			return err
+		}
+		entries = append(entries, ConfigEntry(decoded))
 	}
 
-	var decoded configEntryAlias
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		return err
-	}
-
-	*entry = ConfigEntry(decoded)
-	if _, ok := raw["files"]; ok {
-		entry.filesPresent = true
-	}
+	*config = entries
 	return nil
 }
 
-// ValidateConfig checks config invariants that depend on preserving the
-// distinction between an omitted field and an explicitly-authored empty value.
+// ValidateConfig checks config invariants for configs constructed in Go. JSON
+// config ingress rejects explicit null/empty `files` during unmarshaling.
 func ValidateConfig(config RslintConfig) error {
 	for index, entry := range config {
-		if (entry.filesPresent || entry.Files != nil) && len(entry.Files) == 0 {
+		if entry.Files != nil && len(entry.Files) == 0 {
 			return fmt.Errorf("config entry at index %d: key \"files\": expected value to be a non-empty array", index)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -30,10 +31,45 @@ type ConfigEntry struct {
 	Rules           Rules            `json:"rules"`
 	Plugins         []string         `json:"plugins,omitempty"`
 	Settings        Settings         `json:"settings,omitempty"`
+
+	filesPresent bool
 }
 
 // Settings represents shared settings accessible to rules
 type Settings map[string]interface{}
+
+// UnmarshalJSON records whether the `files` key was present so validation can
+// distinguish an omitted field from an explicit null/empty array.
+func (entry *ConfigEntry) UnmarshalJSON(data []byte) error {
+	type configEntryAlias ConfigEntry
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var decoded configEntryAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	*entry = ConfigEntry(decoded)
+	if _, ok := raw["files"]; ok {
+		entry.filesPresent = true
+	}
+	return nil
+}
+
+// ValidateConfig checks config invariants that depend on preserving the
+// distinction between an omitted field and an explicitly-authored empty value.
+func ValidateConfig(config RslintConfig) error {
+	for index, entry := range config {
+		if (entry.filesPresent || entry.Files != nil) && len(entry.Files) == 0 {
+			return fmt.Errorf("config entry at index %d: key \"files\": expected value to be a non-empty array", index)
+		}
+	}
+	return nil
+}
 
 // LanguageOptions contains language-specific configuration options.
 type LanguageOptions struct {
@@ -480,7 +516,7 @@ func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *Merged
 // isGlobalIgnoreEntry returns true if the entry is a global ignore entry
 // (has only ignores, no other fields).
 func isGlobalIgnoreEntry(entry ConfigEntry) bool {
-	return len(entry.Files) == 0 &&
+	return entry.Files == nil &&
 		len(entry.Rules) == 0 &&
 		len(entry.Plugins) == 0 &&
 		entry.Settings == nil &&

--- a/internal/config/config_discovery.go
+++ b/internal/config/config_discovery.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 )
 
 // FindNearestConfig finds the config whose configDirectory is the nearest
@@ -9,11 +10,17 @@ import (
 // matching configDirectory, mirroring ESLint v10's per-file config lookup.
 // Returns the configDirectory and the config, or ("", nil) if no config matches.
 func FindNearestConfig(filePath string, configMap map[string]RslintConfig) (string, RslintConfig) {
+	return FindNearestConfigWithCaseSensitivity(filePath, configMap, true)
+}
+
+// FindNearestConfigWithCaseSensitivity applies the same nearest-ancestor
+// lookup using the filesystem's path comparison semantics.
+func FindNearestConfigWithCaseSensitivity(filePath string, configMap map[string]RslintConfig, useCaseSensitive bool) (string, RslintConfig) {
 	bestDir := ""
 	var bestConfig RslintConfig
 
 	for configDir, cfg := range configMap {
-		if tspath.StartsWithDirectory(filePath, configDir, true) {
+		if tspath.StartsWithDirectory(filePath, configDir, useCaseSensitive) {
 			if len(configDir) > len(bestDir) {
 				bestDir = configDir
 				bestConfig = cfg
@@ -22,4 +29,17 @@ func FindNearestConfig(filePath string, configMap map[string]RslintConfig) (stri
 	}
 
 	return bestDir, bestConfig
+}
+
+// FindNearestConfigWithFS applies filesystem case and realpath semantics. It
+// first preserves a caller's lexical config-root alias when one matches, then
+// falls back to physical config roots for targets expressed through another
+// alias of the same directory.
+func FindNearestConfigWithFS(filePath string, configMap map[string]RslintConfig, fsys vfs.FS) (string, RslintConfig) {
+	index := newConfigDirectoryIndex(configMap, fsys)
+	configDir, ok := index.nearestConfig(filePath)
+	if !ok {
+		return "", nil
+	}
+	return configDir, configMap[configDir]
 }

--- a/internal/config/config_discovery.go
+++ b/internal/config/config_discovery.go
@@ -5,41 +5,115 @@ import (
 	"github.com/microsoft/typescript-go/shim/vfs"
 )
 
-// FindNearestConfig finds the config whose configDirectory is the nearest
-// ancestor of (or exact match for) filePath. It picks the deepest (longest)
-// matching configDirectory, mirroring ESLint v10's per-file config lookup.
-// Returns the configDirectory and the config, or ("", nil) if no config matches.
-func FindNearestConfig(filePath string, configMap map[string]RslintConfig) (string, RslintConfig) {
-	return FindNearestConfigWithCaseSensitivity(filePath, configMap, true)
+// ConfigOwnerResolver snapshots an already-loaded config catalog and resolves
+// which config object governs a runtime file path. It never discovers, reads,
+// or parses config files. Construction is linear in config count. Each lookup
+// tries lexical ancestors, including verified native case aliases, and consults
+// realpath ancestry only when no lexical owner exists.
+type ConfigOwnerResolver struct {
+	configMap map[string]RslintConfig
+	index     *configDirectoryIndex
 }
 
-// FindNearestConfigWithCaseSensitivity applies the same nearest-ancestor
-// lookup using the filesystem's path comparison semantics.
-func FindNearestConfigWithCaseSensitivity(filePath string, configMap map[string]RslintConfig, useCaseSensitive bool) (string, RslintConfig) {
-	bestDir := ""
-	var bestConfig RslintConfig
-
-	for configDir, cfg := range configMap {
-		if tspath.StartsWithDirectory(filePath, configDir, useCaseSensitive) {
-			if len(configDir) > len(bestDir) {
-				bestDir = configDir
-				bestConfig = cfg
-			}
-		}
+func NewConfigOwnerResolver(configMap map[string]RslintConfig, fsys vfs.FS) *ConfigOwnerResolver {
+	configSnapshot := make(map[string]RslintConfig, len(configMap))
+	for configDir, entries := range configMap {
+		configSnapshot[configDir] = entries
 	}
-
-	return bestDir, bestConfig
+	return &ConfigOwnerResolver{
+		configMap: configSnapshot,
+		index:     newConfigDirectoryIndex(configSnapshot, fsys),
+	}
 }
 
-// FindNearestConfigWithFS applies filesystem case and realpath semantics. It
-// first preserves a caller's lexical config-root alias when one matches, then
-// falls back to physical config roots for targets expressed through another
-// alias of the same directory.
-func FindNearestConfigWithFS(filePath string, configMap map[string]RslintConfig, fsys vfs.FS) (string, RslintConfig) {
-	index := newConfigDirectoryIndex(configMap, fsys)
-	configDir, ok := index.nearestConfig(filePath)
+func (resolver *ConfigOwnerResolver) Resolve(filePath string) (string, RslintConfig) {
+	if resolver == nil || resolver.index == nil {
+		return "", nil
+	}
+	configDir, ok := resolver.index.nearestConfig(filePath)
 	if !ok {
 		return "", nil
 	}
-	return configDir, configMap[configDir]
+	return configDir, resolver.configMap[configDir]
+}
+
+// ResolveConfigPathSpace returns the physical path pair used for files and
+// ignores matching. It preserves the file's path relative to the authored
+// config directory, then anchors both paths on the config directory's realpath.
+// Lexical and symlink aliases therefore share one matching space without
+// case-folding distinct path identities.
+func ResolveConfigPathSpace(filePath string, configDir string, fsys vfs.FS) (string, string) {
+	return ResolveConfigPathSpaceWithCanonical(filePath, "", configDir, fsys)
+}
+
+// ResolveConfigPathSpaceWithCanonical is ResolveConfigPathSpace with an
+// optional physical file identity already established by target discovery.
+func ResolveConfigPathSpaceWithCanonical(filePath string, canonicalPath string, configDir string, fsys vfs.FS) (string, string) {
+	filePath = tspath.NormalizePath(filePath)
+	configDir = tspath.NormalizePath(configDir)
+	physicalConfigDir := configDir
+	if fsys != nil {
+		if realPath := fsys.Realpath(configDir); realPath != "" {
+			physicalConfigDir = tspath.NormalizePath(realPath)
+		}
+	}
+
+	return resolveConfigPathSpace(filePath, canonicalPath, configDir, physicalConfigDir, fsys), physicalConfigDir
+}
+
+func resolveConfigPathSpace(
+	filePath string,
+	canonicalPath string,
+	configDir string,
+	physicalConfigDir string,
+	fsys vfs.FS,
+) string {
+	if relative, ok := relativeConfigPath(filePath, configDir, true); ok {
+		return tspath.ResolvePath(physicalConfigDir, relative)
+	}
+	if relative, ok := relativeConfigPath(filePath, configDir, false); ok && fsys != nil {
+		aliasRoot := filePath
+		for remaining := relative; remaining != ""; remaining = tspath.GetDirectoryPath(remaining) {
+			aliasRoot = tspath.GetDirectoryPath(aliasRoot)
+		}
+		if realRoot := fsys.Realpath(aliasRoot); realRoot != "" &&
+			tspath.ComparePaths(
+				tspath.NormalizePath(realRoot),
+				physicalConfigDir,
+				tspath.ComparePathsOptions{UseCaseSensitiveFileNames: true},
+			) == 0 {
+			return tspath.ResolvePath(physicalConfigDir, relative)
+		}
+	}
+
+	physicalFilePath := ""
+	if canonicalPath != "" {
+		physicalFilePath = tspath.NormalizePath(canonicalPath)
+	}
+	if physicalFilePath == "" {
+		physicalFilePath = filePath
+		if fsys != nil {
+			if realPath := fsys.Realpath(filePath); realPath != "" {
+				physicalFilePath = tspath.NormalizePath(realPath)
+			}
+		}
+	}
+	if relative, ok := relativeConfigPath(physicalFilePath, physicalConfigDir, true); ok {
+		return tspath.ResolvePath(physicalConfigDir, relative)
+	}
+	return physicalFilePath
+}
+
+func relativeConfigPath(filePath string, configDir string, useCaseSensitive bool) (string, bool) {
+	options := tspath.ComparePathsOptions{
+		CurrentDirectory:          configDir,
+		UseCaseSensitiveFileNames: useCaseSensitive,
+	}
+	if tspath.ComparePaths(filePath, configDir, options) == 0 {
+		return "", true
+	}
+	if !tspath.StartsWithDirectory(filePath, configDir, useCaseSensitive) {
+		return "", false
+	}
+	return tspath.GetRelativePathFromDirectory(configDir, filePath, options), true
 }

--- a/internal/config/config_discovery_test.go
+++ b/internal/config/config_discovery_test.go
@@ -2,14 +2,175 @@ package config
 
 import (
 	"testing"
+
+	"github.com/microsoft/typescript-go/shim/vfs"
 )
 
-func TestFindNearestConfig_DirectMatch(t *testing.T) {
+type configPathSpaceFS struct {
+	vfs.FS
+	realPaths     map[string]string
+	caseSensitive bool
+}
+
+func (fs *configPathSpaceFS) UseCaseSensitiveFileNames() bool { return fs.caseSensitive }
+func (fs *configPathSpaceFS) Realpath(filePath string) string {
+	if realPath := fs.realPaths[filePath]; realPath != "" {
+		return realPath
+	}
+	return filePath
+}
+
+func resolveConfigOwner(filePath string, configMap map[string]RslintConfig) (string, RslintConfig) {
+	return NewConfigOwnerResolver(configMap, nil).Resolve(filePath)
+}
+
+func TestResolveConfigPathSpace(t *testing.T) {
+	t.Run("symlink aliases use the physical config root", func(t *testing.T) {
+		fs := &configPathSpaceFS{
+			caseSensitive: true,
+			realPaths: map[string]string{
+				"/alias":          "/real",
+				"/alias/src/a.ts": "/real/src/a.ts",
+				"/real/src/a.ts":  "/real/src/a.ts",
+			},
+		}
+		for _, filePath := range []string{"/alias/src/a.ts", "/real/src/a.ts"} {
+			matchFile, matchDir := ResolveConfigPathSpace(filePath, "/alias", fs)
+			if matchFile != "/real/src/a.ts" || matchDir != "/real" {
+				t.Fatalf("ResolveConfigPathSpace(%q) = (%q, %q)", filePath, matchFile, matchDir)
+			}
+		}
+	})
+
+	t.Run("realpath-normalized casing retains one matching space", func(t *testing.T) {
+		fs := &configPathSpaceFS{
+			caseSensitive: false,
+			realPaths: map[string]string{
+				"C:/Repo":              "C:/Repo",
+				"c:/repo/src/index.ts": "C:/Repo/src/index.ts",
+			},
+		}
+		matchFile, matchDir := ResolveConfigPathSpace("c:/repo/src/index.ts", "C:/Repo", fs)
+		if matchFile != "C:/Repo/src/index.ts" || matchDir != "C:/Repo" {
+			t.Fatalf("case-insensitive path space = (%q, %q)", matchFile, matchDir)
+		}
+	})
+
+	t.Run("distinct physical casing is not collapsed by a global case flag", func(t *testing.T) {
+		fs := &configPathSpaceFS{
+			caseSensitive: false,
+			realPaths: map[string]string{
+				"C:/Repo":              "C:/Repo",
+				"c:/repo/src/index.ts": "c:/repo/src/index.ts",
+			},
+		}
+		matchFile, matchDir := ResolveConfigPathSpace("c:/repo/src/index.ts", "C:/Repo", fs)
+		if matchFile != "c:/repo/src/index.ts" || matchDir != "C:/Repo" {
+			t.Fatalf("distinct physical roots were collapsed: (%q, %q)", matchFile, matchDir)
+		}
+	})
+
+	t.Run("native case alias retains relative path when the file symlink escapes", func(t *testing.T) {
+		fs := &configPathSpaceFS{
+			caseSensitive: false,
+			realPaths: map[string]string{
+				"/repo/Project":         "/repo/Project",
+				"/repo/project":         "/repo/Project",
+				"/repo/project/link.ts": "/repo/shared.ts",
+			},
+		}
+		matchFile, matchDir := ResolveConfigPathSpace("/repo/project/link.ts", "/repo/Project", fs)
+		if matchFile != "/repo/Project/link.ts" || matchDir != "/repo/Project" {
+			t.Fatalf("native alias path space = (%q, %q)", matchFile, matchDir)
+		}
+	})
+}
+
+func TestConfigOwnerResolverUsesVerifiedNativeCaseAliasBeforeFileRealpath(t *testing.T) {
+	fs := &configPathSpaceFS{
+		caseSensitive: false,
+		realPaths: map[string]string{
+			"/repo/Project":         "/repo/Project",
+			"/repo/project":         "/repo/Project",
+			"/repo/project/link.ts": "/repo/shared.ts",
+		},
+	}
+	configMap := map[string]RslintConfig{
+		"/repo/Project": {{Rules: Rules{"rule": "error"}}},
+	}
+	dir, cfg := NewConfigOwnerResolver(configMap, fs).Resolve("/repo/project/link.ts")
+	if dir != "/repo/Project" || cfg == nil {
+		t.Fatalf("native case alias did not retain config owner: dir=%q cfg=%v", dir, cfg)
+	}
+}
+
+func TestConfigOwnerResolverPrefersLexicalHierarchy(t *testing.T) {
+	fs := &configPathSpaceFS{
+		caseSensitive: true,
+		realPaths: map[string]string{
+			"/alias/pkg": "/real/pkg",
+		},
+	}
+	configMap := map[string]RslintConfig{
+		"/real":      {{Rules: Rules{"root": "error"}}},
+		"/alias/pkg": {{Rules: Rules{"package": "error"}}},
+	}
+	resolver := NewConfigOwnerResolver(configMap, fs)
+
+	dir, cfg := resolver.Resolve("/real/pkg/src/a.ts")
+	if dir != "/real" || cfg == nil {
+		t.Fatalf("physical config replaced lexical owner: dir=%q cfg=%v", dir, cfg)
+	}
+
+	index := newConfigDirectoryIndex(configMap, fs)
+	children := index.childConfigDirs("/real")
+	if len(children) != 0 {
+		t.Fatalf("physical hierarchy created lexical child boundaries: %v", children)
+	}
+}
+
+func TestConfigOwnerResolverUsesPhysicalFallbackWithoutLexicalOwner(t *testing.T) {
+	fs := &configPathSpaceFS{
+		caseSensitive: true,
+		realPaths: map[string]string{
+			"/alias/pkg":         "/real/pkg",
+			"/outside/link/a.ts": "/real/pkg/src/a.ts",
+		},
+	}
+	configMap := map[string]RslintConfig{
+		"/alias/pkg": {{Rules: Rules{"package": "error"}}},
+	}
+
+	dir, cfg := NewConfigOwnerResolver(configMap, fs).Resolve("/outside/link/a.ts")
+	if dir != "/alias/pkg" || cfg == nil {
+		t.Fatalf("physical fallback did not resolve aliased config: dir=%q cfg=%v", dir, cfg)
+	}
+}
+
+func TestConfigOwnerResolverKeepsLexicalOwnerAcrossUnrelatedRealpathTree(t *testing.T) {
+	fs := &configPathSpaceFS{
+		caseSensitive: true,
+		realPaths: map[string]string{
+			"/lex/link/a.ts": "/physical/a.ts",
+		},
+	}
+	configMap := map[string]RslintConfig{
+		"/lex":      {{Rules: Rules{"lexical": "error"}}},
+		"/physical": {{Rules: Rules{"physical": "error"}}},
+	}
+
+	dir, cfg := NewConfigOwnerResolver(configMap, fs).Resolve("/lex/link/a.ts")
+	if dir != "/lex" || cfg == nil {
+		t.Fatalf("unrelated physical tree replaced lexical owner: dir=%q cfg=%v", dir, cfg)
+	}
+}
+
+func TestConfigOwnerResolver_DirectMatch(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"/project": {{Rules: Rules{"no-console": "error"}}},
 	}
 
-	dir, cfg := FindNearestConfig("/project/src/a.ts", configMap)
+	dir, cfg := resolveConfigOwner("/project/src/a.ts", configMap)
 	if dir != "/project" {
 		t.Errorf("Expected dir /project, got %s", dir)
 	}
@@ -19,12 +180,12 @@ func TestFindNearestConfig_DirectMatch(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_Subdirectory(t *testing.T) {
+func TestConfigOwnerResolver_Subdirectory(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"/project": {{Rules: Rules{"rule-a": "error"}}},
 	}
 
-	dir, cfg := FindNearestConfig("/project/src/deep/nested/file.ts", configMap)
+	dir, cfg := resolveConfigOwner("/project/src/deep/nested/file.ts", configMap)
 	if dir != "/project" {
 		t.Errorf("Expected dir /project, got %s", dir)
 	}
@@ -34,13 +195,13 @@ func TestFindNearestConfig_Subdirectory(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_NearestWins(t *testing.T) {
+func TestConfigOwnerResolver_NearestWins(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"/project":              {{Rules: Rules{"root-rule": "error"}}},
 		"/project/packages/foo": {{Rules: Rules{"foo-rule": "error"}}},
 	}
 
-	dir, cfg := FindNearestConfig("/project/packages/foo/src/a.ts", configMap)
+	dir, cfg := resolveConfigOwner("/project/packages/foo/src/a.ts", configMap)
 	if dir != "/project/packages/foo" {
 		t.Errorf("Expected nearest config dir /project/packages/foo, got %s", dir)
 	}
@@ -53,12 +214,12 @@ func TestFindNearestConfig_NearestWins(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_NoMatch(t *testing.T) {
+func TestConfigOwnerResolver_NoMatch(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"/project": {{Rules: Rules{"rule-a": "error"}}},
 	}
 
-	dir, cfg := FindNearestConfig("/other/file.ts", configMap)
+	dir, cfg := resolveConfigOwner("/other/file.ts", configMap)
 	if dir != "" {
 		t.Errorf("Expected empty dir, got %s", dir)
 	}
@@ -67,10 +228,10 @@ func TestFindNearestConfig_NoMatch(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_EmptyMap(t *testing.T) {
+func TestConfigOwnerResolver_EmptyMap(t *testing.T) {
 	configMap := map[string]RslintConfig{}
 
-	dir, cfg := FindNearestConfig("/project/a.ts", configMap)
+	dir, cfg := resolveConfigOwner("/project/a.ts", configMap)
 	if dir != "" {
 		t.Errorf("Expected empty dir, got %s", dir)
 	}
@@ -79,13 +240,31 @@ func TestFindNearestConfig_EmptyMap(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_FileInConfigDir(t *testing.T) {
+func TestConfigOwnerResolverSnapshotsDirectorySet(t *testing.T) {
+	configMap := map[string]RslintConfig{
+		"/project": {{Rules: Rules{"root-rule": "error"}}},
+	}
+	resolver := NewConfigOwnerResolver(configMap, nil)
+
+	delete(configMap, "/project")
+	configMap["/other"] = RslintConfig{{Rules: Rules{"other-rule": "error"}}}
+
+	dir, cfg := resolver.Resolve("/project/src/a.ts")
+	if dir != "/project" || cfg == nil {
+		t.Fatalf("resolver changed after caller map mutation: dir=%q cfg=%v", dir, cfg)
+	}
+	if dir, cfg := resolver.Resolve("/other/a.ts"); dir != "" || cfg != nil {
+		t.Fatalf("resolver observed a directory added after construction: dir=%q cfg=%v", dir, cfg)
+	}
+}
+
+func TestConfigOwnerResolver_FileInConfigDir(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"/project": {{Rules: Rules{"rule-a": "error"}}},
 	}
 
 	// File directly in config dir (not in a subdirectory)
-	dir, cfg := FindNearestConfig("/project/a.ts", configMap)
+	dir, cfg := resolveConfigOwner("/project/a.ts", configMap)
 	if dir != "/project" {
 		t.Errorf("Expected dir /project, got %s", dir)
 	}
@@ -95,14 +274,14 @@ func TestFindNearestConfig_FileInConfigDir(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_MultipleConfigsSameDepth(t *testing.T) {
+func TestConfigOwnerResolver_MultipleConfigsSameDepth(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"/project/packages/foo": {{Rules: Rules{"foo-rule": "error"}}},
 		"/project/packages/bar": {{Rules: Rules{"bar-rule": "error"}}},
 	}
 
 	// File in foo should get foo's config
-	dir, cfg := FindNearestConfig("/project/packages/foo/src/a.ts", configMap)
+	dir, cfg := resolveConfigOwner("/project/packages/foo/src/a.ts", configMap)
 	if dir != "/project/packages/foo" {
 		t.Errorf("Expected /project/packages/foo, got %s", dir)
 	}
@@ -115,7 +294,7 @@ func TestFindNearestConfig_MultipleConfigsSameDepth(t *testing.T) {
 	}
 
 	// File in bar should get bar's config
-	dir, cfg = FindNearestConfig("/project/packages/bar/src/b.ts", configMap)
+	dir, cfg = resolveConfigOwner("/project/packages/bar/src/b.ts", configMap)
 	if dir != "/project/packages/bar" {
 		t.Errorf("Expected /project/packages/bar, got %s", dir)
 	}
@@ -128,13 +307,13 @@ func TestFindNearestConfig_MultipleConfigsSameDepth(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_SimilarPrefixNoFalseMatch(t *testing.T) {
+func TestConfigOwnerResolver_SimilarPrefixNoFalseMatch(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"/project/src": {{Rules: Rules{"rule-a": "error"}}},
 	}
 
 	// /project/src-other should NOT match /project/src
-	dir, cfg := FindNearestConfig("/project/src-other/a.ts", configMap)
+	dir, cfg := resolveConfigOwner("/project/src-other/a.ts", configMap)
 	if dir != "" {
 		t.Errorf("Expected no match for src-other, got dir %s", dir)
 	}
@@ -143,24 +322,19 @@ func TestFindNearestConfig_SimilarPrefixNoFalseMatch(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfigWithCaseSensitivity_CaseInsensitiveFilesystem(t *testing.T) {
+func TestConfigOwnerResolver_UsesExactCasing(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"C:/Repo":              {{Rules: Rules{"root": "error"}}},
 		"C:/Repo/Packages/App": {{Rules: Rules{"app": "error"}}},
 	}
 
-	dir, cfg := FindNearestConfigWithCaseSensitivity("c:/repo/packages/app/src/a.ts", configMap, false)
-	if dir != "C:/Repo/Packages/App" || cfg == nil {
-		t.Fatalf("expected case-insensitive nearest config, got dir=%q cfg=%v", dir, cfg)
-	}
-
-	dir, cfg = FindNearestConfigWithCaseSensitivity("c:/repo/packages/app/src/a.ts", configMap, true)
+	dir, cfg := resolveConfigOwner("c:/repo/packages/app/src/a.ts", configMap)
 	if dir != "" || cfg != nil {
-		t.Fatalf("case-sensitive lookup should not match different casing, got dir=%q cfg=%v", dir, cfg)
+		t.Fatalf("exact lookup should not match different casing, got dir=%q cfg=%v", dir, cfg)
 	}
 }
 
-func TestFindNearestConfig_NestedConfigDirs(t *testing.T) {
+func TestConfigOwnerResolver_NestedConfigDirs(t *testing.T) {
 	// /project/src and /project/src/components both have configs.
 	// File in components should pick the deeper config.
 	configMap := map[string]RslintConfig{
@@ -168,7 +342,7 @@ func TestFindNearestConfig_NestedConfigDirs(t *testing.T) {
 		"/project/src/components": {{Rules: Rules{"components-rule": "error"}}},
 	}
 
-	dir, cfg := FindNearestConfig("/project/src/components/Button.tsx", configMap)
+	dir, cfg := resolveConfigOwner("/project/src/components/Button.tsx", configMap)
 	if dir != "/project/src/components" {
 		t.Errorf("Expected /project/src/components, got %s", dir)
 	}
@@ -181,7 +355,7 @@ func TestFindNearestConfig_NestedConfigDirs(t *testing.T) {
 	}
 
 	// File in src (not components) should pick src config
-	dir, cfg = FindNearestConfig("/project/src/utils.ts", configMap)
+	dir, cfg = resolveConfigOwner("/project/src/utils.ts", configMap)
 	if dir != "/project/src" {
 		t.Errorf("Expected /project/src, got %s", dir)
 	}
@@ -190,12 +364,12 @@ func TestFindNearestConfig_NestedConfigDirs(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_RootConfig(t *testing.T) {
+func TestConfigOwnerResolver_RootConfig(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"/": {{Rules: Rules{"root-rule": "error"}}},
 	}
 
-	dir, cfg := FindNearestConfig("/any/deep/path/file.ts", configMap)
+	dir, cfg := resolveConfigOwner("/any/deep/path/file.ts", configMap)
 	if dir != "/" {
 		t.Errorf("Expected /, got %s", dir)
 	}
@@ -205,13 +379,13 @@ func TestFindNearestConfig_RootConfig(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_FileAboveAllConfigs(t *testing.T) {
+func TestConfigOwnerResolver_FileAboveAllConfigs(t *testing.T) {
 	// Config only in a subdirectory; file in parent should not match
 	configMap := map[string]RslintConfig{
 		"/project/packages/foo": {{Rules: Rules{"foo-rule": "error"}}},
 	}
 
-	dir, cfg := FindNearestConfig("/project/root-file.ts", configMap)
+	dir, cfg := resolveConfigOwner("/project/root-file.ts", configMap)
 	if dir != "" {
 		t.Errorf("Expected no match, got %s", dir)
 	}
@@ -220,12 +394,12 @@ func TestFindNearestConfig_FileAboveAllConfigs(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_TrailingSlashInKey(t *testing.T) {
+func TestConfigOwnerResolver_TrailingSlashInKey(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"/project/": {{Rules: Rules{"rule-a": "error"}}},
 	}
 
-	dir, cfg := FindNearestConfig("/project/src/a.ts", configMap)
+	dir, cfg := resolveConfigOwner("/project/src/a.ts", configMap)
 	if dir != "/project/" {
 		t.Errorf("Expected /project/, got %s", dir)
 	}
@@ -235,21 +409,21 @@ func TestFindNearestConfig_TrailingSlashInKey(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_EmptyStringKey(t *testing.T) {
+func TestConfigOwnerResolver_EmptyStringKey(t *testing.T) {
 	configMap := map[string]RslintConfig{
 		"": {{Rules: Rules{"rule-a": "error"}}},
 	}
 
 	// Empty string key should not match anything
-	dir, cfg := FindNearestConfig("/project/a.ts", configMap)
+	dir, cfg := resolveConfigOwner("/project/a.ts", configMap)
 	if dir != "" || cfg != nil {
 		t.Errorf("Expected no match for empty key, got dir=%q cfg=%v", dir, cfg)
 	}
 }
 
-func TestFindNearestConfig_NilMap(t *testing.T) {
+func TestConfigOwnerResolver_NilMap(t *testing.T) {
 	// nil map should not panic and should return no match
-	dir, cfg := FindNearestConfig("/project/a.ts", nil)
+	dir, cfg := resolveConfigOwner("/project/a.ts", nil)
 	if dir != "" {
 		t.Errorf("Expected empty dir for nil map, got %s", dir)
 	}
@@ -258,14 +432,14 @@ func TestFindNearestConfig_NilMap(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_FilePathEqualsConfigDir(t *testing.T) {
+func TestConfigOwnerResolver_FilePathEqualsConfigDir(t *testing.T) {
 	// filePath == configDir: StartsWithDirectory returns false,
 	// so the file should NOT match (it's not "inside" the directory)
 	configMap := map[string]RslintConfig{
 		"/project/src": {{Rules: Rules{"rule-a": "error"}}},
 	}
 
-	dir, cfg := FindNearestConfig("/project/src", configMap)
+	dir, cfg := resolveConfigOwner("/project/src", configMap)
 	if dir != "" {
 		t.Errorf("Expected no match when filePath == configDir, got %s", dir)
 	}
@@ -274,14 +448,14 @@ func TestFindNearestConfig_FilePathEqualsConfigDir(t *testing.T) {
 	}
 }
 
-func TestFindNearestConfig_SingleConfigFallback(t *testing.T) {
+func TestConfigOwnerResolver_SingleConfigFallback(t *testing.T) {
 	// Single config that matches — should always work for files under it
 	configMap := map[string]RslintConfig{
 		"/monorepo": {{Rules: Rules{"rule-a": "error"}}},
 	}
 
 	// File deep under config dir
-	dir, cfg := FindNearestConfig("/monorepo/packages/foo/src/deep/file.ts", configMap)
+	dir, cfg := resolveConfigOwner("/monorepo/packages/foo/src/deep/file.ts", configMap)
 	if dir != "/monorepo" {
 		t.Errorf("Expected /monorepo, got %s", dir)
 	}
@@ -291,7 +465,7 @@ func TestFindNearestConfig_SingleConfigFallback(t *testing.T) {
 	}
 
 	// File NOT under config dir
-	_, cfg = FindNearestConfig("/other-repo/file.ts", configMap)
+	_, cfg = resolveConfigOwner("/other-repo/file.ts", configMap)
 	if cfg != nil {
 		t.Error("Expected nil for file outside config dir")
 	}

--- a/internal/config/config_discovery_test.go
+++ b/internal/config/config_discovery_test.go
@@ -143,6 +143,23 @@ func TestFindNearestConfig_SimilarPrefixNoFalseMatch(t *testing.T) {
 	}
 }
 
+func TestFindNearestConfigWithCaseSensitivity_CaseInsensitiveFilesystem(t *testing.T) {
+	configMap := map[string]RslintConfig{
+		"C:/Repo":              {{Rules: Rules{"root": "error"}}},
+		"C:/Repo/Packages/App": {{Rules: Rules{"app": "error"}}},
+	}
+
+	dir, cfg := FindNearestConfigWithCaseSensitivity("c:/repo/packages/app/src/a.ts", configMap, false)
+	if dir != "C:/Repo/Packages/App" || cfg == nil {
+		t.Fatalf("expected case-insensitive nearest config, got dir=%q cfg=%v", dir, cfg)
+	}
+
+	dir, cfg = FindNearestConfigWithCaseSensitivity("c:/repo/packages/app/src/a.ts", configMap, true)
+	if dir != "" || cfg != nil {
+		t.Fatalf("case-sensitive lookup should not match different casing, got dir=%q cfg=%v", dir, cfg)
+	}
+}
+
 func TestFindNearestConfig_NestedConfigDirs(t *testing.T) {
 	// /project/src and /project/src/components both have configs.
 	// File in components should pick the deeper config.

--- a/internal/config/config_init.go
+++ b/internal/config/config_init.go
@@ -142,8 +142,8 @@ func isESMPackage(directory string) bool {
 func InitDefaultConfig(directory string) error {
 	// Check if JS/TS config already exists
 	existingConfigs := []string{
-		"rslint.config.ts", "rslint.config.mts",
-		"rslint.config.js", "rslint.config.mjs",
+		"rslint.config.js", "rslint.config.mjs", "rslint.config.cjs",
+		"rslint.config.ts", "rslint.config.mts", "rslint.config.cts",
 	}
 	for _, name := range existingConfigs {
 		p := filepath.Join(directory, name)

--- a/internal/config/config_init.go
+++ b/internal/config/config_init.go
@@ -204,8 +204,8 @@ func migrateJSONConfig(directory, jsonFileName string) error {
 	// Migration accepts legacy JSON configs that the lint-time loader now
 	// rejects, such as explicit `files: []`, and drops unsupported/empty
 	// fields while generating the JS/TS config below.
-	var legacyEntries []ConfigEntry
-	if err := utils.ParseJSONC(data, &legacyEntries); err != nil {
+	legacyEntries, err := parseLegacyConfigEntries(data)
+	if err != nil {
 		return fmt.Errorf("failed to parse %s: %w", jsonFileName, err)
 	}
 	entries := RslintConfig(legacyEntries)
@@ -274,6 +274,36 @@ func migrateJSONConfig(directory, jsonFileName string) error {
 
 	fmt.Printf("Migrated %s → %s\n", jsonFileName, configName)
 	return nil
+}
+
+func parseLegacyConfigEntries(data []byte) ([]ConfigEntry, error) {
+	var rawEntries []json.RawMessage
+	if err := utils.ParseJSONC(data, &rawEntries); err != nil {
+		return nil, err
+	}
+	entries := make([]ConfigEntry, 0, len(rawEntries))
+	for _, rawEntry := range rawEntries {
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(rawEntry, &object); err != nil {
+			return nil, err
+		}
+		if rawFiles, ok := object["files"]; ok {
+			var selectors []json.RawMessage
+			if err := json.Unmarshal(rawFiles, &selectors); err == nil && len(selectors) == 0 {
+				delete(object, "files")
+			}
+		}
+		cleaned, err := json.Marshal(object)
+		if err != nil {
+			return nil, err
+		}
+		var entry ConfigEntry
+		if err := json.Unmarshal(cleaned, &entry); err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
 }
 
 // extractGlobalIgnores checks if there is exactly one non-global-ignore entry
@@ -493,8 +523,8 @@ func buildOverrideFields(entry ConfigEntry, remainingRules Rules, hasTS bool) st
 	var fields []string
 
 	// files (skip empty arrays)
-	if len(entry.Files) > 0 {
-		fields = append(fields, "    files: "+formatStringArray(entry.Files))
+	if hasFileSelectors(entry) {
+		fields = append(fields, "    files: "+formatFilesSelectors(entry))
 	}
 
 	// ignores
@@ -554,6 +584,24 @@ func formatStringArray(arr []string) string {
 	}
 	buf.WriteString("    ]")
 	return buf.String()
+}
+
+func formatFilesSelectors(entry ConfigEntry) string {
+	parts := make([]string, 0, len(entry.Files)+len(entry.FilePatternGroups))
+	for _, pattern := range entry.Files {
+		parts = append(parts, "'"+escapeJSString(pattern)+"'")
+	}
+	for _, group := range entry.FilePatternGroups {
+		groupParts := make([]string, len(group))
+		for i, pattern := range group {
+			groupParts[i] = "'" + escapeJSString(pattern) + "'"
+		}
+		parts = append(parts, "["+strings.Join(groupParts, ", ")+"]")
+	}
+	if len(parts) <= 3 {
+		return "[" + strings.Join(parts, ", ") + "]"
+	}
+	return "[\n      " + strings.Join(parts, ",\n      ") + ",\n    ]"
 }
 
 // formatRulesBlock formats the rules as a JS object block.

--- a/internal/config/config_init.go
+++ b/internal/config/config_init.go
@@ -45,25 +45,25 @@ export default defineConfig([
 
 // jsRecommendedRules contains all rules in js.configs.recommended with their severities.
 var jsRecommendedRules = map[string]string{
-	"constructor-super":            "error",
-	"for-direction":                "error",
-	"getter-return":                "error",
-	"no-async-promise-executor":    "error",
-	"no-case-declarations":         "error",
-	"no-class-assign":              "error",
-	"no-compare-neg-zero":          "error",
-	"no-cond-assign":               "error",
-	"no-const-assign":              "error",
+	"constructor-super":             "error",
+	"for-direction":                 "error",
+	"getter-return":                 "error",
+	"no-async-promise-executor":     "error",
+	"no-case-declarations":          "error",
+	"no-class-assign":               "error",
+	"no-compare-neg-zero":           "error",
+	"no-cond-assign":                "error",
+	"no-const-assign":               "error",
 	"no-constant-binary-expression": "error",
-	"no-constant-condition":        "error",
-	"no-debugger":                  "error",
-	"no-dupe-args":                 "error",
-	"no-dupe-keys":                 "error",
-	"no-duplicate-case":            "error",
-	"no-empty":                     "error",
-	"no-empty-pattern":             "error",
-	"no-loss-of-precision":         "error",
-	"no-sparse-arrays":             "error",
+	"no-constant-condition":         "error",
+	"no-debugger":                   "error",
+	"no-dupe-args":                  "error",
+	"no-dupe-keys":                  "error",
+	"no-duplicate-case":             "error",
+	"no-empty":                      "error",
+	"no-empty-pattern":              "error",
+	"no-loss-of-precision":          "error",
+	"no-sparse-arrays":              "error",
 }
 
 // tsRecommendedRules contains all rules in ts.configs.recommended with their severities.
@@ -79,42 +79,42 @@ var tsRecommendedRules = map[string]string{
 	"no-array-constructor": "off",
 	"no-unused-vars":       "off",
 	// Core rules kept
-	"for-direction":                "error",
-	"no-async-promise-executor":    "error",
-	"no-case-declarations":         "error",
-	"no-compare-neg-zero":          "error",
-	"no-cond-assign":               "error",
+	"for-direction":                 "error",
+	"no-async-promise-executor":     "error",
+	"no-case-declarations":          "error",
+	"no-compare-neg-zero":           "error",
+	"no-cond-assign":                "error",
 	"no-constant-binary-expression": "error",
-	"no-constant-condition":        "error",
-	"no-debugger":                  "error",
-	"no-duplicate-case":            "error",
-	"no-empty":                     "error",
-	"no-empty-pattern":             "error",
-	"no-loss-of-precision":         "error",
-	"no-sparse-arrays":             "error",
+	"no-constant-condition":         "error",
+	"no-debugger":                   "error",
+	"no-duplicate-case":             "error",
+	"no-empty":                      "error",
+	"no-empty-pattern":              "error",
+	"no-loss-of-precision":          "error",
+	"no-sparse-arrays":              "error",
 	// TypeScript plugin rules
-	"@typescript-eslint/ban-ts-comment":                  "error",
-	"@typescript-eslint/no-array-constructor":             "error",
-	"@typescript-eslint/no-duplicate-enum-values":         "error",
-	"@typescript-eslint/no-explicit-any":                  "error",
-	"@typescript-eslint/no-extra-non-null-assertion":      "error",
-	"@typescript-eslint/no-misused-new":                   "error",
-	"@typescript-eslint/no-namespace":                     "error",
+	"@typescript-eslint/ban-ts-comment":                      "error",
+	"@typescript-eslint/no-array-constructor":                "error",
+	"@typescript-eslint/no-duplicate-enum-values":            "error",
+	"@typescript-eslint/no-explicit-any":                     "error",
+	"@typescript-eslint/no-extra-non-null-assertion":         "error",
+	"@typescript-eslint/no-misused-new":                      "error",
+	"@typescript-eslint/no-namespace":                        "error",
 	"@typescript-eslint/no-non-null-asserted-optional-chain": "error",
-	"@typescript-eslint/no-require-imports":               "error",
-	"@typescript-eslint/no-this-alias":                    "error",
-	"@typescript-eslint/no-unused-vars":                   "error",
-	"@typescript-eslint/prefer-as-const":                  "error",
-	"@typescript-eslint/prefer-namespace-keyword":         "error",
-	"@typescript-eslint/triple-slash-reference":           "error",
+	"@typescript-eslint/no-require-imports":                  "error",
+	"@typescript-eslint/no-this-alias":                       "error",
+	"@typescript-eslint/no-unused-vars":                      "error",
+	"@typescript-eslint/prefer-as-const":                     "error",
+	"@typescript-eslint/prefer-namespace-keyword":            "error",
+	"@typescript-eslint/triple-slash-reference":              "error",
 }
 
 // reactRecommendedRules contains all rules in reactPlugin.configs.recommended with their severities.
 var reactRecommendedRules = map[string]string{
-	"react/jsx-uses-react":    "error",
-	"react/jsx-uses-vars":     "error",
+	"react/jsx-uses-react":     "error",
+	"react/jsx-uses-vars":      "error",
 	"react/react-in-jsx-scope": "error",
-	"react/no-unsafe":         "off",
+	"react/no-unsafe":          "off",
 }
 
 // importRecommendedRules is empty — all import plugin recommended rules are not yet implemented.
@@ -201,10 +201,14 @@ func migrateJSONConfig(directory, jsonFileName string) error {
 		return fmt.Errorf("failed to read %s: %w", jsonFileName, err)
 	}
 
-	var entries RslintConfig
-	if err := utils.ParseJSONC(data, &entries); err != nil {
+	// Migration accepts legacy JSON configs that the lint-time loader now
+	// rejects, such as explicit `files: []`, and drops unsupported/empty
+	// fields while generating the JS/TS config below.
+	var legacyEntries []ConfigEntry
+	if err := utils.ParseJSONC(data, &legacyEntries); err != nil {
 		return fmt.Errorf("failed to parse %s: %w", jsonFileName, err)
 	}
+	entries := RslintConfig(legacyEntries)
 
 	if len(entries) == 0 {
 		return fmt.Errorf("%s is empty", jsonFileName)
@@ -438,7 +442,7 @@ func deduplicateRules(userRules Rules, presetRules map[string]string) Rules {
 			remaining[name] = value
 			continue
 		}
-			userSeverity := extractSeverity(value)
+		userSeverity := extractSeverity(value)
 		if userSeverity == "" {
 			// Array form (e.g., ["warn", { ... }]) — always keep
 			remaining[name] = value

--- a/internal/config/config_init.go
+++ b/internal/config/config_init.go
@@ -136,14 +136,14 @@ func isESMPackage(directory string) bool {
 }
 
 // InitDefaultConfig initializes a default config file in the directory.
-//   - JS/TS config already exists → error
+//   - Automatically discoverable JS/TS config exists → error
 //   - Only JSON/JSONC config exists → migrate to JS/TS config and delete JSON
-//   - Nothing exists → create default JS/TS config
+//   - Otherwise → create a default discoverable JS/TS config
 func InitDefaultConfig(directory string) error {
-	// Check if JS/TS config already exists
+	// Check if an automatically discoverable JS/TS config already exists.
 	existingConfigs := []string{
-		"rslint.config.js", "rslint.config.mjs", "rslint.config.cjs",
-		"rslint.config.ts", "rslint.config.mts", "rslint.config.cts",
+		"rslint.config.js", "rslint.config.mjs",
+		"rslint.config.ts", "rslint.config.mts",
 	}
 	for _, name := range existingConfigs {
 		p := filepath.Join(directory, name)

--- a/internal/config/config_init_test.go
+++ b/internal/config/config_init_test.go
@@ -62,10 +62,8 @@ func TestInitDefaultConfig_AlreadyExists(t *testing.T) {
 	for _, name := range []string{
 		"rslint.config.js",
 		"rslint.config.mjs",
-		"rslint.config.cjs",
 		"rslint.config.ts",
 		"rslint.config.mts",
-		"rslint.config.cts",
 	} {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -76,6 +74,21 @@ func TestInitDefaultConfig_AlreadyExists(t *testing.T) {
 				t.Fatal("expected error when a JS/TS config already exists")
 			}
 			assertContains(t, err.Error(), "config file already exists")
+		})
+	}
+}
+
+func TestInitDefaultConfig_NonDiscoverableJSConfigDoesNotBlock(t *testing.T) {
+	for _, name := range []string{"rslint.config.cjs", "rslint.config.cts"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, name), "")
+
+			if err := InitDefaultConfig(dir); err != nil {
+				t.Fatalf("non-discoverable config should not block initialization: %v", err)
+			}
+			assertFileExists(t, filepath.Join(dir, "rslint.config.mjs"))
+			assertFileExists(t, filepath.Join(dir, name))
 		})
 	}
 }

--- a/internal/config/config_init_test.go
+++ b/internal/config/config_init_test.go
@@ -1265,6 +1265,17 @@ func TestMigrate_RulesOrderDeterministic(t *testing.T) {
 	}
 }
 
+func TestBuildOverrideFieldsPreservesFilesAndGroups(t *testing.T) {
+	entry := ConfigEntry{
+		Files:             []string{"special.ts"},
+		FilePatternGroups: [][]string{{"**/*.js", "!**/*.test.js"}},
+	}
+	got := buildOverrideFields(entry, nil, false)
+	if !strings.Contains(got, "files: ['special.ts', ['**/*.js', '!**/*.test.js']]") {
+		t.Fatalf("expected mixed files selectors in generated override, got:\n%s", got)
+	}
+}
+
 func TestMigrate_EmptyIgnoresArray_Dropped(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "rslint.json"), `[{
@@ -1496,7 +1507,7 @@ func TestDeduplicateRules_AllMatch(t *testing.T) {
 
 func TestDeduplicateRules_NoneMatch(t *testing.T) {
 	user := Rules{
-		"no-console":                            "warn",
+		"no-console": "warn",
 		"@typescript-eslint/no-floating-promises": "warn",
 	}
 	result := deduplicateRules(user, tsRecommendedRules)
@@ -1507,9 +1518,9 @@ func TestDeduplicateRules_NoneMatch(t *testing.T) {
 
 func TestDeduplicateRules_Mixed(t *testing.T) {
 	user := Rules{
-		"@typescript-eslint/no-namespace":     "error", // match → strip
-		"@typescript-eslint/no-explicit-any":  "warn",  // differs → keep
-		"no-console":                          "warn",  // not in preset → keep
+		"@typescript-eslint/no-namespace":    "error", // match → strip
+		"@typescript-eslint/no-explicit-any": "warn",  // differs → keep
+		"no-console":                         "warn",  // not in preset → keep
 	}
 	result := deduplicateRules(user, tsRecommendedRules)
 	if len(result) != 2 {

--- a/internal/config/config_init_test.go
+++ b/internal/config/config_init_test.go
@@ -59,14 +59,25 @@ func TestInitDefaultConfig_JSProject_CJSPackage(t *testing.T) {
 }
 
 func TestInitDefaultConfig_AlreadyExists(t *testing.T) {
-	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "rslint.config.ts"), "")
+	for _, name := range []string{
+		"rslint.config.js",
+		"rslint.config.mjs",
+		"rslint.config.cjs",
+		"rslint.config.ts",
+		"rslint.config.mts",
+		"rslint.config.cts",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, name), "")
 
-	err := InitDefaultConfig(dir)
-	if err == nil {
-		t.Error("Expected error when JS/TS config already exists")
+			err := InitDefaultConfig(dir)
+			if err == nil {
+				t.Fatal("expected error when a JS/TS config already exists")
+			}
+			assertContains(t, err.Error(), "config file already exists")
+		})
 	}
-	assertContains(t, err.Error(), "config file already exists")
 }
 
 // --- Migration branch tests ---

--- a/internal/config/config_merge_test.go
+++ b/internal/config/config_merge_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -180,17 +182,79 @@ func TestGetConfigForFile_RulesShallowMerge(t *testing.T) {
 	}
 }
 
-func TestGetConfigForFile_SettingsShallowMerge(t *testing.T) {
+func TestGetConfigForFile_SeverityOnlyRuleOverridePreservesOptions(t *testing.T) {
+	for _, override := range []any{"warn", 1, []interface{}{float64(1)}} {
+		t.Run(fmt.Sprintf("%T_%v", override, override), func(t *testing.T) {
+			config := RslintConfig{
+				{Rules: Rules{"example": []interface{}{"error", map[string]interface{}{"mode": "strict"}, "tail"}}},
+				{Rules: Rules{"example": override}},
+			}
+
+			merged := config.GetConfigForFile("src/app.ts", "")
+			if merged == nil || merged.Rules["example"] == nil {
+				t.Fatal("expected merged example rule")
+			}
+			ruleConfig := merged.Rules["example"]
+			if ruleConfig.Level != "warn" {
+				t.Fatalf("severity = %q, want warn", ruleConfig.Level)
+			}
+			if len(ruleConfig.Options) != 2 || ruleConfig.Options[1] != "tail" {
+				t.Fatalf("severity-only override lost prior options: %#v", ruleConfig.Options)
+			}
+		})
+	}
+}
+
+func TestGetConfigForFile_NumericRuleSeverities(t *testing.T) {
+	config := RslintConfig{{Rules: Rules{
+		"off":   0,
+		"warn":  float64(1),
+		"error": uint8(2),
+	}}}
+
+	merged := config.GetConfigForFile("src/app.ts", "")
+	if merged == nil {
+		t.Fatal("expected merged config")
+	}
+	for name, want := range map[string]string{"off": "off", "warn": "warn", "error": "error"} {
+		if got := merged.Rules[name]; got == nil || got.Level != want {
+			t.Errorf("rule %q = %#v, want level %q", name, got, want)
+		}
+	}
+}
+
+func TestGetConfigForFile_NumericRuleOverrideWithOptionsReplacesOptions(t *testing.T) {
+	config := RslintConfig{
+		{Rules: Rules{"example": []interface{}{"error", "old", map[string]any{"keep": false}}}},
+		{Rules: Rules{"example": []interface{}{1, "new", true}}},
+	}
+
+	merged := config.GetConfigForFile("src/app.ts", "")
+	ruleConfig := merged.Rules["example"]
+	if ruleConfig.Level != "warn" {
+		t.Fatalf("severity = %q, want warn", ruleConfig.Level)
+	}
+	if !reflect.DeepEqual(ruleConfig.Options, []interface{}{"new", true}) {
+		t.Fatalf("explicit positional options were not replaced: %#v", ruleConfig.Options)
+	}
+}
+
+func TestGetConfigForFile_SettingsDeepMerge(t *testing.T) {
 	config := RslintConfig{
 		{
 			Settings: Settings{
 				"importResolver": "node",
-				"react":          "17",
+				"react": map[string]any{
+					"version": "17",
+					"pragma":  "h",
+				},
+				"extensions": []any{".js"},
 			},
 		},
 		{
 			Settings: Settings{
-				"react": "18",
+				"react":      map[string]any{"version": "18"},
+				"extensions": []any{".ts"},
 			},
 		},
 	}
@@ -204,8 +268,13 @@ func TestGetConfigForFile_SettingsShallowMerge(t *testing.T) {
 	if merged.Settings["importResolver"] != "node" {
 		t.Errorf("Expected importResolver to be 'node', got %v", merged.Settings["importResolver"])
 	}
-	if merged.Settings["react"] != "18" {
-		t.Errorf("Expected react to be '18' (overridden), got %v", merged.Settings["react"])
+	react, ok := merged.Settings["react"].(map[string]any)
+	if !ok || react["version"] != "18" || react["pragma"] != "h" {
+		t.Fatalf("nested settings were not deeply merged: %#v", merged.Settings["react"])
+	}
+	extensions, ok := merged.Settings["extensions"].([]any)
+	if !ok || len(extensions) != 1 || extensions[0] != ".ts" {
+		t.Fatalf("settings arrays should be replaced, got %#v", merged.Settings["extensions"])
 	}
 }
 
@@ -271,6 +340,26 @@ func TestMergeLanguageOptions(t *testing.T) {
 
 		if result.ParserOptions.ProjectService == nil || *result.ParserOptions.ProjectService != true {
 			t.Error("Expected ProjectService to be preserved from base")
+		}
+	})
+
+	t.Run("raw parser options are recursively merged", func(t *testing.T) {
+		base := &LanguageOptions{Raw: map[string]any{
+			"parserOptions": map[string]any{
+				"alpha": map[string]any{"one": float64(1), "two": float64(2)},
+			},
+		}}
+		override := &LanguageOptions{Raw: map[string]any{
+			"parserOptions": map[string]any{
+				"alpha": map[string]any{"one": float64(9)},
+			},
+		}}
+
+		result := mergeLanguageOptions(base, override)
+		parserOptions := result.Raw["parserOptions"].(map[string]any)
+		alpha := parserOptions["alpha"].(map[string]any)
+		if alpha["one"] != float64(9) || alpha["two"] != float64(2) {
+			t.Fatalf("raw parserOptions were not deeply merged: %#v", parserOptions)
 		}
 	})
 }

--- a/internal/config/config_merge_test.go
+++ b/internal/config/config_merge_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -286,8 +287,18 @@ func TestIsGlobalIgnoreEntry(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "ignores with name",
+			entry:    ConfigEntry{Name: "global ignores", Ignores: []string{"dist/**"}},
+			expected: true,
+		},
+		{
 			name:     "ignores with rules",
 			entry:    ConfigEntry{Ignores: []string{"dist/**"}, Rules: Rules{"no-debugger": "error"}},
+			expected: false,
+		},
+		{
+			name:     "ignores with empty rules",
+			entry:    ConfigEntry{Ignores: []string{"dist/**"}, Rules: Rules{}},
 			expected: false,
 		},
 		{
@@ -301,6 +312,11 @@ func TestIsGlobalIgnoreEntry(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "ignores with empty plugins",
+			entry:    ConfigEntry{Ignores: []string{"dist/**"}, Plugins: []string{}},
+			expected: false,
+		},
+		{
 			name:     "ignores with languageOptions",
 			entry:    ConfigEntry{Ignores: []string{"dist/**"}, LanguageOptions: &LanguageOptions{}},
 			expected: false,
@@ -308,6 +324,11 @@ func TestIsGlobalIgnoreEntry(t *testing.T) {
 		{
 			name:     "ignores with settings",
 			entry:    ConfigEntry{Ignores: []string{"dist/**"}, Settings: Settings{"key": "val"}},
+			expected: false,
+		},
+		{
+			name:     "ignores with empty settings",
+			entry:    ConfigEntry{Ignores: []string{"dist/**"}, Settings: Settings{}},
 			expected: false,
 		},
 		{
@@ -485,6 +506,46 @@ func TestGetConfigForFile_EmptyConfig(t *testing.T) {
 	merged := config.GetConfigForFile("src/app.ts", "")
 	if merged != nil {
 		t.Error("Expected nil for empty config (no entries)")
+	}
+}
+
+func TestConfigDecode_PreservesNonGlobalIgnoreObjectShape(t *testing.T) {
+	for _, raw := range []string{
+		`[{"ignores":["dist/**"],"rules":null}]`,
+		`[{"ignores":["dist/**"],"processor":"example"}]`,
+	} {
+		var cfg RslintConfig
+		if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+			t.Fatalf("decode %s: %v", raw, err)
+		}
+		if len(cfg) != 1 || isGlobalIgnoreEntry(cfg[0]) {
+			t.Fatalf("entry with another authored key must not become a global ignore: %#v", cfg)
+		}
+		if ignores := ExtractConfigIgnores(cfg); len(ignores) != 0 {
+			t.Fatalf("entry-level ignore leaked into global ignores: %#v", ignores)
+		}
+	}
+}
+
+func TestGetConfigForFile_UnscopedEntriesStayWithinConfigSelectorUnion(t *testing.T) {
+	config := RslintConfig{
+		{Rules: Rules{"base-rule": "error"}},
+		{Files: []string{"**/*.JS"}, Rules: Rules{"uppercase-rule": "error"}},
+	}
+
+	defaultFile := config.GetConfigForFile("src/app.ts", "")
+	if defaultFile == nil || defaultFile.Rules["base-rule"] == nil {
+		t.Fatalf("default baseline file should receive the unscoped entry: %+v", defaultFile)
+	}
+
+	explicitlySelected := config.GetConfigForFile("src/app.JS", "")
+	if explicitlySelected == nil || explicitlySelected.Rules["base-rule"] == nil || explicitlySelected.Rules["uppercase-rule"] == nil {
+		t.Fatalf("explicit selector should make unscoped entries cascade: %+v", explicitlySelected)
+	}
+
+	outsideSelector := RslintConfig{{Rules: Rules{"base-rule": "error"}}}.GetConfigForFile("src/app.JS", "")
+	if outsideSelector != nil {
+		t.Fatalf("unscoped entry must not configure a path outside the implicit selector: %+v", outsideSelector)
 	}
 }
 
@@ -820,5 +881,27 @@ func TestGetConfigForFile_WindowsPaths(t *testing.T) {
 				t.Errorf("expected no match for filePath=%q cwd=%q", tt.filePath, tt.cwd)
 			}
 		})
+	}
+}
+
+func TestGetConfigForFile_FilesAndGroupsUseOrOutsideAndInside(t *testing.T) {
+	cfg := RslintConfig{{
+		Files: []string{"special.ts"},
+		FilePatternGroups: [][]string{
+			{"src/**", "**/*.js", "!**/*.test.js"},
+		},
+		Rules: Rules{"no-console": "error"},
+	}}
+
+	for _, filePath := range []string{"/repo/special.ts", "/repo/src/app.js"} {
+		merged := cfg.GetConfigForFile(filePath, "/repo")
+		if merged == nil || merged.Rules["no-console"] == nil {
+			t.Fatalf("expected %q to match a files selector", filePath)
+		}
+	}
+	for _, filePath := range []string{"/repo/src/app.test.js", "/repo/other/app.js", "/repo/src/app.ts"} {
+		if merged := cfg.GetConfigForFile(filePath, "/repo"); merged != nil {
+			t.Fatalf("expected %q to fail the complete AND group, got %+v", filePath, merged)
+		}
 	}
 }

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestValidateConfig_AllowsMissingFiles(t *testing.T) {
+	cfg := RslintConfig{
+		{Rules: Rules{"no-console": "error"}},
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig returned error: %v", err)
+	}
+}
+
+func TestValidateConfig_AllowsNonEmptyFiles(t *testing.T) {
+	cfg := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"no-console": "error"}},
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("ValidateConfig returned error: %v", err)
+	}
+}
+
+func TestValidateConfig_RejectsEmptyFilesArray(t *testing.T) {
+	cfg := RslintConfig{
+		{Files: []string{}, Rules: Rules{"no-console": "error"}},
+	}
+	err := ValidateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected empty files array to be rejected")
+	}
+	if got := err.Error(); got != `config entry at index 0: key "files": expected value to be a non-empty array` {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
+func TestValidateConfig_RejectsEmptyFilesOnIgnoreOnlyEntry(t *testing.T) {
+	cfg := RslintConfig{
+		{Files: []string{}, Ignores: []string{"dist/**"}},
+	}
+	if err := ValidateConfig(cfg); err == nil {
+		t.Fatal("expected empty files array on ignore-only entry to be rejected")
+	}
+}
+
+func TestValidateConfig_RejectsNullFilesFromJSON(t *testing.T) {
+	var cfg RslintConfig
+	if err := json.Unmarshal([]byte(`[{"files": null, "rules": {}}]`), &cfg); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	if err := ValidateConfig(cfg); err == nil {
+		t.Fatal("expected null files field to be rejected")
+	}
+}

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -47,10 +47,22 @@ func TestValidateConfig_RejectsEmptyFilesOnIgnoreOnlyEntry(t *testing.T) {
 
 func TestValidateConfig_RejectsNullFilesFromJSON(t *testing.T) {
 	var cfg RslintConfig
-	if err := json.Unmarshal([]byte(`[{"files": null, "rules": {}}]`), &cfg); err != nil {
-		t.Fatalf("json.Unmarshal returned error: %v", err)
+	err := json.Unmarshal([]byte(`[{"files": null, "rules": {}}]`), &cfg)
+	if err == nil {
+		t.Fatal("expected null files field to be rejected while unmarshaling")
 	}
-	if err := ValidateConfig(cfg); err == nil {
-		t.Fatal("expected null files field to be rejected")
+	if got := err.Error(); got != `config entry at index 0: key "files": expected value to be a non-empty array` {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
+func TestValidateConfig_RejectsEmptyFilesArrayFromJSON(t *testing.T) {
+	var cfg RslintConfig
+	err := json.Unmarshal([]byte(`[{"files": [], "rules": {}}]`), &cfg)
+	if err == nil {
+		t.Fatal("expected empty files array to be rejected while unmarshaling")
+	}
+	if got := err.Error(); got != `config entry at index 0: key "files": expected value to be a non-empty array` {
+		t.Fatalf("unexpected error: %q", got)
 	}
 }

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -66,3 +66,48 @@ func TestValidateConfig_RejectsEmptyFilesArrayFromJSON(t *testing.T) {
 		t.Fatalf("unexpected error: %q", got)
 	}
 }
+
+func TestConfigFilesJSONSupportsMixedStringsAndAndGroups(t *testing.T) {
+	input := []byte(`[{
+		"files": ["special.ts", ["**/*.js", "!**/*.test.js"]],
+		"rules": {"no-console": "error"}
+	}]`)
+	var cfg RslintConfig
+	if err := json.Unmarshal(input, &cfg); err != nil {
+		t.Fatalf("unmarshal mixed files selectors: %v", err)
+	}
+	if len(cfg) != 1 || len(cfg[0].Files) != 1 || cfg[0].Files[0] != "special.ts" {
+		t.Fatalf("unexpected top-level files: %+v", cfg)
+	}
+	if len(cfg[0].FilePatternGroups) != 1 || len(cfg[0].FilePatternGroups[0]) != 2 {
+		t.Fatalf("unexpected AND groups: %+v", cfg[0].FilePatternGroups)
+	}
+
+	roundTrip, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal mixed files selectors: %v", err)
+	}
+	var decoded RslintConfig
+	if err := json.Unmarshal(roundTrip, &decoded); err != nil {
+		t.Fatalf("round-trip mixed files selectors: %v", err)
+	}
+	if len(decoded[0].Files) != 1 || len(decoded[0].FilePatternGroups) != 1 {
+		t.Fatalf("mixed files selectors were not preserved: %s", roundTrip)
+	}
+
+	var entry ConfigEntry
+	if err := json.Unmarshal(input[1:len(input)-1], &entry); err != nil {
+		t.Fatalf("direct ConfigEntry unmarshal must support mixed files selectors: %v", err)
+	}
+	if len(entry.Files) != 1 || len(entry.FilePatternGroups) != 1 {
+		t.Fatalf("direct ConfigEntry unmarshal lost mixed selectors: %+v", entry)
+	}
+}
+
+func TestConfigFilesJSONRejectsEmptyAndGroup(t *testing.T) {
+	var cfg RslintConfig
+	err := json.Unmarshal([]byte(`[{"files": [[]], "rules": {}}]`), &cfg)
+	if err == nil {
+		t.Fatal("expected an empty files AND group to be rejected")
+	}
+}

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -104,10 +106,166 @@ func TestConfigFilesJSONSupportsMixedStringsAndAndGroups(t *testing.T) {
 	}
 }
 
-func TestConfigFilesJSONRejectsEmptyAndGroup(t *testing.T) {
+func TestConfigFilesJSONSupportsEmptyAndGroup(t *testing.T) {
 	var cfg RslintConfig
-	err := json.Unmarshal([]byte(`[{"files": [[]], "rules": {}}]`), &cfg)
-	if err == nil {
-		t.Fatal("expected an empty files AND group to be rejected")
+	if err := json.Unmarshal([]byte(`[{"files": [[]], "rules": {}}]`), &cfg); err != nil {
+		t.Fatalf("empty files AND group should be accepted: %v", err)
+	}
+	if len(cfg) != 1 || len(cfg[0].FilePatternGroups) != 1 || cfg[0].FilePatternGroups[0] == nil {
+		t.Fatalf("empty files AND group was not preserved: %+v", cfg)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Fatalf("empty files AND group should validate: %v", err)
+	}
+	if cfg.GetConfigForFile("src/app.ts", "/repo") == nil {
+		t.Fatal("empty files AND group should match as a vacuously true selector")
+	}
+}
+
+func TestConfigFilesJSONRejectsInvalidSelectorValues(t *testing.T) {
+	for _, input := range []string{
+		`[{"files":[null]}]`,
+		`[{"files":[1]}]`,
+		`[{"files":[{}]}]`,
+		`[{"files":[[null]]}]`,
+		`[{"files":[["**/*.ts", 1]]}]`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			var cfg RslintConfig
+			if err := json.Unmarshal([]byte(input), &cfg); err == nil {
+				t.Fatal("expected invalid files selector to be rejected")
+			}
+		})
+	}
+}
+
+func TestValidateConfig_Globals(t *testing.T) {
+	validJSON := `[{
+		"languageOptions": {"globals": {
+			"writableBoolean": true,
+			"writableString": "true",
+			"writable": "writable",
+			"writeable": "writeable",
+			"readonlyBoolean": false,
+			"readonlyString": "false",
+			"readonly": "readonly",
+			"readable": "readable",
+			"nullReadonly": null,
+			"disabled": "off"
+		}}
+	}]`
+	var valid RslintConfig
+	if err := json.Unmarshal([]byte(validJSON), &valid); err != nil {
+		t.Fatalf("unmarshal valid globals: %v", err)
+	}
+	if err := ValidateConfig(valid); err != nil {
+		t.Fatalf("valid globals were rejected: %v", err)
+	}
+
+	for _, input := range []string{
+		`[{"languageOptions":{"globals":null}}]`,
+		`[{"languageOptions":{"globals":[]}}]`,
+		`[{"languageOptions":{"globals":{"value":"invalid"}}}]`,
+		`[{"languageOptions":{"globals":{" padded ":"readonly"}}}]`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			var cfg RslintConfig
+			if err := json.Unmarshal([]byte(input), &cfg); err != nil {
+				t.Fatalf("unmarshal invalid globals fixture: %v", err)
+			}
+			if err := ValidateConfig(cfg); err == nil {
+				t.Fatal("expected invalid globals to be rejected")
+			}
+		})
+	}
+}
+
+func TestValidateConfig_RuleSeverities(t *testing.T) {
+	t.Run("JSON ingress", func(t *testing.T) {
+		var cfg RslintConfig
+		if err := json.Unmarshal([]byte(`[{
+			"rules": {
+				"string-off": "off",
+				"string-warn": "warn",
+				"string-error": "error",
+				"numeric-off": 0,
+				"numeric-warn": 1,
+				"numeric-error": 2,
+				"array-numeric": [2, "first", {"second": true}, null]
+			}
+		}]`), &cfg); err != nil {
+			t.Fatalf("unmarshal numeric rule severities: %v", err)
+		}
+		if err := ValidateConfig(cfg); err != nil {
+			t.Fatalf("valid JSON rule severities were rejected: %v", err)
+		}
+		merged := cfg.GetConfigForFile("src/app.ts", "")
+		if merged == nil {
+			t.Fatal("expected JSON config to merge")
+		}
+		for name, want := range map[string]string{
+			"numeric-off": "off", "numeric-warn": "warn", "numeric-error": "error",
+		} {
+			if got := merged.Rules[name]; got == nil || got.Level != want {
+				t.Errorf("JSON rule %q = %#v, want level %q", name, got, want)
+			}
+		}
+		arrayRule := merged.Rules["array-numeric"]
+		if arrayRule == nil || arrayRule.Level != "error" || len(arrayRule.Options) != 3 {
+			t.Fatalf("JSON numeric array was not preserved: %#v", arrayRule)
+		}
+	})
+
+	t.Run("Go construction", func(t *testing.T) {
+		cfg := RslintConfig{{Rules: Rules{
+			"numeric-off":   int8(0),
+			"numeric-warn":  uint16(1),
+			"numeric-error": float32(2),
+			"array-numeric": []interface{}{uint8(1), "first", true},
+		}}}
+		if err := ValidateConfig(cfg); err != nil {
+			t.Fatalf("valid Go-constructed rule severities were rejected: %v", err)
+		}
+	})
+}
+
+func TestValidateConfig_RejectsInvalidRuleValues(t *testing.T) {
+	invalidJSON := []string{
+		`"fatal"`,
+		`3`,
+		`1.5`,
+		`true`,
+		`null`,
+		`{}`,
+		`[]`,
+		`["warning"]`,
+		`[3]`,
+		`[null]`,
+	}
+	for _, value := range invalidJSON {
+		t.Run("JSON "+value, func(t *testing.T) {
+			var cfg RslintConfig
+			input := `[{"rules":{"example":` + value + `}}]`
+			err := json.Unmarshal([]byte(input), &cfg)
+			if err == nil {
+				t.Fatal("expected invalid rule value to be rejected during JSON ingress")
+			}
+			if message := err.Error(); !strings.Contains(message, `key "rules": rule "example"`) {
+				t.Fatalf("error does not identify the invalid rule: %q", message)
+			}
+		})
+	}
+
+	goConstructed := []any{"fatal", 3, 1.5, true, nil, map[string]any{}, []interface{}{}}
+	for index, value := range goConstructed {
+		t.Run(fmt.Sprintf("Go %d %T", index, value), func(t *testing.T) {
+			err := ValidateConfig(RslintConfig{{Rules: Rules{"example": value}}})
+			if err == nil {
+				t.Fatal("expected invalid Go-constructed rule value to be rejected")
+			}
+			if message := err.Error(); !strings.Contains(message, `key "rules": rule "example"`) {
+				t.Fatalf("error does not identify the invalid rule: %q", message)
+			}
+		})
 	}
 }

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -46,14 +46,18 @@ func isDefaultLintFile(filePath string) bool {
 }
 
 // isFileSelectedByConfig reports whether the config itself selects filePath.
-// The implicit default baseline is always present; explicit `files` patterns
-// extend it. Entry-level ignores do not remove a target from this selector.
+// The implicit default baseline is always present. An explicit `files` entry
+// extends it only for paths not excluded by that same entry's `ignores`.
+// Another matching entry or the default baseline may still select the path.
 func isFileSelectedByConfig(config RslintConfig, filePath string, configDir string) bool {
 	if isDefaultLintFile(filePath) {
 		return true
 	}
 	for _, entry := range config {
-		if !isGlobalIgnoreEntry(entry) && hasFileSelectors(entry) && isFileMatchedByConfigEntry(filePath, entry, configDir) {
+		if !isGlobalIgnoreEntry(entry) &&
+			hasFileSelectors(entry) &&
+			isFileMatchedByConfigEntry(filePath, entry, configDir) &&
+			!isFileIgnored(filePath, ParseIgnorePatterns(entry.Ignores), configDir) {
 			return true
 		}
 	}
@@ -76,8 +80,9 @@ var defaultExcludeDirs = func() map[string]struct{} {
 //   - Rslint's default lintable extensions are always selected. Non-global
 //     config entries contribute additional `files` patterns.
 //   - Global ignores, including injected .gitignore entries, remove files.
-//   - Entry-level ignores affect config/rule selection, not target selection.
-//     A selected file excluded by every entry is still parsed with zero rules.
+//   - Entry-level ignores prevent that entry from selecting or configuring a
+//     file. They do not remove a file selected by the default baseline or a
+//     different entry.
 //   - Explicit file targets are retained even when they do not match any
 //     config entry's files patterns, matching ESLint's empty-result behavior.
 //
@@ -90,10 +95,32 @@ func DiscoverLintFiles(
 	allowDirs []string,
 	singleThreaded bool,
 ) []string {
-	return discoverLintFilesWithStopDirs(config, configDir, fsys, allowFiles, allowDirs, nil, singleThreaded)
+	targets := discoverLintTargetsWithStopDirs(config, configDir, fsys, allowFiles, allowDirs, nil, singleThreaded)
+	files := make([]string, 0, len(targets))
+	for _, target := range targets {
+		files = append(files, target.Path)
+	}
+	return files
 }
 
-func discoverLintFilesWithStopDirs(
+// DiscoverLintTargets is the identity-preserving form of DiscoverLintFiles.
+// CanonicalPath is derived without a per-file realpath call for regular files
+// reached by directory traversal. Explicit directory aliases are resolved once
+// and projected onto their descendants; explicit files and file symlinks are
+// resolved individually because their physical target cannot be inferred from
+// the containing directory.
+func DiscoverLintTargets(
+	config RslintConfig,
+	configDir string,
+	fsys vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	singleThreaded bool,
+) []DiscoveredLintTarget {
+	return discoverLintTargetsWithStopDirs(config, configDir, fsys, allowFiles, allowDirs, nil, singleThreaded)
+}
+
+func discoverLintTargetsWithStopDirs(
 	config RslintConfig,
 	configDir string,
 	fsys vfs.FS,
@@ -101,7 +128,7 @@ func discoverLintFilesWithStopDirs(
 	allowDirs []string,
 	stopDirs []string,
 	singleThreaded bool,
-) []string {
+) []DiscoveredLintTarget {
 	globalIgnores := ExtractConfigIgnores(config)
 	globalIgnores = append(ParseIgnorePatterns(utils.DefaultIgnoreDirGlobs()), globalIgnores...)
 	useCaseSensitive := true
@@ -109,7 +136,7 @@ func discoverLintFilesWithStopDirs(
 		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
 	}
 	comparisonKey := func(filePath string) string {
-		return string(tspath.ToPath(tspath.NormalizePath(filePath), "", useCaseSensitive))
+		return string(tspath.ToPath(tspath.NormalizePath(filePath), "", true))
 	}
 	configDir = tspath.NormalizePath(configDir)
 	configMatchDir := configDir
@@ -119,20 +146,15 @@ func discoverLintFilesWithStopDirs(
 		}
 	}
 	configPathForMatching := func(filePath string) string {
-		filePath = tspath.NormalizePath(filePath)
-		if relative, ok := relativePathWithinConfigRoot(filePath, configDir, useCaseSensitive); ok {
-			return tspath.ResolvePath(configMatchDir, relative)
-		}
-		if fsys != nil {
-			if realPath := fsys.Realpath(filePath); realPath != "" {
-				canonical := tspath.NormalizePath(realPath)
-				if relative, ok := relativePathWithinConfigRoot(canonical, configMatchDir, useCaseSensitive); ok {
-					return tspath.ResolvePath(configMatchDir, relative)
-				}
-			}
-		}
-		return filePath
+		return resolveConfigPathSpace(
+			tspath.NormalizePath(filePath),
+			"",
+			configDir,
+			configMatchDir,
+			fsys,
+		)
 	}
+	resolvedAllowDirs := resolveAllowedDirectories(allowDirs, fsys)
 
 	filesPatterns := collectLintFilePatterns(config)
 	filesMatcher := buildFilesMatcher(filesPatterns)
@@ -149,59 +171,78 @@ func discoverLintFilesWithStopDirs(
 		}
 	}
 
-	targetFiles := []string{}
+	targetFiles := []DiscoveredLintTarget{}
 	seenTargets := make(map[string]struct{})
-	addTarget := func(filePath string) {
+	addTarget := func(filePath string, canonicalPath string) {
+		filePath = tspath.NormalizePath(filePath)
+		if canonicalPath == "" {
+			canonicalPath = filePath
+		} else {
+			canonicalPath = tspath.NormalizePath(canonicalPath)
+		}
 		key := comparisonKey(filePath)
 		if _, seen := seenTargets[key]; seen {
 			return
 		}
 		seenTargets[key] = struct{}{}
-		targetFiles = append(targetFiles, filePath)
+		targetFiles = append(targetFiles, DiscoveredLintTarget{
+			Path:            filePath,
+			CanonicalPath:   canonicalPath,
+			ConfigDirectory: configDir,
+		})
 	}
-	isGloballyIgnored := func(filePath string) bool {
-		matchPath := configPathForMatching(filePath)
+	isGloballyIgnored := func(matchPath string) bool {
 		return isDirBlockedByIgnores(matchPath, globalIgnores, configMatchDir) ||
 			isFileIgnored(matchPath, globalIgnores, configMatchDir)
 	}
 
-	includeExplicitFile := func(filePath string) bool {
+	includeExplicitFile := func(filePath string) (bool, string) {
 		if !IsSupportedLintFile(filePath) {
-			return false
+			return false, ""
 		}
 		if fsys != nil && !fsys.FileExists(filePath) {
-			return false
+			return false, ""
 		}
-		if IsDefaultExcludedPath(configPathForMatching(filePath), configMatchDir, useCaseSensitive) {
-			return false
+		matchPath := configPathForMatching(filePath)
+		if IsDefaultExcludedPath(matchPath, configMatchDir, useCaseSensitive) {
+			return false, ""
 		}
-		return !isGloballyIgnored(filePath)
+		if isGloballyIgnored(matchPath) {
+			return false, ""
+		}
+		canonicalPath := filePath
+		if fsys != nil {
+			if realPath := fsys.Realpath(filePath); realPath != "" {
+				canonicalPath = realPath
+			}
+		}
+		return true, canonicalPath
 	}
 
-	includeDiscoveredFile := func(filePath string) bool {
+	includeDiscoveredFile := func(filePath string) (bool, string) {
 		if !IsSupportedLintFile(filePath) {
-			return false
+			return false, ""
 		}
 		matchPath := configPathForMatching(filePath)
 		if len(filesPatterns) == 0 || !filesMatcher(matchPath, configMatchDir) {
-			return false
+			return false, ""
 		}
 		// Candidate patterns for an AND group intentionally form a superset.
 		// Apply the complete selector here so negated and additional group
 		// members cannot leak candidates into the target set.
 		if !isFileSelectedByConfig(config, matchPath, configMatchDir) {
-			return false
+			return false, ""
 		}
-		if isGloballyIgnored(filePath) {
-			return false
+		if isGloballyIgnored(matchPath) {
+			return false, ""
 		}
-		return true
+		return true, matchPath
 	}
 
 	addExplicitTargets := func() {
 		for _, f := range allowFileSet {
-			if includeExplicitFile(f) {
-				addTarget(f)
+			if include, canonicalPath := includeExplicitFile(f); include {
+				addTarget(f, canonicalPath)
 			}
 		}
 	}
@@ -209,7 +250,7 @@ func discoverLintFilesWithStopDirs(
 	// Fast path for explicit file-only invocations, e.g. lint-staged.
 	if allowFileSet != nil && allowDirs == nil {
 		addExplicitTargets()
-		sort.Strings(targetFiles)
+		sort.Slice(targetFiles, func(i, j int) bool { return targetFiles[i].Path < targetFiles[j].Path })
 		return targetFiles
 	}
 
@@ -232,8 +273,11 @@ func discoverLintFilesWithStopDirs(
 		workers = 1
 	}
 
-	processFile := func(walkPath string) {
+	processFile := func(walkPath string, isSymlink bool) {
 		fullPath := tspath.NormalizePath(tspath.CombinePaths(normalizedConfigDir, walkPath))
+		matchPath := configPathForMatching(fullPath)
+		targetPath := fullPath
+		scopedCanonicalPath := ""
 
 		if allowFileSet != nil || allowDirs != nil {
 			inScope := false
@@ -243,21 +287,32 @@ func discoverLintFilesWithStopDirs(
 				}
 			}
 			if !inScope && allowDirs != nil {
-				if isFileInAllowedDirs(fullPath, allowDirs, useCaseSensitive) {
-					inScope = true
-				}
+				inScope, targetPath, scopedCanonicalPath = resolvePathThroughAllowedDirectories(
+					fullPath,
+					matchPath,
+					resolvedAllowDirs,
+					useCaseSensitive,
+				)
 			}
 			if !inScope {
 				return
 			}
 		}
 
-		if !includeDiscoveredFile(fullPath) {
+		include, canonicalPath := includeDiscoveredFile(fullPath)
+		if !include {
 			return
+		}
+		if isSymlink && fsys != nil {
+			if realPath := fsys.Realpath(fullPath); realPath != "" {
+				canonicalPath = realPath
+			}
+		} else if scopedCanonicalPath != "" {
+			canonicalPath = scopedCanonicalPath
 		}
 
 		targetMu.Lock()
-		addTarget(fullPath)
+		addTarget(targetPath, canonicalPath)
 		targetMu.Unlock()
 	}
 
@@ -299,7 +354,7 @@ func discoverLintFilesWithStopDirs(
 				}
 				childDirs = append(childDirs, childPath)
 			} else {
-				processFile(path.Join(walkPath, name))
+				processFile(path.Join(walkPath, name), e.Type()&fs.ModeSymlink != 0)
 			}
 		}
 		return childDirs
@@ -315,7 +370,7 @@ func discoverLintFilesWithStopDirs(
 		addExplicitTargets()
 	}
 
-	sort.Strings(targetFiles)
+	sort.Slice(targetFiles, func(i, j int) bool { return targetFiles[i].Path < targetFiles[j].Path })
 	return targetFiles
 }
 
@@ -456,6 +511,96 @@ func isFileInAllowedDirs(filePath string, allowDirs []string, useCaseSensitive b
 	return false
 }
 
+func isFileInAllowedDirsWithFS(filePath string, allowDirs []string, fsys vfs.FS) bool {
+	if isFileInAllowedDirs(filePath, allowDirs, true) {
+		return true
+	}
+	if fsys == nil {
+		return false
+	}
+	realFilePath := fsys.Realpath(filePath)
+	if realFilePath == "" {
+		return false
+	}
+	canonicalFile := tspath.NormalizePath(realFilePath)
+	if canonicalFile == tspath.NormalizePath(filePath) {
+		return false
+	}
+	for _, dir := range allowDirs {
+		realDir := fsys.Realpath(tspath.NormalizePath(dir))
+		if realDir == "" {
+			continue
+		}
+		canonicalDir := tspath.NormalizePath(realDir)
+		if pathsEqual(canonicalFile, canonicalDir, true) ||
+			tspath.StartsWithDirectory(canonicalFile, canonicalDir, true) {
+			return true
+		}
+	}
+	return false
+}
+
+type resolvedAllowedDirectory struct {
+	lexicalPath   string
+	canonicalPath string
+}
+
+func resolveAllowedDirectories(allowDirs []string, fsys vfs.FS) []resolvedAllowedDirectory {
+	if allowDirs == nil {
+		return nil
+	}
+	resolved := make([]resolvedAllowedDirectory, 0, len(allowDirs))
+	for _, dir := range allowDirs {
+		lexicalPath := tspath.NormalizePath(dir)
+		canonicalPath := lexicalPath
+		if fsys != nil {
+			if realPath := fsys.Realpath(lexicalPath); realPath != "" {
+				canonicalPath = tspath.NormalizePath(realPath)
+			}
+		}
+		resolved = append(resolved, resolvedAllowedDirectory{
+			lexicalPath:   lexicalPath,
+			canonicalPath: canonicalPath,
+		})
+	}
+	return resolved
+}
+
+func resolvePathThroughAllowedDirectories(
+	filePath string,
+	matchPath string,
+	allowDirs []resolvedAllowedDirectory,
+	useCaseSensitive bool,
+) (bool, string, string) {
+	inScope := false
+	bestLexicalLength := -1
+	bestCanonicalLength := -1
+	lexicalPath := filePath
+	canonicalPath := ""
+	for _, dir := range allowDirs {
+		if relative, within := relativePathWithinConfigRoot(filePath, dir.lexicalPath, useCaseSensitive); within {
+			inScope = true
+			if dir.lexicalPath != dir.canonicalPath && len(dir.lexicalPath) > bestLexicalLength {
+				bestLexicalLength = len(dir.lexicalPath)
+				canonicalPath = tspath.ResolvePath(dir.canonicalPath, relative)
+			}
+		}
+		if dir.lexicalPath == dir.canonicalPath || len(dir.canonicalPath) <= bestCanonicalLength {
+			continue
+		}
+		relative, within := relativePathWithinConfigRoot(filePath, dir.canonicalPath, true)
+		if !within && matchPath != filePath {
+			relative, within = relativePathWithinConfigRoot(matchPath, dir.canonicalPath, true)
+		}
+		if within {
+			inScope = true
+			bestCanonicalLength = len(dir.canonicalPath)
+			lexicalPath = tspath.ResolvePath(dir.lexicalPath, relative)
+		}
+	}
+	return inScope, lexicalPath, canonicalPath
+}
+
 func discoverWalkRoots(configDir string, allowDirs []string, fsys vfs.FS) []string {
 	if allowDirs == nil {
 		return []string{"."}
@@ -464,13 +609,12 @@ func discoverWalkRoots(configDir string, allowDirs []string, fsys vfs.FS) []stri
 		return nil
 	}
 
-	useCaseSensitive := true
+	configDir = tspath.NormalizePath(configDir)
+	canonicalConfigDir := configDir
 	if fsys != nil {
-		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
-	}
-	compareOptions := tspath.ComparePathsOptions{
-		CurrentDirectory:          configDir,
-		UseCaseSensitiveFileNames: useCaseSensitive,
+		if realPath := fsys.Realpath(configDir); realPath != "" {
+			canonicalConfigDir = tspath.NormalizePath(realPath)
+		}
 	}
 	seen := make(map[string]struct{}, len(allowDirs))
 	roots := make([]string, 0, len(allowDirs))
@@ -488,16 +632,16 @@ func discoverWalkRoots(configDir string, allowDirs []string, fsys vfs.FS) []stri
 			if existing == "." {
 				return
 			}
-			if pathsEqual(existing, root, useCaseSensitive) ||
-				tspath.StartsWithDirectory(root, existing, useCaseSensitive) {
+			if pathsEqual(existing, root, true) ||
+				tspath.StartsWithDirectory(root, existing, true) {
 				return
 			}
 		}
 		filtered := roots[:0]
 		seen = make(map[string]struct{}, len(allowDirs))
 		for _, existing := range roots {
-			if pathsEqual(existing, root, useCaseSensitive) ||
-				tspath.StartsWithDirectory(existing, root, useCaseSensitive) {
+			if pathsEqual(existing, root, true) ||
+				tspath.StartsWithDirectory(existing, root, true) {
 				continue
 			}
 			seen[existing] = struct{}{}
@@ -513,12 +657,28 @@ func discoverWalkRoots(configDir string, allowDirs []string, fsys vfs.FS) []stri
 
 	for _, rawDir := range allowDirs {
 		dir := tspath.NormalizePath(rawDir)
-		if pathsEqual(dir, configDir, useCaseSensitive) ||
-			tspath.StartsWithDirectory(configDir, dir, useCaseSensitive) {
+		if pathsEqual(dir, configDir, true) ||
+			tspath.StartsWithDirectory(configDir, dir, true) {
 			return []string{"."}
 		}
-		if tspath.StartsWithDirectory(dir, configDir, useCaseSensitive) {
-			addRoot(tspath.GetRelativePathFromDirectory(configDir, dir, compareOptions))
+		if relative, within := relativePathWithinConfigRoot(dir, configDir, true); within {
+			addRoot(relative)
+			continue
+		}
+		if fsys == nil {
+			continue
+		}
+		realDir := fsys.Realpath(dir)
+		if realDir == "" {
+			continue
+		}
+		canonicalDir := tspath.NormalizePath(realDir)
+		if pathsEqual(canonicalDir, canonicalConfigDir, true) ||
+			tspath.StartsWithDirectory(canonicalConfigDir, canonicalDir, true) {
+			return []string{"."}
+		}
+		if relative, within := relativePathWithinConfigRoot(canonicalDir, canonicalConfigDir, true); within {
+			addRoot(relative)
 		}
 	}
 
@@ -617,21 +777,24 @@ func patternsIncludeAllDefaultExtensions(patterns []string) bool {
 	return true
 }
 
-// LintDiscoveryScope overrides the CLI/API scope for one config.
+// LintDiscoveryScope records explicit-file provenance supplied by the config
+// host. ExplicitOnly keeps a config loaded solely for an explicit file out of
+// directory discovery.
 type LintDiscoveryScope struct {
-	Files []string
-	Dirs  []string
+	Files        []string
+	ExplicitOnly bool
 }
 
 // DiscoveredLintTarget preserves the config owner established during the
 // directory walk so later stages do not need to infer ownership from paths.
 type DiscoveredLintTarget struct {
 	Path            string
+	CanonicalPath   string
 	ConfigDirectory string
 }
 
 // DiscoverLintTargetsMultiConfig resolves owned lint targets across a config
-// map. Per-config scopes override the default scope when present.
+// map. Scope files are already assigned to their config by the JS host.
 func DiscoverLintTargetsMultiConfig(
 	configMap map[string]RslintConfig,
 	scopes map[string]LintDiscoveryScope,
@@ -657,7 +820,30 @@ func DiscoverLintTargetsMultiConfig(
 	// it cannot own. A non-nil empty bucket is preserved below so the explicit
 	// file-only fast path still suppresses directory walking for configs that own
 	// no requested files.
-	filesByConfig := index.assignExplicitFiles(allowFiles)
+	hostAssignedFileOwners := make(map[tspath.Path]string)
+	for _, configDir := range configDirs {
+		scope, ok := scopes[configDir]
+		if !ok || scope.Files == nil {
+			continue
+		}
+		for _, filePath := range scope.Files {
+			key := tspath.ToPath(tspath.NormalizePath(filePath), "", true)
+			if _, exists := hostAssignedFileOwners[key]; !exists {
+				hostAssignedFileOwners[key] = configDir
+			}
+		}
+	}
+	unscopedAllowFiles := allowFiles
+	if len(hostAssignedFileOwners) > 0 {
+		unscopedAllowFiles = make([]string, 0, len(allowFiles))
+		for _, filePath := range allowFiles {
+			key := tspath.ToPath(tspath.NormalizePath(filePath), "", true)
+			if _, scoped := hostAssignedFileOwners[key]; !scoped {
+				unscopedAllowFiles = append(unscopedAllowFiles, filePath)
+			}
+		}
+	}
+	filesByConfig := index.assignExplicitFiles(unscopedAllowFiles)
 	filesSpecifiedByConfig := make(map[string]bool, len(configDirs))
 	if allowFiles != nil {
 		for _, configDir := range configDirs {
@@ -665,17 +851,11 @@ func DiscoverLintTargetsMultiConfig(
 		}
 	}
 	for configDir, scope := range scopes {
-		delete(filesByConfig, configDir)
-		filesSpecifiedByConfig[configDir] = scope.Files != nil
-	}
-	for _, scope := range scopes {
 		if scope.Files == nil {
 			continue
 		}
-		for owner, files := range index.assignExplicitFiles(scope.Files) {
-			filesByConfig[owner] = append(filesByConfig[owner], files...)
-			filesSpecifiedByConfig[owner] = true
-		}
+		filesByConfig[configDir] = append([]string(nil), scope.Files...)
+		filesSpecifiedByConfig[configDir] = true
 	}
 
 	seen := make(map[tspath.Path]struct{})
@@ -689,18 +869,24 @@ func DiscoverLintTargetsMultiConfig(
 			}
 		}
 		configAllowDirs := allowDirs
-		if scope, ok := scopes[configDir]; ok {
-			configAllowDirs = scope.Dirs
+		if scopes[configDir].ExplicitOnly {
+			configAllowDirs = []string{}
 		}
-		targets := discoverLintFilesForConfigInMap(configMap, index, configDir, fsys, configAllowFiles, configAllowDirs, singleThreaded)
-		for _, f := range targets {
-			pathID := tspath.ToPath(tspath.NormalizePath(f), "", index.useCaseSensitive)
+		targets := discoverLintTargetsForConfigInMap(
+			configMap,
+			index,
+			hostAssignedFileOwners,
+			configDir,
+			fsys,
+			configAllowFiles,
+			configAllowDirs,
+			singleThreaded,
+		)
+		for _, target := range targets {
+			pathID := tspath.ToPath(tspath.NormalizePath(target.Path), "", true)
 			if _, exists := seen[pathID]; !exists {
 				seen[pathID] = struct{}{}
-				allTargets = append(allTargets, DiscoveredLintTarget{
-					Path:            f,
-					ConfigDirectory: configDir,
-				})
+				allTargets = append(allTargets, target)
 			}
 		}
 	}
@@ -737,42 +923,58 @@ func DiscoverLintFilesForConfigInMap(
 	allowDirs []string,
 	singleThreaded bool,
 ) []string {
-	return discoverLintFilesForConfigInMap(
+	targets := discoverLintTargetsForConfigInMap(
 		configMap,
 		newConfigDirectoryIndex(configMap, fsys),
+		nil,
 		configDir,
 		fsys,
 		allowFiles,
 		allowDirs,
 		singleThreaded,
 	)
+	files := make([]string, 0, len(targets))
+	for _, target := range targets {
+		files = append(files, target.Path)
+	}
+	return files
 }
 
-func discoverLintFilesForConfigInMap(
+func discoverLintTargetsForConfigInMap(
 	configMap map[string]RslintConfig,
 	index *configDirectoryIndex,
+	hostAssignedFileOwners map[tspath.Path]string,
 	configDir string,
 	fsys vfs.FS,
 	allowFiles []string,
 	allowDirs []string,
 	singleThreaded bool,
-) []string {
+) []DiscoveredLintTarget {
 	cfg, ok := configMap[configDir]
 	if !ok {
 		return nil
 	}
 
 	stopDirs := index.childConfigDirs(configDir)
-	targets := discoverLintFilesWithStopDirs(cfg, configDir, fsys, allowFiles, allowDirs, stopDirs, singleThreaded)
+	targets := discoverLintTargetsWithStopDirs(cfg, configDir, fsys, allowFiles, allowDirs, stopDirs, singleThreaded)
 	if len(targets) == 0 {
 		return targets
 	}
 
-	ownedTargets := make([]string, 0, len(targets))
-	for _, f := range targets {
-		ownerDir, _ := index.nearestConfig(f)
+	ownedTargets := make([]DiscoveredLintTarget, 0, len(targets))
+	for _, target := range targets {
+		targetID := tspath.ToPath(tspath.NormalizePath(target.Path), "", true)
+		if hostOwner, assigned := hostAssignedFileOwners[targetID]; assigned {
+			if hostOwner == configDir {
+				target.ConfigDirectory = configDir
+				ownedTargets = append(ownedTargets, target)
+			}
+			continue
+		}
+		ownerDir, _ := index.nearestConfigWithCanonicalPath(target.Path, target.CanonicalPath)
 		if ownerDir == configDir {
-			ownedTargets = append(ownedTargets, f)
+			target.ConfigDirectory = configDir
+			ownedTargets = append(ownedTargets, target)
 		}
 	}
 	return ownedTargets
@@ -780,27 +982,24 @@ func discoverLintFilesForConfigInMap(
 
 type configDirectoryIndex struct {
 	fsys                     vfs.FS
-	useCaseSensitive         bool
 	configKeyByPath          map[tspath.Path]string
+	caseFoldedConfigKeys     map[tspath.Path][]string
 	canonicalConfigKeyByPath map[tspath.Path]string
 	ambiguousCanonicalPaths  map[tspath.Path]struct{}
 	normalizedByKey          map[string]string
+	canonicalByKey           map[string]string
 	childrenByKey            map[string][]string
 }
 
 func newConfigDirectoryIndex(configMap map[string]RslintConfig, fsys vfs.FS) *configDirectoryIndex {
-	useCaseSensitive := true
-	if fsys != nil {
-		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
-	}
-
 	index := &configDirectoryIndex{
 		fsys:                     fsys,
-		useCaseSensitive:         useCaseSensitive,
 		configKeyByPath:          make(map[tspath.Path]string, len(configMap)),
+		caseFoldedConfigKeys:     make(map[tspath.Path][]string, len(configMap)),
 		canonicalConfigKeyByPath: make(map[tspath.Path]string, len(configMap)),
 		ambiguousCanonicalPaths:  make(map[tspath.Path]struct{}),
 		normalizedByKey:          make(map[string]string, len(configMap)),
+		canonicalByKey:           make(map[string]string, len(configMap)),
 		childrenByKey:            make(map[string][]string, len(configMap)),
 	}
 	configKeys := make([]string, 0, len(configMap))
@@ -810,11 +1009,16 @@ func newConfigDirectoryIndex(configMap map[string]RslintConfig, fsys vfs.FS) *co
 	sort.Strings(configKeys)
 	for _, configKey := range configKeys {
 		normalized := tspath.NormalizePath(configKey)
+		if len(normalized) > tspath.GetRootLength(normalized) {
+			normalized = tspath.RemoveTrailingDirectorySeparators(normalized)
+		}
 		index.normalizedByKey[configKey] = normalized
-		pathID := tspath.ToPath(normalized, "", useCaseSensitive)
+		pathID := tspath.ToPath(normalized, "", true)
 		if _, exists := index.configKeyByPath[pathID]; !exists {
 			index.configKeyByPath[pathID] = configKey
 		}
+		foldedPathID := tspath.ToPath(normalized, "", false)
+		index.caseFoldedConfigKeys[foldedPathID] = append(index.caseFoldedConfigKeys[foldedPathID], configKey)
 
 		canonical := normalized
 		if fsys != nil {
@@ -822,7 +1026,8 @@ func newConfigDirectoryIndex(configMap map[string]RslintConfig, fsys vfs.FS) *co
 				canonical = tspath.NormalizePath(realPath)
 			}
 		}
-		canonicalID := tspath.ToPath(canonical, "", useCaseSensitive)
+		index.canonicalByKey[configKey] = canonical
+		canonicalID := tspath.ToPath(canonical, "", true)
 		if _, ambiguous := index.ambiguousCanonicalPaths[canonicalID]; ambiguous {
 			continue
 		}
@@ -839,22 +1044,39 @@ func newConfigDirectoryIndex(configMap map[string]RslintConfig, fsys vfs.FS) *co
 
 	for _, configKey := range configKeys {
 		normalized := index.normalizedByKey[configKey]
-		for parent := tspath.GetDirectoryPath(normalized); parent != "" && parent != normalized; {
-			if parentKey, ok := index.configKeyByPath[tspath.ToPath(parent, "", useCaseSensitive)]; ok {
-				index.childrenByKey[parentKey] = append(index.childrenByKey[parentKey], normalized)
-				break
-			}
-			next := tspath.GetDirectoryPath(parent)
-			if next == parent {
-				break
-			}
-			parent = next
+		if parentKey, ok := index.nearestLexicalConfigAncestor(normalized); ok {
+			index.addChildBoundary(parentKey, normalized)
 		}
 	}
 	for configKey := range index.childrenByKey {
 		sort.Strings(index.childrenByKey[configKey])
 	}
 	return index
+}
+
+func (index *configDirectoryIndex) nearestLexicalConfigAncestor(configDir string) (string, bool) {
+	current := tspath.GetDirectoryPath(configDir)
+	for current != "" && current != configDir {
+		if configKey, ok := index.configKeyForLexicalDirectory(current); ok {
+			return configKey, true
+		}
+		next := tspath.GetDirectoryPath(current)
+		if next == current {
+			break
+		}
+		current = next
+	}
+	return "", false
+}
+
+func (index *configDirectoryIndex) addChildBoundary(configKey string, boundary string) {
+	boundary = tspath.NormalizePath(boundary)
+	for _, existing := range index.childrenByKey[configKey] {
+		if existing == boundary {
+			return
+		}
+	}
+	index.childrenByKey[configKey] = append(index.childrenByKey[configKey], boundary)
 }
 
 func (index *configDirectoryIndex) childConfigDirs(configKey string) []string {
@@ -869,7 +1091,7 @@ func (index *configDirectoryIndex) nearestConfig(filePath string) (string, bool)
 		return "", false
 	}
 	filePath = tspath.NormalizePath(filePath)
-	if configKey, ok := index.nearestConfigInPathSpace(filePath, index.configKeyByPath); ok {
+	if configKey, ok := index.nearestLexicalConfig(filePath); ok {
 		return configKey, true
 	}
 	if index.fsys == nil {
@@ -879,13 +1101,87 @@ func (index *configDirectoryIndex) nearestConfig(filePath string) (string, bool)
 	if realPath == "" {
 		return "", false
 	}
-	return index.nearestConfigInPathSpace(tspath.NormalizePath(realPath), index.canonicalConfigKeyByPath)
+	return index.nearestConfigInPathSpace(
+		tspath.NormalizePath(realPath),
+		index.canonicalConfigKeyByPath,
+	)
 }
 
-func (index *configDirectoryIndex) nearestConfigInPathSpace(filePath string, configKeyByPath map[tspath.Path]string) (string, bool) {
+func (index *configDirectoryIndex) nearestConfigWithCanonicalPath(
+	filePath string,
+	canonicalPath string,
+) (string, bool) {
+	if index == nil {
+		return "", false
+	}
+	filePath = tspath.NormalizePath(filePath)
+	lexicalKey, lexicalFound := index.nearestLexicalConfig(filePath)
+	if lexicalFound {
+		return lexicalKey, true
+	}
+	if canonicalPath == "" {
+		return "", false
+	}
+	canonicalPath = tspath.NormalizePath(canonicalPath)
+	return index.nearestConfigInPathSpace(
+		canonicalPath,
+		index.canonicalConfigKeyByPath,
+	)
+}
+
+func (index *configDirectoryIndex) nearestLexicalConfig(filePath string) (string, bool) {
+	if index == nil {
+		return "", false
+	}
+	filePath = tspath.NormalizePath(filePath)
 	current := tspath.GetDirectoryPath(filePath)
 	for current != "" {
-		if configKey, ok := configKeyByPath[tspath.ToPath(current, "", index.useCaseSensitive)]; ok {
+		if configKey, ok := index.configKeyForLexicalDirectory(current); ok {
+			return configKey, true
+		}
+		next := tspath.GetDirectoryPath(current)
+		if next == current {
+			break
+		}
+		current = next
+	}
+	return "", false
+}
+
+func (index *configDirectoryIndex) configKeyForLexicalDirectory(directory string) (string, bool) {
+	if index == nil {
+		return "", false
+	}
+	if configKey, ok := index.configKeyByPath[tspath.ToPath(directory, "", true)]; ok {
+		return configKey, true
+	}
+	if index.fsys == nil {
+		return "", false
+	}
+	candidates := index.caseFoldedConfigKeys[tspath.ToPath(directory, "", false)]
+	if len(candidates) == 0 {
+		return "", false
+	}
+	canonicalDirectory := index.fsys.Realpath(directory)
+	if canonicalDirectory == "" {
+		return "", false
+	}
+	canonicalDirectory = tspath.NormalizePath(canonicalDirectory)
+	for _, configKey := range candidates {
+		if pathsEqual(canonicalDirectory, index.canonicalByKey[configKey], true) {
+			return configKey, true
+		}
+	}
+	return "", false
+}
+
+func (index *configDirectoryIndex) nearestConfigInPathSpace(
+	filePath string,
+	configKeyByPath map[tspath.Path]string,
+) (string, bool) {
+	current := tspath.GetDirectoryPath(filePath)
+	for current != "" {
+		if configKey, ok := configKeyByPath[tspath.ToPath(current, "", true)]; ok {
 			return configKey, true
 		}
 		next := tspath.GetDirectoryPath(current)
@@ -913,7 +1209,7 @@ func (index *configDirectoryIndex) assignExplicitFiles(files []string) map[strin
 // DiscoverGapFiles returns resolved lint targets that are absent from existing
 // Programs. The filesystem walk and config/default-files matching are owned by
 // DiscoverLintFiles; this helper only subtracts programFiles for callers that
-// need an AST-only fallback Program.
+// need a non-project-backed fallback Program.
 //
 // Files pass through these filters in DiscoverLintFiles:
 //  1. Inside CLI/API file or directory scope
@@ -989,8 +1285,9 @@ func DiscoverGapFilesMultiConfig(
 	seen := make(map[string]struct{})
 	var allGapFiles []string
 	for _, configDir := range configDirs {
-		targetFiles := discoverLintFilesForConfigInMap(configMap, index, configDir, fsys, allowFiles, allowDirs, singleThreaded)
-		for _, f := range targetFiles {
+		targets := discoverLintTargetsForConfigInMap(configMap, index, nil, configDir, fsys, allowFiles, allowDirs, singleThreaded)
+		for _, target := range targets {
+			f := target.Path
 			if _, exists := programFiles[f]; exists {
 				continue
 			}

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -72,10 +72,28 @@ func DiscoverLintFiles(
 	allowDirs []string,
 	singleThreaded bool,
 ) []string {
+	return discoverLintFilesWithStopDirs(config, configDir, fsys, allowFiles, allowDirs, nil, singleThreaded)
+}
+
+func discoverLintFilesWithStopDirs(
+	config RslintConfig,
+	configDir string,
+	fsys vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	stopDirs []string,
+	singleThreaded bool,
+) []string {
 	globalIgnores := ExtractConfigIgnores(config)
 	globalIgnores = append(ParseIgnorePatterns(utils.DefaultIgnoreDirGlobs()), globalIgnores...)
+	useCaseSensitive := true
+	if fsys != nil {
+		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
+	}
 
 	filesPatterns := collectLintFilePatterns(config)
+	filesMatcher := buildFilesMatcher(filesPatterns)
+	needsEntryConfigCheck := hasEntryLevelIgnores(config)
 
 	var allowFileSet map[string]struct{}
 	if allowFiles != nil {
@@ -106,6 +124,9 @@ func DiscoverLintFiles(
 		if fsys != nil && !fsys.FileExists(filePath) {
 			return false
 		}
+		if IsDefaultExcludedPath(filePath, configDir, useCaseSensitive) {
+			return false
+		}
 		return !isGloballyIgnored(filePath)
 	}
 
@@ -113,11 +134,14 @@ func DiscoverLintFiles(
 		if !IsSupportedLintFile(filePath) {
 			return false
 		}
-		if len(filesPatterns) == 0 || !isFileMatched(filePath, filesPatterns, configDir) {
+		if len(filesPatterns) == 0 || !filesMatcher(filePath, configDir) {
 			return false
 		}
 		if isGloballyIgnored(filePath) {
 			return false
+		}
+		if !needsEntryConfigCheck {
+			return true
 		}
 		return config.GetConfigForFile(filePath, configDir) != nil
 	}
@@ -146,6 +170,7 @@ func DiscoverLintFiles(
 	)
 
 	neg := buildNegReach(globalIgnores)
+	stopWalkDirs := normalizeStopWalkDirs(normalizedConfigDir, stopDirs, useCaseSensitive)
 
 	workers := runtime.GOMAXPROCS(0)
 	if workers < 2 {
@@ -166,11 +191,8 @@ func DiscoverLintFiles(
 				}
 			}
 			if !inScope && allowDirs != nil {
-				for _, dir := range allowDirs {
-					if tspath.StartsWithDirectory(fullPath, dir, true) {
-						inScope = true
-						break
-					}
+				if isFileInAllowedDirs(fullPath, allowDirs, useCaseSensitive) {
+					inScope = true
 				}
 			}
 			if !inScope {
@@ -204,10 +226,13 @@ func DiscoverLintFiles(
 		for _, e := range entries {
 			name := e.Name()
 			if e.IsDir() {
-				if _, excluded := defaultExcludeDirs[name]; excluded {
+				if isDefaultExcludedDirName(name, useCaseSensitive) {
 					continue
 				}
 				childPath := path.Join(walkPath, name)
+				if isStoppedWalkPath(childPath, stopWalkDirs, useCaseSensitive) {
+					continue
+				}
 				if cached, ok := dirIgnore.Load(childPath); ok {
 					blocked, _ := cached.(bool)
 					if blocked {
@@ -229,7 +254,9 @@ func DiscoverLintFiles(
 	}
 
 	pool := newWalkPool(workers)
-	pool.submitMany([]string{"."})
+	walkRoots := discoverWalkRoots(normalizedConfigDir, allowDirs, fsys)
+	walkRoots = filterInitialWalkRoots(walkRoots, globalIgnores, neg, stopWalkDirs, useCaseSensitive)
+	pool.submitMany(walkRoots)
 	pool.run(work)
 
 	if allowFileSet != nil {
@@ -238,6 +265,206 @@ func DiscoverLintFiles(
 
 	sort.Strings(targetFiles)
 	return targetFiles
+}
+
+func normalizeStopWalkDirs(configDir string, stopDirs []string, useCaseSensitive bool) []string {
+	if len(stopDirs) == 0 {
+		return nil
+	}
+
+	compareOptions := tspath.ComparePathsOptions{
+		CurrentDirectory:          configDir,
+		UseCaseSensitiveFileNames: useCaseSensitive,
+	}
+	seen := make(map[string]struct{}, len(stopDirs))
+	normalized := make([]string, 0, len(stopDirs))
+	for _, rawDir := range stopDirs {
+		dir := tspath.NormalizePath(rawDir)
+		if pathsEqual(dir, configDir, useCaseSensitive) ||
+			!tspath.StartsWithDirectory(dir, configDir, useCaseSensitive) {
+			continue
+		}
+		rel := tspath.NormalizePath(tspath.GetRelativePathFromDirectory(configDir, dir, compareOptions))
+		if rel == "" || rel == "." {
+			continue
+		}
+		if _, ok := seen[rel]; ok {
+			continue
+		}
+		seen[rel] = struct{}{}
+		normalized = append(normalized, rel)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func filterInitialWalkRoots(
+	roots []string,
+	globalIgnores []IgnorePattern,
+	neg negReach,
+	stopWalkDirs []string,
+	useCaseSensitive bool,
+) []string {
+	if len(roots) == 0 {
+		return roots
+	}
+
+	filtered := make([]string, 0, len(roots))
+	for _, root := range roots {
+		root = tspath.NormalizePath(root)
+		if root == "" {
+			root = "."
+		}
+		if root != "." {
+			if hasDefaultExcludedSegment(root, useCaseSensitive) ||
+				isStoppedWalkPath(root, stopWalkDirs, useCaseSensitive) ||
+				canPruneDir(root, globalIgnores, neg) {
+				continue
+			}
+		}
+		filtered = append(filtered, root)
+	}
+	return filtered
+}
+
+// IsDefaultExcludedPath reports whether filePath contains one of rslint's
+// always-excluded directory names, interpreted relative to configDir when
+// possible.
+func IsDefaultExcludedPath(filePath string, configDir string, useCaseSensitive bool) bool {
+	filePath = tspath.NormalizePath(filePath)
+	configDir = tspath.NormalizePath(configDir)
+	if pathsEqual(filePath, configDir, useCaseSensitive) ||
+		tspath.StartsWithDirectory(filePath, configDir, useCaseSensitive) {
+		rel := tspath.GetRelativePathFromDirectory(configDir, filePath, tspath.ComparePathsOptions{
+			CurrentDirectory:          configDir,
+			UseCaseSensitiveFileNames: useCaseSensitive,
+		})
+		return hasDefaultExcludedSegment(rel, useCaseSensitive)
+	}
+	return hasDefaultExcludedSegment(filePath, useCaseSensitive)
+}
+
+func isDefaultExcludedDirName(name string, useCaseSensitive bool) bool {
+	for excluded := range defaultExcludeDirs {
+		if pathsEqual(name, excluded, useCaseSensitive) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDefaultExcludedSegment(walkPath string, useCaseSensitive bool) bool {
+	for _, segment := range strings.Split(walkPath, "/") {
+		if isDefaultExcludedDirName(segment, useCaseSensitive) {
+			return true
+		}
+	}
+	return false
+}
+
+func isStoppedWalkPath(walkPath string, stopWalkDirs []string, useCaseSensitive bool) bool {
+	if len(stopWalkDirs) == 0 {
+		return false
+	}
+	walkPath = tspath.NormalizePath(walkPath)
+	if walkPath == "" || walkPath == "." {
+		return false
+	}
+	for _, stopDir := range stopWalkDirs {
+		if pathsEqual(walkPath, stopDir, useCaseSensitive) ||
+			tspath.StartsWithDirectory(walkPath, stopDir, useCaseSensitive) {
+			return true
+		}
+	}
+	return false
+}
+
+func isFileInAllowedDirs(filePath string, allowDirs []string, useCaseSensitive bool) bool {
+	for _, dir := range allowDirs {
+		dir = tspath.NormalizePath(dir)
+		if pathsEqual(filePath, dir, useCaseSensitive) ||
+			tspath.StartsWithDirectory(filePath, dir, useCaseSensitive) {
+			return true
+		}
+	}
+	return false
+}
+
+func discoverWalkRoots(configDir string, allowDirs []string, fsys vfs.FS) []string {
+	if allowDirs == nil {
+		return []string{"."}
+	}
+	if len(allowDirs) == 0 {
+		return nil
+	}
+
+	useCaseSensitive := true
+	if fsys != nil {
+		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
+	}
+	compareOptions := tspath.ComparePathsOptions{
+		CurrentDirectory:          configDir,
+		UseCaseSensitiveFileNames: useCaseSensitive,
+	}
+	seen := make(map[string]struct{}, len(allowDirs))
+	roots := make([]string, 0, len(allowDirs))
+	addRoot := func(root string) {
+		if root == "" {
+			root = "."
+		}
+		root = tspath.NormalizePath(root)
+		if root == "." {
+			roots = []string{"."}
+			seen = map[string]struct{}{".": {}}
+			return
+		}
+		for _, existing := range roots {
+			if existing == "." {
+				return
+			}
+			if pathsEqual(existing, root, useCaseSensitive) ||
+				tspath.StartsWithDirectory(root, existing, useCaseSensitive) {
+				return
+			}
+		}
+		filtered := roots[:0]
+		seen = make(map[string]struct{}, len(allowDirs))
+		for _, existing := range roots {
+			if pathsEqual(existing, root, useCaseSensitive) ||
+				tspath.StartsWithDirectory(existing, root, useCaseSensitive) {
+				continue
+			}
+			seen[existing] = struct{}{}
+			filtered = append(filtered, existing)
+		}
+		roots = filtered
+		if _, ok := seen[root]; ok {
+			return
+		}
+		seen[root] = struct{}{}
+		roots = append(roots, root)
+	}
+
+	for _, rawDir := range allowDirs {
+		dir := tspath.NormalizePath(rawDir)
+		if pathsEqual(dir, configDir, useCaseSensitive) ||
+			tspath.StartsWithDirectory(configDir, dir, useCaseSensitive) {
+			return []string{"."}
+		}
+		if tspath.StartsWithDirectory(dir, configDir, useCaseSensitive) {
+			addRoot(tspath.GetRelativePathFromDirectory(configDir, dir, compareOptions))
+		}
+	}
+
+	sort.Strings(roots)
+	return roots
+}
+
+func pathsEqual(a, b string, useCaseSensitive bool) bool {
+	if useCaseSensitive {
+		return a == b
+	}
+	return strings.EqualFold(a, b)
 }
 
 func collectLintFilePatterns(config RslintConfig) []string {
@@ -255,6 +482,43 @@ func collectLintFilePatterns(config RslintConfig) []string {
 	return deduplicate(patterns)
 }
 
+func buildFilesMatcher(patterns []string) func(filePath string, configDir string) bool {
+	if patternsIncludeAllDefaultExtensions(patterns) {
+		return func(string, string) bool { return true }
+	}
+	return func(filePath string, configDir string) bool {
+		return isFileMatched(filePath, patterns, configDir)
+	}
+}
+
+func patternsIncludeAllDefaultExtensions(patterns []string) bool {
+	if len(patterns) < len(DefaultLintFileExtensions) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(patterns))
+	for _, pattern := range patterns {
+		seen[tspath.NormalizePath(pattern)] = struct{}{}
+	}
+	for _, pattern := range defaultLintFilePatterns() {
+		if _, ok := seen[tspath.NormalizePath(pattern)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func hasEntryLevelIgnores(config RslintConfig) bool {
+	for _, entry := range config {
+		if isGlobalIgnoreEntry(entry) {
+			continue
+		}
+		if len(entry.Ignores) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // DiscoverLintFilesMultiConfig resolves lint targets across a config map.
 func DiscoverLintFilesMultiConfig(
 	configMap map[string]RslintConfig,
@@ -269,13 +533,9 @@ func DiscoverLintFilesMultiConfig(
 
 	seen := make(map[string]struct{})
 	var allTargets []string
-	for configDir, cfg := range configMap {
-		targets := DiscoverLintFiles(cfg, configDir, fsys, allowFiles, allowDirs, singleThreaded)
+	for configDir := range configMap {
+		targets := DiscoverLintFilesForConfigInMap(configMap, configDir, fsys, allowFiles, allowDirs, singleThreaded)
 		for _, f := range targets {
-			ownerDir, _ := FindNearestConfig(f, configMap)
-			if ownerDir != configDir {
-				continue
-			}
 			if _, exists := seen[f]; !exists {
 				seen[f] = struct{}{}
 				allTargets = append(allTargets, f)
@@ -284,6 +544,59 @@ func DiscoverLintFilesMultiConfig(
 	}
 	sort.Strings(allTargets)
 	return allTargets
+}
+
+// DiscoverLintFilesForConfigInMap resolves lint targets owned by one config in
+// a multi-config map. Descendant config directories are treated as handoff
+// boundaries so parent configs don't walk subtrees that a nearer config owns.
+func DiscoverLintFilesForConfigInMap(
+	configMap map[string]RslintConfig,
+	configDir string,
+	fsys vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	singleThreaded bool,
+) []string {
+	cfg, ok := configMap[configDir]
+	if !ok {
+		return nil
+	}
+
+	stopDirs := descendantConfigDirs(configMap, configDir, fsys)
+	targets := discoverLintFilesWithStopDirs(cfg, configDir, fsys, allowFiles, allowDirs, stopDirs, singleThreaded)
+	if len(targets) == 0 {
+		return targets
+	}
+
+	ownedTargets := make([]string, 0, len(targets))
+	for _, f := range targets {
+		ownerDir, _ := FindNearestConfig(f, configMap)
+		if ownerDir == configDir {
+			ownedTargets = append(ownedTargets, f)
+		}
+	}
+	return ownedTargets
+}
+
+func descendantConfigDirs(configMap map[string]RslintConfig, configDir string, fsys vfs.FS) []string {
+	useCaseSensitive := true
+	if fsys != nil {
+		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
+	}
+
+	configDir = tspath.NormalizePath(configDir)
+	descendants := make([]string, 0)
+	for candidate := range configMap {
+		candidate = tspath.NormalizePath(candidate)
+		if pathsEqual(candidate, configDir, useCaseSensitive) {
+			continue
+		}
+		if tspath.StartsWithDirectory(candidate, configDir, useCaseSensitive) {
+			descendants = append(descendants, candidate)
+		}
+	}
+	sort.Strings(descendants)
+	return descendants
 }
 
 // DiscoverGapFiles returns resolved lint targets that are absent from existing
@@ -357,11 +670,10 @@ func DiscoverGapFilesMultiConfig(
 
 	seen := make(map[string]struct{})
 	var allGapFiles []string
-	for configDir, cfg := range configMap {
-		gapFiles := DiscoverGapFiles(cfg, configDir, fsys, programFiles, allowFiles, allowDirs, singleThreaded)
-		for _, f := range gapFiles {
-			ownerDir, _ := FindNearestConfig(f, configMap)
-			if ownerDir != configDir {
+	for configDir := range configMap {
+		targetFiles := DiscoverLintFilesForConfigInMap(configMap, configDir, fsys, allowFiles, allowDirs, singleThreaded)
+		for _, f := range targetFiles {
+			if _, exists := programFiles[f]; exists {
 				continue
 			}
 			if _, exists := seen[f]; !exists {

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -8,11 +8,37 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/bmatcuk/doublestar/v4"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+// DefaultLintFileExtensions are the file extensions rslint discovers when a
+// config entry omits `files`. This intentionally extends ESLint's default
+// .js/.mjs/.cjs set with JSX and TypeScript-family files.
+var DefaultLintFileExtensions = []string{".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx", ".mts", ".cts"}
+
+var defaultLintFileExtensionSet = func() map[string]struct{} {
+	m := make(map[string]struct{}, len(DefaultLintFileExtensions))
+	for _, ext := range DefaultLintFileExtensions {
+		m[ext] = struct{}{}
+	}
+	return m
+}()
+
+func defaultLintFilePatterns() []string {
+	patterns := make([]string, 0, len(DefaultLintFileExtensions))
+	for _, ext := range DefaultLintFileExtensions {
+		patterns = append(patterns, "**/*"+ext)
+	}
+	return patterns
+}
+
+// IsSupportedLintFile reports whether rslint can parse and lint this path.
+func IsSupportedLintFile(filePath string) bool {
+	_, ok := defaultLintFileExtensionSet[strings.ToLower(path.Ext(filePath))]
+	return ok
+}
 
 // defaultExcludeDirs is a set of directory names always excluded from walking.
 var defaultExcludeDirs = func() map[string]struct{} {
@@ -23,65 +49,34 @@ var defaultExcludeDirs = func() map[string]struct{} {
 	return m
 }()
 
-// DiscoverGapFiles scans the filesystem for "gap files" — files that match a config
-// entry's `files` pattern but are not in any tsconfig Program. These files get a
-// fallback Program (AST-only, no type info) and only run non-type-aware rules.
+// DiscoverLintFiles resolves the lint target set for one config directory.
+// Target selection is independent from TypeScript Program membership:
 //
-// Files pass through these filters:
-//  1. Match at least one config entry's `files` pattern
-//  2. Not in global ignores (directory-level and file-level)
-//  3. Not already in programFiles (existing tsconfig Programs)
-//  4. Pass GetConfigForFile (would actually receive lint rules)
+//   - CLI/API files and directories first constrain the search space.
+//   - Non-global config entries then contribute `files` patterns; an omitted
+//     files field contributes rslint's default lintable extensions.
+//   - Global ignores, including injected .gitignore entries, remove files.
+//   - Entry-level ignores are honored through GetConfigForFile for discovered
+//     files. Explicit file targets bypass `files` and entry-level ignores for
+//     target selection, but still use GetConfigForFile later for rule selection
+//     and can therefore be counted as 0-rule lint results.
+//   - Explicit file targets are retained even when they do not match any
+//     config entry's files patterns, matching ESLint's empty-result behavior.
 //
-// Walking model:
-//   - A bounded worker pool (see walkPool) traverses the directory tree.
-//     Total live goroutines at any moment is at most `workers`.
-//   - Default workers = max(2, GOMAXPROCS); singleThreaded forces workers=1
-//     for fully serial traversal (a knob users rely on for debugging,
-//     reproducibility, and constrained environments).
-//   - The vfsAdapter is constructed with followSymlinks=false, so symlinked
-//     subdirectories are skipped entirely. This matches ESLint v10's
-//     flat-config file walker, which uses @humanfs/node and recurses only
-//     when Dirent.isDirectory() is true (Node returns false for symlinks).
-//     It also avoids the otherwise scheduling-dependent "first writer wins"
-//     non-determinism a parallel walker would introduce.
-//
-// When allowFiles/allowDirs are provided (CLI args), only files within scope.
-//
-// Returns:
-//   - nil: no config entry has a `files` field → caller uses legacy tsconfig-only behavior
-//   - []: `files` present but no gaps found
-//   - [...]: gap files to create a fallback Program for (sorted lexically)
-func DiscoverGapFiles(
+// Returned paths are absolute, normalized, deduplicated, and sorted.
+func DiscoverLintFiles(
 	config RslintConfig,
 	configDir string,
 	fsys vfs.FS,
-	programFiles map[string]struct{},
 	allowFiles []string,
 	allowDirs []string,
 	singleThreaded bool,
 ) []string {
-	// 1. Collect global ignore patterns and files patterns from config entries.
 	globalIgnores := ExtractConfigIgnores(config)
+	globalIgnores = append(ParseIgnorePatterns(utils.DefaultIgnoreDirGlobs()), globalIgnores...)
 
-	var allFilesPatterns []string
-	hasFilesField := false
-	for _, entry := range config {
-		if len(entry.Files) > 0 {
-			hasFilesField = true
-			allFilesPatterns = append(allFilesPatterns, entry.Files...)
-		}
-	}
+	filesPatterns := collectLintFilePatterns(config)
 
-	// No entry has files → backward compat, signal caller to skip new logic.
-	if !hasFilesField {
-		return nil
-	}
-
-	// Deduplicate patterns.
-	allFilesPatterns = deduplicate(allFilesPatterns)
-
-	// Build allowFiles set for fast lookup.
 	var allowFileSet map[string]struct{}
 	if allowFiles != nil {
 		allowFileSet = make(map[string]struct{}, len(allowFiles))
@@ -90,65 +85,68 @@ func DiscoverGapFiles(
 		}
 	}
 
-	// 2. Prepend default directory ignores so they are always active
-	// regardless of user config.
-	globalIgnores = append(ParseIgnorePatterns(utils.DefaultIgnoreDirGlobs()), globalIgnores...)
-
-	// Use non-nil empty slice to distinguish "files field present, no gaps"
-	// from "no files field" (nil).
-	gapFiles := []string{}
-
-	// Fast path: when only specific files are provided (e.g., lint-staged),
-	// check each file directly instead of walking the entire filesystem.
-	if allowFileSet != nil && allowDirs == nil {
-		for f := range allowFileSet {
-			if _, exists := programFiles[f]; exists {
-				continue
-			}
-			if isFileIgnored(f, globalIgnores, configDir) {
-				continue
-			}
-			if config.GetConfigForFile(f, configDir) == nil {
-				continue
-			}
-			gapFiles = append(gapFiles, f)
+	targetFiles := []string{}
+	seenTargets := make(map[string]struct{})
+	addTarget := func(filePath string) {
+		if _, seen := seenTargets[filePath]; seen {
+			return
 		}
-		gapFiles = deduplicate(gapFiles)
-		// Map iteration order is non-deterministic; sort to match the walker
-		// path and keep output stable across runs.
-		sort.Strings(gapFiles)
-		return gapFiles
+		seenTargets[filePath] = struct{}{}
+		targetFiles = append(targetFiles, filePath)
+	}
+	isGloballyIgnored := func(filePath string) bool {
+		return isDirBlockedByIgnores(filePath, globalIgnores, configDir) ||
+			isFileIgnored(filePath, globalIgnores, configDir)
 	}
 
-	// 3. Walk the tree with a bounded worker pool. Goroutine count is capped
-	// at `workers`; symlinks are skipped (see vfsAdapter doc) so the result
-	// set is deterministic regardless of scheduling.
+	includeExplicitFile := func(filePath string) bool {
+		if !IsSupportedLintFile(filePath) {
+			return false
+		}
+		if fsys != nil && !fsys.FileExists(filePath) {
+			return false
+		}
+		return !isGloballyIgnored(filePath)
+	}
+
+	includeDiscoveredFile := func(filePath string) bool {
+		if !IsSupportedLintFile(filePath) {
+			return false
+		}
+		if len(filesPatterns) == 0 || !isFileMatched(filePath, filesPatterns, configDir) {
+			return false
+		}
+		if isGloballyIgnored(filePath) {
+			return false
+		}
+		return config.GetConfigForFile(filePath, configDir) != nil
+	}
+
+	addExplicitTargets := func() {
+		for f := range allowFileSet {
+			if includeExplicitFile(f) {
+				addTarget(f)
+			}
+		}
+	}
+
+	// Fast path for explicit file-only invocations, e.g. lint-staged.
+	if allowFileSet != nil && allowDirs == nil {
+		addExplicitTargets()
+		sort.Strings(targetFiles)
+		return targetFiles
+	}
+
 	normalizedConfigDir := normalizeGlobPath(configDir)
 	fsAdapter := &vfsAdapter{vfs: fsys, root: normalizedConfigDir}
 
-	// Normalize patterns relative to configDir for matching.
-	relativePatterns := make([]string, len(allFilesPatterns))
-	for i, pattern := range allFilesPatterns {
-		normalizedPattern := normalizeGlobPath(tspath.ResolvePath(configDir, pattern))
-		relativePatterns[i] = strings.TrimPrefix(normalizedPattern, normalizedConfigDir+"/")
-	}
-
 	var (
-		gapMu     sync.Mutex
-		seen      sync.Map // map[string]struct{} — file dedupe
-		dirIgnore sync.Map // map[string]bool — pattern check cache, write-once per path
+		targetMu  sync.Mutex
+		dirIgnore sync.Map // map[string]bool — pattern check cache
 	)
 
-	// Precompute negation reaches once. canPruneDir uses them to prune gitignore
-	// file-level directories (e.g. target/ → **/target/**/*) without ever
-	// skipping a directory a `!` pattern could re-include.
 	neg := buildNegReach(globalIgnores)
 
-	// Defer the parallelism limit to GOMAXPROCS (Go's standard knob; aligned
-	// with container CGroup CPU limits). Lower bound of 2 keeps the walker
-	// useful on single-core CI runners. singleThreaded overrides to 1 for
-	// fully serial traversal — a knob users depend on for reproducibility,
-	// debugging, and constrained environments.
 	workers := runtime.GOMAXPROCS(0)
 	if workers < 2 {
 		workers = 2
@@ -158,29 +156,8 @@ func DiscoverGapFiles(
 	}
 
 	processFile := func(walkPath string) {
-		// 1. pattern match
-		matched := false
-		for _, pattern := range relativePatterns {
-			if ok, _ := doublestar.Match(pattern, walkPath); ok {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return
-		}
-
 		fullPath := tspath.NormalizePath(path.Join(normalizedConfigDir, walkPath))
 
-		// 2. already in tsconfig Programs
-		if _, exists := programFiles[fullPath]; exists {
-			return
-		}
-		// 3. file-level global ignores
-		if isFileIgnored(fullPath, globalIgnores, configDir) {
-			return
-		}
-		// 4. CLI scope
 		if allowFileSet != nil || allowDirs != nil {
 			inScope := false
 			if allowFileSet != nil {
@@ -200,17 +177,14 @@ func DiscoverGapFiles(
 				return
 			}
 		}
-		// 5. final config check
-		if config.GetConfigForFile(fullPath, configDir) == nil {
+
+		if !includeDiscoveredFile(fullPath) {
 			return
 		}
-		// 6. dedupe + append
-		if _, loaded := seen.LoadOrStore(fullPath, struct{}{}); loaded {
-			return
-		}
-		gapMu.Lock()
-		gapFiles = append(gapFiles, fullPath)
-		gapMu.Unlock()
+
+		targetMu.Lock()
+		addTarget(fullPath)
+		targetMu.Unlock()
 	}
 
 	work := func(walkPath string) []string {
@@ -235,15 +209,11 @@ func DiscoverGapFiles(
 				}
 				childPath := path.Join(walkPath, name)
 				if cached, ok := dirIgnore.Load(childPath); ok {
-					blocked, _ := cached.(bool) // dirIgnore only stores bool (set by Store below)
+					blocked, _ := cached.(bool)
 					if blocked {
 						continue
 					}
 				} else {
-					// canPruneDir unifies both directory-prune cases: absolute
-					// blocks (dir/**, bare names) and negation-aware file-level
-					// gitignore covers (dir/**/*). Sound — prunes only when every
-					// descendant file would be ignored by isFileIgnored.
 					blocked := canPruneDir(childPath, globalIgnores, neg)
 					dirIgnore.Store(childPath, blocked)
 					if blocked {
@@ -262,7 +232,107 @@ func DiscoverGapFiles(
 	pool.submitMany([]string{"."})
 	pool.run(work)
 
-	sort.Strings(gapFiles)
+	if allowFileSet != nil {
+		addExplicitTargets()
+	}
+
+	sort.Strings(targetFiles)
+	return targetFiles
+}
+
+func collectLintFilePatterns(config RslintConfig) []string {
+	var patterns []string
+	for _, entry := range config {
+		if isGlobalIgnoreEntry(entry) {
+			continue
+		}
+		if len(entry.Files) > 0 {
+			patterns = append(patterns, entry.Files...)
+		} else {
+			patterns = append(patterns, defaultLintFilePatterns()...)
+		}
+	}
+	return deduplicate(patterns)
+}
+
+// DiscoverLintFilesMultiConfig resolves lint targets across a config map.
+func DiscoverLintFilesMultiConfig(
+	configMap map[string]RslintConfig,
+	fsys vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	singleThreaded bool,
+) []string {
+	if len(configMap) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var allTargets []string
+	for configDir, cfg := range configMap {
+		targets := DiscoverLintFiles(cfg, configDir, fsys, allowFiles, allowDirs, singleThreaded)
+		for _, f := range targets {
+			ownerDir, _ := FindNearestConfig(f, configMap)
+			if ownerDir != configDir {
+				continue
+			}
+			if _, exists := seen[f]; !exists {
+				seen[f] = struct{}{}
+				allTargets = append(allTargets, f)
+			}
+		}
+	}
+	sort.Strings(allTargets)
+	return allTargets
+}
+
+// DiscoverGapFiles returns resolved lint targets that are absent from existing
+// Programs. The filesystem walk and config/default-files matching are owned by
+// DiscoverLintFiles; this helper only subtracts programFiles for callers that
+// need an AST-only fallback Program.
+//
+// Files pass through these filters in DiscoverLintFiles:
+//  1. Inside CLI/API file or directory scope
+//  2. Selected by config `files` patterns or default lintable extensions;
+//     explicit file targets may pass this step to produce an empty result
+//  3. Not in global ignores or .gitignore-injected ignores
+//  4. Not already in programFiles
+//
+// Walking model:
+//   - A bounded worker pool (see walkPool) traverses the directory tree.
+//     Total live goroutines at any moment is at most `workers`.
+//   - Default workers = max(2, GOMAXPROCS); singleThreaded forces workers=1
+//     for fully serial traversal (a knob users rely on for debugging,
+//     reproducibility, and constrained environments).
+//   - The vfsAdapter is constructed with followSymlinks=false, so symlinked
+//     subdirectories are skipped entirely. This matches ESLint v10's
+//     flat-config file walker, which uses @humanfs/node and recurses only
+//     when Dirent.isDirectory() is true (Node returns false for symlinks).
+//     It also avoids the otherwise scheduling-dependent "first writer wins"
+//     non-determinism a parallel walker would introduce.
+//
+// When allowFiles/allowDirs are provided (CLI args), only files within scope.
+//
+// Returns:
+//   - []: no gaps found
+//   - [...]: gap files to create a fallback Program for (sorted lexically)
+func DiscoverGapFiles(
+	config RslintConfig,
+	configDir string,
+	fsys vfs.FS,
+	programFiles map[string]struct{},
+	allowFiles []string,
+	allowDirs []string,
+	singleThreaded bool,
+) []string {
+	gapFiles := []string{}
+	targetFiles := DiscoverLintFiles(config, configDir, fsys, allowFiles, allowDirs, singleThreaded)
+	for _, fullPath := range targetFiles {
+		if _, exists := programFiles[fullPath]; exists {
+			continue
+		}
+		gapFiles = append(gapFiles, fullPath)
+	}
 	return gapFiles
 }
 
@@ -290,6 +360,10 @@ func DiscoverGapFilesMultiConfig(
 	for configDir, cfg := range configMap {
 		gapFiles := DiscoverGapFiles(cfg, configDir, fsys, programFiles, allowFiles, allowDirs, singleThreaded)
 		for _, f := range gapFiles {
+			ownerDir, _ := FindNearestConfig(f, configMap)
+			if ownerDir != configDir {
+				continue
+			}
 			if _, exists := seen[f]; !exists {
 				seen[f] = struct{}{}
 				allGapFiles = append(allGapFiles, f)
@@ -297,9 +371,6 @@ func DiscoverGapFilesMultiConfig(
 		}
 	}
 
-	if len(allGapFiles) == 0 {
-		return nil
-	}
 	sort.Strings(allGapFiles)
 	return allGapFiles
 }

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -40,6 +40,26 @@ func IsSupportedLintFile(filePath string) bool {
 	return ok
 }
 
+func isDefaultLintFile(filePath string) bool {
+	_, ok := defaultLintFileExtensionSet[path.Ext(filePath)]
+	return ok
+}
+
+// isFileSelectedByConfig reports whether the config itself selects filePath.
+// The implicit default baseline is always present; explicit `files` patterns
+// extend it. Entry-level ignores do not remove a target from this selector.
+func isFileSelectedByConfig(config RslintConfig, filePath string, configDir string) bool {
+	if isDefaultLintFile(filePath) {
+		return true
+	}
+	for _, entry := range config {
+		if !isGlobalIgnoreEntry(entry) && hasFileSelectors(entry) && isFileMatchedByConfigEntry(filePath, entry, configDir) {
+			return true
+		}
+	}
+	return false
+}
+
 // defaultExcludeDirs is a set of directory names always excluded from walking.
 var defaultExcludeDirs = func() map[string]struct{} {
 	m := make(map[string]struct{}, len(utils.DefaultExcludeDirNames))
@@ -53,13 +73,11 @@ var defaultExcludeDirs = func() map[string]struct{} {
 // Target selection is independent from TypeScript Program membership:
 //
 //   - CLI/API files and directories first constrain the search space.
-//   - Non-global config entries then contribute `files` patterns; an omitted
-//     files field contributes rslint's default lintable extensions.
+//   - Rslint's default lintable extensions are always selected. Non-global
+//     config entries contribute additional `files` patterns.
 //   - Global ignores, including injected .gitignore entries, remove files.
-//   - Entry-level ignores are honored through GetConfigForFile for discovered
-//     files. Explicit file targets bypass `files` and entry-level ignores for
-//     target selection, but still use GetConfigForFile later for rule selection
-//     and can therefore be counted as 0-rule lint results.
+//   - Entry-level ignores affect config/rule selection, not target selection.
+//     A selected file excluded by every entry is still parsed with zero rules.
 //   - Explicit file targets are retained even when they do not match any
 //     config entry's files patterns, matching ESLint's empty-result behavior.
 //
@@ -90,31 +108,61 @@ func discoverLintFilesWithStopDirs(
 	if fsys != nil {
 		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
 	}
+	comparisonKey := func(filePath string) string {
+		return string(tspath.ToPath(tspath.NormalizePath(filePath), "", useCaseSensitive))
+	}
+	configDir = tspath.NormalizePath(configDir)
+	configMatchDir := configDir
+	if fsys != nil {
+		if realPath := fsys.Realpath(configDir); realPath != "" {
+			configMatchDir = tspath.NormalizePath(realPath)
+		}
+	}
+	configPathForMatching := func(filePath string) string {
+		filePath = tspath.NormalizePath(filePath)
+		if relative, ok := relativePathWithinConfigRoot(filePath, configDir, useCaseSensitive); ok {
+			return tspath.ResolvePath(configMatchDir, relative)
+		}
+		if fsys != nil {
+			if realPath := fsys.Realpath(filePath); realPath != "" {
+				canonical := tspath.NormalizePath(realPath)
+				if relative, ok := relativePathWithinConfigRoot(canonical, configMatchDir, useCaseSensitive); ok {
+					return tspath.ResolvePath(configMatchDir, relative)
+				}
+			}
+		}
+		return filePath
+	}
 
 	filesPatterns := collectLintFilePatterns(config)
 	filesMatcher := buildFilesMatcher(filesPatterns)
-	needsEntryConfigCheck := hasEntryLevelIgnores(config)
 
-	var allowFileSet map[string]struct{}
+	var allowFileSet map[string]string
 	if allowFiles != nil {
-		allowFileSet = make(map[string]struct{}, len(allowFiles))
+		allowFileSet = make(map[string]string, len(allowFiles))
 		for _, f := range allowFiles {
-			allowFileSet[tspath.NormalizePath(f)] = struct{}{}
+			normalized := tspath.NormalizePath(f)
+			key := comparisonKey(normalized)
+			if _, exists := allowFileSet[key]; !exists {
+				allowFileSet[key] = normalized
+			}
 		}
 	}
 
 	targetFiles := []string{}
 	seenTargets := make(map[string]struct{})
 	addTarget := func(filePath string) {
-		if _, seen := seenTargets[filePath]; seen {
+		key := comparisonKey(filePath)
+		if _, seen := seenTargets[key]; seen {
 			return
 		}
-		seenTargets[filePath] = struct{}{}
+		seenTargets[key] = struct{}{}
 		targetFiles = append(targetFiles, filePath)
 	}
 	isGloballyIgnored := func(filePath string) bool {
-		return isDirBlockedByIgnores(filePath, globalIgnores, configDir) ||
-			isFileIgnored(filePath, globalIgnores, configDir)
+		matchPath := configPathForMatching(filePath)
+		return isDirBlockedByIgnores(matchPath, globalIgnores, configMatchDir) ||
+			isFileIgnored(matchPath, globalIgnores, configMatchDir)
 	}
 
 	includeExplicitFile := func(filePath string) bool {
@@ -124,7 +172,7 @@ func discoverLintFilesWithStopDirs(
 		if fsys != nil && !fsys.FileExists(filePath) {
 			return false
 		}
-		if IsDefaultExcludedPath(filePath, configDir, useCaseSensitive) {
+		if IsDefaultExcludedPath(configPathForMatching(filePath), configMatchDir, useCaseSensitive) {
 			return false
 		}
 		return !isGloballyIgnored(filePath)
@@ -134,20 +182,24 @@ func discoverLintFilesWithStopDirs(
 		if !IsSupportedLintFile(filePath) {
 			return false
 		}
-		if len(filesPatterns) == 0 || !filesMatcher(filePath, configDir) {
+		matchPath := configPathForMatching(filePath)
+		if len(filesPatterns) == 0 || !filesMatcher(matchPath, configMatchDir) {
+			return false
+		}
+		// Candidate patterns for an AND group intentionally form a superset.
+		// Apply the complete selector here so negated and additional group
+		// members cannot leak candidates into the target set.
+		if !isFileSelectedByConfig(config, matchPath, configMatchDir) {
 			return false
 		}
 		if isGloballyIgnored(filePath) {
 			return false
 		}
-		if !needsEntryConfigCheck {
-			return true
-		}
-		return config.GetConfigForFile(filePath, configDir) != nil
+		return true
 	}
 
 	addExplicitTargets := func() {
-		for f := range allowFileSet {
+		for _, f := range allowFileSet {
 			if includeExplicitFile(f) {
 				addTarget(f)
 			}
@@ -181,12 +233,12 @@ func discoverLintFilesWithStopDirs(
 	}
 
 	processFile := func(walkPath string) {
-		fullPath := tspath.NormalizePath(path.Join(normalizedConfigDir, walkPath))
+		fullPath := tspath.NormalizePath(tspath.CombinePaths(normalizedConfigDir, walkPath))
 
 		if allowFileSet != nil || allowDirs != nil {
 			inScope := false
 			if allowFileSet != nil {
-				if _, ok := allowFileSet[fullPath]; ok {
+				if _, ok := allowFileSet[comparisonKey(fullPath)]; ok {
 					inScope = true
 				}
 			}
@@ -265,6 +317,20 @@ func discoverLintFilesWithStopDirs(
 
 	sort.Strings(targetFiles)
 	return targetFiles
+}
+
+func relativePathWithinConfigRoot(filePath string, configDir string, useCaseSensitive bool) (string, bool) {
+	compareOptions := tspath.ComparePathsOptions{
+		CurrentDirectory:          configDir,
+		UseCaseSensitiveFileNames: useCaseSensitive,
+	}
+	if tspath.ComparePaths(filePath, configDir, compareOptions) == 0 {
+		return "", true
+	}
+	if !tspath.StartsWithDirectory(filePath, configDir, useCaseSensitive) {
+		return "", false
+	}
+	return tspath.GetRelativePathFromDirectory(configDir, filePath, compareOptions), true
 }
 
 func normalizeStopWalkDirs(configDir string, stopDirs []string, useCaseSensitive bool) []string {
@@ -468,26 +534,70 @@ func pathsEqual(a, b string, useCaseSensitive bool) bool {
 }
 
 func collectLintFilePatterns(config RslintConfig) []string {
-	var patterns []string
+	patterns := defaultLintFilePatterns()
 	for _, entry := range config {
 		if isGlobalIgnoreEntry(entry) {
 			continue
 		}
-		if len(entry.Files) > 0 {
-			patterns = append(patterns, entry.Files...)
-		} else {
-			patterns = append(patterns, defaultLintFilePatterns()...)
+		for _, pattern := range entry.Files {
+			if candidate, ok := positiveFilesCandidate(pattern); ok {
+				patterns = append(patterns, candidate)
+			} else {
+				patterns = append(patterns, "**/*")
+			}
+		}
+		for _, group := range entry.FilePatternGroups {
+			hasPositiveCandidate := false
+			for _, pattern := range group {
+				if candidate, ok := positiveFilesCandidate(pattern); ok {
+					patterns = append(patterns, candidate)
+					hasPositiveCandidate = true
+				}
+			}
+			if !hasPositiveCandidate {
+				patterns = append(patterns, "**/*")
+			}
 		}
 	}
 	return deduplicate(patterns)
 }
 
-func buildFilesMatcher(patterns []string) func(filePath string, configDir string) bool {
-	if patternsIncludeAllDefaultExtensions(patterns) {
-		return func(string, string) bool { return true }
+func positiveFilesCandidate(pattern string) (string, bool) {
+	negated := false
+	for strings.HasPrefix(pattern, "!") {
+		negated = !negated
+		pattern = strings.TrimPrefix(pattern, "!")
 	}
+	return pattern, !negated && pattern != ""
+}
+
+func buildFilesMatcher(patterns []string) func(filePath string, configDir string) bool {
+	hasDefaultBaseline := patternsIncludeAllDefaultExtensions(patterns)
+	if !hasDefaultBaseline {
+		return func(filePath string, configDir string) bool {
+			return isFileMatched(filePath, patterns, configDir)
+		}
+	}
+
+	defaultPatterns := make(map[string]struct{}, len(DefaultLintFileExtensions))
+	for _, pattern := range defaultLintFilePatterns() {
+		defaultPatterns[tspath.NormalizePath(pattern)] = struct{}{}
+	}
+	additionalPatterns := make([]string, 0, len(patterns)-len(defaultPatterns))
+	for _, pattern := range patterns {
+		if _, isDefault := defaultPatterns[tspath.NormalizePath(pattern)]; !isDefault {
+			additionalPatterns = append(additionalPatterns, pattern)
+		}
+	}
+
 	return func(filePath string, configDir string) bool {
-		return isFileMatched(filePath, patterns, configDir)
+		// ESLint's default extension globs are case-sensitive even on a
+		// case-insensitive filesystem. Keep this fast path exact-case; explicit
+		// user patterns are evaluated normally below.
+		if isDefaultLintFile(filePath) {
+			return true
+		}
+		return len(additionalPatterns) > 0 && isFileMatched(filePath, additionalPatterns, configDir)
 	}
 }
 
@@ -507,19 +617,100 @@ func patternsIncludeAllDefaultExtensions(patterns []string) bool {
 	return true
 }
 
-func hasEntryLevelIgnores(config RslintConfig) bool {
-	for _, entry := range config {
-		if isGlobalIgnoreEntry(entry) {
-			continue
-		}
-		if len(entry.Ignores) > 0 {
-			return true
-		}
-	}
-	return false
+// LintDiscoveryScope overrides the CLI/API scope for one config.
+type LintDiscoveryScope struct {
+	Files []string
+	Dirs  []string
 }
 
-// DiscoverLintFilesMultiConfig resolves lint targets across a config map.
+// DiscoveredLintTarget preserves the config owner established during the
+// directory walk so later stages do not need to infer ownership from paths.
+type DiscoveredLintTarget struct {
+	Path            string
+	ConfigDirectory string
+}
+
+// DiscoverLintTargetsMultiConfig resolves owned lint targets across a config
+// map. Per-config scopes override the default scope when present.
+func DiscoverLintTargetsMultiConfig(
+	configMap map[string]RslintConfig,
+	scopes map[string]LintDiscoveryScope,
+	fsys vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	singleThreaded bool,
+) []DiscoveredLintTarget {
+	if len(configMap) == 0 {
+		return nil
+	}
+
+	index := newConfigDirectoryIndex(configMap, fsys)
+	configDirs := make([]string, 0, len(configMap))
+	for configDir := range configMap {
+		configDirs = append(configDirs, configDir)
+	}
+	sort.Strings(configDirs)
+
+	// Explicit files are assigned to their nearest config once. Passing the
+	// complete list to every config makes lint-staged-style invocations
+	// O(configs*files), and also asks every config to evaluate ignores for files
+	// it cannot own. A non-nil empty bucket is preserved below so the explicit
+	// file-only fast path still suppresses directory walking for configs that own
+	// no requested files.
+	filesByConfig := index.assignExplicitFiles(allowFiles)
+	filesSpecifiedByConfig := make(map[string]bool, len(configDirs))
+	if allowFiles != nil {
+		for _, configDir := range configDirs {
+			filesSpecifiedByConfig[configDir] = true
+		}
+	}
+	for configDir, scope := range scopes {
+		delete(filesByConfig, configDir)
+		filesSpecifiedByConfig[configDir] = scope.Files != nil
+	}
+	for _, scope := range scopes {
+		if scope.Files == nil {
+			continue
+		}
+		for owner, files := range index.assignExplicitFiles(scope.Files) {
+			filesByConfig[owner] = append(filesByConfig[owner], files...)
+			filesSpecifiedByConfig[owner] = true
+		}
+	}
+
+	seen := make(map[tspath.Path]struct{})
+	var allTargets []DiscoveredLintTarget
+	for _, configDir := range configDirs {
+		var configAllowFiles []string
+		if filesSpecifiedByConfig[configDir] {
+			configAllowFiles = filesByConfig[configDir]
+			if configAllowFiles == nil {
+				configAllowFiles = []string{}
+			}
+		}
+		configAllowDirs := allowDirs
+		if scope, ok := scopes[configDir]; ok {
+			configAllowDirs = scope.Dirs
+		}
+		targets := discoverLintFilesForConfigInMap(configMap, index, configDir, fsys, configAllowFiles, configAllowDirs, singleThreaded)
+		for _, f := range targets {
+			pathID := tspath.ToPath(tspath.NormalizePath(f), "", index.useCaseSensitive)
+			if _, exists := seen[pathID]; !exists {
+				seen[pathID] = struct{}{}
+				allTargets = append(allTargets, DiscoveredLintTarget{
+					Path:            f,
+					ConfigDirectory: configDir,
+				})
+			}
+		}
+	}
+	sort.Slice(allTargets, func(i, j int) bool {
+		return allTargets[i].Path < allTargets[j].Path
+	})
+	return allTargets
+}
+
+// DiscoverLintFilesMultiConfig resolves lint target paths across a config map.
 func DiscoverLintFilesMultiConfig(
 	configMap map[string]RslintConfig,
 	fsys vfs.FS,
@@ -527,23 +718,12 @@ func DiscoverLintFilesMultiConfig(
 	allowDirs []string,
 	singleThreaded bool,
 ) []string {
-	if len(configMap) == 0 {
-		return nil
+	targets := DiscoverLintTargetsMultiConfig(configMap, nil, fsys, allowFiles, allowDirs, singleThreaded)
+	files := make([]string, 0, len(targets))
+	for _, target := range targets {
+		files = append(files, target.Path)
 	}
-
-	seen := make(map[string]struct{})
-	var allTargets []string
-	for configDir := range configMap {
-		targets := DiscoverLintFilesForConfigInMap(configMap, configDir, fsys, allowFiles, allowDirs, singleThreaded)
-		for _, f := range targets {
-			if _, exists := seen[f]; !exists {
-				seen[f] = struct{}{}
-				allTargets = append(allTargets, f)
-			}
-		}
-	}
-	sort.Strings(allTargets)
-	return allTargets
+	return files
 }
 
 // DiscoverLintFilesForConfigInMap resolves lint targets owned by one config in
@@ -557,12 +737,32 @@ func DiscoverLintFilesForConfigInMap(
 	allowDirs []string,
 	singleThreaded bool,
 ) []string {
+	return discoverLintFilesForConfigInMap(
+		configMap,
+		newConfigDirectoryIndex(configMap, fsys),
+		configDir,
+		fsys,
+		allowFiles,
+		allowDirs,
+		singleThreaded,
+	)
+}
+
+func discoverLintFilesForConfigInMap(
+	configMap map[string]RslintConfig,
+	index *configDirectoryIndex,
+	configDir string,
+	fsys vfs.FS,
+	allowFiles []string,
+	allowDirs []string,
+	singleThreaded bool,
+) []string {
 	cfg, ok := configMap[configDir]
 	if !ok {
 		return nil
 	}
 
-	stopDirs := descendantConfigDirs(configMap, configDir, fsys)
+	stopDirs := index.childConfigDirs(configDir)
 	targets := discoverLintFilesWithStopDirs(cfg, configDir, fsys, allowFiles, allowDirs, stopDirs, singleThreaded)
 	if len(targets) == 0 {
 		return targets
@@ -570,7 +770,7 @@ func DiscoverLintFilesForConfigInMap(
 
 	ownedTargets := make([]string, 0, len(targets))
 	for _, f := range targets {
-		ownerDir, _ := FindNearestConfig(f, configMap)
+		ownerDir, _ := index.nearestConfig(f)
 		if ownerDir == configDir {
 			ownedTargets = append(ownedTargets, f)
 		}
@@ -578,25 +778,136 @@ func DiscoverLintFilesForConfigInMap(
 	return ownedTargets
 }
 
-func descendantConfigDirs(configMap map[string]RslintConfig, configDir string, fsys vfs.FS) []string {
+type configDirectoryIndex struct {
+	fsys                     vfs.FS
+	useCaseSensitive         bool
+	configKeyByPath          map[tspath.Path]string
+	canonicalConfigKeyByPath map[tspath.Path]string
+	ambiguousCanonicalPaths  map[tspath.Path]struct{}
+	normalizedByKey          map[string]string
+	childrenByKey            map[string][]string
+}
+
+func newConfigDirectoryIndex(configMap map[string]RslintConfig, fsys vfs.FS) *configDirectoryIndex {
 	useCaseSensitive := true
 	if fsys != nil {
 		useCaseSensitive = fsys.UseCaseSensitiveFileNames()
 	}
 
-	configDir = tspath.NormalizePath(configDir)
-	descendants := make([]string, 0)
-	for candidate := range configMap {
-		candidate = tspath.NormalizePath(candidate)
-		if pathsEqual(candidate, configDir, useCaseSensitive) {
+	index := &configDirectoryIndex{
+		fsys:                     fsys,
+		useCaseSensitive:         useCaseSensitive,
+		configKeyByPath:          make(map[tspath.Path]string, len(configMap)),
+		canonicalConfigKeyByPath: make(map[tspath.Path]string, len(configMap)),
+		ambiguousCanonicalPaths:  make(map[tspath.Path]struct{}),
+		normalizedByKey:          make(map[string]string, len(configMap)),
+		childrenByKey:            make(map[string][]string, len(configMap)),
+	}
+	configKeys := make([]string, 0, len(configMap))
+	for configKey := range configMap {
+		configKeys = append(configKeys, configKey)
+	}
+	sort.Strings(configKeys)
+	for _, configKey := range configKeys {
+		normalized := tspath.NormalizePath(configKey)
+		index.normalizedByKey[configKey] = normalized
+		pathID := tspath.ToPath(normalized, "", useCaseSensitive)
+		if _, exists := index.configKeyByPath[pathID]; !exists {
+			index.configKeyByPath[pathID] = configKey
+		}
+
+		canonical := normalized
+		if fsys != nil {
+			if realPath := fsys.Realpath(normalized); realPath != "" {
+				canonical = tspath.NormalizePath(realPath)
+			}
+		}
+		canonicalID := tspath.ToPath(canonical, "", useCaseSensitive)
+		if _, ambiguous := index.ambiguousCanonicalPaths[canonicalID]; ambiguous {
 			continue
 		}
-		if tspath.StartsWithDirectory(candidate, configDir, useCaseSensitive) {
-			descendants = append(descendants, candidate)
+		if existing, exists := index.canonicalConfigKeyByPath[canonicalID]; !exists {
+			index.canonicalConfigKeyByPath[canonicalID] = configKey
+		} else if existing != configKey {
+			// Lexical aliases remain independently addressable. A physical-path
+			// fallback cannot choose between them, so leave it unresolved instead
+			// of silently assigning the file to the first map entry.
+			delete(index.canonicalConfigKeyByPath, canonicalID)
+			index.ambiguousCanonicalPaths[canonicalID] = struct{}{}
 		}
 	}
-	sort.Strings(descendants)
-	return descendants
+
+	for _, configKey := range configKeys {
+		normalized := index.normalizedByKey[configKey]
+		for parent := tspath.GetDirectoryPath(normalized); parent != "" && parent != normalized; {
+			if parentKey, ok := index.configKeyByPath[tspath.ToPath(parent, "", useCaseSensitive)]; ok {
+				index.childrenByKey[parentKey] = append(index.childrenByKey[parentKey], normalized)
+				break
+			}
+			next := tspath.GetDirectoryPath(parent)
+			if next == parent {
+				break
+			}
+			parent = next
+		}
+	}
+	for configKey := range index.childrenByKey {
+		sort.Strings(index.childrenByKey[configKey])
+	}
+	return index
+}
+
+func (index *configDirectoryIndex) childConfigDirs(configKey string) []string {
+	if index == nil {
+		return nil
+	}
+	return index.childrenByKey[configKey]
+}
+
+func (index *configDirectoryIndex) nearestConfig(filePath string) (string, bool) {
+	if index == nil {
+		return "", false
+	}
+	filePath = tspath.NormalizePath(filePath)
+	if configKey, ok := index.nearestConfigInPathSpace(filePath, index.configKeyByPath); ok {
+		return configKey, true
+	}
+	if index.fsys == nil {
+		return "", false
+	}
+	realPath := index.fsys.Realpath(filePath)
+	if realPath == "" {
+		return "", false
+	}
+	return index.nearestConfigInPathSpace(tspath.NormalizePath(realPath), index.canonicalConfigKeyByPath)
+}
+
+func (index *configDirectoryIndex) nearestConfigInPathSpace(filePath string, configKeyByPath map[tspath.Path]string) (string, bool) {
+	current := tspath.GetDirectoryPath(filePath)
+	for current != "" {
+		if configKey, ok := configKeyByPath[tspath.ToPath(current, "", index.useCaseSensitive)]; ok {
+			return configKey, true
+		}
+		next := tspath.GetDirectoryPath(current)
+		if next == current {
+			break
+		}
+		current = next
+	}
+	return "", false
+}
+
+func (index *configDirectoryIndex) assignExplicitFiles(files []string) map[string][]string {
+	if index == nil || files == nil {
+		return nil
+	}
+	filesByConfig := make(map[string][]string)
+	for _, filePath := range files {
+		if owner, ok := index.nearestConfig(filePath); ok {
+			filesByConfig[owner] = append(filesByConfig[owner], filePath)
+		}
+	}
+	return filesByConfig
 }
 
 // DiscoverGapFiles returns resolved lint targets that are absent from existing
@@ -668,10 +979,17 @@ func DiscoverGapFilesMultiConfig(
 		return nil
 	}
 
+	index := newConfigDirectoryIndex(configMap, fsys)
+	configDirs := make([]string, 0, len(configMap))
+	for configDir := range configMap {
+		configDirs = append(configDirs, configDir)
+	}
+	sort.Strings(configDirs)
+
 	seen := make(map[string]struct{})
 	var allGapFiles []string
-	for configDir := range configMap {
-		targetFiles := DiscoverLintFilesForConfigInMap(configMap, configDir, fsys, allowFiles, allowDirs, singleThreaded)
+	for _, configDir := range configDirs {
+		targetFiles := discoverLintFilesForConfigInMap(configMap, index, configDir, fsys, allowFiles, allowDirs, singleThreaded)
 		for _, f := range targetFiles {
 			if _, exists := programFiles[f]; exists {
 				continue

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -134,20 +134,24 @@ func TestDiscoverGapFiles_GetConfigForFilePreFilter(t *testing.T) {
 	assert.Equal(t, len(gapFiles), 0)
 }
 
-func TestDiscoverGapFiles_NoFilesField_ReturnsNil(t *testing.T) {
-	configDir, _ := setupDiscoveryFixture(t, []string{
+func TestDiscoverGapFiles_NoFilesField_UsesDefaultExtensions(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
 		"src/a.ts",
+		"src/b.jsx",
+		"src/c.cjs",
+		"src/d.cts",
+		"src/styles.css",
 	})
 
-	// JSON-style config: no files field
 	config := RslintConfig{
 		{Rules: Rules{"test-rule": "error"}},
 	}
 
 	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
 
-	// Should return nil (backward compat signal)
-	assert.Assert(t, gapFiles == nil, "should return nil when no entry has files field")
+	expected := []string{paths["src/a.ts"], paths["src/b.jsx"], paths["src/c.cjs"], paths["src/d.cts"]}
+	sort.Strings(expected)
+	assert.DeepEqual(t, gapFiles, expected)
 }
 
 func TestDiscoverGapFiles_AllowDirsScope(t *testing.T) {
@@ -245,14 +249,42 @@ func TestDiscoverGapFiles_AllowFilesScope(t *testing.T) {
 	assert.Equal(t, gapFiles[0], paths["scripts/b.ts"])
 }
 
-func TestDiscoverGapFiles_AllExtensionsDiscoveredByPattern(t *testing.T) {
-	configDir, _ := setupDiscoveryFixture(t, []string{
+func TestDiscoverLintFiles_ExplicitFileBypassesFilesWithDirScope(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"explicit.js",
 		"src/a.ts",
+	})
+
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	srcDir := tspath.NormalizePath(filepath.Join(configDir, "src"))
+	targets := DiscoverLintFiles(
+		config,
+		configDir,
+		osvfs.FS(),
+		[]string{paths["explicit.js"]},
+		[]string{srcDir},
+		false,
+	)
+
+	expected := []string{paths["explicit.js"], paths["src/a.ts"]}
+	sort.Strings(expected)
+	assert.DeepEqual(t, targets, expected)
+}
+
+func TestDiscoverGapFiles_AllExtensionsDiscoveredByPattern(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/a.ts",
+		"src/b.jsx",
+		"src/c.cjs",
 		"src/readme.md",
 		"src/data.json",
 	})
 
-	// files: ['**/*'] matches all files — no extension filtering
+	// files: ['**/*'] matches the whole tree, but rslint still only lints
+	// extensions it can parse.
 	config := RslintConfig{
 		{Files: []string{"**/*"}, Rules: Rules{"test-rule": "error"}},
 	}
@@ -262,8 +294,9 @@ func TestDiscoverGapFiles_AllExtensionsDiscoveredByPattern(t *testing.T) {
 	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
-	// All files matching the pattern should be discovered (no extension filter)
-	assert.Equal(t, len(gapFiles), 3)
+	expected := []string{paths["src/a.ts"], paths["src/b.jsx"], paths["src/c.cjs"]}
+	sort.Strings(expected)
+	assert.DeepEqual(t, gapFiles, expected)
 }
 
 func TestDiscoverGapFilesMultiConfig(t *testing.T) {
@@ -300,20 +333,50 @@ func TestDiscoverGapFilesMultiConfig(t *testing.T) {
 	assert.Assert(t, hasB, "should find b.tsx")
 }
 
-func TestDiscoverGapFiles_EmptyFilesArray(t *testing.T) {
-	configDir, _ := setupDiscoveryFixture(t, []string{
-		"src/a.ts",
+func TestDiscoverLintFilesMultiConfig_UsesNearestConfigOwner(t *testing.T) {
+	rootDir, rootPaths := setupDiscoveryFixture(t, []string{
+		"root.ts",
+		"pkg/child.ts",
 	})
+	childDir := tspath.NormalizePath(filepath.Join(rootDir, "pkg"))
 
-	// Entry with files: [] (empty array, not absent)
-	config := RslintConfig{
-		{Files: []string{}, Rules: Rules{"test-rule": "error"}},
+	configMap := map[string]RslintConfig{
+		rootDir: {
+			{Files: []string{"**/*.ts"}, Rules: Rules{"root-rule": "error"}},
+		},
+		childDir: {
+			{Files: []string{"**/*.jsx"}, Rules: Rules{"child-rule": "error"}},
+		},
 	}
 
-	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
+	targets := DiscoverLintFilesMultiConfig(configMap, osvfs.FS(), nil, []string{rootDir}, false)
 
-	// Empty files array has no patterns to match → same as no files field → nil (legacy mode)
-	assert.Assert(t, gapFiles == nil, "should return nil for empty files array")
+	expected := []string{rootPaths["root.ts"]}
+	assert.DeepEqual(t, targets, expected)
+}
+
+func TestDiscoverGapFilesMultiConfig_UsesNearestConfigOwner(t *testing.T) {
+	rootDir, rootPaths := setupDiscoveryFixture(t, []string{
+		"root.ts",
+		"pkg/child.ts",
+		"pkg/child.jsx",
+	})
+	childDir := tspath.NormalizePath(filepath.Join(rootDir, "pkg"))
+
+	configMap := map[string]RslintConfig{
+		rootDir: {
+			{Files: []string{"**/*.ts"}, Rules: Rules{"root-rule": "error"}},
+		},
+		childDir: {
+			{Files: []string{"**/*.jsx"}, Rules: Rules{"child-rule": "error"}},
+		},
+	}
+
+	gapFiles := DiscoverGapFilesMultiConfig(configMap, osvfs.FS(), map[string]struct{}{}, nil, []string{rootDir}, false)
+
+	expected := []string{rootPaths["pkg/child.jsx"], rootPaths["root.ts"]}
+	sort.Strings(expected)
+	assert.DeepEqual(t, gapFiles, expected)
 }
 
 func TestDiscoverGapFiles_FilesButNoRules(t *testing.T) {

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"gotest.tools/v3/assert"
 )
@@ -107,7 +109,7 @@ func TestDiscoverGapFiles_ProgramFilesSkipped(t *testing.T) {
 	assert.Equal(t, len(gapFiles), 0)
 }
 
-func TestDiscoverGapFiles_GetConfigForFilePreFilter(t *testing.T) {
+func TestDiscoverGapFiles_EntryIgnoreDoesNotRemoveTarget(t *testing.T) {
 	configDir, paths := setupDiscoveryFixture(t, []string{
 		"src/a.ts",
 		"test/b.ts",
@@ -128,10 +130,158 @@ func TestDiscoverGapFiles_GetConfigForFilePreFilter(t *testing.T) {
 
 	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
-	// test/b.ts matches **/*.ts but is excluded by entry-level ignores →
-	// GetConfigForFile returns nil → not a gap file
+	// Entry-level ignores only control whether this entry contributes rules.
+	// Both files remain lint targets; test/b.ts runs with zero rules.
 	assert.Assert(t, gapFiles != nil)
-	assert.Equal(t, len(gapFiles), 0)
+	assert.DeepEqual(t, gapFiles, []string{paths["test/b.ts"]})
+}
+
+func TestDiscoverLintFiles_DefaultBaselineIsIndependentOfConfigEntries(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/a.js",
+		"src/b.mjs",
+		"src/c.cjs",
+		"src/d.jsx",
+		"src/e.ts",
+		"src/f.tsx",
+		"src/g.mts",
+		"src/h.cts",
+		"src/G.JS",
+		"src/styles.css",
+	})
+
+	tests := []struct {
+		name   string
+		config RslintConfig
+	}{
+		{name: "empty config"},
+		{
+			name: "global ignore only",
+			config: RslintConfig{
+				{Ignores: []string{"generated/**"}},
+			},
+		},
+		{
+			name: "explicit TS entry does not remove defaults",
+			config: RslintConfig{
+				{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+			},
+		},
+	}
+
+	expected := []string{
+		paths["src/a.js"],
+		paths["src/b.mjs"],
+		paths["src/c.cjs"],
+		paths["src/d.jsx"],
+		paths["src/e.ts"],
+		paths["src/f.tsx"],
+		paths["src/g.mts"],
+		paths["src/h.cts"],
+	}
+	sort.Strings(expected)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targets := DiscoverLintFiles(tt.config, configDir, osvfs.FS(), nil, nil, true)
+			assert.DeepEqual(t, targets, expected)
+		})
+	}
+}
+
+func TestDiscoverLintFiles_PreservesUNCRoot(t *testing.T) {
+	const configDir = "//server/share/repo"
+	mock := &gitignoreMockFS{
+		FS: osvfs.FS(),
+		entries: map[string]vfs.Entries{
+			configDir: {
+				Directories: []string{"src"},
+				Symlinks:    map[string]struct{}{},
+			},
+			configDir + "/src": {
+				Files:    []string{"a.ts"},
+				Symlinks: map[string]struct{}{},
+			},
+		},
+		files:     map[string]string{},
+		realpaths: map[string]string{},
+	}
+
+	targets := DiscoverLintFiles(nil, configDir, mock, nil, nil, true)
+	assert.DeepEqual(t, targets, []string{"//server/share/repo/src/a.ts"})
+}
+
+type caseInsensitiveDiscoveryFS struct {
+	vfs.FS
+	files map[string]bool
+}
+
+func (f *caseInsensitiveDiscoveryFS) UseCaseSensitiveFileNames() bool { return false }
+func (f *caseInsensitiveDiscoveryFS) FileExists(filePath string) bool {
+	return f.files[strings.ToLower(tspath.NormalizePath(filePath))]
+}
+func (f *caseInsensitiveDiscoveryFS) Realpath(filePath string) string {
+	return tspath.NormalizePath(filePath)
+}
+
+type fileExistsCountingFS struct {
+	vfs.FS
+	calls atomic.Int32
+}
+
+func (f *fileExistsCountingFS) FileExists(filePath string) bool {
+	f.calls.Add(1)
+	return f.FS.FileExists(filePath)
+}
+
+func TestDiscoverLintFiles_DeduplicatesExplicitPathCasing(t *testing.T) {
+	fsys := &caseInsensitiveDiscoveryFS{
+		FS: osvfs.FS(),
+		files: map[string]bool{
+			"c:/repo/src/a.ts": true,
+		},
+	}
+	targets := DiscoverLintFiles(
+		nil,
+		"C:/Repo",
+		fsys,
+		[]string{"C:/Repo/Src/A.ts", "c:/repo/src/a.ts"},
+		nil,
+		true,
+	)
+	assert.DeepEqual(t, targets, []string{"C:/Repo/Src/A.ts"})
+}
+
+func TestDiscoverLintFiles_ExplicitPatternCanExtendCaseSensitiveBaseline(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{"src/A.JS", "src/b.js"})
+
+	withoutExplicitPattern := DiscoverLintFiles(nil, configDir, osvfs.FS(), nil, nil, true)
+	assert.DeepEqual(t, withoutExplicitPattern, []string{paths["src/b.js"]})
+
+	config := RslintConfig{{Files: []string{"**/*.JS"}}}
+	withExplicitPattern := DiscoverLintFiles(config, configDir, osvfs.FS(), nil, nil, true)
+	expected := []string{paths["src/A.JS"], paths["src/b.js"]}
+	sort.Strings(expected)
+	assert.DeepEqual(t, withExplicitPattern, expected)
+}
+
+func TestDiscoverLintFiles_FilesAndGroupAppliesCandidatePostFilter(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/A.JS",
+		"src/A.test.JS",
+		"other/B.JS",
+		"src/default.ts",
+	})
+	config := RslintConfig{{
+		FilePatternGroups: [][]string{
+			{"src/**", "**/*.JS", "!**/*.test.JS"},
+		},
+	}}
+
+	targets := DiscoverLintFiles(config, configDir, osvfs.FS(), nil, nil, true)
+	expected := []string{paths["src/A.JS"], paths["src/default.ts"]}
+	sort.Strings(expected)
+	assert.DeepEqual(t, targets, expected)
 }
 
 func TestDiscoverGapFiles_NoFilesField_UsesDefaultExtensions(t *testing.T) {
@@ -356,7 +506,7 @@ func TestDiscoverGapFiles_MultipleFilesPatterns(t *testing.T) {
 	config := RslintConfig{
 		{Files: []string{"**/*.ts"}, Rules: Rules{"rule-a": "error"}},
 		{Files: []string{"**/*.tsx"}, Rules: Rules{"rule-b": "error"}},
-		// .js files have no matching entry
+		// .js remains in the default target baseline with zero matching rules.
 	}
 
 	programFiles := map[string]struct{}{}
@@ -366,7 +516,7 @@ func TestDiscoverGapFiles_MultipleFilesPatterns(t *testing.T) {
 	assert.Assert(t, gapFiles != nil)
 	sort.Strings(gapFiles)
 
-	expected := []string{paths["src/a.ts"], paths["src/b.tsx"]}
+	expected := []string{paths["src/a.ts"], paths["src/b.tsx"], paths["src/c.js"]}
 	sort.Strings(expected)
 
 	assert.Equal(t, len(gapFiles), len(expected))
@@ -375,13 +525,13 @@ func TestDiscoverGapFiles_MultipleFilesPatterns(t *testing.T) {
 	}
 }
 
-func TestDiscoverGapFiles_JsFilesNotDiscoveredWithoutPattern(t *testing.T) {
+func TestDiscoverGapFiles_DefaultJsDiscoveredWithoutExplicitPattern(t *testing.T) {
 	configDir, _ := setupDiscoveryFixture(t, []string{
 		"src/a.ts",
 		"src/b.js",
 	})
 
-	// Only **/*.ts in files, no **/*.js
+	// An explicit TypeScript selector does not remove the default JS target.
 	config := RslintConfig{
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
 	}
@@ -391,8 +541,7 @@ func TestDiscoverGapFiles_JsFilesNotDiscoveredWithoutPattern(t *testing.T) {
 	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
 	assert.Assert(t, gapFiles != nil)
-	// b.js should NOT be discovered because no entry has files: ['**/*.js']
-	assert.Equal(t, len(gapFiles), 1)
+	assert.Equal(t, len(gapFiles), 2)
 }
 
 func TestDiscoverGapFiles_AllowFilesScope(t *testing.T) {
@@ -522,7 +671,17 @@ func TestDiscoverLintFilesMultiConfig_UsesNearestConfigOwner(t *testing.T) {
 	targets := DiscoverLintFilesMultiConfig(configMap, osvfs.FS(), nil, []string{rootDir}, false)
 
 	expected := []string{rootPaths["root.ts"]}
+	expected = append(expected, rootPaths["pkg/child.ts"])
+	sort.Strings(expected)
 	assert.DeepEqual(t, targets, expected)
+
+	ownedTargets := DiscoverLintTargetsMultiConfig(configMap, nil, osvfs.FS(), nil, []string{rootDir}, false)
+	owners := make(map[string]string, len(ownedTargets))
+	for _, target := range ownedTargets {
+		owners[target.Path] = target.ConfigDirectory
+	}
+	assert.Equal(t, owners[rootPaths["root.ts"]], rootDir)
+	assert.Equal(t, owners[rootPaths["pkg/child.ts"]], childDir)
 }
 
 func TestDiscoverLintFilesMultiConfig_DoesNotWalkChildConfigFromParent(t *testing.T) {
@@ -557,6 +716,114 @@ func TestDiscoverLintFilesMultiConfig_DoesNotWalkChildConfigFromParent(t *testin
 	assert.Equal(t, childAccesses, 1, "child config directory should be entered only by its owning config")
 }
 
+func TestConfigDirectoryIndex_UsesImmediateBoundariesAndNearestOwner(t *testing.T) {
+	configMap := map[string]RslintConfig{
+		"/repo":          nil,
+		"/repo/pkg":      nil,
+		"/repo/pkg/deep": nil,
+		"/other":         nil,
+	}
+	index := newConfigDirectoryIndex(configMap, nil)
+
+	assert.DeepEqual(t, index.childConfigDirs("/repo"), []string{"/repo/pkg"})
+	assert.DeepEqual(t, index.childConfigDirs("/repo/pkg"), []string{"/repo/pkg/deep"})
+	owner, ok := index.nearestConfig("/repo/pkg/deep/src/index.ts")
+	assert.Assert(t, ok)
+	assert.Equal(t, owner, "/repo/pkg/deep")
+}
+
+func TestConfigDirectoryIndex_UsesFilesystemCaseSensitivity(t *testing.T) {
+	fsys := &caseInsensitiveDiscoveryFS{FS: osvfs.FS()}
+	configMap := map[string]RslintConfig{
+		"C:/Repo":         nil,
+		"C:/Repo/Package": nil,
+	}
+	index := newConfigDirectoryIndex(configMap, fsys)
+
+	owner, ok := index.nearestConfig("c:/repo/package/src/index.ts")
+	assert.Assert(t, ok)
+	assert.Equal(t, owner, "C:/Repo/Package")
+}
+
+func TestConfigDirectoryIndex_UsesPhysicalConfigRootForAliasedTarget(t *testing.T) {
+	realDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(realDir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "src/index.ts"), []byte("export {};\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(filepath.Dir(realDir), filepath.Base(realDir)+"-config-link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	defer os.Remove(linkDir)
+
+	linkDir = tspath.NormalizePath(linkDir)
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	index := newConfigDirectoryIndex(map[string]RslintConfig{linkDir: nil}, fsys)
+	owner, ok := index.nearestConfig(filepath.Join(realDir, "src/index.ts"))
+	assert.Assert(t, ok)
+	assert.Equal(t, owner, linkDir)
+}
+
+func TestDiscoverLintTargetsMultiConfig_MatchesIgnoresInPhysicalConfigSpace(t *testing.T) {
+	realDir, paths := setupDiscoveryFixture(t, []string{"src/keep.ts", "src/ignored.ts"})
+	linkDir := filepath.Join(filepath.Dir(realDir), filepath.Base(realDir)+"-config-link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	defer os.Remove(linkDir)
+	linkDir = tspath.NormalizePath(linkDir)
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	configMap := map[string]RslintConfig{
+		linkDir: {
+			{Ignores: []string{"src/ignored.ts"}},
+			{Files: []string{"src/**/*.ts"}, Rules: Rules{"rule": "error"}},
+		},
+	}
+
+	targets := DiscoverLintTargetsMultiConfig(
+		configMap,
+		nil,
+		fsys,
+		[]string{paths["src/ignored.ts"], paths["src/keep.ts"]},
+		nil,
+		true,
+	)
+	assert.DeepEqual(t, targets, []DiscoveredLintTarget{{
+		Path:            paths["src/keep.ts"],
+		ConfigDirectory: linkDir,
+	}})
+}
+
+func TestDiscoverLintTargetsMultiConfig_AssignsExplicitFilesBeforeConfigProcessing(t *testing.T) {
+	rootDir, paths := setupDiscoveryFixture(t, []string{"root.ts", "pkg/child.ts"})
+	childDir := tspath.NormalizePath(filepath.Join(rootDir, "pkg"))
+	fsys := &fileExistsCountingFS{FS: osvfs.FS()}
+	configMap := map[string]RslintConfig{
+		rootDir:  {{Files: []string{"**/*.jsx"}, Rules: Rules{"root": "error"}}},
+		childDir: {{Files: []string{"**/*.jsx"}, Rules: Rules{"child": "error"}}},
+	}
+
+	targets := DiscoverLintTargetsMultiConfig(
+		configMap,
+		nil,
+		fsys,
+		[]string{paths["pkg/child.ts"], paths["root.ts"]},
+		nil,
+		true,
+	)
+	assert.Equal(t, len(targets), 2)
+	owners := map[string]string{}
+	for _, target := range targets {
+		owners[target.Path] = target.ConfigDirectory
+	}
+	assert.Equal(t, owners[paths["root.ts"]], rootDir)
+	assert.Equal(t, owners[paths["pkg/child.ts"]], childDir)
+	assert.Equal(t, fsys.calls.Load(), int32(2), "each explicit file should be checked only by its owner")
+}
+
 func TestDiscoverGapFilesMultiConfig_UsesNearestConfigOwner(t *testing.T) {
 	rootDir, rootPaths := setupDiscoveryFixture(t, []string{
 		"root.ts",
@@ -576,7 +843,7 @@ func TestDiscoverGapFilesMultiConfig_UsesNearestConfigOwner(t *testing.T) {
 
 	gapFiles := DiscoverGapFilesMultiConfig(configMap, osvfs.FS(), map[string]struct{}{}, nil, []string{rootDir}, false)
 
-	expected := []string{rootPaths["pkg/child.jsx"], rootPaths["root.ts"]}
+	expected := []string{rootPaths["pkg/child.jsx"], rootPaths["pkg/child.ts"], rootPaths["root.ts"]}
 	sort.Strings(expected)
 	assert.DeepEqual(t, gapFiles, expected)
 }
@@ -586,18 +853,15 @@ func TestDiscoverGapFiles_FilesButNoRules(t *testing.T) {
 		"src/a.ts",
 	})
 
-	// Entry has files but no rules → GetConfigForFile returns MergedConfig
-	// with empty rules → but entryMatched is true → not nil
-	// However, linter will skip (len(rules) == 0)
+	// The selector contributes a target even though the entry has no rules.
 	config := RslintConfig{
 		{Files: []string{"**/*.ts"}},
 	}
 
 	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), map[string]struct{}{}, nil, nil, false)
 
-	// GetConfigForFile returns non-nil (entry matched), so the file IS a gap file.
-	// The linter will subsequently skip it because it has no rules, but that's
-	// the linter's concern, not discovery's.
+	// Discovery retains the gap target; the linter counts and parses it but does
+	// not execute a rule traversal when the merged rule set is empty.
 	assert.Assert(t, gapFiles != nil)
 }
 

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -176,6 +176,176 @@ func TestDiscoverGapFiles_AllowDirsScope(t *testing.T) {
 	assert.Equal(t, gapFiles[0], paths["scripts/b.ts"])
 }
 
+func TestDiscoverLintFiles_AllowDirsStartsWalkAtScopedRoot(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"packages/app/src/a.ts",
+		"packages/other/src/b.ts",
+	})
+
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+	appDir := tspath.NormalizePath(filepath.Join(configDir, "packages/app"))
+	spy := &gitignoreSpyFS{FS: osvfs.FS()}
+
+	targets := DiscoverLintFiles(config, configDir, spy, nil, []string{appDir}, true)
+
+	assert.DeepEqual(t, targets, []string{paths["packages/app/src/a.ts"]})
+
+	rootDir := tspath.NormalizePath(configDir)
+	otherDir := tspath.NormalizePath(filepath.Join(configDir, "packages/other"))
+	for _, accessed := range spy.accessedDirs {
+		if accessed == rootDir {
+			t.Fatalf("scoped walk should not open config root %s; accessed=%v", rootDir, spy.accessedDirs)
+		}
+		if strings.HasPrefix(accessed, otherDir) {
+			t.Fatalf("scoped walk should not enter sibling %s; accessed=%v", otherDir, spy.accessedDirs)
+		}
+	}
+}
+
+func TestDiscoverLintFiles_AllowDirsSkipsDefaultExcludedRoot(t *testing.T) {
+	configDir, _ := setupDiscoveryFixture(t, []string{
+		"node_modules/pkg/a.ts",
+		"src/a.ts",
+	})
+
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+	nodeModulesDir := tspath.NormalizePath(filepath.Join(configDir, "node_modules"))
+	spy := &spyFS{FS: osvfs.FS()}
+
+	targets := DiscoverLintFiles(config, configDir, spy, nil, []string{nodeModulesDir}, true)
+
+	assert.DeepEqual(t, targets, []string{})
+	for _, accessed := range spy.snapshotAccessedDirs() {
+		if strings.Contains(accessed, "node_modules") {
+			t.Fatalf("default-excluded initial root should not be entered; accessed=%v", spy.snapshotAccessedDirs())
+		}
+	}
+}
+
+func TestDiscoverLintFiles_AllowDirsSkipsGloballyIgnoredRoot(t *testing.T) {
+	configDir, _ := setupDiscoveryFixture(t, []string{
+		"dist/a.ts",
+		"src/a.ts",
+	})
+
+	config := RslintConfig{
+		{Ignores: []string{"dist/**"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+	distDir := tspath.NormalizePath(filepath.Join(configDir, "dist"))
+	spy := &spyFS{FS: osvfs.FS()}
+
+	targets := DiscoverLintFiles(config, configDir, spy, nil, []string{distDir}, true)
+
+	assert.DeepEqual(t, targets, []string{})
+	for _, accessed := range spy.snapshotAccessedDirs() {
+		if accessed == distDir || strings.HasPrefix(accessed, distDir+"/") {
+			t.Fatalf("globally ignored initial root should not be entered; accessed=%v", spy.snapshotAccessedDirs())
+		}
+	}
+}
+
+func TestDiscoverLintFiles_AllowDirsKeepsIgnoredRootWithNegation(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"dist/drop.ts",
+		"dist/keep.ts",
+	})
+
+	config := RslintConfig{
+		{Ignores: []string{"dist/**/*", "!dist/keep.ts"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+	distDir := tspath.NormalizePath(filepath.Join(configDir, "dist"))
+	spy := &spyFS{FS: osvfs.FS()}
+
+	targets := DiscoverLintFiles(config, configDir, spy, nil, []string{distDir}, true)
+
+	assert.DeepEqual(t, targets, []string{paths["dist/keep.ts"]})
+	enteredDist := false
+	for _, accessed := range spy.snapshotAccessedDirs() {
+		if accessed == distDir {
+			enteredDist = true
+			break
+		}
+	}
+	assert.Assert(t, enteredDist, "negated ignored root must still be entered")
+}
+
+func TestDiscoverLintFiles_EmptyAllowDirsDoesNotWalk(t *testing.T) {
+	configDir, _ := setupDiscoveryFixture(t, []string{
+		"src/a.ts",
+	})
+
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+	spy := &spyFS{FS: osvfs.FS()}
+
+	targets := DiscoverLintFiles(config, configDir, spy, nil, []string{}, true)
+
+	assert.Equal(t, len(targets), 0)
+	assert.Equal(t, len(spy.snapshotAccessedDirs()), 0)
+}
+
+func TestDiscoverLintFiles_ExplicitFileSkipsNestedDefaultExcludedDir(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"packages/app/node_modules/pkg/a.ts",
+		"src/a.ts",
+	})
+
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	targets := DiscoverLintFiles(
+		config,
+		configDir,
+		osvfs.FS(),
+		[]string{paths["packages/app/node_modules/pkg/a.ts"]},
+		nil,
+		true,
+	)
+
+	assert.DeepEqual(t, targets, []string{})
+}
+
+func TestDiscoverLintFiles_OverlappingAllowDirsWalkChildOnce(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"packages/app/src/a.ts",
+		"packages/app/src/nested/b.ts",
+		"packages/other/src/c.ts",
+	})
+
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+	appDir := tspath.NormalizePath(filepath.Join(configDir, "packages/app"))
+	srcDir := tspath.NormalizePath(filepath.Join(configDir, "packages/app/src"))
+	spy := &spyFS{FS: osvfs.FS()}
+
+	targets := DiscoverLintFiles(config, configDir, spy, nil, []string{appDir, srcDir}, true)
+
+	expected := []string{paths["packages/app/src/a.ts"], paths["packages/app/src/nested/b.ts"]}
+	assert.DeepEqual(t, targets, expected)
+
+	srcAccesses := 0
+	for _, accessed := range spy.snapshotAccessedDirs() {
+		if accessed == srcDir {
+			srcAccesses++
+		}
+	}
+	assert.Equal(t, srcAccesses, 1, "overlapping allowDirs should not walk child roots twice")
+}
+
+func TestIsFileInAllowedDirsHonorsCaseSensitivity(t *testing.T) {
+	assert.Assert(t, isFileInAllowedDirs("/Repo/Src/a.ts", []string{"/repo/src"}, false))
+	assert.Assert(t, !isFileInAllowedDirs("/Repo/Src/a.ts", []string{"/repo/src"}, true))
+}
+
 func TestDiscoverGapFiles_MultipleFilesPatterns(t *testing.T) {
 	configDir, paths := setupDiscoveryFixture(t, []string{
 		"src/a.ts",
@@ -353,6 +523,38 @@ func TestDiscoverLintFilesMultiConfig_UsesNearestConfigOwner(t *testing.T) {
 
 	expected := []string{rootPaths["root.ts"]}
 	assert.DeepEqual(t, targets, expected)
+}
+
+func TestDiscoverLintFilesMultiConfig_DoesNotWalkChildConfigFromParent(t *testing.T) {
+	rootDir, rootPaths := setupDiscoveryFixture(t, []string{
+		"root.ts",
+		"pkg/child.ts",
+	})
+	childDir := tspath.NormalizePath(filepath.Join(rootDir, "pkg"))
+
+	configMap := map[string]RslintConfig{
+		rootDir: {
+			{Files: []string{"**/*.ts"}, Rules: Rules{"root-rule": "error"}},
+		},
+		childDir: {
+			{Files: []string{"**/*.ts"}, Rules: Rules{"child-rule": "error"}},
+		},
+	}
+	spy := &spyFS{FS: osvfs.FS()}
+
+	targets := DiscoverLintFilesMultiConfig(configMap, spy, nil, []string{rootDir}, true)
+
+	expected := []string{rootPaths["pkg/child.ts"], rootPaths["root.ts"]}
+	sort.Strings(expected)
+	assert.DeepEqual(t, targets, expected)
+
+	childAccesses := 0
+	for _, accessed := range spy.snapshotAccessedDirs() {
+		if accessed == childDir {
+			childAccesses++
+		}
+	}
+	assert.Equal(t, childAccesses, 1, "child config directory should be entered only by its owning config")
 }
 
 func TestDiscoverGapFilesMultiConfig_UsesNearestConfigOwner(t *testing.T) {
@@ -632,6 +834,14 @@ func (s *spyFS) snapshotAccessedDirs() []string {
 	return out
 }
 
+type caseInsensitiveSpyFS struct {
+	*spyFS
+}
+
+func (s *caseInsensitiveSpyFS) UseCaseSensitiveFileNames() bool {
+	return false
+}
+
 func TestDiscoverGapFiles_PrunesNodeModulesAtWalkLevel(t *testing.T) {
 	configDir, _ := setupDiscoveryFixture(t, []string{
 		"src/index.ts",
@@ -649,6 +859,26 @@ func TestDiscoverGapFiles_PrunesNodeModulesAtWalkLevel(t *testing.T) {
 	for _, dir := range spy.snapshotAccessedDirs() {
 		if strings.Contains(dir, "node_modules") {
 			t.Errorf("node_modules directory was entered during walk (GetAccessibleEntries called for %s)", dir)
+		}
+	}
+}
+
+func TestDiscoverGapFiles_PrunesDefaultExcludesCaseInsensitive(t *testing.T) {
+	configDir, _ := setupDiscoveryFixture(t, []string{
+		"src/index.ts",
+		"Node_Modules/pkg/index.ts",
+	})
+
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	spy := &caseInsensitiveSpyFS{spyFS: &spyFS{FS: osvfs.FS()}}
+	DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, true)
+
+	for _, dir := range spy.snapshotAccessedDirs() {
+		if strings.Contains(dir, "Node_Modules") {
+			t.Errorf("Node_Modules directory was entered on case-insensitive FS (GetAccessibleEntries called for %s)", dir)
 		}
 	}
 }

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -130,10 +130,34 @@ func TestDiscoverGapFiles_EntryIgnoreDoesNotRemoveTarget(t *testing.T) {
 
 	gapFiles := DiscoverGapFiles(config, configDir, osvfs.FS(), programFiles, nil, nil, false)
 
-	// Entry-level ignores only control whether this entry contributes rules.
-	// Both files remain lint targets; test/b.ts runs with zero rules.
+	// The default TypeScript baseline independently selects both files, so the
+	// entry-level ignore only prevents this entry from contributing rules.
 	assert.Assert(t, gapFiles != nil)
 	assert.DeepEqual(t, gapFiles, []string{paths["test/b.ts"]})
+}
+
+func TestDiscoverLintFiles_EntryIgnorePreventsSelectorContribution(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/ignored.JS",
+		"src/included.JS",
+	})
+	config := RslintConfig{
+		{Rules: Rules{"no-debugger": "error"}},
+		{
+			Files:   []string{"**/*.JS"},
+			Ignores: []string{"**/ignored.JS"},
+			Rules:   Rules{"no-console": "error"},
+		},
+	}
+
+	targets := DiscoverLintFiles(config, configDir, osvfs.FS(), nil, nil, true)
+	assert.DeepEqual(t, targets, []string{paths["src/included.JS"]})
+	if merged := config.GetConfigForFile(paths["src/ignored.JS"], configDir); merged != nil {
+		t.Fatalf("locally ignored selector made the non-default extension configurable: %#v", merged)
+	}
+	if merged := config.GetConfigForFile(paths["src/included.JS"], configDir); merged == nil || merged.Rules["no-debugger"] == nil {
+		t.Fatalf("matching selector should make unscoped entries apply: %#v", merged)
+	}
 }
 
 func TestDiscoverLintFiles_DefaultBaselineIsIndependentOfConfigEntries(t *testing.T) {
@@ -203,8 +227,8 @@ func TestDiscoverLintFiles_PreservesUNCRoot(t *testing.T) {
 				Symlinks: map[string]struct{}{},
 			},
 		},
-		files:     map[string]string{},
-		realpaths: map[string]string{},
+		files:         map[string]string{},
+		resolvedPaths: map[string]string{},
 	}
 
 	targets := DiscoverLintFiles(nil, configDir, mock, nil, nil, true)
@@ -221,7 +245,7 @@ func (f *caseInsensitiveDiscoveryFS) FileExists(filePath string) bool {
 	return f.files[strings.ToLower(tspath.NormalizePath(filePath))]
 }
 func (f *caseInsensitiveDiscoveryFS) Realpath(filePath string) string {
-	return tspath.NormalizePath(filePath)
+	return strings.ToLower(tspath.NormalizePath(filePath))
 }
 
 type fileExistsCountingFS struct {
@@ -234,7 +258,27 @@ func (f *fileExistsCountingFS) FileExists(filePath string) bool {
 	return f.FS.FileExists(filePath)
 }
 
-func TestDiscoverLintFiles_DeduplicatesExplicitPathCasing(t *testing.T) {
+type realpathCountingFS struct {
+	vfs.FS
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func (f *realpathCountingFS) Realpath(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	f.mu.Lock()
+	f.calls[filePath]++
+	f.mu.Unlock()
+	return f.FS.Realpath(filePath)
+}
+
+func (f *realpathCountingFS) callCount(filePath string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[tspath.NormalizePath(filePath)]
+}
+
+func TestDiscoverLintFiles_PreservesDistinctLexicalPathCasing(t *testing.T) {
 	fsys := &caseInsensitiveDiscoveryFS{
 		FS: osvfs.FS(),
 		files: map[string]bool{
@@ -249,7 +293,7 @@ func TestDiscoverLintFiles_DeduplicatesExplicitPathCasing(t *testing.T) {
 		nil,
 		true,
 	)
-	assert.DeepEqual(t, targets, []string{"C:/Repo/Src/A.ts"})
+	assert.DeepEqual(t, targets, []string{"C:/Repo/Src/A.ts", "c:/repo/src/a.ts"})
 }
 
 func TestDiscoverLintFiles_ExplicitPatternCanExtendCaseSensitiveBaseline(t *testing.T) {
@@ -280,6 +324,23 @@ func TestDiscoverLintFiles_FilesAndGroupAppliesCandidatePostFilter(t *testing.T)
 
 	targets := DiscoverLintFiles(config, configDir, osvfs.FS(), nil, nil, true)
 	expected := []string{paths["src/A.JS"], paths["src/default.ts"]}
+	sort.Strings(expected)
+	assert.DeepEqual(t, targets, expected)
+}
+
+func TestDiscoverLintFiles_EmptyFilesAndGroupMatchesSupportedBaseline(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/a.js",
+		"src/b.ts",
+		"src/readme.md",
+	})
+	config := RslintConfig{{
+		FilePatternGroups: [][]string{{}},
+		Rules:             Rules{"test-rule": "error"},
+	}}
+
+	targets := DiscoverLintFiles(config, configDir, osvfs.FS(), nil, nil, true)
+	expected := []string{paths["src/a.js"], paths["src/b.ts"]}
 	sort.Strings(expected)
 	assert.DeepEqual(t, targets, expected)
 }
@@ -491,9 +552,82 @@ func TestDiscoverLintFiles_OverlappingAllowDirsWalkChildOnce(t *testing.T) {
 	assert.Equal(t, srcAccesses, 1, "overlapping allowDirs should not walk child roots twice")
 }
 
+func TestDiscoverLintTargets_DirectoryWalkAvoidsPerFileRealpath(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{
+		"src/a.ts",
+		"src/b.ts",
+		"src/c.ts",
+	})
+	fsys := &realpathCountingFS{FS: osvfs.FS(), calls: make(map[string]int)}
+	targets := DiscoverLintTargets(
+		RslintConfig{{Rules: Rules{"test-rule": "error"}}},
+		configDir,
+		fsys,
+		nil,
+		[]string{configDir},
+		true,
+	)
+	assert.Equal(t, len(targets), 3)
+	for _, filePath := range paths {
+		assert.Equal(t, fsys.callCount(filePath), 0, "regular walk target should use the config-root canonical hint")
+	}
+}
+
+func TestDiscoverLintTargets_ExplicitFileResolvesPhysicalIdentity(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{"src/a.ts"})
+	fsys := &realpathCountingFS{FS: osvfs.FS(), calls: make(map[string]int)}
+	targets := DiscoverLintTargets(nil, configDir, fsys, []string{paths["src/a.ts"]}, nil, true)
+	assert.Equal(t, len(targets), 1)
+	assert.Assert(t, fsys.callCount(paths["src/a.ts"]) > 0)
+}
+
+func TestDiscoverLintTargets_FileSymlinkResolvesPhysicalIdentity(t *testing.T) {
+	configDir, paths := setupDiscoveryFixture(t, []string{"src/a.ts"})
+	linkPath := tspath.NormalizePath(filepath.Join(configDir, "src/link.ts"))
+	if err := os.Symlink(paths["src/a.ts"], linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fsys := &realpathCountingFS{FS: osvfs.FS(), calls: make(map[string]int)}
+	targets := DiscoverLintTargets(nil, configDir, fsys, nil, []string{configDir}, true)
+	assert.Equal(t, len(targets), 2)
+
+	canonicalByPath := make(map[string]string, len(targets))
+	for _, target := range targets {
+		canonicalByPath[target.Path] = target.CanonicalPath
+	}
+	assert.Equal(t, canonicalByPath[linkPath], tspath.NormalizePath(fsys.FS.Realpath(paths["src/a.ts"])))
+	assert.Equal(t, fsys.callCount(paths["src/a.ts"]), 0)
+	assert.Assert(t, fsys.callCount(linkPath) > 0)
+}
+
 func TestIsFileInAllowedDirsHonorsCaseSensitivity(t *testing.T) {
 	assert.Assert(t, isFileInAllowedDirs("/Repo/Src/a.ts", []string{"/repo/src"}, false))
 	assert.Assert(t, !isFileInAllowedDirs("/Repo/Src/a.ts", []string{"/repo/src"}, true))
+}
+
+func TestIsFileInAllowedDirsUsesExactCanonicalIdentity(t *testing.T) {
+	fsys := &configPathSpaceFS{
+		caseSensitive: false,
+		realPaths: map[string]string{
+			"/Alias/Src/a.ts": "/Real/Src/a.ts",
+			"/real/src":       "/Real/Src",
+			"/Repo/Src/b.ts":  "/Repo/Src/b.ts",
+			"/repo/src":       "/repo/src",
+		},
+	}
+	assert.Assert(t, isFileInAllowedDirsWithFS("/Alias/Src/a.ts", []string{"/real/src"}, fsys))
+	assert.Assert(t, !isFileInAllowedDirsWithFS("/Repo/Src/b.ts", []string{"/repo/src"}, fsys))
+}
+
+func TestDiscoverWalkRootsMapsCanonicalDirectoryAlias(t *testing.T) {
+	fsys := &configPathSpaceFS{
+		caseSensitive: true,
+		realPaths: map[string]string{
+			"/alias":    "/real",
+			"/real/pkg": "/real/pkg",
+		},
+	}
+	assert.DeepEqual(t, discoverWalkRoots("/alias", []string{"/real/pkg"}, fsys), []string{"pkg"})
 }
 
 func TestDiscoverGapFiles_MultipleFilesPatterns(t *testing.T) {
@@ -732,17 +866,23 @@ func TestConfigDirectoryIndex_UsesImmediateBoundariesAndNearestOwner(t *testing.
 	assert.Equal(t, owner, "/repo/pkg/deep")
 }
 
-func TestConfigDirectoryIndex_UsesFilesystemCaseSensitivity(t *testing.T) {
+func TestConfigDirectoryIndex_UsesVerifiedNativeCaseHierarchy(t *testing.T) {
 	fsys := &caseInsensitiveDiscoveryFS{FS: osvfs.FS()}
 	configMap := map[string]RslintConfig{
 		"C:/Repo":         nil,
-		"C:/Repo/Package": nil,
+		"c:/repo/Package": nil,
 	}
 	index := newConfigDirectoryIndex(configMap, fsys)
 
-	owner, ok := index.nearestConfig("c:/repo/package/src/index.ts")
-	assert.Assert(t, ok)
-	assert.Equal(t, owner, "C:/Repo/Package")
+	assert.DeepEqual(t, index.childConfigDirs("C:/Repo"), []string{"c:/repo/Package"})
+	for _, filePath := range []string{
+		"C:/Repo/Package/src/index.ts",
+		"c:/repo/package/src/index.ts",
+	} {
+		owner, ok := index.nearestConfig(filePath)
+		assert.Assert(t, ok)
+		assert.Equal(t, owner, "c:/repo/Package")
+	}
 }
 
 func TestConfigDirectoryIndex_UsesPhysicalConfigRootForAliasedTarget(t *testing.T) {
@@ -793,6 +933,7 @@ func TestDiscoverLintTargetsMultiConfig_MatchesIgnoresInPhysicalConfigSpace(t *t
 	)
 	assert.DeepEqual(t, targets, []DiscoveredLintTarget{{
 		Path:            paths["src/keep.ts"],
+		CanonicalPath:   tspath.NormalizePath(fsys.Realpath(paths["src/keep.ts"])),
 		ConfigDirectory: linkDir,
 	}})
 }
@@ -822,6 +963,121 @@ func TestDiscoverLintTargetsMultiConfig_AssignsExplicitFilesBeforeConfigProcessi
 	assert.Equal(t, owners[paths["root.ts"]], rootDir)
 	assert.Equal(t, owners[paths["pkg/child.ts"]], childDir)
 	assert.Equal(t, fsys.calls.Load(), int32(2), "each explicit file should be checked only by its owner")
+}
+
+func TestDiscoverLintTargetsMultiConfig_PreservesHostAssignedExplicitOwner(t *testing.T) {
+	rootDir, paths := setupDiscoveryFixture(t, []string{"pkg/index.ts"})
+	childDir := tspath.NormalizePath(filepath.Join(rootDir, "pkg"))
+	aliasPath := tspath.NormalizePath(filepath.Join(rootDir, "alias.ts"))
+	if err := os.Symlink(paths["pkg/index.ts"], aliasPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	configMap := map[string]RslintConfig{
+		rootDir:  {{Rules: Rules{"root": "error"}}},
+		childDir: {{Rules: Rules{"child": "error"}}},
+	}
+
+	targets := DiscoverLintTargetsMultiConfig(
+		configMap,
+		map[string]LintDiscoveryScope{
+			rootDir: {Files: []string{aliasPath}},
+		},
+		fsys,
+		[]string{aliasPath},
+		nil,
+		true,
+	)
+	if len(targets) != 1 {
+		t.Fatalf("expected one explicitly assigned target, got %+v", targets)
+	}
+	assert.Equal(t, targets[0].Path, aliasPath)
+	assert.Equal(t, targets[0].CanonicalPath, tspath.NormalizePath(fsys.Realpath(aliasPath)))
+	assert.Equal(t, targets[0].ConfigDirectory, rootDir)
+}
+
+func TestDiscoverLintTargetsMultiConfig_PrefersLexicalOwnerOverPhysicalConfig(t *testing.T) {
+	rootDir, paths := setupDiscoveryFixture(t, []string{
+		"real/other.ts",
+		"real/sub/index.ts",
+		"real/sub/nested/child.ts",
+	})
+	linkDir := tspath.NormalizePath(filepath.Join(rootDir, "link"))
+	if err := os.Symlink(filepath.Join(rootDir, "real/sub"), linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fSys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	realConfigDir := tspath.NormalizePath(filepath.Join(rootDir, "real"))
+	nestedConfigDir := tspath.NormalizePath(filepath.Join(linkDir, "nested"))
+	configMap := map[string]RslintConfig{
+		rootDir:         {{Rules: Rules{"root": "error"}}},
+		realConfigDir:   {{Rules: Rules{"physical": "error"}}},
+		nestedConfigDir: {{Rules: Rules{"nested": "error"}}},
+	}
+
+	targets := DiscoverLintTargetsMultiConfig(
+		configMap,
+		map[string]LintDiscoveryScope{
+			realConfigDir: {Files: []string{paths["real/other.ts"]}},
+		},
+		fSys,
+		[]string{paths["real/other.ts"]},
+		[]string{linkDir},
+		true,
+	)
+	owners := make(map[string]string, len(targets))
+	for _, target := range targets {
+		owners[target.Path] = target.ConfigDirectory
+	}
+	assert.Equal(t, owners[tspath.ResolvePath(linkDir, "index.ts")], rootDir)
+	assert.Equal(t, owners[tspath.ResolvePath(linkDir, "nested/child.ts")], nestedConfigDir)
+	assert.Equal(t, owners[paths["real/other.ts"]], realConfigDir)
+	assert.Equal(t, len(owners), 3)
+}
+
+func TestDiscoverLintTargets_DirectorySymlinkPreservesCanonicalIdentity(t *testing.T) {
+	rootDir, paths := setupDiscoveryFixture(t, []string{"real/index.ts"})
+	linkDir := tspath.NormalizePath(filepath.Join(rootDir, "link"))
+	if err := os.Symlink(filepath.Join(rootDir, "real"), linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	targets := DiscoverLintTargets(
+		RslintConfig{{Rules: Rules{"rule": "error"}}},
+		rootDir,
+		fsys,
+		nil,
+		[]string{linkDir},
+		true,
+	)
+	if len(targets) != 1 {
+		t.Fatalf("expected one target through directory symlink, got %+v", targets)
+	}
+	assert.Equal(t, targets[0].Path, tspath.ResolvePath(linkDir, "index.ts"))
+	assert.Equal(t, targets[0].CanonicalPath, tspath.NormalizePath(fsys.Realpath(paths["real/index.ts"])))
+}
+
+func TestDiscoverLintTargets_PhysicalConfigFallbackPreservesDirectoryAliasPath(t *testing.T) {
+	rootDir, paths := setupDiscoveryFixture(t, []string{"real/sub/index.ts"})
+	linkDir := tspath.NormalizePath(filepath.Join(rootDir, "link"))
+	if err := os.Symlink(filepath.Join(rootDir, "real/sub"), linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	fSys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	realConfigDir := tspath.NormalizePath(filepath.Join(rootDir, "real"))
+	targets := DiscoverLintTargets(
+		RslintConfig{{Rules: Rules{"rule": "error"}}},
+		realConfigDir,
+		fSys,
+		nil,
+		[]string{linkDir},
+		true,
+	)
+	if len(targets) != 1 {
+		t.Fatalf("expected one target through physical config fallback, got %+v", targets)
+	}
+	assert.Equal(t, targets[0].Path, tspath.ResolvePath(linkDir, "index.ts"))
+	assert.Equal(t, targets[0].CanonicalPath, tspath.NormalizePath(fSys.Realpath(paths["real/sub/index.ts"])))
 }
 
 func TestDiscoverGapFilesMultiConfig_UsesNearestConfigOwner(t *testing.T) {

--- a/internal/config/file_resolver.go
+++ b/internal/config/file_resolver.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"sync"
+
+	"github.com/web-infra-dev/rslint/internal/linter"
+)
+
+type cachedMergedConfig struct {
+	value *MergedConfig
+}
+
+type cachedEnabledRules struct {
+	value []linter.ConfiguredRule
+}
+
+// FileConfigResolver caches per-file config and rule resolution for one lint
+// run. It is safe for concurrent use by RunLinter workers.
+type FileConfigResolver struct {
+	config         RslintConfig
+	cwd            string
+	enforcePlugins bool
+
+	mu          sync.RWMutex
+	configCache map[string]cachedMergedConfig
+	rulesCache  map[string]cachedEnabledRules
+}
+
+// NewFileConfigResolver creates a per-run resolver for one config root.
+func NewFileConfigResolver(config RslintConfig, cwd string, enforcePlugins bool) *FileConfigResolver {
+	return &FileConfigResolver{
+		config:         config,
+		cwd:            cwd,
+		enforcePlugins: enforcePlugins,
+		configCache:    make(map[string]cachedMergedConfig),
+		rulesCache:     make(map[string]cachedEnabledRules),
+	}
+}
+
+// ConfigForFile returns the merged config for filePath, caching nil misses.
+func (r *FileConfigResolver) ConfigForFile(filePath string) *MergedConfig {
+	r.mu.RLock()
+	if cached, ok := r.configCache[filePath]; ok {
+		r.mu.RUnlock()
+		return cached.value
+	}
+	r.mu.RUnlock()
+
+	merged := r.config.GetConfigForFile(filePath, r.cwd)
+
+	r.mu.Lock()
+	if cached, ok := r.configCache[filePath]; ok {
+		r.mu.Unlock()
+		return cached.value
+	}
+	r.configCache[filePath] = cachedMergedConfig{value: merged}
+	r.mu.Unlock()
+	return merged
+}
+
+// EnabledRulesForFile returns cached enabled rules and their merged config.
+// The returned rule slice is shared cache state and must be treated read-only.
+func (r *FileConfigResolver) EnabledRulesForFile(filePath string) ([]linter.ConfiguredRule, *MergedConfig) {
+	r.mu.RLock()
+	if cached, ok := r.rulesCache[filePath]; ok {
+		merged := r.configCache[filePath].value
+		r.mu.RUnlock()
+		return cached.value, merged
+	}
+	r.mu.RUnlock()
+
+	merged := r.ConfigForFile(filePath)
+	enabledRules := GlobalRuleRegistry.GetEnabledRulesForMergedConfig(merged, r.enforcePlugins)
+
+	r.mu.Lock()
+	if cached, ok := r.rulesCache[filePath]; ok {
+		merged = r.configCache[filePath].value
+		r.mu.Unlock()
+		return cached.value, merged
+	}
+	r.rulesCache[filePath] = cachedEnabledRules{value: enabledRules}
+	r.mu.Unlock()
+	return enabledRules, merged
+}
+
+// ActiveRulesForFile filters cached enabled rules by the optional type-info set.
+func (r *FileConfigResolver) ActiveRulesForFile(filePath string, typeInfoFiles map[string]struct{}) []linter.ConfiguredRule {
+	activeRules, _ := r.EnabledRulesForFile(filePath)
+	if typeInfoFiles != nil {
+		if _, hasTypeInfo := typeInfoFiles[filePath]; !hasTypeInfo {
+			activeRules = linter.FilterNonTypeAwareRules(activeRules)
+		}
+	}
+	return activeRules
+}
+
+// ActiveRulesForFileHasTypeInfo filters cached enabled rules by a known type-info flag.
+func (r *FileConfigResolver) ActiveRulesForFileHasTypeInfo(filePath string, hasTypeInfo bool) []linter.ConfiguredRule {
+	activeRules, _ := r.EnabledRulesForFile(filePath)
+	if !hasTypeInfo {
+		activeRules = linter.FilterNonTypeAwareRules(activeRules)
+	}
+	return activeRules
+}

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/vfs"
@@ -31,15 +32,74 @@ func ReadGitignoreAsGlobs(configDir string, fsys vfs.FS, configIgnores []IgnoreP
 	normalizedRoot := normalizeGlobPath(configDir)
 	var allGlobs []string
 
-	// Phase 1: collect ancestor .gitignore files (walk UP).
-	// Ancestor patterns apply globally (no path prefix needed since they
-	// are above configDir and affect everything below).
-	ancestorGlobs := collectAncestorGitignoreGlobs(normalizedRoot, fsys)
+	// Phase 1: collect ancestor .gitignore files (walk UP). Their patterns
+	// are interpreted relative to the ancestor .gitignore's directory, then
+	// projected into configDir-relative globs because rslint ignore matching
+	// evaluates paths relative to each configDir.
+	ancestorGlobs, configRootIgnored := collectAncestorGitignoreGlobs(normalizedRoot, fsys)
 	allGlobs = append(allGlobs, ancestorGlobs...)
+	if configRootIgnored {
+		return allGlobs
+	}
 
 	// Phase 2: collect descendant .gitignore files (walk DOWN from configDir).
 	collectGitignoreGlobs(normalizedRoot, "", fsys, &allGlobs, configIgnores)
 
+	if len(allGlobs) == 0 {
+		return nil
+	}
+	return allGlobs
+}
+
+// ReadGitignoreAsGlobsForFiles reads only .gitignore files on the ancestor
+// chains of explicit target files. This is used by API-style calls where the
+// target set is already known; unlike ReadGitignoreAsGlobs, it does not scan
+// every descendant of configDir.
+func ReadGitignoreAsGlobsForFiles(configDir string, fsys vfs.FS, files []string) []string {
+	if fsys == nil || len(files) == 0 {
+		return nil
+	}
+
+	normalizedConfigDir := normalizeGlobPath(configDir)
+	dirSet := make(map[string]struct{})
+	for _, file := range files {
+		current := dirOfPath(normalizeGlobPath(file))
+		for current != "" {
+			dirSet[current] = struct{}{}
+			next := parentDir(current)
+			if next == current {
+				break
+			}
+			current = next
+		}
+	}
+
+	dirs := make([]string, 0, len(dirSet))
+	for dir := range dirSet {
+		dirs = append(dirs, dir)
+	}
+	sortByPathDepth(dirs)
+
+	var allGlobs []string
+	var pruneRules []gitignorePruneRule
+	for _, dir := range dirs {
+		if isDirIgnoredByPruneRules(dir, pruneRules) {
+			continue
+		}
+
+		content, ok := fsys.ReadFile(dir + "/.gitignore")
+		if !ok {
+			continue
+		}
+		if rel, ok := relativeDir(normalizedConfigDir, dir); ok {
+			allGlobs = append(allGlobs, convertGitignoreToGlobs(content, rel)...)
+		} else {
+			allGlobs = append(allGlobs, convertAncestorGitignoreToGlobs(content, dir, normalizedConfigDir)...)
+		}
+		if rule, ok := newGitignorePruneRule(dir, content); ok {
+			pruneRules = append(pruneRules, rule)
+		}
+	}
 	if len(allGlobs) == 0 {
 		return nil
 	}
@@ -62,14 +122,14 @@ func ExtractConfigIgnores(config RslintConfig) []IgnorePattern {
 	return ParseIgnorePatterns(ignores)
 }
 
-// collectAncestorGitignoreGlobs walks UP from dir to filesystem root,
+// collectAncestorGitignoreGlobs walks UP from configDir to filesystem root,
 // collecting .gitignore patterns from each ancestor directory.
 // Returns patterns in root-first order (outermost ancestor first).
-func collectAncestorGitignoreGlobs(dir string, fsys vfs.FS) []string {
+func collectAncestorGitignoreGlobs(configDir string, fsys vfs.FS) ([]string, bool) {
 	// Collect ancestor dirs (from dir's parent up to root)
 	var ancestors []string
-	current := parentDir(dir)
-	for current != "" && current != dir {
+	current := parentDir(configDir)
+	for current != "" && current != configDir {
 		ancestors = append(ancestors, current)
 		next := parentDir(current)
 		if next == current {
@@ -85,16 +145,112 @@ func collectAncestorGitignoreGlobs(dir string, fsys vfs.FS) []string {
 
 	// Read .gitignore from each ancestor
 	var globs []string
+	var pruneRules []gitignorePruneRule
+	configRootIgnored := false
 	for _, ancestor := range ancestors {
+		if isDirIgnoredByPruneRules(ancestor, pruneRules) {
+			configRootIgnored = true
+			break
+		}
 		gitignorePath := ancestor + "/.gitignore"
 		if content, ok := fsys.ReadFile(gitignorePath); ok {
-			// Ancestor patterns have no prefix — they apply globally
-			// relative to the config, matching at any depth.
-			converted := convertGitignoreToGlobs(content, "")
+			converted := convertAncestorGitignoreToGlobs(content, ancestor, configDir)
 			globs = append(globs, converted...)
+			if rule, ok := newGitignorePruneRule(ancestor, content); ok {
+				pruneRules = append(pruneRules, rule)
+				configRootIgnored = isDirIgnoredByPruneRules(configDir, pruneRules)
+			}
 		}
 	}
-	return globs
+	return globs, configRootIgnored
+}
+
+type gitignorePruneRule struct {
+	baseDir  string
+	patterns []gitignorePrunePattern
+}
+
+type gitignorePrunePattern struct {
+	negated bool
+	rooted  bool
+	pattern string
+}
+
+func newGitignorePruneRule(baseDir string, content string) (gitignorePruneRule, bool) {
+	patterns := parseGitignorePrunePatterns(content)
+	if len(patterns) == 0 {
+		return gitignorePruneRule{}, false
+	}
+	return gitignorePruneRule{baseDir: baseDir, patterns: patterns}, true
+}
+
+func parseGitignorePrunePatterns(content string) []gitignorePrunePattern {
+	var patterns []gitignorePrunePattern
+	for _, line := range strings.Split(content, "\n") {
+		line, ok := normalizeGitignoreLine(line)
+		if !ok {
+			continue
+		}
+		negated := false
+		if strings.HasPrefix(line, "!") {
+			negated = true
+			line = line[1:]
+		}
+		line = strings.TrimSuffix(line, "/")
+		rooted := false
+		if strings.HasPrefix(line, "/") {
+			rooted = true
+			line = strings.TrimPrefix(line, "/")
+		} else if strings.Contains(line, "/") {
+			rooted = true
+		}
+		if line == "" {
+			continue
+		}
+		patterns = append(patterns, gitignorePrunePattern{
+			negated: negated,
+			rooted:  rooted,
+			pattern: line,
+		})
+	}
+	return patterns
+}
+
+func isDirIgnoredByPruneRules(dir string, rules []gitignorePruneRule) bool {
+	ignored := false
+	for _, rule := range rules {
+		rel, ok := relativeDir(rule.baseDir, dir)
+		if !ok || rel == "" {
+			continue
+		}
+		for _, pattern := range rule.patterns {
+			if gitignorePrunePatternCoversDir(pattern, rel) {
+				ignored = !pattern.negated
+			}
+		}
+	}
+	return ignored
+}
+
+func gitignorePrunePatternCoversDir(pattern gitignorePrunePattern, relDir string) bool {
+	for current := relDir; current != ""; current = parentDir(current) {
+		if gitignorePrunePatternMatchesPath(pattern, current) {
+			return true
+		}
+	}
+	return false
+}
+
+func gitignorePrunePatternMatchesPath(pattern gitignorePrunePattern, relPath string) bool {
+	if pattern.rooted {
+		return matchGlob(pattern.pattern, relPath)
+	}
+	for _, part := range splitPathComponents(relPath) {
+		if matchGlob(pattern.pattern, part) {
+			return true
+		}
+	}
+	return false
 }
 
 // parentDir returns the parent directory of dir, or "" if at root.
@@ -106,10 +262,47 @@ func parentDir(dir string) string {
 	return dir[:idx]
 }
 
+func dirOfPath(filePath string) string {
+	idx := strings.LastIndex(filePath, "/")
+	if idx < 0 {
+		return ""
+	}
+	if idx == 0 {
+		return "/"
+	}
+	return filePath[:idx]
+}
+
+func relativeDir(root string, dir string) (string, bool) {
+	if root == dir {
+		return "", true
+	}
+	prefix := root
+	if prefix != "/" {
+		prefix += "/"
+	}
+	if strings.HasPrefix(dir, prefix) {
+		return strings.TrimPrefix(dir, prefix), true
+	}
+	return "", false
+}
+
+func sortByPathDepth(paths []string) {
+	sort.Slice(paths, func(i, j int) bool {
+		depthI := strings.Count(paths[i], "/")
+		depthJ := strings.Count(paths[j], "/")
+		if depthI != depthJ {
+			return depthI < depthJ
+		}
+		return paths[i] < paths[j]
+	})
+}
+
 // collectGitignoreGlobs recursively scans for .gitignore files and converts
-// their patterns to globs. Already-converted patterns from parent .gitignore
-// are used to prune directories during scanning (avoids entering e.g. target/
-// with thousands of subdirectories).
+// their patterns to globs. Raw patterns from parent .gitignore files are used
+// to prune directories during scanning (avoids entering e.g. target/ with
+// thousands of subdirectories) without confusing "dir contents ignored" with
+// "dir itself ignored".
 //
 // configIgnores provides additional directory-level pruning from the user's
 // lint config. If isDirAbsolutelyBlocked returns true for a directory against
@@ -119,10 +312,17 @@ func parentDir(dir string) string {
 // here, its files will never be linted, so collecting its .gitignore is
 // unnecessary.
 func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string, configIgnores []IgnorePattern) {
+	collectGitignoreGlobsRecursive(absDir, relDir, fsys, result, configIgnores, nil)
+}
+
+func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, result *[]string, configIgnores []IgnorePattern, pruneRules []gitignorePruneRule) {
 	gitignorePath := absDir + "/.gitignore"
 	if content, ok := fsys.ReadFile(gitignorePath); ok {
 		localGlobs := convertGitignoreToGlobs(content, relDir)
 		*result = append(*result, localGlobs...)
+		if rule, ok := newGitignorePruneRule(absDir, content); ok {
+			pruneRules = append(pruneRules, rule)
+		}
 	}
 
 	entries := fsys.GetAccessibleEntries(absDir)
@@ -150,45 +350,16 @@ func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]
 			continue
 		}
 
-		// Prune directories already matched by collected gitignore patterns.
-		// This is a scan-local heuristic over the growing glob set (sequential
-		// `!` handling); the gap-file walk independently re-validates soundness
-		// via canPruneDir, so this stays a fast string-set match. Critical for
-		// performance: without it, scanning rspack enters target/ (6,277 Rust
-		// build dirs, 0 .ts files).
-		if isDirIgnoredByGlobs(*result, childRel) {
+		childAbs := absDir + "/" + dir
+		// Prune directories already ignored as directories by collected
+		// gitignore patterns. Critical for performance: without it, scanning
+		// rspack enters target/ (6,277 Rust build dirs, 0 .ts files).
+		if isDirIgnoredByPruneRules(childAbs, pruneRules) {
 			continue
 		}
 
-		childAbs := absDir + "/" + dir
-		collectGitignoreGlobs(childAbs, childRel, fsys, result, configIgnores)
+		collectGitignoreGlobsRecursive(childAbs, childRel, fsys, result, configIgnores, pruneRules)
 	}
-}
-
-// isDirIgnoredByGlobs reports whether relDir is ignored by the collected
-// gitignore globs (sequential `!` evaluation, later overrides earlier). It is
-// scan-local: a fast string-set match used only to prune which nested
-// .gitignore files get collected, NOT a soundness predicate. The gap-file walk
-// re-derives directory pruning from the structured patterns via canPruneDir, so
-// for the patterns that ARE collected the walk stays sound regardless. The one
-// behavior this skips is a `!` re-include inside an already-ignored directory's
-// nested .gitignore — which matches git's own rule that a file cannot be
-// re-included once a parent directory is excluded. This logic is unchanged by
-// the IgnorePattern refactor.
-func isDirIgnoredByGlobs(globs []string, relDir string) bool {
-	ignored := false
-	for _, pattern := range globs {
-		if strings.HasPrefix(pattern, "!") {
-			if matchGlob(pattern[1:], relDir) || matchGlob(pattern[1:], relDir+"/x") {
-				ignored = false
-			}
-		} else {
-			if matchGlob(pattern, relDir) || matchGlob(pattern, relDir+"/x") {
-				ignored = true
-			}
-		}
-	}
-	return ignored
 }
 
 // convertGitignoreToGlobs converts .gitignore file content into rslint glob
@@ -209,20 +380,137 @@ func isDirIgnoredByGlobs(globs []string, relDir string) bool {
 func convertGitignoreToGlobs(content string, baseDir string) []string {
 	var globs []string
 	for _, line := range strings.Split(content, "\n") {
-		// Strip trailing whitespace (git spec)
-		line = strings.TrimRight(line, " \t\r")
-		if line == "" || strings.HasPrefix(line, "#") {
+		line, ok := normalizeGitignoreLine(line)
+		if !ok {
 			continue
 		}
-		// Strip leading whitespace
-		line = strings.TrimLeft(line, " \t")
-
 		glob := convertSinglePattern(line, baseDir)
 		if glob != "" {
 			globs = append(globs, glob)
 		}
 	}
 	return globs
+}
+
+func normalizeGitignoreLine(line string) (string, bool) {
+	// Strip trailing whitespace (git spec)
+	line = strings.TrimRight(line, " \t\r")
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", false
+	}
+	// Strip leading whitespace
+	line = strings.TrimLeft(line, " \t")
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", false
+	}
+	return line, true
+}
+
+func convertAncestorGitignoreToGlobs(content string, ancestorDir string, configDir string) []string {
+	configRel := strings.TrimPrefix(configDir, ancestorDir+"/")
+	if configRel == configDir {
+		configRel = ""
+	}
+
+	var globs []string
+	for _, line := range strings.Split(content, "\n") {
+		line, ok := normalizeGitignoreLine(line)
+		if !ok {
+			continue
+		}
+		glob := convertAncestorSinglePattern(line, configRel)
+		if glob != "" {
+			globs = append(globs, glob)
+		}
+	}
+	return globs
+}
+
+func convertAncestorSinglePattern(line string, configRel string) string {
+	negated := false
+	body := line
+	if strings.HasPrefix(body, "!") {
+		negated = true
+		body = body[1:]
+	}
+	body = strings.TrimSuffix(body, "/")
+
+	rooted := strings.HasPrefix(body, "/") || strings.Contains(body, "/")
+	if !rooted {
+		glob := convertSinglePattern(line, "")
+		if configRel != "" && unrootedPatternCoversConfigRel(body, configRel) {
+			if negated {
+				return "!**/*"
+			}
+			return "**/*"
+		}
+		return glob
+	}
+
+	glob := convertSinglePattern(line, "")
+	if glob == "" || configRel == "" {
+		return glob
+	}
+	if negated {
+		glob = strings.TrimPrefix(glob, "!")
+	}
+
+	relGlob, ok := stripAncestorConfigPrefix(glob, configRel)
+	if !ok {
+		return ""
+	}
+	if negated {
+		return "!" + relGlob
+	}
+	return relGlob
+}
+
+func unrootedPatternCoversConfigRel(pattern string, configRel string) bool {
+	for _, part := range splitPathComponents(configRel) {
+		if matchGlob(pattern, part) {
+			return true
+		}
+	}
+	return false
+}
+
+func stripAncestorConfigPrefix(glob string, configRel string) (string, bool) {
+	globParts := splitPathComponents(glob)
+	configParts := splitPathComponents(configRel)
+	if len(globParts) == 0 || len(configParts) == 0 {
+		return glob, true
+	}
+
+	pi := 0
+	for ci := 0; ci < len(configParts); ci++ {
+		if pi >= len(globParts) {
+			return "**/*", true
+		}
+		part := globParts[pi]
+		if part == "**" {
+			return strings.Join(globParts[pi:], "/"), true
+		}
+		if !matchGlob(part, configParts[ci]) {
+			return "", false
+		}
+		pi++
+	}
+
+	if pi >= len(globParts) {
+		return "**/*", true
+	}
+	return strings.Join(globParts[pi:], "/"), true
+}
+
+func splitPathComponents(p string) []string {
+	var parts []string
+	for _, part := range strings.Split(p, "/") {
+		if part == "" || part == "." {
+			continue
+		}
+		parts = append(parts, part)
+	}
+	return parts
 }
 
 // convertSinglePattern converts one gitignore pattern line to a glob.

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -482,7 +482,7 @@ func stripAncestorConfigPrefix(glob string, configRel string) (string, bool) {
 	}
 
 	pi := 0
-	for ci := 0; ci < len(configParts); ci++ {
+	for _, configPart := range configParts {
 		if pi >= len(globParts) {
 			return "**/*", true
 		}
@@ -490,7 +490,7 @@ func stripAncestorConfigPrefix(glob string, configRel string) (string, bool) {
 		if part == "**" {
 			return strings.Join(globParts[pi:], "/"), true
 		}
-		if !matchGlob(part, configParts[ci]) {
+		if !matchGlob(part, configPart) {
 			return "", false
 		}
 		pi++

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -415,22 +415,22 @@ func filesystemPathDepth(path string) int {
 // unnecessary.
 func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string, configIgnores []IgnorePattern) {
 	collectGitignoreGlobsRecursive(absDir, relDir, fsys, result, configIgnores, nil, &gitignoreWalkState{
-		realpaths: make(map[string]string),
-		visited:   make(map[string]struct{}),
+		resolvedPaths: make(map[string]string),
+		visited:       make(map[string]struct{}),
 	})
 }
 
 type gitignoreWalkState struct {
-	realpaths map[string]string
-	visited   map[string]struct{}
+	resolvedPaths map[string]string
+	visited       map[string]struct{}
 }
 
 func (s *gitignoreWalkState) realpath(path string, fsys vfs.FS) string {
-	if realpath, ok := s.realpaths[path]; ok {
+	if realpath, ok := s.resolvedPaths[path]; ok {
 		return realpath
 	}
 	realpath := fsys.Realpath(path)
-	s.realpaths[path] = realpath
+	s.resolvedPaths[path] = realpath
 	return realpath
 }
 

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 )
 
@@ -83,18 +84,18 @@ func ReadGitignoreAsGlobsForFiles(configDir string, fsys vfs.FS, files []string)
 	var allGlobs []string
 	var pruneRules []gitignorePruneRule
 	for _, dir := range dirs {
-		if isDirIgnoredByPruneRules(dir, pruneRules) {
+		if isDirIgnoredByPruneRules(dir, pruneRules, fsys.UseCaseSensitiveFileNames()) {
 			continue
 		}
 
-		content, ok := fsys.ReadFile(dir + "/.gitignore")
+		content, ok := fsys.ReadFile(tspath.CombinePaths(dir, ".gitignore"))
 		if !ok {
 			continue
 		}
-		if rel, ok := relativeDir(normalizedConfigDir, dir); ok {
+		if rel, ok := relativeDir(normalizedConfigDir, dir, fsys.UseCaseSensitiveFileNames()); ok {
 			allGlobs = append(allGlobs, convertGitignoreToGlobs(content, rel)...)
 		} else {
-			allGlobs = append(allGlobs, convertAncestorGitignoreToGlobs(content, dir, normalizedConfigDir)...)
+			allGlobs = append(allGlobs, convertAncestorGitignoreToGlobs(content, dir, normalizedConfigDir, fsys.UseCaseSensitiveFileNames())...)
 		}
 		if rule, ok := newGitignorePruneRule(dir, content); ok {
 			pruneRules = append(pruneRules, rule)
@@ -148,17 +149,17 @@ func collectAncestorGitignoreGlobs(configDir string, fsys vfs.FS) ([]string, boo
 	var pruneRules []gitignorePruneRule
 	configRootIgnored := false
 	for _, ancestor := range ancestors {
-		if isDirIgnoredByPruneRules(ancestor, pruneRules) {
+		if isDirIgnoredByPruneRules(ancestor, pruneRules, fsys.UseCaseSensitiveFileNames()) {
 			configRootIgnored = true
 			break
 		}
-		gitignorePath := ancestor + "/.gitignore"
+		gitignorePath := tspath.CombinePaths(ancestor, ".gitignore")
 		if content, ok := fsys.ReadFile(gitignorePath); ok {
-			converted := convertAncestorGitignoreToGlobs(content, ancestor, configDir)
+			converted := convertAncestorGitignoreToGlobs(content, ancestor, configDir, fsys.UseCaseSensitiveFileNames())
 			globs = append(globs, converted...)
 			if rule, ok := newGitignorePruneRule(ancestor, content); ok {
 				pruneRules = append(pruneRules, rule)
-				configRootIgnored = isDirIgnoredByPruneRules(configDir, pruneRules)
+				configRootIgnored = isDirIgnoredByPruneRules(configDir, pruneRules, fsys.UseCaseSensitiveFileNames())
 			}
 		}
 	}
@@ -216,10 +217,10 @@ func parseGitignorePrunePatterns(content string) []gitignorePrunePattern {
 	return patterns
 }
 
-func isDirIgnoredByPruneRules(dir string, rules []gitignorePruneRule) bool {
+func isDirIgnoredByPruneRules(dir string, rules []gitignorePruneRule, useCaseSensitive bool) bool {
 	ignored := false
 	for _, rule := range rules {
-		rel, ok := relativeDir(rule.baseDir, dir)
+		rel, ok := relativeDir(rule.baseDir, dir, useCaseSensitive)
 		if !ok || rel == "" {
 			continue
 		}
@@ -253,49 +254,150 @@ func gitignorePrunePatternMatchesPath(pattern gitignorePrunePattern, relPath str
 	return false
 }
 
-// parentDir returns the parent directory of dir, or "" if at root.
+type filesystemPath struct {
+	root            string
+	rest            string
+	caseInsensitive bool
+}
+
+// splitFilesystemPath treats a UNC server/share pair as the volume root.
+// tspath's generic root parser stops at the server, which is appropriate for
+// URLs but would let filesystem traversal escape above a Windows share.
+func splitFilesystemPath(path string) filesystemPath {
+	path = tspath.NormalizePath(path)
+	if strings.HasPrefix(path, "//") {
+		serverAndRest := path[2:]
+		serverEnd := strings.Index(serverAndRest, "/")
+		if serverEnd < 0 {
+			return filesystemPath{root: path, caseInsensitive: true}
+		}
+
+		shareStart := 2 + serverEnd + 1
+		shareAndRest := path[shareStart:]
+		shareEnd := strings.Index(shareAndRest, "/")
+		if shareAndRest == "" {
+			return filesystemPath{root: path, caseInsensitive: true}
+		}
+
+		rootEnd := len(path)
+		if shareEnd >= 0 {
+			rootEnd = shareStart + shareEnd
+		}
+		root := strings.TrimSuffix(path[:rootEnd], "/") + "/"
+		rest := strings.Trim(path[rootEnd:], "/")
+		return filesystemPath{root: root, rest: rest, caseInsensitive: true}
+	}
+
+	rootLength := tspath.GetRootLength(path)
+	if rootLength == 0 {
+		return filesystemPath{rest: strings.Trim(path, "/")}
+	}
+
+	root := path[:rootLength]
+	caseInsensitive := len(root) >= 2 && root[1] == ':'
+	if caseInsensitive && strings.HasSuffix(root, ":") {
+		root += "/"
+	}
+	return filesystemPath{
+		root:            root,
+		rest:            strings.Trim(path[rootLength:], "/"),
+		caseInsensitive: caseInsensitive,
+	}
+}
+
+func joinFilesystemPath(path filesystemPath, rest string) string {
+	if rest == "" {
+		return path.root
+	}
+	if path.root == "" {
+		return rest
+	}
+	return tspath.CombinePaths(path.root, rest)
+}
+
+func sameFilesystemRoot(left filesystemPath, right filesystemPath, useCaseSensitive bool) bool {
+	if left.caseInsensitive != right.caseInsensitive {
+		return false
+	}
+	if left.caseInsensitive || !useCaseSensitive {
+		return strings.EqualFold(left.root, right.root)
+	}
+	return left.root == right.root
+}
+
+func equalFilesystemPath(left string, right string, caseInsensitive bool) bool {
+	if caseInsensitive {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
+}
+
+// parentDir returns the parent directory of dir. Filesystem roots are returned
+// as the parent of their direct children and "" as their own parent.
 func parentDir(dir string) string {
-	idx := strings.LastIndex(dir, "/")
-	if idx <= 0 {
+	path := splitFilesystemPath(dir)
+	if path.rest == "" {
 		return ""
 	}
-	return dir[:idx]
+
+	idx := strings.LastIndex(path.rest, "/")
+	if idx < 0 {
+		return path.root
+	}
+	return joinFilesystemPath(path, path.rest[:idx])
 }
 
 func dirOfPath(filePath string) string {
-	idx := strings.LastIndex(filePath, "/")
+	path := splitFilesystemPath(filePath)
+	if path.rest == "" {
+		return path.root
+	}
+
+	idx := strings.LastIndex(path.rest, "/")
 	if idx < 0 {
-		return ""
+		return path.root
 	}
-	if idx == 0 {
-		return "/"
-	}
-	return filePath[:idx]
+	return joinFilesystemPath(path, path.rest[:idx])
 }
 
-func relativeDir(root string, dir string) (string, bool) {
-	if root == dir {
+func relativeDir(root string, dir string, useCaseSensitive bool) (string, bool) {
+	rootPath := splitFilesystemPath(root)
+	dirPath := splitFilesystemPath(dir)
+	if !sameFilesystemRoot(rootPath, dirPath, useCaseSensitive) {
+		return "", false
+	}
+	caseInsensitive := rootPath.caseInsensitive || !useCaseSensitive
+	if equalFilesystemPath(rootPath.rest, dirPath.rest, caseInsensitive) {
 		return "", true
 	}
-	prefix := root
-	if prefix != "/" {
-		prefix += "/"
+	if rootPath.rest == "" {
+		return dirPath.rest, true
 	}
-	if strings.HasPrefix(dir, prefix) {
-		return strings.TrimPrefix(dir, prefix), true
+
+	prefix := rootPath.rest + "/"
+	if len(dirPath.rest) > len(prefix) && equalFilesystemPath(prefix, dirPath.rest[:len(prefix)], caseInsensitive) {
+		return dirPath.rest[len(prefix):], true
 	}
 	return "", false
 }
 
 func sortByPathDepth(paths []string) {
 	sort.Slice(paths, func(i, j int) bool {
-		depthI := strings.Count(paths[i], "/")
-		depthJ := strings.Count(paths[j], "/")
+		depthI := filesystemPathDepth(paths[i])
+		depthJ := filesystemPathDepth(paths[j])
 		if depthI != depthJ {
 			return depthI < depthJ
 		}
 		return paths[i] < paths[j]
 	})
+}
+
+func filesystemPathDepth(path string) int {
+	rest := splitFilesystemPath(path).rest
+	if rest == "" {
+		return 0
+	}
+	return strings.Count(rest, "/") + 1
 }
 
 // collectGitignoreGlobs recursively scans for .gitignore files and converts
@@ -312,11 +414,28 @@ func sortByPathDepth(paths []string) {
 // here, its files will never be linted, so collecting its .gitignore is
 // unnecessary.
 func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string, configIgnores []IgnorePattern) {
-	collectGitignoreGlobsRecursive(absDir, relDir, fsys, result, configIgnores, nil)
+	collectGitignoreGlobsRecursive(absDir, relDir, fsys, result, configIgnores, nil, &gitignoreWalkState{
+		realpaths: make(map[string]string),
+		visited:   make(map[string]struct{}),
+	})
 }
 
-func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, result *[]string, configIgnores []IgnorePattern, pruneRules []gitignorePruneRule) {
-	gitignorePath := absDir + "/.gitignore"
+type gitignoreWalkState struct {
+	realpaths map[string]string
+	visited   map[string]struct{}
+}
+
+func (s *gitignoreWalkState) realpath(path string, fsys vfs.FS) string {
+	if realpath, ok := s.realpaths[path]; ok {
+		return realpath
+	}
+	realpath := fsys.Realpath(path)
+	s.realpaths[path] = realpath
+	return realpath
+}
+
+func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, result *[]string, configIgnores []IgnorePattern, pruneRules []gitignorePruneRule, state *gitignoreWalkState) {
+	gitignorePath := tspath.CombinePaths(absDir, ".gitignore")
 	if content, ok := fsys.ReadFile(gitignorePath); ok {
 		localGlobs := convertGitignoreToGlobs(content, relDir)
 		*result = append(*result, localGlobs...)
@@ -326,9 +445,30 @@ func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, r
 	}
 
 	entries := fsys.GetAccessibleEntries(absDir)
+	parentRealPath := ""
+	if entries.Symlinks == nil && len(entries.Directories) > 0 {
+		parentRealPath = state.realpath(absDir, fsys)
+		state.visited[parentRealPath] = struct{}{}
+	}
 	for _, dir := range entries.Directories {
-		if _, excluded := defaultExcludeDirs[dir]; excluded {
+		if isDefaultExcludedDirName(dir, fsys.UseCaseSensitiveFileNames()) {
 			continue
+		}
+
+		childAbs := tspath.CombinePaths(absDir, dir)
+		childRealPath := ""
+		if entries.Symlinks != nil {
+			if _, isSymlink := entries.Symlinks[dir]; isSymlink {
+				continue
+			}
+		} else {
+			childRealPath = state.realpath(childAbs, fsys)
+			expectedRealPath := tspath.CombinePaths(parentRealPath, dir)
+			if tspath.ComparePaths(childRealPath, expectedRealPath, tspath.ComparePathsOptions{
+				UseCaseSensitiveFileNames: fsys.UseCaseSensitiveFileNames(),
+			}) != 0 {
+				continue
+			}
 		}
 
 		childRel := dir
@@ -350,15 +490,21 @@ func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, r
 			continue
 		}
 
-		childAbs := absDir + "/" + dir
 		// Prune directories already ignored as directories by collected
 		// gitignore patterns. Critical for performance: without it, scanning
 		// rspack enters target/ (6,277 Rust build dirs, 0 .ts files).
-		if isDirIgnoredByPruneRules(childAbs, pruneRules) {
+		if isDirIgnoredByPruneRules(childAbs, pruneRules, fsys.UseCaseSensitiveFileNames()) {
 			continue
 		}
 
-		collectGitignoreGlobsRecursive(childAbs, childRel, fsys, result, configIgnores, pruneRules)
+		if childRealPath != "" {
+			if _, visited := state.visited[childRealPath]; visited {
+				continue
+			}
+			state.visited[childRealPath] = struct{}{}
+		}
+
+		collectGitignoreGlobsRecursive(childAbs, childRel, fsys, result, configIgnores, pruneRules, state)
 	}
 }
 
@@ -406,10 +552,10 @@ func normalizeGitignoreLine(line string) (string, bool) {
 	return line, true
 }
 
-func convertAncestorGitignoreToGlobs(content string, ancestorDir string, configDir string) []string {
-	configRel := strings.TrimPrefix(configDir, ancestorDir+"/")
-	if configRel == configDir {
-		configRel = ""
+func convertAncestorGitignoreToGlobs(content string, ancestorDir string, configDir string, useCaseSensitive bool) []string {
+	configRel, ok := relativeDir(ancestorDir, configDir, useCaseSensitive)
+	if !ok {
+		return nil
 	}
 
 	var globs []string

--- a/internal/config/gitignore_test.go
+++ b/internal/config/gitignore_test.go
@@ -23,6 +23,40 @@ func (s *gitignoreSpyFS) GetAccessibleEntries(path string) vfs.Entries {
 	return s.FS.GetAccessibleEntries(path)
 }
 
+type gitignoreMockFS struct {
+	vfs.FS
+	entries         map[string]vfs.Entries
+	files           map[string]string
+	realpaths       map[string]string
+	readFileCalls   []string
+	accessedDirs    []string
+	realpathCalls   []string
+	caseSensitiveFS bool
+}
+
+func (m *gitignoreMockFS) ReadFile(path string) (string, bool) {
+	m.readFileCalls = append(m.readFileCalls, path)
+	content, ok := m.files[path]
+	return content, ok
+}
+
+func (m *gitignoreMockFS) GetAccessibleEntries(path string) vfs.Entries {
+	m.accessedDirs = append(m.accessedDirs, path)
+	return m.entries[path]
+}
+
+func (m *gitignoreMockFS) Realpath(path string) string {
+	m.realpathCalls = append(m.realpathCalls, path)
+	if realpath, ok := m.realpaths[path]; ok {
+		return realpath
+	}
+	return path
+}
+
+func (m *gitignoreMockFS) UseCaseSensitiveFileNames() bool {
+	return m.caseSensitiveFS
+}
+
 func setupGitignoreFixture(t *testing.T, files map[string]string) string {
 	t.Helper()
 	tmpDir := t.TempDir()
@@ -235,6 +269,27 @@ func TestReadGitignoreAsGlobs_SkipsNodeModules(t *testing.T) {
 	assert.Equal(t, globs[0], "**/dist/**/*")
 }
 
+func TestReadGitignoreAsGlobs_SkipsDefaultDirsCaseInsensitively(t *testing.T) {
+	mock := &gitignoreMockFS{
+		FS: osvfs.FS(),
+		entries: map[string]vfs.Entries{
+			"/repo": {
+				Directories: []string{"NODE_MODULES"},
+				Symlinks:    map[string]struct{}{},
+			},
+		},
+		files:           map[string]string{},
+		caseSensitiveFS: false,
+	}
+
+	ReadGitignoreAsGlobs("/repo", mock, nil)
+	for _, accessed := range mock.accessedDirs {
+		if strings.EqualFold(accessed, "/repo/node_modules") {
+			t.Fatalf("case-insensitive filesystem must not scan default excluded directory %q", accessed)
+		}
+	}
+}
+
 // --- Scope isolation tests ---
 
 func TestConvertGitignoreToGlobs_ScopeIsolation(t *testing.T) {
@@ -271,6 +326,64 @@ func TestReadGitignoreAsGlobs_ThreeLevelNested(t *testing.T) {
 	assert.Assert(t, hasRoot, "root dist")
 	assert.Assert(t, hasApp, "app tmp")
 	assert.Assert(t, hasSub, "sub cache")
+}
+
+func TestReadGitignoreAsGlobs_SkipsDescendantSymlinkCycle(t *testing.T) {
+	mock := &gitignoreMockFS{
+		FS: osvfs.FS(),
+		files: map[string]string{
+			"/repo/.gitignore":        "root-cache/\n",
+			"/repo/a/.gitignore":      "nested-cache/\n",
+			"/repo/a/loop/.gitignore": "cycle-cache/\n",
+		},
+		entries: map[string]vfs.Entries{
+			"/repo": {
+				Directories: []string{"a"},
+				Symlinks:    map[string]struct{}{},
+			},
+			"/repo/a": {
+				Directories: []string{"loop"},
+				Symlinks:    map[string]struct{}{"loop": {}},
+			},
+			"/repo/a/loop": {
+				Directories: []string{"a"},
+				Symlinks:    map[string]struct{}{},
+			},
+		},
+		realpaths: map[string]string{"/repo/a/loop": "/repo"},
+	}
+
+	globs := ReadGitignoreAsGlobs("/repo", mock, nil)
+
+	assert.DeepEqual(t, globs, []string{"**/root-cache/**/*", "a/**/nested-cache/**/*"})
+	assert.DeepEqual(t, mock.accessedDirs, []string{"/repo", "/repo/a"})
+	assert.Equal(t, len(mock.realpathCalls), 0, "symlink metadata should avoid Realpath fallback")
+}
+
+func TestReadGitignoreAsGlobs_LegacySymlinkCycleUsesCachedRealpaths(t *testing.T) {
+	mock := &gitignoreMockFS{
+		FS: osvfs.FS(),
+		files: map[string]string{
+			"/repo/.gitignore":        "root-cache/\n",
+			"/repo/a/.gitignore":      "nested-cache/\n",
+			"/repo/a/loop/.gitignore": "cycle-cache/\n",
+		},
+		entries: map[string]vfs.Entries{
+			"/repo":   {Directories: []string{"a"}},
+			"/repo/a": {Directories: []string{"loop"}},
+		},
+		realpaths: map[string]string{
+			"/repo":        "/repo",
+			"/repo/a":      "/repo/a",
+			"/repo/a/loop": "/repo",
+		},
+	}
+
+	globs := ReadGitignoreAsGlobs("/repo", mock, nil)
+
+	assert.DeepEqual(t, globs, []string{"**/root-cache/**/*", "a/**/nested-cache/**/*"})
+	assert.DeepEqual(t, mock.accessedDirs, []string{"/repo", "/repo/a"})
+	assert.DeepEqual(t, mock.realpathCalls, []string{"/repo", "/repo/a", "/repo/a/loop"})
 }
 
 // --- Additional edge case tests ---
@@ -328,6 +441,150 @@ func TestConvertGitignoreToGlobs_DirOnlySuffixDedup(t *testing.T) {
 }
 
 // --- Ancestor inheritance tests ---
+
+func TestParentDirStopsAtFilesystemRoot(t *testing.T) {
+	tests := []struct {
+		path   string
+		parent string
+	}{
+		{path: "/repo/pkg", parent: "/repo"},
+		{path: "/repo", parent: "/"},
+		{path: "/", parent: ""},
+		{path: "C:/repo", parent: "C:/"},
+		{path: "C:/", parent: ""},
+		{path: "//server/share/repo", parent: "//server/share/"},
+		{path: "//server/share/", parent: ""},
+		{path: "pkg/src", parent: "pkg"},
+		{path: "pkg", parent: ""},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, parentDir(test.path), test.parent, "parentDir(%q)", test.path)
+	}
+}
+
+func TestRelativeDirIsVolumeAndShareAware(t *testing.T) {
+	tests := []struct {
+		name string
+		root string
+		dir  string
+		rel  string
+		ok   bool
+	}{
+		{name: "posix", root: "/repo", dir: "/repo/pkg", rel: "pkg", ok: true},
+		{name: "posix sibling", root: "/repo", dir: "/repository/pkg", ok: false},
+		{name: "drive", root: "C:/repo", dir: "c:/repo/pkg", rel: "pkg", ok: true},
+		{name: "other drive", root: "C:/repo", dir: "D:/repo/pkg", ok: false},
+		{name: "unc", root: "//server/share/repo", dir: "//SERVER/SHARE/repo/pkg", rel: "pkg", ok: true},
+		{name: "other share", root: "//server/share/repo", dir: "//server/other/repo/pkg", ok: false},
+		{name: "share prefix", root: "//server/share/repo", dir: "//server/share-other/repo/pkg", ok: false},
+		{name: "other server", root: "//server/share/repo", dir: "//other/share/repo/pkg", ok: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rel, ok := relativeDir(test.root, test.dir, true)
+			assert.Equal(t, ok, test.ok)
+			assert.Equal(t, rel, test.rel)
+		})
+	}
+
+	rel, ok := relativeDir("/Repo", "/repo/pkg", false)
+	assert.Assert(t, ok)
+	assert.Equal(t, rel, "pkg")
+}
+
+func TestSortByPathDepthTreatsUNCShareAsRoot(t *testing.T) {
+	paths := []string{
+		"//server/share/repo/pkg",
+		"//server/share/repo",
+		"//server/share/",
+	}
+
+	sortByPathDepth(paths)
+
+	assert.DeepEqual(t, paths, []string{
+		"//server/share/",
+		"//server/share/repo",
+		"//server/share/repo/pkg",
+	})
+}
+
+func TestReadGitignoreAsGlobs_JoinsFilesystemRoots(t *testing.T) {
+	tests := []struct {
+		name         string
+		configDir    string
+		rootIgnore   string
+		configIgnore string
+	}{
+		{name: "posix", configDir: "/repo", rootIgnore: "/.gitignore", configIgnore: "/repo/.gitignore"},
+		{name: "drive", configDir: "C:/repo", rootIgnore: "C:/.gitignore", configIgnore: "C:/repo/.gitignore"},
+		{name: "unc", configDir: "//server/share/repo", rootIgnore: "//server/share/.gitignore", configIgnore: "//server/share/repo/.gitignore"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := &gitignoreMockFS{
+				FS: osvfs.FS(),
+				files: map[string]string{
+					test.rootIgnore: "root-cache/\n",
+				},
+				entries: map[string]vfs.Entries{
+					test.configDir: {Symlinks: map[string]struct{}{}},
+				},
+			}
+
+			globs := ReadGitignoreAsGlobs(test.configDir, mock, nil)
+
+			assert.DeepEqual(t, globs, []string{"**/root-cache/**/*"})
+			assert.DeepEqual(t, mock.readFileCalls, []string{test.rootIgnore, test.configIgnore})
+		})
+	}
+}
+
+func TestConvertAncestorGitignoreToGlobs_IsVolumeAndShareAware(t *testing.T) {
+	tests := []struct {
+		name      string
+		ancestor  string
+		configDir string
+		content   string
+		expected  []string
+	}{
+		{
+			name:      "same drive preserves config base",
+			ancestor:  "C:/repo",
+			configDir: "C:/repo/packages/app",
+			content:   "/packages/app/dist/\n",
+			expected:  []string{"dist/**/*"},
+		},
+		{
+			name:      "same share preserves config base",
+			ancestor:  "//server/share/repo",
+			configDir: "//server/share/repo/packages/app",
+			content:   "/packages/app/dist/\n",
+			expected:  []string{"dist/**/*"},
+		},
+		{
+			name:      "other drive is not ancestor",
+			ancestor:  "D:/repo",
+			configDir: "C:/repo/packages/app",
+			content:   "dist/\n",
+		},
+		{
+			name:      "other share is not ancestor",
+			ancestor:  "//server/other/repo",
+			configDir: "//server/share/repo/packages/app",
+			content:   "dist/\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := convertAncestorGitignoreToGlobs(test.content, test.ancestor, test.configDir, true)
+			assert.DeepEqual(t, actual, test.expected)
+		})
+	}
+}
 
 func TestReadGitignoreAsGlobs_AncestorInheritance(t *testing.T) {
 	// Root has .gitignore with dist/. configDir is packages/app (child).

--- a/internal/config/gitignore_test.go
+++ b/internal/config/gitignore_test.go
@@ -348,6 +348,224 @@ func TestReadGitignoreAsGlobs_AncestorInheritance(t *testing.T) {
 	assert.Assert(t, hasDistGlob, "child configDir should inherit root .gitignore dist/ pattern")
 }
 
+func TestReadGitignoreAsGlobs_AncestorAnchoredOutsideConfigDoesNotApply(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                 "/dist/\n",
+		"dist/root-build.js":         "x",
+		"packages/app/dist/app.js":   "x",
+		"packages/app/src/index.js":  "x",
+		"packages/app/rslint.jsonc":  "[]",
+		"packages/other/dist/app.js": "x",
+	})
+	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
+	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+
+	for _, g := range globs {
+		if strings.Contains(g, "dist") {
+			t.Fatalf("root-anchored /dist/ must not become a config-relative dist ignore for nested configs, got %v", globs)
+		}
+	}
+	cfg := RslintConfig{
+		{Ignores: globs},
+		{Rules: Rules{"no-debugger": "error"}},
+	}
+	appDist := tspath.NormalizePath(filepath.Join(appDir, "dist/app.js"))
+	if cfg.GetConfigForFile(appDist, appDir) == nil {
+		t.Fatalf("ancestor /dist/ should not ignore nested config dist file; globs=%v", globs)
+	}
+}
+
+func TestReadGitignoreAsGlobs_AncestorAnchoredInsideConfigApplies(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                "/packages/app/dist/\n",
+		"packages/app/dist/app.js":  "x",
+		"packages/app/src/index.js": "x",
+	})
+	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
+	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+
+	gs := globSet(globs)
+	assert.Assert(t, gs["dist/**/*"], "ancestor pattern anchored into config should become config-relative dist/**/*, got: %v", globs)
+
+	cfg := RslintConfig{
+		{Ignores: globs},
+		{Rules: Rules{"no-debugger": "error"}},
+	}
+	appDist := tspath.NormalizePath(filepath.Join(appDir, "dist/app.js"))
+	if cfg.GetConfigForFile(appDist, appDir) != nil {
+		t.Fatalf("ancestor /packages/app/dist/ should ignore app dist; globs=%v", globs)
+	}
+	srcFile := tspath.NormalizePath(filepath.Join(appDir, "src/index.js"))
+	if cfg.GetConfigForFile(srcFile, appDir) == nil {
+		t.Fatalf("ancestor /packages/app/dist/ must not ignore src; globs=%v", globs)
+	}
+}
+
+func TestReadGitignoreAsGlobs_AncestorWildcardInsideConfigApplies(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                "/packages/*/dist/\n",
+		"packages/app/dist/app.js":  "x",
+		"packages/app/src/index.js": "x",
+	})
+	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
+	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+
+	gs := globSet(globs)
+	assert.Assert(t, gs["dist/**/*"], "ancestor wildcard path should be projected under configDir, got: %v", globs)
+}
+
+func TestReadGitignoreAsGlobs_AncestorAnchoredParentDirCoversConfig(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                "/packages/\n",
+		"packages/app/src/index.js": "x",
+	})
+	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
+	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+
+	gs := globSet(globs)
+	assert.Assert(t, gs["**/*"], "ancestor pattern covering configDir should project to **/*, got: %v", globs)
+	cfg := RslintConfig{
+		{Ignores: globs},
+		{Rules: Rules{"no-debugger": "error"}},
+	}
+	srcFile := tspath.NormalizePath(filepath.Join(appDir, "src/index.js"))
+	if cfg.GetConfigForFile(srcFile, appDir) != nil {
+		t.Fatalf("ancestor /packages/ should ignore all files under packages/app; globs=%v", globs)
+	}
+}
+
+func TestReadGitignoreAsGlobs_AncestorUnrootedParentDirCoversConfig(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                "packages/\n",
+		"packages/app/src/index.js": "x",
+	})
+	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
+	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+
+	gs := globSet(globs)
+	assert.Assert(t, gs["**/*"], "ancestor unrooted packages/ should cover configDir, got: %v", globs)
+	cfg := RslintConfig{
+		{Ignores: globs},
+		{Rules: Rules{"no-debugger": "error"}},
+	}
+	srcFile := tspath.NormalizePath(filepath.Join(appDir, "src/index.js"))
+	if cfg.GetConfigForFile(srcFile, appDir) != nil {
+		t.Fatalf("ancestor packages/ should ignore all files under packages/app; globs=%v", globs)
+	}
+}
+
+func TestReadGitignoreAsGlobs_AncestorIgnoredConfigRootSkipsOwnGitignore(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                "packages/\n",
+		"packages/app/.gitignore":   "!src/index.js\n",
+		"packages/app/src/index.js": "x",
+	})
+	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
+	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+
+	for _, glob := range globs {
+		if strings.HasPrefix(glob, "!") {
+			t.Fatalf("config root ignored by ancestor must not read own negation .gitignore, got: %v", globs)
+		}
+	}
+	cfg := RslintConfig{
+		{Ignores: globs},
+		{Rules: Rules{"no-debugger": "error"}},
+	}
+	srcFile := tspath.NormalizePath(filepath.Join(appDir, "src/index.js"))
+	if cfg.GetConfigForFile(srcFile, appDir) != nil {
+		t.Fatalf("ancestor packages/ should not be re-included by packages/app/.gitignore; globs=%v", globs)
+	}
+}
+
+func TestReadGitignoreAsGlobs_AncestorIgnoredIntermediateSkipsGitignore(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                "packages/\n",
+		"packages/.gitignore":       "!app/src/index.js\n",
+		"packages/app/src/index.js": "x",
+	})
+	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
+	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+
+	for _, glob := range globs {
+		if strings.HasPrefix(glob, "!") {
+			t.Fatalf("ignored intermediate ancestor must not re-include from its .gitignore, got: %v", globs)
+		}
+	}
+	cfg := RslintConfig{
+		{Ignores: globs},
+		{Rules: Rules{"no-debugger": "error"}},
+	}
+	srcFile := tspath.NormalizePath(filepath.Join(appDir, "src/index.js"))
+	if cfg.GetConfigForFile(srcFile, appDir) != nil {
+		t.Fatalf("ancestor packages/ should not be re-included by packages/.gitignore; globs=%v", globs)
+	}
+}
+
+func TestReadGitignoreAsGlobs_AncestorChildWildcardReadsIntermediateGitignore(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                                   "packages/*\n!packages/app/\n",
+		"packages/.gitignore":                          "app/src/generated/\n",
+		"packages/app/src/generated/file.js":           "x",
+		"packages/app/src/generated/nested/other.js":   "x",
+		"packages/app/src/not-generated/file.js":       "x",
+		"packages/app/src/not-generated/nested/app.js": "x",
+	})
+	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
+	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
+
+	gs := globSet(globs)
+	assert.Assert(t, gs["src/generated/**/*"], "packages/.gitignore should be collected, got: %v", globs)
+	cfg := RslintConfig{
+		{Ignores: globs},
+		{Rules: Rules{"no-debugger": "error"}},
+	}
+	generated := tspath.NormalizePath(filepath.Join(appDir, "src/generated/file.js"))
+	if cfg.GetConfigForFile(generated, appDir) != nil {
+		t.Fatalf("intermediate .gitignore should ignore generated file; globs=%v", globs)
+	}
+	normal := tspath.NormalizePath(filepath.Join(appDir, "src/not-generated/file.js"))
+	if cfg.GetConfigForFile(normal, appDir) == nil {
+		t.Fatalf("root negation should keep non-generated file lintable; globs=%v", globs)
+	}
+}
+
+func TestReadGitignoreAsGlobsForFiles_ChildWildcardReadsIntermediateGitignore(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                         "packages/*\n!packages/app/\n",
+		"packages/.gitignore":                "app/src/generated/\n",
+		"packages/app/src/generated/file.js": "x",
+	})
+	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
+	generated := tspath.NormalizePath(filepath.Join(appDir, "src/generated/file.js"))
+
+	globs := ReadGitignoreAsGlobsForFiles(appDir, osvfs.FS(), []string{generated})
+
+	gs := globSet(globs)
+	assert.Assert(t, gs["src/generated/**/*"], "explicit-file gitignore chain should include packages/.gitignore, got: %v", globs)
+	cfg := RslintConfig{
+		{Ignores: globs},
+		{Rules: Rules{"no-debugger": "error"}},
+	}
+	if cfg.GetConfigForFile(generated, appDir) != nil {
+		t.Fatalf("intermediate .gitignore should ignore explicit generated file; globs=%v", globs)
+	}
+}
+
+func TestReadGitignoreAsGlobs_DescendantChildWildcardReadsIntermediateGitignore(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                         "packages/*\n!packages/app/\n",
+		"packages/.gitignore":                "app/src/generated/\n",
+		"packages/app/src/generated/file.js": "x",
+		"packages/app/src/index.js":          "x",
+	})
+
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+
+	gs := globSet(globs)
+	assert.Assert(t, gs["packages/app/src/generated/**/*"], "root scan should read packages/.gitignore, got: %v", globs)
+}
+
 func TestReadGitignoreAsGlobs_AncestorPlusOwn(t *testing.T) {
 	// Root has dist/, child has tmp/. Both should be in globs.
 	dir := setupGitignoreFixture(t, map[string]string{
@@ -671,24 +889,22 @@ func TestReadGitignoreAsGlobs_ExactPathConfigIgnore(t *testing.T) {
 
 // A10: ExtractConfigIgnores only extracts from global-ignore entries.
 // An entry is "global ignore" when it has ONLY ignores — no files, rules, plugins, etc.
-// Note: {Files: []string{}} (empty slice) still counts as len(Files)==0, so IS global.
 func TestExtractConfigIgnores_OnlyGlobalEntries(t *testing.T) {
 	config := RslintConfig{
 		{Ignores: []string{"**/tests/**"}},                            // global ignore ✓
 		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},      // has files+rules → NOT global
 		{Ignores: []string{"scripts/**"}},                             // global ignore ✓
-		{Files: []string{}, Ignores: []string{"also-global"}},         // empty files + only ignores → IS global (len(Files)==0)
+		{Files: []string{}, Ignores: []string{"not-global-empty"}},    // explicit empty files → NOT global (invalid at ingress)
 		{Ignores: []string{"vendor/**"}, Rules: Rules{"r": "error"}},  // has rules → NOT global
 		{Files: []string{"**/*.js"}, Ignores: []string{"not-global"}}, // has non-empty files → NOT global
 	}
 
 	ignores := ExtractConfigIgnores(config)
 
-	// Entries 0, 2, 3 are global ignores. Entries 1, 4, 5 are not.
-	assert.Equal(t, len(ignores), 3, "should extract exactly 3 patterns, got: %v", ignores)
+	// Entries 0 and 2 are global ignores. Entries 1, 3, 4, 5 are not.
+	assert.Equal(t, len(ignores), 2, "should extract exactly 2 patterns, got: %v", ignores)
 	assert.Equal(t, ignores[0].Glob, "**/tests/**")
 	assert.Equal(t, ignores[1].Glob, "scripts/**")
-	assert.Equal(t, ignores[2].Glob, "also-global")
 }
 
 // A11: multiple global ignore entries — all patterns combined.

--- a/internal/config/gitignore_test.go
+++ b/internal/config/gitignore_test.go
@@ -27,7 +27,7 @@ type gitignoreMockFS struct {
 	vfs.FS
 	entries         map[string]vfs.Entries
 	files           map[string]string
-	realpaths       map[string]string
+	resolvedPaths   map[string]string
 	readFileCalls   []string
 	accessedDirs    []string
 	realpathCalls   []string
@@ -47,7 +47,7 @@ func (m *gitignoreMockFS) GetAccessibleEntries(path string) vfs.Entries {
 
 func (m *gitignoreMockFS) Realpath(path string) string {
 	m.realpathCalls = append(m.realpathCalls, path)
-	if realpath, ok := m.realpaths[path]; ok {
+	if realpath, ok := m.resolvedPaths[path]; ok {
 		return realpath
 	}
 	return path
@@ -350,7 +350,7 @@ func TestReadGitignoreAsGlobs_SkipsDescendantSymlinkCycle(t *testing.T) {
 				Symlinks:    map[string]struct{}{},
 			},
 		},
-		realpaths: map[string]string{"/repo/a/loop": "/repo"},
+		resolvedPaths: map[string]string{"/repo/a/loop": "/repo"},
 	}
 
 	globs := ReadGitignoreAsGlobs("/repo", mock, nil)
@@ -372,7 +372,7 @@ func TestReadGitignoreAsGlobs_LegacySymlinkCycleUsesCachedRealpaths(t *testing.T
 			"/repo":   {Directories: []string{"a"}},
 			"/repo/a": {Directories: []string{"loop"}},
 		},
-		realpaths: map[string]string{
+		resolvedPaths: map[string]string{
 			"/repo":        "/repo",
 			"/repo/a":      "/repo/a",
 			"/repo/a/loop": "/repo",

--- a/internal/config/globals_test.go
+++ b/internal/config/globals_test.go
@@ -45,3 +45,40 @@ func TestExtractGlobals_NoLanguageOptions(t *testing.T) {
 		t.Errorf("ExtractGlobals(empty) = %v, want nil", got)
 	}
 }
+
+func TestMergeLanguageOptions_MergesGlobalsByName(t *testing.T) {
+	base := &LanguageOptions{Raw: map[string]any{
+		"globals": map[string]any{
+			"baseOnly": "readonly",
+			"shared":   "writable",
+		},
+	}}
+	override := &LanguageOptions{Raw: map[string]any{
+		"globals": map[string]any{
+			"overrideOnly": "readonly",
+			"shared":       "off",
+		},
+	}}
+
+	merged := mergeLanguageOptions(base, override)
+	merged = mergeLanguageOptions(merged, &LanguageOptions{Raw: map[string]any{
+		"globals": map[string]any{},
+	}})
+
+	rawGlobals, ok := merged.Raw["globals"].(map[string]any)
+	if !ok {
+		t.Fatalf("merged globals has type %T, want map[string]any", merged.Raw["globals"])
+	}
+	if got := rawGlobals["baseOnly"]; got != "readonly" {
+		t.Errorf("baseOnly = %v, want readonly", got)
+	}
+	if got := rawGlobals["overrideOnly"]; got != "readonly" {
+		t.Errorf("overrideOnly = %v, want readonly", got)
+	}
+	if got := rawGlobals["shared"]; got != "off" {
+		t.Errorf("shared = %v, want off", got)
+	}
+	if got := ExtractGlobals(merged)["shared"]; got {
+		t.Error("later off value should undeclare shared")
+	}
+}

--- a/internal/config/globals_test.go
+++ b/internal/config/globals_test.go
@@ -2,20 +2,23 @@ package config
 
 import "testing"
 
-// Locks in normalizeConfigGlobal parity with ESLint (source-code.js): only
-// the string "off" un-declares a global. Boolean false and null both map to
-// "readonly" and remain declared — a common mix-up since other ESLint config
-// knobs treat false/"off" as equivalent, but globals don't.
+// ExtractGlobals preserves the declared/disabled state needed by native rules.
+// Access aliases, including null-as-readonly, remain declared; only "off"
+// explicitly disables a name.
 func TestExtractGlobals(t *testing.T) {
 	langOpts := &LanguageOptions{
 		Raw: map[string]any{
 			"globals": map[string]any{
-				"stringOff":      "off",
-				"stringReadonly": "readonly",
-				"stringWritable": "writable",
 				"boolTrue":       true,
+				"stringTrue":     "true",
+				"writable":       "writable",
+				"writeable":      "writeable",
 				"boolFalse":      false,
-				"nullValue":      nil,
+				"stringFalse":    "false",
+				"readonly":       "readonly",
+				"readable":       "readable",
+				"nullReadonly":   nil,
+				"stringDisabled": "off",
 			},
 		},
 	}
@@ -23,12 +26,16 @@ func TestExtractGlobals(t *testing.T) {
 	globals := ExtractGlobals(langOpts)
 
 	cases := map[string]bool{
-		"stringOff":      false,
-		"stringReadonly": true,
-		"stringWritable": true,
 		"boolTrue":       true,
+		"stringTrue":     true,
+		"writable":       true,
+		"writeable":      true,
 		"boolFalse":      true,
-		"nullValue":      true,
+		"stringFalse":    true,
+		"readonly":       true,
+		"readable":       true,
+		"nullReadonly":   true,
+		"stringDisabled": false,
 	}
 	for name, want := range cases {
 		if got := globals[name]; got != want {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -202,7 +202,7 @@ func (loader *ConfigLoader) expandProjectGlob(configDirectory string, pattern st
 		return nil, nil
 	}
 
-	relativePattern := strings.TrimPrefix(resolvedPattern, searchRoot+"/")
+	relativePattern := relativeGlobPattern(searchRoot, resolvedPattern)
 	// expandProjectGlob historically follows symlinks (e.g. tsconfig
 	// referenced via packages/*/tsconfig.json where packages may be
 	// symlinks in pnpm workspaces). It runs single-threaded under
@@ -221,6 +221,11 @@ func (loader *ConfigLoader) expandProjectGlob(configDirectory string, pattern st
 
 	sort.Strings(matches)
 	return matches, nil
+}
+
+func relativeGlobPattern(searchRoot string, resolvedPattern string) string {
+	relativePattern := strings.TrimPrefix(resolvedPattern, searchRoot)
+	return strings.TrimPrefix(relativePattern, "/")
 }
 
 func containsGlobPattern(path string) bool {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -54,6 +54,9 @@ func (loader *ConfigLoader) LoadRslintConfig(configPath string) (RslintConfig, s
 	if err := utils.ParseJSONC([]byte(data), &config); err != nil {
 		return nil, "", fmt.Errorf("error parsing rslint config file %q: %w", configFileName, err)
 	}
+	if err := ValidateConfig(config); err != nil {
+		return nil, "", fmt.Errorf("invalid rslint config file %q: %w", configFileName, err)
+	}
 
 	// Normalize JSON config: inject core rules and plugin rules into each entry's Rules map.
 	// User-specified rules take precedence (they are applied after the defaults).

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -273,18 +273,19 @@ func normalizeGlobPath(path string) string {
 	return strings.ReplaceAll(tspath.NormalizePath(path), "\\", "/")
 }
 
-// LoadConfiguration is a convenience method that loads both rslint and tsconfig configurations
-func (loader *ConfigLoader) LoadConfiguration(configPath string) (RslintConfig, []string, string, error) {
-	var rslintConfig RslintConfig
-	var configDirectory string
-	var err error
-
+// LoadRslintConfiguration loads and validates only the rslint configuration.
+// Project resolution is a separate orchestration step because plain linting
+// first needs the effective target set.
+func (loader *ConfigLoader) LoadRslintConfiguration(configPath string) (RslintConfig, string, error) {
 	if configPath != "" {
-		rslintConfig, configDirectory, err = loader.LoadRslintConfig(configPath)
-	} else {
-		rslintConfig, configDirectory, err = loader.LoadDefaultRslintConfig()
+		return loader.LoadRslintConfig(configPath)
 	}
+	return loader.LoadDefaultRslintConfig()
+}
 
+// LoadConfiguration is a convenience method that loads both rslint and tsconfig configurations.
+func (loader *ConfigLoader) LoadConfiguration(configPath string) (RslintConfig, []string, string, error) {
+	rslintConfig, configDirectory, err := loader.LoadRslintConfiguration(configPath)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -295,18 +296,4 @@ func (loader *ConfigLoader) LoadConfiguration(configPath string) (RslintConfig, 
 	}
 
 	return rslintConfig, tsConfigs, configDirectory, nil
-}
-
-// LoadConfigurationWithFallback loads configuration and handles errors by printing to stderr and exiting
-// This is for backward compatibility with the existing cmd behavior
-func LoadConfigurationWithFallback(configPath string, currentDirectory string, fs vfs.FS) (RslintConfig, []string, string) {
-	loader := NewConfigLoader(fs, currentDirectory)
-
-	rslintConfig, tsConfigs, configDirectory, err := loader.LoadConfiguration(configPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-
-	return rslintConfig, tsConfigs, configDirectory
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -31,6 +31,22 @@ func TestContainsGlobPattern(t *testing.T) {
 	}
 }
 
+func TestRelativeGlobPatternPreservesFilesystemRoots(t *testing.T) {
+	tests := []struct {
+		root     string
+		pattern  string
+		expected string
+	}{
+		{root: "/", pattern: "/*/tsconfig.json", expected: "*/tsconfig.json"},
+		{root: "/repo", pattern: "/repo/packages/*/tsconfig.json", expected: "packages/*/tsconfig.json"},
+		{root: "C:/", pattern: "C:/*/tsconfig.json", expected: "*/tsconfig.json"},
+		{root: "//server/share/", pattern: "//server/share/*/tsconfig.json", expected: "*/tsconfig.json"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, relativeGlobPattern(tt.root, tt.pattern), tt.expected)
+	}
+}
+
 func TestLoadRslintConfig_RejectsEmptyFilesArray(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "rslint.jsonc")

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -31,6 +31,41 @@ func TestContainsGlobPattern(t *testing.T) {
 	}
 }
 
+func TestLoadRslintConfig_RejectsEmptyFilesArray(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "rslint.jsonc")
+	if err := os.WriteFile(configPath, []byte(`[
+		{
+			"files": [],
+			"rules": { "no-console": "error" }
+		}
+	]`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	loader := NewConfigLoader(osvfs.FS(), tmpDir)
+	_, _, err := loader.LoadRslintConfig("rslint.jsonc")
+	assert.ErrorContains(t, err, `key "files": expected value to be a non-empty array`)
+}
+
+func TestLoadRslintConfig_AllowsMissingFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "rslint.jsonc")
+	if err := os.WriteFile(configPath, []byte(`[
+		{
+			"rules": { "no-console": "error" }
+		}
+	]`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	loader := NewConfigLoader(osvfs.FS(), tmpDir)
+	cfg, _, err := loader.LoadRslintConfig("rslint.jsonc")
+	assert.NilError(t, err)
+	assert.Equal(t, len(cfg), 1)
+	assert.Assert(t, cfg[0].Files == nil)
+}
+
 func TestLoadTsConfigsFromRslintConfig_GlobExpansion(t *testing.T) {
 	tmpDir := t.TempDir()
 	createTestFile(t, filepath.Join(tmpDir, "packages/ui/tsconfig.json"))

--- a/internal/config/parse_array_rule_test.go
+++ b/internal/config/parse_array_rule_test.go
@@ -13,39 +13,64 @@ import (
 // option list (["error","a","b"]) which becomes ["a","b"].
 func TestParseArrayRuleConfig_OptionShapes(t *testing.T) {
 	tests := []struct {
-		name string
-		in   []interface{}
-		want []interface{}
+		name      string
+		in        []interface{}
+		wantLevel string
+		want      []interface{}
 	}{
 		{
-			name: "no options",
-			in:   []interface{}{"error"},
-			want: nil,
+			name:      "no options",
+			in:        []interface{}{"error"},
+			wantLevel: "error",
+			want:      nil,
 		},
 		{
-			name: "single string option stays wrapped",
-			in:   []interface{}{"error", "both"},
-			want: []interface{}{"both"},
+			name:      "numeric zero is off",
+			in:        []interface{}{0},
+			wantLevel: "off",
+			want:      nil,
 		},
 		{
-			name: "single object option stays wrapped",
-			in:   []interface{}{"error", map[string]interface{}{"k": float64(1)}},
-			want: []interface{}{map[string]interface{}{"k": float64(1)}},
+			name:      "numeric one is warn",
+			in:        []interface{}{float64(1)},
+			wantLevel: "warn",
+			want:      nil,
 		},
 		{
-			name: "single array option keeps its wrapper",
-			in:   []interface{}{"error", []interface{}{"a", "b"}},
-			want: []interface{}{[]interface{}{"a", "b"}},
+			name:      "numeric two is error",
+			in:        []interface{}{uint8(2)},
+			wantLevel: "error",
+			want:      nil,
 		},
 		{
-			name: "multiple options pass through as the args list",
-			in:   []interface{}{"error", "a", "b"},
-			want: []interface{}{"a", "b"},
+			name:      "single string option stays wrapped",
+			in:        []interface{}{"error", "both"},
+			wantLevel: "error",
+			want:      []interface{}{"both"},
 		},
 		{
-			name: "multiple options including an object",
-			in:   []interface{}{"error", "both", map[string]interface{}{"k": float64(1)}},
-			want: []interface{}{"both", map[string]interface{}{"k": float64(1)}},
+			name:      "single object option stays wrapped",
+			in:        []interface{}{"error", map[string]interface{}{"k": float64(1)}},
+			wantLevel: "error",
+			want:      []interface{}{map[string]interface{}{"k": float64(1)}},
+		},
+		{
+			name:      "single array option keeps its wrapper",
+			in:        []interface{}{"error", []interface{}{"a", "b"}},
+			wantLevel: "error",
+			want:      []interface{}{[]interface{}{"a", "b"}},
+		},
+		{
+			name:      "multiple options pass through as the args list",
+			in:        []interface{}{"error", "a", "b"},
+			wantLevel: "error",
+			want:      []interface{}{"a", "b"},
+		},
+		{
+			name:      "multiple options including an object",
+			in:        []interface{}{"error", "both", map[string]interface{}{"k": float64(1)}},
+			wantLevel: "error",
+			want:      []interface{}{"both", map[string]interface{}{"k": float64(1)}},
 		},
 	}
 	for _, tt := range tests {
@@ -54,8 +79,8 @@ func TestParseArrayRuleConfig_OptionShapes(t *testing.T) {
 			if rc == nil {
 				t.Fatal("parseArrayRuleConfig returned nil")
 			}
-			if rc.Level != "error" {
-				t.Errorf("Level = %q, want \"error\"", rc.Level)
+			if rc.Level != tt.wantLevel {
+				t.Errorf("Level = %q, want %q", rc.Level, tt.wantLevel)
 			}
 			if !reflect.DeepEqual(rc.Options, tt.want) {
 				t.Errorf("Options = %#v, want %#v", rc.Options, tt.want)

--- a/internal/config/rule_registry.go
+++ b/internal/config/rule_registry.go
@@ -48,8 +48,17 @@ func (r *RuleRegistry) GetEnabledRules(config RslintConfig, filePath string, cwd
 		return nil, nil // file is globally ignored
 	}
 
-	globals := ExtractGlobals(mergedConfig.LanguageOptions)
+	return r.GetEnabledRulesForMergedConfig(mergedConfig, enforcePlugins), mergedConfig
+}
 
+// GetEnabledRulesForMergedConfig converts an already-resolved config into
+// enabled rule handlers without re-running files/ignores matching.
+func (r *RuleRegistry) GetEnabledRulesForMergedConfig(mergedConfig *MergedConfig, enforcePlugins bool) []linter.ConfiguredRule {
+	if mergedConfig == nil {
+		return nil
+	}
+
+	globals := ExtractGlobals(mergedConfig.LanguageOptions)
 	var enabledRules []linter.ConfiguredRule
 	for ruleName, ruleConfig := range mergedConfig.Rules {
 		if ruleConfig.IsEnabled() {
@@ -90,7 +99,7 @@ func (r *RuleRegistry) GetEnabledRules(config RslintConfig, filePath string, cwd
 		return strings.Compare(a.Name, b.Name)
 	})
 
-	return enabledRules, mergedConfig
+	return enabledRules
 }
 
 // GetActiveRulesForFile returns the lint rules that should run on a file.

--- a/internal/config/rule_registry.go
+++ b/internal/config/rule_registry.go
@@ -37,9 +37,12 @@ func (r *RuleRegistry) GetAllRules() map[string]rule.Rule {
 }
 
 // GetEnabledRules returns rules that are enabled in the configuration for a given file.
-// Returns nil if no config entry matches the file (file should not be linted).
+// It returns nil rules and a nil merged config when no config entry matches.
+// Target planning remains responsible for deciding whether an explicitly
+// requested file is still parsed without lint rules.
 // When enforcePlugins is true (JS/TS config), rules with a plugin prefix (e.g. "@typescript-eslint/")
-// are only included if the corresponding plugin is declared in the merged config's Plugins set.
+// are included only when the normalized native or third-party prefix is
+// declared in the merged config's Plugins set.
 // Core rules (no "/" prefix) are always included regardless of enforcePlugins.
 // cwd is the config directory used to resolve files/ignores patterns.
 func (r *RuleRegistry) GetEnabledRules(config RslintConfig, filePath string, cwd string, enforcePlugins bool) ([]linter.ConfiguredRule, *MergedConfig) {
@@ -75,6 +78,7 @@ func (r *RuleRegistry) GetEnabledRulesForMergedConfig(mergedConfig *MergedConfig
 
 			if ruleImpl, exists := r.rules[ruleName]; exists {
 				ruleConfigCopy := ruleConfig
+				options := rule.NormalizeOptions(ruleConfigCopy.Options)
 				enabledRules = append(enabledRules, linter.ConfiguredRule{
 					Name:               ruleName,
 					Settings:           CloneSettings(mergedConfig.Settings),
@@ -82,9 +86,9 @@ func (r *RuleRegistry) GetEnabledRulesForMergedConfig(mergedConfig *MergedConfig
 					Severity:           ruleConfig.GetSeverity(),
 					RequiresTypeInfo:   ruleImpl.RequiresTypeInfo,
 					IsEslintPluginRule: ruleImpl.IsEslintPluginRule,
-					Options:            ruleConfigCopy.Options,
+					Options:            options,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {
-						return ruleImpl.Run(ctx, rule.NormalizeOptions(ruleConfigCopy.Options))
+						return ruleImpl.Run(ctx, options)
 					},
 				})
 			}

--- a/internal/config/rule_registry_test.go
+++ b/internal/config/rule_registry_test.go
@@ -634,6 +634,12 @@ func TestFileConfigResolver_MatchesRegistryAndFiltersTypeAwareRules(t *testing.T
 	cfg := RslintConfig{
 		{
 			Files: []string{"src/**/*.ts"},
+			LanguageOptions: &LanguageOptions{Raw: map[string]any{
+				"globals": map[string]any{
+					"readonlyGlobal": "readonly",
+					"disabledGlobal": "off",
+				},
+			}},
 			Rules: Rules{
 				"@typescript-eslint/require-await": "error",
 				"no-console":                       "warn",
@@ -654,6 +660,16 @@ func TestFileConfigResolver_MatchesRegistryAndFiltersTypeAwareRules(t *testing.T
 		for name := range want {
 			if !got[name] {
 				t.Fatalf("resolver rules differ from registry rules: got %v want %v", ruleNames(cachedRules), ruleNames(registryRules))
+			}
+		}
+	}
+	for _, rules := range [][]linter.ConfiguredRule{cachedRules, registryRules} {
+		for _, rule := range rules {
+			if !rule.Globals["readonlyGlobal"] {
+				t.Fatalf("expected resolver/registry rule %q to carry declared global", rule.Name)
+			}
+			if rule.Globals["disabledGlobal"] {
+				t.Fatalf("expected resolver/registry rule %q to carry disabled global as false", rule.Name)
 			}
 		}
 	}

--- a/internal/config/rule_registry_test.go
+++ b/internal/config/rule_registry_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/linter"
@@ -338,7 +339,7 @@ func TestGetEnabledRules_EnforcePlugins_MultiplePluginsInSameEntry(t *testing.T)
 			Rules: Rules{
 				"@typescript-eslint/no-explicit-any": "error",
 				"react/jsx-uses-react":               "error",
-				"import/no-self-import":               "error", // import plugin NOT in plugins array
+				"import/no-self-import":              "error", // import plugin NOT in plugins array
 			},
 		},
 	}
@@ -446,7 +447,7 @@ func TestGetEnabledRules_EnforcePlugins_PresetPlusAdditionalPlugin(t *testing.T)
 			Files:   []string{"**/*.tsx"},
 			Plugins: []string{"react"},
 			Rules: Rules{
-				"react/jsx-uses-react":             "error",
+				"react/jsx-uses-react":              "error",
 				"@typescript-eslint/ban-ts-comment": "error", // TS rule in react entry
 			},
 		},
@@ -625,6 +626,92 @@ func TestGetActiveRulesForFile_NilTypeInfoFilesNoFiltering(t *testing.T) {
 	if !found {
 		t.Error("Expected require-await when typeInfoFiles is nil (no filtering)")
 	}
+}
+
+func TestFileConfigResolver_MatchesRegistryAndFiltersTypeAwareRules(t *testing.T) {
+	RegisterAllRules()
+
+	cfg := RslintConfig{
+		{
+			Files: []string{"src/**/*.ts"},
+			Rules: Rules{
+				"@typescript-eslint/require-await": "error",
+				"no-console":                       "warn",
+			},
+		},
+	}
+	resolver := NewFileConfigResolver(cfg, "/repo", false)
+
+	filePath := "/repo/src/app.ts"
+	cachedRules, cachedMerged := resolver.EnabledRulesForFile(filePath)
+	registryRules, registryMerged := GlobalRuleRegistry.GetEnabledRules(cfg, filePath, "/repo", false)
+	if cachedMerged == nil || registryMerged == nil {
+		t.Fatalf("expected both resolver and registry to return merged config")
+	}
+	if got, want := ruleNameSet(cachedRules), ruleNameSet(registryRules); len(got) != len(want) {
+		t.Fatalf("resolver rules differ from registry rules: got %v want %v", ruleNames(cachedRules), ruleNames(registryRules))
+	} else {
+		for name := range want {
+			if !got[name] {
+				t.Fatalf("resolver rules differ from registry rules: got %v want %v", ruleNames(cachedRules), ruleNames(registryRules))
+			}
+		}
+	}
+
+	uncovered := resolver.ActiveRulesForFile(filePath, map[string]struct{}{})
+	if len(uncovered) != 1 {
+		t.Fatalf("expected only non-type-aware rule for uncovered file, got %v", ruleNames(uncovered))
+	}
+	if uncovered[0].Name != "no-console" {
+		t.Fatalf("expected no-console for uncovered file, got %q", uncovered[0].Name)
+	}
+
+	if ignoredConfig := resolver.ConfigForFile("/repo/test/app.ts"); ignoredConfig != nil {
+		t.Fatalf("expected files-miss path to have no merged config")
+	}
+	filesMissRules, filesMissConfig := resolver.EnabledRulesForFile("/repo/test/app.ts")
+	if filesMissRules != nil || filesMissConfig != nil {
+		t.Fatalf("expected files-miss path to return nil rules/config, got %v %#v", ruleNames(filesMissRules), filesMissConfig)
+	}
+}
+
+func TestFileConfigResolver_ConcurrentAccess(t *testing.T) {
+	RegisterAllRules()
+
+	cfg := RslintConfig{
+		{
+			Files: []string{"src/**/*.ts"},
+			Rules: Rules{
+				"@typescript-eslint/require-await": "error",
+				"no-console":                       "warn",
+			},
+		},
+	}
+	resolver := NewFileConfigResolver(cfg, "/repo", false)
+	paths := []string{
+		"/repo/src/a.ts",
+		"/repo/src/b.ts",
+		"/repo/test/a.ts",
+	}
+	typeInfoFiles := map[string]struct{}{
+		"/repo/src/a.ts": {},
+	}
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				for _, filePath := range paths {
+					_ = resolver.ConfigForFile(filePath)
+					_, _ = resolver.EnabledRulesForFile(filePath)
+					_ = resolver.ActiveRulesForFile(filePath, typeInfoFiles)
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func ruleNames(rules []linter.ConfiguredRule) []string {

--- a/internal/config/vfs_adapter.go
+++ b/internal/config/vfs_adapter.go
@@ -29,19 +29,19 @@ import (
 //     output is deterministic regardless of the concurrency model, and
 //     cycles cannot occur.
 //
-//   - true (used by expandProjectGlob): symlinks are followed, with cycle
-//     detection via visitedSymTargets. expandProjectGlob runs single-threaded
-//     under doublestar.GlobWalk, so the dedupe decision order is bounded by
-//     the FS layout (no goroutine scheduling concern).
+//   - true (used by expandProjectGlob): symlinks are followed unless their
+//     resolved target is already in the current path's ancestor chain. This
+//     prevents traversal cycles while preserving distinct aliases that point
+//     to the same directory.
 //
-// visitedSymTargets uses sync.Map so the followSymlinks=true path is also
-// safe under future concurrent callers, but it is currently exercised only
-// by the single-threaded loader.
+// Realpath results are cached behind a mutex so the adapter remains safe if a
+// caller traverses it concurrently in the future.
 type vfsAdapter struct {
-	vfs               vfs.FS
-	root              string
-	followSymlinks    bool
-	visitedSymTargets sync.Map
+	vfs            vfs.FS
+	root           string
+	followSymlinks bool
+	realpathMu     sync.Mutex
+	realpaths      map[string]string
 }
 
 var _ fs.FS = (*vfsAdapter)(nil)
@@ -68,6 +68,42 @@ func (a *vfsAdapter) fullPath(name string) string {
 	return tspath.ResolvePath(a.root, name)
 }
 
+func (a *vfsAdapter) cachedRealpath(path string) string {
+	a.realpathMu.Lock()
+	defer a.realpathMu.Unlock()
+
+	if realpath, ok := a.realpaths[path]; ok {
+		return realpath
+	}
+	if a.realpaths == nil {
+		a.realpaths = make(map[string]string)
+	}
+	realpath := a.vfs.Realpath(path)
+	a.realpaths[path] = realpath
+	return realpath
+}
+
+func (a *vfsAdapter) pointsToAncestor(path string, targetRealpath string) bool {
+	compareOptions := tspath.ComparePathsOptions{
+		UseCaseSensitiveFileNames: a.vfs.UseCaseSensitiveFileNames(),
+	}
+	root := tspath.NormalizePath(a.root)
+	current := tspath.NormalizePath(path)
+	for {
+		if tspath.ComparePaths(a.cachedRealpath(current), targetRealpath, compareOptions) == 0 {
+			return true
+		}
+		if tspath.ComparePaths(current, root, compareOptions) == 0 {
+			return false
+		}
+		parent := tspath.GetDirectoryPath(current)
+		if parent == current || parent == "" {
+			return false
+		}
+		current = parent
+	}
+}
+
 // vfsDirFile implements fs.ReadDirFile for directories.
 type vfsDirFile struct {
 	adapter *vfsAdapter
@@ -92,18 +128,29 @@ func (f *vfsDirFile) Close() error { return nil }
 func (f *vfsDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 	if f.entries == nil {
 		accessible := f.adapter.vfs.GetAccessibleEntries(f.path)
-		parentRealPath := f.adapter.vfs.Realpath(f.path)
 
 		f.entries = make([]fs.DirEntry, 0, len(accessible.Directories)+len(accessible.Files))
 
+		var parentRealPath string
 		for _, dir := range accessible.Directories {
-			dirPath := tspath.ResolvePath(f.path, dir)
-			dirRealPath := f.adapter.vfs.Realpath(dirPath)
-
-			// A regular subdirectory's realpath equals parentRealPath + "/" + name.
-			// If it differs, the entry is a symlink.
-			expectedRealPath := parentRealPath + "/" + dir
-			isSymlink := dirRealPath != expectedRealPath
+			dirPath := tspath.CombinePaths(f.path, dir)
+			dirRealPath := ""
+			isSymlink := false
+			if accessible.Symlinks != nil {
+				_, isSymlink = accessible.Symlinks[dir]
+			} else {
+				// Older VFS implementations do not expose symlink metadata.
+				// Resolve each path at most once and compare against the path a
+				// regular child would have under its resolved parent.
+				if parentRealPath == "" {
+					parentRealPath = f.adapter.cachedRealpath(f.path)
+				}
+				dirRealPath = f.adapter.cachedRealpath(dirPath)
+				expectedRealPath := tspath.CombinePaths(parentRealPath, dir)
+				isSymlink = tspath.ComparePaths(dirRealPath, expectedRealPath, tspath.ComparePathsOptions{
+					UseCaseSensitiveFileNames: f.adapter.vfs.UseCaseSensitiveFileNames(),
+				}) != 0
+			}
 
 			if isSymlink {
 				if !f.adapter.followSymlinks {
@@ -111,9 +158,13 @@ func (f *vfsDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 					// for why this is the default for DiscoverGapFiles.
 					continue
 				}
-				// Cycle dedupe: LoadOrStore returns loaded=true on second
-				// encounter of the same realpath; skip in that case.
-				if _, loaded := f.adapter.visitedSymTargets.LoadOrStore(dirRealPath, struct{}{}); loaded {
+				if dirRealPath == "" {
+					dirRealPath = f.adapter.cachedRealpath(dirPath)
+				}
+				// A repeated target is valid when two different aliases point to
+				// the same directory. Skip only a target already present in this
+				// lexical path's ancestor chain, which is an actual traversal cycle.
+				if f.adapter.pointsToAncestor(f.path, dirRealPath) {
 					continue
 				}
 			}

--- a/internal/config/vfs_adapter.go
+++ b/internal/config/vfs_adapter.go
@@ -41,7 +41,7 @@ type vfsAdapter struct {
 	root           string
 	followSymlinks bool
 	realpathMu     sync.Mutex
-	realpaths      map[string]string
+	resolvedPaths  map[string]string
 }
 
 var _ fs.FS = (*vfsAdapter)(nil)
@@ -72,14 +72,14 @@ func (a *vfsAdapter) cachedRealpath(path string) string {
 	a.realpathMu.Lock()
 	defer a.realpathMu.Unlock()
 
-	if realpath, ok := a.realpaths[path]; ok {
+	if realpath, ok := a.resolvedPaths[path]; ok {
 		return realpath
 	}
-	if a.realpaths == nil {
-		a.realpaths = make(map[string]string)
+	if a.resolvedPaths == nil {
+		a.resolvedPaths = make(map[string]string)
 	}
 	realpath := a.vfs.Realpath(path)
-	a.realpaths[path] = realpath
+	a.resolvedPaths[path] = realpath
 	return realpath
 }
 
@@ -172,7 +172,8 @@ func (f *vfsDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 			f.entries = append(f.entries, &vfsDirEntry{name: dir, isDir: true})
 		}
 		for _, file := range accessible.Files {
-			f.entries = append(f.entries, &vfsDirEntry{name: file, isDir: false})
+			_, isSymlink := accessible.Symlinks[file]
+			f.entries = append(f.entries, &vfsDirEntry{name: file, isSymlink: isSymlink})
 		}
 		sort.Slice(f.entries, func(i, j int) bool {
 			return f.entries[i].Name() < f.entries[j].Name()
@@ -206,8 +207,9 @@ func (f *vfsDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 
 // vfsDirEntry implements fs.DirEntry.
 type vfsDirEntry struct {
-	name  string
-	isDir bool
+	name      string
+	isDir     bool
+	isSymlink bool
 }
 
 func (e *vfsDirEntry) Name() string { return e.name }
@@ -215,6 +217,9 @@ func (e *vfsDirEntry) IsDir() bool  { return e.isDir }
 func (e *vfsDirEntry) Type() fs.FileMode {
 	if e.isDir {
 		return fs.ModeDir
+	}
+	if e.isSymlink {
+		return fs.ModeSymlink
 	}
 	return 0
 }

--- a/internal/config/vfs_adapter_test.go
+++ b/internal/config/vfs_adapter_test.go
@@ -200,7 +200,7 @@ func TestVfsAdapter_SymlinkCycleFilteredWhenFollowing(t *testing.T) {
 type vfsAdapterMockFS struct {
 	vfs.FS
 	entries         map[string]vfs.Entries
-	realpaths       map[string]string
+	resolvedPaths   map[string]string
 	realpathCalls   []string
 	caseSensitiveFS bool
 }
@@ -211,7 +211,7 @@ func (m *vfsAdapterMockFS) GetAccessibleEntries(path string) vfs.Entries {
 
 func (m *vfsAdapterMockFS) Realpath(path string) string {
 	m.realpathCalls = append(m.realpathCalls, path)
-	if realpath, ok := m.realpaths[path]; ok {
+	if realpath, ok := m.resolvedPaths[path]; ok {
 		return realpath
 	}
 	return path
@@ -232,7 +232,7 @@ func TestVfsAdapter_UsesSymlinkMetadataBeforeRealpath(t *testing.T) {
 						Symlinks:    map[string]struct{}{"link": {}},
 					},
 				},
-				realpaths: map[string]string{"/repo/link": "/target"},
+				resolvedPaths: map[string]string{"/repo/link": "/target"},
 			}
 			adapter := &vfsAdapter{vfs: mock, root: "/repo", followSymlinks: followSymlinks}
 
@@ -268,7 +268,7 @@ func TestVfsAdapter_FollowSymlinksKeepsDistinctAliasesToSameTarget(t *testing.T)
 				},
 			},
 		},
-		realpaths: map[string]string{
+		resolvedPaths: map[string]string{
 			"/repo":         "/repo",
 			"/repo/alias-a": "/shared",
 			"/repo/alias-b": "/shared",
@@ -360,6 +360,10 @@ func TestVfsDirEntry_TypeAndInfo(t *testing.T) {
 	fileEntry := &vfsDirEntry{name: "file.txt", isDir: false}
 	assert.Assert(t, !fileEntry.IsDir())
 	assert.Equal(t, fileEntry.Type(), fs.FileMode(0))
+
+	symlinkEntry := &vfsDirEntry{name: "link.ts", isSymlink: true}
+	assert.Assert(t, !symlinkEntry.IsDir())
+	assert.Equal(t, symlinkEntry.Type(), fs.ModeSymlink)
 }
 
 // spyVFS wraps a real VFS and counts DirectoryExists calls.

--- a/internal/config/vfs_adapter_test.go
+++ b/internal/config/vfs_adapter_test.go
@@ -168,7 +168,7 @@ func TestVfsAdapter_SymlinksSkippedByDefault(t *testing.T) {
 	assert.Assert(t, hasReal, "regular files must still be returned")
 }
 
-// Opt-in vfsAdapter (followSymlinks=true) follows symlinks but dedupes cycles.
+// Opt-in vfsAdapter (followSymlinks=true) follows symlinks but skips cycles.
 // This is what loader.expandProjectGlob uses (single-threaded).
 func TestVfsAdapter_SymlinkCycleFilteredWhenFollowing(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -179,7 +179,8 @@ func TestVfsAdapter_SymlinkCycleFilteredWhenFollowing(t *testing.T) {
 
 	adapter := &vfsAdapter{vfs: osvfs.FS(), root: tmpDir, followSymlinks: true}
 
-	// Open "a" and read its entries — first encounter of the symlink is kept.
+	// The target is already an ancestor of "a", so entering the symlink would
+	// create a cycle immediately.
 	f, err := adapter.Open("a")
 	assert.NilError(t, err)
 	defer f.Close()
@@ -193,36 +194,155 @@ func TestVfsAdapter_SymlinkCycleFilteredWhenFollowing(t *testing.T) {
 			hasLoop = true
 		}
 	}
-	assert.Assert(t, hasLoop, "first encounter of symlink should be included")
+	assert.Assert(t, !hasLoop, "symlink target already in the ancestor chain must be skipped")
+}
 
-	// Open "a/loop" (resolves to tmpDir) and read its entries.
-	f2, err := adapter.Open("a/loop")
-	assert.NilError(t, err)
-	defer f2.Close()
+type vfsAdapterMockFS struct {
+	vfs.FS
+	entries         map[string]vfs.Entries
+	realpaths       map[string]string
+	realpathCalls   []string
+	caseSensitiveFS bool
+}
 
-	entries2, err := f2.(fs.ReadDirFile).ReadDir(-1)
-	assert.NilError(t, err)
+func (m *vfsAdapterMockFS) GetAccessibleEntries(path string) vfs.Entries {
+	return m.entries[path]
+}
 
-	hasA := false
-	for _, e := range entries2 {
-		if e.Name() == "a" {
-			hasA = true
-		}
+func (m *vfsAdapterMockFS) Realpath(path string) string {
+	m.realpathCalls = append(m.realpathCalls, path)
+	if realpath, ok := m.realpaths[path]; ok {
+		return realpath
 	}
-	assert.Assert(t, hasA, "should see 'a' directory inside the symlink target")
+	return path
+}
 
-	// Open a/loop/a — second encounter of the cycle target → deduped.
-	f3, err := adapter.Open("a/loop/a")
+func (m *vfsAdapterMockFS) UseCaseSensitiveFileNames() bool {
+	return m.caseSensitiveFS
+}
+
+func TestVfsAdapter_UsesSymlinkMetadataBeforeRealpath(t *testing.T) {
+	for _, followSymlinks := range []bool{false, true} {
+		t.Run(map[bool]string{false: "skip", true: "follow"}[followSymlinks], func(t *testing.T) {
+			mock := &vfsAdapterMockFS{
+				FS: osvfs.FS(),
+				entries: map[string]vfs.Entries{
+					"/repo": {
+						Directories: []string{"link", "regular"},
+						Symlinks:    map[string]struct{}{"link": {}},
+					},
+				},
+				realpaths: map[string]string{"/repo/link": "/target"},
+			}
+			adapter := &vfsAdapter{vfs: mock, root: "/repo", followSymlinks: followSymlinks}
+
+			file, err := adapter.Open(".")
+			assert.NilError(t, err)
+			entries, err := file.(fs.ReadDirFile).ReadDir(-1)
+			assert.NilError(t, err)
+
+			names := make([]string, 0, len(entries))
+			for _, entry := range entries {
+				names = append(names, entry.Name())
+			}
+			if followSymlinks {
+				assert.DeepEqual(t, names, []string{"link", "regular"})
+				assert.DeepEqual(t, mock.realpathCalls, []string{"/repo/link", "/repo"})
+			} else {
+				assert.DeepEqual(t, names, []string{"regular"})
+				assert.Equal(t, len(mock.realpathCalls), 0)
+			}
+		})
+	}
+}
+
+func TestVfsAdapter_FollowSymlinksKeepsDistinctAliasesToSameTarget(t *testing.T) {
+	mock := &vfsAdapterMockFS{
+		FS: osvfs.FS(),
+		entries: map[string]vfs.Entries{
+			"/repo": {
+				Directories: []string{"alias-a", "alias-b"},
+				Symlinks: map[string]struct{}{
+					"alias-a": {},
+					"alias-b": {},
+				},
+			},
+		},
+		realpaths: map[string]string{
+			"/repo":         "/repo",
+			"/repo/alias-a": "/shared",
+			"/repo/alias-b": "/shared",
+		},
+	}
+	adapter := &vfsAdapter{vfs: mock, root: "/repo", followSymlinks: true}
+
+	file, err := adapter.Open(".")
 	assert.NilError(t, err)
-	defer f3.Close()
+	entries, err := file.(fs.ReadDirFile).ReadDir(-1)
+	assert.NilError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	assert.DeepEqual(t, names, []string{"alias-a", "alias-b"})
+}
 
-	entries3, err := f3.(fs.ReadDirFile).ReadDir(-1)
+func TestVfsAdapter_RealpathFallbackIsCached(t *testing.T) {
+	mock := &vfsAdapterMockFS{
+		FS: osvfs.FS(),
+		entries: map[string]vfs.Entries{
+			"/repo":       {Directories: []string{"child"}},
+			"/repo/child": {Directories: []string{"grandchild"}},
+		},
+	}
+	adapter := &vfsAdapter{vfs: mock, root: "/repo"}
+
+	root, err := adapter.Open(".")
+	assert.NilError(t, err)
+	_, err = root.(fs.ReadDirFile).ReadDir(-1)
 	assert.NilError(t, err)
 
-	for _, e := range entries3 {
-		if e.Name() == "loop" {
-			t.Fatal("symlink cycle should have been deduped on second encounter")
-		}
+	child, err := adapter.Open("child")
+	assert.NilError(t, err)
+	_, err = child.(fs.ReadDirFile).ReadDir(-1)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, mock.realpathCalls, []string{
+		"/repo",
+		"/repo/child",
+		"/repo/child/grandchild",
+	})
+}
+
+func TestVfsAdapter_RealpathFallbackJoinsFilesystemRoots(t *testing.T) {
+	tests := []struct {
+		name      string
+		root      string
+		childPath string
+	}{
+		{name: "posix", root: "/", childPath: "/child"},
+		{name: "drive", root: "C:/", childPath: "C:/child"},
+		{name: "unc", root: "//server/share/", childPath: "//server/share/child"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := &vfsAdapterMockFS{
+				FS: osvfs.FS(),
+				entries: map[string]vfs.Entries{
+					test.root: {Directories: []string{"child"}},
+				},
+			}
+			adapter := &vfsAdapter{vfs: mock, root: test.root}
+
+			file, err := adapter.Open(".")
+			assert.NilError(t, err)
+			entries, err := file.(fs.ReadDirFile).ReadDir(-1)
+			assert.NilError(t, err)
+			assert.Equal(t, len(entries), 1)
+			assert.Equal(t, entries[0].Name(), "child")
+			assert.DeepEqual(t, mock.realpathCalls, []string{test.root, test.childPath})
+		})
 	}
 }
 

--- a/internal/ipc/channel.go
+++ b/internal/ipc/channel.go
@@ -240,11 +240,11 @@ func (c *Channel) readLoop() {
 }
 
 // dispatch routes one decoded frame. Two KNOWN LIMITATIONS are left as-is
-// because current usage never exercises them (verified: the Go side registers
-// no notification handlers and receives at most one synchronous `init` request
-// per run). Revisit if this channel ever carries high-frequency or
-// order-sensitive INBOUND traffic (a future Go-side reverse request, or a
-// streamed inbound notification):
+// because current inbound request traffic is limited to initialization and no
+// notifications are registered. Third-party plugin reverse RPC adds response
+// frames, which are routed inline and do not use the asynchronous handler path
+// described below. Revisit if this channel carries high-frequency or
+// order-sensitive inbound requests or notifications:
 //
 //  1. Inbound concurrency is UNBOUNDED — every notification/request gets its
 //     own goroutine (the async dispatch below is intentional: it lets an

--- a/internal/linter/eslint_plugin.go
+++ b/internal/linter/eslint_plugin.go
@@ -39,6 +39,7 @@ type EslintPluginLintFile struct {
 }
 
 type EslintPluginLintRequest struct {
+	Generation      string                            `json:"generation,omitempty"`
 	Files           []EslintPluginLintFile            `json:"files"`
 	Rules           map[string]EslintPluginRuleConfig `json:"rules"`
 	Fix             bool                              `json:"fix"`

--- a/internal/linter/eslint_plugin.go
+++ b/internal/linter/eslint_plugin.go
@@ -306,7 +306,7 @@ func groupEslintPluginFiles(files []EslintPluginFileInput) [][]EslintPluginFileI
 func eslintPluginBatchKey(f EslintPluginFileInput) string {
 	type sigRule struct {
 		Name    string `json:"name"`
-		Options any    `json:"options"`
+		Options []any  `json:"options"`
 	}
 	sig := make([]sigRule, 0, len(f.Rules))
 	for _, r := range f.Rules {
@@ -318,7 +318,7 @@ func eslintPluginBatchKey(f EslintPluginFileInput) string {
 		Rules     []sigRule `json:"rules"`
 	}{f.ConfigKey, sig})
 	if err != nil {
-		// A rule's Options is `any`; a value that can't be marshaled would break
+		// A non-serializable option value would break
 		// the batch key. Fall back to a per-file key so the file lints in its own
 		// batch rather than silently mis-grouping with others.
 		return f.Path
@@ -329,7 +329,7 @@ func eslintPluginBatchKey(f EslintPluginFileInput) string {
 func buildEslintPluginRequest(batch []EslintPluginFileInput, fix bool, suggestionsMode string) EslintPluginLintRequest {
 	rules := map[string]EslintPluginRuleConfig{}
 	for _, r := range batch[0].Rules {
-		rules[r.Name] = EslintPluginRuleConfig{Options: rule.NormalizeOptions(r.Options)}
+		rules[r.Name] = EslintPluginRuleConfig{Options: r.Options}
 	}
 	wireFiles := make([]EslintPluginLintFile, 0, len(batch))
 	for _, f := range batch {

--- a/internal/linter/eslint_plugin_test.go
+++ b/internal/linter/eslint_plugin_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
-func pluginRule(name string, opts any, sev rule.DiagnosticSeverity) ConfiguredRule {
+func pluginRule(name string, opts []any, sev rule.DiagnosticSeverity) ConfiguredRule {
 	return ConfiguredRule{Name: name, Options: opts, Severity: sev, IsEslintPluginRule: true}
 }
 

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -69,6 +69,8 @@ type runProgramOptions struct {
 	Scope           FileScope
 	ExcludePaths    []string
 	FileFilter      FileFilter
+	TargetFiles     []string
+	HasTargetFiles  bool
 	GetRulesForFile RuleHandler
 	// SingleThreaded, when true, lints this program's file shards
 	// sequentially on the calling goroutine instead of in parallel workers.
@@ -415,14 +417,16 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 //
 // Phase 1 — lint rules: each program is processed via
 // runLintRulesInProgram, with files filtered through opts.ExcludePaths,
-// opts.Scope, opts.PerProgramFilter and the program's own owned-file set.
+// opts.Scope, opts.PerProgramFilter and, in legacy scan mode, the program's
+// own owned-file set. When opts.TargetFiles is non-nil, Phase 1 uses that exact
+// per-Program target plan instead of scanning Program roots.
 // Within a program, files are linted in parallel shards (one per pool
 // checker); diagnostics therefore arrive in nondeterministic cross-file
 // order and callers that print them should impose an explicit order.
 // When opts.GetRulesForFile is nil, Phase 1 is skipped entirely — no work
-// group is created, no per-program goroutines are spawned, and no
-// owned-file sets are built. This is how callers run a pure type-check
-// pass (--type-check-only) without paying lint-side setup cost.
+// group is created and no per-program goroutines are spawned. This is how
+// callers run a pure type-check pass (--type-check-only) without paying
+// lint-side setup cost.
 //
 // Phase 2 — type-check (skipped when opts.TypeCheck is false): each
 // non-skipped program is handed to runTypeCheckAcrossPrograms, which
@@ -462,14 +466,23 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 			if i < len(opts.PerProgramFilter) {
 				perProgramFilter = opts.PerProgramFilter[i]
 			}
-			ownedFiles := buildOwnedFileSet(program)
-			filter := composeOwnedFilter(perProgramFilter, ownedFiles)
+			var targetFiles []string
+			if opts.TargetFiles != nil && i < len(opts.TargetFiles) {
+				targetFiles = opts.TargetFiles[i]
+			}
+			filter := perProgramFilter
+			if opts.TargetFiles == nil {
+				ownedFiles := buildOwnedFileSet(program)
+				filter = composeOwnedFilter(perProgramFilter, ownedFiles)
+			}
 
 			programOpts := runProgramOptions{
 				Program:         program,
 				Scope:           opts.Scope,
 				ExcludePaths:    opts.ExcludePaths,
 				FileFilter:      filter,
+				TargetFiles:     targetFiles,
+				HasTargetFiles:  opts.TargetFiles != nil,
 				GetRulesForFile: trackedGetRules,
 				SingleThreaded:  opts.SingleThreaded,
 				TypeInfoFiles:   opts.TypeInfoFiles,
@@ -505,6 +518,10 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 // lint) and CollectLintTargets (eslint-plugin dispatch) so both observe an
 // identical file set.
 func collectFilesToLint(opts runProgramOptions) []*ast.SourceFile {
+	if opts.HasTargetFiles {
+		return collectExactFilesToLint(opts)
+	}
+
 	var allowFileInfos []os.FileInfo
 	if opts.Scope.Files != nil {
 		allowFileInfos = precomputeAllowFileInfos(opts.Scope.Files)
@@ -540,6 +557,38 @@ func collectFilesToLint(opts runProgramOptions) []*ast.SourceFile {
 	return filesToLint
 }
 
+func collectExactFilesToLint(opts runProgramOptions) []*ast.SourceFile {
+	var filesToLint []*ast.SourceFile
+	seen := make(map[string]struct{}, len(opts.TargetFiles))
+	for _, target := range opts.TargetFiles {
+		file := opts.Program.GetSourceFile(target)
+		if file == nil {
+			continue
+		}
+		fileName := file.FileName()
+		if _, ok := seen[fileName]; ok {
+			continue
+		}
+		seen[fileName] = struct{}{}
+		p := string(file.Path())
+		skipFile := false
+		for _, skipPattern := range opts.ExcludePaths {
+			if strings.Contains(p, skipPattern) {
+				skipFile = true
+				break
+			}
+		}
+		if skipFile {
+			continue
+		}
+		if opts.FileFilter != nil && !opts.FileFilter(fileName) {
+			continue
+		}
+		filesToLint = append(filesToLint, file)
+	}
+	return filesToLint
+}
+
 // LintTarget is one file paired with the rules configured for it, as
 // resolved by RunLinterOptions.GetRulesForFile.
 type LintTarget struct {
@@ -551,7 +600,8 @@ type LintTarget struct {
 // rules configured for it — WITHOUT running them. The CLI/LSP host uses it
 // to split out eslint-plugin rules and dispatch them to the Node worker in
 // parallel with native linting, reusing the exact same file-set filtering
-// as RunLinter (ExcludePaths / Scope / per-program ownership + ignores).
+// as RunLinter (exact TargetFiles when present, otherwise Scope / legacy
+// owned-file filtering, plus ExcludePaths and per-program filters).
 func CollectLintTargets(opts RunLinterOptions) []LintTarget {
 	if opts.GetRulesForFile == nil {
 		return nil
@@ -566,12 +616,21 @@ func CollectLintTargets(opts RunLinterOptions) []LintTarget {
 		if i < len(opts.PerProgramFilter) {
 			perProgramFilter = opts.PerProgramFilter[i]
 		}
-		filter := composeOwnedFilter(perProgramFilter, buildOwnedFileSet(program))
+		var targetFiles []string
+		if opts.TargetFiles != nil && i < len(opts.TargetFiles) {
+			targetFiles = opts.TargetFiles[i]
+		}
+		filter := perProgramFilter
+		if opts.TargetFiles == nil {
+			filter = composeOwnedFilter(perProgramFilter, buildOwnedFileSet(program))
+		}
 		files := collectFilesToLint(runProgramOptions{
-			Program:      program,
-			Scope:        opts.Scope,
-			ExcludePaths: excludePaths,
-			FileFilter:   filter,
+			Program:        program,
+			Scope:          opts.Scope,
+			ExcludePaths:   excludePaths,
+			FileFilter:     filter,
+			TargetFiles:    targetFiles,
+			HasTargetFiles: opts.TargetFiles != nil,
 		})
 		for _, file := range files {
 			rules := opts.GetRulesForFile(file)

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -65,13 +65,14 @@ func isDirAllowed(fileName string, allowDirs []string) bool {
 
 // runProgramOptions is the internal per-program input to runLintRulesInProgram.
 type runProgramOptions struct {
-	Program         *compiler.Program
-	Scope           FileScope
-	ExcludePaths    []string
-	FileFilter      FileFilter
-	TargetFiles     []string
-	HasTargetFiles  bool
-	GetRulesForFile RuleHandler
+	Program          *compiler.Program
+	Scope            FileScope
+	ExcludePaths     []string
+	FileFilter       FileFilter
+	TargetFiles      []string
+	HasTargetFiles   bool
+	SyntaxErrorFiles map[string]struct{}
+	GetRulesForFile  RuleHandler
 	// SingleThreaded, when true, lints this program's file shards
 	// sequentially on the calling goroutine instead of in parallel workers.
 	SingleThreaded bool
@@ -119,18 +120,13 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 		return 0
 	}
 
-	// lintFile lints one file with the given checker. All per-file state
+	// lintFile lints one file with its already-resolved rules and checker. All per-file state
 	// (listener map, comments, DisableManager, rule contexts) lives inside
 	// this function, so concurrent calls for different files are independent;
 	// the checker is the only shared resource and is owned exclusively by the
 	// calling worker (see the sharding below).
-	lintFile := func(file *ast.SourceFile, chk *checker.Checker) {
+	lintFile := func(file *ast.SourceFile, rules []ConfiguredRule, chk *checker.Checker) {
 		registeredListeners := make(map[ast.Kind][](func(node *ast.Node)), 20)
-
-		rules := getRulesForFile(file)
-		if len(rules) == 0 {
-			return
-		}
 
 		comments := make([]*ast.CommentRange, 0)
 		utils.ForEachComment(&file.Node, func(comment *ast.CommentRange) { comments = append(comments, comment) }, file)
@@ -389,26 +385,52 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 	// Correctness never depends on the grouping: each worker only uses the
 	// checker it acquired exclusively for its own shard.
 	ctx := context.Background()
+	rulesByFile := make(map[*ast.SourceFile][]ConfiguredRule, len(filesToLint))
 	checkerGroups := make(map[*checker.Checker][]*ast.SourceFile)
 	for _, file := range filesToLint {
+		if shouldSkipRulesForSyntax(opts, file, ctx) {
+			continue
+		}
+		rules := getRulesForFile(file)
+		if len(rules) == 0 {
+			continue
+		}
+		rulesByFile[file] = rules
+		if opts.TypeInfoFiles != nil {
+			if _, hasTypeInfo := opts.TypeInfoFiles[file.FileName()]; !hasTypeInfo {
+				checkerGroups[nil] = append(checkerGroups[nil], file)
+				continue
+			}
+		}
 		chk, release := opts.Program.GetTypeCheckerForFile(ctx, file)
 		release()
 		checkerGroups[chk] = append(checkerGroups[chk], file)
 	}
 
 	wg := core.NewWorkGroup(opts.SingleThreaded)
-	for _, files := range checkerGroups {
+	for chk, files := range checkerGroups {
 		wg.Queue(func() {
-			chk, done := opts.Program.GetTypeCheckerForFileExclusive(ctx, files[0])
-			defer done()
+			if chk != nil {
+				var done func()
+				chk, done = opts.Program.GetTypeCheckerForFileExclusive(ctx, files[0])
+				defer done()
+			}
 			for _, file := range files {
-				lintFile(file, chk)
+				lintFile(file, rulesByFile[file], chk)
 			}
 		})
 	}
 	wg.RunAndWait()
 
 	return lintedFileCount
+}
+
+func shouldSkipRulesForSyntax(opts runProgramOptions, file *ast.SourceFile, ctx context.Context) bool {
+	if opts.SyntaxErrorFiles != nil {
+		_, invalid := opts.SyntaxErrorFiles[file.FileName()]
+		return invalid
+	}
+	return len(opts.Program.GetSyntacticDiagnostics(ctx, file)) > 0
 }
 
 // RunLinter runs all configured lint rules across the given programs in
@@ -477,16 +499,17 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 			}
 
 			programOpts := runProgramOptions{
-				Program:         program,
-				Scope:           opts.Scope,
-				ExcludePaths:    opts.ExcludePaths,
-				FileFilter:      filter,
-				TargetFiles:     targetFiles,
-				HasTargetFiles:  opts.TargetFiles != nil,
-				GetRulesForFile: trackedGetRules,
-				SingleThreaded:  opts.SingleThreaded,
-				TypeInfoFiles:   opts.TypeInfoFiles,
-				OnDiagnostic:    opts.OnDiagnostic,
+				Program:          program,
+				Scope:            opts.Scope,
+				ExcludePaths:     opts.ExcludePaths,
+				FileFilter:       filter,
+				TargetFiles:      targetFiles,
+				HasTargetFiles:   opts.TargetFiles != nil,
+				GetRulesForFile:  trackedGetRules,
+				SyntaxErrorFiles: opts.SyntaxErrorFiles,
+				SingleThreaded:   opts.SingleThreaded,
+				TypeInfoFiles:    opts.TypeInfoFiles,
+				OnDiagnostic:     opts.OnDiagnostic,
 			}
 			wg.Queue(func() {
 				n := runLintRulesInProgram(programOpts)
@@ -502,7 +525,6 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 			Programs:       opts.Programs,
 			Skip:           opts.SkipTypeCheckPrograms,
 			SingleThreaded: opts.SingleThreaded,
-			TypeInfoFiles:  opts.TypeInfoFiles,
 			OnDiagnostic:   opts.OnDiagnostic,
 		})
 	}
@@ -625,14 +647,21 @@ func CollectLintTargets(opts RunLinterOptions) []LintTarget {
 			filter = composeOwnedFilter(perProgramFilter, buildOwnedFileSet(program))
 		}
 		files := collectFilesToLint(runProgramOptions{
-			Program:        program,
-			Scope:          opts.Scope,
-			ExcludePaths:   excludePaths,
-			FileFilter:     filter,
-			TargetFiles:    targetFiles,
-			HasTargetFiles: opts.TargetFiles != nil,
+			Program:          program,
+			Scope:            opts.Scope,
+			ExcludePaths:     excludePaths,
+			FileFilter:       filter,
+			TargetFiles:      targetFiles,
+			HasTargetFiles:   opts.TargetFiles != nil,
+			SyntaxErrorFiles: opts.SyntaxErrorFiles,
 		})
 		for _, file := range files {
+			if shouldSkipRulesForSyntax(runProgramOptions{
+				Program:          program,
+				SyntaxErrorFiles: opts.SyntaxErrorFiles,
+			}, file, context.Background()) {
+				continue
+			}
 			rules := opts.GetRulesForFile(file)
 			if len(rules) == 0 {
 				continue
@@ -652,11 +681,16 @@ func LintSingleFile(opts LintSingleFileOptions) {
 	if opts.OnDiagnostic == nil {
 		opts.OnDiagnostic = func(rule.RuleDiagnostic) {}
 	}
+	var typeInfoFiles map[string]struct{}
+	if !opts.HasTypeInfo {
+		typeInfoFiles = map[string]struct{}{}
+	}
 	runLintRulesInProgram(runProgramOptions{
 		Program:         opts.Program,
 		Scope:           FileScope{Files: []string{opts.File}},
 		ExcludePaths:    opts.ExcludePaths,
 		GetRulesForFile: opts.GetRulesForFile,
+		TypeInfoFiles:   typeInfoFiles,
 		// A single file is a single shard — run it on the calling goroutine
 		// instead of spawning a worker.
 		SingleThreaded: true,

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -73,14 +73,13 @@ type runProgramOptions struct {
 	HasTargetFiles   bool
 	SyntaxErrorFiles map[string]struct{}
 	GetRulesForFile  RuleHandler
+	ExecutedRules    *sync.Map
 	// SingleThreaded, when true, lints this program's file shards
 	// sequentially on the calling goroutine instead of in parallel workers.
 	SingleThreaded bool
-	// TypeInfoFiles is the set of files with reliable type information.
-	// Gap files (not in this set) get a nil TypeChecker passed to rule
-	// contexts as defense-in-depth — type-aware rules are already filtered
-	// out by GetRulesForFile, this just guards rules with optional
-	// TypeChecker usage. nil = no gap-file distinction.
+	// TypeInfoFiles is the set of files with reliable project type information.
+	// Rules that require type information are filtered for every other file,
+	// and remaining rules receive a nil TypeChecker. nil = no gap distinction.
 	TypeInfoFiles map[string]struct{}
 	OnDiagnostic  DiagnosticHandler
 }
@@ -138,11 +137,6 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 		// DisableManager above. Rules receive both declaration metadata and the
 		// merged result instead of parsing comments or config themselves.
 		inlineGlobals, inlineGlobalDeclarations := rule.ParseInlineGlobals(file, comments)
-
-		// For gap files (not in caller's TypeInfoFiles), pass nil TypeChecker
-		// as defense-in-depth. Type-aware rules are already filtered out by
-		// getRulesForFile, but this ensures rules with optional TypeChecker
-		// usage degrade gracefully.
 		fileChecker := chk
 		if opts.TypeInfoFiles != nil {
 			if _, hasTypeInfo := opts.TypeInfoFiles[file.FileName()]; !hasTypeInfo {
@@ -391,7 +385,17 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 		if shouldSkipRulesForSyntax(opts, file, ctx) {
 			continue
 		}
-		rules := getRulesForFile(file)
+		rules := filterRulesForTypeInfo(
+			getRulesForFile(file),
+			file.FileName(),
+			opts.TypeInfoFiles,
+		)
+		if opts.ExecutedRules != nil {
+			for _, configuredRule := range rules {
+				opts.ExecutedRules.Store(configuredRule.Name, struct{}{})
+			}
+		}
+		rules = filterNativeRules(rules)
 		if len(rules) == 0 {
 			continue
 		}
@@ -423,6 +427,41 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 	wg.RunAndWait()
 
 	return lintedFileCount
+}
+
+// filterNativeRules removes Node-dispatched ESLint plugin placeholders from
+// the native pass without mutating the resolver's shared cached slice. The
+// original list remains available to CollectLintTargets for plugin dispatch.
+func filterNativeRules(rules []ConfiguredRule) []ConfiguredRule {
+	firstPlugin := -1
+	for i, configuredRule := range rules {
+		if configuredRule.IsEslintPluginRule {
+			firstPlugin = i
+			break
+		}
+	}
+	if firstPlugin < 0 {
+		return rules
+	}
+
+	nativeRules := make([]ConfiguredRule, 0, len(rules)-1)
+	nativeRules = append(nativeRules, rules[:firstPlugin]...)
+	for _, configuredRule := range rules[firstPlugin+1:] {
+		if !configuredRule.IsEslintPluginRule {
+			nativeRules = append(nativeRules, configuredRule)
+		}
+	}
+	return nativeRules
+}
+
+func filterRulesForTypeInfo(rules []ConfiguredRule, fileName string, typeInfoFiles map[string]struct{}) []ConfiguredRule {
+	if typeInfoFiles == nil {
+		return rules
+	}
+	if _, hasTypeInfo := typeInfoFiles[fileName]; hasTypeInfo {
+		return rules
+	}
+	return FilterNonTypeAwareRules(rules)
 }
 
 func shouldSkipRulesForSyntax(opts runProgramOptions, file *ast.SourceFile, ctx context.Context) bool {
@@ -473,15 +512,6 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 	// Phase 1: lint rules per program (parallel). Skipped when no rule
 	// handler was supplied — see doc above.
 	if opts.GetRulesForFile != nil {
-		base := opts.GetRulesForFile
-		trackedGetRules := func(sf *ast.SourceFile) []ConfiguredRule {
-			rules := base(sf)
-			for _, r := range rules {
-				executedRules.Store(r.Name, struct{}{})
-			}
-			return rules
-		}
-
 		wg := core.NewWorkGroup(opts.SingleThreaded)
 		for i, program := range opts.Programs {
 			var perProgramFilter FileFilter
@@ -505,7 +535,8 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 				FileFilter:       filter,
 				TargetFiles:      targetFiles,
 				HasTargetFiles:   opts.TargetFiles != nil,
-				GetRulesForFile:  trackedGetRules,
+				GetRulesForFile:  opts.GetRulesForFile,
+				ExecutedRules:    &executedRules,
 				SyntaxErrorFiles: opts.SyntaxErrorFiles,
 				SingleThreaded:   opts.SingleThreaded,
 				TypeInfoFiles:    opts.TypeInfoFiles,
@@ -654,6 +685,7 @@ func CollectLintTargets(opts RunLinterOptions) []LintTarget {
 			TargetFiles:      targetFiles,
 			HasTargetFiles:   opts.TargetFiles != nil,
 			SyntaxErrorFiles: opts.SyntaxErrorFiles,
+			TypeInfoFiles:    opts.TypeInfoFiles,
 		})
 		for _, file := range files {
 			if shouldSkipRulesForSyntax(runProgramOptions{
@@ -662,7 +694,7 @@ func CollectLintTargets(opts RunLinterOptions) []LintTarget {
 			}, file, context.Background()) {
 				continue
 			}
-			rules := opts.GetRulesForFile(file)
+			rules := filterRulesForTypeInfo(opts.GetRulesForFile(file), file.FileName(), opts.TypeInfoFiles)
 			if len(rules) == 0 {
 				continue
 			}
@@ -673,7 +705,7 @@ func CollectLintTargets(opts RunLinterOptions) []LintTarget {
 }
 
 // LintSingleFile runs lint rules against a single file in a single program.
-// Designed for IDE / LSP per-keystroke usage. Does not run type-check.
+// The caller owns syntactic diagnostics; this pass does not run type-check.
 func LintSingleFile(opts LintSingleFileOptions) {
 	if opts.ExcludePaths == nil {
 		opts.ExcludePaths = utils.ExcludePaths
@@ -681,16 +713,19 @@ func LintSingleFile(opts LintSingleFileOptions) {
 	if opts.OnDiagnostic == nil {
 		opts.OnDiagnostic = func(rule.RuleDiagnostic) {}
 	}
-	var typeInfoFiles map[string]struct{}
-	if !opts.HasTypeInfo {
-		typeInfoFiles = map[string]struct{}{}
+	getRulesForFile := opts.GetRulesForFile
+	if !opts.HasTypeInfo && getRulesForFile != nil {
+		base := getRulesForFile
+		getRulesForFile = func(file *ast.SourceFile) []ConfiguredRule {
+			return FilterNonTypeAwareRules(base(file))
+		}
 	}
 	runLintRulesInProgram(runProgramOptions{
-		Program:         opts.Program,
-		Scope:           FileScope{Files: []string{opts.File}},
-		ExcludePaths:    opts.ExcludePaths,
-		GetRulesForFile: opts.GetRulesForFile,
-		TypeInfoFiles:   typeInfoFiles,
+		Program:          opts.Program,
+		Scope:            FileScope{Files: []string{opts.File}},
+		ExcludePaths:     opts.ExcludePaths,
+		GetRulesForFile:  getRulesForFile,
+		SyntaxErrorFiles: map[string]struct{}{},
 		// A single file is a single shard — run it on the calling goroutine
 		// instead of spawning a worker.
 		SingleThreaded: true,

--- a/internal/linter/linter_allowfiles_test.go
+++ b/internal/linter/linter_allowfiles_test.go
@@ -1,13 +1,17 @@
 package linter
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -216,4 +220,105 @@ func TestRunLinter_AllowFilesNilPassthrough(t *testing.T) {
 	if result.LintedFileCount < 2 {
 		t.Errorf("Expected at least 2 files, got %d", result.LintedFileCount)
 	}
+}
+
+func TestRunLinter_TargetFilesEmptyDoesNotScanProgram(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+	})
+
+	called := false
+	result, err := RunLinter(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{nil},
+		GetRulesForFile: func(sf *ast.SourceFile) []ConfiguredRule {
+			called = true
+			return noopRule()
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+	if called {
+		t.Fatal("GetRulesForFile should not be called for an empty target plan")
+	}
+	if result.LintedFileCount != 0 {
+		t.Fatalf("expected zero linted files for an empty target plan, got %d", result.LintedFileCount)
+	}
+
+	targets := CollectLintTargets(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{nil},
+		GetRulesForFile: func(sf *ast.SourceFile) []ConfiguredRule {
+			return noopRule()
+		},
+	})
+	if len(targets) != 0 {
+		t.Fatalf("CollectLintTargets should also see zero files for an empty target plan, got %+v", targets)
+	}
+}
+
+func TestRunLinter_TargetFilesCanSelectImportedNonRootFile(t *testing.T) {
+	program, paths := createImportedNonRootProgram(t)
+	target := paths["lib.ts"]
+
+	var linted []string
+	result, err := RunLinter(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{{target}},
+		GetRulesForFile: func(sf *ast.SourceFile) []ConfiguredRule {
+			linted = append(linted, sf.FileName())
+			return noopRule()
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+	if result.LintedFileCount != 1 {
+		t.Fatalf("expected exactly one imported non-root file to be linted, got %d", result.LintedFileCount)
+	}
+	if len(linted) != 1 || linted[0] != target {
+		t.Fatalf("expected only lib.ts to be linted, got %v", linted)
+	}
+
+	targets := CollectLintTargets(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{{target}},
+		GetRulesForFile: func(sf *ast.SourceFile) []ConfiguredRule {
+			return noopRule()
+		},
+	})
+	if len(targets) != 1 || targets[0].File.FileName() != target || len(targets[0].Rules) == 0 {
+		t.Fatalf("CollectLintTargets should mirror native exact targeting, got %+v", targets)
+	}
+}
+
+func createImportedNonRootProgram(t *testing.T) (*compiler.Program, map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	files := map[string]string{
+		"main.ts":       "import { value } from './lib';\nconsole.log(value);\n",
+		"lib.ts":        "export const value = 1;\n",
+		"tsconfig.json": `{"files": ["main.ts"], "compilerOptions": {"module": "ESNext"}}`,
+	}
+	paths := make(map[string]string, len(files))
+	for name, content := range files {
+		fullPath := filepath.Join(dir, name)
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		paths[name] = tspath.NormalizePath(fullPath)
+	}
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := utils.CreateCompilerHost(dir, fs)
+	program, err := utils.CreateProgram(true, fs, dir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("CreateProgram: %v", err)
+	}
+	return program, paths
 }

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -108,6 +108,41 @@ func TestRunLinter_ExecutedRules(t *testing.T) {
 	}
 }
 
+func TestRunLinter_DoesNotExecutePluginPlaceholderInNativePass(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+	})
+	pluginRunCalled := false
+
+	result, err := RunLinter(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{{paths["a.ts"]}},
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{{
+				Name:               "community/example",
+				IsEslintPluginRule: true,
+				Run: func(rule.RuleContext) rule.RuleListeners {
+					pluginRunCalled = true
+					return nil
+				},
+			}}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+	if pluginRunCalled {
+		t.Fatal("Node-dispatched plugin placeholder executed in the native pass")
+	}
+	if _, ok := result.ExecutedRules["community/example"]; !ok {
+		t.Fatal("plugin rule should still contribute to the run's rule count")
+	}
+	if result.LintedFileCount != 1 {
+		t.Fatalf("plugin-only target should still count as linted, got %d", result.LintedFileCount)
+	}
+}
+
 func TestRunLinter_GlobalDeclarationMetadata(t *testing.T) {
 	source := "#!/usr/bin/env node\n" +
 		"/*global configOn:off, inlineOn, repeated:off */\n" +

--- a/internal/linter/linter_typecheck_matrix_test.go
+++ b/internal/linter/linter_typecheck_matrix_test.go
@@ -305,8 +305,8 @@ export type T = typeof M;
 
 // Inverse control: BOTH programs skipLibCheck:true → ZERO TS2307 reported.
 // Together with the previous test this proves:
-//   1. the d.ts genuinely has the error (program A in the previous test reported it),
-//   2. when ALL programs containing it have skipLibCheck:true, none reports.
+//  1. the d.ts genuinely has the error (program A in the previous test reported it),
+//  2. when ALL programs containing it have skipLibCheck:true, none reports.
 func TestMatrix_MultiProgram_BothSkipLibCheck_NoDtsErrors(t *testing.T) {
 	root := t.TempDir()
 	writeFiles(t, root, map[string]string{
@@ -438,11 +438,8 @@ export type T = typeof M;
 	assertExactDiagCount(t, diags, 1)
 }
 
-// === TypeInfoFiles gate as backstop ===
-//
-// Baseline + with-gate: same source, same program. Without the gate, TS2322
-// appears. With TypeInfoFiles excluding the file, the diagnostic is dropped.
-func TestMatrix_TypeInfoFiles_GateActsAsBackstopForGapFiles(t *testing.T) {
+// === TypeInfoFiles is lint-phase only ===
+func TestMatrix_TypeInfoFilesDoesNotRestrictTypeCheck(t *testing.T) {
 	dir := t.TempDir()
 	writeFiles(t, dir, map[string]string{
 		"a.ts":          "const x: number = 'oops';\n",
@@ -475,9 +472,10 @@ func TestMatrix_TypeInfoFiles_GateActsAsBackstopForGapFiles(t *testing.T) {
 	assertOneDiag(t, baseline, "TS2322", "a.ts", 1, 7)
 	assertExactDiagCount(t, baseline, 1)
 
-	// Gate that excludes a.ts → 0.
+	// Excluding a.ts from lint type-info does not narrow program-wide type-check.
 	gated := collect(map[string]struct{}{"/some/other/file.ts": {}})
-	assertExactDiagCount(t, gated, 0)
+	assertOneDiag(t, gated, "TS2322", "a.ts", 1, 7)
+	assertExactDiagCount(t, gated, 1)
 
 	// Gate that includes a.ts → still 1 (the gate is a positive set).
 	included := collect(map[string]struct{}{program.GetSourceFile(filepath.Join(dir, "a.ts")).FileName(): {}})
@@ -490,6 +488,7 @@ func TestMatrix_TypeInfoFiles_GateActsAsBackstopForGapFiles(t *testing.T) {
 // Same source loaded by two programs with different strictness:
 //   - strict program reports TS7006 (param `x` implicitly any) at col 21
 //   - loose program reports nothing
+//
 // Across both, exactly 1 TS7006 should reach the consumer. Asserts the
 // dedup keeps strict's report and that the loose program's silence does
 // not override it.

--- a/internal/linter/linter_typecheck_test.go
+++ b/internal/linter/linter_typecheck_test.go
@@ -8,9 +8,14 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/diagnostics"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -644,6 +649,40 @@ func TestTypeCheckFilesystemPathIDIsStableAcrossSymlinkAliases(t *testing.T) {
 	}
 	if typeCheckFilesystemPathID(program, realPath) != typeCheckFilesystemPathID(program, aliasPath) {
 		t.Fatalf("expected real and alias paths to share a typecheck identity: real=%q alias=%q", realPath, aliasPath)
+	}
+}
+
+type caseInsensitiveTypeCheckFS struct {
+	vfs.FS
+	realPaths map[string]string
+}
+
+func (fs *caseInsensitiveTypeCheckFS) UseCaseSensitiveFileNames() bool { return false }
+func (fs *caseInsensitiveTypeCheckFS) Realpath(filePath string) string {
+	if realPath := fs.realPaths[tspath.NormalizePath(filePath)]; realPath != "" {
+		return realPath
+	}
+	return fs.FS.Realpath(filePath)
+}
+
+func TestTypeCheckFilesystemPathIDPreservesDistinctCanonicalCase(t *testing.T) {
+	dir := tspath.NormalizePath(t.TempDir())
+	upper := tspath.ResolvePath(dir, "Source.ts")
+	lower := tspath.ResolvePath(dir, "source.ts")
+	fsys := &caseInsensitiveTypeCheckFS{
+		FS: bundled.WrapFS(cachedvfs.From(osvfs.FS())),
+		realPaths: map[string]string{
+			upper: upper,
+			lower: lower,
+		},
+	}
+	host := utils.CreateCompilerHost(dir, fsys)
+	program, err := utils.CreateProgramFromOptionsLenient(true, &core.CompilerOptions{}, nil, host)
+	if err != nil {
+		t.Fatalf("CreateProgramFromOptionsLenient: %v", err)
+	}
+	if typeCheckFilesystemPathID(program, upper) == typeCheckFilesystemPathID(program, lower) {
+		t.Fatalf("distinct canonical paths must retain exact identity: upper=%q lower=%q", upper, lower)
 	}
 }
 

--- a/internal/linter/linter_typecheck_test.go
+++ b/internal/linter/linter_typecheck_test.go
@@ -1,12 +1,16 @@
 package linter
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/diagnostics"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -563,6 +567,83 @@ const x: Foo = { a: 'hello' };
 			}
 		}
 		t.Error("Expected multi-line message (message chain) for object type mismatch")
+	}
+}
+
+func TestTypeCheckDedupeKeyIncludesMessageChainAndRelatedInformation(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{"a.ts": "export const value = 1;"})
+	sourceFile := program.GetSourceFile(paths["a.ts"])
+	if sourceFile == nil {
+		t.Fatal("expected a.ts source file")
+	}
+	newBase := func() *ast.Diagnostic {
+		return ast.NewDiagnostic(
+			sourceFile,
+			core.NewTextRange(0, 5),
+			diagnostics.Type_0_is_not_assignable_to_type_1,
+			"Source",
+			"Target",
+		)
+	}
+	withChainA := newBase().AddMessageChain(ast.NewCompilerDiagnostic(
+		diagnostics.Property_0_is_missing_in_type_1_but_required_in_type_2,
+		"first",
+		"Source",
+		"Target",
+	))
+	withChainB := newBase().AddMessageChain(ast.NewCompilerDiagnostic(
+		diagnostics.Property_0_is_missing_in_type_1_but_required_in_type_2,
+		"second",
+		"Source",
+		"Target",
+	))
+	if typeCheckDedupeKeyForDiagnostic(program, withChainA) == typeCheckDedupeKeyForDiagnostic(program, withChainB) {
+		t.Fatal("message-chain differences must remain distinct in the dedupe key")
+	}
+
+	withRelatedA := newBase().AddRelatedInfo(ast.NewDiagnostic(
+		sourceFile,
+		core.NewTextRange(7, 12),
+		diagnostics.The_expected_type_comes_from_property_0_which_is_declared_here_on_type_1,
+		"first",
+		"Target",
+	))
+	withRelatedB := newBase().AddRelatedInfo(ast.NewDiagnostic(
+		sourceFile,
+		core.NewTextRange(7, 12),
+		diagnostics.The_expected_type_comes_from_property_0_which_is_declared_here_on_type_1,
+		"second",
+		"Target",
+	))
+	if typeCheckDedupeKeyForDiagnostic(program, withRelatedA) == typeCheckDedupeKeyForDiagnostic(program, withRelatedB) {
+		t.Fatal("related-information differences must remain distinct in the dedupe key")
+	}
+}
+
+func TestTypeCheckDedupeSurvivorUsesProgramOrder(t *testing.T) {
+	key := typeCheckDedupeKey{path: "/repo/shared.ts", code: 2322, pos: 1, end: 2, message: "same"}
+	collected := [][]collectedTypeCheckDiagnostic{
+		{{key: key, ruleDiagnostic: rule.RuleDiagnostic{FilePath: "/first/shared.ts"}}},
+		{{key: key, ruleDiagnostic: rule.RuleDiagnostic{FilePath: "/second/shared.ts"}}},
+	}
+	var got []rule.RuleDiagnostic
+	emitDeduplicatedTypeCheckDiagnostics(collected, func(d rule.RuleDiagnostic) {
+		got = append(got, d)
+	})
+	if len(got) != 1 || got[0].FilePath != "/first/shared.ts" {
+		t.Fatalf("expected stable first-Program survivor, got %+v", got)
+	}
+}
+
+func TestTypeCheckFilesystemPathIDIsStableAcrossSymlinkAliases(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{"a.ts": "export const value = 1;"})
+	realPath := paths["a.ts"]
+	aliasPath := filepath.Join(filepath.Dir(realPath), "alias.ts")
+	if err := os.Symlink(realPath, aliasPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if typeCheckFilesystemPathID(program, realPath) != typeCheckFilesystemPathID(program, aliasPath) {
+		t.Fatalf("expected real and alias paths to share a typecheck identity: real=%q alias=%q", realPath, aliasPath)
 	}
 }
 

--- a/internal/linter/linter_typeinfo_test.go
+++ b/internal/linter/linter_typeinfo_test.go
@@ -89,21 +89,22 @@ func TestTypeInfoFiles_Nil_AllGetTypeChecker(t *testing.T) {
 		},
 		false,
 		func(d rule.RuleDiagnostic) {},
-		nil, // nil typeInfoFiles = old behavior, all files get checker
+		nil, // nil means no gap-file distinction
 		nil,
 	)
 
 	if checkerWasNil {
-		t.Error("TypeChecker should NOT be nil when typeInfoFiles is nil (old behavior)")
+		t.Error("TypeChecker should NOT be nil when typeInfoFiles is nil")
 	}
 }
 
-func TestTypeCheck_SkipsSemanticDiagnosticsForGapFiles(t *testing.T) {
+func TestTypeCheck_TypeInfoFilesDoesNotRestrictProgramWideDiagnostics(t *testing.T) {
 	program, paths := createTestProgramWithFiles(t, map[string]string{
 		"a.ts": "const x: number = 'hello';", // type error
 	})
 
-	// a.ts is NOT in typeInfoFiles → gap file → semantic diagnostics should be skipped
+	// TypeInfoFiles gates lint-rule TypeChecker access only. Program-wide
+	// type-check diagnostics are controlled by the Program skip mask.
 	typeInfoFiles := map[string]struct{}{
 		"/some/other/file.ts": {},
 	}
@@ -117,11 +118,14 @@ func TestTypeCheck_SkipsSemanticDiagnosticsForGapFiles(t *testing.T) {
 		nil,
 	)
 
-	// Should have NO TypeScript semantic diagnostics for gap files
+	found := false
 	for _, d := range diagnostics {
 		if strings.HasPrefix(d.RuleName, "TypeScript(") {
-			t.Errorf("Gap files should not get semantic diagnostics, but got: %s", d.RuleName)
+			found = true
 		}
+	}
+	if !found {
+		t.Error("expected program-wide semantic diagnostics despite the lint TypeInfoFiles set")
 	}
 	_ = paths
 }

--- a/internal/linter/linter_typeinfo_test.go
+++ b/internal/linter/linter_typeinfo_test.go
@@ -73,8 +73,38 @@ func TestTypeInfoFiles_FileNotInSet_NilTypeChecker(t *testing.T) {
 		t.Error("TypeChecker should be nil for gap files (not in typeInfoFiles)")
 	}
 
-	// Verify the file was still linted (rule ran, just with nil checker)
+	// Verify the file was still linted (rule ran, just with nil checker).
 	_ = paths
+}
+
+func TestTypeInfoFiles_FileNotInSet_FiltersTypeAwareRule(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const x = 1;",
+	})
+	typeInfoFiles := map[string]struct{}{"/some/other/file.ts": {}}
+
+	ruleRan := false
+	RunLinterInProgram(program, nil, nil, utils.ExcludePaths,
+		func(*ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{{
+				Name:             "type-aware-probe",
+				Severity:         rule.SeverityWarning,
+				RequiresTypeInfo: true,
+				Run: func(rule.RuleContext) rule.RuleListeners {
+					ruleRan = true
+					return rule.RuleListeners{}
+				},
+			}}
+		},
+		false,
+		func(rule.RuleDiagnostic) {},
+		typeInfoFiles,
+		nil,
+	)
+
+	if ruleRan {
+		t.Fatal("type-aware rule ran for a file outside typeInfoFiles")
+	}
 }
 
 func TestTypeInfoFiles_Nil_AllGetTypeChecker(t *testing.T) {
@@ -103,7 +133,7 @@ func TestTypeCheck_TypeInfoFilesDoesNotRestrictProgramWideDiagnostics(t *testing
 		"a.ts": "const x: number = 'hello';", // type error
 	})
 
-	// TypeInfoFiles gates lint-rule TypeChecker access only. Program-wide
+	// TypeInfoFiles gates type-aware rule eligibility only. Program-wide
 	// type-check diagnostics are controlled by the Program skip mask.
 	typeInfoFiles := map[string]struct{}{
 		"/some/other/file.ts": {},

--- a/internal/linter/test_helpers.go
+++ b/internal/linter/test_helpers.go
@@ -72,19 +72,23 @@ func RunLinterInProgram(
 	if onDiagnostic == nil {
 		onDiagnostic = func(rule.RuleDiagnostic) {}
 	}
+	// Preserve the adapter's historical lenient behavior so rule tests can
+	// exercise parser-recovered ASTs. Production callers supply the actual set.
+	syntaxErrorFiles := map[string]struct{}{}
 	if typeCheck {
 		// Route through RunLinter so the new program-level type-check phase
 		// runs. The returned LintResult.LintedFileCount equals what
 		// runLintRulesInProgram would have returned for this single program.
 		res, _ := RunLinter(RunLinterOptions{
-			Programs:        []*compiler.Program{program},
-			SingleThreaded:  true,
-			Scope:           FileScope{Files: allowFiles, Dirs: allowDirs},
-			ExcludePaths:    excludes,
-			GetRulesForFile: getRulesForFile,
-			TypeInfoFiles:   typeInfoFiles,
-			TypeCheck:       true,
-			OnDiagnostic:    onDiagnostic,
+			Programs:         []*compiler.Program{program},
+			SingleThreaded:   true,
+			Scope:            FileScope{Files: allowFiles, Dirs: allowDirs},
+			ExcludePaths:     excludes,
+			GetRulesForFile:  getRulesForFile,
+			TypeInfoFiles:    typeInfoFiles,
+			SyntaxErrorFiles: syntaxErrorFiles,
+			TypeCheck:        true,
+			OnDiagnostic:     onDiagnostic,
 			PerProgramFilter: func() []FileFilter {
 				if ff == nil {
 					return nil
@@ -98,12 +102,13 @@ func RunLinterInProgram(
 		return res.LintedFileCount
 	}
 	return runLintRulesInProgram(runProgramOptions{
-		Program:         program,
-		Scope:           FileScope{Files: allowFiles, Dirs: allowDirs},
-		ExcludePaths:    excludes,
-		FileFilter:      ff,
-		GetRulesForFile: getRulesForFile,
-		TypeInfoFiles:   typeInfoFiles,
-		OnDiagnostic:    onDiagnostic,
+		Program:          program,
+		Scope:            FileScope{Files: allowFiles, Dirs: allowDirs},
+		ExcludePaths:     excludes,
+		FileFilter:       ff,
+		GetRulesForFile:  getRulesForFile,
+		TypeInfoFiles:    typeInfoFiles,
+		SyntaxErrorFiles: syntaxErrorFiles,
+		OnDiagnostic:     onDiagnostic,
 	})
 }

--- a/internal/linter/typecheck.go
+++ b/internal/linter/typecheck.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -18,13 +18,7 @@ type typeCheckRequest struct {
 	Programs       []*compiler.Program
 	Skip           []bool // parallel to Programs; nil → check all
 	SingleThreaded bool
-	// TypeInfoFiles, when non-nil, restricts diagnostic output to files in
-	// the set. This honors the gap-file commitment in type-checking.md:
-	// files matched by config `files` but not covered by any tsconfig
-	// (e.g. root scripts, config files) do not receive semantic errors.
-	// nil = no gap-file distinction.
-	TypeInfoFiles map[string]struct{}
-	OnDiagnostic  DiagnosticHandler
+	OnDiagnostic   DiagnosticHandler
 }
 
 // runTypeCheckAcrossPrograms runs program-scoped semantic diagnostics
@@ -40,27 +34,53 @@ type typeCheckRequest struct {
 //
 // Cross-program dedupe: shared declaration files (typical with project
 // references and pulled-in node_modules .d.ts) appear in multiple programs.
-// We dedupe on (filePath, code, pos, end, message).
+// We dedupe on canonical (filePath, code, pos, end, final message), including
+// message chains and related information.
 //
 // req.OnDiagnostic must be non-nil and safe to call from multiple
 // goroutines concurrently — RunLinter is responsible for that contract.
 func runTypeCheckAcrossPrograms(req typeCheckRequest) {
-	var seen sync.Map
+	collected := make([][]collectedTypeCheckDiagnostic, len(req.Programs))
 	wg := core.NewWorkGroup(req.SingleThreaded)
 	for i, prog := range req.Programs {
 		if i < len(req.Skip) && req.Skip[i] {
 			continue
 		}
+		programIndex := i
+		program := prog
 		wg.Queue(func() {
-			runTypeCheckForProgram(prog, &seen, req.TypeInfoFiles, req.OnDiagnostic)
+			collected[programIndex] = runTypeCheckForProgram(program)
 		})
 	}
 	wg.RunAndWait()
+
+	// Program diagnostics are computed in parallel above, but survivor choice
+	// follows stable Program input order rather than goroutine completion order.
+	emitDeduplicatedTypeCheckDiagnostics(collected, req.OnDiagnostic)
 }
 
-func runTypeCheckForProgram(prog *compiler.Program, seen *sync.Map, typeInfoFiles map[string]struct{}, onDiagnostic DiagnosticHandler) {
+func emitDeduplicatedTypeCheckDiagnostics(collected [][]collectedTypeCheckDiagnostic, onDiagnostic DiagnosticHandler) {
+	seen := make(map[typeCheckDedupeKey]struct{})
+	for _, programDiagnostics := range collected {
+		for _, diagnostic := range programDiagnostics {
+			if _, duplicate := seen[diagnostic.key]; duplicate {
+				continue
+			}
+			seen[diagnostic.key] = struct{}{}
+			onDiagnostic(diagnostic.ruleDiagnostic)
+		}
+	}
+}
+
+type collectedTypeCheckDiagnostic struct {
+	key            typeCheckDedupeKey
+	ruleDiagnostic rule.RuleDiagnostic
+}
+
+func runTypeCheckForProgram(prog *compiler.Program) []collectedTypeCheckDiagnostic {
 	ctx := context.Background()
-	diags := collectNoEmitDiagnostics(ctx, prog, typeInfoFiles)
+	diags := collectNoEmitDiagnostics(ctx, prog)
+	collected := make([]collectedTypeCheckDiagnostic, 0, len(diags))
 
 	for _, d := range diags {
 		file := d.File()
@@ -78,35 +98,28 @@ func runTypeCheckForProgram(prog *compiler.Program, seen *sync.Map, typeInfoFile
 			continue
 		}
 
-		// Gap-file gate: when TypeInfoFiles is supplied, drop diagnostics
-		// for files outside it (matches the commitment in
-		// type-checking.md).
-		if typeInfoFiles != nil {
-			if _, ok := typeInfoFiles[file.FileName()]; !ok {
-				continue
-			}
-		}
-
-		if !markSeen(seen, file, d) {
-			continue
-		}
-
 		// Suppression for @ts-ignore / @ts-expect-error / @ts-nocheck and
 		// the corresponding TS2578 unused-directive errors is already
 		// handled inside typescript-go (GetDiagnosticsOfAnyProgram). We do
 		// not add an rslint-specific disable channel here on purpose:
 		// type-check is meant to be a transparent passthrough of tsc.
 
-		onDiagnostic(rule.RuleDiagnostic{
-			RuleName:     fmt.Sprintf("TypeScript(TS%d)", d.Code()),
-			Range:        d.Loc(),
-			Message:      rule.RuleMessage{Description: flattenDiagnosticMessage(d)},
-			SourceFile:   file,
-			FilePath:     file.FileName(),
-			Severity:     rule.SeverityError,
-			PreFormatted: true,
+		message := flattenDiagnosticMessage(d)
+		loc := d.Loc()
+		collected = append(collected, collectedTypeCheckDiagnostic{
+			key: typeCheckDedupeKeyForDiagnostic(prog, d),
+			ruleDiagnostic: rule.RuleDiagnostic{
+				RuleName:     fmt.Sprintf("TypeScript(TS%d)", d.Code()),
+				Range:        loc,
+				Message:      rule.RuleMessage{Description: message},
+				SourceFile:   file,
+				FilePath:     file.FileName(),
+				Severity:     rule.SeverityError,
+				PreFormatted: true,
+			},
 		})
 	}
+	return collected
 }
 
 type typeCheckDedupeKey struct {
@@ -117,27 +130,47 @@ type typeCheckDedupeKey struct {
 	message string
 }
 
-// markSeen records (filePath, code, pos, end, message) and reports whether
-// this exact tuple has been seen before. Callers must pass a non-nil
-// `file` — runTypeCheckForProgram has already filtered out file=nil
-// diagnostics before reaching here.
-func markSeen(seen *sync.Map, file *ast.SourceFile, d *ast.Diagnostic) bool {
+func typeCheckDedupeKeyForDiagnostic(prog *compiler.Program, d *ast.Diagnostic) typeCheckDedupeKey {
 	loc := d.Loc()
-	key := typeCheckDedupeKey{
-		path:    file.FileName(),
+	return typeCheckDedupeKey{
+		path:    typeCheckFilesystemPathID(prog, d.File().FileName()),
 		code:    d.Code(),
 		pos:     loc.Pos(),
 		end:     loc.End(),
-		message: d.String(),
+		message: flattenDiagnosticMessageForIdentity(prog, d),
 	}
-	_, dup := seen.LoadOrStore(key, struct{}{})
-	return !dup
+}
+
+func typeCheckFilesystemPathID(prog *compiler.Program, filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	if prog == nil {
+		return filePath
+	}
+	fsys := prog.Host().FS()
+	if fsys != nil {
+		if realPath := fsys.Realpath(filePath); realPath != "" {
+			filePath = tspath.NormalizePath(realPath)
+		}
+	}
+	return string(tspath.ToPath(filePath, prog.GetCurrentDirectory(), prog.UseCaseSensitiveFileNames()))
 }
 
 // flattenDiagnosticMessage builds a human-readable message from a
 // TypeScript diagnostic, including its MessageChain and
 // RelatedInformation. Format mirrors tsc's output.
 func flattenDiagnosticMessage(d *ast.Diagnostic) string {
+	return flattenDiagnosticMessageWithRelatedPath(d, func(file *ast.SourceFile) string {
+		return file.FileName()
+	})
+}
+
+func flattenDiagnosticMessageForIdentity(prog *compiler.Program, d *ast.Diagnostic) string {
+	return flattenDiagnosticMessageWithRelatedPath(d, func(file *ast.SourceFile) string {
+		return typeCheckFilesystemPathID(prog, file.FileName())
+	})
+}
+
+func flattenDiagnosticMessageWithRelatedPath(d *ast.Diagnostic, relatedPath func(*ast.SourceFile) string) string {
 	var b strings.Builder
 	b.WriteString(d.String())
 	for _, chain := range d.MessageChain() {
@@ -146,7 +179,7 @@ func flattenDiagnosticMessage(d *ast.Diagnostic) string {
 	for _, related := range d.RelatedInformation() {
 		if related.File() != nil {
 			line, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(related.File(), related.Pos())
-			fmt.Fprintf(&b, "\n  %s:%d: %s", related.File().FileName(), line+1, related.String())
+			fmt.Fprintf(&b, "\n  %s:%d: %s", relatedPath(related.File()), line+1, related.String())
 		}
 	}
 	return b.String()
@@ -187,28 +220,24 @@ func flattenMessageChain(b *strings.Builder, chain *ast.Diagnostic, level int) {
 // This function reproduces the GetDiagnosticsOfAnyProgram contract but:
 //
 //  1. Strips diagnostics that would not survive runTypeCheckForProgram's
-//     downstream filters (nil file, or file outside typeInfoFiles when the
-//     gap-file gate is in effect) before applying the short-circuit.
-//     This keeps invisible option errors from masking real semantic work.
-//     File-anchored syntactic / program errors that DO reach the user
-//     still short-circuit semantic collection — matching tsc's behaviour
-//     for real pre-semantic errors.
+//     downstream filters (nil-file and tsconfig-anchored option diagnostics)
+//     before applying the short-circuit. This keeps invisible option errors
+//     from masking real semantic work. File-anchored syntactic / program
+//     errors that do reach the user still short-circuit semantic collection,
+//     matching tsc's behaviour for real pre-semantic errors.
 //  2. Re-applies compiler.FilterNoEmitSemanticDiagnostics over the
 //     semantic diagnostics with NoEmit=true, so emit-only checks
 //     (SkippedOnNoEmit, e.g. __esModule reservation errors) drop out
 //     even when the user's tsconfig leaves NoEmit unset.
 //  3. Collects declaration diagnostics under the noEmit branch, matching
 //     tsc --noEmit's behaviour when GetEmitDeclarations() is set.
-//
-// typeInfoFiles is the set of files for which type errors should reach
-// the user; nil means no gap-file restriction.
-func collectNoEmitDiagnostics(ctx context.Context, prog *compiler.Program, typeInfoFiles map[string]struct{}) []*ast.Diagnostic {
+func collectNoEmitDiagnostics(ctx context.Context, prog *compiler.Program) []*ast.Diagnostic {
 	noEmitOpts := prog.Options().Clone()
 	noEmitOpts.NoEmit = core.TSTrue
 	configFilePath := prog.Options().ConfigFilePath
 
 	keep := func(in []*ast.Diagnostic) []*ast.Diagnostic {
-		return filterShortCircuitDiagnostics(in, typeInfoFiles, configFilePath)
+		return filterShortCircuitDiagnostics(in, configFilePath)
 	}
 
 	configDiags := keep(prog.GetConfigFileParsingDiagnostics())
@@ -252,12 +281,10 @@ func collectNoEmitDiagnostics(ctx context.Context, prog *compiler.Program, typeI
 //     itself, not with the user's source code, and rslint --type-check is
 //     defined to mirror tsc --noEmit, which silently suppresses noEmit-gated
 //     option errors when --noEmit is on the command line),
-//   - diagnostics anchored to a file outside typeInfoFiles when the gap-file
-//     gate is active (those will be dropped downstream too).
 //
 // Diagnostics anchored to user source files (real syntactic / program errors)
 // flow through unchanged, so they still trip the short-circuit — matching tsc.
-func filterShortCircuitDiagnostics(in []*ast.Diagnostic, typeInfoFiles map[string]struct{}, configFilePath string) []*ast.Diagnostic {
+func filterShortCircuitDiagnostics(in []*ast.Diagnostic, configFilePath string) []*ast.Diagnostic {
 	out := make([]*ast.Diagnostic, 0, len(in))
 	for _, d := range in {
 		f := d.File()
@@ -266,11 +293,6 @@ func filterShortCircuitDiagnostics(in []*ast.Diagnostic, typeInfoFiles map[strin
 		}
 		if configFilePath != "" && f.FileName() == configFilePath {
 			continue
-		}
-		if typeInfoFiles != nil {
-			if _, ok := typeInfoFiles[f.FileName()]; !ok {
-				continue
-			}
 		}
 		out = append(out, d)
 	}

--- a/internal/linter/typecheck.go
+++ b/internal/linter/typecheck.go
@@ -146,13 +146,14 @@ func typeCheckFilesystemPathID(prog *compiler.Program, filePath string) string {
 	if prog == nil {
 		return filePath
 	}
+	filePath = tspath.GetNormalizedAbsolutePath(filePath, prog.GetCurrentDirectory())
 	fsys := prog.Host().FS()
 	if fsys != nil {
 		if realPath := fsys.Realpath(filePath); realPath != "" {
 			filePath = tspath.NormalizePath(realPath)
 		}
 	}
-	return string(tspath.ToPath(filePath, prog.GetCurrentDirectory(), prog.UseCaseSensitiveFileNames()))
+	return string(tspath.ToPath(filePath, "", true))
 }
 
 // flattenDiagnosticMessage builds a human-readable message from a

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -80,7 +80,7 @@ type LintResult struct {
 //     (substring match against utils.ExcludePaths). Pass an explicit empty
 //     slice to disable the default.
 //   - PerProgramFilter=nil                → no per-program ad-hoc filter
-//     (multi-config ownership / config `ignores`). Entries within the slice
+//     (for example config global ignores). Entries within the slice
 //     may be nil individually.
 //   - GetRulesForFile=nil                 → no lint rules executed
 //   - TypeInfoFiles=nil                   → no gap-file distinction
@@ -105,6 +105,12 @@ type RunLinterOptions struct {
 	Scope            FileScope
 	ExcludePaths     []string
 	PerProgramFilter []FileFilter
+	// TargetFiles, when non-nil, enables an exact per-Program lint target plan.
+	// Entries are parallel to Programs; a missing, nil, or empty entry means
+	// that Program has no lint-rule targets. CLI/API use this after resolving
+	// lint targets from config `files`/ignores independently from TypeScript
+	// Program membership. nil preserves the legacy Program scan.
+	TargetFiles [][]string
 
 	GetRulesForFile RuleHandler
 	TypeInfoFiles   map[string]struct{}

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -25,7 +25,7 @@ type ConfiguredRule struct {
 	// Options is the raw user-configured rule options (ESLint's
 	// post-severity args). Consumed when dispatching plugin rules to the
 	// Node worker; native rules read options through Run's closure instead.
-	Options any
+	Options []any
 	Run     func(ctx rule.RuleContext) rule.RuleListeners
 }
 
@@ -86,14 +86,14 @@ type LintResult struct {
 //   - SyntaxErrorFiles=nil                → RunLinter checks each lint target
 //     for syntax errors before resolving or running rules. A non-nil set means
 //     the caller already performed that check and names the invalid files.
-//   - TypeInfoFiles=nil                   → no gap-file distinction in the
-//     lint-rule phase (all lint targets may receive a TypeChecker). This field
-//     never restricts the program-wide type-check phase.
+//   - TypeInfoFiles=nil                   → no gap-file distinction. A non-nil
+//     set filters RequiresTypeInfo rules and withholds the TypeChecker for files
+//     outside it. This field never restricts program-wide type-check.
 //   - TypeCheck=false                     → skip the type-check phase
 //   - SkipTypeCheckPrograms=nil           → every program participates in
 //     type-check. When non-nil, must be parallel to Programs; entries set
 //     to true mark the corresponding program to be skipped (typically the
-//     AST-only fallback Program with synthesized CompilerOptions).
+//     non-project fallback Program with synthesized CompilerOptions).
 //   - OnDiagnostic=nil                    → diagnostics are dropped
 //
 // Thread-safety: OnDiagnostic is invoked from multiple goroutines
@@ -125,13 +125,13 @@ type RunLinterOptions struct {
 	OnDiagnostic DiagnosticHandler
 }
 
-// LintSingleFileOptions configures a single-file, single-program lint pass.
-// Designed for IDE/LSP per-keystroke usage. Does not run type-check.
+// LintSingleFileOptions configures a single-file, single-program rule pass.
+// The caller must handle syntactic diagnostics before invoking it.
 type LintSingleFileOptions struct {
 	Program *compiler.Program
 	File    string
-	// HasTypeInfo controls whether rule execution may acquire and expose a
-	// TypeChecker. False keeps plain-LSP linting AST-only.
+	// HasTypeInfo controls whether rules marked RequiresTypeInfo are eligible.
+	// Non-type-aware rules may still use the Program's checker for local analysis.
 	HasTypeInfo     bool
 	GetRulesForFile RuleHandler
 	ExcludePaths    []string

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -83,8 +83,12 @@ type LintResult struct {
 //     (for example config global ignores). Entries within the slice
 //     may be nil individually.
 //   - GetRulesForFile=nil                 → no lint rules executed
-//   - TypeInfoFiles=nil                   → no gap-file distinction
-//     (all files may run type-aware rules)
+//   - SyntaxErrorFiles=nil                → RunLinter checks each lint target
+//     for syntax errors before resolving or running rules. A non-nil set means
+//     the caller already performed that check and names the invalid files.
+//   - TypeInfoFiles=nil                   → no gap-file distinction in the
+//     lint-rule phase (all lint targets may receive a TypeChecker). This field
+//     never restricts the program-wide type-check phase.
 //   - TypeCheck=false                     → skip the type-check phase
 //   - SkipTypeCheckPrograms=nil           → every program participates in
 //     type-check. When non-nil, must be parallel to Programs; entries set
@@ -111,8 +115,9 @@ type RunLinterOptions struct {
 	// Program membership. nil preserves the legacy Program scan.
 	TargetFiles [][]string
 
-	GetRulesForFile RuleHandler
-	TypeInfoFiles   map[string]struct{}
+	GetRulesForFile  RuleHandler
+	TypeInfoFiles    map[string]struct{}
+	SyntaxErrorFiles map[string]struct{}
 
 	TypeCheck             bool
 	SkipTypeCheckPrograms []bool
@@ -123,8 +128,11 @@ type RunLinterOptions struct {
 // LintSingleFileOptions configures a single-file, single-program lint pass.
 // Designed for IDE/LSP per-keystroke usage. Does not run type-check.
 type LintSingleFileOptions struct {
-	Program         *compiler.Program
-	File            string
+	Program *compiler.Program
+	File    string
+	// HasTypeInfo controls whether rule execution may acquire and expose a
+	// TypeChecker. False keeps plain-LSP linting AST-only.
+	HasTypeInfo     bool
 	GetRulesForFile RuleHandler
 	ExcludePaths    []string
 	OnDiagnostic    DiagnosticHandler

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -89,8 +89,7 @@ type LintResult struct {
 //   - SkipTypeCheckPrograms=nil           → every program participates in
 //     type-check. When non-nil, must be parallel to Programs; entries set
 //     to true mark the corresponding program to be skipped (typically the
-//     gap-file fallback or no-tsconfig fallback Program with synthesized
-//     CompilerOptions).
+//     AST-only fallback Program with synthesized CompilerOptions).
 //   - OnDiagnostic=nil                    → diagnostics are dropped
 //
 // Thread-safety: OnDiagnostic is invoked from multiple goroutines

--- a/internal/lsp/config_watch_test.go
+++ b/internal/lsp/config_watch_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/microsoft/typescript-go/shim/jsonrpc"
 	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/config"
@@ -69,18 +70,28 @@ func TestIsTsConfigURI(t *testing.T) {
 
 // ======== reloadConfigAndRelint guard tests ========
 
-func TestReloadConfigAndRelint_SkipsWhenJSConfigsActive(t *testing.T) {
+func TestReloadConfigAndRelint_RefreshesJSONFallbackWhenJSConfigsActive(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "rslint.json")
+	if err := os.WriteFile(configPath, []byte(`[{"rules":{"no-debugger":"error"}}]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	s := newTestServer()
-	s.fs = &mockFS{files: map[string]bool{"/project/rslint.json": true}}
-	s.cwd = "/project"
-	// Simulate JS configs being active
-	s.jsConfigs["file:///project"] = config.RslintConfig{{}}
+	s.fs = osvfs.FS()
+	s.cwd = dir
+	s.jsConfigs["file:///other"] = config.RslintConfig{{Rules: config.Rules{"no-console": "error"}}}
 
 	s.reloadConfigAndRelint()
 
-	// Should NOT load JSON config because JS configs take priority
-	if s.rslintConfigPath != "" {
-		t.Errorf("expected empty config path (skipped), got %q", s.rslintConfigPath)
+	if s.rslintConfigPath != configPath {
+		t.Fatalf("expected JSON fallback path %q, got %q", configPath, s.rslintConfigPath)
+	}
+	if len(s.jsonConfig) != 1 || s.jsonConfig[0].Rules["no-debugger"] != "error" {
+		t.Fatalf("expected refreshed JSON fallback, got %v", s.jsonConfig)
+	}
+	if len(s.jsConfigs) != 1 {
+		t.Fatalf("expected active JS configs to remain loaded, got %v", s.jsConfigs)
 	}
 }
 
@@ -596,6 +607,34 @@ func TestHandleInitialized_WatchDisabledWhenCapabilitiesNil(t *testing.T) {
 func TestIsBlockingMethod_ConfigUpdate(t *testing.T) {
 	if !isBlockingMethod(lsproto.Method("rslint/configUpdate")) {
 		t.Error("rslint/configUpdate must be a blocking method to avoid data races on jsConfigs")
+	}
+}
+
+func TestConfigUpdateRequestAcknowledgesAcceptedGeneration(t *testing.T) {
+	s, outgoing := newTestServerWithQueue()
+	id := jsonrpc.NewIDString("config-update-1")
+	req := &lsproto.RequestMessage{
+		ID:     id,
+		Method: lsproto.Method("rslint/configUpdate"),
+		Params: map[string]any{
+			"generation": "accepted",
+			"configs": []any{
+				map[string]any{"configDirectory": "file:///project", "entries": []any{}},
+			},
+		},
+	}
+
+	if err := handlers()[req.Method](s, context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case message := <-outgoing:
+		response := message.AsResponse()
+		if response.ID == nil || response.ID.String() != id.String() || response.Error != nil {
+			t.Fatalf("unexpected config update response: %+v", response)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("config update request was not acknowledged")
 	}
 }
 

--- a/internal/lsp/eslint_plugin.go
+++ b/internal/lsp/eslint_plugin.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/microsoft/typescript-go/shim/jsonrpc"
 	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
 
 	"github.com/web-infra-dev/rslint/internal/config"
@@ -72,12 +71,19 @@ func (s *Server) installEslintPluginDispatch() linter.EslintPluginDispatcher {
 // Must be called from the main dispatch loop: it reads s.jsConfigs (lock-free)
 // and the s.documents overlay.
 func (s *Server) buildPluginFileInput(uri lsproto.DocumentUri, textOverride *string) (linter.EslintPluginFileInput, bool) {
+	if s.isUnavailableConfigForURI(uri) {
+		return linter.EslintPluginFileInput{}, false
+	}
 	rslintConfig, configCwd, isJSConfig := s.getConfigForURI(uri)
 	configKey := s.pluginConfigKeyForURI(uri)
 	filePath := uriToPath(uri)
+	configFilePath, matchConfigDir := config.ResolveConfigPathSpace(filePath, configCwd, s.fs)
+	if isDefaultExcludedLintPath(configFilePath, matchConfigDir, s.fs) {
+		return linter.EslintPluginFileInput{}, false
+	}
 
-	fileConfigResolver := config.NewFileConfigResolver(rslintConfig, configCwd, isJSConfig)
-	enabledRules, merged := fileConfigResolver.EnabledRulesForFile(filePath)
+	fileConfigResolver := config.NewFileConfigResolver(rslintConfig, matchConfigDir, isJSConfig)
+	enabledRules, merged := fileConfigResolver.EnabledRulesForFile(configFilePath)
 	if merged == nil {
 		// File is globally ignored — no plugin (or native) diagnostics.
 		return linter.EslintPluginFileInput{}, false
@@ -154,28 +160,15 @@ func (s *Server) dispatchPluginLint(uri lsproto.DocumentUri, generation uint64) 
 	}
 	ctx, cancel := context.WithTimeout(s.backgroundCtx, timeout)
 
-	// Register so a later supersede/close can cancel us; sendRequest fills in the
-	// reverse-request id via the sink so cancelInflightPluginDispatch can
-	// $/cancelRequest it.
-	handle := &pluginDispatchHandle{cancel: cancel}
+	// Register so a later supersede or close can cancel the request. sendRequest
+	// forwards that context cancellation to the client.
+	handle := &pluginDispatchHandle{cancel: cancel, done: make(chan struct{})}
 	s.inflightPluginDispatchMu.Lock()
 	s.inflightPluginDispatch[uri] = handle
 	s.inflightPluginDispatchMu.Unlock()
-	ctx = context.WithValue(ctx, pluginReqIDSinkKey{}, func(id *jsonrpc.ID) {
-		s.inflightPluginDispatchMu.Lock()
-		if s.inflightPluginDispatch[uri] == handle {
-			handle.reqID = id
-			s.inflightPluginDispatchMu.Unlock()
-			return
-		}
-		// Already superseded before the id was minted: the supersede saw a nil
-		// reqID and could not $/cancelRequest. Send it now so the client still
-		// stops the worker — closes the narrow reqID==nil race window.
-		s.inflightPluginDispatchMu.Unlock()
-		s.sendCancelRequest(id)
-	})
 
 	go func() {
+		defer close(handle.done)
 		defer cancel()
 		defer s.clearInflightPluginDispatch(uri, handle)
 		// onDiagnostic is invoked serially (DispatchEslintPluginRules emits
@@ -235,18 +228,16 @@ func (s *Server) dispatchPluginLint(uri lsproto.DocumentUri, generation uint64) 
 func (s *Server) cancelInflightPluginDispatch(uri lsproto.DocumentUri) {
 	s.inflightPluginDispatchMu.Lock()
 	handle, ok := s.inflightPluginDispatch[uri]
-	var reqID *jsonrpc.ID
 	if ok {
-		reqID = handle.reqID
 		delete(s.inflightPluginDispatch, uri)
 	}
 	s.inflightPluginDispatchMu.Unlock()
 	if !ok {
 		return
 	}
-	handle.cancel() // Go-side: sendRequest's ctx.Done frees the goroutine + pending entry
-	if reqID != nil {
-		s.sendCancelRequest(reqID) // client-side: stop the Node worker
+	handle.cancel()
+	if handle.done != nil {
+		<-handle.done
 	}
 }
 

--- a/internal/lsp/eslint_plugin.go
+++ b/internal/lsp/eslint_plugin.go
@@ -111,18 +111,8 @@ func (s *Server) buildPluginFileInput(uri lsproto.DocumentUri, textOverride *str
 // configs cannot mount object-form plugins), and a file with no plugin rules never
 // reaches dispatch.
 func (s *Server) pluginConfigKeyForURI(uri lsproto.DocumentUri) string {
-	if len(s.jsConfigs) > 0 {
-		dir := uriDirname(string(uri))
-		for {
-			if _, ok := s.jsConfigs[dir]; ok {
-				return dir
-			}
-			parent := uriDirname(dir)
-			if parent == dir {
-				break
-			}
-			dir = parent
-		}
+	if configKey, ok := s.nearestJSConfigKey(uri); ok {
+		return configKey
 	}
 	return ""
 }
@@ -153,7 +143,7 @@ func (s *Server) dispatchPluginLint(uri lsproto.DocumentUri, generation uint64) 
 	if !ok {
 		return
 	}
-	dispatch := s.installEslintPluginDispatch()
+	dispatch := s.pluginDispatchForGeneration(s.eslintPluginConfigGeneration)
 
 	// Bound the reverse request as a backstop: even with supersede-cancel, a
 	// client that neither answers nor is ever superseded (the user stops typing)
@@ -325,7 +315,7 @@ func (s *Server) lintPluginRulesSync(ctx context.Context, uri lsproto.DocumentUr
 	if !ok {
 		return nil
 	}
-	dispatch := s.installEslintPluginDispatch()
+	dispatch := s.pluginDispatchForGeneration(s.eslintPluginConfigGeneration)
 
 	var diags []rule.RuleDiagnostic
 	err := linter.DispatchEslintPluginRules(
@@ -353,4 +343,12 @@ func (s *Server) lintPluginRulesSync(ctx context.Context, uri lsproto.DocumentUr
 		return nil
 	}
 	return diags
+}
+
+func (s *Server) pluginDispatchForGeneration(generation string) linter.EslintPluginDispatcher {
+	dispatch := s.installEslintPluginDispatch()
+	return func(ctx context.Context, req linter.EslintPluginLintRequest) (*linter.EslintPluginLintResult, error) {
+		req.Generation = generation
+		return dispatch(ctx, req)
+	}
 }

--- a/internal/lsp/eslint_plugin.go
+++ b/internal/lsp/eslint_plugin.go
@@ -76,7 +76,8 @@ func (s *Server) buildPluginFileInput(uri lsproto.DocumentUri, textOverride *str
 	configKey := s.pluginConfigKeyForURI(uri)
 	filePath := uriToPath(uri)
 
-	enabledRules, merged := config.GlobalRuleRegistry.GetEnabledRules(rslintConfig, filePath, configCwd, isJSConfig)
+	fileConfigResolver := config.NewFileConfigResolver(rslintConfig, configCwd, isJSConfig)
+	enabledRules, merged := fileConfigResolver.EnabledRulesForFile(filePath)
 	if merged == nil {
 		// File is globally ignored — no plugin (or native) diagnostics.
 		return linter.EslintPluginFileInput{}, false

--- a/internal/lsp/eslint_plugin_test.go
+++ b/internal/lsp/eslint_plugin_test.go
@@ -262,6 +262,72 @@ func TestBuildPluginFileInput_TextOverridePrecedence(t *testing.T) {
 	}
 }
 
+func TestBuildPluginFileInput_RespectsFiles(t *testing.T) {
+	config.RegisterEslintPluginRules([]config.EslintPluginEntry{
+		{Prefix: "tplfiles", RuleNames: []string{"no-foo"}},
+	})
+
+	s := newTestServer()
+	s.jsConfigs["file:///proj"] = config.RslintConfig{
+		{
+			Files:   []string{"**/*.ts"},
+			Plugins: []string{"tplfiles"},
+			Rules:   config.Rules{"tplfiles/no-foo": "error"},
+		},
+	}
+	s.documents["file:///proj/matched.ts"] = "foo();"
+	s.documents["file:///proj/outside.js"] = "foo();"
+
+	if in, ok := s.buildPluginFileInput("file:///proj/matched.ts", nil); !ok {
+		t.Fatal("expected matching TS file to produce plugin input")
+	} else if len(in.Rules) != 1 || in.Rules[0].Name != "tplfiles/no-foo" {
+		t.Fatalf("expected tplfiles/no-foo for matching file, got %+v", in.Rules)
+	}
+
+	if in, ok := s.buildPluginFileInput("file:///proj/outside.js", nil); ok {
+		t.Fatalf("files-scope miss must not dispatch plugin lint, got input %+v", in)
+	}
+}
+
+func TestBuildPluginFileInput_NestedEncodedConfigKeyAndCwd(t *testing.T) {
+	config.RegisterEslintPluginRules([]config.EslintPluginEntry{
+		{Prefix: "tprootcfg", RuleNames: []string{"no-root"}},
+		{Prefix: "tpnestedcfg", RuleNames: []string{"no-foo"}},
+	})
+
+	s := newTestServer()
+	s.jsConfigs["file:///Users/John%20Doe/my%20project"] = config.RslintConfig{
+		{
+			Files:   []string{"**/*.ts"},
+			Plugins: []string{"tprootcfg"},
+			Rules:   config.Rules{"tprootcfg/no-root": "error"},
+		},
+	}
+	s.jsConfigs["file:///Users/John%20Doe/my%20project/packages/foo"] = config.RslintConfig{
+		{
+			Files:   []string{"src/**/*.ts"},
+			Plugins: []string{"tpnestedcfg"},
+			Rules:   config.Rules{"tpnestedcfg/no-foo": "error"},
+		},
+	}
+	uri := lsproto.DocumentUri("file:///Users/John%20Doe/my%20project/packages/foo/src/index.ts")
+	s.documents[uri] = "foo();"
+
+	in, ok := s.buildPluginFileInput(uri, nil)
+	if !ok {
+		t.Fatal("expected nested encoded config to produce plugin input")
+	}
+	if in.ConfigKey != "file:///Users/John%20Doe/my%20project/packages/foo" {
+		t.Fatalf("configKey = %q, want encoded nested config URI", in.ConfigKey)
+	}
+	if in.Path != "/Users/John Doe/my project/packages/foo/src/index.ts" {
+		t.Fatalf("path = %q, want decoded filesystem path", in.Path)
+	}
+	if len(in.Rules) != 1 || in.Rules[0].Name != "tpnestedcfg/no-foo" {
+		t.Fatalf("expected only the nested plugin rule, got %+v", in.Rules)
+	}
+}
+
 // TestLintPluginRulesSync_RebuildsWithFixes verifies the synchronous fixAll
 // helper turns a mocked worker result into a RuleDiagnostic carrying the fix
 // (so ApplyRuleFixes can apply it) with the configured severity reattached.
@@ -840,6 +906,80 @@ func TestDispatchPluginLint_SupersedeCancelsPrior(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("supersede did not $/cancelRequest the prior reverse request")
+	}
+}
+
+func TestDispatchPluginLint_FilesMissCancelsPriorWithoutNewRequest(t *testing.T) {
+	config.RegisterEslintPluginRules([]config.EslintPluginEntry{
+		{Prefix: "tpfilescancel", RuleNames: []string{"no-bar"}},
+	})
+	s, queue := newTestServerWithQueue()
+	s.pendingServerRequests = make(map[jsonrpc.ID]chan *lsproto.ResponseMessage)
+	s.backgroundCtx = context.Background()
+	s.pluginReverseTimeout = 500 * time.Millisecond
+	s.jsConfigs["file:///proj"] = config.RslintConfig{
+		{Plugins: []string{"tpfilescancel"}, Rules: config.Rules{"tpfilescancel/no-bar": "error"}},
+	}
+	uri := lsproto.DocumentUri("file:///proj/a.ts")
+	s.documents[uri] = "const bar = 1;"
+	s.docGeneration[uri] = 1
+
+	s.dispatchPluginLint(uri, 1)
+
+	var firstID *jsonrpc.ID
+	deadline := time.Now().Add(2 * time.Second)
+	for firstID == nil {
+		if time.Now().After(deadline) {
+			t.Fatal("first dispatch never registered its reverse-request id")
+		}
+		s.inflightPluginDispatchMu.Lock()
+		if h := s.inflightPluginDispatch[uri]; h != nil {
+			firstID = h.reqID
+		}
+		s.inflightPluginDispatchMu.Unlock()
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	select {
+	case msg := <-queue:
+		if req := msg.AsRequest(); req.Method != methodPluginLint {
+			t.Fatalf("first message = %q, want %q", req.Method, methodPluginLint)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first reverse request was not sent")
+	}
+
+	// Reconfigure the same open TS file out of the plugin entry's files scope.
+	// The next dispatch has no plugin work, but it still must cancel the stale
+	// in-flight worker from the previous generation.
+	s.jsConfigs["file:///proj"] = config.RslintConfig{
+		{
+			Files:   []string{"**/*.js"},
+			Plugins: []string{"tpfilescancel"},
+			Rules:   config.Rules{"tpfilescancel/no-bar": "error"},
+		},
+	}
+	s.docGeneration[uri] = 2
+	s.dispatchPluginLint(uri, 2)
+
+	select {
+	case msg := <-queue:
+		req := msg.AsRequest()
+		if req.Method != lsproto.MethodCancelRequest {
+			t.Fatalf("files-miss dispatch queued %q, want only %q", req.Method, lsproto.MethodCancelRequest)
+		}
+		cp, ok := req.Params.(*lsproto.CancelParams)
+		if !ok || cp.Id.String == nil || *cp.Id.String != firstID.String() {
+			t.Fatalf("cancel targeted %+v, want the prior id %s", req.Params, firstID.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("files-miss dispatch did not cancel the prior reverse request")
+	}
+
+	select {
+	case msg := <-queue:
+		t.Fatalf("files-miss dispatch must not send a new pluginLint request, got %q", msg.AsRequest().Method)
+	default:
 	}
 }
 

--- a/internal/lsp/eslint_plugin_test.go
+++ b/internal/lsp/eslint_plugin_test.go
@@ -98,6 +98,23 @@ func TestMergePluginDiagnostics_MergesAndPublishes(t *testing.T) {
 	}
 }
 
+func TestPluginDispatchForGeneration_StampsRequest(t *testing.T) {
+	s := newTestServer()
+	var received string
+	s.eslintPluginDispatch = func(_ context.Context, req linter.EslintPluginLintRequest) (*linter.EslintPluginLintResult, error) {
+		received = req.Generation
+		return &linter.EslintPluginLintResult{}, nil
+	}
+
+	_, err := s.pluginDispatchForGeneration("config-12")(context.Background(), linter.EslintPluginLintRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if received != "config-12" {
+		t.Fatalf("request generation = %q, want config-12", received)
+	}
+}
+
 func TestMergePluginDiagnostics_DropsStaleGeneration(t *testing.T) {
 	s, queue := newTestServerWithQueue()
 	uri := lsproto.DocumentUri("file:///project/a.ts")
@@ -439,19 +456,19 @@ func TestComputeFixAllContent_FoldsPluginFixes(t *testing.T) {
 	// Injected native lint: fix the first "1" → "2" wherever it appears. Returns
 	// no fix once the digit is gone (so the loop converges).
 	var nativePasses int
-	s.fixAllNativeLint = func(_ context.Context, _ lsproto.DocumentUri, _ int, content string, _ config.RslintConfig, _ string, _ bool, _ []string) ([]rule.RuleDiagnostic, error) {
+	s.fixAllNativeLint = func(_ context.Context, _ lsproto.DocumentUri, _ int, content string, _ config.RslintConfig, _ string, _ bool, _ []string) (lintPassResult, error) {
 		nativePasses++
 		idx := strings.Index(content, "1")
 		if idx < 0 {
-			return nil, nil
+			return lintPassResult{}, nil
 		}
-		return []rule.RuleDiagnostic{{
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{{
 			RuleName:   "native/prefer-2",
 			Range:      core.NewTextRange(idx, idx+1),
 			Message:    rule.RuleMessage{Description: "use 2"},
 			SourceFile: textOnlySourceFile{text: content},
 			FixesPtr:   &[]rule.RuleFix{{Text: "2", Range: core.NewTextRange(idx, idx+1)}},
-		}}, nil
+		}}}, nil
 	}
 
 	got := s.computeFixAllContent(context.Background(), uri, original, config.RslintConfig{}, "", true, nil)
@@ -495,18 +512,18 @@ func TestComputeFixAllContent_PluginTimeoutFallsBackNativeOnly(t *testing.T) {
 		return nil, ctx.Err()
 	}
 	// Injected native lint: fix the first "1" → "2", nothing once it is gone.
-	s.fixAllNativeLint = func(_ context.Context, _ lsproto.DocumentUri, _ int, content string, _ config.RslintConfig, _ string, _ bool, _ []string) ([]rule.RuleDiagnostic, error) {
+	s.fixAllNativeLint = func(_ context.Context, _ lsproto.DocumentUri, _ int, content string, _ config.RslintConfig, _ string, _ bool, _ []string) (lintPassResult, error) {
 		idx := strings.Index(content, "1")
 		if idx < 0 {
-			return nil, nil
+			return lintPassResult{}, nil
 		}
-		return []rule.RuleDiagnostic{{
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{{
 			RuleName:   "native/prefer-2",
 			Range:      core.NewTextRange(idx, idx+1),
 			Message:    rule.RuleMessage{Description: "use 2"},
 			SourceFile: textOnlySourceFile{text: content},
 			FixesPtr:   &[]rule.RuleFix{{Text: "2", Range: core.NewTextRange(idx, idx+1)}},
-		}}, nil
+		}}}, nil
 	}
 
 	start := time.Now()
@@ -529,6 +546,30 @@ func TestComputeFixAllContent_PluginTimeoutFallsBackNativeOnly(t *testing.T) {
 	// reverse request to the client per remaining pass.
 	if dispatchCalls != 1 {
 		t.Errorf("expected exactly 1 plugin dispatch (pass 0; later passes skip on expiry), got %d", dispatchCalls)
+	}
+}
+
+func TestComputeFixAllContent_SyntaxErrorSkipsPluginPass(t *testing.T) {
+	s := newTestServer()
+	uri := lsproto.DocumentUri("file:///proj/a.ts")
+	const malformed = "const value = ;"
+	s.documents[uri] = malformed
+
+	pluginCalls := 0
+	s.eslintPluginDispatch = func(context.Context, linter.EslintPluginLintRequest) (*linter.EslintPluginLintResult, error) {
+		pluginCalls++
+		return &linter.EslintPluginLintResult{}, nil
+	}
+	s.fixAllNativeLint = func(context.Context, lsproto.DocumentUri, int, string, config.RslintConfig, string, bool, []string) (lintPassResult, error) {
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}, HasSyntaxErrors: true}, nil
+	}
+
+	got := s.computeFixAllContent(context.Background(), uri, malformed, config.RslintConfig{}, "", true, nil)
+	if got != malformed {
+		t.Fatalf("syntax-error fixAll changed content to %q", got)
+	}
+	if pluginCalls != 0 {
+		t.Fatalf("syntax-error fixAll dispatched %d plugin passes, want 0", pluginCalls)
 	}
 }
 

--- a/internal/lsp/eslint_plugin_test.go
+++ b/internal/lsp/eslint_plugin_test.go
@@ -306,6 +306,28 @@ func TestBuildPluginFileInput_RespectsFiles(t *testing.T) {
 	}
 }
 
+func TestBuildPluginFileInput_RespectsDefaultExcludedDirectories(t *testing.T) {
+	config.RegisterEslintPluginRules([]config.EslintPluginEntry{
+		{Prefix: "tplexcluded", RuleNames: []string{"no-foo"}},
+	})
+
+	s := newTestServer()
+	s.jsConfigs["file:///proj"] = config.RslintConfig{{
+		Plugins: []string{"tplexcluded"},
+		Rules:   config.Rules{"tplexcluded/no-foo": "error"},
+	}}
+
+	for _, uri := range []lsproto.DocumentUri{
+		"file:///proj/node_modules/pkg/index.ts",
+		"file:///proj/.git/hooks/pre-commit.ts",
+	} {
+		s.documents[uri] = "foo();"
+		if input, ok := s.buildPluginFileInput(uri, nil); ok {
+			t.Fatalf("default-excluded file %q produced plugin input %+v", uri, input)
+		}
+	}
+}
+
 func TestBuildPluginFileInput_NestedEncodedConfigKeyAndCwd(t *testing.T) {
 	config.RegisterEslintPluginRules([]config.EslintPluginEntry{
 		{Prefix: "tprootcfg", RuleNames: []string{"no-root"}},
@@ -885,8 +907,8 @@ func TestSendCancelRequest_QueuesCancelNotification(t *testing.T) {
 // TestDispatchPluginLint_SupersedeCancelsPrior pins the full supersede path: a
 // newer keystroke's dispatch cancels the prior in-flight one Go-side AND sends
 // the client a $/cancelRequest for its reverse-request id (so the Node worker
-// stops instead of running to completion). Uses the real sendRequest path so the
-// id sink + reqID registration are exercised end to end.
+// stops instead of running to completion). Uses the real sendRequest path so
+// automatic context-to-$/cancelRequest forwarding is exercised end to end.
 func TestDispatchPluginLint_SupersedeCancelsPrior(t *testing.T) {
 	config.RegisterEslintPluginRules([]config.EslintPluginEntry{
 		{Prefix: "tpsup", RuleNames: []string{"no-bar"}},
@@ -902,27 +924,18 @@ func TestDispatchPluginLint_SupersedeCancelsPrior(t *testing.T) {
 	s.documents[uri] = "const bar = 1;"
 	s.docGeneration[uri] = 1
 
-	// First dispatch: real sendRequest mints an id, fills reqID via the sink,
-	// then blocks on a response that never comes.
+	// First dispatch queues a reverse request, then blocks on a response that
+	// never comes.
 	s.dispatchPluginLint(uri, 1)
 
 	var firstID *jsonrpc.ID
-	deadline := time.Now().Add(2 * time.Second)
-	for firstID == nil {
-		if time.Now().After(deadline) {
-			t.Fatal("first dispatch never registered its reverse-request id")
-		}
-		s.inflightPluginDispatchMu.Lock()
-		if h := s.inflightPluginDispatch[uri]; h != nil {
-			firstID = h.reqID
-		}
-		s.inflightPluginDispatchMu.Unlock()
-		time.Sleep(2 * time.Millisecond)
-	}
-
-	// Drain the first rslint/pluginLint request off the queue.
 	select {
-	case <-queue:
+	case msg := <-queue:
+		request := msg.AsRequest()
+		if request.Method != methodPluginLint {
+			t.Fatalf("first message = %q, want %q", request.Method, methodPluginLint)
+		}
+		firstID = request.ID
 	case <-time.After(time.Second):
 		t.Fatal("first reverse request was not sent")
 	}
@@ -968,24 +981,13 @@ func TestDispatchPluginLint_FilesMissCancelsPriorWithoutNewRequest(t *testing.T)
 	s.dispatchPluginLint(uri, 1)
 
 	var firstID *jsonrpc.ID
-	deadline := time.Now().Add(2 * time.Second)
-	for firstID == nil {
-		if time.Now().After(deadline) {
-			t.Fatal("first dispatch never registered its reverse-request id")
-		}
-		s.inflightPluginDispatchMu.Lock()
-		if h := s.inflightPluginDispatch[uri]; h != nil {
-			firstID = h.reqID
-		}
-		s.inflightPluginDispatchMu.Unlock()
-		time.Sleep(2 * time.Millisecond)
-	}
-
 	select {
 	case msg := <-queue:
-		if req := msg.AsRequest(); req.Method != methodPluginLint {
+		req := msg.AsRequest()
+		if req.Method != methodPluginLint {
 			t.Fatalf("first message = %q, want %q", req.Method, methodPluginLint)
 		}
+		firstID = req.ID
 	case <-time.After(time.Second):
 		t.Fatal("first reverse request was not sent")
 	}
@@ -1045,19 +1047,16 @@ func TestHandleDidClose_CancelsInflightDispatch(t *testing.T) {
 	s.dispatchPluginLint(uri, 1)
 
 	var firstID *jsonrpc.ID
-	deadline := time.Now().Add(2 * time.Second)
-	for firstID == nil {
-		if time.Now().After(deadline) {
-			t.Fatal("dispatch never registered its reverse-request id")
+	select {
+	case msg := <-queue:
+		request := msg.AsRequest()
+		if request.Method != methodPluginLint {
+			t.Fatalf("first message = %q, want %q", request.Method, methodPluginLint)
 		}
-		s.inflightPluginDispatchMu.Lock()
-		if h := s.inflightPluginDispatch[uri]; h != nil {
-			firstID = h.reqID
-		}
-		s.inflightPluginDispatchMu.Unlock()
-		time.Sleep(2 * time.Millisecond)
+		firstID = request.ID
+	case <-time.After(time.Second):
+		t.Fatal("plugin lint request was not sent")
 	}
-	<-queue // drain the rslint/pluginLint request
 
 	if err := s.handleDidClose(context.Background(), &lsproto.DidCloseTextDocumentParams{
 		TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -173,8 +173,9 @@ type Server struct {
 	// For the JS-config path (multi-config monorepo) use tsConfigPathsByConfig
 	// which keys per-config-directory so a nested config with no tsconfig
 	// does not disable filtering for files under other configs.
-	tsConfigPaths         []string
-	tsConfigPathsByConfig map[string][]string                           // configDirectory URI -> resolved tsconfig paths (nil value = allow-all for that config's files)
+	tsConfigPaths []string
+	// A nil map value means the corresponding config has no type information.
+	tsConfigPathsByConfig map[string][]string
 	documents             map[lsproto.DocumentUri]string                // URI -> content
 	diagnostics           map[lsproto.DocumentUri][]rule.RuleDiagnostic // URI -> diagnostics
 
@@ -194,12 +195,17 @@ type Server struct {
 	// nil until the first config update installs it. Safe to call from a
 	// goroutine (it only touches sendRequest, which is goroutine-safe).
 	eslintPluginDispatch linter.EslintPluginDispatcher
+	// eslintPluginConfigGeneration identifies the JS config and Node worker
+	// generation that must serve reverse plugin-lint requests. It changes only
+	// on the serialized configUpdate path and is captured before dispatching
+	// work to a goroutine.
+	eslintPluginConfigGeneration string
 
 	// fixAllNativeLint, when non-nil, overrides the per-pass native lint used by
 	// computeFixAllContent. Production leaves it nil (defaultFixAllNativeLint is
-	// used, driving the real TS session); tests inject a mock to exercise the
+	// used, driving an isolated overlay Program); tests inject a mock to exercise the
 	// plugin-fix fold loop without spinning up a language service.
-	fixAllNativeLint func(ctx context.Context, uri lsproto.DocumentUri, pass int, content string, rslintConfig config.RslintConfig, configCwd string, isJSConfig bool, tsConfigPaths []string) ([]rule.RuleDiagnostic, error)
+	fixAllNativeLint func(ctx context.Context, uri lsproto.DocumentUri, pass int, content string, rslintConfig config.RslintConfig, configCwd string, isJSConfig bool, tsConfigPaths []string) (lintPassResult, error)
 
 	// pluginReverseTimeout bounds each eslint-plugin reverse request to the
 	// client (rslint/pluginLint) on BOTH paths: source.fixAll (summed across
@@ -556,11 +562,6 @@ func (s *Server) writeLoop(ctx context.Context) error {
 
 func (s *Server) sendRequest(ctx context.Context, method lsproto.Method, params any) (any, error) {
 	id := jsonrpc.NewIDString(fmt.Sprintf("ts%d", s.clientSeq.Add(1)))
-	// Hand the minted id to a caller that registered a sink (dispatchPluginLint),
-	// so a later supersede can $/cancelRequest this exact reverse request.
-	if sink, ok := ctx.Value(pluginReqIDSinkKey{}).(func(*jsonrpc.ID)); ok {
-		sink(id)
-	}
 	req := &lsproto.RequestMessage{
 		ID:     id,
 		Method: method,
@@ -572,7 +573,19 @@ func (s *Server) sendRequest(ctx context.Context, method lsproto.Method, params 
 	s.pendingServerRequests[*id] = responseChan
 	s.pendingServerRequestsMu.Unlock()
 
-	s.outgoingQueue <- req.Message()
+	select {
+	case s.outgoingQueue <- req.Message():
+		// Expose the id only after the request is registered and queued. Any
+		// subsequent $/cancelRequest is therefore ordered after the request.
+		if sink, ok := ctx.Value(pluginReqIDSinkKey{}).(func(*jsonrpc.ID)); ok {
+			sink(id)
+		}
+	case <-ctx.Done():
+		s.pendingServerRequestsMu.Lock()
+		delete(s.pendingServerRequests, *id)
+		s.pendingServerRequestsMu.Unlock()
+		return nil, ctx.Err()
+	}
 
 	select {
 	case <-ctx.Done():
@@ -673,10 +686,29 @@ var handlers = sync.OnceValue(func() handlerMap {
 	registerNotificationHandler(handlers, lsproto.WorkspaceDidChangeWatchedFilesInfo, (*Server).handleDidChangeWatchedFiles)
 	registerRequestHandler(handlers, lsproto.TextDocumentCodeActionInfo, (*Server).handleCodeAction)
 
-	// Custom rslint notification
+	// Custom rslint config update. New clients send a request so the Node side
+	// can commit its staged plugin host only after Go accepts the same config
+	// generation. Notifications remain supported for older clients.
 	handlers[lsproto.Method("rslint/configUpdate")] = func(s *Server, ctx context.Context, req *lsproto.RequestMessage) error {
 		if err := s.handleConfigUpdate(ctx, req.Params); err != nil {
-			log.Printf("[rslint] Error handling config update: %v", err)
+			if req.ID == nil {
+				log.Printf("[rslint] Error handling config update: %v", err)
+				return nil
+			}
+			return err
+		}
+		if req.ID != nil {
+			s.sendResult(req.ID, struct {
+				Generation string `json:"generation"`
+			}{Generation: s.eslintPluginConfigGeneration})
+		}
+		return nil
+	}
+	handlers[lsproto.Method("rslint/configCapabilities")] = func(s *Server, _ context.Context, req *lsproto.RequestMessage) error {
+		if req.ID != nil {
+			s.sendResult(req.ID, struct {
+				TransactionVersion int `json:"transactionVersion"`
+			}{TransactionVersion: 1})
 		}
 		return nil
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -60,6 +60,7 @@ func NewServer(opts *ServerOptions) *Server {
 		typingsLocation:        opts.TypingsLocation,
 		parseCache:             opts.ParseCache,
 		jsConfigs:              make(map[string]config.RslintConfig),
+		jsUnavailableConfigs:   make(map[string]struct{}),
 		documents:              make(map[lsproto.DocumentUri]string),
 		diagnostics:            make(map[lsproto.DocumentUri][]rule.RuleDiagnostic),
 		refreshCh:              make(chan struct{}, 1),
@@ -77,6 +78,7 @@ var (
 
 type pendingClientRequest struct {
 	req    *lsproto.RequestMessage
+	ctx    context.Context
 	cancel context.CancelFunc
 }
 
@@ -165,9 +167,16 @@ type Server struct {
 	compilerOptionsForInferredProjects *core.CompilerOptions
 
 	// rslint config
-	jsConfigs        map[string]config.RslintConfig // configDirectory URI -> config entries (from JS/TS configs)
-	jsonConfig       config.RslintConfig            // fallback JSON config (rslint.json/rslint.jsonc)
-	rslintConfigPath string                         // path to rslint.json/rslint.jsonc, empty if not found
+	jsConfigs map[string]config.RslintConfig // configDirectory URI -> config entries (from JS/TS configs)
+	// The resolver is rebuilt atomically with each config transaction. Its keys
+	// are filesystem paths; jsConfigKeyByPath maps them back to protocol URIs.
+	jsConfigOwnerResolver *config.ConfigOwnerResolver
+	jsConfigKeyByPath     map[string]string
+	// jsUnavailableConfigs contains config-directory protocol keys for failed
+	// JS/TS config boundaries. They participate in ownership but suppress lint.
+	jsUnavailableConfigs map[string]struct{}
+	jsonConfig           config.RslintConfig // fallback JSON config (rslint.json/rslint.jsonc)
+	rslintConfigPath     string              // path to rslint.json/rslint.jsonc, empty if not found
 	// tsConfigPaths holds resolved parserOptions.project tsconfig paths.
 	// For the JSON-config path this is a single global list.
 	// For the JS-config path (multi-config monorepo) use tsConfigPathsByConfig
@@ -448,6 +457,9 @@ func (s *Server) readLoop(ctx context.Context) error {
 					s.cancelRequest(cancelParams.Id)
 				}
 			} else {
+				if req.ID != nil {
+					s.registerClientRequest(ctx, req)
+				}
 				s.requestQueue <- req
 			}
 		}
@@ -457,10 +469,47 @@ func (s *Server) readLoop(ctx context.Context) error {
 func (s *Server) cancelRequest(rawID lsproto.IntegerOrString) {
 	id := lsproto.NewID(rawID)
 	s.pendingClientRequestsMu.Lock()
-	defer s.pendingClientRequestsMu.Unlock()
 	if pendingReq, ok := s.pendingClientRequests[*id]; ok {
+		s.pendingClientRequestsMu.Unlock()
 		pendingReq.cancel()
-		delete(s.pendingClientRequests, *id)
+		return
+	}
+	s.pendingClientRequestsMu.Unlock()
+}
+
+func (s *Server) registerClientRequest(ctx context.Context, req *lsproto.RequestMessage) context.Context {
+	requestCtx, cancel := context.WithCancel(core.WithRequestID(ctx, req.ID.String()))
+	s.pendingClientRequestsMu.Lock()
+	if s.pendingClientRequests == nil {
+		s.pendingClientRequests = make(map[jsonrpc.ID]pendingClientRequest)
+	}
+	if previous, exists := s.pendingClientRequests[*req.ID]; exists {
+		previous.cancel()
+	}
+	s.pendingClientRequests[*req.ID] = pendingClientRequest{req: req, ctx: requestCtx, cancel: cancel}
+	s.pendingClientRequestsMu.Unlock()
+	return requestCtx
+}
+
+func (s *Server) clientRequestContext(ctx context.Context, req *lsproto.RequestMessage) context.Context {
+	s.pendingClientRequestsMu.Lock()
+	pending, ok := s.pendingClientRequests[*req.ID]
+	s.pendingClientRequestsMu.Unlock()
+	if ok {
+		return pending.ctx
+	}
+	// Tests and embedded callers may inject directly into requestQueue.
+	// Production requests are registered by readLoop before dispatch.
+	return s.registerClientRequest(ctx, req)
+}
+
+func (s *Server) finishClientRequest(id *jsonrpc.ID) {
+	s.pendingClientRequestsMu.Lock()
+	pending, ok := s.pendingClientRequests[*id]
+	delete(s.pendingClientRequests, *id)
+	s.pendingClientRequestsMu.Unlock()
+	if ok {
+		pending.cancel()
 	}
 }
 
@@ -495,17 +544,13 @@ func (s *Server) dispatchLoop(ctx context.Context) error {
 		case req := <-s.requestQueue:
 			requestCtx := ctx
 			if req.ID != nil {
-				var cancel context.CancelFunc
-				requestCtx, cancel = context.WithCancel(core.WithRequestID(requestCtx, req.ID.String()))
-				s.pendingClientRequestsMu.Lock()
-				s.pendingClientRequests[*req.ID] = pendingClientRequest{
-					req:    req,
-					cancel: cancel,
-				}
-				s.pendingClientRequestsMu.Unlock()
+				requestCtx = s.clientRequestContext(requestCtx, req)
 			}
 
 			handle := func() {
+				if req.ID != nil {
+					defer s.finishClientRequest(req.ID)
+				}
 				defer func() {
 					if r := recover(); r != nil {
 						stack := debug.Stack()
@@ -529,12 +574,6 @@ func (s *Server) dispatchLoop(ctx context.Context) error {
 					} else {
 						s.sendError(req.ID, err)
 					}
-				}
-
-				if req.ID != nil {
-					s.pendingClientRequestsMu.Lock()
-					delete(s.pendingClientRequests, *req.ID)
-					s.pendingClientRequestsMu.Unlock()
 				}
 			}
 
@@ -575,11 +614,6 @@ func (s *Server) sendRequest(ctx context.Context, method lsproto.Method, params 
 
 	select {
 	case s.outgoingQueue <- req.Message():
-		// Expose the id only after the request is registered and queued. Any
-		// subsequent $/cancelRequest is therefore ordered after the request.
-		if sink, ok := ctx.Value(pluginReqIDSinkKey{}).(func(*jsonrpc.ID)); ok {
-			sink(id)
-		}
 	case <-ctx.Done():
 		s.pendingServerRequestsMu.Lock()
 		delete(s.pendingServerRequests, *id)
@@ -590,10 +624,13 @@ func (s *Server) sendRequest(ctx context.Context, method lsproto.Method, params 
 	select {
 	case <-ctx.Done():
 		s.pendingServerRequestsMu.Lock()
-		defer s.pendingServerRequestsMu.Unlock()
-		if respChan, ok := s.pendingServerRequests[*id]; ok {
-			close(respChan)
+		_, pending := s.pendingServerRequests[*id]
+		if pending {
 			delete(s.pendingServerRequests, *id)
+		}
+		s.pendingServerRequestsMu.Unlock()
+		if pending {
+			s.sendCancelRequest(id)
 		}
 		return nil, ctx.Err()
 	case resp := <-responseChan:
@@ -604,22 +641,17 @@ func (s *Server) sendRequest(ctx context.Context, method lsproto.Method, params 
 	}
 }
 
-// pluginReqIDSinkKey carries a callback (set by dispatchPluginLint) that
-// sendRequest invokes with the reverse-request id it mints, so a later supersede
-// can $/cancelRequest that exact request.
-type pluginReqIDSinkKey struct{}
-
 // pluginDispatchHandle is the cancel handle for an in-flight background plugin
-// dispatch: cancel() frees the Go goroutine + pending-request entry; reqID (once
-// sendRequest mints it) lets us tell the client to cancel the Node worker.
+// dispatch. sendRequest forwards context cancellation to the client after the
+// reverse request has been queued.
 type pluginDispatchHandle struct {
 	cancel context.CancelFunc
-	reqID  *jsonrpc.ID
+	done   chan struct{}
 }
 
-// sendCancelRequest asks the client to cancel a reverse request we issued (a
-// superseded eslint-plugin dispatch) so its Node worker stops instead of running
-// to completion. Best-effort: a notification, no reply expected.
+// sendCancelRequest asks the client to cancel a reverse request so its worker
+// can stop instead of running to completion. It is best-effort: cancellation
+// must never block the caller when the outgoing queue is saturated.
 func (s *Server) sendCancelRequest(id *jsonrpc.ID) {
 	var raw lsproto.IntegerOrString
 	if n, ok := id.TryInt(); ok {
@@ -628,7 +660,10 @@ func (s *Server) sendCancelRequest(id *jsonrpc.ID) {
 		str := id.String()
 		raw.String = &str
 	}
-	s.outgoingQueue <- lsproto.CancelRequestInfo.NewNotificationMessage(&lsproto.CancelParams{Id: raw}).Message()
+	select {
+	case s.outgoingQueue <- lsproto.CancelRequestInfo.NewNotificationMessage(&lsproto.CancelParams{Id: raw}).Message():
+	default:
+	}
 }
 
 func (s *Server) sendResult(id *jsonrpc.ID, result any) {

--- a/internal/lsp/server_request_test.go
+++ b/internal/lsp/server_request_test.go
@@ -1,0 +1,137 @@
+package lsp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/microsoft/typescript-go/shim/jsonrpc"
+	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
+)
+
+func stringRequestID(value string) (*jsonrpc.ID, lsproto.IntegerOrString) {
+	return jsonrpc.NewIDString(value), lsproto.IntegerOrString{String: &value}
+}
+
+func TestClientRequestCancelBeforeDispatch(t *testing.T) {
+	s := &Server{}
+	id, rawID := stringRequestID("client-1")
+	req := &lsproto.RequestMessage{ID: id, Method: lsproto.Method("test/request")}
+	requestCtx := s.registerClientRequest(context.Background(), req)
+	s.cancelRequest(rawID)
+	if !errors.Is(requestCtx.Err(), context.Canceled) {
+		t.Fatalf("registered request context error = %v, want context.Canceled", requestCtx.Err())
+	}
+
+	s.pendingClientRequestsMu.Lock()
+	_, pending := s.pendingClientRequests[*id]
+	s.pendingClientRequestsMu.Unlock()
+	if !pending {
+		t.Fatal("canceled request was not registered for normal completion cleanup")
+	}
+
+	s.finishClientRequest(id)
+	s.pendingClientRequestsMu.Lock()
+	pendingCount := len(s.pendingClientRequests)
+	s.pendingClientRequestsMu.Unlock()
+	if pendingCount != 0 {
+		t.Fatalf("finished request retained %d pending entries", pendingCount)
+	}
+}
+
+func TestDispatchLoopHonorsCancelBeforeRequestRegistration(t *testing.T) {
+	s, outgoing := newTestServerWithQueue()
+	s.requestQueue = make(chan *lsproto.RequestMessage, 1)
+	id, rawID := stringRequestID("queued-client-1")
+	req := &lsproto.RequestMessage{
+		ID:     id,
+		Method: lsproto.MethodTextDocumentCodeAction,
+		Params: &lsproto.CodeActionParams{
+			TextDocument: lsproto.TextDocumentIdentifier{Uri: "file:///project/index.ts"},
+		},
+	}
+	s.registerClientRequest(context.Background(), req)
+	s.requestQueue <- req
+	// readLoop registers before enqueueing, so cancellation cannot race ahead of
+	// the request context even when dispatch has not started.
+	s.cancelRequest(rawID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.dispatchLoop(ctx) }()
+
+	select {
+	case msg := <-outgoing:
+		resp := msg.AsResponse()
+		if resp.ID == nil || *resp.ID != *id {
+			t.Fatalf("response id = %v, want %s", resp.ID, id.String())
+		}
+		if resp.Error == nil || resp.Error.Code != int32(lsproto.ErrorCodeRequestCancelled) {
+			t.Fatalf("response error = %+v, want request cancelled", resp.Error)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("dispatch loop did not cancel the request queued before registration")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("dispatch loop did not stop")
+	}
+
+	s.pendingClientRequestsMu.Lock()
+	pendingCount := len(s.pendingClientRequests)
+	s.pendingClientRequestsMu.Unlock()
+	if pendingCount != 0 {
+		t.Fatalf("request state leaked after dispatch: pending=%d", pendingCount)
+	}
+}
+
+func TestSendRequestCancellationDoesNotBlockOnFullOutgoingQueue(t *testing.T) {
+	queue := make(chan *lsproto.Message, 1)
+	s := &Server{
+		outgoingQueue:         queue,
+		pendingServerRequests: make(map[jsonrpc.ID]chan *lsproto.ResponseMessage),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := s.sendRequest(ctx, lsproto.Method("test/reverseRequest"), nil)
+		result <- err
+	}()
+
+	var request *lsproto.Message
+	select {
+	case request = <-queue:
+	case <-time.After(time.Second):
+		t.Fatal("sendRequest did not queue the reverse request")
+	}
+	queue <- request
+	cancel()
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("sendRequest error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sendRequest blocked while dropping cancellation on a full outgoing queue")
+	}
+
+	s.pendingServerRequestsMu.Lock()
+	pendingCount := len(s.pendingServerRequests)
+	s.pendingServerRequestsMu.Unlock()
+	if pendingCount != 0 {
+		t.Fatalf("canceled reverse request retained %d pending entries", pendingCount)
+	}
+	select {
+	case got := <-queue:
+		if got != request {
+			t.Fatal("full outgoing queue was modified instead of dropping cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("full outgoing queue unexpectedly became empty")
+	}
+}

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"context"
 	stdjson "encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -16,6 +17,7 @@ import (
 	"unicode"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
 	"github.com/microsoft/typescript-go/shim/project"
@@ -27,9 +29,15 @@ import (
 	"github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 const codeActionKindSourceFixAllRslint = lsproto.CodeActionKind("source.fixAll.rslint")
+
+type lintPassResult struct {
+	Diagnostics     []rule.RuleDiagnostic
+	HasSyntaxErrors bool
+}
 
 // ruleFixToTextEdit converts a rule fix into an LSP TextEdit using the
 // source file's line map for position encoding.
@@ -139,19 +147,49 @@ func (s *Server) handleInitialized(ctx context.Context, params *lsproto.Initiali
 }
 
 // reloadConfig loads (or reloads) the rslint JSON configuration from s.rslintConfigPath.
-// The LSP session discovers tsconfig files on its own via projectService for
-// providing type information. However, we still need to know which files are
-// covered by parserOptions.project so that type-aware rules (e.g. require-await)
-// are only enabled for files in the configured tsconfigs — matching CLI behavior.
+// The LSP reuses projects already loaded by project service and builds an
+// isolated overlay Program on demand for a declared custom project. Resolving
+// project paths here preserves declaration order and ensures type-aware rules
+// run only when the governing config's first containing project supplies type
+// information.
 func (s *Server) reloadConfig() error {
 	loader := config.NewConfigLoader(s.fs, s.cwd)
 	rslintConfig, _, err := loader.LoadRslintConfig(s.rslintConfigPath)
 	if err != nil {
 		return fmt.Errorf("could not load rslint config: %w", err)
 	}
+	paths, err := s.resolveTsConfigPaths(rslintConfig, s.cwd)
+	if err != nil {
+		return fmt.Errorf("could not resolve tsconfig paths for %q: %w", s.rslintConfigPath, err)
+	}
 	s.jsonConfig = rslintConfig
-	s.rebuildTsConfigPaths()
+	s.tsConfigPaths = paths
 	return nil
+}
+
+// loadJSONConfigFallback resolves the complete JSON fallback without mutating
+// live server state. Config-update transactions use it before committing an
+// explicitly empty JS/TS config catalog.
+func (s *Server) loadJSONConfigFallback() (config.RslintConfig, string, []string, error) {
+	if s.fs == nil {
+		return s.jsonConfig, "", nil, nil
+	}
+
+	configPath, found := findRslintConfig(s.fs, s.cwd)
+	if !found {
+		return config.RslintConfig{}, "", nil, nil
+	}
+
+	loader := config.NewConfigLoader(s.fs, s.cwd)
+	rslintConfig, _, err := loader.LoadRslintConfig(configPath)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("load JSON fallback %q: %w", configPath, err)
+	}
+	paths, err := s.resolveTsConfigPaths(rslintConfig, s.cwd)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("resolve tsconfig paths for JSON fallback %q: %w", configPath, err)
+	}
+	return rslintConfig, configPath, paths, nil
 }
 
 func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
@@ -162,7 +200,8 @@ func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
 	}
 
 	var payload struct {
-		Configs []struct {
+		Generation string `json:"generation,omitempty"`
+		Configs    []struct {
 			ConfigDirectory string              `json:"configDirectory"`
 			Entries         config.RslintConfig `json:"entries"`
 		} `json:"configs"`
@@ -185,22 +224,70 @@ func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
 		log.Printf("[rslint] Config update has no configs field; keeping existing JS configs intact")
 		return nil
 	}
+	seenConfigDirs := make(map[string]string, len(payload.Configs))
 	for _, cfg := range payload.Configs {
+		if cfg.ConfigDirectory == "" {
+			return errors.New("config update contains an empty configDirectory")
+		}
+		configID := lspFilesystemPathID(uriToPath(lsproto.DocumentUri(cfg.ConfigDirectory)), s.fs)
+		if previous, exists := seenConfigDirs[configID]; exists {
+			return fmt.Errorf(
+				"config update contains duplicate directories %q and %q",
+				previous,
+				cfg.ConfigDirectory,
+			)
+		}
+		seenConfigDirs[configID] = cfg.ConfigDirectory
 		if err := config.ValidateConfig(cfg.Entries); err != nil {
 			return fmt.Errorf("invalid config for %q: %w", cfg.ConfigDirectory, err)
 		}
 	}
 
+	// Resolve every declared project before touching live config state. A bad
+	// project path rejects the whole generation, matching the CLI/API and
+	// preserving the previous config atomically.
+	candidateConfigs := make(map[string]config.RslintConfig, len(payload.Configs))
+	candidateTsConfigs := make(map[string][]string, len(payload.Configs))
+	for _, cfg := range payload.Configs {
+		configDir := uriToPath(lsproto.DocumentUri(cfg.ConfigDirectory))
+		paths, err := s.resolveTsConfigPaths(cfg.Entries, configDir)
+		if err != nil {
+			return fmt.Errorf("resolve tsconfig paths for %q: %w", cfg.ConfigDirectory, err)
+		}
+		candidateConfigs[cfg.ConfigDirectory] = cfg.Entries
+		candidateTsConfigs[cfg.ConfigDirectory] = paths
+	}
+
+	candidateJSONConfig := s.jsonConfig
+	candidateJSONConfigPath := s.rslintConfigPath
+	candidateJSONTsConfigs := s.tsConfigPaths
+	if len(payload.Configs) == 0 {
+		candidateJSONConfig, candidateJSONConfigPath, candidateJSONTsConfigs, err = s.loadJSONConfigFallback()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Invalidate work created from the previous config before committing the new
+	// generation. Cancellation is best-effort; docGeneration also prevents an
+	// already-completed old result from being merged after this update.
+	for uri := range s.documents {
+		s.docGeneration[uri]++
+		s.cancelInflightPluginDispatch(uri)
+		delete(s.diagnostics, uri)
+	}
+
 	// Replace all JS configs with the new set (may be empty when all deleted).
 	// Keys are URI strings (e.g. "file:///project") sent from VS Code,
 	// matching the URI format used throughout the LSP protocol.
-	s.jsConfigs = make(map[string]config.RslintConfig, len(payload.Configs))
-	for _, cfg := range payload.Configs {
-		s.jsConfigs[cfg.ConfigDirectory] = cfg.Entries
+	s.jsConfigs = candidateConfigs
+	s.tsConfigPathsByConfig = candidateTsConfigs
+	s.eslintPluginConfigGeneration = payload.Generation
+	if len(payload.Configs) == 0 {
+		s.jsonConfig = candidateJSONConfig
+		s.rslintConfigPath = candidateJSONConfigPath
+		s.tsConfigPaths = candidateJSONTsConfigs
 	}
-	// Clear the JSON config path so that a subsequent JSON file-watcher event
-	// does not silently overwrite the JS/TS configs.
-	s.rslintConfigPath = ""
 	log.Printf("[rslint] Config updated from JS/TS configs (%d config files)", len(payload.Configs))
 
 	// Register placeholder rules for mounted ESLint plugins so their rule
@@ -209,8 +296,6 @@ func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
 	// a same-named native rule always wins (RegisterEslintPluginRules skips it).
 	// RegisterAllRules already ran in handleInitialized, so native rules exist.
 	config.RegisterEslintPluginRules(payload.EslintPlugins)
-
-	s.rebuildTsConfigPaths()
 
 	// Ask the client to re-pull diagnostics with the updated config.
 	if err := s.RefreshDiagnostics(ctx); err != nil {
@@ -250,7 +335,9 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, params *lsprot
 		// tsconfig changed — rebuild tsConfigPaths so type-aware rule filtering
 		// stays in sync. Session already handles the project state update and
 		// triggers RefreshDiagnostics for relinting.
-		s.rebuildTsConfigPaths()
+		if err := s.rebuildTsConfigPaths(); err != nil {
+			log.Printf("[rslint] Failed to rebuild tsconfig paths: %v", err)
+		}
 	}
 
 	return nil
@@ -275,12 +362,18 @@ func isTsConfigURI(uri string) bool {
 
 // resolveTsConfigPaths resolves parserOptions.project from a config and
 // normalizes paths with realpath for cross-platform consistency.
-func (s *Server) resolveTsConfigPaths(cfg config.RslintConfig, cwd string) []string {
-	paths, _ := config.ResolveTsConfigPaths(cfg, cwd, s.fs)
-	for i, p := range paths {
-		paths[i] = tspath.NormalizePath(s.fs.Realpath(p))
+func (s *Server) resolveTsConfigPaths(cfg config.RslintConfig, cwd string) ([]string, error) {
+	paths, err := config.ResolveTsConfigPaths(cfg, cwd, s.fs)
+	if err != nil {
+		return nil, err
 	}
-	return paths
+	for i, p := range paths {
+		if realPath := s.fs.Realpath(p); realPath != "" {
+			p = realPath
+		}
+		paths[i] = tspath.NormalizePath(p)
+	}
+	return paths, nil
 }
 
 // rebuildTsConfigPaths resolves parserOptions.project from the current config.
@@ -289,35 +382,42 @@ func (s *Server) resolveTsConfigPaths(cfg config.RslintConfig, cwd string) []str
 //
 // For JS/TS configs we resolve per-config directory into tsConfigPathsByConfig.
 // A config whose parserOptions.project is empty and has no auto-detected
-// tsconfig resolves to nil — this disables type-aware-rule filtering only for
-// files governed by that config, not globally across the workspace. A nested
-// template / fixture config without a tsconfig must not relax filtering for
-// other configs' files.
-func (s *Server) rebuildTsConfigPaths() {
+// tsconfig resolves to nil. Files governed by that config have no type info,
+// without affecting files governed by other configs. A nested template or
+// fixture config without a tsconfig must not change sibling config behavior.
+func (s *Server) rebuildTsConfigPaths() error {
+	var tsConfigPaths []string
+	if s.rslintConfigPath != "" {
+		var err error
+		tsConfigPaths, err = s.resolveTsConfigPaths(s.jsonConfig, s.cwd)
+		if err != nil {
+			return fmt.Errorf("resolve tsconfig paths for %q: %w", s.rslintConfigPath, err)
+		}
+	}
+
+	var byConfig map[string][]string
 	if len(s.jsConfigs) > 0 {
-		byConfig := make(map[string][]string, len(s.jsConfigs))
+		byConfig = make(map[string][]string, len(s.jsConfigs))
 		for dir, entries := range s.jsConfigs {
 			configDir := uriToPath(lsproto.DocumentUri(dir))
-			byConfig[dir] = s.resolveTsConfigPaths(entries, configDir)
+			paths, err := s.resolveTsConfigPaths(entries, configDir)
+			if err != nil {
+				return fmt.Errorf("resolve tsconfig paths for %q: %w", dir, err)
+			}
+			byConfig[dir] = paths
 		}
-		s.tsConfigPathsByConfig = byConfig
-		s.tsConfigPaths = nil
-	} else if s.rslintConfigPath != "" {
-		s.tsConfigPaths = s.resolveTsConfigPaths(s.jsonConfig, s.cwd)
-		s.tsConfigPathsByConfig = nil
-	} else {
-		s.tsConfigPaths = nil
-		s.tsConfigPathsByConfig = nil
 	}
+
+	s.tsConfigPaths = tsConfigPaths
+	s.tsConfigPathsByConfig = byConfig
+	return nil
 }
 
 // reloadConfigAndRelint re-discovers and reloads the rslint JSON config, then
-// re-lints all open documents. Skips when JS/TS configs are active — those
-// take priority and are managed by handleConfigUpdate.
+// re-lints all open documents. The JSON config remains a live fallback for
+// files that have no JS/TS config ancestor, so it must stay current even while
+// one or more JS/TS configs are active.
 func (s *Server) reloadConfigAndRelint() {
-	if len(s.jsConfigs) > 0 {
-		return
-	}
 	log.Printf("Reloading rslint config...")
 
 	configPath, found := findRslintConfig(s.fs, s.cwd)
@@ -327,8 +427,10 @@ func (s *Server) reloadConfigAndRelint() {
 		s.rslintConfigPath = ""
 		s.tsConfigPaths = nil
 	} else {
+		previousPath := s.rslintConfigPath
 		s.rslintConfigPath = configPath
 		if err := s.reloadConfig(); err != nil {
+			s.rslintConfigPath = previousPath
 			log.Printf("Error reloading rslint config: %v", err)
 			return
 		}
@@ -630,11 +732,15 @@ func (s *Server) computeFixAllContent(ctx context.Context, uri lsproto.DocumentU
 
 	currentContent := originalContent
 	for pass := range maxFixPasses {
-		ruleDiags, err := nativeLint(ctx, uri, pass, currentContent, rslintConfig, configCwd, isJSConfig, tsConfigPaths)
+		lintResult, err := nativeLint(ctx, uri, pass, currentContent, rslintConfig, configCwd, isJSConfig, tsConfigPaths)
 		if err != nil {
 			log.Printf("Error running lint for fixAll pass %d: %v", pass, err)
 			break
 		}
+		if lintResult.HasSyntaxErrors {
+			break
+		}
+		ruleDiags := lintResult.Diagnostics
 
 		// Fold in eslint-plugin fixes so source.fixAll applies plugin rule fixes
 		// too, not just native. The plugin pass lints the SAME currentContent, so
@@ -661,16 +767,11 @@ func (s *Server) computeFixAllContent(ctx context.Context, uri lsproto.DocumentU
 	return currentContent
 }
 
-// defaultFixAllNativeLint is the production per-pass native lint: for passes
-// after the first it updates the session overlay so the language service sees
-// the previous pass's fixed content, then runs the native lint pass.
-func (s *Server) defaultFixAllNativeLint(ctx context.Context, uri lsproto.DocumentUri, pass int, content string, rslintConfig config.RslintConfig, configCwd string, isJSConfig bool, tsConfigPaths []string) ([]rule.RuleDiagnostic, error) {
-	if pass > 0 {
-		s.session.DidChangeFile(ctx, uri, int32(pass), []lsproto.TextDocumentContentChangePartialOrWholeDocument{
-			{WholeDocument: &lsproto.TextDocumentContentChangeWholeDocument{Text: content}},
-		})
-	}
-	return runLintWithSession(uri, s.session, ctx, rslintConfig, configCwd, isJSConfig, tsConfigPaths, s.fs)
+// defaultFixAllNativeLint builds each pass from an isolated editor overlay.
+// The pass number is intentionally unused: speculative content never enters
+// the real TypeScript Session, regardless of how many fix cycles run.
+func (s *Server) defaultFixAllNativeLint(ctx context.Context, uri lsproto.DocumentUri, _ int, content string, rslintConfig config.RslintConfig, configCwd string, isJSConfig bool, tsConfigPaths []string) (lintPassResult, error) {
+	return s.runConfiguredLintForContent(uri, ctx, content, rslintConfig, configCwd, isJSConfig, tsConfigPaths)
 }
 
 // computeEndPosition returns the line and UTF-16 character offset of the end
@@ -730,6 +831,9 @@ func uriToPath(uri lsproto.DocumentUri) string {
 		return uriStr // fallback: return as-is for non-URI strings
 	}
 	p := u.Path
+	if u.Host != "" {
+		return "//" + u.Host + p
+	}
 	// Windows drive letter: /C:/... → C:/...
 	if len(p) >= 3 && p[0] == '/' && unicode.IsLetter(rune(p[1])) && p[2] == ':' {
 		return p[1:]
@@ -758,46 +862,58 @@ type LintResponse struct {
 	RuleCount   int                  `json:"ruleCount"`
 }
 
+type lintProgramLoader func(tsConfigPath string) (*compiler.Program, error)
+
 func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx context.Context, rslintConfig config.RslintConfig, cwd string, enforcePlugins bool, tsConfigPaths []string, fs vfs.FS) ([]rule.RuleDiagnostic, error) {
+	result, err := runLintWithProgramLoader(uri, session, ctx, rslintConfig, cwd, enforcePlugins, tsConfigPaths, fs, nil)
+	return result.Diagnostics, err
+}
+
+func runLintWithProgramLoader(
+	uri lsproto.DocumentUri,
+	session *project.Session,
+	ctx context.Context,
+	rslintConfig config.RslintConfig,
+	cwd string,
+	enforcePlugins bool,
+	tsConfigPaths []string,
+	fs vfs.FS,
+	loadProgram lintProgramLoader,
+) (lintPassResult, error) {
 	filename := uriToPath(uri)
 
 	// Files excluded by the config's `ignores` patterns produce no diagnostics,
 	// matching CLI behavior. Return early before spinning up the language service.
 	if rslintConfig.IsFileIgnored(filename, cwd) {
-		return []rule.RuleDiagnostic{}, nil
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
 	}
 	fileConfigResolver := config.NewFileConfigResolver(rslintConfig, cwd, enforcePlugins)
 	// Files outside the config's `files` set should not spin up TypeScript LS.
 	if fileConfigResolver.ConfigForFile(filename) == nil {
-		return []rule.RuleDiagnostic{}, nil
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
 	}
 
-	// GetLanguageService flushes any pending changes (from DidChangeFile) and
-	// returns a language service whose program reflects the latest overlay content.
-	languageService, err := session.GetLanguageService(ctx, uri)
+	program, hasTypeInfo, err := selectLintProgram(uri, session, ctx, tsConfigPaths, fs, loadProgram)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get language service: %w", err)
+		return lintPassResult{}, err
 	}
-	program := languageService.GetProgram()
+	return lintSingleFile(program, filename, hasTypeInfo, fileConfigResolver, ctx, fs), nil
+}
 
-	// Determine if this file has type information from the configured tsconfigs.
-	// The session's program has a ConfigFilePath (the tsconfig it was created from).
-	// If that tsconfig is NOT in parserOptions.project, type-aware rules should
-	// be filtered out — matching CLI behavior.
-	hasTypeInfo := true
-	if tsConfigPaths != nil {
-		configFilePath := program.Options().ConfigFilePath
-		if configFilePath != "" {
-			configFilePath = fs.Realpath(configFilePath)
-		}
-		programConfig := tspath.NormalizePath(configFilePath)
-		hasTypeInfo = false
-		for _, tc := range tsConfigPaths {
-			if tc == programConfig {
-				hasTypeInfo = true
-				break
-			}
-		}
+func lintSingleFile(
+	program *compiler.Program,
+	filename string,
+	hasTypeInfo bool,
+	fileConfigResolver *config.FileConfigResolver,
+	ctx context.Context,
+	fs vfs.FS,
+) lintPassResult {
+	sourceFile := sourceFileForPath(program, filename, fs)
+	if sourceFile == nil {
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}
+	}
+	if len(program.GetSyntacticDiagnostics(ctx, sourceFile)) > 0 {
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}, HasSyntaxErrors: true}
 	}
 
 	// Collect diagnostics
@@ -812,10 +928,11 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 	}
 
 	linter.LintSingleFile(linter.LintSingleFileOptions{
-		Program: program,
-		File:    filename,
-		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
-			return fileConfigResolver.ActiveRulesForFileHasTypeInfo(sourceFile.FileName(), hasTypeInfo)
+		Program:     program,
+		File:        sourceFile.FileName(),
+		HasTypeInfo: hasTypeInfo,
+		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+			return fileConfigResolver.ActiveRulesForFileHasTypeInfo(filename, hasTypeInfo)
 		},
 		OnDiagnostic: diagnosticCollector,
 	})
@@ -823,7 +940,189 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 	if diagnostics == nil {
 		diagnostics = []rule.RuleDiagnostic{}
 	}
-	return diagnostics, nil
+	return lintPassResult{Diagnostics: diagnostics}
+}
+
+func selectLintProgram(
+	uri lsproto.DocumentUri,
+	session *project.Session,
+	ctx context.Context,
+	tsConfigPaths []string,
+	fs vfs.FS,
+	loadProgram lintProgramLoader,
+) (*compiler.Program, bool, error) {
+	filename := uriToPath(uri)
+	// Flush pending document changes and collect every already-loaded project
+	// containing the file. The default language service remains the AST-only
+	// fallback when none of the config's declared projects contains the file.
+	_, languageService, loadedProjects, err := session.GetLanguageServiceAndProjectsForFile(ctx, uri)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get language service: %w", err)
+	}
+	program := languageService.GetProgram()
+
+	// Type information follows parserOptions.project declaration order, not the
+	// TypeScript session's default-project heuristic. Prefer an already-loaded
+	// containing project. Custom config names that the project service has not
+	// loaded are supplied by an isolated standalone Program; this avoids
+	// mutating the Session's permanent API-open project set.
+	loadedByConfig := make(map[string]*compiler.Program, len(loadedProjects))
+	for _, candidate := range loadedProjects {
+		if candidate == nil || candidate.GetProgram() == nil || !programContainsFile(candidate.GetProgram(), filename, fs) {
+			continue
+		}
+		loadedByConfig[lspFilesystemPathID(string(candidate.Id()), fs)] = candidate.GetProgram()
+	}
+	for _, tsConfigPath := range tsConfigPaths {
+		configID := lspFilesystemPathID(tsConfigPath, fs)
+		if loadedProgram := loadedByConfig[configID]; loadedProgram != nil {
+			return loadedProgram, true, nil
+		}
+		if loadProgram == nil {
+			continue
+		}
+		candidate, loadErr := loadProgram(tsConfigPath)
+		if loadErr != nil {
+			return nil, false, fmt.Errorf("load configured project %q: %w", tsConfigPath, loadErr)
+		}
+		if programContainsFile(candidate, filename, fs) {
+			return candidate, true, nil
+		}
+	}
+	return program, false, nil
+}
+
+func programContainsFile(program *compiler.Program, filename string, fs vfs.FS) bool {
+	return sourceFileForPath(program, filename, fs) != nil
+}
+
+func sourceFileForPath(program *compiler.Program, filename string, fs vfs.FS) *ast.SourceFile {
+	if program == nil {
+		return nil
+	}
+	if sourceFile := program.GetSourceFile(filename); sourceFile != nil {
+		return sourceFile
+	}
+	if fs != nil {
+		if realPath := fs.Realpath(filename); realPath != "" && realPath != filename {
+			return program.GetSourceFile(realPath)
+		}
+	}
+	return nil
+}
+
+func (s *Server) currentEditorOverlayFS() vfs.FS {
+	files := make(map[string]string, len(s.documents))
+	for uri, content := range s.documents {
+		files[tspath.NormalizePath(uriToPath(uri))] = content
+	}
+	return utils.NewOverlayVFS(s.fs, files)
+}
+
+func (s *Server) newStandaloneLintProgramLoader() lintProgramLoader {
+	var overlayFS vfs.FS
+	return func(tsConfigPath string) (*compiler.Program, error) {
+		if overlayFS == nil {
+			overlayFS = s.currentEditorOverlayFS()
+		}
+		return createStandaloneLintProgram(tsConfigPath, overlayFS)
+	}
+}
+
+func createStandaloneLintProgram(tsConfigPath string, fs vfs.FS) (*compiler.Program, error) {
+	configDir := tspath.GetDirectoryPath(tspath.NormalizePath(tsConfigPath))
+	host := utils.CreateCompilerHost(configDir, fs)
+	return utils.CreateProgramLenient(true, fs, configDir, tsConfigPath, host)
+}
+
+func createStandaloneFallbackProgram(filename string, cwd string, fs vfs.FS) (*compiler.Program, error) {
+	host := utils.CreateCompilerHost(cwd, fs)
+	return utils.CreateProgramFromOptionsLenient(true, &core.CompilerOptions{
+		Target:    core.ScriptTargetESNext,
+		Module:    core.ModuleKindESNext,
+		Jsx:       core.JsxEmitPreserve,
+		AllowJs:   core.TSTrue,
+		NoLib:     core.TSTrue,
+		NoResolve: core.TSTrue,
+	}, []string{filename}, host)
+}
+
+func (s *Server) runConfiguredLint(
+	uri lsproto.DocumentUri,
+	ctx context.Context,
+	rslintConfig config.RslintConfig,
+	cwd string,
+	enforcePlugins bool,
+	tsConfigPaths []string,
+) (lintPassResult, error) {
+	return runLintWithProgramLoader(
+		uri,
+		s.session,
+		ctx,
+		rslintConfig,
+		cwd,
+		enforcePlugins,
+		tsConfigPaths,
+		s.fs,
+		s.newStandaloneLintProgramLoader(),
+	)
+}
+
+// runConfiguredLintForContent lints a speculative fix pass against an
+// isolated overlay. It never mutates the TypeScript Session's open document,
+// so cancelling or declining a code action cannot change later LSP results.
+func (s *Server) runConfiguredLintForContent(
+	uri lsproto.DocumentUri,
+	ctx context.Context,
+	content string,
+	rslintConfig config.RslintConfig,
+	cwd string,
+	enforcePlugins bool,
+	tsConfigPaths []string,
+) (lintPassResult, error) {
+	filename := tspath.NormalizePath(uriToPath(uri))
+	if rslintConfig.IsFileIgnored(filename, cwd) {
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
+	}
+	resolver := config.NewFileConfigResolver(rslintConfig, cwd, enforcePlugins)
+	if resolver.ConfigForFile(filename) == nil {
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
+	}
+
+	files := make(map[string]string, len(s.documents)+1)
+	for documentURI, documentContent := range s.documents {
+		files[tspath.NormalizePath(uriToPath(documentURI))] = documentContent
+	}
+	files[filename] = content
+	overlayFS := utils.NewOverlayVFS(s.fs, files)
+
+	for _, tsConfigPath := range tsConfigPaths {
+		program, err := createStandaloneLintProgram(tsConfigPath, overlayFS)
+		if err != nil {
+			return lintPassResult{}, fmt.Errorf("load configured project %q: %w", tsConfigPath, err)
+		}
+		if programContainsFile(program, filename, overlayFS) {
+			return lintSingleFile(program, filename, true, resolver, ctx, overlayFS), nil
+		}
+	}
+
+	program, err := createStandaloneFallbackProgram(filename, cwd, overlayFS)
+	if err != nil {
+		return lintPassResult{}, fmt.Errorf("create fallback lint program: %w", err)
+	}
+	return lintSingleFile(program, filename, false, resolver, ctx, overlayFS), nil
+}
+
+func lspFilesystemPathID(filePath string, fs vfs.FS) string {
+	filePath = tspath.NormalizePath(filePath)
+	useCaseSensitive := true
+	if fs != nil {
+		useCaseSensitive = fs.UseCaseSensitiveFileNames()
+		if realPath := fs.Realpath(filePath); realPath != "" {
+			filePath = tspath.NormalizePath(realPath)
+		}
+	}
+	return string(tspath.ToPath(filePath, "", useCaseSensitive))
 }
 
 func lspActiveRulesForFile(rslintConfig config.RslintConfig, filePath string, cwd string, enforcePlugins bool, hasTypeInfo bool) []linter.ConfiguredRule {
@@ -1001,45 +1300,53 @@ func createDisableRuleForFileAction(ruleDiag rule.RuleDiagnostic, uri lsproto.Do
 // For JS configs the cwd is the config's own directory (URI → path);
 // for the JSON fallback it is s.cwd.
 func (s *Server) getConfigForURI(uri lsproto.DocumentUri) (config.RslintConfig, string, bool) {
-	if len(s.jsConfigs) > 0 {
-		// Both keys and lookups use URI strings (e.g. "file:///project"),
-		// so path separators are always forward slashes — no platform issues.
-		dir := uriDirname(string(uri))
-		for {
-			if cfg, ok := s.jsConfigs[dir]; ok {
-				return cfg, uriToPath(lsproto.DocumentUri(dir)), true
-			}
-			parent := uriDirname(dir)
-			if parent == dir {
-				break
-			}
-			dir = parent
-		}
+	if configKey, ok := s.nearestJSConfigKey(uri); ok {
+		return s.jsConfigs[configKey], uriToPath(lsproto.DocumentUri(configKey)), true
 	}
 	return s.jsonConfig, s.cwd, false
+}
+
+// nearestJSConfigKey returns the deepest JS/TS config directory containing uri.
+// Matching uses filesystem path semantics instead of URI string identity so
+// Windows drive letters, UNC authorities, and path casing behave consistently
+// with the compiler and config resolver.
+func (s *Server) nearestJSConfigKey(uri lsproto.DocumentUri) (string, bool) {
+	if len(s.jsConfigs) == 0 {
+		return "", false
+	}
+	useCaseSensitive := true
+	if s.fs != nil {
+		useCaseSensitive = s.fs.UseCaseSensitiveFileNames()
+	}
+	filePath := tspath.NormalizePath(uriToPath(uri))
+	compareOptions := tspath.ComparePathsOptions{UseCaseSensitiveFileNames: useCaseSensitive}
+	bestKey := ""
+	bestDir := ""
+	for configKey := range s.jsConfigs {
+		configDir := tspath.NormalizePath(uriToPath(lsproto.DocumentUri(configKey)))
+		if configDir == "" {
+			continue
+		}
+		contains := tspath.ComparePaths(filePath, configDir, compareOptions) == 0 ||
+			tspath.StartsWithDirectory(filePath, configDir, useCaseSensitive)
+		if contains && len(configDir) > len(bestDir) {
+			bestKey = configKey
+			bestDir = configDir
+		}
+	}
+	return bestKey, bestKey != ""
 }
 
 // tsConfigPathsForURI returns the resolved parserOptions.project tsconfig
 // paths for the rslint config that governs the given URI. It walks parents
 // the same way getConfigForURI does so a nested config with no tsconfig
-// does not leak its "allow-all" fallback into sibling configs.
+// does not affect type-info decisions for sibling configs.
 //
-// A nil return means the governing config has no resolved tsconfig; callers
-// should treat this as "disable type-aware filtering for this file only".
+// A nil return means the governing config has no resolved tsconfig, so callers
+// must disable type-aware rules for this file.
 func (s *Server) tsConfigPathsForURI(uri lsproto.DocumentUri) []string {
-	if len(s.jsConfigs) > 0 {
-		dir := uriDirname(string(uri))
-		for {
-			if _, ok := s.jsConfigs[dir]; ok {
-				return s.tsConfigPathsByConfig[dir]
-			}
-			parent := uriDirname(dir)
-			if parent == dir {
-				break
-			}
-			dir = parent
-		}
-		return nil
+	if configKey, ok := s.nearestJSConfigKey(uri); ok {
+		return s.tsConfigPathsByConfig[configKey]
 	}
 	return s.tsConfigPaths
 }
@@ -1082,11 +1389,12 @@ func (s *Server) pushDiagnostics(uri lsproto.DocumentUri) {
 
 	rslintConfig, configCwd, isJSConfig := s.getConfigForURI(uri)
 	tsConfigPaths := s.tsConfigPathsForURI(uri)
-	ruleDiags, err := runLintWithSession(uri, s.session, ctx, rslintConfig, configCwd, isJSConfig, tsConfigPaths, s.fs)
+	lintResult, err := s.runConfiguredLint(uri, ctx, rslintConfig, configCwd, isJSConfig, tsConfigPaths)
 	if err != nil {
 		log.Printf("Error running lint for push diagnostics: %v", err)
 		return
 	}
+	ruleDiags := lintResult.Diagnostics
 
 	s.diagnostics[uri] = ruleDiags
 
@@ -1107,5 +1415,7 @@ func (s *Server) pushDiagnostics(uri lsproto.DocumentUri) {
 	// MUST NOT run synchronously here — it would block the dispatch loop (and
 	// thus all editor interaction) until the Node worker replies. Results merge
 	// back via pluginResultCh on the main loop (s.diagnostics is lock-free).
-	s.dispatchPluginLint(uri, generation)
+	if !lintResult.HasSyntaxErrors {
+		s.dispatchPluginLint(uri, generation)
+	}
 }

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -185,6 +185,11 @@ func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
 		log.Printf("[rslint] Config update has no configs field; keeping existing JS configs intact")
 		return nil
 	}
+	for _, cfg := range payload.Configs {
+		if err := config.ValidateConfig(cfg.Entries); err != nil {
+			return fmt.Errorf("invalid config for %q: %w", cfg.ConfigDirectory, err)
+		}
+	}
 
 	// Replace all JS configs with the new set (may be empty when all deleted).
 	// Keys are URI strings (e.g. "file:///project") sent from VS Code,

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -766,8 +766,9 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 	if rslintConfig.IsFileIgnored(filename, cwd) {
 		return []rule.RuleDiagnostic{}, nil
 	}
+	fileConfigResolver := config.NewFileConfigResolver(rslintConfig, cwd, enforcePlugins)
 	// Files outside the config's `files` set should not spin up TypeScript LS.
-	if rslintConfig.GetConfigForFile(filename, cwd) == nil {
+	if fileConfigResolver.ConfigForFile(filename) == nil {
 		return []rule.RuleDiagnostic{}, nil
 	}
 
@@ -814,7 +815,7 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 		Program: program,
 		File:    filename,
 		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
-			return lspActiveRulesForFile(rslintConfig, sourceFile.FileName(), cwd, enforcePlugins, hasTypeInfo)
+			return fileConfigResolver.ActiveRulesForFileHasTypeInfo(sourceFile.FileName(), hasTypeInfo)
 		},
 		OnDiagnostic: diagnosticCollector,
 	})
@@ -826,11 +827,8 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 }
 
 func lspActiveRulesForFile(rslintConfig config.RslintConfig, filePath string, cwd string, enforcePlugins bool, hasTypeInfo bool) []linter.ConfiguredRule {
-	activeRules, _ := config.GlobalRuleRegistry.GetEnabledRules(rslintConfig, filePath, cwd, enforcePlugins)
-	if !hasTypeInfo {
-		activeRules = linter.FilterNonTypeAwareRules(activeRules)
-	}
-	return activeRules
+	return config.NewFileConfigResolver(rslintConfig, cwd, enforcePlugins).
+		ActiveRulesForFileHasTypeInfo(filePath, hasTypeInfo)
 }
 
 // Helper function to check if two ranges overlap

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -204,6 +204,7 @@ func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
 		Configs    []struct {
 			ConfigDirectory string              `json:"configDirectory"`
 			Entries         config.RslintConfig `json:"entries"`
+			Unavailable     bool                `json:"unavailable,omitempty"`
 		} `json:"configs"`
 		// EslintPlugins carries the {prefix, ruleNames} metadata for every
 		// ESLint plugin mounted across all configs, aggregated by the VS Code
@@ -238,6 +239,9 @@ func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
 			)
 		}
 		seenConfigDirs[configID] = cfg.ConfigDirectory
+		if cfg.Unavailable && len(cfg.Entries) != 0 {
+			return fmt.Errorf("unavailable config %q must not contain entries", cfg.ConfigDirectory)
+		}
 		if err := config.ValidateConfig(cfg.Entries); err != nil {
 			return fmt.Errorf("invalid config for %q: %w", cfg.ConfigDirectory, err)
 		}
@@ -248,6 +252,9 @@ func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
 	// preserving the previous config atomically.
 	candidateConfigs := make(map[string]config.RslintConfig, len(payload.Configs))
 	candidateTsConfigs := make(map[string][]string, len(payload.Configs))
+	candidateConfigsByPath := make(map[string]config.RslintConfig, len(payload.Configs))
+	candidateConfigKeyByPath := make(map[string]string, len(payload.Configs))
+	candidateUnavailableConfigs := make(map[string]struct{})
 	for _, cfg := range payload.Configs {
 		configDir := uriToPath(lsproto.DocumentUri(cfg.ConfigDirectory))
 		paths, err := s.resolveTsConfigPaths(cfg.Entries, configDir)
@@ -256,7 +263,14 @@ func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
 		}
 		candidateConfigs[cfg.ConfigDirectory] = cfg.Entries
 		candidateTsConfigs[cfg.ConfigDirectory] = paths
+		normalizedConfigDir := tspath.NormalizePath(configDir)
+		candidateConfigsByPath[normalizedConfigDir] = cfg.Entries
+		candidateConfigKeyByPath[normalizedConfigDir] = cfg.ConfigDirectory
+		if cfg.Unavailable {
+			candidateUnavailableConfigs[cfg.ConfigDirectory] = struct{}{}
+		}
 	}
+	candidateConfigResolver := config.NewConfigOwnerResolver(candidateConfigsByPath, s.fs)
 
 	candidateJSONConfig := s.jsonConfig
 	candidateJSONConfigPath := s.rslintConfigPath
@@ -282,6 +296,9 @@ func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
 	// matching the URI format used throughout the LSP protocol.
 	s.jsConfigs = candidateConfigs
 	s.tsConfigPathsByConfig = candidateTsConfigs
+	s.jsConfigOwnerResolver = candidateConfigResolver
+	s.jsConfigKeyByPath = candidateConfigKeyByPath
+	s.jsUnavailableConfigs = candidateUnavailableConfigs
 	s.eslintPluginConfigGeneration = payload.Generation
 	if len(payload.Configs) == 0 {
 		s.jsonConfig = candidateJSONConfig
@@ -489,6 +506,13 @@ func (s *Server) handleDidChange(ctx context.Context, params *lsproto.DidChangeT
 		s.documents[uri] = params.ContentChanges[0].WholeDocument.Text
 	}
 
+	// A content version change supersedes plugin work immediately, not when the
+	// debounce timer eventually starts the next lint. Otherwise an older worker
+	// result can be published against the new buffer while the user is typing.
+	s.docGeneration[uri]++
+	s.cancelInflightPluginDispatch(uri)
+	delete(s.diagnostics, uri)
+
 	// Notify session immediately so tsgo's overlay stays up-to-date for
 	// other LSP features (completions, hover, etc.).  Lint is deferred
 	// via scheduleLint to avoid running the linter on every keystroke.
@@ -644,8 +668,8 @@ func isFixAllRequest(ctx *lsproto.CodeActionContext) bool {
 const maxFixPasses = 10
 
 // handleFixAllCodeAction computes all auto-fixes for the given URI using
-// multi-pass fixing: each pass lints → applies fixes → updates the session
-// overlay, repeating until no more fixes are found or maxFixPasses is reached.
+// multi-pass fixing: each pass lints and applies fixes to an isolated overlay,
+// repeating until no more fixes are found or maxFixPasses is reached.
 // This handles cascading fixes (e.g. no-wrapper-object-types fix triggers no-inferrable-types).
 // It does NOT push diagnostics or update s.diagnostics — that is left to the
 // subsequent didSave handler in the normal save flow.
@@ -660,6 +684,9 @@ func (s *Server) handleFixAllCodeAction(ctx context.Context, uri lsproto.Documen
 		return empty, nil
 	}
 	if !isLintableScriptFile(uri) {
+		return empty, nil
+	}
+	if s.isUnavailableConfigForURI(uri) {
 		return empty, nil
 	}
 
@@ -881,28 +908,29 @@ func runLintWithProgramLoader(
 	loadProgram lintProgramLoader,
 ) (lintPassResult, error) {
 	filename := uriToPath(uri)
+	configFilePath, configCwd := config.ResolveConfigPathSpace(filename, cwd, fs)
+	if isDefaultExcludedLintPath(configFilePath, configCwd, fs) {
+		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
+	}
 
 	// Files excluded by the config's `ignores` patterns produce no diagnostics,
 	// matching CLI behavior. Return early before spinning up the language service.
-	if rslintConfig.IsFileIgnored(filename, cwd) {
+	if rslintConfig.IsFileIgnored(configFilePath, configCwd) {
 		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
 	}
-	fileConfigResolver := config.NewFileConfigResolver(rslintConfig, cwd, enforcePlugins)
-	// Files outside the config's `files` set should not spin up TypeScript LS.
-	if fileConfigResolver.ConfigForFile(filename) == nil {
-		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
-	}
+	fileConfigResolver := config.NewFileConfigResolver(rslintConfig, configCwd, enforcePlugins)
 
 	program, hasTypeInfo, err := selectLintProgram(uri, session, ctx, tsConfigPaths, fs, loadProgram)
 	if err != nil {
 		return lintPassResult{}, err
 	}
-	return lintSingleFile(program, filename, hasTypeInfo, fileConfigResolver, ctx, fs), nil
+	return lintSingleFile(program, filename, configFilePath, hasTypeInfo, fileConfigResolver, ctx, fs), nil
 }
 
 func lintSingleFile(
 	program *compiler.Program,
 	filename string,
+	configFilePath string,
 	hasTypeInfo bool,
 	fileConfigResolver *config.FileConfigResolver,
 	ctx context.Context,
@@ -912,8 +940,20 @@ func lintSingleFile(
 	if sourceFile == nil {
 		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}
 	}
-	if len(program.GetSyntacticDiagnostics(ctx, sourceFile)) > 0 {
-		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}, HasSyntaxErrors: true}
+	if syntacticDiagnostics := program.GetSyntacticDiagnostics(ctx, sourceFile); len(syntacticDiagnostics) > 0 {
+		diagnostics := make([]rule.RuleDiagnostic, 0, len(syntacticDiagnostics))
+		for _, diagnostic := range syntacticDiagnostics {
+			diagnostics = append(diagnostics, rule.RuleDiagnostic{
+				RuleName:     fmt.Sprintf("TypeScript(TS%d)", diagnostic.Code()),
+				SourceFile:   sourceFile,
+				FilePath:     sourceFile.FileName(),
+				Range:        diagnostic.Loc(),
+				Message:      rule.RuleMessage{Description: diagnostic.String()},
+				Severity:     rule.SeverityError,
+				PreFormatted: true,
+			})
+		}
+		return lintPassResult{Diagnostics: diagnostics, HasSyntaxErrors: true}
 	}
 
 	// Collect diagnostics
@@ -932,7 +972,7 @@ func lintSingleFile(
 		File:        sourceFile.FileName(),
 		HasTypeInfo: hasTypeInfo,
 		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
-			return fileConfigResolver.ActiveRulesForFileHasTypeInfo(filename, hasTypeInfo)
+			return fileConfigResolver.ActiveRulesForFileHasTypeInfo(configFilePath, hasTypeInfo)
 		},
 		OnDiagnostic: diagnosticCollector,
 	})
@@ -953,8 +993,9 @@ func selectLintProgram(
 ) (*compiler.Program, bool, error) {
 	filename := uriToPath(uri)
 	// Flush pending document changes and collect every already-loaded project
-	// containing the file. The default language service remains the AST-only
-	// fallback when none of the config's declared projects contains the file.
+	// containing the file. The default language service remains the
+	// non-project-backed fallback when none of the config's declared projects
+	// contains the file.
 	_, languageService, loadedProjects, err := session.GetLanguageServiceAndProjectsForFile(ctx, uri)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get language service: %w", err)
@@ -968,7 +1009,7 @@ func selectLintProgram(
 	// mutating the Session's permanent API-open project set.
 	loadedByConfig := make(map[string]*compiler.Program, len(loadedProjects))
 	for _, candidate := range loadedProjects {
-		if candidate == nil || candidate.GetProgram() == nil || !programContainsFile(candidate.GetProgram(), filename, fs) {
+		if candidate == nil || candidate.GetProgram() == nil {
 			continue
 		}
 		loadedByConfig[lspFilesystemPathID(string(candidate.Id()), fs)] = candidate.GetProgram()
@@ -997,33 +1038,45 @@ func programContainsFile(program *compiler.Program, filename string, fs vfs.FS) 
 }
 
 func sourceFileForPath(program *compiler.Program, filename string, fs vfs.FS) *ast.SourceFile {
-	if program == nil {
-		return nil
+	return utils.NewProgramSourceLookup(program, fs).SourceFileForPath(filename)
+}
+
+func (s *Server) currentEditorOverlayFS(preferred ...lsproto.DocumentUri) vfs.FS {
+	return utils.NewOverlayVFS(s.fs, s.currentEditorOverlayFiles(preferred...))
+}
+
+func (s *Server) currentEditorOverlayFiles(preferred ...lsproto.DocumentUri) map[string]string {
+	files := make(map[string]string, len(s.documents)*2)
+	for uri, content := range s.documents {
+		if len(preferred) > 0 && uri == preferred[0] {
+			continue
+		}
+		s.addEditorOverlayFile(files, uriToPath(uri), content)
 	}
-	if sourceFile := program.GetSourceFile(filename); sourceFile != nil {
-		return sourceFile
-	}
-	if fs != nil {
-		if realPath := fs.Realpath(filename); realPath != "" && realPath != filename {
-			return program.GetSourceFile(realPath)
+	if len(preferred) > 0 {
+		if content, ok := s.documents[preferred[0]]; ok {
+			s.addEditorOverlayFile(files, uriToPath(preferred[0]), content)
 		}
 	}
-	return nil
+	return files
 }
 
-func (s *Server) currentEditorOverlayFS() vfs.FS {
-	files := make(map[string]string, len(s.documents))
-	for uri, content := range s.documents {
-		files[tspath.NormalizePath(uriToPath(uri))] = content
+func (s *Server) addEditorOverlayFile(files map[string]string, filePath string, content string) {
+	filePath = tspath.NormalizePath(filePath)
+	files[filePath] = content
+	if s.fs == nil {
+		return
 	}
-	return utils.NewOverlayVFS(s.fs, files)
+	if realPath := s.fs.Realpath(filePath); realPath != "" {
+		files[tspath.NormalizePath(realPath)] = content
+	}
 }
 
-func (s *Server) newStandaloneLintProgramLoader() lintProgramLoader {
+func (s *Server) newStandaloneLintProgramLoader(uri lsproto.DocumentUri) lintProgramLoader {
 	var overlayFS vfs.FS
 	return func(tsConfigPath string) (*compiler.Program, error) {
 		if overlayFS == nil {
-			overlayFS = s.currentEditorOverlayFS()
+			overlayFS = s.currentEditorOverlayFS(uri)
 		}
 		return createStandaloneLintProgram(tsConfigPath, overlayFS)
 	}
@@ -1064,7 +1117,7 @@ func (s *Server) runConfiguredLint(
 		enforcePlugins,
 		tsConfigPaths,
 		s.fs,
-		s.newStandaloneLintProgramLoader(),
+		s.newStandaloneLintProgramLoader(uri),
 	)
 }
 
@@ -1081,19 +1134,19 @@ func (s *Server) runConfiguredLintForContent(
 	tsConfigPaths []string,
 ) (lintPassResult, error) {
 	filename := tspath.NormalizePath(uriToPath(uri))
-	if rslintConfig.IsFileIgnored(filename, cwd) {
+	configFilePath, configCwd := config.ResolveConfigPathSpace(filename, cwd, s.fs)
+	if isDefaultExcludedLintPath(configFilePath, configCwd, s.fs) {
 		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
 	}
-	resolver := config.NewFileConfigResolver(rslintConfig, cwd, enforcePlugins)
-	if resolver.ConfigForFile(filename) == nil {
+	if rslintConfig.IsFileIgnored(configFilePath, configCwd) {
 		return lintPassResult{Diagnostics: []rule.RuleDiagnostic{}}, nil
 	}
+	resolver := config.NewFileConfigResolver(rslintConfig, configCwd, enforcePlugins)
 
-	files := make(map[string]string, len(s.documents)+1)
-	for documentURI, documentContent := range s.documents {
-		files[tspath.NormalizePath(uriToPath(documentURI))] = documentContent
-	}
-	files[filename] = content
+	files := s.currentEditorOverlayFiles()
+	// Apply the speculative target last so it wins over every open URI alias
+	// that resolves to the same physical file.
+	s.addEditorOverlayFile(files, filename, content)
 	overlayFS := utils.NewOverlayVFS(s.fs, files)
 
 	for _, tsConfigPath := range tsConfigPaths {
@@ -1102,27 +1155,33 @@ func (s *Server) runConfiguredLintForContent(
 			return lintPassResult{}, fmt.Errorf("load configured project %q: %w", tsConfigPath, err)
 		}
 		if programContainsFile(program, filename, overlayFS) {
-			return lintSingleFile(program, filename, true, resolver, ctx, overlayFS), nil
+			return lintSingleFile(program, filename, configFilePath, true, resolver, ctx, overlayFS), nil
 		}
 	}
 
-	program, err := createStandaloneFallbackProgram(filename, cwd, overlayFS)
+	program, err := createStandaloneFallbackProgram(filename, configCwd, overlayFS)
 	if err != nil {
 		return lintPassResult{}, fmt.Errorf("create fallback lint program: %w", err)
 	}
-	return lintSingleFile(program, filename, false, resolver, ctx, overlayFS), nil
+	return lintSingleFile(program, filename, configFilePath, false, resolver, ctx, overlayFS), nil
 }
 
 func lspFilesystemPathID(filePath string, fs vfs.FS) string {
 	filePath = tspath.NormalizePath(filePath)
-	useCaseSensitive := true
 	if fs != nil {
-		useCaseSensitive = fs.UseCaseSensitiveFileNames()
 		if realPath := fs.Realpath(filePath); realPath != "" {
 			filePath = tspath.NormalizePath(realPath)
 		}
 	}
-	return string(tspath.ToPath(filePath, "", useCaseSensitive))
+	return string(tspath.ToPath(filePath, "", true))
+}
+
+func isDefaultExcludedLintPath(filePath string, cwd string, fs vfs.FS) bool {
+	useCaseSensitive := true
+	if fs != nil {
+		useCaseSensitive = fs.UseCaseSensitiveFileNames()
+	}
+	return config.IsDefaultExcludedPath(filePath, cwd, useCaseSensitive)
 }
 
 func lspActiveRulesForFile(rslintConfig config.RslintConfig, filePath string, cwd string, enforcePlugins bool, hasTypeInfo bool) []linter.ConfiguredRule {
@@ -1201,6 +1260,9 @@ func createCodeActionFromSuggestion(ruleDiag rule.RuleDiagnostic, suggestion rul
 
 // Helper function to create disable rule actions for diagnostics without fixes
 func createDisableRuleActions(ruleDiag rule.RuleDiagnostic, uri lsproto.DocumentUri) []lsproto.CommandOrCodeAction {
+	if strings.HasPrefix(ruleDiag.RuleName, "TypeScript(TS") {
+		return nil
+	}
 	var actions []lsproto.CommandOrCodeAction
 
 	lspDiagnostic := convertRuleDiagnosticToLSP(ruleDiag)
@@ -1291,10 +1353,9 @@ func createDisableRuleForFileAction(ruleDiag rule.RuleDiagnostic, uri lsproto.Do
 	}
 }
 
-// getConfigForURI resolves the rslint config for a given file URI.
-// It walks upward from the file's directory looking for the closest
-// JS/TS config (matching ESLint v10 flat config behavior).
-// Falls back to the JSON config if no JS/TS config matches.
+// getConfigForURI resolves a file against the JS/TS config catalog supplied by
+// the extension. It falls back to the JSON config when that catalog has no
+// owner for the file.
 // Returns the config entries, the directory to use as cwd for glob matching,
 // and whether the config is from a JS/TS config (for plugin enforcement).
 // For JS configs the cwd is the config's own directory (URI → path);
@@ -1306,41 +1367,52 @@ func (s *Server) getConfigForURI(uri lsproto.DocumentUri) (config.RslintConfig, 
 	return s.jsonConfig, s.cwd, false
 }
 
-// nearestJSConfigKey returns the deepest JS/TS config directory containing uri.
-// Matching uses filesystem path semantics instead of URI string identity so
-// Windows drive letters, UNC authorities, and path casing behave consistently
-// with the compiler and config resolver.
+func (s *Server) isUnavailableConfigForURI(uri lsproto.DocumentUri) bool {
+	configKey, ok := s.nearestJSConfigKey(uri)
+	if !ok {
+		return false
+	}
+	_, unavailable := s.jsUnavailableConfigs[configKey]
+	return unavailable
+}
+
+// nearestJSConfigKey returns the nearest supplied JS/TS config directory for
+// uri. Matching uses normalized filesystem paths instead of URI identity;
+// lexical ownership is tried before a realpath fallback.
 func (s *Server) nearestJSConfigKey(uri lsproto.DocumentUri) (string, bool) {
 	if len(s.jsConfigs) == 0 {
 		return "", false
 	}
-	useCaseSensitive := true
-	if s.fs != nil {
-		useCaseSensitive = s.fs.UseCaseSensitiveFileNames()
-	}
 	filePath := tspath.NormalizePath(uriToPath(uri))
-	compareOptions := tspath.ComparePathsOptions{UseCaseSensitiveFileNames: useCaseSensitive}
-	bestKey := ""
-	bestDir := ""
-	for configKey := range s.jsConfigs {
-		configDir := tspath.NormalizePath(uriToPath(lsproto.DocumentUri(configKey)))
-		if configDir == "" {
-			continue
-		}
-		contains := tspath.ComparePaths(filePath, configDir, compareOptions) == 0 ||
-			tspath.StartsWithDirectory(filePath, configDir, useCaseSensitive)
-		if contains && len(configDir) > len(bestDir) {
-			bestKey = configKey
-			bestDir = configDir
+	if s.jsConfigOwnerResolver != nil {
+		if configDir, _ := s.jsConfigOwnerResolver.Resolve(filePath); configDir != "" {
+			if configKey := s.jsConfigKeyByPath[configDir]; configKey != "" {
+				if _, active := s.jsConfigs[configKey]; active {
+					return configKey, true
+				}
+			}
 		}
 	}
-	return bestKey, bestKey != ""
+
+	// Compatibility fallback for tests and embedded callers that populate jsConfigs
+	// directly instead of committing a config transaction.
+	configsByPath := make(map[string]config.RslintConfig, len(s.jsConfigs))
+	configKeyByPath := make(map[string]string, len(s.jsConfigs))
+	for configKey, entries := range s.jsConfigs {
+		configDir := tspath.NormalizePath(uriToPath(lsproto.DocumentUri(configKey)))
+		if configDir != "" {
+			configsByPath[configDir] = entries
+			configKeyByPath[configDir] = configKey
+		}
+	}
+	configDir, _ := config.NewConfigOwnerResolver(configsByPath, s.fs).Resolve(filePath)
+	configKey := configKeyByPath[configDir]
+	return configKey, configKey != ""
 }
 
-// tsConfigPathsForURI returns the resolved parserOptions.project tsconfig
-// paths for the rslint config that governs the given URI. It walks parents
-// the same way getConfigForURI does so a nested config with no tsconfig
-// does not affect type-info decisions for sibling configs.
+// tsConfigPathsForURI returns parserOptions.project paths from the config owner
+// selected by getConfigForURI. A nested config with no tsconfig therefore does
+// not affect type-info decisions for sibling configs.
 //
 // A nil return means the governing config has no resolved tsconfig, so callers
 // must disable type-aware rules for this file.
@@ -1380,18 +1452,35 @@ func (s *Server) pushDiagnostics(uri lsproto.DocumentUri) {
 		return
 	}
 
-	// Bump this URI's generation BEFORE linting. Native diagnostics are
-	// published synchronously below; the eslint-plugin pass runs in a
-	// goroutine and stamps its result with this value so the main loop can
-	// drop it if a newer keystroke relints in the meantime.
+	// Supersede the previous plugin pass before linting. Native diagnostics are
+	// published synchronously below; the next plugin pass is stamped with this
+	// generation so the main loop can reject an older result.
 	s.docGeneration[uri]++
 	generation := s.docGeneration[uri]
+	s.cancelInflightPluginDispatch(uri)
+	if s.isUnavailableConfigForURI(uri) {
+		delete(s.diagnostics, uri)
+		if err := s.PublishDiagnostics(ctx, &lsproto.PublishDiagnosticsParams{
+			Uri:         uri,
+			Diagnostics: []*lsproto.Diagnostic{},
+		}); err != nil {
+			log.Printf("Error clearing diagnostics for unavailable config: %v", err)
+		}
+		return
+	}
 
 	rslintConfig, configCwd, isJSConfig := s.getConfigForURI(uri)
 	tsConfigPaths := s.tsConfigPathsForURI(uri)
 	lintResult, err := s.runConfiguredLint(uri, ctx, rslintConfig, configCwd, isJSConfig, tsConfigPaths)
 	if err != nil {
 		log.Printf("Error running lint for push diagnostics: %v", err)
+		delete(s.diagnostics, uri)
+		if publishErr := s.PublishDiagnostics(ctx, &lsproto.PublishDiagnosticsParams{
+			Uri:         uri,
+			Diagnostics: []*lsproto.Diagnostic{},
+		}); publishErr != nil {
+			log.Printf("Error clearing diagnostics after lint failure: %v", publishErr)
+		}
 		return
 	}
 	ruleDiags := lintResult.Diagnostics

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -557,7 +557,7 @@ func (s *Server) handleFixAllCodeAction(ctx context.Context, uri lsproto.Documen
 	if s.session == nil {
 		return empty, nil
 	}
-	if !isTypeScriptFile(string(uri)) {
+	if !isLintableScriptFile(uri) {
 		return empty, nil
 	}
 
@@ -711,12 +711,8 @@ func convertRuleDiagnosticToLSP(ruleDiag rule.RuleDiagnostic) *lsproto.Diagnosti
 	}
 }
 
-func isTypeScriptFile(uri string) bool {
-	path := strings.ToLower(uri)
-	return strings.HasSuffix(path, ".ts") ||
-		strings.HasSuffix(path, ".tsx") ||
-		strings.HasSuffix(path, ".js") ||
-		strings.HasSuffix(path, ".jsx")
+func isLintableScriptFile(uri lsproto.DocumentUri) bool {
+	return config.IsSupportedLintFile(uriToPath(uri))
 }
 
 func uriToPath(uri lsproto.DocumentUri) string {
@@ -770,6 +766,10 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 	if rslintConfig.IsFileIgnored(filename, cwd) {
 		return []rule.RuleDiagnostic{}, nil
 	}
+	// Files outside the config's `files` set should not spin up TypeScript LS.
+	if rslintConfig.GetConfigForFile(filename, cwd) == nil {
+		return []rule.RuleDiagnostic{}, nil
+	}
 
 	// GetLanguageService flushes any pending changes (from DidChangeFile) and
 	// returns a language service whose program reflects the latest overlay content.
@@ -814,11 +814,7 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 		Program: program,
 		File:    filename,
 		GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
-			activeRules, _ := config.GlobalRuleRegistry.GetEnabledRules(rslintConfig, sourceFile.FileName(), cwd, enforcePlugins)
-			if !hasTypeInfo {
-				activeRules = linter.FilterNonTypeAwareRules(activeRules)
-			}
-			return activeRules
+			return lspActiveRulesForFile(rslintConfig, sourceFile.FileName(), cwd, enforcePlugins, hasTypeInfo)
 		},
 		OnDiagnostic: diagnosticCollector,
 	})
@@ -827,6 +823,14 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 		diagnostics = []rule.RuleDiagnostic{}
 	}
 	return diagnostics, nil
+}
+
+func lspActiveRulesForFile(rslintConfig config.RslintConfig, filePath string, cwd string, enforcePlugins bool, hasTypeInfo bool) []linter.ConfiguredRule {
+	activeRules, _ := config.GlobalRuleRegistry.GetEnabledRules(rslintConfig, filePath, cwd, enforcePlugins)
+	if !hasTypeInfo {
+		activeRules = linter.FilterNonTypeAwareRules(activeRules)
+	}
+	return activeRules
 }
 
 // Helper function to check if two ranges overlap
@@ -1067,7 +1071,7 @@ func (s *Server) pushDiagnostics(uri lsproto.DocumentUri) {
 
 	ctx := s.backgroundCtx
 
-	if !isTypeScriptFile(string(uri)) {
+	if !isLintableScriptFile(uri) {
 		return
 	}
 

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -40,6 +40,14 @@ func newTestServer() *Server {
 	}
 }
 
+func documentURIFromPath(filePath string) lsproto.DocumentUri {
+	uriPath := filepath.ToSlash(filePath)
+	if len(uriPath) >= 2 && uriPath[1] == ':' {
+		uriPath = "/" + uriPath
+	}
+	return lsproto.DocumentUri((&url.URL{Scheme: "file", Path: uriPath}).String())
+}
+
 // helper to build a didChange params for full-sync mode
 func makeDidChangeParams(uri lsproto.DocumentUri, version int32, text string) *lsproto.DidChangeTextDocumentParams {
 	return &lsproto.DidChangeTextDocumentParams{
@@ -1234,7 +1242,7 @@ func TestHandleConfigUpdate_InvalidTsConfigPreservesPreviousGeneration(t *testin
 	err := s.handleConfigUpdate(context.Background(), map[string]any{
 		"generation": "rejected-generation",
 		"configs": []any{map[string]any{
-			"configDirectory": lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(dir)}).String()),
+			"configDirectory": documentURIFromPath(dir),
 			"entries": []any{map[string]any{
 				"languageOptions": map[string]any{
 					"parserOptions": map[string]any{"project": []any{"./missing-tsconfig.json"}},
@@ -1676,6 +1684,17 @@ func TestGetConfigForURI_IsJSConfig(t *testing.T) {
 }
 
 // ======== uriToPath tests ========
+
+func TestDocumentURIFromPath_WindowsDriveRoundTrip(t *testing.T) {
+	const filePath = "C:/Users/Test User/project/index.ts"
+	uri := documentURIFromPath(filePath)
+	if uri != "file:///C:/Users/Test%20User/project/index.ts" {
+		t.Fatalf("documentURIFromPath(%q) = %q", filePath, uri)
+	}
+	if got := uriToPath(uri); got != filePath {
+		t.Fatalf("uriToPath(%q) = %q, want %q", uri, got, filePath)
+	}
+}
 
 func TestUriToPath(t *testing.T) {
 	tests := []struct {
@@ -2246,7 +2265,7 @@ func TestSelectLintProgram_UsesDeclaredProjectOrderAndGapFallback(t *testing.T) 
 	defer s.session.Close()
 
 	toURI := func(filePath string) lsproto.DocumentUri {
-		return lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String())
+		return documentURIFromPath(filePath)
 	}
 	for _, file := range []string{sourcePath, gapPath} {
 		uri := toURI(file)
@@ -2333,7 +2352,7 @@ func TestRunConfiguredLintForContent_SyntaxErrorSkipsRules(t *testing.T) {
 	s := newTestServer()
 	s.cwd = dir
 	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String())
+	uri := documentURIFromPath(filePath)
 	s.documents[uri] = malformed
 
 	result, err := s.runConfiguredLintForContent(
@@ -2386,7 +2405,7 @@ func TestRunConfiguredLintForContent_ZeroRuleTargetsReportSyntaxErrors(t *testin
 	s := newTestServer()
 	s.cwd = dir
 	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String())
+	uri := documentURIFromPath(filePath)
 	s.documents[uri] = malformed
 
 	tests := []struct {
@@ -2471,15 +2490,15 @@ func TestRunConfiguredLintForContent_OverlaysLexicalAndRealpath(t *testing.T) {
 		realRoot:  realRoot,
 	}
 	aliasFile := filepath.Join(aliasRoot, "src", "index.ts")
-	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(aliasFile)}).String())
-	realURI := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(realFile)}).String())
+	uri := documentURIFromPath(aliasFile)
+	realURI := documentURIFromPath(realFile)
 	const openContent = "const editorValue = 2;\n"
 	s.documents[realURI] = "const competingAliasValue = 3;\n"
 	s.documents[uri] = openContent
 
 	editorOverlay := s.currentEditorOverlayFS(uri)
 	for _, filePath := range []string{aliasFile, realFile} {
-		if got, ok := editorOverlay.ReadFile(filePath); !ok || got != openContent {
+		if got, ok := editorOverlay.ReadFile(tspath.NormalizePath(filePath)); !ok || got != openContent {
 			t.Fatalf("editor overlay read %q = %q, %v; want open content", filePath, got, ok)
 		}
 	}
@@ -2529,7 +2548,7 @@ func TestRunConfiguredLintForContent_SymlinkedConfigRootKeepsRulePathSpace(t *te
 	s.cwd = aliasRoot
 	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
 	aliasFile := filepath.Join(aliasRoot, "src", "index.ts")
-	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(aliasFile)}).String())
+	uri := documentURIFromPath(aliasFile)
 	s.documents[uri] = source
 	result, err := s.runConfiguredLintForContent(
 		uri,
@@ -2571,8 +2590,8 @@ func TestConfigTransaction_SymlinkedOwnerMatchesPhysicalFile(t *testing.T) {
 	s := newTestServer()
 	s.cwd = realRoot
 	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	configURI := (&url.URL{Scheme: "file", Path: filepath.ToSlash(aliasRoot)}).String()
-	fileURI := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(realFile)}).String())
+	configURI := string(documentURIFromPath(aliasRoot))
+	fileURI := documentURIFromPath(realFile)
 	if err := s.handleConfigUpdate(context.Background(), map[string]any{
 		"generation": "symlink-generation",
 		"configs": []any{map[string]any{
@@ -2587,7 +2606,7 @@ func TestConfigTransaction_SymlinkedOwnerMatchesPhysicalFile(t *testing.T) {
 	}
 
 	cfg, configCwd, isJSConfig := s.getConfigForURI(fileURI)
-	if !isJSConfig || configCwd != aliasRoot {
+	if !isJSConfig || tspath.NormalizePath(configCwd) != tspath.NormalizePath(aliasRoot) {
 		t.Fatalf("physical file resolved to config cwd %q, JS=%v", configCwd, isJSConfig)
 	}
 	result, err := s.runConfiguredLintForContent(
@@ -2624,7 +2643,7 @@ func TestConfigTransaction_PrefersLexicalOwnerOverPhysicalConfig(t *testing.T) {
 	}
 
 	toURI := func(filePath string) string {
-		return (&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String()
+		return string(documentURIFromPath(filePath))
 	}
 	config.RegisterAllRules()
 	s := newTestServer()
@@ -2652,7 +2671,7 @@ func TestConfigTransaction_PrefersLexicalOwnerOverPhysicalConfig(t *testing.T) {
 
 	fileURI := lsproto.DocumentUri(toURI(filepath.Join(aliasDir, "index.ts")))
 	cfg, configCwd, isJSConfig := s.getConfigForURI(fileURI)
-	if !isJSConfig || configCwd != root {
+	if !isJSConfig || tspath.NormalizePath(configCwd) != tspath.NormalizePath(root) {
 		t.Fatalf("lexical file resolved to config cwd %q, JS=%v", configCwd, isJSConfig)
 	}
 	result, err := s.runConfiguredLintForContent(
@@ -2694,7 +2713,7 @@ func TestComputeFixAllContent_DefaultExcludedFileIsUnchanged(t *testing.T) {
 	s := newTestServer()
 	s.cwd = root
 	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String())
+	uri := documentURIFromPath(filePath)
 	s.documents[uri] = source
 	got := s.computeFixAllContent(
 		context.Background(),
@@ -2726,7 +2745,7 @@ func TestComputeFixAllContent_NoTsconfigKeepsNativeFixes(t *testing.T) {
 	s := newTestServer()
 	s.cwd = root
 	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String())
+	uri := documentURIFromPath(filePath)
 	s.documents[uri] = source
 	cfg := config.RslintConfig{{
 		Files: []string{"**/*.ts"},

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/config"
@@ -113,6 +114,43 @@ func TestHandleDidChange(t *testing.T) {
 
 	if s.documents[uri] != "const x = 2;" {
 		t.Errorf("document content = %q, want %q", s.documents[uri], "const x = 2;")
+	}
+}
+
+func TestHandleDidChangeImmediatelyInvalidatesPluginWork(t *testing.T) {
+	s, queue := newTestServerWithQueue()
+	uri := lsproto.DocumentUri("file:///project/test.ts")
+	s.documents[uri] = "const oldValue = 1;"
+	s.docGeneration[uri] = 4
+	s.diagnostics[uri] = []rule.RuleDiagnostic{{RuleName: "native/old"}}
+
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	s.inflightPluginDispatch[uri] = &pluginDispatchHandle{cancel: cancel}
+
+	if err := s.handleDidChange(context.Background(), makeDidChangeParams(uri, 2, "const newValue = 2;")); err != nil {
+		t.Fatalf("handleDidChange failed: %v", err)
+	}
+	if s.docGeneration[uri] != 5 {
+		t.Fatalf("document generation = %d, want 5", s.docGeneration[uri])
+	}
+	select {
+	case <-dispatchCtx.Done():
+	default:
+		t.Fatal("didChange did not cancel the previous plugin dispatch")
+	}
+
+	s.mergePluginDiagnostics(pluginLintResult{
+		uri:        uri,
+		generation: 4,
+		diags:      []rule.RuleDiagnostic{{RuleName: "plugin/stale"}},
+	})
+	if _, cached := s.diagnostics[uri]; cached {
+		t.Fatal("didChange retained diagnostics from the previous document version")
+	}
+	select {
+	case <-queue:
+		t.Fatal("stale plugin result published after didChange")
+	default:
 	}
 }
 
@@ -1239,6 +1277,80 @@ func TestHandleConfigUpdate_CommitClearsOldDiagnostics(t *testing.T) {
 	}
 }
 
+func TestHandleConfigUpdate_DistinguishesEmptyAndUnavailableConfigs(t *testing.T) {
+	s := newTestServer()
+	uri := lsproto.DocumentUri("file:///project/src/index.ts")
+
+	if err := s.handleConfigUpdate(context.Background(), map[string]any{
+		"generation": "empty-config",
+		"configs": []any{map[string]any{
+			"configDirectory": "file:///project",
+			"entries":         []any{},
+		}},
+	}); err != nil {
+		t.Fatalf("commit empty config: %v", err)
+	}
+	if s.isUnavailableConfigForURI(uri) {
+		t.Fatal("a valid empty config was marked unavailable")
+	}
+
+	if err := s.handleConfigUpdate(context.Background(), map[string]any{
+		"generation": "unavailable-config",
+		"configs": []any{map[string]any{
+			"configDirectory": "file:///project",
+			"entries":         []any{},
+			"unavailable":     true,
+		}},
+	}); err != nil {
+		t.Fatalf("commit unavailable config boundary: %v", err)
+	}
+	if !s.isUnavailableConfigForURI(uri) {
+		t.Fatal("failed config boundary was not marked unavailable")
+	}
+
+	err := s.handleConfigUpdate(context.Background(), map[string]any{
+		"generation": "invalid-unavailable-config",
+		"configs": []any{map[string]any{
+			"configDirectory": "file:///project",
+			"entries":         []any{map[string]any{"rules": map[string]any{"no-debugger": "error"}}},
+			"unavailable":     true,
+		}},
+	})
+	if err == nil {
+		t.Fatal("unavailable config with entries was accepted")
+	}
+	if s.eslintPluginConfigGeneration != "unavailable-config" || !s.isUnavailableConfigForURI(uri) {
+		t.Fatal("rejected update changed the committed config generation")
+	}
+}
+
+func TestHandleConfigUpdate_CommitsNearestConfigIndex(t *testing.T) {
+	s := newTestServer()
+	err := s.handleConfigUpdate(context.Background(), map[string]any{
+		"generation": "indexed-generation",
+		"configs": []any{
+			map[string]any{
+				"configDirectory": "file:///project",
+				"entries":         []any{map[string]any{"rules": map[string]any{"root": "error"}}},
+			},
+			map[string]any{
+				"configDirectory": "file:///project/packages/app",
+				"entries":         []any{map[string]any{"rules": map[string]any{"nested": "error"}}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleConfigUpdate failed: %v", err)
+	}
+	if s.jsConfigOwnerResolver == nil {
+		t.Fatal("config transaction did not build the config-owner index")
+	}
+	key, ok := s.nearestJSConfigKey("file:///project/packages/app/src/index.ts")
+	if !ok || key != "file:///project/packages/app" {
+		t.Fatalf("nearest config = %q, %v; want nested config", key, ok)
+	}
+}
+
 // ======== getConfigForURI tests ========
 
 func TestNearestJSConfigKey_UsesFilesystemCaseSensitivity(t *testing.T) {
@@ -1334,6 +1446,34 @@ func TestGetConfigForURI_JSConfigOverridesJSON(t *testing.T) {
 	}
 	if cwd != "/project" {
 		t.Errorf("JS config cwd should be /project, got %q", cwd)
+	}
+}
+
+func TestGetConfigForURI_EmptyRootBoundaryProtectsJSONFallback(t *testing.T) {
+	s := newTestServer()
+	s.jsonConfig = config.RslintConfig{{
+		Rules: map[string]any{"no-debugger": "error"},
+	}}
+	s.jsConfigs["file:///project"] = config.RslintConfig{}
+	s.jsConfigs["file:///project/packages/app"] = config.RslintConfig{{
+		Rules: map[string]any{"no-console": "error"},
+	}}
+
+	rootCfg, rootCwd, rootIsJS := s.getConfigForURI("file:///project/src/index.ts")
+	if len(rootCfg) != 0 || rootCwd != "/project" || !rootIsJS {
+		t.Fatalf("root file must use empty JS boundary: cfg=%v cwd=%q isJS=%v", rootCfg, rootCwd, rootIsJS)
+	}
+
+	nestedCfg, nestedCwd, nestedIsJS := s.getConfigForURI("file:///project/packages/app/src/index.ts")
+	if len(nestedCfg) != 1 || nestedCfg[0].Rules["no-console"] != "error" ||
+		nestedCwd != "/project/packages/app" || !nestedIsJS {
+		t.Fatalf("nested file must use nested JS config: cfg=%v cwd=%q isJS=%v", nestedCfg, nestedCwd, nestedIsJS)
+	}
+
+	outsideCfg, outsideCwd, outsideIsJS := s.getConfigForURI("file:///other/src/index.ts")
+	if len(outsideCfg) != 1 || outsideCfg[0].Rules["no-debugger"] != "error" ||
+		outsideCwd != s.cwd || outsideIsJS {
+		t.Fatalf("file outside JS boundaries must retain JSON fallback: cfg=%v cwd=%q isJS=%v", outsideCfg, outsideCwd, outsideIsJS)
 	}
 }
 
@@ -1973,10 +2113,101 @@ func TestLSPActiveRulesForFile_RespectsFiles(t *testing.T) {
 	}
 }
 
-func TestLSPFilesystemPathID_UsesFilesystemCaseSensitivity(t *testing.T) {
+func TestLSPFilesystemPathID_UsesCanonicalFilesystemIdentity(t *testing.T) {
 	caseInsensitiveFS := &caseInsensitiveLSPTestFS{mockFS: mockFS{files: map[string]bool{}}}
 	if lspFilesystemPathID("C:/Repo/TSConfig.json", caseInsensitiveFS) != lspFilesystemPathID("c:/repo/tsconfig.json", caseInsensitiveFS) {
 		t.Fatal("case-insensitive filesystem path IDs must ignore casing")
+	}
+}
+
+type exactCaseLSPProgramFS struct {
+	vfs.FS
+	files map[string]string
+}
+
+func (fs *exactCaseLSPProgramFS) UseCaseSensitiveFileNames() bool { return false }
+func (fs *exactCaseLSPProgramFS) FileExists(filePath string) bool {
+	if _, ok := fs.files[tspath.NormalizePath(filePath)]; ok {
+		return true
+	}
+	return fs.FS.FileExists(filePath)
+}
+func (fs *exactCaseLSPProgramFS) ReadFile(filePath string) (string, bool) {
+	if content, ok := fs.files[tspath.NormalizePath(filePath)]; ok {
+		return content, true
+	}
+	return fs.FS.ReadFile(filePath)
+}
+func (fs *exactCaseLSPProgramFS) Realpath(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	if _, ok := fs.files[filePath]; ok {
+		return filePath
+	}
+	return fs.FS.Realpath(filePath)
+}
+
+func TestSourceFileForPath_RejectsCaseFoldedDifferentFile(t *testing.T) {
+	upper := "/repo/Source.ts"
+	lower := "/repo/source.ts"
+	fsys := &exactCaseLSPProgramFS{
+		FS: osvfs.FS(),
+		files: map[string]string{
+			upper: "export const upper = 1;\n",
+			lower: "export const lower = 2;\n",
+		},
+	}
+	program, err := utils.CreateProgramFromOptionsLenient(true, &core.CompilerOptions{
+		NoLib:     core.TSTrue,
+		NoResolve: core.TSTrue,
+	}, []string{upper}, utils.CreateCompilerHost("/repo", fsys))
+	if err != nil {
+		t.Fatalf("CreateProgramFromOptionsLenient: %v", err)
+	}
+	if source := program.GetSourceFile(lower); source == nil || source.FileName() != upper {
+		t.Fatalf("fixture must exercise case-folded Program lookup, got %v", source)
+	}
+	if source := sourceFileForPath(program, lower, fsys); source != nil {
+		t.Fatalf("case-distinct target bound to %q", source.FileName())
+	}
+}
+
+func TestSourceFileForPath_FindsProgramFileSymlinkFromRealTarget(t *testing.T) {
+	sharedDir := t.TempDir()
+	repoDir := t.TempDir()
+	realTarget := filepath.Join(sharedDir, "shared.ts")
+	linkedPath := filepath.Join(repoDir, "linked.ts")
+	if err := os.WriteFile(realTarget, []byte("export const value = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realTarget, linkedPath); err != nil {
+		t.Skipf("file symlink unavailable: %v", err)
+	}
+
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	linkedPath = tspath.NormalizePath(linkedPath)
+	realTarget = tspath.NormalizePath(realTarget)
+	program, err := utils.CreateProgramFromOptionsLenient(true, &core.CompilerOptions{
+		NoLib:     core.TSTrue,
+		NoResolve: core.TSTrue,
+	}, []string{linkedPath}, utils.CreateCompilerHost(repoDir, fsys))
+	if err != nil {
+		t.Fatalf("CreateProgramFromOptionsLenient: %v", err)
+	}
+	sourceName := ""
+	for _, sourceFile := range program.GetSourceFiles() {
+		if sourceFile.FileName() == linkedPath || sourceFile.FileName() == realTarget {
+			sourceName = sourceFile.FileName()
+			break
+		}
+	}
+	if sourceName == "" {
+		t.Fatal("Program does not contain the symlinked source")
+	}
+	if sourceName == realTarget {
+		t.Skip("compiler canonicalized the file symlink before Program lookup")
+	}
+	if source := sourceFileForPath(program, realTarget, fsys); source == nil || source.FileName() != sourceName {
+		t.Fatalf("real target did not bind to Program source %q: %v", sourceName, source)
 	}
 }
 
@@ -2030,13 +2261,14 @@ func TestSelectLintProgram_UsesDeclaredProjectOrderAndGapFallback(t *testing.T) 
 		}
 	}
 
+	sourceURI := toURI(sourcePath)
 	program, hasTypeInfo, err := selectLintProgram(
-		toURI(sourcePath),
+		sourceURI,
 		s.session,
 		ctx,
 		[]string{secondConfig, firstConfig},
 		fsys,
-		s.newStandaloneLintProgramLoader(),
+		s.newStandaloneLintProgramLoader(sourceURI),
 	)
 	if err != nil {
 		t.Fatalf("select typed program: %v", err)
@@ -2071,13 +2303,14 @@ func TestSelectLintProgram_UsesDeclaredProjectOrderAndGapFallback(t *testing.T) 
 		t.Fatalf("speculative fix polluted Session overlay: got %q", got)
 	}
 
+	gapURI := toURI(gapPath)
 	gapProgram, gapHasTypeInfo, err := selectLintProgram(
-		toURI(gapPath),
+		gapURI,
 		s.session,
 		ctx,
 		[]string{secondConfig, firstConfig},
 		fsys,
-		s.newStandaloneLintProgramLoader(),
+		s.newStandaloneLintProgramLoader(gapURI),
 	)
 	if err != nil {
 		t.Fatalf("select gap program: %v", err)
@@ -2118,8 +2351,157 @@ func TestRunConfiguredLintForContent_SyntaxErrorSkipsRules(t *testing.T) {
 	if !result.HasSyntaxErrors {
 		t.Fatal("malformed file was not marked as having syntax errors")
 	}
-	if len(result.Diagnostics) != 0 {
-		t.Fatalf("rules ran for malformed file: %+v", result.Diagnostics)
+	if len(result.Diagnostics) == 0 || !strings.HasPrefix(result.Diagnostics[0].RuleName, "TypeScript(TS") {
+		t.Fatalf("expected a TypeScript syntax diagnostic, got %+v", result.Diagnostics)
+	}
+	for _, diagnostic := range result.Diagnostics {
+		if diagnostic.RuleName == "no-debugger" {
+			t.Fatalf("rules ran for malformed file: %+v", result.Diagnostics)
+		}
+	}
+	s.diagnostics[uri] = result.Diagnostics
+	response, err := s.handleCodeAction(context.Background(), &lsproto.CodeActionParams{
+		TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},
+		Range: lsproto.Range{
+			Start: lsproto.Position{Line: 0, Character: 0},
+			End:   lsproto.Position{Line: 0, Character: uint32(len(malformed))},
+		},
+		Context: &lsproto.CodeActionContext{},
+	})
+	if err != nil {
+		t.Fatalf("get syntax diagnostic code actions: %v", err)
+	}
+	if actions := response.CommandOrCodeActionArray; actions == nil || len(*actions) != 0 {
+		t.Fatalf("syntax diagnostic offered an inapplicable rule action: %+v", actions)
+	}
+}
+
+func TestRunConfiguredLintForContent_ZeroRuleTargetsReportSyntaxErrors(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "malformed.js")
+	const malformed = "debugger; const value = ;\n"
+	if err := os.WriteFile(filePath, []byte(malformed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := newTestServer()
+	s.cwd = dir
+	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String())
+	s.documents[uri] = malformed
+
+	tests := []struct {
+		name   string
+		config config.RslintConfig
+	}{
+		{
+			name: "no matching config entry",
+			config: config.RslintConfig{{
+				Files: []string{"**/*.ts"},
+				Rules: config.Rules{"no-debugger": "error"},
+			}},
+		},
+		{name: "valid empty config", config: config.RslintConfig{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := s.runConfiguredLintForContent(
+				uri,
+				context.Background(),
+				malformed,
+				test.config,
+				dir,
+				false,
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("run lint: %v", err)
+			}
+			if !result.HasSyntaxErrors || len(result.Diagnostics) == 0 || !strings.HasPrefix(result.Diagnostics[0].RuleName, "TypeScript(TS") {
+				t.Fatalf("zero-rule target did not report its syntax error: %+v", result)
+			}
+			for _, diagnostic := range result.Diagnostics {
+				if diagnostic.RuleName == "no-debugger" {
+					t.Fatalf("a rule ran outside its files selector: %+v", result.Diagnostics)
+				}
+			}
+		})
+	}
+}
+
+type realpathAliasLSPTestFS struct {
+	vfs.FS
+	aliasRoot string
+	realRoot  string
+}
+
+func (fs *realpathAliasLSPTestFS) Realpath(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	aliasRoot := tspath.NormalizePath(fs.aliasRoot)
+	if filePath == aliasRoot {
+		return tspath.NormalizePath(fs.realRoot)
+	}
+	if strings.HasPrefix(filePath, aliasRoot+"/") {
+		return tspath.NormalizePath(fs.realRoot) + strings.TrimPrefix(filePath, aliasRoot)
+	}
+	return fs.FS.Realpath(filePath)
+}
+
+func TestRunConfiguredLintForContent_OverlaysLexicalAndRealpath(t *testing.T) {
+	root := t.TempDir()
+	realRoot := filepath.Join(root, "real-workspace")
+	aliasRoot := filepath.Join(root, "alias-workspace")
+	realFile := filepath.Join(realRoot, "src", "index.ts")
+	if err := os.MkdirAll(filepath.Dir(realFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(realFile, []byte("const diskValue = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tsConfigPath := filepath.Join(realRoot, "tsconfig.json")
+	if err := os.WriteFile(tsConfigPath, []byte(`{"compilerOptions":{"noLib":true},"files":["src/index.ts"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	config.RegisterAllRules()
+	s := newTestServer()
+	s.cwd = aliasRoot
+	s.fs = &realpathAliasLSPTestFS{
+		FS:        bundled.WrapFS(cachedvfs.From(osvfs.FS())),
+		aliasRoot: aliasRoot,
+		realRoot:  realRoot,
+	}
+	aliasFile := filepath.Join(aliasRoot, "src", "index.ts")
+	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(aliasFile)}).String())
+	realURI := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(realFile)}).String())
+	const openContent = "const editorValue = 2;\n"
+	s.documents[realURI] = "const competingAliasValue = 3;\n"
+	s.documents[uri] = openContent
+
+	editorOverlay := s.currentEditorOverlayFS(uri)
+	for _, filePath := range []string{aliasFile, realFile} {
+		if got, ok := editorOverlay.ReadFile(filePath); !ok || got != openContent {
+			t.Fatalf("editor overlay read %q = %q, %v; want open content", filePath, got, ok)
+		}
+	}
+
+	const fixedContent = "debugger;\n"
+	result, err := s.runConfiguredLintForContent(
+		uri,
+		context.Background(),
+		fixedContent,
+		config.RslintConfig{{
+			Files: []string{"src/**/*.ts"},
+			Rules: config.Rules{"no-debugger": "error"},
+		}},
+		aliasRoot,
+		false,
+		[]string{tsConfigPath},
+	)
+	if err != nil {
+		t.Fatalf("runConfiguredLintForContent failed: %v", err)
+	}
+	if len(result.Diagnostics) != 1 || result.Diagnostics[0].RuleName != "no-debugger" {
+		t.Fatalf("canonical program read stale disk content: %+v", result.Diagnostics)
 	}
 }
 
@@ -2169,11 +2551,217 @@ func TestRunConfiguredLintForContent_SymlinkedConfigRootKeepsRulePathSpace(t *te
 	}
 }
 
+func TestConfigTransaction_SymlinkedOwnerMatchesPhysicalFile(t *testing.T) {
+	parent := t.TempDir()
+	realRoot := filepath.Join(parent, "real-root")
+	aliasRoot := filepath.Join(parent, "alias-root")
+	realFile := filepath.Join(realRoot, "src", "index.ts")
+	if err := os.MkdirAll(filepath.Dir(realFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const source = "debugger;\n"
+	if err := os.WriteFile(realFile, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realRoot, aliasRoot); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	config.RegisterAllRules()
+	s := newTestServer()
+	s.cwd = realRoot
+	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	configURI := (&url.URL{Scheme: "file", Path: filepath.ToSlash(aliasRoot)}).String()
+	fileURI := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(realFile)}).String())
+	if err := s.handleConfigUpdate(context.Background(), map[string]any{
+		"generation": "symlink-generation",
+		"configs": []any{map[string]any{
+			"configDirectory": configURI,
+			"entries": []any{map[string]any{
+				"files": []any{"src/**/*.ts"},
+				"rules": map[string]any{"no-debugger": "error"},
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("handleConfigUpdate failed: %v", err)
+	}
+
+	cfg, configCwd, isJSConfig := s.getConfigForURI(fileURI)
+	if !isJSConfig || configCwd != aliasRoot {
+		t.Fatalf("physical file resolved to config cwd %q, JS=%v", configCwd, isJSConfig)
+	}
+	result, err := s.runConfiguredLintForContent(
+		fileURI,
+		context.Background(),
+		source,
+		cfg,
+		configCwd,
+		isJSConfig,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("runConfiguredLintForContent failed: %v", err)
+	}
+	if len(result.Diagnostics) != 1 || result.Diagnostics[0].RuleName != "no-debugger" {
+		t.Fatalf("physical file lost aliased files selector: %+v", result.Diagnostics)
+	}
+}
+
+func TestConfigTransaction_PrefersLexicalOwnerOverPhysicalConfig(t *testing.T) {
+	root := t.TempDir()
+	physicalDir := filepath.Join(root, "physical")
+	physicalSubdir := filepath.Join(physicalDir, "sub")
+	if err := os.MkdirAll(physicalSubdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const source = "console.log('value');\ndebugger;\n"
+	if err := os.WriteFile(filepath.Join(physicalSubdir, "index.ts"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasDir := filepath.Join(root, "link")
+	if err := os.Symlink(physicalSubdir, aliasDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	toURI := func(filePath string) string {
+		return (&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String()
+	}
+	config.RegisterAllRules()
+	s := newTestServer()
+	s.cwd = root
+	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	if err := s.handleConfigUpdate(context.Background(), map[string]any{
+		"generation": "lexical-owner-generation",
+		"configs": []any{
+			map[string]any{
+				"configDirectory": toURI(root),
+				"entries": []any{map[string]any{
+					"rules": map[string]any{"no-console": "error"},
+				}},
+			},
+			map[string]any{
+				"configDirectory": toURI(physicalDir),
+				"entries": []any{map[string]any{
+					"rules": map[string]any{"no-debugger": "error"},
+				}},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("handleConfigUpdate failed: %v", err)
+	}
+
+	fileURI := lsproto.DocumentUri(toURI(filepath.Join(aliasDir, "index.ts")))
+	cfg, configCwd, isJSConfig := s.getConfigForURI(fileURI)
+	if !isJSConfig || configCwd != root {
+		t.Fatalf("lexical file resolved to config cwd %q, JS=%v", configCwd, isJSConfig)
+	}
+	result, err := s.runConfiguredLintForContent(
+		fileURI,
+		context.Background(),
+		source,
+		cfg,
+		configCwd,
+		isJSConfig,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("runConfiguredLintForContent failed: %v", err)
+	}
+	ruleNames := make(map[string]struct{}, len(result.Diagnostics))
+	for _, diagnostic := range result.Diagnostics {
+		ruleNames[diagnostic.RuleName] = struct{}{}
+	}
+	if _, ok := ruleNames["no-console"]; !ok {
+		t.Fatalf("lexical owner rule missing: %+v", result.Diagnostics)
+	}
+	if _, ok := ruleNames["no-debugger"]; ok {
+		t.Fatalf("physical config replaced lexical owner: %+v", result.Diagnostics)
+	}
+}
+
+func TestComputeFixAllContent_DefaultExcludedFileIsUnchanged(t *testing.T) {
+	root := t.TempDir()
+	filePath := filepath.Join(root, ".git", "hooks", "check.ts")
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const source = "var value = 1;\n"
+	if err := os.WriteFile(filePath, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	config.RegisterAllRules()
+	s := newTestServer()
+	s.cwd = root
+	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String())
+	s.documents[uri] = source
+	got := s.computeFixAllContent(
+		context.Background(),
+		uri,
+		source,
+		config.RslintConfig{{Rules: config.Rules{"no-var": "error"}}},
+		root,
+		false,
+		nil,
+	)
+	if got != source {
+		t.Fatalf("fixAll modified a default-excluded file: %q", got)
+	}
+}
+
+func TestComputeFixAllContent_NoTsconfigKeepsNativeFixes(t *testing.T) {
+	root := t.TempDir()
+	configDir := filepath.Join(root, "template-nested")
+	filePath := filepath.Join(configDir, "orphan.ts")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const source = "export const orphan = (() => { var output = 1; return output; })();\n"
+	if err := os.WriteFile(filePath, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	config.RegisterAllRules()
+	s := newTestServer()
+	s.cwd = root
+	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String())
+	s.documents[uri] = source
+	cfg := config.RslintConfig{{
+		Files: []string{"**/*.ts"},
+		Rules: config.Rules{"no-var": "error"},
+	}}
+	result, err := s.runConfiguredLintForContent(uri, context.Background(), source, cfg, configDir, true, nil)
+	if err != nil {
+		t.Fatalf("lint without tsconfig: %v", err)
+	}
+	if len(result.Diagnostics) != 1 || result.Diagnostics[0].RuleName != "no-var" {
+		t.Fatalf("lint without tsconfig lost native diagnostics: %+v", result.Diagnostics)
+	}
+	got := s.computeFixAllContent(
+		context.Background(),
+		uri,
+		source,
+		cfg,
+		configDir,
+		true,
+		nil,
+	)
+	const want = "export const orphan = (() => { let output = 1; return output; })();\n"
+	if got != want {
+		t.Fatalf("fixAll without tsconfig = %q, want %q", got, want)
+	}
+}
+
 type caseInsensitiveLSPTestFS struct {
 	mockFS
 }
 
 func (f *caseInsensitiveLSPTestFS) UseCaseSensitiveFileNames() bool { return false }
+func (f *caseInsensitiveLSPTestFS) Realpath(filePath string) string {
+	return strings.ToLower(tspath.NormalizePath(filePath))
+}
 
 func TestLSPActiveRulesForFile_NoTsconfigFiltersTypeAwareNativeRules(t *testing.T) {
 	config.RegisterAllRules()
@@ -2263,44 +2851,26 @@ func TestRunLintWithSession_IgnoredFileShortCircuits(t *testing.T) {
 	})
 }
 
-func TestRunLintWithSession_FilesMissShortCircuits(t *testing.T) {
-	ctx := context.Background()
-	cwd := "/project"
-	cfg := config.RslintConfig{
-		{
-			Files: []string{"**/*.ts"},
-			Rules: config.Rules{"no-debugger": "error"},
-		},
+func TestRunLintWithSession_DefaultExcludedDirectoryShortCircuits(t *testing.T) {
+	cfg := config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}}
+	for _, uri := range []lsproto.DocumentUri{
+		"file:///project/node_modules/pkg/index.ts",
+		"file:///project/.git/hooks/pre-commit.ts",
+	} {
+		t.Run(string(uri), func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("default-excluded file reached the nil session: %v", recovered)
+				}
+			}()
+
+			diagnostics, err := runLintWithSession(uri, nil, context.Background(), cfg, "/project", false, nil, nil)
+			if err != nil {
+				t.Fatalf("runLintWithSession returned an error: %v", err)
+			}
+			if diagnostics == nil || len(diagnostics) != 0 {
+				t.Fatalf("default-excluded file diagnostics = %+v, want a non-nil empty slice", diagnostics)
+			}
+		})
 	}
-
-	missedURI := lsproto.DocumentUri("file:///project/src/outside.js")
-	matchedURI := lsproto.DocumentUri("file:///project/src/main.ts")
-
-	t.Run("files miss returns empty without touching session", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Fatalf("runLintWithSession panicked on files miss (early-return missing?): %v", r)
-			}
-		}()
-
-		diags, err := runLintWithSession(missedURI, nil, ctx, cfg, cwd, false, nil, nil)
-		if err != nil {
-			t.Fatalf("expected nil error, got %v", err)
-		}
-		if diags == nil {
-			t.Fatal("expected non-nil empty slice (LSP protocol expects [], not null)")
-		}
-		if len(diags) != 0 {
-			t.Errorf("expected 0 diagnostics for files miss, got %d: %+v", len(diags), diags)
-		}
-	})
-
-	t.Run("files match falls through to session (nil-session panic)", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Fatal("expected panic when matching file is given a nil session, got none")
-			}
-		}()
-		_, _ = runLintWithSession(matchedURI, nil, ctx, cfg, cwd, false, nil, nil)
-	})
 }

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -3,13 +3,23 @@ package lsp
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/config"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // newTestServer creates a minimal Server for handler unit tests.
@@ -1643,6 +1653,91 @@ func TestRebuildTsConfigPaths_NoConfig(t *testing.T) {
 
 // ======== runLintWithSession: ignored-file short-circuit ========
 
+func TestIsLintableScriptFile_UsesDefaultLintExtensions(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"a.js", true},
+		{"a.mjs", true},
+		{"a.cjs", true},
+		{"a.jsx", true},
+		{"a.ts", true},
+		{"a.mts", true},
+		{"a.cts", true},
+		{"a.tsx", true},
+		{"style.css", false},
+		{"data.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uri := lsproto.DocumentUri("file:///project/" + tt.name)
+			if got := isLintableScriptFile(uri); got != tt.want {
+				t.Fatalf("isLintableScriptFile(%q) = %v, want %v", uri, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLSPActiveRulesForFile_RespectsFiles(t *testing.T) {
+	config.RegisterAllRules()
+
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	tsFile := tspath.NormalizePath(filepath.Join(srcDir, "matched.ts"))
+	jsFile := tspath.NormalizePath(filepath.Join(srcDir, "outside.js"))
+	for _, file := range []string{tsFile, jsFile} {
+		if err := os.WriteFile(file, []byte("debugger;\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+	}
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := utils.CreateCompilerHost(dir, fs)
+	program, err := utils.CreateProgramFromOptionsLenient(true, &core.CompilerOptions{
+		Target:  core.ScriptTargetESNext,
+		Module:  core.ModuleKindESNext,
+		AllowJs: core.TSTrue,
+		CheckJs: core.TSTrue,
+	}, []string{tsFile, jsFile}, host)
+	if err != nil {
+		t.Fatalf("CreateProgramFromOptionsLenient: %v", err)
+	}
+
+	cfg := config.RslintConfig{
+		{
+			Files: []string{"**/*.ts"},
+			Rules: config.Rules{"no-debugger": "error"},
+		},
+	}
+	collect := func(file string) []rule.RuleDiagnostic {
+		t.Helper()
+		var diags []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program: program,
+			File:    file,
+			GetRulesForFile: func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
+				return lspActiveRulesForFile(cfg, sourceFile.FileName(), dir, false, true)
+			},
+			OnDiagnostic: func(d rule.RuleDiagnostic) {
+				diags = append(diags, d)
+			},
+		})
+		return diags
+	}
+
+	if got := collect(tsFile); len(got) != 1 {
+		t.Fatalf("matching TS file should run no-debugger once, got %d diagnostics: %+v", len(got), got)
+	}
+	if got := collect(jsFile); len(got) != 0 {
+		t.Fatalf("files-scope miss must not run LSP native rules, got %+v", got)
+	}
+}
+
 // runLintWithSession must early-return for files matching the config's
 // `ignores` patterns, WITHOUT touching the session. This test proves the
 // guard semantically (not just by coincidence of a no-op session):
@@ -1661,6 +1756,7 @@ func TestRunLintWithSession_IgnoredFileShortCircuits(t *testing.T) {
 	cfg := config.RslintConfig{
 		// Global ignores entry: hides everything under lib/.
 		{Ignores: []string{"lib/**"}},
+		{Rules: config.Rules{"no-debugger": "error"}},
 	}
 
 	ignoredURI := lsproto.DocumentUri("file:///project/lib/util.ts")
@@ -1697,5 +1793,47 @@ func TestRunLintWithSession_IgnoredFileShortCircuits(t *testing.T) {
 			}
 		}()
 		_, _ = runLintWithSession(normalURI, nil, ctx, cfg, cwd, false, nil, nil)
+	})
+}
+
+func TestRunLintWithSession_FilesMissShortCircuits(t *testing.T) {
+	ctx := context.Background()
+	cwd := "/project"
+	cfg := config.RslintConfig{
+		{
+			Files: []string{"**/*.ts"},
+			Rules: config.Rules{"no-debugger": "error"},
+		},
+	}
+
+	missedURI := lsproto.DocumentUri("file:///project/src/outside.js")
+	matchedURI := lsproto.DocumentUri("file:///project/src/main.ts")
+
+	t.Run("files miss returns empty without touching session", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("runLintWithSession panicked on files miss (early-return missing?): %v", r)
+			}
+		}()
+
+		diags, err := runLintWithSession(missedURI, nil, ctx, cfg, cwd, false, nil, nil)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if diags == nil {
+			t.Fatal("expected non-nil empty slice (LSP protocol expects [], not null)")
+		}
+		if len(diags) != 0 {
+			t.Errorf("expected 0 diagnostics for files miss, got %d: %+v", len(diags), diags)
+		}
+	})
+
+	t.Run("files match falls through to session (nil-session panic)", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected panic when matching file is given a nil session, got none")
+			}
+		}()
+		_, _ = runLintWithSession(matchedURI, nil, ctx, cfg, cwd, false, nil, nil)
 	})
 }

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -917,6 +918,33 @@ func TestHandleConfigUpdate_ReplacesOldConfigs(t *testing.T) {
 	}
 	if _, ok := s.jsConfigs["file:///new-project"]; !ok {
 		t.Error("new config should exist")
+	}
+}
+
+func TestHandleConfigUpdate_RejectsEmptyFilesArray(t *testing.T) {
+	s := newTestServer()
+	ctx := context.Background()
+	s.jsConfigs["file:///old-project"] = config.RslintConfig{{Rules: config.Rules{"no-console": "error"}}}
+
+	err := s.handleConfigUpdate(ctx, map[string]any{
+		"configs": []any{
+			map[string]any{
+				"configDirectory": "file:///new-project",
+				"entries":         []any{map[string]any{"files": []any{}, "rules": map[string]any{"no-debugger": "error"}}},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected handleConfigUpdate to reject empty files array")
+	}
+	if !strings.Contains(err.Error(), `key "files": expected value to be a non-empty array`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := s.jsConfigs["file:///old-project"]; !ok {
+		t.Fatal("old config should be preserved after invalid update")
+	}
+	if _, ok := s.jsConfigs["file:///new-project"]; ok {
+		t.Fatal("invalid new config should not be installed")
 	}
 }
 

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -757,14 +758,15 @@ func TestHandleDidChange_UsesDebounce(t *testing.T) {
 
 // ======== handleConfigUpdate tests ========
 
-func TestHandleConfigUpdate_ClearsConfigPath(t *testing.T) {
+func TestHandleConfigUpdate_PreservesJSONFallbackPath(t *testing.T) {
 	s := newTestServer()
 	ctx := context.Background()
 
 	// Simulate a previously loaded JSON config
 	s.rslintConfigPath = "/project/rslint.json"
 
-	// Send a JS config update — should clear the JSON config path
+	// A JS config takes priority for its subtree, but the JSON config remains the
+	// fallback for files outside every JS config directory.
 	err := s.handleConfigUpdate(ctx, map[string]any{
 		"configs": []any{
 			map[string]any{
@@ -782,8 +784,8 @@ func TestHandleConfigUpdate_ClearsConfigPath(t *testing.T) {
 		t.Fatalf("handleConfigUpdate failed: %v", err)
 	}
 
-	if s.rslintConfigPath != "" {
-		t.Errorf("rslintConfigPath should be cleared after JS config update, got %q", s.rslintConfigPath)
+	if s.rslintConfigPath != "/project/rslint.json" {
+		t.Errorf("rslintConfigPath should be preserved as the fallback, got %q", s.rslintConfigPath)
 	}
 
 	cfg, ok := s.jsConfigs["file:///project"]
@@ -836,6 +838,39 @@ func TestHandleConfigUpdate_MultipleConfigs(t *testing.T) {
 	fooCfg := s.jsConfigs["file:///project/packages/foo"]
 	if len(fooCfg) != 1 {
 		t.Errorf("foo config should have 1 entry, got %d", len(fooCfg))
+	}
+}
+
+func TestHandleConfigUpdate_CommitsGenerationAndInvalidatesPluginWork(t *testing.T) {
+	s := newTestServer()
+	uri := lsproto.DocumentUri("file:///project/src/index.ts")
+	s.documents[uri] = "const value = 1"
+	s.docGeneration[uri] = 7
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	s.inflightPluginDispatch[uri] = &pluginDispatchHandle{cancel: cancel}
+
+	err := s.handleConfigUpdate(context.Background(), map[string]any{
+		"generation": "config-8",
+		"configs": []any{
+			map[string]any{
+				"configDirectory": "file:///project",
+				"entries":         []any{map[string]any{"rules": map[string]any{"no-console": "error"}}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleConfigUpdate failed: %v", err)
+	}
+	if s.eslintPluginConfigGeneration != "config-8" {
+		t.Fatalf("generation = %q, want config-8", s.eslintPluginConfigGeneration)
+	}
+	if s.docGeneration[uri] != 8 {
+		t.Fatalf("document generation = %d, want 8", s.docGeneration[uri])
+	}
+	select {
+	case <-dispatchCtx.Done():
+	default:
+		t.Fatal("previous plugin dispatch was not canceled")
 	}
 }
 
@@ -999,11 +1034,11 @@ func TestHandleConfigUpdate_MalformedPayload(t *testing.T) {
 	}
 }
 
-func TestHandleConfigUpdate_MissingConfigDirectory(t *testing.T) {
+func TestHandleConfigUpdate_RejectsMissingConfigDirectory(t *testing.T) {
 	s := newTestServer()
 	ctx := context.Background()
+	s.jsConfigs["file:///old"] = config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}}
 
-	// Entry with empty configDirectory — should still be stored (keyed by "")
 	err := s.handleConfigUpdate(ctx, map[string]any{
 		"configs": []any{
 			map[string]any{
@@ -1013,13 +1048,30 @@ func TestHandleConfigUpdate_MissingConfigDirectory(t *testing.T) {
 			},
 		},
 	})
-	if err != nil {
-		t.Fatalf("handleConfigUpdate failed: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "empty configDirectory") {
+		t.Fatalf("expected empty configDirectory error, got %v", err)
 	}
+	if _, ok := s.jsConfigs["file:///old"]; !ok {
+		t.Fatal("invalid update replaced the previous config")
+	}
+}
 
-	// Empty key should exist
-	if _, ok := s.jsConfigs[""]; !ok {
-		t.Error("config with empty configDirectory should still be stored")
+func TestHandleConfigUpdate_RejectsDuplicateConfigDirectories(t *testing.T) {
+	s := newTestServer()
+	s.fs = &caseInsensitiveLSPTestFS{mockFS: mockFS{files: map[string]bool{}}}
+	s.jsConfigs["file:///old"] = config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}}
+
+	err := s.handleConfigUpdate(context.Background(), map[string]any{
+		"configs": []any{
+			map[string]any{"configDirectory": "file:///C:/Repo", "entries": []any{}},
+			map[string]any{"configDirectory": "file:///c:/repo", "entries": []any{}},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate directories") {
+		t.Fatalf("expected duplicate config directory error, got %v", err)
+	}
+	if _, ok := s.jsConfigs["file:///old"]; !ok {
+		t.Fatal("invalid update replaced the previous config")
 	}
 }
 
@@ -1076,8 +1128,8 @@ func TestJSConfigDeletedFallsBackToJSON(t *testing.T) {
 	if len(cfg) != 1 || cfg[0].Rules["no-console"] != "warn" {
 		t.Fatalf("expected JS config, got %v", cfg)
 	}
-	if s.rslintConfigPath != "" {
-		t.Fatalf("rslintConfigPath should be cleared, got %q", s.rslintConfigPath)
+	if s.rslintConfigPath != "/project/rslint.json" {
+		t.Fatalf("rslintConfigPath should remain available as fallback, got %q", s.rslintConfigPath)
 	}
 
 	// 3. All JS configs deleted — send explicitly empty configs array.
@@ -1096,7 +1148,132 @@ func TestJSConfigDeletedFallsBackToJSON(t *testing.T) {
 	}
 }
 
+func TestHandleConfigUpdate_EmptyConfigsReloadsJSONTsConfigPaths(t *testing.T) {
+	dir := t.TempDir()
+	tsConfigPath := filepath.Join(dir, "tsconfig.json")
+	if err := os.WriteFile(tsConfigPath, []byte(`{"include":["src"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	jsonConfigPath := filepath.Join(dir, "rslint.json")
+	jsonConfig := `[{"languageOptions":{"parserOptions":{"project":["./tsconfig.json"]}},"rules":{"no-debugger":"error"}}]`
+	if err := os.WriteFile(jsonConfigPath, []byte(jsonConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestServer()
+	s.fs = osvfs.FS()
+	s.cwd = dir
+	s.jsConfigs["file:///project"] = config.RslintConfig{{Rules: config.Rules{"no-console": "error"}}}
+
+	if err := s.handleConfigUpdate(context.Background(), map[string]any{"configs": []any{}}); err != nil {
+		t.Fatalf("handleConfigUpdate failed: %v", err)
+	}
+
+	if s.rslintConfigPath != jsonConfigPath {
+		t.Fatalf("expected JSON config path %q, got %q", jsonConfigPath, s.rslintConfigPath)
+	}
+	if len(s.jsonConfig) != 1 || s.jsonConfig[0].Rules["no-debugger"] != "error" {
+		t.Fatalf("expected reloaded JSON fallback, got %v", s.jsonConfig)
+	}
+	expectedTsConfig := tspath.NormalizePath(s.fs.Realpath(tsConfigPath))
+	if len(s.tsConfigPaths) != 1 || s.tsConfigPaths[0] != expectedTsConfig {
+		t.Fatalf("expected JSON tsconfig paths [%q], got %v", expectedTsConfig, s.tsConfigPaths)
+	}
+}
+
+func TestHandleConfigUpdate_InvalidTsConfigPreservesPreviousGeneration(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestServer()
+	s.fs = osvfs.FS()
+	s.cwd = dir
+	s.jsConfigs = map[string]config.RslintConfig{
+		"file:///old": {{Rules: config.Rules{"no-debugger": "error"}}},
+	}
+	s.eslintPluginConfigGeneration = "old-generation"
+	uri := lsproto.DocumentUri("file:///old/index.ts")
+	s.diagnostics[uri] = []rule.RuleDiagnostic{{RuleName: "no-debugger"}}
+
+	err := s.handleConfigUpdate(context.Background(), map[string]any{
+		"generation": "rejected-generation",
+		"configs": []any{map[string]any{
+			"configDirectory": lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(dir)}).String()),
+			"entries": []any{map[string]any{
+				"languageOptions": map[string]any{
+					"parserOptions": map[string]any{"project": []any{"./missing-tsconfig.json"}},
+				},
+			}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected a missing declared tsconfig to reject the config generation")
+	}
+	if s.eslintPluginConfigGeneration != "old-generation" {
+		t.Fatalf("generation changed after rejected update: %q", s.eslintPluginConfigGeneration)
+	}
+	if _, ok := s.jsConfigs["file:///old"]; !ok || len(s.jsConfigs) != 1 {
+		t.Fatalf("JS config state changed after rejected update: %+v", s.jsConfigs)
+	}
+	if len(s.diagnostics[uri]) != 1 {
+		t.Fatalf("diagnostic cache changed before config commit: %+v", s.diagnostics[uri])
+	}
+}
+
+func TestHandleConfigUpdate_CommitClearsOldDiagnostics(t *testing.T) {
+	s := newTestServer()
+	uri := lsproto.DocumentUri("file:///project/index.ts")
+	s.documents[uri] = "debugger;"
+	s.diagnostics[uri] = []rule.RuleDiagnostic{{RuleName: "old-rule"}}
+
+	err := s.handleConfigUpdate(context.Background(), map[string]any{
+		"generation": "new-generation",
+		"configs": []any{map[string]any{
+			"configDirectory": "file:///project",
+			"entries":         []any{map[string]any{"rules": map[string]any{"no-debugger": "error"}}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("handleConfigUpdate failed: %v", err)
+	}
+	if _, ok := s.diagnostics[uri]; ok {
+		t.Fatal("committed config generation retained diagnostics and quick fixes from the old generation")
+	}
+}
+
 // ======== getConfigForURI tests ========
+
+func TestNearestJSConfigKey_UsesFilesystemCaseSensitivity(t *testing.T) {
+	s := newTestServer()
+	s.fs = &caseInsensitiveLSPTestFS{mockFS: mockFS{files: map[string]bool{}}}
+	s.jsConfigs = map[string]config.RslintConfig{
+		"file:///C:/Repo":              {{Rules: config.Rules{"root": "error"}}},
+		"file:///C:/Repo/Packages/App": {{Rules: config.Rules{"nested": "error"}}},
+	}
+
+	key, ok := s.nearestJSConfigKey("file:///c:/repo/packages/app/src/index.ts")
+	if !ok || key != "file:///C:/Repo/Packages/App" {
+		t.Fatalf("nearest key = %q, %v; want nested config", key, ok)
+	}
+	cfg, _, isJS := s.getConfigForURI("file:///c:/repo/packages/app/src/index.ts")
+	if !isJS || cfg[0].Rules["nested"] != "error" {
+		t.Fatalf("getConfigForURI selected %v, isJS=%v", cfg, isJS)
+	}
+}
+
+func TestNearestJSConfigKey_HandlesUNCAndFilesystemRoot(t *testing.T) {
+	s := newTestServer()
+	s.fs = &caseInsensitiveLSPTestFS{mockFS: mockFS{files: map[string]bool{}}}
+	s.jsConfigs = map[string]config.RslintConfig{
+		"file:///":                       {{Rules: config.Rules{"root": "error"}}},
+		"file://Server/Share/Repository": {{Rules: config.Rules{"unc": "error"}}},
+	}
+
+	if key, ok := s.nearestJSConfigKey("file://server/share/repository/src/a.ts"); !ok || key != "file://Server/Share/Repository" {
+		t.Fatalf("UNC nearest key = %q, %v", key, ok)
+	}
+	if key, ok := s.nearestJSConfigKey("file:///outside.ts"); !ok || key != "file:///" {
+		t.Fatalf("filesystem-root nearest key = %q, %v", key, ok)
+	}
+}
 
 func TestGetConfigForURI_ClosestJSConfig(t *testing.T) {
 	s := newTestServer()
@@ -1379,7 +1556,8 @@ func TestUriToPath(t *testing.T) {
 		{"file:///Users/John%20Doe/my%20project/src/index.ts", "/Users/John Doe/my project/src/index.ts"},
 		// Edge cases
 		{"file:///", "/"},
-		{"file://host/share", "/share"}, // UNC: authority is host, path is /share
+		{"file://host/share", "//host/share"},
+		{"file://server/share/project/src/index.ts", "//server/share/project/src/index.ts"},
 		{"not-a-uri", "not-a-uri"},
 		{"", ""},
 	}
@@ -1596,12 +1774,12 @@ func TestRebuildTsConfigPaths_AllConfigsHaveProject(t *testing.T) {
 }
 
 // Regression test: a nested config without any resolvable tsconfig must not
-// cascade its "allow-all" fallback onto files under OTHER configs.
+// affect type-info decisions for files under other configs.
 // See https://github.com/web-infra-dev/rslint/issues/671 — the create-rstack
 // workspace ships a `template-rslint/` starter directory with its own
 // rslint.config.ts but no tsconfig.json, which used to flip the whole
-// workspace into allow-all and incorrectly run type-aware rules on files
-// under the root config.
+// workspace's type-aware rules without checking the governing config's
+// resolved tsconfigs.
 func TestTsConfigPathsForURI_NestedConfigWithoutTsconfigDoesNotLeak(t *testing.T) {
 	s := newTestServer()
 	s.fs = &mockFS{files: map[string]bool{"/project/tsconfig.json": true}}
@@ -1631,11 +1809,68 @@ func TestTsConfigPathsForURI_NestedConfigWithoutTsconfigDoesNotLeak(t *testing.T
 		t.Errorf("expected root-config file to see [/project/tsconfig.json], got %v", rootPaths)
 	}
 
-	// File under nested template config → nil (allow-all) but scoped to this
+	// File under nested template config -> nil (no type info), scoped to this
 	// config only; the root config's list above must remain unaffected.
 	nestedPaths := s.tsConfigPathsForURI("file:///project/template-rslint/foo.ts")
 	if nestedPaths != nil {
-		t.Errorf("expected nested-config file to see nil tsconfig paths (allow-all), got %v", nestedPaths)
+		t.Errorf("expected nested-config file to see nil tsconfig paths (no type info), got %v", nestedPaths)
+	}
+}
+
+func TestTsConfigPathsForURI_JSONFallbackRemainsTypedWithNestedJSConfig(t *testing.T) {
+	s := newTestServer()
+	s.cwd = "/workspace"
+	s.rslintConfigPath = "/workspace/rslint.json"
+	s.fs = &mockFS{files: map[string]bool{
+		"/workspace/tsconfig.json":              true,
+		"/workspace/packages/app/tsconfig.json": true,
+	}}
+	s.jsonConfig = config.RslintConfig{{
+		LanguageOptions: &config.LanguageOptions{
+			ParserOptions: &config.ParserOptions{Project: []string{"./tsconfig.json"}},
+		},
+	}}
+	s.jsConfigs = map[string]config.RslintConfig{
+		"file:///workspace/packages/app": {{
+			LanguageOptions: &config.LanguageOptions{
+				ParserOptions: &config.ParserOptions{Project: []string{"./tsconfig.json"}},
+			},
+		}},
+	}
+
+	s.rebuildTsConfigPaths()
+
+	jsonPaths := s.tsConfigPathsForURI("file:///workspace/packages/lib/src/index.ts")
+	if len(jsonPaths) != 1 || jsonPaths[0] != "/workspace/tsconfig.json" {
+		t.Fatalf("expected JSON fallback tsconfig, got %v", jsonPaths)
+	}
+	jsPaths := s.tsConfigPathsForURI("file:///workspace/packages/app/src/index.ts")
+	if len(jsPaths) != 1 || jsPaths[0] != "/workspace/packages/app/tsconfig.json" {
+		t.Fatalf("expected nested JS config tsconfig, got %v", jsPaths)
+	}
+}
+
+func TestReloadJSONFallbackWhileJSConfigIsActive(t *testing.T) {
+	dir := t.TempDir()
+	jsonConfigPath := filepath.Join(dir, "rslint.json")
+	if err := os.WriteFile(jsonConfigPath, []byte(`[{"rules":{"no-debugger":"error"}}]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestServer()
+	s.cwd = dir
+	s.fs = osvfs.FS()
+	s.jsConfigs = map[string]config.RslintConfig{
+		"file:///other": {{Rules: config.Rules{"no-console": "error"}}},
+	}
+	s.reloadConfigAndRelint()
+
+	if s.rslintConfigPath != jsonConfigPath {
+		t.Fatalf("expected JSON fallback path %q, got %q", jsonConfigPath, s.rslintConfigPath)
+	}
+	cfg, _, isJS := s.getConfigForURI("file:///workspace/src/index.ts")
+	if isJS || len(cfg) != 1 || cfg[0].Rules["no-debugger"] != "error" {
+		t.Fatalf("expected refreshed JSON fallback while JS config remains active, got isJS=%v config=%v", isJS, cfg)
 	}
 }
 
@@ -1735,6 +1970,238 @@ func TestLSPActiveRulesForFile_RespectsFiles(t *testing.T) {
 	}
 	if got := collect(jsFile); len(got) != 0 {
 		t.Fatalf("files-scope miss must not run LSP native rules, got %+v", got)
+	}
+}
+
+func TestLSPFilesystemPathID_UsesFilesystemCaseSensitivity(t *testing.T) {
+	caseInsensitiveFS := &caseInsensitiveLSPTestFS{mockFS: mockFS{files: map[string]bool{}}}
+	if lspFilesystemPathID("C:/Repo/TSConfig.json", caseInsensitiveFS) != lspFilesystemPathID("c:/repo/tsconfig.json", caseInsensitiveFS) {
+		t.Fatal("case-insensitive filesystem path IDs must ignore casing")
+	}
+}
+
+func TestSelectLintProgram_UsesDeclaredProjectOrderAndGapFallback(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "src", "index.ts")
+	gapPath := filepath.Join(dir, "gap.ts")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range []string{sourcePath, gapPath} {
+		if err := os.WriteFile(file, []byte("export const value = 1;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	firstConfig := filepath.Join(dir, "tsconfig.lint-first.json")
+	secondConfig := filepath.Join(dir, "tsconfig.lint-second.json")
+	for _, configPath := range []string{firstConfig, secondConfig} {
+		if err := os.WriteFile(configPath, []byte(`{"files":["src/index.ts"]}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ctx := context.Background()
+	fsys := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	s := NewServer(&ServerOptions{
+		Cwd:                dir,
+		FS:                 fsys,
+		DefaultLibraryPath: bundled.LibPath(),
+	})
+	s.backgroundCtx = ctx
+	s.initializeParams = &lsproto.InitializeParams{}
+	if err := s.handleInitialized(ctx, &lsproto.InitializedParams{}); err != nil {
+		t.Fatalf("initialize test session: %v", err)
+	}
+	defer s.session.Close()
+
+	toURI := func(filePath string) lsproto.DocumentUri {
+		return lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String())
+	}
+	for _, file := range []string{sourcePath, gapPath} {
+		uri := toURI(file)
+		if err := s.handleDidOpen(ctx, &lsproto.DidOpenTextDocumentParams{
+			TextDocument: &lsproto.TextDocumentItem{
+				Uri:     uri,
+				Version: 1,
+				Text:    "export const value = 1;\n",
+			},
+		}); err != nil {
+			t.Fatalf("open %s: %v", file, err)
+		}
+	}
+
+	program, hasTypeInfo, err := selectLintProgram(
+		toURI(sourcePath),
+		s.session,
+		ctx,
+		[]string{secondConfig, firstConfig},
+		fsys,
+		s.newStandaloneLintProgramLoader(),
+	)
+	if err != nil {
+		t.Fatalf("select typed program: %v", err)
+	}
+	if !hasTypeInfo {
+		t.Fatal("expected source to have type information")
+	}
+	if got := lspFilesystemPathID(program.Options().ConfigFilePath, fsys); got != lspFilesystemPathID(secondConfig, fsys) {
+		t.Fatalf("expected first declared containing project %q, got %q", secondConfig, program.Options().ConfigFilePath)
+	}
+	secondConfigID := tspath.ToPath(fsys.Realpath(secondConfig), "", fsys.UseCaseSensitiveFileNames())
+	if opened := s.session.Snapshot().ProjectCollection.ConfiguredProject(secondConfigID); opened != nil {
+		t.Fatal("lint-only custom tsconfig must not be added to the Session's permanent API-open project set")
+	}
+	if _, err := s.defaultFixAllNativeLint(
+		ctx,
+		toURI(sourcePath),
+		1,
+		"export const value = 2;\n",
+		config.RslintConfig{{}},
+		dir,
+		false,
+		[]string{secondConfig},
+	); err != nil {
+		t.Fatalf("isolated fix pass: %v", err)
+	}
+	languageService, err := s.session.GetLanguageService(ctx, toURI(sourcePath))
+	if err != nil {
+		t.Fatalf("get language service after speculative fix: %v", err)
+	}
+	if got := languageService.GetProgram().GetSourceFile(tspath.NormalizePath(sourcePath)).Text(); got != "export const value = 1;\n" {
+		t.Fatalf("speculative fix polluted Session overlay: got %q", got)
+	}
+
+	gapProgram, gapHasTypeInfo, err := selectLintProgram(
+		toURI(gapPath),
+		s.session,
+		ctx,
+		[]string{secondConfig, firstConfig},
+		fsys,
+		s.newStandaloneLintProgramLoader(),
+	)
+	if err != nil {
+		t.Fatalf("select gap program: %v", err)
+	}
+	if gapHasTypeInfo {
+		t.Fatal("file outside every declared project must not have type information")
+	}
+	if gapProgram.GetSourceFile(tspath.NormalizePath(gapPath)) == nil {
+		t.Fatal("gap fallback program must contain the open file")
+	}
+}
+
+func TestRunConfiguredLintForContent_SyntaxErrorSkipsRules(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "malformed.ts")
+	const malformed = "debugger; const value = ;\n"
+	if err := os.WriteFile(filePath, []byte(malformed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := newTestServer()
+	s.cwd = dir
+	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(filePath)}).String())
+	s.documents[uri] = malformed
+
+	result, err := s.runConfiguredLintForContent(
+		uri,
+		context.Background(),
+		malformed,
+		config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}},
+		dir,
+		false,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("run lint: %v", err)
+	}
+	if !result.HasSyntaxErrors {
+		t.Fatal("malformed file was not marked as having syntax errors")
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("rules ran for malformed file: %+v", result.Diagnostics)
+	}
+}
+
+func TestRunConfiguredLintForContent_SymlinkedConfigRootKeepsRulePathSpace(t *testing.T) {
+	parent := t.TempDir()
+	realRoot := filepath.Join(parent, "real-root")
+	aliasRoot := filepath.Join(parent, "alias-root")
+	realFile := filepath.Join(realRoot, "src", "index.ts")
+	if err := os.MkdirAll(filepath.Dir(realFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const source = "debugger;\n"
+	if err := os.WriteFile(realFile, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realRoot, "tsconfig.json"), []byte(`{"include":["src"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realRoot, aliasRoot); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	config.RegisterAllRules()
+	s := newTestServer()
+	s.cwd = aliasRoot
+	s.fs = bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	aliasFile := filepath.Join(aliasRoot, "src", "index.ts")
+	uri := lsproto.DocumentUri((&url.URL{Scheme: "file", Path: filepath.ToSlash(aliasFile)}).String())
+	s.documents[uri] = source
+	result, err := s.runConfiguredLintForContent(
+		uri,
+		context.Background(),
+		source,
+		config.RslintConfig{{
+			Files: []string{"src/**/*.ts"},
+			Rules: config.Rules{"no-debugger": "error"},
+		}},
+		aliasRoot,
+		false,
+		[]string{filepath.Join(aliasRoot, "tsconfig.json")},
+	)
+	if err != nil {
+		t.Fatalf("run lint through symlinked root: %v", err)
+	}
+	if len(result.Diagnostics) != 1 || result.Diagnostics[0].RuleName != "no-debugger" {
+		t.Fatalf("symlinked config path lost scoped rules: %+v", result.Diagnostics)
+	}
+}
+
+type caseInsensitiveLSPTestFS struct {
+	mockFS
+}
+
+func (f *caseInsensitiveLSPTestFS) UseCaseSensitiveFileNames() bool { return false }
+
+func TestLSPActiveRulesForFile_NoTsconfigFiltersTypeAwareNativeRules(t *testing.T) {
+	config.RegisterAllRules()
+	cfg := config.RslintConfig{{
+		Rules: config.Rules{
+			"no-debugger": "error",
+			"@typescript-eslint/no-unsafe-member-access": "error",
+		},
+		Plugins: []string{"@typescript-eslint"},
+	}}
+
+	withoutTypeInfo := lspActiveRulesForFile(cfg, "/project/index.ts", "/project", true, false)
+	if len(withoutTypeInfo) != 1 || withoutTypeInfo[0].Name != "no-debugger" {
+		t.Fatalf("expected only non-type-aware native rule without tsconfig, got %+v", withoutTypeInfo)
+	}
+
+	withTypeInfo := lspActiveRulesForFile(cfg, "/project/index.ts", "/project", true, true)
+	if len(withTypeInfo) != 2 {
+		t.Fatalf("expected both native rules with type info, got %+v", withTypeInfo)
+	}
+	foundTypeAware := false
+	for _, configuredRule := range withTypeInfo {
+		if configuredRule.Name == "@typescript-eslint/no-unsafe-member-access" && configuredRule.RequiresTypeInfo {
+			foundTypeAware = true
+		}
+	}
+	if !foundTypeAware {
+		t.Fatalf("expected configured type-aware rule, got %+v", withTypeInfo)
 	}
 }
 

--- a/internal/plugins/import/utils/export_map.go
+++ b/internal/plugins/import/utils/export_map.go
@@ -122,7 +122,7 @@ type exportKey struct {
 }
 
 func hasExport(ctx rule.RuleContext, origin *ast.SourceFile, moduleSpecifier *ast.Node, exportName string, seen map[exportKey]bool) (bool, bool) {
-	_, sourceFile, ok := ResolveSourceFileFromSourceFile(ctx, origin, moduleSpecifier)
+	_, sourceFile, ok := ResolveModuleReferenceFromSourceFile(ctx, origin, moduleSpecifier)
 	if !ok {
 		return false, false
 	}
@@ -138,7 +138,7 @@ func getExportMap(ctx rule.RuleContext, origin *ast.SourceFile, moduleSpecifier 
 		return nil, false
 	}
 
-	_, sourceFile, ok := ResolveSourceFileFromSourceFile(ctx, origin, moduleSpecifier)
+	_, sourceFile, ok := ResolveModuleReferenceFromSourceFile(ctx, origin, moduleSpecifier)
 	if !ok {
 		return nil, false
 	}

--- a/internal/utils/create_program.go
+++ b/internal/utils/create_program.go
@@ -43,6 +43,21 @@ func CreateProgram(singleThreaded bool, fs vfs.FS, cwd string, tsconfigPath stri
 	return createProgramFromConfig(singleThreaded, configParseResult, host)
 }
 
+// CreateProgramLenient creates a tsconfig-backed Program but tolerates
+// syntactic errors. CLI/API plain lint uses this so the final lint target set
+// decides which syntax diagnostics are user-visible; type-check modes still
+// report diagnostics from the tsconfig-backed Program boundary.
+func CreateProgramLenient(singleThreaded bool, fs vfs.FS, cwd string, tsconfigPath string, host compiler.CompilerHost) (*compiler.Program, error) {
+	resolvedConfigPath := tspath.ResolvePath(cwd, tsconfigPath)
+	if !fs.FileExists(resolvedConfigPath) {
+		return nil, fmt.Errorf("couldn't read tsconfig at %v", resolvedConfigPath)
+	}
+
+	configParseResult, _ := tsoptions.GetParsedCommandLineOfConfigFile(tsconfigPath, &core.CompilerOptions{}, nil, host, nil)
+
+	return createProgramFromConfigLenient(singleThreaded, configParseResult, host)
+}
+
 // CreateProgramFromOptions creates a program from in-memory compiler options and root file names,
 // without requiring a tsconfig file on disk.
 func CreateProgramFromOptions(singleThreaded bool, compilerOptions *core.CompilerOptions, rootFileNames []string, host compiler.CompilerHost) (*compiler.Program, error) {
@@ -63,8 +78,12 @@ func CreateProgramFromOptionsLenient(singleThreaded bool, compilerOptions *core.
 		CurrentDirectory:          host.GetCurrentDirectory(),
 	})
 
+	return createProgramFromConfigLenient(singleThreaded, configParseResult, host)
+}
+
+func createProgramFromConfigLenient(singleThreaded bool, config *tsoptions.ParsedCommandLine, host compiler.CompilerHost) (*compiler.Program, error) {
 	opts := compiler.ProgramOptions{
-		Config:         configParseResult,
+		Config:         config,
 		SingleThreaded: core.TSTrue,
 		Host:           host,
 	}

--- a/internal/utils/overlay_vfs.go
+++ b/internal/utils/overlay_vfs.go
@@ -26,14 +26,14 @@ func (vfs *OverlayVFS) UseCaseSensitiveFileNames() bool {
 }
 
 func (vfs *OverlayVFS) FileExists(path string) bool {
-	if _, ok := vfs.VirtualFiles[path]; ok {
-		return ok
+	if _, ok := vfs.virtualFile(path); ok {
+		return true
 	}
 	return vfs.fs.FileExists(path)
 }
 
 func (vfs *OverlayVFS) ReadFile(path string) (contents string, ok bool) {
-	if src, ok := vfs.VirtualFiles[path]; ok {
+	if src, ok := vfs.virtualFile(path); ok {
 		return src, ok
 	}
 	return vfs.fs.ReadFile(path)
@@ -121,7 +121,7 @@ func (fi *overlayVFSFileInfo) Type() fs.FileMode {
 }
 
 func (vfs *OverlayVFS) Stat(path string) vfs.FileInfo {
-	if src, ok := vfs.VirtualFiles[path]; ok {
+	if src, ok := vfs.virtualFile(path); ok {
 		return &overlayVFSFileInfo{
 			name: path,
 			size: int64(len(src)),
@@ -137,30 +137,45 @@ func (vfs *OverlayVFS) WalkDir(root string, walkFn vfs.WalkDirFunc) error {
 
 func (vfs *OverlayVFS) Realpath(path string) string {
 	if _, ok := vfs.VirtualFiles[path]; ok {
+		if realPath := vfs.fs.Realpath(path); realPath != "" {
+			return realPath
+		}
 		return path
 	}
 	return vfs.fs.Realpath(path)
 }
 
 func (vfs *OverlayVFS) WriteFile(path string, data string) error {
-	if _, ok := vfs.VirtualFiles[path]; ok {
+	if _, ok := vfs.virtualFile(path); ok {
 		panic("not implemented: cannot write to overlay file system")
 	}
 	return vfs.fs.WriteFile(path, data)
 }
 
 func (vfs *OverlayVFS) AppendFile(path string, data string) error {
-	if _, ok := vfs.VirtualFiles[path]; ok {
+	if _, ok := vfs.virtualFile(path); ok {
 		panic("not implemented: cannot append to overlay file system")
 	}
 	return vfs.fs.AppendFile(path, data)
 }
 
 func (vfs *OverlayVFS) Remove(path string) error {
-	if _, ok := vfs.VirtualFiles[path]; ok {
+	if _, ok := vfs.virtualFile(path); ok {
 		panic("not implemented: cannot remove from overlay file system")
 	}
 	return vfs.fs.Remove(path)
+}
+
+func (vfs *OverlayVFS) virtualFile(path string) (string, bool) {
+	if src, ok := vfs.VirtualFiles[path]; ok {
+		return src, true
+	}
+	realPath := vfs.fs.Realpath(path)
+	if realPath == "" || realPath == path {
+		return "", false
+	}
+	src, ok := vfs.VirtualFiles[realPath]
+	return src, ok
 }
 
 func NewOverlayVFS(baseFS vfs.FS, virtualFiles map[string]string) vfs.FS {

--- a/internal/utils/program_source_lookup.go
+++ b/internal/utils/program_source_lookup.go
@@ -1,0 +1,109 @@
+package utils
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
+)
+
+// ProgramSourceLookup resolves a filesystem target to the exact source file in
+// one Program. Its canonical source index is built lazily and lives only for
+// the lookup's owning lint operation.
+type ProgramSourceLookup struct {
+	program             *compiler.Program
+	fs                  vfs.FS
+	canonicalIndexBuilt bool
+	canonicalSources    map[string]*ast.SourceFile
+}
+
+// NewProgramSourceLookup creates an exact source lookup for one Program.
+func NewProgramSourceLookup(program *compiler.Program, fs vfs.FS) *ProgramSourceLookup {
+	return &ProgramSourceLookup{program: program, fs: fs}
+}
+
+func exactProgramSourcePathID(filePath string) string {
+	return string(tspath.ToPath(tspath.NormalizePath(filePath), "", true))
+}
+
+func (lookup *ProgramSourceLookup) canonicalPathID(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	if lookup.fs != nil {
+		if realPath := lookup.fs.Realpath(filePath); realPath != "" {
+			filePath = tspath.NormalizePath(realPath)
+		}
+	}
+	return exactProgramSourcePathID(filePath)
+}
+
+// SourceFileForCandidate validates a Program lookup against the target's exact
+// canonical identity. This rejects a case-folded lookup that returned a
+// different physical file.
+func (lookup *ProgramSourceLookup) SourceFileForCandidate(candidate string, canonicalTarget string) *ast.SourceFile {
+	if lookup == nil || lookup.program == nil || candidate == "" {
+		return nil
+	}
+	candidate = tspath.NormalizePath(candidate)
+	sourceFile := lookup.program.GetSourceFile(candidate)
+	if sourceFile == nil {
+		return nil
+	}
+	if exactProgramSourcePathID(sourceFile.FileName()) == exactProgramSourcePathID(candidate) {
+		return sourceFile
+	}
+	if canonicalTarget == "" {
+		return nil
+	}
+	if lookup.canonicalPathID(sourceFile.FileName()) == lookup.canonicalPathID(canonicalTarget) {
+		return sourceFile
+	}
+	return nil
+}
+
+// CanonicalSourceFile finds a Program source by physical filesystem identity.
+// The index is created only after direct candidate lookups miss.
+func (lookup *ProgramSourceLookup) CanonicalSourceFile(canonicalPath string) *ast.SourceFile {
+	if lookup == nil || lookup.program == nil || lookup.fs == nil || canonicalPath == "" {
+		return nil
+	}
+	if !lookup.canonicalIndexBuilt {
+		lookup.canonicalIndexBuilt = true
+		lookup.canonicalSources = make(map[string]*ast.SourceFile)
+		for _, sourceFile := range lookup.program.GetSourceFiles() {
+			canonicalID := lookup.canonicalPathID(sourceFile.FileName())
+			existing := lookup.canonicalSources[canonicalID]
+			if existing == nil || sourceFile.FileName() < existing.FileName() {
+				lookup.canonicalSources[canonicalID] = sourceFile
+			}
+		}
+	}
+	return lookup.canonicalSources[lookup.canonicalPathID(canonicalPath)]
+}
+
+// SourceFileForPath resolves a lexical filesystem path through exact and
+// canonical Program source identities.
+func (lookup *ProgramSourceLookup) SourceFileForPath(filePath string) *ast.SourceFile {
+	if lookup == nil || lookup.program == nil || filePath == "" {
+		return nil
+	}
+	filePath = tspath.NormalizePath(filePath)
+	if sourceFile := lookup.SourceFileForCandidate(filePath, ""); sourceFile != nil {
+		return sourceFile
+	}
+
+	canonicalPath := filePath
+	if lookup.fs != nil {
+		if realPath := lookup.fs.Realpath(filePath); realPath != "" {
+			canonicalPath = tspath.NormalizePath(realPath)
+		}
+	}
+	if sourceFile := lookup.SourceFileForCandidate(filePath, canonicalPath); sourceFile != nil {
+		return sourceFile
+	}
+	if exactProgramSourcePathID(canonicalPath) != exactProgramSourcePathID(filePath) {
+		if sourceFile := lookup.SourceFileForCandidate(canonicalPath, canonicalPath); sourceFile != nil {
+			return sourceFile
+		}
+	}
+	return lookup.CanonicalSourceFile(canonicalPath)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -383,7 +383,7 @@ var ExcludePaths = []string{"/node_modules/", "bundled:"}
 
 // DefaultExcludeDirNames contains directory names that are always excluded
 // from file scanning. This is the single source of truth for default directory
-// exclusions, used by DiscoverGapFiles and the no-tsconfig fallback.
+// exclusions used by lint target discovery and fallback Program roots.
 // Aligned with JS-side SCAN_EXCLUDE_DIRS: new Set(['node_modules', '.git']).
 var DefaultExcludeDirNames = []string{"node_modules", ".git"}
 

--- a/packages/rslint-test-tools/tests/cli/file-args.test.ts
+++ b/packages/rslint-test-tools/tests/cli/file-args.test.ts
@@ -312,10 +312,11 @@ describe('CLI File Arguments', () => {
     });
 
     try {
-      // No file args — should lint all files
+      // The default .mjs baseline includes the config file itself, matching
+      // ESLint v10's no-argument directory scan.
       const result = await runRslint([], tempDir);
       expect(result.exitCode).not.toBe(0);
-      expect(result.stdout).toContain('linted 2 files');
+      expect(result.stdout).toContain('linted 3 files');
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint-test-tools/tests/cli/file-args.test.ts
+++ b/packages/rslint-test-tools/tests/cli/file-args.test.ts
@@ -224,7 +224,7 @@ describe('CLI File Arguments', () => {
     }
   });
 
-  test('should warn per-file when specified file is not in the project', async () => {
+  test('should warn per-file when specified file is missing', async () => {
     const tempDir = await createTempDir({
       'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
@@ -236,13 +236,13 @@ describe('CLI File Arguments', () => {
       // Should warn about the file not found and exit with 0
       expect(result.exitCode).toBe(0);
       expect(result.stderr).toContain('nonexistent.ts');
-      expect(result.stderr).toContain('not found in the project');
+      expect(result.stderr).toContain('was not found');
     } finally {
       await cleanupTempDir(tempDir);
     }
   });
 
-  test('should warn per-file when multiple specified files are all not in the project', async () => {
+  test('should warn per-file when multiple specified files are missing', async () => {
     const tempDir = await createTempDir({
       'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
@@ -263,7 +263,7 @@ describe('CLI File Arguments', () => {
     }
   });
 
-  test('should warn for non-project file while linting project files', async () => {
+  test('should warn for missing file while linting existing files', async () => {
     const tempDir = await createTempDir({
       'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
@@ -274,15 +274,15 @@ describe('CLI File Arguments', () => {
       const result = await runRslint(['clean.ts', 'nonexistent.ts'], tempDir);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('linted 1 file');
-      // Should still warn about the non-project file
+      // Should still warn about the missing file
       expect(result.stderr).toContain('nonexistent.ts');
-      expect(result.stderr).toContain('not found in the project');
+      expect(result.stderr).toContain('was not found');
     } finally {
       await cleanupTempDir(tempDir);
     }
   });
 
-  test('should exit 0 with --max-warnings 0 when files are not in project', async () => {
+  test('should exit 0 with --max-warnings 0 when files are missing', async () => {
     const tempDir = await createTempDir({
       'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
@@ -297,7 +297,7 @@ describe('CLI File Arguments', () => {
       // Warning goes to stderr, not counted as lint warning, so exit 0
       expect(result.exitCode).toBe(0);
       expect(result.stderr).toContain('nonexistent.ts');
-      expect(result.stderr).toContain('not found in the project');
+      expect(result.stderr).toContain('was not found');
     } finally {
       await cleanupTempDir(tempDir);
     }
@@ -432,7 +432,7 @@ describe('CLI File Arguments', () => {
       expect(result.stdout).toContain('linted 1 file');
       // Should warn about the nonexistent file
       expect(result.stderr).toContain('nonexistent.ts');
-      expect(result.stderr).toContain('not found in the project');
+      expect(result.stderr).toContain('was not found');
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
@@ -1,4 +1,6 @@
 import { describe, test, expect } from '@rstest/core';
+import fs from 'node:fs';
+import path from 'node:path';
 import {
   runRslint,
   createTempDir,
@@ -231,6 +233,428 @@ describe('CLI config discovery (upward traversal)', () => {
       // Should still lint root.ts with root config, skipping broken package
       expect(result.stdout).toContain('root.ts');
       expect(result.stderr).toContain('Warning: skipping config');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('explicit file falls back from a broken nearest config to its ancestor', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.js': `export default [{
+        files: ['**/*.ts'],
+        rules: { 'no-debugger': 'error' },
+      }];`,
+      'packages/broken/rslint.config.js':
+        'export default [INVALID CHILD CONFIG;',
+      'packages/broken/index.ts': 'debugger;\n',
+    });
+    try {
+      const result = await runRslint(
+        ['--format', 'jsonline', 'packages/broken/index.ts'],
+        tempDir,
+      );
+      expect(result.stdout).toContain('no-debugger');
+      expect(result.stderr).toContain('Warning: skipping config');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('explicit file symlink keeps lexical config ownership', async () => {
+    const tempDir = await createTempDir({
+      'physical/rslint.config.js': `export default [{
+        files: ['**/*.ts'],
+        rules: { 'no-debugger': 'error' },
+      }];`,
+      'physical/index.ts': 'console.log("value");\ndebugger;\n',
+      'lexical/rslint.config.js': `export default [{
+        files: ['**/*.ts'],
+        rules: { 'no-console': 'error' },
+      }];`,
+    });
+    try {
+      const lexicalFile = path.join(tempDir, 'lexical/index.ts');
+      try {
+        fs.symlinkSync(path.join(tempDir, 'physical/index.ts'), lexicalFile);
+      } catch {
+        return;
+      }
+
+      const result = await runRslint(
+        ['--format', 'jsonline', 'lexical/index.ts'],
+        tempDir,
+      );
+      expect(result.stdout).toContain('no-console');
+      expect(result.stdout).not.toContain('no-debugger');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('file selector matching is independent from symlink target Program membership', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [{
+        files: ['link.ts'],
+        languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
+        rules: { 'no-console': 'error' },
+      }];`,
+      'tsconfig.json': JSON.stringify({ files: ['physical/index.ts'] }),
+      'physical/index.ts': 'console.log("value");\n',
+    });
+    try {
+      try {
+        fs.symlinkSync(
+          path.join(tempDir, 'physical/index.ts'),
+          path.join(tempDir, 'link.ts'),
+        );
+      } catch {
+        return;
+      }
+
+      const result = await runRslint(
+        ['--format', 'jsonline', 'link.ts'],
+        tempDir,
+      );
+      expect(result.stdout).toContain('no-console');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('explicit file ownership remains lexical when its physical config is also loaded', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.js': `export default [{
+        files: ['**/*.ts'],
+        rules: { 'no-console': 'error' },
+      }];`,
+      'packages/app/rslint.config.js': `export default [{
+        files: ['**/*.ts'],
+        rules: { 'no-debugger': 'error' },
+      }];`,
+      'packages/app/index.ts': 'console.log("value");\ndebugger;\n',
+      'packages/app/other.ts': 'debugger;\n',
+    });
+    try {
+      const lexicalFile = path.join(tempDir, 'link.ts');
+      try {
+        fs.symlinkSync(
+          path.join(tempDir, 'packages/app/index.ts'),
+          lexicalFile,
+        );
+      } catch {
+        return;
+      }
+
+      const result = await runRslint(
+        ['--format', 'jsonline', 'link.ts', 'packages/app/other.ts'],
+        tempDir,
+      );
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map(
+          (line) => JSON.parse(line) as { filePath: string; ruleName: string },
+        );
+      expect(
+        diagnostics.some(
+          (diagnostic) =>
+            diagnostic.filePath === 'link.ts' &&
+            diagnostic.ruleName === 'no-console',
+        ),
+      ).toBe(true);
+      expect(
+        diagnostics.some(
+          (diagnostic) =>
+            diagnostic.filePath === 'link.ts' &&
+            diagnostic.ruleName === 'no-debugger',
+        ),
+      ).toBe(false);
+      expect(
+        diagnostics.some(
+          (diagnostic) =>
+            diagnostic.filePath.includes('other.ts') &&
+            diagnostic.ruleName === 'no-debugger',
+        ),
+      ).toBe(true);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('case aliases load one physical config once', async () => {
+    const tempDir = await createTempDir({
+      'Project/rslint.config.mjs': `
+        import fs from 'node:fs';
+        fs.appendFileSync(new URL('./loads.txt', import.meta.url), 'x');
+        export default [{ rules: { 'no-debugger': 'error' } }];
+      `,
+      'Project/a.ts': 'debugger;\n',
+      'Project/b.ts': 'debugger;\n',
+    });
+    try {
+      const upperDir = path.join(tempDir, 'Project');
+      const lowerDir = path.join(tempDir, 'project');
+      if (!fs.existsSync(lowerDir)) {
+        return;
+      }
+
+      const result = await runRslint(
+        ['--format', 'jsonline', 'Project/a.ts', 'project/b.ts'],
+        tempDir,
+      );
+      expect(result.stderr).not.toContain('duplicate config directories');
+      expect(result.stdout).toContain('a.ts');
+      expect(result.stdout).toContain('b.ts');
+      expect(fs.readFileSync(path.join(upperDir, 'loads.txt'), 'utf8')).toBe(
+        'x',
+      );
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('broken config fallback reuses an already loaded native case alias', async () => {
+    const tempDir = await createTempDir({
+      'Project/rslint.config.mjs': `
+        import fs from 'node:fs';
+        fs.appendFileSync(new URL('./loads.txt', import.meta.url), 'x');
+        export default [{ rules: { 'no-debugger': 'error' } }];
+      `,
+      'Project/a.ts': 'debugger;\n',
+      'Project/broken/rslint.config.mjs':
+        'export default [INVALID CHILD CONFIG;',
+      'Project/broken/b.ts': 'debugger;\n',
+    });
+    try {
+      const upperDir = path.join(tempDir, 'Project');
+      const lowerDir = path.join(tempDir, 'project');
+      if (!fs.existsSync(lowerDir)) {
+        return;
+      }
+
+      const result = await runRslint(
+        ['--format', 'jsonline', 'Project/a.ts', 'project/broken/b.ts'],
+        tempDir,
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Warning: skipping config');
+      expect(result.stderr).not.toContain('same filesystem location');
+      expect(result.stdout).toContain('a.ts');
+      expect(result.stdout).toContain('b.ts');
+      expect(fs.readFileSync(path.join(upperDir, 'loads.txt'), 'utf8')).toBe(
+        'x',
+      );
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('directory aliases of one physical config root are rejected', async () => {
+    const tempDir = await createTempDir({
+      'shared/rslint.config.mjs': `export default [{
+        rules: { 'no-debugger': 'error' },
+      }];`,
+      'shared/a.ts': 'debugger;\n',
+      'shared/b.ts': 'debugger;\n',
+    });
+    try {
+      try {
+        fs.symlinkSync(
+          path.join(tempDir, 'shared'),
+          path.join(tempDir, 'owner-a'),
+          'dir',
+        );
+        fs.symlinkSync(
+          path.join(tempDir, 'shared'),
+          path.join(tempDir, 'owner-b'),
+          'dir',
+        );
+      } catch {
+        return;
+      }
+
+      const result = await runRslint(
+        ['--format', 'jsonline', 'owner-a/a.ts', 'owner-b/b.ts'],
+        tempDir,
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        'resolve to the same filesystem location',
+      );
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('alternate casing of one directory symlink remains one config owner', async () => {
+    const tempDir = await createTempDir({
+      'real/rslint.config.mjs': `export default [{
+        rules: { 'no-debugger': 'error' },
+      }];`,
+      'real/a.ts': 'debugger;\n',
+      'real/b.ts': 'debugger;\n',
+    });
+    try {
+      const upperDir = path.join(tempDir, 'Project');
+      const lowerDir = path.join(tempDir, 'project');
+      try {
+        fs.symlinkSync(path.join(tempDir, 'real'), upperDir, 'dir');
+      } catch {
+        return;
+      }
+      if (!fs.existsSync(lowerDir)) {
+        return;
+      }
+
+      const result = await runRslint(
+        ['--format', 'jsonline', 'Project/a.ts', 'project/b.ts'],
+        tempDir,
+      );
+      expect(result.stderr).not.toContain('same filesystem location');
+      expect(result.stdout).toContain('a.ts');
+      expect(result.stdout).toContain('b.ts');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('directory symlink uses its physical config scope', async () => {
+    const tempDir = await createTempDir({
+      'real/rslint.config.mjs': `export default [{
+        rules: { 'no-debugger': 'error' },
+      }];`,
+      'real/sub/index.ts': 'debugger;\n',
+    });
+    try {
+      const linkDir = path.join(tempDir, 'link');
+      try {
+        fs.symlinkSync(path.join(tempDir, 'real/sub'), linkDir, 'dir');
+      } catch {
+        return;
+      }
+
+      const result = await runRslint(['--format', 'jsonline', 'link'], tempDir);
+      expect(result.stdout).toContain('no-debugger');
+      const diagnostic = JSON.parse(result.stdout.trim().split('\n')[0]) as {
+        filePath: string;
+      };
+      expect(diagnostic.filePath.split(path.sep).join('/')).toMatch(
+        /(^|\/)link\/index\.ts$/,
+      );
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('explicit directory ownership remains lexical when its physical config is also loaded', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [{
+        rules: { 'no-console': 'error' },
+      }];`,
+      'real/rslint.config.mjs': `export default [{
+        rules: { 'no-debugger': 'error' },
+      }];`,
+      'real/sub/index.ts': 'console.log("value");\ndebugger;\n',
+      'real/sub/nested/rslint.config.mjs': `export default [{
+        rules: { 'no-alert': 'error' },
+      }];`,
+      'real/sub/nested/child.ts': 'alert("value");\ndebugger;\n',
+      'real/other.ts': 'debugger;\n',
+    });
+    try {
+      try {
+        fs.symlinkSync(
+          path.join(tempDir, 'real/sub'),
+          path.join(tempDir, 'link'),
+          'dir',
+        );
+      } catch {
+        return;
+      }
+
+      const result = await runRslint(
+        ['--format', 'jsonline', 'link', 'real/other.ts'],
+        tempDir,
+      );
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map(
+          (line) => JSON.parse(line) as { filePath: string; ruleName: string },
+        );
+      expect(
+        diagnostics.some(
+          ({ filePath, ruleName }) =>
+            filePath.split(path.sep).join('/').endsWith('link/index.ts') &&
+            ruleName === 'no-console',
+        ),
+      ).toBe(true);
+      expect(
+        diagnostics.some(
+          ({ filePath, ruleName }) =>
+            filePath.split(path.sep).join('/').endsWith('link/index.ts') &&
+            ruleName === 'no-debugger',
+        ),
+      ).toBe(false);
+      expect(
+        diagnostics.some(
+          ({ filePath, ruleName }) =>
+            filePath.split(path.sep).join('/').endsWith('real/other.ts') &&
+            ruleName === 'no-debugger',
+        ),
+      ).toBe(true);
+      expect(
+        diagnostics.some(
+          ({ filePath, ruleName }) =>
+            filePath
+              .split(path.sep)
+              .join('/')
+              .endsWith('link/nested/child.ts') && ruleName === 'no-alert',
+        ),
+      ).toBe(true);
+      expect(
+        diagnostics.some(
+          ({ filePath, ruleName }) =>
+            filePath
+              .split(path.sep)
+              .join('/')
+              .endsWith('link/nested/child.ts') && ruleName === 'no-debugger',
+        ),
+      ).toBe(false);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('two lexical owners for one physical file are rejected', async () => {
+    const tempDir = await createTempDir({
+      'shared.ts': 'debugger;\n',
+      'owner-a/rslint.config.js': `export default [{
+        files: ['**/*.ts'],
+        rules: { 'no-debugger': 'error' },
+      }];`,
+      'owner-b/rslint.config.js': `export default [{
+        files: ['**/*.ts'],
+        rules: { 'no-debugger': 'error' },
+      }];`,
+    });
+    try {
+      const sharedFile = path.join(tempDir, 'shared.ts');
+      try {
+        fs.symlinkSync(sharedFile, path.join(tempDir, 'owner-a/index.ts'));
+        fs.symlinkSync(sharedFile, path.join(tempDir, 'owner-b/index.ts'));
+      } catch {
+        return;
+      }
+
+      const result = await runRslint(
+        ['--format', 'jsonline', 'owner-a/index.ts', 'owner-b/index.ts'],
+        tempDir,
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('governed by different configs');
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
@@ -716,4 +716,36 @@ describe('CLI config discovery (upward traversal)', () => {
       await cleanupTempDir(tempDir);
     }
   });
+
+  test.each(['cjs', 'cts'])(
+    '--config should load an explicitly selected .%s config',
+    async (extension) => {
+      const config =
+        extension === 'cts'
+          ? `const config: Array<Record<string, unknown>> = [{
+  files: ['**/*.ts'],
+  rules: { 'no-debugger': 'error' },
+}];
+module.exports = config;`
+          : `module.exports = [{
+  files: ['**/*.ts'],
+  rules: { 'no-debugger': 'error' },
+}];`;
+      const configName = `custom.config.${extension}`;
+      const tempDir = await createTempDir({
+        [configName]: config,
+        'test.ts': 'debugger;\n',
+      });
+      try {
+        const result = await runRslint(
+          ['--config', configName, '--format', 'jsonline', 'test.ts'],
+          tempDir,
+        );
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout).toContain('no-debugger');
+      } finally {
+        await cleanupTempDir(tempDir);
+      }
+    },
+  );
 });

--- a/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
@@ -170,7 +170,7 @@ describe('CLI config discovery (upward traversal)', () => {
     }
   });
 
-  test('broken sub-package config should be fatal when discovered', async () => {
+  test('broken sub-package config should be skipped in multi-config', async () => {
     const tempDir = await createTempDir({
       'tsconfig.json': TS_CONFIG,
       'rslint.config.js': jsConfig(),
@@ -184,45 +184,9 @@ describe('CLI config discovery (upward traversal)', () => {
     });
     try {
       const result = await runRslint(['--format', 'jsonline'], tempDir);
-      expect(result.exitCode).not.toBe(0);
-      expect(result.stderr).toContain('failed to load config');
-      expect(result.stderr).toContain('packages/broken/rslint.config.js');
-    } finally {
-      await cleanupTempDir(tempDir);
-    }
-  });
-
-  test('broken sub-package config hidden by parent global ignores should be skipped', async () => {
-    const tempDir = await createTempDir({
-      'tsconfig.json': TS_CONFIG,
-      'rslint.config.js': `export default [
-        { ignores: ['packages/broken/**'] },
-        ${JSON.stringify({
-          files: ['**/*.ts'],
-          languageOptions: {
-            parserOptions: {
-              projectService: false,
-              project: ['./tsconfig.json'],
-            },
-          },
-          rules: { '@typescript-eslint/no-unsafe-member-access': 'error' },
-          plugins: ['@typescript-eslint'],
-        })}
-      ];`,
-      // This config has invalid syntax but should never be loaded because the
-      // parent global ignore blocks traversal into packages/broken.
-      'packages/broken/rslint.config.js':
-        'export default [INVALID SYNTAX HERE;',
-      'packages/broken/tsconfig.json': TS_CONFIG,
-      'packages/broken/src/a.ts': 'let a: any = 10;\na.b = 20;\n',
-      'root.ts': 'let b: any = 10;\nb.c = 20;\n',
-    });
-    try {
-      const result = await runRslint(['--format', 'jsonline'], tempDir);
-      expect(result.exitCode).not.toBe(0);
+      // Should still lint root.ts with root config, skipping broken package
       expect(result.stdout).toContain('root.ts');
-      expect(result.stderr).not.toContain('failed to load config');
-      expect(result.stderr).not.toContain('packages/broken/rslint.config.js');
+      expect(result.stderr).toContain('Warning: skipping config');
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
@@ -8,6 +8,50 @@ import {
 } from './helpers.js';
 
 describe('CLI config discovery (upward traversal)', () => {
+  test('invalid empty files array should fail before linting', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [
+        {
+          files: [],
+          rules: { 'no-debugger': 'error' },
+        },
+      ];`,
+      'src/index.js': 'debugger;\n',
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('invalid config');
+      expect(result.stderr).toContain('"files" must be a non-empty array');
+      expect(result.stdout).not.toContain('no-debugger');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('invalid files value should fail before linting', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [
+        {
+          files: '**/*.js',
+          rules: { 'no-debugger': 'error' },
+        },
+      ];`,
+      'src/index.js': 'debugger;\n',
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('invalid config');
+      expect(result.stderr).toContain('"files" must be an array');
+      expect(result.stdout).not.toContain('no-debugger');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   test('should find config in parent directory', async () => {
     const tempDir = await createTempDir({
       'tsconfig.json': TS_CONFIG,

--- a/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
@@ -148,7 +148,7 @@ describe('CLI config discovery (upward traversal)', () => {
     }
   });
 
-  test('broken sub-package config should be skipped in multi-config', async () => {
+  test('broken sub-package config should be fatal when discovered', async () => {
     const tempDir = await createTempDir({
       'tsconfig.json': TS_CONFIG,
       'rslint.config.js': jsConfig(),
@@ -162,9 +162,45 @@ describe('CLI config discovery (upward traversal)', () => {
     });
     try {
       const result = await runRslint(['--format', 'jsonline'], tempDir);
-      // Should still lint root.ts with root config, skipping broken package
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('failed to load config');
+      expect(result.stderr).toContain('packages/broken/rslint.config.js');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('broken sub-package config hidden by parent global ignores should be skipped', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.js': `export default [
+        { ignores: ['packages/broken/**'] },
+        ${JSON.stringify({
+          files: ['**/*.ts'],
+          languageOptions: {
+            parserOptions: {
+              projectService: false,
+              project: ['./tsconfig.json'],
+            },
+          },
+          rules: { '@typescript-eslint/no-unsafe-member-access': 'error' },
+          plugins: ['@typescript-eslint'],
+        })}
+      ];`,
+      // This config has invalid syntax but should never be loaded because the
+      // parent global ignore blocks traversal into packages/broken.
+      'packages/broken/rslint.config.js':
+        'export default [INVALID SYNTAX HERE;',
+      'packages/broken/tsconfig.json': TS_CONFIG,
+      'packages/broken/src/a.ts': 'let a: any = 10;\na.b = 20;\n',
+      'root.ts': 'let b: any = 10;\nb.c = 20;\n',
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+      expect(result.exitCode).not.toBe(0);
       expect(result.stdout).toContain('root.ts');
-      expect(result.stderr).toContain('Warning: skipping config');
+      expect(result.stderr).not.toContain('failed to load config');
+      expect(result.stderr).not.toContain('packages/broken/rslint.config.js');
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
@@ -148,6 +148,28 @@ describe('CLI config discovery (upward traversal)', () => {
     }
   });
 
+  test('directory discovery uses js config priority within the same directory', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.js': `export default [{
+        files: ['**/*.ts'],
+        rules: { 'no-console': 'error' },
+      }];`,
+      'rslint.config.mjs': `export default [{
+        files: ['**/*.ts'],
+        rules: { 'no-debugger': 'error' },
+      }];`,
+      'test.ts': `console.log('x');\ndebugger;\n`,
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+      expect(result.stdout).toContain('no-console');
+      expect(result.stdout).not.toContain('no-debugger');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   test('broken sub-package config should be fatal when discovered', async () => {
     const tempDir = await createTempDir({
       'tsconfig.json': TS_CONFIG,

--- a/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/config-discovery.test.ts
@@ -192,6 +192,31 @@ describe('CLI config discovery (upward traversal)', () => {
     }
   });
 
+  test('all broken JS configs should not fall back to JSON config', async () => {
+    const tempDir = await createTempDir({
+      'rslint.json': JSON.stringify([
+        {
+          files: ['**/*.ts'],
+          rules: { 'no-debugger': 'error' },
+        },
+      ]),
+      'rslint.config.js': 'export default [INVALID ROOT CONFIG;',
+      'packages/broken/rslint.config.js':
+        'export default [INVALID CHILD CONFIG;',
+      'root.ts': 'debugger;\n',
+      'packages/broken/src/a.ts': 'debugger;\n',
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).not.toContain('no-debugger');
+      expect(result.stderr).toContain('Warning: skipping config');
+      expect(result.stderr).not.toContain('JSON configuration is deprecated');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   test('--config should override automatic discovery', async () => {
     const tempDir = await createTempDir({
       'tsconfig.json': TS_CONFIG,

--- a/packages/rslint-test-tools/tests/cli/js-config/config-ignores-filter.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/config-ignores-filter.test.ts
@@ -316,6 +316,64 @@ describe('Config discovery: parent global ignores filter nested configs', () => 
     }
   });
 
+  test('mixed explicit files keep nearest config even when parent also loads', async () => {
+    const { diagnostics, cleanup } = await lintAndParse(
+      {
+        'rslint.config.mjs': `export default [
+        { ignores: ['__tests__/**'] },
+        { files: ['**/*.ts'], rules: { 'no-debugger': 'error' } },
+      ];`,
+        '__tests__/fixtures/rslint.config.mjs': nestedConfig('no-console'),
+        'src/index.ts': `debugger;\nconsole.log('root');\n`,
+        '__tests__/fixtures/src/test.ts': `debugger;\nconsole.log('test');\n`,
+      },
+      ['src/index.ts', '__tests__/fixtures/src/test.ts'],
+    );
+    try {
+      const rootRules = ruleNames(diagsFor(diagnostics, 'src/index.ts'));
+      expect(rootRules).toContain('no-debugger');
+
+      const testRules = ruleNames(
+        diagsFor(diagnostics, '__tests__/fixtures/src/test.ts'),
+      );
+      expect(testRules).toContain('no-console');
+      expect(testRules).not.toContain('no-debugger');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('explicit file in ignored dir does not reopen directory scanning', async () => {
+    const { diagnostics, cleanup } = await lintAndParse(
+      {
+        'rslint.config.mjs': `export default [
+        { ignores: ['__tests__/**'] },
+        { files: ['**/*.ts'], rules: { 'no-debugger': 'error' } },
+      ];`,
+        '__tests__/fixtures/rslint.config.mjs': nestedConfig('no-console'),
+        'src/index.ts': `debugger;\n`,
+        '__tests__/fixtures/src/test.ts': `console.log('test');\n`,
+        '__tests__/fixtures/src/other.ts': `console.log('other');\n`,
+      },
+      ['.', '__tests__/fixtures/src/test.ts'],
+    );
+    try {
+      expect(ruleNames(diagsFor(diagnostics, 'src/index.ts'))).toContain(
+        'no-debugger',
+      );
+
+      const testRules = ruleNames(
+        diagsFor(diagnostics, '__tests__/fixtures/src/test.ts'),
+      );
+      expect(testRules).toContain('no-console');
+      expect(diagsFor(diagnostics, '__tests__/fixtures/src/other.ts')).toEqual(
+        [],
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
   test('three levels: root → package → sub-package with ignores at each level', async () => {
     const { diagnostics, cleanup } = await lintAndParse({
       'tsconfig.json': JSON.stringify({

--- a/packages/rslint-test-tools/tests/cli/js-config/config-ignores-filter.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/config-ignores-filter.test.ts
@@ -83,7 +83,7 @@ describe('Config discovery: parent global ignores filter nested configs', () => 
   test('nested config in globally ignored directory should not be used', async () => {
     const { diagnostics, cleanup } = await lintAndParse({
       'tsconfig.json': TS_CONFIG,
-      'rslint.config.mjs': rootConfig(['__tests__/**']),
+      'rslint.config.mjs': rootConfig(['__tests__/**/*']),
       '__tests__/fixtures/rslint.config.mjs': nestedConfig('no-console'),
       'src/index.ts': `const x: any = 1;\n`,
       '__tests__/fixtures/src/test.ts': `console.log('test');\nconst a: any = 1;\n`,

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
@@ -320,6 +320,13 @@ function runRslintChunk(
       const d = JSON.parse(t) as RslintDiag;
       const idx = fileToIndex.get(d.filePath);
       if (idx === undefined) continue;
+      if (d.ruleName.startsWith('rslint/')) {
+        throw new Error(
+          `rslint infrastructure diagnostic for ${d.filePath}: ${d.ruleName}: ${d.message}`,
+        );
+      }
+      const c = cases[idx];
+      if (d.ruleName !== `${aliasFor(c.pkg)}/${c.rule}`) continue;
       byIndex.get(idx)!.push(normRslint(d));
     }
   } finally {

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/harness.ts
@@ -320,6 +320,9 @@ function runRslintChunk(
       const d = JSON.parse(t) as RslintDiag;
       const idx = fileToIndex.get(d.filePath);
       if (idx === undefined) continue;
+      // Compare only the community-plugin rule under test for this fixture.
+      // Native rslint infrastructure diagnostics indicate a bad harness setup;
+      // unrelated rule diagnostics from the same file are ignored for this case.
       if (d.ruleName.startsWith('rslint/')) {
         throw new Error(
           `rslint infrastructure diagnostic for ${d.filePath}: ${d.ruleName}: ${d.message}`,

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugins.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugins.test.ts
@@ -41,6 +41,22 @@ const LOCAL_PLUGIN = `export default {
         };
       },
     },
+    'replace-one-zero': {
+      meta: { type: 'suggestion', fixable: 'code', schema: [], messages: { replace: 'Replace one zero.' } },
+      create(context) {
+        return {
+          Program(node) {
+            const index = context.sourceCode.text.indexOf('0');
+            if (index === -1) return;
+            context.report({
+              node,
+              messageId: 'replace',
+              fix: (fixer) => fixer.replaceTextRange([index, index + 1], '1'),
+            });
+          },
+        };
+      },
+    },
   },
 };
 `;
@@ -125,6 +141,35 @@ describe('CLI community plugins (object-form) end-to-end', () => {
       const content = await fs.readFile(path.join(dir, 'b.ts'), 'utf8');
       expect(content).toContain('.some(');
       expect(content).not.toContain('.filter(');
+    } finally {
+      await cleanupTempDir(dir);
+    }
+  });
+
+  test('--fix performs a final verification after the tenth write pass', async () => {
+    const config = `import local from './local-plugin.mjs';
+export default [{
+  files: ['**/*.ts'],
+  plugins: { local },
+  rules: { 'local/replace-one-zero': 'error' },
+}];
+`;
+    const dir = await createTempDir({
+      'local-plugin.mjs': LOCAL_PLUGIN,
+      'rslint.config.mjs': config,
+      'tsconfig.json': TSCONFIG,
+      'ten.ts': "const value = '0000000000';\n",
+    });
+    try {
+      const result = await runRslint(
+        ['--format', 'jsonline', '--fix', 'ten.ts'],
+        dir,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain('local/replace-one-zero');
+      expect(await fs.readFile(path.join(dir, 'ten.ts'), 'utf8')).toBe(
+        "const value = '1111111111';\n",
+      );
     } finally {
       await cleanupTempDir(dir);
     }

--- a/packages/rslint-test-tools/tests/cli/js-config/files-driven-lint.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/files-driven-lint.test.ts
@@ -195,6 +195,69 @@ describe('Files-driven lint: gap file auto-degrade', () => {
     }
   });
 
+  test('project without tsconfig should lint targets but gate type-aware rules', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [
+        {
+          files: ['**/*.ts'],
+          rules: {
+            '@typescript-eslint/ban-ts-comment': 'error',
+            '@typescript-eslint/no-unsafe-member-access': 'error',
+          },
+          plugins: ['@typescript-eslint'],
+        },
+      ];`,
+      'src/index.ts': `// @ts-ignore\nlet value: any = 1;\nvalue.deep = 2;\n`,
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l));
+      const resultRules = diagnostics.map((d: any) => d.ruleName);
+
+      expect(resultRules).toContain('@typescript-eslint/ban-ts-comment');
+      expect(resultRules).not.toContain(
+        '@typescript-eslint/no-unsafe-member-access',
+      );
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('project without tsconfig should keep import rule module resolution', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [
+        {
+          files: ['**/*.ts'],
+          rules: {
+            'import/default': 'error',
+          },
+          plugins: ['import'],
+        },
+      ];`,
+      'src/index.ts': `import missingDefault from './mod';\nconsole.log(missingDefault);\n`,
+      'src/mod.ts': `export const named = 1;\n`,
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l));
+
+      expect(result.exitCode).toBe(1);
+      expect(diagnostics.map((d: any) => d.ruleName)).toContain(
+        'import/default',
+      );
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   test('JSON config without files field should scan default lintable extensions', async () => {
     const tempDir = await createTempDir({
       'tsconfig.json': JSON.stringify({
@@ -291,6 +354,41 @@ describe('Files-driven lint: gap file auto-degrade', () => {
           expect(d.ruleName).not.toMatch(/^TypeScript\(/);
         }
       }
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('JS config without files field should scan default lintable extensions', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [
+        {
+          rules: {
+            'no-debugger': 'error',
+          },
+        },
+      ];`,
+      'src/index.ts': `debugger;\n`,
+      'scripts/build.jsx': `debugger;\n`,
+      'styles/site.css': `debugger;\n`,
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l));
+
+      expect(
+        diagnostics.some((d: any) => d.filePath.includes('src/index.ts')),
+      ).toBe(true);
+      expect(
+        diagnostics.some((d: any) => d.filePath.includes('scripts/build.jsx')),
+      ).toBe(true);
+      expect(
+        diagnostics.some((d: any) => d.filePath.includes('styles/site.css')),
+      ).toBe(false);
     } finally {
       await cleanupTempDir(tempDir);
     }
@@ -538,6 +636,38 @@ describe('Files-driven lint: CLI interaction', () => {
       // no-inferrable-types should have removed the type annotation
       expect(fixed).not.toContain(': number');
       expect(fixed).toContain('const x = 42');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('--fix should keep remaining target syntax diagnostics after relint', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [
+        {
+          files: ['**/*.ts'],
+          rules: {
+            '@typescript-eslint/no-inferrable-types': 'error',
+          },
+          plugins: ['@typescript-eslint'],
+        },
+      ];`,
+      'src/fixable.ts': `const x: number = 42;\n`,
+      'src/bad.ts': `const = ;\n`,
+    });
+    try {
+      const result = await runRslint(
+        ['--fix', '--format', 'jsonline'],
+        tempDir,
+      );
+      const fs = await import('node:fs/promises');
+      const fixed = await fs.readFile(`${tempDir}/src/fixable.ts`, 'utf8');
+
+      expect(fixed).toContain('const x = 42');
+      expect(fixed).not.toContain(': number');
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('src/bad.ts');
+      expect(result.stdout).toContain('TypeScript(TS');
     } finally {
       await cleanupTempDir(tempDir);
     }
@@ -1033,6 +1163,295 @@ describe('Files-driven lint: recommended + user override cascade', () => {
 });
 
 describe('Files-driven lint: edge cases', () => {
+  test('syntax error outside config files should not fail tsconfig-backed lint', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { target: 'ES2020', module: 'ESNext', strict: true },
+        include: ['**/*.ts'],
+      }),
+      'rslint.config.mjs': `export default [
+        {
+          files: ['src/**/*.ts'],
+          languageOptions: {
+            parserOptions: {
+              projectService: false,
+              project: ['./tsconfig.json'],
+            },
+          },
+          rules: {
+            'no-debugger': 'error',
+          },
+        },
+      ];`,
+      'src/index.ts': `debugger;\n`,
+      'test/bad.ts': `const = ;\n`,
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l));
+
+      expect(diagnostics.map((d: any) => d.ruleName)).toContain('no-debugger');
+      expect(
+        diagnostics.some((d: any) => d.filePath.includes('test/bad.ts')),
+      ).toBe(false);
+      expect(result.stderr).not.toContain('test/bad.ts');
+      expect(result.stderr).not.toContain('TS1134');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('type-check still reports tsconfig files outside config files without linting them', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2020',
+          module: 'ESNext',
+          strict: true,
+          skipLibCheck: true,
+        },
+        include: ['**/*.ts'],
+      }),
+      'rslint.config.mjs': `export default [
+        {
+          files: ['src/**/*.ts'],
+          languageOptions: {
+            parserOptions: {
+              projectService: false,
+              project: ['./tsconfig.json'],
+            },
+          },
+          rules: {
+            'no-debugger': 'error',
+          },
+        },
+      ];`,
+      'src/index.ts': `debugger;\nconst ok: number = 1;\n`,
+      'test/bad.ts': `debugger;\nconst bad: number = "oops";\n`,
+    });
+    try {
+      const result = await runRslint(
+        ['--type-check', '--format', 'jsonline'],
+        tempDir,
+      );
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l));
+
+      expect(result.exitCode).toBe(1);
+      expect(
+        diagnostics.some(
+          (d: any) =>
+            d.filePath.includes('src/index.ts') && d.ruleName === 'no-debugger',
+        ),
+      ).toBe(true);
+      expect(
+        diagnostics.some(
+          (d: any) =>
+            d.filePath.includes('test/bad.ts') &&
+            d.ruleName === 'TypeScript(TS2322)',
+        ),
+      ).toBe(true);
+      expect(
+        diagnostics.some(
+          (d: any) =>
+            d.filePath.includes('test/bad.ts') && d.ruleName === 'no-debugger',
+        ),
+      ).toBe(false);
+
+      const typeCheckOnlyResult = await runRslint(
+        ['--type-check-only', '--format', 'jsonline'],
+        tempDir,
+      );
+      const typeCheckOnlyDiagnostics = typeCheckOnlyResult.stdout
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l));
+
+      expect(typeCheckOnlyResult.exitCode).toBe(1);
+      expect(
+        typeCheckOnlyDiagnostics.some(
+          (d: any) =>
+            d.filePath.includes('test/bad.ts') &&
+            d.ruleName === 'TypeScript(TS2322)',
+        ),
+      ).toBe(true);
+      expect(
+        typeCheckOnlyDiagnostics.some((d: any) => d.ruleName === 'no-debugger'),
+      ).toBe(false);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('type-check-only still reports syntax errors outside config files from tsconfig', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { target: 'ES2020', module: 'ESNext', strict: true },
+        include: ['**/*.ts'],
+      }),
+      'rslint.config.mjs': `export default [
+        {
+          files: ['src/**/*.ts'],
+          languageOptions: {
+            parserOptions: {
+              projectService: false,
+              project: ['./tsconfig.json'],
+            },
+          },
+          rules: {
+            'no-debugger': 'error',
+          },
+        },
+      ];`,
+      'src/index.ts': `debugger;\n`,
+      'test/bad.ts': `debugger;\nconst = ;\n`,
+    });
+    try {
+      const result = await runRslint(
+        ['--type-check-only', '--format', 'jsonline'],
+        tempDir,
+      );
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l));
+
+      expect(result.exitCode).toBe(1);
+      expect(
+        diagnostics.some(
+          (d: any) =>
+            d.filePath.includes('test/bad.ts') &&
+            d.ruleName.startsWith('TypeScript(TS'),
+        ),
+      ).toBe(true);
+      expect(diagnostics.some((d: any) => d.ruleName === 'no-debugger')).toBe(
+        false,
+      );
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('syntax error outside config files should not fail no-tsconfig lint', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [
+        {
+          files: ['src/**/*.ts'],
+          rules: {
+            'no-debugger': 'error',
+          },
+        },
+      ];`,
+      'src/index.ts': `debugger;\n`,
+      'test/bad.ts': `const = ;\n`,
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l));
+
+      expect(diagnostics.map((d: any) => d.ruleName)).toContain('no-debugger');
+      expect(
+        diagnostics.some((d: any) => d.filePath.includes('test/bad.ts')),
+      ).toBe(false);
+      expect(result.stderr).not.toContain('test/bad.ts');
+      expect(result.stderr).not.toContain('TS1134');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('syntax error inside config files should be reported in no-tsconfig lint', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `export default [
+        {
+          files: ['src/**/*.ts'],
+          rules: {},
+        },
+      ];`,
+      'src/bad.ts': `const = ;\n`,
+      'test/ok.ts': `const ok = 1;\n`,
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l));
+
+      expect(result.exitCode).toBe(1);
+      expect(
+        diagnostics.some(
+          (d: any) =>
+            d.filePath.includes('src/bad.ts') &&
+            d.ruleName.startsWith('TypeScript(TS'),
+        ),
+      ).toBe(true);
+      expect(
+        diagnostics.some((d: any) => d.filePath.includes('test/ok.ts')),
+      ).toBe(false);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('syntax error inside config files should still be reported', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { target: 'ES2020', module: 'ESNext', strict: true },
+        include: ['**/*.ts'],
+      }),
+      'rslint.config.mjs': `export default [
+        {
+          files: ['src/**/*.ts'],
+          languageOptions: {
+            parserOptions: {
+              projectService: false,
+              project: ['./tsconfig.json'],
+            },
+          },
+          rules: {},
+        },
+      ];`,
+      'src/bad.ts': `const = ;\n`,
+      'test/ok.ts': `const ok = 1;\n`,
+    });
+    try {
+      const result = await runRslint(['--format', 'jsonline'], tempDir);
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l));
+
+      expect(
+        diagnostics.some(
+          (d: any) =>
+            d.filePath.includes('src/bad.ts') &&
+            d.ruleName.startsWith('TypeScript(TS'),
+        ),
+      ).toBe(true);
+      expect(
+        diagnostics.some((d: any) => d.filePath.includes('test/ok.ts')),
+      ).toBe(false);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   test('gap file with syntax errors should still be linted (not crash)', async () => {
     const tempDir = await createTempDir({
       'tsconfig.json': JSON.stringify({

--- a/packages/rslint-test-tools/tests/cli/js-config/files-driven-lint.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/files-driven-lint.test.ts
@@ -195,7 +195,7 @@ describe('Files-driven lint: gap file auto-degrade', () => {
     }
   });
 
-  test('JSON config without files field should use legacy behavior (tsconfig-driven)', async () => {
+  test('JSON config without files field should scan default lintable extensions', async () => {
     const tempDir = await createTempDir({
       'tsconfig.json': JSON.stringify({
         compilerOptions: { target: 'ES2020', module: 'ESNext', strict: true },
@@ -212,13 +212,16 @@ describe('Files-driven lint: gap file auto-degrade', () => {
           },
           rules: {
             '@typescript-eslint/no-unsafe-member-access': 'error',
+            'no-debugger': 'error',
           },
           plugins: ['@typescript-eslint'],
         },
       ]),
       'src/index.ts': `let a: any = 1;\na.b = 2;\n`,
-      // This file is NOT in tsconfig include — should NOT be linted in legacy mode
-      'scripts/build.ts': `let x: any = 1;\nx.y = 2;\n`,
+      // This file is NOT in tsconfig include. It should still be linted by
+      // syntax-only rules because omitted files selects rslint's default
+      // lintable extensions, but type-aware rules should be gated off.
+      'scripts/build.ts': `debugger;\nlet x: any = 1;\nx.y = 2;\n`,
     });
     try {
       const result = await runRslint(['--format', 'jsonline'], tempDir);
@@ -235,11 +238,14 @@ describe('Files-driven lint: gap file auto-degrade', () => {
       );
       expect(srcDiags.length).toBeGreaterThan(0);
 
-      // scripts/build.ts should NOT be linted (legacy mode: tsconfig-driven)
       const scriptDiags = diagnostics.filter((d: any) =>
         d.filePath.includes('scripts/build.ts'),
       );
-      expect(scriptDiags.length).toBe(0);
+      const scriptRules = scriptDiags.map((d: any) => d.ruleName);
+      expect(scriptRules).toContain('no-debugger');
+      expect(scriptRules).not.toContain(
+        '@typescript-eslint/no-unsafe-member-access',
+      );
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint-test-tools/tests/cli/js-config/files-driven-lint.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/files-driven-lint.test.ts
@@ -330,12 +330,12 @@ describe('Files-driven lint: gap file auto-degrade', () => {
               project: ['./tsconfig.json'],
             },
           },
-          rules: {},
+          rules: { 'no-debugger': 'error' },
           plugins: ['@typescript-eslint'],
         },
       ];`,
-      // Gap file with type error
-      'scripts/build.ts': `const x: number = 'hello';\n`,
+      // Gap file with a syntax-only rule violation and a semantic type error.
+      'scripts/build.ts': `debugger;\nconst x: number = 'hello';\n`,
     });
     try {
       const result = await runRslint(
@@ -348,13 +348,15 @@ describe('Files-driven lint: gap file auto-degrade', () => {
         .split('\n')
         .filter((l) => l.trim());
 
-      // Gap files should NOT get TypeScript semantic diagnostics
+      const gapRuleNames: string[] = [];
       for (const line of lines) {
         const d = JSON.parse(line);
         if (d.filePath.includes('scripts/build.ts')) {
+          gapRuleNames.push(d.ruleName);
           expect(d.ruleName).not.toMatch(/^TypeScript\(/);
         }
       }
+      expect(gapRuleNames).toContain('no-debugger');
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint-test-tools/tests/cli/js-config/files-driven-lint.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/files-driven-lint.test.ts
@@ -32,8 +32,8 @@ function rules(diagnostics: Diagnostic[]): string[] {
 }
 
 /**
- * Tests for files-driven lint: config `files` controls what gets linted,
- * tsconfig `include` controls which files get type-aware rules.
+ * Tests for files-driven lint: the default extension baseline plus config
+ * `files` select targets; tsconfig membership controls type-aware rules.
  */
 describe('Files-driven lint: gap file auto-degrade', () => {
   test('file matching config files but NOT in tsconfig include should only get syntax rules', async () => {
@@ -96,7 +96,7 @@ describe('Files-driven lint: gap file auto-degrade', () => {
     }
   });
 
-  test('file in tsconfig include but NOT matching config files should NOT be linted', async () => {
+  test('file outside an entry files selector should not run that entry rules', async () => {
     const tempDir = await createTempDir({
       // tsconfig includes both src/ and test/
       'tsconfig.json': JSON.stringify({
@@ -137,7 +137,8 @@ describe('Files-driven lint: gap file auto-degrade', () => {
       );
       expect(srcDiags.length).toBeGreaterThan(0);
 
-      // test/test.ts should NOT be linted (not matching config files)
+      // test/test.ts is a baseline target, but this scoped entry contributes no
+      // rules because its files selector does not match.
       const testDiags = diagnostics.filter((d: any) =>
         d.filePath.includes('test/test.ts'),
       );
@@ -1163,7 +1164,7 @@ describe('Files-driven lint: recommended + user override cascade', () => {
 });
 
 describe('Files-driven lint: edge cases', () => {
-  test('syntax error outside config files should not fail tsconfig-backed lint', async () => {
+  test('default-baseline target outside entry files reports syntax in tsconfig-backed lint', async () => {
     const tempDir = await createTempDir({
       'tsconfig.json': JSON.stringify({
         compilerOptions: { target: 'ES2020', module: 'ESNext', strict: true },
@@ -1195,9 +1196,14 @@ describe('Files-driven lint: edge cases', () => {
         .map((l) => JSON.parse(l));
 
       expect(diagnostics.map((d: any) => d.ruleName)).toContain('no-debugger');
+      expect(result.exitCode).toBe(1);
       expect(
-        diagnostics.some((d: any) => d.filePath.includes('test/bad.ts')),
-      ).toBe(false);
+        diagnostics.some(
+          (d: any) =>
+            d.filePath.includes('test/bad.ts') &&
+            d.ruleName === 'TypeScript(TS1134)',
+        ),
+      ).toBe(true);
       expect(result.stderr).not.toContain('test/bad.ts');
       expect(result.stderr).not.toContain('TS1134');
     } finally {
@@ -1341,7 +1347,7 @@ describe('Files-driven lint: edge cases', () => {
     }
   });
 
-  test('syntax error outside config files should not fail no-tsconfig lint', async () => {
+  test('default-baseline target outside entry files reports syntax without tsconfig', async () => {
     const tempDir = await createTempDir({
       'rslint.config.mjs': `export default [
         {
@@ -1363,9 +1369,14 @@ describe('Files-driven lint: edge cases', () => {
         .map((l) => JSON.parse(l));
 
       expect(diagnostics.map((d: any) => d.ruleName)).toContain('no-debugger');
+      expect(result.exitCode).toBe(1);
       expect(
-        diagnostics.some((d: any) => d.filePath.includes('test/bad.ts')),
-      ).toBe(false);
+        diagnostics.some(
+          (d: any) =>
+            d.filePath.includes('test/bad.ts') &&
+            d.ruleName === 'TypeScript(TS1134)',
+        ),
+      ).toBe(true);
       expect(result.stderr).not.toContain('test/bad.ts');
       expect(result.stderr).not.toContain('TS1134');
     } finally {

--- a/packages/rslint-test-tools/tests/cli/js-config/files-driven-monorepo.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/files-driven-monorepo.test.ts
@@ -31,7 +31,7 @@ function rules(diagnostics: Diagnostic[]): string[] {
   return diagnostics.map((d) => d.ruleName);
 }
 
-describe('Monorepo multi-config: ownership dedup', () => {
+describe('Monorepo multi-config: target dedup', () => {
   test('B1: root+child configs, each has own tsconfig — no duplicate violations', async () => {
     const { diagnostics, cleanup } = await lintJsonline({
       'rslint.config.mjs': `export default [{ files: ["*.ts"], rules: { "no-console": "error" } }];`,

--- a/packages/rslint-test-tools/tests/cli/type-check/__snapshots__/type-check-snapshot.test.ts.snap
+++ b/packages/rslint-test-tools/tests/cli/type-check/__snapshots__/type-check-snapshot.test.ts.snap
@@ -9,7 +9,7 @@ exports[`--type-check output snapshots (default format) > --quiet suppresses war
   │ 3 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 1 warning (linted 1 file with 1 rule in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 1 warning (linted 2 files with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -28,7 +28,7 @@ exports[`--type-check output snapshots (default format) > both lint error and ty
   │ 3 │  
   ╰────────────────────────────────
 
-Found 1 lint error, 1 type error and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> threads)
+Found 1 lint error, 1 type error and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -40,7 +40,7 @@ exports[`--type-check output snapshots (default format) > lint error only with -
   │ 2 │  console.log(a);
   ╰────────────────────────────────
 
-Found 1 lint error, 0 type errors and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> threads)
+Found 1 lint error, 0 type errors and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -52,7 +52,7 @@ exports[`--type-check output snapshots (default format) > lint error without --t
   │ 2 │  console.log(a);
   ╰────────────────────────────────
 
-Found 1 error and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> threads)
+Found 1 error and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -66,7 +66,7 @@ exports[`--type-check output snapshots (default format) > multi-line lint error 
   │ 6 │  console.log(fn);
   ╰────────────────────────────────
 
-Found 1 error and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> threads)
+Found 1 error and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -87,7 +87,7 @@ exports[`--type-check output snapshots (default format) > multi-line lint error 
   │ 7 │  
   ╰────────────────────────────────
 
-Found 1 lint error, 1 type error and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> threads)
+Found 1 lint error, 1 type error and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -100,7 +100,7 @@ exports[`--type-check output snapshots (default format) > multi-line: MessageCha
   │ 2 │  console.log(foo);
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
 "
 `;
 
@@ -114,7 +114,7 @@ exports[`--type-check output snapshots (default format) > multi-line: RelatedInf
   │ 3 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
 "
 `;
 
@@ -128,7 +128,7 @@ exports[`--type-check output snapshots (default format) > multi-line: RelatedInf
   │ 3 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
 "
 `;
 
@@ -143,12 +143,12 @@ exports[`--type-check output snapshots (default format) > multi-line: deep Messa
   │ 4 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
 "
 `;
 
 exports[`--type-check output snapshots (default format) > no errors with --type-check 1`] = `
-"Found 0 lint errors, 0 type errors and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
+"Found 0 lint errors, 0 type errors and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
 "
 `;
 
@@ -160,7 +160,7 @@ exports[`--type-check output snapshots (default format) > type error only (TS232
   │ 2 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
 "
 `;
 

--- a/packages/rslint-test-tools/tests/cli/type-check/ignores-suppression.test.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/ignores-suppression.test.ts
@@ -108,8 +108,8 @@ describe('--type-check + config ignores', () => {
       );
 
       // LintedFileCount counts the lint-rule pass only — ignored files do
-      // not contribute. Only src/bad.ts is "linted".
-      expect(r.lintedFileCount).toBe(1);
+      // not contribute. The targets are src/bad.ts and rslint.config.mjs.
+      expect(r.lintedFileCount).toBe(2);
     } finally {
       await cleanupTempDir(tempDir);
     }
@@ -155,8 +155,9 @@ describe('--type-check + config ignores', () => {
       expect(utilDiags.length).toBeGreaterThan(0);
       expect(utilDiags.some((d) => d.ruleName.includes('TS2322'))).toBe(true);
 
-      // Lint-rule pass excludes the ignored file: count is 1 (caller.ts).
-      expect(r.lintedFileCount).toBe(1);
+      // Lint-rule pass excludes the ignored file. caller.ts and the default
+      // .mjs target rslint.config.mjs remain.
+      expect(r.lintedFileCount).toBe(2);
     } finally {
       await cleanupTempDir(tempDir);
     }
@@ -208,8 +209,9 @@ describe('--type-check + config ignores', () => {
       expect(childDiags.length).toBeGreaterThan(0);
       expect(childDiags.some((d) => d.ruleName.includes('TS2322'))).toBe(true);
 
-      // Lint-rule pass excludes the ignored child file: count is 1 (src/ok.ts).
-      expect(r.lintedFileCount).toBe(1);
+      // Lint-rule pass excludes the ignored child file. src/ok.ts and the
+      // default .mjs target rslint.config.mjs remain.
+      expect(r.lintedFileCount).toBe(2);
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint-test-tools/tests/cli/type-check/type-check-only.test.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/type-check-only.test.ts
@@ -8,7 +8,7 @@ import { runRslint, createTempDir, cleanupTempDir, TS_CONFIG } from './helpers';
 //   1. Type-check-only skips the lint phase entirely (no rule diagnostics,
 //      no lint-file count) while still running Phase 2 type-check.
 //   2. `--fix` and `--rule` are rejected because the lint phase is gone.
-//   3. Lint-phase per-file warnings ("X was not found in the project" and
+//   3. Lint-phase per-file warnings ("X was not found" and
 //      "X is ignored because of a matching ignore pattern") are suppressed
 //      in --type-check-only — they describe a phase that didn't run, and
 //      Phase 2 itself ignores rslint's `ignores`/scope.
@@ -165,10 +165,10 @@ describe('--type-check-only flag compatibility', () => {
 });
 
 describe('--type-check-only suppresses lint-phase warnings', () => {
-  test('"was not found in the project" warning is suppressed', async () => {
-    // A CLI-specified file outside every program is a lint-phase concept
-    // (it would mean "Phase 1 has nothing to do"). Phase 2 is program-wide
-    // and unaffected, so the warning is noise in --type-check-only.
+  test('"was not found" warning is suppressed', async () => {
+    // A missing CLI-specified file is a lint-phase warning. Phase 2 is
+    // program-wide and unaffected, so the warning is noise in
+    // --type-check-only.
     const tempDir = await createTempDir({
       'tsconfig.json': TS_CONFIG,
       'rslint.config.mjs': makeConfigPlain(),
@@ -179,7 +179,7 @@ describe('--type-check-only suppresses lint-phase warnings', () => {
         ['--type-check-only', 'nonexistent.ts'],
         tempDir,
       );
-      expect(r.stderr).not.toContain('not found in the project');
+      expect(r.stderr).not.toContain('was not found');
       expect(r.stderr).not.toContain('nonexistent.ts');
     } finally {
       await cleanupTempDir(tempDir);
@@ -253,7 +253,7 @@ describe('--type-check (non-only) does not short-circuit on Phase 2 diagnostics'
       // And the lint-side "not found" warning still fires in --type-check
       // (non-only) mode — only --type-check-only suppresses it.
       expect(r.stderr).toContain('nonexistent.ts');
-      expect(r.stderr).toContain('not found in the project');
+      expect(r.stderr).toContain('was not found');
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rslint.config.mjs
@@ -1,6 +1,5 @@
 export default [
   {
-    files: [],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rslint.config.mjs
@@ -1,6 +1,5 @@
 export default [
   {
-    files: [],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rslint.config.mjs
@@ -1,6 +1,5 @@
 export default [
   {
-    files: [],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rslint.config.mjs
@@ -1,6 +1,5 @@
 export default [
   {
-    files: [],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rslint.config.mjs
@@ -1,6 +1,5 @@
 export default [
   {
-    files: [],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rslint.config.mjs
@@ -1,6 +1,5 @@
 export default [
   {
-    files: [],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rslint.config.mjs
@@ -1,6 +1,5 @@
 export default [
   {
-    files: [],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/rslint-test-tools/tests/eslint/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/eslint/rslint.config.mjs
@@ -1,6 +1,5 @@
 export default [
   {
-    files: [],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/rslint-test-tools/tests/typescript-eslint/fixtures/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/typescript-eslint/fixtures/rslint.config.mjs
@@ -1,6 +1,5 @@
 export default [
   {
-    files: [],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/rslint/fixtures/rslint.json
+++ b/packages/rslint/fixtures/rslint.json
@@ -1,7 +1,6 @@
 [
   {
     "language": "javascript",
-    "files": [],
     "languageOptions": {
       "parserOptions": {
         "projectService": false,

--- a/packages/rslint/fixtures/rslint.virtual.json
+++ b/packages/rslint/fixtures/rslint.virtual.json
@@ -1,7 +1,6 @@
 [
   {
     "language": "javascript",
-    "files": [],
     "languageOptions": {
       "parserOptions": {
         "projectService": false,

--- a/packages/rslint/src/api/path-identity.ts
+++ b/packages/rslint/src/api/path-identity.ts
@@ -1,0 +1,156 @@
+import path from 'node:path';
+
+type PathOperations = Pick<
+  typeof path,
+  'dirname' | 'isAbsolute' | 'normalize' | 'parse' | 'relative' | 'sep'
+>;
+
+export interface PathIdentity {
+  readonly paths: PathOperations;
+  key(filePath: string): string;
+  normalize(filePath: string): string;
+  equals(left: string, right: string): boolean;
+  isSameOrChild(parent: string, child: string): boolean;
+  compare(left: string, right: string): number;
+}
+
+/**
+ * Create lexical filesystem-path identity for a platform path implementation.
+ * The caller supplies the host filesystem's case behavior independently from
+ * its separator/path flavor (notably, macOS uses POSIX paths but folds case).
+ */
+export function createPathIdentity(
+  paths: PathOperations,
+  caseSensitive: boolean,
+): PathIdentity {
+  const normalize = (filePath: string): string => {
+    let normalized = paths.normalize(filePath);
+    const root = paths.parse(normalized).root;
+    while (normalized.length > root.length && normalized.endsWith(paths.sep)) {
+      normalized = normalized.slice(0, -1);
+    }
+    return normalized;
+  };
+
+  const key = (filePath: string): string => {
+    const normalized = normalize(filePath);
+    return caseSensitive ? normalized : normalized.toLowerCase();
+  };
+
+  return {
+    paths,
+    key,
+    normalize,
+    equals: (left, right) => key(left) === key(right),
+    isSameOrChild: (parent, child) => {
+      if (key(parent) === key(child)) return true;
+      const relative = paths.relative(key(parent), key(child));
+      return (
+        relative !== '' &&
+        relative !== '..' &&
+        !relative.startsWith(`..${paths.sep}`) &&
+        !paths.isAbsolute(relative)
+      );
+    },
+    compare: (left, right) =>
+      key(left).localeCompare(key(right)) ||
+      normalize(left).localeCompare(normalize(right)),
+  };
+}
+
+export const nativePathIdentity = createPathIdentity(
+  path,
+  process.platform !== 'win32' && process.platform !== 'darwin',
+);
+
+/** Cache an upward lookup, including misses, for every traversed directory. */
+export function createCachedAncestorFinder<T>(
+  findInDirectory: (directory: string) => T | undefined,
+  identity: PathIdentity = nativePathIdentity,
+): (startDirectory: string) => T | undefined {
+  const cache = new Map<string, T | undefined>();
+
+  return (startDirectory: string): T | undefined => {
+    const visited: string[] = [];
+    let directory = identity.normalize(startDirectory);
+    let found: T | undefined;
+
+    while (true) {
+      const key = identity.key(directory);
+      if (cache.has(key)) {
+        found = cache.get(key);
+        break;
+      }
+      visited.push(key);
+
+      found = findInDirectory(directory);
+      if (found !== undefined) break;
+
+      const parent = identity.paths.dirname(directory);
+      if (identity.equals(parent, directory)) break;
+      directory = parent;
+    }
+
+    for (const key of visited) cache.set(key, found);
+    return found;
+  };
+}
+
+/**
+ * Nearest-ancestor lookup over an immutable directory set. Misses and hits are
+ * cached for every traversed directory, so repeated files in one tree do only
+ * lexical path work and never trigger filesystem probes.
+ */
+export class AncestorPathIndex<T> {
+  readonly #identity: PathIdentity;
+  readonly #entries = new Map<string, T>();
+  readonly #cache = new Map<string, T | undefined>();
+
+  constructor(
+    entries: Iterable<readonly [directory: string, value: T]>,
+    identity: PathIdentity = nativePathIdentity,
+  ) {
+    this.#identity = identity;
+    for (const [directory, value] of entries) {
+      const key = identity.key(directory);
+      if (!this.#entries.has(key)) this.#entries.set(key, value);
+    }
+  }
+
+  find(startDirectory: string): T | undefined {
+    const startKey = this.#identity.key(startDirectory);
+    if (this.#cache.has(startKey)) return this.#cache.get(startKey);
+
+    const visited: string[] = [];
+    let directory = this.#identity.normalize(startDirectory);
+    let found: T | undefined;
+
+    while (true) {
+      const key = this.#identity.key(directory);
+      visited.push(key);
+
+      if (this.#entries.has(key)) {
+        found = this.#entries.get(key);
+        break;
+      }
+      if (this.#cache.has(key)) {
+        found = this.#cache.get(key);
+        break;
+      }
+
+      const parent = this.#identity.paths.dirname(directory);
+      if (this.#identity.equals(parent, directory)) break;
+      directory = parent;
+    }
+
+    for (const key of visited) this.#cache.set(key, found);
+    return found;
+  }
+
+  findParent(directory: string): T | undefined {
+    const normalized = this.#identity.normalize(directory);
+    const parent = this.#identity.paths.dirname(normalized);
+    if (this.#identity.equals(parent, normalized)) return undefined;
+    return this.find(parent);
+  }
+}

--- a/packages/rslint/src/api/path-identity.ts
+++ b/packages/rslint/src/api/path-identity.ts
@@ -1,8 +1,9 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
 type PathOperations = Pick<
   typeof path,
-  'dirname' | 'isAbsolute' | 'normalize' | 'parse' | 'relative' | 'sep'
+  'dirname' | 'normalize' | 'parse' | 'sep'
 >;
 
 export interface PathIdentity {
@@ -16,8 +17,8 @@ export interface PathIdentity {
 
 /**
  * Create lexical filesystem-path identity for a platform path implementation.
- * The caller supplies the host filesystem's case behavior independently from
- * its separator/path flavor (notably, macOS uses POSIX paths but folds case).
+ * Physical equivalence is deliberately outside this helper and must be based on
+ * a filesystem-resolved path.
  */
 export function createPathIdentity(
   paths: PathOperations,
@@ -43,14 +44,13 @@ export function createPathIdentity(
     normalize,
     equals: (left, right) => key(left) === key(right),
     isSameOrChild: (parent, child) => {
-      if (key(parent) === key(child)) return true;
-      const relative = paths.relative(key(parent), key(child));
-      return (
-        relative !== '' &&
-        relative !== '..' &&
-        !relative.startsWith(`..${paths.sep}`) &&
-        !paths.isAbsolute(relative)
-      );
+      const parentKey = key(parent);
+      const childKey = key(child);
+      if (parentKey === childKey) return true;
+      const prefix = parentKey.endsWith(paths.sep)
+        ? parentKey
+        : `${parentKey}${paths.sep}`;
+      return childKey.startsWith(prefix);
     },
     compare: (left, right) =>
       key(left).localeCompare(key(right)) ||
@@ -58,10 +58,126 @@ export function createPathIdentity(
   };
 }
 
-export const nativePathIdentity = createPathIdentity(
-  path,
-  process.platform !== 'win32' && process.platform !== 'darwin',
-);
+export const nativePathIdentity = createPathIdentity(path, true);
+
+export interface ResolvedFilesystemPath {
+  lexicalPath: string;
+  lexicalKey: string;
+  canonicalPath: string;
+  canonicalKey: string;
+}
+
+type ResolvedPathState = ResolvedFilesystemPath & {
+  physicallyResolved: boolean;
+};
+
+async function realpathNative(filePath: string): Promise<string> {
+  const resolvedPath = await new Promise<string>((resolve, reject) => {
+    fs.realpath.native(filePath, (error, resolvedPath) => {
+      if (error) reject(error);
+      else resolve(resolvedPath);
+    });
+  });
+  return resolvedPath;
+}
+
+/**
+ * Resolves physical path identity for one lint operation. The memo is scoped to
+ * this instance and callers should discard it when the operation completes.
+ */
+export class RunPathResolver {
+  readonly #resolved = new Map<string, Promise<ResolvedPathState>>();
+
+  async resolve(filePath: string): Promise<ResolvedFilesystemPath> {
+    const resolved = await this.#resolveState(filePath);
+    return resolved;
+  }
+
+  async #resolveState(filePath: string): Promise<ResolvedPathState> {
+    const lexicalPath = nativePathIdentity.normalize(filePath);
+    const lexicalKey = nativePathIdentity.key(lexicalPath);
+    let pending = this.#resolved.get(lexicalKey);
+    if (!pending) {
+      pending = (async () => {
+        let canonicalPath = lexicalPath;
+        let physicallyResolved = false;
+        try {
+          canonicalPath = nativePathIdentity.normalize(
+            await realpathNative(lexicalPath),
+          );
+          physicallyResolved = true;
+        } catch {
+          // Virtual, missing, or inaccessible paths retain exact lexical identity.
+        }
+        return {
+          lexicalPath,
+          lexicalKey,
+          canonicalPath,
+          canonicalKey: nativePathIdentity.key(canonicalPath),
+          physicallyResolved,
+        };
+      })();
+      this.#resolved.set(lexicalKey, pending);
+    }
+    const resolved = await pending;
+    return resolved;
+  }
+
+  /**
+   * Resolve a virtual or missing path through its nearest existing ancestor.
+   * The unresolved suffix is appended to that ancestor's realpath, preserving
+   * directory-symlink identity without requiring the target itself on disk.
+   */
+  async resolveWithAncestorFallback(
+    filePath: string,
+  ): Promise<ResolvedFilesystemPath> {
+    const exact = await this.#resolveState(filePath);
+    if (exact.physicallyResolved) return exact;
+
+    const suffix: string[] = [];
+    let current = exact.lexicalPath;
+    while (true) {
+      const parent = path.dirname(current);
+      if (nativePathIdentity.equals(parent, current)) return exact;
+      suffix.unshift(path.basename(current));
+
+      const resolvedParent = await this.#resolveState(parent);
+      if (resolvedParent.physicallyResolved) {
+        const canonicalPath = nativePathIdentity.normalize(
+          path.resolve(resolvedParent.canonicalPath, ...suffix),
+        );
+        return {
+          lexicalPath: exact.lexicalPath,
+          lexicalKey: exact.lexicalKey,
+          canonicalPath,
+          canonicalKey: nativePathIdentity.key(canonicalPath),
+        };
+      }
+      current = parent;
+    }
+  }
+
+  async resolveAll(
+    filePaths: readonly string[],
+    concurrency = 32,
+  ): Promise<ResolvedFilesystemPath[]> {
+    const results = new Array<ResolvedFilesystemPath>(filePaths.length);
+    let next = 0;
+    const worker = async (): Promise<void> => {
+      while (true) {
+        const index = next++;
+        if (index >= filePaths.length) return;
+        results[index] = await this.resolve(filePaths[index]);
+      }
+    };
+    const workerCount = Math.min(
+      filePaths.length,
+      Math.max(1, Math.floor(concurrency)),
+    );
+    await Promise.all(Array.from({ length: workerCount }, worker));
+    return results;
+  }
+}
 
 /** Cache an upward lookup, including misses, for every traversed directory. */
 export function createCachedAncestorFinder<T>(

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -56,15 +56,15 @@ export interface RslintOptions {
   /** Apply rule auto-fixes; results carry `output` (the JS side persists via outputFixes). */
   fix?: boolean;
   /**
-   * In-memory file overlay (path → content) for fully in-memory linting (issue
-   * #1106): put the `tsconfig.json` that `parserOptions.project` names plus any
+   * In-memory file overlay (path → content) for project inputs (issue #1106):
+   * put the `tsconfig.json` that `parserOptions.project` names plus any
    * dependency files here, then lint a buffer with `lintText`. Keys resolve
    * against `cwd` like a linted path (relative or absolute both work); a
    * same-path `lintText` code entry wins. Inside the tsconfig (`files`) and
    * `parserOptions.project`, use relative paths — the TS compiler resolves
    * those, and a bare POSIX-absolute path there has no drive letter on Windows,
-   * so it won't match the overlay. rslint-only — ESLint has no in-memory file
-   * map.
+   * so it won't match the overlay. The overlay permits filesystem fallback and
+   * is not a sandbox. rslint-only — ESLint has no in-memory file map.
    *
    * Give the tsconfig explicit `files`, not a broad `include` glob: a glob is
    * expanded against the real filesystem and would scan `cwd` on disk.

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -13,13 +13,27 @@
  * service; `close()` tears it down (mirrors RSLintService.close()).
  */
 import path from 'node:path';
-import { readFile, writeFile } from 'node:fs/promises';
-import { glob } from 'tinyglobby';
+import { lstat, readFile, stat, writeFile } from 'node:fs/promises';
+import { glob, isDynamicPattern } from 'tinyglobby';
 
 import { RSLintService } from '../service/service.js';
 import { NodeRslintService } from '../internal/node.js';
-import { loadConfigFile, normalizeConfig } from '../config/config-loader.js';
-import { findJSConfigUp } from '../utils/config-discovery.js';
+import {
+  collectPluginMeta,
+  loadConfigFile,
+  normalizeConfig,
+} from '../config/config-loader.js';
+import {
+  discoverConfigs,
+  filterConfigsByParentIgnores,
+  findJSConfig,
+  type ConfigEntry,
+} from '../utils/config-discovery.js';
+import {
+  AncestorPathIndex,
+  createCachedAncestorFinder,
+  nativePathIdentity,
+} from './path-identity.js';
 import type { RslintConfigEntry } from '../config/define-config.js';
 import type { Diagnostic, Fix, LintResponse } from '../types.js';
 
@@ -89,6 +103,238 @@ export interface LintResult {
   output?: string; // present only when fix:true changed the file
 }
 
+interface ResolvedConfig {
+  config: Record<string, unknown>[];
+  configPath?: string;
+  configDirectory: string;
+  routingKey: string;
+}
+
+interface PluginLintHost {
+  lint(request: unknown): Promise<unknown>;
+  shutdown(): Promise<void>;
+}
+
+interface PluginLintSession {
+  host: PluginLintHost;
+  eslintPlugins: Array<{ prefix: string; ruleNames: string[] }>;
+}
+
+type CreatePluginLintHost = (
+  configs: Array<{ configPath: string; configDirectory: string }>,
+  onLog?: (record: { level: string; source: string; text: string }) => void,
+) => Promise<PluginLintHost>;
+
+let pluginHostFactoryPromise: Promise<CreatePluginLintHost> | undefined;
+
+function loadPluginHostFactory(): Promise<CreatePluginLintHost> {
+  pluginHostFactoryPromise ??= (async () => {
+    // A package self-reference resolves to src under the test condition and to
+    // dist/eslint-plugin in published builds. Keep it runtime-only: the library
+    // declaration build deliberately excludes the worker implementation.
+    const pluginEntry: string = '@rslint/core/eslint-plugin';
+    const module: { createPluginLintHost: CreatePluginLintHost } = await import(
+      /* webpackIgnore: true */ pluginEntry
+    );
+    return module.createPluginLintHost;
+  })();
+  return pluginHostFactoryPromise;
+}
+
+interface LoadedConfigCandidate {
+  status: 'loaded';
+  configPath: string;
+  configDirectory: string;
+  baseConfig: Record<string, unknown>[];
+  resolved: ResolvedConfig;
+}
+
+interface FailedConfigCandidate {
+  status: 'failed';
+  configPath: string;
+  configDirectory: string;
+  error: Error;
+}
+
+type ConfigCandidate = LoadedConfigCandidate | FailedConfigCandidate;
+
+interface ClassifiedLintPatterns {
+  literalFilePatterns: string[];
+  scanDirectories: string[];
+}
+
+function rebaseRelativePath(
+  value: string,
+  fromDirectory: string,
+  toDirectory: string,
+  allowNegation: boolean,
+): string {
+  const negated = allowNegation && value.startsWith('!');
+  const relativePath = negated ? value.slice(1) : value;
+  if (!relativePath || path.isAbsolute(relativePath)) return value;
+
+  const prefix = path
+    .relative(toDirectory, fromDirectory)
+    .split(path.sep)
+    .join('/');
+  if (!prefix) return value;
+
+  const normalizedPath = relativePath.split(path.sep).join('/');
+  const rebased = path.posix.normalize(path.posix.join(prefix, normalizedPath));
+  return negated ? `!${rebased}` : rebased;
+}
+
+function rebaseConfigPaths(
+  config: Record<string, unknown>[],
+  fromDirectory: string,
+  toDirectory: string,
+): Record<string, unknown>[] {
+  if (nativePathIdentity.equals(fromDirectory, toDirectory)) return config;
+
+  return config.map((entry) => {
+    const rebased: Record<string, unknown> = { ...entry };
+
+    if (Array.isArray(entry.files)) {
+      rebased.files = entry.files.map((selector) => {
+        if (Array.isArray(selector)) {
+          return selector.map((pattern) =>
+            rebaseRelativePath(
+              pattern as string,
+              fromDirectory,
+              toDirectory,
+              true,
+            ),
+          );
+        }
+        return rebaseRelativePath(
+          selector as string,
+          fromDirectory,
+          toDirectory,
+          true,
+        );
+      });
+    }
+    if (Array.isArray(entry.ignores)) {
+      rebased.ignores = entry.ignores.map((pattern) =>
+        rebaseRelativePath(pattern as string, fromDirectory, toDirectory, true),
+      );
+    }
+
+    const languageOptions = entry.languageOptions;
+    if (languageOptions == null || typeof languageOptions !== 'object') {
+      return rebased;
+    }
+    const parserOptions = (languageOptions as Record<string, unknown>)
+      .parserOptions;
+    if (parserOptions == null || typeof parserOptions !== 'object') {
+      return rebased;
+    }
+    const project = (parserOptions as Record<string, unknown>).project;
+    if (typeof project !== 'string' && !Array.isArray(project)) return rebased;
+
+    const rebaseProject = (projectPath: string): string =>
+      rebaseRelativePath(projectPath, fromDirectory, toDirectory, false);
+    rebased.languageOptions = {
+      ...(languageOptions as Record<string, unknown>),
+      parserOptions: {
+        ...(parserOptions as Record<string, unknown>),
+        project:
+          typeof project === 'string'
+            ? rebaseProject(project)
+            : project.map((projectPath) =>
+                rebaseProject(projectPath as string),
+              ),
+      },
+    };
+    return rebased;
+  });
+}
+
+function staticGlobRoot(pattern: string, cwd: string): string {
+  const absolutePattern = path.resolve(cwd, pattern);
+  const root = path.parse(absolutePattern).root;
+  const segments = absolutePattern.slice(root.length).split(path.sep);
+  let current = root;
+  for (const segment of segments) {
+    if (!segment || isDynamicPattern(segment)) break;
+    current = path.join(current, segment);
+  }
+  return current || cwd;
+}
+
+function compactScanDirectories(directories: Iterable<string>): string[] {
+  const byIdentity = new Map<string, string>();
+  for (const directory of directories) {
+    const normalized = path.normalize(directory);
+    const key = nativePathIdentity.key(normalized);
+    if (!byIdentity.has(key)) byIdentity.set(key, normalized);
+  }
+  const sorted = [...byIdentity.values()].sort(
+    (a, b) => a.length - b.length || nativePathIdentity.compare(a, b),
+  );
+  const compact: string[] = [];
+  for (const directory of sorted) {
+    if (
+      !compact.some((parent) =>
+        nativePathIdentity.isSameOrChild(parent, directory),
+      )
+    ) {
+      compact.push(directory);
+    }
+  }
+  return compact;
+}
+
+async function classifyLintPatterns(
+  patterns: string[],
+  cwd: string,
+): Promise<ClassifiedLintPatterns> {
+  const literalFilePatterns: string[] = [];
+  const scanDirectories = new Set<string>();
+
+  for (const pattern of patterns) {
+    if (pattern.startsWith('!')) continue;
+    if (isDynamicPattern(pattern)) {
+      const scanRoot = staticGlobRoot(pattern, cwd);
+      try {
+        if (!(await lstat(scanRoot)).isSymbolicLink()) {
+          scanDirectories.add(scanRoot);
+        }
+      } catch {
+        // A missing static root cannot contribute a matched target.
+      }
+      continue;
+    }
+
+    const absolute = path.resolve(cwd, pattern);
+    try {
+      const info = await stat(absolute);
+      if (info.isDirectory()) {
+        if (!(await lstat(absolute)).isSymbolicLink()) {
+          scanDirectories.add(absolute);
+        }
+      } else if (info.isFile()) {
+        literalFilePatterns.push(pattern);
+      }
+    } catch {
+      // tinyglobby will omit a missing literal from the match set.
+    }
+  }
+
+  return {
+    literalFilePatterns,
+    scanDirectories: compactScanDirectories(scanDirectories),
+  };
+}
+
+function createCachedConfigFinder(): (startDirectory: string) => string | null {
+  const find = createCachedAncestorFinder((directory) => {
+    const configPath = findJSConfig(directory);
+    return configPath ? path.normalize(configPath) : undefined;
+  });
+  return (startDirectory) => find(path.resolve(startDirectory)) ?? null;
+}
+
 export class Rslint {
   readonly #service: RSLintService;
   readonly #cwd: string;
@@ -96,6 +342,10 @@ export class Rslint {
   readonly #overrideConfigFile?: string | true | null;
   readonly #fix: boolean;
   readonly #virtualFiles?: Record<string, string>;
+  readonly #activePluginHosts = new Set<PluginLintHost>();
+  #normalizedOverrideConfig?: Record<string, unknown>[];
+  #closeRequested = false;
+  #closePromise?: Promise<void>;
 
   constructor(options: RslintOptions = {}) {
     this.#cwd = options.cwd ? path.resolve(options.cwd) : process.cwd();
@@ -124,37 +374,53 @@ export class Rslint {
     options: { filePath?: string } = {},
   ): Promise<LintResult[]> {
     const filePath = path.resolve(this.#cwd, options.filePath ?? '__text__.ts');
-    const { config, configDirectory } = await this.#resolveConfig(
-      path.dirname(filePath),
-    );
-    const response = await this.#service.lint({
-      config,
-      configDirectory,
-      workingDirectory: this.#cwd,
-      files: [filePath],
-      // Overlay (in-memory tsconfig + deps) underlays the code buffer; a
-      // same-path code entry wins so `lintText` always lints `code`.
-      fileContents: { ...this.#resolveOverlay(), [filePath]: code },
-      fix: this.#fix,
-    });
-    const results = this.#toLintResults(response, configDirectory, [filePath], {
-      [filePath]: code,
-    });
-    // ESLint's lintText returns exactly one result — for the linted buffer. An
-    // in-memory overlay dependency file (pulled into the program and matching
-    // the config) can carry its own diagnostics; keep only the linted file so
-    // they neither leak a second result nor get written back by outputFixes.
-    const primary = results.filter((r) => r.filePath === filePath);
-    // ESLint: with no filePath, the result's path is the non-absolute "<text>"
-    // sentinel, so outputFixes skips it (we lint at a synthetic absolute path
-    // so Go can build a program, then relabel). A user-supplied filePath stays
-    // absolute — outputFixes writing it back is then the caller's intent.
-    if (options.filePath == null) {
-      for (const r of primary) {
-        if (r.filePath === filePath) r.filePath = '<text>';
+    const resolved = await this.#resolveConfig(path.dirname(filePath));
+    const { config, configDirectory } = resolved;
+    const pluginSession = await this.#createPluginLintSession([resolved]);
+    try {
+      const response = await this.#service.lint(
+        {
+          config,
+          eslintPlugins: pluginSession?.eslintPlugins,
+          configDirectory,
+          workingDirectory: this.#cwd,
+          files: [filePath],
+          // Overlay (in-memory tsconfig + deps) underlays the code buffer; a
+          // same-path code entry wins so `lintText` always lints `code`.
+          fileContents: { ...this.#resolveOverlay(), [filePath]: code },
+          fix: this.#fix,
+        },
+        pluginSession
+          ? { pluginLint: (request) => pluginSession.host.lint(request) }
+          : {},
+      );
+      const results = this.#toLintResults(
+        response,
+        configDirectory,
+        [filePath],
+        { [filePath]: code },
+      );
+      // ESLint's lintText returns exactly one result — for the linted buffer. An
+      // in-memory overlay dependency file (pulled into the program and matching
+      // the config) can carry its own diagnostics; keep only the linted file so
+      // they neither leak a second result nor get written back by outputFixes.
+      const primary = results.filter((r) =>
+        nativePathIdentity.equals(r.filePath, filePath),
+      );
+      // ESLint: with no filePath, the result's path is the non-absolute "<text>"
+      // sentinel, so outputFixes skips it. A user-supplied filePath stays
+      // absolute, making outputFixes writing it back the caller's intent.
+      if (options.filePath == null) {
+        for (const r of primary) {
+          if (nativePathIdentity.equals(r.filePath, filePath)) {
+            r.filePath = '<text>';
+          }
+        }
       }
+      return primary;
+    } finally {
+      await this.#shutdownPluginSession(pluginSession);
     }
-    return primary;
   }
 
   /**
@@ -163,83 +429,144 @@ export class Rslint {
    */
   async lintFiles(patterns: string | string[]): Promise<LintResult[]> {
     const globs = Array.isArray(patterns) ? patterns : [patterns];
-    const matched = await glob(globs, {
+    const { literalFilePatterns, scanDirectories } = await classifyLintPatterns(
+      globs,
+      this.#cwd,
+    );
+    const globOptions = {
       cwd: this.#cwd,
       absolute: true,
       onlyFiles: true,
+      dot: true,
+      ignore: ['**/node_modules/**', '**/.git/**'],
+    } as const;
+    const matched = await glob(globs, {
+      ...globOptions,
+      followSymbolicLinks: false,
     });
-    const files = matched.map((f) => path.normalize(f));
+    const literalMatches =
+      literalFilePatterns.length === 0
+        ? []
+        : await glob(
+            [
+              ...literalFilePatterns,
+              ...globs.filter((pattern) => pattern.startsWith('!')),
+            ],
+            {
+              ...globOptions,
+              // This glob contains only literal file positives. Following them
+              // includes a file symlink without allowing a directory walk.
+              followSymbolicLinks: true,
+            },
+          );
+
+    const filesByIdentity = new Map<string, string>();
+    for (const file of matched) {
+      const normalized = path.normalize(file);
+      const key = nativePathIdentity.key(normalized);
+      if (!filesByIdentity.has(key)) filesByIdentity.set(key, normalized);
+    }
+    const explicitFiles = new Set<string>();
+    for (const file of literalMatches) {
+      const normalized = path.normalize(file);
+      const key = nativePathIdentity.key(normalized);
+      explicitFiles.add(key);
+      // Preserve the spelling of a literal target over an overlapping glob.
+      filesByIdentity.set(key, normalized);
+    }
+
+    const files = [...filesByIdentity.values()];
     if (files.length === 0) return [];
 
+    const configByFile = await this.#resolveLintFileConfigs(
+      files,
+      explicitFiles,
+      scanDirectories,
+    );
     const groups = new Map<
       string,
       {
         config: Record<string, unknown>[];
+        configPath?: string;
         configDirectory: string;
+        routingKey: string;
         files: string[];
       }
     >();
-    const configCache = new Map<
-      string,
-      Promise<{ config: Record<string, unknown>[]; configDirectory: string }>
-    >();
 
-    for (const file of [...files].sort()) {
-      const fromDir = path.dirname(file);
-      let resolved = configCache.get(fromDir);
-      if (!resolved) {
-        resolved = this.#resolveConfig(fromDir);
-        configCache.set(fromDir, resolved);
-      }
-      const { config, configDirectory } = await resolved;
-      let group = groups.get(configDirectory);
+    for (const file of [...files].sort(nativePathIdentity.compare)) {
+      const resolved = configByFile.get(file);
+      if (!resolved) continue;
+      const { config, configPath, configDirectory, routingKey } = resolved;
+      let group = groups.get(routingKey);
       if (!group) {
-        group = { config, configDirectory, files: [] };
-        groups.set(configDirectory, group);
+        group = {
+          config,
+          configPath,
+          configDirectory,
+          routingKey,
+          files: [],
+        };
+        groups.set(routingKey, group);
       }
       group.files.push(file);
     }
 
-    const results: LintResult[] = [];
-    for (const group of [...groups.values()].sort((a, b) =>
-      a.configDirectory.localeCompare(b.configDirectory),
-    )) {
-      const response = await this.#service.lint({
-        config: group.config,
-        configDirectory: group.configDirectory,
-        workingDirectory: this.#cwd,
-        files: group.files,
-        // Overlay (e.g. an in-memory tsconfig) for the program over disk files.
-        fileContents: this.#resolveOverlay(),
-        fix: this.#fix,
-      });
-      const { contents, bomFiles } = await this.#readDiagnosticContents(
-        response,
-        group.configDirectory,
-      );
-      // Seed results from the files Go actually linted (config `ignores`
-      // already excluded, paths program-canonical) rather than the glob matches:
-      // an ignored match produces no phantom empty result, and a symlinked glob
-      // path can't duplicate a result whose diagnostic is keyed to the program
-      // path. Fall back to the glob matches if an older binary omits lintedFiles.
-      const linted = response.lintedFiles
-        ? response.lintedFiles.map((f) =>
-            path.isAbsolute(f)
-              ? path.normalize(f)
-              : path.resolve(group.configDirectory, f),
-          )
-        : group.files;
-      results.push(
-        ...this.#toLintResults(
+    const pluginSession = await this.#createPluginLintSession([
+      ...groups.values(),
+    ]);
+    try {
+      const results: LintResult[] = [];
+      // Files are inserted in deterministic path order above. Keep that group
+      // order instead of imposing a parent-first config execution dependency.
+      for (const group of groups.values()) {
+        const response = await this.#service.lint(
+          {
+            config: group.config,
+            eslintPlugins: pluginSession?.eslintPlugins,
+            configDirectory: group.configDirectory,
+            workingDirectory: this.#cwd,
+            files: group.files,
+            // Overlay (e.g. an in-memory tsconfig) for the program over disk files.
+            fileContents: this.#resolveOverlay(),
+            fix: this.#fix,
+          },
+          pluginSession
+            ? { pluginLint: (request) => pluginSession.host.lint(request) }
+            : {},
+        );
+        const { contents, bomFiles } = await this.#readDiagnosticContents(
           response,
           group.configDirectory,
-          linted,
-          contents,
-          bomFiles,
-        ),
+        );
+        // Seed results from the files Go actually linted (config `ignores`
+        // already excluded) rather than the glob matches. Go preserves each
+        // selected target's path identity even when its Program uses a canonical
+        // or symlinked source path. Fall back to the glob matches if an older
+        // binary omits lintedFiles.
+        const linted = response.lintedFiles
+          ? response.lintedFiles.map((f) =>
+              path.isAbsolute(f)
+                ? path.normalize(f)
+                : path.resolve(group.configDirectory, f),
+            )
+          : group.files;
+        results.push(
+          ...this.#toLintResults(
+            response,
+            group.configDirectory,
+            linted,
+            contents,
+            bomFiles,
+          ),
+        );
+      }
+      return results.sort((a, b) =>
+        nativePathIdentity.compare(a.filePath, b.filePath),
       );
+    } finally {
+      await this.#shutdownPluginSession(pluginSession);
     }
-    return results.sort((a, b) => a.filePath.localeCompare(b.filePath));
   }
 
   /**
@@ -258,8 +585,30 @@ export class Rslint {
   }
 
   /** Tear down the long-lived Go `--api` process. */
-  async close(): Promise<void> {
-    await this.#service.close();
+  close(): Promise<void> {
+    this.#closePromise ??= this.#closeResources();
+    return this.#closePromise;
+  }
+
+  async #closeResources(): Promise<void> {
+    this.#closeRequested = true;
+    const shutdownActiveHosts = async (): Promise<void> => {
+      await Promise.allSettled(
+        [...this.#activePluginHosts].map((host) => host.shutdown()),
+      );
+      this.#activePluginHosts.clear();
+    };
+
+    // Unblock any Go lint request currently awaiting pluginLint before queuing
+    // the service's exit request behind it. A second sweep catches a host whose
+    // initialization raced the first snapshot; such a host also observes
+    // #closeRequested and shuts itself down before becoming active.
+    await shutdownActiveHosts();
+    try {
+      await this.#service.close();
+    } finally {
+      await shutdownActiveHosts();
+    }
   }
 
   async [Symbol.asyncDispose](): Promise<void> {
@@ -280,49 +629,416 @@ export class Rslint {
     return resolved;
   }
 
-  async #resolveConfig(fromDir: string): Promise<{
-    config: Record<string, unknown>[];
-    configDirectory: string;
-  }> {
+  async #createPluginLintSession(
+    resolvedConfigs: ReadonlyArray<ResolvedConfig>,
+  ): Promise<PluginLintSession | null> {
+    const configsByDescriptor = new Map<
+      string,
+      {
+        configPath: string;
+        configDirectory: string;
+        entries: ReadonlyArray<unknown>;
+      }
+    >();
+    for (const resolved of resolvedConfigs) {
+      if (!resolved.configPath) continue;
+      const key = `${nativePathIdentity.key(resolved.configPath)}\0${resolved.configDirectory}`;
+      if (!configsByDescriptor.has(key)) {
+        configsByDescriptor.set(key, {
+          configPath: resolved.configPath,
+          configDirectory: resolved.configDirectory,
+          entries: resolved.config,
+        });
+      }
+    }
+
+    const { eslintPluginEntries, pluginConfigs } = collectPluginMeta([
+      ...configsByDescriptor.values(),
+    ]);
+    if (pluginConfigs.length === 0) return null;
+
+    const createPluginLintHost = await loadPluginHostFactory();
+    const host = await createPluginLintHost(pluginConfigs, (record) => {
+      process.stderr.write(`[rslint:plugin] ${record.text}\n`);
+    });
+    if (this.#closeRequested) {
+      await host.shutdown();
+      throw new Error('rslint service is closing');
+    }
+    this.#activePluginHosts.add(host);
+    return { host, eslintPlugins: eslintPluginEntries };
+  }
+
+  async #shutdownPluginSession(
+    session: PluginLintSession | null,
+  ): Promise<void> {
+    if (!session) return;
+    try {
+      await session.host.shutdown();
+    } finally {
+      this.#activePluginHosts.delete(session.host);
+    }
+  }
+
+  async #loadConfigCandidate(
+    configPath: string,
+    configDirectory: string,
+    candidatesByPath: Map<string, ConfigCandidate>,
+  ): Promise<ConfigCandidate> {
+    const normalizedPath = path.normalize(configPath);
+    const key = nativePathIdentity.key(normalizedPath);
+    const existing = candidatesByPath.get(key);
+    if (existing) return existing;
+
+    const normalizedDirectory = path.normalize(configDirectory);
+    let baseConfig: Record<string, unknown>[];
+    try {
+      baseConfig = normalizeConfig(await loadConfigFile(normalizedPath));
+    } catch (error) {
+      const candidate: FailedConfigCandidate = {
+        status: 'failed',
+        configPath: normalizedPath,
+        configDirectory: normalizedDirectory,
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+      candidatesByPath.set(key, candidate);
+      return candidate;
+    }
+
+    const candidate: LoadedConfigCandidate = {
+      status: 'loaded',
+      configPath: normalizedPath,
+      configDirectory: normalizedDirectory,
+      baseConfig,
+      resolved: this.#composeConfig(
+        baseConfig,
+        normalizedDirectory,
+        `config:${key}`,
+        normalizedPath,
+      ),
+    };
+    candidatesByPath.set(key, candidate);
+    return candidate;
+  }
+
+  async #resolveLintFileConfigs(
+    files: string[],
+    explicitFiles: Set<string>,
+    scanDirectories: string[],
+  ): Promise<Map<string, ResolvedConfig | null>> {
+    const result = new Map<string, ResolvedConfig | null>();
+
+    // Explicit config modes use one config for every target. Go remains the
+    // source of truth for that config's own files/ignores matching.
+    if (this.#overrideConfigFile != null) {
+      const resolved = await this.#resolveConfig(this.#cwd);
+      for (const file of files) result.set(file, resolved);
+      return result;
+    }
+
+    const findConfigUp = createCachedConfigFinder();
+    const discovered = new Map<
+      string,
+      { configPath: string; configDirectory: string }
+    >();
+    const addDiscovered = (
+      configPath: string,
+      configDirectory = path.dirname(configPath),
+    ): void => {
+      const normalizedPath = path.normalize(configPath);
+      const key = nativePathIdentity.key(normalizedPath);
+      if (!discovered.has(key)) {
+        discovered.set(key, {
+          configPath: normalizedPath,
+          configDirectory: path.normalize(configDirectory),
+        });
+      }
+    };
+
+    if (scanDirectories.length > 0) {
+      const scanned = await discoverConfigs(
+        [],
+        scanDirectories,
+        this.#cwd,
+        null,
+      );
+      for (const [configPath, configDirectory] of scanned) {
+        addDiscovered(configPath, configDirectory);
+      }
+    }
+    for (const file of files) {
+      if (!explicitFiles.has(nativePathIdentity.key(file))) continue;
+      const configPath = findConfigUp(path.dirname(file));
+      if (configPath) addDiscovered(configPath);
+    }
+
+    if (discovered.size === 0) {
+      const emptyConfig = this.#composeConfig(
+        [],
+        this.#cwd,
+        `empty:${nativePathIdentity.key(this.#cwd)}`,
+      );
+      for (const file of files) result.set(file, emptyConfig);
+      return result;
+    }
+
+    const candidatesByPath = new Map<string, ConfigCandidate>();
+    const loadCandidate = async (
+      configPath: string,
+      configDirectory: string,
+    ): Promise<ConfigCandidate> =>
+      this.#loadConfigCandidate(configPath, configDirectory, candidatesByPath);
+
+    const failedQueue: FailedConfigCandidate[] = [];
+    for (const { configPath, configDirectory } of discovered.values()) {
+      const candidate = await loadCandidate(configPath, configDirectory);
+      if (candidate.status === 'failed') failedQueue.push(candidate);
+    }
+
+    // Only failed configs need their undiscovered ancestors. This keeps an
+    // explicit file target local while still providing normal ancestor
+    // fallback, and config discovery remains proportional to unique dirs.
+    for (let i = 0; i < failedQueue.length; i++) {
+      const failed = failedQueue[i];
+      const ancestorPath = findConfigUp(path.dirname(failed.configDirectory));
+      if (!ancestorPath) continue;
+
+      const key = nativePathIdentity.key(ancestorPath);
+      if (candidatesByPath.has(key)) continue;
+      const ancestor = await loadCandidate(
+        ancestorPath,
+        path.dirname(ancestorPath),
+      );
+      if (ancestor.status === 'failed') failedQueue.push(ancestor);
+    }
+
+    const candidates = [...candidatesByPath.values()];
+    const loadedCandidates = candidates.filter(
+      (candidate): candidate is LoadedConfigCandidate =>
+        candidate.status === 'loaded',
+    );
+    const failedCandidates = candidates.filter(
+      (candidate): candidate is FailedConfigCandidate =>
+        candidate.status === 'failed',
+    );
+    if (loadedCandidates.length === 0) {
+      const first = failedCandidates[0];
+      throw new Error(
+        first
+          ? `Failed to load config ${first.configPath}: ${first.error.message}`
+          : 'No discovered rslint config could be loaded',
+      );
+    }
+    for (const failed of failedCandidates) {
+      console.warn(
+        `[rslint] Skipping config ${failed.configPath}: ${failed.error.message}`,
+      );
+    }
+
+    const candidateIndex = new AncestorPathIndex(
+      candidates.map(
+        (candidate) => [candidate.configDirectory, candidate] as const,
+      ),
+    );
+    const nearestLoadedCandidate = (
+      candidate: ConfigCandidate | undefined,
+    ): LoadedConfigCandidate | undefined => {
+      let current = candidate;
+      while (current) {
+        if (current.status === 'loaded') return current;
+        current = candidateIndex.findParent(current.configDirectory);
+      }
+      return undefined;
+    };
+
+    const configEntries: ConfigEntry[] = loadedCandidates.map((candidate) => ({
+      configDirectory: candidate.configDirectory,
+      // Parent-ignore discovery belongs to the authored file config. The API
+      // override is evaluated later from cwd and must not move this boundary.
+      entries: candidate.baseConfig as RslintConfigEntry[],
+    }));
+
+    const explicitConfigDirs = new Set<string>();
+    for (const file of files) {
+      if (!explicitFiles.has(nativePathIdentity.key(file))) continue;
+      const loaded = nearestLoadedCandidate(
+        candidateIndex.find(path.dirname(file)),
+      );
+      if (loaded) explicitConfigDirs.add(loaded.configDirectory);
+    }
+
+    const directoryEntries = filterConfigsByParentIgnores(configEntries);
+    const directoryConfigDirs = new Set(
+      directoryEntries.map((entry) =>
+        nativePathIdentity.key(entry.configDirectory),
+      ),
+    );
+    const effectiveEntries = filterConfigsByParentIgnores(
+      configEntries,
+      explicitConfigDirs,
+    );
+    const effectiveConfigDirs = new Set(
+      effectiveEntries.map((entry) =>
+        nativePathIdentity.key(entry.configDirectory),
+      ),
+    );
+
+    const emptyConfig = this.#composeConfig(
+      [],
+      this.#cwd,
+      `empty:${nativePathIdentity.key(this.#cwd)}`,
+    );
+    for (const file of files) {
+      let candidate = candidateIndex.find(path.dirname(file));
+      if (!candidate) {
+        result.set(file, emptyConfig);
+        continue;
+      }
+
+      const allowedDirs = explicitFiles.has(nativePathIdentity.key(file))
+        ? effectiveConfigDirs
+        : directoryConfigDirs;
+      let firstFailure: FailedConfigCandidate | undefined;
+      while (candidate.status === 'failed') {
+        firstFailure ??= candidate;
+        candidate = candidateIndex.findParent(candidate.configDirectory);
+        if (!candidate) break;
+      }
+
+      if (!candidate) {
+        if (explicitFiles.has(nativePathIdentity.key(file)) && firstFailure) {
+          throw new Error(
+            `Failed to load config ${firstFailure.configPath}: ${firstFailure.error.message}`,
+          );
+        }
+        result.set(file, null);
+        continue;
+      }
+
+      result.set(
+        file,
+        allowedDirs.has(nativePathIdentity.key(candidate.configDirectory))
+          ? candidate.resolved
+          : null,
+      );
+    }
+    return result;
+  }
+
+  #getNormalizedOverrideConfig(): Record<string, unknown>[] | null {
+    if (this.#overrideConfig == null) return null;
+    if (this.#normalizedOverrideConfig) return this.#normalizedOverrideConfig;
+    const override = Array.isArray(this.#overrideConfig)
+      ? this.#overrideConfig
+      : [this.#overrideConfig];
+    for (const [index, entry] of override.entries()) {
+      if (entry == null || typeof entry !== 'object' || Array.isArray(entry)) {
+        continue;
+      }
+      const plugins = (entry as Record<string, unknown>).plugins;
+      if (
+        plugins !== null &&
+        typeof plugins === 'object' &&
+        !Array.isArray(plugins)
+      ) {
+        throw new Error(
+          `[rslint] overrideConfig entry at index ${index} uses object-form "plugins". ` +
+            'Community ESLint plugins in overrideConfig are not supported because ' +
+            'the plugin worker cannot re-import an in-memory plugin object. Move ' +
+            'the plugin declaration to rslint.config.js (or .mjs/.ts/.mts), or use ' +
+            'array-form built-in plugins.',
+        );
+      }
+    }
+    this.#normalizedOverrideConfig = normalizeConfig(override);
+    return this.#normalizedOverrideConfig;
+  }
+
+  #composeConfig(
+    base: Record<string, unknown>[],
+    configDirectory: string,
+    routingKey: string,
+    configPath?: string,
+  ): ResolvedConfig {
+    const override = this.#getNormalizedOverrideConfig();
+    if (!override) {
+      return { config: base, configPath, configDirectory, routingKey };
+    }
+
+    // One IPC config has one path base. Move the authored nested config's
+    // relative fields to cwd, then append the override unchanged so all three
+    // override path-bearing fields use Rslint's cwd as documented.
+    return {
+      config: [
+        ...rebaseConfigPaths(base, configDirectory, this.#cwd),
+        ...override,
+      ],
+      configPath,
+      configDirectory: this.#cwd,
+      routingKey,
+    };
+  }
+
+  async #resolveConfig(fromDir: string): Promise<ResolvedConfig> {
     let base: Record<string, unknown>[] = [];
+    let configPath: string | undefined;
     let configDirectory = this.#cwd;
+    let routingKey = `empty:${nativePathIdentity.key(this.#cwd)}`;
 
     if (this.#overrideConfigFile === true) {
       // Only overrideConfig — no file, no discovery.
+      routingKey = `override:${nativePathIdentity.key(this.#cwd)}`;
     } else if (typeof this.#overrideConfigFile === 'string') {
-      const configPath = path.resolve(this.#cwd, this.#overrideConfigFile);
+      configPath = path.resolve(this.#cwd, this.#overrideConfigFile);
       base = normalizeConfig(await loadConfigFile(configPath));
       // Explicit overrideConfigFile follows CLI --config semantics: files,
       // ignores, and parserOptions.project resolve from invocation cwd.
       configDirectory = this.#cwd;
+      routingKey = `config:${nativePathIdentity.key(configPath)}`;
     } else {
-      ({ config: base, configDirectory } =
-        await this.#resolveAutoConfig(fromDir));
+      return this.#resolveAutoConfig(fromDir);
     }
 
-    if (this.#overrideConfig != null) {
-      const override = Array.isArray(this.#overrideConfig)
-        ? this.#overrideConfig
-        : [this.#overrideConfig];
-      base = [...base, ...normalizeConfig(override)];
-    }
-
-    return { config: base, configDirectory };
+    return this.#composeConfig(base, configDirectory, routingKey, configPath);
   }
 
-  async #resolveAutoConfig(fromDir: string): Promise<{
-    config: Record<string, unknown>[];
-    configDirectory: string;
-  }> {
-    const nearestConfig = findJSConfigUp(fromDir);
-    if (!nearestConfig) {
-      return { config: [], configDirectory: this.#cwd };
+  async #resolveAutoConfig(fromDir: string): Promise<ResolvedConfig> {
+    const findConfigUp = createCachedConfigFinder();
+    let configPath = findConfigUp(fromDir);
+    if (!configPath) {
+      return this.#composeConfig(
+        [],
+        this.#cwd,
+        `empty:${nativePathIdentity.key(this.#cwd)}`,
+      );
     }
 
-    return {
-      config: normalizeConfig(await loadConfigFile(nearestConfig)),
-      configDirectory: path.dirname(nearestConfig),
-    };
+    const candidatesByPath = new Map<string, ConfigCandidate>();
+    let nearestFailure: FailedConfigCandidate | undefined;
+    const failures: FailedConfigCandidate[] = [];
+    while (configPath) {
+      const candidate = await this.#loadConfigCandidate(
+        configPath,
+        path.dirname(configPath),
+        candidatesByPath,
+      );
+      if (candidate.status === 'loaded') {
+        for (const failed of failures) {
+          console.warn(
+            `[rslint] Skipping config ${failed.configPath}: ${failed.error.message}`,
+          );
+        }
+        return candidate.resolved;
+      }
+
+      nearestFailure ??= candidate;
+      failures.push(candidate);
+      configPath = findConfigUp(path.dirname(candidate.configDirectory));
+    }
+
+    throw new Error(
+      `Failed to load config ${nearestFailure!.configPath}: ${nearestFailure!.error.message}`,
+    );
   }
 
   async #readDiagnosticContents(
@@ -351,7 +1067,7 @@ export class Rslint {
         try {
           const raw = await readFile(abs, 'utf8');
           if (raw.charCodeAt(0) === 0xfeff) {
-            bomFiles.add(abs);
+            bomFiles.add(nativePathIdentity.key(abs));
             contents[abs] = raw.slice(1); // BOM-stripped, matching Go's offsets
           } else {
             contents[abs] = raw;
@@ -374,28 +1090,42 @@ export class Rslint {
     const toAbs = (p: string): string =>
       path.isAbsolute(p) ? path.normalize(p) : path.resolve(configDirectory, p);
 
+    const contentByPath = new Map<string, string>();
+    for (const [filePath, source] of Object.entries(contents ?? {})) {
+      contentByPath.set(nativePathIdentity.key(filePath), source);
+    }
+
     // Every linted file gets a result, even with zero messages (ESLint shape).
-    const byFile = new Map<string, LintMessage[]>();
-    for (const f of files) byFile.set(path.normalize(f), []);
+    // Identity keys coalesce path-casing variants on case-insensitive hosts.
+    const byFile = new Map<
+      string,
+      { filePath: string; messages: LintMessage[] }
+    >();
+    for (const file of files) {
+      const filePath = path.normalize(file);
+      const key = nativePathIdentity.key(filePath);
+      if (!byFile.has(key)) byFile.set(key, { filePath, messages: [] });
+    }
 
     for (const d of response.diagnostics ?? []) {
       const abs = toAbs(d.filePath);
-      let messages = byFile.get(abs);
-      if (!messages) {
-        messages = [];
-        byFile.set(abs, messages);
+      const key = nativePathIdentity.key(abs);
+      let bucket = byFile.get(key);
+      if (!bucket) {
+        bucket = { filePath: abs, messages: [] };
+        byFile.set(key, bucket);
       }
-      messages.push(toLintMessage(d, contents?.[abs]));
+      bucket.messages.push(toLintMessage(d, contentByPath.get(key)));
     }
 
     // Wire `output` is keyed by relative path; remap to absolute.
-    const outputByAbs = new Map<string, string>();
+    const outputByPath = new Map<string, string>();
     for (const [rel, fixed] of Object.entries(response.output ?? {})) {
-      outputByAbs.set(toAbs(rel), fixed);
+      outputByPath.set(nativePathIdentity.key(toAbs(rel)), fixed);
     }
 
     const results: LintResult[] = [];
-    for (const [filePath, messages] of byFile) {
+    for (const [key, { filePath, messages }] of byFile) {
       let errorCount = 0;
       let warningCount = 0;
       let fixableErrorCount = 0;
@@ -417,13 +1147,13 @@ export class Rslint {
         fixableErrorCount,
         fixableWarningCount,
       };
-      const output = outputByAbs.get(filePath);
+      const output = outputByPath.get(key);
       if (output !== undefined) {
         // Go's Output is BOM-stripped (ApplyRuleFixes runs over the decoded
         // SourceFile text); re-prepend the BOM for a disk file that had one so
         // outputFixes writes back a file identical to the original but for the
         // fix.
-        result.output = bomFiles?.has(filePath) ? '\uFEFF' + output : output;
+        result.output = bomFiles?.has(key) ? '\uFEFF' + output : output;
       }
       results.push(result);
     }

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -14,7 +14,8 @@
  */
 import path from 'node:path';
 import { lstat, readFile, stat, writeFile } from 'node:fs/promises';
-import { glob, isDynamicPattern } from 'tinyglobby';
+import { convertPathToPattern, glob, isDynamicPattern } from 'tinyglobby';
+import picomatch from 'picomatch';
 
 import { RSLintService } from '../service/service.js';
 import { NodeRslintService } from '../internal/node.js';
@@ -24,15 +25,19 @@ import {
   normalizeConfig,
 } from '../config/config-loader.js';
 import {
+  coalesceCaseAliasedConfigs,
   discoverConfigs,
   filterConfigsByParentIgnores,
   findJSConfig,
+  findNativeCaseAliasConfigPath,
   type ConfigEntry,
 } from '../utils/config-discovery.js';
 import {
   AncestorPathIndex,
   createCachedAncestorFinder,
   nativePathIdentity,
+  RunPathResolver,
+  type ResolvedFilesystemPath,
 } from './path-identity.js';
 import type { RslintConfigEntry } from '../config/define-config.js';
 import type { Diagnostic, Fix, LintResponse } from '../types.js';
@@ -107,6 +112,7 @@ interface ResolvedConfig {
   config: Record<string, unknown>[];
   configPath?: string;
   configDirectory: string;
+  pluginConfigDirectory: string;
   routingKey: string;
 }
 
@@ -127,7 +133,7 @@ type CreatePluginLintHost = (
 
 let pluginHostFactoryPromise: Promise<CreatePluginLintHost> | undefined;
 
-function loadPluginHostFactory(): Promise<CreatePluginLintHost> {
+async function loadPluginHostFactory(): Promise<CreatePluginLintHost> {
   pluginHostFactoryPromise ??= (async () => {
     // A package self-reference resolves to src under the test condition and to
     // dist/eslint-plugin in published builds. Keep it runtime-only: the library
@@ -138,7 +144,12 @@ function loadPluginHostFactory(): Promise<CreatePluginLintHost> {
     );
     return module.createPluginLintHost;
   })();
-  return pluginHostFactoryPromise;
+  const factory = await pluginHostFactoryPromise;
+  return factory;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 interface LoadedConfigCandidate {
@@ -160,95 +171,25 @@ type ConfigCandidate = LoadedConfigCandidate | FailedConfigCandidate;
 
 interface ClassifiedLintPatterns {
   literalFilePatterns: string[];
+  literalDirectorySymlinks: string[];
   scanDirectories: string[];
 }
 
-function rebaseRelativePath(
-  value: string,
-  fromDirectory: string,
-  toDirectory: string,
-  allowNegation: boolean,
-): string {
-  const negated = allowNegation && value.startsWith('!');
-  const relativePath = negated ? value.slice(1) : value;
-  if (!relativePath || path.isAbsolute(relativePath)) return value;
+type GlobPatternRole = 'match' | 'ignore' | 'skip';
 
-  const prefix = path
-    .relative(toDirectory, fromDirectory)
-    .split(path.sep)
-    .join('/');
-  if (!prefix) return value;
-
-  const normalizedPath = relativePath.split(path.sep).join('/');
-  const rebased = path.posix.normalize(path.posix.join(prefix, normalizedPath));
-  return negated ? `!${rebased}` : rebased;
+// Keep this classification aligned with tinyglobby's processPatterns(): a
+// leading `!(` starts a positive extglob, while `!pattern` is an exclusion.
+function globPatternRole(pattern: string): GlobPatternRole {
+  if (pattern[0] !== '!' || pattern[1] === '(') return 'match';
+  if (pattern[1] !== '!' || pattern[2] === '(') return 'ignore';
+  return 'skip';
 }
 
-function rebaseConfigPaths(
-  config: Record<string, unknown>[],
-  fromDirectory: string,
-  toDirectory: string,
-): Record<string, unknown>[] {
-  if (nativePathIdentity.equals(fromDirectory, toDirectory)) return config;
-
-  return config.map((entry) => {
-    const rebased: Record<string, unknown> = { ...entry };
-
-    if (Array.isArray(entry.files)) {
-      rebased.files = entry.files.map((selector) => {
-        if (Array.isArray(selector)) {
-          return selector.map((pattern) =>
-            rebaseRelativePath(
-              pattern as string,
-              fromDirectory,
-              toDirectory,
-              true,
-            ),
-          );
-        }
-        return rebaseRelativePath(
-          selector as string,
-          fromDirectory,
-          toDirectory,
-          true,
-        );
-      });
-    }
-    if (Array.isArray(entry.ignores)) {
-      rebased.ignores = entry.ignores.map((pattern) =>
-        rebaseRelativePath(pattern as string, fromDirectory, toDirectory, true),
-      );
-    }
-
-    const languageOptions = entry.languageOptions;
-    if (languageOptions == null || typeof languageOptions !== 'object') {
-      return rebased;
-    }
-    const parserOptions = (languageOptions as Record<string, unknown>)
-      .parserOptions;
-    if (parserOptions == null || typeof parserOptions !== 'object') {
-      return rebased;
-    }
-    const project = (parserOptions as Record<string, unknown>).project;
-    if (typeof project !== 'string' && !Array.isArray(project)) return rebased;
-
-    const rebaseProject = (projectPath: string): string =>
-      rebaseRelativePath(projectPath, fromDirectory, toDirectory, false);
-    rebased.languageOptions = {
-      ...(languageOptions as Record<string, unknown>),
-      parserOptions: {
-        ...(parserOptions as Record<string, unknown>),
-        project:
-          typeof project === 'string'
-            ? rebaseProject(project)
-            : project.map((projectPath) =>
-                rebaseProject(projectPath as string),
-              ),
-      },
-    };
-    return rebased;
-  });
+interface PlannedLintFile extends ResolvedFilesystemPath {
+  explicit: boolean;
 }
+
+const DEFAULT_LINT_GLOB_IGNORES = ['**/node_modules/**', '**/.git/**'];
 
 function staticGlobRoot(pattern: string, cwd: string): string {
   const absolutePattern = path.resolve(cwd, pattern);
@@ -285,19 +226,60 @@ function compactScanDirectories(directories: Iterable<string>): string[] {
   return compact;
 }
 
+function normalizeGlobPatternForCwd(pattern: string, cwd: string): string {
+  let normalized = pattern;
+  if (normalized.endsWith('/') || normalized.endsWith('\\')) {
+    normalized = normalized.slice(0, -1);
+  }
+  if (path.isAbsolute(normalized)) {
+    normalized = path.relative(cwd, normalized);
+  }
+  normalized = normalized.split(path.sep).join('/');
+  return path.posix.normalize(normalized);
+}
+
+function matchesExcludedLiteral(
+  filePath: string,
+  patterns: readonly string[],
+  cwd: string,
+): boolean {
+  const candidate = path.relative(cwd, filePath).split(path.sep).join('/');
+  for (const rawPattern of patterns) {
+    let pattern = rawPattern;
+    if (pattern.startsWith('!')) {
+      if (pattern[1] === '(') continue;
+      if (pattern[1] === '!' && pattern[2] !== '(') continue;
+      pattern = pattern.slice(1);
+    }
+    pattern = normalizeGlobPatternForCwd(pattern, cwd);
+    const expandedPatterns = pattern.endsWith('*')
+      ? [pattern]
+      : [pattern, `${pattern}/**`];
+    if (picomatch(expandedPatterns, { dot: true, nocase: false })(candidate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function classifyLintPatterns(
   patterns: string[],
   cwd: string,
 ): Promise<ClassifiedLintPatterns> {
   const literalFilePatterns: string[] = [];
+  const literalDirectorySymlinks: string[] = [];
   const scanDirectories = new Set<string>();
+  const excludedLiteralPatterns = [
+    ...DEFAULT_LINT_GLOB_IGNORES,
+    ...patterns.filter((pattern) => globPatternRole(pattern) === 'ignore'),
+  ];
 
   for (const pattern of patterns) {
-    if (pattern.startsWith('!')) continue;
+    if (globPatternRole(pattern) !== 'match') continue;
     if (isDynamicPattern(pattern)) {
       const scanRoot = staticGlobRoot(pattern, cwd);
       try {
-        if (!(await lstat(scanRoot)).isSymbolicLink()) {
+        if ((await stat(scanRoot)).isDirectory()) {
           scanDirectories.add(scanRoot);
         }
       } catch {
@@ -310,11 +292,17 @@ async function classifyLintPatterns(
     try {
       const info = await stat(absolute);
       if (info.isDirectory()) {
-        if (!(await lstat(absolute)).isSymbolicLink()) {
-          scanDirectories.add(absolute);
+        scanDirectories.add(absolute);
+        if ((await lstat(absolute)).isSymbolicLink()) {
+          literalDirectorySymlinks.push(absolute);
         }
       } else if (info.isFile()) {
-        literalFilePatterns.push(pattern);
+        const absolutePattern = path.resolve(cwd, pattern);
+        if (
+          !matchesExcludedLiteral(absolutePattern, excludedLiteralPatterns, cwd)
+        ) {
+          literalFilePatterns.push(absolutePattern);
+        }
       }
     } catch {
       // tinyglobby will omit a missing literal from the match set.
@@ -323,6 +311,7 @@ async function classifyLintPatterns(
 
   return {
     literalFilePatterns,
+    literalDirectorySymlinks,
     scanDirectories: compactScanDirectories(scanDirectories),
   };
 }
@@ -374,8 +363,16 @@ export class Rslint {
     options: { filePath?: string } = {},
   ): Promise<LintResult[]> {
     const filePath = path.resolve(this.#cwd, options.filePath ?? '__text__.ts');
-    const resolved = await this.#resolveConfig(path.dirname(filePath));
-    const { config, configDirectory } = resolved;
+    const lexicalDirectory = path.dirname(filePath);
+    const pathResolver = new RunPathResolver();
+    const resolvedFile =
+      await pathResolver.resolveWithAncestorFallback(filePath);
+    const canonicalDirectory = path.dirname(resolvedFile.canonicalPath);
+    const resolved = await this.#resolveConfig(
+      lexicalDirectory,
+      canonicalDirectory,
+    );
+    const { config, configDirectory, pluginConfigDirectory } = resolved;
     const pluginSession = await this.#createPluginLintSession([resolved]);
     try {
       const response = await this.#service.lint(
@@ -383,6 +380,7 @@ export class Rslint {
           config,
           eslintPlugins: pluginSession?.eslintPlugins,
           configDirectory,
+          pluginConfigDirectory,
           workingDirectory: this.#cwd,
           files: [filePath],
           // Overlay (in-memory tsconfig + deps) underlays the code buffer; a
@@ -391,7 +389,12 @@ export class Rslint {
           fix: this.#fix,
         },
         pluginSession
-          ? { pluginLint: (request) => pluginSession.host.lint(request) }
+          ? {
+              pluginLint: async (request) => {
+                const result = await pluginSession.host.lint(request);
+                return result;
+              },
+            }
           : {},
       );
       const results = this.#toLintResults(
@@ -429,59 +432,76 @@ export class Rslint {
    */
   async lintFiles(patterns: string | string[]): Promise<LintResult[]> {
     const globs = Array.isArray(patterns) ? patterns : [patterns];
-    const { literalFilePatterns, scanDirectories } = await classifyLintPatterns(
-      globs,
-      this.#cwd,
-    );
+    const { literalFilePatterns, literalDirectorySymlinks, scanDirectories } =
+      await classifyLintPatterns(globs, this.#cwd);
     const globOptions = {
       cwd: this.#cwd,
       absolute: true,
       onlyFiles: true,
       dot: true,
-      ignore: ['**/node_modules/**', '**/.git/**'],
+      ignore: DEFAULT_LINT_GLOB_IGNORES,
     } as const;
     const matched = await glob(globs, {
       ...globOptions,
       followSymbolicLinks: false,
     });
-    const literalMatches =
-      literalFilePatterns.length === 0
+    const directorySymlinkMatches =
+      literalDirectorySymlinks.length === 0
         ? []
         : await glob(
             [
-              ...literalFilePatterns,
+              ...literalDirectorySymlinks.map(
+                (directory) => `${convertPathToPattern(directory)}/**/*`,
+              ),
               ...globs.filter((pattern) => pattern.startsWith('!')),
             ],
             {
               ...globOptions,
-              // This glob contains only literal file positives. Following them
-              // includes a file symlink without allowing a directory walk.
-              followSymbolicLinks: true,
+              // The explicitly named symlink is the scan root; nested directory
+              // symlinks remain excluded.
+              followSymbolicLinks: false,
             },
           );
+    // stat() already established each literal as a file. Keep its caller
+    // spelling directly, including file symlinks, without a second glob crawl.
+    const literalMatches = literalFilePatterns;
 
-    const filesByIdentity = new Map<string, string>();
-    for (const file of matched) {
+    const filesByIdentity = new Map<
+      string,
+      { filePath: string; explicit: boolean }
+    >();
+    for (const file of [...matched, ...directorySymlinkMatches]) {
       const normalized = path.normalize(file);
       const key = nativePathIdentity.key(normalized);
-      if (!filesByIdentity.has(key)) filesByIdentity.set(key, normalized);
+      if (!filesByIdentity.has(key)) {
+        filesByIdentity.set(key, { filePath: normalized, explicit: false });
+      }
     }
-    const explicitFiles = new Set<string>();
     for (const file of literalMatches) {
       const normalized = path.normalize(file);
       const key = nativePathIdentity.key(normalized);
-      explicitFiles.add(key);
       // Preserve the spelling of a literal target over an overlapping glob.
-      filesByIdentity.set(key, normalized);
+      filesByIdentity.set(key, { filePath: normalized, explicit: true });
     }
 
-    const files = [...filesByIdentity.values()];
-    if (files.length === 0) return [];
+    const lexicalFiles = [...filesByIdentity.values()];
+    if (lexicalFiles.length === 0) return [];
+
+    const pathResolver = new RunPathResolver();
+    const resolvedPaths = await pathResolver.resolveAll(
+      lexicalFiles.map(({ filePath }) => filePath),
+    );
+    const plannedFiles: PlannedLintFile[] = resolvedPaths.map(
+      (resolved, index) => ({
+        ...resolved,
+        explicit: lexicalFiles[index].explicit,
+      }),
+    );
 
     const configByFile = await this.#resolveLintFileConfigs(
-      files,
-      explicitFiles,
+      plannedFiles,
       scanDirectories,
+      pathResolver,
     );
     const groups = new Map<
       string,
@@ -489,27 +509,82 @@ export class Rslint {
         config: Record<string, unknown>[];
         configPath?: string;
         configDirectory: string;
+        pluginConfigDirectory: string;
         routingKey: string;
         files: string[];
+        canonicalFiles: string[];
       }
     >();
 
-    for (const file of [...files].sort(nativePathIdentity.compare)) {
-      const resolved = configByFile.get(file);
+    const selectedByCanonicalPath = new Map<
+      string,
+      {
+        file: PlannedLintFile;
+        resolved: ResolvedConfig;
+        ownerCanonicalKey: string;
+      }
+    >();
+    for (const file of [...plannedFiles].sort((left, right) =>
+      nativePathIdentity.compare(left.lexicalPath, right.lexicalPath),
+    )) {
+      const resolved = configByFile.get(file.lexicalKey);
       if (!resolved) continue;
-      const { config, configPath, configDirectory, routingKey } = resolved;
+      const owner = await pathResolver.resolve(resolved.pluginConfigDirectory);
+      const existing = selectedByCanonicalPath.get(file.canonicalKey);
+      if (existing) {
+        if (existing.ownerCanonicalKey !== owner.canonicalKey) {
+          throw new Error(
+            `Lint target aliases ${JSON.stringify(existing.file.lexicalPath)} and ${JSON.stringify(file.lexicalPath)} ` +
+              `resolve to the same file but are governed by different config directories ` +
+              `${JSON.stringify(existing.resolved.pluginConfigDirectory)} and ${JSON.stringify(resolved.pluginConfigDirectory)}`,
+          );
+        }
+        const preferFile =
+          (file.explicit && !existing.file.explicit) ||
+          (file.explicit === existing.file.explicit &&
+            nativePathIdentity.compare(
+              file.lexicalPath,
+              existing.file.lexicalPath,
+            ) < 0);
+        if (preferFile) {
+          selectedByCanonicalPath.set(file.canonicalKey, {
+            file,
+            resolved,
+            ownerCanonicalKey: owner.canonicalKey,
+          });
+        }
+        continue;
+      }
+      selectedByCanonicalPath.set(file.canonicalKey, {
+        file,
+        resolved,
+        ownerCanonicalKey: owner.canonicalKey,
+      });
+    }
+
+    for (const { file, resolved } of selectedByCanonicalPath.values()) {
+      const {
+        config,
+        configPath,
+        configDirectory,
+        pluginConfigDirectory,
+        routingKey,
+      } = resolved;
       let group = groups.get(routingKey);
       if (!group) {
         group = {
           config,
           configPath,
           configDirectory,
+          pluginConfigDirectory,
           routingKey,
           files: [],
+          canonicalFiles: [],
         };
         groups.set(routingKey, group);
       }
-      group.files.push(file);
+      group.files.push(file.lexicalPath);
+      group.canonicalFiles.push(file.canonicalPath);
     }
 
     const pluginSession = await this.#createPluginLintSession([
@@ -525,14 +600,21 @@ export class Rslint {
             config: group.config,
             eslintPlugins: pluginSession?.eslintPlugins,
             configDirectory: group.configDirectory,
+            pluginConfigDirectory: group.pluginConfigDirectory,
             workingDirectory: this.#cwd,
             files: group.files,
+            canonicalFiles: group.canonicalFiles,
             // Overlay (e.g. an in-memory tsconfig) for the program over disk files.
             fileContents: this.#resolveOverlay(),
             fix: this.#fix,
           },
           pluginSession
-            ? { pluginLint: (request) => pluginSession.host.lint(request) }
+            ? {
+                pluginLint: async (request) => {
+                  const result = await pluginSession.host.lint(request);
+                  return result;
+                },
+              }
             : {},
         );
         const { contents, bomFiles } = await this.#readDiagnosticContents(
@@ -585,16 +667,18 @@ export class Rslint {
   }
 
   /** Tear down the long-lived Go `--api` process. */
-  close(): Promise<void> {
+  async close(): Promise<void> {
     this.#closePromise ??= this.#closeResources();
-    return this.#closePromise;
+    await this.#closePromise;
   }
 
   async #closeResources(): Promise<void> {
     this.#closeRequested = true;
     const shutdownActiveHosts = async (): Promise<void> => {
       await Promise.allSettled(
-        [...this.#activePluginHosts].map((host) => host.shutdown()),
+        [...this.#activePluginHosts].map(async (host) => {
+          await host.shutdown();
+        }),
       );
       this.#activePluginHosts.clear();
     };
@@ -642,11 +726,11 @@ export class Rslint {
     >();
     for (const resolved of resolvedConfigs) {
       if (!resolved.configPath) continue;
-      const key = `${nativePathIdentity.key(resolved.configPath)}\0${resolved.configDirectory}`;
+      const key = `${nativePathIdentity.key(resolved.configPath)}\0${resolved.pluginConfigDirectory}`;
       if (!configsByDescriptor.has(key)) {
         configsByDescriptor.set(key, {
           configPath: resolved.configPath,
-          configDirectory: resolved.configDirectory,
+          configDirectory: resolved.pluginConfigDirectory,
           entries: resolved.config,
         });
       }
@@ -722,9 +806,9 @@ export class Rslint {
   }
 
   async #resolveLintFileConfigs(
-    files: string[],
-    explicitFiles: Set<string>,
+    files: PlannedLintFile[],
     scanDirectories: string[],
+    pathResolver: RunPathResolver,
   ): Promise<Map<string, ResolvedConfig | null>> {
     const result = new Map<string, ResolvedConfig | null>();
 
@@ -732,7 +816,7 @@ export class Rslint {
     // source of truth for that config's own files/ignores matching.
     if (this.#overrideConfigFile != null) {
       const resolved = await this.#resolveConfig(this.#cwd);
-      for (const file of files) result.set(file, resolved);
+      for (const file of files) result.set(file.lexicalKey, resolved);
       return result;
     }
 
@@ -767,8 +851,11 @@ export class Rslint {
       }
     }
     for (const file of files) {
-      if (!explicitFiles.has(nativePathIdentity.key(file))) continue;
-      const configPath = findConfigUp(path.dirname(file));
+      if (!file.explicit) continue;
+      let configPath = findConfigUp(path.dirname(file.lexicalPath));
+      if (!configPath && file.canonicalKey !== file.lexicalKey) {
+        configPath = findConfigUp(path.dirname(file.canonicalPath));
+      }
       if (configPath) addDiscovered(configPath);
     }
 
@@ -778,9 +865,28 @@ export class Rslint {
         this.#cwd,
         `empty:${nativePathIdentity.key(this.#cwd)}`,
       );
-      for (const file of files) result.set(file, emptyConfig);
+      for (const file of files) result.set(file.lexicalKey, emptyConfig);
       return result;
     }
+
+    const coalescedDiscovered = coalesceCaseAliasedConfigs(
+      new Map(
+        [...discovered.values()].map(({ configPath, configDirectory }) => [
+          configPath,
+          configDirectory,
+        ]),
+      ),
+    ).configs;
+    discovered.clear();
+    for (const [configPath, configDirectory] of coalescedDiscovered) {
+      addDiscovered(configPath, configDirectory);
+    }
+    const discoveredConfigs = new Map(
+      [...discovered.values()].map(({ configPath, configDirectory }) => [
+        configPath,
+        configDirectory,
+      ]),
+    );
 
     const candidatesByPath = new Map<string, ConfigCandidate>();
     const loadCandidate = async (
@@ -803,12 +909,18 @@ export class Rslint {
       const ancestorPath = findConfigUp(path.dirname(failed.configDirectory));
       if (!ancestorPath) continue;
 
-      const key = nativePathIdentity.key(ancestorPath);
+      const normalizedPath = path.normalize(ancestorPath);
+      const configDirectory = path.dirname(normalizedPath);
+      const selectedPath =
+        findNativeCaseAliasConfigPath(
+          normalizedPath,
+          configDirectory,
+          discoveredConfigs,
+        ) ?? normalizedPath;
+      const key = nativePathIdentity.key(selectedPath);
       if (candidatesByPath.has(key)) continue;
-      const ancestor = await loadCandidate(
-        ancestorPath,
-        path.dirname(ancestorPath),
-      );
+      discoveredConfigs.set(selectedPath, configDirectory);
+      const ancestor = await loadCandidate(selectedPath, configDirectory);
       if (ancestor.status === 'failed') failedQueue.push(ancestor);
     }
 
@@ -840,6 +952,42 @@ export class Rslint {
         (candidate) => [candidate.configDirectory, candidate] as const,
       ),
     );
+    const candidateDirectories = await pathResolver.resolveAll(
+      candidates.map((candidate) => candidate.configDirectory),
+    );
+    const canonicalCandidates = new Map<
+      string,
+      { canonicalDirectory: string; candidate: ConfigCandidate }
+    >();
+    for (let index = 0; index < candidates.length; index++) {
+      const candidate = candidates[index];
+      const directory = candidateDirectories[index];
+      if (!canonicalCandidates.has(directory.canonicalKey)) {
+        canonicalCandidates.set(directory.canonicalKey, {
+          canonicalDirectory: directory.canonicalPath,
+          candidate,
+        });
+      } else {
+        const existing = canonicalCandidates.get(directory.canonicalKey);
+        if (existing?.candidate !== candidate) {
+          throw new Error(
+            `Config directories ${JSON.stringify(existing?.candidate.configDirectory)} and ` +
+              `${JSON.stringify(candidate.configDirectory)} resolve to the same filesystem location`,
+          );
+        }
+      }
+    }
+    const canonicalCandidateIndex = new AncestorPathIndex(
+      [...canonicalCandidates.values()].map(
+        ({ canonicalDirectory, candidate }) =>
+          [canonicalDirectory, candidate] as const,
+      ),
+    );
+    const nearestCandidateForFile = (
+      file: PlannedLintFile,
+    ): ConfigCandidate | undefined =>
+      candidateIndex.find(path.dirname(file.lexicalPath)) ??
+      canonicalCandidateIndex.find(path.dirname(file.canonicalPath));
     const nearestLoadedCandidate = (
       candidate: ConfigCandidate | undefined,
     ): LoadedConfigCandidate | undefined => {
@@ -860,10 +1008,8 @@ export class Rslint {
 
     const explicitConfigDirs = new Set<string>();
     for (const file of files) {
-      if (!explicitFiles.has(nativePathIdentity.key(file))) continue;
-      const loaded = nearestLoadedCandidate(
-        candidateIndex.find(path.dirname(file)),
-      );
+      if (!file.explicit) continue;
+      const loaded = nearestLoadedCandidate(nearestCandidateForFile(file));
       if (loaded) explicitConfigDirs.add(loaded.configDirectory);
     }
 
@@ -889,34 +1035,27 @@ export class Rslint {
       `empty:${nativePathIdentity.key(this.#cwd)}`,
     );
     for (const file of files) {
-      let candidate = candidateIndex.find(path.dirname(file));
+      let candidate = nearestCandidateForFile(file);
       if (!candidate) {
-        result.set(file, emptyConfig);
+        result.set(file.lexicalKey, emptyConfig);
         continue;
       }
 
-      const allowedDirs = explicitFiles.has(nativePathIdentity.key(file))
+      const allowedDirs = file.explicit
         ? effectiveConfigDirs
         : directoryConfigDirs;
-      let firstFailure: FailedConfigCandidate | undefined;
       while (candidate.status === 'failed') {
-        firstFailure ??= candidate;
         candidate = candidateIndex.findParent(candidate.configDirectory);
         if (!candidate) break;
       }
 
       if (!candidate) {
-        if (explicitFiles.has(nativePathIdentity.key(file)) && firstFailure) {
-          throw new Error(
-            `Failed to load config ${firstFailure.configPath}: ${firstFailure.error.message}`,
-          );
-        }
-        result.set(file, null);
+        result.set(file.lexicalKey, null);
         continue;
       }
 
       result.set(
-        file,
+        file.lexicalKey,
         allowedDirs.has(nativePathIdentity.key(candidate.configDirectory))
           ? candidate.resolved
           : null,
@@ -935,7 +1074,7 @@ export class Rslint {
       if (entry == null || typeof entry !== 'object' || Array.isArray(entry)) {
         continue;
       }
-      const plugins = (entry as Record<string, unknown>).plugins;
+      const plugins = isRecord(entry) ? entry.plugins : undefined;
       if (
         plugins !== null &&
         typeof plugins === 'object' &&
@@ -945,7 +1084,7 @@ export class Rslint {
           `[rslint] overrideConfig entry at index ${index} uses object-form "plugins". ` +
             'Community ESLint plugins in overrideConfig are not supported because ' +
             'the plugin worker cannot re-import an in-memory plugin object. Move ' +
-            'the plugin declaration to rslint.config.js (or .mjs/.ts/.mts), or use ' +
+            'the plugin declaration to rslint.config.js (or .mjs/.cjs/.ts/.mts/.cts), or use ' +
             'array-form built-in plugins.',
         );
       }
@@ -962,24 +1101,30 @@ export class Rslint {
   ): ResolvedConfig {
     const override = this.#getNormalizedOverrideConfig();
     if (!override) {
-      return { config: base, configPath, configDirectory, routingKey };
+      return {
+        config: base,
+        configPath,
+        configDirectory,
+        pluginConfigDirectory: configDirectory,
+        routingKey,
+      };
     }
 
-    // One IPC config has one path base. Move the authored nested config's
-    // relative fields to cwd, then append the override unchanged so all three
-    // override path-bearing fields use Rslint's cwd as documented.
+    // ESLint resolves overrideConfig relative to the selected config's base.
+    // Explicit overrideConfigFile already supplies cwd as configDirectory.
     return {
-      config: [
-        ...rebaseConfigPaths(base, configDirectory, this.#cwd),
-        ...override,
-      ],
+      config: [...base, ...override],
       configPath,
-      configDirectory: this.#cwd,
+      configDirectory,
+      pluginConfigDirectory: configDirectory,
       routingKey,
     };
   }
 
-  async #resolveConfig(fromDir: string): Promise<ResolvedConfig> {
+  async #resolveConfig(
+    fromDir: string,
+    canonicalFromDir = fromDir,
+  ): Promise<ResolvedConfig> {
     let base: Record<string, unknown>[] = [];
     let configPath: string | undefined;
     let configDirectory = this.#cwd;
@@ -996,15 +1141,21 @@ export class Rslint {
       configDirectory = this.#cwd;
       routingKey = `config:${nativePathIdentity.key(configPath)}`;
     } else {
-      return this.#resolveAutoConfig(fromDir);
+      return this.#resolveAutoConfig(fromDir, canonicalFromDir);
     }
 
     return this.#composeConfig(base, configDirectory, routingKey, configPath);
   }
 
-  async #resolveAutoConfig(fromDir: string): Promise<ResolvedConfig> {
+  async #resolveAutoConfig(
+    fromDir: string,
+    canonicalFromDir: string,
+  ): Promise<ResolvedConfig> {
     const findConfigUp = createCachedConfigFinder();
     let configPath = findConfigUp(fromDir);
+    if (!configPath && !nativePathIdentity.equals(fromDir, canonicalFromDir)) {
+      configPath = findConfigUp(canonicalFromDir);
+    }
     if (!configPath) {
       return this.#composeConfig(
         [],

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -170,67 +170,76 @@ export class Rslint {
     });
     const files = matched.map((f) => path.normalize(f));
     if (files.length === 0) return [];
-    const { config, configDirectory } = await this.#resolveConfig(this.#cwd);
-    const response = await this.#service.lint({
-      config,
-      configDirectory,
-      workingDirectory: this.#cwd,
-      files,
-      // Overlay (e.g. an in-memory tsconfig) for the program over disk files.
-      fileContents: this.#resolveOverlay(),
-      fix: this.#fix,
-    });
-    // Read source for each file that produced a diagnostic so mergeFixes can
-    // gap-fill multi-edit fixes (parity with lintText, which has the source
-    // in-hand). Only diagnosed files are read; a lint with no findings reads
-    // nothing.
-    const contents: Record<string, string> = {};
-    // Disk files whose bytes start with a UTF-8 BOM. Go reads them through a
-    // decoder that strips the BOM, so its fix offsets AND Output are
-    // BOM-stripped. We strip the BOM from the source fed to mergeFixes so the
-    // gap-fill slices line up with those offsets — and `fix.range` therefore
-    // stays BOM-stripped, matching ESLint v10 and the message line/column —
-    // then re-prepend the BOM to Output (in toLintResults) so outputFixes writes
-    // back the real file. (lintText is unaffected: its overlay keeps the BOM and
-    // Go's offsets already include it, so no adjustment is needed there.)
-    const bomFiles = new Set<string>();
-    for (const d of response.diagnostics ?? []) {
-      const abs = path.isAbsolute(d.filePath)
-        ? path.normalize(d.filePath)
-        : path.resolve(configDirectory, d.filePath);
-      if (!(abs in contents)) {
-        try {
-          const raw = await readFile(abs, 'utf8');
-          if (raw.charCodeAt(0) === 0xfeff) {
-            bomFiles.add(abs);
-            contents[abs] = raw.slice(1); // BOM-stripped, matching Go's offsets
-          } else {
-            contents[abs] = raw;
-          }
-        } catch {
-          // Unreadable (e.g. virtual/deleted) — mergeFixes degrades to first edit.
-        }
+
+    const groups = new Map<
+      string,
+      {
+        config: Record<string, unknown>[];
+        configDirectory: string;
+        files: string[];
       }
+    >();
+    const configCache = new Map<
+      string,
+      Promise<{ config: Record<string, unknown>[]; configDirectory: string }>
+    >();
+
+    for (const file of [...files].sort()) {
+      const fromDir = path.dirname(file);
+      let resolved = configCache.get(fromDir);
+      if (!resolved) {
+        resolved = this.#resolveConfig(fromDir);
+        configCache.set(fromDir, resolved);
+      }
+      const { config, configDirectory } = await resolved;
+      let group = groups.get(configDirectory);
+      if (!group) {
+        group = { config, configDirectory, files: [] };
+        groups.set(configDirectory, group);
+      }
+      group.files.push(file);
     }
-    // Seed results from the files Go actually linted (config `ignores` already
-    // excluded, paths program-canonical) rather than the glob matches: an
-    // ignored match produces no phantom empty result, and a symlinked glob path
-    // can't duplicate a result whose diagnostic is keyed to the program path.
-    // Fall back to the glob matches if an older binary omits lintedFiles.
-    const linted = response.lintedFiles
-      ? response.lintedFiles.map((f) =>
-          path.isAbsolute(f)
-            ? path.normalize(f)
-            : path.resolve(configDirectory, f),
-        )
-      : files;
-    return this.#toLintResults(
-      response,
-      configDirectory,
-      linted,
-      contents,
-      bomFiles,
-    );
+
+    const results: LintResult[] = [];
+    for (const group of [...groups.values()].sort((a, b) =>
+      a.configDirectory.localeCompare(b.configDirectory),
+    )) {
+      const response = await this.#service.lint({
+        config: group.config,
+        configDirectory: group.configDirectory,
+        workingDirectory: this.#cwd,
+        files: group.files,
+        // Overlay (e.g. an in-memory tsconfig) for the program over disk files.
+        fileContents: this.#resolveOverlay(),
+        fix: this.#fix,
+      });
+      const { contents, bomFiles } = await this.#readDiagnosticContents(
+        response,
+        group.configDirectory,
+      );
+      // Seed results from the files Go actually linted (config `ignores`
+      // already excluded, paths program-canonical) rather than the glob matches:
+      // an ignored match produces no phantom empty result, and a symlinked glob
+      // path can't duplicate a result whose diagnostic is keyed to the program
+      // path. Fall back to the glob matches if an older binary omits lintedFiles.
+      const linted = response.lintedFiles
+        ? response.lintedFiles.map((f) =>
+            path.isAbsolute(f)
+              ? path.normalize(f)
+              : path.resolve(group.configDirectory, f),
+          )
+        : group.files;
+      results.push(
+        ...this.#toLintResults(
+          response,
+          group.configDirectory,
+          linted,
+          contents,
+          bomFiles,
+        ),
+      );
+    }
+    return results.sort((a, b) => a.filePath.localeCompare(b.filePath));
   }
 
   /**
@@ -283,14 +292,12 @@ export class Rslint {
     } else if (typeof this.#overrideConfigFile === 'string') {
       const configPath = path.resolve(this.#cwd, this.#overrideConfigFile);
       base = normalizeConfig(await loadConfigFile(configPath));
-      configDirectory = path.dirname(configPath);
+      // Explicit overrideConfigFile follows CLI --config semantics: files,
+      // ignores, and parserOptions.project resolve from invocation cwd.
+      configDirectory = this.#cwd;
     } else {
-      // null / absent: auto-discover the nearest config from fromDir upward.
-      const configPath = findJSConfigUp(fromDir);
-      if (configPath) {
-        base = normalizeConfig(await loadConfigFile(configPath));
-        configDirectory = path.dirname(configPath);
-      }
+      ({ config: base, configDirectory } =
+        await this.#resolveAutoConfig(fromDir));
     }
 
     if (this.#overrideConfig != null) {
@@ -301,6 +308,60 @@ export class Rslint {
     }
 
     return { config: base, configDirectory };
+  }
+
+  async #resolveAutoConfig(fromDir: string): Promise<{
+    config: Record<string, unknown>[];
+    configDirectory: string;
+  }> {
+    const nearestConfig = findJSConfigUp(fromDir);
+    if (!nearestConfig) {
+      return { config: [], configDirectory: this.#cwd };
+    }
+
+    return {
+      config: normalizeConfig(await loadConfigFile(nearestConfig)),
+      configDirectory: path.dirname(nearestConfig),
+    };
+  }
+
+  async #readDiagnosticContents(
+    response: LintResponse,
+    configDirectory: string,
+  ): Promise<{ contents: Record<string, string>; bomFiles: Set<string> }> {
+    // Read source for each file that produced a diagnostic so mergeFixes can
+    // gap-fill multi-edit fixes (parity with lintText, which has the source
+    // in-hand). Only diagnosed files are read; a lint with no findings reads
+    // nothing.
+    const contents: Record<string, string> = {};
+    // Disk files whose bytes start with a UTF-8 BOM. Go reads them through a
+    // decoder that strips the BOM, so its fix offsets AND Output are
+    // BOM-stripped. We strip the BOM from the source fed to mergeFixes so the
+    // gap-fill slices line up with those offsets — and `fix.range` therefore
+    // stays BOM-stripped, matching ESLint v10 and the message line/column —
+    // then re-prepend the BOM to Output (in toLintResults) so outputFixes writes
+    // back the real file. (lintText is unaffected: its overlay keeps the BOM and
+    // Go's offsets already include it, so no adjustment is needed there.)
+    const bomFiles = new Set<string>();
+    for (const d of response.diagnostics ?? []) {
+      const abs = path.isAbsolute(d.filePath)
+        ? path.normalize(d.filePath)
+        : path.resolve(configDirectory, d.filePath);
+      if (!(abs in contents)) {
+        try {
+          const raw = await readFile(abs, 'utf8');
+          if (raw.charCodeAt(0) === 0xfeff) {
+            bomFiles.add(abs);
+            contents[abs] = raw.slice(1); // BOM-stripped, matching Go's offsets
+          } else {
+            contents[abs] = raw;
+          }
+        } catch {
+          // Unreadable (e.g. virtual/deleted) — mergeFixes degrades to first edit.
+        }
+      }
+    }
+    return { contents, bomFiles };
   }
 
   #toLintResults(

--- a/packages/rslint/src/cli/cli.ts
+++ b/packages/rslint/src/cli/cli.ts
@@ -9,6 +9,8 @@ import { parseArgs, classifyArgs, isJSConfigFile } from '../utils/args.js';
 import {
   discoverConfigs,
   filterConfigsByParentIgnores,
+  findJSConfigUp,
+  isConfigDirIgnoredByParentIgnores,
   type ConfigEntry,
 } from '../utils/config-discovery.js';
 import { resolveRslintBinary } from '../internal/resolve-binary.js';
@@ -23,8 +25,8 @@ export type RunCLIOptions = {
 
 /**
  * Load multiple JS/TS configs and run them through the Go binary over IPC.
- * Tolerates individual config load failures — skips broken configs with a
- * warning and continues with the remaining configs.
+ * Any discovered config load/validation failure is fatal, matching ESLint's
+ * config validation behavior.
  */
 async function runWithJSConfigs(
   binPath: string,
@@ -32,25 +34,41 @@ async function runWithJSConfigs(
   goArgs: string[],
   cwd: string,
   singleThreaded: boolean,
+  protectedConfigFiles = new Map<string, string[]>(),
 ): Promise<number> {
   const configEntries: ConfigEntry[] = [];
   const dirToPath = new Map<string, string>();
-  const isSingleConfig = configs.size === 1;
+  const scopedTargetFilesByDir = new Map<string, string[]>();
+  const protectedConfigDirs = new Set(
+    [...protectedConfigFiles.keys()].map((configPath) =>
+      path.dirname(configPath),
+    ),
+  );
 
   for (const [configPath, configDir] of configs) {
+    const ignoredByParent = isConfigDirIgnoredByParentIgnores(
+      configDir,
+      configEntries,
+    );
+    if (!protectedConfigFiles.has(configPath) && ignoredByParent) {
+      continue;
+    }
+    if (ignoredByParent) {
+      const protectedFiles = protectedConfigFiles.get(configPath);
+      if (protectedFiles) {
+        scopedTargetFilesByDir.set(configDir, protectedFiles);
+      }
+    }
+
     let rawConfig: unknown;
     try {
       rawConfig = await loadConfigFile(configPath);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (isSingleConfig) {
-        process.stderr.write(
-          `Error: failed to load config ${configPath}: ${msg}\n`,
-        );
-        return 1;
-      }
-      process.stderr.write(`Warning: skipping config ${configPath}: ${msg}\n`);
-      continue;
+      process.stderr.write(
+        `Error: failed to load config ${configPath}: ${msg}\n`,
+      );
+      return 1;
     }
 
     let entries: ConfigEntry['entries'];
@@ -58,14 +76,8 @@ async function runWithJSConfigs(
       entries = normalizeConfig(rawConfig);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (isSingleConfig) {
-        process.stderr.write(
-          `Error: invalid config in ${configPath}: ${msg}\n`,
-        );
-        return 1;
-      }
-      process.stderr.write(`Warning: skipping config ${configPath}: ${msg}\n`);
-      continue;
+      process.stderr.write(`Error: invalid config in ${configPath}: ${msg}\n`);
+      return 1;
     }
 
     configEntries.push({ configDirectory: configDir, entries });
@@ -76,27 +88,25 @@ async function runWithJSConfigs(
   // of the browser/wasm bundle, loaded only on the real CLI path.
   const { runEngine } = await import('./engine.js');
 
-  // All configs failed to load — fall back to Go loading JSON config from disk
-  // (init with no configs → Go's ConfigStdin=false branch).
-  if (configEntries.length === 0) {
-    return runEngine({ binPath, goArgs, configs: [], cwd });
-  }
-
   // Filter out nested configs whose directory is covered by a parent config's
   // global ignores (ESLint v10 alignment). Then hand the configs to Go in the
   // IPC `init` payload (no more `--config-stdin` stdin pipe).
-  const filteredEntries = filterConfigsByParentIgnores(configEntries);
-  const { eslintPluginEntries, pluginConfigs } = collectPluginMeta(
-    filteredEntries.map((ce) => ({
-      configPath: dirToPath.get(ce.configDirectory) ?? '',
-      configDirectory: ce.configDirectory,
-      entries: ce.entries,
-    })),
+  const filteredEntries = filterConfigsByParentIgnores(
+    configEntries,
+    protectedConfigDirs,
   );
+  const wireConfigEntries = filteredEntries.map((ce) => ({
+    configPath: dirToPath.get(ce.configDirectory) ?? '',
+    configDirectory: ce.configDirectory,
+    entries: ce.entries,
+    targetFiles: scopedTargetFilesByDir.get(ce.configDirectory),
+  }));
+  const { eslintPluginEntries, pluginConfigs } =
+    collectPluginMeta(wireConfigEntries);
   return runEngine({
     binPath,
     goArgs,
-    configs: filteredEntries,
+    configs: wireConfigEntries,
     cwd,
     eslintPluginEntries,
     pluginConfigs,
@@ -137,6 +147,20 @@ export async function run(
 
   // Discover JS/TS configs
   const configs = await discoverConfigs(files, dirs, cwd, args.config);
+  const protectedConfigFiles = new Map<string, string[]>();
+  if (!args.config) {
+    for (const file of files) {
+      const nearestConfig = findJSConfigUp(path.dirname(file));
+      if (nearestConfig) {
+        const protectedFiles = protectedConfigFiles.get(nearestConfig);
+        if (protectedFiles) {
+          protectedFiles.push(file);
+        } else {
+          protectedConfigFiles.set(nearestConfig, [file]);
+        }
+      }
+    }
+  }
 
   // Check if any discovered config is a JS/TS config.
   // NOTE: If any JS config is found (even in subdirectories), the entire flow
@@ -157,6 +181,7 @@ export async function run(
       goArgs,
       cwd,
       args.singleThreaded,
+      protectedConfigFiles,
     );
   }
 

--- a/packages/rslint/src/cli/cli.ts
+++ b/packages/rslint/src/cli/cli.ts
@@ -83,10 +83,10 @@ async function runWithJSConfigs(
   // of the browser/wasm bundle, loaded only on the real CLI path.
   const { runEngine } = await import('./engine.js');
 
-  // All configs failed to load — fall back to Go loading JSON config from disk
-  // (init with no configs → Go's ConfigStdin=false branch).
+  // JS configs were discovered, but none survived loading/normalization. Do
+  // not fall back to JSON/default config; that would lint with unrelated rules.
   if (configEntries.length === 0) {
-    return runEngine({ binPath, goArgs, configs: [], cwd });
+    return 1;
   }
 
   // Filter out nested configs whose directory is covered by a parent config's

--- a/packages/rslint/src/cli/cli.ts
+++ b/packages/rslint/src/cli/cli.ts
@@ -10,7 +10,6 @@ import {
   discoverConfigs,
   filterConfigsByParentIgnores,
   findJSConfigUp,
-  isConfigDirIgnoredByParentIgnores,
   type ConfigEntry,
 } from '../utils/config-discovery.js';
 import { resolveRslintBinary } from '../internal/resolve-binary.js';
@@ -25,8 +24,8 @@ export type RunCLIOptions = {
 
 /**
  * Load multiple JS/TS configs and run them through the Go binary over IPC.
- * Any discovered config load/validation failure is fatal, matching ESLint's
- * config validation behavior.
+ * Tolerates individual config load failures — skips broken configs with a
+ * warning and continues with the remaining configs.
  */
 async function runWithJSConfigs(
   binPath: string,
@@ -38,7 +37,7 @@ async function runWithJSConfigs(
 ): Promise<number> {
   const configEntries: ConfigEntry[] = [];
   const dirToPath = new Map<string, string>();
-  const scopedTargetFilesByDir = new Map<string, string[]>();
+  const isSingleConfig = configs.size === 1;
   const protectedConfigDirs = new Set(
     [...protectedConfigFiles.keys()].map((configPath) =>
       path.dirname(configPath),
@@ -46,29 +45,19 @@ async function runWithJSConfigs(
   );
 
   for (const [configPath, configDir] of configs) {
-    const ignoredByParent = isConfigDirIgnoredByParentIgnores(
-      configDir,
-      configEntries,
-    );
-    if (!protectedConfigFiles.has(configPath) && ignoredByParent) {
-      continue;
-    }
-    if (ignoredByParent) {
-      const protectedFiles = protectedConfigFiles.get(configPath);
-      if (protectedFiles) {
-        scopedTargetFilesByDir.set(configDir, protectedFiles);
-      }
-    }
-
     let rawConfig: unknown;
     try {
       rawConfig = await loadConfigFile(configPath);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(
-        `Error: failed to load config ${configPath}: ${msg}\n`,
-      );
-      return 1;
+      if (isSingleConfig) {
+        process.stderr.write(
+          `Error: failed to load config ${configPath}: ${msg}\n`,
+        );
+        return 1;
+      }
+      process.stderr.write(`Warning: skipping config ${configPath}: ${msg}\n`);
+      continue;
     }
 
     let entries: ConfigEntry['entries'];
@@ -76,8 +65,14 @@ async function runWithJSConfigs(
       entries = normalizeConfig(rawConfig);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`Error: invalid config in ${configPath}: ${msg}\n`);
-      return 1;
+      if (isSingleConfig) {
+        process.stderr.write(
+          `Error: invalid config in ${configPath}: ${msg}\n`,
+        );
+        return 1;
+      }
+      process.stderr.write(`Warning: skipping config ${configPath}: ${msg}\n`);
+      continue;
     }
 
     configEntries.push({ configDirectory: configDir, entries });
@@ -88,9 +83,19 @@ async function runWithJSConfigs(
   // of the browser/wasm bundle, loaded only on the real CLI path.
   const { runEngine } = await import('./engine.js');
 
+  // All configs failed to load — fall back to Go loading JSON config from disk
+  // (init with no configs → Go's ConfigStdin=false branch).
+  if (configEntries.length === 0) {
+    return runEngine({ binPath, goArgs, configs: [], cwd });
+  }
+
   // Filter out nested configs whose directory is covered by a parent config's
   // global ignores (ESLint v10 alignment). Then hand the configs to Go in the
   // IPC `init` payload (no more `--config-stdin` stdin pipe).
+  const unprotectedEntries = filterConfigsByParentIgnores(configEntries);
+  const unprotectedDirs = new Set(
+    unprotectedEntries.map((entry) => entry.configDirectory),
+  );
   const filteredEntries = filterConfigsByParentIgnores(
     configEntries,
     protectedConfigDirs,
@@ -99,7 +104,9 @@ async function runWithJSConfigs(
     configPath: dirToPath.get(ce.configDirectory) ?? '',
     configDirectory: ce.configDirectory,
     entries: ce.entries,
-    targetFiles: scopedTargetFilesByDir.get(ce.configDirectory),
+    targetFiles: unprotectedDirs.has(ce.configDirectory)
+      ? undefined
+      : protectedConfigFiles.get(dirToPath.get(ce.configDirectory) ?? ''),
   }));
   const { eslintPluginEntries, pluginConfigs } =
     collectPluginMeta(wireConfigEntries);

--- a/packages/rslint/src/cli/cli.ts
+++ b/packages/rslint/src/cli/cli.ts
@@ -7,8 +7,12 @@ import {
 } from '../config/config-loader.js';
 import { parseArgs, classifyArgs, isJSConfigFile } from '../utils/args.js';
 import {
+  coalesceCaseAliasedConfigs,
   discoverConfigs,
   filterConfigsByParentIgnores,
+  findNativeCaseAliasConfigPath,
+  findJSConfigsForDirectories,
+  findJSConfigsForFiles,
   findJSConfigUp,
   type ConfigEntry,
 } from '../utils/config-discovery.js';
@@ -24,8 +28,9 @@ export type RunCLIOptions = {
 
 /**
  * Load multiple JS/TS configs and run them through the Go binary over IPC.
- * Tolerates individual config load failures — skips broken configs with a
- * warning and continues with the remaining configs.
+ * Broken candidates are skipped when another selected config remains usable.
+ * For an explicit file, ancestor configs are loaded lazily only after its
+ * nearer candidate fails.
  */
 async function runWithJSConfigs(
   binPath: string,
@@ -34,29 +39,92 @@ async function runWithJSConfigs(
   cwd: string,
   singleThreaded: boolean,
   explicitFileTargetsByConfigPath = new Map<string, string[]>(),
+  explicitDirectoryTargetsByConfigPath = new Map<string, string[]>(),
 ): Promise<number> {
+  ({
+    configs,
+    explicitFileTargetsByConfigPath,
+    explicitDirectoryTargetsByConfigPath,
+  } = coalesceCaseAliasedConfigs(
+    configs,
+    explicitFileTargetsByConfigPath,
+    explicitDirectoryTargetsByConfigPath,
+  ));
   const configEntries: ConfigEntry[] = [];
   const dirToPath = new Map<string, string>();
-  const isSingleConfig = configs.size === 1;
-  const explicitFileConfigDirs = new Set(
-    [...explicitFileTargetsByConfigPath.keys()].map((configPath) =>
-      path.dirname(configPath),
-    ),
+  const initialConfigCount = configs.size;
+  const pendingConfigs = [...configs];
+  const knownConfigPaths = new Set(
+    pendingConfigs.map(([configPath]) => path.normalize(configPath)),
   );
+  const loadedConfigPaths = new Set<string>();
+  const failedConfigPaths = new Set<string>();
+  const failures: Array<{
+    configPath: string;
+    kind: 'load' | 'invalid';
+    message: string;
+  }> = [];
 
-  for (const [configPath, configDir] of configs) {
+  const addTargets = (
+    targetMap: Map<string, string[]>,
+    configPath: string,
+    targets: readonly string[],
+  ): void => {
+    if (targets.length === 0) return;
+    const existing = targetMap.get(configPath) ?? [];
+    targetMap.set(configPath, [...new Set([...existing, ...targets])]);
+  };
+
+  const scheduleAncestorFallback = (
+    failedConfigDirectory: string,
+    files: readonly string[],
+    directories: readonly string[],
+  ): void => {
+    if (files.length === 0 && directories.length === 0) return;
+    const ancestorPath = findJSConfigUp(path.dirname(failedConfigDirectory));
+    if (!ancestorPath) return;
+
+    const normalizedPath = path.normalize(ancestorPath);
+    const configDirectory = path.dirname(normalizedPath);
+    const selectedPath =
+      findNativeCaseAliasConfigPath(normalizedPath, configDirectory, configs) ??
+      normalizedPath;
+    addTargets(explicitFileTargetsByConfigPath, selectedPath, files);
+    addTargets(explicitDirectoryTargetsByConfigPath, selectedPath, directories);
+    if (loadedConfigPaths.has(selectedPath)) return;
+    if (failedConfigPaths.has(selectedPath)) {
+      scheduleAncestorFallback(
+        configs.get(selectedPath) ?? path.dirname(selectedPath),
+        files,
+        directories,
+      );
+      return;
+    }
+    if (!knownConfigPaths.has(selectedPath)) {
+      configs.set(selectedPath, configDirectory);
+      knownConfigPaths.add(selectedPath);
+      pendingConfigs.push([selectedPath, configDirectory]);
+    }
+  };
+  for (let index = 0; index < pendingConfigs.length; index++) {
+    const [configPath, configDir] = pendingConfigs[index];
+    const normalizedConfigPath = path.normalize(configPath);
     let rawConfig: unknown;
     try {
-      rawConfig = await loadConfigFile(configPath);
+      rawConfig = await loadConfigFile(normalizedConfigPath);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (isSingleConfig) {
-        process.stderr.write(
-          `Error: failed to load config ${configPath}: ${msg}\n`,
-        );
-        return 1;
-      }
-      process.stderr.write(`Warning: skipping config ${configPath}: ${msg}\n`);
+      failures.push({
+        configPath: normalizedConfigPath,
+        kind: 'load',
+        message: msg,
+      });
+      failedConfigPaths.add(normalizedConfigPath);
+      scheduleAncestorFallback(
+        configDir,
+        explicitFileTargetsByConfigPath.get(normalizedConfigPath) ?? [],
+        explicitDirectoryTargetsByConfigPath.get(normalizedConfigPath) ?? [],
+      );
       continue;
     }
 
@@ -65,18 +133,23 @@ async function runWithJSConfigs(
       entries = normalizeConfig(rawConfig);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (isSingleConfig) {
-        process.stderr.write(
-          `Error: invalid config in ${configPath}: ${msg}\n`,
-        );
-        return 1;
-      }
-      process.stderr.write(`Warning: skipping config ${configPath}: ${msg}\n`);
+      failures.push({
+        configPath: normalizedConfigPath,
+        kind: 'invalid',
+        message: msg,
+      });
+      failedConfigPaths.add(normalizedConfigPath);
+      scheduleAncestorFallback(
+        configDir,
+        explicitFileTargetsByConfigPath.get(normalizedConfigPath) ?? [],
+        explicitDirectoryTargetsByConfigPath.get(normalizedConfigPath) ?? [],
+      );
       continue;
     }
 
     configEntries.push({ configDirectory: configDir, entries });
-    dirToPath.set(configDir, configPath);
+    dirToPath.set(configDir, normalizedConfigPath);
+    loadedConfigPaths.add(normalizedConfigPath);
   }
 
   // Lazy import — keeps engine.ts (and its node:child_process dependency) out
@@ -86,14 +159,40 @@ async function runWithJSConfigs(
   // JS configs were discovered, but none survived loading/normalization. Do
   // not fall back to JSON/default config; that would lint with unrelated rules.
   if (configEntries.length === 0) {
+    if (initialConfigCount === 1 && failures.length > 0) {
+      const nearest = failures[0];
+      const description =
+        nearest.kind === 'load' ? 'failed to load config' : 'invalid config in';
+      process.stderr.write(
+        `Error: ${description} ${nearest.configPath}: ${nearest.message}\n`,
+      );
+    } else {
+      for (const failure of failures) {
+        process.stderr.write(
+          `Warning: skipping config ${failure.configPath}: ${failure.message}\n`,
+        );
+      }
+    }
     return 1;
   }
 
-  // Directory traversal drops nested configs hidden behind a parent config's
-  // global ignores. Explicit file args are different: ESLint resolves the
-  // nearest config for each file even if directory traversal would not enter
-  // that subtree. Keep those explicit-file configs, but scope them to the
-  // explicit files so they do not reopen full directory discovery.
+  for (const failure of failures) {
+    process.stderr.write(
+      `Warning: skipping config ${failure.configPath}: ${failure.message}\n`,
+    );
+  }
+
+  // Exclude loaded nested config candidates hidden behind a parent config's
+  // global ignores from the directory target set. Explicit file args are
+  // different: ESLint resolves the nearest config for each file even if
+  // directory traversal would not enter that subtree. Keep those explicit-file
+  // configs, but scope them to the explicit files so they do not reopen full
+  // directory discovery.
+  const explicitFileConfigDirs = new Set(
+    [...explicitFileTargetsByConfigPath.keys()].map((configPath) =>
+      path.dirname(configPath),
+    ),
+  );
   const directoryFilteredEntries = filterConfigsByParentIgnores(configEntries);
   const directoryFilteredDirs = new Set(
     directoryFilteredEntries.map((entry) => entry.configDirectory),
@@ -104,13 +203,17 @@ async function runWithJSConfigs(
   );
   const wireConfigEntries = filteredEntries.map((ce) => {
     const configPath = dirToPath.get(ce.configDirectory) ?? '';
+    const explicitTargets = explicitFileTargetsByConfigPath.get(configPath);
+    const explicitOnly = !directoryFilteredDirs.has(ce.configDirectory);
     return {
       configPath,
       configDirectory: ce.configDirectory,
       entries: ce.entries,
-      targetFiles: directoryFilteredDirs.has(ce.configDirectory)
-        ? undefined
-        : explicitFileTargetsByConfigPath.get(configPath),
+      targetFiles:
+        explicitTargets && explicitTargets.length > 0
+          ? explicitTargets
+          : undefined,
+      explicitOnly: explicitOnly || undefined,
     };
   });
   const { eslintPluginEntries, pluginConfigs } =
@@ -158,11 +261,21 @@ export async function run(
   const { files, dirs } = classifyArgs(args.positionals, cwd);
 
   // Discover JS/TS configs
-  const configs = await discoverConfigs(files, dirs, cwd, args.config);
+  const fileConfigs = findJSConfigsForFiles(files);
+  const directoryConfigs = findJSConfigsForDirectories(dirs);
+  const configs = await discoverConfigs(
+    files,
+    dirs,
+    cwd,
+    args.config,
+    fileConfigs,
+    directoryConfigs,
+  );
   const explicitFileTargetsByConfigPath = new Map<string, string[]>();
+  const explicitDirectoryTargetsByConfigPath = new Map<string, string[]>();
   if (!args.config) {
     for (const file of files) {
-      const nearestConfig = findJSConfigUp(path.dirname(file));
+      const nearestConfig = fileConfigs.get(path.normalize(file));
       if (nearestConfig) {
         const explicitTargets =
           explicitFileTargetsByConfigPath.get(nearestConfig);
@@ -171,6 +284,17 @@ export async function run(
         } else {
           explicitFileTargetsByConfigPath.set(nearestConfig, [file]);
         }
+      }
+    }
+    for (const dir of dirs) {
+      const nearestConfig = directoryConfigs.get(path.normalize(dir));
+      if (!nearestConfig) continue;
+      const explicitTargets =
+        explicitDirectoryTargetsByConfigPath.get(nearestConfig);
+      if (explicitTargets) {
+        explicitTargets.push(dir);
+      } else {
+        explicitDirectoryTargetsByConfigPath.set(nearestConfig, [dir]);
       }
     }
   }
@@ -195,6 +319,7 @@ export async function run(
       cwd,
       args.singleThreaded,
       explicitFileTargetsByConfigPath,
+      explicitDirectoryTargetsByConfigPath,
     );
   }
 

--- a/packages/rslint/src/cli/cli.ts
+++ b/packages/rslint/src/cli/cli.ts
@@ -33,13 +33,13 @@ async function runWithJSConfigs(
   goArgs: string[],
   cwd: string,
   singleThreaded: boolean,
-  protectedConfigFiles = new Map<string, string[]>(),
+  explicitFileTargetsByConfigPath = new Map<string, string[]>(),
 ): Promise<number> {
   const configEntries: ConfigEntry[] = [];
   const dirToPath = new Map<string, string>();
   const isSingleConfig = configs.size === 1;
-  const protectedConfigDirs = new Set(
-    [...protectedConfigFiles.keys()].map((configPath) =>
+  const explicitFileConfigDirs = new Set(
+    [...explicitFileTargetsByConfigPath.keys()].map((configPath) =>
       path.dirname(configPath),
     ),
   );
@@ -89,25 +89,30 @@ async function runWithJSConfigs(
     return 1;
   }
 
-  // Filter out nested configs whose directory is covered by a parent config's
-  // global ignores (ESLint v10 alignment). Then hand the configs to Go in the
-  // IPC `init` payload (no more `--config-stdin` stdin pipe).
-  const unprotectedEntries = filterConfigsByParentIgnores(configEntries);
-  const unprotectedDirs = new Set(
-    unprotectedEntries.map((entry) => entry.configDirectory),
+  // Directory traversal drops nested configs hidden behind a parent config's
+  // global ignores. Explicit file args are different: ESLint resolves the
+  // nearest config for each file even if directory traversal would not enter
+  // that subtree. Keep those explicit-file configs, but scope them to the
+  // explicit files so they do not reopen full directory discovery.
+  const directoryFilteredEntries = filterConfigsByParentIgnores(configEntries);
+  const directoryFilteredDirs = new Set(
+    directoryFilteredEntries.map((entry) => entry.configDirectory),
   );
   const filteredEntries = filterConfigsByParentIgnores(
     configEntries,
-    protectedConfigDirs,
+    explicitFileConfigDirs,
   );
-  const wireConfigEntries = filteredEntries.map((ce) => ({
-    configPath: dirToPath.get(ce.configDirectory) ?? '',
-    configDirectory: ce.configDirectory,
-    entries: ce.entries,
-    targetFiles: unprotectedDirs.has(ce.configDirectory)
-      ? undefined
-      : protectedConfigFiles.get(dirToPath.get(ce.configDirectory) ?? ''),
-  }));
+  const wireConfigEntries = filteredEntries.map((ce) => {
+    const configPath = dirToPath.get(ce.configDirectory) ?? '';
+    return {
+      configPath,
+      configDirectory: ce.configDirectory,
+      entries: ce.entries,
+      targetFiles: directoryFilteredDirs.has(ce.configDirectory)
+        ? undefined
+        : explicitFileTargetsByConfigPath.get(configPath),
+    };
+  });
   const { eslintPluginEntries, pluginConfigs } =
     collectPluginMeta(wireConfigEntries);
   return runEngine({
@@ -154,16 +159,17 @@ export async function run(
 
   // Discover JS/TS configs
   const configs = await discoverConfigs(files, dirs, cwd, args.config);
-  const protectedConfigFiles = new Map<string, string[]>();
+  const explicitFileTargetsByConfigPath = new Map<string, string[]>();
   if (!args.config) {
     for (const file of files) {
       const nearestConfig = findJSConfigUp(path.dirname(file));
       if (nearestConfig) {
-        const protectedFiles = protectedConfigFiles.get(nearestConfig);
-        if (protectedFiles) {
-          protectedFiles.push(file);
+        const explicitTargets =
+          explicitFileTargetsByConfigPath.get(nearestConfig);
+        if (explicitTargets) {
+          explicitTargets.push(file);
         } else {
-          protectedConfigFiles.set(nearestConfig, [file]);
+          explicitFileTargetsByConfigPath.set(nearestConfig, [file]);
         }
       }
     }
@@ -188,7 +194,7 @@ export async function run(
       goArgs,
       cwd,
       args.singleThreaded,
-      protectedConfigFiles,
+      explicitFileTargetsByConfigPath,
     );
   }
 

--- a/packages/rslint/src/config/config-hierarchy.ts
+++ b/packages/rslint/src/config/config-hierarchy.ts
@@ -1,0 +1,168 @@
+import path from 'node:path';
+import picomatch from 'picomatch';
+
+export interface ConfigEntry {
+  configDirectory: string;
+  entries: unknown[];
+}
+
+/**
+ * Check if a config entry is a "global ignore" entry: an entry with only
+ * `ignores` and an optional `name`.
+ */
+function isGlobalIgnoreEntry(
+  entry: unknown,
+): entry is { ignores: string[]; name?: string } {
+  if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+    return false;
+  }
+
+  const ignores = 'ignores' in entry ? entry.ignores : undefined;
+  if (
+    !Array.isArray(ignores) ||
+    ignores.length === 0 ||
+    ignores.some((pattern) => typeof pattern !== 'string')
+  ) {
+    return false;
+  }
+
+  return Object.keys(entry).every((key) => key === 'ignores' || key === 'name');
+}
+
+function getGlobalIgnores(entries: unknown[]): string[] {
+  const patterns: string[] = [];
+  for (const entry of entries) {
+    if (isGlobalIgnoreEntry(entry)) patterns.push(...entry.ignores);
+  }
+  return patterns;
+}
+
+function normalizeGlobPattern(pattern: string): string {
+  const normalized = path.posix.normalize(pattern.replaceAll('\\', '/'));
+  return normalized === '.' ? '' : normalized.replace(/^\.\//, '');
+}
+
+/** Check whether a parent config's global ignores block directory traversal. */
+function isDirIgnoredByPatterns(
+  dirPath: string,
+  patterns: string[],
+  parentConfigDir: string,
+): boolean {
+  const relDir = path.relative(parentConfigDir, dirPath);
+  if (!isRelativeChildPath(relDir)) return false;
+
+  const segments = relDir.split(path.sep).filter(Boolean);
+  let current = '';
+
+  // ESLint checks each ancestor directory in order. Once an ancestor remains
+  // ignored after applying the patterns sequentially, descendants cannot be
+  // reached and therefore cannot be re-included by a later pattern.
+  for (const segment of segments) {
+    current = current ? `${current}/${segment}` : segment;
+    let ignored = false;
+
+    for (const rawPattern of patterns) {
+      if (!rawPattern) continue;
+      const negated = rawPattern.startsWith('!');
+      if (negated !== ignored) continue;
+
+      const pattern = normalizeGlobPattern(
+        negated ? rawPattern.slice(1) : rawPattern,
+      );
+      if (!pattern) continue;
+      const isMatch = picomatch(pattern, { dot: true });
+      if (isMatch(current) || isMatch(`${current}/`)) {
+        ignored = !negated;
+      }
+    }
+
+    if (ignored) return true;
+  }
+
+  return false;
+}
+
+function isRelativeChildPath(relPath: string): boolean {
+  return (
+    relPath !== '' &&
+    relPath !== '..' &&
+    !relPath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relPath)
+  );
+}
+
+function isSameOrChildDirectory(parentDir: string, childDir: string): boolean {
+  const parent = path.normalize(parentDir);
+  const child = path.normalize(childDir);
+  if (parent === child) return true;
+  const prefix = parent.endsWith(path.sep) ? parent : `${parent}${path.sep}`;
+  return child.startsWith(prefix);
+}
+
+function normalizeConfigDirectory(configDirectory: string): string {
+  let dir = configDirectory;
+  const root = path.parse(dir).root;
+  while (dir.length > root.length && /[/\\]$/.test(dir)) {
+    dir = dir.slice(0, -1);
+  }
+  return path.normalize(dir);
+}
+
+/**
+ * Filter loaded nested config candidates whose directory is covered by an
+ * ancestor config's global ignores. Candidate discovery and module loading are
+ * intentionally independent from this effective-catalog step.
+ *
+ * `forceIncludeConfigDirectories` is for explicit CLI file targets: ESLint
+ * resolves the nearest config for an explicit file even when parent directory
+ * traversal would have been blocked.
+ */
+export function filterConfigsByParentIgnores<T extends ConfigEntry>(
+  configEntries: T[],
+  forceIncludeConfigDirectories = new Set<string>(),
+): T[] {
+  if (configEntries.length <= 1) return configEntries;
+
+  const forceIncludedDirs = new Set(
+    [...forceIncludeConfigDirectories].map(normalizeConfigDirectory),
+  );
+  const normalizedEntries = configEntries
+    .map((config) => ({
+      config,
+      directory: normalizeConfigDirectory(config.configDirectory),
+    }))
+    // Ordering only ensures an ancestor is evaluated before its descendants;
+    // containment, not sort position, determines the effective parent.
+    .sort((a, b) => a.directory.length - b.directory.length);
+  const result: typeof normalizedEntries = [];
+
+  for (const entry of normalizedEntries) {
+    let ignored = false;
+    let nearestParent: (typeof normalizedEntries)[number] | undefined;
+
+    for (const parent of result) {
+      if (!isSameOrChildDirectory(parent.directory, entry.directory)) continue;
+      if (
+        nearestParent === undefined ||
+        parent.directory.length > nearestParent.directory.length
+      ) {
+        nearestParent = parent;
+      }
+    }
+
+    if (nearestParent !== undefined) {
+      const globalIgnores = getGlobalIgnores(nearestParent.config.entries);
+      ignored =
+        globalIgnores.length > 0 &&
+        isDirIgnoredByPatterns(
+          entry.directory,
+          globalIgnores,
+          nearestParent.directory,
+        );
+    }
+
+    if (!ignored || forceIncludedDirs.has(entry.directory)) result.push(entry);
+  }
+
+  return result.map(({ config }) => config);
+}

--- a/packages/rslint/src/config/config-loader.ts
+++ b/packages/rslint/src/config/config-loader.ts
@@ -3,6 +3,13 @@ import { pathToFileURL } from 'node:url';
 import { NATIVE_PLUGIN_RESERVED_NAMES } from './define-config.js';
 import { selectPluginSource, unwrapPluginModule } from './plugin-source.js';
 
+export const JS_CONFIG_FILES = [
+  'rslint.config.js',
+  'rslint.config.mjs',
+  'rslint.config.ts',
+  'rslint.config.mts',
+] as const;
+
 /**
  * Load a JS/TS config file.
  * - .js/.mjs: native import()
@@ -79,109 +86,176 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
     );
   }
 
-  return config
-    .filter((entry: unknown, index: number) => {
-      if (entry == null || typeof entry !== 'object') {
-        console.warn(
-          `[rslint] Config entry at index ${index} is not an object (got ${entry === null ? 'null' : typeof entry}), skipping.`,
-        );
-        return false;
-      }
-      return true;
-    })
-    .map((entry: Record<string, unknown>, index: number) => {
-      const hasFiles = Object.prototype.hasOwnProperty.call(entry, 'files');
-      if (
-        hasFiles &&
-        entry.files !== undefined &&
-        !Array.isArray(entry.files)
-      ) {
-        throw new Error(
-          `[rslint] Config entry at index ${index}: "files" must be an array, got ${typeof entry.files}`,
-        );
-      }
-      if (hasFiles && Array.isArray(entry.files) && entry.files.length === 0) {
-        throw new Error(
-          `[rslint] Config entry at index ${index}: "files" must be a non-empty array`,
-        );
-      }
-      if (
-        hasFiles &&
-        Array.isArray(entry.files) &&
-        entry.files.some((pattern) => typeof pattern !== 'string')
-      ) {
-        throw new Error(
-          `[rslint] Config entry at index ${index}: "files" must contain only strings`,
-        );
-      }
-      if (entry.ignores != null && !Array.isArray(entry.ignores)) {
-        throw new Error(
-          `[rslint] Config entry at index ${index}: "ignores" must be an array, got ${typeof entry.ignores}`,
-        );
-      }
-      if (
-        Array.isArray(entry.ignores) &&
-        entry.ignores.some((pattern) => typeof pattern !== 'string')
-      ) {
-        throw new Error(
-          `[rslint] Config entry at index ${index}: "ignores" must contain only strings`,
-        );
-      }
+  return config.map((rawEntry: unknown, index: number) => {
+    if (rawEntry === null) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: unexpected null config`,
+      );
+    }
+    if (Array.isArray(rawEntry)) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: unexpected array`,
+      );
+    }
+    if (typeof rawEntry !== 'object') {
+      throw new Error(
+        `[rslint] Config entry at index ${index} must be an object, got ${typeof rawEntry}`,
+      );
+    }
 
-      // Extract ESLint-plugin metadata from the object-form `plugins`. Live
-      // plugin objects carry functions and must NEVER reach the serializable
-      // payload sent to Go — only {prefix, ruleNames} crosses the wire. The
-      // worker re-imports this config file to obtain the live instances.
-      // Source selection (object-form `plugins`) is shared with the worker
-      // loader via `selectPluginSource` so the two never drift.
-      const pluginSource = selectPluginSource(entry);
-      const eslintPluginMeta: Record<string, { ruleNames: string[] }> = {};
-      const pluginPrefixes: string[] = [];
-      if (pluginSource != null) {
-        for (const prefix of Object.keys(pluginSource)) {
-          if (NATIVE_PLUGIN_RESERVED_NAMES.has(prefix)) {
-            throw new Error(
-              `[rslint] Config entry at index ${index}: plugins prefix "${prefix}" collides with the built-in plugin of the same name; choose a different prefix.`,
-            );
-          }
-          const plugin = unwrapPluginModule(pluginSource[prefix]);
-          const pluginRules = plugin?.rules;
-          if (pluginRules == null || typeof pluginRules !== 'object') {
-            throw new Error(
-              `[rslint] Config entry at index ${index}: plugins["${prefix}"] must expose a "rules" object.`,
-            );
-          }
-          eslintPluginMeta[prefix] = {
-            ruleNames: Object.keys(pluginRules).sort(),
-          };
-          pluginPrefixes.push(prefix);
+    const entry = rawEntry as Record<string, unknown>;
+
+    const hasFiles = Object.prototype.hasOwnProperty.call(entry, 'files');
+    if (hasFiles && !Array.isArray(entry.files)) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "files" must be an array, got ${typeof entry.files}`,
+      );
+    }
+    if (hasFiles && Array.isArray(entry.files) && entry.files.length === 0) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "files" must be a non-empty array`,
+      );
+    }
+    if (
+      hasFiles &&
+      Array.isArray(entry.files) &&
+      entry.files.some(
+        (pattern) =>
+          typeof pattern !== 'string' &&
+          (!Array.isArray(pattern) ||
+            pattern.some((nestedPattern) => typeof nestedPattern !== 'string')),
+      )
+    ) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "files" must contain only strings or arrays of strings`,
+      );
+    }
+    const hasIgnores = Object.prototype.hasOwnProperty.call(entry, 'ignores');
+    if (hasIgnores && !Array.isArray(entry.ignores)) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "ignores" must be an array, got ${typeof entry.ignores}`,
+      );
+    }
+    if (
+      Array.isArray(entry.ignores) &&
+      entry.ignores.some((pattern) => typeof pattern !== 'string')
+    ) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "ignores" must contain only strings`,
+      );
+    }
+
+    for (const key of ['rules', 'languageOptions', 'settings'] as const) {
+      if (
+        Object.prototype.hasOwnProperty.call(entry, key) &&
+        (entry[key] === null ||
+          typeof entry[key] !== 'object' ||
+          Array.isArray(entry[key]))
+      ) {
+        throw new Error(
+          `[rslint] Config entry at index ${index}: "${key}" must be an object`,
+        );
+      }
+    }
+
+    const hasPlugins = Object.prototype.hasOwnProperty.call(entry, 'plugins');
+    if (
+      hasPlugins &&
+      (entry.plugins === null || typeof entry.plugins !== 'object')
+    ) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "plugins" must be an object or an array of strings`,
+      );
+    }
+    if (
+      Array.isArray(entry.plugins) &&
+      entry.plugins.some((plugin) => typeof plugin !== 'string')
+    ) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "plugins" must contain only strings`,
+      );
+    }
+    if (
+      Object.prototype.hasOwnProperty.call(entry, 'name') &&
+      typeof entry.name !== 'string'
+    ) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "name" must be a string`,
+      );
+    }
+
+    // Extract ESLint-plugin metadata from the object-form `plugins`. Live
+    // plugin objects carry functions and must NEVER reach the serializable
+    // payload sent to Go — only {prefix, ruleNames} crosses the wire. The
+    // worker re-imports this config file to obtain the live instances.
+    // Source selection (object-form `plugins`) is shared with the worker
+    // loader via `selectPluginSource` so the two never drift.
+    const pluginSource = selectPluginSource(entry);
+    const eslintPluginMeta: Record<string, { ruleNames: string[] }> = {};
+    const pluginPrefixes: string[] = [];
+    if (pluginSource != null) {
+      for (const prefix of Object.keys(pluginSource)) {
+        if (NATIVE_PLUGIN_RESERVED_NAMES.has(prefix)) {
+          throw new Error(
+            `[rslint] Config entry at index ${index}: plugins prefix "${prefix}" collides with the built-in plugin of the same name; choose a different prefix.`,
+          );
         }
+        const plugin = unwrapPluginModule(pluginSource[prefix]);
+        const pluginRules = plugin?.rules;
+        if (pluginRules == null || typeof pluginRules !== 'object') {
+          throw new Error(
+            `[rslint] Config entry at index ${index}: plugins["${prefix}"] must expose a "rules" object.`,
+          );
+        }
+        eslintPluginMeta[prefix] = {
+          ruleNames: Object.keys(pluginRules).sort(),
+        };
+        pluginPrefixes.push(prefix);
       }
+    }
 
-      // The serializable `plugins` handed to Go is a string[] of declared
-      // prefixes (its native-plugin gate keys off this set). Merge any
-      // array-form (native) names the user wrote with the object-form
-      // (community) prefixes; drop the live object-form `plugins` values
-      // (functions can't be JSON-serialized to Go).
-      const stringPlugins = Array.isArray(entry.plugins)
-        ? entry.plugins.filter((p): p is string => typeof p === 'string')
-        : [];
-      const plugins = [...new Set([...stringPlugins, ...pluginPrefixes])];
+    // The serializable `plugins` handed to Go is a string[] of declared
+    // prefixes (its native-plugin gate keys off this set). Merge any
+    // array-form (native) names the user wrote with the object-form
+    // (community) prefixes; drop the live object-form `plugins` values
+    // (functions can't be JSON-serialized to Go). Preserve an explicitly
+    // empty field, but do not add `plugins` when the field was omitted.
+    const stringPlugins = Array.isArray(entry.plugins)
+      ? entry.plugins.filter((p): p is string => typeof p === 'string')
+      : [];
+    const plugins = [...new Set([...stringPlugins, ...pluginPrefixes])];
+    // ESLint decides whether an ignores-bearing object is global from its
+    // authored keys, including keys whose value is undefined. Preserve that
+    // distinction when normalization omits an undefined or unsupported field.
+    const authoredNonGlobalKey = Object.keys(entry).some(
+      (key) => key !== 'name' && key !== 'ignores',
+    );
+    const serializesNonGlobalKey =
+      hasFiles ||
+      entry.languageOptions !== undefined ||
+      entry.rules !== undefined ||
+      hasPlugins ||
+      entry.settings !== undefined;
+    const needsNonGlobalShapeMarker =
+      authoredNonGlobalKey && !serializesNonGlobalKey;
 
-      return {
-        ...(entry.files !== undefined ? { files: entry.files } : {}),
-        ...(entry.ignores !== undefined ? { ignores: entry.ignores } : {}),
-        ...(entry.languageOptions !== undefined
-          ? { languageOptions: entry.languageOptions }
+    return {
+      ...(entry.name !== undefined ? { name: entry.name } : {}),
+      ...(hasFiles ? { files: entry.files } : {}),
+      ...(entry.ignores !== undefined ? { ignores: entry.ignores } : {}),
+      ...(entry.languageOptions !== undefined
+        ? { languageOptions: entry.languageOptions }
+        : {}),
+      ...(entry.rules !== undefined ? { rules: entry.rules } : {}),
+      ...(hasPlugins ? { plugins } : {}),
+      ...(entry.settings !== undefined
+        ? { settings: entry.settings }
+        : needsNonGlobalShapeMarker
+          ? { settings: {} }
           : {}),
-        ...(entry.rules !== undefined ? { rules: entry.rules } : {}),
-        plugins,
-        ...(entry.settings !== undefined ? { settings: entry.settings } : {}),
-        ...(pluginPrefixes.length > 0
-          ? { eslintPlugins: eslintPluginMeta }
-          : {}),
-      };
-    });
+      ...(pluginPrefixes.length > 0 ? { eslintPlugins: eslintPluginMeta } : {}),
+    };
+  });
 }
 
 /** A worker-pool config descriptor: which config file to import and the

--- a/packages/rslint/src/config/config-loader.ts
+++ b/packages/rslint/src/config/config-loader.ts
@@ -90,14 +90,41 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
       return true;
     })
     .map((entry: Record<string, unknown>, index: number) => {
-      if (entry.files != null && !Array.isArray(entry.files)) {
+      const hasFiles = Object.prototype.hasOwnProperty.call(entry, 'files');
+      if (
+        hasFiles &&
+        entry.files !== undefined &&
+        !Array.isArray(entry.files)
+      ) {
         throw new Error(
           `[rslint] Config entry at index ${index}: "files" must be an array, got ${typeof entry.files}`,
+        );
+      }
+      if (hasFiles && Array.isArray(entry.files) && entry.files.length === 0) {
+        throw new Error(
+          `[rslint] Config entry at index ${index}: "files" must be a non-empty array`,
+        );
+      }
+      if (
+        hasFiles &&
+        Array.isArray(entry.files) &&
+        entry.files.some((pattern) => typeof pattern !== 'string')
+      ) {
+        throw new Error(
+          `[rslint] Config entry at index ${index}: "files" must contain only strings`,
         );
       }
       if (entry.ignores != null && !Array.isArray(entry.ignores)) {
         throw new Error(
           `[rslint] Config entry at index ${index}: "ignores" must be an array, got ${typeof entry.ignores}`,
+        );
+      }
+      if (
+        Array.isArray(entry.ignores) &&
+        entry.ignores.some((pattern) => typeof pattern !== 'string')
+      ) {
+        throw new Error(
+          `[rslint] Config entry at index ${index}: "ignores" must contain only strings`,
         );
       }
 
@@ -142,12 +169,14 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
       const plugins = [...new Set([...stringPlugins, ...pluginPrefixes])];
 
       return {
-        files: entry.files,
-        ignores: entry.ignores,
-        languageOptions: entry.languageOptions,
-        rules: entry.rules,
+        ...(entry.files !== undefined ? { files: entry.files } : {}),
+        ...(entry.ignores !== undefined ? { ignores: entry.ignores } : {}),
+        ...(entry.languageOptions !== undefined
+          ? { languageOptions: entry.languageOptions }
+          : {}),
+        ...(entry.rules !== undefined ? { rules: entry.rules } : {}),
         plugins,
-        settings: entry.settings,
+        ...(entry.settings !== undefined ? { settings: entry.settings } : {}),
         ...(pluginPrefixes.length > 0
           ? { eslintPlugins: eslintPluginMeta }
           : {}),

--- a/packages/rslint/src/config/config-loader.ts
+++ b/packages/rslint/src/config/config-loader.ts
@@ -1,32 +1,46 @@
 import path from 'node:path';
+import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { NATIVE_PLUGIN_RESERVED_NAMES } from './define-config.js';
 import { selectPluginSource, unwrapPluginModule } from './plugin-source.js';
 
+export {
+  filterConfigsByParentIgnores,
+  type ConfigEntry,
+} from './config-hierarchy.js';
+
 export const JS_CONFIG_FILES = [
   'rslint.config.js',
   'rslint.config.mjs',
+  'rslint.config.cjs',
   'rslint.config.ts',
   'rslint.config.mts',
+  'rslint.config.cts',
 ] as const;
+
+let freshConfigLoadNonce = 0;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
 
 /**
  * Load a JS/TS config file.
- * - .js/.mjs: native import()
- * - .ts/.mts: native import() when Node.js has TypeScript support (>= 22.6),
+ * - .js/.mjs/.cjs: native import()
+ * - .ts/.mts/.cts: native import() when Node.js has TypeScript support (>= 22.6),
  *             otherwise fall back to jiti
  */
 export async function loadConfigFile(configPath: string): Promise<unknown> {
   const ext = path.extname(configPath);
 
-  if (ext === '.js' || ext === '.mjs') {
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
     const mod: Record<string, unknown> = await import(
       pathToFileURL(configPath).href
     );
     return mod.default ?? mod;
   }
 
-  if (ext === '.ts' || ext === '.mts') {
+  if (ext === '.ts' || ext === '.mts' || ext === '.cts') {
     // Use feature detection to decide the loading strategy (same as rsbuild).
     // process.features.typescript is available in Node.js >= 22.6.
     const useNative = Boolean(process.features.typescript);
@@ -53,6 +67,55 @@ export async function loadConfigFile(configPath: string): Promise<unknown> {
   }
 
   throw new Error(`Unsupported config file extension: ${ext}`);
+}
+
+/**
+ * Load a config without reusing the config module from a previous reload.
+ * TypeScript loading selects native stripping or jiti before evaluation so a
+ * runtime exception from the config is propagated without executing it again.
+ */
+export async function loadConfigFileFresh(
+  configPath: string,
+): Promise<unknown> {
+  const ext = path.extname(configPath);
+  const requireFromConfig = createRequire(pathToFileURL(configPath));
+  const evictCommonJSCache = (): void => {
+    try {
+      Reflect.deleteProperty(
+        requireFromConfig.cache,
+        requireFromConfig.resolve(configPath),
+      );
+    } catch {
+      // ESM-only configs are not present in the CommonJS module cache.
+    }
+  };
+
+  if (ext === '.cjs') {
+    evictCommonJSCache();
+    return requireFromConfig(configPath) as unknown;
+  }
+
+  if (ext === '.js' || ext === '.mjs') {
+    evictCommonJSCache();
+    return importConfigFresh(configPath);
+  }
+
+  if (ext === '.ts' || ext === '.mts' || ext === '.cts') {
+    evictCommonJSCache();
+    if (process.features.typescript) {
+      return importConfigFresh(configPath);
+    }
+    return loadConfigFile(configPath);
+  }
+
+  throw new Error(`Unsupported config file extension: ${ext}`);
+}
+
+async function importConfigFresh(configPath: string): Promise<unknown> {
+  const url = pathToFileURL(configPath);
+  url.searchParams.set('rslint', String(freshConfigLoadNonce++));
+  const mod: Record<string, unknown> = await import(url.href);
+  return mod.default ?? mod;
 }
 
 /**
@@ -86,6 +149,14 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
     );
   }
 
+  for (let index = 0; index < config.length; index++) {
+    if (!Object.prototype.hasOwnProperty.call(config, index)) {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: unexpected undefined config`,
+      );
+    }
+  }
+
   return config.map((rawEntry: unknown, index: number) => {
     if (rawEntry === null) {
       throw new Error(
@@ -97,13 +168,13 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
         `[rslint] Config entry at index ${index}: unexpected array`,
       );
     }
-    if (typeof rawEntry !== 'object') {
+    if (!isRecord(rawEntry)) {
       throw new Error(
         `[rslint] Config entry at index ${index} must be an object, got ${typeof rawEntry}`,
       );
     }
 
-    const entry = rawEntry as Record<string, unknown>;
+    const entry = rawEntry;
 
     const hasFiles = Object.prototype.hasOwnProperty.call(entry, 'files');
     if (hasFiles && !Array.isArray(entry.files)) {
@@ -156,6 +227,20 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
           `[rslint] Config entry at index ${index}: "${key}" must be an object`,
         );
       }
+    }
+
+    if (isRecord(entry.rules)) {
+      validateRules(entry.rules, index);
+    }
+
+    const languageOptions = isRecord(entry.languageOptions)
+      ? entry.languageOptions
+      : undefined;
+    if (
+      languageOptions &&
+      Object.prototype.hasOwnProperty.call(languageOptions, 'globals')
+    ) {
+      validateGlobals(languageOptions.globals, index);
     }
 
     const hasPlugins = Object.prototype.hasOwnProperty.call(entry, 'plugins');
@@ -258,6 +343,59 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
   });
 }
 
+const GLOBAL_ACCESS_VALUES = new Set<unknown>([
+  true,
+  'true',
+  'writable',
+  'writeable',
+  false,
+  'false',
+  'readonly',
+  'readable',
+  null,
+  'off',
+]);
+
+const RULE_SEVERITIES = new Set<unknown>(['off', 'warn', 'error', 0, 1, 2]);
+
+function validateRules(
+  rules: Record<string, unknown>,
+  entryIndex: number,
+): void {
+  for (const [name, value] of Object.entries(rules)) {
+    const severity = Array.isArray(value) ? value[0] : value;
+    if (
+      (Array.isArray(value) && value.length === 0) ||
+      !RULE_SEVERITIES.has(severity)
+    ) {
+      throw new Error(
+        `[rslint] Config entry at index ${entryIndex}: rule "${name}" must use severity ` +
+          `'off', 'warn', 'error', 0, 1, or 2`,
+      );
+    }
+  }
+}
+
+function validateGlobals(value: unknown, entryIndex: number): void {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(
+      `[rslint] Config entry at index ${entryIndex}: "languageOptions.globals" must be an object`,
+    );
+  }
+  for (const [name, access] of Object.entries(value)) {
+    if (name !== name.trim()) {
+      throw new Error(
+        `[rslint] Config entry at index ${entryIndex}: global "${name}" has leading or trailing whitespace`,
+      );
+    }
+    if (!GLOBAL_ACCESS_VALUES.has(access)) {
+      throw new Error(
+        `[rslint] Config entry at index ${entryIndex}: global "${name}" must be "readonly", "writable", or "off"`,
+      );
+    }
+  }
+}
+
 /** A worker-pool config descriptor: which config file to import and the
  *  directory key per-file plugin-lint tasks route on. */
 export interface PluginConfigDescriptor {
@@ -273,9 +411,9 @@ export interface PluginConfigDescriptor {
  * (Rslint.ts) so both produce the identical `eslintPlugins` shape Go parses.
  * ruleNames for a shared prefix are merged (set union) across configs: Go's
  * placeholder registry is a per-prefix superset, while the worker routes the
- * actual rules per-config. This is NOT a validation — a genuinely conflicting
- * redefinition (same prefix, different plugin object) is caught at worker init
- * (plugin-loader throws ESLint's `Cannot redefine plugin` error), not here.
+ * actual rules per config. This is not the validation boundary: worker config
+ * loading rejects conflicting plugin definitions, including duplicate routing
+ * descriptors that mount different instances under the same prefix.
  */
 export function collectPluginMeta(
   configs: ReadonlyArray<{

--- a/packages/rslint/src/config/config-loader.ts
+++ b/packages/rslint/src/config/config-loader.ts
@@ -9,13 +9,12 @@ export {
   type ConfigEntry,
 } from './config-hierarchy.js';
 
+/** Config basenames eligible for automatic discovery. */
 export const JS_CONFIG_FILES = [
   'rslint.config.js',
   'rslint.config.mjs',
-  'rslint.config.cjs',
   'rslint.config.ts',
   'rslint.config.mts',
-  'rslint.config.cts',
 ] as const;
 
 let freshConfigLoadNonce = 0;
@@ -25,20 +24,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Load a JS/TS config file.
- * - .js/.mjs/.cjs: native import()
- * - .ts/.mts/.cts: native import() when Node.js has TypeScript support (>= 22.6),
- *             otherwise fall back to jiti
+ * Load a selected JS/TS config file.
+ * TypeScript modules use native import when Node.js supports type stripping
+ * and otherwise fall back to jiti. Other module formats use native import.
  */
 export async function loadConfigFile(configPath: string): Promise<unknown> {
   const ext = path.extname(configPath);
-
-  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
-    const mod: Record<string, unknown> = await import(
-      pathToFileURL(configPath).href
-    );
-    return mod.default ?? mod;
-  }
 
   if (ext === '.ts' || ext === '.mts' || ext === '.cts') {
     // Use feature detection to decide the loading strategy (same as rsbuild).
@@ -60,13 +51,16 @@ export async function loadConfigFile(configPath: string): Promise<unknown> {
 
     throw new Error(
       `Failed to load TypeScript config file: ${configPath}\n` +
-        `To load .ts config files, either:\n` +
+        `To load .ts/.mts/.cts config files, either:\n` +
         `  1. Use Node.js >= 22.6 (with native TypeScript support)\n` +
         `  2. Install jiti as a dependency: npm install -D jiti`,
     );
   }
 
-  throw new Error(`Unsupported config file extension: ${ext}`);
+  const mod: Record<string, unknown> = await import(
+    pathToFileURL(configPath).href
+  );
+  return mod.default ?? mod;
 }
 
 /**
@@ -90,25 +84,14 @@ export async function loadConfigFileFresh(
     }
   };
 
-  if (ext === '.cjs') {
-    evictCommonJSCache();
-    return requireFromConfig(configPath) as unknown;
-  }
-
-  if (ext === '.js' || ext === '.mjs') {
-    evictCommonJSCache();
-    return importConfigFresh(configPath);
-  }
-
-  if (ext === '.ts' || ext === '.mts' || ext === '.cts') {
-    evictCommonJSCache();
-    if (process.features.typescript) {
-      return importConfigFresh(configPath);
-    }
+  evictCommonJSCache();
+  if (
+    (ext === '.ts' || ext === '.mts' || ext === '.cts') &&
+    !process.features.typescript
+  ) {
     return loadConfigFile(configPath);
   }
-
-  throw new Error(`Unsupported config file extension: ${ext}`);
+  return importConfigFresh(configPath);
 }
 
 async function importConfigFresh(configPath: string): Promise<unknown> {

--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -2,7 +2,7 @@
 /**
  * Severity level for a rule.
  */
-export type RuleSeverity = 'off' | 'warn' | 'error';
+export type RuleSeverity = 'off' | 'warn' | 'error' | 0 | 1 | 2;
 
 /**
  * Source of truth for the rule prefixes owned by rslint's built-in
@@ -105,7 +105,16 @@ export interface ParserOptions {
 /**
  * Access level for a declared global variable.
  */
-export type GlobalAccess = boolean | 'readonly' | 'writable' | 'off';
+export type GlobalAccess =
+  | boolean
+  | null
+  | 'true'
+  | 'false'
+  | 'readonly'
+  | 'readable'
+  | 'writable'
+  | 'writeable'
+  | 'off';
 
 /**
  * Map of global variable name to its access level.
@@ -122,10 +131,9 @@ export interface LanguageOptions {
   parserOptions?: ParserOptions;
   /**
    * Global variables available in this file's scope, e.g. from a browser
-   * or Node.js runtime. `'readonly'`/`true` allows reading; `'writable'`
-   * allows reassignment. Only the string `'off'` un-declares a global
-   * (undoes one a base config added) — `false` still declares it (as
-   * read-only), matching ESLint's own `normalizeConfigGlobal`.
+   * or Node.js runtime. `'readonly'`, `false`, and `null` allow reading;
+   * `'writable'` and `true` allow reassignment. Only the string `'off'`
+   * un-declares a global inherited from an earlier entry.
    *
    * @example
    * globals: { myGlobal: 'readonly' }

--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -151,13 +151,17 @@ export interface ESLintPlugin {
  * different file globs and are merged at lint time.
  */
 export interface RslintConfigEntry {
+  /** Optional human-readable name for this config entry. */
+  name?: string;
   /**
-   * Glob patterns for files this entry applies to.
+   * Glob selectors for files this entry applies to. Top-level selectors are
+   * ORed; strings inside one nested array are ANDed, matching ESLint flat
+   * config semantics.
    *
    * @example
    * files: ['src/**', 'tests/**']
    */
-  files?: string[];
+  files?: Array<string | string[]>;
   /**
    * Glob patterns excluded from this entry.
    *

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -1,13 +1,11 @@
-import globals from 'globals';
 import type { RslintConfigEntry } from '../define-config.js';
 
 // Aligned with official eslint-plugin-unicorn@64.x recommended.
 // Rules commented out with "not implemented" are in the official preset but not yet available.
+// The official preset also injects `languageOptions.globals` (Array, Promise, Map, …);
+// rslint's config entry doesn't expose a `globals` field, so that part is omitted.
 const recommended: RslintConfigEntry = {
   plugins: ['unicorn'],
-  languageOptions: {
-    globals: globals.builtin,
-  },
   rules: {
     // Core ESLint rules disabled by upstream once their unicorn equivalents take over.
     // Keep them enabled (i.e. don't override) until the unicorn replacements are implemented,

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -1,11 +1,13 @@
+import globals from 'globals';
 import type { RslintConfigEntry } from '../define-config.js';
 
 // Aligned with official eslint-plugin-unicorn@64.x recommended.
 // Rules commented out with "not implemented" are in the official preset but not yet available.
-// The official preset also injects `languageOptions.globals` (Array, Promise, Map, …);
-// rslint's config entry doesn't expose a `globals` field, so that part is omitted.
 const recommended: RslintConfigEntry = {
   plugins: ['unicorn'],
+  languageOptions: {
+    globals: globals.builtin,
+  },
   rules: {
     // Core ESLint rules disabled by upstream once their unicorn equivalents take over.
     // Keep them enabled (i.e. don't override) until the unicorn replacements are implemented,

--- a/packages/rslint/src/eslint-plugin/ast/scope-factory.ts
+++ b/packages/rslint/src/eslint-plugin/ast/scope-factory.ts
@@ -32,6 +32,9 @@ import * as eslintScopePkg from 'eslint-scope';
 
 import { VISITOR_KEYS } from './visitor-keys.js';
 import { BUILTIN_GLOBAL_NAMES } from './builtin-globals.js';
+import type { GlobalAccess } from '../types.js';
+
+type NormalizedGlobalAccess = 'readonly' | 'writable' | 'off';
 
 /** Subset of options accepted by both analyzers. */
 export interface ScopeFactoryOptions {
@@ -41,11 +44,11 @@ export interface ScopeFactoryOptions {
   ecmaVersion?: number | 'latest';
   /**
    * `languageOptions.globals` from the user's flat-config — a map of
-   * `name → 'readonly' | 'writable' | 'off'`. Used to seed the
-   * scope-manager so user-declared globals don't false-positive
-   * `no-undef` and similar rules.
+   * global names to ESLint-compatible access values. Used to seed the
+   * scope-manager so user-declared globals don't false-positive `no-undef`
+   * and similar rules.
    */
-  globals?: Record<string, 'readonly' | 'writable' | 'off'>;
+  globals?: Record<string, GlobalAccess>;
   /**
    * `languageOptions.parserOptions.ecmaFeatures.impliedStrict`. ESLint
    * v10 default is `false`; setting it `true` treats the source as if
@@ -200,6 +203,8 @@ interface SyntheticGlobal {
   scope: unknown;
 }
 
+const syntheticGlobals = new WeakSet<object>();
+
 interface GlobalScopeLike {
   variables: SyntheticGlobal[];
   set?: Map<string, SyntheticGlobal>;
@@ -210,7 +215,8 @@ interface GlobalScopeLike {
  * Add or update a synthetic global Variable in `globalScope`. Returns
  * the (newly created or existing) Variable.
  *
- * Mode is ALWAYS synced to `mode` — even on existing entries. ESLint's
+ * Mode is synced to `mode` for existing synthetic entries. Source-declared
+ * Variables are left unchanged. ESLint's
  * apply-environments + apply-globals pipeline lets user globals
  * (`languageOptions.globals: { Array: 'writable' }`) override the
  * built-in mode flags layered earlier by `seedEcmaGlobals`. Pre-fix
@@ -229,6 +235,9 @@ function ensureGlobal(
 ): SyntheticGlobal {
   const existing = gs.set?.get(name);
   if (existing) {
+    // A source declaration can share a name with a configured/built-in global.
+    // Config globals must not rewrite that lexical Variable's semantics.
+    if (!syntheticGlobals.has(existing)) return existing;
     // Sync mode — see jsdoc. The Variable's identity stays; only the
     // mode flags shift. Downstream rules consult `writeable` (the
     // typo'd-as-eslint-compat field) and `eslintImplicitGlobalSetting`
@@ -246,6 +255,7 @@ function ensureGlobal(
     eslintImplicitGlobalSetting: mode,
     scope: gs,
   };
+  syntheticGlobals.add(v);
   gs.variables.push(v);
   gs.set?.set(name, v);
   return v;
@@ -325,7 +335,7 @@ export function seedEcmaGlobals(scopeManager: unknown): void {
  */
 export function seedGlobals(
   scopeManager: unknown,
-  globals: Record<string, 'readonly' | 'writable' | 'off'> | undefined,
+  globals: Record<string, GlobalAccess> | undefined,
 ): void {
   if (!scopeManager) return;
   const sm = scopeManager as { globalScope?: GlobalScopeLike };
@@ -339,11 +349,13 @@ export function seedGlobals(
     return;
   }
 
-  for (const [name, mode] of Object.entries(globals)) {
+  for (const [name, access] of Object.entries(globals)) {
+    const mode = normalizeGlobalAccess(access);
+    if (mode == null) continue;
     if (mode === 'off') {
       // 'off' explicitly removes the binding — drop any synthetic entry.
-      if (gs.set?.has(name)) {
-        const v = gs.set.get(name)!;
+      const v = gs.set?.get(name);
+      if (v && syntheticGlobals.has(v)) {
         // Restore any references that `seedEcmaGlobals` previously
         // moved from `gs.through` onto this Variable. Without this,
         // every ref is left dangling on a deleted Variable —
@@ -370,11 +382,36 @@ export function seedGlobals(
         }
         const idx = gs.variables.indexOf(v);
         if (idx >= 0) gs.variables.splice(idx, 1);
-        gs.set.delete(name);
+        gs.set?.delete(name);
       }
       continue;
     }
     ensureGlobal(gs, name, mode);
   }
   resolveThroughReferences(gs);
+}
+
+function normalizeGlobalAccess(
+  access: GlobalAccess,
+): NormalizedGlobalAccess | undefined {
+  switch (access) {
+    case true:
+    case 'true':
+    case 'writable':
+    case 'writeable':
+      return 'writable';
+    case false:
+    case null:
+    case 'false':
+    case 'readonly':
+    case 'readable':
+      return 'readonly';
+    case 'off':
+      return 'off';
+    default:
+      // Config validation rejects unknown values before plugin execution.
+      // Keep the scope boundary defensive so a runtime value that bypassed
+      // validation cannot become an invalid eslintImplicitGlobalSetting.
+      return undefined;
+  }
 }

--- a/packages/rslint/src/eslint-plugin/linter/context.ts
+++ b/packages/rslint/src/eslint-plugin/linter/context.ts
@@ -42,6 +42,7 @@ import {
   type ReportDescriptor,
   type SuggestionsMode,
 } from './diagnostic-builder.js';
+import type { GlobalsConfig } from '../types.js';
 
 // ─────────────────────────────────────────────────────────────────────
 // Public types
@@ -73,7 +74,7 @@ export interface LanguageOptions {
   ecmaVersion?: number | 'latest';
   /** Module / script / commonjs — top-level in ESLint v10. Same rationale as `ecmaVersion`. */
   sourceType?: 'module' | 'script' | 'commonjs';
-  globals?: Record<string, 'readonly' | 'writable' | 'off'>;
+  globals?: GlobalsConfig;
   /**
    * Parser-specific extras. Only `ecmaFeatures` lives here in v10
    * (rules that gate on `jsx` / `globalReturn` / `impliedStrict` read

--- a/packages/rslint/src/eslint-plugin/linter/ecma-language-plugin.ts
+++ b/packages/rslint/src/eslint-plugin/linter/ecma-language-plugin.ts
@@ -53,6 +53,7 @@ import {
 } from './context.js';
 import type { LoadedPlugins } from '../plugin/plugin-loader.js';
 import type { Fix } from './fixer.js';
+import type { GlobalsConfig } from '../types.js';
 import { applyDisableDirectives } from './apply-disable-directives.js';
 
 /**
@@ -127,7 +128,7 @@ export interface LintFileRequest {
   languageOptions?: {
     ecmaVersion?: number | 'latest';
     sourceType?: 'module' | 'script' | 'commonjs';
-    globals?: Record<string, 'readonly' | 'writable' | 'off'>;
+    globals?: GlobalsConfig;
     parserOptions?: {
       ecmaFeatures?: {
         jsx?: boolean;

--- a/packages/rslint/src/eslint-plugin/plugin/plugin-lint-protocol.ts
+++ b/packages/rslint/src/eslint-plugin/plugin/plugin-lint-protocol.ts
@@ -33,6 +33,8 @@ import type { LintFileResult } from '../linter/ecma-language-plugin.js';
  * doesn't need to re-validate Go's serialization.
  */
 export interface EslintPluginLintRequest {
+  /** LSP config/worker generation. Omitted by the CLI's single-host path. */
+  generation?: string;
   files: ReadonlyArray<{
     path: string;
     /**

--- a/packages/rslint/src/eslint-plugin/plugin/plugin-loader.ts
+++ b/packages/rslint/src/eslint-plugin/plugin/plugin-loader.ts
@@ -39,7 +39,7 @@ import {
 /**
  * Extension-aware config loader for worker init. Mirrors the strategy
  * `packages/rslint/src/config/config-loader.ts::loadConfigFile` uses on the
- * main thread so a `.ts`/`.mts` config file loads identically in both
+ * main thread so a `.ts`/`.mts`/`.cts` config file loads identically in both
  * places.
  *
  * The previous implementation directly called `await import(url)` for
@@ -48,7 +48,7 @@ import {
  * `rslint.config.ts` + object-form `plugins` would fail worker init even
  * though the main thread had already loaded the same file via jiti.
  *
- * Resolution order for `.ts`/`.mts`:
+ * Resolution order for `.ts`/`.mts`/`.cts`:
  *
  *   1. `process.features.typescript` (Node ≥ 22.6 with native TS) →
  *      native `import()`.
@@ -313,18 +313,18 @@ export async function loadPluginsFromConfigs(
   for (let i = 0; i < configs.length; i++) {
     const dir = configs[i].configDirectory;
     const existing = out.get(dir);
-    // Two ConfigDescriptors can share a `configDirectory` (e.g. the
-    // config-discovery layer surfacing `rslint.config.js` AND
-    // `rslint.config.mjs` in one folder). The map is keyed by
-    // directory, so a plain `out.set` would let the second config
-    // SILENTLY overwrite the first — files in that directory would then
-    // resolve against only the later config's plugins, losing the
-    // earlier ones with no signal. Merge instead (union of plugins +
-    // rules), warning loudly on a genuine same-key rule conflict.
+    // Duplicate descriptors are harmless when they resolve to the same plugin
+    // instances. A different plugin instance under the same prefix and routing
+    // key is invalid even when the two instances expose disjoint rule names.
     out.set(
       dir,
       existing
-        ? mergeLoadedPlugins(existing, loadedList[i], dir)
+        ? mergeLoadedPlugins(
+            existing,
+            loadedList[i],
+            dir,
+            configs[i].configPath,
+          )
         : loadedList[i],
     );
   }
@@ -332,31 +332,48 @@ export async function loadPluginsFromConfigs(
 }
 
 /**
- * Merge two `LoadedPlugins` for the SAME `configDirectory`. Unions the
- * plugin lists and rule maps. On a rule-key collision: same instance →
- * harmless dedup; DIFFERENT instances → a real conflict (two plugins
- * under one prefix in one directory), kept first-wins with a loud
- * stderr warning so it isn't a silent drop.
+ * Merge two `LoadedPlugins` for the SAME `configDirectory`. Plugin prefixes
+ * are routing identities: the same plugin instance is harmless deduplication,
+ * while a different instance under the same prefix is always rejected.
  */
 function mergeLoadedPlugins(
   a: LoadedPlugins,
   b: LoadedPlugins,
   dir: string,
+  configPath: string,
 ): LoadedPlugins {
+  const plugins = [...a.plugins];
+  const pluginsByPrefix = new Map(
+    plugins.map((loaded) => [loaded.prefix, loaded] as const),
+  );
+  for (const loaded of b.plugins) {
+    const existing = pluginsByPrefix.get(loaded.prefix);
+    if (existing) {
+      if (existing.plugin !== loaded.plugin) {
+        throw new PluginLoaderError(
+          configPath,
+          `Cannot redefine plugin "${loaded.prefix}" for routing key "${dir}".`,
+        );
+      }
+      continue;
+    }
+    pluginsByPrefix.set(loaded.prefix, loaded);
+    plugins.push(loaded);
+  }
+
   const rules = new Map(a.rules);
   for (const [key, rule] of b.rules) {
     const existing = rules.get(key);
     if (existing !== undefined && existing !== rule) {
-      process.stderr.write(
-        `[rslint] plugin rule "${key}" is defined by more than one config ` +
-          `in the same directory (${dir}); keeping the first. Deduplicate ` +
-          `the rslint.config.* files for this directory.\n`,
+      throw new PluginLoaderError(
+        configPath,
+        `[rslint] plugin rule "${key}" is defined by different plugin ` +
+          `instances for the same config key (${dir})`,
       );
-      continue;
     }
     rules.set(key, rule);
   }
-  return { plugins: [...a.plugins, ...b.plugins], rules };
+  return { plugins, rules };
 }
 
 function ensureNodeVersion(): void {

--- a/packages/rslint/src/eslint-plugin/plugin/plugin-loader.ts
+++ b/packages/rslint/src/eslint-plugin/plugin/plugin-loader.ts
@@ -67,9 +67,6 @@ import {
  */
 async function importConfigFile(configFilePath: string): Promise<unknown> {
   const ext = path.extname(configFilePath);
-  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
-    return import(pathToFileURL(configFilePath).href);
-  }
   if (ext === '.ts' || ext === '.mts' || ext === '.cts') {
     const useNative = Boolean(
       (process.features as { typescript?: boolean }).typescript,
@@ -105,7 +102,7 @@ async function importConfigFile(configFilePath: string): Promise<unknown> {
     // unwrap.
     return resolved;
   }
-  throw new Error(`Unsupported config file extension: ${ext}`);
+  return import(pathToFileURL(configFilePath).href);
 }
 
 /**

--- a/packages/rslint/src/eslint-plugin/types.ts
+++ b/packages/rslint/src/eslint-plugin/types.ts
@@ -32,7 +32,7 @@ export type GlobalsConfig = Record<string, GlobalAccess>;
  * it as a Map key for per-file dispatch.
  */
 export interface ConfigDescriptor {
-  /** Absolute filesystem path of the rslint config file (`rslint.config.{js,mjs,cjs,ts,mts,cts}`). */
+  /** Absolute filesystem path of the selected JS/TS config file. */
   configPath: string;
   /** Absolute filesystem path of the directory holding the config file.
    *  Matches the `ConfigKey` Go emits per file during plugin-lint dispatch. */

--- a/packages/rslint/src/eslint-plugin/types.ts
+++ b/packages/rslint/src/eslint-plugin/types.ts
@@ -6,6 +6,24 @@
  */
 
 /**
+ * ESLint-compatible access values carried to the plugin worker. This mirrors
+ * the public config authoring type without coupling the worker build project to
+ * the config-loader build project.
+ */
+export type GlobalAccess =
+  | boolean
+  | null
+  | 'true'
+  | 'false'
+  | 'readonly'
+  | 'readable'
+  | 'writable'
+  | 'writeable'
+  | 'off';
+
+export type GlobalsConfig = Record<string, GlobalAccess>;
+
+/**
  * Per-config descriptor handed to the worker pool. Each worker imports
  * every descriptor's `configPath` once at init, then routes per-file
  * lint tasks via `configKey === configDirectory` to the right plugin
@@ -14,7 +32,7 @@
  * it as a Map key for per-file dispatch.
  */
 export interface ConfigDescriptor {
-  /** Absolute filesystem path of the rslint config file (`rslint.config.{js,mjs,ts,mts}`). */
+  /** Absolute filesystem path of the rslint config file (`rslint.config.{js,mjs,cjs,ts,mts,cts}`). */
   configPath: string;
   /** Absolute filesystem path of the directory holding the config file.
    *  Matches the `ConfigKey` Go emits per file during plugin-lint dispatch. */

--- a/packages/rslint/src/internal/node.ts
+++ b/packages/rslint/src/internal/node.ts
@@ -7,6 +7,7 @@ import type {
   RSlintOptions,
   PendingMessage,
   IpcMessage,
+  InboundRequestHandler,
   LintOptions,
   LintResponse,
 } from '../types.js';
@@ -31,6 +32,8 @@ export class NodeRslintService implements RslintServiceInterface {
   // requests instead of rejecting them — otherwise close()'s pending 'exit'
   // request could reject and surface as an unhandledRejection.
   private closing: boolean;
+  private inboundHandler: InboundRequestHandler | null;
+  private activeInboundRequests: number;
 
   constructor(options: RSlintOptions = {}) {
     this.nextMessageId = 1;
@@ -38,6 +41,8 @@ export class NodeRslintService implements RslintServiceInterface {
     this.rslintPath = options.rslintPath || resolveRslintBinary();
     this.dead = false;
     this.closing = false;
+    this.inboundHandler = null;
+    this.activeInboundRequests = 0;
 
     this.process = spawn(this.rslintPath, ['--api'], {
       stdio: ['pipe', 'pipe', 'inherit'],
@@ -116,6 +121,18 @@ export class NodeRslintService implements RslintServiceInterface {
     }
   }
 
+  private updateLoopActivity(): void {
+    this.setLoopActive(
+      !this.dead &&
+        (this.pendingMessages.size > 0 || this.activeInboundRequests > 0),
+    );
+  }
+
+  /** Install the handler for positive-id requests sent by the Go peer. */
+  setInboundHandler(handler: InboundRequestHandler | null): void {
+    this.inboundHandler = handler;
+  }
+
   /**
    * Send a message to the rslint process
    */
@@ -138,19 +155,25 @@ export class NodeRslintService implements RslintServiceInterface {
 
       // Register promise callbacks
       this.pendingMessages.set(id, { resolve, reject });
-      // First in-flight request: ref the child + pipes so the loop stays alive
-      // until its response arrives (a pending promise alone would not).
-      if (this.pendingMessages.size === 1) this.setLoopActive(true);
-
-      // Write message length as 4 bytes in little endian
-      const json = JSON.stringify(message);
-      const jsonBuffer = Buffer.from(json, 'utf8');
-      const length = Buffer.alloc(4);
-      length.writeUInt32LE(jsonBuffer.length, 0);
-
-      // Send message
-      this.process.stdin!.write(Buffer.concat([length, jsonBuffer]));
+      // Keep the child + pipes referenced until the response arrives (a
+      // pending promise alone does not keep Node's event loop alive).
+      this.updateLoopActivity();
+      try {
+        this.writeMessage(message);
+      } catch (error) {
+        this.pendingMessages.delete(id);
+        this.updateLoopActivity();
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
     });
+  }
+
+  private writeMessage(message: IpcMessage): void {
+    if (this.dead) return;
+    const jsonBuffer = Buffer.from(JSON.stringify(message), 'utf8');
+    const length = Buffer.alloc(4);
+    length.writeUInt32LE(jsonBuffer.length, 0);
+    this.process.stdin!.write(Buffer.concat([length, jsonBuffer]));
   }
 
   /**
@@ -202,23 +225,68 @@ export class NodeRslintService implements RslintServiceInterface {
    */
   private handleMessage(message: IpcMessage): void {
     const { id, kind, data } = message;
-    const pending = this.pendingMessages.get(id);
-    if (!pending) return;
+    // IDs are allocated independently in each direction and can collide. Only
+    // response/error frames settle an outbound request; every other positive-id
+    // frame is a request from Go that must be answered independently.
+    if (kind === 'response' || kind === 'error') {
+      const pending = this.pendingMessages.get(id);
+      if (!pending) return;
 
-    this.pendingMessages.delete(id);
-
-    if (kind === 'error') {
-      pending.reject(new Error(data.message));
-    } else {
-      pending.resolve(data);
+      this.pendingMessages.delete(id);
+      if (kind === 'error') {
+        pending.reject(new Error(data?.message ?? 'rslint request failed'));
+      } else {
+        pending.resolve(data);
+      }
+      this.updateLoopActivity();
+      return;
     }
 
-    // Back to idle once the last in-flight request settles: unref so the loop
-    // can exit without an explicit close(). A continuation that immediately
-    // sends another request re-refs via sendMessage before the loop drains
-    // (the resolve continuation runs as a microtask, ahead of the loop's exit
-    // check).
-    if (this.pendingMessages.size === 0) this.setLoopActive(false);
+    if (id <= 0) return;
+
+    this.activeInboundRequests++;
+    this.updateLoopActivity();
+    void Promise.resolve()
+      .then(async () => {
+        if (!this.inboundHandler) {
+          throw new Error(
+            `no inbound handler registered (kind=${message.kind})`,
+          );
+        }
+        return this.inboundHandler(message);
+      })
+      .then(
+        (result) => {
+          try {
+            this.writeMessage({ id, kind: 'response', data: result });
+          } catch (error) {
+            const detail =
+              error instanceof Error ? error.message : String(error);
+            this.writeMessage({
+              id,
+              kind: 'error',
+              data: { message: `failed to encode inbound response: ${detail}` },
+            });
+          }
+        },
+        (error: unknown) => {
+          const detail = error instanceof Error ? error.message : String(error);
+          this.writeMessage({
+            id,
+            kind: 'error',
+            data: { message: detail },
+          });
+        },
+      )
+      .finally(() => {
+        this.activeInboundRequests--;
+        this.updateLoopActivity();
+      })
+      .catch(() => {
+        // A terminal stdin write failure is reported by the stream/process
+        // handlers, which also settle the outer request. Avoid a detached
+        // reverse-response chain becoming an unhandled rejection meanwhile.
+      });
   }
 
   /**
@@ -232,6 +300,7 @@ export class NodeRslintService implements RslintServiceInterface {
       pending.reject(err);
     }
     this.pendingMessages.clear();
+    this.updateLoopActivity();
   }
 
   /**
@@ -245,6 +314,7 @@ export class NodeRslintService implements RslintServiceInterface {
       pending.resolve(null);
     }
     this.pendingMessages.clear();
+    this.updateLoopActivity();
   }
 
   /**

--- a/packages/rslint/src/internal/node.ts
+++ b/packages/rslint/src/internal/node.ts
@@ -343,9 +343,11 @@ export async function lint(options: LintOptions): Promise<LintResponse> {
       workingDirectory: options.workingDirectory,
     }),
   );
-  const result = await service.lint(options);
-  await service.close();
-  return result;
+  try {
+    return await service.lint(options);
+  } finally {
+    await service.close();
+  }
 }
 
 export type { LintOptions, LintResponse, Diagnostic } from '../types.js';

--- a/packages/rslint/src/service/protocol.ts
+++ b/packages/rslint/src/service/protocol.ts
@@ -1,0 +1,2 @@
+export const API_PROTOCOL_VERSION = '2.0.0';
+export const API_REVERSE_PLUGIN_LINT_CAPABILITY = 'reversePluginLint';

--- a/packages/rslint/src/service/service.ts
+++ b/packages/rslint/src/service/service.ts
@@ -7,6 +7,12 @@ import type {
   IpcMessage,
   LintInboundHandlers,
 } from '../types.js';
+import {
+  API_PROTOCOL_VERSION,
+  API_REVERSE_PLUGIN_LINT_CAPABILITY,
+} from './protocol.js';
+
+const EXIT_REQUEST_TIMEOUT_MS = 1_000;
 
 /**
  * Environment-agnostic RslintService facade: drives the handshake +
@@ -47,34 +53,40 @@ export class RSLintService {
 
       this.activeLintHandlers = handlers;
       try {
-        return await this.lintExclusive(options);
+        return await this.lintExclusive(options, Boolean(handlers.pluginLint));
       } finally {
         this.activeLintHandlers = null;
       }
     });
   }
 
-  private async lintExclusive(options: LintOptions): Promise<LintResponse> {
+  private async lintExclusive(
+    options: LintOptions,
+    requiresReversePluginLint: boolean,
+  ): Promise<LintResponse> {
     const {
       files,
+      canonicalFiles,
       config,
       eslintPlugins,
       configDirectory,
+      pluginConfigDirectory,
       workingDirectory,
       fileContents,
       includeEncodedSourceFiles,
       fix,
     } = options;
 
-    // Send handshake
-    await this.service.sendMessage('handshake', { version: '1.0.0' });
+    await this.handshake(requiresReversePluginLint);
 
     // Send lint request
     return this.service.sendMessage('lint', {
       files,
+      canonicalFiles,
       config,
       eslintPlugins,
       configDirectory,
+      pluginConfigDirectory,
       workingDirectory,
       fileContents,
       includeEncodedSourceFiles,
@@ -91,7 +103,10 @@ export class RSLintService {
       throw new Error('rslint service is closing');
     }
 
-    return this.enqueue(() => this.getAstInfoExclusive(options));
+    return this.enqueue(async () => {
+      const response = await this.getAstInfoExclusive(options);
+      return response;
+    });
   }
 
   private async getAstInfoExclusive(
@@ -107,8 +122,7 @@ export class RSLintService {
       compilerOptions,
     } = options;
 
-    // Send handshake
-    await this.service.sendMessage('handshake', { version: '1.0.0' });
+    await this.handshake(false);
 
     // Send getAstInfo request
     return this.service.sendMessage('getAstInfo', {
@@ -125,35 +139,88 @@ export class RSLintService {
   /**
    * Close the service
    */
-  close(): Promise<void> {
-    if (this.closePromise) return this.closePromise;
+  async close(): Promise<void> {
+    if (this.closePromise) {
+      await this.closePromise;
+      return;
+    }
     this.closeRequested = true;
 
-    this.closePromise = this.enqueue(async () => {
-      // Ask the peer to exit, then tear down regardless. The peer may exit
-      // before its ack frame is read; swallow rejection on that expected path.
+    let timedOut = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(() => {
+        timedOut = true;
+        resolve();
+      }, EXIT_REQUEST_TIMEOUT_MS);
+    });
+    const gracefulExit = this.enqueue(async () => {
+      // Never interleave exit with an active request. If waiting for the queue
+      // consumed the shutdown budget, terminate without sending a late exit.
+      if (timedOut) return;
       try {
         await this.service.sendMessage('exit', {});
       } catch {
         // peer already gone — expected during close
       }
-      this.service.terminate();
     });
-    return this.closePromise;
+
+    this.closePromise = (async () => {
+      try {
+        await Promise.race([gracefulExit, timeout]);
+      } finally {
+        timedOut = true;
+        if (timer) clearTimeout(timer);
+        this.service.terminate();
+      }
+    })();
+    await this.closePromise;
   }
 
-  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+  private async handshake(requiresReversePluginLint: boolean): Promise<void> {
+    const requestedCapabilities = requiresReversePluginLint
+      ? [API_REVERSE_PLUGIN_LINT_CAPABILITY]
+      : [];
+    const response: unknown = await this.service.sendMessage('handshake', {
+      version: API_PROTOCOL_VERSION,
+      capabilities: requestedCapabilities,
+    });
+    if (response === null || typeof response !== 'object') {
+      throw new Error('rslint backend returned an invalid handshake response');
+    }
+    const handshake = response as {
+      version?: unknown;
+      ok?: unknown;
+      capabilities?: unknown;
+    };
+    if (handshake.ok !== true || handshake.version !== API_PROTOCOL_VERSION) {
+      throw new Error(
+        `rslint API protocol mismatch: expected ${API_PROTOCOL_VERSION}, received ${String(handshake.version)}`,
+      );
+    }
+    if (requiresReversePluginLint) {
+      const capabilities = Array.isArray(handshake.capabilities)
+        ? handshake.capabilities
+        : [];
+      if (!capabilities.includes(API_REVERSE_PLUGIN_LINT_CAPABILITY)) {
+        throw new Error(
+          'rslint backend does not support reverse pluginLint requests',
+        );
+      }
+    }
+  }
+
+  private async enqueue<T>(operation: () => Promise<T>): Promise<T> {
     const result = this.requestQueue.then(operation, operation);
     this.requestQueue = result.then(
       () => undefined,
       () => undefined,
     );
-    return result;
+    const value = await result;
+    return value;
   }
 
-  private handleInboundRequest(
-    message: IpcMessage,
-  ): Promise<unknown> | unknown {
+  private handleInboundRequest(message: IpcMessage): unknown {
     if (message.kind !== 'pluginLint') {
       throw new Error(
         `rslint service received unexpected inbound request '${message.kind}'`,

--- a/packages/rslint/src/service/service.ts
+++ b/packages/rslint/src/service/service.ts
@@ -4,6 +4,8 @@ import type {
   LintResponse,
   GetAstInfoRequest,
   GetAstInfoResponse,
+  IpcMessage,
+  LintInboundHandlers,
 } from '../types.js';
 
 /**
@@ -13,18 +15,50 @@ import type {
  */
 export class RSLintService {
   private readonly service: RslintServiceBackend;
+  private activeLintHandlers: LintInboundHandlers | null = null;
+  private requestQueue: Promise<void> = Promise.resolve();
+  private closeRequested = false;
+  private closePromise: Promise<void> | null = null;
 
   constructor(service: RslintServiceBackend) {
     this.service = service;
+    this.service.setInboundHandler?.((message) =>
+      this.handleInboundRequest(message),
+    );
   }
 
   /**
    * Run the linter on specified files
    */
-  async lint(options: LintOptions = {}): Promise<LintResponse> {
+  async lint(
+    options: LintOptions = {},
+    handlers: LintInboundHandlers = {},
+  ): Promise<LintResponse> {
+    if (this.closeRequested) {
+      throw new Error('rslint service is closing');
+    }
+
+    return this.enqueue(async () => {
+      if (handlers.pluginLint && !this.service.setInboundHandler) {
+        throw new Error(
+          'rslint backend does not support reverse pluginLint requests',
+        );
+      }
+
+      this.activeLintHandlers = handlers;
+      try {
+        return await this.lintExclusive(options);
+      } finally {
+        this.activeLintHandlers = null;
+      }
+    });
+  }
+
+  private async lintExclusive(options: LintOptions): Promise<LintResponse> {
     const {
       files,
       config,
+      eslintPlugins,
       configDirectory,
       workingDirectory,
       fileContents,
@@ -39,6 +73,7 @@ export class RSLintService {
     return this.service.sendMessage('lint', {
       files,
       config,
+      eslintPlugins,
       configDirectory,
       workingDirectory,
       fileContents,
@@ -52,6 +87,16 @@ export class RSLintService {
    * Returns Node, Type, Symbol, Signature, and Flow information
    */
   async getAstInfo(options: GetAstInfoRequest): Promise<GetAstInfoResponse> {
+    if (this.closeRequested) {
+      throw new Error('rslint service is closing');
+    }
+
+    return this.enqueue(() => this.getAstInfoExclusive(options));
+  }
+
+  private async getAstInfoExclusive(
+    options: GetAstInfoRequest,
+  ): Promise<GetAstInfoResponse> {
     const {
       fileContent,
       position,
@@ -80,18 +125,47 @@ export class RSLintService {
   /**
    * Close the service
    */
-  async close(): Promise<void> {
-    // Ask the peer to exit, then tear down regardless. The peer may exit before
-    // its ack frame is read; the exit handler resolves the pending on that
-    // expected path, but swallow any rejection too (defensive — e.g. the
-    // process was already dead) so a floating promise can't become an
-    // unhandledRejection.
-    try {
-      await this.service.sendMessage('exit', {});
-    } catch {
-      // peer already gone — expected during close
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closeRequested = true;
+
+    this.closePromise = this.enqueue(async () => {
+      // Ask the peer to exit, then tear down regardless. The peer may exit
+      // before its ack frame is read; swallow rejection on that expected path.
+      try {
+        await this.service.sendMessage('exit', {});
+      } catch {
+        // peer already gone — expected during close
+      }
+      this.service.terminate();
+    });
+    return this.closePromise;
+  }
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.requestQueue.then(operation, operation);
+    this.requestQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private handleInboundRequest(
+    message: IpcMessage,
+  ): Promise<unknown> | unknown {
+    if (message.kind !== 'pluginLint') {
+      throw new Error(
+        `rslint service received unexpected inbound request '${message.kind}'`,
+      );
     }
-    this.service.terminate();
+    const handler = this.activeLintHandlers?.pluginLint;
+    if (!handler) {
+      throw new Error(
+        'rslint service received pluginLint without an active plugin host',
+      );
+    }
+    return handler(message.data);
   }
 }
 
@@ -104,6 +178,8 @@ export type {
   RslintServiceInterface,
   PendingMessage,
   IpcMessage,
+  InboundRequestHandler,
+  LintInboundHandlers,
   // AST Info types
   GetAstInfoRequest,
   GetAstInfoResponse,

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -49,7 +49,7 @@ export interface LintResponse {
   fixableWarningCount: number;
   fileCount: number;
   ruleCount: number;
-  // Files actually linted (config `ignores` excluded), each a program-canonical
+  // Files actually linted (config `ignores` excluded), each a requested target
   // path relative to configDirectory — same path space as Diagnostic.filePath.
   // Present for lintFiles so the Rslint class seeds one result per linted file.
   lintedFiles?: string[];
@@ -68,6 +68,10 @@ export interface LintOptions {
   // explicitly under an entry's `rules` (or pulled in via a preset that does
   // so), matching ESLint flat-config semantics.
   config?: Record<string, unknown>[];
+  // Community ESLint-plugin rules available to this request. Go registers
+  // request-scoped placeholder rules from this metadata, then asks the Node
+  // peer to execute them through a reverse `pluginLint` request.
+  eslintPlugins?: Array<{ prefix: string; ruleNames: string[] }>;
   // Anchor dir for resolving the config's relative files/ignores/project.
   configDirectory?: string;
   workingDirectory?: string;
@@ -96,9 +100,21 @@ export interface IpcMessage {
   data: any;
 }
 
+/** Handler for a positive-id request frame sent by the Go peer. */
+export type InboundRequestHandler = (
+  message: IpcMessage,
+) => Promise<unknown> | unknown;
+
+/** Reverse-request handlers that are scoped to one outer lint request. */
+export interface LintInboundHandlers {
+  pluginLint?: (request: unknown) => Promise<unknown> | unknown;
+}
+
 // Service interface that all implementations must follow
 export interface RslintServiceInterface {
   sendMessage(kind: string, data: any): Promise<any>;
+  /** Optional for one-way backends such as the current browser worker. */
+  setInboundHandler?(handler: InboundRequestHandler | null): void;
   terminate(): void;
 }
 

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -59,6 +59,9 @@ export interface LintResponse {
 
 export interface LintOptions {
   files?: string[];
+  // Optional physical paths parallel to files. High-level Node APIs provide
+  // these after target planning so Go does not repeat realpath resolution.
+  canonicalFiles?: string[];
   // Final resolved config — normalized config entries (normalizeConfig output:
   // plain objects, plugins as string[], no live functions). The JS side
   // resolves overrideConfig / config-file / discovery / normalize into this;
@@ -74,6 +77,9 @@ export interface LintOptions {
   eslintPlugins?: Array<{ prefix: string; ruleNames: string[] }>;
   // Anchor dir for resolving the config's relative files/ignores/project.
   configDirectory?: string;
+  // Opaque routing key for community-plugin workers. High-level APIs set this
+  // when config path rebasing makes it differ from configDirectory.
+  pluginConfigDirectory?: string;
   workingDirectory?: string;
   fileContents?: Record<string, string>; // Map of file paths to their contents for VFS
   includeEncodedSourceFiles?: boolean; // Whether to include encoded source files in response
@@ -101,13 +107,11 @@ export interface IpcMessage {
 }
 
 /** Handler for a positive-id request frame sent by the Go peer. */
-export type InboundRequestHandler = (
-  message: IpcMessage,
-) => Promise<unknown> | unknown;
+export type InboundRequestHandler = (message: IpcMessage) => unknown;
 
 /** Reverse-request handlers that are scoped to one outer lint request. */
 export interface LintInboundHandlers {
-  pluginLint?: (request: unknown) => Promise<unknown> | unknown;
+  pluginLint?: (request: unknown) => unknown;
 }
 
 // Service interface that all implementations must follow

--- a/packages/rslint/src/utils/args.ts
+++ b/packages/rslint/src/utils/args.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { parseArgs as nodeParseArgs } from 'node:util';
 
 export function isJSConfigFile(filePath: string): boolean {
-  return /\.(ts|mts|js|mjs)$/.test(filePath);
+  return /\.(ts|mts|cts|js|mjs|cjs)$/.test(filePath);
 }
 
 export function parseArgs(argv: string[]) {
@@ -85,8 +85,9 @@ export function parseArgs(argv: string[]) {
 
 /**
  * Classify positional args into files and directories.
- * Resolves symlinks so paths are consistent with process.cwd() and
- * TypeScript's SourceFile.FileName() which both return real paths.
+ * Keeps the caller's absolute lexical path. Config discovery and Go target
+ * binding resolve physical identity separately, after lexical ownership has
+ * had the first opportunity to match.
  */
 export function classifyArgs(
   positionals: string[],
@@ -97,11 +98,10 @@ export function classifyArgs(
   for (const arg of positionals) {
     const resolved = path.resolve(cwd, arg);
     try {
-      const real = fs.realpathSync(resolved);
-      if (fs.statSync(real).isDirectory()) {
-        dirs.push(real);
+      if (fs.statSync(resolved).isDirectory()) {
+        dirs.push(resolved);
       } else {
-        files.push(real);
+        files.push(resolved);
       }
     } catch {
       // Non-existent path: treat as file (Go will handle the error)

--- a/packages/rslint/src/utils/config-discovery.ts
+++ b/packages/rslint/src/utils/config-discovery.ts
@@ -265,13 +265,22 @@ function isRelativeChildPath(relPath: string): boolean {
   );
 }
 
+function isSameOrChildDirectory(parentDir: string, childDir: string): boolean {
+  const relPath = path.relative(parentDir, childDir);
+  return relPath === '' || isRelativeChildPath(relPath);
+}
+
 export interface ConfigEntry {
   configDirectory: string;
   entries: RslintConfigEntry[];
 }
 
 function resolveConfigDirectory(configDirectory: string): string {
-  let dir = configDirectory.replace(/[/\\]+$/, '');
+  let dir = configDirectory;
+  const root = path.parse(dir).root;
+  while (dir.length > root.length && /[/\\]$/.test(dir)) {
+    dir = dir.slice(0, -1);
+  }
   try {
     dir = fs.realpathSync(dir);
   } catch {
@@ -289,12 +298,20 @@ function resolveConfigDirectory(configDirectory: string): string {
  * Example: root config has `{ ignores: ['__tests__/**'] }`.
  * A nested config at `__tests__/fixtures/rslint.config.js` is filtered out
  * because `__tests__/fixtures/` is within the root config's global ignores.
+ *
+ * `forceIncludeConfigDirectories` is for explicit CLI file targets: ESLint
+ * resolves the nearest config for an explicit file even when a parent global
+ * ignore would have blocked directory traversal into that subtree.
  */
 export function filterConfigsByParentIgnores(
   configEntries: ConfigEntry[],
-  protectedConfigDirectories = new Set<string>(),
+  forceIncludeConfigDirectories = new Set<string>(),
 ): ConfigEntry[] {
   if (configEntries.length <= 1) return configEntries;
+
+  const forceIncludedDirs = new Set(
+    [...forceIncludeConfigDirectories].map(resolveConfigDirectory),
+  );
 
   const resolvedDirs = new Map<ConfigEntry, string>();
   for (const entry of configEntries) {
@@ -314,10 +331,7 @@ export function filterConfigsByParentIgnores(
 
     for (const parent of result) {
       const parentDir = resolvedDirs.get(parent)!;
-      if (
-        !configDir.startsWith(parentDir + path.sep) &&
-        configDir !== parentDir
-      ) {
+      if (!isSameOrChildDirectory(parentDir, configDir)) {
         continue;
       }
 
@@ -330,7 +344,7 @@ export function filterConfigsByParentIgnores(
       }
     }
 
-    if (!ignored || protectedConfigDirectories.has(config.configDirectory)) {
+    if (!ignored || forceIncludedDirs.has(configDir)) {
       result.push(config);
     }
   }

--- a/packages/rslint/src/utils/config-discovery.ts
+++ b/packages/rslint/src/utils/config-discovery.ts
@@ -62,11 +62,7 @@ export async function findJSConfigsInDir(startDir: string): Promise<string[]> {
     }
   }
 
-  const orderedConfigs = new Map<string, string>();
-  for (const configPath of effectiveConfigsByDir.values()) {
-    addConfigParentFirst(orderedConfigs, configPath);
-  }
-  return [...orderedConfigs.keys()];
+  return [...effectiveConfigsByDir.values()];
 }
 
 /**
@@ -93,7 +89,9 @@ export async function discoverConfigs(
     configPath: string,
     configDirectory = path.dirname(configPath),
   ): void => {
-    addConfigParentFirst(configs, configPath, configDirectory);
+    if (!configs.has(configPath)) {
+      configs.set(configPath, configDirectory);
+    }
   };
 
   if (explicitConfig) {
@@ -133,11 +131,11 @@ export async function discoverConfigs(
   }
 
   // Scan for nested configs within the target scope (no-args and dir-args).
-  // runWithJSConfigs loads parents first, skips configs hidden by parent
-  // global ignores, and treats every remaining broken config as fatal.
-  // Serial await (not Promise.all over scanDirs): tinyglobby's async crawl
-  // already parallelizes filesystem work. Parallelizing across scan roots mainly
-  // creates duplicate I/O when roots overlap, e.g. `.` plus a nested dir.
+  // Broken configs are tolerated by runWithJSConfigs (skipped with warning).
+  // Serial await (not Promise.all over scanDirs): a single async glob already
+  // saturates the libuv thread pool, so parallelizing across scanDirs adds no
+  // speed — it only creates I/O contention when scanDirs overlap (e.g. `.` plus
+  // a nested subdir each crawling the shared subtree at the same time).
   for (const dir of scanDirs) {
     for (const configPath of await findJSConfigsInDir(dir)) {
       addConfig(configPath);
@@ -145,35 +143,6 @@ export async function discoverConfigs(
   }
 
   return configs;
-}
-
-function isAncestorDirectory(ancestorDir: string, childDir: string): boolean {
-  return isRelativeChildPath(path.relative(ancestorDir, childDir));
-}
-
-function addConfigParentFirst(
-  configs: Map<string, string>,
-  configPath: string,
-  configDirectory = path.dirname(configPath),
-): void {
-  if (configs.has(configPath)) return;
-
-  const entries = [...configs.entries()];
-  const insertIndex = entries.findIndex(([, existingConfigDirectory]) =>
-    isAncestorDirectory(configDirectory, existingConfigDirectory),
-  );
-  if (insertIndex === -1) {
-    configs.set(configPath, configDirectory);
-    return;
-  }
-
-  configs.clear();
-  for (let i = 0; i < entries.length; i++) {
-    if (i === insertIndex) {
-      configs.set(configPath, configDirectory);
-    }
-    configs.set(entries[i][0], entries[i][1]);
-  }
 }
 
 function getConfigPriority(configPath: string): number {
@@ -311,32 +280,6 @@ function resolveConfigDirectory(configDirectory: string): string {
   return dir;
 }
 
-export function isConfigDirIgnoredByParentIgnores(
-  configDirectory: string,
-  parentConfigs: ConfigEntry[],
-): boolean {
-  const configDir = resolveConfigDirectory(configDirectory);
-
-  for (const parent of parentConfigs) {
-    const parentDir = resolveConfigDirectory(parent.configDirectory);
-    if (
-      !configDir.startsWith(parentDir + path.sep) &&
-      configDir !== parentDir
-    ) {
-      continue;
-    }
-
-    const globalIgnores = getGlobalIgnores(parent.entries);
-    if (globalIgnores.length === 0) continue;
-
-    if (isDirIgnoredByPatterns(configDir, globalIgnores, parentDir)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 /**
  * Filter out nested configs whose directory is covered by an ancestor config's
  * global ignores. Aligns with ESLint v10 behavior: when traversing directories,
@@ -346,8 +289,6 @@ export function isConfigDirIgnoredByParentIgnores(
  * Example: root config has `{ ignores: ['__tests__/**'] }`.
  * A nested config at `__tests__/fixtures/rslint.config.js` is filtered out
  * because `__tests__/fixtures/` is within the root config's global ignores.
- *
- * Expects configEntries in parent-first order, as produced by discoverConfigs.
  */
 export function filterConfigsByParentIgnores(
   configEntries: ConfigEntry[],
@@ -355,13 +296,41 @@ export function filterConfigsByParentIgnores(
 ): ConfigEntry[] {
   if (configEntries.length <= 1) return configEntries;
 
+  const resolvedDirs = new Map<ConfigEntry, string>();
+  for (const entry of configEntries) {
+    resolvedDirs.set(entry, resolveConfigDirectory(entry.configDirectory));
+  }
+
+  const sorted = [...configEntries].sort(
+    (a, b) =>
+      (resolvedDirs.get(a)?.length ?? 0) - (resolvedDirs.get(b)?.length ?? 0),
+  );
+
   const result: ConfigEntry[] = [];
 
-  for (const config of configEntries) {
-    if (
-      protectedConfigDirectories.has(config.configDirectory) ||
-      !isConfigDirIgnoredByParentIgnores(config.configDirectory, result)
-    ) {
+  for (const config of sorted) {
+    let ignored = false;
+    const configDir = resolvedDirs.get(config)!;
+
+    for (const parent of result) {
+      const parentDir = resolvedDirs.get(parent)!;
+      if (
+        !configDir.startsWith(parentDir + path.sep) &&
+        configDir !== parentDir
+      ) {
+        continue;
+      }
+
+      const globalIgnores = getGlobalIgnores(parent.entries);
+      if (globalIgnores.length === 0) continue;
+
+      if (isDirIgnoredByPatterns(configDir, globalIgnores, parentDir)) {
+        ignored = true;
+        break;
+      }
+    }
+
+    if (!ignored || protectedConfigDirectories.has(config.configDirectory)) {
       result.push(config);
     }
   }

--- a/packages/rslint/src/utils/config-discovery.ts
+++ b/packages/rslint/src/utils/config-discovery.ts
@@ -148,28 +148,22 @@ function sortConfigsParentFirst(
         index,
       }))
       .sort((a, b) => {
-        if (a.configDirectory === b.configDirectory) {
-          return a.index - b.index;
-        }
-
-        const aToB = path.relative(a.configDirectory, b.configDirectory);
-        if (aToB && !aToB.startsWith('..') && !path.isAbsolute(aToB)) {
-          return -1;
-        }
-
-        const bToA = path.relative(b.configDirectory, a.configDirectory);
-        if (bToA && !bToA.startsWith('..') && !path.isAbsolute(bToA)) {
-          return 1;
-        }
-
-        const aDepth = a.configDirectory.split(path.sep).length;
-        const bDepth = b.configDirectory.split(path.sep).length;
+        const aDepth = getPathDepth(a.configDirectory);
+        const bDepth = getPathDepth(b.configDirectory);
         if (aDepth !== bDepth) return aDepth - bDepth;
 
         return a.index - b.index;
       })
       .map(({ configPath, configDirectory }) => [configPath, configDirectory]),
   );
+}
+
+function getPathDepth(p: string): number {
+  return path
+    .normalize(p)
+    .replace(/[/\\]+$/, '')
+    .split(path.sep)
+    .filter(Boolean).length;
 }
 
 /**
@@ -228,7 +222,7 @@ function isDirIgnoredByPatterns(
   parentConfigDir: string,
 ): boolean {
   const relDir = path.relative(parentConfigDir, dirPath);
-  if (!relDir || relDir.startsWith('..')) return false;
+  if (!isRelativeChildPath(relDir)) return false;
 
   const normalizedRelDir = relDir.split(path.sep).join('/');
 
@@ -276,6 +270,15 @@ function isDirIgnoredByPatterns(
   }
 
   return false;
+}
+
+function isRelativeChildPath(relPath: string): boolean {
+  return (
+    relPath !== '' &&
+    relPath !== '..' &&
+    !relPath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relPath)
+  );
 }
 
 export interface ConfigEntry {

--- a/packages/rslint/src/utils/config-discovery.ts
+++ b/packages/rslint/src/utils/config-discovery.ts
@@ -122,7 +122,8 @@ export async function discoverConfigs(
   }
 
   // Scan for nested configs within the target scope (no-args and dir-args).
-  // Broken configs are tolerated by runWithJSConfigs (skipped with warning).
+  // runWithJSConfigs loads parents first, skips configs hidden by parent
+  // global ignores, and treats every remaining broken config as fatal.
   // Serial await (not Promise.all over scanDirs): a single async glob already
   // saturates the libuv thread pool, so parallelizing across scanDirs adds no
   // speed — it only creates I/O contention when scanDirs overlap (e.g. `.` plus
@@ -133,7 +134,42 @@ export async function discoverConfigs(
     }
   }
 
-  return configs;
+  return sortConfigsParentFirst(configs);
+}
+
+function sortConfigsParentFirst(
+  configs: Map<string, string>,
+): Map<string, string> {
+  return new Map(
+    [...configs.entries()]
+      .map(([configPath, configDirectory], index) => ({
+        configPath,
+        configDirectory,
+        index,
+      }))
+      .sort((a, b) => {
+        if (a.configDirectory === b.configDirectory) {
+          return a.index - b.index;
+        }
+
+        const aToB = path.relative(a.configDirectory, b.configDirectory);
+        if (aToB && !aToB.startsWith('..') && !path.isAbsolute(aToB)) {
+          return -1;
+        }
+
+        const bToA = path.relative(b.configDirectory, a.configDirectory);
+        if (bToA && !bToA.startsWith('..') && !path.isAbsolute(bToA)) {
+          return 1;
+        }
+
+        const aDepth = a.configDirectory.split(path.sep).length;
+        const bDepth = b.configDirectory.split(path.sep).length;
+        if (aDepth !== bDepth) return aDepth - bDepth;
+
+        return a.index - b.index;
+      })
+      .map(({ configPath, configDirectory }) => [configPath, configDirectory]),
+  );
 }
 
 /**
@@ -247,6 +283,42 @@ export interface ConfigEntry {
   entries: RslintConfigEntry[];
 }
 
+function resolveConfigDirectory(configDirectory: string): string {
+  let dir = configDirectory.replace(/[/\\]+$/, '');
+  try {
+    dir = fs.realpathSync(dir);
+  } catch {
+    // Keep the original (stripped) path if realpath fails.
+  }
+  return dir;
+}
+
+export function isConfigDirIgnoredByParentIgnores(
+  configDirectory: string,
+  parentConfigs: ConfigEntry[],
+): boolean {
+  const configDir = resolveConfigDirectory(configDirectory);
+
+  for (const parent of parentConfigs) {
+    const parentDir = resolveConfigDirectory(parent.configDirectory);
+    if (
+      !configDir.startsWith(parentDir + path.sep) &&
+      configDir !== parentDir
+    ) {
+      continue;
+    }
+
+    const globalIgnores = getGlobalIgnores(parent.entries);
+    if (globalIgnores.length === 0) continue;
+
+    if (isDirIgnoredByPatterns(configDir, globalIgnores, parentDir)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Filter out nested configs whose directory is covered by an ancestor config's
  * global ignores. Aligns with ESLint v10 behavior: when traversing directories,
@@ -259,52 +331,24 @@ export interface ConfigEntry {
  */
 export function filterConfigsByParentIgnores(
   configEntries: ConfigEntry[],
+  protectedConfigDirectories = new Set<string>(),
 ): ConfigEntry[] {
   if (configEntries.length <= 1) return configEntries;
-
-  // Resolve symlinks and normalize trailing slashes for reliable ancestor checks.
-  const resolvedDirs = new Map<ConfigEntry, string>();
-  for (const entry of configEntries) {
-    let dir = entry.configDirectory.replace(/[/\\]+$/, '');
-    try {
-      dir = fs.realpathSync(dir);
-    } catch {
-      // Keep the original (stripped) path if realpath fails
-    }
-    resolvedDirs.set(entry, dir);
-  }
 
   // Sort by directory depth (shallowest first) so parents are processed first
   const sorted = [...configEntries].sort(
     (a, b) =>
-      (resolvedDirs.get(a)?.length ?? 0) - (resolvedDirs.get(b)?.length ?? 0),
+      resolveConfigDirectory(a.configDirectory).length -
+      resolveConfigDirectory(b.configDirectory).length,
   );
 
   const result: ConfigEntry[] = [];
 
   for (const config of sorted) {
-    let ignored = false;
-    const configDir = resolvedDirs.get(config)!;
-
-    for (const parent of result) {
-      const parentDir = resolvedDirs.get(parent)!;
-      if (
-        !configDir.startsWith(parentDir + path.sep) &&
-        configDir !== parentDir
-      ) {
-        continue;
-      }
-
-      const globalIgnores = getGlobalIgnores(parent.entries);
-      if (globalIgnores.length === 0) continue;
-
-      if (isDirIgnoredByPatterns(configDir, globalIgnores, parentDir)) {
-        ignored = true;
-        break;
-      }
-    }
-
-    if (!ignored) {
+    if (
+      protectedConfigDirectories.has(config.configDirectory) ||
+      !isConfigDirIgnoredByParentIgnores(config.configDirectory, result)
+    ) {
       result.push(config);
     }
   }

--- a/packages/rslint/src/utils/config-discovery.ts
+++ b/packages/rslint/src/utils/config-discovery.ts
@@ -35,15 +35,10 @@ export function findJSConfigUp(startDir: string): string | null {
 }
 
 /**
- * Recursively scan a directory for all rslint JS/TS config files.
+ * Recursively scan a directory for effective rslint JS/TS config files.
  * Skips node_modules and .git directories (aligned with ESLint defaults).
- * Uses tinyglobby's async glob; the directory walk is I/O-bound, so an async
- * crawl parallelizes it across the libuv thread pool.
- *
- * tinyglobby returns POSIX-style paths even on Windows, so the result is
- * normalized through path.normalize to match the native separator that
- * findJSConfigUp / path.join produce. Without this, Map<configPath, ...>
- * dedupe against findJSConfigUp results fails on Windows.
+ * Uses tinyglobby's async crawl for filesystem traversal performance and edge
+ * cases, then applies rslint config semantics to the small candidate set.
  */
 export async function findJSConfigsInDir(startDir: string): Promise<string[]> {
   const resolved = path.resolve(startDir);
@@ -53,7 +48,25 @@ export async function findJSConfigsInDir(startDir: string): Promise<string[]> {
     dot: true,
     ignore: ['**/node_modules/**', '**/.git/**'],
   });
-  return matches.map((p) => path.normalize(p));
+
+  const effectiveConfigsByDir = new Map<string, string>();
+  for (const match of matches) {
+    const configPath = path.normalize(match);
+    const configDirectory = path.dirname(configPath);
+    const existing = effectiveConfigsByDir.get(configDirectory);
+    if (
+      !existing ||
+      getConfigPriority(configPath) < getConfigPriority(existing)
+    ) {
+      effectiveConfigsByDir.set(configDirectory, configPath);
+    }
+  }
+
+  const orderedConfigs = new Map<string, string>();
+  for (const configPath of effectiveConfigsByDir.values()) {
+    addConfigParentFirst(orderedConfigs, configPath);
+  }
+  return [...orderedConfigs.keys()];
 }
 
 /**
@@ -80,9 +93,7 @@ export async function discoverConfigs(
     configPath: string,
     configDirectory = path.dirname(configPath),
   ): void => {
-    if (!configs.has(configPath)) {
-      configs.set(configPath, configDirectory);
-    }
+    addConfigParentFirst(configs, configPath, configDirectory);
   };
 
   if (explicitConfig) {
@@ -124,46 +135,50 @@ export async function discoverConfigs(
   // Scan for nested configs within the target scope (no-args and dir-args).
   // runWithJSConfigs loads parents first, skips configs hidden by parent
   // global ignores, and treats every remaining broken config as fatal.
-  // Serial await (not Promise.all over scanDirs): a single async glob already
-  // saturates the libuv thread pool, so parallelizing across scanDirs adds no
-  // speed — it only creates I/O contention when scanDirs overlap (e.g. `.` plus
-  // a nested subdir each crawling the shared subtree at the same time).
+  // Serial await (not Promise.all over scanDirs): tinyglobby's async crawl
+  // already parallelizes filesystem work. Parallelizing across scan roots mainly
+  // creates duplicate I/O when roots overlap, e.g. `.` plus a nested dir.
   for (const dir of scanDirs) {
     for (const configPath of await findJSConfigsInDir(dir)) {
       addConfig(configPath);
     }
   }
 
-  return sortConfigsParentFirst(configs);
+  return configs;
 }
 
-function sortConfigsParentFirst(
+function isAncestorDirectory(ancestorDir: string, childDir: string): boolean {
+  return isRelativeChildPath(path.relative(ancestorDir, childDir));
+}
+
+function addConfigParentFirst(
   configs: Map<string, string>,
-): Map<string, string> {
-  return new Map(
-    [...configs.entries()]
-      .map(([configPath, configDirectory], index) => ({
-        configPath,
-        configDirectory,
-        index,
-      }))
-      .sort((a, b) => {
-        const aDepth = getPathDepth(a.configDirectory);
-        const bDepth = getPathDepth(b.configDirectory);
-        if (aDepth !== bDepth) return aDepth - bDepth;
+  configPath: string,
+  configDirectory = path.dirname(configPath),
+): void {
+  if (configs.has(configPath)) return;
 
-        return a.index - b.index;
-      })
-      .map(({ configPath, configDirectory }) => [configPath, configDirectory]),
+  const entries = [...configs.entries()];
+  const insertIndex = entries.findIndex(([, existingConfigDirectory]) =>
+    isAncestorDirectory(configDirectory, existingConfigDirectory),
   );
+  if (insertIndex === -1) {
+    configs.set(configPath, configDirectory);
+    return;
+  }
+
+  configs.clear();
+  for (let i = 0; i < entries.length; i++) {
+    if (i === insertIndex) {
+      configs.set(configPath, configDirectory);
+    }
+    configs.set(entries[i][0], entries[i][1]);
+  }
 }
 
-function getPathDepth(p: string): number {
-  return path
-    .normalize(p)
-    .replace(/[/\\]+$/, '')
-    .split(path.sep)
-    .filter(Boolean).length;
+function getConfigPriority(configPath: string): number {
+  const index = JS_CONFIG_FILES.indexOf(path.basename(configPath));
+  return index === -1 ? Number.POSITIVE_INFINITY : index;
 }
 
 /**
@@ -331,6 +346,8 @@ export function isConfigDirIgnoredByParentIgnores(
  * Example: root config has `{ ignores: ['__tests__/**'] }`.
  * A nested config at `__tests__/fixtures/rslint.config.js` is filtered out
  * because `__tests__/fixtures/` is within the root config's global ignores.
+ *
+ * Expects configEntries in parent-first order, as produced by discoverConfigs.
  */
 export function filterConfigsByParentIgnores(
   configEntries: ConfigEntry[],
@@ -338,16 +355,9 @@ export function filterConfigsByParentIgnores(
 ): ConfigEntry[] {
   if (configEntries.length <= 1) return configEntries;
 
-  // Sort by directory depth (shallowest first) so parents are processed first
-  const sorted = [...configEntries].sort(
-    (a, b) =>
-      resolveConfigDirectory(a.configDirectory).length -
-      resolveConfigDirectory(b.configDirectory).length,
-  );
-
   const result: ConfigEntry[] = [];
 
-  for (const config of sorted) {
+  for (const config of configEntries) {
     if (
       protectedConfigDirectories.has(config.configDirectory) ||
       !isConfigDirIgnoredByParentIgnores(config.configDirectory, result)

--- a/packages/rslint/src/utils/config-discovery.ts
+++ b/packages/rslint/src/utils/config-discovery.ts
@@ -95,13 +95,16 @@ function findJSConfigFromCanonicalTarget(
  */
 export async function findJSConfigsInDir(startDir: string): Promise<string[]> {
   const resolved = path.resolve(startDir);
-  const matches = await glob(['**/rslint.config.{js,mjs,cjs,ts,mts,cts}'], {
-    cwd: resolved,
-    absolute: true,
-    dot: true,
-    followSymbolicLinks: false,
-    ignore: ['**/node_modules/**', '**/.git/**'],
-  });
+  const matches = await glob(
+    JS_CONFIG_FILES.map((name) => `**/${name}`),
+    {
+      cwd: resolved,
+      absolute: true,
+      dot: true,
+      followSymbolicLinks: false,
+      ignore: ['**/node_modules/**', '**/.git/**'],
+    },
+  );
 
   const candidateDirectories = new Set<string>();
   for (const match of matches) {

--- a/packages/rslint/src/utils/config-discovery.ts
+++ b/packages/rslint/src/utils/config-discovery.ts
@@ -1,16 +1,23 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import picomatch from 'picomatch';
 import { glob } from 'tinyglobby';
-import { type RslintConfigEntry } from '../config/define-config.ts';
 import { JS_CONFIG_FILES } from '../config/config-loader.ts';
+
+export {
+  filterConfigsByParentIgnores,
+  type ConfigEntry,
+} from '../config/config-hierarchy.ts';
 
 export { JS_CONFIG_FILES };
 
 export function findJSConfig(cwd: string): string | null {
   for (const name of JS_CONFIG_FILES) {
     const p = path.join(cwd, name);
-    if (fs.existsSync(p)) return p;
+    try {
+      if (fs.statSync(p).isFile()) return p;
+    } catch {
+      // Continue through the configured filename priority.
+    }
   }
   return null;
 }
@@ -31,6 +38,56 @@ export function findJSConfigUp(startDir: string): string | null {
 }
 
 /**
+ * Find the governing config for one target without discarding lexical path
+ * ownership. Physical ancestry is only a fallback when the lexical ancestry
+ * contains no config.
+ */
+export function findJSConfigForTarget(
+  targetPath: string,
+  isDirectory: boolean,
+): string | null {
+  const lexicalPath = path.resolve(targetPath);
+  const lexicalDirectory = isDirectory
+    ? lexicalPath
+    : path.dirname(lexicalPath);
+  const lexicalConfig = findJSConfigUp(lexicalDirectory);
+  if (lexicalConfig) return lexicalConfig;
+
+  return findJSConfigFromCanonicalTarget(
+    lexicalPath,
+    lexicalDirectory,
+    isDirectory,
+  );
+}
+
+function findJSConfigFromCanonicalTarget(
+  lexicalPath: string,
+  lexicalDirectory: string,
+  isDirectory: boolean,
+  configByCanonicalDirectory?: Map<string, string | null>,
+): string | null {
+  try {
+    const canonicalPath = fs.realpathSync(lexicalPath);
+    const canonicalDirectory = isDirectory
+      ? canonicalPath
+      : path.dirname(canonicalPath);
+    if (
+      path.normalize(canonicalDirectory) !== path.normalize(lexicalDirectory)
+    ) {
+      const normalizedDirectory = path.normalize(canonicalDirectory);
+      const cached = configByCanonicalDirectory?.get(normalizedDirectory);
+      if (cached !== undefined) return cached;
+      const configPath = findJSConfigUp(normalizedDirectory);
+      configByCanonicalDirectory?.set(normalizedDirectory, configPath);
+      return configPath;
+    }
+  } catch {
+    // Missing or inaccessible targets have no physical fallback.
+  }
+  return null;
+}
+
+/**
  * Recursively scan a directory for effective rslint JS/TS config files.
  * Skips node_modules and .git directories (aligned with ESLint defaults).
  * Uses tinyglobby's async crawl for filesystem traversal performance and edge
@@ -38,7 +95,7 @@ export function findJSConfigUp(startDir: string): string | null {
  */
 export async function findJSConfigsInDir(startDir: string): Promise<string[]> {
   const resolved = path.resolve(startDir);
-  const matches = await glob(['**/rslint.config.{js,mjs,ts,mts}'], {
+  const matches = await glob(['**/rslint.config.{js,mjs,cjs,ts,mts,cts}'], {
     cwd: resolved,
     absolute: true,
     dot: true,
@@ -46,20 +103,17 @@ export async function findJSConfigsInDir(startDir: string): Promise<string[]> {
     ignore: ['**/node_modules/**', '**/.git/**'],
   });
 
-  const effectiveConfigsByDir = new Map<string, string>();
+  const candidateDirectories = new Set<string>();
   for (const match of matches) {
-    const configPath = path.normalize(match);
-    const configDirectory = path.dirname(configPath);
-    const existing = effectiveConfigsByDir.get(configDirectory);
-    if (
-      !existing ||
-      getConfigPriority(configPath) < getConfigPriority(existing)
-    ) {
-      effectiveConfigsByDir.set(configDirectory, configPath);
-    }
+    candidateDirectories.add(path.dirname(path.normalize(match)));
   }
 
-  return [...effectiveConfigsByDir.values()];
+  const effectiveConfigs: string[] = [];
+  for (const configDirectory of candidateDirectories) {
+    const configPath = findJSConfig(configDirectory);
+    if (configPath) effectiveConfigs.push(path.normalize(configPath));
+  }
+  return effectiveConfigs;
 }
 
 /**
@@ -78,6 +132,8 @@ export async function discoverConfigs(
   dirs: string[],
   cwd: string,
   explicitConfig: string | null,
+  fileConfigs?: ReadonlyMap<string, string | null>,
+  directoryConfigs?: ReadonlyMap<string, string | null>,
 ): Promise<Map<string, string>> {
   // Map: configPath -> configDirectory
   const configs = new Map<string, string>();
@@ -99,32 +155,27 @@ export async function discoverConfigs(
     return configs;
   }
 
-  // Collect unique start directories for upward config search
-  const startDirs = new Set<string>();
   // Collect directories to scan for nested configs
   const scanDirs: string[] = [];
 
   if (files.length === 0 && dirs.length === 0) {
-    startDirs.add(cwd);
+    const configPath = findJSConfigForTarget(cwd, true);
+    if (configPath) addConfig(configPath);
     scanDirs.push(cwd);
   }
 
-  // Deduplicate file directories before searching
+  const resolvedFileConfigs = fileConfigs ?? findJSConfigsForFiles(files);
   for (const file of files) {
-    startDirs.add(path.dirname(file));
+    const configPath = resolvedFileConfigs.get(path.normalize(file));
+    if (configPath) addConfig(configPath);
   }
 
   for (const dir of dirs) {
-    startDirs.add(dir);
+    const configPath =
+      directoryConfigs?.get(path.normalize(dir)) ??
+      findJSConfigForTarget(dir, true);
+    if (configPath) addConfig(configPath);
     scanDirs.push(dir);
-  }
-
-  // Upward traversal: find nearest config for each start directory
-  for (const startDir of startDirs) {
-    const configPath = findJSConfigUp(startDir);
-    if (configPath) {
-      addConfig(configPath);
-    }
   }
 
   // Scan for nested configs within the target scope (no-args and dir-args).
@@ -142,199 +193,199 @@ export async function discoverConfigs(
   return configs;
 }
 
-function getConfigPriority(configPath: string): number {
-  const index = JS_CONFIG_FILES.indexOf(
-    path.basename(configPath) as (typeof JS_CONFIG_FILES)[number],
-  );
-  return index === -1 ? Number.POSITIVE_INFINITY : index;
-}
-
-/**
- * Check if a config entry is a "global ignore" entry — an entry with only
- * `ignores` and an optional `name`. Aligns with ESLint flat config semantics
- * where such entries prevent directory traversal.
- */
-function isGlobalIgnoreEntry(
-  entry: RslintConfigEntry,
-): entry is Required<Pick<RslintConfigEntry, 'ignores'>> {
-  const ignores = entry.ignores;
-  if (!Array.isArray(ignores) || ignores.length === 0) return false;
-
-  return Object.keys(entry).every((key) => key === 'ignores' || key === 'name');
-}
-
-/**
- * Extract global ignore patterns from a config's entries.
- */
-function getGlobalIgnores(entries: RslintConfigEntry[]): string[] {
-  const patterns: string[] = [];
-  for (const entry of entries) {
-    if (isGlobalIgnoreEntry(entry)) {
-      for (const pattern of entry.ignores) {
-        patterns.push(pattern);
-      }
+/** Resolve each explicit file's config once while preserving lexical ownership. */
+export function findJSConfigsForFiles(
+  files: readonly string[],
+): Map<string, string | null> {
+  const result = new Map<string, string | null>();
+  const lexicalConfigByDirectory = new Map<string, string | null>();
+  const canonicalConfigByDirectory = new Map<string, string | null>();
+  for (const rawFile of files) {
+    const file = path.normalize(rawFile);
+    const fileDirectory = path.dirname(file);
+    let configPath = lexicalConfigByDirectory.get(fileDirectory);
+    if (configPath === undefined) {
+      configPath = findJSConfigUp(fileDirectory);
+      lexicalConfigByDirectory.set(fileDirectory, configPath);
     }
+    if (!configPath) {
+      configPath = findJSConfigFromCanonicalTarget(
+        path.resolve(file),
+        fileDirectory,
+        false,
+        canonicalConfigByDirectory,
+      );
+    }
+    result.set(file, configPath);
   }
-  return patterns;
+  return result;
 }
 
-/**
- * Check if a directory path is matched by any of the given ignore patterns.
- * Patterns are resolved relative to the parent config's directory.
- * Uses picomatch for full glob support (**, *, {}, etc.).
- *
- * A directory is considered ignored if the pattern matches the directory
- * itself or any of its ancestor paths. For example, pattern `__tests__/**`
- * matches both `__tests__/` and `__tests__/fixtures/`.
- */
-function isDirIgnoredByPatterns(
-  dirPath: string,
-  patterns: string[],
-  parentConfigDir: string,
-): boolean {
-  const relDir = path.relative(parentConfigDir, dirPath);
-  if (!isRelativeChildPath(relDir)) return false;
-
-  const normalizedRelDir = relDir.split(path.sep).join('/');
-
-  for (const pattern of patterns) {
-    // Skip empty or negation patterns.
-    if (!pattern || pattern.startsWith('!')) continue;
-
-    // Skip file-level patterns (ending with /**/* or /*). These only ignore
-    // files inside a directory, NOT the directory itself. ESLint v10's
-    // isDirectoryIgnored does not block traversal for file-level patterns,
-    // allowing `!` re-include to work for files inside.
-    // Only directory-level patterns (ending with /** or /) block traversal.
-    if (
-      pattern.endsWith('/**/*') ||
-      (pattern.endsWith('/*') && !pattern.endsWith('/**'))
-    )
-      continue;
-
-    const isMatch = picomatch(pattern, { dot: true });
-
-    // Check if the pattern matches the directory itself or a file inside it.
-    // We test: the dir path, dir path + trailing slash, and a synthetic
-    // child path to handle patterns like `dir/**`.
-    if (
-      isMatch(normalizedRelDir) ||
-      isMatch(normalizedRelDir + '/') ||
-      isMatch(normalizedRelDir + '/x')
-    ) {
-      return true;
+/** Resolve each explicit directory's config once while preserving its alias. */
+export function findJSConfigsForDirectories(
+  directories: readonly string[],
+): Map<string, string | null> {
+  const result = new Map<string, string | null>();
+  const lexicalConfigByDirectory = new Map<string, string | null>();
+  const canonicalConfigByDirectory = new Map<string, string | null>();
+  for (const rawDirectory of directories) {
+    const directory = path.normalize(rawDirectory);
+    let configPath = lexicalConfigByDirectory.get(directory);
+    if (configPath === undefined) {
+      configPath = findJSConfigUp(directory);
+      lexicalConfigByDirectory.set(directory, configPath);
     }
+    if (!configPath) {
+      configPath = findJSConfigFromCanonicalTarget(
+        path.resolve(directory),
+        directory,
+        true,
+        canonicalConfigByDirectory,
+      );
+    }
+    result.set(directory, configPath);
+  }
+  return result;
+}
 
-    // For nested dirs, also check if any parent segment matches.
-    // e.g., pattern `__tests__/**` should match `__tests__/fixtures/deep`.
-    const segments = normalizedRelDir.split('/');
-    for (let i = 1; i < segments.length; i++) {
-      const partial = segments.slice(0, i).join('/');
-      if (
-        isMatch(partial) ||
-        isMatch(partial + '/') ||
-        isMatch(partial + '/x')
-      ) {
+function caseDifferenceTraversesSymlink(
+  leftDirectory: string,
+  rightDirectory: string,
+): boolean {
+  const leftRoot = path.parse(leftDirectory).root;
+  const rightRoot = path.parse(rightDirectory).root;
+  const leftSegments = leftDirectory.slice(leftRoot.length).split(path.sep);
+  const rightSegments = rightDirectory.slice(rightRoot.length).split(path.sep);
+  let leftCurrent = leftRoot;
+  let rightCurrent = rightRoot;
+  for (let index = 0; index < leftSegments.length; index++) {
+    const leftSegment = leftSegments[index];
+    const rightSegment = rightSegments[index];
+    if (!leftSegment || !rightSegment) continue;
+    leftCurrent = path.join(leftCurrent, leftSegment);
+    rightCurrent = path.join(rightCurrent, rightSegment);
+    if (leftSegment === rightSegment) continue;
+    try {
+      const leftInfo = fs.lstatSync(leftCurrent);
+      const rightInfo = fs.lstatSync(rightCurrent);
+      const leftIsSymlink = leftInfo.isSymbolicLink();
+      const rightIsSymlink = rightInfo.isSymbolicLink();
+      if (leftIsSymlink || rightIsSymlink) {
+        // Alternate casing of one symlink/junction is one native path. Distinct
+        // symlink entries that happen to share a target remain separate owners.
+        if (
+          leftIsSymlink &&
+          rightIsSymlink &&
+          (leftInfo.dev !== 0 || leftInfo.ino !== 0) &&
+          leftInfo.dev === rightInfo.dev &&
+          leftInfo.ino === rightInfo.ino
+        ) {
+          continue;
+        }
         return true;
       }
+    } catch {
+      return true;
     }
   }
-
   return false;
 }
 
-function isRelativeChildPath(relPath: string): boolean {
-  return (
-    relPath !== '' &&
-    relPath !== '..' &&
-    !relPath.startsWith(`..${path.sep}`) &&
-    !path.isAbsolute(relPath)
-  );
-}
-
-function isSameOrChildDirectory(parentDir: string, childDir: string): boolean {
-  const relPath = path.relative(parentDir, childDir);
-  return relPath === '' || isRelativeChildPath(relPath);
-}
-
-export interface ConfigEntry {
-  configDirectory: string;
-  entries: RslintConfigEntry[];
-}
-
-function resolveConfigDirectory(configDirectory: string): string {
-  let dir = configDirectory;
-  const root = path.parse(dir).root;
-  while (dir.length > root.length && /[/\\]$/.test(dir)) {
-    dir = dir.slice(0, -1);
+function isNativeCaseAlias(
+  leftPath: string,
+  leftDirectory: string,
+  rightPath: string,
+  rightDirectory: string,
+): boolean {
+  if (
+    leftPath === rightPath ||
+    leftPath.toLowerCase() !== rightPath.toLowerCase()
+  ) {
+    return false;
   }
   try {
-    dir = fs.realpathSync(dir);
+    if (
+      path.normalize(fs.realpathSync.native(leftDirectory)) !==
+        path.normalize(fs.realpathSync.native(rightDirectory)) ||
+      path.normalize(fs.realpathSync.native(leftPath)) !==
+        path.normalize(fs.realpathSync.native(rightPath))
+    ) {
+      return false;
+    }
   } catch {
-    // Keep the original (stripped) path if realpath fails.
+    return false;
   }
-  return dir;
+  return !caseDifferenceTraversesSymlink(leftDirectory, rightDirectory);
 }
 
-/**
- * Filter out nested configs whose directory is covered by an ancestor config's
- * global ignores. Aligns with ESLint v10 behavior: when traversing directories,
- * global ignores in a parent config prevent entering ignored directories, so
- * nested configs in those directories are never discovered.
- *
- * Example: root config has `{ ignores: ['__tests__/**'] }`.
- * A nested config at `__tests__/fixtures/rslint.config.js` is filtered out
- * because `__tests__/fixtures/` is within the root config's global ignores.
- *
- * `forceIncludeConfigDirectories` is for explicit CLI file targets: ESLint
- * resolves the nearest config for an explicit file even when a parent global
- * ignore would have blocked directory traversal into that subtree.
- */
-export function filterConfigsByParentIgnores(
-  configEntries: ConfigEntry[],
-  forceIncludeConfigDirectories = new Set<string>(),
-): ConfigEntry[] {
-  if (configEntries.length <= 1) return configEntries;
-
-  const forceIncludedDirs = new Set(
-    [...forceIncludeConfigDirectories].map(resolveConfigDirectory),
-  );
-
-  const resolvedDirs = new Map<ConfigEntry, string>();
-  for (const entry of configEntries) {
-    resolvedDirs.set(entry, resolveConfigDirectory(entry.configDirectory));
-  }
-
-  const sorted = [...configEntries].sort(
-    (a, b) =>
-      (resolvedDirs.get(a)?.length ?? 0) - (resolvedDirs.get(b)?.length ?? 0),
-  );
-
-  const result: ConfigEntry[] = [];
-
-  for (const config of sorted) {
-    let ignored = false;
-    const configDir = resolvedDirs.get(config)!;
-
-    for (const parent of result) {
-      const parentDir = resolvedDirs.get(parent)!;
-      if (!isSameOrChildDirectory(parentDir, configDir)) {
-        continue;
-      }
-
-      const globalIgnores = getGlobalIgnores(parent.entries);
-      if (globalIgnores.length === 0) continue;
-
-      if (isDirIgnoredByPatterns(configDir, globalIgnores, parentDir)) {
-        ignored = true;
-        break;
-      }
-    }
-
-    if (!ignored || forceIncludedDirs.has(configDir)) {
-      result.push(config);
+/** Find an already-known spelling of the same native case-aliased config. */
+export function findNativeCaseAliasConfigPath(
+  configPath: string,
+  configDirectory: string,
+  configs: ReadonlyMap<string, string>,
+): string | null {
+  const normalizedPath = path.normalize(configPath);
+  const normalizedDirectory = path.normalize(configDirectory);
+  const foldedPath = normalizedPath.toLowerCase();
+  for (const [candidatePath, candidateDirectory] of configs) {
+    if (path.normalize(candidatePath).toLowerCase() !== foldedPath) continue;
+    if (
+      isNativeCaseAlias(
+        normalizedPath,
+        normalizedDirectory,
+        path.normalize(candidatePath),
+        path.normalize(candidateDirectory),
+      )
+    ) {
+      return candidatePath;
     }
   }
+  return null;
+}
 
-  return result;
+/** Coalesce native case aliases without collapsing explicit symlink roots. */
+export function coalesceCaseAliasedConfigs(
+  configs: Map<string, string>,
+  explicitTargets: Map<string, string[]> = new Map(),
+  explicitDirectories: Map<string, string[]> = new Map(),
+): {
+  configs: Map<string, string>;
+  explicitFileTargetsByConfigPath: Map<string, string[]>;
+  explicitDirectoryTargetsByConfigPath: Map<string, string[]>;
+} {
+  const coalescedConfigs = new Map<string, string>();
+  const coalescedTargets = new Map<string, string[]>();
+  const coalescedDirectories = new Map<string, string[]>();
+
+  for (const [rawConfigPath, rawConfigDirectory] of configs) {
+    const configPath = path.normalize(rawConfigPath);
+    const configDirectory = path.normalize(rawConfigDirectory);
+    const representative = findNativeCaseAliasConfigPath(
+      configPath,
+      configDirectory,
+      coalescedConfigs,
+    );
+    const selectedPath = representative ?? configPath;
+    if (!representative) {
+      coalescedConfigs.set(configPath, configDirectory);
+    }
+
+    const mergeTargets = (
+      source: Map<string, string[]>,
+      destination: Map<string, string[]>,
+    ): void => {
+      const targets = source.get(rawConfigPath) ?? source.get(configPath);
+      if (!targets || targets.length === 0) return;
+      const existing = destination.get(selectedPath) ?? [];
+      destination.set(selectedPath, [...new Set([...existing, ...targets])]);
+    };
+    mergeTargets(explicitTargets, coalescedTargets);
+    mergeTargets(explicitDirectories, coalescedDirectories);
+  }
+
+  return {
+    configs: coalescedConfigs,
+    explicitFileTargetsByConfigPath: coalescedTargets,
+    explicitDirectoryTargetsByConfigPath: coalescedDirectories,
+  };
 }

--- a/packages/rslint/src/utils/config-discovery.ts
+++ b/packages/rslint/src/utils/config-discovery.ts
@@ -3,13 +3,9 @@ import path from 'node:path';
 import picomatch from 'picomatch';
 import { glob } from 'tinyglobby';
 import { type RslintConfigEntry } from '../config/define-config.ts';
+import { JS_CONFIG_FILES } from '../config/config-loader.ts';
 
-export const JS_CONFIG_FILES = [
-  'rslint.config.js',
-  'rslint.config.mjs',
-  'rslint.config.ts',
-  'rslint.config.mts',
-];
+export { JS_CONFIG_FILES };
 
 export function findJSConfig(cwd: string): string | null {
   for (const name of JS_CONFIG_FILES) {
@@ -46,6 +42,7 @@ export async function findJSConfigsInDir(startDir: string): Promise<string[]> {
     cwd: resolved,
     absolute: true,
     dot: true,
+    followSymbolicLinks: false,
     ignore: ['**/node_modules/**', '**/.git/**'],
   });
 
@@ -146,14 +143,16 @@ export async function discoverConfigs(
 }
 
 function getConfigPriority(configPath: string): number {
-  const index = JS_CONFIG_FILES.indexOf(path.basename(configPath));
+  const index = JS_CONFIG_FILES.indexOf(
+    path.basename(configPath) as (typeof JS_CONFIG_FILES)[number],
+  );
   return index === -1 ? Number.POSITIVE_INFINITY : index;
 }
 
 /**
  * Check if a config entry is a "global ignore" entry — an entry with only
- * `ignores` and no other meaningful fields. Aligns with ESLint flat config
- * semantics where such entries prevent directory traversal.
+ * `ignores` and an optional `name`. Aligns with ESLint flat config semantics
+ * where such entries prevent directory traversal.
  */
 function isGlobalIgnoreEntry(
   entry: RslintConfigEntry,
@@ -161,19 +160,7 @@ function isGlobalIgnoreEntry(
   const ignores = entry.ignores;
   if (!Array.isArray(ignores) || ignores.length === 0) return false;
 
-  return (
-    entry.files == null &&
-    entry.rules == null &&
-    // No meaningful plugins: absent, an empty array-form whitelist, or an empty
-    // object-form map. `plugins` is a union (string[] native names XOR a live
-    // community-plugin object), so branch on the shape before measuring length.
-    (entry.plugins == null ||
-      (Array.isArray(entry.plugins)
-        ? entry.plugins.length === 0
-        : Object.keys(entry.plugins).length === 0)) &&
-    entry.languageOptions == null &&
-    entry.settings == null
-  );
+  return Object.keys(entry).every((key) => key === 'ignores' || key === 'name');
 }
 
 /**

--- a/packages/rslint/tests/args.test.ts
+++ b/packages/rslint/tests/args.test.ts
@@ -45,7 +45,7 @@ describe('isJSConfigFile', () => {
     expect(isJSConfigFile('/project/rslint.config.ts')).toBe(true);
   });
 
-  test('returns true for .cjs and .cts', () => {
+  test('returns true for explicitly selectable .cjs and .cts configs', () => {
     expect(isJSConfigFile('rslint.config.cjs')).toBe(true);
     expect(isJSConfigFile('rslint.config.cts')).toBe(true);
   });

--- a/packages/rslint/tests/args.test.ts
+++ b/packages/rslint/tests/args.test.ts
@@ -45,8 +45,9 @@ describe('isJSConfigFile', () => {
     expect(isJSConfigFile('/project/rslint.config.ts')).toBe(true);
   });
 
-  test('returns false for .cjs', () => {
-    expect(isJSConfigFile('rslint.config.cjs')).toBe(false);
+  test('returns true for .cjs and .cts', () => {
+    expect(isJSConfigFile('rslint.config.cjs')).toBe(true);
+    expect(isJSConfigFile('rslint.config.cts')).toBe(true);
   });
 });
 
@@ -60,9 +61,8 @@ describe('classifyArgs', () => {
   test('classifies existing directory', () => {
     const tmp = createTempDir();
     try {
-      const realTmp = fs.realpathSync(tmp);
       const result = classifyArgs([tmp], '/');
-      expect(result.dirs).toEqual([realTmp]);
+      expect(result.dirs).toEqual([path.resolve(tmp)]);
       expect(result.files).toEqual([]);
     } finally {
       cleanup(tmp);
@@ -74,9 +74,8 @@ describe('classifyArgs', () => {
     const filePath = path.join(tmp, 'test.ts');
     try {
       fs.writeFileSync(filePath, 'const x = 1;');
-      const realFile = fs.realpathSync(filePath);
       const result = classifyArgs([filePath], '/');
-      expect(result.files).toEqual([realFile]);
+      expect(result.files).toEqual([path.resolve(filePath)]);
       expect(result.dirs).toEqual([]);
     } finally {
       cleanup(tmp);
@@ -98,11 +97,9 @@ describe('classifyArgs', () => {
     try {
       fs.mkdirSync(dir);
       fs.writeFileSync(filePath, 'const x = 1;');
-      const realDir = fs.realpathSync(dir);
-      const realFile = fs.realpathSync(filePath);
       const result = classifyArgs([dir, filePath], '/');
-      expect(result.dirs).toEqual([realDir]);
-      expect(result.files).toEqual([realFile]);
+      expect(result.dirs).toEqual([path.resolve(dir)]);
+      expect(result.files).toEqual([path.resolve(filePath)]);
     } finally {
       cleanup(tmp);
     }
@@ -113,15 +110,14 @@ describe('classifyArgs', () => {
     const filePath = path.join(tmp, 'test.ts');
     try {
       fs.writeFileSync(filePath, 'const x = 1;');
-      const realFile = fs.realpathSync(filePath);
       const result = classifyArgs(['test.ts'], tmp);
-      expect(result.files).toEqual([realFile]);
+      expect(result.files).toEqual([path.resolve(filePath)]);
     } finally {
       cleanup(tmp);
     }
   });
 
-  test('resolves symlinks in path', () => {
+  test('preserves a symlinked file path', () => {
     const tmp = createTempDir();
     const realDir = path.join(tmp, 'real');
     const linkDir = path.join(tmp, 'link');
@@ -131,13 +127,13 @@ describe('classifyArgs', () => {
       fs.writeFileSync(filePath, 'const x = 1;');
       fs.symlinkSync(realDir, linkDir);
       const result = classifyArgs([path.join(linkDir, 'test.ts')], '/');
-      expect(result.files).toEqual([fs.realpathSync(filePath)]);
+      expect(result.files).toEqual([path.resolve(linkDir, 'test.ts')]);
     } finally {
       cleanup(tmp);
     }
   });
 
-  test('resolves symlinked directory arg', () => {
+  test('preserves a symlinked directory arg', () => {
     const tmp = createTempDir();
     const realDir = path.join(tmp, 'real');
     const linkDir = path.join(tmp, 'link');
@@ -145,7 +141,7 @@ describe('classifyArgs', () => {
       fs.mkdirSync(realDir);
       fs.symlinkSync(realDir, linkDir);
       const result = classifyArgs([linkDir], '/');
-      expect(result.dirs).toEqual([fs.realpathSync(realDir)]);
+      expect(result.dirs).toEqual([path.resolve(linkDir)]);
     } finally {
       cleanup(tmp);
     }

--- a/packages/rslint/tests/config-discovery.test.ts
+++ b/packages/rslint/tests/config-discovery.test.ts
@@ -1,8 +1,10 @@
 import { describe, test, expect } from '@rstest/core';
 import {
+  coalesceCaseAliasedConfigs,
   discoverConfigs,
   filterConfigsByParentIgnores,
   findJSConfig,
+  findJSConfigForTarget,
   findJSConfigUp,
   findJSConfigsInDir,
   JS_CONFIG_FILES,
@@ -208,6 +210,104 @@ describe('discoverConfigs', () => {
       cleanup(tmp);
     }
   });
+
+  test('file symlink uses lexical config before physical config', async () => {
+    const tmp = createTempDir();
+    const physicalDir = path.join(tmp, 'physical');
+    const lexicalDir = path.join(tmp, 'lexical');
+    const physicalConfig = path.join(physicalDir, 'rslint.config.js');
+    const lexicalConfig = path.join(lexicalDir, 'rslint.config.js');
+    const physicalFile = path.join(physicalDir, 'index.ts');
+    const lexicalFile = path.join(lexicalDir, 'index.ts');
+    try {
+      fs.mkdirSync(physicalDir);
+      fs.mkdirSync(lexicalDir);
+      fs.writeFileSync(physicalConfig, 'export default []');
+      fs.writeFileSync(lexicalConfig, 'export default []');
+      fs.writeFileSync(physicalFile, 'export {};');
+      fs.symlinkSync(physicalFile, lexicalFile, 'file');
+
+      expect(findJSConfigForTarget(lexicalFile, false)).toBe(lexicalConfig);
+      const result = await discoverConfigs([lexicalFile], [], tmp, null);
+      expect([...result.keys()]).toEqual([lexicalConfig]);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
+  test('file symlink falls back to physical config without a lexical config', async () => {
+    const tmp = createTempDir();
+    const physicalDir = path.join(tmp, 'physical');
+    const lexicalDir = path.join(tmp, 'lexical');
+    const physicalConfig = path.join(physicalDir, 'rslint.config.js');
+    const physicalFile = path.join(physicalDir, 'index.ts');
+    const lexicalFile = path.join(lexicalDir, 'index.ts');
+    try {
+      fs.mkdirSync(physicalDir);
+      fs.mkdirSync(lexicalDir);
+      fs.writeFileSync(physicalConfig, 'export default []');
+      fs.writeFileSync(physicalFile, 'export {};');
+      fs.symlinkSync(physicalFile, lexicalFile, 'file');
+
+      const canonicalConfig = fs.realpathSync(physicalConfig);
+      expect(findJSConfigForTarget(lexicalFile, false)).toBe(canonicalConfig);
+      const result = await discoverConfigs([lexicalFile], [], tmp, null);
+      expect([...result.keys()]).toEqual([canonicalConfig]);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+});
+
+describe('coalesceCaseAliasedConfigs', () => {
+  test('keeps case-distinct config roots when only their config files share a target', () => {
+    const tmp = createTempDir();
+    const upperDir = path.join(tmp, 'Project');
+    const lowerDir = path.join(tmp, 'project');
+    try {
+      fs.mkdirSync(upperDir);
+      try {
+        fs.mkdirSync(lowerDir);
+      } catch {
+        return;
+      }
+      const sharedConfig = path.join(tmp, 'shared.config.mjs');
+      fs.writeFileSync(sharedConfig, 'export default []');
+      const upperConfig = path.join(upperDir, 'rslint.config.mjs');
+      const lowerConfig = path.join(lowerDir, 'rslint.config.mjs');
+      try {
+        fs.symlinkSync(sharedConfig, upperConfig, 'file');
+        fs.symlinkSync(sharedConfig, lowerConfig, 'file');
+      } catch {
+        return;
+      }
+
+      const result = coalesceCaseAliasedConfigs(
+        new Map([
+          [upperConfig, upperDir],
+          [lowerConfig, lowerDir],
+        ]),
+      );
+      expect(result.configs.size).toBe(2);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+});
+
+describe('findJSConfig', () => {
+  test('skips a higher-priority filename that is a directory', () => {
+    const tmp = createTempDir();
+    try {
+      fs.mkdirSync(path.join(tmp, 'rslint.config.js'));
+      const configPath = path.join(tmp, 'rslint.config.mjs');
+      fs.writeFileSync(configPath, 'export default []');
+
+      expect(findJSConfig(tmp)).toBe(configPath);
+    } finally {
+      cleanup(tmp);
+    }
+  });
 });
 
 // --- filterConfigsByParentIgnores ---
@@ -264,6 +364,46 @@ describe('filterConfigsByParentIgnores', () => {
     ]);
     expect(result).toHaveLength(1);
     expect(dirs(result)).toEqual([P()]);
+  });
+
+  test.each([
+    'packages//ignored/**',
+    'packages/./ignored/**',
+    './packages/ignored/**',
+  ])(
+    'normalizes parent ignore pattern %s before hierarchy matching',
+    (pattern) => {
+      const result = filterConfigsByParentIgnores([
+        cfg(P(), globalIgnore(pattern), ruleEntry(['**/*.ts'], {})),
+        cfg(P('packages', 'ignored'), ruleEntry(['**/*.ts'], {})),
+      ]);
+
+      expect(dirs(result)).toEqual([P()]);
+    },
+  );
+
+  test('builds the effective transaction catalog from loaded candidates', () => {
+    const parent = {
+      ...cfg(P(), globalIgnore('generated/**')),
+      configPath: P('rslint.config.js'),
+    };
+    const ignoredNested = {
+      ...cfg(P('generated', 'package'), ruleEntry(['**/*.ts'], {})),
+      configPath: P('generated', 'package', 'rslint.config.js'),
+    };
+    const sibling = {
+      ...cfg(P('packages', 'app'), ruleEntry(['**/*.ts'], {})),
+      configPath: P('packages', 'app', 'rslint.config.js'),
+    };
+
+    const result = filterConfigsByParentIgnores([
+      ignoredNested,
+      sibling,
+      parent,
+    ]);
+
+    expect(result).toEqual([parent, sibling]);
+    expect(result).not.toContain(ignoredNested);
   });
 
   test('explicit empty config fields make ignores entry-level', () => {
@@ -409,6 +549,19 @@ describe('filterConfigsByParentIgnores', () => {
     expect(dirs(result)).toContain(P('packages', 'lib'));
   });
 
+  test('nearest config boundary replaces ancestor global ignores', () => {
+    const result = filterConfigsByParentIgnores([
+      cfg(
+        P(),
+        globalIgnore('packages/app/generated/**'),
+        ruleEntry(['**/*.ts'], {}),
+      ),
+      cfg(P('packages', 'app'), ruleEntry(['**/*.ts'], {})),
+      cfg(P('packages', 'app', 'generated'), ruleEntry(['**/*.ts'], {})),
+    ]);
+    expect(dirs(result)).toContain(P('packages', 'app', 'generated'));
+  });
+
   test('global ignore entry with name field is still recognized', () => {
     const result = filterConfigsByParentIgnores([
       cfg(
@@ -437,10 +590,15 @@ describe('filterConfigsByParentIgnores', () => {
       cfg(P('e2e', 'helpers'), ruleEntry(['**/*.ts'], {})),
       cfg(P('packages', 'app', 'dist', 'gen'), ruleEntry(['**/*.ts'], {})),
     ]);
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(4);
     expect(dirs(result)).toContain(P());
     expect(dirs(result)).toContain(P('packages', 'app'));
     expect(dirs(result)).toContain(P('packages', 'lib'));
+    expect(dirs(result)).toContain(P('packages', 'app', 'dist', 'gen'));
+    expect(dirs(result)).not.toContain(
+      P('packages', 'vscode-ext', '__tests__', 'fixtures'),
+    );
+    expect(dirs(result)).not.toContain(P('e2e', 'helpers'));
   });
 
   // --- Glob pattern coverage (picomatch) ---
@@ -497,9 +655,9 @@ describe('filterConfigsByParentIgnores', () => {
     expect(result[0].configDirectory).toBe(P());
   });
 
-  test('negation pattern is skipped — does not re-include or accidentally filter', () => {
-    // Negation (!) is skipped at directory level (aligned with ESLint v10).
-    // `vendor/**` filters vendor dirs, `!vendor/keep/**` is ignored.
+  test('negation cannot re-include a descendant of an ignored directory', () => {
+    // `vendor/**` ignores the parent directory before the descendant negation
+    // can be reached, matching ESLint v10 directory traversal.
     const result = filterConfigsByParentIgnores([
       cfg(
         P(),
@@ -508,13 +666,11 @@ describe('filterConfigsByParentIgnores', () => {
       ),
       cfg(P('vendor', 'lib'), ruleEntry(['**/*.ts'], {})),
       cfg(P('vendor', 'keep'), ruleEntry(['**/*.ts'], {})),
-      // Unrelated dirs should NOT be affected by the negation pattern
+      // Unrelated directories are not affected by the negation pattern.
       cfg(P('packages', 'app'), ruleEntry(['**/*.ts'], {})),
     ]);
-    // vendor/* filtered by positive pattern
     expect(dirs(result)).not.toContain(P('vendor', 'lib'));
     expect(dirs(result)).not.toContain(P('vendor', 'keep'));
-    // Unrelated dirs must NOT be filtered (negation pattern skipped safely)
     expect(dirs(result)).toContain(P('packages', 'app'));
     expect(dirs(result)).toContain(P());
   });
@@ -529,32 +685,50 @@ describe('filterConfigsByParentIgnores', () => {
     expect(result).toHaveLength(3);
   });
 
-  // --- File-level vs directory-level patterns (ESLint v10 aligned) ---
-
-  test('dir/** blocks traversal, dir/**/* does not (ESLint v10 behavior)', () => {
-    // vendor/** = directory-level → filters nested configs
-    // vendor/**/* = file-level → does NOT filter (allows traversal)
+  test('dir/** and dir/**/* both block ignored descendant directories', () => {
     const withDirPattern = filterConfigsByParentIgnores([
       cfg(P(), globalIgnore('vendor/**'), ruleEntry(['**/*.ts'], {})),
       cfg(P('vendor', 'keep'), ruleEntry(['**/*.ts'], {})),
     ]);
-    expect(withDirPattern).toHaveLength(1); // vendor/keep filtered
+    expect(withDirPattern).toHaveLength(1);
 
     const withFilePattern = filterConfigsByParentIgnores([
       cfg(P(), globalIgnore('vendor/**/*'), ruleEntry(['**/*.ts'], {})),
       cfg(P('vendor', 'keep'), ruleEntry(['**/*.ts'], {})),
     ]);
-    expect(withFilePattern).toHaveLength(2); // vendor/keep NOT filtered
-    expect(dirs(withFilePattern)).toContain(P('vendor', 'keep'));
+    expect(withFilePattern).toHaveLength(1);
   });
 
-  test('dir/* (single-level file glob) does not block traversal', () => {
+  test('dir/* blocks a directly matched child directory', () => {
     const result = filterConfigsByParentIgnores([
       cfg(P(), globalIgnore('vendor/*'), ruleEntry(['**/*.ts'], {})),
       cfg(P('vendor', 'keep'), ruleEntry(['**/*.ts'], {})),
     ]);
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(1);
+  });
+
+  test('directory negations keep nested config traversal reachable', () => {
+    const result = filterConfigsByParentIgnores([
+      cfg(
+        P(),
+        globalIgnore('vendor/**/*', '!vendor/**/*/'),
+        ruleEntry(['**/*.ts'], {}),
+      ),
+      cfg(P('vendor', 'keep'), ruleEntry(['**/*.ts'], {})),
+      cfg(P('vendor', 'drop'), ruleEntry(['**/*.ts'], {})),
+    ]);
     expect(dirs(result)).toContain(P('vendor', 'keep'));
+    expect(dirs(result)).toContain(P('vendor', 'drop'));
+  });
+
+  test('top-level negation re-includes a directory', () => {
+    const result = filterConfigsByParentIgnores([
+      cfg(P(), globalIgnore('*', '!vendor'), ruleEntry(['**/*.ts'], {})),
+      cfg(P('vendor', 'keep'), ruleEntry(['**/*.ts'], {})),
+      cfg(P('packages', 'app'), ruleEntry(['**/*.ts'], {})),
+    ]);
+    expect(dirs(result)).toContain(P('vendor', 'keep'));
+    expect(dirs(result)).not.toContain(P('packages', 'app'));
   });
 
   // --- Mixed global + entry-level ignores in same config ---
@@ -688,8 +862,7 @@ describe('filterConfigsByParentIgnores', () => {
     expect(dirs(result)).toContain(P('packages', 'lib'));
   });
 
-  test('uses real filesystem paths for symlink resolution', () => {
-    // Create actual temp dirs to test realpathSync
+  test('filters lexical child configs in ignored directories', () => {
     const tmp = createTempDir();
     const nestedDir = path.join(tmp, 'sub', 'nested');
     fs.mkdirSync(nestedDir, { recursive: true });
@@ -704,9 +877,44 @@ describe('filterConfigsByParentIgnores', () => {
       cleanup(tmp);
     }
   });
+
+  test('does not infer config ancestry through a directory symlink', () => {
+    const tmp = createTempDir();
+    const physicalRoot = path.join(tmp, 'physical');
+    const physicalChild = path.join(physicalRoot, 'child');
+    const aliasRoot = path.join(tmp, 'alias');
+    fs.mkdirSync(physicalChild, { recursive: true });
+    try {
+      fs.symlinkSync(
+        physicalRoot,
+        aliasRoot,
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
+      const result = filterConfigsByParentIgnores([
+        cfg(aliasRoot, globalIgnore('child/**')),
+        cfg(physicalChild, ruleEntry(['**/*.ts'], {})),
+      ]);
+
+      expect(dirs(result)).toContain(aliasRoot);
+      expect(dirs(result)).toContain(physicalChild);
+    } finally {
+      cleanup(tmp);
+    }
+  });
 });
 
 describe('findJSConfig', () => {
+  test('keeps the full config filename priority order', () => {
+    expect(JS_CONFIG_FILES).toEqual([
+      'rslint.config.js',
+      'rslint.config.mjs',
+      'rslint.config.cjs',
+      'rslint.config.ts',
+      'rslint.config.mts',
+      'rslint.config.cts',
+    ]);
+  });
+
   test('finds rslint.config.js in cwd', () => {
     const tmp = createTempDir();
     try {
@@ -728,10 +936,10 @@ describe('findJSConfig', () => {
     }
   });
 
-  test('prefers js over mjs over ts over mts', () => {
+  test('uses ESLint config filename priority', () => {
     const tmp = createTempDir();
     try {
-      // Create all four config files
+      // Create every supported config variant.
       for (const name of JS_CONFIG_FILES) {
         fs.writeFileSync(path.join(tmp, name), 'export default []');
       }
@@ -757,6 +965,20 @@ describe('findJSConfig', () => {
     }
   });
 
+  test('finds cjs when js and mjs do not exist', () => {
+    const tmp = createTempDir();
+    try {
+      fs.writeFileSync(
+        path.join(tmp, 'rslint.config.cjs'),
+        'module.exports = []',
+      );
+      const result = findJSConfig(tmp);
+      expect(result).toBe(path.join(tmp, 'rslint.config.cjs'));
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
   test('finds .ts config when js and mjs do not exist', () => {
     const tmp = createTempDir();
     try {
@@ -777,6 +999,20 @@ describe('findJSConfig', () => {
       );
       const result = findJSConfig(tmp);
       expect(result).toBe(path.join(tmp, 'rslint.config.mts'));
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
+  test('finds .cts config when no other config exists', () => {
+    const tmp = createTempDir();
+    try {
+      fs.writeFileSync(
+        path.join(tmp, 'rslint.config.cts'),
+        'export default []',
+      );
+      const result = findJSConfig(tmp);
+      expect(result).toBe(path.join(tmp, 'rslint.config.cts'));
     } finally {
       cleanup(tmp);
     }

--- a/packages/rslint/tests/config-discovery.test.ts
+++ b/packages/rslint/tests/config-discovery.test.ts
@@ -161,98 +161,6 @@ describe('discoverConfigs', () => {
     }
   });
 
-  test('discovered configs are returned parent-first', async () => {
-    const tmp = createTempDir();
-    try {
-      fs.mkdirSync(path.join(tmp, 'packages', 'app'), { recursive: true });
-      fs.writeFileSync(path.join(tmp, 'rslint.config.js'), 'export default []');
-      fs.writeFileSync(
-        path.join(tmp, 'packages', 'rslint.config.js'),
-        'export default []',
-      );
-      fs.writeFileSync(
-        path.join(tmp, 'packages', 'app', 'rslint.config.js'),
-        'export default []',
-      );
-
-      const result = await discoverConfigs([], [], tmp, null);
-      expect([...result.values()]).toEqual([
-        tmp,
-        path.join(tmp, 'packages'),
-        path.join(tmp, 'packages', 'app'),
-      ]);
-    } finally {
-      cleanup(tmp);
-    }
-  });
-
-  test('directory scan returns parent before deep child config', async () => {
-    const tmp = createTempDir();
-    try {
-      const deepDir = path.join(tmp, 'a', 'b', 'c');
-      fs.mkdirSync(deepDir, { recursive: true });
-      fs.writeFileSync(path.join(tmp, 'rslint.config.js'), 'export default []');
-      fs.writeFileSync(
-        path.join(deepDir, 'rslint.config.js'),
-        'export default []',
-      );
-
-      const result = await discoverConfigs([], [], tmp, null);
-      expect([...result.values()]).toEqual([tmp, deepDir]);
-    } finally {
-      cleanup(tmp);
-    }
-  });
-
-  test('mixed file and dir args still return parent before child config', async () => {
-    const tmp = createTempDir();
-    try {
-      const appDir = path.join(tmp, 'packages', 'app');
-      fs.mkdirSync(appDir, { recursive: true });
-      fs.writeFileSync(path.join(tmp, 'rslint.config.js'), 'export default []');
-      fs.writeFileSync(
-        path.join(appDir, 'rslint.config.js'),
-        'export default []',
-      );
-      fs.writeFileSync(path.join(appDir, 'a.ts'), 'const a = 1;');
-
-      const result = await discoverConfigs(
-        [path.join(appDir, 'a.ts')],
-        [tmp],
-        tmp,
-        null,
-      );
-      expect([...result.values()]).toEqual([tmp, appDir]);
-    } finally {
-      cleanup(tmp);
-    }
-  });
-
-  test('file args still return parent before child config when passed child first', async () => {
-    const tmp = createTempDir();
-    try {
-      const appDir = path.join(tmp, 'packages', 'app');
-      fs.mkdirSync(appDir, { recursive: true });
-      fs.writeFileSync(path.join(tmp, 'rslint.config.js'), 'export default []');
-      fs.writeFileSync(
-        path.join(appDir, 'rslint.config.js'),
-        'export default []',
-      );
-      fs.writeFileSync(path.join(tmp, 'root.ts'), 'const root = 1;');
-      fs.writeFileSync(path.join(appDir, 'app.ts'), 'const app = 1;');
-
-      const result = await discoverConfigs(
-        [path.join(appDir, 'app.ts'), path.join(tmp, 'root.ts')],
-        [],
-        tmp,
-        null,
-      );
-      expect([...result.values()]).toEqual([tmp, appDir]);
-    } finally {
-      cleanup(tmp);
-    }
-  });
-
   test('dir arg discovers nested configs within scope', async () => {
     const tmp = createTempDir();
     try {
@@ -1028,13 +936,13 @@ describe('findJSConfigsInDir', () => {
         path.join(tmp, 'packages', 'bar', 'rslint.config.mjs'),
         'export default []',
       );
-      const result = await findJSConfigsInDir(tmp);
-      expect(result[0]).toBe(path.join(tmp, 'rslint.config.js'));
-      expect(new Set(result.slice(1))).toEqual(
-        new Set([
+      const result = (await findJSConfigsInDir(tmp)).sort();
+      expect(result).toEqual(
+        [
+          path.join(tmp, 'rslint.config.js'),
           path.join(tmp, 'packages', 'bar', 'rslint.config.mjs'),
           path.join(tmp, 'packages', 'foo', 'rslint.config.ts'),
-        ]),
+        ].sort(),
       );
     } finally {
       cleanup(tmp);

--- a/packages/rslint/tests/config-discovery.test.ts
+++ b/packages/rslint/tests/config-discovery.test.ts
@@ -186,6 +186,24 @@ describe('discoverConfigs', () => {
     }
   });
 
+  test('directory scan returns parent before deep child config', async () => {
+    const tmp = createTempDir();
+    try {
+      const deepDir = path.join(tmp, 'a', 'b', 'c');
+      fs.mkdirSync(deepDir, { recursive: true });
+      fs.writeFileSync(path.join(tmp, 'rslint.config.js'), 'export default []');
+      fs.writeFileSync(
+        path.join(deepDir, 'rslint.config.js'),
+        'export default []',
+      );
+
+      const result = await discoverConfigs([], [], tmp, null);
+      expect([...result.values()]).toEqual([tmp, deepDir]);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
   test('mixed file and dir args still return parent before child config', async () => {
     const tmp = createTempDir();
     try {
@@ -201,6 +219,31 @@ describe('discoverConfigs', () => {
       const result = await discoverConfigs(
         [path.join(appDir, 'a.ts')],
         [tmp],
+        tmp,
+        null,
+      );
+      expect([...result.values()]).toEqual([tmp, appDir]);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
+  test('file args still return parent before child config when passed child first', async () => {
+    const tmp = createTempDir();
+    try {
+      const appDir = path.join(tmp, 'packages', 'app');
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(path.join(tmp, 'rslint.config.js'), 'export default []');
+      fs.writeFileSync(
+        path.join(appDir, 'rslint.config.js'),
+        'export default []',
+      );
+      fs.writeFileSync(path.join(tmp, 'root.ts'), 'const root = 1;');
+      fs.writeFileSync(path.join(appDir, 'app.ts'), 'const app = 1;');
+
+      const result = await discoverConfigs(
+        [path.join(appDir, 'app.ts'), path.join(tmp, 'root.ts')],
+        [],
         tmp,
         null,
       );
@@ -985,13 +1028,13 @@ describe('findJSConfigsInDir', () => {
         path.join(tmp, 'packages', 'bar', 'rslint.config.mjs'),
         'export default []',
       );
-      const result = (await findJSConfigsInDir(tmp)).sort();
-      expect(result).toEqual(
-        [
-          path.join(tmp, 'rslint.config.js'),
-          path.join(tmp, 'packages', 'foo', 'rslint.config.ts'),
+      const result = await findJSConfigsInDir(tmp);
+      expect(result[0]).toBe(path.join(tmp, 'rslint.config.js'));
+      expect(new Set(result.slice(1))).toEqual(
+        new Set([
           path.join(tmp, 'packages', 'bar', 'rslint.config.mjs'),
-        ].sort(),
+          path.join(tmp, 'packages', 'foo', 'rslint.config.ts'),
+        ]),
       );
     } finally {
       cleanup(tmp);
@@ -1077,15 +1120,37 @@ describe('findJSConfigsInDir', () => {
     }
   });
 
-  test('finds all config file types', async () => {
+  test('uses config file priority within the same directory', async () => {
     const tmp = createTempDir();
     try {
       for (const name of JS_CONFIG_FILES) {
         fs.writeFileSync(path.join(tmp, name), 'export default []');
       }
-      const result = (await findJSConfigsInDir(tmp)).sort();
-      expect(result).toEqual(
-        JS_CONFIG_FILES.map((name) => path.join(tmp, name)).sort(),
+      const result = await findJSConfigsInDir(tmp);
+      expect(result).toEqual([path.join(tmp, 'rslint.config.js')]);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
+  test('follows symlinked directories like tinyglobby', async () => {
+    const tmp = createTempDir();
+    const realDir = path.join(tmp, 'real');
+    const linkDir = path.join(tmp, 'link');
+    try {
+      fs.mkdirSync(realDir);
+      fs.writeFileSync(
+        path.join(realDir, 'rslint.config.js'),
+        'export default []',
+      );
+      fs.symlinkSync(realDir, linkDir, 'dir');
+
+      const result = await findJSConfigsInDir(tmp);
+      expect(new Set(result)).toEqual(
+        new Set([
+          path.join(realDir, 'rslint.config.js'),
+          path.join(linkDir, 'rslint.config.js'),
+        ]),
       );
     } finally {
       cleanup(tmp);

--- a/packages/rslint/tests/config-discovery.test.ts
+++ b/packages/rslint/tests/config-discovery.test.ts
@@ -186,6 +186,30 @@ describe('discoverConfigs', () => {
     }
   });
 
+  test('mixed file and dir args still return parent before child config', async () => {
+    const tmp = createTempDir();
+    try {
+      const appDir = path.join(tmp, 'packages', 'app');
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(path.join(tmp, 'rslint.config.js'), 'export default []');
+      fs.writeFileSync(
+        path.join(appDir, 'rslint.config.js'),
+        'export default []',
+      );
+      fs.writeFileSync(path.join(appDir, 'a.ts'), 'const a = 1;');
+
+      const result = await discoverConfigs(
+        [path.join(appDir, 'a.ts')],
+        [tmp],
+        tmp,
+        null,
+      );
+      expect([...result.values()]).toEqual([tmp, appDir]);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
   test('dir arg discovers nested configs within scope', async () => {
     const tmp = createTempDir();
     try {
@@ -509,6 +533,15 @@ describe('filterConfigsByParentIgnores', () => {
     ]);
     expect(result).toHaveLength(1);
     expect(dirs(result)).toEqual([P()]);
+  });
+
+  test('directory names starting with .. are still child directories', () => {
+    const result = filterConfigsByParentIgnores([
+      cfg(P(), globalIgnore('..foo/**'), ruleEntry(['**/*.ts'], {})),
+      cfg(P('..foo'), ruleEntry(['**/*.ts'], {})),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].configDirectory).toBe(P());
   });
 
   test('negation pattern is skipped — does not re-include or accidentally filter', () => {

--- a/packages/rslint/tests/config-discovery.test.ts
+++ b/packages/rslint/tests/config-discovery.test.ts
@@ -266,16 +266,18 @@ describe('filterConfigsByParentIgnores', () => {
     expect(dirs(result)).toEqual([P()]);
   });
 
-  test('empty array-form or object-form plugins still counts as a global ignore', () => {
-    // An ignores-only entry stays "global" even with an empty `plugins`. Since
-    // `plugins` is a union (string[] XOR object), isGlobalIgnoreEntry must treat
-    // both an empty array AND an empty object as "no plugins" — otherwise the
-    // entry would lose global-ignore status and stop blocking nested discovery.
-    for (const emptyPlugins of [{ plugins: [] }, { plugins: {} }]) {
+  test('explicit empty config fields make ignores entry-level', () => {
+    for (const emptyField of [
+      { rules: {} },
+      { plugins: [] },
+      { plugins: {} },
+      { settings: {} },
+      { languageOptions: {} },
+    ]) {
       const result = filterConfigsByParentIgnores([
         cfg(
           P(),
-          { ignores: ['__tests__/**'], ...emptyPlugins },
+          { ignores: ['__tests__/**'], ...emptyField },
           ruleEntry(['**/*.ts'], {}),
         ),
         cfg(
@@ -283,8 +285,8 @@ describe('filterConfigsByParentIgnores', () => {
           ruleEntry(['**/*.ts'], { 'no-console': 'error' }),
         ),
       ]);
-      expect(result).toHaveLength(1);
-      expect(dirs(result)).toEqual([P()]);
+      expect(result).toHaveLength(2);
+      expect(dirs(result)).toContain(P('__tests__', 'fixtures'));
     }
   });
 
@@ -1058,7 +1060,7 @@ describe('findJSConfigsInDir', () => {
     }
   });
 
-  test('follows symlinked directories like tinyglobby', async () => {
+  test('does not follow symlinked directories', async () => {
     const tmp = createTempDir();
     const realDir = path.join(tmp, 'real');
     const linkDir = path.join(tmp, 'link');
@@ -1071,12 +1073,7 @@ describe('findJSConfigsInDir', () => {
       fs.symlinkSync(realDir, linkDir, 'dir');
 
       const result = await findJSConfigsInDir(tmp);
-      expect(new Set(result)).toEqual(
-        new Set([
-          path.join(realDir, 'rslint.config.js'),
-          path.join(linkDir, 'rslint.config.js'),
-        ]),
-      );
+      expect(result).toEqual([path.join(realDir, 'rslint.config.js')]);
     } finally {
       cleanup(tmp);
     }

--- a/packages/rslint/tests/config-discovery.test.ts
+++ b/packages/rslint/tests/config-discovery.test.ts
@@ -161,6 +161,31 @@ describe('discoverConfigs', () => {
     }
   });
 
+  test('discovered configs are returned parent-first', async () => {
+    const tmp = createTempDir();
+    try {
+      fs.mkdirSync(path.join(tmp, 'packages', 'app'), { recursive: true });
+      fs.writeFileSync(path.join(tmp, 'rslint.config.js'), 'export default []');
+      fs.writeFileSync(
+        path.join(tmp, 'packages', 'rslint.config.js'),
+        'export default []',
+      );
+      fs.writeFileSync(
+        path.join(tmp, 'packages', 'app', 'rslint.config.js'),
+        'export default []',
+      );
+
+      const result = await discoverConfigs([], [], tmp, null);
+      expect([...result.values()]).toEqual([
+        tmp,
+        path.join(tmp, 'packages'),
+        path.join(tmp, 'packages', 'app'),
+      ]);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
   test('dir arg discovers nested configs within scope', async () => {
     const tmp = createTempDir();
     try {

--- a/packages/rslint/tests/config-discovery.test.ts
+++ b/packages/rslint/tests/config-discovery.test.ts
@@ -597,6 +597,23 @@ describe('filterConfigsByParentIgnores', () => {
     expect(result).toHaveLength(1);
   });
 
+  test('trailing slash normalization preserves filesystem root', () => {
+    const root = path.parse(path.resolve('/')).root;
+    const child = path.join(root, 'rslint-root-child');
+    const result = filterConfigsByParentIgnores([
+      cfg(
+        root,
+        globalIgnore('rslint-root-child/**'),
+        ruleEntry(['**/*.ts'], {}),
+      ),
+      cfg(child, ruleEntry(['**/*.ts'], {})),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(dirs(result)).toContain(root);
+    expect(dirs(result)).not.toContain(child);
+  });
+
   // --- Cross-package ignore isolation ---
 
   test('child global ignore does NOT bubble up to filter parent', () => {

--- a/packages/rslint/tests/config-discovery.test.ts
+++ b/packages/rslint/tests/config-discovery.test.ts
@@ -908,10 +908,8 @@ describe('findJSConfig', () => {
     expect(JS_CONFIG_FILES).toEqual([
       'rslint.config.js',
       'rslint.config.mjs',
-      'rslint.config.cjs',
       'rslint.config.ts',
       'rslint.config.mts',
-      'rslint.config.cts',
     ]);
   });
 
@@ -936,10 +934,10 @@ describe('findJSConfig', () => {
     }
   });
 
-  test('uses ESLint config filename priority', () => {
+  test('uses the automatic config filename priority', () => {
     const tmp = createTempDir();
     try {
-      // Create every supported config variant.
+      // Create every automatically discoverable config variant.
       for (const name of JS_CONFIG_FILES) {
         fs.writeFileSync(path.join(tmp, name), 'export default []');
       }
@@ -960,20 +958,6 @@ describe('findJSConfig', () => {
       );
       const result = findJSConfig(tmp);
       expect(result).toBe(path.join(tmp, 'rslint.config.mjs'));
-    } finally {
-      cleanup(tmp);
-    }
-  });
-
-  test('finds cjs when js and mjs do not exist', () => {
-    const tmp = createTempDir();
-    try {
-      fs.writeFileSync(
-        path.join(tmp, 'rslint.config.cjs'),
-        'module.exports = []',
-      );
-      const result = findJSConfig(tmp);
-      expect(result).toBe(path.join(tmp, 'rslint.config.cjs'));
     } finally {
       cleanup(tmp);
     }
@@ -1004,19 +988,18 @@ describe('findJSConfig', () => {
     }
   });
 
-  test('finds .cts config when no other config exists', () => {
-    const tmp = createTempDir();
-    try {
-      fs.writeFileSync(
-        path.join(tmp, 'rslint.config.cts'),
-        'export default []',
-      );
-      const result = findJSConfig(tmp);
-      expect(result).toBe(path.join(tmp, 'rslint.config.cts'));
-    } finally {
-      cleanup(tmp);
-    }
-  });
+  test.each(['cjs', 'cts'])(
+    'does not auto-discover .%s configs',
+    (extension) => {
+      const tmp = createTempDir();
+      try {
+        fs.writeFileSync(path.join(tmp, `rslint.config.${extension}`), '');
+        expect(findJSConfig(tmp)).toBe(null);
+      } finally {
+        cleanup(tmp);
+      }
+    },
+  );
 
   test('returns null for non-existent directory', () => {
     const result = findJSConfig('/tmp/definitely-does-not-exist-99999');

--- a/packages/rslint/tests/config-loader.test.ts
+++ b/packages/rslint/tests/config-loader.test.ts
@@ -94,7 +94,7 @@ describe('normalizeConfig', () => {
     );
   });
 
-  test('strips unknown fields', () => {
+  test('preserves name and strips unknown fields', () => {
     const result = normalizeConfig([
       {
         name: 'my-config',
@@ -103,7 +103,7 @@ describe('normalizeConfig', () => {
         unknownField: 123,
       },
     ]);
-    expect(result[0]).not.toHaveProperty('name');
+    expect(result[0].name).toBe('my-config');
     expect(result[0]).not.toHaveProperty('unknownField');
   });
 
@@ -132,16 +132,17 @@ describe('normalizeConfig', () => {
     expect(normalizeConfig([])).toEqual([]);
   });
 
-  test('skips null and non-object entries', () => {
-    const result = normalizeConfig([
-      { files: ['**/*.ts'], rules: { 'no-console': 'error' } },
-      null,
-      undefined,
-      42,
-      'string',
-    ]);
-    expect(result).toHaveLength(1);
-    expect(result[0].rules).toEqual({ 'no-console': 'error' });
+  test.each([null, undefined, 42, 'string'])(
+    'rejects non-object config entry %p',
+    (entry) => {
+      expect(() => normalizeConfig([entry])).toThrow(/must be an object|null/);
+    },
+  );
+
+  test('rejects nested config arrays', () => {
+    expect(() => normalizeConfig([[{ rules: {} }]])).toThrow(
+      /unexpected array/,
+    );
   });
 
   test('throws when files is a string instead of array', () => {
@@ -162,10 +163,20 @@ describe('normalizeConfig', () => {
     );
   });
 
-  test('throws when files contains non-string values', () => {
+  test('throws when files contains invalid selector values', () => {
     expect(() => normalizeConfig([{ files: [123], rules: {} }])).toThrow(
-      '"files" must contain only strings',
+      '"files" must contain only strings or arrays of strings',
     );
+  });
+
+  test('preserves ESLint AND selector groups, including an empty group', () => {
+    const [entry] = normalizeConfig([
+      {
+        files: ['**/*.ts', ['**/*.js', '!**/*.test.js'], []],
+        rules: {},
+      },
+    ]);
+    expect(entry.files).toEqual(['**/*.ts', ['**/*.js', '!**/*.test.js'], []]);
   });
 
   test('throws when ignores is a string instead of array', () => {
@@ -189,13 +200,31 @@ describe('normalizeConfig', () => {
     expect(Object.hasOwn(result[0], 'ignores')).toBe(false);
   });
 
-  test('allows files set to undefined', () => {
-    const result = normalizeConfig([
-      { files: undefined, rules: { 'no-console': 'error' } },
+  test('throws when files is explicitly undefined', () => {
+    expect(() =>
+      normalizeConfig([{ files: undefined, rules: { 'no-console': 'error' } }]),
+    ).toThrow('"files" must be an array');
+  });
+
+  test('preserves non-global shape when unsupported fields are stripped', () => {
+    const [entry] = normalizeConfig([
+      { ignores: ['dist/**'], processor: 'example-processor' },
     ]);
-    expect(result).toHaveLength(1);
-    expect(result[0].files).toBeUndefined();
-    expect(Object.hasOwn(result[0], 'files')).toBe(false);
+    expect(entry).toEqual({ ignores: ['dist/**'], settings: {} });
+  });
+
+  test('rejects authored undefined known fields like ESLint v10', () => {
+    for (const authoredField of [
+      { rules: undefined },
+      { languageOptions: undefined },
+      { settings: undefined },
+      { plugins: undefined },
+      { ignores: undefined },
+    ]) {
+      expect(() =>
+        normalizeConfig([{ ignores: ['dist/**'], ...authoredField }]),
+      ).toThrow(/must be/);
+    }
   });
 });
 
@@ -325,15 +354,25 @@ describe('normalizeConfig — community plugins (object-form)', () => {
       { files: ['**/*.ts'], rules: {} },
     ]) as NormalizedPluginEntry[];
     expect(entry.eslintPlugins).toBeUndefined();
-    expect(entry.plugins).toEqual([]);
+    expect(entry.plugins).toBeUndefined();
+    expect(Object.hasOwn(entry, 'plugins')).toBe(false);
   });
 
-  test('empty object-form plugins {} is a no-op (no carrier, empty gate)', () => {
+  test('explicit empty object-form plugins {} is preserved as an empty gate', () => {
     const [entry] = normalizeConfig([
       { files: ['**/*.ts'], plugins: {}, rules: {} },
     ]) as NormalizedPluginEntry[];
     expect(entry.eslintPlugins).toBeUndefined();
     expect(entry.plugins).toEqual([]);
+  });
+
+  test('explicit empty array-form plugins [] is preserved on the wire', () => {
+    const [entry] = normalizeConfig([
+      { files: ['**/*.ts'], plugins: [], rules: {} },
+    ]) as NormalizedPluginEntry[];
+    expect(entry.eslintPlugins).toBeUndefined();
+    expect(entry.plugins).toEqual([]);
+    expect(Object.hasOwn(entry, 'plugins')).toBe(true);
   });
 });
 

--- a/packages/rslint/tests/config-loader.test.ts
+++ b/packages/rslint/tests/config-loader.test.ts
@@ -150,9 +150,33 @@ describe('normalizeConfig', () => {
     );
   });
 
+  test('throws when files is an empty array', () => {
+    expect(() => normalizeConfig([{ files: [], rules: {} }])).toThrow(
+      '"files" must be a non-empty array',
+    );
+  });
+
+  test('throws when files is null', () => {
+    expect(() => normalizeConfig([{ files: null, rules: {} }])).toThrow(
+      '"files" must be an array',
+    );
+  });
+
+  test('throws when files contains non-string values', () => {
+    expect(() => normalizeConfig([{ files: [123], rules: {} }])).toThrow(
+      '"files" must contain only strings',
+    );
+  });
+
   test('throws when ignores is a string instead of array', () => {
     expect(() => normalizeConfig([{ ignores: 'dist/**', rules: {} }])).toThrow(
       '"ignores" must be an array',
+    );
+  });
+
+  test('throws when ignores contains non-string values', () => {
+    expect(() => normalizeConfig([{ ignores: [null], rules: {} }])).toThrow(
+      '"ignores" must contain only strings',
     );
   });
 
@@ -160,7 +184,18 @@ describe('normalizeConfig', () => {
     const result = normalizeConfig([{ rules: { 'no-console': 'error' } }]);
     expect(result).toHaveLength(1);
     expect(result[0].files).toBeUndefined();
+    expect(Object.hasOwn(result[0], 'files')).toBe(false);
     expect(result[0].ignores).toBeUndefined();
+    expect(Object.hasOwn(result[0], 'ignores')).toBe(false);
+  });
+
+  test('allows files set to undefined', () => {
+    const result = normalizeConfig([
+      { files: undefined, rules: { 'no-console': 'error' } },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].files).toBeUndefined();
+    expect(Object.hasOwn(result[0], 'files')).toBe(false);
   });
 });
 

--- a/packages/rslint/tests/config-loader.test.ts
+++ b/packages/rslint/tests/config-loader.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from '@rstest/core';
 import {
   loadConfigFile,
+  loadConfigFileFresh,
   normalizeConfig,
   collectPluginMeta,
 } from '../src/config/config-loader.js';
@@ -48,6 +49,37 @@ describe('loadConfigFile', () => {
     }
   });
 
+  test('loads a .cjs config file', async () => {
+    const tmp = createTempDir();
+    try {
+      fs.writeFileSync(
+        path.join(tmp, 'rslint.config.cjs'),
+        'module.exports = [{ files: ["**/*.js"], rules: { "no-console": "error" } }];',
+      );
+      const result = await loadConfigFile(path.join(tmp, 'rslint.config.cjs'));
+      expect(Array.isArray(result)).toBe(true);
+      expect((result as Array<{ rules: unknown }>)[0].rules).toEqual({
+        'no-console': 'error',
+      });
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
+  test('loads a .cts config file', async () => {
+    const tmp = createTempDir();
+    try {
+      fs.writeFileSync(
+        path.join(tmp, 'rslint.config.cts'),
+        'const config: Array<Record<string, unknown>> = [{ files: ["**/*.ts"], rules: {} }]; module.exports = config;',
+      );
+      const result = await loadConfigFile(path.join(tmp, 'rslint.config.cts'));
+      expect(Array.isArray(result)).toBe(true);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
   test('resolves a thenable (Promise) default export', async () => {
     const tmp = createTempDir();
     try {
@@ -78,6 +110,53 @@ describe('loadConfigFile', () => {
   });
 });
 
+describe('loadConfigFileFresh', () => {
+  test.each(['cjs', 'cts'])(
+    'reloads a changed .%s config',
+    async (extension) => {
+      const tmp = createTempDir();
+      const configPath = path.join(tmp, `rslint.config.${extension}`);
+      try {
+        fs.writeFileSync(configPath, 'module.exports = [{ name: "first" }];');
+        expect(await loadConfigFileFresh(configPath)).toEqual([
+          { name: 'first' },
+        ]);
+
+        fs.writeFileSync(configPath, 'module.exports = [{ name: "second" }];');
+        expect(await loadConfigFileFresh(configPath)).toEqual([
+          { name: 'second' },
+        ]);
+      } finally {
+        cleanup(tmp);
+      }
+    },
+  );
+
+  test.each(['ts', 'mts', 'cts'])(
+    'does not re-execute a .%s config after a runtime error',
+    async (extension) => {
+      const tmp = createTempDir();
+      const configPath = path.join(tmp, `rslint.config.${extension}`);
+      const sideEffectPath = path.join(tmp, 'executions.txt');
+      const sideEffect = `fs.appendFileSync(${JSON.stringify(sideEffectPath)}, 'x');`;
+      const source =
+        extension === 'mts'
+          ? `import fs from 'node:fs'; ${sideEffect} throw new Error('config runtime failure'); export default [];`
+          : `const fs = require('node:fs'); ${sideEffect} throw new Error('config runtime failure'); module.exports = [];`;
+
+      try {
+        fs.writeFileSync(configPath, source);
+        await expect(loadConfigFileFresh(configPath)).rejects.toThrow(
+          'config runtime failure',
+        );
+        expect(fs.readFileSync(sideEffectPath, 'utf8')).toBe('x');
+      } finally {
+        cleanup(tmp);
+      }
+    },
+  );
+});
+
 describe('normalizeConfig', () => {
   test('accepts a valid flat config array', () => {
     const result = normalizeConfig([
@@ -87,6 +166,33 @@ describe('normalizeConfig', () => {
     expect(result[0].files).toEqual(['**/*.ts']);
     expect(result[0].rules).toEqual({ 'no-console': 'error' });
   });
+
+  test('accepts numeric rule severities and positional options', () => {
+    expect(
+      normalizeConfig([
+        {
+          rules: {
+            off: 0,
+            warn: [1],
+            error: [2, 'always', { exceptRange: true }],
+          },
+        },
+      ])[0].rules,
+    ).toEqual({
+      off: 0,
+      warn: [1],
+      error: [2, 'always', { exceptRange: true }],
+    });
+  });
+
+  test.each([3, 'fatal', [], [3], {}, null])(
+    'rejects invalid rule configuration %p',
+    (ruleValue) => {
+      expect(() =>
+        normalizeConfig([{ rules: { example: ruleValue } }]),
+      ).toThrow(/rule "example".*severity/);
+    },
+  );
 
   test('throws when config is not an array', () => {
     expect(() => normalizeConfig({ rules: {} })).toThrow(
@@ -130,6 +236,12 @@ describe('normalizeConfig', () => {
 
   test('handles empty array', () => {
     expect(normalizeConfig([])).toEqual([]);
+  });
+
+  test('rejects sparse config arrays', () => {
+    expect(() => normalizeConfig(new Array(1))).toThrow(
+      /unexpected undefined config/,
+    );
   });
 
   test.each([null, undefined, 42, 'string'])(
@@ -199,6 +311,33 @@ describe('normalizeConfig', () => {
     expect(result[0].ignores).toBeUndefined();
     expect(Object.hasOwn(result[0], 'ignores')).toBe(false);
   });
+
+  test('accepts ESLint global access values', () => {
+    const globals = {
+      writableBoolean: true,
+      writableString: 'true',
+      writable: 'writable',
+      writeable: 'writeable',
+      readonlyBoolean: false,
+      readonlyString: 'false',
+      readonly: 'readonly',
+      readable: 'readable',
+      nullReadonly: null,
+      disabled: 'off',
+    };
+    expect(normalizeConfig([{ languageOptions: { globals } }])[0]).toEqual({
+      languageOptions: { globals },
+    });
+  });
+
+  test.each([null, [], { value: 'invalid' }, { ' padded ': 'readonly' }])(
+    'rejects invalid globals value %p',
+    (globals) => {
+      expect(() => normalizeConfig([{ languageOptions: { globals } }])).toThrow(
+        /globals|global/,
+      );
+    },
+  );
 
   test('throws when files is explicitly undefined', () => {
     expect(() =>

--- a/packages/rslint/tests/config-loader.test.ts
+++ b/packages/rslint/tests/config-loader.test.ts
@@ -96,18 +96,6 @@ describe('loadConfigFile', () => {
       cleanup(tmp);
     }
   });
-
-  test('throws for an unsupported extension', async () => {
-    const tmp = createTempDir();
-    try {
-      fs.writeFileSync(path.join(tmp, 'rslint.config.yaml'), 'rules: {}');
-      await expect(
-        loadConfigFile(path.join(tmp, 'rslint.config.yaml')),
-      ).rejects.toThrow('Unsupported config file extension');
-    } finally {
-      cleanup(tmp);
-    }
-  });
 });
 
 describe('loadConfigFileFresh', () => {

--- a/packages/rslint/tests/eslint-plugin/ast/scope-factory-ecma-features.test.ts
+++ b/packages/rslint/tests/eslint-plugin/ast/scope-factory-ecma-features.test.ts
@@ -20,6 +20,10 @@ import { describe, test, expect } from '@rstest/core';
 import { lintFile } from '../../../src/eslint-plugin/linter/ecma-language-plugin.js';
 import type { LoadedPlugins } from '../../../src/eslint-plugin/plugin/plugin-loader.js';
 import type { RuleContext } from '../../../src/eslint-plugin/linter/context.js';
+import {
+  seedEcmaGlobals,
+  seedGlobals,
+} from '../../../src/eslint-plugin/ast/scope-factory.js';
 
 interface Probe {
   globalScopeType?: string;
@@ -254,5 +258,101 @@ describe("scope-factory: globals: { name: 'off' } restores refs to gs.through", 
     expect(observed.throughNames).toEqual(
       expect.arrayContaining(['Array']) as never,
     );
+  });
+});
+
+describe('scope-factory: global access aliases', () => {
+  interface GlobalProbeVariable {
+    name: string;
+    defs?: unknown[];
+    writeable: boolean;
+    eslintImplicitGlobalSetting?: 'readonly' | 'writable';
+    references: Array<{ resolved?: unknown }>;
+  }
+
+  function makeScopeManager() {
+    const variables: GlobalProbeVariable[] = [];
+    const set = new Map<string, GlobalProbeVariable>();
+    return {
+      variables,
+      set,
+      scopeManager: { globalScope: { variables, set, through: [] } },
+    };
+  }
+
+  test('normalizes every legal writable and readonly alias', () => {
+    const { variables, set, scopeManager } = makeScopeManager();
+
+    seedGlobals(scopeManager, {
+      writableBoolean: true,
+      writableString: 'true',
+      writable: 'writable',
+      writeable: 'writeable',
+      readonlyBoolean: false,
+      readonlyString: 'false',
+      readonly: 'readonly',
+      readable: 'readable',
+      nullReadonly: null,
+      offDisabled: 'off',
+    });
+
+    const expectedModes = {
+      writableBoolean: 'writable',
+      writableString: 'writable',
+      writable: 'writable',
+      writeable: 'writable',
+      readonlyBoolean: 'readonly',
+      readonlyString: 'readonly',
+      readonly: 'readonly',
+      readable: 'readonly',
+      nullReadonly: 'readonly',
+    } as const;
+    for (const [name, mode] of Object.entries(expectedModes)) {
+      const variable = set.get(name);
+      expect(variable?.writeable).toBe(mode === 'writable');
+      expect(variable?.eslintImplicitGlobalSetting).toBe(mode);
+    }
+
+    expect(set.has('offDisabled')).toBe(false);
+    expect(variables).toHaveLength(Object.keys(expectedModes).length);
+    for (const variable of variables) {
+      expect(['readonly', 'writable']).toContain(
+        variable.eslintImplicitGlobalSetting,
+      );
+    }
+  });
+
+  test('null keeps an existing global readonly while off removes it', () => {
+    const { set, scopeManager } = makeScopeManager();
+    seedEcmaGlobals(scopeManager);
+    expect(set.has('Array')).toBe(true);
+    expect(set.has('Object')).toBe(true);
+
+    seedGlobals(scopeManager, { Array: null, Object: 'off' });
+
+    expect(set.get('Array')?.writeable).toBe(false);
+    expect(set.get('Array')?.eslintImplicitGlobalSetting).toBe('readonly');
+    expect(set.has('Object')).toBe(false);
+  });
+
+  test('configured globals never remove or rewrite source declarations', () => {
+    const { variables, set, scopeManager } = makeScopeManager();
+    const lexical = {
+      name: 'Array',
+      defs: [{}],
+      writeable: false,
+      references: [],
+    } satisfies GlobalProbeVariable;
+    variables.push(lexical);
+    set.set('Array', lexical);
+
+    seedGlobals(scopeManager, { Array: 'writable' });
+    expect(set.get('Array')).toBe(lexical);
+    expect(lexical.writeable).toBe(false);
+    expect(lexical).not.toHaveProperty('eslintImplicitGlobalSetting');
+
+    seedGlobals(scopeManager, { Array: 'off' });
+    expect(set.get('Array')).toBe(lexical);
+    expect(variables).toContain(lexical);
   });
 });

--- a/packages/rslint/tests/eslint-plugin/fixtures/close-hang-plugin.mjs
+++ b/packages/rslint/tests/eslint-plugin/fixtures/close-hang-plugin.mjs
@@ -1,0 +1,22 @@
+import { writeFileSync } from 'node:fs';
+
+export default {
+  rules: {
+    hang: {
+      meta: { type: 'problem', schema: [] },
+      create() {
+        return {
+          Program() {
+            const marker = process.env.RSLINT_API_CLOSE_MARKER;
+            if (marker) writeFileSync(marker, 'started');
+            // close() must terminate this worker; the listener never yields.
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+              // empty
+            }
+          },
+        };
+      },
+    },
+  },
+};

--- a/packages/rslint/tests/eslint-plugin/fixtures/close-hang.config.mjs
+++ b/packages/rslint/tests/eslint-plugin/fixtures/close-hang.config.mjs
@@ -1,0 +1,8 @@
+import plugin from './close-hang-plugin.mjs';
+
+export default [
+  {
+    plugins: { close: plugin },
+    rules: { 'close/hang': 'error' },
+  },
+];

--- a/packages/rslint/tests/eslint-plugin/fixtures/local-invalid.config.mjs
+++ b/packages/rslint/tests/eslint-plugin/fixtures/local-invalid.config.mjs
@@ -1,0 +1,11 @@
+import localPlugin from './local-plugin.mjs';
+
+export default [
+  {
+    plugins: { local: localPlugin },
+    // normalizeConfig preserves nested parser options; Go's typed config
+    // decoder rejects this project value only after the host has initialized.
+    languageOptions: { parserOptions: { project: 42 } },
+    rules: { 'local/program-listener': 'error' },
+  },
+];

--- a/packages/rslint/tests/eslint-plugin/fixtures/local-plugin.mjs
+++ b/packages/rslint/tests/eslint-plugin/fixtures/local-plugin.mjs
@@ -20,6 +20,7 @@
 //                        `null` → `undefined`.
 //   prefer-array-some  — autofix rule: rewrites a `.filter` member name
 //                        to `some`.
+//   program-listener   — reports once from a Program listener.
 
 export default {
   meta: { name: 'local-plugin', version: '1.0.0' },
@@ -94,6 +95,22 @@ export default {
                 fix: (fixer) => fixer.replaceText(node.property, 'some'),
               });
             }
+          },
+        };
+      },
+    },
+    'program-listener': {
+      meta: {
+        type: 'problem',
+        schema: [],
+        messages: {
+          visited: 'Program listener visited this file.',
+        },
+      },
+      create(context) {
+        return {
+          Program(node) {
+            context.report({ node, messageId: 'visited' });
           },
         };
       },

--- a/packages/rslint/tests/eslint-plugin/fixtures/local.config.mjs
+++ b/packages/rslint/tests/eslint-plugin/fixtures/local.config.mjs
@@ -5,5 +5,8 @@ export default [
     plugins: {
       local: localPlugin,
     },
+    rules: {
+      'local/program-listener': 'error',
+    },
   },
 ];

--- a/packages/rslint/tests/eslint-plugin/linter/language-options.test.ts
+++ b/packages/rslint/tests/eslint-plugin/linter/language-options.test.ts
@@ -26,6 +26,7 @@ import { describe, test, expect } from '@rstest/core';
 import { lintFile } from '../../../src/eslint-plugin/linter/ecma-language-plugin.js';
 import type { LoadedPlugins } from '../../../src/eslint-plugin/plugin/plugin-loader.js';
 import type { RuleContext } from '../../../src/eslint-plugin/linter/context.js';
+import type { GlobalAccess } from '../../../src/eslint-plugin/types.js';
 
 // ── Stub plugin that records the ctx fields it observes ───────────
 
@@ -348,12 +349,10 @@ describe('A15: listener throw is attributed to its rule in ruleErrors', () => {
 //
 // Pre-fix `ensureGlobal` short-circuited on existing entries without
 // updating mode, so user-supplied `'writable'` had no effect on
-// built-ins. Empirically confirmed against ESLint v9 (Linter.verify
+// built-ins. Confirmed against ESLint v10 (Linter.verify
 // returns writeable=true for the same setup).
 describe('A16: user globals override built-in mode flags', () => {
-  function readArrayMode(
-    globalsOpt: Record<string, 'readonly' | 'writable' | 'off'>,
-  ): {
+  function readArrayMode(globalsOpt: Record<string, GlobalAccess>): {
     writeable: boolean | undefined;
     eslintImplicitGlobalSetting: string | undefined;
   } {

--- a/packages/rslint/tests/eslint-plugin/plugin/plugin-loader-error-quality.test.ts
+++ b/packages/rslint/tests/eslint-plugin/plugin/plugin-loader-error-quality.test.ts
@@ -148,49 +148,108 @@ export default [
     );
   });
 
-  // G1: worker MUST be able to load `.ts/.mts` config files via the
-  // same fallback strategy the main thread uses. The previous
-  // implementation called `await import(url)` directly — which works
-  // for `.js/.mjs/.cjs` and for `.ts` only on Node ≥ 22.6 (with
-  // native TypeScript support); on Node 20 (the declared support
-  // floor in `engines.node`) any user with a `rslint.config.ts` +
-  // object-form plugins would hit worker init failure even though the host
-  // had successfully loaded the same file via jiti.
-  test('G1: loadPluginsFromConfigFile handles .ts config via the same extension-aware path the host uses', async () => {
+  test('different config files cannot redefine a prefix under one routing key even with disjoint rules', async () => {
     await withTempConfig(
       {
-        'plugin.mjs': `export default {
-  meta: { name: 'ts-cfg-plug' },
-  rules: { 'fires': { meta: { messages: { x: 'ok' } }, create() { return {}; } } },
-};`,
-        'rslint.config.ts': `import plugin from './plugin.mjs';
-export default [
-  {
-    files: ['src/**/*.ts'],
-    // @ts-ignore — type comes from @rslint/core but we don't depend
-    // on it in this fixture; the runner only needs the runtime shape.
-    plugins: { ts: plugin as unknown as Record<string, unknown> },
-  },
-];`,
+        'plugin-a.mjs': `export default { rules: { alpha: { meta: {}, create() { return {}; } } } };`,
+        'plugin-b.mjs': `export default { rules: { beta: { meta: {}, create() { return {}; } } } };`,
+        'rslint.config.mjs': `import plugin from './plugin-a.mjs'; export default [{ plugins: { p: plugin } }];`,
+        'second.config.mjs': `import plugin from './plugin-b.mjs'; export default [{ plugins: { p: plugin } }];`,
       },
-      async (configMjsPath) => {
-        // The fixture writer wrote `rslint.config.ts`; the helper
-        // returns the `.mjs` path. Swap the extension.
-        const tsConfigPath = configMjsPath.replace(/\.mjs$/, '.ts');
-        const loaded = await loadPluginsFromConfigs([
-          {
-            configPath: tsConfigPath,
-            configDirectory: path.dirname(tsConfigPath),
-          },
-        ]);
-        const ld = loaded.get(path.dirname(tsConfigPath));
-        expect(ld).toBeDefined();
-        expect(ld!.plugins).toHaveLength(1);
-        expect(ld!.plugins[0].prefix).toBe('ts');
-        // Sanity: rules were registered. The exact rule object is the
-        // plugin's `fires` definition.
-        expect(ld!.rules.has('ts/fires')).toBe(true);
+      async (configPath) => {
+        const secondConfigPath = path.join(
+          path.dirname(configPath),
+          'second.config.mjs',
+        );
+        let caught: unknown;
+        try {
+          await loadPluginsFromConfigs([
+            { configPath, configDirectory: '/shared-routing-key' },
+            {
+              configPath: secondConfigPath,
+              configDirectory: '/shared-routing-key',
+            },
+          ]);
+        } catch (error) {
+          caught = error;
+        }
+        expect(caught).toBeInstanceOf(PluginLoaderError);
+        expect((caught as PluginLoaderError).configPath).toBe(secondConfigPath);
+        expect((caught as Error).message).toMatch(
+          /Cannot redefine plugin "p".*shared-routing-key/,
+        );
       },
     );
   });
+
+  test('different config files dedupe the same plugin instance under one routing key', async () => {
+    await withTempConfig(
+      {
+        'plugin.mjs': `export default { rules: { check: { meta: {}, create() { return {}; } } } };`,
+        'rslint.config.mjs': `import plugin from './plugin.mjs'; export default [{ plugins: { p: plugin } }];`,
+        'second.config.mjs': `import plugin from './plugin.mjs'; export default [{ plugins: { p: plugin } }];`,
+      },
+      async (configPath) => {
+        const secondConfigPath = path.join(
+          path.dirname(configPath),
+          'second.config.mjs',
+        );
+        const map = await loadPluginsFromConfigs([
+          { configPath, configDirectory: '/shared-routing-key' },
+          {
+            configPath: secondConfigPath,
+            configDirectory: '/shared-routing-key',
+          },
+        ]);
+
+        const loaded = map.get('/shared-routing-key');
+        expect(loaded).toBeDefined();
+        expect(loaded!.plugins).toHaveLength(1);
+        expect([...loaded!.rules.keys()]).toEqual(['p/check']);
+      },
+    );
+  });
+
+  test.each(['ts', 'mts', 'cts'])(
+    'loads object-form plugins from a .%s config through the worker loader',
+    async (extension) => {
+      const configSource =
+        extension === 'cts'
+          ? `const plugin = require('./plugin.cjs');
+const config: Array<Record<string, unknown>> = [{
+  files: ['src/**/*.ts'],
+  plugins: { probe: plugin },
+}];
+module.exports = config;`
+          : `import plugin from './plugin.cjs';
+export default [{
+  files: ['src/**/*.ts'],
+  plugins: { probe: plugin as unknown as Record<string, unknown> },
+}];`;
+
+      await withTempConfig(
+        {
+          'plugin.cjs': `module.exports = {
+  meta: { name: 'ts-config-plugin' },
+  rules: { fires: { meta: { messages: { x: 'ok' } }, create() { return {}; } } },
+};`,
+          [`rslint.config.${extension}`]: configSource,
+        },
+        async (configMjsPath) => {
+          const configPath = configMjsPath.replace(/\.mjs$/, `.${extension}`);
+          const loaded = await loadPluginsFromConfigs([
+            {
+              configPath,
+              configDirectory: path.dirname(configPath),
+            },
+          ]);
+          const pluginSet = loaded.get(path.dirname(configPath));
+          expect(pluginSet).toBeDefined();
+          expect(pluginSet!.plugins).toHaveLength(1);
+          expect(pluginSet!.plugins[0].prefix).toBe('probe');
+          expect(pluginSet!.rules.has('probe/fires')).toBe(true);
+        },
+      );
+    },
+  );
 });

--- a/packages/rslint/tests/eslint-plugin/plugin/plugin-loader-error-quality.test.ts
+++ b/packages/rslint/tests/eslint-plugin/plugin/plugin-loader-error-quality.test.ts
@@ -210,18 +210,24 @@ export default [
     );
   });
 
-  test.each(['ts', 'mts', 'cts'])(
+  test.each(['cjs', 'ts', 'mts', 'cts'])(
     'loads object-form plugins from a .%s config through the worker loader',
     async (extension) => {
       const configSource =
-        extension === 'cts'
+        extension === 'cjs'
           ? `const plugin = require('./plugin.cjs');
+module.exports = [{
+  files: ['src/**/*.ts'],
+  plugins: { probe: plugin },
+}];`
+          : extension === 'cts'
+            ? `const plugin = require('./plugin.cjs');
 const config: Array<Record<string, unknown>> = [{
   files: ['src/**/*.ts'],
   plugins: { probe: plugin },
 }];
 module.exports = config;`
-          : `import plugin from './plugin.cjs';
+            : `import plugin from './plugin.cjs';
 export default [{
   files: ['src/**/*.ts'],
   plugins: { probe: plugin as unknown as Record<string, unknown> },

--- a/packages/rslint/tests/fixtures/close-active-plugin-exit.mjs
+++ b/packages/rslint/tests/fixtures/close-active-plugin-exit.mjs
@@ -1,0 +1,41 @@
+import { access, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Rslint } from '@rslint/core';
+
+const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-close-plugin-'));
+const marker = path.join(tmp, 'started');
+process.env.RSLINT_API_CLOSE_MARKER = marker;
+const fixtureDirectory = path.resolve(
+  import.meta.dirname,
+  '../eslint-plugin/fixtures',
+);
+const rslint = new Rslint({
+  cwd: fixtureDirectory,
+  overrideConfigFile: 'close-hang.config.mjs',
+});
+const lint = rslint
+  .lintText('const value = 1;\n', { filePath: 'probe.ts' })
+  .catch(() => undefined);
+
+try {
+  const deadline = Date.now() + 15000;
+  while (true) {
+    try {
+      await access(marker);
+      break;
+    } catch {
+      if (Date.now() >= deadline) {
+        console.error('plugin listener did not start');
+        process.exit(2);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
+  await rslint.close();
+  await lint;
+} finally {
+  delete process.env.RSLINT_API_CLOSE_MARKER;
+  await rm(tmp, { recursive: true, force: true });
+}

--- a/packages/rslint/tests/fixtures/fake-api-binary.cjs
+++ b/packages/rslint/tests/fixtures/fake-api-binary.cjs
@@ -24,7 +24,11 @@ function onMessage(msg) {
     send({
       kind: 'response',
       id: msg.id,
-      data: { version: '1.0.0', ok: true },
+      data: {
+        version: '2.0.0',
+        ok: true,
+        capabilities: ['reversePluginLint'],
+      },
     });
   } else if (msg.kind === 'crash') {
     process.exit(42);

--- a/packages/rslint/tests/fixtures/fake-api-binary.cjs
+++ b/packages/rslint/tests/fixtures/fake-api-binary.cjs
@@ -4,11 +4,13 @@
 //   - handshake → response {version, ok}
 //   - crash     → process.exit(42)            (simulate an unexpected crash)
 //   - exit      → response {} then exit 0      (normal close)
+//   - reverse   → pluginLint request, then echo the Node response/error
 //   - anything else (e.g. lint) → no reply     (stays in-flight, so the test
 //     can kill/terminate while a request is pending)
 // Lets the reject-all-pending logic be exercised without the real Go binary.
 
 let buf = Buffer.alloc(0);
+const reverseRequests = new Set();
 
 function send(msg) {
   const body = Buffer.from(JSON.stringify(msg), 'utf8');
@@ -26,6 +28,26 @@ function onMessage(msg) {
     });
   } else if (msg.kind === 'crash') {
     process.exit(42);
+  } else if (msg.kind === 'reverse') {
+    // Deliberately reuse the outer request ID. Request IDs are independent in
+    // each direction, so Node must route by frame kind rather than treating
+    // this pluginLint frame as the response to `reverse`.
+    reverseRequests.add(msg.id);
+    send({
+      kind: 'pluginLint',
+      id: msg.id,
+      data: { files: [{ path: 'probe.ts' }], rules: {} },
+    });
+  } else if (
+    reverseRequests.has(msg.id) &&
+    (msg.kind === 'response' || msg.kind === 'error')
+  ) {
+    reverseRequests.delete(msg.id);
+    send({
+      kind: 'response',
+      id: msg.id,
+      data: { reverseKind: msg.kind, reverseData: msg.data },
+    });
   } else if (msg.kind === 'exit') {
     // Silent mode: exit WITHOUT sending the ack, simulating the peer exiting
     // before its 'exit' response is read — the close() race that must settle

--- a/packages/rslint/tests/fixtures/no-close-plugin-error-exit.mjs
+++ b/packages/rslint/tests/fixtures/no-close-plugin-error-exit.mjs
@@ -1,0 +1,26 @@
+// Failure-path counterpart to no-close-plugin-exit.mjs. The config contains a
+// loadable community plugin (so its worker host initializes) but an invalid
+// parserOptions.project (so Go rejects the lint request). Rslint must shut the
+// host down in finally before this caught rejection returns control here.
+import { Rslint } from '@rslint/core';
+import path from 'node:path';
+
+const fixtureDirectory = path.resolve(
+  import.meta.dirname,
+  '../eslint-plugin/fixtures',
+);
+const rslint = new Rslint({
+  cwd: fixtureDirectory,
+  overrideConfigFile: 'local-invalid.config.mjs',
+});
+try {
+  await rslint.lintText('const value = 1;\n', { filePath: 'probe.ts' });
+  console.error('expected lintText to reject invalid parserOptions.project');
+  process.exit(2);
+} catch (error) {
+  if (!String(error).includes('invalid config')) {
+    console.error('unexpected lint error: ' + String(error));
+    process.exit(3);
+  }
+}
+// Intentionally no rslint.close().

--- a/packages/rslint/tests/fixtures/no-close-plugin-exit.mjs
+++ b/packages/rslint/tests/fixtures/no-close-plugin-exit.mjs
@@ -1,0 +1,25 @@
+// The per-call community-plugin host must be shut down before lintText returns.
+// This script intentionally leaves the Rslint instance open: the Go child is
+// unref'd, so a leaked plugin worker is the only thing that can keep Node alive.
+import { Rslint } from '@rslint/core';
+import path from 'node:path';
+
+const fixtureDirectory = path.resolve(
+  import.meta.dirname,
+  '../eslint-plugin/fixtures',
+);
+const rslint = new Rslint({
+  cwd: fixtureDirectory,
+  overrideConfigFile: 'local.config.mjs',
+});
+const [result] = await rslint.lintText('const value = 1;\n', {
+  filePath: 'probe.ts',
+});
+if (
+  result?.messages.length !== 1 ||
+  result.messages[0].ruleId !== 'local/program-listener'
+) {
+  console.error('unexpected plugin result: ' + JSON.stringify(result ?? null));
+  process.exit(2);
+}
+// Intentionally no rslint.close().

--- a/packages/rslint/tests/node-service.test.ts
+++ b/packages/rslint/tests/node-service.test.ts
@@ -20,6 +20,41 @@ function childOf(svc: NodeRslintService): { kill: (sig?: string) => void } {
 }
 
 suite('NodeRslintService reject-all-pending on crash/terminate', () => {
+  test('answers an inbound request without confusing a colliding outbound id', async () => {
+    const svc = new NodeRslintService({ rslintPath: FAKE });
+    svc.setInboundHandler(async (message) => ({
+      kind: message.kind,
+      file: message.data.files[0].path,
+    }));
+    await expect(svc.sendMessage('reverse', {})).resolves.toEqual({
+      reverseKind: 'response',
+      reverseData: { kind: 'pluginLint', file: 'probe.ts' },
+    });
+    svc.terminate();
+  });
+
+  test('returns an error frame when an inbound handler throws', async () => {
+    const svc = new NodeRslintService({ rslintPath: FAKE });
+    svc.setInboundHandler(() => {
+      throw new Error('plugin host failed');
+    });
+    await expect(svc.sendMessage('reverse', {})).resolves.toEqual({
+      reverseKind: 'error',
+      reverseData: { message: 'plugin host failed' },
+    });
+    svc.terminate();
+  });
+
+  test('returns a clear error frame when no inbound handler is installed', async () => {
+    const svc = new NodeRslintService({ rslintPath: FAKE });
+    const result = await svc.sendMessage('reverse', {});
+    expect(result.reverseKind).toBe('error');
+    expect(result.reverseData.message).toMatch(
+      /no inbound handler.*pluginLint/,
+    );
+    svc.terminate();
+  });
+
   test('rejects in-flight requests when the process crashes', async () => {
     const svc = new NodeRslintService({ rslintPath: FAKE });
     const inflight = svc.sendMessage('lint', {}); // never answered → in-flight

--- a/packages/rslint/tests/node-service.test.ts
+++ b/packages/rslint/tests/node-service.test.ts
@@ -82,8 +82,12 @@ suite('NodeRslintService reject-all-pending on crash/terminate', () => {
   test('does not harm a normal request/response round-trip', async () => {
     const svc = new NodeRslintService({ rslintPath: FAKE });
     await expect(
-      svc.sendMessage('handshake', { version: '1.0.0' }),
-    ).resolves.toEqual({ version: '1.0.0', ok: true });
+      svc.sendMessage('handshake', { version: '2.0.0' }),
+    ).resolves.toEqual({
+      version: '2.0.0',
+      ok: true,
+      capabilities: ['reversePluginLint'],
+    });
     svc.terminate();
   });
 
@@ -105,7 +109,7 @@ suite('NodeRslintService reject-all-pending on crash/terminate', () => {
     process.env.RSLINT_FAKE_EXIT_SILENT = '1';
     try {
       const svc = new NodeRslintService({ rslintPath: FAKE });
-      await svc.sendMessage('handshake', { version: '1.0.0' });
+      await svc.sendMessage('handshake', { version: '2.0.0' });
       await expect(svc.sendMessage('exit', {})).resolves.toBeNull();
     } finally {
       delete process.env.RSLINT_FAKE_EXIT_SILENT;

--- a/packages/rslint/tests/path-identity.test.ts
+++ b/packages/rslint/tests/path-identity.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from '@rstest/core';
+import path from 'node:path';
+
+import {
+  AncestorPathIndex,
+  createCachedAncestorFinder,
+  createPathIdentity,
+} from '../src/api/path-identity.js';
+
+describe('path identity', () => {
+  test('uses case-sensitive POSIX identity', () => {
+    const identity = createPathIdentity(path.posix, true);
+
+    expect(identity.equals('/repo/App', '/repo/app')).toBe(false);
+    expect(identity.isSameOrChild('/repo/App', '/repo/app/file.ts')).toBe(
+      false,
+    );
+    expect(identity.isSameOrChild('/repo/App', '/repo/App/file.ts')).toBe(true);
+
+    const caseInsensitive = createPathIdentity(path.posix, false);
+    expect(
+      caseInsensitive.isSameOrChild('/Repo/App', '/repo/app/file.ts'),
+    ).toBe(true);
+  });
+
+  test('normalizes case, separators, and drive letters for Windows paths', () => {
+    const identity = createPathIdentity(path.win32, false);
+
+    expect(identity.equals('C:/Repo/App/', 'c:\\repo\\app')).toBe(true);
+    expect(identity.isSameOrChild('C:\\Repo', 'c:/REPO/src/file.ts')).toBe(
+      true,
+    );
+    expect(identity.isSameOrChild('C:\\Repo', 'D:\\Repo\\file.ts')).toBe(false);
+
+    const index = new AncestorPathIndex(
+      [
+        ['C:\\Repo', 'root'],
+        ['C:\\Repo\\Packages\\App', 'app'],
+      ],
+      identity,
+    );
+    expect(index.find('c:/repo/packages/APP/src')).toBe('app');
+    expect(index.find('C:\\REPO\\other')).toBe('root');
+    expect(index.find('D:\\Repo')).toBeUndefined();
+  });
+
+  test('routes UNC paths with Windows case semantics', () => {
+    const identity = createPathIdentity(path.win32, false);
+    const index = new AncestorPathIndex(
+      [
+        ['\\\\Server\\Share\\Repo', 'root'],
+        ['\\\\server\\share\\repo\\packages\\app', 'app'],
+      ],
+      identity,
+    );
+
+    expect(index.find('\\\\SERVER\\SHARE\\Repo\\Packages\\App\\src')).toBe(
+      'app',
+    );
+    expect(index.find('\\\\server\\other\\repo')).toBeUndefined();
+  });
+
+  test('caches shared ancestor probes by directory', () => {
+    const identity = createPathIdentity(path.posix, true);
+    const probes: string[] = [];
+    const find = createCachedAncestorFinder((directory) => {
+      probes.push(directory);
+      return directory === '/repo' ? '/repo/rslint.config.mjs' : undefined;
+    }, identity);
+
+    expect(find('/repo/packages/app/src')).toBe('/repo/rslint.config.mjs');
+    expect(find('/repo/packages/app/test')).toBe('/repo/rslint.config.mjs');
+    expect(probes).toEqual([
+      '/repo/packages/app/src',
+      '/repo/packages/app',
+      '/repo/packages',
+      '/repo',
+      '/repo/packages/app/test',
+    ]);
+  });
+});

--- a/packages/rslint/tests/path-identity.test.ts
+++ b/packages/rslint/tests/path-identity.test.ts
@@ -42,6 +42,12 @@ describe('path identity', () => {
     expect(index.find('c:/repo/packages/APP/src')).toBe('app');
     expect(index.find('C:\\REPO\\other')).toBe('root');
     expect(index.find('D:\\Repo')).toBeUndefined();
+
+    const caseSensitive = createPathIdentity(path.win32, true);
+    expect(caseSensitive.equals('C:\\Repo', 'C:\\repo')).toBe(false);
+    expect(
+      caseSensitive.isSameOrChild('C:\\Repo', 'C:\\repo\\src\\file.ts'),
+    ).toBe(false);
   });
 
   test('routes UNC paths with Windows case semantics', () => {

--- a/packages/rslint/tests/rslint.test.mjs
+++ b/packages/rslint/tests/rslint.test.mjs
@@ -222,6 +222,52 @@ describe('Rslint class', () => {
     }
   });
 
+  test('lintText resolves config from the canonical ancestor of a virtual file', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-virtual-symlink-'),
+    );
+    const realRoot = path.join(tmp, 'real-workspace');
+    const realPackage = path.join(realRoot, 'packages', 'app');
+    const aliasPackage = path.join(tmp, 'alias-app');
+    await mkdir(realPackage, { recursive: true });
+    await writeFile(
+      path.join(realRoot, 'rslint.config.mjs'),
+      [
+        'export default [{',
+        "  files: ['**/*.ts'],",
+        "  plugins: ['@typescript-eslint'],",
+        "  rules: { '@typescript-eslint/array-type': 'error' },",
+        '}];',
+        '',
+      ].join('\n'),
+    );
+
+    try {
+      try {
+        await symlink(realPackage, aliasPackage, 'dir');
+      } catch {
+        return;
+      }
+
+      const virtualFile = path.join(aliasPackage, 'src', 'virtual.ts');
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        const [result] = await rslint.lintText(
+          'let values: Array<string> = [];\n',
+          { filePath: virtualFile },
+        );
+        expect(result.filePath).toBe(path.normalize(virtualFile));
+        expect(result.messages.map((message) => message.ruleId)).toEqual([
+          '@typescript-eslint/array-type',
+        ]);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('warn level maps to severity 1', async () => {
     const rslint = new Rslint({
       cwd: fixturesDir,
@@ -497,6 +543,36 @@ describe('Rslint class', () => {
     }
   });
 
+  test('lintFiles discovers config for a positive extglob', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-extglob-'));
+    try {
+      await writeFile(
+        path.join(tmp, 'rslint.config.mjs'),
+        "export default [{ rules: { 'no-debugger': 'error' } }];\n",
+      );
+      await mkdir(path.join(tmp, 'included'), { recursive: true });
+      await mkdir(path.join(tmp, 'vendor'), { recursive: true });
+      await writeFile(path.join(tmp, 'included', 'index.ts'), 'debugger;\n');
+      await writeFile(path.join(tmp, 'vendor', 'index.ts'), 'debugger;\n');
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        const results = await rslint.lintFiles('!(vendor)/**/*.ts');
+        expect(results).toHaveLength(1);
+        expect(path.relative(tmp, results[0].filePath)).toBe(
+          path.join('included', 'index.ts'),
+        );
+        expect(results[0].messages.map((message) => message.ruleId)).toEqual([
+          'no-debugger',
+        ]);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('lintFiles routes matched files through their nearest discovered config', async () => {
     const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-nearest-'));
     try {
@@ -587,6 +663,67 @@ describe('Rslint class', () => {
             .get(path.join('packages', 'y', 'index.ts'))
             .messages.map((message) => message.ruleId),
         ).toEqual(['py/no-bar']);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('overrideConfig preserves authored routing for same-prefix community plugins', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-plugin-override-routing-'),
+    );
+    const xDir = path.join(tmp, 'packages', 'x');
+    const yDir = path.join(tmp, 'packages', 'y');
+    const pluginSource = (message) => `export default {
+  rules: {
+    check: {
+      meta: { type: 'problem', schema: [] },
+      create(context) {
+        return {
+          Identifier(node) {
+            if (node.name === 'value') context.report({ node, message: ${JSON.stringify(message)} });
+          },
+        };
+      },
+    },
+  },
+};
+`;
+    try {
+      await mkdir(xDir, { recursive: true });
+      await mkdir(yDir, { recursive: true });
+      await writeFile(path.join(xDir, 'plugin.mjs'), pluginSource('from-x'));
+      await writeFile(path.join(yDir, 'plugin.mjs'), pluginSource('from-y'));
+      const configSource =
+        "import plugin from './plugin.mjs';\n" +
+        "export default [{ plugins: { p: plugin }, rules: { 'p/check': 'error' } }];\n";
+      await writeFile(path.join(xDir, 'rslint.config.mjs'), configSource);
+      await writeFile(path.join(yDir, 'rslint.config.mjs'), configSource);
+      await writeFile(path.join(xDir, 'index.ts'), 'const value = 1;\n');
+      await writeFile(path.join(yDir, 'index.ts'), 'const value = 1;\n');
+
+      const rslint = new Rslint({ cwd: tmp, overrideConfig: [{}] });
+      try {
+        const results = await rslint.lintFiles('**/*.ts');
+        const byRelativePath = new Map(
+          results.map((result) => [
+            path.relative(tmp, result.filePath),
+            result,
+          ]),
+        );
+        expect(
+          byRelativePath
+            .get(path.join('packages', 'x', 'index.ts'))
+            .messages.find((message) => message.ruleId === 'p/check')?.message,
+        ).toBe('from-x');
+        expect(
+          byRelativePath
+            .get(path.join('packages', 'y', 'index.ts'))
+            .messages.find((message) => message.ruleId === 'p/check')?.message,
+        ).toBe('from-y');
       } finally {
         await rslint.close();
       }
@@ -702,7 +839,7 @@ describe('Rslint class', () => {
     }
   });
 
-  test('lintFiles keeps glob-skip and explicit-error semantics when every applicable config fails', async () => {
+  test('lintFiles skips a broken subtree when another selected config loads', async () => {
     const tmp = await mkdtemp(
       path.join(os.tmpdir(), 'rslint-api-broken-boundary-'),
     );
@@ -734,9 +871,17 @@ describe('Rslint class', () => {
           'no-debugger',
         ]);
 
-        await expect(
-          rslint.lintFiles(['broken/index.ts', 'healthy/index.ts']),
-        ).rejects.toThrow(/Failed to load config .*rslint\.config\.mjs/);
+        const explicitResults = await rslint.lintFiles([
+          'broken/index.ts',
+          'healthy/index.ts',
+        ]);
+        expect(explicitResults).toHaveLength(1);
+        expect(path.relative(tmp, explicitResults[0].filePath)).toBe(
+          path.join('healthy', 'index.ts'),
+        );
+        expect(
+          explicitResults[0].messages.map((message) => message.ruleId),
+        ).toEqual(['no-debugger']);
       } finally {
         await rslint.close();
       }
@@ -745,7 +890,7 @@ describe('Rslint class', () => {
     }
   });
 
-  test('nested configs keep overrideConfig files, ignores, and project relative to cwd', async () => {
+  test('nested configs resolve overrideConfig paths from each discovered config', async () => {
     const tmp = await mkdtemp(
       path.join(os.tmpdir(), 'rslint-api-nested-override-'),
     );
@@ -763,14 +908,12 @@ describe('Rslint class', () => {
         "export default [{ files: ['src/**/*.ts'], rules: { 'no-debugger': 'error' } }];\n",
       );
       await writeFile(
-        path.join(tmp, 'tsconfig.json'),
-        JSON.stringify({
-          files: [
-            'packages/app/src/index.ts',
-            'packages/app/src/ignored.ts',
-            'packages/lib/src/index.ts',
-          ],
-        }),
+        path.join(tmp, 'packages', 'app', 'tsconfig.json'),
+        JSON.stringify({ files: ['src/index.ts', 'src/ignored.ts'] }),
+      );
+      await writeFile(
+        path.join(tmp, 'packages', 'lib', 'tsconfig.json'),
+        JSON.stringify({ files: ['src/index.ts'] }),
       );
       const appSource = 'const values: string[] = [];\nconsole.log(values);\n';
       await writeFile(path.join(appSourceDir, 'index.ts'), appSource);
@@ -783,9 +926,9 @@ describe('Rslint class', () => {
       const rslint = new Rslint({
         cwd: tmp,
         overrideConfig: [
-          { ignores: ['packages/app/src/ignored.ts'] },
+          { ignores: ['src/ignored.ts'] },
           {
-            files: ['packages/*/src/**/*.ts'],
+            files: ['src/**/*.ts'],
             plugins: ['@typescript-eslint'],
             languageOptions: {
               parserOptions: { project: ['./tsconfig.json'] },
@@ -834,7 +977,7 @@ describe('Rslint class', () => {
         path.join(tmp, 'rslint.config.mjs'),
         [
           'export default [',
-          "  { ignores: ['packages/app/**'] },",
+          "  { ignores: ['packages/app/**/*'] },",
           "  { files: ['**/*.ts'], rules: { 'no-console': 'error' } },",
           '];',
           '',
@@ -965,6 +1108,422 @@ describe('Rslint class', () => {
     }
   });
 
+  test('lintFiles coalesces aliases of one physical file under the same config', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-file-alias-dedupe-'),
+    );
+    try {
+      const target = path.join(tmp, 'target.ts');
+      const link = path.join(tmp, 'link.ts');
+      await writeFile(target, 'debugger;\n');
+      try {
+        await symlink(target, link, 'file');
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [{ rules: { 'no-debugger': 'error' } }],
+      });
+      try {
+        const results = await rslint.lintFiles(['target.ts', 'link.ts']);
+        expect(results).toHaveLength(1);
+        expect(results[0].filePath).toBe(path.normalize(link));
+        expect(results[0].messages.map((message) => message.ruleId)).toEqual([
+          'no-debugger',
+        ]);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles rejects one physical file governed by different configs', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-file-alias-owner-'),
+    );
+    try {
+      const shared = path.join(tmp, 'shared.ts');
+      const ownerA = path.join(tmp, 'a');
+      const ownerB = path.join(tmp, 'b');
+      await mkdir(ownerA);
+      await mkdir(ownerB);
+      await writeFile(shared, 'debugger;\n');
+      try {
+        await symlink(shared, path.join(ownerA, 'target.ts'), 'file');
+        await symlink(shared, path.join(ownerB, 'target.ts'), 'file');
+      } catch {
+        return;
+      }
+      await writeFile(
+        path.join(ownerA, 'rslint.config.mjs'),
+        "export default [{ rules: { 'no-debugger': 'error' } }];\n",
+      );
+      await writeFile(
+        path.join(ownerB, 'rslint.config.mjs'),
+        "export default [{ rules: { 'no-console': 'error' } }];\n",
+      );
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        await expect(
+          rslint.lintFiles(['a/target.ts', 'b/target.ts']),
+        ).rejects.toThrow(
+          /resolve to the same file.*different config directories/,
+        );
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles rejects aliases of one physical config directory', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-config-directory-alias-'),
+    );
+    try {
+      const shared = path.join(tmp, 'shared');
+      const ownerA = path.join(tmp, 'a');
+      const ownerB = path.join(tmp, 'b');
+      await mkdir(shared);
+      await writeFile(path.join(shared, 'a.ts'), 'debugger;\n');
+      await writeFile(path.join(shared, 'b.ts'), 'debugger;\n');
+      await writeFile(
+        path.join(shared, 'rslint.config.mjs'),
+        "export default [{ rules: { 'no-debugger': 'error' } }];\n",
+      );
+      try {
+        await symlink(
+          shared,
+          ownerA,
+          process.platform === 'win32' ? 'junction' : 'dir',
+        );
+        await symlink(
+          shared,
+          ownerB,
+          process.platform === 'win32' ? 'junction' : 'dir',
+        );
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        await expect(rslint.lintFiles(['a/a.ts', 'b/b.ts'])).rejects.toThrow(
+          /Config directories .* resolve to the same filesystem location/,
+        );
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles finds a config through the unique physical path fallback', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-file-alias-config-'),
+    );
+    try {
+      const configured = path.join(tmp, 'configured');
+      const entry = path.join(tmp, 'entry');
+      await mkdir(configured);
+      await mkdir(entry);
+      const target = path.join(configured, 'target.ts');
+      const link = path.join(entry, 'link.ts');
+      await writeFile(target, 'debugger;\n');
+      await writeFile(
+        path.join(configured, 'rslint.config.mjs'),
+        "export default [{ files: ['**/*.ts'], rules: { 'no-debugger': 'error' } }];\n",
+      );
+      try {
+        await symlink(target, link, 'file');
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        const results = await rslint.lintFiles('entry/link.ts');
+        expect(results).toHaveLength(1);
+        expect(results[0].filePath).toBe(path.normalize(link));
+        expect(results[0].messages.map((message) => message.ruleId)).toEqual([
+          'no-debugger',
+        ]);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles keeps lexical files matching when a symlink target belongs to the Program', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-program-symlink-selector-'),
+    );
+    try {
+      const physicalDir = path.join(tmp, 'physical');
+      const physicalFile = path.join(physicalDir, 'index.ts');
+      const linkFile = path.join(tmp, 'link.ts');
+      await mkdir(physicalDir);
+      await writeFile(physicalFile, 'console.log("value");\n');
+      await writeFile(
+        path.join(tmp, 'tsconfig.json'),
+        JSON.stringify({ files: ['physical/index.ts'] }),
+      );
+      await writeFile(
+        path.join(tmp, 'rslint.config.mjs'),
+        `export default [{
+          files: ['link.ts'],
+          languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
+          rules: { 'no-console': 'error' },
+        }];\n`,
+      );
+      try {
+        await symlink(physicalFile, linkFile, 'file');
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        const results = await rslint.lintFiles('link.ts');
+        expect(results).toHaveLength(1);
+        expect(results[0].filePath).toBe(path.normalize(linkFile));
+        expect(results[0].messages.map((message) => message.ruleId)).toEqual([
+          'no-console',
+        ]);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles keeps case-distinct files separate on a case-sensitive filesystem', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-case-sensitive-paths-'),
+    );
+    try {
+      const upperDir = path.join(tmp, 'Foo');
+      const lowerDir = path.join(tmp, 'foo');
+      await mkdir(upperDir);
+      try {
+        await mkdir(lowerDir);
+      } catch {
+        return;
+      }
+      await writeFile(path.join(upperDir, 'index.ts'), 'debugger;\n');
+      await writeFile(path.join(lowerDir, 'index.ts'), 'debugger;\n');
+
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [{ rules: { 'no-debugger': 'error' } }],
+      });
+      try {
+        const results = await rslint.lintFiles([
+          'Foo/index.ts',
+          'foo/index.ts',
+        ]);
+        expect(results).toHaveLength(2);
+        expect(
+          results.map((result) => path.relative(tmp, result.filePath)).sort(),
+        ).toEqual([path.join('Foo', 'index.ts'), path.join('foo', 'index.ts')]);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles applies negative patterns case-sensitively to a literal file symlink', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-literal-negative-case-'),
+    );
+    try {
+      const upperDir = path.join(tmp, 'Foo');
+      const lowerDir = path.join(tmp, 'foo');
+      await mkdir(upperDir);
+      try {
+        await mkdir(lowerDir);
+      } catch {
+        return;
+      }
+      const target = path.join(upperDir, 'target.ts');
+      const link = path.join(upperDir, 'link.ts');
+      await writeFile(target, 'debugger;\n');
+      try {
+        await symlink(target, link, 'file');
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [{ rules: { 'no-debugger': 'error' } }],
+      });
+      try {
+        const results = await rslint.lintFiles(['Foo/link.ts', '!foo/link.ts']);
+        expect(results).toHaveLength(1);
+        expect(results[0].filePath).toBe(path.normalize(link));
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles excludes a literal file symlink matched by a negative pattern', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-literal-negative-'),
+    );
+    try {
+      const target = path.join(tmp, 'target.ts');
+      const link = path.join(tmp, 'link.ts');
+      await writeFile(target, 'debugger;\n');
+      try {
+        await symlink(target, link, 'file');
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [{ rules: { 'no-debugger': 'error' } }],
+      });
+      try {
+        expect(await rslint.lintFiles(['link.ts', '!link.ts'])).toHaveLength(0);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles preserves a valid alternate-case literal spelling', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-alternate-case-literal-'),
+    );
+    try {
+      const actualDir = path.join(tmp, 'Project');
+      const callerPath = path.join(tmp, 'project', 'a.ts');
+      await mkdir(actualDir);
+      await writeFile(path.join(actualDir, 'a.ts'), 'debugger;\n');
+      try {
+        await readFile(callerPath);
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [{ rules: { 'no-debugger': 'error' } }],
+      });
+      try {
+        const results = await rslint.lintFiles('project/a.ts');
+        expect(results).toHaveLength(1);
+        expect(results[0].filePath).toBe(path.normalize(callerPath));
+        expect(results[0].messages.map((message) => message.ruleId)).toEqual([
+          'no-debugger',
+        ]);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles preserves each alternate-case literal spelling', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-alternate-case-literals-'),
+    );
+    try {
+      const actualDir = path.join(tmp, 'Project');
+      const alternateFile = path.join(tmp, 'project', 'b.ts');
+      await mkdir(actualDir);
+      await writeFile(path.join(actualDir, 'a.ts'), 'debugger;\n');
+      await writeFile(path.join(actualDir, 'b.ts'), 'debugger;\n');
+      try {
+        await readFile(alternateFile);
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [{ rules: { 'no-debugger': 'error' } }],
+      });
+      try {
+        const results = await rslint.lintFiles([
+          'Project/a.ts',
+          'project/b.ts',
+        ]);
+        expect(results.map((result) => result.filePath).sort()).toEqual(
+          [path.join(tmp, 'Project', 'a.ts'), alternateFile].sort(),
+        );
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles coalesces native case aliases of one config', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-config-case-alias-'),
+    );
+    try {
+      const actualDir = path.join(tmp, 'Project');
+      const alternateFile = path.join(tmp, 'project', 'b.ts');
+      await mkdir(actualDir);
+      await writeFile(path.join(actualDir, 'a.ts'), 'debugger;\n');
+      await writeFile(path.join(actualDir, 'b.ts'), 'debugger;\n');
+      await writeFile(
+        path.join(actualDir, 'rslint.config.mjs'),
+        "export default [{ rules: { 'no-debugger': 'error' } }];\n",
+      );
+      try {
+        await readFile(alternateFile);
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        const results = await rslint.lintFiles([
+          'Project/a.ts',
+          'project/b.ts',
+        ]);
+        expect(results).toHaveLength(2);
+        expect(
+          results.map((result) => path.basename(result.filePath)).sort(),
+        ).toEqual(['a.ts', 'b.ts']);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('lintFiles does not recurse through a directory symlink cycle', async () => {
     const tmp = await mkdtemp(
       path.join(os.tmpdir(), 'rslint-api-directory-symlink-'),
@@ -994,6 +1553,48 @@ describe('Rslint class', () => {
         expect(path.relative(tmp, results[0].filePath)).toBe(
           path.join('src', 'index.ts'),
         );
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles scans an explicit directory symlink with its physical ancestor config', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-explicit-directory-symlink-'),
+    );
+    try {
+      const realRoot = path.join(tmp, 'real');
+      const realSubdir = path.join(realRoot, 'sub');
+      const linkDir = path.join(tmp, 'link');
+      await mkdir(realSubdir, { recursive: true });
+      await writeFile(
+        path.join(realRoot, 'rslint.config.mjs'),
+        "export default [{ files: ['sub/**/*.ts'], rules: { 'no-debugger': 'error' } }];\n",
+      );
+      await writeFile(path.join(realSubdir, 'index.ts'), 'debugger;\n');
+      try {
+        await symlink(
+          realSubdir,
+          linkDir,
+          process.platform === 'win32' ? 'junction' : 'dir',
+        );
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        for (const pattern of ['link', 'link/**/*.ts']) {
+          const results = await rslint.lintFiles(pattern);
+          expect(results).toHaveLength(1);
+          expect(results[0].filePath).toBe(path.join(linkDir, 'index.ts'));
+          expect(results[0].messages.map((message) => message.ruleId)).toEqual([
+            'no-debugger',
+          ]);
+        }
       } finally {
         await rslint.close();
       }
@@ -1177,10 +1778,9 @@ describe('Rslint class', () => {
     const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-ignored-'));
     try {
       await writeFile(path.join(tmp, 'tsconfig.json'), '{}');
-      await writeFile(
-        path.join(tmp, 'ignored.ts'),
-        'let a: Array<string> = [];\n',
-      );
+      // Intentional syntax-error fixtures must be ignored by configuration;
+      // parse failure itself is not an implicit ignore signal.
+      await writeFile(path.join(tmp, 'ignored.ts'), 'const = ;\n');
       const rslint = new Rslint({
         cwd: tmp,
         overrideConfigFile: true,

--- a/packages/rslint/tests/rslint.test.mjs
+++ b/packages/rslint/tests/rslint.test.mjs
@@ -3,9 +3,22 @@ import { lint } from '@rslint/core/internal';
 import { describe, test, expect } from '@rstest/core';
 import path from 'node:path';
 import os from 'node:os';
-import { writeFile, rm, mkdtemp, mkdir, readFile, cp } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import {
+  writeFile,
+  rm,
+  mkdtemp,
+  mkdir,
+  readFile,
+  cp,
+  symlink,
+} from 'node:fs/promises';
 
 const fixturesDir = path.resolve(import.meta.dirname, '../fixtures');
+const eslintPluginFixturesDir = path.resolve(
+  import.meta.dirname,
+  'eslint-plugin/fixtures',
+);
 
 // A self-contained config (overrideConfigFile:true → no discovery, only
 // overrideConfig). array-type is non-type-aware so it runs even on a gap file.
@@ -110,6 +123,102 @@ describe('Rslint class', () => {
       expect(m.fix.text).toBe('string[]');
     } finally {
       await rslint.close();
+    }
+  });
+
+  test('lintText runs a local community plugin Program listener and returns its fix output', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-plugin-'));
+    const pluginUrl = pathToFileURL(
+      path.join(eslintPluginFixturesDir, 'local-plugin.mjs'),
+    ).href;
+    await writeFile(
+      path.join(tmp, 'rslint.config.mjs'),
+      [
+        `import local from ${JSON.stringify(pluginUrl)};`,
+        'export default [{',
+        '  plugins: { local },',
+        '  rules: {',
+        "    'local/program-listener': 'error',",
+        "    'local/prefer-array-some': 'error',",
+        '  },',
+        '}];',
+        '',
+      ].join('\n'),
+    );
+
+    const rslint = new Rslint({ cwd: tmp, fix: true });
+    try {
+      const [result] = await rslint.lintText(
+        'const found = [1].filter(Boolean);\n',
+        { filePath: 'probe.ts' },
+      );
+      expect(result.messages.map((message) => message.ruleId).sort()).toEqual([
+        'local/prefer-array-some',
+        'local/program-listener',
+      ]);
+      expect(result.fixableErrorCount).toBe(1);
+      expect(result.output).toBe('const found = [1].some(Boolean);\n');
+    } finally {
+      await rslint.close();
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects object-form community plugins in overrideConfig before linting', async () => {
+    const rslint = new Rslint({
+      cwd: '/',
+      overrideConfigFile: true,
+      overrideConfig: [
+        {
+          plugins: { local: { rules: { probe: {} } } },
+          rules: { 'local/probe': 'error' },
+        },
+      ],
+    });
+    try {
+      await expect(
+        rslint.lintText('const value = 1;', { filePath: 'probe.ts' }),
+      ).rejects.toThrow(/overrideConfig.*object-form.*cannot re-import/s);
+    } finally {
+      await rslint.close();
+    }
+  });
+
+  test('lintText preserves the requested path when the Program uses a symlink alias', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-symlink-'));
+    const realDir = path.join(tmp, 'real');
+    const linkDir = path.join(tmp, 'link');
+    const realTarget = path.join(realDir, 'src', 'a.ts');
+    await mkdir(path.dirname(realTarget), { recursive: true });
+    await writeFile(realTarget, 'let a: string[] = [];\n');
+    await writeFile(
+      path.join(realDir, 'tsconfig.json'),
+      JSON.stringify({ include: ['src/a.ts'] }),
+    );
+    try {
+      try {
+        await symlink(realDir, linkDir, 'dir');
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({
+        cwd: linkDir,
+        overrideConfigFile: true,
+        overrideConfig: arrayTypeConfig,
+      });
+      try {
+        const results = await rslint.lintText('let a: Array<string> = [];\n', {
+          filePath: realTarget,
+        });
+        expect(results).toHaveLength(1);
+        expect(results[0].filePath).toBe(path.normalize(realTarget));
+        expect(results[0].messages).toHaveLength(1);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
     }
   });
 
@@ -430,6 +539,292 @@ describe('Rslint class', () => {
     }
   });
 
+  test('lintFiles routes community plugins through one multi-config host', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-plugin-routing-'),
+    );
+    const xDir = path.join(tmp, 'packages', 'x');
+    const yDir = path.join(tmp, 'packages', 'y');
+    const pluginXUrl = pathToFileURL(
+      path.join(eslintPluginFixturesDir, 'cfgX', 'plugin-x.mjs'),
+    ).href;
+    const pluginYUrl = pathToFileURL(
+      path.join(eslintPluginFixturesDir, 'cfgY', 'plugin-y.mjs'),
+    ).href;
+    try {
+      await mkdir(xDir, { recursive: true });
+      await mkdir(yDir, { recursive: true });
+      await writeFile(
+        path.join(xDir, 'rslint.config.mjs'),
+        `import plugin from ${JSON.stringify(pluginXUrl)};\n` +
+          "export default [{ plugins: { px: plugin }, rules: { 'px/no-foo': 'error' } }];\n",
+      );
+      await writeFile(
+        path.join(yDir, 'rslint.config.mjs'),
+        `import plugin from ${JSON.stringify(pluginYUrl)};\n` +
+          "export default [{ plugins: { py: plugin }, rules: { 'py/no-bar': 'error' } }];\n",
+      );
+      const source = 'const foo = 1; const bar = 2;\n';
+      await writeFile(path.join(xDir, 'index.ts'), source);
+      await writeFile(path.join(yDir, 'index.ts'), source);
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        const results = await rslint.lintFiles('**/*.ts');
+        const byRelativePath = new Map(
+          results.map((result) => [
+            path.relative(tmp, result.filePath),
+            result,
+          ]),
+        );
+        expect(
+          byRelativePath
+            .get(path.join('packages', 'x', 'index.ts'))
+            .messages.map((message) => message.ruleId),
+        ).toEqual(['px/no-foo']);
+        expect(
+          byRelativePath
+            .get(path.join('packages', 'y', 'index.ts'))
+            .messages.map((message) => message.ruleId),
+        ).toEqual(['py/no-bar']);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles falls back from a broken nested config to the nearest loaded ancestor', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-broken-fallback-'),
+    );
+    try {
+      await writeFile(
+        path.join(tmp, 'rslint.config.mjs'),
+        "export default [{ rules: { 'no-console': 'error' } }];\n",
+      );
+      await mkdir(path.join(tmp, 'packages', 'app'), { recursive: true });
+      await writeFile(
+        path.join(tmp, 'packages', 'app', 'rslint.config.mjs'),
+        'export default [;\n',
+      );
+      await writeFile(
+        path.join(tmp, 'packages', 'app', 'index.ts'),
+        'debugger;\nconsole.log("fallback");\n',
+      );
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        for (const target of ['**/*.ts', 'packages/app/index.ts']) {
+          const results = await rslint.lintFiles(target);
+          expect(results).toHaveLength(1);
+          const ruleIds = results[0].messages.map((message) => message.ruleId);
+          expect(ruleIds).toContain('no-console');
+          expect(ruleIds).not.toContain('no-debugger');
+        }
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintText falls back from a broken nearest JS config to a loaded ancestor', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-text-broken-fallback-'),
+    );
+    const nested = path.join(tmp, 'packages', 'app');
+    try {
+      await writeFile(
+        path.join(tmp, 'rslint.config.mjs'),
+        "export default [{ rules: { 'no-console': 'error' } }];\n",
+      );
+      await mkdir(nested, { recursive: true });
+      await writeFile(
+        path.join(nested, 'rslint.config.mjs'),
+        'export default [;\n',
+      );
+      // JSON configs are not candidates for the JS programmatic API fallback.
+      await writeFile(
+        path.join(nested, 'rslint.json'),
+        JSON.stringify({ rules: { 'no-debugger': 'error' } }),
+      );
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        const [result] = await rslint.lintText(
+          'debugger;\nconsole.log("ancestor");\n',
+          { filePath: path.join(nested, 'index.ts') },
+        );
+        const ruleIds = result.messages.map((message) => message.ruleId);
+        expect(ruleIds).toContain('no-console');
+        expect(ruleIds).not.toContain('no-debugger');
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintText throws the nearest JS config error when no ancestor loads', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-text-broken-boundary-'),
+    );
+    const nested = path.join(tmp, 'packages', 'app');
+    try {
+      await writeFile(
+        path.join(tmp, 'rslint.config.mjs'),
+        'export default [;\n',
+      );
+      await writeFile(
+        path.join(tmp, 'rslint.json'),
+        JSON.stringify({ rules: { 'no-console': 'error' } }),
+      );
+      await mkdir(nested, { recursive: true });
+      const nestedConfig = path.join(nested, 'rslint.config.mjs');
+      await writeFile(nestedConfig, 'export default [;\n');
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        await expect(
+          rslint.lintText('console.log("no fallback");\n', {
+            filePath: path.join(nested, 'index.ts'),
+          }),
+        ).rejects.toThrow(`Failed to load config ${nestedConfig}`);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles keeps glob-skip and explicit-error semantics when every applicable config fails', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-broken-boundary-'),
+    );
+    try {
+      await writeFile(
+        path.join(tmp, 'rslint.config.mjs'),
+        'export default [;\n',
+      );
+      await mkdir(path.join(tmp, 'broken'), { recursive: true });
+      await writeFile(
+        path.join(tmp, 'broken', 'index.ts'),
+        'console.log("broken");\n',
+      );
+      await mkdir(path.join(tmp, 'healthy'), { recursive: true });
+      await writeFile(
+        path.join(tmp, 'healthy', 'rslint.config.mjs'),
+        "export default [{ rules: { 'no-debugger': 'error' } }];\n",
+      );
+      await writeFile(path.join(tmp, 'healthy', 'index.ts'), 'debugger;\n');
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        const results = await rslint.lintFiles('**/*.ts');
+        expect(results).toHaveLength(1);
+        expect(path.relative(tmp, results[0].filePath)).toBe(
+          path.join('healthy', 'index.ts'),
+        );
+        expect(results[0].messages.map((message) => message.ruleId)).toEqual([
+          'no-debugger',
+        ]);
+
+        await expect(
+          rslint.lintFiles(['broken/index.ts', 'healthy/index.ts']),
+        ).rejects.toThrow(/Failed to load config .*rslint\.config\.mjs/);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('nested configs keep overrideConfig files, ignores, and project relative to cwd', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-nested-override-'),
+    );
+    const appSourceDir = path.join(tmp, 'packages', 'app', 'src');
+    const libSourceDir = path.join(tmp, 'packages', 'lib', 'src');
+    try {
+      await mkdir(appSourceDir, { recursive: true });
+      await mkdir(libSourceDir, { recursive: true });
+      await writeFile(
+        path.join(tmp, 'packages', 'app', 'rslint.config.mjs'),
+        "export default [{ files: ['src/**/*.ts'], rules: { 'no-console': 'error' } }];\n",
+      );
+      await writeFile(
+        path.join(tmp, 'packages', 'lib', 'rslint.config.mjs'),
+        "export default [{ files: ['src/**/*.ts'], rules: { 'no-debugger': 'error' } }];\n",
+      );
+      await writeFile(
+        path.join(tmp, 'tsconfig.json'),
+        JSON.stringify({
+          files: [
+            'packages/app/src/index.ts',
+            'packages/app/src/ignored.ts',
+            'packages/lib/src/index.ts',
+          ],
+        }),
+      );
+      const appSource = 'const values: string[] = [];\nconsole.log(values);\n';
+      await writeFile(path.join(appSourceDir, 'index.ts'), appSource);
+      await writeFile(path.join(appSourceDir, 'ignored.ts'), appSource);
+      await writeFile(
+        path.join(libSourceDir, 'index.ts'),
+        'const values: string[] = [];\ndebugger;\n',
+      );
+
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfig: [
+          { ignores: ['packages/app/src/ignored.ts'] },
+          {
+            files: ['packages/*/src/**/*.ts'],
+            plugins: ['@typescript-eslint'],
+            languageOptions: {
+              parserOptions: { project: ['./tsconfig.json'] },
+            },
+            rules: {
+              '@typescript-eslint/array-type': [
+                'error',
+                { default: 'generic' },
+              ],
+            },
+          },
+        ],
+      });
+      try {
+        const results = await rslint.lintFiles('packages/*/src/*.ts');
+        expect(results).toHaveLength(2);
+        const byPackage = new Map(
+          results.map((result) => [
+            path.relative(path.join(tmp, 'packages'), result.filePath),
+            result.messages.map((message) => message.ruleId),
+          ]),
+        );
+        const appRuleIds = byPackage.get(path.join('app', 'src', 'index.ts'));
+        expect(appRuleIds).toContain('no-console');
+        expect(appRuleIds).toContain('@typescript-eslint/array-type');
+        expect(appRuleIds).not.toContain('no-debugger');
+
+        const libRuleIds = byPackage.get(path.join('lib', 'src', 'index.ts'));
+        expect(libRuleIds).toContain('no-debugger');
+        expect(libRuleIds).toContain('@typescript-eslint/array-type');
+        expect(libRuleIds).not.toContain('no-console');
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('lintFiles explicit file in parent-ignored subtree still uses nearest config', async () => {
     const tmp = await mkdtemp(
       path.join(os.tmpdir(), 'rslint-api-nearest-ignored-'),
@@ -462,6 +857,143 @@ describe('Rslint class', () => {
         const ruleIds = results[0].messages.map((m) => m.ruleId);
         expect(ruleIds).toContain('no-debugger');
         expect(ruleIds).not.toContain('no-console');
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles glob does not enter a parent-ignored nested config', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-glob-parent-ignore-'),
+    );
+    try {
+      await writeFile(
+        path.join(tmp, 'rslint.config.mjs'),
+        [
+          'export default [',
+          "  { ignores: ['packages/app/**'] },",
+          "  { rules: { 'no-console': 'error' } },",
+          '];',
+          '',
+        ].join('\n'),
+      );
+      await mkdir(path.join(tmp, 'packages', 'app'), { recursive: true });
+      await writeFile(
+        path.join(tmp, 'packages', 'app', 'rslint.config.mjs'),
+        "export default [{ rules: { 'no-debugger': 'error' } }];\n",
+      );
+      await writeFile(
+        path.join(tmp, 'packages', 'app', 'index.ts'),
+        'debugger;\n',
+      );
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        expect(await rslint.lintFiles('**/*.ts')).toEqual([]);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles includes dotfiles but skips default excluded directories', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-dotfiles-'));
+    try {
+      await mkdir(path.join(tmp, 'node_modules', 'pkg'), { recursive: true });
+      await writeFile(path.join(tmp, '.hidden.ts'), 'debugger;\n');
+      await writeFile(
+        path.join(tmp, 'node_modules', 'pkg', 'index.ts'),
+        'debugger;\n',
+      );
+
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [{ rules: { 'no-debugger': 'error' } }],
+      });
+      try {
+        const results = await rslint.lintFiles('**/*.ts');
+        expect(results).toHaveLength(1);
+        expect(path.basename(results[0].filePath)).toBe('.hidden.ts');
+        expect(results[0].messages.map((message) => message.ruleId)).toEqual([
+          'no-debugger',
+        ]);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles includes a literal file symlink without following directory symlinks', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-file-symlink-'),
+    );
+    try {
+      const target = path.join(tmp, 'target.ts');
+      const link = path.join(tmp, 'link.ts');
+      await writeFile(target, 'debugger;\n');
+      try {
+        await symlink(target, link, 'file');
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [{ rules: { 'no-debugger': 'error' } }],
+      });
+      try {
+        const results = await rslint.lintFiles('link.ts');
+        expect(results).toHaveLength(1);
+        expect(results[0].filePath).toBe(path.normalize(link));
+        expect(results[0].messages.map((message) => message.ruleId)).toEqual([
+          'no-debugger',
+        ]);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles does not recurse through a directory symlink cycle', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-directory-symlink-'),
+    );
+    try {
+      const sourceDir = path.join(tmp, 'src');
+      await mkdir(sourceDir, { recursive: true });
+      await writeFile(path.join(sourceDir, 'index.ts'), 'debugger;\n');
+      try {
+        await symlink(
+          tmp,
+          path.join(sourceDir, 'loop'),
+          process.platform === 'win32' ? 'junction' : 'dir',
+        );
+      } catch {
+        return;
+      }
+
+      const rslint = new Rslint({
+        cwd: tmp,
+        overrideConfigFile: true,
+        overrideConfig: [{ rules: { 'no-debugger': 'error' } }],
+      });
+      try {
+        const results = await rslint.lintFiles('**/*.ts');
+        expect(results).toHaveLength(1);
+        expect(path.relative(tmp, results[0].filePath)).toBe(
+          path.join('src', 'index.ts'),
+        );
       } finally {
         await rslint.close();
       }
@@ -701,6 +1233,78 @@ describe('Rslint class', () => {
     });
     // 0 = the fixture linted (it asserts exactly 1 message) AND the process
     // exited without close(); 'TIMEOUT-HANG' = unref regressed.
+    expect(code).toBe(0);
+  });
+
+  test('community plugin host initializes and shuts down before lintText returns', async () => {
+    const { spawn } = await import('node:child_process');
+    const script = path.resolve(
+      import.meta.dirname,
+      'fixtures',
+      'no-close-plugin-exit.mjs',
+    );
+    const child = spawn(process.execPath, [script], {
+      cwd: path.resolve(import.meta.dirname, '..'),
+      stdio: 'inherit',
+    });
+    const code = await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve('TIMEOUT-HANG');
+      }, 30000);
+      child.on('exit', (exitCode) => {
+        clearTimeout(timer);
+        resolve(exitCode);
+      });
+    });
+    expect(code).toBe(0);
+  });
+
+  test('community plugin host shuts down when the Go lint request fails', async () => {
+    const { spawn } = await import('node:child_process');
+    const script = path.resolve(
+      import.meta.dirname,
+      'fixtures',
+      'no-close-plugin-error-exit.mjs',
+    );
+    const child = spawn(process.execPath, [script], {
+      cwd: path.resolve(import.meta.dirname, '..'),
+      stdio: 'inherit',
+    });
+    const code = await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve('TIMEOUT-HANG');
+      }, 30000);
+      child.on('exit', (exitCode) => {
+        clearTimeout(timer);
+        resolve(exitCode);
+      });
+    });
+    expect(code).toBe(0);
+  });
+
+  test('close shuts down an active community plugin host', async () => {
+    const { spawn } = await import('node:child_process');
+    const script = path.resolve(
+      import.meta.dirname,
+      'fixtures',
+      'close-active-plugin-exit.mjs',
+    );
+    const child = spawn(process.execPath, [script], {
+      cwd: path.resolve(import.meta.dirname, '..'),
+      stdio: 'inherit',
+    });
+    const code = await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve('TIMEOUT-HANG');
+      }, 20000);
+      child.on('exit', (exitCode) => {
+        clearTimeout(timer);
+        resolve(exitCode);
+      });
+    });
     expect(code).toBe(0);
   });
 

--- a/packages/rslint/tests/rslint.test.mjs
+++ b/packages/rslint/tests/rslint.test.mjs
@@ -322,6 +322,41 @@ describe('Rslint class', () => {
     }
   });
 
+  test('overrideConfigFile outside cwd still resolves files from cwd', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-override-cwd-'));
+    const projectDir = path.join(tmp, 'project');
+    const configDir = path.join(tmp, 'configs');
+    try {
+      await mkdir(path.join(projectDir, 'src'), { recursive: true });
+      await mkdir(configDir, { recursive: true });
+      const configFile = path.join(configDir, 'custom.config.mjs');
+      await writeFile(
+        configFile,
+        "export default [{ files: ['src/**/*.ts'], rules: { 'no-console': 'error' } }];\n",
+      );
+      await writeFile(
+        path.join(projectDir, 'src', 'index.ts'),
+        'console.log("project");\n',
+      );
+
+      const rslint = new Rslint({
+        cwd: projectDir,
+        overrideConfigFile: configFile,
+      });
+      try {
+        const results = await rslint.lintFiles('src/index.ts');
+        expect(results).toHaveLength(1);
+        expect(results[0].messages.map((m) => m.ruleId)).toContain(
+          'no-console',
+        );
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
   test('lintFiles returns one result per matched file, routed correctly', async () => {
     const { mkdtemp, writeFile, mkdir, rm } = await import('node:fs/promises');
     const os = await import('node:os');
@@ -345,6 +380,88 @@ describe('Rslint class', () => {
         expect(byBase.get('dirty.ts').messages[0].ruleId).toBe('no-var');
         // clean file still produces a (zero-message) result.
         expect(byBase.get('clean.ts').messages).toHaveLength(0);
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles routes matched files through their nearest discovered config', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-nearest-'));
+    try {
+      await writeFile(
+        path.join(tmp, 'rslint.config.mjs'),
+        "export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];\n",
+      );
+      await mkdir(path.join(tmp, 'packages', 'app'), { recursive: true });
+      await writeFile(
+        path.join(tmp, 'packages', 'app', 'rslint.config.mjs'),
+        "export default [{ files: ['**/*.ts'], rules: { 'no-debugger': 'error' } }];\n",
+      );
+      await writeFile(path.join(tmp, 'root.ts'), 'console.log("root");\n');
+      await writeFile(
+        path.join(tmp, 'packages', 'app', 'index.ts'),
+        'debugger;\nconsole.log("app");\n',
+      );
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        const results = await rslint.lintFiles('**/*.ts');
+        const byRel = new Map(
+          results.map((r) => [path.relative(tmp, r.filePath), r]),
+        );
+
+        expect(byRel.get('root.ts').messages.map((m) => m.ruleId)).toContain(
+          'no-console',
+        );
+        const appRuleIds =
+          byRel
+            .get(path.join('packages', 'app', 'index.ts'))
+            ?.messages.map((m) => m.ruleId) ?? [];
+        expect(appRuleIds).toContain('no-debugger');
+        expect(appRuleIds).not.toContain('no-console');
+      } finally {
+        await rslint.close();
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('lintFiles explicit file in parent-ignored subtree still uses nearest config', async () => {
+    const tmp = await mkdtemp(
+      path.join(os.tmpdir(), 'rslint-api-nearest-ignored-'),
+    );
+    try {
+      await writeFile(
+        path.join(tmp, 'rslint.config.mjs'),
+        [
+          'export default [',
+          "  { ignores: ['packages/app/**'] },",
+          "  { files: ['**/*.ts'], rules: { 'no-console': 'error' } },",
+          '];',
+          '',
+        ].join('\n'),
+      );
+      await mkdir(path.join(tmp, 'packages', 'app'), { recursive: true });
+      await writeFile(
+        path.join(tmp, 'packages', 'app', 'rslint.config.mjs'),
+        "export default [{ files: ['**/*.ts'], rules: { 'no-debugger': 'error' } }];\n",
+      );
+      await writeFile(
+        path.join(tmp, 'packages', 'app', 'index.ts'),
+        'debugger;\nconsole.log("app");\n',
+      );
+
+      const rslint = new Rslint({ cwd: tmp });
+      try {
+        const results = await rslint.lintFiles('packages/app/index.ts');
+        expect(results).toHaveLength(1);
+        const ruleIds = results[0].messages.map((m) => m.ruleId);
+        expect(ruleIds).toContain('no-debugger');
+        expect(ruleIds).not.toContain('no-console');
       } finally {
         await rslint.close();
       }

--- a/packages/rslint/tests/rslint.test.mjs
+++ b/packages/rslint/tests/rslint.test.mjs
@@ -512,6 +512,44 @@ describe('Rslint class', () => {
     }
   });
 
+  test.each(['cjs', 'cts'])(
+    'overrideConfigFile loads an explicitly selected .%s config',
+    async (extension) => {
+      const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-override-ext-'));
+      const configPath = path.join(tmp, `custom.config.${extension}`);
+      const config =
+        extension === 'cts'
+          ? `const config: Array<Record<string, unknown>> = [{
+  files: ['**/*.ts'],
+  rules: { 'no-debugger': 'error' },
+}];
+module.exports = config;`
+          : `module.exports = [{
+  files: ['**/*.ts'],
+  rules: { 'no-debugger': 'error' },
+}];`;
+      try {
+        await writeFile(configPath, config);
+        await writeFile(path.join(tmp, 'test.ts'), 'debugger;\n');
+        const rslint = new Rslint({
+          cwd: tmp,
+          overrideConfigFile: configPath,
+        });
+        try {
+          const results = await rslint.lintFiles('test.ts');
+          expect(results).toHaveLength(1);
+          expect(
+            results[0].messages.map((message) => message.ruleId),
+          ).toContain('no-debugger');
+        } finally {
+          await rslint.close();
+        }
+      } finally {
+        await rm(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
   test('lintFiles returns one result per matched file, routed correctly', async () => {
     const { mkdtemp, writeFile, mkdir, rm } = await import('node:fs/promises');
     const os = await import('node:os');

--- a/packages/rslint/tests/service.test.ts
+++ b/packages/rslint/tests/service.test.ts
@@ -16,7 +16,12 @@ class ReverseLintBackend implements RslintServiceInterface {
   }
 
   async sendMessage(kind: string, data: any): Promise<any> {
-    if (kind === 'handshake') return { version: '1.0.0', ok: true };
+    if (kind === 'handshake')
+      return {
+        version: '2.0.0',
+        ok: true,
+        capabilities: ['reversePluginLint'],
+      };
     if (kind === 'exit') return {};
     if (kind !== 'lint') throw new Error(`unexpected kind ${kind}`);
 
@@ -32,7 +37,57 @@ class ReverseLintBackend implements RslintServiceInterface {
     } satisfies IpcMessage);
   }
 
-  terminate(): void {}
+  terminate(): void {
+    // No process is owned by this in-memory backend.
+  }
+}
+
+class HangingExitBackend extends ReverseLintBackend {
+  terminated = false;
+
+  override async sendMessage(kind: string, data: any): Promise<any> {
+    if (kind === 'exit')
+      return new Promise(() => {
+        // Deliberately unresolved to exercise forced shutdown.
+      });
+    return super.sendMessage(kind, data);
+  }
+
+  override terminate(): void {
+    this.terminated = true;
+  }
+}
+
+class HangingLintBackend extends ReverseLintBackend {
+  terminated = false;
+  exitRequests = 0;
+  readonly lintStarted: Promise<void>;
+  private markLintStarted!: () => void;
+
+  constructor() {
+    super();
+    this.lintStarted = new Promise((resolve) => {
+      this.markLintStarted = resolve;
+    });
+  }
+
+  override async sendMessage(kind: string, data: any): Promise<any> {
+    if (kind === 'lint') {
+      this.markLintStarted();
+      return new Promise(() => {
+        // Deliberately unresolved to keep the lint request active.
+      });
+    }
+    if (kind === 'exit') {
+      this.exitRequests++;
+      return {};
+    }
+    return super.sendMessage(kind, data);
+  }
+
+  override terminate(): void {
+    this.terminated = true;
+  }
 }
 
 describe('RSLintService reverse lint request scoping', () => {
@@ -51,6 +106,24 @@ describe('RSLintService reverse lint request scoping', () => {
     await service.close();
   });
 
+  test('forwards canonical paths parallel to lint files', async () => {
+    const backend = new ReverseLintBackend();
+    const service = new RSLintService(backend);
+
+    await service.lint(
+      {
+        files: ['/lexical/a.ts'],
+        canonicalFiles: ['/physical/a.ts'],
+      },
+      { pluginLint: () => ({ diagnostics: [] }) },
+    );
+    expect(backend.lintPayloads[0]).toMatchObject({
+      files: ['/lexical/a.ts'],
+      canonicalFiles: ['/physical/a.ts'],
+    });
+    await service.close();
+  });
+
   test('serializes concurrent lint frames so handlers cannot overwrite each other', async () => {
     const backend = new ReverseLintBackend();
     const service = new RSLintService(backend);
@@ -63,5 +136,59 @@ describe('RSLintService reverse lint request scoping', () => {
     expect(a).toEqual({ host: 'a' });
     expect(b).toEqual({ host: 'b' });
     await service.close();
+  });
+
+  test('rejects an incompatible backend protocol before linting', async () => {
+    const backend = new ReverseLintBackend();
+    backend.sendMessage = async (kind: string, data: any): Promise<any> => {
+      if (kind === 'handshake') return { version: '1.0.0', ok: true };
+      return ReverseLintBackend.prototype.sendMessage.call(backend, kind, data);
+    };
+    const service = new RSLintService(backend);
+    await expect(service.lint({ files: ['a.ts'] })).rejects.toThrow(
+      /protocol mismatch.*2\.0\.0.*1\.0\.0/,
+    );
+    await service.close();
+  });
+
+  test('requires negotiated reverse lint support for community plugins', async () => {
+    const backend = new ReverseLintBackend();
+    backend.sendMessage = async (kind: string, data: any): Promise<any> => {
+      if (kind === 'handshake') {
+        return { version: '2.0.0', ok: true, capabilities: [] };
+      }
+      return ReverseLintBackend.prototype.sendMessage.call(backend, kind, data);
+    };
+    const service = new RSLintService(backend);
+    await expect(
+      service.lint(
+        { files: ['a.ts'] },
+        { pluginLint: () => ({ diagnostics: [] }) },
+      ),
+    ).rejects.toThrow(/does not support reverse pluginLint/);
+    await service.close();
+  });
+
+  test('bounds graceful shutdown when the peer never acknowledges exit', async () => {
+    const backend = new HangingExitBackend();
+    const service = new RSLintService(backend);
+    const started = Date.now();
+    await service.close();
+    expect(backend.terminated).toBe(true);
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  test('starts the shutdown bound while an active request is hung', async () => {
+    const backend = new HangingLintBackend();
+    const service = new RSLintService(backend);
+    void service.lint({ files: ['hung.ts'] });
+    await backend.lintStarted;
+
+    const started = Date.now();
+    await service.close();
+
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(backend.terminated).toBe(true);
+    expect(backend.exitRequests).toBe(0);
   });
 });

--- a/packages/rslint/tests/service.test.ts
+++ b/packages/rslint/tests/service.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from '@rstest/core';
+
+import { RSLintService } from '../src/service/service.js';
+import type {
+  InboundRequestHandler,
+  IpcMessage,
+  RslintServiceInterface,
+} from '../src/types.js';
+
+class ReverseLintBackend implements RslintServiceInterface {
+  inbound: InboundRequestHandler | null = null;
+  lintPayloads: unknown[] = [];
+
+  setInboundHandler(handler: InboundRequestHandler | null): void {
+    this.inbound = handler;
+  }
+
+  async sendMessage(kind: string, data: any): Promise<any> {
+    if (kind === 'handshake') return { version: '1.0.0', ok: true };
+    if (kind === 'exit') return {};
+    if (kind !== 'lint') throw new Error(`unexpected kind ${kind}`);
+
+    this.lintPayloads.push(data);
+    // Yield before dispatching the reverse request. Without service-level
+    // serialization, a concurrent lint could replace the active handler here.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    if (!this.inbound) throw new Error('missing inbound handler');
+    return this.inbound({
+      id: 100,
+      kind: 'pluginLint',
+      data: { token: data.files[0] },
+    } satisfies IpcMessage);
+  }
+
+  terminate(): void {}
+}
+
+describe('RSLintService reverse lint request scoping', () => {
+  test('forwards eslintPlugins and dispatches pluginLint to the call handler', async () => {
+    const backend = new ReverseLintBackend();
+    const service = new RSLintService(backend);
+    const eslintPlugins = [{ prefix: 'local', ruleNames: ['program'] }];
+
+    await expect(
+      service.lint(
+        { files: ['a.ts'], eslintPlugins },
+        { pluginLint: (request) => ({ request, ok: true }) },
+      ),
+    ).resolves.toEqual({ request: { token: 'a.ts' }, ok: true });
+    expect(backend.lintPayloads[0]).toMatchObject({ eslintPlugins });
+    await service.close();
+  });
+
+  test('serializes concurrent lint frames so handlers cannot overwrite each other', async () => {
+    const backend = new ReverseLintBackend();
+    const service = new RSLintService(backend);
+
+    const [a, b] = await Promise.all([
+      service.lint({ files: ['a.ts'] }, { pluginLint: () => ({ host: 'a' }) }),
+      service.lint({ files: ['b.ts'] }, { pluginLint: () => ({ host: 'b' }) }),
+    ]);
+
+    expect(a).toEqual({ host: 'a' });
+    expect(b).toEqual({ host: 'b' });
+    await service.close();
+  });
+});

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -13,18 +13,13 @@ export namespace TSESTree {
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace TSESLint {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   export class Linter {
-    constructor(options: { configType: string }) {
-      void options;
-    }
-    defineParser(name: string, parser: any) {
-      void name;
-      void parser;
-    }
-    verifyAndFix(code: string, options: any, options2: any): any {
-      void code;
-      void options;
-      void options2;
-    }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    constructor(options: { configType: string }) {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    defineParser(name: string, parser: any) {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    verifyAndFix(code: string, options: any, options2: any): any {}
   }
 }

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -13,13 +13,18 @@ export namespace TSESTree {
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace TSESLint {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   export class Linter {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    constructor(options: { configType: string }) {}
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    defineParser(name: string, parser: any) {}
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    verifyAndFix(code: string, options: any, options2: any): any {}
+    constructor(options: { configType: string }) {
+      void options;
+    }
+    defineParser(name: string, parser: any) {
+      void name;
+      void parser;
+    }
+    verifyAndFix(code: string, options: any, options2: any): any {
+      void code;
+      void options;
+      void options2;
+    }
   }
 }

--- a/packages/vscode-extension/__tests__/fixtures-project-service-scope/template-nested/orphan.ts
+++ b/packages/vscode-extension/__tests__/fixtures-project-service-scope/template-nested/orphan.ts
@@ -2,8 +2,9 @@
 // The nearest rslint config says `projectService: true` + no explicit
 // `project`, so rslint can't resolve a tsconfig for it.
 //
-// CLI and LSP must agree on whether `@typescript-eslint/no-unused-vars`
-// (a type-aware rule) runs here.
+// The LSP must not run `@typescript-eslint/no-unused-vars` (a type-aware rule)
+// here, but non-type-aware native rules and their fixes must remain active.
 export const orphan = ((command: string, args: string[], options: unknown) => {
-  return { stdout: '', stderr: '', exitCode: 0 };
+  var output = command;
+  return { stdout: output, stderr: '', exitCode: 0 };
 }) as unknown;

--- a/packages/vscode-extension/__tests__/fixtures-project-service-scope/template-nested/rslint.config.js
+++ b/packages/vscode-extension/__tests__/fixtures-project-service-scope/template-nested/rslint.config.js
@@ -2,10 +2,8 @@
 // ship a tsconfig.json. Mirrors the create-rstack layout where the
 // `template-rslint/` starter directory carries a rslint.config.ts but no
 // tsconfig. Previously this caused the LSP to fall back to a global
-// "allow-all" mode, incorrectly enabling type-aware rules on files under
-// OTHER configs (e.g. root-level test files outside the root tsconfig's
-// include). The fix scopes tsConfigPaths per-config so this only disables
-// filtering for files under THIS config's directory.
+// "allow-all" mode, incorrectly enabling type-aware rules. A config without
+// any resolved tsconfig now disables type-aware rules for its own files.
 export default [
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
@@ -17,6 +15,7 @@ export default [
     },
     rules: {
       '@typescript-eslint/no-unused-vars': 'error',
+      'no-var': 'error',
     },
   },
 ];

--- a/packages/vscode-extension/__tests__/runTest.ts
+++ b/packages/vscode-extension/__tests__/runTest.ts
@@ -7,7 +7,7 @@ function resolveFixture(name: string): string {
 }
 
 async function main() {
-  const extensionDevelopmentPath = path.resolve(__dirname, '..');
+  const extensionDevelopmentPath = path.resolve(__dirname, '../..');
   let failed = false;
 
   // --- Existing tests (JSON config workspace) ---

--- a/packages/vscode-extension/__tests__/suite-eslint-plugins/plugin-pool.test.ts
+++ b/packages/vscode-extension/__tests__/suite-eslint-plugins/plugin-pool.test.ts
@@ -1,0 +1,308 @@
+import * as assert from 'node:assert';
+
+import type {
+  ConfigDescriptor,
+  EslintPluginLintRequest,
+  EslintPluginLintResult,
+  PluginLintHost,
+} from '@rslint/core/eslint-plugin';
+import { CancellationTokenSource } from 'vscode';
+import { PluginLintPool } from '../../src/PluginLintPool';
+import type { Logger } from '../../src/logger';
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+class TestHost implements PluginLintHost {
+  readonly started = deferred<void>();
+  lintCalls = 0;
+  shutdownCalls = 0;
+  lintResult: Promise<EslintPluginLintResult> = Promise.resolve({
+    results: [],
+  });
+
+  async lint(): Promise<EslintPluginLintResult> {
+    this.lintCalls++;
+    this.started.resolve();
+    return this.lintResult;
+  }
+
+  async shutdown(): Promise<void> {
+    this.shutdownCalls++;
+  }
+}
+
+function descriptor(name: string): ConfigDescriptor[] {
+  return [{ configPath: `/${name}.mjs`, configDirectory: `file:///${name}` }];
+}
+
+function request(generation: string): EslintPluginLintRequest {
+  return {
+    generation,
+    files: [],
+    rules: {},
+    fix: false,
+    suggestionsMode: 'off',
+  };
+}
+
+function testLogger(): Logger {
+  return {
+    error() {},
+    debug() {},
+  } as unknown as Logger;
+}
+
+suite('PluginLintPool generations', () => {
+  test('an installed generation does not wait for a slow prepare', async () => {
+    const hostA = new TestHost();
+    const hostB = new TestHost();
+    const hostBReady = deferred<PluginLintHost>();
+    const hostBCreateStarted = deferred<void>();
+    const pool = new PluginLintPool(testLogger(), async (configs) => {
+      if (configs[0].configPath === '/a.mjs') return hostA;
+      hostBCreateStarted.resolve();
+      return hostBReady.promise;
+    });
+
+    assert.strictEqual(
+      await pool.prepare(descriptor('a'), 'fingerprint-a', 'a'),
+      true,
+    );
+    assert.strictEqual(await pool.commit('a'), true);
+
+    const prepareB = pool.prepare(descriptor('b'), 'fingerprint-b', 'b');
+    await hostBCreateStarted.promise;
+    const lintA = pool.lint(request('a'));
+    await Promise.resolve();
+    const callsBeforeBWasReady = hostA.lintCalls;
+
+    hostBReady.resolve(hostB);
+    await prepareB;
+    await lintA;
+    await pool.abort('b');
+    await pool.dispose();
+
+    assert.strictEqual(
+      callsBeforeBWasReady,
+      1,
+      'an unrelated host build must not block an installed generation',
+    );
+  });
+
+  test('a generation still being installed waits and is rechecked', async () => {
+    const host = new TestHost();
+    const hostReady = deferred<PluginLintHost>();
+    const hostCreateStarted = deferred<void>();
+    const pool = new PluginLintPool(testLogger(), async () => {
+      hostCreateStarted.resolve();
+      return hostReady.promise;
+    });
+
+    const prepare = pool.prepare(descriptor('a'), 'fingerprint-a', 'a');
+    await hostCreateStarted.promise;
+    const lint = pool.lint(request('a'));
+    await Promise.resolve();
+    assert.strictEqual(host.lintCalls, 0);
+
+    hostReady.resolve(host);
+    assert.strictEqual(await prepare, true);
+    await lint;
+    assert.strictEqual(host.lintCalls, 1);
+
+    await pool.abort('a');
+    await pool.dispose();
+  });
+
+  test('cancellation interrupts the wait for an uninstalled generation', async () => {
+    const host = new TestHost();
+    const hostReady = deferred<PluginLintHost>();
+    const hostCreateStarted = deferred<void>();
+    const pool = new PluginLintPool(testLogger(), async () => {
+      hostCreateStarted.resolve();
+      return hostReady.promise;
+    });
+    const cancellation = new CancellationTokenSource();
+
+    const prepare = pool.prepare(descriptor('a'), 'fingerprint-a', 'a');
+    await hostCreateStarted.promise;
+    let lintSettled = false;
+    const lint = pool.lint(request('a'), cancellation.token).then((result) => {
+      lintSettled = true;
+      return result;
+    });
+    cancellation.cancel();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const settledBeforeHostWasReady = lintSettled;
+
+    hostReady.resolve(host);
+    await prepare;
+    const result = await lint;
+    await pool.abort('a');
+    await pool.dispose();
+    cancellation.dispose();
+
+    assert.strictEqual(settledBeforeHostWasReady, true);
+    assert.deepStrictEqual(result, { results: [] });
+    assert.strictEqual(host.lintCalls, 0);
+  });
+
+  test('staged generations route safely and old hosts drain before shutdown', async () => {
+    const hosts = new Map<string, TestHost>();
+    const pool = new PluginLintPool(
+      testLogger(),
+      async (configs) => {
+        const host = new TestHost();
+        hosts.set(configs[0].configPath, host);
+        return host;
+      },
+      0,
+    );
+
+    assert.strictEqual(
+      await pool.prepare(descriptor('a'), 'fingerprint-a', 'a'),
+      true,
+    );
+    assert.strictEqual(await pool.commit('a'), true);
+    const hostA = hosts.get('/a.mjs')!;
+    const lintAResult = deferred<EslintPluginLintResult>();
+    hostA.lintResult = lintAResult.promise;
+    const lintA = pool.lint(request('a'));
+    await hostA.started.promise;
+
+    assert.strictEqual(
+      await pool.prepare(descriptor('b'), 'fingerprint-b', 'b'),
+      true,
+    );
+    const hostB = hosts.get('/b.mjs')!;
+    await pool.lint(request('b'));
+    assert.strictEqual(
+      hostB.lintCalls,
+      1,
+      'Go can route an accepted generation before Node observes the ack',
+    );
+
+    assert.strictEqual(await pool.commit('b'), true);
+    assert.strictEqual(
+      hostA.shutdownCalls,
+      0,
+      'the old host still has an active lint lease',
+    );
+    await pool.lint(request('b'));
+    assert.strictEqual(hostB.lintCalls, 2);
+
+    lintAResult.resolve({ results: [] });
+    await lintA;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(hostA.shutdownCalls, 1);
+
+    await pool.dispose();
+    assert.strictEqual(hostB.shutdownCalls, 1);
+  });
+
+  test('default grace retains at most two old WorkerPools', async () => {
+    const hosts = new Map<string, TestHost>();
+    const pool = new PluginLintPool(testLogger(), async (configs) => {
+      const host = new TestHost();
+      hosts.set(configs[0].configPath, host);
+      return host;
+    });
+
+    for (const name of ['a', 'b', 'c', 'd']) {
+      assert.strictEqual(
+        await pool.prepare(descriptor(name), `fingerprint-${name}`, name),
+        true,
+      );
+      assert.strictEqual(await pool.commit(name), true);
+    }
+
+    const shutdownsDuringGrace = ['a', 'b', 'c', 'd'].map(
+      (name) => hosts.get(`/${name}.mjs`)!.shutdownCalls,
+    );
+    await pool.dispose();
+
+    assert.deepStrictEqual(
+      shutdownsDuringGrace,
+      [1, 0, 0, 0],
+      'the oldest pool is retired without waiting for the default 30s delay',
+    );
+  });
+
+  test('the grace cap drains an acquired lease before shutdown', async () => {
+    const hosts = new Map<string, TestHost>();
+    const pool = new PluginLintPool(testLogger(), async (configs) => {
+      const host = new TestHost();
+      hosts.set(configs[0].configPath, host);
+      return host;
+    });
+
+    assert.strictEqual(
+      await pool.prepare(descriptor('a'), 'fingerprint-a', 'a'),
+      true,
+    );
+    assert.strictEqual(await pool.commit('a'), true);
+    const hostA = hosts.get('/a.mjs')!;
+    const lintAResult = deferred<EslintPluginLintResult>();
+    hostA.lintResult = lintAResult.promise;
+    const lintA = pool.lint(request('a'));
+    await hostA.started.promise;
+
+    for (const name of ['b', 'c', 'd']) {
+      assert.strictEqual(
+        await pool.prepare(descriptor(name), `fingerprint-${name}`, name),
+        true,
+      );
+      assert.strictEqual(await pool.commit(name), true);
+    }
+    assert.strictEqual(
+      hostA.shutdownCalls,
+      0,
+      'capacity eviction must not shut down an acquired lease',
+    );
+
+    lintAResult.resolve({ results: [] });
+    await lintA;
+    assert.strictEqual(hostA.shutdownCalls, 1);
+
+    await pool.dispose();
+  });
+
+  test('a failed replacement can be aborted without changing the active host', async () => {
+    const hostA = new TestHost();
+    const pool = new PluginLintPool(
+      testLogger(),
+      async (configs) => {
+        if (configs[0].configPath === '/b.mjs')
+          throw new Error('broken plugin');
+        return hostA;
+      },
+      0,
+    );
+
+    assert.strictEqual(
+      await pool.prepare(descriptor('a'), 'fingerprint-a', 'a'),
+      true,
+    );
+    assert.strictEqual(await pool.commit('a'), true);
+    assert.strictEqual(
+      await pool.prepare(descriptor('b'), 'fingerprint-b', 'b'),
+      false,
+    );
+    await pool.abort('b');
+
+    await pool.lint(request('a'));
+    assert.strictEqual(hostA.lintCalls, 1);
+    assert.strictEqual(hostA.shutdownCalls, 0);
+
+    await pool.dispose();
+    assert.strictEqual(hostA.shutdownCalls, 1);
+  });
+});

--- a/packages/vscode-extension/__tests__/suite-eslint-plugins/plugin-pool.test.ts
+++ b/packages/vscode-extension/__tests__/suite-eslint-plugins/plugin-pool.test.ts
@@ -275,6 +275,43 @@ suite('PluginLintPool generations', () => {
     await pool.dispose();
   });
 
+  test('dispose shuts down a retired host that still has an active lease', async () => {
+    const hosts = new Map<string, TestHost>();
+    const pool = new PluginLintPool(
+      testLogger(),
+      async (configs) => {
+        const host = new TestHost();
+        hosts.set(configs[0].configPath, host);
+        return host;
+      },
+      0,
+    );
+
+    await pool.prepare(descriptor('a'), 'fingerprint-a', 'a');
+    await pool.commit('a');
+    const hostA = hosts.get('/a.mjs')!;
+    const lintResult = deferred<EslintPluginLintResult>();
+    hostA.lintResult = lintResult.promise;
+    const lint = pool.lint(request('a'));
+    await hostA.started.promise;
+
+    await pool.prepare(descriptor('b'), 'fingerprint-b', 'b');
+    await pool.commit('b');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(hostA.shutdownCalls, 0);
+
+    await pool.dispose();
+    assert.strictEqual(
+      hostA.shutdownCalls,
+      1,
+      'dispose must include retired states that are no longer routable',
+    );
+    assert.strictEqual(hosts.get('/b.mjs')!.shutdownCalls, 1);
+
+    lintResult.resolve({ results: [] });
+    await lint;
+  });
+
   test('a failed replacement can be aborted without changing the active host', async () => {
     const hostA = new TestHost();
     const pool = new PluginLintPool(

--- a/packages/vscode-extension/__tests__/suite-jsconfig/jsconfig.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/jsconfig.test.ts
@@ -208,58 +208,6 @@ suite('rslint JS config support', function () {
     }
   });
 
-  test('CJS and CTS configs support create and hot reload', async () => {
-    const root = getWorkspaceRoot();
-    const jsConfigPath = path.join(root, 'rslint.config.js');
-    const originalJSConfig = fs.readFileSync(jsConfigPath, 'utf8');
-    const probePath = path.join(root, 'src', 'config-extension-probe.ts');
-    const configSource = (ruleName: string): string => `module.exports = [{
-  files: ['**/*.ts'],
-  rules: { ${JSON.stringify(ruleName)}: 'error' },
-}];
-`;
-
-    fs.writeFileSync(probePath, 'debugger;\nconsole.log("probe");\n', 'utf8');
-    const doc = await vscode.workspace.openTextDocument(probePath);
-    await vscode.window.showTextDocument(doc);
-    fs.unlinkSync(jsConfigPath);
-
-    try {
-      for (const extension of ['cjs', 'cts']) {
-        const configPath = path.join(root, `rslint.config.${extension}`);
-        const debuggerDiagnostics = waitForDiagnostics(doc, (diagnostics) =>
-          diagnostics.some((diagnostic) =>
-            diagnostic.message.includes("Unexpected 'debugger' statement"),
-          ),
-        );
-        fs.writeFileSync(configPath, configSource('no-debugger'), 'utf8');
-        await debuggerDiagnostics;
-
-        const consoleDiagnostics = waitForDiagnostics(
-          doc,
-          (diagnostics) =>
-            diagnostics.some((diagnostic) =>
-              diagnostic.message.includes('Unexpected console statement'),
-            ) &&
-            !diagnostics.some((diagnostic) =>
-              diagnostic.message.includes("Unexpected 'debugger' statement"),
-            ),
-        );
-        fs.writeFileSync(configPath, configSource('no-console'), 'utf8');
-        await consoleDiagnostics;
-        fs.unlinkSync(configPath);
-      }
-    } finally {
-      for (const extension of ['cjs', 'cts']) {
-        fs.rmSync(path.join(root, `rslint.config.${extension}`), {
-          force: true,
-        });
-      }
-      fs.writeFileSync(jsConfigPath, originalJSConfig, 'utf8');
-      fs.rmSync(probePath, { force: true });
-    }
-  });
-
   test('deleting JS config should clear diagnostics', async () => {
     const doc = await openFixture('index.ts');
     await vscode.window.showTextDocument(doc);
@@ -569,14 +517,12 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
     }
   });
 
-  test('same-directory configs use .js > .mjs > .cjs > .ts > .mts > .cts priority', async () => {
+  test('same-directory configs use .js > .mjs > .ts > .mts priority', async () => {
     const root = getWorkspaceRoot();
     const jsPath = path.join(root, 'rslint.config.js');
     const mjsPath = path.join(root, 'rslint.config.mjs');
-    const cjsPath = path.join(root, 'rslint.config.cjs');
     const tsPath = path.join(root, 'rslint.config.ts');
     const mtsPath = path.join(root, 'rslint.config.mts');
-    const ctsPath = path.join(root, 'rslint.config.cts');
     const originalJS = fs.readFileSync(jsPath, 'utf8');
     const doc = await openFixture('index.ts');
     await vscode.window.showTextDocument(doc);
@@ -585,8 +531,7 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
       enabledRule:
         | '@typescript-eslint/no-explicit-any'
         | '@typescript-eslint/no-unsafe-member-access',
-      commonJS = false,
-    ): string => `${commonJS ? 'module.exports =' : 'export default'} [
+    ): string => `export default [
   {
     files: ['**/*.ts'],
     languageOptions: {
@@ -628,27 +573,17 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
       );
       fs.writeFileSync(
         tsPath,
-        configFor('@typescript-eslint/no-explicit-any'),
-        'utf8',
-      );
-      fs.writeFileSync(
-        mtsPath,
         configFor('@typescript-eslint/no-unsafe-member-access'),
         'utf8',
       );
       fs.writeFileSync(
-        cjsPath,
-        configFor('@typescript-eslint/no-unsafe-member-access', true),
-        'utf8',
-      );
-      fs.writeFileSync(
-        ctsPath,
-        configFor('@typescript-eslint/no-explicit-any', true),
+        mtsPath,
+        configFor('@typescript-eslint/no-explicit-any'),
         'utf8',
       );
       await new Promise((resolve) => setTimeout(resolve, 1500));
 
-      let diagnostics = vscode.languages.getDiagnostics(doc.uri);
+      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
       assert.ok(
         diagnostics.some(
           (d) =>
@@ -664,20 +599,8 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
       fs.unlinkSync(mjsPath);
       await expectWarning('no-unsafe-member-access');
 
-      fs.unlinkSync(cjsPath);
-      await expectWarning('no-explicit-any');
-
       fs.unlinkSync(tsPath);
-      await expectWarning('no-unsafe-member-access');
-
-      fs.unlinkSync(mtsPath);
       await expectWarning('no-explicit-any');
-
-      diagnostics = vscode.languages.getDiagnostics(doc.uri);
-      assert.ok(
-        !diagnostics.some((d) => d.message.includes('no-unsafe-member-access')),
-        '.cts should govern after all higher-priority variants are removed',
-      );
     } finally {
       const restored = waitForDiagnostics(doc, (diags) =>
         diags.some(
@@ -688,10 +611,8 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
       ).catch(() => undefined);
       fs.writeFileSync(jsPath, originalJS, 'utf8');
       fs.rmSync(mjsPath, { force: true });
-      fs.rmSync(cjsPath, { force: true });
       fs.rmSync(tsPath, { force: true });
       fs.rmSync(mtsPath, { force: true });
-      fs.rmSync(ctsPath, { force: true });
       await restored;
     }
   });

--- a/packages/vscode-extension/__tests__/suite-jsconfig/jsconfig.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/jsconfig.test.ts
@@ -76,6 +76,12 @@ suite('rslint JS config support', function () {
     return vscode.workspace.openTextDocument(filePath);
   }
 
+  async function triggerRelint(doc: vscode.TextDocument): Promise<void> {
+    const editor = await vscode.window.showTextDocument(doc);
+    await editor.edit((edit) => edit.insert(new vscode.Position(0, 0), ' '));
+    await editor.edit((edit) => edit.delete(new vscode.Range(0, 0, 0, 1)));
+  }
+
   test('JS config should produce diagnostics', async () => {
     const doc = await openFixture('index.ts');
     await vscode.window.showTextDocument(doc);
@@ -256,6 +262,229 @@ suite('rslint JS config support', function () {
         diags.some((d) => d.message.includes('no-unsafe-member-access')),
       ).catch(() => undefined);
       fs.writeFileSync(configPath, originalConfig, 'utf8');
+      await restored;
+    }
+  });
+
+  test('a newly discovered broken nested config keeps valid ancestor config active', async () => {
+    const root = getWorkspaceRoot();
+    const rootConfigPath = path.join(root, 'rslint.config.js');
+    const originalRootConfig = fs.readFileSync(rootConfigPath, 'utf8');
+    const nestedDir = path.join(root, 'broken-nested-config');
+    const nestedFilePath = path.join(nestedDir, 'index.ts');
+    const nestedConfigPath = path.join(nestedDir, 'rslint.config.js');
+    const rootDoc = await openFixture('index.ts');
+
+    const rootConfigWithMarker = `export default [{
+  files: ['**/*.ts'],
+  languageOptions: {
+    parserOptions: { projectService: false, project: ['./tsconfig.json'] },
+  },
+  rules: {
+    '@typescript-eslint/no-unsafe-member-access': 'error',
+    'no-debugger': 'error',
+  },
+  plugins: ['@typescript-eslint'],
+}];
+`;
+
+    try {
+      fs.mkdirSync(nestedDir, { recursive: true });
+      fs.writeFileSync(nestedFilePath, 'debugger;\n', 'utf8');
+      fs.writeFileSync(rootConfigPath, rootConfigWithMarker, 'utf8');
+
+      await vscode.window.showTextDocument(rootDoc);
+      const nestedDoc = await vscode.workspace.openTextDocument(nestedFilePath);
+      await vscode.window.showTextDocument(nestedDoc);
+      await waitForDiagnostics(nestedDoc, (diags) =>
+        diags.some((d) => d.message.includes('no-debugger')),
+      );
+
+      fs.writeFileSync(
+        nestedConfigPath,
+        'export default [BROKEN SYNTAX;',
+        'utf8',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      await triggerRelint(nestedDoc);
+
+      const nestedDiagnostics = await waitForDiagnostics(nestedDoc, (diags) =>
+        diags.some((d) => d.message.includes('no-debugger')),
+      );
+      assert.ok(
+        nestedDiagnostics.some((d) => d.message.includes('no-debugger')),
+        'The broken nested config should be skipped so the root config remains active',
+      );
+
+      const rootDiagnostics = await waitForDiagnostics(rootDoc, (diags) =>
+        diags.some((d) => d.message.includes('no-unsafe-member-access')),
+      );
+      assert.ok(
+        rootDiagnostics.some((d) =>
+          d.message.includes('no-unsafe-member-access'),
+        ),
+        'The valid root config must remain active outside the broken nested config',
+      );
+    } finally {
+      const rootRestored = waitForDiagnostics(rootDoc, (diags) =>
+        diags.some((d) => d.message.includes('no-unsafe-member-access')),
+      ).catch(() => undefined);
+      fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
+      fs.rmSync(nestedDir, { recursive: true, force: true });
+      await rootRestored;
+    }
+  });
+
+  test('same-directory configs use .js > .mjs > .ts > .mts priority', async () => {
+    const root = getWorkspaceRoot();
+    const jsPath = path.join(root, 'rslint.config.js');
+    const mjsPath = path.join(root, 'rslint.config.mjs');
+    const tsPath = path.join(root, 'rslint.config.ts');
+    const mtsPath = path.join(root, 'rslint.config.mts');
+    const originalJS = fs.readFileSync(jsPath, 'utf8');
+    const doc = await openFixture('index.ts');
+    await vscode.window.showTextDocument(doc);
+
+    const configFor = (
+      enabledRule:
+        | '@typescript-eslint/no-explicit-any'
+        | '@typescript-eslint/no-unsafe-member-access',
+    ): string => `export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: ['./tsconfig.json'],
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': '${enabledRule.endsWith('no-explicit-any') ? 'warn' : 'off'}',
+      '@typescript-eslint/no-unsafe-member-access': '${enabledRule.endsWith('no-unsafe-member-access') ? 'warn' : 'off'}',
+    },
+    plugins: ['@typescript-eslint'],
+  },
+];
+`;
+
+    const expectWarning = async (ruleName: string): Promise<void> => {
+      const diagnostics = await waitForDiagnostics(doc, (diags) =>
+        diags.some(
+          (d) =>
+            d.message.includes(ruleName) &&
+            d.severity === vscode.DiagnosticSeverity.Warning,
+        ),
+      );
+      const diagnostic = diagnostics.find((d) => d.message.includes(ruleName));
+      assert.strictEqual(
+        diagnostic?.severity,
+        vscode.DiagnosticSeverity.Warning,
+        `Expected ${ruleName} from the selected config`,
+      );
+    };
+
+    try {
+      fs.writeFileSync(
+        mjsPath,
+        configFor('@typescript-eslint/no-explicit-any'),
+        'utf8',
+      );
+      fs.writeFileSync(
+        tsPath,
+        configFor('@typescript-eslint/no-unsafe-member-access'),
+        'utf8',
+      );
+      fs.writeFileSync(
+        mtsPath,
+        configFor('@typescript-eslint/no-explicit-any'),
+        'utf8',
+      );
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+
+      let diagnostics = vscode.languages.getDiagnostics(doc.uri);
+      assert.ok(
+        diagnostics.some(
+          (d) =>
+            d.message.includes('no-unsafe-member-access') &&
+            d.severity === vscode.DiagnosticSeverity.Error,
+        ),
+        '.js should remain selected while lower-priority configs coexist',
+      );
+
+      fs.unlinkSync(jsPath);
+      await expectWarning('no-explicit-any');
+
+      fs.unlinkSync(mjsPath);
+      await expectWarning('no-unsafe-member-access');
+
+      fs.unlinkSync(tsPath);
+      await expectWarning('no-explicit-any');
+
+      diagnostics = vscode.languages.getDiagnostics(doc.uri);
+      assert.ok(
+        !diagnostics.some((d) => d.message.includes('no-unsafe-member-access')),
+        '.mts should govern after all higher-priority variants are removed',
+      );
+    } finally {
+      const restored = waitForDiagnostics(doc, (diags) =>
+        diags.some(
+          (d) =>
+            d.message.includes('no-unsafe-member-access') &&
+            d.severity === vscode.DiagnosticSeverity.Error,
+        ),
+      ).catch(() => undefined);
+      fs.writeFileSync(jsPath, originalJS, 'utf8');
+      fs.rmSync(mjsPath, { force: true });
+      fs.rmSync(tsPath, { force: true });
+      fs.rmSync(mtsPath, { force: true });
+      await restored;
+    }
+  });
+
+  test('broken higher-priority config preserves last-good and does not load a lower variant', async () => {
+    const root = getWorkspaceRoot();
+    const jsPath = path.join(root, 'rslint.config.js');
+    const mjsPath = path.join(root, 'rslint.config.mjs');
+    const originalJS = fs.readFileSync(jsPath, 'utf8');
+    const doc = await openFixture('index.ts');
+    await vscode.window.showTextDocument(doc);
+    await waitForDiagnostics(doc, (diags) =>
+      diags.some((d) => d.message.includes('no-unsafe-member-access')),
+    );
+
+    const lowerPriorityConfig = `export default [{
+  languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-unsafe-member-access': 'off',
+  },
+  plugins: ['@typescript-eslint'],
+}];
+`;
+
+    try {
+      fs.writeFileSync(mjsPath, lowerPriorityConfig, 'utf8');
+      fs.writeFileSync(jsPath, 'export default [BROKEN SYNTAX;', 'utf8');
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await triggerRelint(doc);
+
+      const diagnostics = await waitForDiagnostics(doc, (diags) =>
+        diags.some((d) => d.message.includes('no-unsafe-member-access')),
+      );
+      assert.ok(
+        diagnostics.some((d) => d.message.includes('no-unsafe-member-access')),
+        'The last-good .js config should remain active',
+      );
+      assert.ok(
+        !diagnostics.some((d) => d.message.includes('no-explicit-any')),
+        'A broken .js must not fall through to .mjs or JSON',
+      );
+    } finally {
+      const restored = waitForDiagnostics(doc, (diags) =>
+        diags.some((d) => d.message.includes('no-unsafe-member-access')),
+      ).catch(() => undefined);
+      fs.writeFileSync(jsPath, originalJS, 'utf8');
+      fs.rmSync(mjsPath, { force: true });
       await restored;
     }
   });

--- a/packages/vscode-extension/__tests__/suite-jsconfig/jsconfig.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/jsconfig.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
 import fs from 'node:fs';
+import { selectUnavailableConfigBoundaryDirectories } from '../../src/Rslint';
 
 suite('rslint JS config support', function () {
   this.timeout(120_000);
@@ -81,6 +82,33 @@ suite('rslint JS config support', function () {
     await editor.edit((edit) => edit.insert(new vscode.Position(0, 0), ' '));
     await editor.edit((edit) => edit.delete(new vscode.Range(0, 0, 0, 1)));
   }
+
+  test('unavailable config boundaries preserve JS ownership without hiding valid ancestors', () => {
+    const root = path.resolve('/workspace');
+    const app = path.join(root, 'packages', 'app');
+    const broken = path.join(root, 'packages', 'broken');
+
+    assert.deepStrictEqual(
+      selectUnavailableConfigBoundaryDirectories([app], [root]),
+      [root],
+      'a valid descendant must not expose JSON through an unavailable root',
+    );
+    assert.deepStrictEqual(
+      selectUnavailableConfigBoundaryDirectories([root], [broken]),
+      [],
+      'an unavailable child must fall back to its usable JS ancestor',
+    );
+    assert.deepStrictEqual(
+      selectUnavailableConfigBoundaryDirectories([], [broken]),
+      [broken],
+      'a lone unavailable nested config protects only its own subtree',
+    );
+    assert.deepStrictEqual(
+      selectUnavailableConfigBoundaryDirectories([], [root, broken]),
+      [root],
+      'an outer empty boundary makes a nested duplicate unnecessary',
+    );
+  });
 
   test('JS config should produce diagnostics', async () => {
     const doc = await openFixture('index.ts');
@@ -177,6 +205,58 @@ suite('rslint JS config support', function () {
       );
     } finally {
       fs.writeFileSync(configPath, originalConfig, 'utf8');
+    }
+  });
+
+  test('CJS and CTS configs support create and hot reload', async () => {
+    const root = getWorkspaceRoot();
+    const jsConfigPath = path.join(root, 'rslint.config.js');
+    const originalJSConfig = fs.readFileSync(jsConfigPath, 'utf8');
+    const probePath = path.join(root, 'src', 'config-extension-probe.ts');
+    const configSource = (ruleName: string): string => `module.exports = [{
+  files: ['**/*.ts'],
+  rules: { ${JSON.stringify(ruleName)}: 'error' },
+}];
+`;
+
+    fs.writeFileSync(probePath, 'debugger;\nconsole.log("probe");\n', 'utf8');
+    const doc = await vscode.workspace.openTextDocument(probePath);
+    await vscode.window.showTextDocument(doc);
+    fs.unlinkSync(jsConfigPath);
+
+    try {
+      for (const extension of ['cjs', 'cts']) {
+        const configPath = path.join(root, `rslint.config.${extension}`);
+        const debuggerDiagnostics = waitForDiagnostics(doc, (diagnostics) =>
+          diagnostics.some((diagnostic) =>
+            diagnostic.message.includes("Unexpected 'debugger' statement"),
+          ),
+        );
+        fs.writeFileSync(configPath, configSource('no-debugger'), 'utf8');
+        await debuggerDiagnostics;
+
+        const consoleDiagnostics = waitForDiagnostics(
+          doc,
+          (diagnostics) =>
+            diagnostics.some((diagnostic) =>
+              diagnostic.message.includes('Unexpected console statement'),
+            ) &&
+            !diagnostics.some((diagnostic) =>
+              diagnostic.message.includes("Unexpected 'debugger' statement"),
+            ),
+        );
+        fs.writeFileSync(configPath, configSource('no-console'), 'utf8');
+        await consoleDiagnostics;
+        fs.unlinkSync(configPath);
+      }
+    } finally {
+      for (const extension of ['cjs', 'cts']) {
+        fs.rmSync(path.join(root, `rslint.config.${extension}`), {
+          force: true,
+        });
+      }
+      fs.writeFileSync(jsConfigPath, originalJSConfig, 'utf8');
+      fs.rmSync(probePath, { force: true });
     }
   });
 
@@ -335,12 +415,168 @@ suite('rslint JS config support', function () {
     }
   });
 
-  test('same-directory configs use .js > .mjs > .ts > .mts priority', async () => {
+  test('parent global ignores remove nested configs from the effective catalog', async () => {
+    const root = getWorkspaceRoot();
+    const rootConfigPath = path.join(root, 'rslint.config.js');
+    const originalRootConfig = fs.readFileSync(rootConfigPath, 'utf8');
+    const nestedDir = path.join(root, 'parent-ignore-catalog-probe');
+    const nestedConfigPath = path.join(nestedDir, 'rslint.config.mjs');
+    const nestedFilePath = path.join(nestedDir, 'index.ts');
+    const loadMarkerPath = path.join(nestedDir, 'config-loads.txt');
+    const rootDoc = await openFixture('index.ts');
+
+    const ignoredRootConfig = originalRootConfig
+      .replace(
+        'export default [',
+        "export default [{ ignores: ['parent-ignore-catalog-probe/**'] },",
+      )
+      .replace(
+        "'@typescript-eslint/no-explicit-any': 'off'",
+        "'@typescript-eslint/no-explicit-any': 'warn'",
+      );
+
+    try {
+      fs.mkdirSync(nestedDir, { recursive: true });
+      fs.writeFileSync(nestedFilePath, 'console.log("nested");\n', 'utf8');
+      fs.writeFileSync(
+        nestedConfigPath,
+        `import fs from 'node:fs';
+fs.appendFileSync(${JSON.stringify(loadMarkerPath)}, 'x');
+export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
+`,
+        'utf8',
+      );
+
+      const nestedDoc = await vscode.workspace.openTextDocument(nestedFilePath);
+      await vscode.window.showTextDocument(nestedDoc);
+      await waitForDiagnostics(nestedDoc, (diagnostics) =>
+        diagnostics.some((diagnostic) =>
+          diagnostic.message.includes('Unexpected console statement'),
+        ),
+      );
+
+      await vscode.window.showTextDocument(rootDoc);
+      const parentApplied = waitForDiagnostics(rootDoc, (diagnostics) =>
+        diagnostics.some((diagnostic) =>
+          diagnostic.message.includes('no-explicit-any'),
+        ),
+      );
+      const nestedCleared = waitForDiagnostics(
+        nestedDoc,
+        (diagnostics) =>
+          !diagnostics.some((diagnostic) =>
+            diagnostic.message.includes('Unexpected console statement'),
+          ),
+      );
+
+      fs.writeFileSync(rootConfigPath, ignoredRootConfig, 'utf8');
+      await Promise.all([parentApplied, nestedCleared]);
+
+      assert.ok(
+        fs.readFileSync(loadMarkerPath, 'utf8').length >= 2,
+        'The ignored nested candidate should still be scanned and loaded',
+      );
+      assert.ok(
+        !vscode.languages
+          .getDiagnostics(nestedDoc.uri)
+          .some((diagnostic) =>
+            diagnostic.message.includes('Unexpected console statement'),
+          ),
+        'The ignored nested config must not be sent in the effective catalog',
+      );
+    } finally {
+      const restored = waitForDiagnostics(
+        rootDoc,
+        (diagnostics) =>
+          diagnostics.some((diagnostic) =>
+            diagnostic.message.includes('no-unsafe-member-access'),
+          ) &&
+          !diagnostics.some((diagnostic) =>
+            diagnostic.message.includes('no-explicit-any'),
+          ),
+      ).catch(() => undefined);
+      fs.rmSync(nestedDir, { recursive: true, force: true });
+      fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
+      await restored;
+    }
+  });
+
+  test('config search excludes node_modules and .git', async () => {
+    const root = getWorkspaceRoot();
+    const rootConfigPath = path.join(root, 'rslint.config.js');
+    const originalRootConfig = fs.readFileSync(rootConfigPath, 'utf8');
+    const rootDoc = await openFixture('index.ts');
+    const gitDirectory = path.join(root, '.git');
+    const gitDirectoryExisted = fs.existsSync(gitDirectory);
+    const probes = [
+      path.join(root, 'node_modules', 'rslint-config-search-probe'),
+      path.join(gitDirectory, 'rslint-config-search-probe'),
+    ];
+    const markerPaths = probes.map((probe) => path.join(probe, 'loaded.txt'));
+    const changedRootConfig = originalRootConfig.replace(
+      "'@typescript-eslint/no-explicit-any': 'off'",
+      "'@typescript-eslint/no-explicit-any': 'warn'",
+    );
+
+    try {
+      for (let index = 0; index < probes.length; index++) {
+        fs.mkdirSync(probes[index], { recursive: true });
+        fs.writeFileSync(
+          path.join(probes[index], 'rslint.config.mjs'),
+          `import fs from 'node:fs'; fs.writeFileSync(${JSON.stringify(markerPaths[index])}, 'loaded'); export default [];`,
+          'utf8',
+        );
+      }
+
+      await vscode.window.showTextDocument(rootDoc);
+      const reloaded = waitForDiagnostics(rootDoc, (diagnostics) =>
+        diagnostics.some((diagnostic) =>
+          diagnostic.message.includes('no-explicit-any'),
+        ),
+      );
+      fs.writeFileSync(rootConfigPath, changedRootConfig, 'utf8');
+      await reloaded;
+
+      for (const markerPath of markerPaths) {
+        assert.ok(
+          !fs.existsSync(markerPath),
+          `Excluded config was unexpectedly loaded: ${markerPath}`,
+        );
+      }
+    } finally {
+      const restored = waitForDiagnostics(
+        rootDoc,
+        (diagnostics) =>
+          diagnostics.some((diagnostic) =>
+            diagnostic.message.includes('no-unsafe-member-access'),
+          ) &&
+          !diagnostics.some((diagnostic) =>
+            diagnostic.message.includes('no-explicit-any'),
+          ),
+      ).catch(() => undefined);
+      for (const probe of probes) {
+        fs.rmSync(probe, { recursive: true, force: true });
+      }
+      if (!gitDirectoryExisted) {
+        try {
+          fs.rmdirSync(gitDirectory);
+        } catch {
+          // Leave a concurrently populated directory intact.
+        }
+      }
+      fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
+      await restored;
+    }
+  });
+
+  test('same-directory configs use .js > .mjs > .cjs > .ts > .mts > .cts priority', async () => {
     const root = getWorkspaceRoot();
     const jsPath = path.join(root, 'rslint.config.js');
     const mjsPath = path.join(root, 'rslint.config.mjs');
+    const cjsPath = path.join(root, 'rslint.config.cjs');
     const tsPath = path.join(root, 'rslint.config.ts');
     const mtsPath = path.join(root, 'rslint.config.mts');
+    const ctsPath = path.join(root, 'rslint.config.cts');
     const originalJS = fs.readFileSync(jsPath, 'utf8');
     const doc = await openFixture('index.ts');
     await vscode.window.showTextDocument(doc);
@@ -349,7 +585,8 @@ suite('rslint JS config support', function () {
       enabledRule:
         | '@typescript-eslint/no-explicit-any'
         | '@typescript-eslint/no-unsafe-member-access',
-    ): string => `export default [
+      commonJS = false,
+    ): string => `${commonJS ? 'module.exports =' : 'export default'} [
   {
     files: ['**/*.ts'],
     languageOptions: {
@@ -391,12 +628,22 @@ suite('rslint JS config support', function () {
       );
       fs.writeFileSync(
         tsPath,
-        configFor('@typescript-eslint/no-unsafe-member-access'),
+        configFor('@typescript-eslint/no-explicit-any'),
         'utf8',
       );
       fs.writeFileSync(
         mtsPath,
-        configFor('@typescript-eslint/no-explicit-any'),
+        configFor('@typescript-eslint/no-unsafe-member-access'),
+        'utf8',
+      );
+      fs.writeFileSync(
+        cjsPath,
+        configFor('@typescript-eslint/no-unsafe-member-access', true),
+        'utf8',
+      );
+      fs.writeFileSync(
+        ctsPath,
+        configFor('@typescript-eslint/no-explicit-any', true),
         'utf8',
       );
       await new Promise((resolve) => setTimeout(resolve, 1500));
@@ -417,13 +664,19 @@ suite('rslint JS config support', function () {
       fs.unlinkSync(mjsPath);
       await expectWarning('no-unsafe-member-access');
 
+      fs.unlinkSync(cjsPath);
+      await expectWarning('no-explicit-any');
+
       fs.unlinkSync(tsPath);
+      await expectWarning('no-unsafe-member-access');
+
+      fs.unlinkSync(mtsPath);
       await expectWarning('no-explicit-any');
 
       diagnostics = vscode.languages.getDiagnostics(doc.uri);
       assert.ok(
         !diagnostics.some((d) => d.message.includes('no-unsafe-member-access')),
-        '.mts should govern after all higher-priority variants are removed',
+        '.cts should govern after all higher-priority variants are removed',
       );
     } finally {
       const restored = waitForDiagnostics(doc, (diags) =>
@@ -435,8 +688,10 @@ suite('rslint JS config support', function () {
       ).catch(() => undefined);
       fs.writeFileSync(jsPath, originalJS, 'utf8');
       fs.rmSync(mjsPath, { force: true });
+      fs.rmSync(cjsPath, { force: true });
       fs.rmSync(tsPath, { force: true });
       fs.rmSync(mtsPath, { force: true });
+      fs.rmSync(ctsPath, { force: true });
       await restored;
     }
   });

--- a/packages/vscode-extension/__tests__/suite-monorepo/monorepo.test.ts
+++ b/packages/vscode-extension/__tests__/suite-monorepo/monorepo.test.ts
@@ -129,7 +129,8 @@ suite('rslint monorepo multi-config support', function () {
   });
 
   test('broken sub-package file should fall back to root config', async () => {
-    // broken/ has an invalid config, so its files should fall back to root config
+    // Partial config failures retain the established behavior: the failed
+    // config is skipped while the valid ancestor config remains active.
     const doc = await openFile('packages/broken/src/index.ts');
     await vscode.window.showTextDocument(doc);
 
@@ -139,7 +140,7 @@ suite('rslint monorepo multi-config support', function () {
 
     assert.ok(
       diagnostics.some((d) => d.message.includes('no-explicit-any')),
-      'Broken package file should fall back to root config (no-explicit-any: error)',
+      'Broken package file should fall back to the root config',
     );
   });
 

--- a/packages/vscode-extension/__tests__/suite-noconfig/noconfig.test.ts
+++ b/packages/vscode-extension/__tests__/suite-noconfig/noconfig.test.ts
@@ -198,7 +198,31 @@ suite('rslint no config fallback', function () {
         'Step 4: no-unsafe-member-access should be gone (JS config deleted)',
       );
 
-      // ── Step 5: Delete JSON config → no diagnostics ──
+      // ── Step 5: Broken JS with no last-good → explicit no-lint state ──
+      const disabledByBrokenJS = waitForDiagnostics(
+        doc,
+        (ds) => ds.filter((d) => d.source === 'rslint').length === 0,
+      );
+      fs.writeFileSync(jsConfigPath, 'export default [BROKEN SYNTAX;', 'utf8');
+      diags = await disabledByBrokenJS;
+      assert.strictEqual(
+        diags.filter((d) => d.source === 'rslint').length,
+        0,
+        'Step 5: A broken discovered JS config must not fall back to JSON',
+      );
+
+      // ── Step 6: Delete broken JS → legitimate deletion restores JSON ──
+      const jsonRestored = waitForDiagnostics(doc, (ds) =>
+        ds.some((d) => d.message.includes('no-explicit-any')),
+      );
+      fs.unlinkSync(jsConfigPath);
+      diags = await jsonRestored;
+      assert.ok(
+        diags.some((d) => d.message.includes('no-explicit-any')),
+        'Step 6: Deleting all JS configs should restore the JSON fallback',
+      );
+
+      // ── Step 7: Delete JSON config → no diagnostics ──
       fs.unlinkSync(jsonConfigPath);
 
       await new Promise((resolve) => setTimeout(resolve, 3000));
@@ -212,7 +236,7 @@ suite('rslint no config fallback', function () {
       assert.strictEqual(
         diags.filter((d) => d.source === 'rslint').length,
         0,
-        'Step 5: After deleting all configs, should have no rslint diagnostics',
+        'Step 7: After deleting all configs, should have no rslint diagnostics',
       );
     } finally {
       // Clean up — ensure no config files remain for other test runs

--- a/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
+++ b/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
@@ -1,13 +1,13 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
+import { findFixAllAction, requestFixAll } from '../suite/fixall-helpers';
 
 // Type-aware rule scope when parserOptions uses `projectService: true`
 // (the shape `ts.configs.recommended` exports) without an explicit
 // `project`. The LSP and CLI must agree: only files covered by the
 // fallback tsconfig's `include` get type-aware rules, AND a nested
-// config that has no tsconfig must not leak allow-all onto sibling
-// configs' files.
+// config that has no tsconfig must not enable type-aware rules.
 //
 // Fixture: fixtures-project-service-scope
 //   - rslint.config.js            — parserOptions.projectService: true (no explicit project).
@@ -20,11 +20,9 @@ import path from 'node:path';
 //                                    Contains a `console.log` so the marker rule triggers.
 //   - template-nested/rslint.config.js — nested config, also projectService: true,
 //                                    but the dir has NO tsconfig.json.
-//   - template-nested/orphan.ts   — under the nested config. Both CLI and LSP
-//                                    treat this as "has type info" (CLI via the
-//                                    scan-directory fallback Program, LSP via
-//                                    allow-all for the nested config's scope),
-//                                    so no-unused-vars SHOULD fire.
+//   - template-nested/orphan.ts   — under the nested config. no-unused-vars
+//                                    should NOT fire, while native no-var should
+//                                    diagnose and participate in fixAll.
 suite('rslint projectService type-aware scope', function () {
   this.timeout(60000);
 
@@ -108,31 +106,42 @@ suite('rslint projectService type-aware scope', function () {
     );
   });
 
-  test('template-nested/orphan.ts (nested config without tsconfig) — no-unused-vars SHOULD fire, matching CLI', async () => {
-    // Alignment check with CLI: when the nearest rslint config has no
-    // resolvable tsconfig, the CLI builds a scan-directory AllowJs Program
-    // and runs type-aware rules; the LSP falls through to allow-all scoped
-    // to that config. Both engines must produce the same no-unused-vars
-    // diagnostics on this file.
+  test('template-nested/orphan.ts (nested config without tsconfig) filters type-aware rules', async () => {
     const doc = await vscode.workspace.openTextDocument(
       path.join(workspaceRoot(), 'template-nested/orphan.ts'),
     );
     await vscode.window.showTextDocument(doc);
 
     const diagnostics = await waitForDiagnostics(doc, (diags) =>
-      rslintDiagnostics(diags).some((d) =>
-        d.message.includes('no-unused-vars'),
-      ),
+      rslintDiagnostics(diags).some((d) => d.message.includes('no-var')),
     );
 
     const rslintDiags = rslintDiagnostics(diagnostics);
-    const unusedVarDiags = rslintDiags.filter((d) =>
-      d.message.includes('no-unused-vars'),
+    assert.ok(
+      rslintDiags.some((d) => d.message.includes('no-var')),
+      `Expected native no-var marker. Got: ${rslintDiags.map((d) => d.message).join(' | ')}`,
     );
-    assert.strictEqual(
-      unusedVarDiags.length,
-      3,
-      `Expected 3 no-unused-vars diagnostics (command/args/options) to match CLI output. Got ${unusedVarDiags.length}: ${unusedVarDiags.map((d) => d.message).join(' | ')}`,
+    assert.ok(
+      !rslintDiags.some((d) => d.message.includes('no-unused-vars')),
+      `no-unused-vars should not run without a resolved tsconfig. Got: ${rslintDiags.map((d) => d.message).join(' | ')}`,
+    );
+  });
+
+  test('native fixAll remains available without a resolved tsconfig', async () => {
+    const doc = await vscode.workspace.openTextDocument(
+      path.join(workspaceRoot(), 'template-nested/orphan.ts'),
+    );
+    await vscode.window.showTextDocument(doc);
+    await waitForDiagnostics(doc, (diags) =>
+      rslintDiagnostics(diags).some((d) => d.message.includes('no-var')),
+    );
+
+    const fixAll = findFixAllAction(await requestFixAll(doc));
+    const edits = fixAll?.edit?.get(doc.uri);
+    assert.ok(edits && edits.length > 0, 'Expected a native fixAll edit');
+    assert.ok(
+      edits.some((edit) => edit.newText.includes('let output = command;')),
+      `Expected no-var fix in fixAll edit. Got: ${edits.map((edit) => edit.newText).join(' | ')}`,
     );
   });
 });

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -80,7 +80,7 @@
     "build": "node scripts/build.js",
     "watch": "node scripts/build.js --watch",
     "package": "vsce package",
-    "test": "tsgo -p tsconfig.spec.emit.json && node .vscode-test-out/runTest.js"
+    "test": "tsgo -p tsconfig.spec.emit.json && node .vscode-test-out/__tests__/runTest.js"
   },
   "devDependencies": {
     "@rslint/core": "workspace:*",

--- a/packages/vscode-extension/src/PluginLintPool.ts
+++ b/packages/vscode-extension/src/PluginLintPool.ts
@@ -41,6 +41,17 @@ interface EslintPluginModule {
   ): Promise<PluginLintHost>;
 }
 
+type PluginHostFactory = (
+  configs: ConfigDescriptor[],
+  onLog: (rec: { level: string; source: string; text: string }) => void,
+) => Promise<PluginLintHost>;
+
+// Keep enough history for requests already dispatched by the previous two
+// configs, while bounding grace-retained WorkerPools to two plus the active
+// pool. Hosts with an acquired lint lease may temporarily exceed this bound
+// until their in-flight requests drain.
+const MAX_RETAINED_GENERATIONS = 2;
+
 let modPromise: Promise<EslintPluginModule> | undefined;
 
 /**
@@ -77,22 +88,37 @@ let warnedOnce = false;
 
 export class PluginLintPool {
   private readonly logger: Logger;
-  /** The live host, once initialized. */
-  private host: PluginLintHost | undefined;
-  /** Fingerprint of the inputs `host` was built from. */
-  private fingerprint: string | undefined;
+  private readonly generations = new Map<string, HostGeneration>();
+  private readonly generationRetirementTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  private activeGeneration: string | undefined;
+  private activeState: HostGeneration | undefined;
+  private readonly shutdowns = new Set<Promise<void>>();
   /**
-   * Serializes every lifecycle op (ensure/dispose). Each op chains onto the
-   * previous one's settlement, so at most one host is ever being built or torn
-   * down at a time — concurrent config reloads can't race two worker pools
-   * into existence or leak one. `lint` awaits this too, so it always runs
-   * against the settled current host, never a half-torn-down one.
+   * Serializes every lifecycle op (prepare/commit/abort/dispose). Each op
+   * chains onto the previous one's settlement, so concurrent config reloads
+   * cannot race host installation or map mutation. Lint requests for an
+   * installed generation take a lease immediately; only a generation that is
+   * not installed yet waits for this chain and checks again.
    */
   private opChain: Promise<void> = Promise.resolve();
   private disposed = false;
+  private readonly createHost: PluginHostFactory;
+  private readonly retirementDelayMs: number;
 
-  constructor(logger: Logger) {
+  constructor(
+    logger: Logger,
+    createHost: PluginHostFactory = async (configs, onLog) => {
+      const mod = await loadModule();
+      return mod.createPluginLintHost(configs, onLog);
+    },
+    retirementDelayMs = 30_000,
+  ) {
     this.logger = logger;
+    this.createHost = createHost;
+    this.retirementDelayMs = retirementDelayMs;
   }
 
   /** Append `op` to the serialized lifecycle chain and await its turn. */
@@ -106,56 +132,87 @@ export class PluginLintPool {
   }
 
   /**
-   * Ensure a host exists that matches `descriptors`/`fingerprint`, rebuilding
-   * if the fingerprint changed (config file or lockfile mtime/size moved).
+   * Prepare a generation without making it active. The caller commits only
+   * after Go acknowledges the matching config payload, so reverse requests
+   * can never observe a worker from a config generation Go has not accepted.
    *
-   * Empty `descriptors` still builds a host — it spawns no workers (zero
-   * overhead) but can still answer a `lint` request with empty results, which
-   * keeps the request handler total even before any plugin config is seen.
+   * Returns whether the requested host state is active. Rebuilds are
+   * transactional: a failed replacement leaves the previous host available so
+   * the caller can preserve the matching last-good config payload.
+   *
+   * Empty `descriptors` needs no host. `lint` already returns an empty result
+   * without one, avoiding a module load and worker-pool allocation when no
+   * object-form community plugins are configured.
    */
-  async ensure(
+  async prepare(
     descriptors: ConfigDescriptor[],
     fingerprint: string,
-  ): Promise<void> {
-    return this.enqueue(async () => {
-      if (this.disposed) return;
-      // Already serving exactly this fingerprint — reuse the live host.
-      if (this.host && this.fingerprint === fingerprint) return;
+    generation: string,
+  ): Promise<boolean> {
+    let ready = false;
+    await this.enqueue(async () => {
+      if (this.disposed || generation === '') return;
 
-      // Tear down the previous host before standing up the new one so we never
-      // hold two worker pools at once.
-      const old = this.host;
-      this.host = undefined;
-      this.fingerprint = undefined;
-      if (old) {
-        await old.shutdown().catch((err: unknown) => {
-          this.logger.error('Error shutting down previous plugin host', err);
-        });
+      const existing = this.generations.get(generation);
+      if (existing) {
+        ready = existing.ready;
+        return;
       }
-      if (this.disposed) return; // disposed mid-teardown — don't spin a new pool
+
+      // Config-only changes can reuse the same plugin host. The new generation
+      // is still staged separately and is not routable as active until commit.
+      if (
+        this.activeState?.ready &&
+        this.activeState.fingerprint === fingerprint
+      ) {
+        this.generations.set(generation, this.activeState);
+        ready = true;
+        return;
+      }
+
+      if (descriptors.length === 0) {
+        this.generations.set(generation, {
+          fingerprint,
+          ready: true,
+          activeLints: 0,
+          retiring: false,
+        });
+        ready = true;
+        return;
+      }
 
       try {
-        const mod = await loadModule();
-        const host = await mod.createPluginLintHost(descriptors, (rec) => {
+        const replacement = await this.createHost(descriptors, (rec) => {
           const text = `[rslint:plugin] ${rec.text}`;
           if (rec.level === 'error') this.logger.error(text);
           else this.logger.debug(text);
         });
         if (this.disposed) {
           // Disposed while initializing — shut the fresh pool back down.
-          await host.shutdown().catch(() => undefined);
+          await replacement.shutdown().catch(() => undefined);
           return;
         }
-        this.host = host;
-        this.fingerprint = fingerprint;
+        this.generations.set(generation, {
+          fingerprint,
+          host: replacement,
+          ready: true,
+          activeLints: 0,
+          retiring: false,
+        });
+        ready = true;
       } catch (err: unknown) {
         // Init failed: either the host module couldn't be loaded (a packaging
-        // regression — the vsix didn't ship `dist/eslint-plugin/` or its
-        // native `.node`), or a referenced plugin failed to import. Leave host
-        // unset so we serve empty until the next config change retries, rather
-        // than wedging diagnostics.
-        this.host = undefined;
-        this.fingerprint = undefined;
+        // regression — the vsix didn't ship `dist/eslint-plugin/` or its native
+        // `.node`), or a referenced plugin failed to import. Keep the previous
+        // active host intact. Record an unavailable staged generation so the
+        // first valid config can still be committed and serve native rules;
+        // later prepares retry instead of caching this failure as ready.
+        this.generations.set(generation, {
+          fingerprint,
+          ready: false,
+          activeLints: 0,
+          retiring: false,
+        });
         this.logger.error('Failed to initialize ESLint-plugin host', err);
         // Make the failure visible — but ONLY when a config actually mounted
         // plugins (an empty-descriptor host builds no worker and failing is
@@ -169,6 +226,41 @@ export class PluginLintPool {
         }
       }
     });
+    return ready;
+  }
+
+  /** Commit a previously prepared generation after Go accepts its config. */
+  async commit(generation: string): Promise<boolean> {
+    let committed = false;
+    await this.enqueue(async () => {
+      if (this.disposed) return;
+      const next = this.generations.get(generation);
+      if (!next) return;
+
+      const previousGeneration = this.activeGeneration;
+      const previous = this.activeState;
+      this.activeGeneration = generation;
+      this.activeState = next;
+      committed = true;
+
+      if (previousGeneration && previousGeneration !== generation) {
+        this.scheduleGenerationRetirement(previousGeneration, previous);
+      }
+    });
+    return committed;
+  }
+
+  /** Discard a staged generation when source validation or Go commit fails. */
+  async abort(generation: string): Promise<void> {
+    await this.enqueue(async () => {
+      if (generation === this.activeGeneration) return;
+      const state = this.generations.get(generation);
+      if (!state) return;
+      this.generations.delete(generation);
+      if (state !== this.activeState && !this.hasGenerationReference(state)) {
+        this.retire(state);
+      }
+    });
   }
 
   /**
@@ -180,39 +272,181 @@ export class PluginLintPool {
     req: EslintPluginLintRequest,
     token?: CancellationToken,
   ): Promise<EslintPluginLintResult> {
-    // Wait for any in-flight lifecycle op so we lint against the settled host,
-    // not one mid-rebuild.
-    await this.opChain;
-    const host = this.host;
+    if (this.disposed) return { results: [] };
+
+    let state = req.generation
+      ? this.generations.get(req.generation)
+      : this.activeState;
+
+    // A reverse request may arrive after Go accepts a config but just before
+    // Node installs that generation. Wait only in that case. Existing
+    // generations must remain routable while an unrelated prepare is slow.
+    if (req.generation && !state) {
+      if (!(await this.waitForLifecycle(token))) return { results: [] };
+      if (this.disposed) return { results: [] };
+      state = this.generations.get(req.generation);
+    }
+    if (req.generation && !state) {
+      throw new Error(
+        `unknown ESLint-plugin config generation: ${req.generation}`,
+      );
+    }
+    if (!state) return { results: [] };
+    const host = state.host;
     if (!host) return { results: [] };
+
+    // Take the lease before yielding. Retirement removes future routing
+    // references, but cannot shut this state down until the lease is released.
+    state.activeLints++;
     // Bridge the LSP CancellationToken → AbortSignal for the core host, so a
     // superseding keystroke / close (Go sends $/cancelRequest) stops the worker
     // instead of letting it run to completion.
     let signal: AbortSignal | undefined;
-    if (token) {
-      const ac = new AbortController();
-      if (token.isCancellationRequested) ac.abort();
-      else
-        token.onCancellationRequested(() => {
-          ac.abort();
-        });
-      signal = ac.signal;
+    let cancellationSubscription: { dispose(): unknown } | undefined;
+    try {
+      if (token) {
+        const ac = new AbortController();
+        if (token.isCancellationRequested) ac.abort();
+        else
+          cancellationSubscription = token.onCancellationRequested(() => {
+            ac.abort();
+          });
+        signal = ac.signal;
+      }
+      return await host.lint(req, signal);
+    } finally {
+      cancellationSubscription?.dispose();
+      state.activeLints--;
+      if (state.retiring && state.activeLints === 0) {
+        this.startShutdown(state);
+      }
     }
-    return host.lint(req, signal);
+  }
+
+  /** Wait for the lifecycle snapshot that could be installing a generation. */
+  private async waitForLifecycle(token?: CancellationToken): Promise<boolean> {
+    const pending = this.opChain;
+    if (!token) {
+      await pending;
+      return true;
+    }
+    if (token.isCancellationRequested) return false;
+
+    let cancellationSubscription: { dispose(): unknown } | undefined;
+    const cancelled = new Promise<false>((resolve) => {
+      cancellationSubscription = token.onCancellationRequested(() => {
+        resolve(false);
+      });
+    });
+    try {
+      return await Promise.race([pending.then(() => true as const), cancelled]);
+    } finally {
+      cancellationSubscription?.dispose();
+    }
+  }
+
+  private hasGenerationReference(state: HostGeneration): boolean {
+    for (const candidate of this.generations.values()) {
+      if (candidate === state) return true;
+    }
+    return false;
+  }
+
+  private retire(state: HostGeneration): void {
+    state.retiring = true;
+    if (state.activeLints === 0) this.startShutdown(state);
+  }
+
+  private scheduleGenerationRetirement(
+    generation: string,
+    state: HostGeneration | undefined,
+  ): void {
+    const existing = this.generationRetirementTimers.get(generation);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      this.completeGenerationRetirement(generation, state);
+    }, this.retirementDelayMs);
+    this.generationRetirementTimers.set(generation, timer);
+
+    // A burst of config updates must not retain one complete WorkerPool per
+    // generation for the full production grace period. Expire the oldest
+    // routing generation immediately once the bounded history is full.
+    while (this.generationRetirementTimers.size > MAX_RETAINED_GENERATIONS) {
+      const oldest = this.generationRetirementTimers.keys().next().value;
+      if (oldest === undefined) break;
+      this.completeGenerationRetirement(oldest, this.generations.get(oldest));
+    }
+  }
+
+  private completeGenerationRetirement(
+    generation: string,
+    state: HostGeneration | undefined,
+  ): void {
+    const timer = this.generationRetirementTimers.get(generation);
+    if (!timer) return;
+    clearTimeout(timer);
+    this.generationRetirementTimers.delete(generation);
+    if (this.activeGeneration === generation) return;
+    if (this.generations.get(generation) !== state) return;
+
+    this.generations.delete(generation);
+    if (
+      state &&
+      state !== this.activeState &&
+      !this.hasGenerationReference(state)
+    ) {
+      this.retire(state);
+    }
+  }
+
+  private startShutdown(state: HostGeneration): void {
+    if (state.shutdown) return;
+    for (const [generation, candidate] of this.generations) {
+      if (candidate === state) {
+        this.generations.delete(generation);
+        const timer = this.generationRetirementTimers.get(generation);
+        if (timer) clearTimeout(timer);
+        this.generationRetirementTimers.delete(generation);
+      }
+    }
+    const shutdown = state.host
+      ? state.host.shutdown().catch((err: unknown) => {
+          this.logger.error('Error shutting down previous plugin host', err);
+        })
+      : Promise.resolve();
+    state.shutdown = shutdown;
+    this.shutdowns.add(shutdown);
+    void shutdown.finally(() => this.shutdowns.delete(shutdown));
   }
 
   /** Shut down the worker pool. Idempotent. */
   async dispose(): Promise<void> {
-    return this.enqueue(async () => {
-      this.disposed = true;
-      const host = this.host;
-      this.host = undefined;
-      this.fingerprint = undefined;
-      if (host) {
-        await host.shutdown().catch((err: unknown) => {
-          this.logger.error('Error disposing ESLint-plugin host', err);
-        });
+    this.disposed = true;
+    await this.enqueue(async () => {
+      const states = new Set(this.generations.values());
+      if (this.activeState) states.add(this.activeState);
+      this.generations.clear();
+      for (const timer of this.generationRetirementTimers.values()) {
+        clearTimeout(timer);
+      }
+      this.generationRetirementTimers.clear();
+      this.activeGeneration = undefined;
+      this.activeState = undefined;
+      for (const state of states) {
+        // Terminal disposal intentionally forces shutdown even if a request is
+        // still active; WorkerPool turns those tasks into benign cancellation.
+        this.startShutdown(state);
       }
     });
+    await Promise.all([...this.shutdowns]);
   }
+}
+
+interface HostGeneration {
+  fingerprint: string;
+  host?: PluginLintHost;
+  ready: boolean;
+  activeLints: number;
+  retiring: boolean;
+  shutdown?: Promise<void>;
 }

--- a/packages/vscode-extension/src/PluginLintPool.ts
+++ b/packages/vscode-extension/src/PluginLintPool.ts
@@ -95,6 +95,7 @@ export class PluginLintPool {
   >();
   private activeGeneration: string | undefined;
   private activeState: HostGeneration | undefined;
+  private readonly liveStates = new Set<HostGeneration>();
   private readonly shutdowns = new Set<Promise<void>>();
   /**
    * Serializes every lifecycle op (prepare/commit/abort/dispose). Each op
@@ -171,12 +172,14 @@ export class PluginLintPool {
       }
 
       if (descriptors.length === 0) {
-        this.generations.set(generation, {
+        const state: HostGeneration = {
           fingerprint,
           ready: true,
           activeLints: 0,
           retiring: false,
-        });
+        };
+        this.liveStates.add(state);
+        this.generations.set(generation, state);
         ready = true;
         return;
       }
@@ -192,13 +195,15 @@ export class PluginLintPool {
           await replacement.shutdown().catch(() => undefined);
           return;
         }
-        this.generations.set(generation, {
+        const state: HostGeneration = {
           fingerprint,
           host: replacement,
           ready: true,
           activeLints: 0,
           retiring: false,
-        });
+        };
+        this.liveStates.add(state);
+        this.generations.set(generation, state);
         ready = true;
       } catch (err: unknown) {
         // Init failed: either the host module couldn't be loaded (a packaging
@@ -207,12 +212,14 @@ export class PluginLintPool {
         // active host intact. Record an unavailable staged generation so the
         // first valid config can still be committed and serve native rules;
         // later prepares retry instead of caching this failure as ready.
-        this.generations.set(generation, {
+        const state: HostGeneration = {
           fingerprint,
           ready: false,
           activeLints: 0,
           retiring: false,
-        });
+        };
+        this.liveStates.add(state);
+        this.generations.set(generation, state);
         this.logger.error('Failed to initialize ESLint-plugin host', err);
         // Make the failure visible — but ONLY when a config actually mounted
         // plugins (an empty-descriptor host builds no worker and failing is
@@ -416,15 +423,17 @@ export class PluginLintPool {
       : Promise.resolve();
     state.shutdown = shutdown;
     this.shutdowns.add(shutdown);
-    void shutdown.finally(() => this.shutdowns.delete(shutdown));
+    void shutdown.finally(() => {
+      this.shutdowns.delete(shutdown);
+      this.liveStates.delete(state);
+    });
   }
 
   /** Shut down the worker pool. Idempotent. */
   async dispose(): Promise<void> {
     this.disposed = true;
     await this.enqueue(async () => {
-      const states = new Set(this.generations.values());
-      if (this.activeState) states.add(this.activeState);
+      const states = [...this.liveStates];
       this.generations.clear();
       for (const timer of this.generationRetirementTimers.values()) {
         clearTimeout(timer);

--- a/packages/vscode-extension/src/Rslint.ts
+++ b/packages/vscode-extension/src/Rslint.ts
@@ -43,8 +43,14 @@ const LOCKFILE_NAMES = [
   'yarn.lock',
 ] as const;
 
-export const JS_CONFIG_SEARCH_GLOB = '**/rslint.config.{js,mjs,cjs,ts,mts,cts}';
+export const JS_CONFIG_SEARCH_GLOB = `**/{${JS_CONFIG_FILES.join(',')}}`;
 export const JS_CONFIG_SEARCH_EXCLUDE_PATTERN = '**/{node_modules,.git}/**';
+const CONFIG_WATCH_GLOB = `**/{${[
+  ...JS_CONFIG_FILES,
+  'rslint.json',
+  'rslint.jsonc',
+  ...LOCKFILE_NAMES,
+].join(',')}}`;
 
 /** A loaded + normalized config file with its source path. */
 interface LoadedConfig {
@@ -209,9 +215,7 @@ export class Rslint implements Disposable {
         { scheme: 'file', language: 'javascriptreact' },
       ],
       synchronize: {
-        fileEvents: workspace.createFileSystemWatcher(
-          '**/{rslint.config.{js,mjs,cjs,ts,mts,cts},rslint.{json,jsonc},package-lock.json,pnpm-lock.yaml,yarn.lock}',
-        ),
+        fileEvents: workspace.createFileSystemWatcher(CONFIG_WATCH_GLOB),
       },
       outputChannel: this.outputChannel,
     };

--- a/packages/vscode-extension/src/Rslint.ts
+++ b/packages/vscode-extension/src/Rslint.ts
@@ -22,11 +22,11 @@ import { fileExists, getPlatformBinRequests, RslintBinPath } from './utils';
 import path from 'node:path';
 import fs from 'node:fs';
 import { createHash } from 'node:crypto';
-import { pathToFileURL } from 'node:url';
 import {
-  loadConfigFile,
+  loadConfigFileFresh,
   normalizeConfig,
   collectPluginMeta,
+  filterConfigsByParentIgnores,
   JS_CONFIG_FILES,
 } from '@rslint/core/config-loader';
 import { PluginLintPool } from './PluginLintPool';
@@ -43,20 +43,63 @@ const LOCKFILE_NAMES = [
   'yarn.lock',
 ] as const;
 
+export const JS_CONFIG_SEARCH_GLOB = '**/rslint.config.{js,mjs,cjs,ts,mts,cts}';
+export const JS_CONFIG_SEARCH_EXCLUDE_PATTERN = '**/{node_modules,.git}/**';
+
 /** A loaded + normalized config file with its source path. */
 interface LoadedConfig {
   configPath: string;
+  hierarchyDirectory: string;
   configDirectory: string;
   entries: Record<string, unknown>[];
   sourceFingerprint: string;
+  /** Marks a failed config boundary that must not lint its owned subtree. */
+  unavailable?: boolean;
+}
+
+function isSameOrChildDirectory(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return (
+    relative === '' ||
+    (relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
+}
+
+export function selectUnavailableConfigBoundaryDirectories(
+  usableDirectories: readonly string[],
+  unavailableDirectories: readonly string[],
+): string[] {
+  const usable = usableDirectories.map((directory) =>
+    path.normalize(directory),
+  );
+  const unavailable = [
+    ...new Set(
+      unavailableDirectories.map((directory) => path.normalize(directory)),
+    ),
+  ];
+  const withoutUsableAncestor = unavailable.filter(
+    (directory) =>
+      !usable.some((ancestor) => isSameOrChildDirectory(ancestor, directory)),
+  );
+  return withoutUsableAncestor.filter(
+    (directory, index) =>
+      !withoutUsableAncestor.some(
+        (ancestor, ancestorIndex) =>
+          ancestorIndex !== index &&
+          isSameOrChildDirectory(ancestor, directory),
+      ),
+  );
 }
 
 function selectEffectiveConfigFiles(configFiles: readonly Uri[]): Uri[] {
   const selectedByDirectory = new Map<string, { uri: Uri; priority: number }>();
 
   for (const uri of configFiles) {
-    const priority = JS_CONFIG_FILES.indexOf(
-      path.basename(uri.fsPath) as (typeof JS_CONFIG_FILES)[number],
+    const configName = path.basename(uri.fsPath);
+    const priority = JS_CONFIG_FILES.findIndex(
+      (candidateName) => candidateName === configName,
     );
     if (priority < 0) continue;
 
@@ -70,6 +113,18 @@ function selectEffectiveConfigFiles(configFiles: readonly Uri[]): Uri[] {
   return [...selectedByDirectory.values()]
     .map(({ uri }) => uri)
     .sort((a, b) => a.fsPath.localeCompare(b.fsPath));
+}
+
+export function filterEffectiveConfigCatalog<
+  T extends { hierarchyDirectory: string; entries: unknown[] },
+>(configs: T[]): T[] {
+  return filterConfigsByParentIgnores(
+    configs.map((config) => ({
+      configDirectory: config.hierarchyDirectory,
+      entries: config.entries,
+      config,
+    })),
+  ).map(({ config }) => config);
 }
 
 export class Rslint implements Disposable {
@@ -155,7 +210,7 @@ export class Rslint implements Disposable {
       ],
       synchronize: {
         fileEvents: workspace.createFileSystemWatcher(
-          '**/{rslint.config.{ts,mts,js,mjs},rslint.{json,jsonc},package-lock.json,pnpm-lock.yaml,yarn.lock}',
+          '**/{rslint.config.{js,mjs,cjs,ts,mts,cts},rslint.{json,jsonc},package-lock.json,pnpm-lock.yaml,yarn.lock}',
         ),
       },
       outputChannel: this.outputChannel,
@@ -209,10 +264,7 @@ export class Rslint implements Disposable {
       // first import is running then queues a second, serialized reload instead
       // of being missed between initial load and watcher registration.
       this.configWatcher = workspace.createFileSystemWatcher(
-        new RelativePattern(
-          this.workspaceFolder,
-          '**/rslint.config.{ts,mts,js,mjs}',
-        ),
+        new RelativePattern(this.workspaceFolder, JS_CONFIG_SEARCH_GLOB),
       );
       const reloadConfig = (kind: string) => (uri: Uri) => {
         this.logger.debug(`${kind} changed: ${uri.fsPath}`);
@@ -263,18 +315,18 @@ export class Rslint implements Disposable {
     }
   }
 
-  private loadAndSendConfig(): Promise<void> {
+  private async loadAndSendConfig(): Promise<void> {
     const epoch = this.lifecycleEpoch;
     const client = this.client;
     const pluginLintPool = this.pluginLintPool;
-    if (!client || this.pluginLintPoolDisposed) return Promise.resolve();
-    const reload = this.configReloadChain.then(() =>
-      this.performLoadAndSendConfig(epoch, client, pluginLintPool),
-    );
+    if (!client || this.pluginLintPoolDisposed) return;
+    const reload = this.configReloadChain.then(async () => {
+      await this.performLoadAndSendConfig(epoch, client, pluginLintPool);
+    });
     // Keep future reloads usable after a failed import while still returning
     // this reload's rejection to the caller for logging.
     this.configReloadChain = reload.catch(() => undefined);
-    return reload;
+    await reload;
   }
 
   private isLifecycleCurrent(
@@ -353,11 +405,8 @@ export class Rslint implements Disposable {
   ): Promise<void> {
     if (!this.isLifecycleCurrent(epoch, client, pluginLintPool)) return;
     const discoveredConfigFiles = await workspace.findFiles(
-      new RelativePattern(
-        this.workspaceFolder,
-        '**/rslint.config.{js,mjs,ts,mts}',
-      ),
-      '**/node_modules/**',
+      new RelativePattern(this.workspaceFolder, JS_CONFIG_SEARCH_GLOB),
+      JS_CONFIG_SEARCH_EXCLUDE_PATTERN,
     );
     if (!this.isLifecycleCurrent(epoch, client, pluginLintPool)) return;
     const configFiles = selectEffectiveConfigFiles(discoveredConfigFiles);
@@ -388,7 +437,7 @@ export class Rslint implements Disposable {
     const results = await Promise.allSettled(
       configFiles.map(async (uri) => {
         const fingerprintBeforeLoad = this.computeFileFingerprint(uri.fsPath);
-        const rawConfig = await this.loadConfigFresh(uri.fsPath);
+        const rawConfig = await loadConfigFileFresh(uri.fsPath);
         const entries = normalizeConfig(rawConfig);
         const sourceFingerprint = this.computeFileFingerprint(uri.fsPath);
         if (sourceFingerprint !== fingerprintBeforeLoad) {
@@ -396,6 +445,7 @@ export class Rslint implements Disposable {
         }
         return {
           configPath: uri.fsPath,
+          hierarchyDirectory: path.dirname(uri.fsPath),
           // URI form, kept byte-identical to the per-file `configKey` Go
           // returns (its `getConfigForURI` cwd) so the worker's per-config
           // dispatch keys match. Also the key Go uses in `s.jsConfigs`.
@@ -407,7 +457,6 @@ export class Rslint implements Disposable {
     );
 
     const loadedConfigs = new Map<string, LoadedConfig>();
-    const failedConfigs: Uri[] = [];
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       if (result.status === 'fulfilled') {
@@ -416,7 +465,6 @@ export class Rslint implements Disposable {
           result.value,
         );
       } else {
-        failedConfigs.push(configFiles[i]);
         this.logger.error(
           `Failed to load JS config: ${configFiles[i].fsPath}`,
           result.reason,
@@ -426,14 +474,13 @@ export class Rslint implements Disposable {
 
     const configs: LoadedConfig[] = [];
     const nextLastGoodConfigs = new Map<string, LoadedConfig>();
-    let usableConfigCount = 0;
+    const unavailableConfigs: Uri[] = [];
     for (const uri of configFiles) {
       const configPath = path.normalize(uri.fsPath);
       const loaded = loadedConfigs.get(configPath);
       if (loaded) {
         configs.push(loaded);
         nextLastGoodConfigs.set(configPath, loaded);
-        usableConfigCount++;
         continue;
       }
 
@@ -441,39 +488,55 @@ export class Rslint implements Disposable {
       if (lastGood) {
         configs.push(lastGood);
         nextLastGoodConfigs.set(configPath, lastGood);
-        usableConfigCount++;
         this.logger.error(
           `Preserving the last good JS config for ${uri.fsPath}`,
         );
         continue;
       }
 
-      // Preserve the CLI's established partial-failure behavior: log and skip
-      // a newly discovered config that has never loaded successfully. Other
-      // valid configs continue to apply, including normal ancestor fallback.
+      unavailableConfigs.push(uri);
     }
-    if (failedConfigs.length > 0 && usableConfigCount === 0) {
-      // No selected JS config has ever loaded successfully. A workspace-level
-      // empty boundary represents an explicit no-lint state; otherwise a lone
-      // broken nested config would incorrectly expose the JSON fallback in the
-      // rest of the workspace.
-      configs.length = 0;
+
+    // A failed candidate without a last-good value still owns its subtree
+    // unless a usable JS ancestor can take over. Keep only the outermost empty
+    // boundary when several unavailable candidates are nested.
+    const boundaryDirectories = selectUnavailableConfigBoundaryDirectories(
+      configs.map((config) => config.hierarchyDirectory),
+      unavailableConfigs.map((uri) => path.dirname(uri.fsPath)),
+    );
+    const unavailableByDirectory = new Map(
+      unavailableConfigs.map((uri) => [
+        path.normalize(path.dirname(uri.fsPath)),
+        uri,
+      ]),
+    );
+    for (const hierarchyDirectory of boundaryDirectories) {
+      const uri = unavailableByDirectory.get(hierarchyDirectory);
+      if (!uri) continue;
       configs.push({
-        configPath: failedConfigs[0].fsPath,
-        configDirectory: this.workspaceFolder.uri.toString(),
+        configPath: uri.fsPath,
+        hierarchyDirectory,
+        configDirectory: Uri.file(hierarchyDirectory).toString(),
         entries: [],
         sourceFingerprint: 'unavailable',
+        unavailable: true,
       });
+    }
+
+    if (boundaryDirectories.length > 0) {
       this.logger.error(
-        'No selected JS config could be loaded; linting is disabled until one loads successfully',
+        'JS configs without a usable ancestor were replaced by empty config boundaries until they load successfully',
       );
-    } else if (failedConfigs.length > 0) {
+    }
+    if (unavailableConfigs.length > boundaryDirectories.length) {
       this.logger.error(
-        'JS configs without a last-good value were skipped; remaining configs stay active',
+        'JS configs covered by an ancestor config or empty boundary were omitted from the catalog',
       );
     }
 
     configs.sort((a, b) => a.configPath.localeCompare(b.configPath));
+    const effectiveConfigs = filterEffectiveConfigCatalog(configs);
+    effectiveConfigs.sort((a, b) => a.configPath.localeCompare(b.configPath));
 
     // Collect the ESLint-plugin metadata once: the worker-pool descriptors
     // (one per config that actually mounts plugins — others stay zero-overhead)
@@ -481,7 +544,7 @@ export class Rslint implements Disposable {
     // placeholder rules. Single pass so the two never disagree about which
     // configs carry plugins.
     const { pluginConfigs: descriptors, eslintPluginEntries } =
-      collectPluginMeta(configs);
+      collectPluginMeta(effectiveConfigs);
 
     // Spin up / refresh the host. Fingerprint over the config files + lockfiles
     // so an edit or dependency install rebuilds the workers.
@@ -490,7 +553,7 @@ export class Rslint implements Disposable {
       descriptors,
       this.computeFingerprint(
         descriptors.map((c) => c.configPath),
-        configs,
+        effectiveConfigs,
       ),
       generation,
     );
@@ -529,15 +592,15 @@ export class Rslint implements Disposable {
       return;
     }
 
-    // Wire shape Go's handleConfigUpdate parses: per-config {configDirectory,
-    // entries} plus the top-level `eslintPlugins` aggregate (same shape the CLI
-    // sends in its init payload). `configPath` is a host-local detail for the
-    // worker descriptors, not the wire.
+    // Wire shape Go's handleConfigUpdate parses: per-config configDirectory,
+    // entries, and an optional unavailable-boundary marker, plus the top-level
+    // `eslintPlugins` aggregate. `configPath` is a host-local worker detail.
     try {
       await this.sendConfigUpdate(client, pluginLintPool, generation, {
-        configs: configs.map((c) => ({
+        configs: effectiveConfigs.map((c) => ({
           configDirectory: c.configDirectory,
           entries: c.entries,
+          unavailable: c.unavailable || undefined,
         })),
         eslintPlugins: eslintPluginEntries,
       });
@@ -547,31 +610,6 @@ export class Rslint implements Disposable {
     }
     this.lastGoodConfigs = nextLastGoodConfigs;
     this.hasSentJSConfig = true;
-  }
-
-  /**
-   * Load a JS/TS config file with ESM cache busting for hot reload.
-   * Appends ?t=timestamp to the file URL so that Node.js treats each
-   * reload as a new module (bypassing ESM cache). For .ts/.mts, if
-   * native import fails (e.g. Electron without strip-types), falls
-   * back to loadConfigFile which uses jiti (no caching issue).
-   */
-  private async loadConfigFresh(configPath: string): Promise<unknown> {
-    const ext = path.extname(configPath);
-    if (ext === '.js' || ext === '.mjs') {
-      const url = `${pathToFileURL(configPath).href}?t=${Date.now()}`;
-      const mod: Record<string, unknown> = await import(url);
-      return mod.default ?? mod;
-    }
-    // .ts/.mts: try native import with cache busting first (Node >= 22.6),
-    // fall back to loadConfigFile (jiti) if native TS import is not supported.
-    try {
-      const url = `${pathToFileURL(configPath).href}?t=${Date.now()}`;
-      const mod: Record<string, unknown> = await import(url);
-      return mod.default ?? mod;
-    } catch {
-      return loadConfigFile(configPath);
-    }
   }
 
   /**

--- a/packages/vscode-extension/src/Rslint.ts
+++ b/packages/vscode-extension/src/Rslint.ts
@@ -21,19 +21,21 @@ import type { Extension } from './Extension';
 import { fileExists, getPlatformBinRequests, RslintBinPath } from './utils';
 import path from 'node:path';
 import fs from 'node:fs';
+import { createHash } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 import {
   loadConfigFile,
   normalizeConfig,
   collectPluginMeta,
+  JS_CONFIG_FILES,
 } from '@rslint/core/config-loader';
 import { PluginLintPool } from './PluginLintPool';
 import type { EslintPluginLintRequest } from '@rslint/core/eslint-plugin';
 
 /**
- * Workspace-relative lockfiles whose mtime feeds the plugin-host
- * fingerprint: a dependency install can swap a plugin's implementation
- * without touching the config file, so the host must rebuild on it too.
+ * Workspace-relative lockfiles whose individual metadata feeds the
+ * plugin-host fingerprint. A dependency install can swap a plugin's
+ * implementation without touching the config file, so the host must rebuild.
  */
 const LOCKFILE_NAMES = [
   'package-lock.json',
@@ -46,6 +48,28 @@ interface LoadedConfig {
   configPath: string;
   configDirectory: string;
   entries: Record<string, unknown>[];
+  sourceFingerprint: string;
+}
+
+function selectEffectiveConfigFiles(configFiles: readonly Uri[]): Uri[] {
+  const selectedByDirectory = new Map<string, { uri: Uri; priority: number }>();
+
+  for (const uri of configFiles) {
+    const priority = JS_CONFIG_FILES.indexOf(
+      path.basename(uri.fsPath) as (typeof JS_CONFIG_FILES)[number],
+    );
+    if (priority < 0) continue;
+
+    const directory = path.normalize(path.dirname(uri.fsPath));
+    const selected = selectedByDirectory.get(directory);
+    if (!selected || priority < selected.priority) {
+      selectedByDirectory.set(directory, { uri, priority });
+    }
+  }
+
+  return [...selectedByDirectory.values()]
+    .map(({ uri }) => uri)
+    .sort((a, b) => a.fsPath.localeCompare(b.fsPath));
 }
 
 export class Rslint implements Disposable {
@@ -56,14 +80,22 @@ export class Rslint implements Disposable {
   private readonly lspOutputChannel: OutputChannel | undefined;
   private readonly outputChannel: OutputChannel | undefined;
   private configWatcher: FileSystemWatcher | undefined;
+  private dependencyWatcher: FileSystemWatcher | undefined;
   private configReloadTimer: ReturnType<typeof setTimeout> | undefined;
+  private configReloadChain: Promise<void> = Promise.resolve();
+  private lastGoodConfigs = new Map<string, LoadedConfig>();
+  private hasSentJSConfig = false;
+  private lifecycleEpoch = 0;
+  private configGeneration = 0;
+  private pluginLintPoolDisposed = false;
+  private configTransactionVersion = 0;
   /**
    * Hosts the in-process WorkerPool that answers Go's reverse
    * `rslint/pluginLint` requests for rules mounted via a config's
-   * object-form `plugins`. Lazily spins workers — stays a no-op no-worker
-   * host until a config actually mounts plugins.
+   * object-form `plugins`. It stays uninitialized until a config actually
+   * mounts plugins.
    */
-  private readonly pluginLintPool: PluginLintPool;
+  private pluginLintPool: PluginLintPool;
 
   constructor(
     extension: Extension,
@@ -84,6 +116,16 @@ export class Rslint implements Disposable {
       this.logger.warn('Rslint client is already running');
       return;
     }
+
+    if (this.pluginLintPoolDisposed) {
+      this.pluginLintPool = new PluginLintPool(this.logger);
+      this.pluginLintPoolDisposed = false;
+    }
+    this.configReloadChain = Promise.resolve();
+    this.lifecycleEpoch++;
+    const pluginLintPool = this.pluginLintPool;
+    this.hasSentJSConfig = false;
+    this.lastGoodConfigs.clear();
 
     const binPath = await this.getBinaryPath();
     this.logger.info('Rslint binary path:', binPath);
@@ -138,6 +180,10 @@ export class Rslint implements Disposable {
     try {
       await this.client.start();
 
+      this.configTransactionVersion = await this.detectConfigTransactionVersion(
+        this.client,
+      );
+
       // Answer Go's reverse `rslint/pluginLint` requests: Go lints
       // natively but dispatches rules mounted via a config's object-form
       // `plugins` back to us, where the JS WorkerPool runs them. The generic
@@ -149,7 +195,7 @@ export class Rslint implements Disposable {
       this.client.onRequest(
         'rslint/pluginLint',
         async (params: EslintPluginLintRequest, token: CancellationToken) =>
-          this.pluginLintPool.lint(params, token),
+          pluginLintPool.lint(params, token),
       );
 
       if (traceEnabled) {
@@ -159,18 +205,17 @@ export class Rslint implements Disposable {
         this.logger.info(`LSP trace level set to: ${traceServer}`);
       }
 
-      // Load JS config and send to LSP server
-      await this.loadAndSendConfig();
-
-      // Watch for JS config file changes anywhere in the workspace
+      // Install the watchers before the initial load. A file changed while the
+      // first import is running then queues a second, serialized reload instead
+      // of being missed between initial load and watcher registration.
       this.configWatcher = workspace.createFileSystemWatcher(
         new RelativePattern(
           this.workspaceFolder,
           '**/rslint.config.{ts,mts,js,mjs}',
         ),
       );
-      const reloadConfig = (uri: Uri) => {
-        this.logger.debug(`JS config file changed: ${uri.fsPath}`);
+      const reloadConfig = (kind: string) => (uri: Uri) => {
+        this.logger.debug(`${kind} changed: ${uri.fsPath}`);
         clearTimeout(this.configReloadTimer);
         this.configReloadTimer = setTimeout(() => {
           this.configReloadTimer = undefined;
@@ -179,42 +224,176 @@ export class Rslint implements Disposable {
           });
         }, 300);
       };
-      this.configWatcher.onDidChange(reloadConfig);
-      this.configWatcher.onDidCreate(reloadConfig);
-      this.configWatcher.onDidDelete(reloadConfig);
+      const reloadJSConfig = reloadConfig('JS config file');
+      this.configWatcher.onDidChange(reloadJSConfig);
+      this.configWatcher.onDidCreate(reloadJSConfig);
+      this.configWatcher.onDidDelete(reloadJSConfig);
+
+      // computeFingerprint includes workspace-root dependency lockfiles because
+      // an install can replace a mounted plugin without changing its config.
+      // The language client's watcher only informs Go; this watcher is what
+      // rebuilds the Node plugin host.
+      this.dependencyWatcher = workspace.createFileSystemWatcher(
+        new RelativePattern(
+          this.workspaceFolder,
+          '{package-lock.json,pnpm-lock.yaml,yarn.lock}',
+        ),
+      );
+      const reloadDependencies = reloadConfig('Dependency lockfile');
+      this.dependencyWatcher.onDidChange(reloadDependencies);
+      this.dependencyWatcher.onDidCreate(reloadDependencies);
+      this.dependencyWatcher.onDidDelete(reloadDependencies);
+
+      // Load JS config and send it to the LSP server. Reloads queued by either
+      // watcher above run after this call through configReloadChain.
+      await this.loadAndSendConfig();
 
       this.logger.info('Rslint language client started successfully');
     } catch (err: unknown) {
       this.logger.error('Failed to start Rslint language client', err);
+      try {
+        await this.stop();
+      } catch (cleanupError: unknown) {
+        this.logger.error(
+          'Failed to clean up a partial Rslint start',
+          cleanupError,
+        );
+      }
       throw err;
     }
   }
 
-  private async loadAndSendConfig(): Promise<void> {
-    const configFiles = await workspace.findFiles(
+  private loadAndSendConfig(): Promise<void> {
+    const epoch = this.lifecycleEpoch;
+    const client = this.client;
+    const pluginLintPool = this.pluginLintPool;
+    if (!client || this.pluginLintPoolDisposed) return Promise.resolve();
+    const reload = this.configReloadChain.then(() =>
+      this.performLoadAndSendConfig(epoch, client, pluginLintPool),
+    );
+    // Keep future reloads usable after a failed import while still returning
+    // this reload's rejection to the caller for logging.
+    this.configReloadChain = reload.catch(() => undefined);
+    return reload;
+  }
+
+  private isLifecycleCurrent(
+    epoch: number,
+    client: LanguageClient,
+    pluginLintPool: PluginLintPool,
+  ): boolean {
+    return (
+      epoch === this.lifecycleEpoch &&
+      client === this.client &&
+      pluginLintPool === this.pluginLintPool &&
+      !this.pluginLintPoolDisposed
+    );
+  }
+
+  private nextConfigGeneration(): string {
+    this.configGeneration++;
+    return String(this.configGeneration);
+  }
+
+  private async detectConfigTransactionVersion(
+    client: LanguageClient,
+  ): Promise<number> {
+    try {
+      const capabilities = await client.sendRequest<{
+        transactionVersion?: number;
+      }>('rslint/configCapabilities');
+      return capabilities.transactionVersion === 1 ? 1 : 0;
+    } catch {
+      // An older custom binary does not implement the capability request. Keep
+      // its historical notification/single-host protocol instead of hanging on
+      // a configUpdate request that never acknowledges.
+      return 0;
+    }
+  }
+
+  private async sendConfigUpdate(
+    client: LanguageClient,
+    pluginLintPool: PluginLintPool,
+    generation: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    if (this.configTransactionVersion === 1) {
+      const ack = await client.sendRequest<{ generation: string }>(
+        'rslint/configUpdate',
+        { generation, ...payload },
+      );
+      if (ack.generation !== generation) {
+        throw new Error(
+          `config update acknowledged generation ${ack.generation}, expected ${generation}`,
+        );
+      }
+      if (!(await pluginLintPool.commit(generation))) {
+        throw new Error(
+          `failed to commit plugin-host generation ${generation}`,
+        );
+      }
+      return;
+    }
+
+    // Compatibility mode for an older Go binary: it sends reverse requests
+    // without generation and accepts only the historical notification. This is
+    // necessarily best-effort rather than transactional: commit the host first
+    // so requests after the notification use the new plugins, accepting the
+    // brief pre-notification window where old config may reach the new host.
+    if (!(await pluginLintPool.commit(generation))) {
+      throw new Error(`failed to commit plugin-host generation ${generation}`);
+    }
+    await client.sendNotification('rslint/configUpdate', payload);
+  }
+
+  private async performLoadAndSendConfig(
+    epoch: number,
+    client: LanguageClient,
+    pluginLintPool: PluginLintPool,
+  ): Promise<void> {
+    if (!this.isLifecycleCurrent(epoch, client, pluginLintPool)) return;
+    const discoveredConfigFiles = await workspace.findFiles(
       new RelativePattern(
         this.workspaceFolder,
         '**/rslint.config.{js,mjs,ts,mts}',
       ),
       '**/node_modules/**',
     );
-    this.logger.debug(`Found ${configFiles.length} JS config file(s)`);
+    if (!this.isLifecycleCurrent(epoch, client, pluginLintPool)) return;
+    const configFiles = selectEffectiveConfigFiles(discoveredConfigFiles);
+    this.logger.debug(
+      `Found ${discoveredConfigFiles.length} JS config file(s); selected ${configFiles.length}`,
+    );
 
     if (configFiles.length === 0) {
-      // No JS configs found — send empty configs to clear any previous state,
-      // and tear down any plugin workers a prior config left running.
-      await this.pluginLintPool.ensure([], this.computeFingerprint([]));
-      if (!this.client) return;
-      await this.client.sendNotification('rslint/configUpdate', {
-        configs: [],
-      });
+      const generation = this.nextConfigGeneration();
+      await pluginLintPool.prepare([], this.computeFingerprint([]), generation);
+      if (!this.isLifecycleCurrent(epoch, client, pluginLintPool)) {
+        await pluginLintPool.abort(generation);
+        return;
+      }
+      try {
+        await this.sendConfigUpdate(client, pluginLintPool, generation, {
+          configs: [],
+        });
+      } catch (error) {
+        await pluginLintPool.abort(generation);
+        throw error;
+      }
+      this.lastGoodConfigs.clear();
+      this.hasSentJSConfig = false;
       return;
     }
 
     const results = await Promise.allSettled(
       configFiles.map(async (uri) => {
+        const fingerprintBeforeLoad = this.computeFileFingerprint(uri.fsPath);
         const rawConfig = await this.loadConfigFresh(uri.fsPath);
         const entries = normalizeConfig(rawConfig);
+        const sourceFingerprint = this.computeFileFingerprint(uri.fsPath);
+        if (sourceFingerprint !== fingerprintBeforeLoad) {
+          throw new Error('config changed while it was being loaded');
+        }
         return {
           configPath: uri.fsPath,
           // URI form, kept byte-identical to the per-file `configKey` Go
@@ -222,22 +401,79 @@ export class Rslint implements Disposable {
           // dispatch keys match. Also the key Go uses in `s.jsConfigs`.
           configDirectory: Uri.file(path.dirname(uri.fsPath)).toString(),
           entries,
+          sourceFingerprint,
         };
       }),
     );
 
-    const configs: LoadedConfig[] = [];
+    const loadedConfigs = new Map<string, LoadedConfig>();
+    const failedConfigs: Uri[] = [];
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       if (result.status === 'fulfilled') {
-        configs.push(result.value);
+        loadedConfigs.set(
+          path.normalize(result.value.configPath),
+          result.value,
+        );
       } else {
+        failedConfigs.push(configFiles[i]);
         this.logger.error(
           `Failed to load JS config: ${configFiles[i].fsPath}`,
           result.reason,
         );
       }
     }
+
+    const configs: LoadedConfig[] = [];
+    const nextLastGoodConfigs = new Map<string, LoadedConfig>();
+    let usableConfigCount = 0;
+    for (const uri of configFiles) {
+      const configPath = path.normalize(uri.fsPath);
+      const loaded = loadedConfigs.get(configPath);
+      if (loaded) {
+        configs.push(loaded);
+        nextLastGoodConfigs.set(configPath, loaded);
+        usableConfigCount++;
+        continue;
+      }
+
+      const lastGood = this.lastGoodConfigs.get(configPath);
+      if (lastGood) {
+        configs.push(lastGood);
+        nextLastGoodConfigs.set(configPath, lastGood);
+        usableConfigCount++;
+        this.logger.error(
+          `Preserving the last good JS config for ${uri.fsPath}`,
+        );
+        continue;
+      }
+
+      // Preserve the CLI's established partial-failure behavior: log and skip
+      // a newly discovered config that has never loaded successfully. Other
+      // valid configs continue to apply, including normal ancestor fallback.
+    }
+    if (failedConfigs.length > 0 && usableConfigCount === 0) {
+      // No selected JS config has ever loaded successfully. A workspace-level
+      // empty boundary represents an explicit no-lint state; otherwise a lone
+      // broken nested config would incorrectly expose the JSON fallback in the
+      // rest of the workspace.
+      configs.length = 0;
+      configs.push({
+        configPath: failedConfigs[0].fsPath,
+        configDirectory: this.workspaceFolder.uri.toString(),
+        entries: [],
+        sourceFingerprint: 'unavailable',
+      });
+      this.logger.error(
+        'No selected JS config could be loaded; linting is disabled until one loads successfully',
+      );
+    } else if (failedConfigs.length > 0) {
+      this.logger.error(
+        'JS configs without a last-good value were skipped; remaining configs stay active',
+      );
+    }
+
+    configs.sort((a, b) => a.configPath.localeCompare(b.configPath));
 
     // Collect the ESLint-plugin metadata once: the worker-pool descriptors
     // (one per config that actually mounts plugins — others stay zero-overhead)
@@ -249,23 +485,68 @@ export class Rslint implements Disposable {
 
     // Spin up / refresh the host. Fingerprint over the config files + lockfiles
     // so an edit or dependency install rebuilds the workers.
-    await this.pluginLintPool.ensure(
+    const generation = this.nextConfigGeneration();
+    const pluginHostReady = await pluginLintPool.prepare(
       descriptors,
-      this.computeFingerprint(configs.map((c) => c.configPath)),
+      this.computeFingerprint(
+        descriptors.map((c) => c.configPath),
+        configs,
+      ),
+      generation,
     );
 
-    if (!this.client) return;
+    if (!this.isLifecycleCurrent(epoch, client, pluginLintPool)) {
+      await pluginLintPool.abort(generation);
+      return;
+    }
+
+    // Workers re-import plugin-bearing configs. Validate every freshly-loaded
+    // source again after prepare so Go's normalized entries and the staged
+    // workers cannot commit across a concurrent config rewrite.
+    for (const loaded of loadedConfigs.values()) {
+      if (
+        this.computeFileFingerprint(loaded.configPath) !==
+        loaded.sourceFingerprint
+      ) {
+        await pluginLintPool.abort(generation);
+        throw new Error(
+          `config changed while staging workers: ${loaded.configPath}`,
+        );
+      }
+    }
+
+    // A cached config can remain usable while its file is temporarily broken,
+    // but a changed community-plugin topology cannot be reconstructed from the
+    // normalized wire entries alone. If the transactional host rebuild fails,
+    // keep the previous Go payload and previous host together. The payload is
+    // retained as a unit because plugin metadata and ordinary config entries
+    // share one configUpdate notification.
+    if (!pluginHostReady && this.hasSentJSConfig) {
+      await pluginLintPool.abort(generation);
+      this.logger.error(
+        'Failed to refresh the ESLint-plugin host; preserving the previous config payload',
+      );
+      return;
+    }
+
     // Wire shape Go's handleConfigUpdate parses: per-config {configDirectory,
     // entries} plus the top-level `eslintPlugins` aggregate (same shape the CLI
     // sends in its init payload). `configPath` is a host-local detail for the
     // worker descriptors, not the wire.
-    await this.client.sendNotification('rslint/configUpdate', {
-      configs: configs.map((c) => ({
-        configDirectory: c.configDirectory,
-        entries: c.entries,
-      })),
-      eslintPlugins: eslintPluginEntries,
-    });
+    try {
+      await this.sendConfigUpdate(client, pluginLintPool, generation, {
+        configs: configs.map((c) => ({
+          configDirectory: c.configDirectory,
+          entries: c.entries,
+        })),
+        eslintPlugins: eslintPluginEntries,
+      });
+    } catch (error) {
+      await pluginLintPool.abort(generation);
+      throw error;
+    }
+    this.lastGoodConfigs = nextLastGoodConfigs;
+    this.hasSentJSConfig = true;
   }
 
   /**
@@ -295,55 +576,87 @@ export class Rslint implements Disposable {
 
   /**
    * Fingerprint the inputs that decide whether the plugin host must rebuild:
-   * each config file's {mtime,size} plus the newest workspace lockfile mtime.
-   * A change in either can swap a mounted plugin's behavior (edit) or its code
-   * (install) without otherwise signaling us, so both feed the key. Missing
-   * files contribute a stable marker (so deletion still moves the fingerprint).
+   * each loaded config snapshot's content plus each workspace-root lockfile's
+   * existence, mtime, and size. A last-good config retains its successful snapshot while
+   * the current file is broken, keeping the worker and Go payload on the same
+   * generation. A dependency install can replace plugin code without changing
+   * config, so the lockfile also feeds the key.
    */
-  private computeFingerprint(configPaths: string[]): string {
+  private computeFileFingerprint(configPath: string): string {
+    try {
+      const content = fs.readFileSync(configPath);
+      return `${content.byteLength}:${createHash('sha256').update(content).digest('hex')}`;
+    } catch {
+      return 'absent';
+    }
+  }
+
+  private computeMetadataFingerprint(filePath: string): string {
+    try {
+      const stat = fs.statSync(filePath);
+      return `${stat.mtimeMs}:${stat.size}`;
+    } catch {
+      return 'absent';
+    }
+  }
+
+  private computeFingerprint(
+    configPaths: string[],
+    configs: readonly LoadedConfig[] = [],
+  ): string {
     const parts: string[] = [];
+    const sourceFingerprintByPath = new Map(
+      configs.map((config) => [
+        path.normalize(config.configPath),
+        config.sourceFingerprint,
+      ]),
+    );
     for (const p of [...configPaths].sort()) {
-      try {
-        const st = fs.statSync(p);
-        parts.push(`${p}:${st.mtimeMs}:${st.size}`);
-      } catch {
-        parts.push(`${p}:absent`);
-      }
+      const sourceFingerprint =
+        sourceFingerprintByPath.get(path.normalize(p)) ??
+        this.computeFileFingerprint(p);
+      parts.push(`${p}:${sourceFingerprint}`);
     }
-    let newestLock = 0;
     for (const name of LOCKFILE_NAMES) {
-      try {
-        const st = fs.statSync(
-          path.join(this.workspaceFolder.uri.fsPath, name),
-        );
-        if (st.mtimeMs > newestLock) newestLock = st.mtimeMs;
-      } catch {
-        // lockfile absent for this manager — ignore.
-      }
+      const lockPath = path.join(this.workspaceFolder.uri.fsPath, name);
+      parts.push(`lock:${name}:${this.computeMetadataFingerprint(lockPath)}`);
     }
-    parts.push(`lock:${newestLock}`);
     return parts.join('|');
   }
 
   public async stop(): Promise<void> {
-    // Tear down the plugin worker pool regardless of client state so its
-    // threads never outlive the instance.
-    await this.pluginLintPool.dispose();
+    this.lifecycleEpoch++;
+    clearTimeout(this.configReloadTimer);
+    this.configWatcher?.dispose();
+    this.configWatcher = undefined;
+    this.dependencyWatcher?.dispose();
+    this.dependencyWatcher = undefined;
+    // Do not await configReloadChain: user config evaluation can contain a
+    // non-settling top-level await. The epoch above makes any late completion
+    // side-effect free, while resetting the chain keeps a future start usable.
+    this.configReloadChain = Promise.resolve();
 
-    if (!this.client) {
+    const client = this.client;
+    this.client = undefined;
+    const pluginLintPool = this.pluginLintPool;
+    this.pluginLintPoolDisposed = true;
+
+    const [poolResult, clientResult] = await Promise.allSettled([
+      pluginLintPool.dispose(),
+      client ? client.stop() : Promise.resolve(),
+    ]);
+    if (!client) {
+      this.lastGoodConfigs.clear();
+      this.hasSentJSConfig = false;
       this.logger.debug('Rslint client is not running');
-      return;
-    }
-
-    try {
-      await this.client.stop();
+    } else if (clientResult.status === 'fulfilled') {
       this.logger.info('Rslint language client stopped');
-    } catch (err: unknown) {
-      this.logger.error('Error stopping Rslint language client', err);
-      throw err;
-    } finally {
-      this.client = undefined;
     }
+    this.lastGoodConfigs.clear();
+    this.hasSentJSConfig = false;
+    this.configTransactionVersion = 0;
+    if (poolResult.status === 'rejected') throw poolResult.reason;
+    if (clientResult.status === 'rejected') throw clientResult.reason;
   }
 
   public isRunning(): boolean {
@@ -362,14 +675,20 @@ export class Rslint implements Disposable {
   }
 
   public dispose(): void {
+    this.lifecycleEpoch++;
     clearTimeout(this.configReloadTimer);
+    this.configReloadChain = Promise.resolve();
+    this.pluginLintPoolDisposed = true;
     void this.pluginLintPool.dispose();
-    if (this.client) {
-      this.client.stop().catch((err: unknown) => {
+    const client = this.client;
+    this.client = undefined;
+    if (client) {
+      client.stop().catch((err: unknown) => {
         this.logger.error('Error disposing Rslint client', err);
       });
     }
     this.configWatcher?.dispose();
+    this.dependencyWatcher?.dispose();
     this.lspOutputChannel?.dispose();
   }
 

--- a/packages/vscode-extension/tsconfig.spec.json
+++ b/packages/vscode-extension/tsconfig.spec.json
@@ -4,7 +4,7 @@
     "outDir": ".vscode-test-out",
     "module": "commonjs",
     "moduleResolution": "node",
-    "rootDir": "./__tests__",
+    "rootDir": ".",
     "skipLibCheck": true,
     "allowArbitraryExtensions": true,
     "allowImportingTsExtensions": false,
@@ -12,6 +12,6 @@
     "emitDeclarationOnly": false
   },
   "references": [],
-  "include": ["__tests__"],
+  "include": ["__tests__", "src"],
   "exclude": ["__tests__/fixtures-*"]
 }

--- a/rslint-schema.json
+++ b/rslint-schema.json
@@ -4,7 +4,6 @@
   "title": "Rslint Configuration",
   "description": "Configuration file for Rslint - a high-performance TypeScript/JavaScript linter",
   "type": "array",
-  "minItems": 1,
   "items": {
     "$ref": "#/definitions/ConfigEntry"
   },
@@ -13,19 +12,28 @@
       "type": "object",
       "description": "A single configuration entry in the rslint.json array",
       "properties": {
-        "language": {
+        "name": {
           "type": "string",
-          "description": "Programming language for this configuration entry",
-          "enum": ["javascript"],
-          "default": "javascript"
+          "description": "Optional human-readable name for this configuration entry"
         },
         "files": {
           "type": "array",
-          "description": "Non-empty glob patterns selecting files this config entry applies to. Omit to use rslint's default lintable extensions.",
+          "description": "Non-empty file selector list. Top-level selectors are ORed; patterns inside a nested array are ANDed. Rslint unions these selectors with its default JavaScript and TypeScript extension baseline.",
           "minItems": 1,
           "items": {
-            "type": "string",
-            "description": "File pattern (glob) to include"
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "File pattern (glob) to include"
+              },
+              {
+                "type": "array",
+                "description": "File patterns that must all match",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
           }
         },
         "ignores": {
@@ -51,13 +59,25 @@
           "description": "List of plugin names to enable",
           "items": {
             "type": "string",
-            "enum": ["@typescript-eslint"]
+            "enum": [
+              "@typescript-eslint",
+              "import",
+              "jest",
+              "jsx-a11y",
+              "promise",
+              "react",
+              "react-hooks",
+              "unicorn"
+            ]
           },
           "uniqueItems": true,
           "examples": [["@typescript-eslint"]]
+        },
+        "settings": {
+          "type": "object",
+          "description": "Shared settings exposed to enabled rules"
         }
       },
-      "required": ["language"],
       "additionalProperties": false
     },
     "LanguageOptions": {
@@ -67,6 +87,19 @@
         "parserOptions": {
           "$ref": "#/definitions/ParserOptions",
           "description": "Parser-specific configuration options"
+        },
+        "globals": {
+          "type": "object",
+          "description": "Global variables available to rules for matching files",
+          "additionalProperties": {
+            "oneOf": [
+              { "type": "boolean" },
+              {
+                "type": "string",
+                "enum": ["readonly", "writable", "off"]
+              }
+            ]
+          }
         }
       },
       "additionalProperties": false
@@ -81,12 +114,20 @@
           "default": false
         },
         "project": {
-          "type": "array",
           "description": "TypeScript project configuration files to use for typed linting",
-          "items": {
-            "type": "string",
-            "description": "Path to tsconfig.json file"
-          },
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Path or glob for a tsconfig file"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Path or glob for a tsconfig file"
+              }
+            }
+          ],
           "examples": [
             ["./tsconfig.json"],
             ["./packages/*/tsconfig.json", "./tsconfig.base.json"]

--- a/rslint-schema.json
+++ b/rslint-schema.json
@@ -21,12 +21,12 @@
         },
         "files": {
           "type": "array",
-          "description": "Additional files to include beyond those specified in tsconfig.json",
+          "description": "Non-empty glob patterns selecting files this config entry applies to. Omit to use rslint's default lintable extensions.",
+          "minItems": 1,
           "items": {
             "type": "string",
             "description": "File pattern (glob) to include"
-          },
-          "default": []
+          }
         },
         "ignores": {
           "type": "array",
@@ -306,7 +306,6 @@
     [
       {
         "language": "javascript",
-        "files": [],
         "ignores": ["node_modules/**", "dist/**", "*.test.ts"],
         "languageOptions": {
           "parserOptions": {

--- a/rslint-schema.json
+++ b/rslint-schema.json
@@ -90,13 +90,22 @@
         },
         "globals": {
           "type": "object",
-          "description": "Global variables available to rules for matching files",
+          "description": "Global variables available to rules for matching files. Null is readonly; \"off\" disables a global; all other accepted values declare it as readonly or writable.",
           "additionalProperties": {
             "oneOf": [
               { "type": "boolean" },
+              { "type": "null" },
               {
                 "type": "string",
-                "enum": ["readonly", "writable", "off"]
+                "enum": [
+                  "true",
+                  "writable",
+                  "writeable",
+                  "false",
+                  "readonly",
+                  "readable",
+                  "off"
+                ]
               }
             ]
           }
@@ -301,44 +310,31 @@
       "description": "Rule configuration value",
       "oneOf": [
         {
-          "type": "string",
-          "enum": ["off", "warn", "error"],
-          "description": "Simple rule severity level"
+          "$ref": "#/definitions/RuleSeverity"
         },
         {
           "type": "array",
-          "description": "Array format rule configuration [severity, options]",
+          "description": "Array rule configuration [severity, ...positionalOptions]",
           "minItems": 1,
-          "maxItems": 2,
           "items": [
             {
-              "type": "string",
-              "enum": ["off", "warn", "error"],
-              "description": "Rule severity level"
-            },
-            {
-              "type": "object",
-              "description": "Rule-specific options",
-              "additionalProperties": true
+              "$ref": "#/definitions/RuleSeverity"
             }
-          ]
+          ],
+          "additionalItems": true
+        }
+      ]
+    },
+    "RuleSeverity": {
+      "description": "Rule severity: 0/off, 1/warn, or 2/error",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["off", "warn", "error"]
         },
         {
-          "type": "object",
-          "description": "Object format rule configuration",
-          "properties": {
-            "level": {
-              "type": "string",
-              "enum": ["off", "warn", "error"],
-              "description": "Rule severity level"
-            },
-            "options": {
-              "type": "object",
-              "description": "Rule-specific options",
-              "additionalProperties": true
-            }
-          },
-          "additionalProperties": false
+          "type": "integer",
+          "enum": [0, 1, 2]
         }
       ]
     }
@@ -346,7 +342,6 @@
   "examples": [
     [
       {
-        "language": "javascript",
         "ignores": ["node_modules/**", "dist/**", "*.test.ts"],
         "languageOptions": {
           "parserOptions": {

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -328,6 +328,7 @@ nilerr
 nilnesserr
 nilnil
 Nkoo
+nocase
 noconfig
 nodesep
 noembed

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -267,6 +267,7 @@ libsyncrpc
 lifecycles
 Lingui
 lingui
+lintable
 lintedfile
 listitem
 llms

--- a/website/docs/en/config/ignoring-files.md
+++ b/website/docs/en/config/ignoring-files.md
@@ -98,7 +98,7 @@ For directory-level patterns (`dir/**`), `!` negation cannot re-include files be
 
 ## .gitignore integration
 
-Rslint automatically reads `.gitignore` files and treats their patterns as additional global ignores. This means files ignored by git (build outputs, coverage reports, etc.) are also ignored by the linter without extra configuration.
+The CLI and JavaScript API automatically read `.gitignore` files and treat their patterns as additional global ignores. This means files ignored by git (build outputs, coverage reports, etc.) are also ignored by those integrations without extra configuration. The LSP does not currently read `.gitignore`; use a config global ignore when editor diagnostics must follow the same exclusion.
 
 - **Nested `.gitignore` files** are supported — each one only affects its own directory subtree
 - **Parent patterns cascade** to child directories (e.g., root `dist/` also ignores `packages/app/dist/`)

--- a/website/docs/en/config/ignoring-files.md
+++ b/website/docs/en/config/ignoring-files.md
@@ -4,7 +4,7 @@
 
 - **Type:** `string[]`
 
-Glob patterns for files to exclude. An entry with **only** `ignores` (no other fields) acts as a global ignore — matching files are excluded from all rules.
+Glob patterns for files to exclude. An entry containing **only** `ignores` and an optional `name` acts as a global ignore: matching files are removed from the lint target set. An entry-level ignore only prevents that entry from contributing rules and options; it does not prevent another entry or the zero-rule syntax pass from processing the target.
 
 ```ts
 // Global ignore entry

--- a/website/docs/en/config/ignoring-files.md
+++ b/website/docs/en/config/ignoring-files.md
@@ -4,7 +4,7 @@
 
 - **Type:** `string[]`
 
-Glob patterns for files to exclude. An entry containing **only** `ignores` and an optional `name` acts as a global ignore: matching files are removed from the lint target set. An entry-level ignore only prevents that entry from contributing rules and options; it does not prevent another entry or the zero-rule syntax pass from processing the target.
+Glob patterns for files to exclude. An entry containing **only** `ignores` and an optional `name` acts as a global ignore: matching files are removed from the lint target set. An entry-level ignore prevents that entry's `files` selector, rules, and options from contributing. It cannot remove a path selected by the default extension baseline or another entry, so such a path may still receive configuration or a zero-rule syntax pass.
 
 ```ts
 // Global ignore entry

--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -4,14 +4,15 @@ Rslint uses a flat config format (an array of config entries), aligned with ESLi
 
 ## Configuration Files
 
-Rslint looks for config files in the following order:
+During automatic discovery, Rslint checks config files in the following order:
 
 1. `rslint.config.js`
 2. `rslint.config.mjs`
-3. `rslint.config.cjs`
-4. `rslint.config.ts`
-5. `rslint.config.mts`
-6. `rslint.config.cts`
+3. `rslint.config.ts`
+4. `rslint.config.mts`
+
+Automatic discovery does not consider `.cjs` or `.cts` config files. They can
+still be selected explicitly with `--config` or API `overrideConfigFile`.
 
 ### Config Discovery
 
@@ -106,7 +107,7 @@ Glob selectors specifying which files this config entry applies to. Top-level se
 
 If `files` is present, its outer array must be non-empty. Use an omitted `files` field for shared/default entries; `files: []` is invalid. A nested empty AND group (`files: [[]]`) is valid and matches vacuously.
 
-Lint targets are selected from the CLI/API target range. Rslint always includes its default extension baseline and adds paths selected by explicit `files` entries unless the same entry's `ignores` excludes them. Global ignores and `.gitignore` then remove targets. An entry-level ignore cannot remove a path selected by the baseline or another entry; it only prevents its own selector and config contribution. An explicitly requested file outside the selector union is still parsed and included in the results, but no lint rules run for it; syntax diagnostics can still be reported.
+Lint targets are selected from the CLI/API target range and are limited to Rslint's supported script extensions. Rslint always includes its default extension baseline and adds other supported candidates selected by explicit `files` entries unless the same entry's `ignores` excludes them. A `files` selector cannot make an unsupported source extension lintable. Global ignores then remove targets; CLI and JavaScript API runs also apply `.gitignore`. An entry-level ignore cannot remove a path selected by the baseline or another entry; it only prevents its own selector and config contribution. Every selected target is parsed even when no config entry contributes rules, so syntax diagnostics can still be reported. This includes default-baseline files found by a directory or no-argument scan and explicitly requested supported files that do not match a config entry's `files`.
 
 The implicit default baseline is:
 
@@ -119,7 +120,7 @@ The implicit default baseline is:
 - `.mts`
 - `.cts`
 
-This is independent of tsconfig's `include`: a file in tsconfig but outside rslint's lint target set will not run lint rules, while a selected file not covered by a tsconfig declared by its governing config still runs syntax-only rules.
+This is independent of tsconfig's `include`: a file in tsconfig but outside rslint's lint target set will not run lint rules, while a selected file not covered by a tsconfig declared by its governing config still runs rules that do not require type information.
 
 ```ts
 {
@@ -211,7 +212,7 @@ Enable TypeScript's project service for automatic tsconfig discovery. This is th
 
 - **Type:** `string | string[]`
 
-Explicit tsconfig.json paths. Supports glob patterns for monorepos. Files included by these tsconfigs receive full type information, enabling type-aware rules (e.g. `@typescript-eslint/no-floating-promises`, `@typescript-eslint/await-thenable`). Files outside all tsconfigs are still linted but only with syntax-level rules.
+Explicit tsconfig.json paths. Supports glob patterns for monorepos. Files included by these tsconfigs receive full type information, enabling type-aware rules (e.g. `@typescript-eslint/no-floating-promises`, `@typescript-eslint/await-thenable`). Files outside all tsconfigs are still linted, but only rules that do not require type information run.
 
 ```ts
 {
@@ -265,7 +266,7 @@ When multiple config entries match a file, they are merged in array order:
 7. **Settings** — ordinary nested objects merge recursively; arrays and scalar values are replaced
 8. **Language options** — ordinary nested objects merge recursively; arrays and scalar values are replaced
 
-If no entry matches a file, no lint rules run for it. An explicitly requested file is still parsed and included in the result unless a global ignore or `.gitignore` excludes it, so parser diagnostics can remain visible without configured rules.
+If no entry matches a selected file, no lint rules run for it, but the file is still parsed and included in the result so parser diagnostics remain visible. This applies to default-baseline files found during directory discovery as well as explicitly requested supported files. Global ignores remove matching targets; CLI and JavaScript API runs apply `.gitignore` as an additional global ignore source.
 
 ## JSON Configuration (Deprecated)
 

--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -36,22 +36,22 @@ When linting from the monorepo root, rslint automatically discovers all nested c
 
 #### Global Ignores and Nested Configs
 
-Global ignores in a parent config prevent nested configs in ignored directories from being discovered. This aligns with ESLint v10 behavior.
+For directory or no-argument lint runs, global ignores in a parent config prevent nested configs in ignored directories from contributing lint targets.
 
 ```ts
 // monorepo/rslint.config.ts
 export default defineConfig([
-  // Global ignore — blocks config discovery in these directories
+  // Global ignore — blocks directory target discovery in these directories
   { ignores: ['**/fixtures/**', 'e2e/**'] },
   ts.configs.recommended,
   // ...
 ]);
 ```
 
-With this config, a `rslint.config.ts` inside `e2e/` or any `fixtures/` directory will **not** be used when linting from the monorepo root. This prevents test fixture configs from interfering with the main lint run.
+With this config, a `rslint.config.ts` inside `e2e/` or any `fixtures/` directory is not used by a root directory traversal. An explicitly named file is still resolved from its nearest config, matching the explicit-target behavior described below.
 
 :::tip
-Only **global ignore entries** (entries with only `ignores` and no other fields) block nested config discovery. Entry-level ignores (entries with both `files` and `ignores`) do not affect config discovery.
+Only **global ignore entries** (entries with only `ignores` and an optional `name`) block directory target discovery. Entry-level ignores do not affect config discovery.
 :::
 
 You can also specify a config file explicitly (overrides automatic discovery):
@@ -98,15 +98,15 @@ For available presets, rule severity, and plugin configuration, see [Rules & Pre
 
 ### files
 
-- **Type:** `string[]`
+- **Type:** `(string | string[])[]`
 
-Glob patterns specifying which files this config entry applies to. If omitted, the entry applies to rslint's default lintable file set.
+Glob selectors specifying which files this config entry applies to. Top-level selectors are ORed. Patterns in a nested array are ANDed, so `files: [['**/*.js', '!**/*.test.js']]` selects JavaScript files except test files. If omitted, the entry cascades across files selected by the config's implicit or explicit selectors.
 
 If `files` is present, it must contain at least one pattern. Use an omitted `files` field for shared/default entries; `files: []` is invalid.
 
-Lint targets are selected from the CLI/API target range, then filtered by `files`, global ignores, and `.gitignore`. Explicit file arguments are the exception: an explicit file can still appear as a lint result even when it does not match any `files` pattern, but no rules run unless at least one config entry applies to that file. Global ignores and `.gitignore` still remove explicit files from the result set.
+Lint targets are selected from the CLI/API target range. Rslint always includes its default extension baseline, unions every explicit `files` pattern, and then removes global ignores and `.gitignore` matches. Entry-level ignores skip that entry during config merging but do not remove the file from the target set. Explicit file arguments can also appear as 0-rule results outside the selector union. Every selected target is parsed, so syntax diagnostics can still be reported when no rules apply.
 
-Each non-global entry that omits `files` contributes this default set:
+The implicit default baseline is:
 
 - `.js`
 - `.mjs`
@@ -117,7 +117,7 @@ Each non-global entry that omits `files` contributes this default set:
 - `.mts`
 - `.cts`
 
-This is independent of tsconfig's `include`: a file in tsconfig but not selected by rslint's lint scope will not be linted, while a selected file that is not in any tsconfig will still be linted with syntax-only rules (type-aware rules require tsconfig coverage).
+This is independent of tsconfig's `include`: a file in tsconfig but outside rslint's lint target set will not run lint rules, while a selected file not covered by a tsconfig declared by its governing config still runs syntax-only rules.
 
 ```ts
 {
@@ -127,7 +127,7 @@ This is independent of tsconfig's `include`: a file in tsconfig but not selected
 ```
 
 :::tip
-Files that match `files` but are not included in any tsconfig automatically receive a reduced rule set — only rules that don't require type information will run. To enable type-aware rules for these files, add them to your tsconfig's `include`.
+Selected files not covered by a tsconfig declared by their governing config automatically receive a reduced rule set: only rules that do not require type information run. To enable type-aware rules, add the file to one of that config's tsconfigs.
 :::
 
 ### ignores
@@ -224,13 +224,14 @@ Shared settings accessible to all rules. Later entries override earlier ones.
 
 When multiple config entries match a file, they are merged in array order:
 
-1. **Global ignores** — entries with only `ignores` exclude files from all rules
-2. **Files matching** — entries whose `files` patterns don't match are skipped
-3. **Entry-level ignores** — entries whose `ignores` match are skipped
-4. **Rules** — shallow merge, later entries override earlier ones
-5. **Plugins** — union from all matching entries
-6. **Settings** — shallow merge
-7. **Language options** — deep merge at field level
+1. **Global ignores** — entries containing only `ignores` and an optional `name` remove files from the target set
+2. **Selector union** — the implicit default baseline and explicit `files` patterns decide whether the config selects the file
+3. **Files matching** — entries whose explicit `files` patterns don't match are skipped; entries without `files` cascade across the selector union
+4. **Entry-level ignores** — matching entries are skipped without removing the target
+5. **Rules** — shallow merge, later entries override earlier ones
+6. **Plugins** — union from all matching entries
+7. **Settings** — shallow merge
+8. **Language options** — parser options merge by field and globals merge by name
 
 If no entry matches a file, no rules run for it. Explicit file arguments may still be reported as 0-rule results unless global ignores or `.gitignore` exclude them.
 

--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -104,7 +104,7 @@ Glob patterns specifying which files this config entry applies to. If omitted, t
 
 If `files` is present, it must contain at least one pattern. Use an omitted `files` field for shared/default entries; `files: []` is invalid.
 
-Lint targets are selected from the CLI/API target range, then filtered by `files`, global ignores, and `.gitignore`. Explicit file arguments are the exception: an explicit file can still appear as a lint result even when it does not match any `files` pattern, but no rules run for it unless `GetConfigForFile` finds a matching entry. Global ignores and `.gitignore` still remove explicit files from the result set.
+Lint targets are selected from the CLI/API target range, then filtered by `files`, global ignores, and `.gitignore`. Explicit file arguments are the exception: an explicit file can still appear as a lint result even when it does not match any `files` pattern, but no rules run unless at least one config entry applies to that file. Global ignores and `.gitignore` still remove explicit files from the result set.
 
 Each non-global entry that omits `files` contributes this default set:
 

--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -100,9 +100,24 @@ For available presets, rule severity, and plugin configuration, see [Rules & Pre
 
 - **Type:** `string[]`
 
-Glob patterns specifying which files this config entry applies to. If omitted, the entry applies to all files matched by other entries.
+Glob patterns specifying which files this config entry applies to. If omitted, the entry applies to rslint's default lintable file set.
 
-The `files` field determines the **lint scope** — only files matching at least one entry's `files` pattern will be linted. This is independent of tsconfig's `include`: a file in tsconfig but not matching any `files` pattern will not be linted, while a file matching `files` but not in any tsconfig will still be linted with syntax-only rules (type-aware rules require tsconfig coverage).
+If `files` is present, it must contain at least one pattern. Use an omitted `files` field for shared/default entries; `files: []` is invalid.
+
+Lint targets are selected from the CLI/API target range, then filtered by `files`, global ignores, and `.gitignore`. Explicit file arguments are the exception: an explicit file can still appear as a lint result even when it does not match any `files` pattern, but no rules run for it unless `GetConfigForFile` finds a matching entry. Global ignores and `.gitignore` still remove explicit files from the result set.
+
+Each non-global entry that omits `files` contributes this default set:
+
+- `.js`
+- `.mjs`
+- `.cjs`
+- `.jsx`
+- `.ts`
+- `.tsx`
+- `.mts`
+- `.cts`
+
+This is independent of tsconfig's `include`: a file in tsconfig but not selected by rslint's lint scope will not be linted, while a selected file that is not in any tsconfig will still be linted with syntax-only rules (type-aware rules require tsconfig coverage).
 
 ```ts
 {
@@ -217,7 +232,7 @@ When multiple config entries match a file, they are merged in array order:
 6. **Settings** — shallow merge
 7. **Language options** — deep merge at field level
 
-If no entry matches a file, it is not linted.
+If no entry matches a file, no rules run for it. Explicit file arguments may still be reported as 0-rule results unless global ignores or `.gitignore` exclude them.
 
 ## JSON Configuration (Deprecated)
 

--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -8,12 +8,14 @@ Rslint looks for config files in the following order:
 
 1. `rslint.config.js`
 2. `rslint.config.mjs`
-3. `rslint.config.ts`
-4. `rslint.config.mts`
+3. `rslint.config.cjs`
+4. `rslint.config.ts`
+5. `rslint.config.mts`
+6. `rslint.config.cts`
 
 ### Config Discovery
 
-When you run `rslint`, it searches for the config file by walking **upward** from the target file or directory to the filesystem root, stopping at the first config found.
+When you run `rslint`, it searches for a config file by walking **upward** from the target file or directory to the filesystem root. It uses the nearest candidate that loads successfully and falls back to an ancestor when a nearer candidate cannot be loaded.
 
 - `rslint src/foo.ts` — searches from `src/` upward
 - `rslint src/` — searches from `src/` upward
@@ -102,9 +104,9 @@ For available presets, rule severity, and plugin configuration, see [Rules & Pre
 
 Glob selectors specifying which files this config entry applies to. Top-level selectors are ORed. Patterns in a nested array are ANDed, so `files: [['**/*.js', '!**/*.test.js']]` selects JavaScript files except test files. If omitted, the entry cascades across files selected by the config's implicit or explicit selectors.
 
-If `files` is present, it must contain at least one pattern. Use an omitted `files` field for shared/default entries; `files: []` is invalid.
+If `files` is present, its outer array must be non-empty. Use an omitted `files` field for shared/default entries; `files: []` is invalid. A nested empty AND group (`files: [[]]`) is valid and matches vacuously.
 
-Lint targets are selected from the CLI/API target range. Rslint always includes its default extension baseline, unions every explicit `files` pattern, and then removes global ignores and `.gitignore` matches. Entry-level ignores skip that entry during config merging but do not remove the file from the target set. Explicit file arguments can also appear as 0-rule results outside the selector union. Every selected target is parsed, so syntax diagnostics can still be reported when no rules apply.
+Lint targets are selected from the CLI/API target range. Rslint always includes its default extension baseline and adds paths selected by explicit `files` entries unless the same entry's `ignores` excludes them. Global ignores and `.gitignore` then remove targets. An entry-level ignore cannot remove a path selected by the baseline or another entry; it only prevents its own selector and config contribution. An explicitly requested file outside the selector union is still parsed and included in the results, but no lint rules run for it; syntax diagnostics can still be reported.
 
 The implicit default baseline is:
 
@@ -136,7 +138,14 @@ For file exclusion patterns, negation, and `.gitignore` integration, see [Ignori
 
 ### rules
 
-For rule severity levels, option format, and plugin configuration, see [Rules & Presets](/config/rules-and-presets).
+- **Type:** `RuleSeverity | [RuleSeverity, ...unknown[]]`
+- **RuleSeverity:** `'off' | 'warn' | 'error' | 0 | 1 | 2`
+
+The numeric levels follow ESLint: `0` disables a rule, `1` reports warnings, and `2` reports errors. Array entries pass every item after the severity to the rule as positional options, so configurations such as `['error', 'always', { exceptRange: true }]` are supported. Invalid severities and rule value shapes are rejected while the configuration is loaded.
+
+When a later matching entry changes only the severity, the rule keeps options from the earlier entry. Supplying any positional option in the later array replaces the earlier options.
+
+For available rules, presets, and plugin configuration, see [Rules & Presets](/config/rules-and-presets).
 
 ### plugins
 
@@ -158,7 +167,7 @@ Built-in plugin names: `@typescript-eslint`, `import`, `jest`, `jsx-a11y`, `prom
 }
 ```
 
-**Object of plugin instances** — community ESLint plugins. Map a prefix key to an imported plugin object, then enable its rules under the `<prefix>/<rule>` namespace. The plugin's JS rules run in a Node worker. Requires a JS/TS config — a live plugin object can't be expressed in JSON.
+**Object of plugin instances** — third-party ESLint plugins. Map a prefix key to an imported plugin object, then enable its rules under the `<prefix>/<rule>` namespace. These JavaScript rules run in the Node plugin worker and are routed through the same per-file flat config as native rules. This form requires a JS/TS config because JSON cannot carry a live plugin object.
 
 ```ts
 import examplePlugin from 'eslint-plugin-example';
@@ -172,7 +181,7 @@ import examplePlugin from 'eslint-plugin-example';
 }
 ```
 
-A single entry uses one form. To combine built-in and community plugins, declare them in separate config entries (merged at lint time). A community prefix may not collide with a built-in plugin name.
+A single entry uses one form. To combine built-in and third-party plugins, declare them in separate config entries; matching entries are merged before linting. A third-party prefix may not collide with a built-in plugin name.
 
 ESLint core rules (unprefixed names like `no-unused-vars` or `prefer-const`) are not part of any plugin and can be enabled directly in `rules` without listing anything here. Presets like `ts.configs.recommended` already include their own `plugins` entry, so you only need this field when configuring plugin rules outside a preset.
 
@@ -214,26 +223,49 @@ Explicit tsconfig.json paths. Supports glob patterns for monorepos. Files includ
 }
 ```
 
+#### languageOptions.globals
+
+- **Type:** `Record<string, boolean | null | 'true' | 'false' | 'readonly' | 'readable' | 'writable' | 'writeable' | 'off'>`
+
+Declares globals available to matching files. Values are normalized before rules or third-party plugins receive the scope:
+
+- Writable: `true`, `'true'`, `'writable'`, `'writeable'`
+- Read-only: `false`, `null`, `'false'`, `'readonly'`, `'readable'`
+- Disabled: `'off'`
+
+A disabled value removes a declaration inherited from an earlier matching entry, including an ECMAScript built-in in the third-party plugin scope.
+
+```ts
+{
+  languageOptions: {
+    globals: {
+      BUILD_ID: 'readonly',
+      testRuntime: 'writable',
+    },
+  },
+}
+```
+
 ### settings
 
 - **Type:** `Record<string, unknown>`
 
-Shared settings accessible to all rules. Later entries override earlier ones.
+Shared settings accessible to all rules. Ordinary nested objects are merged recursively; later arrays and scalar values replace earlier values.
 
 ## Config Merging
 
 When multiple config entries match a file, they are merged in array order:
 
 1. **Global ignores** — entries containing only `ignores` and an optional `name` remove files from the target set
-2. **Selector union** — the implicit default baseline and explicit `files` patterns decide whether the config selects the file
+2. **Selector union** — the implicit default baseline and effective explicit `files` entries decide whether the config selects the file
 3. **Files matching** — entries whose explicit `files` patterns don't match are skipped; entries without `files` cascade across the selector union
-4. **Entry-level ignores** — matching entries are skipped without removing the target
-5. **Rules** — shallow merge, later entries override earlier ones
+4. **Entry-level ignores** — matching entries do not select or configure the file, but cannot remove a target selected elsewhere
+5. **Rules** — later entries override earlier ones; a severity-only value retains earlier options
 6. **Plugins** — union from all matching entries
-7. **Settings** — shallow merge
-8. **Language options** — parser options merge by field and globals merge by name
+7. **Settings** — ordinary nested objects merge recursively; arrays and scalar values are replaced
+8. **Language options** — ordinary nested objects merge recursively; arrays and scalar values are replaced
 
-If no entry matches a file, no rules run for it. Explicit file arguments may still be reported as 0-rule results unless global ignores or `.gitignore` exclude them.
+If no entry matches a file, no lint rules run for it. An explicitly requested file is still parsed and included in the result unless a global ignore or `.gitignore` excludes it, so parser diagnostics can remain visible without configured rules.
 
 ## JSON Configuration (Deprecated)
 

--- a/website/docs/en/guide/cli.md
+++ b/website/docs/en/guide/cli.md
@@ -44,7 +44,7 @@ When no arguments are given, rslint scopes linting to the current working direct
 
 ### Config Discovery
 
-For each target file or directory, rslint searches for `rslint.config.{js,mjs,ts,mts}` starting from that location and walking upward to the filesystem root. The first config found is used.
+For each target file or directory, rslint searches for `rslint.config.{js,mjs,cjs,ts,mts,cts}` starting from that location and walking upward to the filesystem root. The nearest successfully loaded config is used. If a discovered config cannot be loaded, rslint warns and tries its next ancestor; the command fails when none of the discovered candidates can be loaded.
 
 In monorepo setups, rslint automatically discovers nested configs and applies the nearest one to each file:
 

--- a/website/docs/en/guide/cli.md
+++ b/website/docs/en/guide/cli.md
@@ -14,6 +14,7 @@ rslint [options] [files/directories...]
 | `-c, --config <path>` | Specify which config file to use                                                               |
 | `--fix`               | Automatically fix problems                                                                     |
 | `--type-check`        | Enable TypeScript semantic type checking ([details](/guide/type-checking))                     |
+| `--type-check-only`   | Run TypeScript semantic type checking without lint rules ([details](/guide/type-checking))     |
 | `--format <format>`   | Output format: `default`, `jsonline`, `github`, or `gitlab` ([details](/guide/output-formats)) |
 | `--quiet`             | Report errors only, suppress warnings                                                          |
 | `--max-warnings <n>`  | Exit with error if warning count exceeds this number                                           |
@@ -44,7 +45,9 @@ When no arguments are given, rslint scopes linting to the current working direct
 
 ### Config Discovery
 
-For each target file or directory, rslint searches for `rslint.config.{js,mjs,cjs,ts,mts,cts}` starting from that location and walking upward to the filesystem root. The nearest successfully loaded config is used. If a discovered config cannot be loaded, rslint warns and tries its next ancestor; the command fails when none of the discovered candidates can be loaded.
+For each target file or directory, rslint searches for `rslint.config.{js,mjs,ts,mts}` starting from that location and walking upward to the filesystem root. The nearest successfully loaded config is used. If a discovered config cannot be loaded, rslint warns and tries its next ancestor; the command fails when none of the discovered candidates can be loaded.
+
+`.cjs` and `.cts` config files are not discovered automatically, but remain supported when passed explicitly with `--config` or `-c`.
 
 In monorepo setups, rslint automatically discovers nested configs and applies the nearest one to each file:
 
@@ -106,3 +109,4 @@ rslint src/ --rule 'no-console: off' --format github
 | ---- | ------------------------------------------------- |
 | `0`  | No errors (warnings may be present)               |
 | `1`  | Errors found, or warnings exceed `--max-warnings` |
+| `2`  | Invalid command-line usage or flag combinations   |

--- a/website/docs/en/guide/js-api.md
+++ b/website/docs/en/guide/js-api.md
@@ -21,7 +21,7 @@ for (const result of results) {
 
 ## Linting files
 
-`lintFiles` takes one or more glob patterns (resolved against `cwd`) and lints every matching file. By default the nearest config is auto-discovered from `cwd`.
+`lintFiles` takes one or more glob patterns resolved against `cwd`. It keeps supported source-file extensions that are not excluded by global config ignores or `.gitignore`. With automatic discovery, each selected file is routed to its nearest loadable config, so files in different monorepo packages can use different configs.
 
 ```ts
 const results = await rslint.lintFiles(['src/**/*.ts', 'test/**/*.ts']);
@@ -43,19 +43,19 @@ const [result] = await rslint.lintText('const x = 1', {
 
 `lintText` always returns exactly one result — for the linted buffer. If you omit `filePath`, the result's `filePath` is the `"<text>"` sentinel (matching ESLint).
 
-## Fully in-memory linting
+## In-memory linting
 
-By default `lintText` still reads the config and tsconfig from disk. To lint with **no disk access at all** — source, config, and tsconfig all in memory — combine `overrideConfigFile: true` (use only the inline config), an inline `overrideConfig`, and a `virtualFiles` overlay:
+By default `lintText` still reads the config and tsconfig from disk. To provide the source, config, tsconfig, and project files from memory, combine `overrideConfigFile: true` (use only the inline config), an inline `overrideConfig`, and a `virtualFiles` overlay:
 
 ```ts
 const rslint = new Rslint({
-  cwd: '/', // virtual root: doesn't touch the host cwd or disk
+  cwd: '/', // stable root for the virtual paths below
   overrideConfigFile: true, // use only overrideConfig — skip config discovery
   overrideConfig: [
     {
       files: ['**/*.ts'],
       // The tsconfig + parserOptions.project below are needed ONLY for
-      // type-aware rules (like no-for-in-array). Syntax-only rules need neither.
+      // type-aware rules (like no-for-in-array). Other rules need neither.
       languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
       plugins: ['@typescript-eslint'],
       rules: { '@typescript-eslint/no-for-in-array': 'error' },
@@ -75,11 +75,11 @@ const [result] = await rslint.lintText(
 );
 ```
 
-`virtualFiles` is an in-memory file overlay (path → content) — an rslint extension; ESLint has no in-memory file map. Type-aware rules run against it with no disk access: put the `tsconfig.json` that `parserOptions.project` names, plus any dependency files, in the overlay.
+`virtualFiles` is an in-memory file overlay (path → content) — an rslint extension; ESLint has no in-memory file map. Put the `tsconfig.json` that `parserOptions.project` names, plus any dependency files, in the overlay. The overlay does not disable filesystem fallback: rslint may still consult disk for `.gitignore` and TypeScript resolution, so this API is not a filesystem sandbox.
 
 **Declaring plugins.** A rule from a plugin (`@typescript-eslint/*`, `unicorn/*`, and so on) runs only when that plugin is listed in `plugins` — rslint enforces this exactly like ESLint. Core rules (no `/` prefix) need no declaration.
 
-**Type-aware vs syntax-only rules.** The `tsconfig.json` and `parserOptions.project` matter only for **type-aware** rules, which need a real TypeScript program (see [Type Checking](/guide/type-checking)). If your config has only syntax-only rules, you can drop both — no tsconfig, no `parserOptions.project`.
+**Type-aware vs non-type-aware rules.** The `tsconfig.json` and `parserOptions.project` matter only for **type-aware** rules, which need a real TypeScript program (see [Type Checking](/guide/type-checking)). If your config has only rules that do not require type information, you can drop both — no tsconfig, no `parserOptions.project`.
 
 **Use relative paths** in `virtualFiles` keys and inside the tsconfig:
 
@@ -175,4 +175,4 @@ Each `LintMessage`:
 | `overrideConfig`     | `RslintConfigEntry \| RslintConfigEntry[] \| null` | —           | Extra config appended after the resolved/discovered config (ESLint's `overrideConfig`)                                                 |
 | `overrideConfigFile` | `string \| true \| null`                           | `null`      | `string`: use this config file (no discovery); `true`: use only `overrideConfig` (no file, no discovery); `null`/absent: auto-discover |
 | `fix`                | `boolean`                                          | `false`     | Apply rule auto-fixes; results carry `output`                                                                                          |
-| `virtualFiles`       | `Record<string, string>`                           | —           | In-memory file overlay (path → content) for fully in-memory linting                                                                    |
+| `virtualFiles`       | `Record<string, string>`                           | —           | In-memory file overlay (path → content); unresolved reads may fall back to disk                                                        |

--- a/website/docs/en/guide/type-checking.md
+++ b/website/docs/en/guide/type-checking.md
@@ -28,7 +28,7 @@ rslint --type-check .         # lint + type-check
 rslint --type-check-only .    # type-check only
 ```
 
-Without `parserOptions.project` no TypeScript program is built and type-check produces no diagnostics.
+When `parserOptions.project` is omitted, rslint uses `tsconfig.json` in the governing config directory when present. If neither configured projects nor that fallback tsconfig exist, no real TypeScript Program is built and type-check produces no diagnostics for that config.
 
 ## What gets type-checked
 
@@ -44,7 +44,7 @@ parserOptions: {
 }
 ```
 
-Each entry produces one TypeScript program. Type-check runs over every program independently.
+Each canonical tsconfig produces one TypeScript Program, even when multiple rslint configs reference it. Rslint retains every config association and project declaration order for lint-rule binding. Type-check runs over every real Program independently.
 
 **The type-check scope is each tsconfig's `include` / `files` minus `exclude` — nothing in your rslint config or on the CLI changes it.** Specifically, the following are **lint-phase concepts** that do **not** affect type-check scope:
 
@@ -57,7 +57,7 @@ If a file is included by tsconfig but matched by rslint `ignores`, lint rules do
 
 ### Gap files
 
-Files that match your rslint config's `files` pattern but are **not** in any tsconfig (root-level scripts, ad-hoc config files, etc.) are called _gap files_. Syntactic lint rules still run on them, but type-check skips them — semantic type information requires tsconfig coverage. To enable type-check for a gap file, add it to an existing tsconfig's `include` or create a dedicated tsconfig that covers it.
+Selected files that are **not** present in any tsconfig Program declared by their governing config (root-level scripts, ad-hoc config files, etc.) are called _gap files_. They receive an AST-only fallback Program, so syntax-only rules still run but type-aware rules do not. The program-wide type-check phase also skips the fallback. To enable type information, add the file to one of the governing config's tsconfigs or declare a dedicated project there.
 
 ## Output
 

--- a/website/docs/en/guide/type-checking.md
+++ b/website/docs/en/guide/type-checking.md
@@ -44,7 +44,7 @@ parserOptions: {
 }
 ```
 
-Each canonical tsconfig produces one TypeScript Program, even when multiple rslint configs reference it. Rslint retains every config association and project declaration order for lint-rule binding. Type-check runs over every real Program independently.
+Each normalized declared tsconfig path produces one TypeScript Program, even when multiple rslint configs reference that path. File-symlink declarations remain distinct because TypeScript resolves relative paths from the declared location. Rslint retains every config association and project declaration order for lint-rule binding. Type-check runs over every real Program independently.
 
 **The type-check scope is each tsconfig's `include` / `files` minus `exclude` — nothing in your rslint config or on the CLI changes it.** Specifically, the following are **lint-phase concepts** that do **not** affect type-check scope:
 
@@ -57,7 +57,7 @@ If a file is included by tsconfig but matched by rslint `ignores`, lint rules do
 
 ### Gap files
 
-Selected files that are **not** present in any tsconfig Program declared by their governing config (root-level scripts, ad-hoc config files, etc.) are called _gap files_. They receive an AST-only fallback Program, so syntax-only rules still run but type-aware rules do not. The program-wide type-check phase also skips the fallback. To enable type information, add the file to one of the governing config's tsconfigs or declare a dedicated project there.
+Selected files that are **not** present in any tsconfig Program declared by their governing config (root-level scripts, ad-hoc config files, etc.) are called _gap files_. They receive a non-project-backed fallback Program, so syntax-only rules still run but type-aware rules do not. The program-wide type-check phase also skips the fallback. To enable type information, add the file to one of the governing config's tsconfigs or declare a dedicated project there.
 
 ## Output
 

--- a/website/docs/en/guide/type-checking.md
+++ b/website/docs/en/guide/type-checking.md
@@ -44,9 +44,9 @@ parserOptions: {
 }
 ```
 
-Each normalized declared tsconfig path produces one TypeScript Program, even when multiple rslint configs reference that path. File-symlink declarations remain distinct because TypeScript resolves relative paths from the declared location. Rslint retains every config association and project declaration order for lint-rule binding. Type-check runs over every real Program independently.
+Each normalized declared tsconfig path in the effective loaded config catalog produces one TypeScript Program, even when multiple rslint configs reference that path. Parent global ignores can prevent a nested config from entering that catalog during directory discovery. File-symlink declarations remain distinct because TypeScript resolves relative paths from the declared location. Rslint retains every config association and project declaration order for lint-rule binding. Type-check runs over every real Program independently.
 
-**The type-check scope is each tsconfig's `include` / `files` minus `exclude` — nothing in your rslint config or on the CLI changes it.** Specifically, the following are **lint-phase concepts** that do **not** affect type-check scope:
+**After the effective config catalog is established, each Program's type-check scope is its tsconfig `include` / `files` minus `exclude`.** The following lint-phase concepts do not filter that Program scope:
 
 - rslint config's `files` patterns
 - rslint config's `ignores` patterns (root-level or per-entry)
@@ -57,7 +57,7 @@ If a file is included by tsconfig but matched by rslint `ignores`, lint rules do
 
 ### Gap files
 
-Selected files that are **not** present in any tsconfig Program declared by their governing config (root-level scripts, ad-hoc config files, etc.) are called _gap files_. They receive a non-project-backed fallback Program, so syntax-only rules still run but type-aware rules do not. The program-wide type-check phase also skips the fallback. To enable type information, add the file to one of the governing config's tsconfigs or declare a dedicated project there.
+Selected files that are **not** present in any tsconfig Program declared by their governing config (root-level scripts, ad-hoc config files, etc.) are called _gap files_. They receive a non-project-backed fallback Program, so rules that do not require type information still run while type-aware rules do not. The program-wide type-check phase also skips the fallback. To enable type information, add the file to one of the governing config's tsconfigs or declare a dedicated project there.
 
 ## Output
 

--- a/website/docs/en/guide/type-checking.md
+++ b/website/docs/en/guide/type-checking.md
@@ -159,7 +159,7 @@ rslint --type-check-only .
 | `--type-check`      |     ✓      |        ✓         |                      no                      |
 | `--type-check-only` |     ✗      |        ✓         |                     yes                      |
 
-<sup>\*</sup> The lint phase emits per-file stderr warnings like `<file> was not found in the project, skipping` and `<file> is ignored because of a matching ignore pattern`. In `--type-check-only` the lint phase doesn't run, so these are suppressed — they would otherwise mislead users into thinking the file wasn't type-checked, when in fact Phase 2 is independent of CLI scope and rslint ignores (see [What gets type-checked](#what-gets-type-checked)).
+<sup>\*</sup> The lint phase emits per-file stderr warnings like `<file> was not found, skipping` and `<file> is ignored because of a matching ignore pattern`. In `--type-check-only` the lint phase doesn't run, so these are suppressed — they would otherwise mislead users into thinking the file wasn't type-checked, when in fact Phase 2 is independent of CLI scope and rslint ignores (see [What gets type-checked](#what-gets-type-checked)).
 
 ## Flag matrix
 


### PR DESCRIPTION
## Summary

This PR separates lint target selection from TypeScript Program membership and aligns config-driven selection across the CLI, JavaScript API, and LSP.

- Build a stable lint target plan from caller scope, supported source extensions, config `files`, global ignores, and the existing CLI/API `.gitignore` behavior.
- Use TypeScript Programs as execution and type-information containers. A selected file outside every project declared by its governing config uses a non-project-backed fallback Program.
- Keep JS/TS config discovery, evaluation, and normalization in Node. Go receives config objects and handles runtime ownership, matching, Program construction, and lint execution.
- Preserve project-driven type-checking after the effective loaded config catalog has been established.

## Behavior

- An omitted `files` field uses the default `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, and `.cts` baseline. Explicit selectors contribute only supported source files and cannot make another extension lintable.
- `files: []` and invalid selector values are rejected. Top-level selectors use OR semantics, nested selector arrays use AND semantics, and `files: [[]]` is a valid vacuously matching AND group.
- Every selected target is parsed even when no config entry contributes rules. This includes default-baseline files found by directory or no-argument discovery and explicitly requested supported files that miss every entry's `files`.
- Global ignores remove targets. Entry-level ignores affect only that entry's selection and config contribution. CLI and JavaScript API target planning also applies `.gitignore`; LSP `.gitignore` parity remains a follow-up.
- Under automatic discovery, each selected file uses its nearest loadable config; explicit `--config` and `overrideConfigFile` modes use the selected config directly. Parent global ignores constrain directory and no-argument discovery, while an explicitly requested file resolves its nearest config separately.
- Automatic config discovery priority is `.js`, `.mjs`, `.ts`, then `.mts`. Explicit CLI `--config` and API `overrideConfigFile` additionally accept `.cjs` and `.cts`. For CLI/API discovery, a failed nearest candidate falls back to a loadable ancestor; the operation fails when candidates exist but none load. LSP config reloads instead preserve a last-good config or an unavailable boundary.
- A selected file absent from every project declared by its governing config still runs rules that do not require type information. Its fallback Program is excluded from program-wide type-checking; the same physical file can still be checked if another real Program in the effective catalog includes it.
- `--type-check` and `--type-check-only` build every real tsconfig declared by the effective loaded config catalog. Once that catalog is established, lint `files`/`ignores`, `.gitignore`, and CLI target scope do not filter Program diagnostics.
- JavaScript API `overrideConfigFile` follows ESLint semantics: `true` disables config-file discovery, a string uses that file, and `null` or omission performs discovery. Relative patterns from an explicit override file use `cwd`, matching CLI `--config`.

## Architecture

- CLI multi-config mode and LSP route already-loaded config catalogs through `ConfigOwnerResolver`. `Rslint.lintFiles()` performs equivalent lexical-first routing in Node, groups files by resolved config, and sends single-config IPC lint requests.
- Plain lint creates Programs only for configs governing selected targets. Type-check modes use the effective loaded catalog. Exact normalized tsconfig paths are deduplicated while preserving each config association and project declaration order.
- Program binding first uses an exact lexical source name, then exact canonical filesystem identity. A target can bind only to a Program declared by its governing config; no directory-parent or root-alias inference participates.
- CLI/API binding builds a canonical source index for one binding pass only when a direct lookup misses. Source paths are deduplicated before realpath work, and `--singleThreaded` keeps that work serial.
- CLI multi-pass `--fix` rebuilds real Programs and rebinds the unchanged target plan after each pass. Type-aware rules follow the resulting binding, while fallback Programs remain excluded from semantic diagnostics.
- LSP uses its session-based orchestration and an independent lookup helper, but follows the same exact-lexical-then-canonical identity semantics. An available zero-rule config still permits syntax diagnostics for an open supported file.

## Follow-ups

- LSP `.gitignore` parity and a fully isolated virtual-filesystem mode for the JavaScript API remain separate work. `virtualFiles` continues to be an overlay with filesystem fallback.
