### PR TITLE
feat(config): type languageOptions.globals/sourceType/ecmaFeatures

### DIFF
--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -84,7 +84,9 @@ export type RuleEntry =
 export type RulesRecord = Record<string, RuleEntry>;
 
 /**
- * TypeScript parser options. `project` may be a single tsconfig path or a list.
+ * Parser-specific extras, nested under `parserOptions` per ESLint v10's
+ * flat-config layout (`ecmaVersion`/`sourceType` moved to the top level of
+ * `languageOptions`; only `ecmaFeatures` and TS-project settings remain here).
  */
 export interface ParserOptions {
   /**
@@ -103,12 +105,66 @@ export interface ParserOptions {
    * project: ['./tsconfig.*.json']
    */
   project?: string | string[];
+  /**
+   * Grammar toggles forwarded to both the native parser and the scope
+   * analyzer.
+   */
+  ecmaFeatures?: {
+    /**
+     * Parse `.js`/`.ts` files as `.jsx`/`.tsx` (JSX inside a non-`x`
+     * extension). `.jsx`/`.tsx` files don't need this — it's inferred from
+     * the extension already.
+     */
+    jsx?: boolean;
+    /**
+     * Allow a top-level `return`. Node CommonJS scripts are implicitly
+     * wrapped in a function at runtime (`(function (exports, require,
+     * module, __filename, __dirname) { ... })`), so top-level `return` /
+     * `arguments` / `this` are valid there; sets are inferred automatically
+     * for `sourceType: 'commonjs'`.
+     */
+    globalReturn?: boolean;
+    /**
+     * Treat the source as if it begins with `'use strict'`. ESLint v10
+     * default is `false`. Modules are always strict regardless of this
+     * setting.
+     */
+    impliedStrict?: boolean;
+  };
 }
 
 /**
  * Language-specific configuration.
  */
 export interface LanguageOptions {
+  /**
+   * The type of JavaScript source code. `'module'` allows `import`/`export`
+   * and is always strict mode; `'script'` is a plain non-module file;
+   * `'commonjs'` additionally implies a Node-style function wrapper (see
+   * `parserOptions.ecmaFeatures.globalReturn`).
+   *
+   * @default 'module' for .js/.mjs/.ts/.tsx; 'commonjs' for .cjs/.cts
+   */
+  sourceType?: 'module' | 'script' | 'commonjs';
+  /**
+   * Additional identifiers to treat as globals, beyond the ECMAScript
+   * built-ins (`Array`, `Promise`, `globalThis`, ...) rslint always seeds.
+   * `'readonly'` / `'writable'` control whether `no-const-assign`-style
+   * write-checks flag reassignment; `'off'` un-declares a global that a
+   * broader config entry added.
+   *
+   * Only rules that do scope analysis honour this (community plugin rules
+   * run through rslint's ESLint-compat runtime, and any rslint-native rule
+   * that walks scope). It is NOT consulted by rslint's own `no-undef`,
+   * `no-shadow`, or `no-redeclare` — those are typed-linting rules that ask
+   * the TypeScript checker whether a name resolves (so add an ambient
+   * `.d.ts` — or `@types/*` — declaration instead if those rules flag a
+   * global as undefined).
+   *
+   * @example
+   * globals: { describe: 'readonly', it: 'readonly' }
+   */
+  globals?: Record<string, 'readonly' | 'writable' | 'off'>;
   parserOptions?: ParserOptions;
 }
 

--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -84,9 +84,7 @@ export type RuleEntry =
 export type RulesRecord = Record<string, RuleEntry>;
 
 /**
- * Parser-specific extras, nested under `parserOptions` per ESLint v10's
- * flat-config layout (`ecmaVersion`/`sourceType` moved to the top level of
- * `languageOptions`; only `ecmaFeatures` and TS-project settings remain here).
+ * Parser-specific options: TypeScript project settings and grammar toggles.
  */
 export interface ParserOptions {
   /**
@@ -125,9 +123,8 @@ export interface ParserOptions {
      */
     globalReturn?: boolean;
     /**
-     * Treat the source as if it begins with `'use strict'`. ESLint v10
-     * default is `false`. Modules are always strict regardless of this
-     * setting.
+     * Treat the source as if it begins with `'use strict'`. Modules are
+     * always strict regardless of this setting.
      */
     impliedStrict?: boolean;
   };
@@ -166,17 +163,12 @@ export interface LanguageOptions {
   /**
    * Additional identifiers to treat as globals, beyond the ECMAScript
    * built-ins (`Array`, `Promise`, `globalThis`, ...) rslint always seeds.
-   * `'readonly'` / `'writable'` control whether `no-const-assign`-style
-   * write-checks flag reassignment; `'off'` un-declares a global that a
-   * broader config entry added.
+   * `'readonly'` / `'writable'` control whether reassignment is flagged;
+   * `'off'` un-declares a global that a broader config entry added.
    *
-   * Only rules that do scope analysis honour this (community plugin rules
-   * run through rslint's ESLint-compat runtime, and any rslint-native rule
-   * that walks scope). It is NOT consulted by rslint's own `no-undef`,
-   * `no-shadow`, or `no-redeclare` — those are typed-linting rules that ask
-   * the TypeScript checker whether a name resolves (so add an ambient
-   * `.d.ts` — or `@types/*` — declaration instead if those rules flag a
-   * global as undefined).
+   * Consulted by scope-analysis-based rules only. `no-undef`, `no-shadow`,
+   * and `no-redeclare` resolve names via the TypeScript checker instead and
+   * don't read this field.
    *
    * @example
    * globals: { describe: 'readonly', it: 'readonly' }

--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -131,6 +131,23 @@ export interface ParserOptions {
      */
     impliedStrict?: boolean;
   };
+  /**
+   * The identifier that's used for JSX element creation, so unused-import/
+   * unused-variable checks recognize the pragma as "used" instead of
+   * flagging it (e.g. `import { h } from 'preact'` with `jsxPragma: 'h'`).
+   * Only relevant when the classic (non-automatic) JSX runtime is in play.
+   *
+   * @default 'React'
+   */
+  jsxPragma?: string | null;
+  /**
+   * The identifier used for JSX fragment elements (`<>...</>`), analogous to
+   * `jsxPragma` — set this when a custom pragma also provides its own
+   * fragment component (e.g. Preact's `Fragment`).
+   *
+   * @default null
+   */
+  jsxFragmentName?: string | null;
 }
 
 /**

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -2,10 +2,9 @@ import type { RslintConfigEntry } from '../define-config.js';
 
 // Aligned with official eslint-plugin-unicorn@64.x recommended.
 // Rules commented out with "not implemented" are in the official preset but not yet available.
-// The official preset also injects `languageOptions.globals` (Array, Promise, Map, …) so
-// `no-undef` doesn't flag them; rslint's `unicorn/*` rules are natively ported and don't do
-// their own scope analysis, so that part is omitted here (see `LanguageOptions.globals`'s
-// doc comment in define-config.ts for which rules actually honour it).
+// The official preset also injects `languageOptions.globals` (Array, Promise, Map, …);
+// rslint's `unicorn/*` rules are natively ported and don't do their own scope analysis,
+// so that part is omitted here.
 const recommended: RslintConfigEntry = {
   plugins: ['unicorn'],
   rules: {

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -2,8 +2,10 @@ import type { RslintConfigEntry } from '../define-config.js';
 
 // Aligned with official eslint-plugin-unicorn@64.x recommended.
 // Rules commented out with "not implemented" are in the official preset but not yet available.
-// The official preset also injects `languageOptions.globals` (Array, Promise, Map, …);
-// rslint's config entry doesn't expose a `globals` field, so that part is omitted.
+// The official preset also injects `languageOptions.globals` (Array, Promise, Map, …) so
+// `no-undef` doesn't flag them; rslint's `unicorn/*` rules are natively ported and don't do
+// their own scope analysis, so that part is omitted here (see `LanguageOptions.globals`'s
+// doc comment in define-config.ts for which rules actually honour it).
 const recommended: RslintConfigEntry = {
   plugins: ['unicorn'],
   rules: {


### PR DESCRIPTION
## Summary

- Add `globals`, `sourceType`, and `parserOptions.ecmaFeatures.{jsx,globalReturn,impliedStrict}` to `defineConfig()`'s `LanguageOptions`/`ParserOptions` types — the runtime already forwards/consumes these, only the type was missing them, so writing them in `rslint.config.ts` was a TS error.
- Also add `parserOptions.jsxPragma`/`jsxFragmentName` now that the worker wire forwards them (#1230).
- Leave out `ecmaVersion` — it never reaches the TS scope-manager branch and no rule reads it back, so typing it would silently do nothing.
- Fix a stale comment in `presets/unicorn.ts` claiming `globals` couldn't be expressed at all.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required) — type-only change, verified via a `tsc` probe and `pnpm typecheck`.
- [x] Documentation updated (or not required) — inline doc comments on the new fields.
