### PR TITLE
feat: port rule react-hooks/preserve-manual-memoization

### DIFF
--- a/internal/plugins/react_hooks/all.go
+++ b/internal/plugins/react_hooks/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/globals"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/immutability"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/incompatible_library"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/preserve_manual_memoization"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/rules_of_hooks"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -20,5 +21,6 @@ func GetAllRules() []rule.Rule {
 		globals.GlobalsRule,
 		immutability.ImmutabilityRule,
 		incompatible_library.IncompatibleLibraryRule,
+		preserve_manual_memoization.PreserveManualMemoizationRule,
 	}
 }

--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -412,6 +412,38 @@ func GetFunctionBody(fn *ast.Node) *ast.Node {
 	return nil
 }
 
+// WalkFunctionBody visits the executable body of fn. Nested function-like
+// containers are passed to visit, but their bodies are not traversed. It returns
+// true when visit stops the walk.
+func WalkFunctionBody(fn *ast.Node, visit func(*ast.Node) bool) bool {
+	body := GetFunctionBody(fn)
+	if body == nil {
+		return false
+	}
+	var walk func(*ast.Node) bool
+	walk = func(node *ast.Node) bool {
+		if node == nil {
+			return false
+		}
+		if node != fn && IsFunctionLikeContainer(node) {
+			return visit(node)
+		}
+		if visit(node) {
+			return true
+		}
+		stop := false
+		node.ForEachChild(func(child *ast.Node) bool {
+			if walk(child) {
+				stop = true
+				return true
+			}
+			return false
+		})
+		return stop
+	}
+	return walk(body)
+}
+
 // HasAsyncModifier reports whether the function-like node carries
 // the `async` modifier.
 func HasAsyncModifier(fn *ast.Node) bool {

--- a/internal/plugins/react_hooks/rules/globals/globals.go
+++ b/internal/plugins/react_hooks/rules/globals/globals.go
@@ -366,32 +366,7 @@ func functionIdentifierName(fn *ast.Node) string {
 }
 
 func walkRenderParentBody(fn *ast.Node, visit func(*ast.Node) bool) {
-	body := react_hooksutil.GetFunctionBody(fn)
-	if body == nil {
-		return
-	}
-	var walk func(*ast.Node) bool
-	walk = func(node *ast.Node) bool {
-		if node == nil {
-			return false
-		}
-		if node != body && utils.IsFunctionLikeContainer(node) {
-			return false
-		}
-		if visit(node) {
-			return true
-		}
-		stop := false
-		node.ForEachChild(func(child *ast.Node) bool {
-			if walk(child) {
-				stop = true
-				return true
-			}
-			return false
-		})
-		return stop
-	}
-	walk(body)
+	react_hooksutil.WalkFunctionBody(fn, visit)
 }
 
 func functionReturnsJsx(fn *ast.Node) bool {

--- a/internal/plugins/react_hooks/rules/preserve_manual_memoization/preserve_manual_memoization.go
+++ b/internal/plugins/react_hooks/rules/preserve_manual_memoization/preserve_manual_memoization.go
@@ -1,0 +1,876 @@
+package preserve_manual_memoization
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const preserveManualMemoizationReason = "Existing memoization could not be preserved"
+
+type dependencyPathPart struct {
+	property string
+	optional bool
+}
+
+type memoDependency struct {
+	root string
+	path []dependencyPathPart
+	node *ast.Node
+}
+
+func (dep memoDependency) String() string {
+	var builder strings.Builder
+	builder.WriteString(dep.root)
+	for _, part := range dep.path {
+		if part.optional {
+			builder.WriteString("?.")
+		} else {
+			builder.WriteString(".")
+		}
+		builder.WriteString(part.property)
+	}
+	return builder.String()
+}
+
+func (dep memoDependency) hasRefCurrentAccess() bool {
+	for _, part := range dep.path {
+		if part.property == "current" {
+			return true
+		}
+	}
+	return false
+}
+
+type compareDependencyResult int
+
+const (
+	compareDependencyOk compareDependencyResult = iota
+	compareDependencyRootDifference
+	compareDependencyPathDifference
+	compareDependencySubpath
+	compareDependencyRefAccessDifference
+)
+
+type preserveManualMemoizationState struct {
+	checked map[*ast.Node]bool
+}
+
+type rootMemoContext struct {
+	reactNames     map[string]bool
+	memoNames      map[string]string
+	moduleBindings map[string]bool
+	stableBindings map[string]bool
+}
+
+// PreserveManualMemoizationRule is the rslint port of upstream
+// `react-hooks/preserve-manual-memoization`.
+//
+// The upstream ESLint rule is backed by React Compiler diagnostics. This port
+// implements the user-facing dependency-preservation contract locally: manual
+// useMemo/useCallback dependency arrays must cover the dependencies inferred
+// from the memo callback, while stable React values are ignored.
+var PreserveManualMemoizationRule = rule.Rule{
+	Name: "react-hooks/preserve-manual-memoization",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		state := &preserveManualMemoizationState{checked: map[*ast.Node]bool{}}
+		check := func(node *ast.Node) {
+			state.checkFunction(ctx, node)
+		}
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration: check,
+			ast.KindFunctionExpression:  check,
+			ast.KindArrowFunction:       check,
+		}
+	},
+}
+
+func (state *preserveManualMemoizationState) checkFunction(ctx rule.RuleContext, fn *ast.Node) {
+	if fn == nil || state.checked[fn] {
+		return
+	}
+	state.checked[fn] = true
+	if react_hooksutil.GetCompilerReactFunctionType(fn) == "" {
+		return
+	}
+
+	memoCtx := buildRootMemoContext(ctx.SourceFile, fn)
+	react_hooksutil.WalkFunctionBody(fn, func(node *ast.Node) bool {
+		if node.Kind != ast.KindCallExpression {
+			return false
+		}
+		state.checkMemoCall(ctx, fn, node, memoCtx)
+		return false
+	})
+}
+
+func (state *preserveManualMemoizationState) checkMemoCall(ctx rule.RuleContext, rootFn, callNode *ast.Node, memoCtx rootMemoContext) {
+	call := callNode.AsCallExpression()
+	if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) < 2 {
+		return
+	}
+	kind, ok := manualMemoCalleeKind(call.Expression, memoCtx)
+	if !ok || (kind != "useMemo" && kind != "useCallback") {
+		return
+	}
+
+	callback := utils.SkipAssertionsAndParens(call.Arguments.Nodes[0])
+	if !react_hooksutil.IsCompilerFunctionKind(callback) {
+		return
+	}
+	sourceDeps, validDeps := collectSourceDependencies(call.Arguments.Nodes[1])
+	if !validDeps {
+		return
+	}
+
+	collector := newDependencyCollector(callback, memoCtx)
+	inferredDeps := collector.collect()
+	for _, inferred := range inferredDeps {
+		result := compareDependencySet(inferred, sourceDeps)
+		if result == compareDependencyOk {
+			continue
+		}
+		ctx.ReportNode(callback, buildPreservedManualMemoizationDependencyMessage(inferred, sourceDeps, result))
+	}
+
+	for _, sourceDep := range sourceDeps {
+		if dependencyMutatedAfterCall(rootFn, callNode, sourceDep) {
+			reportNode := sourceDep.node
+			if reportNode == nil {
+				reportNode = callback
+			}
+			ctx.ReportNode(reportNode, buildPreservedManualMemoizationMutationMessage())
+		}
+	}
+}
+
+func buildPreservedManualMemoizationDependencyMessage(dep memoDependency, sourceDeps []memoDependency, result compareDependencyResult) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "preserveManualMemoization",
+		Description: fmt.Sprintf(
+			"Compilation Skipped: %s\n\nReact Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. The inferred dependency was `%s`, but the source dependencies were [%s]. %s",
+			preserveManualMemoizationReason,
+			dep.String(),
+			printDependencyList(sourceDeps),
+			compareDependencyResultDescription(result),
+		),
+		Data: map[string]string{
+			"dependency": dep.String(),
+		},
+	}
+}
+
+func buildPreservedManualMemoizationMutationMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "preserveManualMemoization",
+		Description: fmt.Sprintf(
+			"Compilation Skipped: %s\n\nReact Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. This dependency may be mutated later, which could cause the value to change unexpectedly.",
+			preserveManualMemoizationReason,
+		),
+	}
+}
+
+func compareDependencyResultDescription(result compareDependencyResult) string {
+	switch result {
+	case compareDependencyRootDifference:
+		return "Inferred dependency not present in source."
+	case compareDependencyPathDifference:
+		return "Inferred different dependency than source."
+	case compareDependencySubpath:
+		return "Inferred less specific property than source."
+	case compareDependencyRefAccessDifference:
+		return "Differences in ref.current access."
+	default:
+		return "Dependencies equal."
+	}
+}
+
+func compareDependencySet(inferred memoDependency, sourceDeps []memoDependency) compareDependencyResult {
+	if len(sourceDeps) == 0 {
+		return compareDependencyRootDifference
+	}
+	var best compareDependencyResult
+	for i, source := range sourceDeps {
+		result := compareDependencies(inferred, source)
+		if result == compareDependencyOk {
+			return compareDependencyOk
+		}
+		if i == 0 || result > best {
+			best = result
+		}
+	}
+	return best
+}
+
+func compareDependencies(inferred, source memoDependency) compareDependencyResult {
+	if inferred.root != source.root {
+		return compareDependencyRootDifference
+	}
+
+	isSubpath := true
+	limit := min(len(inferred.path), len(source.path))
+	for i := range limit {
+		if inferred.path[i].property != source.path[i].property {
+			isSubpath = false
+			break
+		}
+		if inferred.path[i].optional && !source.path[i].optional {
+			return compareDependencyPathDifference
+		}
+	}
+
+	if isSubpath && (len(source.path) == len(inferred.path) || (len(inferred.path) >= len(source.path) && !inferred.hasRefCurrentAccess())) {
+		return compareDependencyOk
+	}
+	if isSubpath {
+		if source.hasRefCurrentAccess() || inferred.hasRefCurrentAccess() {
+			return compareDependencyRefAccessDifference
+		}
+		return compareDependencySubpath
+	}
+	return compareDependencyPathDifference
+}
+
+func printDependencyList(deps []memoDependency) string {
+	parts := make([]string, 0, len(deps))
+	for _, dep := range deps {
+		parts = append(parts, dep.String())
+	}
+	return strings.Join(parts, ", ")
+}
+
+func buildRootMemoContext(sourceFile *ast.SourceFile, rootFn *ast.Node) rootMemoContext {
+	ctx := rootMemoContext{
+		reactNames:     map[string]bool{"React": true},
+		memoNames:      map[string]string{"useMemo": "useMemo", "useCallback": "useCallback"},
+		moduleBindings: map[string]bool{},
+		stableBindings: map[string]bool{},
+	}
+	for name := range builtinStableNames {
+		ctx.stableBindings[name] = true
+	}
+	collectModuleBindings(sourceFile, &ctx)
+	collectStableRootBindings(rootFn, &ctx)
+	return ctx
+}
+
+var builtinStableNames = map[string]bool{
+	"Array":           true,
+	"Boolean":         true,
+	"Date":            true,
+	"Error":           true,
+	"Intl":            true,
+	"JSON":            true,
+	"Math":            true,
+	"Number":          true,
+	"Object":          true,
+	"Promise":         true,
+	"RegExp":          true,
+	"Set":             true,
+	"String":          true,
+	"Symbol":          true,
+	"URL":             true,
+	"URLSearchParams": true,
+	"console":         true,
+	"document":        true,
+	"globalThis":      true,
+	"window":          true,
+}
+
+func collectModuleBindings(sourceFile *ast.SourceFile, memoCtx *rootMemoContext) {
+	if sourceFile == nil || sourceFile.Statements == nil {
+		return
+	}
+	for _, stmt := range sourceFile.Statements.Nodes {
+		switch stmt.Kind {
+		case ast.KindImportDeclaration:
+			collectImportBindings(stmt, memoCtx)
+		case ast.KindFunctionDeclaration, ast.KindClassDeclaration:
+			if name := stmt.Name(); name != nil && name.Kind == ast.KindIdentifier {
+				memoCtx.moduleBindings[name.AsIdentifier().Text] = true
+			}
+		case ast.KindVariableStatement:
+			stmt.ForEachChild(func(child *ast.Node) bool {
+				if child.Kind == ast.KindVariableDeclaration {
+					utils.CollectBindingNames(child.AsVariableDeclaration().Name(), func(_ *ast.Node, name string) {
+						memoCtx.moduleBindings[name] = true
+					})
+				}
+				return false
+			})
+		}
+	}
+}
+
+func collectImportBindings(node *ast.Node, memoCtx *rootMemoContext) {
+	importDecl := node.AsImportDeclaration()
+	if importDecl == nil || importDecl.ModuleSpecifier == nil || importDecl.ImportClause == nil {
+		return
+	}
+	source := utils.GetStaticStringValue(importDecl.ModuleSpecifier)
+	clause := importDecl.ImportClause.AsImportClause()
+	if clause == nil {
+		return
+	}
+	if clause.Name() != nil && clause.Name().Kind == ast.KindIdentifier {
+		local := clause.Name().AsIdentifier().Text
+		memoCtx.moduleBindings[local] = true
+		if source == "react" {
+			memoCtx.reactNames[local] = true
+		}
+	}
+	if clause.NamedBindings == nil {
+		return
+	}
+	switch clause.NamedBindings.Kind {
+	case ast.KindNamespaceImport:
+		name := clause.NamedBindings.Name()
+		if name != nil && name.Kind == ast.KindIdentifier {
+			local := name.AsIdentifier().Text
+			memoCtx.moduleBindings[local] = true
+			if source == "react" {
+				memoCtx.reactNames[local] = true
+			}
+		}
+	case ast.KindNamedImports:
+		named := clause.NamedBindings.AsNamedImports()
+		if named == nil || named.Elements == nil {
+			return
+		}
+		for _, elem := range named.Elements.Nodes {
+			spec := elem.AsImportSpecifier()
+			if spec == nil || spec.Name() == nil || spec.Name().Kind != ast.KindIdentifier {
+				continue
+			}
+			local := spec.Name().AsIdentifier().Text
+			memoCtx.moduleBindings[local] = true
+			imported := local
+			if spec.PropertyName != nil {
+				imported = spec.PropertyName.Text()
+			}
+			if source == "react" {
+				switch imported {
+				case "useMemo", "useCallback":
+					memoCtx.memoNames[local] = imported
+				}
+			}
+		}
+	}
+}
+
+func collectStableRootBindings(rootFn *ast.Node, memoCtx *rootMemoContext) {
+	react_hooksutil.WalkFunctionBody(rootFn, func(node *ast.Node) bool {
+		if node.Kind != ast.KindVariableDeclaration {
+			return false
+		}
+		decl := node.AsVariableDeclaration()
+		if decl == nil || decl.Initializer == nil {
+			return false
+		}
+		init := utils.SkipAssertionsAndParens(decl.Initializer)
+		if kind, ok := manualMemoCalleeKind(init, *memoCtx); ok {
+			utils.CollectBindingNames(decl.Name(), func(_ *ast.Node, name string) {
+				memoCtx.memoNames[name] = kind
+			})
+			return false
+		}
+		if init == nil || init.Kind != ast.KindCallExpression {
+			return false
+		}
+		hookName := hookCalleeName(init.AsCallExpression().Expression, *memoCtx)
+		switch hookName {
+		case "useState", "useReducer", "useTransition", "useActionState", "useOptimistic":
+			addSecondArrayBindingName(decl.Name(), memoCtx.stableBindings)
+		case "useRef":
+			utils.CollectBindingNames(decl.Name(), func(_ *ast.Node, name string) {
+				memoCtx.stableBindings[name] = true
+			})
+		}
+		return false
+	})
+}
+
+func addSecondArrayBindingName(nameNode *ast.Node, stable map[string]bool) {
+	nameNode = utils.SkipAssertionsAndParens(nameNode)
+	if nameNode == nil || nameNode.Kind != ast.KindArrayBindingPattern {
+		return
+	}
+	pattern := nameNode.AsBindingPattern()
+	if pattern == nil || pattern.Elements == nil || len(pattern.Elements.Nodes) < 2 {
+		return
+	}
+	second := pattern.Elements.Nodes[1]
+	if second == nil || second.Kind != ast.KindBindingElement {
+		return
+	}
+	utils.CollectBindingNames(second.AsBindingElement().Name(), func(_ *ast.Node, name string) {
+		stable[name] = true
+	})
+}
+
+func manualMemoCalleeKind(callee *ast.Node, memoCtx rootMemoContext) (string, bool) {
+	callee = utils.SkipAssertionsAndParens(callee)
+	if callee == nil {
+		return "", false
+	}
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		kind, ok := memoCtx.memoNames[callee.AsIdentifier().Text]
+		return kind, ok
+	case ast.KindPropertyAccessExpression:
+		prop := callee.AsPropertyAccessExpression().Name()
+		if prop == nil || prop.Kind != ast.KindIdentifier {
+			return "", false
+		}
+		name := prop.AsIdentifier().Text
+		if name != "useMemo" && name != "useCallback" {
+			return "", false
+		}
+		obj := utils.SkipAssertionsAndParens(callee.AsPropertyAccessExpression().Expression)
+		if obj != nil && obj.Kind == ast.KindIdentifier && memoCtx.reactNames[obj.AsIdentifier().Text] {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func hookCalleeName(callee *ast.Node, memoCtx rootMemoContext) string {
+	callee = utils.SkipAssertionsAndParens(callee)
+	if callee == nil {
+		return ""
+	}
+	if callee.Kind == ast.KindIdentifier {
+		return callee.AsIdentifier().Text
+	}
+	if callee.Kind == ast.KindPropertyAccessExpression {
+		prop := callee.AsPropertyAccessExpression().Name()
+		obj := utils.SkipAssertionsAndParens(callee.AsPropertyAccessExpression().Expression)
+		if prop != nil && prop.Kind == ast.KindIdentifier &&
+			obj != nil && obj.Kind == ast.KindIdentifier && memoCtx.reactNames[obj.AsIdentifier().Text] {
+			return prop.AsIdentifier().Text
+		}
+	}
+	return ""
+}
+
+func collectSourceDependencies(node *ast.Node) ([]memoDependency, bool) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil || node.Kind != ast.KindArrayLiteralExpression {
+		return nil, false
+	}
+	array := node.AsArrayLiteralExpression()
+	if array == nil || array.Elements == nil {
+		return nil, true
+	}
+	deps := make([]memoDependency, 0, len(array.Elements.Nodes))
+	seen := map[string]bool{}
+	for _, elem := range array.Elements.Nodes {
+		if elem == nil || elem.Kind == ast.KindSpreadElement {
+			return nil, false
+		}
+		dep, ok := parseMemoDependency(elem)
+		if !ok {
+			return nil, false
+		}
+		key := dep.String()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		deps = append(deps, dep)
+	}
+	return deps, true
+}
+
+func parseMemoDependency(node *ast.Node) (memoDependency, bool) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return memoDependency{}, false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return memoDependency{root: node.AsIdentifier().Text, node: node}, node.AsIdentifier().Text != ""
+	case ast.KindPropertyAccessExpression:
+		access := node.AsPropertyAccessExpression()
+		base, ok := parseMemoDependency(access.Expression)
+		if !ok {
+			return memoDependency{}, false
+		}
+		name := access.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return memoDependency{}, false
+		}
+		base.path = append(base.path, dependencyPathPart{
+			property: name.AsIdentifier().Text,
+			optional: access.QuestionDotToken != nil,
+		})
+		base.node = node
+		return base, true
+	case ast.KindElementAccessExpression:
+		access := node.AsElementAccessExpression()
+		base, ok := parseMemoDependency(access.Expression)
+		if !ok {
+			return memoDependency{}, false
+		}
+		property, ok := utils.GetStaticExpressionValue(utils.SkipAssertionsAndParens(access.ArgumentExpression))
+		if !ok {
+			return memoDependency{}, false
+		}
+		base.path = append(base.path, dependencyPathPart{
+			property: property,
+			optional: access.QuestionDotToken != nil,
+		})
+		base.node = node
+		return base, true
+	}
+	return memoDependency{}, false
+}
+
+type dependencyUse struct {
+	dep  memoDependency
+	node *ast.Node
+}
+
+type dependencyCollector struct {
+	callback      *ast.Node
+	memoCtx       rootMemoContext
+	localBindings map[string]bool
+	seen          map[string]bool
+	dependencies  []dependencyUse
+}
+
+func newDependencyCollector(callback *ast.Node, memoCtx rootMemoContext) *dependencyCollector {
+	collector := &dependencyCollector{
+		callback:      callback,
+		memoCtx:       memoCtx,
+		localBindings: collectFunctionLocalBindings(callback),
+		seen:          map[string]bool{},
+	}
+	return collector
+}
+
+func (collector *dependencyCollector) collect() []memoDependency {
+	body := react_hooksutil.GetFunctionBody(collector.callback)
+	if body != nil {
+		collector.walk(body)
+	}
+	sort.SliceStable(collector.dependencies, func(i, j int) bool {
+		return collector.dependencies[i].node.Pos() < collector.dependencies[j].node.Pos()
+	})
+	out := make([]memoDependency, 0, len(collector.dependencies))
+	for _, use := range collector.dependencies {
+		out = append(out, use.dep)
+	}
+	return out
+}
+
+func collectFunctionLocalBindings(fn *ast.Node) map[string]bool {
+	locals := map[string]bool{}
+	for _, param := range fn.Parameters() {
+		utils.CollectBindingNames(param.Name(), func(_ *ast.Node, name string) {
+			locals[name] = true
+		})
+	}
+	if name := fn.Name(); name != nil && name.Kind == ast.KindIdentifier {
+		locals[name.AsIdentifier().Text] = true
+	}
+	body := react_hooksutil.GetFunctionBody(fn)
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node != fn && react_hooksutil.IsFunctionLikeContainer(node) {
+			if node.Kind == ast.KindFunctionDeclaration {
+				if name := node.Name(); name != nil && name.Kind == ast.KindIdentifier {
+					locals[name.AsIdentifier().Text] = true
+				}
+			}
+			return
+		}
+		switch node.Kind {
+		case ast.KindVariableDeclaration:
+			utils.CollectBindingNames(node.AsVariableDeclaration().Name(), func(_ *ast.Node, name string) {
+				locals[name] = true
+			})
+		case ast.KindFunctionDeclaration, ast.KindClassDeclaration:
+			if name := node.Name(); name != nil && name.Kind == ast.KindIdentifier {
+				locals[name.AsIdentifier().Text] = true
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(body)
+	return locals
+}
+
+func (collector *dependencyCollector) walk(node *ast.Node) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil || ast.IsTypeNode(node) {
+		return
+	}
+	if node != collector.callback && react_hooksutil.IsFunctionLikeContainer(node) {
+		return
+	}
+	if collector.collectCallExpressionDependencies(node) {
+		return
+	}
+	if dep, ok := collector.dependencyFromAccess(node); ok {
+		collector.add(dep, node)
+		collector.walkDynamicElementArgument(node)
+		return
+	}
+	if node.Kind == ast.KindIdentifier {
+		if collector.isExternalReference(node) {
+			collector.add(memoDependency{root: node.AsIdentifier().Text, node: node}, node)
+		}
+		return
+	}
+	node.ForEachChild(func(child *ast.Node) bool {
+		collector.walk(child)
+		return false
+	})
+}
+
+func (collector *dependencyCollector) collectCallExpressionDependencies(node *ast.Node) bool {
+	if node.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := node.AsCallExpression()
+	if call == nil {
+		return false
+	}
+	callee := utils.SkipAssertionsAndParens(call.Expression)
+	if callee == nil || !ast.IsAccessExpression(callee) {
+		return false
+	}
+	// React Compiler treats a member call as depending on the receiver, not on
+	// the method property itself. This keeps `prop.x()` aligned with an
+	// inferred `prop` dependency instead of `prop.x`.
+	receiver := utils.SkipAssertionsAndParens(utils.AccessExpressionObject(callee))
+	if dep, ok := parseAccessDependency(receiver); ok && collector.shouldKeepDependency(dep.root) {
+		collector.add(dep, receiver)
+	} else {
+		collector.walk(receiver)
+	}
+	collector.walkDynamicElementArgument(callee)
+	if call.Arguments != nil {
+		for _, arg := range call.Arguments.Nodes {
+			collector.walk(arg)
+		}
+	}
+	return true
+}
+
+func (collector *dependencyCollector) walkDynamicElementArgument(node *ast.Node) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return
+	}
+	if node.Kind == ast.KindElementAccessExpression {
+		elem := node.AsElementAccessExpression()
+		if _, ok := utils.GetStaticExpressionValue(utils.SkipAssertionsAndParens(elem.ArgumentExpression)); !ok {
+			collector.walk(elem.ArgumentExpression)
+		}
+		collector.walkDynamicElementArgument(elem.Expression)
+		return
+	}
+	if node.Kind == ast.KindPropertyAccessExpression {
+		collector.walkDynamicElementArgument(node.AsPropertyAccessExpression().Expression)
+	}
+}
+
+func (collector *dependencyCollector) dependencyFromAccess(node *ast.Node) (memoDependency, bool) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil || !ast.IsAccessExpression(node) {
+		return memoDependency{}, false
+	}
+	dep, ok := parseAccessDependency(node)
+	if !ok || !collector.shouldKeepDependency(dep.root) {
+		return memoDependency{}, false
+	}
+	return dep, true
+}
+
+func parseAccessDependency(node *ast.Node) (memoDependency, bool) {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return memoDependency{}, false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return memoDependency{root: node.AsIdentifier().Text, node: node}, node.AsIdentifier().Text != ""
+	case ast.KindPropertyAccessExpression:
+		access := node.AsPropertyAccessExpression()
+		base, ok := parseAccessDependency(access.Expression)
+		if !ok {
+			return memoDependency{}, false
+		}
+		name := access.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return memoDependency{}, false
+		}
+		base.path = append(base.path, dependencyPathPart{
+			property: name.AsIdentifier().Text,
+			optional: access.QuestionDotToken != nil,
+		})
+		base.node = node
+		return base, true
+	case ast.KindElementAccessExpression:
+		access := node.AsElementAccessExpression()
+		base, ok := parseAccessDependency(access.Expression)
+		if !ok {
+			return memoDependency{}, false
+		}
+		if property, ok := utils.GetStaticExpressionValue(utils.SkipAssertionsAndParens(access.ArgumentExpression)); ok {
+			base.path = append(base.path, dependencyPathPart{
+				property: property,
+				optional: access.QuestionDotToken != nil,
+			})
+		}
+		base.node = node
+		return base, true
+	}
+	return memoDependency{}, false
+}
+
+func (collector *dependencyCollector) isExternalReference(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindIdentifier || utils.IsNonReferenceIdentifier(node) {
+		return false
+	}
+	return collector.shouldKeepDependency(node.AsIdentifier().Text)
+}
+
+func (collector *dependencyCollector) shouldKeepDependency(name string) bool {
+	if name == "" || collector.localBindings[name] || collector.memoCtx.stableBindings[name] || collector.memoCtx.moduleBindings[name] {
+		return false
+	}
+	return true
+}
+
+func (collector *dependencyCollector) add(dep memoDependency, node *ast.Node) {
+	key := dep.String()
+	if collector.seen[key] {
+		return
+	}
+	for _, existing := range collector.dependencies {
+		if compareDependencies(dep, existing.dep) == compareDependencyOk {
+			return
+		}
+	}
+	dependencies := collector.dependencies[:0]
+	for _, existing := range collector.dependencies {
+		if compareDependencies(existing.dep, dep) == compareDependencyOk {
+			delete(collector.seen, existing.dep.String())
+			continue
+		}
+		dependencies = append(dependencies, existing)
+	}
+	collector.dependencies = dependencies
+	collector.seen[key] = true
+	collector.dependencies = append(collector.dependencies, dependencyUse{dep: dep, node: node})
+}
+
+func dependencyMutatedAfterCall(rootFn, callNode *ast.Node, dep memoDependency) bool {
+	found := false
+	react_hooksutil.WalkFunctionBody(rootFn, func(node *ast.Node) bool {
+		if found || node.Pos() <= callNode.End() {
+			return false
+		}
+		if isMutationOfDependency(node, dep) {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+func isMutationOfDependency(node *ast.Node, dep memoDependency) bool {
+	stripped := utils.SkipAssertionsAndParens(node)
+	if stripped != nil && (stripped.Kind == ast.KindIdentifier || ast.IsAccessExpression(stripped)) &&
+		utils.IsWriteReference(stripped) && targetMatchesDependency(stripped, dep) {
+		return true
+	}
+
+	switch node.Kind {
+	case ast.KindBinaryExpression:
+		if !ast.IsAssignmentExpression(node, false) {
+			return false
+		}
+		left := node.AsBinaryExpression().Left
+		return targetMatchesDependency(left, dep)
+	case ast.KindPrefixUnaryExpression:
+		expr := node.AsPrefixUnaryExpression()
+		if expr == nil || (expr.Operator != ast.KindPlusPlusToken && expr.Operator != ast.KindMinusMinusToken) {
+			return false
+		}
+		return targetMatchesDependency(expr.Operand, dep)
+	case ast.KindPostfixUnaryExpression:
+		expr := node.AsPostfixUnaryExpression()
+		if expr == nil {
+			return false
+		}
+		return targetMatchesDependency(expr.Operand, dep)
+	case ast.KindDeleteExpression:
+		return targetMatchesDependency(node.AsDeleteExpression().Expression, dep)
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		if call == nil {
+			return false
+		}
+		callee := utils.SkipAssertionsAndParens(call.Expression)
+		if callee == nil || !ast.IsAccessExpression(callee) {
+			return false
+		}
+		name, ok := utils.AccessExpressionStaticName(callee)
+		if !ok || !mutatingMethodNames[name] {
+			return false
+		}
+		return targetMatchesDependency(utils.AccessExpressionObject(callee), dep)
+	}
+	return false
+}
+
+var mutatingMethodNames = map[string]bool{
+	"copyWithin": true,
+	"fill":       true,
+	"pop":        true,
+	"push":       true,
+	"reverse":    true,
+	"shift":      true,
+	"sort":       true,
+	"splice":     true,
+	"unshift":    true,
+	"set":        true,
+	"add":        true,
+	"delete":     true,
+	"clear":      true,
+}
+
+func targetMatchesDependency(target *ast.Node, dep memoDependency) bool {
+	targetDep, ok := parseAccessDependency(target)
+	if !ok {
+		return false
+	}
+	if targetDep.root != dep.root {
+		return false
+	}
+	if len(targetDep.path) < len(dep.path) {
+		return false
+	}
+	for i, part := range dep.path {
+		if targetDep.path[i].property != part.property {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/plugins/react_hooks/rules/preserve_manual_memoization/preserve_manual_memoization.md
+++ b/internal/plugins/react_hooks/rules/preserve_manual_memoization/preserve_manual_memoization.md
@@ -1,0 +1,48 @@
+# preserve-manual-memoization
+
+## Rule Details
+
+Validates that manual `useMemo` and `useCallback` dependency arrays preserve the memoization behavior that React Compiler infers.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function Component({ data, filter }) {
+  const filtered = useMemo(() => data.filter(filter), [data]);
+  return <List items={filtered} />;
+}
+```
+
+```javascript
+function Component({ onUpdate, value }) {
+  const handleClick = useCallback(() => {
+    onUpdate(value);
+  }, [onUpdate]);
+  return <button onClick={handleClick} />;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function Component({ data, filter }) {
+  const filtered = useMemo(() => data.filter(filter), [data, filter]);
+  return <List items={filtered} />;
+}
+```
+
+```javascript
+function Component({ data, filter }) {
+  const filtered = data.filter(filter);
+  return <List items={filtered} />;
+}
+```
+
+## Differences from ESLint
+
+- rslint implements this rule as a syntax-level dependency preservation check and does not run the full React Compiler pipeline. Some compiler-only diagnostics about pruned memo blocks may not be reported.
+
+## Original Documentation
+
+- [react.dev - preserve-manual-memoization](https://react.dev/reference/eslint-plugin-react-hooks/lints/preserve-manual-memoization)
+- [Source code](https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts)

--- a/internal/plugins/react_hooks/rules/preserve_manual_memoization/preserve_manual_memoization_extras_test.go
+++ b/internal/plugins/react_hooks/rules/preserve_manual_memoization/preserve_manual_memoization_extras_test.go
@@ -1,0 +1,278 @@
+package preserve_manual_memoization
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestPreserveManualMemoizationExtras locks in branches and edge shapes that
+// the upstream fixture suite doesn't exercise. Each case carries an inline
+// comment pointing at the specific branch / Dimension 4 row / issue shape it
+// covers, so future refactors can't silently regress them without breaking a
+// named lock-in.
+
+func preserveManualMemoizationMutationError(line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "preserveManualMemoization",
+		Message:   buildPreservedManualMemoizationMutationMessage().Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func TestPreserveManualMemoizationExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Dimension 4: parenthesized receiver and callback body are transparent. ----
+		{Code: `
+function Component({ data, filter }) {
+  const filtered = (useMemo)((() => ((data)).filter(filter)), [data, filter]);
+  return <List items={filtered} />;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: TS assertion wrappers in dependency expressions are transparent. ----
+		{Code: `
+type Props = { data: string[], filter: (value: string) => boolean };
+function Component({ data, filter }: Props) {
+  const filtered = useMemo(() => (data as string[]).filter(filter), [data as string[], filter satisfies unknown]);
+  return <List items={filtered} />;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: static element access dependencies are equivalent to property dependencies. ----
+		{Code: `
+function Component({ data }) {
+  const label = useMemo(() => data['label'], [data.label]);
+  return <span>{label}</span>;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: dynamic element access collects the dynamic key. ----
+		{Code: `
+function Component({ data, keyName }) {
+  const label = useMemo(() => data[keyName], [data, keyName]);
+  return <span>{label}</span>;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: nested callbacks are traversal boundaries. ----
+		{Code: `
+function Component({ value }) {
+  const fn = useCallback(() => {
+    return () => value;
+  }, []);
+  return <button onClick={fn} />;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: state setters are stable and do not need source deps. ----
+		{Code: `
+function Component() {
+  const [count, setCount] = useState(0);
+  const onClick = useCallback(() => {
+    setCount(count => count + 1);
+  }, []);
+  return <button onClick={onClick}>{count}</button>;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: React import aliases and namespace imports are recognized. ----
+		{Code: `
+import R, { useCallback as callback } from 'react';
+function Component({ value }) {
+  const first = callback(() => value, [value]);
+  const second = R.useMemo(() => value + 1, [value]);
+  return <button onClick={first}>{second}</button>;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: class methods are not Compiler render functions for this rule. ----
+		{Code: `
+class Component {
+  render(data, filter) {
+    return useMemo(() => data.filter(filter), [data]);
+  }
+}
+		`, Tsx: true},
+		// ---- Dimension 4: nested function bodies after the memo call are traversal boundaries. ----
+		{Code: `
+function Component({ items }) {
+  const value = useMemo(() => items.length, [items]);
+  function resetLater() {
+    items.push(1);
+  }
+  return <span onClick={resetLater}>{value}</span>;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: expression-bodied callbacks that return functions do not inspect the returned function body. ----
+		{Code: `
+function Component({ value }) {
+  const makeHandler = useMemo(() => () => value, []);
+  return <button onClick={makeHandler()} />;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: empty dependency arrays degrade gracefully. ----
+		{Code: `
+function Component() {
+  const label = useMemo(() => 'static', []);
+  return <span>{label}</span>;
+}
+		`, Tsx: true},
+		// ---- Dimension 4: unsupported dynamic dependency arrays are left to use-memo/exhaustive-deps. ----
+		{Code: `
+function Component({ data, deps }) {
+  const label = useMemo(() => data.label, deps);
+  return <span>{label}</span>;
+}
+		`, Tsx: true},
+		// ---- Real-user: facebook/react#34957 state setter in useCallback remains stable. ----
+		{Code: `
+function Example({ things }) {
+  const thing = things.find(thing => thing.something > 0);
+  const [count, setCount] = React.useState(0);
+  const label = thing.label.toLowerCase();
+  const handleClick = React.useCallback(() => {
+    setCount(count => count + 1);
+  }, []);
+  return <button onClick={handleClick}>{label}: {count}</button>;
+}
+		`, Tsx: true},
+		// ---- Real-user: facebook/react#36384 state setter does not need a manual dep. ----
+		{Code: `
+function Gallery({ images }) {
+  const [selected, setImages] = useState(images);
+  const update = useCallback(() => {
+    setImages(prev => prev.slice(1));
+  }, []);
+  return <button onClick={update}>{selected.length}</button>;
+}
+		`, Tsx: true},
+		// N/A: private property names, class fields, overload signatures, and
+		// React.memo comparison functions are not useMemo/useCallback dependency
+		// arrays for this syntax-level preservation check.
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: optional chain source deps must preserve optional precision. ----
+		{
+			Code: `
+function Component({ data }) {
+  const label = useMemo(() => data?.label, [data.label]);
+  return <span>{label}</span>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMessage(
+					memoDependency{root: "data", path: []dependencyPathPart{{property: "label", optional: true}}},
+					[]memoDependency{{root: "data", path: []dependencyPathPart{{property: "label"}}}},
+					compareDependencyPathDifference,
+					3, 25, 3, 42,
+				),
+			},
+		},
+		// ---- Dimension 4: ref.current access requires exact source precision for non-stable refs. ----
+		{
+			Code: `
+function Component({ ref }) {
+  const value = useMemo(() => ref.current, [ref]);
+  return <span>{value}</span>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMessage(
+					memoDependency{root: "ref", path: []dependencyPathPart{{property: "current"}}},
+					[]memoDependency{{root: "ref"}},
+					compareDependencyRefAccessDifference,
+					3, 25, 3, 42,
+				),
+			},
+		},
+		// Locks in upstream compareDeps() arm: source path that is more specific than inferred is invalid.
+		{
+			Code: `
+function Component({ data }) {
+  const value = useMemo(() => data, [data.label]);
+  return <span>{value.label}</span>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMessage(
+					memoDependency{root: "data"},
+					[]memoDependency{{root: "data", path: []dependencyPathPart{{property: "label"}}}},
+					compareDependencySubpath,
+					3, 25, 3, 35,
+				),
+			},
+		},
+		// Locks in upstream StartMemoize operand arm: source dependency mutated later.
+		{
+			Code: `
+function Component({ items }) {
+  const value = useMemo(() => items.length, [items]);
+  items.push(1);
+  return <span>{value}</span>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMutationError(3, 46, 3, 51),
+			},
+		},
+		// ---- Dimension 4: destructuring writes are later mutations of source dependencies. ----
+		{
+			Code: `
+function Component({ items }) {
+  const value = useMemo(() => items.length, [items]);
+  [items] = [[]];
+  return <span>{value}</span>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMutationError(3, 46, 3, 51),
+			},
+		},
+		// ---- Dimension 4: property writes through TS wrappers are later mutations. ----
+		{
+			Code: `
+function Component({ item }) {
+  const value = useMemo(() => item.label, [item]);
+  (item as any).label = 'next';
+  return <span>{value}</span>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMutationError(3, 44, 3, 48),
+			},
+		},
+		// Locks in upstream collectMaybeMemoDependencies() arm: dynamic element key is inferred.
+		{
+			Code: `
+function Component({ data, keyName }) {
+  const label = useMemo(() => data[keyName], [data]);
+  return <span>{label}</span>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationDependencyError("keyName", []string{"data"}, compareDependencyRootDifference, 3, 25, 3, 44),
+			},
+		},
+		// ---- Dimension 2: member-call receivers that are calls still traverse receiver arguments. ----
+		{
+			Code: `
+function Component({ makeObj, value }) {
+  const result = useMemo(() => makeObj(value).method(), [makeObj]);
+  return <span>{result}</span>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationDependencyError("value", []string{"makeObj"}, compareDependencyRootDifference, 3, 26, 3, 55),
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreserveManualMemoizationRule, valid, invalid)
+}

--- a/internal/plugins/react_hooks/rules/preserve_manual_memoization/preserve_manual_memoization_upstream_test.go
+++ b/internal/plugins/react_hooks/rules/preserve_manual_memoization/preserve_manual_memoization_upstream_test.go
@@ -1,0 +1,381 @@
+package preserve_manual_memoization
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestPreserveManualMemoizationUpstream migrates the public docs and
+// representative React Compiler preserve-memo fixtures for
+// react-hooks/preserve-manual-memoization. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in the
+// preserve_manual_memoization_extras_test.go file.
+
+func preserveManualMemoizationDependencyError(dep string, sourceDeps []string, result compareDependencyResult, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	source := make([]memoDependency, 0, len(sourceDeps))
+	for _, sourceDep := range sourceDeps {
+		source = append(source, memoDependency{root: sourceDep})
+	}
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "preserveManualMemoization",
+		Message: buildPreservedManualMemoizationDependencyMessage(
+			memoDependency{root: dep},
+			source,
+			result,
+		).Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func preserveManualMemoizationMessage(dep memoDependency, sourceDeps []memoDependency, result compareDependencyResult, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "preserveManualMemoization",
+		Message:   buildPreservedManualMemoizationDependencyMessage(dep, sourceDeps, result).Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}
+
+func TestPreserveManualMemoizationUpstream(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- react.dev docs: complete useMemo dependencies. ----
+		{Code: `
+function Component({ data, filter }) {
+  const filtered = useMemo(
+    () => data.filter(filter),
+    [data, filter]
+  );
+  return <List items={filtered} />;
+}
+		`, Tsx: true},
+		// ---- react.dev docs: complete useCallback dependencies. ----
+		{Code: `
+function Component({ onUpdate, value }) {
+  const handleClick = useCallback(() => {
+    onUpdate(value);
+  }, [onUpdate, value]);
+  return <button onClick={handleClick} />;
+}
+		`, Tsx: true},
+		// ---- react.dev docs: no manual memoization needed. ----
+		{Code: `
+function Component({ data, filter }) {
+  const filtered = data.filter(filter);
+  return <List items={filtered} />;
+}
+		`, Tsx: true},
+		// ---- React Compiler fixture: preserve-use-callback-stable-built-ins.ts. ----
+		{Code: `
+function Component({ items }) {
+  const onClick = useCallback(() => {
+    console.log(items.length, Math.max(1, items.length));
+  }, [items]);
+  return <button onClick={onClick} />;
+}
+		`, Tsx: true},
+		// ---- React Compiler fixture: preserve-use-memo-ref-missing-ok.ts. ----
+		{Code: `
+function Component() {
+  const ref = useRef(null);
+  const value = useMemo(() => ref.current, []);
+  return <div>{value}</div>;
+}
+		`, Tsx: true},
+		// ---- React Compiler fixture: preserve-use-memo-transition.ts. ----
+		{Code: `
+function Component() {
+  const [pending, startTransition] = useTransition();
+  const onClick = useCallback(() => {
+    startTransition(() => {});
+  }, []);
+  return <button disabled={pending} onClick={onClick} />;
+}
+		`, Tsx: true},
+		// ---- React Compiler fixture: useMemo-alias-property-load-dep.ts. ----
+		{Code: `
+import {useMemo} from 'react';
+import {sum} from 'shared-runtime';
+
+function Component({propA, propB}) {
+  const x = propB.x.y;
+  return useMemo(() => {
+    return sum(propA.x, x);
+  }, [propA.x, x]);
+}
+		`, Tsx: true},
+		// ---- React Compiler fixture: useCallback-alias-property-load-dep.ts. ----
+		{Code: `
+import {useCallback} from 'react';
+import {sum} from 'shared-runtime';
+
+function Component({propA, propB}) {
+  const x = propB.x.y;
+  return useCallback(() => {
+    return sum(propA.x, x);
+  }, [propA.x, x]);
+}
+		`, Tsx: true},
+		// ---- React Compiler fixture: useMemo-infer-more-specific.ts. ----
+		{Code: `
+import {useMemo} from 'react';
+
+function useHook(x) {
+  return useMemo(() => [x.y.z], [x]);
+}
+		`},
+		// ---- React Compiler fixture: useCallback-infer-more-specific.ts. ----
+		{Code: `
+import {useCallback} from 'react';
+
+function useHook(x) {
+  return useCallback(() => [x.y.z], [x]);
+}
+		`},
+		// ---- React Compiler fixture: useMemo-dep-array-literal-access.ts. ----
+		{Code: `
+import {useMemo} from 'react';
+
+function Foo(props) {
+  const x = makeArray(props);
+  return useMemo(() => [x[0]], [x[0]]);
+}
+		`},
+		// ---- React Compiler fixture: useMemo-inner-decl.ts. ----
+		{Code: `
+import {useMemo} from 'react';
+import {identity} from 'shared-runtime';
+
+function useFoo(data) {
+  return useMemo(() => {
+    const temp = identity(data.a);
+    return {temp};
+  }, [data.a]);
+}
+		`},
+		// ---- React Compiler ESLint options schema: first option object is accepted. ----
+		{Code: `
+function Component({ data, filter }) {
+  const filtered = useMemo(() => data.filter(filter), [data, filter]);
+  return <List items={filtered} />;
+}
+		`, Tsx: true, Options: map[string]interface{}{"compilationMode": "annotation", "panicThreshold": "none"}},
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- react.dev docs: missing useMemo dependency. ----
+		{
+			Code: `
+function Component({ data, filter }) {
+  const filtered = useMemo(
+    () => data.filter(filter),
+    [data]
+  );
+  return <List items={filtered} />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationDependencyError("filter", []string{"data"}, compareDependencyRootDifference, 4, 5, 4, 30),
+			},
+		},
+		// ---- react.dev docs: missing useCallback dependency. ----
+		{
+			Code: `
+function Component({ onUpdate, value }) {
+  const handleClick = useCallback(() => {
+    onUpdate(value);
+  }, [onUpdate]);
+  return <button onClick={handleClick} />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationDependencyError("value", []string{"onUpdate"}, compareDependencyRootDifference, 3, 35, 5, 4),
+			},
+		},
+		// ---- React Compiler fixture: error.useMemo-property-call-dep.ts. ----
+		{
+			Code: `
+import {useMemo} from 'react';
+
+function Component({propA}) {
+  return useMemo(() => {
+    return propA.x();
+  }, [propA.x]);
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMessage(
+					memoDependency{root: "propA"},
+					[]memoDependency{{root: "propA", path: []dependencyPathPart{{property: "x"}}}},
+					compareDependencySubpath,
+					5, 18, 7, 4,
+				),
+			},
+		},
+		// ---- React Compiler fixture: error.useMemo-property-call-chained-object.ts. ----
+		{
+			Code: `
+import {useMemo} from 'react';
+
+function Component({propA}) {
+  return useMemo(() => {
+    return {
+      value: propA.x().y,
+    };
+  }, [propA.x]);
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMessage(
+					memoDependency{root: "propA"},
+					[]memoDependency{{root: "propA", path: []dependencyPathPart{{property: "x"}}}},
+					compareDependencySubpath,
+					5, 18, 9, 4,
+				),
+			},
+		},
+		// ---- React Compiler fixture: error.useCallback-property-call-dep.ts. ----
+		{
+			Code: `
+import {useCallback} from 'react';
+
+function Component({propA}) {
+  return useCallback(() => {
+    return propA.x();
+  }, [propA.x]);
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMessage(
+					memoDependency{root: "propA"},
+					[]memoDependency{{root: "propA", path: []dependencyPathPart{{property: "x"}}}},
+					compareDependencySubpath,
+					5, 22, 7, 4,
+				),
+			},
+		},
+		// ---- React Compiler fixture: error.preserve-use-memo-ref-missing-reactive.ts. ----
+		{
+			Code: `
+function Component({ cond, ref1, ref2 }) {
+  const ref = cond ? ref1 : ref2;
+  const cb = useCallback(() => {
+    ref.current();
+  }, []);
+  return <button onClick={cb} />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMessage(
+					memoDependency{root: "ref"},
+					nil,
+					compareDependencyRootDifference,
+					4, 26, 6, 4,
+				),
+			},
+		},
+		// ---- React Compiler fixture: error.useMemo-aliased-var.ts. ----
+		{
+			Code: `
+function useHook(x) {
+  const aliasedX = x;
+  const aliasedProp = x.y.z;
+
+  return useMemo(() => [x, x.y.z], [aliasedX, aliasedProp]);
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMessage(
+					memoDependency{root: "x"},
+					[]memoDependency{{root: "aliasedX"}, {root: "aliasedProp"}},
+					compareDependencyRootDifference,
+					6, 18, 6, 34,
+				),
+			},
+		},
+		// ---- React Compiler fixture: error.useCallback-aliased-var.ts. ----
+		{
+			Code: `
+function useHook(x) {
+  const aliasedX = x;
+  const aliasedProp = x.y.z;
+
+  return useCallback(() => [aliasedX, x.y.z], [x, aliasedProp]);
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMessage(
+					memoDependency{root: "aliasedX"},
+					[]memoDependency{{root: "x"}, {root: "aliasedProp"}},
+					compareDependencyRootDifference,
+					6, 22, 6, 45,
+				),
+			},
+		},
+		// ---- React Compiler fixture: error.useCallback-conditional-access-noAlloc.ts. ----
+		{
+			Code: `
+import {useCallback} from 'react';
+
+function Component({propA, propB}) {
+  return useCallback(() => {
+    return {
+      value: propB?.x.y,
+      other: propA,
+    };
+  }, [propA, propB.x.y]);
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				preserveManualMemoizationMessage(
+					memoDependency{root: "propB", path: []dependencyPathPart{{property: "x", optional: true}, {property: "y"}}},
+					[]memoDependency{{root: "propA"}, {root: "propB", path: []dependencyPathPart{{property: "x"}, {property: "y"}}}},
+					compareDependencyPathDifference,
+					5, 22, 10, 4,
+				),
+			},
+		},
+		// SKIP: React Compiler fixture error.false-positive-useMemo-dropped-infer-always-invalidating.ts
+		// depends on the compiler's pruned reactive-scope output, which this syntax-level rule cannot observe.
+		{Skip: true, Code: `
+function useFoo(props) {
+  const x = [];
+  useHook();
+  x.push(props);
+  return useMemo(() => [x], [x]);
+}
+		`},
+		// SKIP: React Compiler fixture error.false-positive-useMemo-infer-mutate-deps.ts
+		// reports a conservative HIR mutable-range diagnostic without a later source write.
+		{Skip: true, Code: `
+function useFoo() {
+  const val = [1, 2, 3];
+  return useMemo(() => identity(val), [val]);
+}
+		`},
+		// SKIP: React Compiler fixture error.useMemo-infer-less-specific-conditional-access.ts
+		// relies on conditional reactive-scope hoisting rather than a syntax-visible dependency mismatch.
+		{Skip: true, Code: `
+function Component({propA, propB}) {
+  return useMemo(() => {
+    const x = {};
+    if (propA?.a) {
+      mutate(x);
+      return {value: propB.x.y};
+    }
+  }, [propA?.a, propB.x.y]);
+}
+		`},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreserveManualMemoizationRule, valid, invalid)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -218,6 +218,7 @@ export default defineConfig({
     './tests/eslint-plugin-react-hooks/rules/globals.test.ts',
     './tests/eslint-plugin-react-hooks/rules/immutability.test.ts',
     './tests/eslint-plugin-react-hooks/rules/incompatible-library.test.ts',
+    './tests/eslint-plugin-react-hooks/rules/preserve-manual-memoization.test.ts',
 
     // eslint-plugin-jsx-a11y
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/preserve-manual-memoization.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/preserve-manual-memoization.test.ts
@@ -1,0 +1,92 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const preserveManualMemoizationMessage = (
+  dependency: string,
+  sourceDependencies: string,
+  detail: string,
+) =>
+  `Compilation Skipped: Existing memoization could not be preserved\n\n` +
+  `React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. ` +
+  `The inferred dependencies did not match the manually specified dependencies, which could cause the value to change more or less frequently than expected. ` +
+  `The inferred dependency was \`${dependency}\`, but the source dependencies were [${sourceDependencies}]. ${detail}`;
+
+const preserveManualMemoizationMutationMessage =
+  `Compilation Skipped: Existing memoization could not be preserved\n\n` +
+  `React Compiler has skipped optimizing this component because the existing manual memoization could not be preserved. ` +
+  `This dependency may be mutated later, which could cause the value to change unexpectedly.`;
+
+ruleTester.run('preserve-manual-memoization', {} as never, {
+  valid: [
+    {
+      code: `
+        function Component({ data, filter }) {
+          const filtered = useMemo(
+            () => data.filter(filter),
+            [data, filter]
+          );
+          return <List items={filtered} />;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component({ onUpdate, value }) {
+          const handleClick = useCallback(() => {
+            onUpdate(value);
+          }, [onUpdate, value]);
+          return <button onClick={handleClick} />;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          const ref = useRef(null);
+          const value = useMemo(() => ref.current, []);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function Component({ propA }) {
+          const value = useMemo(() => {
+            return propA.x();
+          }, [propA.x]);
+          return <span>{value}</span>;
+        }
+      `,
+      errors: [
+        {
+          message: preserveManualMemoizationMessage(
+            'propA',
+            'propA.x',
+            'Inferred less specific property than source.',
+          ),
+        },
+        {
+          message:
+            "React Hook useMemo has a missing dependency: 'propA'. Either include it or remove the dependency array.",
+        },
+      ],
+    },
+    {
+      code: `
+        function Component({ items }) {
+          const value = useMemo(() => items.length, [items]);
+          items.push(1);
+          return <span>{value}</span>;
+        }
+      `,
+      errors: [
+        {
+          message: preserveManualMemoizationMutationMessage,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react-hooks/preserve-manual-memoization` rule to rslint.

The rule validates manual `useMemo` and `useCallback` dependency arrays against the dependencies inferred from the memo callback, including member-call receiver dependencies, optional-chain precision, `ref.current` precision, stable React hook returns, dynamic keys, and later dependency mutations.

## Related Links

- React docs: https://react.dev/reference/eslint-plugin-react-hooks/lints/preserve-manual-memoization
- React Compiler validation source: https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidatePreservedManualMemoization.ts
- ESLint plugin bridge: https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/shared/ReactCompiler.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
