### PR TITLE
fix: honor languageOptions.parserOptions.jsxPragma / jsxFragmentName

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -1233,7 +1233,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 
 		// Rebuild fallback Program for gap files (content may have changed after fixes).
 		if len(capturedGapFiles) > 0 {
-			fallback, _ := createFallbackProgram(capturedGapFiles, singleThreaded, cwd, fs, parseCache)
+			jsxFactory, jsxFragmentFactory := resolveGapJsxPragma(configMap, rslintConfig)
+			fallback, _ := createFallbackProgram(capturedGapFiles, singleThreaded, cwd, fs, parseCache, jsxFactory, jsxFragmentFactory)
 			if fallback != nil {
 				baseProgs = append(baseProgs, fallback)
 			}

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -125,7 +125,12 @@ func createProgramsForConfig(
 		includes := []string{"**/*"}
 		rootFiles := vfsmatch.ReadDirectory(fsys, configDir, configDir, sourceExts, excludes, includes, vfsmatch.UnlimitedDepth)
 		if len(rootFiles) > 0 {
-			program, err := utils.CreateProgramFromOptions(singleThreaded, &core.CompilerOptions{AllowJs: core.TSTrue}, rootFiles, host)
+			jsxFactory, jsxFragmentFactory := rslintconfig.ResolveJsxPragmaOptions(entries)
+			program, err := utils.CreateProgramFromOptions(singleThreaded, &core.CompilerOptions{
+				AllowJs:            core.TSTrue,
+				JsxFactory:         jsxFactory,
+				JsxFragmentFactory: jsxFragmentFactory,
+			}, rootFiles, host)
 			if err != nil {
 				w := bufio.NewWriter(os.Stderr)
 				if !reportSyntacticErrors(err, w, tspath.ComparePathsOptions{
@@ -146,19 +151,27 @@ func createProgramsForConfig(
 // createFallbackProgram creates a Program for "gap" files — files matched by
 // config `files` patterns but not included in any tsconfig. Uses minimal
 // compiler options sufficient for AST parsing (no type checking).
+// jsxFactory / jsxFragmentFactory come from the owning config's
+// languageOptions.parserOptions.jsxPragma / jsxFragmentName (see
+// rslintconfig.ResolveJsxPragmaOptions); empty strings leave TypeScript's
+// own "React" / "Fragment" defaults in place.
 func createFallbackProgram(
 	gapFiles []string,
 	singleThreaded bool,
 	configDir string,
 	fsys vfs.FS,
 	parseCache *utils.ParseCache,
+	jsxFactory string,
+	jsxFragmentFactory string,
 ) (*compiler.Program, int) {
 	host := utils.WithParseCache(utils.CreateCompilerHost(configDir, fsys), parseCache)
 	program, err := utils.CreateProgramFromOptionsLenient(singleThreaded, &core.CompilerOptions{
-		Target:  core.ScriptTargetESNext,
-		Module:  core.ModuleKindESNext,
-		Jsx:     core.JsxEmitPreserve,
-		AllowJs: core.TSTrue,
+		Target:             core.ScriptTargetESNext,
+		Module:             core.ModuleKindESNext,
+		Jsx:                core.JsxEmitPreserve,
+		AllowJs:            core.TSTrue,
+		JsxFactory:         jsxFactory,
+		JsxFragmentFactory: jsxFragmentFactory,
 	}, gapFiles, host)
 	if err != nil {
 		// Non-fatal: gap files failing to parse should not block the entire run.
@@ -254,7 +267,8 @@ func buildProgramsWithGapFallback(
 		capturedGapFiles = gapFiles
 
 		if len(gapFiles) > 0 {
-			fallback, _ := createFallbackProgram(gapFiles, singleThreaded, currentDirectory, fs, parseCache)
+			jsxFactory, jsxFragmentFactory := resolveGapJsxPragma(configMap, rslintConfig)
+			fallback, _ := createFallbackProgram(gapFiles, singleThreaded, currentDirectory, fs, parseCache, jsxFactory, jsxFragmentFactory)
 			if fallback != nil {
 				programs = append(programs, fallback)
 			}
@@ -262,6 +276,29 @@ func buildProgramsWithGapFallback(
 	}
 
 	return programs, typeInfoFiles, capturedGapFiles
+}
+
+// resolveGapJsxPragma resolves the jsxPragma / jsxFragmentName to seed the
+// gap-file fallback Program's CompilerOptions with. In multi-config mode
+// (configMap non-nil) the gap-file batch can span multiple config
+// directories, so this unions across all of them — a best-effort default for
+// the (rare) case where directories disagree, matching the same
+// single-Program-for-many-files tradeoff the fallback Program already makes.
+// Single-config mode resolves directly against rslintConfig.
+func resolveGapJsxPragma(configMap map[string]rslintconfig.RslintConfig, rslintConfig rslintconfig.RslintConfig) (jsxFactory, jsxFragmentFactory string) {
+	if configMap != nil {
+		for _, entries := range configMap {
+			f, ff := rslintconfig.ResolveJsxPragmaOptions(entries)
+			if f != "" {
+				jsxFactory = f
+			}
+			if ff != "" {
+				jsxFragmentFactory = ff
+			}
+		}
+		return jsxFactory, jsxFragmentFactory
+	}
+	return rslintconfig.ResolveJsxPragmaOptions(rslintConfig)
 }
 
 // buildFileOwnerMap determines which config directory "owns" each file across

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -151,10 +151,8 @@ func createProgramsForConfig(
 // createFallbackProgram creates a Program for "gap" files — files matched by
 // config `files` patterns but not included in any tsconfig. Uses minimal
 // compiler options sufficient for AST parsing (no type checking).
-// jsxFactory / jsxFragmentFactory come from the owning config's
-// languageOptions.parserOptions.jsxPragma / jsxFragmentName (see
-// rslintconfig.ResolveJsxPragmaOptions); empty strings leave TypeScript's
-// own "React" / "Fragment" defaults in place.
+// Empty jsxFactory / jsxFragmentFactory leave TypeScript's own "React" /
+// "Fragment" defaults in place.
 func createFallbackProgram(
 	gapFiles []string,
 	singleThreaded bool,
@@ -281,10 +279,7 @@ func buildProgramsWithGapFallback(
 // resolveGapJsxPragma resolves the jsxPragma / jsxFragmentName to seed the
 // gap-file fallback Program's CompilerOptions with. In multi-config mode
 // (configMap non-nil) the gap-file batch can span multiple config
-// directories, so this unions across all of them — a best-effort default for
-// the (rare) case where directories disagree, matching the same
-// single-Program-for-many-files tradeoff the fallback Program already makes.
-// Single-config mode resolves directly against rslintConfig.
+// directories, so this unions across all of them.
 func resolveGapJsxPragma(configMap map[string]rslintconfig.RslintConfig, rslintConfig rslintconfig.RslintConfig) (jsxFactory, jsxFragmentFactory string) {
 	if configMap != nil {
 		for _, entries := range configMap {

--- a/cmd/rslint/programs_gate_regression_test.go
+++ b/cmd/rslint/programs_gate_regression_test.go
@@ -86,7 +86,7 @@ func runBypassedGateScenario() {
 	fs = utils.NewOverlayVFS(fs, map[string]string{gapFile: "let a: any = 10;\na.b = 20;\n"})
 
 	parseCache := utils.NewParseCache()
-	fallback, _ := createFallbackProgram([]string{gapFile}, false, tmpDir, fs, parseCache)
+	fallback, _ := createFallbackProgram([]string{gapFile}, false, tmpDir, fs, parseCache, "", "")
 	if fallback == nil {
 		return // could not build the program → cannot reproduce; parent fails
 	}

--- a/cmd/rslint/programs_jsx_pragma_test.go
+++ b/cmd/rslint/programs_jsx_pragma_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// TestCreateProgramsForConfig_NoTsconfig_JsxPragma is a regression test for
+// https://github.com/web-infra-dev/rslint/issues/1230: a project with NO
+// tsconfig.json (so createProgramsForConfig takes the directory-scan
+// fallback branch) that sets languageOptions.parserOptions.jsxPragma to a
+// non-default value (e.g. Preact's "h") must have that value reach the
+// synthesized Program's CompilerOptions.JsxFactory, so the Go-native
+// `@typescript-eslint/no-unused-vars` rule's implicit-JSX-usage check
+// (markJsxFactoryUsed) marks the configured pragma's import as used
+// instead of hard-coding "React".
+func TestCreateProgramsForConfig_NoTsconfig_JsxPragma(t *testing.T) {
+	rslintconfig.RegisterAllRules()
+
+	dir := t.TempDir()
+	writeProgramTestFiles(t, dir, map[string]string{
+		"src/index.jsx": `import { h } from 'preact';
+
+export function App() {
+  return <div>Hello Preact</div>;
+}
+`,
+	})
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	jsxFile := tspath.NormalizePath(filepath.Join(dir, "src/index.jsx"))
+
+	runNoUnusedVars := func(t *testing.T, jsxPragma *string) []rule.RuleDiagnostic {
+		t.Helper()
+		cfg := rslintconfig.RslintConfig{
+			{
+				Files:   []string{"**/*.jsx"},
+				Plugins: []string{"@typescript-eslint"},
+				Rules:   rslintconfig.Rules{"@typescript-eslint/no-unused-vars": "error"},
+				LanguageOptions: &rslintconfig.LanguageOptions{
+					ParserOptions: &rslintconfig.ParserOptions{JsxPragma: jsxPragma},
+				},
+			},
+		}
+
+		programs, exitCode := createProgramsForConfig(dir, cfg, true, fs, nil, utils.NewParseCache())
+		if exitCode != 0 {
+			t.Fatalf("createProgramsForConfig exit code = %d", exitCode)
+		}
+		if len(programs) != 1 {
+			t.Fatalf("expected one synthesized no-tsconfig program, got %d", len(programs))
+		}
+
+		wantFactory := ""
+		if jsxPragma != nil {
+			wantFactory = *jsxPragma
+		}
+		if got := programs[0].Options().JsxFactory; got != wantFactory {
+			t.Fatalf("expected Program CompilerOptions.JsxFactory = %q, got %q", wantFactory, got)
+		}
+
+		rules, _ := rslintconfig.GlobalRuleRegistry.GetEnabledRules(cfg, jsxFile, dir, false)
+
+		var diags []rule.RuleDiagnostic
+		_, err := linter.RunLinter(linter.RunLinterOptions{
+			Programs: programs,
+			Scope:    linter.FileScope{Files: []string{jsxFile}},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return rules
+			},
+			OnDiagnostic: func(d rule.RuleDiagnostic) {
+				diags = append(diags, d)
+			},
+		})
+		if err != nil {
+			t.Fatalf("RunLinter: %v", err)
+		}
+		return diags
+	}
+
+	pragma := "h"
+	if diags := runNoUnusedVars(t, &pragma); len(diags) != 0 {
+		t.Fatalf("jsxPragma:'h' — expected 'h' to be marked used via JSX, got diagnostics: %+v", diags)
+	}
+
+	// Negative control: without jsxPragma configured, "React" is the
+	// implicit-usage default, so the `h` import genuinely IS unused — pins
+	// that the above assertion is exercising the pragma, not just always
+	// passing.
+	if diags := runNoUnusedVars(t, nil); len(diags) == 0 {
+		t.Fatal("expected 'h' to be reported as unused when jsxPragma is not configured (default pragma is 'React')")
+	}
+}

--- a/cmd/rslint/programs_jsx_pragma_test.go
+++ b/cmd/rslint/programs_jsx_pragma_test.go
@@ -15,15 +15,13 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// TestCreateProgramsForConfig_NoTsconfig_JsxPragma is a regression test for
-// https://github.com/web-infra-dev/rslint/issues/1230: a project with NO
+// TestCreateProgramsForConfig_NoTsconfig_JsxPragma: a project with no
 // tsconfig.json (so createProgramsForConfig takes the directory-scan
 // fallback branch) that sets languageOptions.parserOptions.jsxPragma to a
 // non-default value (e.g. Preact's "h") must have that value reach the
 // synthesized Program's CompilerOptions.JsxFactory, so the Go-native
-// `@typescript-eslint/no-unused-vars` rule's implicit-JSX-usage check
-// (markJsxFactoryUsed) marks the configured pragma's import as used
-// instead of hard-coding "React".
+// `@typescript-eslint/no-unused-vars` rule marks the configured pragma's
+// import as used.
 func TestCreateProgramsForConfig_NoTsconfig_JsxPragma(t *testing.T) {
 	rslintconfig.RegisterAllRules()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,11 +94,7 @@ type ParserOptions struct {
 	// JsxPragma / JsxFragmentName mirror @typescript-eslint/parser's
 	// `parserOptions.jsxPragma` / `parserOptions.jsxFragmentName` — the
 	// identifier implicitly referenced by JSX elements / fragments (Preact's
-	// `h`/`Fragment`, a custom factory, ...). Consumed by
-	// ResolveJsxPragmaOptions to seed CompilerOptions.JsxFactory /
-	// JsxFragmentFactory for Programs synthesized without a tsconfig (see
-	// cmd/rslint/programs.go), so the Go-native `no-unused-vars` implicit-
-	// usage check (markJsxFactoryUsed) doesn't hard-code "React".
+	// `h`/`Fragment`, a custom factory, ...).
 	JsxPragma       *string `json:"jsxPragma,omitempty"`
 	JsxFragmentName *string `json:"jsxFragmentName,omitempty"`
 }
@@ -584,12 +580,8 @@ func mergeLanguageOptions(base, override *LanguageOptions) *LanguageOptions {
 	}
 	// Deep-merge the raw languageOptions map (override wins per key; nested
 	// objects like `parserOptions` are merged key-by-key rather than replaced
-	// wholesale). Without this, overriding only `parserOptions.jsxPragma` in a
-	// later entry silently dropped an earlier entry's `parserOptions.project`
-	// (and any other nested parserOptions/globals) because the whole
-	// `parserOptions` object was swapped out — see
-	// https://github.com/web-infra-dev/rslint/issues/1230. merged is a shallow
-	// copy of base, so build a fresh map rather than mutating base.Raw.
+	// wholesale). merged is a shallow copy of base, so build a fresh map
+	// rather than mutating base.Raw.
 	if len(override.Raw) > 0 {
 		merged.Raw = deepMergeRawMaps(base.Raw, override.Raw)
 	}
@@ -626,11 +618,7 @@ func deepMergeRawMaps(base, override map[string]any) map[string]any {
 // earlier ones (matching GetConfigForFile's merge order). It exists for the
 // Programs that synthesize CompilerOptions for a batch of files instead of
 // resolving a single file's merged config — the no-tsconfig directory scan
-// and the gap-file fallback Program (cmd/rslint/programs.go) — so their
-// JsxFactory / JsxFragmentFactory aren't hard-coded to TypeScript's "React"
-// default when the user only configured Preact/Vue-style pragmas via rslint
-// config rather than tsconfig.json. See
-// https://github.com/web-infra-dev/rslint/issues/1230.
+// and the gap-file fallback Program (cmd/rslint/programs.go).
 func ResolveJsxPragmaOptions(entries RslintConfig) (jsxFactory, jsxFragmentFactory string) {
 	for _, entry := range entries {
 		if entry.LanguageOptions == nil || entry.LanguageOptions.ParserOptions == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,16 @@ func (p *ProjectPaths) UnmarshalJSON(data []byte) error {
 type ParserOptions struct {
 	ProjectService *bool        `json:"projectService,omitempty"`
 	Project        ProjectPaths `json:"project,omitempty"`
+	// JsxPragma / JsxFragmentName mirror @typescript-eslint/parser's
+	// `parserOptions.jsxPragma` / `parserOptions.jsxFragmentName` — the
+	// identifier implicitly referenced by JSX elements / fragments (Preact's
+	// `h`/`Fragment`, a custom factory, ...). Consumed by
+	// ResolveJsxPragmaOptions to seed CompilerOptions.JsxFactory /
+	// JsxFragmentFactory for Programs synthesized without a tsconfig (see
+	// cmd/rslint/programs.go), so the Go-native `no-unused-vars` implicit-
+	// usage check (markJsxFactoryUsed) doesn't hard-code "React".
+	JsxPragma       *string `json:"jsxPragma,omitempty"`
+	JsxFragmentName *string `json:"jsxFragmentName,omitempty"`
 }
 
 // BoolPtr returns a pointer to the given bool value.
@@ -563,25 +573,78 @@ func mergeLanguageOptions(base, override *LanguageOptions) *LanguageOptions {
 			if len(override.ParserOptions.Project) > 0 {
 				po.Project = override.ParserOptions.Project
 			}
+			if override.ParserOptions.JsxPragma != nil {
+				po.JsxPragma = override.ParserOptions.JsxPragma
+			}
+			if override.ParserOptions.JsxFragmentName != nil {
+				po.JsxFragmentName = override.ParserOptions.JsxFragmentName
+			}
 			merged.ParserOptions = &po
 		}
 	}
-	// Shallow-merge the raw languageOptions map (override wins per key). This is
-	// intentionally shallow, NOT ESLint's recursive flat-config deepMerge of
-	// nested parserOptions/globals — matching that merge fidelity is a separate
-	// concern from wiring eslintPlugins and is out of scope here. merged is a
-	// shallow copy of base, so build a fresh map rather than mutating base.Raw.
+	// Deep-merge the raw languageOptions map (override wins per key; nested
+	// objects like `parserOptions` are merged key-by-key rather than replaced
+	// wholesale). Without this, overriding only `parserOptions.jsxPragma` in a
+	// later entry silently dropped an earlier entry's `parserOptions.project`
+	// (and any other nested parserOptions/globals) because the whole
+	// `parserOptions` object was swapped out — see
+	// https://github.com/web-infra-dev/rslint/issues/1230. merged is a shallow
+	// copy of base, so build a fresh map rather than mutating base.Raw.
 	if len(override.Raw) > 0 {
-		mergedRaw := make(map[string]any, len(base.Raw)+len(override.Raw))
-		for k, v := range base.Raw {
-			mergedRaw[k] = v
-		}
-		for k, v := range override.Raw {
-			mergedRaw[k] = v
-		}
-		merged.Raw = mergedRaw
+		merged.Raw = deepMergeRawMaps(base.Raw, override.Raw)
 	}
 	return &merged
+}
+
+// deepMergeRawMaps recursively merges override into base (override wins on
+// conflicting scalar/array keys); when both sides have a `map[string]any`
+// at the same key, they are merged recursively instead of override
+// replacing the whole nested object. Matches ESLint flat-config's
+// languageOptions merge semantics closely enough for parserOptions/globals
+// nesting without pulling in a general-purpose deep-merge dependency.
+func deepMergeRawMaps(base, override map[string]any) map[string]any {
+	merged := make(map[string]any, len(base)+len(override))
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range override {
+		if baseVal, ok := merged[k]; ok {
+			if baseMap, ok := baseVal.(map[string]any); ok {
+				if overrideMap, ok := v.(map[string]any); ok {
+					merged[k] = deepMergeRawMaps(baseMap, overrideMap)
+					continue
+				}
+			}
+		}
+		merged[k] = v
+	}
+	return merged
+}
+
+// ResolveJsxPragmaOptions scans entries for a `languageOptions.parserOptions`
+// jsxPragma / jsxFragmentName, in entry order, later entries overriding
+// earlier ones (matching GetConfigForFile's merge order). It exists for the
+// Programs that synthesize CompilerOptions for a batch of files instead of
+// resolving a single file's merged config — the no-tsconfig directory scan
+// and the gap-file fallback Program (cmd/rslint/programs.go) — so their
+// JsxFactory / JsxFragmentFactory aren't hard-coded to TypeScript's "React"
+// default when the user only configured Preact/Vue-style pragmas via rslint
+// config rather than tsconfig.json. See
+// https://github.com/web-infra-dev/rslint/issues/1230.
+func ResolveJsxPragmaOptions(entries RslintConfig) (jsxFactory, jsxFragmentFactory string) {
+	for _, entry := range entries {
+		if entry.LanguageOptions == nil || entry.LanguageOptions.ParserOptions == nil {
+			continue
+		}
+		po := entry.LanguageOptions.ParserOptions
+		if po.JsxPragma != nil && *po.JsxPragma != "" {
+			jsxFactory = *po.JsxPragma
+		}
+		if po.JsxFragmentName != nil && *po.JsxFragmentName != "" {
+			jsxFragmentFactory = *po.JsxFragmentName
+		}
+	}
+	return jsxFactory, jsxFragmentFactory
 }
 
 // RulePluginPrefix extracts the plugin prefix from a rule name.

--- a/internal/config/config_merge_test.go
+++ b/internal/config/config_merge_test.go
@@ -272,6 +272,62 @@ func TestMergeLanguageOptions(t *testing.T) {
 			t.Error("Expected ProjectService to be preserved from base")
 		}
 	})
+
+	t.Run("jsxPragma/jsxFragmentName override wins, unset fields preserve base", func(t *testing.T) {
+		base := &LanguageOptions{
+			ParserOptions: &ParserOptions{
+				Project: ProjectPaths{"./tsconfig.json"},
+			},
+		}
+		pragma := "h"
+		override := &LanguageOptions{
+			ParserOptions: &ParserOptions{
+				JsxPragma: &pragma,
+			},
+		}
+		result := mergeLanguageOptions(base, override)
+
+		if result.ParserOptions.JsxPragma == nil || *result.ParserOptions.JsxPragma != "h" {
+			t.Error("Expected JsxPragma to be set from override")
+		}
+		if len(result.ParserOptions.Project) != 1 || result.ParserOptions.Project[0] != "./tsconfig.json" {
+			t.Error("Expected Project to be preserved from base")
+		}
+	})
+
+	// Regression test for https://github.com/web-infra-dev/rslint/issues/1230:
+	// a later entry overriding only parserOptions.jsxPragma must not discard
+	// an earlier entry's parserOptions.project — the Raw map merge used to be
+	// a one-level shallow overwrite, so setting ANY key under `parserOptions`
+	// replaced the whole nested object.
+	t.Run("raw parserOptions deep merge preserves sibling keys", func(t *testing.T) {
+		base := &LanguageOptions{
+			Raw: map[string]any{
+				"parserOptions": map[string]any{
+					"project": "./tsconfig.json",
+				},
+			},
+		}
+		override := &LanguageOptions{
+			Raw: map[string]any{
+				"parserOptions": map[string]any{
+					"jsxPragma": "h",
+				},
+			},
+		}
+		result := mergeLanguageOptions(base, override)
+
+		po, ok := result.Raw["parserOptions"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected parserOptions to be a map in the merged Raw config")
+		}
+		if po["project"] != "./tsconfig.json" {
+			t.Errorf("Expected base's parserOptions.project to survive the merge, got %v", po["project"])
+		}
+		if po["jsxPragma"] != "h" {
+			t.Errorf("Expected override's parserOptions.jsxPragma to be applied, got %v", po["jsxPragma"])
+		}
+	})
 }
 
 func TestIsGlobalIgnoreEntry(t *testing.T) {
@@ -815,4 +871,63 @@ func TestGetConfigForFile_WindowsPaths(t *testing.T) {
 			}
 		})
 	}
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestResolveJsxPragmaOptions(t *testing.T) {
+	t.Run("no entries set jsxPragma", func(t *testing.T) {
+		entries := RslintConfig{
+			{LanguageOptions: &LanguageOptions{ParserOptions: &ParserOptions{}}},
+		}
+		factory, fragment := ResolveJsxPragmaOptions(entries)
+		if factory != "" || fragment != "" {
+			t.Errorf("expected empty defaults, got factory=%q fragment=%q", factory, fragment)
+		}
+	})
+
+	t.Run("single entry sets both", func(t *testing.T) {
+		entries := RslintConfig{
+			{LanguageOptions: &LanguageOptions{ParserOptions: &ParserOptions{
+				JsxPragma:       strPtr("h"),
+				JsxFragmentName: strPtr("Fragment"),
+			}}},
+		}
+		factory, fragment := ResolveJsxPragmaOptions(entries)
+		if factory != "h" {
+			t.Errorf("expected factory=%q, got %q", "h", factory)
+		}
+		if fragment != "Fragment" {
+			t.Errorf("expected fragment=%q, got %q", "Fragment", fragment)
+		}
+	})
+
+	t.Run("later entry overrides earlier entry", func(t *testing.T) {
+		entries := RslintConfig{
+			{LanguageOptions: &LanguageOptions{ParserOptions: &ParserOptions{
+				JsxPragma: strPtr("React"),
+			}}},
+			{LanguageOptions: &LanguageOptions{ParserOptions: &ParserOptions{
+				JsxPragma: strPtr("h"),
+			}}},
+		}
+		factory, _ := ResolveJsxPragmaOptions(entries)
+		if factory != "h" {
+			t.Errorf("expected the later entry's factory=%q to win, got %q", "h", factory)
+		}
+	})
+
+	t.Run("nil LanguageOptions/ParserOptions are skipped", func(t *testing.T) {
+		entries := RslintConfig{
+			{},
+			{LanguageOptions: &LanguageOptions{}},
+			{LanguageOptions: &LanguageOptions{ParserOptions: &ParserOptions{
+				JsxPragma: strPtr("h"),
+			}}},
+		}
+		factory, _ := ResolveJsxPragmaOptions(entries)
+		if factory != "h" {
+			t.Errorf("expected factory=%q, got %q", "h", factory)
+		}
+	})
 }

--- a/internal/config/config_merge_test.go
+++ b/internal/config/config_merge_test.go
@@ -295,11 +295,8 @@ func TestMergeLanguageOptions(t *testing.T) {
 		}
 	})
 
-	// Regression test for https://github.com/web-infra-dev/rslint/issues/1230:
-	// a later entry overriding only parserOptions.jsxPragma must not discard
-	// an earlier entry's parserOptions.project — the Raw map merge used to be
-	// a one-level shallow overwrite, so setting ANY key under `parserOptions`
-	// replaced the whole nested object.
+	// A later entry overriding only parserOptions.jsxPragma must not discard
+	// an earlier entry's parserOptions.project.
 	t.Run("raw parserOptions deep merge preserves sibling keys", func(t *testing.T) {
 		base := &LanguageOptions{
 			Raw: map[string]any{

--- a/packages/rslint/src/eslint-plugin/ast/scope-factory.ts
+++ b/packages/rslint/src/eslint-plugin/ast/scope-factory.ts
@@ -66,7 +66,8 @@ export interface ScopeFactoryOptions {
    */
   globalReturn?: boolean;
   /**
-   * `languageOptions.parserOptions.ecmaFeatures.jsxPragma`. The TS
+   * `languageOptions.parserOptions.jsxPragma` — a top-level parserOptions
+   * key (sibling of `ecmaFeatures`, not nested under it). The TS
    * scope-manager treats `<X />` as a reference to this identifier so
    * `no-unused-vars` on the JSX-pragma import doesn't false-positive.
    * Defaults to `'React'` to match the historical behaviour, but
@@ -74,8 +75,9 @@ export interface ScopeFactoryOptions {
    */
   jsxPragma?: string;
   /**
-   * `languageOptions.parserOptions.ecmaFeatures.jsxFragmentName`. The
-   * TS scope-manager treats `<>...</>` as a reference to this
+   * `languageOptions.parserOptions.jsxFragmentName` — a top-level
+   * parserOptions key (sibling of `ecmaFeatures`, not nested under it).
+   * The TS scope-manager treats `<>...</>` as a reference to this
    * identifier (defaults to `'Fragment'`). Preact users set this to
    * `'Fragment'` already; some bundlers / TS configs use a custom
    * fragment factory.
@@ -145,7 +147,8 @@ function analyze(ast: object, opts: ScopeFactoryOptions): unknown {
       // names` and similar in legacy bundles.
       impliedStrict: opts.impliedStrict ?? false,
       // Defaults preserved for back-compat; Preact / Vue JSX users
-      // override via languageOptions.parserOptions.ecmaFeatures.
+      // override via languageOptions.parserOptions.jsxPragma /
+      // jsxFragmentName (top-level, not nested under ecmaFeatures).
       jsxPragma: opts.jsxPragma ?? 'React',
       jsxFragmentName: opts.jsxFragmentName ?? 'Fragment',
     });

--- a/packages/rslint/src/eslint-plugin/linter/context.ts
+++ b/packages/rslint/src/eslint-plugin/linter/context.ts
@@ -87,6 +87,9 @@ export interface LanguageOptions {
       globalReturn?: boolean;
       impliedStrict?: boolean;
     };
+    /** Top-level parserOptions keys (siblings of `ecmaFeatures`); see ecma-language-plugin.ts's LintFileRequest. */
+    jsxPragma?: string | null;
+    jsxFragmentName?: string | null;
   };
 }
 

--- a/packages/rslint/src/eslint-plugin/linter/ecma-language-plugin.ts
+++ b/packages/rslint/src/eslint-plugin/linter/ecma-language-plugin.ts
@@ -134,6 +134,16 @@ export interface LintFileRequest {
         globalReturn?: boolean;
         impliedStrict?: boolean;
       };
+      /**
+       * `@typescript-eslint/parser`-compatible top-level `parserOptions`
+       * knobs (siblings of `ecmaFeatures`, NOT nested under it). Consumed
+       * by the scope-manager factory below so `<Pragma />` / `<>...</>`
+       * resolve to the configured identifier instead of hard-coded
+       * `React` / `Fragment` — see
+       * https://github.com/web-infra-dev/rslint/issues/1230.
+       */
+      jsxPragma?: string | null;
+      jsxFragmentName?: string | null;
     };
   };
   /** Merged flat-config `settings` for plugin consumption (e.g. `react.version`). */
@@ -267,7 +277,8 @@ export function lintFile(
   // ESLint v10: sourceType / ecmaVersion / globals are top-level fields
   // of `languageOptions`. No legacy positions are accepted.
   const globals = req.languageOptions?.globals;
-  const ecmaFeatures = req.languageOptions?.parserOptions?.ecmaFeatures;
+  const parserOptions = req.languageOptions?.parserOptions;
+  const ecmaFeatures = parserOptions?.ecmaFeatures;
   const scopeManagerFactory = (() => {
     const inner = makeScopeManagerFactory(ast, {
       filePath: req.filePath,
@@ -281,6 +292,16 @@ export function lintFile(
       // are filled in by `scope-factory` to match ESLint v10.
       impliedStrict: ecmaFeatures?.impliedStrict,
       globalReturn: ecmaFeatures?.globalReturn,
+      // `jsxPragma` / `jsxFragmentName` are top-level `parserOptions` keys
+      // (siblings of `ecmaFeatures`), NOT nested under it — reading them
+      // off `ecmaFeatures` (the pre-fix code didn't forward them at all)
+      // silently fell back to `scope-factory`'s 'React'/'Fragment'
+      // defaults for every Preact/Vue/custom-pragma config. `?? undefined`
+      // normalizes an explicit `null` (parserOptions.jsxPragma=null is
+      // typescript-eslint's "disable pragma tracking") to "use the
+      // scope-factory default" — rslint doesn't yet expose that opt-out.
+      jsxPragma: parserOptions?.jsxPragma ?? undefined,
+      jsxFragmentName: parserOptions?.jsxFragmentName ?? undefined,
     });
     return () => {
       const sm = inner();

--- a/packages/rslint/src/eslint-plugin/linter/ecma-language-plugin.ts
+++ b/packages/rslint/src/eslint-plugin/linter/ecma-language-plugin.ts
@@ -136,11 +136,7 @@ export interface LintFileRequest {
       };
       /**
        * `@typescript-eslint/parser`-compatible top-level `parserOptions`
-       * knobs (siblings of `ecmaFeatures`, NOT nested under it). Consumed
-       * by the scope-manager factory below so `<Pragma />` / `<>...</>`
-       * resolve to the configured identifier instead of hard-coded
-       * `React` / `Fragment` — see
-       * https://github.com/web-infra-dev/rslint/issues/1230.
+       * knobs (siblings of `ecmaFeatures`, NOT nested under it).
        */
       jsxPragma?: string | null;
       jsxFragmentName?: string | null;
@@ -292,14 +288,11 @@ export function lintFile(
       // are filled in by `scope-factory` to match ESLint v10.
       impliedStrict: ecmaFeatures?.impliedStrict,
       globalReturn: ecmaFeatures?.globalReturn,
-      // `jsxPragma` / `jsxFragmentName` are top-level `parserOptions` keys
-      // (siblings of `ecmaFeatures`), NOT nested under it — reading them
-      // off `ecmaFeatures` (the pre-fix code didn't forward them at all)
-      // silently fell back to `scope-factory`'s 'React'/'Fragment'
-      // defaults for every Preact/Vue/custom-pragma config. `?? undefined`
-      // normalizes an explicit `null` (parserOptions.jsxPragma=null is
-      // typescript-eslint's "disable pragma tracking") to "use the
-      // scope-factory default" — rslint doesn't yet expose that opt-out.
+      // `jsxPragma` / `jsxFragmentName` are top-level `parserOptions` keys,
+      // siblings of `ecmaFeatures` — NOT nested under it. `?? undefined`
+      // normalizes an explicit `null` (typescript-eslint's "disable pragma
+      // tracking") to "use the scope-factory default" — rslint doesn't yet
+      // expose that opt-out.
       jsxPragma: parserOptions?.jsxPragma ?? undefined,
       jsxFragmentName: parserOptions?.jsxFragmentName ?? undefined,
     });

--- a/packages/rslint/tests/eslint-plugin/ast/scope-factory-jsx-pragma.test.ts
+++ b/packages/rslint/tests/eslint-plugin/ast/scope-factory-jsx-pragma.test.ts
@@ -1,16 +1,8 @@
 /**
- * Regression test pinning that `languageOptions.parserOptions.jsxPragma` /
- * `jsxFragmentName` actually reach the (TS) scope analyzer.
- *
- * These are top-level `parserOptions` keys — siblings of `ecmaFeatures`,
- * NOT nested under it — per `@typescript-eslint/types`' `ParserOptions`.
- * Pre-fix, `ecma-language-plugin.ts` only ever read
- * `parserOptions.ecmaFeatures.*` and silently dropped `jsxPragma` /
- * `jsxFragmentName` entirely, so `makeScopeManagerFactory` always fell back
- * to its 'React' / 'Fragment' defaults — breaking Preact/Vue/custom-pragma
- * configs (`<h />` with `import { h } from 'preact'` was flagged as an
- * unused import by any scope-based unused-import check). See
- * https://github.com/web-infra-dev/rslint/issues/1230.
+ * Pins that `languageOptions.parserOptions.jsxPragma` / `jsxFragmentName`
+ * reach the (TS) scope analyzer. These are top-level `parserOptions` keys —
+ * siblings of `ecmaFeatures`, not nested under it — per
+ * `@typescript-eslint/types`' `ParserOptions`.
  *
  * `jsxPragma` only affects the TS scope-manager (`.tsx`/`.ts`), so the probe
  * uses a `.tsx` file.

--- a/packages/rslint/tests/eslint-plugin/ast/scope-factory-jsx-pragma.test.ts
+++ b/packages/rslint/tests/eslint-plugin/ast/scope-factory-jsx-pragma.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression test pinning that `languageOptions.parserOptions.jsxPragma` /
+ * `jsxFragmentName` actually reach the (TS) scope analyzer.
+ *
+ * These are top-level `parserOptions` keys — siblings of `ecmaFeatures`,
+ * NOT nested under it — per `@typescript-eslint/types`' `ParserOptions`.
+ * Pre-fix, `ecma-language-plugin.ts` only ever read
+ * `parserOptions.ecmaFeatures.*` and silently dropped `jsxPragma` /
+ * `jsxFragmentName` entirely, so `makeScopeManagerFactory` always fell back
+ * to its 'React' / 'Fragment' defaults — breaking Preact/Vue/custom-pragma
+ * configs (`<h />` with `import { h } from 'preact'` was flagged as an
+ * unused import by any scope-based unused-import check). See
+ * https://github.com/web-infra-dev/rslint/issues/1230.
+ *
+ * `jsxPragma` only affects the TS scope-manager (`.tsx`/`.ts`), so the probe
+ * uses a `.tsx` file.
+ */
+import { describe, test, expect } from '@rstest/core';
+
+import { lintFile } from '../../../src/eslint-plugin/linter/ecma-language-plugin.js';
+import type { LoadedPlugins } from '../../../src/eslint-plugin/plugin/plugin-loader.js';
+import type { RuleContext } from '../../../src/eslint-plugin/linter/context.js';
+
+interface ScopeLike {
+  variables: Array<{ name: string; references: unknown[] }>;
+  childScopes: ScopeLike[];
+}
+
+function findVariable(
+  scope: ScopeLike,
+  name: string,
+): { name: string; references: unknown[] } | undefined {
+  for (const v of scope.variables) {
+    if (v.name === name) return v;
+  }
+  for (const child of scope.childScopes) {
+    const found = findVariable(child, name);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function makeProbePlugin(observed: {
+  referencedNames: string[];
+}): LoadedPlugins {
+  return {
+    plugins: [],
+    rules: new Map<string, unknown>([
+      [
+        'stub/jsx-pragma-probe',
+        {
+          meta: { name: 'jsx-pragma-probe' },
+          create(ctx: RuleContext) {
+            return {
+              'Program:exit'() {
+                const sm = ctx.sourceCode.scopeManager as {
+                  globalScope: ScopeLike;
+                };
+                for (const name of ['h', 'Fragment', 'React']) {
+                  const v = findVariable(sm.globalScope, name);
+                  if (v && v.references.length > 0) {
+                    observed.referencedNames.push(name);
+                  }
+                }
+              },
+            };
+          },
+        },
+      ],
+    ]),
+  };
+}
+
+function baseReq(text: string) {
+  return {
+    filePath: 'probe.tsx',
+    text,
+    rules: { 'stub/jsx-pragma-probe': { options: [] } },
+    collectFixes: false,
+    suggestionsMode: 'off' as const,
+  };
+}
+
+describe('scope-factory: jsxPragma / jsxFragmentName forward from languageOptions.parserOptions', () => {
+  test('jsxPragma:"h" marks the `h` import as referenced by <div />, not "React"', () => {
+    const observed = { referencedNames: [] as string[] };
+    const loaded = makeProbePlugin(observed);
+
+    const result = lintFile(
+      {
+        ...baseReq(`import { h } from 'preact';\nconst el = <div>hi</div>;\n`),
+        languageOptions: {
+          parserOptions: {
+            ecmaFeatures: { jsx: true },
+            jsxPragma: 'h',
+          },
+        },
+      },
+      loaded,
+    );
+
+    expect(result.parseError).toBeUndefined();
+    expect(observed.referencedNames).toContain('h');
+    expect(observed.referencedNames).not.toContain('React');
+  });
+
+  test('jsxFragmentName:"Fragment" marks the `Fragment` import as referenced by <>...</>', () => {
+    const observed = { referencedNames: [] as string[] };
+    const loaded = makeProbePlugin(observed);
+
+    const result = lintFile(
+      {
+        ...baseReq(`import { Fragment } from 'preact';\nconst el = <>hi</>;\n`),
+        languageOptions: {
+          parserOptions: {
+            ecmaFeatures: { jsx: true },
+            jsxFragmentName: 'Fragment',
+          },
+        },
+      },
+      loaded,
+    );
+
+    expect(result.parseError).toBeUndefined();
+    expect(observed.referencedNames).toContain('Fragment');
+  });
+
+  test('omitted jsxPragma still defaults to "React" (back-compat)', () => {
+    const observed = { referencedNames: [] as string[] };
+    const loaded = makeProbePlugin(observed);
+
+    const result = lintFile(
+      {
+        ...baseReq(`import React from 'react';\nconst el = <div>hi</div>;\n`),
+        languageOptions: {
+          parserOptions: {
+            ecmaFeatures: { jsx: true },
+          },
+        },
+      },
+      loaded,
+    );
+
+    expect(result.parseError).toBeUndefined();
+    expect(observed.referencedNames).toContain('React');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three separate bugs that all contributed to `languageOptions.parserOptions.jsxPragma` / `jsxFragmentName` being ignored (custom JSX pragmas like Preact's `h` were flagged as unused imports, while ESLint correctly recognized them):

- **JS/TS worker scope-manager** (`ecma-language-plugin.ts`): `jsxPragma`/`jsxFragmentName` are top-level `parserOptions` keys (siblings of `ecmaFeatures`, not nested under it), but the runner only ever read `ecmaFeatures` and never forwarded them to the scope-manager factory, so it silently fell back to the hard-coded `'React'`/`'Fragment'` defaults.
- **Go config merge** (`internal/config/config.go`): `mergeLanguageOptions` shallow-overwrote the whole `parserOptions` object on merge, so a later config entry setting only `jsxPragma` would silently discard an earlier entry's `parserOptions.project` (or any other nested key). Replaced with a recursive deep-merge, and added typed `JsxPragma`/`JsxFragmentName` fields to `ParserOptions`.
- **Go-native rule fallback Programs** (`cmd/rslint/programs.go`): the no-tsconfig directory-scan Program and the gap-file fallback Program never mapped `jsxPragma`/`jsxFragmentName` to `CompilerOptions.JsxFactory`/`JsxFragmentFactory`, so the native `@typescript-eslint/no-unused-vars` rule's implicit-JSX-usage check always looked for `React` regardless of config.

## Related Links

Fixes #1230

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).