### PR TITLE
feat: port rule react-hooks/use-memo

### DIFF
--- a/internal/plugins/react_hooks/all.go
+++ b/internal/plugins/react_hooks/all.go
@@ -8,6 +8,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/immutability"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/incompatible_library"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/rules_of_hooks"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/use_memo"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -20,5 +21,6 @@ func GetAllRules() []rule.Rule {
 		globals.GlobalsRule,
 		immutability.ImmutabilityRule,
 		incompatible_library.IncompatibleLibraryRule,
+		use_memo.UseMemoRule,
 	}
 }

--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -196,6 +196,146 @@ func AccessChainRootIdentifier(node *ast.Node) *ast.Node {
 	return nil
 }
 
+// ImportSpecifierImportedName returns the module-exported name for an import
+// specifier. For `import {foo as bar}`, this is `foo`; for `import {bar}`,
+// this is `bar`.
+func ImportSpecifierImportedName(spec *ast.ImportSpecifier) string {
+	if spec == nil {
+		return ""
+	}
+	name := spec.Name()
+	if spec.PropertyName != nil {
+		name = spec.PropertyName
+	}
+	return moduleExportNameText(name)
+}
+
+func moduleExportNameText(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindIdentifier, ast.KindStringLiteral:
+		return node.Text()
+	}
+	return ""
+}
+
+// AssignmentTargetIdentifier is a binding written by an assignment target.
+// Identifier points at the actual identifier node, while Node is the broader
+// target to report when destructuring defaults need the full assignment node.
+type AssignmentTargetIdentifier struct {
+	Identifier *ast.Node
+	Node       *ast.Node
+	Name       string
+}
+
+// CollectAssignmentTargetIdentifiers returns every identifier written by an
+// assignment target, including nested array/object destructuring targets and
+// default values in destructuring patterns. It only peels parentheses, matching
+// the upstream globals rule's assignment-target handling.
+func CollectAssignmentTargetIdentifiers(node *ast.Node) []AssignmentTargetIdentifier {
+	var targets []AssignmentTargetIdentifier
+	collectAssignmentTargetIdentifiersInto(node, &targets, false)
+	return targets
+}
+
+// CollectAssignmentTargetIdentifiersThroughAssertions is the same assignment
+// target collector, but it also peels TS assertion wrappers before matching the
+// target shape.
+func CollectAssignmentTargetIdentifiersThroughAssertions(node *ast.Node) []AssignmentTargetIdentifier {
+	var targets []AssignmentTargetIdentifier
+	collectAssignmentTargetIdentifiersInto(node, &targets, true)
+	return targets
+}
+
+func collectAssignmentTargetIdentifiersInto(node *ast.Node, targets *[]AssignmentTargetIdentifier, throughAssertions bool) {
+	node = skipAssignmentTargetWrappers(node, throughAssertions)
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		appendAssignmentTargetIdentifier(targets, node, node)
+	case ast.KindObjectLiteralExpression:
+		obj := node.AsObjectLiteralExpression()
+		if obj == nil || obj.Properties == nil {
+			return
+		}
+		for _, prop := range obj.Properties.Nodes {
+			switch prop.Kind {
+			case ast.KindShorthandPropertyAssignment:
+				shorthand := prop.AsShorthandPropertyAssignment()
+				name := prop.Name()
+				if shorthand != nil && shorthand.ObjectAssignmentInitializer != nil {
+					appendAssignmentTargetIdentifier(targets, name, prop)
+					continue
+				}
+				collectAssignmentTargetIdentifiersInto(name, targets, throughAssertions)
+			case ast.KindPropertyAssignment:
+				assignment := prop.AsPropertyAssignment()
+				if assignment != nil {
+					collectAssignmentTargetIdentifiersInto(assignment.Initializer, targets, throughAssertions)
+				}
+			case ast.KindSpreadAssignment:
+				spread := prop.AsSpreadAssignment()
+				if spread != nil {
+					collectAssignmentTargetIdentifiersInto(spread.Expression, targets, throughAssertions)
+				}
+			}
+		}
+	case ast.KindArrayLiteralExpression:
+		array := node.AsArrayLiteralExpression()
+		if array == nil || array.Elements == nil {
+			return
+		}
+		for _, elem := range array.Elements.Nodes {
+			collectAssignmentTargetIdentifiersInto(elem, targets, throughAssertions)
+		}
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary == nil || binary.OperatorToken == nil || binary.OperatorToken.Kind != ast.KindEqualsToken {
+			return
+		}
+		left := skipAssignmentTargetWrappers(binary.Left, throughAssertions)
+		if left != nil && left.Kind == ast.KindIdentifier {
+			appendAssignmentTargetIdentifier(targets, left, node)
+			return
+		}
+		collectAssignmentTargetIdentifiersInto(left, targets, throughAssertions)
+	case ast.KindSpreadElement:
+		spread := node.AsSpreadElement()
+		if spread != nil {
+			collectAssignmentTargetIdentifiersInto(spread.Expression, targets, throughAssertions)
+		}
+	}
+}
+
+func skipAssignmentTargetWrappers(node *ast.Node, throughAssertions bool) *ast.Node {
+	if throughAssertions {
+		return utils.SkipAssertionsAndParens(node)
+	}
+	return ast.SkipParentheses(node)
+}
+
+func appendAssignmentTargetIdentifier(targets *[]AssignmentTargetIdentifier, id, reportNode *ast.Node) {
+	if id == nil || id.Kind != ast.KindIdentifier {
+		return
+	}
+	name := id.AsIdentifier().Text
+	if name == "" {
+		return
+	}
+	if reportNode == nil {
+		reportNode = id
+	}
+	*targets = append(*targets, AssignmentTargetIdentifier{
+		Identifier: id,
+		Node:       reportNode,
+		Name:       name,
+	})
+}
+
 // ContainsNode reports whether `descendant` is inside `ancestor` in the same
 // source file.
 func ContainsNode(ancestor, descendant *ast.Node) bool {

--- a/internal/plugins/react_hooks/rules/error_boundaries/error_boundaries.go
+++ b/internal/plugins/react_hooks/rules/error_boundaries/error_boundaries.go
@@ -54,7 +54,7 @@ func checkTopLevelNode(node *ast.Node) bool {
 	}
 	switch node.Kind {
 	case ast.KindFunctionDeclaration:
-		if isGeneratorFunction(node) {
+		if ast.GetFunctionFlags(node)&ast.FunctionFlagsGenerator != 0 {
 			return false
 		}
 		if name := node.Name(); isReactComponentOrHookName(name) {
@@ -121,7 +121,7 @@ func isFunctionExpressionLike(node *ast.Node) bool {
 	if node == nil {
 		return false
 	}
-	if node.Kind == ast.KindFunctionExpression && node.AsFunctionExpression().AsteriskToken != nil {
+	if node.Kind == ast.KindFunctionExpression && ast.GetFunctionFlags(node)&ast.FunctionFlagsGenerator != 0 {
 		return false
 	}
 	return node.Kind == ast.KindFunctionExpression || node.Kind == ast.KindArrowFunction
@@ -131,7 +131,7 @@ func isCompilerLintFunction(fn *ast.Node) bool {
 	if fn == nil {
 		return false
 	}
-	if isGeneratorFunction(fn) {
+	if ast.GetFunctionFlags(fn)&ast.FunctionFlagsGenerator != 0 {
 		return false
 	}
 	// Keep this narrower than react_hooksutil.IsComponentOrHookFn: the
@@ -183,16 +183,6 @@ func callOrCalleeIsOptionalChain(callNode *ast.Node) bool {
 	call := callNode.AsCallExpression()
 	callee := ast.SkipParentheses(call.Expression)
 	return callee != nil && ast.IsOptionalChain(callee)
-}
-
-func isGeneratorFunction(fn *ast.Node) bool {
-	switch fn.Kind {
-	case ast.KindFunctionDeclaration:
-		return fn.AsFunctionDeclaration().AsteriskToken != nil
-	case ast.KindFunctionExpression:
-		return fn.AsFunctionExpression().AsteriskToken != nil
-	}
-	return false
 }
 
 func walkUpParens(node *ast.Node) (*ast.Node, *ast.Node) {

--- a/internal/plugins/react_hooks/rules/globals/globals.go
+++ b/internal/plugins/react_hooks/rules/globals/globals.go
@@ -55,22 +55,22 @@ func (state *globalsState) checkAssignment(ctx rule.RuleContext, node *ast.Node)
 	if utils.IsDefaultValueInDestructuringAssignment(node) {
 		return
 	}
-	targets := collectAssignmentTargets(binary.Left)
+	targets := react_hooksutil.CollectAssignmentTargetIdentifiers(binary.Left)
 	for _, target := range targets {
-		fn := react_hooksutil.FindEnclosingFunction(target.node)
+		fn := react_hooksutil.FindEnclosingFunction(target.Node)
 		if fn == nil || state.activeFunctionKind(fn) == activeFunctionNone {
 			continue
 		}
-		if state.isLocalToFunction(fn, target.node, target.name) {
+		if state.isLocalToFunction(fn, target.Node, target.Name) {
 			continue
 		}
-		reportNode := target.node
+		reportNode := target.Node
 		if binary.OperatorToken.Kind != ast.KindEqualsToken {
 			// Upstream reports compound assignments over the whole assignment
 			// expression, while plain assignments point at the written binding.
 			reportNode = node
 		}
-		ctx.ReportNode(reportNode, buildGlobalReassignmentMessage(target.name))
+		ctx.ReportNode(reportNode, buildGlobalReassignmentMessage(target.Name))
 	}
 }
 
@@ -85,81 +85,6 @@ func buildGlobalReassignmentMessage(name string) rule.RuleMessage {
 		Data: map[string]string{
 			"name": name,
 		},
-	}
-}
-
-type assignmentTarget struct {
-	node *ast.Node
-	name string
-}
-
-func collectAssignmentTargets(node *ast.Node) []assignmentTarget {
-	var targets []assignmentTarget
-	collectAssignmentTargetsInto(node, &targets)
-	return targets
-}
-
-func collectAssignmentTargetsInto(node *ast.Node, targets *[]assignmentTarget) {
-	if node == nil {
-		return
-	}
-	node = ast.SkipParentheses(node)
-	switch node.Kind {
-	case ast.KindIdentifier:
-		name := node.AsIdentifier().Text
-		if name != "" {
-			*targets = append(*targets, assignmentTarget{node: node, name: name})
-		}
-	case ast.KindObjectLiteralExpression:
-		obj := node.AsObjectLiteralExpression()
-		if obj == nil || obj.Properties == nil {
-			return
-		}
-		for _, prop := range obj.Properties.Nodes {
-			switch prop.Kind {
-			case ast.KindShorthandPropertyAssignment:
-				shorthand := prop.AsShorthandPropertyAssignment()
-				name := prop.Name()
-				if shorthand != nil && shorthand.ObjectAssignmentInitializer != nil && name != nil && name.Kind == ast.KindIdentifier {
-					*targets = append(*targets, assignmentTarget{node: prop, name: name.AsIdentifier().Text})
-					continue
-				}
-				collectAssignmentTargetsInto(name, targets)
-			case ast.KindPropertyAssignment:
-				assignment := prop.AsPropertyAssignment()
-				if assignment != nil {
-					collectAssignmentTargetsInto(assignment.Initializer, targets)
-				}
-			case ast.KindSpreadAssignment:
-				prop.ForEachChild(func(child *ast.Node) bool {
-					collectAssignmentTargetsInto(child, targets)
-					return false
-				})
-			}
-		}
-	case ast.KindArrayLiteralExpression:
-		node.ForEachChild(func(child *ast.Node) bool {
-			collectAssignmentTargetsInto(child, targets)
-			return false
-		})
-	case ast.KindBinaryExpression:
-		binary := node.AsBinaryExpression()
-		if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
-			left := ast.SkipParentheses(binary.Left)
-			if left != nil && left.Kind == ast.KindIdentifier {
-				name := left.AsIdentifier().Text
-				if name != "" {
-					*targets = append(*targets, assignmentTarget{node: node, name: name})
-				}
-				return
-			}
-			collectAssignmentTargetsInto(left, targets)
-		}
-	case ast.KindSpreadElement:
-		node.ForEachChild(func(child *ast.Node) bool {
-			collectAssignmentTargetsInto(child, targets)
-			return false
-		})
 	}
 }
 

--- a/internal/plugins/react_hooks/rules/incompatible_library/incompatible_library.go
+++ b/internal/plugins/react_hooks/rules/incompatible_library/incompatible_library.go
@@ -131,7 +131,7 @@ func (state *incompatibleLibraryState) processNamedImports(moduleName string, no
 		if spec == nil || spec.Name() == nil || spec.IsTypeOnly {
 			continue
 		}
-		importedName := importSpecifierImportedName(spec)
+		importedName := react_hooksutil.ImportSpecifierImportedName(spec)
 		localName := spec.Name()
 		switch {
 		case moduleName == "react-hook-form" && importedName == "useForm":
@@ -715,27 +715,6 @@ func (state *incompatibleLibraryState) lookup(name string) bindingKind {
 		}
 	}
 	return bindingUnknown
-}
-
-func importSpecifierImportedName(spec *ast.ImportSpecifier) string {
-	if spec.PropertyName != nil {
-		return moduleExportNameText(spec.PropertyName)
-	}
-	if spec.Name() != nil {
-		return spec.Name().Text()
-	}
-	return ""
-}
-
-func moduleExportNameText(node *ast.Node) string {
-	if node == nil {
-		return ""
-	}
-	switch node.Kind {
-	case ast.KindIdentifier, ast.KindStringLiteral:
-		return node.Text()
-	}
-	return ""
 }
 
 func bindingElementPropertyName(node *ast.Node) string {

--- a/internal/plugins/react_hooks/rules/use_memo/use_memo.go
+++ b/internal/plugins/react_hooks/rules/use_memo/use_memo.go
@@ -1,0 +1,333 @@
+package use_memo
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	expectedMemoizationFunctionReason = "Expected a callback function to be passed to useMemo"
+	expectedInlineFunctionReason      = "Expected the first argument to be an inline function expression"
+	expectedArrayLiteralReason        = "Expected the dependency list for useMemo to be an array literal"
+	expectedSimpleDepsReason          = "Expected the dependency list to be an array of simple expressions (e.g. `x`, `x.y.z`, `x?.y?.z`)"
+	callbackParamsReason              = "useMemo() callbacks may not accept parameters"
+	asyncGeneratorReason              = "useMemo() callbacks may not be async or generator functions"
+	reassignOuterVariableReason       = "useMemo() callbacks may not reassign variables declared outside of the callback"
+)
+
+const (
+	expectedMemoizationFunctionDescription = "The first argument to useMemo() must be a function that calculates a result to cache"
+	expectedInlineFunctionDescription      = expectedInlineFunctionReason
+	expectedArrayLiteralDescription        = expectedArrayLiteralReason
+	expectedSimpleDepsDescription          = expectedSimpleDepsReason
+	callbackParamsDescription              = "useMemo() callbacks are called by React to cache calculations across re-renders. They should not take parameters. Instead, directly reference the props, state, or local variables needed for the computation"
+	asyncGeneratorDescription              = "useMemo() callbacks are called once and must synchronously return a value"
+	reassignOuterVariableDescription       = "useMemo() callbacks must be pure functions and cannot reassign variables defined outside of the callback function"
+)
+
+type useMemoState struct {
+	ctx rule.RuleContext
+}
+
+// UseMemoRule is the rslint port of upstream `react-hooks/use-memo`.
+//
+// Upstream emits this rule from React Compiler's UseMemo diagnostic category.
+// This port validates the published call-shape contract locally: useMemo must
+// receive an inline function, dependency lists must be array literals of simple
+// dependency expressions, callbacks cannot accept parameters or be async /
+// generator functions, and callbacks cannot reassign variables captured from
+// outside the callback.
+var UseMemoRule = rule.Rule{
+	Name: "react-hooks/use-memo",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		state := &useMemoState{ctx: ctx}
+		return rule.RuleListeners{
+			ast.KindCallExpression: state.processCallExpression,
+		}
+	},
+}
+
+func (state *useMemoState) processCallExpression(node *ast.Node) {
+	call := node.AsCallExpression()
+	if call == nil || !state.isUseMemoCallee(call.Expression) {
+		return
+	}
+
+	args := call.Arguments
+	if args == nil || len(args.Nodes) == 0 {
+		state.ctx.ReportNode(node, buildUseMemoMessage("expectedMemoizationFunction", expectedMemoizationFunctionReason, expectedMemoizationFunctionDescription, "Expected a memoization function"))
+		return
+	}
+
+	callback := ast.SkipParentheses(args.Nodes[0])
+	if callback != nil && callback.Kind == ast.KindSpreadElement {
+		return
+	}
+	if callback == nil || !ast.IsFunctionExpressionOrArrowFunction(callback) {
+		reportNode := node
+		if callback != nil {
+			reportNode = callback
+		}
+		state.ctx.ReportNode(reportNode, buildUseMemoMessage("expectedInlineFunction", expectedInlineFunctionReason, expectedInlineFunctionDescription, "Expected the first argument to be an inline function expression"))
+		return
+	}
+
+	state.checkCallback(callback)
+	state.checkDependencyList(args.Nodes)
+}
+
+func (state *useMemoState) isUseMemoCallee(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return state.isManualMemoIdentifier(node, "useMemo")
+	case ast.KindPropertyAccessExpression:
+		if ast.IsOptionalChain(node) {
+			return false
+		}
+		name := node.AsPropertyAccessExpression().Name()
+		if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "useMemo" {
+			return false
+		}
+		obj := ast.SkipParentheses(node.AsPropertyAccessExpression().Expression)
+		if obj == nil || obj.Kind != ast.KindIdentifier {
+			return false
+		}
+		return state.isManualMemoIdentifier(obj, "React")
+	}
+	return false
+}
+
+func (state *useMemoState) isManualMemoIdentifier(id *ast.Node, expected string) bool {
+	if id == nil || id.Kind != ast.KindIdentifier || id.AsIdentifier().Text != expected {
+		return false
+	}
+	if state.ctx.TypeChecker == nil {
+		return true
+	}
+	sym := utils.GetReferenceSymbol(id, state.ctx.TypeChecker)
+	if sym == nil || len(sym.Declarations) == 0 {
+		return true
+	}
+	for _, decl := range sym.Declarations {
+		if isManualMemoDeclaration(decl, expected) {
+			return true
+		}
+	}
+	return false
+}
+
+func isManualMemoDeclaration(decl *ast.Node, expected string) bool {
+	if decl == nil {
+		return false
+	}
+	switch decl.Kind {
+	case ast.KindImportClause, ast.KindNamespaceImport, ast.KindImportSpecifier:
+		return true
+	case ast.KindBindingElement:
+		return !isInsideParameter(decl)
+	case ast.KindVariableDeclaration:
+		name := decl.Name()
+		if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != expected {
+			return false
+		}
+		initializer := ast.SkipParentheses(decl.AsVariableDeclaration().Initializer)
+		if initializer == nil {
+			return true
+		}
+		if expected == "useMemo" && ast.IsFunctionExpressionOrArrowFunction(initializer) {
+			return false
+		}
+		if expected == "React" && initializer.Kind == ast.KindObjectLiteralExpression {
+			return false
+		}
+		return true
+	case ast.KindParameter, ast.KindFunctionDeclaration:
+		return false
+	}
+	return false
+}
+
+func isInsideParameter(node *ast.Node) bool {
+	for cur := node; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindParameter:
+			return true
+		case ast.KindVariableDeclaration:
+			return false
+		}
+	}
+	return false
+}
+
+func (state *useMemoState) checkCallback(callback *ast.Node) {
+	params := callback.Parameters()
+	if len(params) > 0 {
+		reportNode := params[0]
+		if name := params[0].Name(); name != nil {
+			reportNode = name
+		}
+		state.ctx.ReportNode(reportNode, buildUseMemoMessage("noCallbackParameters", callbackParamsReason, callbackParamsDescription, "Callbacks with parameters are not supported"))
+	}
+	flags := ast.GetFunctionFlags(callback)
+	if flags&(ast.FunctionFlagsAsync|ast.FunctionFlagsGenerator) != 0 {
+		state.ctx.ReportNode(callback, buildUseMemoMessage("noAsyncOrGenerator", asyncGeneratorReason, asyncGeneratorDescription, "Async and generator functions are not supported"))
+	}
+	state.checkExternalReassignments(callback)
+}
+
+func (state *useMemoState) checkDependencyList(args []*ast.Node) {
+	if len(args) < 2 {
+		return
+	}
+	deps := ast.SkipParentheses(args[1])
+	if deps != nil && deps.Kind == ast.KindSpreadElement {
+		return
+	}
+	if deps == nil || deps.Kind != ast.KindArrayLiteralExpression {
+		reportNode := args[1]
+		if deps != nil {
+			reportNode = deps
+		}
+		state.ctx.ReportNode(reportNode, buildUseMemoMessage("expectedArrayLiteral", expectedArrayLiteralReason, expectedArrayLiteralDescription, expectedArrayLiteralReason))
+		return
+	}
+	array := deps.AsArrayLiteralExpression()
+	if array == nil || array.Elements == nil {
+		return
+	}
+	for _, elem := range array.Elements.Nodes {
+		if elem == nil {
+			continue
+		}
+		if elem.Kind == ast.KindSpreadElement || elem.Kind == ast.KindOmittedExpression {
+			state.ctx.ReportNode(deps, buildUseMemoMessage("expectedArrayLiteral", expectedArrayLiteralReason, expectedArrayLiteralDescription, expectedArrayLiteralReason))
+			return
+		}
+		expr := skipDependencyParensAndNonNull(elem)
+		if expr == nil || !isSimpleDependencyExpression(expr) {
+			state.ctx.ReportNode(elem, buildUseMemoMessage("expectedSimpleDependencies", expectedSimpleDepsReason, expectedSimpleDepsDescription, expectedSimpleDepsReason))
+		}
+	}
+}
+
+func isSimpleDependencyExpression(node *ast.Node) bool {
+	node = skipDependencyParensAndNonNull(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier, ast.KindThisKeyword, ast.KindSuperKeyword:
+		return true
+	case ast.KindPropertyAccessExpression:
+		return isSimpleDependencyExpression(node.AsPropertyAccessExpression().Expression)
+	case ast.KindElementAccessExpression:
+		access := node.AsElementAccessExpression()
+		if access == nil || !isSimpleDependencyExpression(access.Expression) {
+			return false
+		}
+		key := ast.SkipParentheses(access.ArgumentExpression)
+		if key == nil {
+			return false
+		}
+		switch key.Kind {
+		case ast.KindStringLiteral, ast.KindNumericLiteral:
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+func skipDependencyParensAndNonNull(node *ast.Node) *ast.Node {
+	return ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKNonNullAssertions)
+}
+
+func (state *useMemoState) checkExternalReassignments(callback *ast.Node) {
+	reported := map[*ast.Node]bool{}
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node != callback && react_hooksutil.IsCompilerFunctionKind(node) {
+			return
+		}
+
+		switch node.Kind {
+		case ast.KindBinaryExpression:
+			if ast.IsAssignmentExpression(node, false) {
+				binary := node.AsBinaryExpression()
+				if binary != nil {
+					state.reportExternalAssignmentTargets(callback, binary.Left, reported)
+				}
+			}
+		case ast.KindPrefixUnaryExpression:
+			prefix := node.AsPrefixUnaryExpression()
+			if prefix != nil && (prefix.Operator == ast.KindPlusPlusToken || prefix.Operator == ast.KindMinusMinusToken) {
+				state.reportExternalAssignmentTargets(callback, prefix.Operand, reported)
+			}
+		case ast.KindPostfixUnaryExpression:
+			postfix := node.AsPostfixUnaryExpression()
+			if postfix != nil && (postfix.Operator == ast.KindPlusPlusToken || postfix.Operator == ast.KindMinusMinusToken) {
+				state.reportExternalAssignmentTargets(callback, postfix.Operand, reported)
+			}
+		}
+
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(callback)
+}
+
+func (state *useMemoState) reportExternalAssignmentTargets(callback *ast.Node, target *ast.Node, reported map[*ast.Node]bool) {
+	for _, assignmentTarget := range react_hooksutil.CollectAssignmentTargetIdentifiersThroughAssertions(target) {
+		id := assignmentTarget.Identifier
+		if id == nil || reported[id] || !state.isDeclaredOutsideCallback(callback, id) {
+			continue
+		}
+		reported[id] = true
+		state.ctx.ReportNode(id, buildUseMemoMessage("noExternalReassignment", reassignOuterVariableReason, reassignOuterVariableDescription, "Cannot reassign variable"))
+	}
+}
+
+func (state *useMemoState) isDeclaredOutsideCallback(callback *ast.Node, id *ast.Node) bool {
+	if id == nil || id.Kind != ast.KindIdentifier || state.ctx.TypeChecker == nil {
+		return false
+	}
+	sym := utils.GetReferenceSymbol(id, state.ctx.TypeChecker)
+	if sym == nil {
+		return false
+	}
+	for _, decl := range sym.Declarations {
+		if decl == nil || ast.GetSourceFileOfNode(decl) != state.ctx.SourceFile {
+			continue
+		}
+		if react_hooksutil.ContainsNode(callback, decl) {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+func buildUseMemoMessage(id, reason, description, detail string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          id,
+		Description: fmt.Sprintf("Error: %s\n\n%s.", reason, description),
+		Data: map[string]string{
+			"detail":      detail,
+			"description": description,
+			"reason":      reason,
+		},
+	}
+}

--- a/internal/plugins/react_hooks/rules/use_memo/use_memo.md
+++ b/internal/plugins/react_hooks/rules/use_memo/use_memo.md
@@ -1,0 +1,51 @@
+# react-hooks/use-memo
+
+## Rule Details
+
+Validates usage of the `useMemo()` hook against common mistakes.
+
+`useMemo()` should receive an inline function that computes the cached value and an optional dependency array that can be checked statically. The callback should be synchronous, take no parameters, and should not reassign variables declared outside of the callback.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function Component({ value }) {
+  const doubled = useMemo(async () => value * 2, [value]);
+  return <div>{doubled}</div>;
+}
+```
+
+```javascript
+function Component({ value, deps }) {
+  const doubled = useMemo(() => value * 2, deps);
+  return <div>{doubled}</div>;
+}
+```
+
+```javascript
+function Component() {
+  let value;
+  const memoized = useMemo(() => {
+    value = [];
+    return value;
+  }, []);
+  return <div>{memoized}</div>;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function Component({ value }) {
+  const doubled = useMemo(() => value * 2, [value]);
+  return <div>{doubled}</div>;
+}
+```
+
+This rule follows `eslint-plugin-react-hooks@7.x`: checking that a `useMemo()` callback returns a value belongs to the separate upstream `react-hooks/void-use-memo` rule. Like upstream, this rule tracks direct `useMemo()` and `React.useMemo()` call shapes.
+
+## Original Documentation
+
+- [react.dev - use-memo](https://react.dev/reference/eslint-plugin-react-hooks/lints/use-memo)
+- [Source code - ValidateUseMemo.ts](https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateUseMemo.ts)
+- [Source code - DropManualMemoization.ts](https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts)

--- a/internal/plugins/react_hooks/rules/use_memo/use_memo_extras_test.go
+++ b/internal/plugins/react_hooks/rules/use_memo/use_memo_extras_test.go
@@ -1,0 +1,368 @@
+package use_memo
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestUseMemoExtras locks in branches and edge shapes that the upstream test
+// suite doesn't exercise. Each case carries an inline comment pointing at the
+// specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+func TestUseMemoExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Dimension 4: parenthesized receiver and callee wrappers. ----
+		{Code: `function Component(props) {
+  const a = (React).useMemo(() => props.value, [props.value]);
+  const b = ((useMemo))(() => props.value, [props.value]);
+  return <div>{a}{b}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: TS non-null wrappers are transparent in dependency expressions. ----
+		{Code: `type Props = { value: number };
+function Component(props: Props) {
+  const value = useMemo(() => props.value, [props!.value]);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: static element access forms are simple dependency expressions. ----
+		{Code: `function Component(props) {
+  const a = useMemo(() => props.value, [props["value"]]);
+  const b = useMemo(() => props.items[0], [props.items[0]]);
+  return <div>{a}{b}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: dynamic element access does not masquerade as React.useMemo. ----
+		{Code: `function Component(props) {
+  const hook = "useMemo";
+  return React[hook](async () => props.value, []);
+}
+`, Tsx: true},
+		// ---- Dimension 4: static element access and optional namespace calls are outside upstream's input surface. ----
+		{Code: `function Component(props) {
+  const a = React["useMemo"](async () => props.value, []);
+  const b = React?.useMemo(async () => props.value, []);
+  return <div>{a}{b}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: TS assertion wrappers around the callee are not transparent. ----
+		{Code: `function Component(props) {
+  const a = React!.useMemo(async () => props.value, []);
+  const b = (React as any).useMemo(async () => props.value, []);
+  const c = (useMemo as any)(async () => props.value, []);
+  return <div>{a}{b}{c}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: import aliases are outside upstream's input surface. ----
+		{Code: `import {useMemo as memo} from 'react';
+import R from 'react';
+import * as Namespace from 'react';
+function Component() {
+  const a = memo(async () => 1, []);
+  const b = R.useMemo(async () => 1, []);
+  const c = Namespace.useMemo(async () => 1, []);
+  return <div>{a}{b}{c}</div>;
+}
+`, Tsx: true},
+		// Locks in upstream extractManualMemoizationArgs() arm 2: spread first argument is not modeled as a callback.
+		{Code: `function Component(args) {
+  const value = useMemo(...args);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: local callback assignments are allowed. ----
+		{Code: `function Component() {
+  const value = useMemo(() => {
+    let x;
+    x = [];
+    return x;
+  }, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: nested function body does not bleed into the useMemo callback scan. ----
+		{Code: `function Component() {
+  let x;
+  const value = useMemo(() => {
+    function nested() {
+      x = [];
+    }
+    return nested;
+  }, []);
+  return <div>{value}{x}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: shadowed local useMemo is not treated as React's hook. ----
+		{Code: `function Component() {
+  const useMemo = (value) => value;
+  const value = useMemo(1, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: shadowed imported alias is resolved as local, not React's useMemo. ----
+		{Code: `import {useMemo as memo} from 'react';
+function Component() {
+  const memo = (value) => value;
+  const value = memo(1, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: shadowed React namespace import is resolved as local. ----
+		{Code: `import * as R from 'react';
+function Component() {
+  const R = {useMemo: (value) => value};
+  const value = R.useMemo(1, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Dimension 4: property writes are not variable reassignments for this rule. ----
+		{Code: `function Component() {
+  const ref = {current: 0};
+  const value = useMemo(() => {
+    ref.current = 1;
+    return ref.current;
+  }, [ref]);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Real-user: facebook/react#25379 no-return useMemo belongs to void-use-memo, not use-memo. ----
+		{Code: `function Component({value}) {
+  const memo = useMemo(() => {
+    console.log(value);
+  }, [value]);
+  return <div>{memo}</div>;
+}
+`, Tsx: true},
+		// ---- Options contract: upstream accepts an arbitrary object and use-memo ignores it. ----
+		{
+			Code: `function Component({value}) {
+  const memo = useMemo(() => value, [value]);
+  return <div>{memo}</div>;
+}
+`,
+			Options: map[string]interface{}{"someFutureOption": true},
+			Tsx:     true,
+		},
+		// N/A: PrivateIdentifier and object/class property key forms are not inputs inspected by this rule.
+		// N/A: Autofix boundaries do not apply because react-hooks/use-memo has no autofix.
+		// N/A: Class declaration/class expression containers are not rule targets; the rule validates hook calls.
+		// N/A: Empty class bodies and overload signatures do not affect useMemo call validation.
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// Locks in upstream extractManualMemoizationArgs() arm 1: missing first argument.
+		{
+			Code: `function Component() {
+  useMemo();
+  return <div />;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedMemoizationFunction", expectedMemoizationFunctionReason, expectedMemoizationFunctionDescription, "Expected a memoization function", 2, 3, 2, 12),
+			},
+		},
+		// Locks in upstream extractManualMemoizationArgs() arm 1: first argument is not a function.
+		{
+			Code: `function Component() {
+  const value = useMemo(123, []);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedInlineFunction", expectedInlineFunctionReason, expectedInlineFunctionDescription, "Expected the first argument to be an inline function expression", 2, 25, 2, 28),
+			},
+		},
+		// Locks in upstream extractManualMemoizationArgs() arm 3: dependency element is not simple.
+		{
+			Code: `function Component({x}) {
+  const value = useMemo(() => x, [x + 1]);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedSimpleDependencies", expectedSimpleDepsReason, expectedSimpleDepsDescription, expectedSimpleDepsReason, 2, 35, 2, 40),
+			},
+		},
+		// ---- Dimension 4: spread in dependency array is not modeled as an array dependency list upstream. ----
+		{
+			Code: `function Component({x, deps}) {
+  const value = useMemo(() => x, [...deps]);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedArrayLiteral", expectedArrayLiteralReason, expectedArrayLiteralDescription, expectedArrayLiteralReason, 2, 34, 2, 43),
+			},
+		},
+		// ---- Dimension 4: sparse dependency arrays are not modeled as array dependency lists upstream. ----
+		{
+			Code: `function Component({x}) {
+  const value = useMemo(() => x, [, x]);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedArrayLiteral", expectedArrayLiteralReason, expectedArrayLiteralDescription, expectedArrayLiteralReason, 2, 34, 2, 39),
+			},
+		},
+		// ---- Dimension 4: TS as/satisfies wrappers around callback arguments are not transparent upstream. ----
+		{
+			Code: `type Fn = () => number;
+function Component() {
+  const a = useMemo((() => 1) as Fn, []);
+  const b = useMemo((() => 2) satisfies Fn, []);
+  return <div>{a}{b}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedInlineFunction", expectedInlineFunctionReason, expectedInlineFunctionDescription, "Expected the first argument to be an inline function expression", 3, 21, 3, 36),
+				useMemoError("expectedInlineFunction", expectedInlineFunctionReason, expectedInlineFunctionDescription, "Expected the first argument to be an inline function expression", 4, 21, 4, 43),
+			},
+		},
+		// ---- Dimension 4: TS as/satisfies wrappers in dependency expressions are not simple upstream. ----
+		{
+			Code: `type Props = { value: number };
+function Component(props: Props) {
+  const a = useMemo(() => props.value, [(props as Props).value]);
+  const b = useMemo(() => props.value, [(props satisfies Props).value]);
+  return <div>{a}{b}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedSimpleDependencies", expectedSimpleDepsReason, expectedSimpleDepsDescription, expectedSimpleDepsReason, 3, 41, 3, 63),
+				useMemoError("expectedSimpleDependencies", expectedSimpleDepsReason, expectedSimpleDepsDescription, expectedSimpleDepsReason, 4, 41, 4, 70),
+			},
+		},
+		// ---- Dimension 4: no-substitution template element keys are not simple dependency paths upstream. ----
+		{
+			Code: "function Component({props}) {\n  const value = useMemo(() => props.value, [props[`value`]]);\n  return <div>{value}</div>;\n}\n",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedSimpleDependencies", expectedSimpleDepsReason, expectedSimpleDepsDescription, expectedSimpleDepsReason, 2, 45, 2, 59),
+			},
+		},
+		// ---- Real-user: facebook/react#34986 TS wrappers around inline callbacks must still report. ----
+		{
+			Code: `type Noop = () => void;
+function Component() {
+  const handleClick = useMemo(
+    (() => {
+      return 1;
+    }) satisfies Noop,
+    [],
+  );
+  return <button>{handleClick}</button>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedInlineFunction", expectedInlineFunctionReason, expectedInlineFunctionDescription, "Expected the first argument to be an inline function expression", 4, 5, 6, 22),
+			},
+		},
+		// ---- Dimension 4: same-name imports remain inside upstream's input surface. ----
+		{
+			Code: `import {foo as useMemo} from 'not-react';
+import React from 'not-react';
+function Component() {
+  const a = useMemo(async () => 1, []);
+  const b = React.useMemo(async () => 2, []);
+  return <div>{a}{b}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("noAsyncOrGenerator", asyncGeneratorReason, asyncGeneratorDescription, "Async and generator functions are not supported", 4, 21, 4, 34),
+				useMemoError("noAsyncOrGenerator", asyncGeneratorReason, asyncGeneratorDescription, "Async and generator functions are not supported", 5, 27, 5, 40),
+			},
+		},
+		// ---- Options contract: arbitrary options do not change diagnostics. ----
+		{
+			Code: `function Component({value}) {
+  const memo = useMemo(param => value, []);
+  return <div>{memo}</div>;
+}
+`,
+			Options: []interface{}{map[string]interface{}{"someFutureOption": true}},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("noCallbackParameters", callbackParamsReason, callbackParamsDescription, "Callbacks with parameters are not supported", 2, 24, 2, 29),
+			},
+		},
+		// ---- Dimension 4: assignment pattern reassigns a captured variable. ----
+		{
+			Code: `function Component({next}) {
+  let x;
+  const value = useMemo(() => {
+    ({x} = next);
+    return x;
+  }, [next]);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("noExternalReassignment", reassignOuterVariableReason, reassignOuterVariableDescription, "Cannot reassign variable", 4, 7, 4, 8),
+			},
+		},
+		// ---- Dimension 4: nested array/object assignment patterns find every captured identifier. ----
+		{
+			Code: `function Component({next}) {
+  let x;
+  let y;
+  const value = useMemo(() => {
+    [x, {value: y}] = next;
+    return x + y;
+  }, [next]);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("noExternalReassignment", reassignOuterVariableReason, reassignOuterVariableDescription, "Cannot reassign variable", 5, 6, 5, 7),
+				useMemoError("noExternalReassignment", reassignOuterVariableReason, reassignOuterVariableDescription, "Cannot reassign variable", 5, 17, 5, 18),
+			},
+		},
+		// ---- Dimension 4: update expression reassigns a captured variable. ----
+		{
+			Code: `function Component() {
+  let x = 0;
+  const value = useMemo(() => {
+    x++;
+    return x;
+  }, []);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("noExternalReassignment", reassignOuterVariableReason, reassignOuterVariableDescription, "Cannot reassign variable", 4, 5, 4, 6),
+			},
+		},
+		// ---- Real-user: facebook/react#16096 conditional dependency lists are not array literals. ----
+		{
+			Code: `function Component({position}) {
+  const memoPosition = React.useMemo(
+    () => position && gpsToLatLng(position),
+    position ? [position.latitude, position.longitude] : [position],
+  );
+  return <div>{memoPosition}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedArrayLiteral", expectedArrayLiteralReason, expectedArrayLiteralDescription, expectedArrayLiteralReason, 4, 5, 4, 68),
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &UseMemoRule, valid, invalid)
+}

--- a/internal/plugins/react_hooks/rules/use_memo/use_memo_upstream_test.go
+++ b/internal/plugins/react_hooks/rules/use_memo/use_memo_upstream_test.go
@@ -1,0 +1,229 @@
+package use_memo
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestUseMemoUpstream migrates the react-hooks/use-memo cases from upstream
+// compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateUseMemo.ts
+// and related React Compiler fixtures 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// use_memo_extras_test.go.
+func TestUseMemoUpstream(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Upstream fixture: useMemo-simple.js. ----
+		{Code: `function component(a) {
+  let x = useMemo(() => [a], [a]);
+  return <Foo x={x}></Foo>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: aliased useMemo.js. ----
+		{Code: `import {useMemo as myMemo} from 'react';
+
+function Component({x}) {
+  const v = myMemo(() => x * 2, [x]);
+  return <div>{v}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-with-optional.js, missing deps list is allowed by use-memo. ----
+		{Code: `import {useMemo} from 'react';
+function Component(props) {
+  return (
+    useMemo(() => {
+      return [props.value];
+    }) || []
+  );
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-arrow-implicit-return.js. ----
+		{Code: `function Component() {
+  const value = useMemo(() => computeValue(), []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-with-no-deps-list.ts, missing deps list is allowed by use-memo. ----
+		{Code: `function Component(props) {
+  const value = useMemo(() => props.value);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-empty-return.js belongs to void-use-memo, not use-memo. ----
+		{Code: `function Component() {
+  const value = useMemo(() => {
+    return;
+  }, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-explicit-null-return.js is valid for use-memo. ----
+		{Code: `function Component() {
+  const value = useMemo(() => {
+    return null;
+  }, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-multiple-returns.js is valid for use-memo. ----
+		{Code: `function Component({cond, a, b}) {
+  const value = useMemo(() => {
+    if (cond) {
+      return a;
+    }
+    return b;
+  }, [cond, a, b]);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-switch-return.js is valid for use-memo. ----
+		{Code: `function Component({kind, a, b}) {
+  const value = useMemo(() => {
+    switch (kind) {
+      case 'a':
+        return a;
+      default:
+        return b;
+    }
+  }, [kind, a, b]);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-named-function.ts inline named function expressions are valid. ----
+		{Code: `function Component({a}) {
+  const value = useMemo(function named() {
+    return a;
+  }, [a]);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Official react.dev use-memo docs: no-return callbacks belong to void-use-memo, not use-memo. ----
+		{Code: `function Component({ data }) {
+  const processed = useMemo(() => {
+    data.forEach(item => console.log(item));
+  }, [data]);
+  return <div>{processed}</div>;
+}
+`, Tsx: true},
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- Upstream fixture: error.invalid-useMemo-callback-args.js. ----
+		{
+			Code: `function component(a, b) {
+  let x = useMemo(c => a, []);
+  return x;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("noCallbackParameters", callbackParamsReason, callbackParamsDescription, "Callbacks with parameters are not supported", 2, 19, 2, 20),
+			},
+		},
+		// ---- Upstream fixture: error.invalid-useMemo-async-callback.js. ----
+		{
+			Code: `function component(a, b) {
+  let x = useMemo(async () => {
+    await a;
+  }, []);
+  return x;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("noAsyncOrGenerator", asyncGeneratorReason, asyncGeneratorDescription, "Async and generator functions are not supported", 2, 19, 4, 4),
+			},
+		},
+		// ---- Upstream fixture: error.invalid-ReactUseMemo-async-callback.js. ----
+		{
+			Code: `function component(a, b) {
+  let x = React.useMemo(async () => {
+    await a;
+  }, []);
+  return x;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("noAsyncOrGenerator", asyncGeneratorReason, asyncGeneratorDescription, "Async and generator functions are not supported", 2, 25, 4, 4),
+			},
+		},
+		// ---- Upstream fixture: error.useMemo-callback-generator.js. ----
+		{
+			Code: `function component(a, b) {
+  let x = useMemo(function* () {
+    yield a;
+  }, []);
+  return x;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("noAsyncOrGenerator", asyncGeneratorReason, asyncGeneratorDescription, "Async and generator functions are not supported", 2, 19, 4, 4),
+			},
+		},
+		// ---- Upstream fixture: error.invalid-reassign-variable-in-useMemo.js. ----
+		{
+			Code: `function Component() {
+  let x;
+  const y = useMemo(() => {
+    let z;
+    x = [];
+    z = true;
+    return z;
+  }, []);
+  return [x, y];
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("noExternalReassignment", reassignOuterVariableReason, reassignOuterVariableDescription, "Cannot reassign variable", 5, 5, 5, 6),
+			},
+		},
+		// ---- Upstream fixture: error.useMemo-non-literal-deps-list.ts. ----
+		{
+			Code: `import {useMemo} from 'react';
+
+function App({text, hasDeps}) {
+  const resolvedText = useMemo(
+    () => {
+      return text.toUpperCase();
+    },
+    hasDeps ? null : [text],
+  );
+  return resolvedText;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedArrayLiteral", expectedArrayLiteralReason, expectedArrayLiteralDescription, expectedArrayLiteralReason, 8, 5, 8, 28),
+			},
+		},
+		// ---- Upstream fixture: preserve-memo-validation/error.validate-useMemo-named-function.js. ----
+		{
+			Code: `function Component(props) {
+  const x = useMemo(someHelper, []);
+  return x;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				useMemoError("expectedInlineFunction", expectedInlineFunctionReason, expectedInlineFunctionDescription, "Expected the first argument to be an inline function expression", 2, 21, 2, 31),
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &UseMemoRule, valid, invalid)
+}
+
+func useMemoError(id, reason, description, detail string, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: id,
+		Message:   buildUseMemoMessage(id, reason, description, detail).Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -218,6 +218,7 @@ export default defineConfig({
     './tests/eslint-plugin-react-hooks/rules/globals.test.ts',
     './tests/eslint-plugin-react-hooks/rules/immutability.test.ts',
     './tests/eslint-plugin-react-hooks/rules/incompatible-library.test.ts',
+    './tests/eslint-plugin-react-hooks/rules/use-memo.test.ts',
 
     // eslint-plugin-jsx-a11y
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/use-memo.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/use-memo.test.ts
@@ -1,0 +1,240 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const useMemoMessage = (reason: string, description: string) =>
+  `Error: ${reason}\n\n${description}.`;
+
+const noParamsMessage = useMemoMessage(
+  'useMemo() callbacks may not accept parameters',
+  'useMemo() callbacks are called by React to cache calculations across re-renders. They should not take parameters. Instead, directly reference the props, state, or local variables needed for the computation',
+);
+
+const asyncGeneratorMessage = useMemoMessage(
+  'useMemo() callbacks may not be async or generator functions',
+  'useMemo() callbacks are called once and must synchronously return a value',
+);
+
+const reassignmentMessage = useMemoMessage(
+  'useMemo() callbacks may not reassign variables declared outside of the callback',
+  'useMemo() callbacks must be pure functions and cannot reassign variables defined outside of the callback function',
+);
+
+const arrayLiteralMessage = useMemoMessage(
+  'Expected the dependency list for useMemo to be an array literal',
+  'Expected the dependency list for useMemo to be an array literal',
+);
+
+const inlineFunctionMessage = useMemoMessage(
+  'Expected the first argument to be an inline function expression',
+  'Expected the first argument to be an inline function expression',
+);
+
+ruleTester.run('use-memo', {} as never, {
+  valid: [
+    {
+      code: `
+        function component(a) {
+          let x = useMemo(() => [a], [a]);
+          return <Foo x={x}></Foo>;
+        }
+      `,
+    },
+    {
+      code: `
+        import {useMemo as myMemo} from 'react';
+
+        function Component({x}) {
+          const v = myMemo(() => x * 2, [x]);
+          return <div>{v}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        import {useMemo} from 'react';
+        function Component(props) {
+          return (
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+            useMemo(() => {
+              return [props.value];
+            }) || []
+          );
+        }
+      `,
+    },
+    {
+      code: `
+        function Component({ data }) {
+          const processed = useMemo(() => {
+            data.forEach(item => console.log(item));
+          }, [data]);
+          return <div>{processed}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          const value = useMemo(() => computeValue(), []);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component(props) {
+          // eslint-disable-next-line react-hooks/exhaustive-deps
+          const value = useMemo(() => props.value);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          const value = useMemo(() => {
+            return;
+          }, []);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          const value = useMemo(() => {
+            return null;
+          }, []);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component({cond, a, b}) {
+          const value = useMemo(() => {
+            if (cond) {
+              return a;
+            }
+            return b;
+          }, [cond, a, b]);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component({kind, a, b}) {
+          const value = useMemo(() => {
+            switch (kind) {
+              case 'a':
+                return a;
+              default:
+                return b;
+            }
+          }, [kind, a, b]);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component({a}) {
+          const value = useMemo(function named() {
+            return a;
+          }, [a]);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function component(a, b) {
+          let x = useMemo(c => c, []);
+          return x;
+        }
+      `,
+      errors: [{ message: noParamsMessage }],
+    },
+    {
+      code: `
+        function component(a, b) {
+          let x = useMemo(async () => {
+            return 1;
+          }, []);
+          return x;
+        }
+      `,
+      errors: [{ message: asyncGeneratorMessage }],
+    },
+    {
+      code: `
+        function component(a, b) {
+          let x = React.useMemo(async () => {
+            return 1;
+          }, []);
+          return x;
+        }
+      `,
+      errors: [{ message: asyncGeneratorMessage }],
+    },
+    {
+      code: `
+        /* eslint-disable react-hooks/exhaustive-deps */
+        function component(a, b) {
+          let x = useMemo(function* () {
+            yield a;
+          }, []);
+          return x;
+        }
+      `,
+      errors: [{ message: asyncGeneratorMessage }],
+    },
+    {
+      code: `
+        /* eslint-disable react-hooks/exhaustive-deps */
+        function Component() {
+          let x;
+          const y = useMemo(() => {
+            let z;
+            x = [];
+            z = true;
+            return z;
+          }, []);
+          return [x, y];
+        }
+      `,
+      errors: [{ message: reassignmentMessage }],
+    },
+    {
+      code: `
+        /* eslint-disable react-hooks/exhaustive-deps */
+        import {useMemo} from 'react';
+
+        function App({text, hasDeps}) {
+          const resolvedText = useMemo(
+            () => {
+              return text.toUpperCase();
+            },
+            hasDeps ? null : [text],
+          );
+          return resolvedText;
+        }
+      `,
+      errors: [{ message: arrayLiteralMessage }],
+    },
+    {
+      code: `
+        function Component(props) {
+          // eslint-disable-next-line react-hooks/exhaustive-deps
+          const x = useMemo(someHelper, []);
+          return x;
+        }
+      `,
+      errors: [{ message: inlineFunctionMessage }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react-hooks/use-memo` rule from eslint-plugin-react-hooks to rslint.

This adds the Go rule implementation, upstream and rslint-specific edge-case tests, JS integration coverage, and rule documentation.

## Related Links

- [react.dev - use-memo](https://react.dev/reference/eslint-plugin-react-hooks/lints/use-memo)
- [Source code - ValidateUseMemo.ts](https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateUseMemo.ts)
- [Source code - DropManualMemoization.ts](https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Inference/DropManualMemoization.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).