### PR TITLE
feat(eslint-plugin-jest): add `prefer-comparison-matcher` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -23,6 +23,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_test_prefixes"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_unneeded_async_expect_function"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_called_with"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_comparison_matcher"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_each"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_equality_matcher"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_expect_resolves"
@@ -67,6 +68,7 @@ func GetAllRules() []rule.Rule {
 		no_test_prefixes.NoTestPrefixesRule,
 		no_unneeded_async_expect_function.NoUnneededAsyncExpectFunctionRule,
 		prefer_called_with.PreferCalledWithRule,
+		prefer_comparison_matcher.PreferComparisonMatcherRule,
 		prefer_each.PreferEachRule,
 		prefer_equality_matcher.PreferEqualityMatcherRule,
 		prefer_expect_resolves.PreferExpectResolvesRule,

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
@@ -1,0 +1,126 @@
+package prefer_comparison_matcher
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type comparisonMatcher struct {
+	matcher        string
+	negatedMatcher string
+}
+
+var comparisonMatchers = map[ast.Kind]comparisonMatcher{
+	ast.KindGreaterThanToken:       {matcher: "toBeGreaterThan", negatedMatcher: "toBeLessThanOrEqual"},
+	ast.KindLessThanToken:          {matcher: "toBeLessThan", negatedMatcher: "toBeGreaterThanOrEqual"},
+	ast.KindGreaterThanEqualsToken: {matcher: "toBeGreaterThanOrEqual", negatedMatcher: "toBeLessThan"},
+	ast.KindLessThanEqualsToken:    {matcher: "toBeLessThanOrEqual", negatedMatcher: "toBeGreaterThan"},
+}
+
+func buildUseComparisonMatcherMessage(preferredMatcher string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "useToBeComparison",
+		Description: "Prefer using `" + preferredMatcher + "` instead",
+		Data: map[string]string{
+			"preferredMatcher": preferredMatcher,
+		},
+	}
+}
+
+func isStringComparisonOperand(node *ast.Node) bool {
+	return internalUtils.IsStringLiteralOrTemplate(utils.UnwrapBasicTypeAssertions(node))
+}
+
+func parseComparison(node *ast.Node) (left, right *ast.Node, matchers comparisonMatcher, ok bool) {
+	node = ast.SkipParentheses(node)
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return nil, nil, comparisonMatcher{}, false
+	}
+
+	bin := node.AsBinaryExpression()
+	matchers, ok = comparisonMatchers[bin.OperatorToken.Kind]
+	if !ok || isStringComparisonOperand(bin.Left) || isStringComparisonOperand(bin.Right) {
+		return nil, nil, comparisonMatcher{}, false
+	}
+
+	return bin.Left, bin.Right, matchers, true
+}
+
+func buildModifierText(jestFnCall *utils.ParsedJestFnCall) string {
+	if len(jestFnCall.ModifierEntries) > 0 && jestFnCall.ModifierEntries[0].Name != "not" {
+		return "." + jestFnCall.ModifierEntries[0].Name
+	}
+	return ""
+}
+
+var PreferComparisonMatcherRule = rule.Rule{
+	Name: "jest/prefer-comparison-matcher",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				jestFnCall := utils.ParseJestFnCall(node, ctx)
+				if jestFnCall == nil ||
+					jestFnCall.Kind != utils.JestFnTypeExpect ||
+					jestFnCall.MatcherEntry == nil ||
+					!utils.EQUALITY_METHOD_NAMES[jestFnCall.Matcher] {
+					return
+				}
+
+				expectCall := jestFnCall.Head.Local.Node.Parent
+				if expectCall == nil || expectCall.Kind != ast.KindCallExpression {
+					return
+				}
+
+				expectArgs := expectCall.Arguments()
+				if len(expectArgs) == 0 {
+					return
+				}
+
+				left, right, matchers, ok := parseComparison(expectArgs[0])
+				if !ok {
+					return
+				}
+
+				matcherArgs := node.AsCallExpression().Arguments.Nodes
+				if len(matcherArgs) == 0 {
+					return
+				}
+
+				matcherArg := matcherArgs[0]
+				matcherValue, ok := utils.IsBooleanLiteral(matcherArg)
+				if !ok {
+					return
+				}
+
+				preferredMatcher := matchers.matcher
+				if matcherValue == slices.Contains(jestFnCall.Modifiers, "not") {
+					preferredMatcher = matchers.negatedMatcher
+				}
+
+				matcherEntry := jestFnCall.MatcherEntry
+				if matcherEntry.Node == nil || matcherEntry.Node.Parent == nil {
+					return
+				}
+
+				comparison := ast.SkipParentheses(expectArgs[0])
+				leftText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, left, false)
+				rightText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, right, false)
+				modifierRange := core.NewTextRange(expectCall.End(), matcherEntry.Node.Parent.End())
+
+				ctx.ReportNodeWithFixes(
+					matcherEntry.Node,
+					buildUseComparisonMatcherMessage(preferredMatcher),
+					rule.RuleFixReplace(ctx.SourceFile, comparison, leftText),
+					rule.RuleFixReplaceRange(modifierRange, buildModifierText(jestFnCall)+"."+preferredMatcher),
+					rule.RuleFixReplace(ctx.SourceFile, matcherArg, rightText),
+				)
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
@@ -87,7 +87,15 @@ var PreferComparisonMatcherRule = rule.Rule{
 					return
 				}
 
-				matcherArgs := node.AsCallExpression().Arguments.Nodes
+				matcherEntry := jestFnCall.MatcherEntry
+				if matcherEntry.Node == nil ||
+					matcherEntry.Node.Parent == nil ||
+					matcherEntry.Call == nil ||
+					node != matcherEntry.Call {
+					return
+				}
+
+				matcherArgs := matcherEntry.Call.AsCallExpression().Arguments.Nodes
 				if len(matcherArgs) == 0 {
 					return
 				}
@@ -101,11 +109,6 @@ var PreferComparisonMatcherRule = rule.Rule{
 				preferredMatcher := matchers.matcher
 				if matcherValue == slices.Contains(jestFnCall.Modifiers, "not") {
 					preferredMatcher = matchers.negatedMatcher
-				}
-
-				matcherEntry := jestFnCall.MatcherEntry
-				if matcherEntry.Node == nil || matcherEntry.Node.Parent == nil {
-					return
 				}
 
 				comparison := ast.SkipParentheses(expectArgs[0])

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.md
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.md
@@ -1,0 +1,53 @@
+# prefer-comparison-matcher
+
+## Rule Details
+
+Prefer Jest's built-in comparison matchers over wrapping a relational operator in
+`expect(...).toBe(true)` (or `toEqual` / `toStrictEqual`).
+
+Assertions such as `expect(x > 5).toBe(true)` are harder to read and produce less
+helpful failure output than `expect(x).toBeGreaterThan(5)`.
+
+This rule reports `expect(left OP right).<equalityMatcher>(true|false)` patterns
+that can use one of these matchers instead:
+
+- `toBeGreaterThan`
+- `toBeGreaterThanOrEqual`
+- `toBeLessThan`
+- `toBeLessThanOrEqual`
+
+Violations are automatically fixed where possible.
+
+Examples of **incorrect** code for this rule:
+
+```js
+expect(x > 5).toBe(true);
+expect(x < 7).not.toEqual(true);
+expect(x <= y).toStrictEqual(true);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+expect(x).toBeGreaterThan(5);
+expect(x).not.toBeLessThanOrEqual(7);
+expect(x).toBeLessThanOrEqual(y);
+
+// special case - see below
+expect(x < 'Carl').toBe(true);
+```
+
+**String comparisons.** These matchers only accept numbers and bigints. The rule
+assumes operands are numeric and does not report comparisons that involve string
+literals (for example, `expect(x < 'Carl').toBe(true)`). If you intentionally
+compare strings with `>` or `<`, disable the rule for that line—otherwise the
+fix rewrites the assertion to a numeric matcher and fails at runtime:
+
+```js
+// rslint-disable-next-line jest/prefer-comparison-matcher
+expect(myName > theirName).toBe(true);
+```
+
+## Original Documentation
+
+- [jest/prefer-comparison-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-comparison-matcher.md)

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher_test.go
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher_test.go
@@ -1,0 +1,234 @@
+package prefer_comparison_matcher_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_comparison_matcher"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func comparisonColumn(base int, operator string) int {
+	return base + len(operator)
+}
+
+func generateInvalidCases(
+	operator string,
+	equalityMatcher string,
+	preferredMatcher string,
+	preferredMatcherWhenNegated string,
+) []rule_tester.InvalidTestCase {
+	useToBeComparison := func(column int) []rule_tester.InvalidTestCaseError {
+		return []rule_tester.InvalidTestCaseError{
+			{MessageId: "useToBeComparison", Line: 1, Column: comparisonColumn(column, operator)},
+		}
+	}
+
+	return []rule_tester.InvalidTestCase{
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1).%s(true);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).%s(1);`, preferredMatcher)},
+			Errors: useToBeComparison(18),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1,).%s(true,);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value,).%s(1,);`, preferredMatcher)},
+			Errors: useToBeComparison(19),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1)['%s'](true);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).%s(1);`, preferredMatcher)},
+			Errors: useToBeComparison(18),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1).resolves.%s(true);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).resolves.%s(1);`, preferredMatcher)},
+			Errors: useToBeComparison(27),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1).%s(false);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).%s(1);`, preferredMatcherWhenNegated)},
+			Errors: useToBeComparison(18),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1)['%s'](false);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).%s(1);`, preferredMatcherWhenNegated)},
+			Errors: useToBeComparison(18),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1).resolves.%s(false);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).resolves.%s(1);`, preferredMatcherWhenNegated)},
+			Errors: useToBeComparison(27),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1).not.%s(true);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).%s(1);`, preferredMatcherWhenNegated)},
+			Errors: useToBeComparison(22),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1)['not'].%s(true);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).%s(1);`, preferredMatcherWhenNegated)},
+			Errors: useToBeComparison(25),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1).resolves.not.%s(true);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).resolves.%s(1);`, preferredMatcherWhenNegated)},
+			Errors: useToBeComparison(31),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1).not.%s(false);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).%s(1);`, preferredMatcher)},
+			Errors: useToBeComparison(22),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1).resolves.not.%s(false);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).resolves.%s(1);`, preferredMatcher)},
+			Errors: useToBeComparison(31),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1)["resolves"].not.%s(false);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).resolves.%s(1);`, preferredMatcher)},
+			Errors: useToBeComparison(34),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1)["resolves"]["not"].%s(false);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).resolves.%s(1);`, preferredMatcher)},
+			Errors: useToBeComparison(37),
+		},
+		{
+			Code:   fmt.Sprintf(`expect(value %s 1)["resolves"]["not"]['%s'](false);`, operator, equalityMatcher),
+			Output: []string{fmt.Sprintf(`expect(value).resolves.%s(1);`, preferredMatcher)},
+			Errors: useToBeComparison(37),
+		},
+	}
+}
+
+func generateValidStringLiteralCases(operator string, matcher string) []rule_tester.ValidTestCase {
+	pairs := [][2]string{
+		{"x", "'y'"},
+		{"x", "`y`"},
+		{"x", "`y${z}`"},
+	}
+
+	var cases []rule_tester.ValidTestCase
+	for _, pair := range pairs {
+		a, b := pair[0], pair[1]
+		codes := []string{
+			fmt.Sprintf(`expect(%s %s %s).%s(true)`, a, operator, b, matcher),
+			fmt.Sprintf(`expect(%s %s %s).%s(false)`, a, operator, b, matcher),
+			fmt.Sprintf(`expect(%s %s %s).not.%s(true)`, a, operator, b, matcher),
+			fmt.Sprintf(`expect(%s %s %s).not.%s(false)`, a, operator, b, matcher),
+			fmt.Sprintf(`expect(%s %s %s).resolves.%s(true)`, a, operator, b, matcher),
+			fmt.Sprintf(`expect(%s %s %s).resolves.%s(false)`, a, operator, b, matcher),
+			fmt.Sprintf(`expect(%s %s %s).resolves.not.%s(true)`, a, operator, b, matcher),
+			fmt.Sprintf(`expect(%s %s %s).resolves.not.%s(false)`, a, operator, b, matcher),
+			fmt.Sprintf(`expect(%s %s %s).resolves.not.%s(false)`, b, operator, a, matcher),
+			fmt.Sprintf(`expect(%s %s %s).resolves.not.%s(true)`, b, operator, a, matcher),
+			fmt.Sprintf(`expect(%s %s %s).resolves.%s(false)`, b, operator, a, matcher),
+			fmt.Sprintf(`expect(%s %s %s).resolves.%s(true)`, b, operator, a, matcher),
+			fmt.Sprintf(`expect(%s %s %s).not.%s(false)`, b, operator, a, matcher),
+			fmt.Sprintf(`expect(%s %s %s).not.%s(true)`, b, operator, a, matcher),
+			fmt.Sprintf(`expect(%s %s %s).%s(false)`, b, operator, a, matcher),
+			fmt.Sprintf(`expect(%s %s %s).%s(true)`, b, operator, a, matcher),
+		}
+		for _, code := range codes {
+			cases = append(cases, rule_tester.ValidTestCase{Code: code})
+		}
+	}
+	return cases
+}
+
+func comparisonOperatorCases(
+	operator string,
+	preferredMatcher string,
+	preferredMatcherWhenNegated string,
+) (valid []rule_tester.ValidTestCase, invalid []rule_tester.InvalidTestCase) {
+	valid = []rule_tester.ValidTestCase{
+		{Code: `expect()`},
+		{Code: `expect({}).toStrictEqual({})`},
+		{Code: fmt.Sprintf(`expect(value).%s(1);`, preferredMatcher)},
+		{Code: fmt.Sprintf(`expect(value).%s(1);`, preferredMatcherWhenNegated)},
+		{Code: fmt.Sprintf(`expect(value).not.%s(1);`, preferredMatcher)},
+		{Code: fmt.Sprintf(`expect(value).not.%s(1);`, preferredMatcherWhenNegated)},
+	}
+
+	equalityMatchers := []string{"toBe", "toEqual", "toStrictEqual"}
+	for _, equalityMatcher := range equalityMatchers {
+		valid = append(valid, generateValidStringLiteralCases(operator, equalityMatcher)...)
+		invalid = append(invalid, generateInvalidCases(operator, equalityMatcher, preferredMatcher, preferredMatcherWhenNegated)...)
+	}
+
+	return valid, invalid
+}
+
+func TestPreferComparisonMatcherRule(t *testing.T) {
+	var validCases []rule_tester.ValidTestCase
+	var invalidCases []rule_tester.InvalidTestCase
+
+	operators := []struct {
+		operator                    string
+		preferredMatcher            string
+		preferredMatcherWhenNegated string
+	}{
+		{">", "toBeGreaterThan", "toBeLessThanOrEqual"},
+		{"<", "toBeLessThan", "toBeGreaterThanOrEqual"},
+		{">=", "toBeGreaterThanOrEqual", "toBeLessThan"},
+		{"<=", "toBeLessThanOrEqual", "toBeGreaterThan"},
+	}
+
+	for _, op := range operators {
+		valid, invalid := comparisonOperatorCases(op.operator, op.preferredMatcher, op.preferredMatcherWhenNegated)
+		validCases = append(validCases, valid...)
+		invalidCases = append(invalidCases, invalid...)
+	}
+
+	validCases = append(validCases,
+		rule_tester.ValidTestCase{Code: `expect.hasAssertions`},
+		rule_tester.ValidTestCase{Code: `expect.hasAssertions()`},
+		rule_tester.ValidTestCase{Code: `expect.assertions(1)`},
+		rule_tester.ValidTestCase{Code: `expect(true).toBe(...true)`},
+		rule_tester.ValidTestCase{Code: `expect()`},
+		rule_tester.ValidTestCase{Code: `expect({}).toStrictEqual({})`},
+		rule_tester.ValidTestCase{Code: `expect(a === b).toBe(true)`},
+		rule_tester.ValidTestCase{Code: `expect(a !== 2).toStrictEqual(true)`},
+		rule_tester.ValidTestCase{Code: `expect(a === b).not.toEqual(true)`},
+		rule_tester.ValidTestCase{Code: `expect(a !== "string").toStrictEqual(true)`},
+		rule_tester.ValidTestCase{Code: `expect(5 != a).toBe(true)`},
+		rule_tester.ValidTestCase{Code: `expect(a == "string").toBe(true)`},
+		rule_tester.ValidTestCase{Code: `expect(a == "string").not.toBe(true)`},
+	)
+
+	invalidCases = append(invalidCases,
+		rule_tester.InvalidTestCase{
+			Code:   `expect(value > 1).toBe(true as const);`,
+			Output: []string{`expect(value).toBeGreaterThan(1);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useToBeComparison", Line: 1, Column: 19},
+			},
+		},
+		rule_tester.InvalidTestCase{
+			Code:   `expect((a, b) > c).toBe(true);`,
+			Output: []string{`expect((a, b)).toBeGreaterThan(c);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useToBeComparison", Line: 1, Column: 20},
+			},
+		},
+		rule_tester.InvalidTestCase{
+			Code:   `expect(a > (b, c)).toBe(true);`,
+			Output: []string{`expect(a).toBeGreaterThan((b, c));`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useToBeComparison", Line: 1, Column: 20},
+			},
+		},
+	)
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_comparison_matcher.PreferComparisonMatcherRule,
+		validCases,
+		invalidCases,
+	)
+}

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher_test.go
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher_test.go
@@ -197,6 +197,8 @@ func TestPreferComparisonMatcherRule(t *testing.T) {
 		rule_tester.ValidTestCase{Code: `expect(5 != a).toBe(true)`},
 		rule_tester.ValidTestCase{Code: `expect(a == "string").toBe(true)`},
 		rule_tester.ValidTestCase{Code: `expect(a == "string").not.toBe(true)`},
+		rule_tester.ValidTestCase{Code: `expect(value > 1)[matcher].toBe(true);`},
+		rule_tester.ValidTestCase{Code: `expect(value > 1)[foo()].toBe(true);`},
 	)
 
 	invalidCases = append(invalidCases,
@@ -219,6 +221,20 @@ func TestPreferComparisonMatcherRule(t *testing.T) {
 			Output: []string{`expect(a).toBeGreaterThan((b, c));`},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "useToBeComparison", Line: 1, Column: 20},
+			},
+		},
+		rule_tester.InvalidTestCase{
+			Code:   `expect(value > 1).toBe(true).toString();`,
+			Output: []string{`expect(value).toBeGreaterThan(1).toString();`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useToBeComparison", Line: 1, Column: 19},
+			},
+		},
+		rule_tester.InvalidTestCase{
+			Code:   `expect(value > 1).toBe(true).foo(false);`,
+			Output: []string{`expect(value).toBeGreaterThan(1).foo(false);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useToBeComparison", Line: 1, Column: 19},
 			},
 		},
 	)

--- a/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.go
+++ b/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.go
@@ -27,20 +27,6 @@ func buildSuggestEqualityMatcherMessage(equalityMatcher string) rule.RuleMessage
 	}
 }
 
-func isBooleanLiteral(node *ast.Node) (value bool, ok bool) {
-	if node == nil {
-		return false, false
-	}
-	switch node.Kind {
-	case ast.KindTrueKeyword:
-		return true, true
-	case ast.KindFalseKeyword:
-		return false, true
-	default:
-		return false, false
-	}
-}
-
 func parseStrictEqualityComparison(node *ast.Node) (left, right *ast.Node, negated bool, ok bool) {
 	if node == nil || node.Kind != ast.KindBinaryExpression {
 		return nil, nil, false, false
@@ -102,8 +88,8 @@ var PreferEqualityMatcherRule = rule.Rule{
 					return
 				}
 
-				matcherArg := utils.UnwrapBasicTypeAssertions(matcherArgs[0])
-				matcherValue, ok := isBooleanLiteral(matcherArg)
+				matcherArg := matcherArgs[0]
+				matcherValue, ok := utils.IsBooleanLiteral(matcherArg)
 				if !ok {
 					return
 				}
@@ -119,7 +105,7 @@ var PreferEqualityMatcherRule = rule.Rule{
 				leftText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(left), false)
 				rightText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(right), false)
 				replaceComparison := rule.RuleFixReplace(ctx.SourceFile, comparison, leftText)
-				replaceMatcherArg := rule.RuleFixReplace(ctx.SourceFile, matcherArg, rightText)
+				replaceMatcherArg := rule.RuleFixReplace(ctx.SourceFile, utils.UnwrapBasicTypeAssertions(matcherArg), rightText)
 				modifierRange := core.NewTextRange(expectCall.End(), matcherEntry.Node.Parent.End())
 
 				suggestions := make([]rule.RuleSuggestion, len(suggestedEqualityMatchers))

--- a/internal/plugins/jest/utils/jest.go
+++ b/internal/plugins/jest/utils/jest.go
@@ -130,6 +130,7 @@ var VALID_JEST_FN_CALL_CHAINS = map[string]bool{
 type ParsedJestFnMemberEntry struct {
 	Name string
 	Node *ast.Node
+	Call *ast.Node
 }
 
 func JoinJestFnMemberEntries(entries []ParsedJestFnMemberEntry) string {
@@ -210,9 +211,13 @@ func GetJestFnMemberEntries(node *ast.Node) []ParsedJestFnMemberEntry {
 				Node: nameNode,
 			})
 		}
-		return left
+		return nil
 	case ast.KindCallExpression:
-		return GetJestFnMemberEntries(node.AsCallExpression().Expression)
+		entries := GetJestFnMemberEntries(node.AsCallExpression().Expression)
+		if len(entries) > 0 {
+			entries[len(entries)-1].Call = node
+		}
+		return entries
 	case ast.KindTaggedTemplateExpression:
 		return GetJestFnMemberEntries(node.AsTaggedTemplateExpression().Tag)
 	default:

--- a/internal/plugins/jest/utils/jest.go
+++ b/internal/plugins/jest/utils/jest.go
@@ -520,6 +520,23 @@ func GetJestVersion(ctx rule.RuleContext) string {
 	return DefaultJestVersion
 }
 
+// IsBooleanLiteral reports whether node is a `true`/`false` literal after
+// stripping parentheses and basic TS type assertions, and returns its value.
+func IsBooleanLiteral(node *ast.Node) (value bool, ok bool) {
+	node = UnwrapBasicTypeAssertions(node)
+	if node == nil {
+		return false, false
+	}
+	switch node.Kind {
+	case ast.KindTrueKeyword:
+		return true, true
+	case ast.KindFalseKeyword:
+		return false, true
+	default:
+		return false, false
+	}
+}
+
 func IsFunction(node *ast.Node) bool {
 	return ast.IsFunctionDeclaration(node) ||
 		ast.IsFunctionExpressionOrArrowFunction(node) ||

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -512,6 +512,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/no-unneeded-async-expect-function.test.ts',
     './tests/eslint-plugin-jest/rules/no-duplicate-hooks.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-called-with.test.ts',
+    './tests/eslint-plugin-jest/rules/prefer-comparison-matcher.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-each.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-equality-matcher.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-expect-resolves.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-comparison-matcher.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-comparison-matcher.test.ts
@@ -1,0 +1,271 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const generateInvalidCases = (
+  operator: string,
+  equalityMatcher: string,
+  preferredMatcher: string,
+  preferredMatcherWhenNegated: string,
+) => [
+  {
+    code: `expect(value ${operator} 1).${equalityMatcher}(true);`,
+    output: `expect(value).${preferredMatcher}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher },
+        column: 18 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1,).${equalityMatcher}(true,);`,
+    output: `expect(value,).${preferredMatcher}(1,);`,
+    parserOptions: { ecmaVersion: 2017 },
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher },
+        column: 19 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1)['${equalityMatcher}'](true);`,
+    output: `expect(value).${preferredMatcher}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher },
+        column: 18 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1).resolves.${equalityMatcher}(true);`,
+    output: `expect(value).resolves.${preferredMatcher}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher },
+        column: 27 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1).${equalityMatcher}(false);`,
+    output: `expect(value).${preferredMatcherWhenNegated}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher: preferredMatcherWhenNegated },
+        column: 18 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1)['${equalityMatcher}'](false);`,
+    output: `expect(value).${preferredMatcherWhenNegated}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher: preferredMatcherWhenNegated },
+        column: 18 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1).resolves.${equalityMatcher}(false);`,
+    output: `expect(value).resolves.${preferredMatcherWhenNegated}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher: preferredMatcherWhenNegated },
+        column: 27 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1).not.${equalityMatcher}(true);`,
+    output: `expect(value).${preferredMatcherWhenNegated}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher: preferredMatcherWhenNegated },
+        column: 22 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1)['not'].${equalityMatcher}(true);`,
+    output: `expect(value).${preferredMatcherWhenNegated}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher: preferredMatcherWhenNegated },
+        column: 25 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1).resolves.not.${equalityMatcher}(true);`,
+    output: `expect(value).resolves.${preferredMatcherWhenNegated}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher: preferredMatcherWhenNegated },
+        column: 31 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1).not.${equalityMatcher}(false);`,
+    output: `expect(value).${preferredMatcher}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher },
+        column: 22 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1).resolves.not.${equalityMatcher}(false);`,
+    output: `expect(value).resolves.${preferredMatcher}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher },
+        column: 31 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1)["resolves"].not.${equalityMatcher}(false);`,
+    output: `expect(value).resolves.${preferredMatcher}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher },
+        column: 34 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1)["resolves"]["not"].${equalityMatcher}(false);`,
+    output: `expect(value).resolves.${preferredMatcher}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher },
+        column: 37 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+  {
+    code: `expect(value ${operator} 1)["resolves"]["not"]['${equalityMatcher}'](false);`,
+    output: `expect(value).resolves.${preferredMatcher}(1);`,
+    errors: [
+      {
+        messageId: 'useToBeComparison',
+        data: { preferredMatcher },
+        column: 37 + operator.length,
+        line: 1,
+      },
+    ],
+  },
+];
+
+const generateValidStringLiteralCases = (operator: string, matcher: string) =>
+  [
+    ['x', "'y'"],
+    ['x', '`y`'],
+    ['x', '`y${z}`'],
+  ].flatMap(([a, b]) => [
+    `expect(${a} ${operator} ${b}).${matcher}(true)`,
+    `expect(${a} ${operator} ${b}).${matcher}(false)`,
+    `expect(${a} ${operator} ${b}).not.${matcher}(true)`,
+    `expect(${a} ${operator} ${b}).not.${matcher}(false)`,
+    `expect(${a} ${operator} ${b}).resolves.${matcher}(true)`,
+    `expect(${a} ${operator} ${b}).resolves.${matcher}(false)`,
+    `expect(${a} ${operator} ${b}).resolves.not.${matcher}(true)`,
+    `expect(${a} ${operator} ${b}).resolves.not.${matcher}(false)`,
+    `expect(${b} ${operator} ${a}).resolves.not.${matcher}(false)`,
+    `expect(${b} ${operator} ${a}).resolves.not.${matcher}(true)`,
+    `expect(${b} ${operator} ${a}).resolves.${matcher}(false)`,
+    `expect(${b} ${operator} ${a}).resolves.${matcher}(true)`,
+    `expect(${b} ${operator} ${a}).not.${matcher}(false)`,
+    `expect(${b} ${operator} ${a}).not.${matcher}(true)`,
+    `expect(${b} ${operator} ${a}).${matcher}(false)`,
+    `expect(${b} ${operator} ${a}).${matcher}(true)`,
+  ]);
+
+const testComparisonOperator = (
+  operator: string,
+  preferredMatcher: string,
+  preferredMatcherWhenNegated: string,
+) => {
+  ruleTester.run(`prefer-comparison-matcher`, {} as never, {
+    valid: [
+      { code: 'expect()' },
+      { code: 'expect({}).toStrictEqual({})' },
+      { code: `expect(value).${preferredMatcher}(1);` },
+      { code: `expect(value).${preferredMatcherWhenNegated}(1);` },
+      { code: `expect(value).not.${preferredMatcher}(1);` },
+      { code: `expect(value).not.${preferredMatcherWhenNegated}(1);` },
+      ...['toBe', 'toEqual', 'toStrictEqual'].flatMap(
+        (equalityMatcher: string) =>
+          generateValidStringLiteralCases(operator, equalityMatcher).map(
+            (code) => ({ code }),
+          ),
+      ),
+    ],
+    invalid: ['toBe', 'toEqual', 'toStrictEqual'].flatMap((equalityMatcher) =>
+      generateInvalidCases(
+        operator,
+        equalityMatcher,
+        preferredMatcher,
+        preferredMatcherWhenNegated,
+      ),
+    ),
+  });
+};
+
+testComparisonOperator('>', 'toBeGreaterThan', 'toBeLessThanOrEqual');
+testComparisonOperator('<', 'toBeLessThan', 'toBeGreaterThanOrEqual');
+testComparisonOperator('>=', 'toBeGreaterThanOrEqual', 'toBeLessThan');
+testComparisonOperator('<=', 'toBeLessThanOrEqual', 'toBeGreaterThan');
+
+ruleTester.run(`prefer-comparison-matcher`, {} as never, {
+  valid: [
+    { code: 'expect.hasAssertions' },
+    { code: 'expect.hasAssertions()' },
+    { code: 'expect.assertions(1)' },
+    { code: 'expect(true).toBe(...true)' },
+    { code: 'expect()' },
+    { code: 'expect({}).toStrictEqual({})' },
+    { code: 'expect(a === b).toBe(true)' },
+    { code: 'expect(a !== 2).toStrictEqual(true)' },
+    { code: 'expect(a === b).not.toEqual(true)' },
+    { code: 'expect(a !== "string").toStrictEqual(true)' },
+    { code: 'expect(5 != a).toBe(true)' },
+    { code: 'expect(a == "string").toBe(true)' },
+    { code: 'expect(a == "string").not.toBe(true)' },
+  ],
+  invalid: [],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-comparison-matcher.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-comparison-matcher.test.ts
@@ -266,6 +266,33 @@ ruleTester.run(`prefer-comparison-matcher`, {} as never, {
     { code: 'expect(5 != a).toBe(true)' },
     { code: 'expect(a == "string").toBe(true)' },
     { code: 'expect(a == "string").not.toBe(true)' },
+    { code: 'expect(value > 1)[matcher].toBe(true);' },
+    { code: 'expect(value > 1)[foo()].toBe(true);' },
   ],
-  invalid: [],
+  invalid: [
+    {
+      code: 'expect(value > 1).toBe(true).toString();',
+      output: 'expect(value).toBeGreaterThan(1).toString();',
+      errors: [
+        {
+          messageId: 'useToBeComparison',
+          data: { preferredMatcher: 'toBeGreaterThan' },
+          column: 19,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(value > 1).toBe(true).foo(false);',
+      output: 'expect(value).toBeGreaterThan(1).foo(false);',
+      errors: [
+        {
+          messageId: 'useToBeComparison',
+          data: { preferredMatcher: 'toBeGreaterThan' },
+          column: 19,
+          line: 1,
+        },
+      ],
+    },
+  ],
 });


### PR DESCRIPTION
## Summary

* Port `prefer-comparison-matcher` from eslint-plugin-jest to rslint

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/prefer-comparison-matcher [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-comparison-matcher.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/prefer-comparison-matcher.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
