### PR TITLE
feat: port react-hooks/void-use-memo

### DIFF
--- a/internal/plugins/react_hooks/all.go
+++ b/internal/plugins/react_hooks/all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/incompatible_library"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/rules_of_hooks"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/use_memo"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/void_use_memo"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -22,5 +23,6 @@ func GetAllRules() []rule.Rule {
 		immutability.ImmutabilityRule,
 		incompatible_library.IncompatibleLibraryRule,
 		use_memo.UseMemoRule,
+		void_use_memo.VoidUseMemoRule,
 	}
 }

--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -119,6 +120,99 @@ func IsUseEffectEventCallee(node *ast.Node) bool {
 // callee — either bare `use` or `React.use`.
 func IsUseIdentifier(node *ast.Node) bool {
 	return IsReactCalleeNamed(node, "use")
+}
+
+// IsManualUseMemoCallee reports whether `node` is a direct `useMemo` or
+// `React.useMemo` callee according to React Compiler's manual memoization
+// input surface. It intentionally does not recognize import aliases or
+// element-access forms; existing React Compiler lint ports rely on the same
+// direct-call contract.
+func IsManualUseMemoCallee(node *ast.Node, typeChecker *checker.Checker) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return isManualMemoIdentifier(node, "useMemo", typeChecker)
+	case ast.KindPropertyAccessExpression:
+		if ast.IsOptionalChain(node) {
+			return false
+		}
+		access := node.AsPropertyAccessExpression()
+		name := access.Name()
+		if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "useMemo" {
+			return false
+		}
+		obj := ast.SkipParentheses(access.Expression)
+		if obj == nil || obj.Kind != ast.KindIdentifier {
+			return false
+		}
+		return isManualMemoIdentifier(obj, "React", typeChecker)
+	}
+	return false
+}
+
+func isManualMemoIdentifier(id *ast.Node, expected string, typeChecker *checker.Checker) bool {
+	if id == nil || id.Kind != ast.KindIdentifier || id.AsIdentifier().Text != expected {
+		return false
+	}
+	if typeChecker == nil {
+		return true
+	}
+	sym := utils.GetReferenceSymbol(id, typeChecker)
+	if sym == nil || len(sym.Declarations) == 0 {
+		return true
+	}
+	for _, decl := range sym.Declarations {
+		if isManualMemoDeclaration(decl, expected) {
+			return true
+		}
+	}
+	return false
+}
+
+func isManualMemoDeclaration(decl *ast.Node, expected string) bool {
+	if decl == nil {
+		return false
+	}
+	switch decl.Kind {
+	case ast.KindImportClause, ast.KindNamespaceImport, ast.KindImportSpecifier:
+		return true
+	case ast.KindBindingElement:
+		return !isInsideParameter(decl)
+	case ast.KindVariableDeclaration:
+		name := decl.Name()
+		if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != expected {
+			return false
+		}
+		initializer := ast.SkipParentheses(decl.AsVariableDeclaration().Initializer)
+		if initializer == nil {
+			return true
+		}
+		if expected == "useMemo" && ast.IsFunctionExpressionOrArrowFunction(initializer) {
+			return false
+		}
+		if expected == "React" && initializer.Kind == ast.KindObjectLiteralExpression {
+			return false
+		}
+		return true
+	case ast.KindParameter, ast.KindFunctionDeclaration:
+		return false
+	}
+	return false
+}
+
+func isInsideParameter(node *ast.Node) bool {
+	for cur := node; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindParameter:
+			return true
+		case ast.KindVariableDeclaration:
+			return false
+		}
+	}
+	return false
 }
 
 // IsHookCallee mirrors upstream's `isHook(node)`: the callee is

--- a/internal/plugins/react_hooks/rules/use_memo/use_memo.go
+++ b/internal/plugins/react_hooks/rules/use_memo/use_memo.go
@@ -53,7 +53,7 @@ var UseMemoRule = rule.Rule{
 
 func (state *useMemoState) processCallExpression(node *ast.Node) {
 	call := node.AsCallExpression()
-	if call == nil || !state.isUseMemoCallee(call.Expression) {
+	if call == nil || !react_hooksutil.IsManualUseMemoCallee(call.Expression, state.ctx.TypeChecker) {
 		return
 	}
 
@@ -78,93 +78,6 @@ func (state *useMemoState) processCallExpression(node *ast.Node) {
 
 	state.checkCallback(callback)
 	state.checkDependencyList(args.Nodes)
-}
-
-func (state *useMemoState) isUseMemoCallee(node *ast.Node) bool {
-	node = ast.SkipParentheses(node)
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindIdentifier:
-		return state.isManualMemoIdentifier(node, "useMemo")
-	case ast.KindPropertyAccessExpression:
-		if ast.IsOptionalChain(node) {
-			return false
-		}
-		name := node.AsPropertyAccessExpression().Name()
-		if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "useMemo" {
-			return false
-		}
-		obj := ast.SkipParentheses(node.AsPropertyAccessExpression().Expression)
-		if obj == nil || obj.Kind != ast.KindIdentifier {
-			return false
-		}
-		return state.isManualMemoIdentifier(obj, "React")
-	}
-	return false
-}
-
-func (state *useMemoState) isManualMemoIdentifier(id *ast.Node, expected string) bool {
-	if id == nil || id.Kind != ast.KindIdentifier || id.AsIdentifier().Text != expected {
-		return false
-	}
-	if state.ctx.TypeChecker == nil {
-		return true
-	}
-	sym := utils.GetReferenceSymbol(id, state.ctx.TypeChecker)
-	if sym == nil || len(sym.Declarations) == 0 {
-		return true
-	}
-	for _, decl := range sym.Declarations {
-		if isManualMemoDeclaration(decl, expected) {
-			return true
-		}
-	}
-	return false
-}
-
-func isManualMemoDeclaration(decl *ast.Node, expected string) bool {
-	if decl == nil {
-		return false
-	}
-	switch decl.Kind {
-	case ast.KindImportClause, ast.KindNamespaceImport, ast.KindImportSpecifier:
-		return true
-	case ast.KindBindingElement:
-		return !isInsideParameter(decl)
-	case ast.KindVariableDeclaration:
-		name := decl.Name()
-		if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != expected {
-			return false
-		}
-		initializer := ast.SkipParentheses(decl.AsVariableDeclaration().Initializer)
-		if initializer == nil {
-			return true
-		}
-		if expected == "useMemo" && ast.IsFunctionExpressionOrArrowFunction(initializer) {
-			return false
-		}
-		if expected == "React" && initializer.Kind == ast.KindObjectLiteralExpression {
-			return false
-		}
-		return true
-	case ast.KindParameter, ast.KindFunctionDeclaration:
-		return false
-	}
-	return false
-}
-
-func isInsideParameter(node *ast.Node) bool {
-	for cur := node; cur != nil; cur = cur.Parent {
-		switch cur.Kind {
-		case ast.KindParameter:
-			return true
-		case ast.KindVariableDeclaration:
-			return false
-		}
-	}
-	return false
 }
 
 func (state *useMemoState) checkCallback(callback *ast.Node) {

--- a/internal/plugins/react_hooks/rules/void_use_memo/void_use_memo.go
+++ b/internal/plugins/react_hooks/rules/void_use_memo/void_use_memo.go
@@ -1,0 +1,167 @@
+package void_use_memo
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/react_hooksutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const (
+	missingReturnReason      = "useMemo() callbacks must return a value"
+	missingReturnDescription = "This useMemo() callback doesn't return a value. useMemo() is for computing and caching values, not for arbitrary side effects"
+	unusedResultReason       = "useMemo() result is unused"
+	unusedResultDescription  = "This useMemo() value is unused. useMemo() is for computing and caching values, not for arbitrary side effects"
+)
+
+type voidUseMemoState struct {
+	ctx rule.RuleContext
+}
+
+// VoidUseMemoRule is the rslint port of upstream `react-hooks/void-use-memo`.
+//
+// Upstream emits this rule from React Compiler's VoidUseMemo diagnostic
+// category. This port validates the published local contract: useMemo
+// callbacks must contain an explicit or implicit return, and a returned
+// useMemo value must not be discarded as a bare expression statement.
+var VoidUseMemoRule = rule.Rule{
+	Name: "react-hooks/void-use-memo",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		state := &voidUseMemoState{ctx: ctx}
+		return rule.RuleListeners{
+			ast.KindCallExpression: state.processCallExpression,
+		}
+	},
+}
+
+func (state *voidUseMemoState) processCallExpression(node *ast.Node) {
+	call := node.AsCallExpression()
+	if call == nil || !react_hooksutil.IsManualUseMemoCallee(call.Expression, state.ctx.TypeChecker) {
+		return
+	}
+	args := call.Arguments
+	if args == nil || len(args.Nodes) == 0 {
+		return
+	}
+
+	callback := ast.SkipParentheses(args.Nodes[0])
+	if callback == nil || callback.Kind == ast.KindSpreadElement || !ast.IsFunctionExpressionOrArrowFunction(callback) {
+		return
+	}
+
+	if !hasUseMemoReturn(callback) {
+		state.ctx.ReportNode(callback, buildVoidUseMemoMessage("missingReturn", missingReturnReason, missingReturnDescription))
+		return
+	}
+	if isUnusedUseMemoResult(node) {
+		state.ctx.ReportNode(reportableCallee(call.Expression), buildVoidUseMemoMessage("unusedResult", unusedResultReason, unusedResultDescription))
+	}
+}
+
+func hasUseMemoReturn(callback *ast.Node) bool {
+	if callback == nil {
+		return false
+	}
+	body := react_hooksutil.GetFunctionBody(callback)
+	if body == nil {
+		return false
+	}
+	// React Compiler treats arrow expression bodies as implicit returns.
+	if callback.Kind == ast.KindArrowFunction {
+		if body.Kind != ast.KindBlock {
+			return true
+		}
+	}
+
+	// React Compiler's HIR-based terminal scan does not count returns from the
+	// try block of a try/finally statement or from its finally block.
+	return ast.ForEachReturnStatement(body, func(stmt *ast.Node) bool {
+		return !isIgnoredTryFinallyReturn(stmt, callback)
+	})
+}
+
+func isIgnoredTryFinallyReturn(ret *ast.Node, callback *ast.Node) bool {
+	child := ret
+	for parent := ret.Parent; parent != nil && parent != callback; parent = parent.Parent {
+		if react_hooksutil.IsFunctionLikeContainer(parent) {
+			return false
+		}
+		if parent.Kind == ast.KindTryStatement {
+			tryStmt := parent.AsTryStatement()
+			if tryStmt != nil && tryStmt.FinallyBlock != nil {
+				if tryStmt.TryBlock != nil && tryStmt.TryBlock.AsNode() == child {
+					return true
+				}
+				if tryStmt.FinallyBlock.AsNode() == child {
+					return true
+				}
+			}
+		}
+		child = parent
+	}
+	return false
+}
+
+func isUnusedUseMemoResult(call *ast.Node) bool {
+	current := call
+	for {
+		child, parent := walkUpResultWrappers(current, current == call)
+		if parent == nil {
+			return false
+		}
+		switch parent.Kind {
+		case ast.KindExpressionStatement:
+			return current == call
+		case ast.KindBinaryExpression:
+			// In a comma expression, every operand except the final one is
+			// discarded even when the comma expression's final result is used.
+			binary := parent.AsBinaryExpression()
+			if binary == nil || binary.OperatorToken == nil || binary.OperatorToken.Kind != ast.KindCommaToken {
+				return false
+			}
+			if binary.Left == child {
+				return true
+			}
+			if binary.Right == child {
+				current = parent
+				continue
+			}
+			return false
+		default:
+			return false
+		}
+	}
+}
+
+func walkUpResultWrappers(node *ast.Node, allowNonNull bool) (*ast.Node, *ast.Node) {
+	child := node
+	parent := child.Parent
+	kinds := ast.OEKParentheses
+	if allowNonNull {
+		kinds |= ast.OEKNonNullAssertions
+	}
+	for parent != nil && ast.IsOuterExpression(parent, kinds) {
+		child = parent
+		parent = child.Parent
+	}
+	return child, parent
+}
+
+func reportableCallee(callee *ast.Node) *ast.Node {
+	if unwrapped := ast.SkipParentheses(callee); unwrapped != nil {
+		return unwrapped
+	}
+	return callee
+}
+
+func buildVoidUseMemoMessage(id, reason, description string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          id,
+		Description: fmt.Sprintf("Error: %s\n\n%s.", reason, description),
+		Data: map[string]string{
+			"description": description,
+			"reason":      reason,
+		},
+	}
+}

--- a/internal/plugins/react_hooks/rules/void_use_memo/void_use_memo.md
+++ b/internal/plugins/react_hooks/rules/void_use_memo/void_use_memo.md
@@ -1,0 +1,58 @@
+# react-hooks/void-use-memo
+
+## Rule Details
+
+Validates that `useMemo()` callbacks return a value and that the memoized value is used.
+
+`useMemo()` is for computing and caching values. If the callback has no return, or if the result of `useMemo()` is discarded, the hook is likely being used for side effects instead.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function Component({ value }) {
+  const memoized = useMemo(() => {
+    console.log(value);
+  }, [value]);
+  return <div>{memoized}</div>;
+}
+```
+
+```javascript
+function Component() {
+  useMemo(() => {
+    return [];
+  }, []);
+  return <div />;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function Component({ value }) {
+  const memoized = useMemo(() => {
+    return value * 2;
+  }, [value]);
+  return <div>{memoized}</div>;
+}
+```
+
+```javascript
+function Component({ value }) {
+  useEffect(() => {
+    console.log(value);
+  }, [value]);
+  return <div>{value}</div>;
+}
+```
+
+Like upstream, this rule tracks direct `useMemo()` and `React.useMemo()` call shapes. It checks that the callback has an explicit or implicit return; it does not inspect the returned value.
+
+## Options
+
+This rule has no rule-specific options. Like upstream, it accepts an option object for forward compatibility and ignores it.
+
+## Original Documentation
+
+- [react.dev - void-use-memo](https://react.dev/reference/eslint-plugin-react-hooks/lints/void-use-memo)
+- [Source code - ValidateUseMemo.ts](https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateUseMemo.ts)

--- a/internal/plugins/react_hooks/rules/void_use_memo/void_use_memo_extras_test.go
+++ b/internal/plugins/react_hooks/rules/void_use_memo/void_use_memo_extras_test.go
@@ -1,0 +1,391 @@
+package void_use_memo
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestVoidUseMemoExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+func TestVoidUseMemoExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Dimension 4: parenthesized callee and callback wrappers are transparent. ----
+		{Code: `function Component({value}) {
+  const memo = ((useMemo))((() => value), [value]);
+  return <div>{memo}</div>;
+}
+`, Tsx: true},
+		// Locks in upstream validateUseMemo() arm: missing callback is handled by react-hooks/use-memo, not void-use-memo.
+		{Code: `function Component() {
+  useMemo();
+  return <div />;
+}
+`, Tsx: true},
+		// Locks in upstream validateUseMemo() arm: non-inline callback is handled by react-hooks/use-memo, not void-use-memo.
+		{Code: `function Component({value}) {
+  const compute = () => value;
+  const memo = useMemo(compute, [value]);
+  return <div>{memo}</div>;
+}
+`, Tsx: true},
+		// Locks in upstream unusedUseMemos deletion arm: the void operator consumes the call result.
+		{Code: `function Component() {
+  void useMemo(() => {
+    return [];
+  }, []);
+  return <div />;
+}
+`, Tsx: true},
+		// Locks in upstream operand deletion arms: logical, conditional, call, array, assignment, and JSX positions consume the result.
+		{Code: `function Component({ok}) {
+  let value;
+  ok && useMemo(() => {
+    return [];
+  }, []);
+  ok ? useMemo(() => {
+    return [];
+  }, []) : value;
+  consume(useMemo(() => {
+    return [];
+  }, []));
+  [useMemo(() => {
+    return [];
+  }, [])];
+  value = useMemo(() => {
+    return [];
+  }, []);
+  return <div>{useMemo(() => {
+    return value;
+  }, [value])}</div>;
+}
+`, Tsx: true},
+		// Locks in upstream comma-expression arm: the final operand's result is not reported.
+		{Code: `function Component() {
+  sideEffect(), useMemo(() => {
+    return [];
+  }, []);
+  return <div />;
+}
+`, Tsx: true},
+		// Locks in upstream comma-expression arm: a final useMemo operand remains consumed when the whole sequence is non-null asserted.
+		{Code: `function Component() {
+  ((sideEffect(), useMemo(() => {
+    return [];
+  }, []))!, last());
+  return <div />;
+}
+`, Tsx: true},
+		// ---- Dimension 4: TS assertion wrappers around a returned value consume the result. ----
+		{Code: `function Component() {
+  (useMemo(() => {
+    return [];
+  }, []) as unknown);
+  (useMemo(() => {
+    return [];
+  }, []) satisfies unknown);
+  return <div />;
+}
+`, Tsx: true},
+		// Locks in upstream unusedUseMemos deletion arm: assigning to a variable consumes the call result even when the binding is never read.
+		{Code: `function Component() {
+  const _ = useMemo(() => {
+    return [];
+  }, []);
+  return <div />;
+}
+`, Tsx: true},
+		// Locks in upstream terminal-operand arm: returning the useMemo result consumes it.
+		{Code: `function Component() {
+  return useMemo(() => {
+    return <div />;
+  }, []);
+}
+`, Tsx: true},
+		// Locks in upstream hasNonVoidReturn() arm: any explicit return terminal is enough.
+		{Code: `function Component({cond}) {
+  const value = useMemo(() => {
+    if (cond) {
+      return 1;
+    }
+  }, [cond]);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// Locks in upstream hasNonVoidReturn() arm: implicit void expression returns still count as a return.
+		{Code: `function Component({effect}) {
+  const value = useMemo(() => void effect(), [effect]);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// Locks in upstream HIR terminal scan: returns inside try/catch count when there is no finally.
+		{Code: `function Component() {
+  const value = useMemo(() => {
+    try {
+      return 1;
+    } catch (error) {
+      return 2;
+    }
+  }, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// Locks in upstream HIR terminal scan: a return after try/finally still counts.
+		{Code: `function Component() {
+  const value = useMemo(() => {
+    try {
+      work();
+    } finally {
+      cleanup();
+    }
+    return 1;
+  }, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// Locks in upstream HIR terminal scan: catch returns count even with a finally block.
+		{Code: `function Component() {
+  const value = useMemo(() => {
+    try {
+      work();
+    } catch (error) {
+      return 1;
+    } finally {
+      cleanup();
+    }
+  }, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Options contract: upstream accepts an arbitrary object and void-use-memo ignores it. ----
+		{
+			Code: `function Component({value}) {
+  const memo = useMemo(() => value, [value]);
+  return <div>{memo}</div>;
+}
+`,
+			Options: map[string]interface{}{"someFutureOption": true},
+			Tsx:     true,
+		},
+		// ---- Dimension 4: local shadowing means the callee is not React's useMemo. ----
+		{Code: `function Component() {
+  const useMemo = (fn) => fn();
+  useMemo(() => {
+    console.log('local');
+  }, []);
+  return <div />;
+}
+`, Tsx: true},
+		// ---- Dimension 4: element access and optional namespace calls are outside upstream's input surface. ----
+		{Code: `function Component() {
+  React["useMemo"](() => {
+    console.log('ignored');
+  }, []);
+  React?.useMemo(() => {
+    console.log('ignored');
+  }, []);
+  return <div />;
+}
+`, Tsx: true},
+		// ---- Dimension 4: TS assertion wrappers around callback arguments are handled by react-hooks/use-memo. ----
+		{Code: `type Fn = () => number;
+function Component() {
+  const value = useMemo((() => 1) as Fn, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// N/A: PrivateIdentifier and object/class property key forms are not inputs inspected by this rule.
+		// N/A: Autofix boundaries do not apply because react-hooks/void-use-memo has no autofix.
+		// N/A: Class declaration/class expression containers are not rule targets; the rule validates hook calls.
+		// N/A: Empty class bodies and overload signatures do not affect useMemo call validation.
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// Locks in upstream validateUseMemo() arm: no callback return reports missingReturn and does not also report unusedResult.
+		{
+			Code: `function Component() {
+  useMemo(() => {
+    console.log('effect');
+  }, []);
+  return <div />;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("missingReturn", missingReturnReason, missingReturnDescription, 2, 11, 4, 4),
+			},
+		},
+		// ---- Dimension 4: parenthesized expression statements still discard the result. ----
+		{
+			Code: `function Component() {
+  (useMemo(() => {
+    return [];
+  }, []));
+  return <div />;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("unusedResult", unusedResultReason, unusedResultDescription, 2, 4, 2, 11),
+			},
+		},
+		// ---- Dimension 4: TS non-null wrappers around the result are transparent for unused-result detection. ----
+		{
+			Code: `function Component() {
+  (useMemo(() => {
+    return [];
+  }, []))!;
+  return <div />;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("unusedResult", unusedResultReason, unusedResultDescription, 2, 4, 2, 11),
+			},
+		},
+		// Locks in upstream comma-expression arm: non-final operands are discarded even when the overall expression is used.
+		{
+			Code: `function Component() {
+  const x = (useMemo(() => {
+    return [];
+  }, []), sideEffect());
+  return <div>{x}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("unusedResult", unusedResultReason, unusedResultDescription, 2, 14, 2, 21),
+			},
+		},
+		// Locks in upstream comma-expression arm: nested non-final sequence operands are discarded inside logical expressions.
+		{
+			Code: `function Component({ok}) {
+  ok && (useMemo(() => {
+    return [];
+  }, []), sideEffect());
+  return <div />;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("unusedResult", unusedResultReason, unusedResultDescription, 2, 10, 2, 17),
+			},
+		},
+		// ---- Dimension 4: React.useMemo expression statements report the full callee. ----
+		{
+			Code: `function Component() {
+  React.useMemo(() => {
+    return [];
+  }, []);
+  return <div />;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("unusedResult", unusedResultReason, unusedResultDescription, 2, 3, 2, 16),
+			},
+		},
+		// ---- Dimension 4: nested function returns do not satisfy the outer useMemo callback. ----
+		{
+			Code: `function Component() {
+  const value = useMemo(() => {
+    function nested() {
+      return 1;
+    }
+    nested();
+  }, []);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("missingReturn", missingReturnReason, missingReturnDescription, 2, 25, 7, 4),
+			},
+		},
+		// Locks in upstream HIR terminal scan: a return inside a try block with finally does not satisfy useMemo.
+		{
+			Code: `function Component() {
+  const value = useMemo(() => {
+    try {
+      return 1;
+    } finally {
+      cleanup();
+    }
+  }, []);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("missingReturn", missingReturnReason, missingReturnDescription, 2, 25, 8, 4),
+			},
+		},
+		// Locks in upstream HIR terminal scan: a return inside finally does not satisfy useMemo.
+		{
+			Code: `function Component() {
+  const value = useMemo(() => {
+    try {
+      work();
+    } finally {
+      return 1;
+    }
+  }, []);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("missingReturn", missingReturnReason, missingReturnDescription, 2, 25, 8, 4),
+			},
+		},
+		// ---- Options contract: arbitrary options do not change diagnostics. ----
+		{
+			Code: `function Component() {
+  const value = useMemo(() => {
+    console.log('effect');
+  }, []);
+  return <div>{value}</div>;
+}
+`,
+			Options: []interface{}{map[string]interface{}{"someFutureOption": true}},
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("missingReturn", missingReturnReason, missingReturnDescription, 2, 25, 4, 4),
+			},
+		},
+		// ---- Real-user: facebook/react#25379 useMemo used for side effects and no returned value. ----
+		{
+			Code: `import {useMemo} from 'react';
+function Component() {
+  const value = useMemo(() => {
+    console.log("Yippee!");
+  }, []);
+  return <div>{value}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("missingReturn", missingReturnReason, missingReturnDescription, 3, 25, 5, 4),
+			},
+		},
+		// ---- Real-user: facebook/react#17962 object-literal-looking callback body is a labeled statement, not a return. ----
+		{
+			Code: `function Component() {
+  const ref2 = useMemo(() => {
+    current: null;
+  }, []);
+  return <div>{ref2}</div>;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("missingReturn", missingReturnReason, missingReturnDescription, 2, 24, 4, 4),
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &VoidUseMemoRule, valid, invalid)
+}

--- a/internal/plugins/react_hooks/rules/void_use_memo/void_use_memo_upstream_test.go
+++ b/internal/plugins/react_hooks/rules/void_use_memo/void_use_memo_upstream_test.go
@@ -1,0 +1,154 @@
+package void_use_memo
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestVoidUseMemoUpstream migrates the react-hooks/void-use-memo cases from
+// upstream compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateUseMemo.ts
+// and related React Compiler fixtures 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// void_use_memo_extras_test.go.
+func TestVoidUseMemoUpstream(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Upstream fixture: useMemo-arrow-implicit-return.js. ----
+		{Code: `function Component() {
+  const value = useMemo(() => computeValue(), []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-empty-return.js; explicit return is non-void for this rule. ----
+		{Code: `function Component() {
+  const value = useMemo(() => {
+    return;
+  }, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-explicit-null-return.js. ----
+		{Code: `function Component() {
+  const value = useMemo(() => {
+    return null;
+  }, []);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-multiple-returns.js. ----
+		{Code: `function Component({items}) {
+  const value = useMemo(() => {
+    for (let item of items) {
+      if (item.match) return item;
+    }
+    return null;
+  }, [items]);
+  return <div>{value}</div>;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: useMemo-switch-return.js. ----
+		{Code: `function Component(props) {
+  const x = useMemo(() => {
+    let y;
+    switch (props.switch) {
+      case 'foo': {
+        return 'foo';
+      }
+      case 'bar': {
+        y = 'bar';
+        break;
+      }
+      default: {
+        y = props.y;
+      }
+    }
+    return y;
+  });
+  return x;
+}
+`, Tsx: true},
+		// ---- Upstream fixture: repro.js; skipped because the source disables validateNoVoidUseMemo via React Compiler test metadata. ----
+		{Code: `function Component(props) {
+  const item = props.item;
+  const thumbnails = [];
+  const baseVideos = getBaseVideos(item);
+  useMemo(() => {
+    baseVideos.forEach(video => {
+      const baseVideo = video.hasBaseVideo;
+      if (Boolean(baseVideo)) {
+        thumbnails.push({extraVideo: true});
+      }
+    });
+  });
+  return <FlatList baseVideos={baseVideos} items={thumbnails} />;
+}
+`, Tsx: true, Skip: true},
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- Upstream fixture: invalid-useMemo-no-return-value.js. ----
+		{
+			Code: `function Component() {
+  const value = useMemo(() => {
+    console.log('computing');
+  }, []);
+  const value2 = React.useMemo(() => {
+    console.log('computing');
+  }, []);
+  return (
+    <div>
+      {value}
+      {value2}
+    </div>
+  );
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("missingReturn", missingReturnReason, missingReturnDescription, 2, 25, 4, 4),
+				voidUseMemoError("missingReturn", missingReturnReason, missingReturnDescription, 5, 32, 7, 4),
+			},
+		},
+		// ---- Upstream fixture: invalid-unused-use-memo.js. ----
+		{
+			Code: `function Component() {
+  useMemo(() => {
+    return [];
+  }, []);
+  return <div />;
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("unusedResult", unusedResultReason, unusedResultDescription, 2, 3, 2, 10),
+			},
+		},
+		// ---- Upstream fixture: invalid-useMemo-return-empty.js. ----
+		{
+			Code: `function component(a) {
+  let x = useMemo(() => {
+    mutate(a);
+  }, []);
+  return x;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				voidUseMemoError("missingReturn", missingReturnReason, missingReturnDescription, 2, 19, 4, 4),
+			},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &VoidUseMemoRule, valid, invalid)
+}
+
+func voidUseMemoError(id, reason, description string, line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: id,
+		Message:   buildVoidUseMemoMessage(id, reason, description).Description,
+		Line:      line,
+		Column:    column,
+		EndLine:   endLine,
+		EndColumn: endColumn,
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -219,6 +219,7 @@ export default defineConfig({
     './tests/eslint-plugin-react-hooks/rules/immutability.test.ts',
     './tests/eslint-plugin-react-hooks/rules/incompatible-library.test.ts',
     './tests/eslint-plugin-react-hooks/rules/use-memo.test.ts',
+    './tests/eslint-plugin-react-hooks/rules/void-use-memo.test.ts',
 
     // eslint-plugin-jsx-a11y
     './tests/eslint-plugin-jsx-a11y/rules/alt-text.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/void-use-memo.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/void-use-memo.test.ts
@@ -1,0 +1,133 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const voidUseMemoMessage = (reason: string, description: string) =>
+  `Error: ${reason}\n\n${description}.`;
+
+const missingReturnMessage = voidUseMemoMessage(
+  'useMemo() callbacks must return a value',
+  "This useMemo() callback doesn't return a value. useMemo() is for computing and caching values, not for arbitrary side effects",
+);
+
+const unusedResultMessage = voidUseMemoMessage(
+  'useMemo() result is unused',
+  'This useMemo() value is unused. useMemo() is for computing and caching values, not for arbitrary side effects',
+);
+
+ruleTester.run('void-use-memo', {} as never, {
+  valid: [
+    {
+      code: `
+        function Component() {
+          const value = useMemo(() => computeValue(), []);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          const value = useMemo(() => {
+            return;
+          }, []);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          const value = useMemo(() => {
+            return null;
+          }, []);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component({items}) {
+          const value = useMemo(() => {
+            for (let item of items) {
+              if (item.match) return item;
+            }
+            return null;
+          }, [items]);
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component(props) {
+          // eslint-disable-next-line react-hooks/exhaustive-deps
+          const x = useMemo(() => {
+            let y;
+            switch (props.switch) {
+              case 'foo': {
+                return 'foo';
+              }
+              case 'bar': {
+                y = 'bar';
+                break;
+              }
+              default: {
+                y = props.y;
+              }
+            }
+            return y;
+          });
+          return x;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function Component() {
+          const value = useMemo(() => {
+            console.log('computing');
+          }, []);
+          const value2 = React.useMemo(() => {
+            console.log('computing');
+          }, []);
+          return (
+            <div>
+              {value}
+              {value2}
+            </div>
+          );
+        }
+      `,
+      errors: [
+        { message: missingReturnMessage },
+        { message: missingReturnMessage },
+      ],
+    },
+    {
+      code: `
+        function Component() {
+          useMemo(() => {
+            return [];
+          }, []);
+          return <div />;
+        }
+      `,
+      errors: [{ message: unusedResultMessage }],
+    },
+    {
+      code: `
+        /* eslint-disable react-hooks/exhaustive-deps */
+        function component(a) {
+          let x = useMemo(() => {
+            mutate(a);
+          }, []);
+          return x;
+        }
+      `,
+      errors: [{ message: missingReturnMessage }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- Port `react-hooks/void-use-memo` to the Go react-hooks plugin and register the rule.
- Share manual `useMemo` callee detection with `react-hooks/use-memo`.
- Add upstream fixture coverage, extra nested/boundary cases, JS e2e coverage, and rule docs.

## Related Links

- https://react.dev/reference/eslint-plugin-react-hooks/lints/void-use-memo
- https://github.com/facebook/react/blob/main/compiler/packages/babel-plugin-react-compiler/src/Validation/ValidateUseMemo.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Validation run locally:

- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m ./internal/plugins/react_hooks ./internal/plugins/react_hooks/react_hooksutil ./internal/plugins/react_hooks/rules/use_memo ./internal/plugins/react_hooks/rules/void_use_memo`