### PR TITLE
feat: add ctx.Globals API for native rules to read declared globals

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -584,6 +584,31 @@ func mergeLanguageOptions(base, override *LanguageOptions) *LanguageOptions {
 	return &merged
 }
 
+// ExtractGlobals reads the effective `languageOptions.globals` for a merged
+// config (the buggy shallow-merged Raw map — see mergeLanguageOptions) and
+// normalizes it to a simple "is this name declared" set.
+//
+// Matches ESLint's own normalizeConfigGlobal (lib/languages/js/source-code/
+// source-code.js): only the string `"off"` un-declares a global. Every other
+// accepted value — including boolean `false` and `null`, which both map to
+// `"readonly"` — still declares it. (`false` does NOT mean "off"; that's a
+// common mix-up since other ESLint config knobs use `false`/`"off"`
+// interchangeably, but globals don't.)
+func ExtractGlobals(langOpts *LanguageOptions) map[string]bool {
+	if langOpts == nil || langOpts.Raw == nil {
+		return nil
+	}
+	raw, ok := langOpts.Raw["globals"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	globals := make(map[string]bool, len(raw))
+	for name, value := range raw {
+		globals[name] = value != "off"
+	}
+	return globals
+}
+
 // RulePluginPrefix extracts the plugin prefix from a rule name.
 // "@typescript-eslint/no-explicit-any" → "@typescript-eslint"
 // "import/no-unresolved" → "import"

--- a/internal/config/globals_test.go
+++ b/internal/config/globals_test.go
@@ -1,0 +1,47 @@
+package config
+
+import "testing"
+
+// Locks in normalizeConfigGlobal parity with ESLint (source-code.js): only
+// the string "off" un-declares a global. Boolean false and null both map to
+// "readonly" and remain declared — a common mix-up since other ESLint config
+// knobs treat false/"off" as equivalent, but globals don't.
+func TestExtractGlobals(t *testing.T) {
+	langOpts := &LanguageOptions{
+		Raw: map[string]any{
+			"globals": map[string]any{
+				"stringOff":      "off",
+				"stringReadonly": "readonly",
+				"stringWritable": "writable",
+				"boolTrue":       true,
+				"boolFalse":      false,
+				"nullValue":      nil,
+			},
+		},
+	}
+
+	globals := ExtractGlobals(langOpts)
+
+	cases := map[string]bool{
+		"stringOff":      false,
+		"stringReadonly": true,
+		"stringWritable": true,
+		"boolTrue":       true,
+		"boolFalse":      true,
+		"nullValue":      true,
+	}
+	for name, want := range cases {
+		if got := globals[name]; got != want {
+			t.Errorf("ExtractGlobals()[%q] = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestExtractGlobals_NoLanguageOptions(t *testing.T) {
+	if got := ExtractGlobals(nil); got != nil {
+		t.Errorf("ExtractGlobals(nil) = %v, want nil", got)
+	}
+	if got := ExtractGlobals(&LanguageOptions{}); got != nil {
+		t.Errorf("ExtractGlobals(empty) = %v, want nil", got)
+	}
+}

--- a/internal/config/rule_registry.go
+++ b/internal/config/rule_registry.go
@@ -48,6 +48,8 @@ func (r *RuleRegistry) GetEnabledRules(config RslintConfig, filePath string, cwd
 		return nil, nil // file is globally ignored
 	}
 
+	globals := ExtractGlobals(mergedConfig.LanguageOptions)
+
 	var enabledRules []linter.ConfiguredRule
 	for ruleName, ruleConfig := range mergedConfig.Rules {
 		if ruleConfig.IsEnabled() {
@@ -67,6 +69,7 @@ func (r *RuleRegistry) GetEnabledRules(config RslintConfig, filePath string, cwd
 				enabledRules = append(enabledRules, linter.ConfiguredRule{
 					Name:               ruleName,
 					Settings:           CloneSettings(mergedConfig.Settings),
+					Globals:            globals,
 					Severity:           ruleConfig.GetSeverity(),
 					RequiresTypeInfo:   ruleImpl.RequiresTypeInfo,
 					IsEslintPluginRule: ruleImpl.IsEslintPluginRule,

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -152,6 +152,7 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 				SourceFile:     file,
 				Program:        opts.Program,
 				Settings:       r.Settings,
+				Globals:        r.Globals,
 				TypeChecker:    fileChecker,
 				DisableManager: disableManager,
 				ReportRange: func(textRange core.TextRange, msg rule.RuleMessage) {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -136,6 +136,11 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 		// Create disable manager for this file
 		disableManager := rule.NewDisableManager(file, comments)
 
+		// Parse inline `/* global */` comments once per file, same as
+		// DisableManager above — rules read the merged result off ctx.Globals
+		// instead of parsing comments or config themselves.
+		inlineGlobals := rule.ParseInlineGlobals(file, comments)
+
 		// For gap files (not in caller's TypeInfoFiles), pass nil TypeChecker
 		// as defense-in-depth. Type-aware rules are already filtered out by
 		// getRulesForFile, but this ensures rules with optional TypeChecker
@@ -152,7 +157,7 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 				SourceFile:     file,
 				Program:        opts.Program,
 				Settings:       r.Settings,
-				Globals:        r.Globals,
+				Globals:        rule.MergeGlobals(r.Globals, inlineGlobals),
 				TypeChecker:    fileChecker,
 				DisableManager: disableManager,
 				ReportRange: func(textRange core.TextRange, msg rule.RuleMessage) {

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -7,8 +7,12 @@ import (
 )
 
 type ConfiguredRule struct {
-	Name             string
-	Settings         map[string]interface{}
+	Name     string
+	Settings map[string]interface{}
+	// Globals is the resolved `languageOptions.globals` for this file (name →
+	// declared), threaded to rules that consult ctx.Globals (e.g. no-undef).
+	// Nil when the config declares none.
+	Globals          map[string]bool
 	Severity         rule.DiagnosticSeverity
 	RequiresTypeInfo bool
 	// IsEslintPluginRule marks a rule that executes in the Node plugin-lint

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -9,9 +9,11 @@ import (
 type ConfiguredRule struct {
 	Name     string
 	Settings map[string]interface{}
-	// Globals is the resolved `languageOptions.globals` for this file (name →
-	// declared), threaded to rules that consult ctx.Globals (e.g. no-undef).
-	// Nil when the config declares none.
+	// Globals is the config-declared `languageOptions.globals` for this file
+	// (name → declared). The linter merges this with inline `/* global */`
+	// comments (parsed once per file, same as DisableManager) before exposing
+	// the combined result to rules as ctx.Globals — rules never parse either
+	// source themselves. Nil when the config declares none.
 	Globals          map[string]bool
 	Severity         rule.DiagnosticSeverity
 	RequiresTypeInfo bool

--- a/internal/rule/inline_globals.go
+++ b/internal/rule/inline_globals.go
@@ -1,0 +1,120 @@
+package rule
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// inlineGlobalsKeywords lists the directive keywords that introduce a
+// `/* global */` comment. "globals" is checked before "global" since it is
+// the longer prefix.
+var inlineGlobalsKeywords = [...]string{"globals", "global"}
+
+// ParseInlineGlobals scans `/* global ... */` / `/* globals ... */` block
+// comments and returns the set of names they declare (name -> declared).
+//
+// This is the DisableManager-equivalent preprocessing step for globals: it
+// runs once per file, over the same real comment tokens DisableManager
+// consumes (not a regex over raw source text, so lookalike text inside a
+// string literal or another comment can't be mistaken for a directive), and
+// its result is merged with config globals before being handed to rules —
+// no rule should parse `/* global */` comments itself.
+//
+// Mirrors ESLint's inline-config handling: only the setting "off" un-declares
+// a name; a bare name or any other setting (e.g. "writable") declares it.
+func ParseInlineGlobals(sourceFile *ast.SourceFile, comments []*ast.CommentRange) map[string]bool {
+	if sourceFile.Text() == "" || len(comments) == 0 {
+		return nil
+	}
+
+	text := sourceFile.Text()
+	var globals map[string]bool
+
+	for _, comment := range comments {
+		// `/* global */` is only recognized as a block comment, matching
+		// ESLint's convention (and rslint's prior behavior).
+		if comment.Kind != ast.KindMultiLineCommentTrivia {
+			continue
+		}
+		content := strings.TrimSpace(text[comment.Pos()+2 : comment.End()-2])
+
+		rest, ok := matchInlineGlobalsDirective(content)
+		if !ok {
+			continue
+		}
+
+		if globals == nil {
+			globals = make(map[string]bool)
+		}
+		for name, setting := range parseGlobalNameList(rest) {
+			globals[name] = setting != "off"
+		}
+	}
+
+	return globals
+}
+
+// matchInlineGlobalsDirective reports whether comment content begins with
+// the "global"/"globals" directive keyword (followed by whitespace or
+// end-of-string, so e.g. "globalConfig setup" is not mistaken for one) and
+// returns the remainder to parse as a name list.
+func matchInlineGlobalsDirective(content string) (string, bool) {
+	for _, kw := range inlineGlobalsKeywords {
+		if !strings.HasPrefix(content, kw) {
+			continue
+		}
+		rest := content[len(kw):]
+		if rest == "" || rest[0] == ' ' || rest[0] == '\t' || rest[0] == '\n' || rest[0] == '\r' {
+			return strings.TrimSpace(rest), true
+		}
+	}
+	return "", false
+}
+
+// MergeGlobals combines config-declared globals with inline `/* global */`
+// comment globals into the single set exposed to rules as ctx.Globals —
+// mirroring ESLint's addDeclaredGlobals, which layers inline comments on top
+// of config (inline wins on conflict). Returns nil if both are empty.
+func MergeGlobals(configGlobals, inlineGlobals map[string]bool) map[string]bool {
+	if len(configGlobals) == 0 {
+		return inlineGlobals
+	}
+	if len(inlineGlobals) == 0 {
+		return configGlobals
+	}
+	merged := make(map[string]bool, len(configGlobals)+len(inlineGlobals))
+	for name, declared := range configGlobals {
+		merged[name] = declared
+	}
+	for name, declared := range inlineGlobals {
+		merged[name] = declared
+	}
+	return merged
+}
+
+// globalSettingSeparatorPattern collapses whitespace around a `:` or `,`
+// separator (e.g. "foo : writable ,  bar" -> "foo:writable,bar") before
+// splitting — mirrors ESLint's own parseStringConfig, which does the same
+// normalization so spaces around a separator don't get mistaken for part of
+// the name/setting.
+var globalSettingSeparatorPattern = regexp.MustCompile(`\s*([:,])\s*`)
+
+// parseGlobalNameList parses a comma-and/or-whitespace separated
+// "name[:setting]" list, e.g. "foo, bar:writable baz:off", returning each
+// name mapped to its raw setting ("" when none was given).
+func parseGlobalNameList(s string) map[string]string {
+	collapsed := globalSettingSeparatorPattern.ReplaceAllString(strings.TrimSpace(s), "$1")
+
+	names := make(map[string]string)
+	for _, part := range strings.FieldsFunc(collapsed, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	}) {
+		name, setting, _ := strings.Cut(part, ":")
+		if name != "" {
+			names[name] = setting
+		}
+	}
+	return names
+}

--- a/internal/rule/inline_globals_test.go
+++ b/internal/rule/inline_globals_test.go
@@ -1,0 +1,70 @@
+package rule
+
+import (
+	"reflect"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// matchInlineGlobalsDirective
+// ---------------------------------------------------------------------------
+
+func TestMatchInlineGlobalsDirective(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expectedRest string
+		expectedOk   bool
+	}{
+		{"global with names", "global foo, bar", "foo, bar", true},
+		{"globals with names", "globals foo, bar", "foo, bar", true},
+		{"bare global", "global", "", true},
+		{"bare globals", "globals", "", true},
+		{"global with tab", "global\tfoo", "foo", true},
+		{"global with newline", "global\nfoo", "foo", true},
+		{"not a directive", "eslint-disable no-console", "", false},
+		{"lookalike prefix is not a directive", "globalConfig setup here", "", false},
+		{"globalsConfig lookalike is not a directive", "globalsConfig setup here", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rest, ok := matchInlineGlobalsDirective(tt.input)
+			if ok != tt.expectedOk {
+				t.Fatalf("ok = %v, want %v", ok, tt.expectedOk)
+			}
+			if ok && rest != tt.expectedRest {
+				t.Errorf("rest = %q, want %q", rest, tt.expectedRest)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseGlobalNameList
+// ---------------------------------------------------------------------------
+
+func TestParseGlobalNameList(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{"empty", "", map[string]string{}},
+		{"single bare name", "foo", map[string]string{"foo": ""}},
+		{"comma separated", "foo, bar", map[string]string{"foo": "", "bar": ""}},
+		{"whitespace separated", "foo bar", map[string]string{"foo": "", "bar": ""}},
+		{"with settings", "foo:readonly, bar:writable, baz:off", map[string]string{"foo": "readonly", "bar": "writable", "baz": "off"}},
+		{"mixed separators and settings", "foo:writable bar, baz:off", map[string]string{"foo": "writable", "bar": "", "baz": "off"}},
+		{"extra whitespace", "  foo : writable ,  bar  ", map[string]string{"foo": "writable", "bar": ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseGlobalNameList(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseGlobalNameList(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -213,8 +213,12 @@ func (d RuleDiagnostic) Fixes() []RuleFix {
 type RuleContext struct {
 	SourceFile *ast.SourceFile
 	Settings   map[string]interface{}
-	// Globals is the resolved `languageOptions.globals` for this file (name →
-	// declared). Nil when the config declares none.
+	// Globals is the fully resolved set of declared global names for this
+	// file — config `languageOptions.globals` merged with inline
+	// `/* global */` comments, computed once per file by the linter (see
+	// DisableManager, built the same way). Rules should read this instead of
+	// parsing comments or config themselves. Nil when none are declared;
+	// a name maps to false only if some source explicitly set it to "off".
 	Globals                    map[string]bool
 	Program                    *compiler.Program
 	TypeChecker                *checker.Checker

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -211,8 +211,11 @@ func (d RuleDiagnostic) Fixes() []RuleFix {
 }
 
 type RuleContext struct {
-	SourceFile                 *ast.SourceFile
-	Settings                   map[string]interface{}
+	SourceFile *ast.SourceFile
+	Settings   map[string]interface{}
+	// Globals is the resolved `languageOptions.globals` for this file (name →
+	// declared). Nil when the config declares none.
+	Globals                    map[string]bool
 	Program                    *compiler.Program
 	TypeChecker                *checker.Checker
 	DisableManager             *DisableManager

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -26,8 +26,10 @@ type ValidTestCase struct {
 	Skip     bool                   `json:"skip"`
 	Options  any                    `json:"options"`
 	Settings map[string]interface{} `json:"settings"`
-	// Globals simulates a merged `languageOptions.globals` (name → declared)
-	// for rules that read ctx.Globals (e.g. no-undef).
+	// Globals simulates a config-declared `languageOptions.globals` (name →
+	// declared) for rules that read ctx.Globals (e.g. no-undef). Inline
+	// `/* global */` comments in Code are picked up automatically by the
+	// linter and merged with this — no separate field needed for those.
 	Globals  map[string]bool `json:"globals"`
 	TSConfig string          `json:"tsConfig"`
 	Tsx      bool            `json:"tsx"`
@@ -58,8 +60,10 @@ type InvalidTestCase struct {
 	Output   []string               `json:"output"`
 	Errors   []InvalidTestCaseError `json:"errors"`
 	Settings map[string]interface{} `json:"settings"`
-	// Globals simulates a merged `languageOptions.globals` (name → declared)
-	// for rules that read ctx.Globals (e.g. no-undef).
+	// Globals simulates a config-declared `languageOptions.globals` (name →
+	// declared) for rules that read ctx.Globals (e.g. no-undef). Inline
+	// `/* global */` comments in Code are picked up automatically by the
+	// linter and merged with this — no separate field needed for those.
 	Globals  map[string]bool `json:"globals"`
 	TSConfig string          `json:"tsConfig"`
 	Options  any             `json:"options"`

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -26,8 +26,11 @@ type ValidTestCase struct {
 	Skip     bool                   `json:"skip"`
 	Options  any                    `json:"options"`
 	Settings map[string]interface{} `json:"settings"`
-	TSConfig string                 `json:"tsConfig"`
-	Tsx      bool                   `json:"tsx"`
+	// Globals simulates a merged `languageOptions.globals` (name → declared)
+	// for rules that read ctx.Globals (e.g. no-undef).
+	Globals  map[string]bool `json:"globals"`
+	TSConfig string          `json:"tsConfig"`
+	Tsx      bool            `json:"tsx"`
 }
 
 type InvalidTestCaseError struct {
@@ -55,9 +58,12 @@ type InvalidTestCase struct {
 	Output   []string               `json:"output"`
 	Errors   []InvalidTestCaseError `json:"errors"`
 	Settings map[string]interface{} `json:"settings"`
-	TSConfig string                 `json:"tsConfig"`
-	Options  any                    `json:"options"`
-	Tsx      bool                   `json:"tsx"`
+	// Globals simulates a merged `languageOptions.globals` (name → declared)
+	// for rules that read ctx.Globals (e.g. no-undef).
+	Globals  map[string]bool `json:"globals"`
+	TSConfig string          `json:"tsConfig"`
+	Options  any             `json:"options"`
+	Tsx      bool            `json:"tsx"`
 }
 
 // TestSuite represents a complete test suite that can be loaded from JSON
@@ -116,7 +122,7 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 	onlyMode := slices.ContainsFunc(validTestCases, func(c ValidTestCase) bool { return c.Only }) ||
 		slices.ContainsFunc(invalidTestCases, func(c InvalidTestCase) bool { return c.Only })
 
-	runLinter := func(t *testing.T, code string, options any, settings map[string]interface{}, tsconfigPathOverride string, fileName string) []rule.RuleDiagnostic {
+	runLinter := func(t *testing.T, code string, options any, settings map[string]interface{}, globals map[string]bool, tsconfigPathOverride string, fileName string) []rule.RuleDiagnostic {
 		var diagnosticsMu sync.Mutex
 		diagnostics := make([]rule.RuleDiagnostic, 0, 3)
 
@@ -144,6 +150,7 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 					{
 						Name:     "test",
 						Settings: settings,
+						Globals:  globals,
 						Severity: rule.SeverityError,
 						Run: func(ctx rule.RuleContext) rule.RuleListeners {
 							return r.Run(ctx, options)
@@ -179,7 +186,7 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 				fileName = testCase.FileName
 			}
 
-			diagnostics := runLinter(t, testCase.Code, testCase.Options, testCase.Settings, testCase.TSConfig, fileName)
+			diagnostics := runLinter(t, testCase.Code, testCase.Options, testCase.Settings, testCase.Globals, testCase.TSConfig, fileName)
 			if len(diagnostics) != 0 {
 				// TODO: pretty errors
 				t.Errorf("Expected valid test case not to contain errors. Code:\n%v", testCase.Code)
@@ -212,7 +219,7 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 			}
 
 			for i := range 10 {
-				diagnostics := runLinter(t, code, testCase.Options, testCase.Settings, testCase.TSConfig, fileName)
+				diagnostics := runLinter(t, code, testCase.Options, testCase.Settings, testCase.Globals, testCase.TSConfig, fileName)
 				if i == 0 {
 					initialDiagnostics = diagnostics
 				}

--- a/internal/rules/no_undef/no_undef.go
+++ b/internal/rules/no_undef/no_undef.go
@@ -2,7 +2,6 @@ package no_undef
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -26,25 +25,6 @@ func parseOptions(opts any) options {
 	return result
 }
 
-var globalCommentPattern = regexp.MustCompile(`/\*\s*global\s+([^*]+)\*/`)
-var globalNamePattern = regexp.MustCompile(`(\w+)\s*(?::\s*\w+)?`)
-
-// parseGlobalComments scans source text for /*global ...*/ block comments and
-// returns the set of variable names declared in them.
-func parseGlobalComments(sourceText string) map[string]bool {
-	globals := make(map[string]bool)
-	for _, match := range globalCommentPattern.FindAllStringSubmatch(sourceText, -1) {
-		if len(match) > 1 {
-			for _, nameMatch := range globalNamePattern.FindAllStringSubmatch(match[1], -1) {
-				if len(nameMatch) > 1 {
-					globals[nameMatch[1]] = true
-				}
-			}
-		}
-	}
-	return globals
-}
-
 var NoUndefRule = rule.Rule{
 	Name:             "no-undef",
 	RequiresTypeInfo: true,
@@ -57,9 +37,6 @@ var NoUndefRule = rule.Rule{
 		if ctx.TypeChecker == nil {
 			return rule.RuleListeners{}
 		}
-
-		// Parse /*global ...*/ comments to find declared globals
-		declaredGlobals := parseGlobalComments(ctx.SourceFile.Text())
 
 		return rule.RuleListeners{
 			ast.KindIdentifier: func(node *ast.Node) {
@@ -85,12 +62,8 @@ var NoUndefRule = rule.Rule{
 
 				name := node.Text()
 
-				// Skip identifiers declared via /*global*/ comments
-				if declaredGlobals[name] {
-					return
-				}
-
-				// Skip identifiers declared via languageOptions.globals
+				// Skip identifiers declared via languageOptions.globals or
+				// /* global */ comments (merged into ctx.Globals by the linter).
 				if ctx.Globals[name] {
 					return
 				}

--- a/internal/rules/no_undef/no_undef.go
+++ b/internal/rules/no_undef/no_undef.go
@@ -90,6 +90,11 @@ var NoUndefRule = rule.Rule{
 					return
 				}
 
+				// Skip identifiers declared via languageOptions.globals
+				if ctx.Globals[name] {
+					return
+				}
+
 				ctx.ReportNode(node, rule.RuleMessage{
 					Id:          "undef",
 					Description: fmt.Sprintf("'%s' is not defined.", name),

--- a/internal/rules/no_undef/no_undef_test.go
+++ b/internal/rules/no_undef/no_undef_test.go
@@ -105,8 +105,11 @@ func TestNoUndefRule(t *testing.T) {
 			{Code: `/*global a, b*/ a = 1; b = 2;`},
 			{Code: `/*global myVar:writable*/ myVar = 1;`},
 
-			// === languageOptions.globals ===
+			// === languageOptions.globals (config) ===
 			{Code: `myConfiguredGlobal;`, Globals: map[string]bool{"myConfiguredGlobal": true}},
+
+			// === languageOptions.globals + /*global*/ comment together ===
+			{Code: `/*global fromComment*/ fromConfig; fromComment;`, Globals: map[string]bool{"fromConfig": true}},
 
 			// === Namespace ===
 			{Code: `namespace MyNS { export var x = 1; } MyNS.x;`},
@@ -336,6 +339,14 @@ func TestNoUndefRule(t *testing.T) {
 				Globals: map[string]bool{"myOffGlobal123": false},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "undef", Line: 1, Column: 1},
+				},
+			},
+
+			// === /*global name:off*/ still reports (matches config "off" semantics) ===
+			{
+				Code: `/*global myOffComment123:off*/ myOffComment123;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 32},
 				},
 			},
 

--- a/internal/rules/no_undef/no_undef_test.go
+++ b/internal/rules/no_undef/no_undef_test.go
@@ -105,6 +105,9 @@ func TestNoUndefRule(t *testing.T) {
 			{Code: `/*global a, b*/ a = 1; b = 2;`},
 			{Code: `/*global myVar:writable*/ myVar = 1;`},
 
+			// === languageOptions.globals ===
+			{Code: `myConfiguredGlobal;`, Globals: map[string]bool{"myConfiguredGlobal": true}},
+
 			// === Namespace ===
 			{Code: `namespace MyNS { export var x = 1; } MyNS.x;`},
 
@@ -324,6 +327,15 @@ func TestNoUndefRule(t *testing.T) {
 				Code: `/*global otherVar*/ unknownVar123 = 1;`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "undef", Line: 1, Column: 21},
+				},
+			},
+
+			// === languageOptions.globals explicitly "off" still reports ===
+			{
+				Code:    `myOffGlobal123;`,
+				Globals: map[string]bool{"myOffGlobal123": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 1},
 				},
 			},
 

--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -106,10 +106,34 @@ export interface ParserOptions {
 }
 
 /**
+ * Access level for a declared global variable.
+ */
+export type GlobalAccess = boolean | 'readonly' | 'writable' | 'off';
+
+/**
+ * Map of global variable name to its access level.
+ *
+ * @example
+ * globals: { myGlobal: 'readonly' }
+ */
+export type GlobalsConfig = Record<string, GlobalAccess>;
+
+/**
  * Language-specific configuration.
  */
 export interface LanguageOptions {
   parserOptions?: ParserOptions;
+  /**
+   * Global variables available in this file's scope, e.g. from a browser
+   * or Node.js runtime. `'readonly'`/`true` allows reading; `'writable'`
+   * allows reassignment. Only the string `'off'` un-declares a global
+   * (undoes one a base config added) — `false` still declares it (as
+   * read-only), matching ESLint's own `normalizeConfigGlobal`.
+   *
+   * @example
+   * globals: { myGlobal: 'readonly' }
+   */
+  globals?: GlobalsConfig;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `ctx.Globals`: a per-file map of declared globals, merged from config `languageOptions.globals` and `/* global */` comments. Parsed once per file in the linter (alongside `DisableManager`), so native rules read declared globals directly instead of parsing config or comments themselves.
- Fix `no-undef` to use `ctx.Globals`, validating the new API. This fixes two bugs: `languageOptions.globals` was never consulted, and `/* global */` comments were parsed with a rule-local regex that ignored `:off`.
- Add typed `globals` support (`GlobalAccess` / `GlobalsConfig`) to `defineConfig()`'s `LanguageOptions`.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).