### PR TITLE
fix: no-sparse-arrays should not flag destructuring assignment targets

### DIFF
--- a/internal/rules/no_sparse_arrays/no_sparse_arrays.go
+++ b/internal/rules/no_sparse_arrays/no_sparse_arrays.go
@@ -11,6 +11,12 @@ var NoSparseArraysRule = rule.Rule{
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindArrayLiteralExpression: func(node *ast.Node) {
+				// Array literals used as destructuring assignment targets (e.g. `[, a] = b`)
+				// are parsed as ArrayLiteralExpression too, but omitted elements there are
+				// valid ES6 syntax for skipping items, not sparse array literals.
+				if ast.IsAssignmentTarget(node) {
+					return
+				}
 				for _, v := range node.AsArrayLiteralExpression().Elements.Nodes {
 					if v.Kind == ast.KindOmittedExpression {
 						ctx.ReportNode(node, rule.RuleMessage{

--- a/internal/rules/no_sparse_arrays/no_sparse_arrays_test.go
+++ b/internal/rules/no_sparse_arrays/no_sparse_arrays_test.go
@@ -16,6 +16,15 @@ func TestNoSparseArraysRule(t *testing.T) {
 		// Valid cases - ported from ESLint
 		[]rule_tester.ValidTestCase{
 			{Code: `var a = [ 1, 2, ]`},
+			// Destructuring assignment targets are parsed as ArrayLiteralExpression
+			// too, but omitted elements there are valid ES6 syntax for skipping
+			// items, not sparse array literals.
+			{Code: `[, suggestion] = await all();`},
+			{Code: `[, , endLine, endChar] = o.range;`},
+			{Code: `[, ref, authorName] = match;`},
+			{Code: `[a, , b] = [1, 2, 3];`},
+			{Code: `for ([, x] of y) {}`},
+			{Code: `[[, a]] = b;`},
 		},
 		// Invalid cases - ported from ESLint
 		[]rule_tester.InvalidTestCase{
@@ -51,6 +60,14 @@ func TestNoSparseArraysRule(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpectedSparseArray", Line: 1, Column: 1},
 					{MessageId: "unexpectedSparseArray", Line: 1, Column: 1},
+				},
+			},
+			{
+				// The destructuring target `[a, b]` is not sparse, but the
+				// RHS is a genuine sparse array literal and must still be flagged.
+				Code: `[a, b] = [1, , 2];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedSparseArray", Line: 1, Column: 10},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

`no-sparse-arrays` was flagging destructuring assignment targets like `[, suggestion] = await all()` as sparse arrays. TypeScript's AST parses these as `ArrayLiteralExpression` (same node kind as real array literals), so omitted elements used to skip items during destructuring were incorrectly treated as sparse-array holes. ESLint's own rule only checks `ArrayExpression` nodes and never flags this, since espree gives destructuring targets a distinct `ArrayPattern` kind. Fixed by skipping nodes where `ast.IsAssignmentTarget(node)` is true, verified against real ESLint 8 output for both the valid destructuring cases and the still-invalid genuine sparse array literals.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).