### PR TITLE
fix: constructor-super false positives in branching/loop/try control flow

### DIFF
--- a/internal/rules/constructor_super/constructor_super.go
+++ b/internal/rules/constructor_super/constructor_super.go
@@ -256,10 +256,116 @@ func findDuplicateSuperCalls(body *ast.Node, superCallLocations []*ast.Node) []*
 					}
 				}
 			}
+
+		case ast.KindTryStatement:
+			tryStmt := stmt.AsTryStatement()
+			if tryStmt != nil {
+				tryHasSuper := tryStmt.TryBlock != nil && analyzeStatements(tryStmt.TryBlock.Statements())
+				finallyHasSuper := tryStmt.FinallyBlock != nil && analyzeStatements(tryStmt.FinallyBlock.Statements())
+				if tryHasSuper && finallyHasSuper {
+					// finally always runs after the try block, so a super()
+					// call there is a genuine duplicate alongside the try
+					// block's own call.
+					findSuperCallsInNode(tryStmt.FinallyBlock, superCallLocations, &duplicates)
+				}
+				if tryStatementHasSuper(tryStmt) {
+					foundFirstSuper = true
+				}
+			}
 		}
 	}
 
 	return duplicates
+}
+
+// findAllSuperDuplicates finds super() calls that are duplicates either
+// because they sit inside a loop that can revisit them (see
+// isSuperCallInLoopWithoutExit) or because they can execute sequentially on
+// the same guaranteed path (see findDuplicateSuperCalls).
+func findAllSuperDuplicates(body *ast.Node, superCallLocations []*ast.Node) []*ast.Node {
+	var duplicates []*ast.Node
+	for _, loc := range superCallLocations {
+		if isSuperCallInLoopWithoutExit(body, loc) {
+			duplicates = append(duplicates, loc)
+		}
+	}
+	for _, loc := range findDuplicateSuperCalls(body, superCallLocations) {
+		if !contains(duplicates, loc) {
+			duplicates = append(duplicates, loc)
+		}
+	}
+	return duplicates
+}
+
+// isSuperCallInLoopWithoutExit reports whether a super() call sits inside its
+// nearest enclosing loop without a guaranteed break/return/throw right after
+// it. ESLint's code-path analysis treats any super() call that could be
+// revisited via a loop back-edge as a duplicate - even when the loop's
+// condition provably allows only one iteration (e.g. `do { super(); } while
+// (false)`) - so the loop's condition truthiness is deliberately not
+// consulted here, only whether the call is unconditionally followed by a
+// clean exit out of the loop.
+func isSuperCallInLoopWithoutExit(body *ast.Node, superCall *ast.Node) bool {
+	for p := superCall.Parent; p != nil && p != body; p = p.Parent {
+		switch p.Kind {
+		case ast.KindWhileStatement:
+			ws := p.AsWhileStatement()
+			return ws == nil || !loopExitsAfterSuper(loopBodyStatements(ws.Statement))
+		case ast.KindDoStatement:
+			ds := p.AsDoStatement()
+			return ds == nil || !loopExitsAfterSuper(loopBodyStatements(ds.Statement))
+		case ast.KindForStatement:
+			fs := p.AsForStatement()
+			return fs == nil || !loopExitsAfterSuper(loopBodyStatements(fs.Statement))
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			// These can run zero times and are already reported as missing;
+			// don't also claim a guaranteed duplicate here.
+			return false
+		}
+	}
+	return false
+}
+
+// loopExitsAfterSuper reports whether, once a loop body's top-level
+// statements reach a super() call, they are guaranteed to hit a break (or
+// return/throw) before falling through to the end of the body or hitting a
+// continue - either of which would loop back and revisit the call. Bails out
+// conservatively (assumes no guaranteed exit, i.e. a possible duplicate) for
+// anything not on the small safe allowlist of statements that can't hide a
+// break/continue.
+func loopExitsAfterSuper(stmts []*ast.Node) bool {
+	seenSuper := false
+	for _, stmt := range stmts {
+		if stmt == nil {
+			continue
+		}
+		if !seenSuper {
+			if hasSuperCall(stmt) {
+				seenSuper = true
+				continue
+			}
+			switch stmt.Kind {
+			case ast.KindExpressionStatement, ast.KindVariableStatement, ast.KindEmptyStatement:
+				continue
+			default:
+				return false
+			}
+		}
+
+		switch stmt.Kind {
+		case ast.KindBreakStatement, ast.KindReturnStatement, ast.KindThrowStatement:
+			return true
+		case ast.KindContinueStatement:
+			return false
+		case ast.KindExpressionStatement, ast.KindVariableStatement, ast.KindEmptyStatement:
+			continue
+		default:
+			return false
+		}
+	}
+	// Reached the end of the body without a guaranteed exit: falls through
+	// and loops back around.
+	return false
 }
 
 // findSuperCallsInNode finds super() calls in a node (excluding direct super calls at the statement level)
@@ -822,9 +928,11 @@ var ConstructorSuperRule = rule.Rule{
 					} else if !analysis.allPathsHaveSuper {
 						// super() called in some paths but not all
 						ctx.ReportNode(node, buildMissingSome())
-					} else if analysis.allPathsHaveSuper && len(analysis.superCallLocations) > 1 {
-						// Check for actual duplicates (super calls that can execute sequentially)
-						duplicates := findDuplicateSuperCalls(body, analysis.superCallLocations)
+					} else {
+						// All paths call super(); check for calls that could
+						// execute more than once (inside a non-exiting loop,
+						// or genuinely sequential duplicates).
+						duplicates := findAllSuperDuplicates(body, analysis.superCallLocations)
 						for _, superCall := range duplicates {
 							// Report on the super keyword, not the call expression
 							superKeyword := superCall.Expression()

--- a/internal/rules/constructor_super/constructor_super.go
+++ b/internal/rules/constructor_super/constructor_super.go
@@ -484,7 +484,7 @@ func checkAllPathsHaveSuper(body *ast.Node) bool {
 
 // analyzeStatements checks if super() is called in all code paths
 func analyzeStatements(statements []*ast.Node) bool {
-	for i, stmt := range statements {
+	for _, stmt := range statements {
 		if stmt == nil {
 			continue
 		}
@@ -507,11 +507,9 @@ func analyzeStatements(statements []*ast.Node) bool {
 					// Has else clause - both branches must have super or terminate
 					elseHasSuper := statementHasSuper(elseStmt)
 					if thenHasSuper && elseHasSuper {
-						// Both branches have super or terminate, so we can continue
-						// Check remaining statements
-						if i+1 < len(statements) {
-							return analyzeStatements(statements[i+1:])
-						}
+						// Both branches call super() (or terminate) on every path,
+						// so the requirement is already satisfied - trailing
+						// statements need not call super() again.
 						return true
 					}
 				}
@@ -520,10 +518,8 @@ func analyzeStatements(statements []*ast.Node) bool {
 		case ast.KindSwitchStatement:
 			// Switch with super in all cases (including default)
 			if switchHasSuper(stmt) {
-				// All switch paths have super, check remaining statements
-				if i+1 < len(statements) {
-					return analyzeStatements(statements[i+1:])
-				}
+				// All switch paths already satisfy the requirement; trailing
+				// statements need not call super() again.
 				return true
 			}
 
@@ -546,10 +542,127 @@ func analyzeStatements(statements []*ast.Node) bool {
 					}
 				}
 			}
+
+		case ast.KindBlock:
+			// A nested block is transparent to control flow.
+			if analyzeStatements(stmt.Statements()) {
+				return true
+			}
+
+		case ast.KindLabeledStatement:
+			// Labels don't affect control flow reachability of the wrapped statement.
+			labeledStmt := stmt.AsLabeledStatement()
+			if labeledStmt != nil && analyzeStatements([]*ast.Node{labeledStmt.Statement}) {
+				return true
+			}
+
+		case ast.KindTryStatement:
+			tryStmt := stmt.AsTryStatement()
+			if tryStmt != nil && tryStatementHasSuper(tryStmt) {
+				return true
+			}
+
+		case ast.KindWhileStatement:
+			// A `while (true)` (or other always-truthy condition) loop always
+			// executes its body at least once.
+			whileStmt := stmt.AsWhileStatement()
+			if whileStmt != nil && isAlwaysTruthyCondition(whileStmt.Expression) &&
+				loopBodyGuaranteesSuper(loopBodyStatements(whileStmt.Statement)) {
+				return true
+			}
+
+		case ast.KindForStatement:
+			// `for (;;)` or `for (...; true; ...)` always executes its body at
+			// least once.
+			forStmt := stmt.AsForStatement()
+			if forStmt != nil && (forStmt.Condition == nil || isAlwaysTruthyCondition(forStmt.Condition)) &&
+				loopBodyGuaranteesSuper(loopBodyStatements(forStmt.Statement)) {
+				return true
+			}
+
+		case ast.KindDoStatement:
+			// A do-while loop always executes its body at least once,
+			// regardless of the condition.
+			doStmt := stmt.AsDoStatement()
+			if doStmt != nil && loopBodyGuaranteesSuper(loopBodyStatements(doStmt.Statement)) {
+				return true
+			}
 		}
 	}
 
 	return false
+}
+
+// loopBodyStatements returns the statement list making up a loop body,
+// handling both block bodies (`while (x) { ... }`) and single-statement
+// bodies without braces (`while (x) foo();`).
+func loopBodyStatements(body *ast.Node) []*ast.Node {
+	if body == nil {
+		return nil
+	}
+	if body.Kind == ast.KindBlock {
+		return body.Statements()
+	}
+	return []*ast.Node{body}
+}
+
+// isAlwaysTruthyCondition reports whether a loop condition is a literal that
+// always evaluates to true, meaning the loop body is guaranteed to run.
+func isAlwaysTruthyCondition(expr *ast.Node) bool {
+	return expr != nil && expr.Kind == ast.KindTrueKeyword
+}
+
+// loopBodyGuaranteesSuper reports whether a loop body that is guaranteed to
+// execute at least once is also guaranteed to call super() before it can be
+// exited via break/continue. It only recognizes the common, unambiguous
+// top-level pattern of statements executed in sequence; anything that might
+// hide a break/continue (nested blocks, if/switch/try, nested loops, labels,
+// ...) causes it to bail out conservatively (return false) rather than risk
+// missing a real "super() not called" case.
+func loopBodyGuaranteesSuper(stmts []*ast.Node) bool {
+	for _, stmt := range stmts {
+		if stmt == nil {
+			continue
+		}
+		if hasSuperCall(stmt) {
+			return true
+		}
+		switch stmt.Kind {
+		case ast.KindReturnStatement, ast.KindThrowStatement:
+			return true
+		case ast.KindBreakStatement, ast.KindContinueStatement:
+			return false
+		case ast.KindExpressionStatement, ast.KindVariableStatement, ast.KindEmptyStatement:
+			continue
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// tryStatementHasSuper reports whether a try statement guarantees super() is
+// called. A finally block that calls super() on every path guarantees it
+// regardless of the try/catch outcome (finally always runs). Otherwise, both
+// the try block and (if present) the catch block must independently
+// guarantee it - if there is no catch clause, an exception thrown before
+// super() propagates out of the constructor, which is an acceptable
+// terminating path (like an explicit throw).
+func tryStatementHasSuper(tryStmt *ast.TryStatement) bool {
+	if tryStmt.FinallyBlock != nil && analyzeStatements(tryStmt.FinallyBlock.Statements()) {
+		return true
+	}
+	if tryStmt.TryBlock == nil || !analyzeStatements(tryStmt.TryBlock.Statements()) {
+		return false
+	}
+	if tryStmt.CatchClause == nil {
+		return true
+	}
+	catchClause := tryStmt.CatchClause.AsCatchClause()
+	if catchClause == nil || catchClause.Block == nil {
+		return false
+	}
+	return analyzeStatements(catchClause.Block.Statements())
 }
 
 // expressionHasSuper checks if an expression contains a super() call
@@ -603,16 +716,7 @@ func statementHasSuper(stmt *ast.Node) bool {
 		return false
 	}
 
-	if stmt.Kind == ast.KindBlock {
-		return analyzeStatements(stmt.Statements())
-	}
-
-	// Return and throw statements are valid path terminators
-	if stmt.Kind == ast.KindReturnStatement || stmt.Kind == ast.KindThrowStatement {
-		return true
-	}
-
-	return hasSuperCall(stmt)
+	return analyzeStatements([]*ast.Node{stmt})
 }
 
 // switchHasSuper checks if a switch statement has super in all branches

--- a/internal/rules/constructor_super/constructor_super_test.go
+++ b/internal/rules/constructor_super/constructor_super_test.go
@@ -55,6 +55,31 @@ func TestConstructorSuperRule(t *testing.T) {
 
 			// Multiple branches with returns
 			{Code: `class A extends B { constructor() { if (a) { return; } else { return; } } }`},
+
+			// If-else with super in both branches followed by other statements
+			// (regression: trailing statements must not be required to also call super())
+			{Code: `class A extends B { constructor() { if (a) { super(); } else { super(); } b(); } }`},
+			{Code: `class A extends B { constructor() { if (a) { c(); super(); d(); } else { super(); } e(); } }`},
+
+			// Switch with super in all cases followed by other statements
+			{Code: `class A extends B { constructor() { switch (a) { case 0: super(); break; default: super(); break; } b(); } }`},
+
+			// Always-truthy loops that call super() before the only exit
+			{Code: `class A extends B { constructor() { while (true) { super(); break; } } }`},
+			{Code: `class A extends B { constructor() { for (;;) { super(); break; } } }`},
+			{Code: `class A extends B { constructor() { label: while (true) { super(); break label; } } }`},
+
+			// do-while always runs its body at least once, regardless of the condition
+			{Code: `class A extends B { constructor() { do { super(); } while (false); } }`},
+
+			// try/finally: finally always runs, so super() there satisfies the
+			// requirement regardless of what the try/catch do
+			{Code: `class A extends B { constructor() { try { super(); } finally {} } }`},
+			{Code: `class A extends B { constructor() { try { a(); } catch (e) { } finally { super(); } } }`},
+
+			// try without catch: an exception before super() propagates out of
+			// the constructor, which is an acceptable terminating path
+			{Code: `class A extends B { constructor() { try { super(); } finally { b(); } } }`},
 		},
 		// Invalid cases
 		[]rule_tester.InvalidTestCase{
@@ -229,6 +254,40 @@ func TestConstructorSuperRule(t *testing.T) {
 				Code: `class A extends B { constructor() { switch (a) { case 0: super(); break; default: super(); break; } super(); } }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "duplicate", Line: 1, Column: 101},
+				},
+			},
+
+			// Loops that may exit without ever calling super()
+			{
+				Code: `class A extends B { constructor() { while (true) { if (a) break; super(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSome", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `class A extends B { constructor() { for (var x of y) { super(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSome", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `class A extends B { constructor() { for (var i = 0; i < 10; i++) { super(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSome", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `class A extends B { constructor() { while (a) { super(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSome", Line: 1, Column: 21},
+				},
+			},
+
+			// try/catch without finally: catch must independently call super() too
+			{
+				Code: `class A extends B { constructor() { try { super(); } catch (e) {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSome", Line: 1, Column: 21},
 				},
 			},
 

--- a/internal/rules/constructor_super/constructor_super_test.go
+++ b/internal/rules/constructor_super/constructor_super_test.go
@@ -69,8 +69,12 @@ func TestConstructorSuperRule(t *testing.T) {
 			{Code: `class A extends B { constructor() { for (;;) { super(); break; } } }`},
 			{Code: `class A extends B { constructor() { label: while (true) { super(); break label; } } }`},
 
-			// do-while always runs its body at least once, regardless of the condition
-			{Code: `class A extends B { constructor() { do { super(); } while (false); } }`},
+			// do-while always runs its body at least once, regardless of the
+			// condition, but only counts as a clean single call if it breaks
+			// out immediately afterward (otherwise it's a duplicate - see
+			// invalid cases below)
+			{Code: `class A extends B { constructor() { do { super(); break; } while (true); } }`},
+			{Code: `class A extends B { constructor() { do { super(); break; } while (false); } }`},
 
 			// try/finally: finally always runs, so super() there satisfies the
 			// requirement regardless of what the try/catch do
@@ -184,6 +188,57 @@ func TestConstructorSuperRule(t *testing.T) {
 				Code: `class A extends B { constructor() { if (a) super(); else super(); super(); } }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "duplicate", Line: 1, Column: 67},
+				},
+			},
+
+			// super() inside a loop without a guaranteed break right after it
+			// can be revisited on a later iteration - a duplicate, regardless
+			// of whether the loop's condition provably allows only one pass
+			{
+				Code: `class A extends B { constructor() { while (true) { super(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicate", Line: 1, Column: 52},
+				},
+			},
+			{
+				Code: `class A extends B { constructor() { while (true) { super(); continue; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicate", Line: 1, Column: 52},
+				},
+			},
+			{
+				Code: `class A extends B { constructor() { do { super(); } while (true); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicate", Line: 1, Column: 42},
+				},
+			},
+			{
+				Code: `class A extends B { constructor() { do { super(); } while (false); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicate", Line: 1, Column: 42},
+				},
+			},
+			{
+				Code: `class A extends B { constructor() { for (;;) { super(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicate", Line: 1, Column: 48},
+				},
+			},
+
+			// finally always runs after the try block, so a second super()
+			// call there duplicates the try block's call
+			{
+				Code: `class A extends B { constructor() { try { super(); } finally { super(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicate", Line: 1, Column: 64},
+				},
+			},
+			// a trailing super() after a try that already satisfied the
+			// requirement is a duplicate too
+			{
+				Code: `class A extends B { constructor() { try { super(); } finally { } super(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "duplicate", Line: 1, Column: 66},
 				},
 			},
 


### PR DESCRIPTION
## Summary

Fix `constructor-super` false positives, verified against upstream ESLint (v10.6.0).

| Case | Upstream ESLint | rslint before fix |
| --- | ---: | ---: |
| `if/else` both call `super()`, then other code | 0 errors | 1 error (false positive) |
| `switch` all cases call `super()`, then other code | 0 errors | 1 error (false positive) |
| `while (true) { super(); break; }` | 0 errors | 1 error (false positive) |
| `try { super(); } finally {}` | 0 errors | 1 error (false positive) |
| `try { a(); } catch(e){} finally { super(); }` | 0 errors | 1 error (false positive) |
| `while (true) { super(); }` (no break) | 1 error (duplicate) | 0 errors (false negative) |
| `while (true) { super(); continue; }` | 1 error (duplicate) | 0 errors (false negative) |
| `do { super(); } while (true \| false);` | 1 error (duplicate) | 0 errors (false negative) |
| `for (;;) { super(); }` (no break) | 1 error (duplicate) | 0 errors (false negative) |
| `try { super(); } finally { super(); }` | 1 error (duplicate) | 0 errors (false negative) |
| `try { super(); } finally {} super();` | 1 error (duplicate) | 0 errors (false negative) |

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).