### PR TITLE
chore: isolate Windows npm CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   test-go:
+    if: ${{ false }}
     name: Test Go
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -83,6 +84,7 @@ jobs:
           }
 
   lint:
+    if: ${{ false }}
     name: Lint&Check
     runs-on: rspack-ubuntu-22.04-large
     steps:
@@ -116,6 +118,7 @@ jobs:
         run: pnpm check-spell
 
   test-node:
+    if: ${{ false }}
     name: Test npm packages
     runs-on: ${{ matrix.os }}
     strategy:
@@ -221,6 +224,7 @@ jobs:
           if-no-files-found: error
 
   test-vscode-windows:
+    if: ${{ false }}
     name: Test vscode-extension (windows-latest)
     runs-on: windows-latest
     needs: test-node-windows
@@ -269,6 +273,7 @@ jobs:
         run: pnpm --filter rslint test
 
   test-wasm:
+    if: ${{ false }}
     name: Test WASM
     runs-on: rspack-ubuntu-22.04-large
     steps:
@@ -294,6 +299,7 @@ jobs:
           pnpm --filter '@rslint/core' build:js
           pnpm --filter '@rslint/wasm' build
   test-rust:
+    if: ${{ false }}
     name: Test Rust
     runs-on: ${{ matrix.os }}
     strategy:
@@ -351,6 +357,7 @@ jobs:
     uses: ./.github/workflows/benchmark-cli.yml
 
   done:
+    if: ${{ false }}
     needs:
       - test-go
       - test-node
@@ -359,7 +366,6 @@ jobs:
       - lint
       - test-wasm
       - test-rust
-    if: always()
     runs-on: ubuntu-latest
     name: CI Done
     steps:


### PR DESCRIPTION
Temporary diagnostic PR to observe the idle-time duration of only `Test npm packages (rspack-windows-2022-large)`.\n\nThis disables the other CI jobs at job level so the PR run avoids consuming extra Windows runners while we compare the target job timing.