### PR TITLE
ci: increase golangci-lint timeout to 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.12.2
-          args: --timeout=10m ./cmd/... ./internal/...
+          args: --timeout=15m ./cmd/... ./internal/...
 
       - name: go vet
         run: npm run lint:go


### PR DESCRIPTION
## Summary

- increase the golangci-lint timeout from 10 minutes to 15 minutes
- keep the lint scope and all other CI behavior unchanged
- add headroom for runs that finish analysis with 0 issues but exceed the current 10-minute threshold

## Related Links

- Failure example: https://github.com/web-infra-dev/rslint/actions/runs/29005588858/job/86076779900

## Checklist

- [x] Tests updated (not required; workflow-only timeout change).
- [x] Documentation updated (not required).