### PR TITLE
feat(rules): align jsx-no-undef, no-shadow, and no-label-var with ESLint global context

### DIFF
--- a/.agents/skills/port-rule/references/PORT_RULE.md
+++ b/.agents/skills/port-rule/references/PORT_RULE.md
@@ -10,13 +10,15 @@ You are an expert Software Engineer tasked with porting ESLint rules to `rslint`
 
 Your job is porting the **rule's semantics** — given equivalent input, produce equivalent diagnostics. You are **not** responsible for re-implementing ESLint framework concepts that rslint deliberately does not expose. Examples:
 
-- `/*global ...*/` / `/*eslint ...*/` directive comments
-- `languageOptions.globals` / `parserOptions.sourceType` override / `parserOptions.ecmaFeatures.*`
+- `/*eslint ...*/` directive comments
+- `parserOptions.sourceType` override / `parserOptions.ecmaFeatures.*`
 - `env: 'browser' | 'node' | ...`
 
-When an upstream test case depends on one of these:
+Note: `languageOptions.globals` and `/*global ...*/` comments are automatically parsed by rslint and exposed through `ctx.Globals`. When porting rules that reference global variables, do not skip these test cases; instead, check `ctx.Globals` (e.g., `ctx.Globals[name]`).
 
-- **Don't** reimplement the concept inside your rule (e.g., parsing `/*global*/` comments yourself).
+When an upstream test case depends on other unsupported concepts (like `env` or `/*eslint*/` configurations):
+
+- **Don't** reimplement the concept inside your rule.
 - **Don't** list the gap under the rule's "Differences from ESLint" section — framework gaps apply to every rule, not yours.
 - **Do** mark the upstream case `skip: true` with an inline reason such as `// SKIP: rslint does not support ESLint's <concept>`.
 

--- a/internal/plugins/react/rules/jsx_no_undef/jsx_no_undef.go
+++ b/internal/plugins/react/rules/jsx_no_undef/jsx_no_undef.go
@@ -12,6 +12,20 @@ import (
 var JsxNoUndefRule = rule.Rule{
 	Name: "react/jsx-no-undef",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		allowGlobals := false
+		optsMap := utils.GetOptionsMap(options)
+		if optsMap != nil {
+			if v, ok := optsMap["allowGlobals"].(bool); ok {
+				allowGlobals = v
+			}
+		}
+		// Upstream only consults the outer global scope (config
+		// `languageOptions.globals` / `/* global */` comments) for script
+		// files, or for module files when `allowGlobals: true` is set — by
+		// default a module's top-level scope sits between the file and the
+		// true global scope, so declared globals are invisible to it.
+		checkGlobals := allowGlobals || !ast.IsExternalModule(ctx.SourceFile)
+
 		check := func(element *ast.Node) {
 			tagName := reactutil.GetJsxTagName(element)
 			if tagName == nil {
@@ -44,6 +58,9 @@ var JsxNoUndefRule = rule.Rule{
 				return
 			}
 			if utils.IsShadowed(identNode, name) {
+				return
+			}
+			if checkGlobals && ctx.Globals[name] {
 				return
 			}
 			ctx.ReportNode(identNode, rule.RuleMessage{

--- a/internal/plugins/react/rules/jsx_no_undef/jsx_no_undef.md
+++ b/internal/plugins/react/rules/jsx_no_undef/jsx_no_undef.md
@@ -31,9 +31,11 @@ var Hello = require('./Hello');
 - Namespaced JSX tags such as `<a:b />` are skipped.
 - For member-expression tags (`<Foo.Bar>`, `<foo.bar.Baz>`), only the leftmost identifier is checked. `<this.Foo>` is always allowed.
 
-## Differences from ESLint
+## Options
 
-- The `allowGlobals` option is **not supported**. A JSX tag identifier that is not declared in the source file (via `var` / `let` / `const` / `function` / `class` / `enum` / `namespace` / `import` / `declare` / function parameter / catch binding / loop binding) is always reported. To silence a report for an ambient value, add an explicit declaration — e.g. `declare const Foo: any;` or `import Foo from '...';`.
+### `allowGlobals`
+
+When `false` (default), a JSX tag identifier in a module (a file with `import`/`export`) is only recognized if it's declared in the source file (via `var` / `let` / `const` / `function` / `class` / `enum` / `namespace` / `import` / `declare` / function parameter / catch binding / loop binding) — names declared only via config `languageOptions.globals` or `/* global */` comments are still reported. Set `allowGlobals: true` to also allow those. Script files (no `import`/`export`) always consult declared globals, regardless of this option — matching ESLint.
 
 ## Original Documentation
 

--- a/internal/plugins/react/rules/jsx_no_undef/jsx_no_undef_test.go
+++ b/internal/plugins/react/rules/jsx_no_undef/jsx_no_undef_test.go
@@ -29,11 +29,24 @@ func TestJsxNoUndefRule(t *testing.T) {
 			`,
 			Tsx: true,
 		},
-		// SKIP: rslint does not support ESLint's `globals` option.
+		// Declared global (script file — no import/export — so `Text` is
+		// visible without `allowGlobals`, matching ESLint).
 		{
-			Code: `var React, Text; React.render(<Text />);`,
-			Tsx:  true,
-			Skip: true,
+			Code:    `var React; React.render(<Text />);`,
+			Tsx:     true,
+			Globals: map[string]bool{"Text": true},
+		},
+		// Declared global in a module file with `allowGlobals: true`.
+		{
+			Code: `
+				import React from "react";
+				export const TextWrapper = function (props) {
+					return <Text />;
+				};
+			`,
+			Tsx:     true,
+			Globals: map[string]bool{"Text": true},
+			Options: map[string]interface{}{"allowGlobals": true},
 		},
 		{
 			Code: `
@@ -143,6 +156,9 @@ func TestJsxNoUndefRule(t *testing.T) {
 			},
 		},
 		{
+			// Module file (has `export`): with `allowGlobals: false` (the
+			// default), a declared global is still invisible to the
+			// module's top-level scope, matching ESLint.
 			Code: `
 				const TextWrapper = function (props) {
 					return (
@@ -152,6 +168,7 @@ func TestJsxNoUndefRule(t *testing.T) {
 				export default TextWrapper;
 			`,
 			Tsx:     true,
+			Globals: map[string]bool{"Text": true},
 			Options: map[string]interface{}{"allowGlobals": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "undefined", Message: "'Text' is not defined."},
@@ -182,9 +199,8 @@ func TestJsxNoUndefRule(t *testing.T) {
 				{MessageId: "undefined", Message: "'Missing' is not defined.", Line: 3, Column: 3, EndLine: 3, EndColumn: 10},
 			},
 		},
-		// `allowGlobals: true` is accepted but has no effect in rslint —
-		// undeclared names are still reported. Documented as a difference
-		// from ESLint.
+		// `allowGlobals: true` only widens the search to declared globals —
+		// a name that isn't declared anywhere is still reported.
 		{
 			Code:    `var x = <Undeclared />;`,
 			Tsx:     true,

--- a/internal/rules/no_label_var/no_label_var.go
+++ b/internal/rules/no_label_var/no_label_var.go
@@ -10,19 +10,21 @@ import (
 //
 // Strategy: hybrid. ESLint's `getVariableByName` walks the scope chain all the
 // way to the global scope, catching both file-local declarations and globals
-// from `env`/`globals`. We approximate it with two complementary checks:
+// from `env`/`globals`. We approximate it with three complementary checks:
 //
 //  1. utils.IsShadowed — fast, works without type info; covers every binding
 //     declared inside the current source file (var/let/const, function, class,
 //     enum, namespace, import, parameter, catch, for-init, function-expression
 //     name, hoisted vars).
-//  2. ctx.TypeChecker.GetSymbolsInScope — when type info is available, also
+//  2. ctx.Globals — catches names declared via config `languageOptions.globals`
+//     or `/* global foo */` comments, mirroring ESLint's env/globals config.
+//  3. ctx.TypeChecker.GetSymbolsInScope — when type info is available, also
 //     catches globals provided by the tsconfig `lib` (e.g. `window`, `Promise`,
-//     `console`). Differs from ESLint's `env`/`globals` config and does not
-//     read `/* global foo */` comments — see the rule docs for details.
+//     `console`).
 //
-// On a JS file with no tsconfig only step 1 runs, so the rule still catches
-// the dominant case (label clashing with a sibling declaration).
+// On a JS file with no tsconfig only steps 1-2 run, so the rule still catches
+// the dominant case (label clashing with a sibling declaration or a declared
+// global).
 var NoLabelVarRule = rule.Rule{
 	Name: "no-label-var",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
@@ -42,6 +44,11 @@ var NoLabelVarRule = rule.Rule{
 				name := ls.Label.Text()
 
 				if utils.IsShadowed(node, name) {
+					report(node)
+					return
+				}
+
+				if ctx.Globals[name] {
 					report(node)
 					return
 				}

--- a/internal/rules/no_label_var/no_label_var.md
+++ b/internal/rules/no_label_var/no_label_var.md
@@ -39,10 +39,9 @@ This rule has no options.
 
 ## Differences from ESLint
 
-- `/* global foo */` directive comments are not recognized — labels colliding
-  with names declared only via these comments are not reported.
-- On files without type information, only declarations written in the file are
-  checked; clashes with built-in globals (`Promise`, `Array`, …) are not
+- On files without type information, only declarations written in the file
+  plus configured globals (`languageOptions.globals` / `/* global foo */`)
+  are checked; clashes with built-in globals (`Promise`, `Array`, …) are not
   reported in that case.
 
 ## Original Documentation

--- a/internal/rules/no_label_var/no_label_var_test.go
+++ b/internal/rules/no_label_var/no_label_var_test.go
@@ -44,6 +44,9 @@ func TestNoLabelVarRule(t *testing.T) {
 			{Code: `class C { m() { q: for(;;) { break q; } } }`},
 			{Code: `const fn = (a) => { q: for(;;) { break q; } };`},
 			{Code: `function* gen() { q: for(;;) { break q; } }`},
+
+			// ---- Declared global that does not clash with the label name ----
+			{Code: `q: for(;;) { break q; }`, Globals: map[string]bool{"myConfiguredGlobal": true}},
 		},
 
 		[]rule_tester.InvalidTestCase{
@@ -213,6 +216,21 @@ func TestNoLabelVarRule(t *testing.T) {
 				Code: `var a = 1; function f() { a: for(;;) { b: for(;;) { break b; } } }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "identifierClashWithLabel", Line: 1, Column: 27},
+				},
+			},
+
+			// ---- Config-declared / `/* global */` comment globals (strategy B path) ----
+			{
+				Code:    `myConfiguredGlobal: for(;;) { break myConfiguredGlobal; }`,
+				Globals: map[string]bool{"myConfiguredGlobal": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/* global fromComment */ fromComment: for(;;) { break fromComment; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 26},
 				},
 			},
 

--- a/internal/rules/no_shadow/no_shadow.go
+++ b/internal/rules/no_shadow/no_shadow.go
@@ -1351,6 +1351,13 @@ func runWithDefaults(defaults options) func(rule.RuleContext, any) rule.RuleList
 			for name := range ecmaScriptGlobals {
 				builtinGlobals[name] = true
 			}
+			// Config `languageOptions.globals` and `/* global */` comments
+			// declare additional globals beyond the ECMAScript/lib set.
+			for name, declared := range ctx.Globals {
+				if declared {
+					builtinGlobals[name] = true
+				}
+			}
 			if ctx.TypeChecker != nil && ctx.Program != nil {
 				for _, sym := range ctx.TypeChecker.GetSymbolsInScope(ctx.SourceFile.AsNode(), ast.SymbolFlagsValue) {
 					if sym == nil || sym.Name == "" {

--- a/internal/rules/no_shadow/no_shadow_test.go
+++ b/internal/rules/no_shadow/no_shadow_test.go
@@ -118,7 +118,8 @@ func TestNoShadowRule(t *testing.T) {
 
 			// ---- builtinGlobals off (default) ----
 			{Code: `function foo() { var Object = 0; }`},
-			// SKIP: `function foo() { var top = 0; }` with globals.browser — requires env.
+			// A declared global does not shadow when `builtinGlobals` is off.
+			{Code: `function foo() { var top = 0; }`, Globals: map[string]bool{"top": true}},
 
 			// Script-mode merging (VALID under script sourceType). Our implementation
 			// always treats the file as a module, so `var Object = 0;` at top level
@@ -601,6 +602,11 @@ function bar() { }`},
 
 			// ---- builtinGlobals ----
 			{Code: `function foo() { var Object = 0; }`, Options: map[string]interface{}{"builtinGlobals": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadowGlobal", Message: "'Object' is already a global variable."}}},
+			// `top` is not an ECMAScript builtin (it's a browser-env global);
+			// declaring it via config `languageOptions.globals` (or a
+			// `/* global */` comment) makes builtinGlobals catch the shadow.
+			{Code: `function foo() { var top = 0; }`, Globals: map[string]bool{"top": true}, Options: map[string]interface{}{"builtinGlobals": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadowGlobal", Message: "'top' is already a global variable."}}},
+			{Code: `/* global top */ function foo() { var top = 0; }`, Options: map[string]interface{}{"builtinGlobals": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadowGlobal", Message: "'top' is already a global variable."}}},
 			// SKIP: `function foo() { var top = 0; }` requires browser globals.
 			{Code: `var Object = 0;`, Options: map[string]interface{}{"builtinGlobals": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadowGlobal"}}},
 			// SKIP: `var top = 0;` browser globals.


### PR DESCRIPTION
## Summary

This pull request aligns three rules (`react/jsx-no-undef`, `no-label-var`, and `no-shadow`) with ESLint's behavior regarding config-defined globals (`languageOptions.globals`) and `/* global */` comment directives (exposed via `ctx.Globals`).

Additionally, it updates the `port-rule` skill documentation to reflect these changes.

### Key Changes & Alignments:
1. **`react/jsx-no-undef`** ([jsx_no_undef.go](file:///home/swwind/rslint2/internal/plugins/react/rules/jsx_no_undef/jsx_no_undef.go))
   - Implemented the `allowGlobals` option.
   - When `allowGlobals` is `true` (or when the file is a script file instead of a module), declared globals in `ctx.Globals` are permitted as JSX tags.
   - When `allowGlobals` is `false` (default) in module files, declared globals are not visible, triggering undefined errors.
   - Added corresponding test cases in [jsx_no_undef_test.go](file:///home/swwind/rslint2/internal/plugins/react/rules/jsx_no_undef/jsx_no_undef_test.go).

2. **`no-label-var`** ([no_label_var.go](file:///home/swwind/rslint2/internal/rules/no_label_var/no_label_var.go))
   - Added checks against `ctx.Globals` to match ESLint behavior.
   - Labels that clash with configured globals or variables defined in `/* global */` comments will now be flagged.
   - Added corresponding test cases in [no_label_var_test.go](file:///home/swwind/rslint2/internal/rules/no_label_var/no_label_var_test.go).

3. **`no-shadow`** ([no_shadow.go](file:///home/swwind/rslint2/internal/rules/no_shadow/no_shadow.go))
   - When `builtinGlobals` is set to `true`, shadowing names defined in `ctx.Globals` (from config/comments) will now trigger shadowing errors.
   - When `builtinGlobals` is `false` (default), shadowing them is permitted.
   - Added corresponding test cases in [no_shadow_test.go](file:///home/swwind/rslint2/internal/rules/no_shadow/no_shadow_test.go).

4. **`port-rule` Skill Documentation** ([PORT_RULE.md](file:///home/swwind/rslint2/.agents/skills/port-rule/references/PORT_RULE.md))
   - Updated the porting guide to instruct AIs/contributors to check `ctx.Globals[name]` when porting rules that reference global variables, instead of skipping them as previously instructed.

---

## Related Links

<!--- Provide links of related issues or pages -->
- Part of https://github.com/web-infra-dev/rslint/issues/1239

---

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
