### PR TITLE
feat: port rule require-number-to-fixed-digits-argument

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_number_properties"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -22,5 +23,6 @@ func GetAllRules() []rule.Rule {
 		no_useless_switch_case.NoUselessSwitchCaseRule,
 		prefer_array_flat_map.PreferArrayFlatMapRule,
 		prefer_number_properties.PreferNumberPropertiesRule,
+		require_number_to_fixed_digits_argument.RequireNumberToFixedDigitsArgumentRule,
 	}
 }

--- a/internal/plugins/unicorn/rules/no_thenable/no_thenable.go
+++ b/internal/plugins/unicorn/rules/no_thenable/no_thenable.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -312,33 +313,19 @@ func reportExpressionNode(node *ast.Node) *ast.Node {
 // utils.IsSpecificMemberAccess intentionally accepts bracket access and
 // optional chains, which would diverge from this rule's upstream matcher.
 func isNonOptionalMethodCall(node *ast.Node, objects []string, method string, minimumArguments int, argumentsLength int) bool {
-	call := node.AsCallExpression()
-	if call == nil || call.QuestionDotToken != nil {
+	options := unicornutil.DotMethodCallOptions{Method: method}
+	if minimumArguments >= 0 {
+		options.MinimumArguments = &minimumArguments
+	}
+	if argumentsLength >= 0 {
+		options.ArgumentsLength = &argumentsLength
+	}
+	call, ok := unicornutil.MatchDotMethodCall(node, options)
+	if !ok {
 		return false
 	}
 
-	args := node.Arguments()
-	if minimumArguments >= 0 && len(args) < minimumArguments {
-		return false
-	}
-	if argumentsLength >= 0 && len(args) != argumentsLength {
-		return false
-	}
-
-	rawCallee := call.Expression
-	callee := ast.SkipParentheses(rawCallee)
-	if callee == nil || (rawCallee != callee && ast.IsOptionalChain(callee)) ||
-		callee.Kind != ast.KindPropertyAccessExpression {
-		return false
-	}
-
-	propertyAccess := callee.AsPropertyAccessExpression()
-	if propertyAccess == nil || propertyAccess.QuestionDotToken != nil ||
-		!isIdentifierNamed(propertyAccess.Name(), method) {
-		return false
-	}
-
-	object := ast.SkipParentheses(propertyAccess.Expression)
+	object := ast.SkipParentheses(call.Object)
 	return object != nil && object.Kind == ast.KindIdentifier &&
 		slices.Contains(objects, object.AsIdentifier().Text)
 }

--- a/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map.go
@@ -6,6 +6,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -17,55 +18,17 @@ var preferArrayFlatMapMessage = rule.RuleMessage{
 	Description: "Prefer `.flatMap(…)` over `.map(…).flat()`.",
 }
 
-type dotMethodCall struct {
-	call      *ast.Node
-	rawCallee *ast.Node
-	callee    *ast.Node
-	object    *ast.Node
-	property  *ast.Node
-}
+type dotMethodCall = unicornutil.DotMethodCall
 
 // matchDotMethodCall mirrors unicorn's isMethodCall with computed:false. The
 // wider utils.IsSpecificMemberAccess helper also matches static bracket access,
 // which would make foo["map"](...).flat() a false positive for this rule.
 func matchDotMethodCall(node *ast.Node, method string, optionalCallFalse bool, optionalMemberFalse bool) (dotMethodCall, bool) {
-	if node == nil || !ast.IsCallExpression(node) {
-		return dotMethodCall{}, false
-	}
-
-	call := node.AsCallExpression()
-	// Check the direct optional token, not ast.IsOptionalChain: in tsgo,
-	// foo?.map(...).flat() marks later links as optional-chain nodes too, but
-	// upstream still reports because only map's member access is optional.
-	if optionalCallFalse && call.QuestionDotToken != nil {
-		return dotMethodCall{}, false
-	}
-
-	rawCallee := call.Expression
-	callee := ast.SkipParentheses(rawCallee)
-	// Parentheses around an optional-chain callee are not transparent to
-	// upstream isMethodCall: (foo?.map)(cb) is not treated as foo?.map(cb).
-	if callee == nil || (rawCallee != callee && ast.IsOptionalChain(callee)) || !ast.IsPropertyAccessExpression(callee) {
-		return dotMethodCall{}, false
-	}
-
-	propAccess := callee.AsPropertyAccessExpression()
-	if optionalMemberFalse && propAccess.QuestionDotToken != nil {
-		return dotMethodCall{}, false
-	}
-
-	property := propAccess.Name()
-	if property == nil || !ast.IsIdentifier(property) || property.AsIdentifier().Text != method {
-		return dotMethodCall{}, false
-	}
-
-	return dotMethodCall{
-		call:      node,
-		rawCallee: rawCallee,
-		callee:    callee,
-		object:    propAccess.Expression,
-		property:  property,
-	}, true
+	return unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+		Method:              method,
+		AllowOptionalCall:   !optionalCallFalse,
+		AllowOptionalMember: !optionalMemberFalse,
+	})
 }
 
 func hasNoDepthOrRawDepthOne(sf *ast.SourceFile, call *ast.Node) bool {
@@ -119,11 +82,11 @@ func nodeMatchesPathParts(node *ast.Node, parts []string) bool {
 }
 
 func buildFixes(sf *ast.SourceFile, flatCall dotMethodCall, mapCall dotMethodCall) []rule.RuleFix {
-	mapPropertyRange := utils.TrimNodeTextRange(sf, mapCall.property)
+	mapPropertyRange := utils.TrimNodeTextRange(sf, mapCall.Property)
 	// Remove the .flat member and the following call separately, preserving any
 	// parentheses around the callee: (foo.map(cb).flat)() -> (foo.flatMap(cb)).
-	removeFlatPropertyRange := core.NewTextRange(flatCall.object.End(), flatCall.callee.End())
-	removeFlatArgumentsRange := core.NewTextRange(flatCall.rawCallee.End(), flatCall.call.End())
+	removeFlatPropertyRange := core.NewTextRange(flatCall.Object.End(), flatCall.Callee.End())
+	removeFlatArgumentsRange := core.NewTextRange(flatCall.RawCallee.End(), flatCall.Call.End())
 	return []rule.RuleFix{
 		rule.RuleFixReplaceRange(mapPropertyRange, "flatMap"),
 		rule.RuleFixRemoveRange(removeFlatPropertyRange),
@@ -142,13 +105,13 @@ var PreferArrayFlatMapRule = rule.Rule{
 					return
 				}
 
-				mapCallObject := ast.SkipParentheses(flatCall.object)
+				mapCallObject := ast.SkipParentheses(flatCall.Object)
 				mapCall, ok := matchDotMethodCall(mapCallObject, "map", true, false)
-				if !ok || isIgnoredMapObject(mapCall.object) {
+				if !ok || isIgnoredMapObject(mapCall.Object) {
 					return
 				}
 
-				reportRange := utils.TrimNodeTextRange(ctx.SourceFile, mapCall.property).WithEnd(node.End())
+				reportRange := utils.TrimNodeTextRange(ctx.SourceFile, mapCall.Property).WithEnd(node.End())
 				ctx.ReportRangeWithFixes(
 					reportRange,
 					preferArrayFlatMapMessage,

--- a/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument.go
+++ b/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument.go
@@ -1,0 +1,95 @@
+package require_number_to_fixed_digits_argument
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const messageID = "require-number-to-fixed-digits-argument"
+
+var missingDigitsMessage = rule.RuleMessage{
+	Id:          messageID,
+	Description: "Missing the digits argument.",
+}
+
+func callParenthesesRange(sourceFile *ast.SourceFile, node *ast.Node) (core.TextRange, core.TextRange, bool) {
+	call := node.AsCallExpression()
+	if call == nil || call.Expression == nil {
+		return core.TextRange{}, core.TextRange{}, false
+	}
+
+	scanStart := call.Expression.End()
+	if call.TypeArguments != nil && len(call.TypeArguments.Nodes) > 0 {
+		scanStart = call.TypeArguments.End()
+	}
+
+	s := scanner.GetScannerForSourceFile(sourceFile, scanStart)
+	var opening core.TextRange
+	depth := 0
+	foundOpening := false
+	for s.TokenStart() < node.End() {
+		switch s.Token() {
+		case ast.KindOpenParenToken:
+			if !foundOpening {
+				opening = s.TokenRange()
+				foundOpening = true
+			}
+			depth++
+		case ast.KindCloseParenToken:
+			if !foundOpening {
+				return core.TextRange{}, core.TextRange{}, false
+			}
+			depth--
+			if depth == 0 {
+				return opening, s.TokenRange(), true
+			}
+		}
+		s.Scan()
+	}
+
+	return core.TextRange{}, core.TextRange{}, false
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/require-number-to-fixed-digits-argument.md
+var RequireNumberToFixedDigitsArgumentRule = rule.Rule{
+	Name: "unicorn/require-number-to-fixed-digits-argument",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		zeroArguments := 0
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Method:              "toFixed",
+					ArgumentsLength:     &zeroArguments,
+					AllowOptionalMember: true,
+				})
+				if !ok {
+					return
+				}
+
+				// Upstream intentionally exempts only a directly constructed
+				// receiver. Calls on variables or factory results remain reportable,
+				// even when they come from a Number-like library.
+				object := ast.SkipParentheses(call.Object)
+				if object != nil && object.Kind == ast.KindNewExpression {
+					return
+				}
+
+				opening, closing, ok := callParenthesesRange(ctx.SourceFile, node)
+				if !ok {
+					return
+				}
+
+				reportRange := core.NewTextRange(opening.Pos(), closing.End())
+				insertRange := core.NewTextRange(closing.Pos(), closing.Pos())
+				ctx.ReportRangeWithFixes(
+					reportRange,
+					missingDigitsMessage,
+					rule.RuleFixReplaceRange(insertRange, "0"),
+				)
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument.md
+++ b/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument.md
@@ -1,0 +1,24 @@
+# require-number-to-fixed-digits-argument
+
+## Rule Details
+
+Requires calls to `Number#toFixed()` to explicitly pass the number of fraction
+digits. Writing the argument makes the intended formatting clear instead of
+relying on the default value of `0`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const value = number.toFixed();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const integer = number.toFixed(0);
+const decimal = number.toFixed(2);
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn require-number-to-fixed-digits-argument](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/require-number-to-fixed-digits-argument.md)

--- a/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument_extras_test.go
+++ b/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument_extras_test.go
@@ -1,0 +1,181 @@
+// TestRequireNumberToFixedDigitsArgumentExtras locks in branches and edge
+// shapes that the upstream test suite doesn't exercise. Each case carries an
+// inline comment pointing at the specific branch, Dimension 4 row, or real-user
+// scenario it covers.
+package require_number_to_fixed_digits_argument_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	require_number_to_fixed_digits_argument "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRequireNumberToFixedDigitsArgumentExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&require_number_to_fixed_digits_argument.RequireNumberToFixedDigitsArgumentRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: element-access key forms are excluded ----
+			{Code: `number['toFixed']()`, FileName: "file.ts"},
+			{Code: "number[`toFixed`]()", FileName: "file.ts"},
+			{Code: `number[0]()`, FileName: "file.ts"},
+			{Code: `number[Symbol.toFixed]()`, FileName: "file.ts"},
+
+			// ---- Dimension 4: optional call is excluded ----
+			{Code: `(number.toFixed)?.()`, FileName: "file.ts"},
+
+			// Locks in upstream create() arm 2: a direct NewExpression receiver is excluded.
+			{Code: `(new Number(1)).toFixed()`, FileName: "file.ts"},
+			{Code: `((new Number(1))).toFixed()`, FileName: "file.ts"},
+
+			// ---- Graceful degradation: spread is an argument ----
+			{Code: `number.toFixed(...digits)`, FileName: "file.ts"},
+
+			// N/A: private member access is invalid outside a declaring class, and #toFixed cannot name Number.prototype.toFixed.
+			// N/A: declaration/container forms; the rule only targets call expressions.
+			// N/A: declaration key forms (string, numeric, private, computed); no declarations are inspected.
+			// N/A: same-kind nesting and ancestor walks; the rule performs no ancestor traversal.
+			// N/A: body-absent declarations and empty containers; the rule only inspects call arguments.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized receiver wrappers ----
+			{
+				Code:     `(number).toFixed()`,
+				FileName: "file.ts",
+				Output:   []string{`(number).toFixed(0)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    17,
+					EndLine:   1,
+					EndColumn: 19,
+				}},
+			},
+			{
+				Code:     `((number)).toFixed()`,
+				FileName: "file.ts",
+				Output:   []string{`((number)).toFixed(0)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    19,
+					EndLine:   1,
+					EndColumn: 21,
+				}},
+			},
+
+			// ---- Dimension 4: TypeScript receiver wrappers ----
+			{
+				Code:     `number!.toFixed()`,
+				FileName: "file.ts",
+				Output:   []string{`number!.toFixed(0)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 18,
+				}},
+			},
+			{
+				Code:     `(number as number).toFixed()`,
+				FileName: "file.ts",
+				Output:   []string{`(number as number).toFixed(0)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    27,
+					EndLine:   1,
+					EndColumn: 29,
+				}},
+			},
+			{
+				Code:     `(number satisfies number).toFixed()`,
+				FileName: "file.ts",
+				Output:   []string{`(number satisfies number).toFixed(0)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    34,
+					EndLine:   1,
+					EndColumn: 36,
+				}},
+			},
+
+			// ---- Dimension 4: optional member access remains reportable ----
+			{
+				Code:     `number?.toFixed()`,
+				FileName: "file.ts",
+				Output:   []string{`number?.toFixed(0)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 18,
+				}},
+			},
+
+			// Locks in upstream isMethodCall() argumentsLength === 0 with type arguments.
+			{
+				Code:     `number.toFixed<number>()`,
+				FileName: "file.ts",
+				Output:   []string{`number.toFixed<number>(0)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    23,
+					EndLine:   1,
+					EndColumn: 25,
+				}},
+			},
+
+			// ---- Real-user: #1463 Number-like factory call remains reportable ----
+			{
+				Code:     `BigNumber(1).toFixed()`,
+				FileName: "file.ts",
+				Output:   []string{`BigNumber(1).toFixed(0)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 23,
+				}},
+			},
+
+			// ---- Real-user: #1601 only the immediate new receiver is exempt ----
+			// Locks in upstream create() arm 2: a non-NewExpression receiver remains reportable.
+			{
+				Code:     `new BigNumber(1).plus(2).toFixed()`,
+				FileName: "file.ts",
+				Output:   []string{`new BigNumber(1).plus(2).toFixed(0)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    33,
+					EndLine:   1,
+					EndColumn: 35,
+				}},
+			},
+
+			// Locks in report range and appendArgument behavior across lines/comments.
+			{
+				Code:     "number.toFixed(\n  /* keep */\n)",
+				FileName: "file.ts",
+				Output:   []string{"number.toFixed(\n  /* keep */\n0)"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    15,
+					EndLine:   3,
+					EndColumn: 2,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument_upstream_test.go
+++ b/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument_upstream_test.go
@@ -1,0 +1,104 @@
+// TestRequireNumberToFixedDigitsArgumentUpstream migrates the full valid/invalid
+// suite from upstream test/require-number-to-fixed-digits-argument.js 1:1.
+// Position assertions cover line/column for every invalid case. rslint-specific
+// lock-in cases live in require_number_to_fixed_digits_argument_extras_test.go.
+package require_number_to_fixed_digits_argument_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	require_number_to_fixed_digits_argument "github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageID = "require-number-to-fixed-digits-argument"
+	message   = "Missing the digits argument."
+)
+
+func TestRequireNumberToFixedDigitsArgumentUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&require_number_to_fixed_digits_argument.RequireNumberToFixedDigitsArgumentRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `number.toFixed(0)`, FileName: "file.js"},
+			{Code: `number.toFixed(...[])`, FileName: "file.js"},
+			{Code: `number.toFixed(2)`, FileName: "file.js"},
+			{Code: `number.toFixed(1,2,3)`, FileName: "file.js"},
+			{Code: `number[toFixed]()`, FileName: "file.js"},
+			{Code: `number["toFixed"]()`, FileName: "file.js"},
+			{Code: `number.toFixed?.()`, FileName: "file.js"},
+			{Code: `number.notToFixed();`, FileName: "file.js"},
+
+			// `callee` object is a NewExpression.
+			{Code: `new BigNumber(1).toFixed()`, FileName: "file.js"},
+			{Code: `new Number(1).toFixed()`, FileName: "file.js"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:     `const string = number.toFixed();`,
+				FileName: "file.js",
+				Output:   []string{`const string = number.toFixed(0);`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Message:   message,
+					Line:      1,
+					Column:    30,
+					EndLine:   1,
+					EndColumn: 32,
+				}},
+			},
+			{
+				Code:     `const string = number?.toFixed() ?? "";`,
+				FileName: "file.js",
+				Output:   []string{`const string = number?.toFixed(0) ?? "";`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    31,
+					EndLine:   1,
+					EndColumn: 33,
+				}},
+			},
+			{
+				Code:     `const string = number.toFixed( /* comment */ );`,
+				FileName: "file.js",
+				Output:   []string{`const string = number.toFixed( /* comment */ 0);`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    30,
+					EndLine:   1,
+					EndColumn: 47,
+				}},
+			},
+			{
+				Code:     `Number(1).toFixed()`,
+				FileName: "file.js",
+				Output:   []string{`Number(1).toFixed(0)`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 20,
+				}},
+			},
+			{
+				Code:     `const bigNumber = new BigNumber(1); const string = bigNumber.toFixed();`,
+				FileName: "file.js",
+				Output:   []string{`const bigNumber = new BigNumber(1); const string = bigNumber.toFixed(0);`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: messageID,
+					Line:      1,
+					Column:    69,
+					EndLine:   1,
+					EndColumn: 71,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/unicornutil/method_call.go
+++ b/internal/plugins/unicorn/unicornutil/method_call.go
@@ -1,0 +1,72 @@
+package unicornutil
+
+import "github.com/microsoft/typescript-go/shim/ast"
+
+// DotMethodCall is a non-computed method call matched by MatchDotMethodCall.
+type DotMethodCall struct {
+	Call      *ast.Node
+	RawCallee *ast.Node
+	Callee    *ast.Node
+	Object    *ast.Node
+	Property  *ast.Node
+}
+
+// DotMethodCallOptions mirrors the subset of unicorn's isMethodCall options
+// used by native rslint rules. Nil argument limits disable that check.
+type DotMethodCallOptions struct {
+	Method              string
+	ArgumentsLength     *int
+	MinimumArguments    *int
+	AllowOptionalCall   bool
+	AllowOptionalMember bool
+}
+
+// MatchDotMethodCall matches a dot-property CallExpression. Static bracket
+// access is intentionally excluded because unicorn's isMethodCall defaults to
+// computed:false. Parentheses are transparent except around optional-chain
+// callees, matching the upstream helper's semantics.
+func MatchDotMethodCall(node *ast.Node, options DotMethodCallOptions) (DotMethodCall, bool) {
+	if node == nil || !ast.IsCallExpression(node) {
+		return DotMethodCall{}, false
+	}
+
+	call := node.AsCallExpression()
+	if !options.AllowOptionalCall && call.QuestionDotToken != nil {
+		return DotMethodCall{}, false
+	}
+
+	args := node.Arguments()
+	if options.ArgumentsLength != nil && len(args) != *options.ArgumentsLength {
+		return DotMethodCall{}, false
+	}
+	if options.MinimumArguments != nil && len(args) < *options.MinimumArguments {
+		return DotMethodCall{}, false
+	}
+
+	rawCallee := call.Expression
+	callee := ast.SkipParentheses(rawCallee)
+	if callee == nil || (rawCallee != callee && ast.IsOptionalChain(callee)) ||
+		!ast.IsPropertyAccessExpression(callee) {
+		return DotMethodCall{}, false
+	}
+
+	propertyAccess := callee.AsPropertyAccessExpression()
+	if propertyAccess == nil ||
+		(!options.AllowOptionalMember && propertyAccess.QuestionDotToken != nil) {
+		return DotMethodCall{}, false
+	}
+
+	property := propertyAccess.Name()
+	if property == nil || !ast.IsIdentifier(property) ||
+		property.AsIdentifier().Text != options.Method {
+		return DotMethodCall{}, false
+	}
+
+	return DotMethodCall{
+		Call:      node,
+		RawCallee: rawCallee,
+		Callee:    callee,
+		Object:    propertyAccess.Expression,
+		Property:  property,
+	}, true
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -554,6 +554,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-number-properties.test.ts',
+    './tests/eslint-plugin-unicorn/rules/require-number-to-fixed-digits-argument.test.ts',
 
     './tests/eslint/rules/no-shadow-restricted-names.test.ts',
   ],

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/require-number-to-fixed-digits-argument.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/require-number-to-fixed-digits-argument.test.ts
@@ -1,0 +1,39 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const message = 'Missing the digits argument.';
+const valid = (code: string) => ({ code, filename: 'file.js' });
+const invalid = (code: string) => ({
+  code,
+  filename: 'file.js',
+  errors: [{ message }],
+});
+
+ruleTester.run('require-number-to-fixed-digits-argument', null as never, {
+  valid: [
+    valid('number.toFixed(0)'),
+    valid('number.toFixed(...[])'),
+    valid('number.toFixed(2)'),
+    valid('number.toFixed(1,2,3)'),
+    valid('number[toFixed]()'),
+    valid('number["toFixed"]()'),
+    valid('number.toFixed?.()'),
+    valid('number.notToFixed();'),
+
+    // `callee` is a `NewExpression`.
+    valid('new BigNumber(1).toFixed()'),
+    valid('new Number(1).toFixed()'),
+  ],
+  invalid: [
+    invalid('const string = number.toFixed();'),
+    invalid('const string = number?.toFixed() ?? "";'),
+    invalid('const string = number.toFixed( /* comment */ );'),
+    invalid('Number(1).toFixed()'),
+
+    // False positive cases.
+    invalid(
+      'const bigNumber = new BigNumber(1); const string = bigNumber.toFixed();',
+    ),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -151,7 +151,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/require-array-join-separator': 'error', // not implemented
     // 'unicorn/require-module-attributes': 'error', // not implemented
     // 'unicorn/require-module-specifiers': 'error', // not implemented
-    // 'unicorn/require-number-to-fixed-digits-argument': 'error', // not implemented
+    'unicorn/require-number-to-fixed-digits-argument': 'error',
     // 'unicorn/require-post-message-target-origin': 'off', // not implemented
     // 'unicorn/string-content': 'off', // not implemented
     // 'unicorn/switch-case-braces': 'error', // not implemented

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -554,6 +554,7 @@ undefinded
 undefinedish
 undefinedundefined
 undereferenced
+unicornutil
 uninit
 uninitialised
 unional


### PR DESCRIPTION
## Summary

Port the `unicorn/require-number-to-fixed-digits-argument` rule from eslint-plugin-unicorn to rslint.

Require calls to `Number#toFixed()` to explicitly provide the number of fraction digits, with an autofix that inserts `0` when the argument is omitted.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/require-number-to-fixed-digits-argument.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/rules/require-number-to-fixed-digits-argument.js

## Checklist

- [x] Tests updated.
- [x] Documentation updated.