### PR TITLE
fix(lsp): preserve newer document content on save

### DIFF
--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -395,8 +395,15 @@ func (s *Server) handleDidChange(ctx context.Context, params *lsproto.DidChangeT
 func (s *Server) handleDidSave(ctx context.Context, params *lsproto.DidSaveTextDocumentParams) error {
 	log.Printf("Handling didSave: %s", params.TextDocument.Uri)
 	uri := params.TextDocument.Uri
-	if params.Text != nil {
-		s.documents[uri] = *params.Text
+
+	// didChange is authoritative for the current content of an open document.
+	// didSave may include the text that reached disk, but carries no document
+	// version, so a save for an older buffer can arrive after a newer didChange.
+	// Never replace the versioned document mirror with this unversioned snapshot.
+	currentContent, open := s.documents[uri]
+	forwardSave := shouldForwardDidSave(currentContent, open, params.Text)
+	if !forwardSave {
+		log.Printf("Ignoring stale didSave for open document %s", uri)
 	}
 
 	// Clear pending debounce lint for this URI — pushDiagnostics below
@@ -405,10 +412,20 @@ func (s *Server) handleDidSave(ctx context.Context, params *lsproto.DidSaveTextD
 
 	// Notify session about the save event
 	if s.session != nil {
-		s.session.DidSaveFile(ctx, uri)
+		if forwardSave {
+			s.session.DidSaveFile(ctx, uri)
+		}
 		s.pushDiagnostics(uri)
 	}
 	return nil
+}
+
+// shouldForwardDidSave suppresses only saves that are known to describe an
+// older version of an open document. Saves without text and saves for documents
+// not tracked as open are forwarded for LSP client compatibility and so tsgo
+// can observe out-of-band disk changes.
+func shouldForwardDidSave(currentContent string, open bool, savedText *string) bool {
+	return savedText == nil || !open || currentContent == *savedText
 }
 
 func (s *Server) handleDidClose(ctx context.Context, params *lsproto.DidCloseTextDocumentParams) error {

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -164,13 +164,25 @@ func TestHandleDidChange_UnopenedDocument(t *testing.T) {
 
 // ======== handleDidSave tests ========
 
-func TestHandleDidSave(t *testing.T) {
+func TestHandleDidSave_DoesNotOverwriteNewerDidChange(t *testing.T) {
 	s := newTestServer()
 	ctx := context.Background()
 	uri := lsproto.DocumentUri("file:///project/test.ts")
-	s.documents[uri] = "old content"
 
-	savedText := "saved content"
+	if err := s.handleDidOpen(ctx, &lsproto.DidOpenTextDocumentParams{
+		TextDocument: &lsproto.TextDocumentItem{
+			Uri:     uri,
+			Version: 1,
+			Text:    "older saved content",
+		},
+	}); err != nil {
+		t.Fatalf("handleDidOpen failed: %v", err)
+	}
+	if err := s.handleDidChange(ctx, makeDidChangeParams(uri, 2, "newer unsaved content")); err != nil {
+		t.Fatalf("handleDidChange failed: %v", err)
+	}
+
+	savedText := "older saved content"
 	err := s.handleDidSave(ctx, &lsproto.DidSaveTextDocumentParams{
 		TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},
 		Text:         &savedText,
@@ -179,8 +191,74 @@ func TestHandleDidSave(t *testing.T) {
 		t.Fatalf("handleDidSave failed: %v", err)
 	}
 
-	if s.documents[uri] != "saved content" {
-		t.Errorf("document content = %q, want %q", s.documents[uri], "saved content")
+	if s.documents[uri] != "newer unsaved content" {
+		t.Errorf("document content = %q, want newer didChange content", s.documents[uri])
+	}
+}
+
+func TestHandleDidSave_DoesNotOpenUntrackedDocument(t *testing.T) {
+	s := newTestServer()
+	ctx := context.Background()
+	uri := lsproto.DocumentUri("file:///project/untracked.ts")
+	savedText := "saved content"
+
+	if err := s.handleDidSave(ctx, &lsproto.DidSaveTextDocumentParams{
+		TextDocument: lsproto.TextDocumentIdentifier{Uri: uri},
+		Text:         &savedText,
+	}); err != nil {
+		t.Fatalf("handleDidSave failed: %v", err)
+	}
+
+	if _, open := s.documents[uri]; open {
+		t.Error("didSave must not add an untracked document to the open-document mirror")
+	}
+}
+
+func TestShouldForwardDidSave(t *testing.T) {
+	matchingText := "current content"
+	staleText := "older content"
+	tests := []struct {
+		name           string
+		currentContent string
+		open           bool
+		savedText      *string
+		want           bool
+	}{
+		{
+			name:           "matching open document",
+			currentContent: matchingText,
+			open:           true,
+			savedText:      &matchingText,
+			want:           true,
+		},
+		{
+			name:           "stale open document",
+			currentContent: matchingText,
+			open:           true,
+			savedText:      &staleText,
+			want:           false,
+		},
+		{
+			name:      "untracked document",
+			open:      false,
+			savedText: &staleText,
+			want:      true,
+		},
+		{
+			name:           "client omitted text",
+			currentContent: matchingText,
+			open:           true,
+			savedText:      nil,
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldForwardDidSave(tt.currentContent, tt.open, tt.savedText); got != tt.want {
+				t.Fatalf("shouldForwardDidSave() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep the versioned `didOpen`/`didChange` document mirror authoritative
- never replace an open document with optional, unversioned `didSave.text`
- suppress forwarding only when a save is provably stale for an open document
- preserve tsgo behavior for matching saves, omitted text, and saves for untracked documents

## Root cause

A save for an older buffer can arrive after a newer `didChange`. The old handler copied that unversioned save text into `s.documents`, while the TypeScript session still held the newer overlay. During source.fixAll, fix offsets computed from the newer source were then applied to the shorter rolled-back string, causing a slice-bounds panic.

## Semantics

`shouldForwardDidSave` covers all four cases explicitly:

- open + matching text: forward
- open + stale text: do not forward
- untracked document: forward so tsgo can observe the disk change
- omitted text: forward for client compatibility

No `didSave` notification adds or overwrites an entry in the open-document mirror.

## Validation

- `go test ./internal/lsp -run 'TestHandleDidSave|TestShouldForwardDidSave' -count=1`
- deterministic regression sequence: `didOpen(old) -> didChange(new) -> didSave(old)`
