### PR TITLE
feat: expose global declaration metadata to rules

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -258,6 +258,9 @@ type RuleListeners map[ast.Kind]func(node *ast.Node)
 type RuleContext struct {
     SourceFile                 *ast.SourceFile
     Settings                   map[string]interface{}
+    ConfigGlobals              map[string]bool
+    InlineGlobals              []InlineGlobal
+    Globals                    map[string]bool
     Program                    *compiler.Program
     TypeChecker                *checker.Checker
     DisableManager             *DisableManager
@@ -269,6 +272,12 @@ type RuleContext struct {
     ReportNodeWithSuggestions  func(node *ast.Node, msg RuleMessage, suggestions ...RuleSuggestion)
 }
 ```
+
+The linter parses `/* global */` comments once per file before rules run.
+`ConfigGlobals` preserves the effective `languageOptions.globals` source,
+`InlineGlobals` preserves ordered comment name ranges, and `Globals` is the
+resolved map after inline settings override configuration. Rules consume this
+context data instead of scanning comments independently.
 
 ### Listener Registration
 

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -137,9 +137,9 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 		disableManager := rule.NewDisableManager(file, comments)
 
 		// Parse inline `/* global */` comments once per file, same as
-		// DisableManager above — rules read the merged result off ctx.Globals
-		// instead of parsing comments or config themselves.
-		inlineGlobals := rule.ParseInlineGlobals(file, comments)
+		// DisableManager above. Rules receive both declaration metadata and the
+		// merged result instead of parsing comments or config themselves.
+		inlineGlobals, inlineGlobalDeclarations := rule.ParseInlineGlobals(file, comments)
 
 		// For gap files (not in caller's TypeInfoFiles), pass nil TypeChecker
 		// as defense-in-depth. Type-aware rules are already filtered out by
@@ -157,6 +157,8 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 				SourceFile:     file,
 				Program:        opts.Program,
 				Settings:       r.Settings,
+				ConfigGlobals:  r.Globals,
+				InlineGlobals:  inlineGlobalDeclarations,
 				Globals:        rule.MergeGlobals(r.Globals, inlineGlobals),
 				TypeChecker:    fileChecker,
 				DisableManager: disableManager,

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -3,6 +3,7 @@ package linter
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -107,6 +108,74 @@ func TestRunLinter_ExecutedRules(t *testing.T) {
 	}
 }
 
+func TestRunLinter_GlobalDeclarationMetadata(t *testing.T) {
+	source := "#!/usr/bin/env node\n" +
+		"/*global configOn:off, inlineOn, repeated:off */\n" +
+		"/*global repeated, inlineOn:off */"
+	program, paths := createTestProgramWithFiles(t, map[string]string{"globals.ts": source})
+	configGlobals := map[string]bool{"configOn": true, "configOff": false}
+
+	var captured *rule.RuleContext
+	result, err := runLinterPositional([]*compiler.Program{program}, true, []string{paths["globals.ts"]}, nil, utils.ExcludePaths,
+		func(*ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{{
+				Name:     "capture-globals",
+				Globals:  configGlobals,
+				Severity: rule.SeverityWarning,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					captured = &ctx
+					return nil
+				},
+			}}
+		},
+		false, func(rule.RuleDiagnostic) {}, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+	if result.LintedFileCount != 1 || captured == nil {
+		t.Fatalf("captured context = %v, linted files = %d; want one", captured != nil, result.LintedFileCount)
+	}
+
+	if !reflect.DeepEqual(captured.ConfigGlobals, configGlobals) {
+		t.Errorf("ConfigGlobals = %#v, want %#v", captured.ConfigGlobals, configGlobals)
+	}
+	wantGlobals := map[string]bool{
+		"configOn": false, "configOff": false, "inlineOn": false, "repeated": true,
+	}
+	if !reflect.DeepEqual(captured.Globals, wantGlobals) {
+		t.Errorf("Globals = %#v, want %#v", captured.Globals, wantGlobals)
+	}
+
+	wantInline := []struct {
+		name      string
+		declared  bool
+		positions []int
+	}{
+		{name: "configOn", declared: false, positions: []int{strings.Index(source, "configOn")}},
+		{name: "inlineOn", declared: false, positions: []int{strings.Index(source, "inlineOn"), strings.LastIndex(source, "inlineOn")}},
+		{name: "repeated", declared: true, positions: []int{strings.Index(source, "repeated"), strings.LastIndex(source, "repeated")}},
+	}
+	if len(captured.InlineGlobals) != len(wantInline) {
+		t.Fatalf("InlineGlobals has %d entries, want %d: %#v", len(captured.InlineGlobals), len(wantInline), captured.InlineGlobals)
+	}
+	for i, want := range wantInline {
+		got := captured.InlineGlobals[i]
+		if got.Name != want.name || got.Declared != want.declared {
+			t.Errorf("InlineGlobals[%d] = (%q, %v), want (%q, %v)", i, got.Name, got.Declared, want.name, want.declared)
+		}
+		if len(got.NameRanges) != len(want.positions) {
+			t.Fatalf("InlineGlobals[%d].NameRanges has %d entries, want %d", i, len(got.NameRanges), len(want.positions))
+		}
+		for rangeIndex, textRange := range got.NameRanges {
+			wantPosition := want.positions[rangeIndex]
+			if textRange.Pos() != wantPosition || source[textRange.Pos():textRange.End()] != want.name {
+				t.Errorf("InlineGlobals[%d].NameRanges[%d] = %d:%d (%q), want %d:%d (%q)", i, rangeIndex, textRange.Pos(), textRange.End(), source[textRange.Pos():textRange.End()], wantPosition, wantPosition+len(want.name), want.name)
+			}
+		}
+	}
+}
+
 func TestRunLinter_ExecutedRulesPerFile(t *testing.T) {
 	program, paths := createTestProgramWithFiles(t, map[string]string{
 		"a.ts": "const a = 1;",
@@ -160,4 +229,3 @@ func TestRunLinter_ExecutedRulesEmpty(t *testing.T) {
 		t.Errorf("Expected 0 executed rules, got %d", len(result.ExecutedRules))
 	}
 }
-

--- a/internal/rule/inline_globals.go
+++ b/internal/rule/inline_globals.go
@@ -1,10 +1,12 @@
 package rule
 
 import (
-	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
 )
 
 // inlineGlobalsKeywords lists the directive keywords that introduce a
@@ -12,71 +14,150 @@ import (
 // the longer prefix.
 var inlineGlobalsKeywords = [...]string{"globals", "global"}
 
+// InlineGlobal describes one name declared by `/* global */` comments.
+// Declared is the name's final inline state after all comments are applied.
+// NameRanges contains one exact name range per comment that mentions the name,
+// in source order. Repeating a name within one comment still contributes only
+// its first range, matching ESLint's comment metadata.
+type InlineGlobal struct {
+	Name       string
+	Declared   bool
+	NameRanges []core.TextRange
+}
+
+type inlineGlobalName struct {
+	name      string
+	setting   string
+	nameRange core.TextRange
+}
+
 // ParseInlineGlobals scans `/* global ... */` / `/* globals ... */` block
-// comments and returns the set of names they declare (name -> declared).
+// comments once and returns both the final name -> declared map and ordered
+// declaration metadata for rules that need to distinguish comment globals
+// from configured globals.
 //
-// This is the DisableManager-equivalent preprocessing step for globals: it
-// runs once per file, over the same real comment tokens DisableManager
-// consumes (not a regex over raw source text, so lookalike text inside a
-// string literal or another comment can't be mistaken for a directive), and
-// its result is merged with config globals before being handed to rules —
-// no rule should parse `/* global */` comments itself.
-//
-// Mirrors ESLint's inline-config handling: only the setting "off" un-declares
-// a name; a bare name or any other setting (e.g. "writable") declares it.
-func ParseInlineGlobals(sourceFile *ast.SourceFile, comments []*ast.CommentRange) map[string]bool {
-	if sourceFile.Text() == "" || len(comments) == 0 {
-		return nil
+// Only real block-comment ranges supplied by the TypeScript scanner are read,
+// so lookalike text in strings, templates, regexes, or line comments is ignored.
+// Within a comment, duplicate names use the last setting and retain the first
+// name range. Across comments, the last setting wins and every comment range is
+// preserved. As in the existing globals API, only "off" un-declares a name.
+func ParseInlineGlobals(sourceFile *ast.SourceFile, comments []*ast.CommentRange) (map[string]bool, []InlineGlobal) {
+	if sourceFile == nil || sourceFile.Text() == "" || len(comments) == 0 {
+		return nil, nil
 	}
 
 	text := sourceFile.Text()
-	var globals map[string]bool
+	var values map[string]bool
+	var globals []InlineGlobal
+	var globalIndexes map[string]int
 
 	for _, comment := range comments {
-		// `/* global */` is only recognized as a block comment, matching
-		// ESLint's convention (and rslint's prior behavior).
-		if comment.Kind != ast.KindMultiLineCommentTrivia {
-			continue
-		}
-		content := strings.TrimSpace(text[comment.Pos()+2 : comment.End()-2])
-
-		rest, ok := matchInlineGlobalsDirective(content)
-		if !ok {
+		entries := parseInlineGlobalComment(text, comment)
+		if len(entries) == 0 {
 			continue
 		}
 
-		if globals == nil {
-			globals = make(map[string]bool)
+		// ESLint's parseStringConfig returns an object, so a repeated name in
+		// one comment has one comment entry: its last setting and first range.
+		commentEntries := make([]inlineGlobalName, 0, len(entries))
+		commentIndexes := make(map[string]int, len(entries))
+		for _, entry := range entries {
+			if index, exists := commentIndexes[entry.name]; exists {
+				commentEntries[index].setting = entry.setting
+				continue
+			}
+			commentIndexes[entry.name] = len(commentEntries)
+			commentEntries = append(commentEntries, entry)
 		}
-		for name, setting := range parseGlobalNameList(rest) {
-			globals[name] = setting != "off"
+
+		if values == nil {
+			values = make(map[string]bool)
+			globalIndexes = make(map[string]int)
+		}
+		for _, entry := range commentEntries {
+			declared := entry.setting != "off"
+			values[entry.name] = declared
+
+			if index, exists := globalIndexes[entry.name]; exists {
+				globals[index].Declared = declared
+				globals[index].NameRanges = append(globals[index].NameRanges, entry.nameRange)
+				continue
+			}
+			globalIndexes[entry.name] = len(globals)
+			globals = append(globals, InlineGlobal{
+				Name:       entry.name,
+				Declared:   declared,
+				NameRanges: []core.TextRange{entry.nameRange},
+			})
 		}
 	}
 
-	return globals
+	return values, globals
 }
 
-// matchInlineGlobalsDirective reports whether comment content begins with
-// the "global"/"globals" directive keyword (followed by whitespace or
-// end-of-string, so e.g. "globalConfig setup" is not mistaken for one) and
-// returns the remainder to parse as a name list.
+func parseInlineGlobalComment(text string, comment *ast.CommentRange) []inlineGlobalName {
+	if comment == nil || comment.Kind != ast.KindMultiLineCommentTrivia {
+		return nil
+	}
+
+	start, end := comment.Pos(), comment.End()
+	if start < 0 || end > len(text) || end-start < len("/*") || text[start:start+2] != "/*" {
+		return nil
+	}
+
+	contentStart, contentEnd := start+2, end
+	if contentEnd-contentStart >= 2 && text[contentEnd-2:contentEnd] == "*/" {
+		contentEnd -= 2
+	}
+	contentStart, contentEnd = trimECMAScriptWhitespaceRange(text, contentStart, contentEnd)
+	if contentStart == contentEnd {
+		return nil
+	}
+
+	restStart, ok := matchInlineGlobalsDirectiveRange(text, contentStart, contentEnd)
+	if !ok {
+		return nil
+	}
+	if justificationStart := findDirectiveJustification(text, restStart, contentEnd); justificationStart >= 0 {
+		contentEnd = justificationStart
+	}
+	restStart, contentEnd = trimECMAScriptWhitespaceRange(text, restStart, contentEnd)
+	return parseGlobalNameListEntries(text, restStart, contentEnd)
+}
+
+// matchInlineGlobalsDirective reports whether comment content begins with the
+// exact lower-case "global"/"globals" directive label followed by ECMAScript
+// whitespace or end-of-string.
 func matchInlineGlobalsDirective(content string) (string, bool) {
-	for _, kw := range inlineGlobalsKeywords {
-		if !strings.HasPrefix(content, kw) {
+	start, end := trimECMAScriptWhitespaceRange(content, 0, len(content))
+	restStart, ok := matchInlineGlobalsDirectiveRange(content, start, end)
+	if !ok {
+		return "", false
+	}
+	restStart, end = trimECMAScriptWhitespaceRange(content, restStart, end)
+	return content[restStart:end], true
+}
+
+func matchInlineGlobalsDirectiveRange(text string, start int, end int) (int, bool) {
+	for _, keyword := range inlineGlobalsKeywords {
+		if !strings.HasPrefix(text[start:end], keyword) {
 			continue
 		}
-		rest := content[len(kw):]
-		if rest == "" || rest[0] == ' ' || rest[0] == '\t' || rest[0] == '\n' || rest[0] == '\r' {
-			return strings.TrimSpace(rest), true
+		restStart := start + len(keyword)
+		if restStart == end {
+			return restStart, true
+		}
+		r, _ := utf8.DecodeRuneInString(text[restStart:end])
+		if isECMAScriptWhitespace(r) {
+			return restStart, true
 		}
 	}
-	return "", false
+	return 0, false
 }
 
 // MergeGlobals combines config-declared globals with inline `/* global */`
-// comment globals into the single set exposed to rules as ctx.Globals —
-// mirroring ESLint's addDeclaredGlobals, which layers inline comments on top
-// of config (inline wins on conflict). Returns nil if both are empty.
+// comment globals into the single set exposed to rules as ctx.Globals. Inline
+// settings win on conflict. Returns nil if both inputs are empty.
 func MergeGlobals(configGlobals, inlineGlobals map[string]bool) map[string]bool {
 	if len(configGlobals) == 0 {
 		return inlineGlobals
@@ -94,27 +175,164 @@ func MergeGlobals(configGlobals, inlineGlobals map[string]bool) map[string]bool 
 	return merged
 }
 
-// globalSettingSeparatorPattern collapses whitespace around a `:` or `,`
-// separator (e.g. "foo : writable ,  bar" -> "foo:writable,bar") before
-// splitting — mirrors ESLint's own parseStringConfig, which does the same
-// normalization so spaces around a separator don't get mistaken for part of
-// the name/setting.
-var globalSettingSeparatorPattern = regexp.MustCompile(`\s*([:,])\s*`)
-
-// parseGlobalNameList parses a comma-and/or-whitespace separated
-// "name[:setting]" list, e.g. "foo, bar:writable baz:off", returning each
-// name mapped to its raw setting ("" when none was given).
+// parseGlobalNameList parses ESLint's comma-and/or-whitespace separated
+// "name[:setting]" syntax. It is kept as a map helper for focused parser tests.
 func parseGlobalNameList(s string) map[string]string {
-	collapsed := globalSettingSeparatorPattern.ReplaceAllString(strings.TrimSpace(s), "$1")
-
 	names := make(map[string]string)
-	for _, part := range strings.FieldsFunc(collapsed, func(r rune) bool {
-		return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
-	}) {
-		name, setting, _ := strings.Cut(part, ":")
-		if name != "" {
-			names[name] = setting
-		}
+	for _, entry := range parseGlobalNameListEntries(s, 0, len(s)) {
+		names[entry.name] = entry.setting
 	}
 	return names
+}
+
+type globalConfigRune struct {
+	value rune
+	start int
+	end   int
+}
+
+func parseGlobalNameListEntries(text string, start int, end int) []inlineGlobalName {
+	runes := normalizeGlobalConfigRunes(text, start, end)
+	var entries []inlineGlobalName
+
+	for index := 0; index < len(runes); {
+		for index < len(runes) && (runes[index].value == ',' || isECMAScriptWhitespace(runes[index].value)) {
+			index++
+		}
+		if index == len(runes) {
+			break
+		}
+
+		tokenStart := index
+		for index < len(runes) && runes[index].value != ',' && !isECMAScriptWhitespace(runes[index].value) {
+			index++
+		}
+		tokenEnd := index
+
+		nameEnd := tokenEnd
+		for i := tokenStart; i < tokenEnd; i++ {
+			if runes[i].value == ':' {
+				nameEnd = i
+				break
+			}
+		}
+		if nameEnd == tokenStart {
+			continue
+		}
+
+		setting := ""
+		if nameEnd < tokenEnd {
+			settingStart, settingEnd := nameEnd+1, tokenEnd
+			for i := settingStart; i < tokenEnd; i++ {
+				if runes[i].value == ':' {
+					settingEnd = i
+					break
+				}
+			}
+			if settingStart < settingEnd {
+				setting = text[runes[settingStart].start:runes[settingEnd-1].end]
+			}
+		}
+
+		nameStartPos := runes[tokenStart].start
+		nameEndPos := runes[nameEnd-1].end
+		entries = append(entries, inlineGlobalName{
+			name:      text[nameStartPos:nameEndPos],
+			setting:   setting,
+			nameRange: core.NewTextRange(nameStartPos, nameEndPos),
+		})
+	}
+
+	return entries
+}
+
+// normalizeGlobalConfigRunes mirrors @eslint/plugin-kit's parseStringConfig:
+// whitespace immediately around ':' and ',' is removed before tokens are
+// split. Source positions stay attached so declaration ranges remain exact.
+func normalizeGlobalConfigRunes(text string, start int, end int) []globalConfigRune {
+	raw := make([]globalConfigRune, 0, end-start)
+	for index := start; index < end; {
+		r, size := utf8.DecodeRuneInString(text[index:end])
+		raw = append(raw, globalConfigRune{value: r, start: index, end: index + size})
+		index += size
+	}
+
+	normalized := make([]globalConfigRune, 0, len(raw))
+	for index := 0; index < len(raw); {
+		if !isECMAScriptWhitespace(raw[index].value) {
+			normalized = append(normalized, raw[index])
+			index++
+			continue
+		}
+
+		whitespaceEnd := index + 1
+		for whitespaceEnd < len(raw) && isECMAScriptWhitespace(raw[whitespaceEnd].value) {
+			whitespaceEnd++
+		}
+		previousIsDelimiter := len(normalized) > 0 && (normalized[len(normalized)-1].value == ':' || normalized[len(normalized)-1].value == ',')
+		nextIsDelimiter := whitespaceEnd < len(raw) && (raw[whitespaceEnd].value == ':' || raw[whitespaceEnd].value == ',')
+		if !previousIsDelimiter && !nextIsDelimiter {
+			normalized = append(normalized, raw[index:whitespaceEnd]...)
+		}
+		index = whitespaceEnd
+	}
+	return normalized
+}
+
+func findDirectiveJustification(text string, start int, end int) int {
+	for index := start; index < end; {
+		r, size := utf8.DecodeRuneInString(text[index:end])
+		if !isECMAScriptWhitespace(r) {
+			index += size
+			continue
+		}
+
+		hyphenStart := index + size
+		afterHyphens := hyphenStart
+		for afterHyphens < end && text[afterHyphens] == '-' {
+			afterHyphens++
+		}
+		if afterHyphens-hyphenStart >= 2 && afterHyphens < end {
+			next, _ := utf8.DecodeRuneInString(text[afterHyphens:end])
+			if isECMAScriptWhitespace(next) {
+				return index
+			}
+		}
+		index += size
+	}
+	return -1
+}
+
+func trimECMAScriptWhitespaceRange(text string, start int, end int) (int, int) {
+	for start < end {
+		r, size := utf8.DecodeRuneInString(text[start:end])
+		if !isECMAScriptWhitespace(r) {
+			break
+		}
+		start += size
+	}
+	for end > start {
+		r, size := utf8.DecodeLastRuneInString(text[start:end])
+		if !isECMAScriptWhitespace(r) {
+			break
+		}
+		end -= size
+	}
+	return start, end
+}
+
+// ECMAScript's \s set is Unicode Zs plus ASCII spacing/line terminators,
+// U+2028/U+2029, and BOM. unicode.IsSpace is not exact: it includes U+0085 and
+// excludes BOM. TypeScript's internal stringutil helper also accepts U+0085
+// and U+200B, so it cannot model ESLint's JavaScript regexp semantics here.
+func isECMAScriptWhitespace(r rune) bool {
+	if unicode.Is(unicode.Zs, r) {
+		return true
+	}
+	switch r {
+	case '\t', '\v', '\f', '\n', '\r', '\u2028', '\u2029', '\uFEFF':
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/rule/inline_globals_test.go
+++ b/internal/rule/inline_globals_test.go
@@ -2,47 +2,206 @@ package rule
 
 import (
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// ---------------------------------------------------------------------------
-// matchInlineGlobalsDirective
-// ---------------------------------------------------------------------------
+func parseInlineGlobalsForTest(t *testing.T, source string) (map[string]bool, []InlineGlobal) {
+	t.Helper()
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, source, core.ScriptKindTS)
+
+	var comments []*ast.CommentRange
+	utils.ForEachComment(sourceFile.AsNode(), func(comment *ast.CommentRange) {
+		comments = append(comments, comment)
+	}, sourceFile)
+	return ParseInlineGlobals(sourceFile, comments)
+}
+
+func assertInlineGlobals(t *testing.T, source string, got []InlineGlobal, want []struct {
+	name      string
+	declared  bool
+	positions []int
+}) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d inline globals, want %d: %#v", len(got), len(want), got)
+	}
+	for i, expected := range want {
+		actual := got[i]
+		if actual.Name != expected.name || actual.Declared != expected.declared {
+			t.Fatalf("inline global %d = (%q, %v), want (%q, %v)", i, actual.Name, actual.Declared, expected.name, expected.declared)
+		}
+		if len(actual.NameRanges) != len(expected.positions) {
+			t.Fatalf("inline global %q has %d ranges, want %d", actual.Name, len(actual.NameRanges), len(expected.positions))
+		}
+		for rangeIndex, textRange := range actual.NameRanges {
+			if textRange.Pos() != expected.positions[rangeIndex] || textRange.End() != expected.positions[rangeIndex]+len(expected.name) {
+				t.Errorf("inline global %q range %d = %d:%d, want %d:%d", actual.Name, rangeIndex, textRange.Pos(), textRange.End(), expected.positions[rangeIndex], expected.positions[rangeIndex]+len(expected.name))
+			}
+			if rangeText := source[textRange.Pos():textRange.End()]; rangeText != expected.name {
+				t.Errorf("inline global %q range %d contains %q", actual.Name, rangeIndex, rangeText)
+			}
+		}
+	}
+}
+
+func TestParseInlineGlobals_MetadataAndSourceFiltering(t *testing.T) {
+	source := "const fake = '/*global stringName*/';\n" +
+		"// global lineName\n" +
+		"/* Global upperName */\n" +
+		"/* globalConfig prefixName */\n" +
+		"/*globals foo, Array:readonly, offName:off, foo:writable -- reason, ignored */\n" +
+		"/*global offName, foo:off */\n"
+
+	values, globals := parseInlineGlobalsForTest(t, source)
+	wantValues := map[string]bool{"foo": false, "Array": true, "offName": true}
+	if !reflect.DeepEqual(values, wantValues) {
+		t.Fatalf("values = %#v, want %#v", values, wantValues)
+	}
+
+	assertInlineGlobals(t, source, globals, []struct {
+		name      string
+		declared  bool
+		positions []int
+	}{
+		{name: "foo", declared: false, positions: []int{strings.Index(source, "foo, Array"), strings.LastIndex(source, "foo:off")}},
+		{name: "Array", declared: true, positions: []int{strings.Index(source, "Array:readonly")}},
+		{name: "offName", declared: true, positions: []int{strings.Index(source, "offName:off"), strings.LastIndex(source, "offName, foo")}},
+	})
+}
+
+func TestParseInlineGlobals_DuplicateAndOverrideSemantics(t *testing.T) {
+	source := "/*global a:off, a, b, b:off */\n" +
+		"/*global a:off, b */\n" +
+		"/*global a */"
+
+	values, globals := parseInlineGlobalsForTest(t, source)
+	wantValues := map[string]bool{"a": true, "b": true}
+	if !reflect.DeepEqual(values, wantValues) {
+		t.Fatalf("values = %#v, want %#v", values, wantValues)
+	}
+
+	firstA := strings.Index(source, "a:off")
+	secondA := strings.Index(source[firstA+1:], "a:off") + firstA + 1
+	lastA := strings.LastIndex(source, "a */")
+	assertInlineGlobals(t, source, globals, []struct {
+		name      string
+		declared  bool
+		positions []int
+	}{
+		{name: "a", declared: true, positions: []int{firstA, secondA, lastA}},
+		{name: "b", declared: true, positions: []int{strings.Index(source, "b, b:off"), strings.LastIndex(source, "b */")}},
+	})
+}
+
+func TestParseInlineGlobals_UnicodeWhitespaceAndNames(t *testing.T) {
+	zeroWidthSpace := string(rune(0x200B))
+	source := "/*global\u0085notADirective*/\n" +
+		"/*global" + zeroWidthSpace + "alsoNotADirective*/\n" +
+		"/*globals\u00A0π\u2003:\uFEFFwritable,\u2028𐐀\u2029名:off */"
+
+	values, globals := parseInlineGlobalsForTest(t, source)
+	wantValues := map[string]bool{"π": true, "𐐀": true, "名": false}
+	if !reflect.DeepEqual(values, wantValues) {
+		t.Fatalf("values = %#v, want %#v", values, wantValues)
+	}
+	assertInlineGlobals(t, source, globals, []struct {
+		name      string
+		declared  bool
+		positions []int
+	}{
+		{name: "π", declared: true, positions: []int{strings.LastIndex(source, "π")}},
+		{name: "𐐀", declared: true, positions: []int{strings.LastIndex(source, "𐐀")}},
+		{name: "名", declared: false, positions: []int{strings.LastIndex(source, "名")}},
+	})
+}
+
+func TestParseInlineGlobals_CommentOnlyFileAfterShebang(t *testing.T) {
+	source := "#!/usr/bin/env node\n/*global onlyComment */"
+	values, globals := parseInlineGlobalsForTest(t, source)
+	if !reflect.DeepEqual(values, map[string]bool{"onlyComment": true}) {
+		t.Fatalf("values = %#v, want onlyComment declared", values)
+	}
+	assertInlineGlobals(t, source, globals, []struct {
+		name      string
+		declared  bool
+		positions []int
+	}{
+		{name: "onlyComment", declared: true, positions: []int{strings.Index(source, "onlyComment")}},
+	})
+}
+
+func TestParseInlineGlobals_TrailingMultilineComment(t *testing.T) {
+	source := "const value = 1; /*globals foo,\r\n    Array */\nfoo; Array;"
+	values, globals := parseInlineGlobalsForTest(t, source)
+	if !reflect.DeepEqual(values, map[string]bool{"foo": true, "Array": true}) {
+		t.Fatalf("values = %#v, want foo and Array declared", values)
+	}
+	assertInlineGlobals(t, source, globals, []struct {
+		name      string
+		declared  bool
+		positions []int
+	}{
+		{name: "foo", declared: true, positions: []int{strings.Index(source, "foo,")}},
+		{name: "Array", declared: true, positions: []int{strings.Index(source, "Array */")}},
+	})
+}
+
+func TestParseInlineGlobals_NoDirective(t *testing.T) {
+	for _, source := range []string{
+		"",
+		"const text = '/*global stringName*/';",
+		"// global lineName\nconst value = 1;",
+	} {
+		values, globals := parseInlineGlobalsForTest(t, source)
+		if values != nil || globals != nil {
+			t.Errorf("ParseInlineGlobals(%q) = (%#v, %#v), want nil results", source, values, globals)
+		}
+	}
+}
 
 func TestMatchInlineGlobalsDirective(t *testing.T) {
+	zeroWidthSpace := string(rune(0x200B))
 	tests := []struct {
 		name         string
 		input        string
 		expectedRest string
-		expectedOk   bool
+		expectedOK   bool
 	}{
-		{"global with names", "global foo, bar", "foo, bar", true},
-		{"globals with names", "globals foo, bar", "foo, bar", true},
-		{"bare global", "global", "", true},
-		{"bare globals", "globals", "", true},
-		{"global with tab", "global\tfoo", "foo", true},
-		{"global with newline", "global\nfoo", "foo", true},
-		{"not a directive", "eslint-disable no-console", "", false},
-		{"lookalike prefix is not a directive", "globalConfig setup here", "", false},
-		{"globalsConfig lookalike is not a directive", "globalsConfig setup here", "", false},
+		{name: "global with names", input: "global foo, bar", expectedRest: "foo, bar", expectedOK: true},
+		{name: "globals with names", input: "globals foo, bar", expectedRest: "foo, bar", expectedOK: true},
+		{name: "bare global", input: "global", expectedOK: true},
+		{name: "tab separator", input: "global\tfoo", expectedRest: "foo", expectedOK: true},
+		{name: "unicode separator", input: "global\u00A0foo", expectedRest: "foo", expectedOK: true},
+		{name: "BOM separator", input: "global\uFEFFfoo", expectedRest: "foo", expectedOK: true},
+		{name: "not a directive", input: "eslint-disable no-console"},
+		{name: "lookalike prefix", input: "globalConfig setup"},
+		{name: "comma after label", input: "global,foo"},
+		{name: "upper-case label", input: "Global foo"},
+		{name: "next-line is not ECMAScript whitespace", input: "global\u0085foo"},
+		{name: "zero-width space is not ECMAScript whitespace", input: "global" + zeroWidthSpace + "foo"},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rest, ok := matchInlineGlobalsDirective(tt.input)
-			if ok != tt.expectedOk {
-				t.Fatalf("ok = %v, want %v", ok, tt.expectedOk)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rest, ok := matchInlineGlobalsDirective(test.input)
+			if ok != test.expectedOK {
+				t.Fatalf("ok = %v, want %v", ok, test.expectedOK)
 			}
-			if ok && rest != tt.expectedRest {
-				t.Errorf("rest = %q, want %q", rest, tt.expectedRest)
+			if ok && rest != test.expectedRest {
+				t.Errorf("rest = %q, want %q", rest, test.expectedRest)
 			}
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// parseGlobalNameList
-// ---------------------------------------------------------------------------
 
 func TestParseGlobalNameList(t *testing.T) {
 	tests := []struct {
@@ -50,21 +209,41 @@ func TestParseGlobalNameList(t *testing.T) {
 		input    string
 		expected map[string]string
 	}{
-		{"empty", "", map[string]string{}},
-		{"single bare name", "foo", map[string]string{"foo": ""}},
-		{"comma separated", "foo, bar", map[string]string{"foo": "", "bar": ""}},
-		{"whitespace separated", "foo bar", map[string]string{"foo": "", "bar": ""}},
-		{"with settings", "foo:readonly, bar:writable, baz:off", map[string]string{"foo": "readonly", "bar": "writable", "baz": "off"}},
-		{"mixed separators and settings", "foo:writable bar, baz:off", map[string]string{"foo": "writable", "bar": "", "baz": "off"}},
-		{"extra whitespace", "  foo : writable ,  bar  ", map[string]string{"foo": "writable", "bar": ""}},
+		{name: "empty", input: "", expected: map[string]string{}},
+		{name: "single bare name", input: "foo", expected: map[string]string{"foo": ""}},
+		{name: "comma separated", input: "foo, bar", expected: map[string]string{"foo": "", "bar": ""}},
+		{name: "whitespace separated", input: "foo bar", expected: map[string]string{"foo": "", "bar": ""}},
+		{name: "settings", input: "foo:readonly, bar:writable, baz:off", expected: map[string]string{"foo": "readonly", "bar": "writable", "baz": "off"}},
+		{name: "spaces around separators", input: "  foo : writable ,  bar  ", expected: map[string]string{"foo": "writable", "bar": ""}},
+		{name: "duplicate uses last setting", input: "foo:off foo:writable", expected: map[string]string{"foo": "writable"}},
+		{name: "only first value segment matters", input: "foo:off:ignored bar:readonly:ignored", expected: map[string]string{"foo": "off", "bar": "readonly"}},
+		{name: "unicode whitespace", input: "π\u2003:\uFEFFwritable\u2028名:off", expected: map[string]string{"π": "writable", "名": "off"}},
+		{name: "next-line remains part of name", input: "foo\u0085bar", expected: map[string]string{"foo\u0085bar": ""}},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := parseGlobalNameList(tt.input)
-			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("parseGlobalNameList(%q) = %v, want %v", tt.input, result, tt.expected)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := parseGlobalNameList(test.input)
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("parseGlobalNameList(%q) = %#v, want %#v", test.input, result, test.expected)
 			}
 		})
+	}
+}
+
+func TestMergeGlobals_InlineOverridesConfigWithoutMutatingInputs(t *testing.T) {
+	config := map[string]bool{"configOnly": true, "overridden": true}
+	inline := map[string]bool{"inlineOnly": true, "overridden": false}
+	want := map[string]bool{"configOnly": true, "inlineOnly": true, "overridden": false}
+
+	got := MergeGlobals(config, inline)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MergeGlobals() = %#v, want %#v", got, want)
+	}
+	if !config["overridden"] {
+		t.Fatal("MergeGlobals mutated config input")
+	}
+	if inline["overridden"] {
+		t.Fatal("MergeGlobals mutated inline input")
 	}
 }

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -213,12 +213,20 @@ func (d RuleDiagnostic) Fixes() []RuleFix {
 type RuleContext struct {
 	SourceFile *ast.SourceFile
 	Settings   map[string]interface{}
+	// ConfigGlobals contains only globals from the effective
+	// `languageOptions.globals` configuration, before inline comments are
+	// applied. A false value is an explicit "off" setting.
+	ConfigGlobals map[string]bool
+	// InlineGlobals contains `/* global */` declaration metadata in first-name
+	// source order. Rules can use its exact name ranges without scanning source
+	// text again. Treat the slice and its nested ranges as read-only.
+	InlineGlobals []InlineGlobal
 	// Globals is the fully resolved set of declared global names for this
 	// file — config `languageOptions.globals` merged with inline
 	// `/* global */` comments, computed once per file by the linter (see
 	// DisableManager, built the same way). Rules should read this instead of
-	// parsing comments or config themselves. Nil when none are declared;
-	// a name maps to false only if some source explicitly set it to "off".
+	// parsing comments or config themselves. Nil only when neither source
+	// mentions any globals; a name maps to false when its final setting is "off".
 	Globals                    map[string]bool
 	Program                    *compiler.Program
 	TypeChecker                *checker.Checker

--- a/internal/utils/for_each_comment_test.go
+++ b/internal/utils/for_each_comment_test.go
@@ -3,12 +3,14 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 )
@@ -83,6 +85,42 @@ func TestForEachComment_ReuseFactoryReportsAllCommentsPerToken(t *testing.T) {
 		if seen[text] != 1 {
 			t.Errorf("comment %q expected exactly once, got %d (factory reuse smeared/dropped?)", text, seen[text])
 		}
+	}
+}
+
+func TestForEachComment_CommentOnlySourceFile(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "mixed comments",
+			source: "/* first */\n// second",
+			want:   []string{"/* first */", "// second"},
+		},
+		{
+			name:   "comments after shebang",
+			source: "#!/usr/bin/env node\n/* first */\n// second",
+			want:   []string{"/* first */", "// second"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/test.ts",
+				Path:     "/test.ts",
+			}, test.source, core.ScriptKindTS)
+
+			var got []string
+			ForEachComment(sourceFile.AsNode(), func(comment *ast.CommentRange) {
+				got = append(got, test.source[comment.Pos():comment.End()])
+			}, sourceFile)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("comments = %#v, want %#v", got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/utils/ts_api_utils.go
+++ b/internal/utils/ts_api_utils.go
@@ -367,6 +367,7 @@ func ForEachComment(node *ast.Node, callback func(comment *ast.CommentRange), so
 	// serially within this single ForEachComment call, so the parallel
 	// per-file lint workers each get their own, never sharing one.
 	commentFactory := &ast.NodeFactory{}
+	sawToken := false
 
 	ForEachToken(
 		node,
@@ -374,6 +375,7 @@ func ForEachComment(node *ast.Node, callback func(comment *ast.CommentRange), so
 			if token.Pos() == token.End() {
 				return
 			}
+			sawToken = true
 
 			if token.Kind != ast.KindJsxText {
 				pos := token.Pos()
@@ -395,6 +397,17 @@ func ForEachComment(node *ast.Node, callback func(comment *ast.CommentRange), so
 		},
 		sourceFile,
 	)
+
+	// A source file containing only comments has no non-empty token to own its
+	// leading trivia. Ask the TypeScript scanner for that leading trivia once;
+	// restricting this fallback to the SourceFile keeps subtree calls scoped to
+	// their node. Files with syntax stay on the normal token-owned path above.
+	if !sawToken && node == &sourceFile.Node {
+		pos := len(scanner.GetShebang(fullText))
+		for comment := range scanner.GetLeadingCommentRanges(commentFactory, fullText, pos) {
+			callback(&comment)
+		}
+	}
 }
 
 // Port https://github.com/JoshuaKGoldberg/ts-api-utils/blob/491c0374725a5dd64632405efea101f20ed5451f/src/comments.ts#L84

--- a/packages/rslint-test-tools/tests/eslint/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint/rule-tester.ts
@@ -1,9 +1,12 @@
 import path from 'node:path';
 import { test, describe, expect } from '@rstest/core';
+import type { RslintConfigEntry } from '@rslint/core';
 import { lint, type LintResponse } from '@rslint/core/internal';
 import assert from 'node:assert';
 
 import { buildConfigForSettings } from '../src/util/load-test-config';
+
+type TestLanguageOptions = NonNullable<RslintConfigEntry['languageOptions']>;
 
 interface TsDiagnostic {
   line?: number;
@@ -58,6 +61,7 @@ export type ValidTestCase =
   | {
       code: string;
       options?: Record<string, unknown>;
+      languageOptions?: TestLanguageOptions;
       only?: boolean;
       skip?: boolean;
     };
@@ -66,6 +70,7 @@ export interface InvalidTestCase {
   code: string;
   errors: TsDiagnostic[];
   options?: Record<string, unknown>;
+  languageOptions?: TestLanguageOptions;
   only?: boolean;
   skip?: boolean;
 }
@@ -116,6 +121,10 @@ export class RuleTester {
             typeof validCase === 'string' ? validCase : validCase.code;
           const options =
             typeof validCase === 'object' ? validCase.options : undefined;
+          const languageOptions =
+            typeof validCase === 'object'
+              ? validCase.languageOptions
+              : undefined;
           const virtual_entry = path.resolve(cwd, 'src/virtual.ts');
 
           const { config: resolvedConfig, configDirectory } =
@@ -129,6 +138,7 @@ export class RuleTester {
             config: [
               ...resolvedConfig,
               {
+                ...(languageOptions ? { languageOptions } : {}),
                 rules: {
                   [ruleName]:
                     ruleArgs.length > 0 ? ['error', ...ruleArgs] : 'error',
@@ -152,7 +162,7 @@ export class RuleTester {
           if (item.skip) continue;
           if (hasOnly && !item.only) continue;
 
-          const { code, errors, options } = item;
+          const { code, errors, options, languageOptions } = item;
           const virtual_entry = path.resolve(cwd, 'src/virtual.ts');
 
           const { config: resolvedConfig, configDirectory } =
@@ -166,6 +176,7 @@ export class RuleTester {
             config: [
               ...resolvedConfig,
               {
+                ...(languageOptions ? { languageOptions } : {}),
                 rules: {
                   [ruleName]:
                     ruleArgs.length > 0 ? ['error', ...ruleArgs] : 'error',

--- a/packages/rslint-test-tools/tests/eslint/rules/no-undef.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-undef.test.ts
@@ -91,6 +91,14 @@ ruleTester.run('no-undef', {
     '/*global a, b*/ a = 1; b = 2;',
     '/*global myVar:writable*/ myVar = 1;',
 
+    // === languageOptions.globals ===
+    {
+      code: 'configuredReadonly; configuredFalse;',
+      languageOptions: {
+        globals: { configuredReadonly: 'readonly', configuredFalse: false },
+      },
+    },
+
     // === Namespace ===
     'namespace MyNS { export var x = 1; } MyNS.x;',
 


### PR DESCRIPTION
## Summary

- Expose config-only globals and ordered inline global declaration metadata on `RuleContext` while preserving the existing resolved `Globals` map.
- Align `/* global */` parsing with ESLint for duplicate names, final overrides, justifications, Unicode whitespace, exact name ranges, and comment-only files.
- Reuse the shared tsgo-backed comment traversal, extend it for comment-only source files, and add per-case `languageOptions` support to the JS rule tester.
- Document the global preprocessing flow in `architecture.md`.

## Related Links

- Follow-up to #1238
- Prerequisite for #1241

## Verification

- `go test -count=1 ./internal/rule`
- `go test -count=1 ./internal/utils`
- `go test -count=1 ./internal/linter`
- `go test -count=1 ./internal/rules/no_undef`
- `pnpm --dir packages/rslint run build`
- `pnpm --dir packages/rslint-test-tools exec rstest run tests/eslint/rules/no-undef.test.ts --pool.maxWorkers=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main --timeout=10m ./internal/linter ./internal/rule ./internal/utils`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).