### PR TITLE
fix(linter): reject malformed rule fix ranges

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -357,7 +357,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		output = make(map[string]string)
 		for filePath, fileDiags := range diagnosticsByFile {
 			originalContent := fileDiags[0].SourceFile.Text()
-			fixedContent, _, didFix := linter.ApplyRuleFixes(originalContent, fileDiags)
+			fixedContent, _, didFix := linter.ApplyRuleFixesWithReporter(originalContent, fileDiags, reportInvalidRuleFix)
 			if didFix {
 				output[tspath.ConvertToRelativePath(filePath, comparePathOptions)] = fixedContent
 			}

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -640,6 +640,18 @@ func groupDiagsByFile(diags []rule.RuleDiagnostic) map[string][]rule.RuleDiagnos
 	return m
 }
 
+func reportInvalidRuleFix(diagnostic rule.RuleDiagnostic, fix rule.RuleFix, reason linter.InvalidFixReason) {
+	fmt.Fprintf(
+		os.Stderr,
+		"rslint: ignoring invalid fix from rule %q in %s at [%d,%d): %s\n",
+		diagnostic.RuleName,
+		diagnostic.FilePath,
+		fix.Range.Pos(),
+		fix.Range.End(),
+		reason,
+	)
+}
+
 // applyFixPass applies auto-fixes for all files in diagnosticsByFile,
 // writes fixed content to disk, and returns the number of issues fixed.
 func applyFixPass(diagnosticsByFile map[string][]rule.RuleDiagnostic) int {
@@ -656,7 +668,7 @@ func applyFixPass(diagnosticsByFile map[string][]rule.RuleDiagnostic) int {
 		}
 
 		originalContent := diagnosticsWithFixes[0].SourceFile.Text()
-		fixedContent, unapplied, wasFixed := linter.ApplyRuleFixes(originalContent, diagnosticsWithFixes)
+		fixedContent, unapplied, wasFixed := linter.ApplyRuleFixesWithReporter(originalContent, diagnosticsWithFixes, reportInvalidRuleFix)
 
 		if wasFixed {
 			err := os.WriteFile(fileName, []byte(fixedContent), 0644)

--- a/internal/linter/source_code_fixer.go
+++ b/internal/linter/source_code_fixer.go
@@ -11,21 +11,50 @@ type LintMessage interface {
 	Fixes() []rule.RuleFix
 }
 
+// InvalidFixReason identifies malformed fix data that cannot be applied safely.
+type InvalidFixReason string
+
+const (
+	InvalidFixNegativeRange InvalidFixReason = "fix range contains a negative position"
+	InvalidFixInvertedRange InvalidFixReason = "fix range end precedes its start"
+	InvalidFixOutOfBounds   InvalidFixReason = "fix range exceeds the source length"
+	InvalidFixOverlap       InvalidFixReason = "fixes within one diagnostic overlap"
+)
+
+// InvalidFixReporter observes malformed fixes while the owning diagnostic is
+// left unapplied.
+type InvalidFixReporter[M LintMessage] func(diagnostic M, fix rule.RuleFix, reason InvalidFixReason)
+
 func ApplyRuleFixes[M LintMessage](code string, diagnostics []M) (string, []M, bool) {
+	return ApplyRuleFixesWithReporter(code, diagnostics, nil)
+}
+
+// ApplyRuleFixesWithReporter applies valid, non-conflicting fixes and reports
+// malformed fix data instead of allowing an invalid range to panic while
+// slicing source text. Invalid diagnostics are returned in unapplied.
+func ApplyRuleFixesWithReporter[M LintMessage](code string, diagnostics []M, reportInvalid InvalidFixReporter[M]) (string, []M, bool) {
 	unapplied := []M{}
 	withFixes := []M{}
 
 	fixed := false
 
 	for _, diagnostic := range diagnostics {
-		if len(diagnostic.Fixes()) > 0 {
-			slices.SortFunc(diagnostic.Fixes(), func(a rule.RuleFix, b rule.RuleFix) int {
+		fixes := diagnostic.Fixes()
+		if len(fixes) > 0 {
+			slices.SortFunc(fixes, func(a rule.RuleFix, b rule.RuleFix) int {
 				start := a.Range.Pos() - b.Range.Pos()
 				if start == 0 {
 					return a.Range.End() - b.Range.End()
 				}
 				return start
 			})
+			if invalidFix, reason, invalid := findInvalidFix(len(code), fixes); invalid {
+				if reportInvalid != nil {
+					reportInvalid(diagnostic, invalidFix, reason)
+				}
+				unapplied = append(unapplied, diagnostic)
+				continue
+			}
 			withFixes = append(withFixes, diagnostic)
 		} else {
 			unapplied = append(unapplied, diagnostic)
@@ -84,4 +113,23 @@ func ApplyRuleFixes[M LintMessage](code string, diagnostics []M) (string, []M, b
 	builder.WriteString(code[lastFixEnd:])
 
 	return builder.String(), unapplied, fixed
+}
+
+func findInvalidFix(codeLength int, fixes []rule.RuleFix) (rule.RuleFix, InvalidFixReason, bool) {
+	previousEnd := 0
+	for i, fix := range fixes {
+		start, end := fix.Range.Pos(), fix.Range.End()
+		switch {
+		case start < 0 || end < 0:
+			return fix, InvalidFixNegativeRange, true
+		case end < start:
+			return fix, InvalidFixInvertedRange, true
+		case end > codeLength:
+			return fix, InvalidFixOutOfBounds, true
+		case i > 0 && start < previousEnd:
+			return fix, InvalidFixOverlap, true
+		}
+		previousEnd = end
+	}
+	return rule.RuleFix{}, "", false
 }

--- a/internal/linter/source_code_fixer_test.go
+++ b/internal/linter/source_code_fixer_test.go
@@ -1,6 +1,7 @@
 package linter
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/core"
@@ -239,6 +240,49 @@ func TestApplyRuleFixes(t *testing.T) {
 			expectedFixedStatus: true,
 		},
 		{
+			name: "out-of-bounds fix is left unapplied",
+			code: "short",
+			diagnostics: []mockDiagnostic{
+				newMockDiagnostic(newReplaceFix(0, 10, "replacement")),
+			},
+			expectedCode:        "short",
+			expectedUnapplied:   1,
+			expectedFixedStatus: false,
+		},
+		{
+			name: "negative fix range is left unapplied",
+			code: "short",
+			diagnostics: []mockDiagnostic{
+				newMockDiagnostic(newReplaceFix(-1, 2, "replacement")),
+			},
+			expectedCode:        "short",
+			expectedUnapplied:   1,
+			expectedFixedStatus: false,
+		},
+		{
+			name: "inverted fix range is left unapplied",
+			code: "short",
+			diagnostics: []mockDiagnostic{
+				newMockDiagnostic(newReplaceFix(4, 2, "replacement")),
+			},
+			expectedCode:        "short",
+			expectedUnapplied:   1,
+			expectedFixedStatus: false,
+		},
+		{
+			name: "overlapping fixes in one diagnostic are left unapplied",
+			code: "abcdefghij",
+			diagnostics: []mockDiagnostic{
+				newMockDiagnostic(
+					newReplaceFix(0, 6, "first"),
+					newReplaceFix(4, 8, "second"),
+				),
+			},
+			expectedCode:        "abcdefghij",
+			expectedUnapplied:   1,
+			expectedFixedStatus: false,
+		},
+		{
 			name: "replacement followed by insertion at same end position - should skip insertion",
 			code: "ABCDEFGHIJ",
 			diagnostics: []mockDiagnostic{
@@ -253,8 +297,8 @@ func TestApplyRuleFixes(t *testing.T) {
 			name: "insertion followed by replacement starting at same position - should skip replacement",
 			code: "ABCDEFGHIJ",
 			diagnostics: []mockDiagnostic{
-				newMockDiagnostic(newInsertFix(0, "XXX")),      // Insert at 0
-				newMockDiagnostic(newReplaceFix(0, 3, "YYY")),  // Replace ABC with YYY
+				newMockDiagnostic(newInsertFix(0, "XXX")),     // Insert at 0
+				newMockDiagnostic(newReplaceFix(0, 3, "YYY")), // Replace ABC with YYY
 			},
 			expectedCode:        "XXXABCDEFGHIJ",
 			expectedUnapplied:   1,
@@ -278,6 +322,68 @@ func TestApplyRuleFixes(t *testing.T) {
 				t.Errorf("ApplyRuleFixes() fixed = %v, want %v", fixed, tt.expectedFixedStatus)
 			}
 		})
+	}
+}
+
+func TestApplyRuleFixesWithReporter(t *testing.T) {
+	code := "short"
+	diagnostics := []mockDiagnostic{
+		newMockDiagnostic(newReplaceFix(-1, 2, "negative")),
+		newMockDiagnostic(newReplaceFix(4, 2, "inverted")),
+		newMockDiagnostic(newReplaceFix(0, 10, "out-of-bounds")),
+		newMockDiagnostic(
+			newReplaceFix(0, 3, "first"),
+			newReplaceFix(2, 4, "overlap"),
+		),
+	}
+	var gotReasons []InvalidFixReason
+	result, unapplied, fixed := ApplyRuleFixesWithReporter(
+		code,
+		diagnostics,
+		func(_ mockDiagnostic, _ rule.RuleFix, reason InvalidFixReason) {
+			gotReasons = append(gotReasons, reason)
+		},
+	)
+	wantReasons := []InvalidFixReason{
+		InvalidFixNegativeRange,
+		InvalidFixInvertedRange,
+		InvalidFixOutOfBounds,
+		InvalidFixOverlap,
+	}
+
+	if result != code {
+		t.Fatalf("ApplyRuleFixesWithReporter() code = %q, want %q", result, code)
+	}
+	if len(unapplied) != len(diagnostics) {
+		t.Fatalf("unapplied count = %d, want %d", len(unapplied), len(diagnostics))
+	}
+	if fixed {
+		t.Fatal("fixed = true, want false")
+	}
+	if !slices.Equal(gotReasons, wantReasons) {
+		t.Fatalf("reported reasons = %v, want %v", gotReasons, wantReasons)
+	}
+}
+
+func TestApplyRuleFixesWithReporter_DoesNotReportNormalConflicts(t *testing.T) {
+	diagnostics := []mockDiagnostic{
+		newMockDiagnostic(newReplaceFix(0, 3, "first")),
+		newMockDiagnostic(newReplaceFix(2, 4, "second")),
+	}
+	reported := 0
+	result, unapplied, fixed := ApplyRuleFixesWithReporter(
+		"short",
+		diagnostics,
+		func(_ mockDiagnostic, _ rule.RuleFix, _ InvalidFixReason) {
+			reported++
+		},
+	)
+
+	if result != "firstrt" || len(unapplied) != 1 || !fixed {
+		t.Fatalf("result = %q, unapplied = %d, fixed = %v", result, len(unapplied), fixed)
+	}
+	if reported != 0 {
+		t.Fatalf("reported %d invalid fixes for a normal inter-diagnostic conflict", reported)
 	}
 }
 

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -627,7 +627,20 @@ func (s *Server) computeFixAllContent(ctx context.Context, uri lsproto.DocumentU
 			}
 		}
 
-		fixedContent, _, wasFixed := linter.ApplyRuleFixes(currentContent, ruleDiags)
+		fixedContent, _, wasFixed := linter.ApplyRuleFixesWithReporter(
+			currentContent,
+			ruleDiags,
+			func(diagnostic rule.RuleDiagnostic, fix rule.RuleFix, reason linter.InvalidFixReason) {
+				log.Printf(
+					"Ignoring invalid fix from rule %q for %s at [%d,%d): %s",
+					diagnostic.RuleName,
+					diagnostic.FilePath,
+					fix.Range.Pos(),
+					fix.Range.End(),
+					reason,
+				)
+			},
+		)
 		if !wasFixed {
 			break
 		}


### PR DESCRIPTION
## Summary

- validate every rule fix range before slicing source text
- leave an entire diagnostic unapplied when one of its fixes is malformed
- distinguish negative, inverted, out-of-bounds, and internally overlapping ranges
- preserve the existing `ApplyRuleFixes` API and add an opt-in reporter for production callers
- log rejected rule name, file, range, and reason in CLI, IPC API, and LSP paths

## Scope

This is defense-in-depth, not the root fix for the stale-`didSave` race. That product-state bug is handled independently in #1252. This PR ensures malformed native or third-party plugin fix data cannot crash any fixer caller and cannot degrade into an unobservable no-op.

Normal conflicts between separate diagnostics retain the existing behavior: one diagnostic is applied and the conflicting one remains unapplied without being reported as malformed.

## Validation

- `go test ./internal/linter -run TestApplyRuleFixes -count=1`
- `go test ./internal/lsp -run TestComputeFixAllContent -count=1`
- `go test ./cmd/rslint -run 'TestHandleLint_FixProducesInBandOutput|TestHandleLint_FixRangeIsUTF16' -count=1`
