### PR TITLE
fix: update require-number rule options signature

### DIFF
--- a/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument.go
+++ b/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument.go
@@ -56,7 +56,7 @@ func callParenthesesRange(sourceFile *ast.SourceFile, node *ast.Node) (core.Text
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/require-number-to-fixed-digits-argument.md
 var RequireNumberToFixedDigitsArgumentRule = rule.Rule{
 	Name: "unicorn/require-number-to-fixed-digits-argument",
-	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		zeroArguments := 0
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {


### PR DESCRIPTION
## Summary

- update `unicorn/require-number-to-fixed-digits-argument` to the `Rule.Run` `[]any` options API
- restore Go, WASM, and npm builds on current `main` without changing rule behavior

## Related Links

- Follow-up to #1250
- Required by the rule options migration in #1248

## Checklist

- [x] Tests updated (not required; signature-only compatibility fix).
- [x] Documentation updated (not required; no behavior or configuration change).