### PR TITLE
perf: reuse source snapshots across programs

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -180,7 +180,7 @@ The current parsing and linting pipeline is built on top of ts-go `Program` and 
 
 ### Detailed Pipeline Steps
 
-1. **Source Text Loading**: Files come from the real filesystem, an overlay VFS, or LSP document overlays.
+1. **Source Text Loading**: Files come from the real filesystem, an overlay VFS, or LSP document overlays. CLI runs and individual API requests keep a compiler-host source snapshot keyed by the exact normalized source path. The snapshot stores the first successful text read and its xxh3 hash for the current generation, allowing later Programs to skip both work items. CLI fix writes replace the entire source generation before rebuilding Programs; API snapshots end with the request. LSP does not use this one-shot layer because its `project.Session` already follows document versions and `didChange` updates.
 2. **Program Construction**: Plain CLI/API lint resolves its effective targets first and builds `Program` objects only for governing configs that own a selected target. Program-wide type-check modes build every project declared by the effective loaded config catalog. LSP reuses matching projects from ts-go `project.Session`; a declared custom tsconfig that project service has not loaded is built on demand against an isolated editor overlay.
 3. **Lexical + Syntax Parsing**: ts-go tokenizes and parses source files into TypeScript-native AST nodes.
 4. **Semantic Analysis**: When needed, the linter acquires a `TypeChecker` from the `Program`.
@@ -671,13 +671,16 @@ goroutines remain outside that guarantee.
 - **Parse Cache in LSP**: the LSP server passes a shared `project.ParseCache` into the session to avoid re-parsing from scratch on every change
 - **Debounced Re-linting**: `refreshCh` and `debounceCh` collapse bursts of file changes and session refreshes onto the main dispatch loop
 - **CLI/API Are Mostly Fresh Runs**: CLI and one-shot API requests generally rebuild `Program` state per run; there is no repository-local rule-result cache or persistent incremental lint cache in the main CLI path today. JavaScript API path canonicalization is also scoped to one `lintFiles()` call.
-- **Run-Scoped Parse Reuse**: CLI Program rebuilds within one invocation share a parse cache, primarily for multi-pass fixing. The cache is discarded with the run and is neither repository-persistent nor shared across lint requests.
+- **Run/Request-Scoped Source Snapshots**: CLI runs and individual API requests share immutable source text/hash snapshots across their Programs. Keys are the exact compiler-host source names, never real paths, so lexical, overlay, and symlink aliases remain distinct. Failed reads are not cached. The source layer in one cache binds to one filesystem view across its generations; compiler hosts using another view bypass this layer while retaining content-keyed AST reuse.
+- **Generation-Based Fix Invalidation**: after every CLI fix write attempt, the compiler host atomically installs an empty source generation before any Program rebuild. Swapping generations rather than clearing a live map prevents an older in-flight read from repopulating the new generation. The API fix path only returns output and does not mutate or rebuild its overlay, while LSP remains version/didChange-driven.
+- **Run-Scoped Parse Reuse**: CLI Program rebuilds within one invocation and Programs within one API request share the existing content-keyed AST parse cache. Source-generation invalidation does not clear AST entries, so unchanged bytes can reuse their `SourceFile`. The cache is discarded with its run/request and is never repository-persistent or shared across lint requests.
 - **Bounded Multi-Pass Fixing**: `--fix` and LSP `fixAll` intentionally rerun lint after applying edits, but cap the cascade at `maxFixPasses = 10`
 
 ### Memory Management
 
 - **ts-go Owns the Heavy Graphs**: AST nodes, checker state, `Program` graphs, and session state are primarily owned by ts-go; rslint adds listener maps, diagnostics, and config-derived rule lists on top
 - **Short-Lived Per-File Structures**: comment slices, disable managers, and registered listener maps are allocated per file and dropped after traversal; `clear(registeredListeners)` helps release references promptly
+- **Source Snapshot Ownership**: snapshot entries hold an immutable source string plus its 128-bit hash without explicitly copying source bytes; on an AST miss, that string is passed directly to the parser. After generation replacement, a retained unchanged AST may still hold the prior equal string while the fresh snapshot owns the new read. Replaced generations are reclaimed after any in-flight lookup releases them. AST retention and source-generation retention remain deliberately separate lifecycles.
 - **Fix Application Uses Linear Rebuilds**: `ApplyRuleFixes` sorts fixes, skips overlapping edits, and rebuilds the output with `strings.Builder` rather than mutating source buffers in place
 - **Bounded Queues**: CLI diagnostics use a buffered channel of 4096 items; LSP request/outgoing queues are buffered to 100, and debounce/refresh signals are single-slot channels
 - **No Repo-Local Pooling Layer Today**: there is no explicit `sync.Pool`-based object pooling strategy in the main lint path at the moment

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -498,6 +498,37 @@ func TestHandleLint_FilesPresenceControlsWhetherFileContentsAreTargets(t *testin
 	}
 }
 
+func TestHandleLint_SourceSnapshotsAreRequestScoped(t *testing.T) {
+	dir := t.TempDir()
+	virtualFile := filepath.Join(dir, "virtual.ts")
+	config := json.RawMessage(`[{"rules":{"no-debugger":"error"}}]`)
+	handler := &IPCHandler{}
+
+	request := func(content string) *api.LintResponse {
+		t.Helper()
+		response, err := handler.HandleLint(api.LintRequest{
+			Config:           config,
+			ConfigDirectory:  dir,
+			WorkingDirectory: dir,
+			Files:            []string{virtualFile},
+			FileContents:     map[string]string{virtualFile: content},
+		})
+		if err != nil {
+			t.Fatalf("HandleLint returned error: %v", err)
+		}
+		return response
+	}
+
+	withDebugger := request("debugger;\n")
+	if len(withDebugger.Diagnostics) != 1 || withDebugger.Diagnostics[0].RuleName != "no-debugger" {
+		t.Fatalf("first request did not lint its overlay content: %+v", withDebugger.Diagnostics)
+	}
+	clean := request("export const clean = true;\n")
+	if len(clean.Diagnostics) != 0 {
+		t.Fatalf("second request reused the first request's source snapshot: %+v", clean.Diagnostics)
+	}
+}
+
 func TestHandleLint_ExplicitFileEntryIgnoredIsCountedWithNoRules(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "ignored.js")

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -1542,6 +1542,11 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	if fix && len(allDiags) > 0 {
 		diagnosticsByFile := groupDiagsByFile(allDiags)
 		passFixed, fixErr := applyFixPass(diagnosticsByFile)
+		// Replace the entire source generation after every write attempt and
+		// before any Program rebuild. os.WriteFile may truncate or partially
+		// mutate a file even when it ultimately returns an error, and whole-
+		// generation invalidation also covers caller/source/symlink aliases.
+		parseCache.InvalidateSourceSnapshots()
 		if fixErr != nil {
 			fmt.Fprintf(os.Stderr, "error applying fixes: %v\n", fixErr)
 			return 1
@@ -1658,6 +1663,9 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			}
 
 			passFixed, fixErr := applyFixPass(groupDiagsByFile(passDiags))
+			// See the first fix pass above: invalidate before inspecting the
+			// result so a partially successful write can never feed a rebuild.
+			parseCache.InvalidateSourceSnapshots()
 			if fixErr != nil {
 				fmt.Fprintf(os.Stderr, "error applying fixes: %v\n", fixErr)
 				return 1

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -908,8 +908,10 @@ func TestBindLintTargetPlan_RecomputesProgramMembershipAfterImportGraphChange(t 
 		t.Fatalf("rewrite main.ts: %v", err)
 	}
 	// Production fix passes reuse the run-scoped filesystem and parse caches.
-	// ParseCache keys include the exact source text hash, so rewritten content
-	// must still produce a fresh AST and updated import graph.
+	// Replacing the source-snapshot generation before rebuilding makes the new
+	// text/hash visible while retaining content-keyed AST entries for unchanged
+	// files.
+	parseCache.InvalidateSourceSnapshots()
 	rebuilt, err := createProgramSetForConfig(dir, config, true, fsys, parseCache)
 	if err != nil {
 		t.Fatalf("rebuilt createProgramSetForConfig: %v", err)

--- a/internal/utils/parse_cache.go
+++ b/internal/utils/parse_cache.go
@@ -2,22 +2,26 @@ package utils
 
 import (
 	"os"
+	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/microsoft/typescript-go/shim/project"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/zeebo/xxh3"
 )
 
-// ParseCache is a run-scoped, append-mostly cache of parsed SourceFiles shared
-// across Programs. Multiple tsconfigs in one run re-parse the same lib /
-// node_modules / shared-source files once per Program today; entries here let
-// every Program whose parse inputs match reuse one *ast.SourceFile object.
+// ParseCache owns two run/request-scoped cache layers shared across Programs:
+// a source snapshot generation keyed by the compiler host's exact normalized
+// file name, and an append-mostly parsed SourceFile cache keyed by every parse
+// input. Multiple tsconfigs can therefore reuse both the source text/hash and
+// the resulting *ast.SourceFile object.
 //
-// The key reuses the upstream project.ParseCacheKey — SourceFileParseOptions
+// The AST key reuses the upstream project.ParseCacheKey — SourceFileParseOptions
 // (FileName + Path + ExternalModuleIndicatorOptions) + ScriptKind + an xxh3
 // hash of the file content. This is exactly the condition under which tsgo's
 // own LSP shares SourceFile objects across projects (see
@@ -26,29 +30,48 @@ import (
 //
 // Sharing is an optimization, never a correctness requirement: two Programs
 // holding two distinct objects for the same file is the no-cache baseline.
-// That is what makes RetainOnly's deletion-only eviction safe (see I7 below).
+// That is what makes RetainOnly's deletion-only eviction safe (see I8 below).
 //
 // Invariants (enforced here, relied on by callers):
 //
-//	I1: the content hash is computed from the exact text handed to the
-//	    parser, read once. This keeps the cache consistent with whatever
-//	    the FS layer returns — even if the file changes between calls or a
-//	    future vfs layer adds read caching, an entry's hash always matches
-//	    its AST, so staleness can never exceed the no-cache baseline.
-//	I2: file.Hash is never written. The --api EncodeAST header encodes
+//	I1: within one source generation, the first successful read of an exact
+//	    FileName is authoritative. Lexical/canonical/symlink/case aliases are
+//	    never merged. Failed reads are not stored.
+//	I2: a source snapshot publishes immutable text and its xxh3 hash as one
+//	    value. The exact same text/hash pair is used to key and build the AST.
+//	I3: file.Hash is never written. The --api EncodeAST header encodes
 //	    sourceFile.Hash (bytes 4-19) and is all-zero today; writing it
 //	    would change encoded output bytes.
-//	I3: concurrent misses on one key resolve via LoadOrStore — the winner's
-//	    object is returned to every caller, losers are discarded. Today
-//	    program construction is serial and per-Program parsing dedups by
-//	    path, so same-key concurrency cannot happen; this is defense for a
-//	    future parallelization.
-//	I4: failed reads return nil and are not cached (no negative entries).
-//	I7: eviction is deletion-only (RetainOnly). A deleted entry is simply
+//	I4: concurrent source and AST misses resolve via LoadOrStore. Every loser
+//	    uses the published winner; duplicate cold reads/parses may occur, but
+//	    callers within a generation observe one winning snapshot/AST per key.
+//	I5: the source layer owned by one cache binds to one exact pointer-identity
+//	    FS across its generations. Hosts backed by another or a non-pointer FS
+//	    bypass only the source layer and still use the content-keyed AST cache.
+//	I6: ScriptKind is derived exactly like the default compiler host.
+//	I7: source invalidation atomically swaps in a fresh generation. It never
+//	    clears a live map, so a pre-invalidation miss can only publish into its
+//	    captured old generation. Invalidation is not a reader barrier.
+//	I8: AST eviction is deletion-only (RetainOnly). A deleted entry is simply
 //	    re-parsed on next request; selective rewriting of entries is
 //	    forbidden — deletion can cost a parse, never a stale result.
+//	I9: cache ownership is explicit and bounded to one CLI run or API request;
+//	    no package-level singleton may extend source/AST lifetime implicitly.
 type ParseCache struct {
 	m sync.Map // project.ParseCacheKey -> *ast.SourceFile
+
+	sourceGeneration atomic.Pointer[sourceSnapshotGeneration]
+	sourceFSMu       sync.Mutex
+	sourceFS         vfs.FS
+}
+
+type sourceSnapshotGeneration struct {
+	entries sync.Map // exact opts.FileName -> sourceSnapshot
+}
+
+type sourceSnapshot struct {
+	text string
+	hash xxh3.Uint128
 }
 
 // NewParseCache returns a fresh cache, or nil (disabling caching entirely via
@@ -59,23 +82,35 @@ func NewParseCache() *ParseCache {
 	if os.Getenv("RSLINT_DISABLE_PARSE_CACHE") != "" {
 		return nil
 	}
-	return &ParseCache{}
+	cache := &ParseCache{}
+	cache.sourceGeneration.Store(&sourceSnapshotGeneration{})
+	return cache
 }
 
 // acquire returns the shared SourceFile for (opts, text), parsing on miss.
 func (c *ParseCache) acquire(opts ast.SourceFileParseOptions, text string) *ast.SourceFile {
+	return c.acquireSnapshot(opts, sourceSnapshot{
+		text: text,
+		hash: xxh3.HashString128(text),
+	})
+}
+
+// acquireSnapshot returns the shared SourceFile for (opts, snapshot), parsing
+// on miss. snapshot.hash must be the hash of snapshot.text; keeping them in one
+// immutable value prevents callers from accidentally tearing the pair.
+func (c *ParseCache) acquireSnapshot(opts ast.SourceFileParseOptions, snapshot sourceSnapshot) *ast.SourceFile {
 	// I6: derive ScriptKind exactly like the default host
 	// (typescript-go/internal/compiler/host.go) so the key always matches
 	// what the parse below actually uses.
 	scriptKind := core.GetScriptKindFromFileName(opts.FileName)
-	key := project.NewParseCacheKey(opts, xxh3.HashString128(text), scriptKind)
+	key := project.NewParseCacheKey(opts, snapshot.hash, scriptKind)
 	if v, ok := c.m.Load(key); ok {
 		if cached, ok := v.(*ast.SourceFile); ok {
 			return cached
 		}
 	}
-	sf := parser.ParseSourceFile(opts, text, scriptKind) // I1/I2: same text, Hash left zero
-	actual, _ := c.m.LoadOrStore(key, sf)                // I3: winner is the only object handed out
+	sf := parser.ParseSourceFile(opts, snapshot.text, scriptKind) // I2/I3: same text, Hash left zero
+	actual, _ := c.m.LoadOrStore(key, sf)                         // I4: winner is the only object handed out
 	if winner, ok := actual.(*ast.SourceFile); ok {
 		return winner
 	}
@@ -87,8 +122,9 @@ func (c *ParseCache) acquire(opts ast.SourceFileParseOptions, text string) *ast.
 // including gap-fallback programs). One sweep reclaims both --fix
 // intermediate versions (old-hash objects absent from rebuilt programs) and
 // build-time dedup losers (parsed but never included in a program).
-// Deletion-only per I7: an evicted entry that is requested again is re-parsed
-// into a fresh object, which is the no-cache baseline behavior.
+// Deletion-only per I8: an evicted entry that is requested again is re-parsed
+// into a fresh object, which is the no-cache baseline behavior. Source
+// snapshots have a separate generation lifetime and are not pruned here.
 func (c *ParseCache) RetainOnly(programs []*compiler.Program) {
 	if c == nil {
 		return
@@ -110,17 +146,60 @@ func (c *ParseCache) RetainOnly(programs []*compiler.Program) {
 	})
 }
 
+// InvalidateSourceSnapshots atomically installs an empty source generation.
+// Lookups that already captured the previous generation may finish against it;
+// subsequent lookups use the new generation. The AST cache is intentionally
+// retained because unchanged content can still reuse its parsed SourceFile.
+func (c *ParseCache) InvalidateSourceSnapshots() {
+	if c == nil {
+		return
+	}
+	c.sourceGeneration.Store(&sourceSnapshotGeneration{})
+}
+
+func (c *ParseCache) currentSourceGeneration() *sourceSnapshotGeneration {
+	for {
+		if generation := c.sourceGeneration.Load(); generation != nil {
+			return generation
+		}
+		generation := &sourceSnapshotGeneration{}
+		if c.sourceGeneration.CompareAndSwap(nil, generation) {
+			return generation
+		}
+	}
+}
+
+// bindSourceSnapshotFS binds the source layer owned by this cache to one exact
+// FS instance across all generations. Only pointer-backed implementations have
+// unambiguous instance identity; all other implementations conservatively
+// bypass the source layer. This check runs once per compiler-host wrapper,
+// never on the GetSourceFile hot path.
+func (c *ParseCache) bindSourceSnapshotFS(fs vfs.FS) bool {
+	c.sourceFSMu.Lock()
+	defer c.sourceFSMu.Unlock()
+
+	if fs == nil || reflect.TypeOf(fs).Kind() != reflect.Pointer {
+		return false
+	}
+	if c.sourceFS == nil {
+		c.sourceFS = fs
+		return true
+	}
+	return c.sourceFS == fs
+}
+
 // cachingCompilerHost overrides only GetSourceFile; the remaining
 // CompilerHost methods (FS, DefaultLibraryPath, GetCurrentDirectory, Trace,
 // GetResolvedProjectReference) are delegated through interface embedding.
 type cachingCompilerHost struct {
 	compiler.CompilerHost
-	cache *ParseCache
+	cache              *ParseCache
+	useSourceSnapshots bool
 }
 
 // WithParseCache wraps host with the shared parse cache. A nil cache returns
 // the host unchanged, so callers need no branches. The cache must be created
-// at the pipeline entry and passed down explicitly (I5) — never stored in a
+// at the pipeline entry and passed down explicitly (I9) — never stored in a
 // package-level singleton, which would silently leak sharing into unrelated
 // paths (rule_tester, --api getAstInfo) and grow without bound in
 // long-running processes.
@@ -128,13 +207,41 @@ func WithParseCache(host compiler.CompilerHost, cache *ParseCache) compiler.Comp
 	if cache == nil {
 		return host
 	}
-	return &cachingCompilerHost{CompilerHost: host, cache: cache}
+	return &cachingCompilerHost{
+		CompilerHost:       host,
+		cache:              cache,
+		useSourceSnapshots: cache.bindSourceSnapshotFS(host.FS()),
+	}
 }
 
 func (h *cachingCompilerHost) GetSourceFile(opts ast.SourceFileParseOptions) *ast.SourceFile {
-	text, ok := h.FS().ReadFile(opts.FileName) // I1: single read; hash and parse share this text
+	if h.useSourceSnapshots {
+		generation := h.cache.currentSourceGeneration() // I7: capture exactly one generation
+		if value, ok := generation.entries.Load(opts.FileName); ok {
+			if snapshot, ok := value.(sourceSnapshot); ok {
+				return h.cache.acquireSnapshot(opts, snapshot)
+			}
+		}
+
+		text, ok := h.FS().ReadFile(opts.FileName)
+		if !ok {
+			return nil // I1: failed reads are never published
+		}
+		candidate := sourceSnapshot{
+			text: text,
+			hash: xxh3.HashString128(text),
+		}
+		actual, _ := generation.entries.LoadOrStore(opts.FileName, candidate)
+		snapshot, ok := actual.(sourceSnapshot)
+		if !ok {
+			snapshot = candidate // unreachable: entries only ever stores sourceSnapshot values
+		}
+		return h.cache.acquireSnapshot(opts, snapshot) // I4: always use the winner
+	}
+
+	text, ok := h.FS().ReadFile(opts.FileName)
 	if !ok {
-		return nil // I4: same as the default host, and never cached
+		return nil // same as the default host, and never cached
 	}
 	return h.cache.acquire(opts, text)
 }

--- a/internal/utils/parse_cache_test.go
+++ b/internal/utils/parse_cache_test.go
@@ -810,7 +810,8 @@ func TestCachingHost_ReadFileFailureNotCached(t *testing.T) {
 	if sf == nil {
 		t.Fatal("file appeared but GetSourceFile still returns nil (negative caching?)")
 	}
-	if got := fs.readCount(target); got != 2 {
+	// Compiler hosts and vfs use TypeScript-normalized paths on every platform.
+	if got := fs.readCount(opts.FileName); got != 2 {
 		t.Fatalf("failed reads must be retried, reads = %d, want 2", got)
 	}
 }

--- a/internal/utils/parse_cache_test.go
+++ b/internal/utils/parse_cache_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -12,12 +13,150 @@ import (
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/zeebo/xxh3"
 
 	"github.com/web-infra-dev/rslint/internal/api"
 )
+
+type readCountingFS struct {
+	vfs.FS
+	mu    sync.Mutex
+	reads map[string]int
+}
+
+func newReadCountingFS(base vfs.FS) *readCountingFS {
+	return &readCountingFS{FS: base, reads: make(map[string]int)}
+}
+
+func (f *readCountingFS) ReadFile(path string) (string, bool) {
+	f.mu.Lock()
+	f.reads[path]++
+	f.mu.Unlock()
+	return f.FS.ReadFile(path)
+}
+
+func (f *readCountingFS) readCount(path string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reads[path]
+}
+
+type memoryReadFS struct {
+	vfs.FS
+	mu        sync.Mutex
+	contents  map[string]string
+	realPaths map[string]string
+	reads     map[string]int
+}
+
+func newMemoryReadFS(contents map[string]string) *memoryReadFS {
+	return &memoryReadFS{
+		FS:        bundled.WrapFS(osvfs.FS()),
+		contents:  contents,
+		realPaths: make(map[string]string),
+		reads:     make(map[string]int),
+	}
+}
+
+func (f *memoryReadFS) ReadFile(path string) (string, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reads[path]++
+	text, ok := f.contents[path]
+	return text, ok
+}
+
+func (f *memoryReadFS) Realpath(path string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if realpath := f.realPaths[path]; realpath != "" {
+		return realpath
+	}
+	return path
+}
+
+func (f *memoryReadFS) set(path string, text string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.contents[path] = text
+}
+
+func (f *memoryReadFS) readCount(path string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reads[path]
+}
+
+// valueReadFS deliberately has a non-pointer dynamic type. The source
+// snapshot layer must bypass it because value equality is not FS identity.
+type valueReadFS struct {
+	vfs.FS
+	source *memoryReadFS
+}
+
+func (f valueReadFS) ReadFile(path string) (string, bool) {
+	return f.source.ReadFile(path)
+}
+
+type divergentConcurrentFS struct {
+	vfs.FS
+	path       string
+	wantReads  int
+	mu         sync.Mutex
+	reads      int
+	allStarted chan struct{}
+	release    chan struct{}
+}
+
+func (f *divergentConcurrentFS) ReadFile(path string) (string, bool) {
+	if path != f.path {
+		return "", false
+	}
+	f.mu.Lock()
+	f.reads++
+	readNumber := f.reads
+	if f.reads == f.wantReads {
+		close(f.allStarted)
+	}
+	f.mu.Unlock()
+	<-f.release
+	return fmt.Sprintf("export const value = %d;\n", readNumber), true
+}
+
+type blockingGenerationFS struct {
+	vfs.FS
+	path    string
+	mu      sync.Mutex
+	text    string
+	reads   int
+	started chan struct{}
+	release chan struct{}
+}
+
+func (f *blockingGenerationFS) ReadFile(path string) (string, bool) {
+	if path != f.path {
+		return "", false
+	}
+	f.mu.Lock()
+	f.reads++
+	first := f.reads == 1
+	text := f.text
+	f.mu.Unlock()
+	if first {
+		close(f.started)
+		<-f.release
+	}
+	return text, true
+}
+
+func (f *blockingGenerationFS) setText(text string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.text = text
+}
 
 func testParseOpts(fileName string, emi ast.ExternalModuleIndicatorOptions) ast.SourceFileParseOptions {
 	return ast.SourceFileParseOptions{
@@ -29,7 +168,7 @@ func testParseOpts(fileName string, emi ast.ExternalModuleIndicatorOptions) ast.
 
 // assertParseEquivalent asserts two SourceFiles are equivalent parses of the
 // same text: full-tree byte comparison via the --api encoder (which also
-// pins I2 — the encoded header hash bytes stay zero) plus field-by-field
+// pins I3 — the encoded header hash bytes stay zero) plus field-by-field
 // parse diagnostics.
 func assertParseEquivalent(t *testing.T, a, b *ast.SourceFile) {
 	t.Helper()
@@ -86,7 +225,276 @@ func TestParseCache_DifferentEMIOptionsNotShared(t *testing.T) {
 	}
 }
 
-// I2: the cache never writes file.Hash — the --api EncodeAST header relies
+func TestCachingHost_SourceSnapshotSharedAcrossParseOptions(t *testing.T) {
+	fileName := "/virtual/options.ts"
+	fs := newMemoryReadFS(map[string]string{fileName: "const value = 1;\n"})
+	cache := &ParseCache{}
+	host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+
+	regular := host.GetSourceFile(testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{}))
+	forced := host.GetSourceFile(testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{Force: true}))
+	if regular == nil || forced == nil {
+		t.Fatal("both parse-option variants must produce a SourceFile")
+	}
+	if regular == forced {
+		t.Fatal("different parse options must retain distinct AST entries")
+	}
+	if got := fs.readCount(fileName); got != 1 {
+		t.Fatalf("source text must be shared across parse options, reads = %d, want 1", got)
+	}
+}
+
+func TestCachingHost_SourceSnapshotReadOnceAcrossPrograms(t *testing.T) {
+	tmpDir := t.TempDir()
+	fileName := tspath.NormalizePath(filepath.Join(tmpDir, "shared.ts"))
+	if err := os.WriteFile(fileName, []byte("export const shared = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := newReadCountingFS(bundled.WrapFS(cachedvfs.From(osvfs.FS())))
+	cache := &ParseCache{}
+	build := func() *compiler.Program {
+		t.Helper()
+		host := WithParseCache(CreateCompilerHost(tmpDir, fs), cache)
+		program, err := CreateProgramFromOptionsLenient(true, &core.CompilerOptions{
+			NoLib:     core.TSTrue,
+			NoResolve: core.TSTrue,
+		}, []string{fileName}, host)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return program
+	}
+
+	firstProgram := build()
+	secondProgram := build()
+	first := firstProgram.GetSourceFile(fileName)
+	second := secondProgram.GetSourceFile(fileName)
+	if first == nil || second == nil {
+		t.Fatal("shared source must be present in both Programs")
+	}
+	if first != second {
+		t.Fatal("same source and parse inputs must share the AST across Programs")
+	}
+	if got := fs.readCount(fileName); got != 1 {
+		t.Fatalf("same source must be read once per generation, reads = %d", got)
+	}
+
+	cache.InvalidateSourceSnapshots()
+	third := build().GetSourceFile(fileName)
+	if got := fs.readCount(fileName); got != 2 {
+		t.Fatalf("new generation must read source again, reads = %d", got)
+	}
+	if third != first {
+		t.Fatal("unchanged content after invalidation must reuse the content-keyed AST")
+	}
+}
+
+func TestCachingHost_ChangedContentRequiresInvalidation(t *testing.T) {
+	fileName := "/virtual/change.ts"
+	oldText := "export const value = 1;\n"
+	newText := "export const value = 2;\n"
+	fs := newMemoryReadFS(map[string]string{fileName: oldText})
+	cache := &ParseCache{}
+	host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+
+	oldSource := host.GetSourceFile(opts)
+	fs.set(fileName, newText)
+	frozenSource := host.GetSourceFile(opts)
+	if frozenSource != oldSource || frozenSource.Text() != oldText {
+		t.Fatal("a generation must retain its first successful source snapshot")
+	}
+	if got := fs.readCount(fileName); got != 1 {
+		t.Fatalf("generation hit must not re-read source, reads = %d", got)
+	}
+
+	cache.InvalidateSourceSnapshots()
+	newSource := host.GetSourceFile(opts)
+	if newSource == nil || newSource.Text() != newText {
+		t.Fatalf("new generation did not observe changed source: %v", newSource)
+	}
+	if newSource == oldSource {
+		t.Fatal("changed content must produce a new AST")
+	}
+	if got := fs.readCount(fileName); got != 2 {
+		t.Fatalf("new generation must perform one new read, reads = %d", got)
+	}
+	value, ok := cache.currentSourceGeneration().entries.Load(fileName)
+	if !ok {
+		t.Fatal("changed source snapshot was not published")
+	}
+	snapshot := value.(sourceSnapshot)
+	if snapshot.text != newText || snapshot.hash != xxh3.HashString128(newText) {
+		t.Fatalf("snapshot text/hash pair is inconsistent: %+v", snapshot)
+	}
+}
+
+func TestCachingHost_EmptySourceIsCached(t *testing.T) {
+	fileName := "/virtual/empty.ts"
+	fs := newMemoryReadFS(map[string]string{fileName: ""})
+	cache := &ParseCache{}
+	host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+
+	first := host.GetSourceFile(opts)
+	second := host.GetSourceFile(opts)
+	if first == nil || second != first || first.Text() != "" {
+		t.Fatal("an empty successful read must be cached as a valid source")
+	}
+	if got := fs.readCount(fileName); got != 1 {
+		t.Fatalf("empty source reads = %d, want 1", got)
+	}
+}
+
+func TestCachingHost_ExactAliasesAreNotMerged(t *testing.T) {
+	aliasPath := "/virtual/alias.ts"
+	canonicalPath := "/virtual/canonical.ts"
+	fs := newMemoryReadFS(map[string]string{
+		aliasPath:     "export const fromAlias = true;\n",
+		canonicalPath: "export const fromCanonical = true;\n",
+	})
+	fs.realPaths[aliasPath] = canonicalPath
+	fs.realPaths[canonicalPath] = canonicalPath
+	cache := &ParseCache{}
+	host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+
+	alias := host.GetSourceFile(testParseOpts(aliasPath, ast.ExternalModuleIndicatorOptions{}))
+	canonical := host.GetSourceFile(testParseOpts(canonicalPath, ast.ExternalModuleIndicatorOptions{}))
+	if alias == nil || canonical == nil {
+		t.Fatal("both aliases must produce a SourceFile")
+	}
+	if alias.Text() == canonical.Text() || alias == canonical {
+		t.Fatal("paths with the same realpath but distinct overlay text must not be merged")
+	}
+	if fs.readCount(aliasPath) != 1 || fs.readCount(canonicalPath) != 1 {
+		t.Fatalf("each exact alias must own one read, alias=%d canonical=%d", fs.readCount(aliasPath), fs.readCount(canonicalPath))
+	}
+}
+
+func TestCachingHost_OverlaySymlinkAliasesWithSharedPathAreNotMerged(t *testing.T) {
+	tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+	canonicalPath := tspath.NormalizePath(filepath.Join(tmpDir, "canonical.ts"))
+	aliasPath := tspath.NormalizePath(filepath.Join(tmpDir, "alias.ts"))
+	if err := os.WriteFile(canonicalPath, []byte("export const fromDisk = true;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(canonicalPath, aliasPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	fs := newReadCountingFS(NewOverlayVFS(
+		bundled.WrapFS(osvfs.FS()),
+		map[string]string{
+			canonicalPath: "export const fromCanonicalOverlay = true;\n",
+			aliasPath:     "export const fromAliasOverlay = true;\n",
+		},
+	))
+	if aliasRealpath, canonicalRealpath := fs.Realpath(aliasPath), fs.Realpath(canonicalPath); aliasRealpath != canonicalRealpath {
+		t.Fatalf("fixture aliases do not share a realpath: %q != %q", aliasRealpath, canonicalRealpath)
+	}
+
+	cache := &ParseCache{}
+	host := WithParseCache(CreateCompilerHost(tmpDir, fs), cache)
+	canonicalOpts := testParseOpts(canonicalPath, ast.ExternalModuleIndicatorOptions{})
+	aliasOpts := testParseOpts(aliasPath, ast.ExternalModuleIndicatorOptions{})
+	// Exercise the strongest alias collision: compiler identity has already
+	// canonicalized Path, while FileName still names the distinct overlays.
+	aliasOpts.Path = canonicalOpts.Path
+
+	canonical := host.GetSourceFile(canonicalOpts)
+	alias := host.GetSourceFile(aliasOpts)
+	if canonical == nil || alias == nil {
+		t.Fatal("both overlay aliases must produce a SourceFile")
+	}
+	if canonical == alias || canonical.Text() == alias.Text() {
+		t.Fatal("exact FileName overlays must remain distinct even when Path and realpath match")
+	}
+	if got := fs.readCount(canonicalPath); got != 1 {
+		t.Fatalf("canonical overlay reads = %d, want 1", got)
+	}
+	if got := fs.readCount(aliasPath); got != 1 {
+		t.Fatalf("alias overlay reads = %d, want 1", got)
+	}
+}
+
+func TestCachingHost_DifferentFilesystemViewsBypassSourceSnapshots(t *testing.T) {
+	fileName := "/virtual/view.ts"
+	fsA := newMemoryReadFS(map[string]string{fileName: "export const view = 'a';\n"})
+	fsB := newMemoryReadFS(map[string]string{fileName: "export const view = 'b';\n"})
+	cache := &ParseCache{}
+	hostA := WithParseCache(CreateCompilerHost("/virtual", fsA), cache)
+	hostB := WithParseCache(CreateCompilerHost("/virtual", fsB), cache)
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+
+	a1, a2 := hostA.GetSourceFile(opts), hostA.GetSourceFile(opts)
+	b1, b2 := hostB.GetSourceFile(opts), hostB.GetSourceFile(opts)
+	if a1 == nil || b1 == nil || a1.Text() == b1.Text() {
+		t.Fatal("different FS views of one path must retain their own content")
+	}
+	if a2 != a1 || b2 != b1 {
+		t.Fatal("both FS views must still reuse their content-keyed AST entries")
+	}
+	if got := fsA.readCount(fileName); got != 1 {
+		t.Fatalf("bound FS reads = %d, want 1", got)
+	}
+	if got := fsB.readCount(fileName); got != 2 {
+		t.Fatalf("different FS must bypass source snapshots, reads = %d, want 2", got)
+	}
+
+	valueBacking := newMemoryReadFS(map[string]string{fileName: "export const view = 'value';\n"})
+	valueFS := valueReadFS{FS: valueBacking.FS, source: valueBacking}
+	valueCache := &ParseCache{}
+	valueHost := WithParseCache(CreateCompilerHost("/virtual", valueFS), valueCache)
+	valueFirst, valueSecond := valueHost.GetSourceFile(opts), valueHost.GetSourceFile(opts)
+	if valueFirst == nil || valueSecond != valueFirst {
+		t.Fatal("non-pointer FS bypass must retain AST-cache correctness")
+	}
+	if got := valueBacking.readCount(fileName); got != 2 {
+		t.Fatalf("non-pointer FS must bypass source snapshots, reads = %d, want 2", got)
+	}
+}
+
+func TestParseCache_ConcurrentFilesystemBindingKeepsViewsIsolated(t *testing.T) {
+	fileName := "/virtual/concurrent-view.ts"
+	textA := "export const view = 'a';\n"
+	textB := "export const view = 'b';\n"
+	fsA := newMemoryReadFS(map[string]string{fileName: textA})
+	fsB := newMemoryReadFS(map[string]string{fileName: textB})
+	cache := &ParseCache{}
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+	start := make(chan struct{})
+	errs := make(chan error, 16)
+
+	var wg sync.WaitGroup
+	for i := range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			fs, want := vfs.FS(fsA), textA
+			if i%2 == 1 {
+				fs, want = fsB, textB
+			}
+			host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+			source := host.GetSourceFile(opts)
+			if source == nil || source.Text() != want {
+				errs <- fmt.Errorf("filesystem view %d returned %v, want %q", i%2, source, want)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// I3: the cache never writes file.Hash — the --api EncodeAST header relies
 // on it staying zero.
 func TestParseCache_HashStaysZero(t *testing.T) {
 	c := &ParseCache{}
@@ -233,11 +641,160 @@ func TestParseCache_ConcurrentAcquireAndRetainOnly(t *testing.T) {
 	assertParseEquivalent(t, ref, final)
 }
 
+func TestCachingHost_ConcurrentMissesUseOneWinningSnapshot(t *testing.T) {
+	const callers = 8
+	fileName := "/virtual/concurrent-winner.ts"
+	fs := &divergentConcurrentFS{
+		FS:         bundled.WrapFS(osvfs.FS()),
+		path:       fileName,
+		wantReads:  callers,
+		allStarted: make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	cache := &ParseCache{}
+	host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+
+	results := make([]*ast.SourceFile, callers)
+	var wg sync.WaitGroup
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = host.GetSourceFile(opts)
+		}()
+	}
+	<-fs.allStarted
+	close(fs.release)
+	wg.Wait()
+
+	winner := results[0]
+	if winner == nil {
+		t.Fatal("concurrent source lookup returned nil")
+	}
+	for i, result := range results[1:] {
+		if result != winner {
+			t.Fatalf("caller %d did not use the source/AST winner", i+1)
+		}
+	}
+	value, ok := cache.currentSourceGeneration().entries.Load(fileName)
+	if !ok {
+		t.Fatal("winning source snapshot was not stored")
+	}
+	snapshot := value.(sourceSnapshot)
+	if winner.Text() != snapshot.text || snapshot.hash != xxh3.HashString128(snapshot.text) {
+		t.Fatal("winner AST and immutable source text/hash pair diverged")
+	}
+}
+
+func TestCachingHost_LateOldGenerationMissCannotRepopulateNewGeneration(t *testing.T) {
+	fileName := "/virtual/generation.ts"
+	oldText := "export const generation = 'old';\n"
+	newText := "export const generation = 'new';\n"
+	fs := &blockingGenerationFS{
+		FS:      bundled.WrapFS(osvfs.FS()),
+		path:    fileName,
+		text:    oldText,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	cache := &ParseCache{}
+	host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+
+	oldResult := make(chan *ast.SourceFile, 1)
+	go func() {
+		oldResult <- host.GetSourceFile(opts)
+	}()
+	<-fs.started
+
+	fs.setText(newText)
+	cache.InvalidateSourceSnapshots()
+	newSource := host.GetSourceFile(opts)
+	if newSource == nil || newSource.Text() != newText {
+		t.Fatalf("new generation did not observe new content: %v", newSource)
+	}
+
+	close(fs.release)
+	oldSource := <-oldResult
+	if oldSource == nil || oldSource.Text() != oldText {
+		t.Fatalf("in-flight old generation did not finish with its captured text: %v", oldSource)
+	}
+	final := host.GetSourceFile(opts)
+	if final != newSource || final.Text() != newText {
+		t.Fatal("late old-generation store contaminated the current generation")
+	}
+}
+
+func TestCachingHost_RetainOnlyDoesNotClearSourceSnapshot(t *testing.T) {
+	fileName := "/virtual/retain-source.ts"
+	text := "export const retained = true;\n"
+	fs := newMemoryReadFS(map[string]string{fileName: text})
+	cache := &ParseCache{}
+	host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+
+	first := host.GetSourceFile(opts)
+	cache.RetainOnly(nil)
+	second := host.GetSourceFile(opts)
+	if first == second {
+		t.Fatal("RetainOnly(nil) must evict the AST entry")
+	}
+	if got := fs.readCount(fileName); got != 1 {
+		t.Fatalf("RetainOnly must not clear source snapshots, reads = %d", got)
+	}
+
+	cache.InvalidateSourceSnapshots()
+	third := host.GetSourceFile(opts)
+	if got := fs.readCount(fileName); got != 2 {
+		t.Fatalf("source invalidation must trigger a new read, reads = %d", got)
+	}
+	if third != second {
+		t.Fatal("source invalidation must retain the unchanged content-keyed AST")
+	}
+}
+
+func TestCachingHost_ConcurrentLookupAndInvalidation(t *testing.T) {
+	fileName := "/virtual/invalidate-race.ts"
+	text := "export const stable = true;\n"
+	fs := newMemoryReadFS(map[string]string{fileName: text})
+	cache := &ParseCache{}
+	host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range 200 {
+				source := host.GetSourceFile(opts)
+				if source == nil || source.Text() != text {
+					t.Errorf("lookup returned an invalid source: %v", source)
+					return
+				}
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 200 {
+			cache.InvalidateSourceSnapshots()
+		}
+	}()
+	close(start)
+	wg.Wait()
+}
+
 // T9: a failed read returns nil and is not cached; once the file appears the
 // host parses it normally.
 func TestCachingHost_ReadFileFailureNotCached(t *testing.T) {
 	tmpDir := t.TempDir()
-	fs := bundled.WrapFS(osvfs.FS()) // no cachedvfs: exists-cache would hide the file's later appearance
+	fs := newReadCountingFS(bundled.WrapFS(osvfs.FS())) // no cachedvfs: exists-cache would hide the file's later appearance
 	cache := &ParseCache{}
 	host := WithParseCache(CreateCompilerHost(tmpDir, fs), cache)
 
@@ -253,6 +810,103 @@ func TestCachingHost_ReadFileFailureNotCached(t *testing.T) {
 	if sf == nil {
 		t.Fatal("file appeared but GetSourceFile still returns nil (negative caching?)")
 	}
+	if got := fs.readCount(target); got != 2 {
+		t.Fatalf("failed reads must be retried, reads = %d, want 2", got)
+	}
+}
+
+func TestCachingHost_BypassReadFailureNotCached(t *testing.T) {
+	fileName := "/virtual/bypass-late.ts"
+	cache := &ParseCache{}
+	boundFS := newMemoryReadFS(map[string]string{
+		fileName: "export const bound = true;\n",
+	})
+	// Binding happens when the wrapper is created; no read is needed.
+	_ = WithParseCache(CreateCompilerHost("/virtual", boundFS), cache)
+
+	bypassFS := newMemoryReadFS(map[string]string{})
+	host := WithParseCache(CreateCompilerHost("/virtual", bypassFS), cache)
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+	if source := host.GetSourceFile(opts); source != nil {
+		t.Fatal("missing file on bypass FS must yield nil")
+	}
+	bypassFS.set(fileName, "export const appeared = true;\n")
+	source := host.GetSourceFile(opts)
+	if source == nil || source.Text() != "export const appeared = true;\n" {
+		t.Fatalf("bypass FS did not retry the failed read: %v", source)
+	}
+	if got := bypassFS.readCount(fileName); got != 2 {
+		t.Fatalf("failed bypass reads must be retried, reads = %d, want 2", got)
+	}
+}
+
+func TestCachingHost_InvalidSourceEntryFallsBackSafely(t *testing.T) {
+	fileName := "/virtual/invalid-entry.ts"
+	text := "export const valid = true;\n"
+	fs := newMemoryReadFS(map[string]string{fileName: text})
+	cache := &ParseCache{}
+	cache.currentSourceGeneration().entries.Store(fileName, "invalid internal value")
+	host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+
+	source := host.GetSourceFile(testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{}))
+	if source == nil || source.Text() != text {
+		t.Fatalf("invalid internal entry did not fall back to the fresh read: %v", source)
+	}
+	if got := fs.readCount(fileName); got != 1 {
+		t.Fatalf("fallback reads = %d, want 1", got)
+	}
+}
+
+func TestParseCache_NilInvalidationIsSafe(t *testing.T) {
+	var cache *ParseCache
+	cache.InvalidateSourceSnapshots()
+}
+
+func TestParseCache_NilRetainOnlyIsSafe(t *testing.T) {
+	var cache *ParseCache
+	cache.RetainOnly(nil)
+	new(ParseCache).RetainOnly([]*compiler.Program{nil})
+}
+
+func TestNewParseCache_EnabledInitializesSourceGeneration(t *testing.T) {
+	t.Setenv("RSLINT_DISABLE_PARSE_CACHE", "")
+	cache := NewParseCache()
+	if cache == nil {
+		t.Fatal("enabled parse cache must be constructed")
+	}
+	initial := cache.sourceGeneration.Load()
+	if initial == nil {
+		t.Fatal("constructor must eagerly publish a source generation")
+	}
+	cache.InvalidateSourceSnapshots()
+	if current := cache.sourceGeneration.Load(); current == nil || current == initial {
+		t.Fatal("invalidation must publish a distinct non-nil generation")
+	}
+}
+
+func TestNewParseCache_DisableEnvironmentBypassesBothLayers(t *testing.T) {
+	t.Setenv("RSLINT_DISABLE_PARSE_CACHE", "1")
+	cache := NewParseCache()
+	if cache != nil {
+		t.Fatal("RSLINT_DISABLE_PARSE_CACHE must return a nil cache")
+	}
+
+	fileName := "/virtual/disabled.ts"
+	fs := newMemoryReadFS(map[string]string{fileName: "export const disabled = true;\n"})
+	baseHost := CreateCompilerHost("/virtual", fs)
+	host := WithParseCache(baseHost, cache)
+	if host != baseHost {
+		t.Fatal("disabled cache must leave the compiler host unwrapped")
+	}
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+	first, second := host.GetSourceFile(opts), host.GetSourceFile(opts)
+	if first == nil || second == nil || first == second {
+		t.Fatal("disabled cache must perform independent source reads/parses")
+	}
+	if got := fs.readCount(fileName); got != 2 {
+		t.Fatalf("disabled cache reads = %d, want 2", got)
+	}
+	cache.InvalidateSourceSnapshots()
 }
 
 func TestWithParseCache_NilPassthrough(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a run/request-scoped source snapshot layer in front of the existing AST parse cache, reusing both source text and its xxh3 hash across TypeScript Programs.
- Keep exact compiler-host source names and filesystem views isolated, avoid negative caching, and atomically replace the source generation after every CLI fix write attempt.
- Keep API snapshots request-scoped and leave LSP on its existing document-versioned `project.Session` cache.
- Document the cache lifecycle and add focused coverage for aliases, overlays, filesystem views, concurrent misses/invalidation, failed reads, retention, API isolation, and fix rebuilds.

## Testing

- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./cmd/rslint ./internal/utils`
- `go test -race -count=1 ./internal/utils -run '^(TestParseCache_|TestCachingHost_|TestWithParseCache_|TestNewParseCache_)'`
- Focused `cmd/rslint` race tests for API request isolation, fix rebuilds, write failures, and CLI/API ignore conformance
- CLI multi-pass fix cascade test
- 53 real repositories: 53/53 same-main A/B aligned across plain and type-check output, with 0 hangs and no residual processes

The full rule suite is intentionally left to CI; local validation only ran tests related to the modified surfaces.

## Performance

12 serial, order-rotated rounds on real repositories, without specifying `--config` (wall-time medians):

| Repository | Mode | Installed 0.6.4 | Main | This PR | This PR vs main |
| --- | --- | ---: | ---: | ---: | ---: |
| rsbuild | plain | 2.137s | 1.989s | 1.906s | -4.63% |
| rsbuild | type-check | 2.761s | 2.427s | 2.135s | -12.13% |
| rspack | plain | 2.117s | 1.922s | 1.884s | -2.39% |
| rspack | type-check | 2.207s | 1.928s | 1.923s | -1.50% |

Main and this PR produced identical normalized diagnostic hashes in all four modes.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
