### PR TITLE
test(vscode): stabilize code-action-on-save startup

### DIFF
--- a/packages/vscode-extension/__tests__/runSuite.ts
+++ b/packages/vscode-extension/__tests__/runSuite.ts
@@ -4,6 +4,12 @@ import Mocha from 'mocha';
 import * as vscode from 'vscode';
 
 const extensionId = 'rstack.rslint';
+const typescriptExtensionId = 'vscode.typescript-language-features';
+const typescriptCodeActionCommands = [
+  '_typescript.applyCodeActionCommand',
+  '_typescript.didApplyRefactoring',
+  '_typescript.didOrganizeImports',
+] as const;
 
 export function run(
   testPath: string,
@@ -26,6 +32,7 @@ async function activateAndRun(
     // loading any tests so cold-start saves and code-action requests cannot run
     // while the language client and workspace configuration are still starting.
     await extension.activate();
+    await waitForTypeScriptCodeActionProviders();
 
     const files = fastGlob.sync('**/*.test.js', { cwd: testPath }).sort();
     if (files.length === 0) {
@@ -37,4 +44,90 @@ async function activateAndRun(
   } catch (error) {
     callback(error);
   }
+}
+
+/**
+ * VS Code's built-in TypeScript extension activates lazily. Its activation
+ * function returns before tsserver is ready, then four modules asynchronously
+ * register the TypeScript code-action providers. A provider registration while
+ * code actions on save are running cancels that save in VS Code 1.128.
+ *
+ * Wait for the observable registrations from the quick-fix, refactor,
+ * organize-imports, and fix-all modules. This is a readiness barrier only:
+ * the save assertions themselves remain single-shot.
+ */
+async function waitForTypeScriptCodeActionProviders(): Promise<void> {
+  const typescriptExtension = vscode.extensions.getExtension(
+    typescriptExtensionId,
+  );
+  if (!typescriptExtension) {
+    throw new Error(`Extension ${typescriptExtensionId} is unavailable`);
+  }
+
+  const [typescriptFile] = await vscode.workspace.findFiles(
+    '**/*.ts',
+    '**/{node_modules,.git}/**',
+    1,
+  );
+  if (!typescriptFile) {
+    return;
+  }
+
+  const document = await vscode.workspace.openTextDocument(typescriptFile);
+  await typescriptExtension.activate();
+
+  const timeoutMs = 60_000;
+  const deadline = Date.now() + timeoutMs;
+  let lastProbeError: unknown;
+
+  while (Date.now() < deadline) {
+    // `filterInternal: false` is intentional: the three sentinels are
+    // internal commands whose registration happens in the constructors of
+    // the quick-fix, refactor, and organize-imports providers.
+    const commands = await vscode.commands.getCommands(false);
+    const commandsReady = typescriptCodeActionCommands.every((command) =>
+      commands.includes(command),
+    );
+
+    let fixAllReady = false;
+    if (commandsReady) {
+      try {
+        const actions = await vscode.commands.executeCommand<
+          vscode.CodeAction[]
+        >(
+          'vscode.executeCodeActionProvider',
+          document.uri,
+          new vscode.Range(0, 0, 0, 0),
+          'source.fixAll.ts',
+        );
+        fixAllReady =
+          actions?.some(
+            (action) => action.kind?.value === 'source.fixAll.ts',
+          ) ?? false;
+        lastProbeError = undefined;
+      } catch (error) {
+        // A provider registering during this non-mutating probe cancels it.
+        // Keep waiting for the complete provider set, but fail closed on
+        // timeout.
+        lastProbeError = error;
+      }
+    }
+
+    if (commandsReady && fixAllReady) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  const commands = await vscode.commands.getCommands(false);
+  const missingCommands = typescriptCodeActionCommands.filter(
+    (command) => !commands.includes(command),
+  );
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for TypeScript code-action providers` +
+      (missingCommands.length > 0
+        ? `; missing commands: ${missingCommands.join(', ')}`
+        : '') +
+      (lastProbeError ? `; last probe error: ${String(lastProbeError)}` : ''),
+  );
 }

--- a/packages/vscode-extension/__tests__/runSuite.ts
+++ b/packages/vscode-extension/__tests__/runSuite.ts
@@ -4,12 +4,14 @@ import Mocha from 'mocha';
 import * as vscode from 'vscode';
 
 const extensionId = 'rstack.rslint';
-const typescriptExtensionId = 'vscode.typescript-language-features';
-const typescriptCodeActionCommands = [
-  '_typescript.applyCodeActionCommand',
-  '_typescript.didApplyRefactoring',
-  '_typescript.didOrganizeImports',
-] as const;
+const typescriptCodeActionProbeSource = `interface RslintCodeActionProbe {
+  value: number;
+}
+class RslintCodeActionProbeImpl implements RslintCodeActionProbe {}
+function rslintCodeActionProbeFunction() {
+  return 1 + 2;
+}
+`;
 
 export function run(
   testPath: string,
@@ -52,59 +54,80 @@ async function activateAndRun(
  * register the TypeScript code-action providers. A provider registration while
  * code actions on save are running cancels that save in VS Code 1.128.
  *
- * Wait for the observable registrations from the quick-fix, refactor,
- * organize-imports, and fix-all modules. This is a readiness barrier only:
- * the save assertions themselves remain single-shot.
+ * Probe the public behavior of the quick-fix, refactor, organize-imports, and
+ * fix-all providers on a controlled untitled document. This is a readiness
+ * barrier only: the save assertions themselves remain single-shot.
  */
 async function waitForTypeScriptCodeActionProviders(): Promise<void> {
-  const typescriptExtension = vscode.extensions.getExtension(
-    typescriptExtensionId,
-  );
-  if (!typescriptExtension) {
-    throw new Error(`Extension ${typescriptExtensionId} is unavailable`);
+  const document = await vscode.workspace.openTextDocument({
+    content: typescriptCodeActionProbeSource,
+    language: 'typescript',
+  });
+
+  const quickFixRange = document.lineAt(3).range;
+  const refactorLine = document.lineAt(5);
+  const refactorExpression = '1 + 2';
+  const refactorStart = refactorLine.text.indexOf(refactorExpression);
+  if (refactorStart < 0) {
+    throw new Error('TypeScript code-action probe expression is unavailable');
   }
 
-  const [typescriptFile] = await vscode.workspace.findFiles(
-    '**/*.ts',
-    '**/{node_modules,.git}/**',
-    1,
-  );
-  if (!typescriptFile) {
-    return;
-  }
-
-  const document = await vscode.workspace.openTextDocument(typescriptFile);
-  await typescriptExtension.activate();
+  const emptyRange = new vscode.Range(0, 0, 0, 0);
+  const probes = new Map<
+    string,
+    {
+      kind: vscode.CodeActionKind;
+      range: vscode.Range | vscode.Selection;
+    }
+  >([
+    [
+      'quick fix',
+      { kind: vscode.CodeActionKind.QuickFix, range: quickFixRange },
+    ],
+    [
+      'refactor',
+      {
+        kind: vscode.CodeActionKind.Refactor,
+        range: new vscode.Selection(
+          refactorLine.lineNumber,
+          refactorStart,
+          refactorLine.lineNumber,
+          refactorStart + refactorExpression.length,
+        ),
+      },
+    ],
+    [
+      'organize imports',
+      { kind: vscode.CodeActionKind.SourceOrganizeImports, range: emptyRange },
+    ],
+    [
+      'fix all',
+      { kind: vscode.CodeActionKind.SourceFixAll, range: emptyRange },
+    ],
+  ]);
 
   const timeoutMs = 60_000;
   const deadline = Date.now() + timeoutMs;
   let lastProbeError: unknown;
 
   while (Date.now() < deadline) {
-    // `filterInternal: false` is intentional: the three sentinels are
-    // internal commands whose registration happens in the constructors of
-    // the quick-fix, refactor, and organize-imports providers.
-    const commands = await vscode.commands.getCommands(false);
-    const commandsReady = typescriptCodeActionCommands.every((command) =>
-      commands.includes(command),
-    );
-
-    let fixAllReady = false;
-    if (commandsReady) {
+    for (const [name, probe] of probes) {
       try {
         const actions = await vscode.commands.executeCommand<
           vscode.CodeAction[]
         >(
           'vscode.executeCodeActionProvider',
           document.uri,
-          new vscode.Range(0, 0, 0, 0),
-          'source.fixAll.ts',
+          probe.range,
+          probe.kind.value,
         );
-        fixAllReady =
+        if (
           actions?.some(
-            (action) => action.kind?.value === 'source.fixAll.ts',
-          ) ?? false;
-        lastProbeError = undefined;
+            (action) => action.kind && probe.kind.contains(action.kind),
+          )
+        ) {
+          probes.delete(name);
+        }
       } catch (error) {
         // A provider registering during this non-mutating probe cancels it.
         // Keep waiting for the complete provider set, but fail closed on
@@ -113,20 +136,16 @@ async function waitForTypeScriptCodeActionProviders(): Promise<void> {
       }
     }
 
-    if (commandsReady && fixAllReady) {
+    if (probes.size === 0) {
       return;
     }
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 100));
   }
 
-  const commands = await vscode.commands.getCommands(false);
-  const missingCommands = typescriptCodeActionCommands.filter(
-    (command) => !commands.includes(command),
-  );
   throw new Error(
     `Timed out after ${timeoutMs}ms waiting for TypeScript code-action providers` +
-      (missingCommands.length > 0
-        ? `; missing commands: ${missingCommands.join(', ')}`
+      (probes.size > 0
+        ? `; missing actions: ${[...probes.keys()].join(', ')}`
         : '') +
       (lastProbeError ? `; last probe error: ${String(lastProbeError)}` : ''),
   );

--- a/packages/vscode-extension/__tests__/suite/fixall-helpers.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-helpers.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
 import fs from 'node:fs';
+import { isDeepStrictEqual } from 'node:util';
 
 export function getFixturesDir(): string {
   return path.resolve(require.resolve('@rslint/core'), '../..', 'fixtures');
@@ -247,22 +248,30 @@ export async function withOnSaveFixAll(
   try {
     const config = vscode.workspace.getConfiguration('editor');
     const previousValue = config.get('codeActionsOnSave');
-    await config.update(
-      'codeActionsOnSave',
+    const configurationChanged = !isDeepStrictEqual(
+      previousValue,
       codeActionsOnSave,
-      vscode.ConfigurationTarget.Workspace,
     );
+    if (configurationChanged) {
+      await config.update(
+        'codeActionsOnSave',
+        codeActionsOnSave,
+        vscode.ConfigurationTarget.Workspace,
+      );
+    }
 
     try {
       const doc = await vscode.workspace.openTextDocument(tmpFile);
       const editor = await vscode.window.showTextDocument(doc);
       await testFn(doc, editor);
     } finally {
-      await config.update(
-        'codeActionsOnSave',
-        previousValue,
-        vscode.ConfigurationTarget.Workspace,
-      );
+      if (configurationChanged) {
+        await config.update(
+          'codeActionsOnSave',
+          previousValue,
+          vscode.ConfigurationTarget.Workspace,
+        );
+      }
     }
   } finally {
     // Close the editor tab so VSCode sends a synchronous didClose to the LSP,


### PR DESCRIPTION
## Summary

- Wait for the rslint client and VS Code's built-in TypeScript quick-fix, refactor, organize-imports, and fix-all providers before loading the Mocha suites.
- Prevent VS Code 1.128 from cancelling an in-flight code-action-on-save request when the TypeScript provider registry changes during lazy startup; that cancellation aborts the write and makes `TextDocument.save()` return `false`.
- Fail closed if the providers never become ready. Only the non-mutating readiness probe is retried; every original one-shot `assert.ok(await doc.save())` and content assertion remains unchanged.
- Avoid rewriting `editor.codeActionsOnSave` when the workspace already has the value required by a test.

## Related Links

- Follow-up to the flaky CI failure observed in #1261.
- VS Code cancels code-action collection when the provider registry changes: https://github.com/microsoft/vscode/blob/1.128.0/src/vs/editor/contrib/codeAction/browser/codeAction.ts#L100-L160
- The built-in TypeScript extension registers its providers asynchronously after activation: https://github.com/microsoft/vscode/blob/1.128.0/extensions/typescript-language-features/src/languageProvider.ts#L48-L99

## Testing

- `pnpm --dir packages/vscode-extension exec tsgo -p tsconfig.spec.emit.json`
- JSON-config VS Code suite: 33/33 passing, including every on-save test
- Rebased cold-start cascade suite: 2/2 passing with the original single-save assertion
- Fail-closed fault injection: a deliberately missing provider sentinel fails before Mocha loads
- `pnpm format:check`
- `pnpm check-spell` (2,271 files, 0 issues)
- `lint:go` not applicable: this PR changes no Go files

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
