### PR TITLE
refactor(cli): extract output reporting

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -105,6 +105,7 @@ The directory map below folds the high-level module relationships into the packa
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `website/`                     | Documentation site and Playground UI                                                                             | Uses `packages/rslint-wasm` to run browser linting and `packages/rslint-api` to decode encoded source files; Playground lint requests ultimately reach `internal/linter`, and inspect requests reach `internal/inspector` through `internal/api`                                                                |
 | `cmd/rslint/`                  | Main Go binary entry point with CLI, API, and LSP modes                                                          | Main CLI path is `internal/config -> cmd/rslint/programs.go -> internal/linter`; `--api` is consumed by `packages/rslint` and `packages/rslint-wasm`; `--lsp` is consumed by `packages/vscode-extension`                                                                                                        |
+| `cmd/rslint/internal/output/`  | CLI report model, summary, colors, and stdout formatters                                                         | Consumes final sorted `internal/rule` diagnostics from the CLI pipeline and renders `default`, `jsonline`, `github`, or `gitlab`; it is intentionally private to `cmd/rslint` and is not shared by the structured API or LSP adapters                                                                           |
 | `cmd/tsgo/`                    | ts-go semantic inspection/export tool                                                                            | Talks directly to `typescript-go` and bypasses the lint framework; consumed by `packages/tsgo` and `crates/tsgo-client`                                                                                                                                                                                         |
 | `internal/api/`                | stdio IPC protocol and service types for JS/WASM integration                                                     | Shared protocol layer for `cmd/rslint --api`; used by `packages/rslint`, `packages/rslint-wasm`, `internal/linter`, and `internal/inspector`                                                                                                                                                                    |
 | `internal/config/`             | Configuration loading, parsing, merging, discovery, and centralized rule registration                            | `RegisterAllRules()` in `config.go` orchestrates registration by iterating each group's `GetAllRules()` slice (`internal/rules/all.go` for core, `internal/plugins/<plugin>/all.go` for each plugin); `rule_registry.go` implements registry/query logic used by `cmd/rslint/programs.go` and `internal/linter` |
@@ -188,7 +189,7 @@ The current parsing and linting pipeline is built on top of ts-go `Program` and 
 6. **AST Traversal**: The linter traverses each file once using a DFS walk.
 7. **Rule Execution**: Listener callbacks inspect nodes and may use syntax only or syntax plus type information.
 8. **Diagnostic Collection**: Findings are reported as `RuleDiagnostic` values, with optional fixes or suggestions.
-9. **Output Generation**: CLI prints results, API returns structured data, and LSP converts them to LSP diagnostics/code actions.
+9. **Output Generation**: CLI builds one report from the final post-fix diagnostics and passes it to `cmd/rslint/internal/output`; API returns structured data, and LSP converts diagnostics to LSP diagnostics/code actions.
 
 ### Error Recovery Strategy
 
@@ -543,8 +544,9 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
 8. **Rule Execution**: `RunLinter()` schedules per-Program work over the exact target plan; the unexported `runLintRulesInProgram()` does the actual per-file traversal. When `--type-check` is enabled, a separate program-wide pass over real tsconfig Programs aggregates `tsc --noEmit`-aligned diagnostics through `collectNoEmitDiagnostics()`
 9. **Result Aggregation**: diagnostics are sent through one run-scoped diagnostics channel and collected at the CLI layer
 10. **Fix Passes**: CLI multi-pass `--fix` applies fixes, rebuilds real Programs, and rebinds the unchanged target plan after each pass; a file may move between a real Program and fallback as its import graph changes
-11. **Output Formatting**: default, JSON line, and GitHub workflow formats are supported
-12. **Exit Code**: depends on diagnostics, warnings, and fix outcomes
+11. **Report Assembly**: the CLI builds one output report from the final post-fix diagnostics plus run metadata. Diagnostics carry an explicit lint or TypeScript origin, and the report computes error/warning/type-error counts once so the summary and exit policy use the same values; `--quiet` filters rendering only.
+12. **Output Formatting**: the CLI-private output subsystem renders `default`, JSON line, GitHub workflow command, or GitLab Code Quality formats. Only `default` emits a summary; machine-readable formats never emit ANSI styling or a summary.
+13. **Exit Code**: depends on the report counts, `--max-warnings`, and fix outcomes
 
 ### Concurrency Model
 

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -1174,9 +1174,9 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	}
 
 	typeCheckedFileCount := 0
-	if typeCheckOnly {
+	if typeCheck {
 		// Count non-skipped Program root files (tsconfig include/files), not
-		// transitive declarations, for the type-check-only summary.
+		// transitive declarations, for every summary that includes type-check.
 		seen := make(map[string]struct{})
 		for i, prog := range programs {
 			if i < len(skipTypeCheck) && skipTypeCheck[i] {

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -1,17 +1,12 @@
 package main
 
 import (
-	"bufio"
 	"cmp"
 	"context"
-	"crypto/md5"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,14 +14,11 @@ import (
 	"runtime/trace"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
-	"unicode"
-	"unicode/utf8"
 
-	"github.com/fatih/color"
+	"github.com/web-infra-dev/rslint/cmd/rslint/internal/output"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -34,7 +26,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/core"
-	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
@@ -76,533 +67,6 @@ type lintArgs struct {
 	// placeholder rules so plugin rule names resolve; the live plugins run
 	// in the Node worker.
 	EslintPlugins []rslintconfig.EslintPluginEntry
-}
-
-// ColorScheme contains all the color functions for different UI elements
-type ColorScheme struct {
-	RuleName    func(format string, a ...interface{}) string
-	FileName    func(format string, a ...interface{}) string
-	ErrorText   func(format string, a ...interface{}) string
-	SuccessText func(format string, a ...interface{}) string
-	DimText     func(format string, a ...interface{}) string
-	BoldText    func(format string, a ...interface{}) string
-	BorderText  func(format string, a ...interface{}) string
-	WarnText    func(format string, a ...interface{}) string
-	// Reset is the trailing SGR reset sequence the summary lines emit (empty
-	// when colors are off) — byte-identical to the inline
-	// color.New().SprintFunc()("") emitters it replaces.
-	Reset string
-}
-
-// newPinnedColor builds a color object pinned to the resolved decision.
-// color.New seeds a per-object noColor switch from the NO_COLOR env at
-// creation time, which would silently override the pipeline-entry decision
-// (e.g. NO_COLOR set but --force-color given) — Enable/DisableColor makes
-// the object follow color.NoColor unconditionally.
-func newPinnedColor(attrs ...color.Attribute) *color.Color {
-	c := color.New(attrs...)
-	if color.NoColor {
-		c.DisableColor()
-	} else {
-		c.EnableColor()
-	}
-	return c
-}
-
-// setupColors builds the SprintfFunc scheme used by the formatters. It is a
-// pure factory: the on/off decision is owned by term.ResolveColorEnabled,
-// applied once at pipeline entry and propagated here via color.NoColor.
-func setupColors() *ColorScheme {
-	return &ColorScheme{
-		RuleName:    newPinnedColor(color.FgHiGreen).SprintfFunc(),
-		FileName:    newPinnedColor(color.FgCyan, color.Italic).SprintfFunc(),
-		ErrorText:   newPinnedColor(color.FgRed, color.Bold).SprintfFunc(),
-		SuccessText: newPinnedColor(color.FgGreen, color.Bold).SprintfFunc(),
-		DimText:     newPinnedColor(color.Faint).SprintfFunc(),
-		BoldText:    newPinnedColor(color.Bold).SprintfFunc(),
-		BorderText:  newPinnedColor(color.Faint).SprintfFunc(),
-		WarnText:    newPinnedColor(color.FgYellow).SprintfFunc(),
-		Reset:       newPinnedColor().SprintFunc()(""),
-	}
-}
-
-// reportSyntacticErrors renders syntax errors with code snippets (like tsc --pretty).
-// Returns true if syntactic errors were found and reported.
-func reportSyntacticErrors(err error, w *bufio.Writer, comparePathOptions tspath.ComparePathsOptions) bool {
-	var syntacticErr *utils.SyntacticError
-	if !errors.As(err, &syntacticErr) {
-		return false
-	}
-	rendered := false
-	for _, d := range syntacticErr.Diagnostics {
-		if d.File() == nil {
-			continue
-		}
-		diag := rule.RuleDiagnostic{
-			RuleName:   fmt.Sprintf("TypeScript(TS%d)", d.Code()),
-			SourceFile: d.File(),
-			FilePath:   d.File().FileName(),
-			Range:      d.Loc(),
-			Message:    rule.RuleMessage{Description: d.String()},
-			Severity:   rule.SeverityError,
-		}
-		printDiagnosticDefault(diag, w, comparePathOptions)
-		rendered = true
-	}
-	w.Flush()
-	return rendered
-}
-
-func printDiagnostic(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOptions tspath.ComparePathsOptions, format string, gitlabState *gitlabReportState) {
-	switch format {
-	case "default":
-		printDiagnosticDefault(d, w, comparePathOptions)
-	case "jsonline":
-		printDiagnosticJsonLine(d, w, comparePathOptions)
-	case "github":
-		printDiagnosticGitHub(d, w, comparePathOptions)
-	case "gitlab":
-		printDiagnosticGitLab(d, w, comparePathOptions, gitlabState)
-	default:
-		panic("not supported format " + format)
-	}
-}
-
-// gitlabReportState tracks the streaming state needed to emit the gitlab
-// format as a single JSON array (one open bracket, comma-separated entries,
-// one close bracket) while diagnostics are still printed one at a time, plus
-// a fingerprint occurrence counter so two diagnostics that would otherwise
-// hash identically (rare) don't collapse into one entry in the GitLab MR
-// widget, which merges issues sharing a fingerprint.
-type gitlabReportState struct {
-	wroteFirst   bool
-	fingerprints map[string]int
-}
-
-func newGitlabReportState() *gitlabReportState {
-	return &gitlabReportState{fingerprints: make(map[string]int)}
-}
-
-// finish closes the JSON array. Must be called exactly once after all
-// diagnostics have been printed.
-func (s *gitlabReportState) finish(w *bufio.Writer) {
-	if s.wroteFirst {
-		w.WriteString("]\n")
-	} else {
-		w.WriteString("[]\n")
-	}
-}
-
-// gitlabFingerprint derives a stable identifier for a diagnostic from its
-// location and content. md5 is used only to derive a short opaque key (no
-// cryptographic resistance is needed), and the seen map breaks ties
-// deterministically instead of the random salt some other gitlab formatters
-// use, which keeps report output reproducible across runs.
-func gitlabFingerprint(seen map[string]int, filePath, ruleName, message string, startLine, startColumn, endLine, endColumn int) string {
-	input := fmt.Sprintf("%s:%s:%s:%d:%d:%d:%d", filePath, ruleName, message, startLine, startColumn, endLine, endColumn)
-	digest := func(s string) string {
-		sum := md5.Sum([]byte(s)) //nolint:gosec // opaque identifier, not a security boundary
-		return hex.EncodeToString(sum[:])
-	}
-
-	fingerprint := digest(input)
-	if n, ok := seen[fingerprint]; ok {
-		seen[fingerprint] = n + 1
-		return digest(input + ":" + strconv.Itoa(n))
-	}
-	seen[fingerprint] = 1
-	return fingerprint
-}
-
-// print as [GitLab Code Quality report](https://docs.gitlab.com/ci/testing/code_quality/)
-// format: a single JSON array of issues, suitable for the `codequality`
-// report artifact consumed by GitLab CI merge request widgets.
-func printDiagnosticGitLab(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOptions tspath.ComparePathsOptions, state *gitlabReportState) {
-	diagnosticStart := d.Range.Pos()
-	diagnosticEnd := d.Range.End()
-
-	startLine, startColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticStart)
-	endLine, endColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticEnd)
-
-	filePath := tspath.ConvertToRelativePath(d.FilePath, comparePathOptions)
-
-	var severity string
-	switch d.Severity {
-	case rule.SeverityError:
-		severity = "major"
-	case rule.SeverityWarning:
-		severity = "minor"
-	default:
-		severity = "info"
-	}
-
-	type gitlabPosition struct {
-		Line   int `json:"line"`
-		Column int `json:"column"`
-	}
-	type gitlabPositions struct {
-		Begin gitlabPosition `json:"begin"`
-		End   gitlabPosition `json:"end"`
-	}
-	type gitlabLines struct {
-		Begin int `json:"begin"`
-		End   int `json:"end"`
-	}
-	type gitlabLocation struct {
-		Path      string          `json:"path"`
-		Lines     gitlabLines     `json:"lines"`
-		Positions gitlabPositions `json:"positions"`
-	}
-	type gitlabIssue struct {
-		Description string         `json:"description"`
-		CheckName   string         `json:"check_name"`
-		Fingerprint string         `json:"fingerprint"`
-		Severity    string         `json:"severity"`
-		Location    gitlabLocation `json:"location"`
-	}
-
-	beginLine, beginColumn := startLine+1, int(startColumn)+1
-	endLineNum, endColumnNum := endLine+1, int(endColumn)+1
-
-	issue := gitlabIssue{
-		Description: d.Message.Description,
-		CheckName:   d.RuleName,
-		Fingerprint: gitlabFingerprint(state.fingerprints, filePath, d.RuleName, d.Message.Description, beginLine, beginColumn, endLineNum, endColumnNum),
-		Severity:    severity,
-		Location: gitlabLocation{
-			Path: filePath,
-			Lines: gitlabLines{
-				Begin: beginLine,
-				End:   endLineNum,
-			},
-			Positions: gitlabPositions{
-				Begin: gitlabPosition{Line: beginLine, Column: beginColumn},
-				End:   gitlabPosition{Line: endLineNum, Column: endColumnNum},
-			},
-		},
-	}
-
-	jsonBytes, err := json.Marshal(issue)
-	if err != nil {
-		// gitlabIssue contains only strings and ints, so Marshal cannot fail
-		// in practice; skip rather than risk corrupting the JSON array.
-		return
-	}
-
-	if state.wroteFirst {
-		w.WriteByte(',')
-	} else {
-		w.WriteByte('[')
-		state.wroteFirst = true
-	}
-	w.Write(jsonBytes)
-}
-
-// print as [Workflow commands for GitHub Actions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands) format
-func printDiagnosticGitHub(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOptions tspath.ComparePathsOptions) {
-	var severity string
-	switch d.Severity {
-	case rule.SeverityError:
-		severity = "error"
-	case rule.SeverityWarning:
-		severity = "warning"
-	default:
-		severity = "notice"
-	}
-
-	diagnosticStart := d.Range.Pos()
-	diagnosticEnd := d.Range.End()
-
-	startLine, startColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticStart)
-	endLine, endColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticEnd)
-
-	filePath := tspath.ConvertToRelativePath(d.FilePath, comparePathOptions)
-	output := fmt.Sprintf(
-		"::%s file=%s,line=%d,endLine=%d,col=%d,endColumn=%d,title=%s::%s\n",
-		severity,
-		escapeProperty(filePath),
-		startLine+1,
-		endLine+1,
-		int(startColumn)+1,
-		int(endColumn)+1,
-		d.RuleName,
-		escapeData(d.Message.Description),
-	)
-	w.WriteString(output)
-}
-
-func pluralize(count int, singular, plural string) string {
-	if count == 1 {
-		return singular
-	}
-	return plural
-}
-
-func escapeData(str string) string {
-	// https://github.com/biomejs/biome/blob/4416573f4d709047a28407d99381810b7bc7dcc7/crates/biome_diagnostics/src/display_github.rs#L85C4-L85C15
-	str = strings.ReplaceAll(str, "%", "%25")
-	str = strings.ReplaceAll(str, "\r", "%0D")
-	str = strings.ReplaceAll(str, "\n", "%0A")
-	return str
-}
-func escapeProperty(str string) string {
-	// https://github.com/biomejs/biome/blob/4416573f4d709047a28407d99381810b7bc7dcc7/crates/biome_diagnostics/src/display_github.rs#L103
-	str = strings.ReplaceAll(str, "%", "%25")
-	str = strings.ReplaceAll(str, "\r", "%0D")
-	str = strings.ReplaceAll(str, "\n", "%0A")
-	str = strings.ReplaceAll(str, ":", "%3A")
-	str = strings.ReplaceAll(str, ",", "%2C")
-	return str
-}
-
-// print as [jsonline](https://jsonlines.org/) format which can be used for lsp
-func printDiagnosticJsonLine(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOptions tspath.ComparePathsOptions) {
-	diagnosticStart := d.Range.Pos()
-	diagnosticEnd := d.Range.End()
-
-	startLine, startColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticStart)
-	endLine, endColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticEnd)
-
-	type Location struct {
-		Line   int `json:"line"`
-		Column int `json:"column"`
-	}
-
-	type Range struct {
-		Start Location `json:"start"`
-		End   Location `json:"end"`
-	}
-
-	type Diagnostic struct {
-		RuleName string `json:"ruleName"`
-		Message  string `json:"message"`
-		FilePath string `json:"filePath"`
-		Range    Range  `json:"range"`
-		Severity string `json:"severity"`
-	}
-
-	diagnostic := Diagnostic{
-		RuleName: d.RuleName,
-		Message:  d.Message.Description,
-		FilePath: tspath.ConvertToRelativePath(d.FilePath, comparePathOptions),
-		Range: Range{
-			Start: Location{
-				Line:   startLine + 1, // Convert to 1-based indexing
-				Column: int(startColumn) + 1,
-			},
-			End: Location{
-				Line:   endLine + 1,
-				Column: int(endColumn) + 1,
-			},
-		},
-		Severity: d.Severity.String(),
-	}
-
-	jsonBytes, err := json.Marshal(diagnostic)
-	if err != nil {
-		type ErrorObject struct {
-			Error string `json:"error"`
-		}
-		errorObject := ErrorObject{Error: fmt.Sprintf("Failed to marshal diagnostic: %s", err)}
-
-		errorBytes, _ := json.Marshal(errorObject) //nolint:errchkjson
-		w.Write(errorBytes)
-		w.WriteByte('\n')
-		return
-	}
-
-	w.Write(jsonBytes)
-	w.WriteByte('\n')
-}
-
-// print a normal logger
-func printDiagnosticDefault(d rule.RuleDiagnostic, w *bufio.Writer, comparePathOptions tspath.ComparePathsOptions) {
-	colors := setupColors()
-
-	diagnosticStart := d.Range.Pos()
-	diagnosticEnd := d.Range.End()
-
-	diagnosticStartLine, diagnosticStartColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticStart)
-	diagnosticEndline, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(d.SourceFile, diagnosticEnd)
-
-	lineMap := scanner.GetECMALineStarts(d.SourceFile)
-	text := d.SourceFile.Text()
-
-	codeboxStartLine := max(diagnosticStartLine-1, 0)
-	codeboxEndLine := min(diagnosticEndline+1, len(lineMap)-1)
-
-	codeboxStart := int(lineMap[codeboxStartLine])
-	var codeboxEnd int
-	if codeboxEndLine == len(lineMap)-1 {
-		codeboxEnd = len(text)
-	} else {
-		codeboxEnd = int(lineMap[codeboxEndLine+1]) - 1
-	}
-
-	// Rule name with conditional coloring
-	w.WriteByte(' ')
-	w.WriteString(colors.RuleName(" %s ", d.RuleName))
-	w.WriteString(" — ")
-
-	// Severity level with conditional coloring
-	severityColor := colors.WarnText
-	if d.Severity == rule.SeverityError {
-		severityColor = colors.ErrorText
-	}
-	w.WriteString(severityColor("[%s] ", d.Severity.String()))
-
-	// Message handling — multi-line continuation:
-	// - PreFormatted (e.g. tsc diagnostics): 2-space indent, message already has indentation
-	// - Lint rules: │ border aligned after rule name
-	messageLineStart := 0
-	for i, char := range d.Message.Description {
-		if char == '\n' {
-			w.WriteString(d.Message.Description[messageLineStart : i+1])
-			messageLineStart = i + 1
-			if d.PreFormatted {
-				w.WriteString("  ")
-			} else {
-				w.WriteString("    ")
-				w.WriteString(colors.BorderText("│"))
-				w.WriteString(strings.Repeat(" ", len(d.RuleName)+1))
-			}
-		}
-	}
-	if messageLineStart <= len(d.Message.Description) {
-		w.WriteString(d.Message.Description[messageLineStart:len(d.Message.Description)])
-	}
-
-	// File path with conditional coloring
-	w.WriteString("\n  ")
-	w.WriteString(colors.BorderText("╭─┴──────────("))
-	w.WriteByte(' ')
-	filePath := tspath.ConvertToRelativePath(d.FilePath, comparePathOptions)
-	location := fmt.Sprintf("%s:%d:%d", filePath, diagnosticStartLine+1, diagnosticStartColumn+1)
-	w.WriteString(colors.FileName("%s", location))
-	w.WriteByte(' ')
-	w.WriteString(colors.BorderText(")─────"))
-	w.WriteByte('\n')
-
-	indentSize := math.MaxInt
-	line := codeboxStartLine
-	lineIndentCalculated := false
-	lastNonSpaceByteIndex := -1
-
-	numLines := codeboxEndLine - codeboxStartLine + 1
-	lineStarts := make([]int, numLines)
-	lineEnds := make([]int, numLines)
-
-	// Iterate by runes to correctly handle multi-byte UTF-8 characters.
-	// Use utf8.DecodeRuneInString to get the true byte width of each rune
-	// (including invalid UTF-8 bytes, which decode as RuneError with size=1).
-	// `for _, char := range str` plus `utf8.RuneLen(char)` is unsafe here
-	// because invalid bytes yield RuneError (U+FFFD) and RuneLen returns 3
-	// (the encoded length of U+FFFD), throwing off the byte counter and
-	// eventually slicing past len(text).
-	codeboxText := text[codeboxStart:codeboxEnd]
-	for i := 0; i < len(codeboxText); {
-		char, size := utf8.DecodeRuneInString(codeboxText[i:])
-		current := codeboxStart + i
-		next := current + size
-		i += size
-
-		if char == '\n' {
-			if line != codeboxEndLine {
-				lineIndentCalculated = false
-				lineEnds[line-codeboxStartLine] = lastNonSpaceByteIndex - int(lineMap[line])
-				lastNonSpaceByteIndex = -1
-				line++
-			}
-			continue
-		}
-
-		if !lineIndentCalculated && !unicode.IsSpace(char) {
-			lineIndentCalculated = true
-			lineStarts[line-codeboxStartLine] = current - int(lineMap[line])
-			indentSize = min(indentSize, lineStarts[line-codeboxStartLine])
-		}
-
-		if lineIndentCalculated && !unicode.IsSpace(char) {
-			lastNonSpaceByteIndex = next
-		}
-	}
-	if line == codeboxEndLine {
-		lineEnds[line-codeboxStartLine] = lastNonSpaceByteIndex - int(lineMap[line])
-	}
-	// If no non-space content was seen anywhere in the codebox,
-	// `indentSize` was never updated from the math.MaxInt sentinel.
-	// Clamping to 0 prevents `lineMap[line] + indentSize` from overflowing
-	// int in the render loop below (which would wrap to a large negative
-	// number and slice out of bounds).
-	if indentSize == math.MaxInt {
-		indentSize = 0
-	}
-
-	diagnosticHighlightActive := false
-	lastLineNumber := strconv.Itoa(codeboxEndLine + 1)
-	// Fold when codebox spans 5+ lines: show first 2 + "..." + last 2 (same as tsc)
-	shouldFold := codeboxEndLine-codeboxStartLine >= 4
-
-	for line := codeboxStartLine; line <= codeboxEndLine; line++ {
-		// Fold: skip middle lines, show first 2 and last 2
-		if shouldFold && codeboxStartLine+1 < line && line < codeboxEndLine-1 {
-			w.WriteString("  ")
-			w.WriteString(colors.BorderText("│ "))
-			foldDots := strings.Repeat(".", len(lastLineNumber))
-			w.WriteString(colors.DimText("%s", foldDots))
-			w.WriteString(colors.BorderText(" │"))
-			w.WriteByte('\n')
-
-			line = codeboxEndLine - 1
-			// Update highlight state for the jumped-to line
-			diagnosticHighlightActive = diagnosticStart < int(lineMap[line]) && diagnosticEnd >= int(lineMap[line])
-			// Fall through to render this line
-		}
-
-		w.WriteString("  ")
-		w.WriteString(colors.BorderText("│ "))
-		if line == codeboxEndLine {
-			w.WriteString(colors.DimText("%s", lastLineNumber))
-		} else {
-			number := strconv.Itoa(line + 1)
-			if len(number) < len(lastLineNumber) {
-				w.WriteByte(' ')
-			}
-			w.WriteString(colors.DimText("%s", number))
-		}
-		w.WriteString(colors.BorderText(" │"))
-		w.WriteString("  ")
-
-		lineTextStart := int(lineMap[line]) + indentSize
-		underlineStart := max(lineTextStart, int(lineMap[line])+lineStarts[line-codeboxStartLine])
-		underlineEnd := underlineStart
-		lineTextEnd := max(int(lineMap[line])+lineEnds[line-codeboxStartLine], lineTextStart)
-
-		if diagnosticHighlightActive {
-			underlineEnd = lineTextEnd
-		} else if int(lineMap[line]) <= diagnosticStart && (line == len(lineMap)-1 || diagnosticStart < int(lineMap[line+1])) {
-			underlineStart = min(max(lineTextStart, diagnosticStart), lineTextEnd)
-			underlineEnd = lineTextEnd
-			diagnosticHighlightActive = true
-		}
-		if int(lineMap[line]) <= diagnosticEnd && (line == len(lineMap)-1 || diagnosticEnd < int(lineMap[line+1])) {
-			underlineEnd = min(max(underlineStart, diagnosticEnd), lineTextEnd)
-			diagnosticHighlightActive = false
-		}
-
-		if underlineStart != underlineEnd {
-			w.WriteString(text[lineTextStart:underlineStart])
-			w.WriteString(severityColor("%s", text[underlineStart:underlineEnd]))
-			w.WriteString(text[underlineEnd:lineTextEnd])
-		} else if lineTextStart != lineTextEnd {
-			w.WriteString(text[lineTextStart:lineTextEnd])
-		}
-
-		w.WriteByte('\n')
-	}
-	w.WriteString("  ")
-	w.WriteString(colors.BorderText("╰────────────────────────────────"))
-	w.WriteString("\n\n")
 }
 
 // repeatedFlag collects multiple values for the same flag (e.g. --rule used multiple times).
@@ -690,7 +154,7 @@ func deduplicateTypeScriptDiagnostics(
 		callerTargetByCanonicalPath = preferredCallerTargets[0]
 	}
 	if len(diags) == 1 {
-		if strings.HasPrefix(diags[0].RuleName, "TypeScript(TS") {
+		if diags[0].Origin == rule.DiagnosticOriginTypeScript {
 			canonicalID := canonicalFilesystemPathID(diags[0].FilePath, fsys)
 			if callerTarget := callerTargetByCanonicalPath[canonicalID]; callerTarget != "" {
 				diags[0].FilePath = callerTarget
@@ -701,7 +165,7 @@ func deduplicateTypeScriptDiagnostics(
 	bestIndex := make(map[typeScriptDiagnosticDedupeKey]int)
 	keys := make([]typeScriptDiagnosticDedupeKey, len(diags))
 	for i, diagnostic := range diags {
-		if !strings.HasPrefix(diagnostic.RuleName, "TypeScript(TS") {
+		if diagnostic.Origin != rule.DiagnosticOriginTypeScript {
 			continue
 		}
 		key := typeScriptDiagnosticDedupeKey{
@@ -720,7 +184,7 @@ func deduplicateTypeScriptDiagnostics(
 
 	result := diags[:0]
 	for i, diagnostic := range diags {
-		if !strings.HasPrefix(diagnostic.RuleName, "TypeScript(TS") {
+		if diagnostic.Origin != rule.DiagnosticOriginTypeScript {
 			result = append(result, diagnostic)
 			continue
 		}
@@ -1066,23 +530,28 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	traceOut := args.TraceOut
 	cpuprofOut := args.CpuprofOut
 	singleThreaded := args.SingleThreaded
-	format := args.Format
 	quiet := args.Quiet
 	maxWarnings := args.MaxWarnings
 	startTimeMs := args.StartTimeMs
 	ruleFlags := args.RuleFlags
 	allowFiles := args.AllowFiles
 	allowDirs := args.AllowDirs
+	format := output.FormatDefault
+	if !init {
+		var formatErr error
+		format, formatErr = output.ParseFormat(args.Format)
+		if formatErr != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", formatErr)
+			return 2
+		}
+	}
 
-	// The single color decision for the whole run. It unconditionally
-	// overwrites fatih/color's package-init value, whose isatty component
-	// keyed off the Go process's own stdout — an IPC pipe in every native
-	// lint run, never the user's terminal (its NO_COLOR/TERM components are
-	// re-derived in the tiers below). Nothing after this line mutates
-	// color.NoColor.
+	// Resolve color against the real output destination. In native CLI runs
+	// the Go process writes to an IPC pipe, so the Node host supplies the TTY
+	// fact for the stdout that ultimately receives forwarded output frames.
 	forceColorEnv, forceColorEnvSet := os.LookupEnv("FORCE_COLOR")
 	_, noColorEnvSet := os.LookupEnv("NO_COLOR")
-	color.NoColor = !term.ResolveColorEnabled(term.ColorInputs{
+	colorEnabled := term.ResolveColorEnabled(term.ColorInputs{
 		NoColorFlag:      args.NoColor,
 		ForceColorFlag:   args.ForceColor,
 		ForceColorEnv:    forceColorEnv,
@@ -1695,168 +1164,64 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		return cmp.Compare(a.Range.Pos(), b.Range.Pos())
 	})
 
-	// Phase 3: Print diagnostics and count errors/warnings.
-	// allDiags contains: original diagnostics (no fix), or remaining after fix.
-	errorsCount := 0
-	warningsCount := 0
-	typeErrorsCount := 0
-	{
-		w := bufio.NewWriterSize(os.Stdout, 4096*100)
-		var gitlabState *gitlabReportState
-		if format == "gitlab" {
-			gitlabState = newGitlabReportState()
-		}
-		for i, d := range allDiags {
-			switch d.Severity {
-			case rule.SeverityError:
-				errorsCount++
-				if typeCheck && strings.HasPrefix(d.RuleName, "TypeScript(") {
-					typeErrorsCount++
-				}
-			case rule.SeverityWarning:
-				warningsCount++
-			}
+	// Phase 3: Build one report from the final post-fix diagnostics, then let
+	// the CLI output subsystem own format dispatch, colors, and summary text.
+	mode := output.ModeLint
+	if typeCheckOnly {
+		mode = output.ModeTypeCheckOnly
+	} else if typeCheck {
+		mode = output.ModeLintAndTypeCheck
+	}
 
-			if i == 0 {
-				w.WriteByte('\n')
-			}
-			// Only print Error message when quiet is true
-			if quiet && d.Severity != rule.SeverityError {
+	typeCheckedFileCount := 0
+	if typeCheckOnly {
+		// Count non-skipped Program root files (tsconfig include/files), not
+		// transitive declarations, for the type-check-only summary.
+		seen := make(map[string]struct{})
+		for i, prog := range programs {
+			if i < len(skipTypeCheck) && skipTypeCheck[i] {
 				continue
 			}
-			printDiagnostic(d, w, comparePathOptions, format, gitlabState)
-			if w.Available() < 4096 {
-				w.Flush()
+			for _, fileName := range prog.CommandLine().FileNames() {
+				seen[fileName] = struct{}{}
 			}
 		}
-		if gitlabState != nil {
-			gitlabState.finish(w)
-		}
-		w.Flush()
+		typeCheckedFileCount = len(seen)
 	}
 
-	lintErrorsCount := errorsCount - typeErrorsCount
-
-	colors := setupColors()
-	var errorsColorFunc func(string, ...interface{}) string
-	if errorsCount == 0 {
-		errorsColorFunc = colors.SuccessText
-	} else {
-		errorsColorFunc = colors.ErrorText
-	}
-
-	var warningsColorFunc func(string, ...interface{}) string
-	if warningsCount == 0 {
-		warningsColorFunc = colors.SuccessText
-	} else {
-		warningsColorFunc = colors.WarnText
-	}
-
-	warningsText := pluralize(warningsCount, "warning", "warnings")
-	filesText := pluralize(int(lintedfileCount), "file", "files")
-	rulesCount := len(lintResult.ExecutedRules)
-	rulesText := pluralize(rulesCount, "rule", "rules")
 	threadsCount := 1
 	if !singleThreaded {
 		threadsCount = runtime.GOMAXPROCS(0)
 	}
-	if format == "default" {
-		// Build the errors summary part.
-		// When type-check is enabled and there are type errors, split the display.
-		var errorsSummary string
-		switch {
-		case typeCheckOnly:
-			// Lint phase was skipped; only type errors are possible.
-			errorsSummary = fmt.Sprintf("%s %s",
-				errorsColorFunc("%d", typeErrorsCount),
-				pluralize(typeErrorsCount, "type error", "type errors"),
-			)
-		case typeCheck:
-			errorsSummary = fmt.Sprintf("%s %s, %s %s",
-				errorsColorFunc("%d", lintErrorsCount),
-				pluralize(lintErrorsCount, "lint error", "lint errors"),
-				errorsColorFunc("%d", typeErrorsCount),
-				pluralize(typeErrorsCount, "type error", "type errors"),
-			)
-		default:
-			errorsSummary = fmt.Sprintf("%s %s",
-				errorsColorFunc("%d", errorsCount),
-				pluralize(errorsCount, "error", "errors"),
-			)
-		}
 
-		if typeCheckOnly {
-			// type-check-only: omit lint-file/rule/warning columns since no
-			// lint ran. Report the type-checked file count derived from
-			// non-skipped programs' root files (tsconfig include/files);
-			// transitive .d.ts imports are excluded for user readability.
-			seen := make(map[string]struct{})
-			for i, prog := range programs {
-				if i < len(skipTypeCheck) && skipTypeCheck[i] {
-					continue
-				}
-				for _, fn := range prog.CommandLine().FileNames() {
-					seen[fn] = struct{}{}
-				}
-			}
-			typeCheckedFileCount := len(seen)
-			fmt.Fprintf(
-				os.Stdout,
-				"Found %s %s(type-checked %s %s in %s using %s threads)%s\n",
-				errorsSummary,
-				colors.DimText(""),
-				colors.BoldText("%d", typeCheckedFileCount),
-				pluralize(typeCheckedFileCount, "file", "files"),
-				colors.BoldText("%v", time.Since(timeBefore).Round(time.Millisecond)),
-				colors.BoldText("%d", threadsCount),
-				colors.Reset,
-			)
-		} else if fix && fixedCount > 0 {
-			fixText := pluralize(fixedCount, "issue", "issues")
-			fmt.Fprintf(
-				os.Stdout,
-				"Found %s and %s %s %s(linted %s %s with %s %s in %s using %s threads, fixed %s %s)%s\n",
-				errorsSummary,
-				warningsColorFunc("%d", warningsCount),
-				warningsText,
-				colors.DimText(""),
-				colors.BoldText("%d", lintedfileCount),
-				filesText,
-				colors.BoldText("%d", rulesCount),
-				rulesText,
-				colors.BoldText("%v", time.Since(timeBefore).Round(time.Millisecond)),
-				colors.BoldText("%d", threadsCount),
-				colors.SuccessText("%d", fixedCount),
-				fixText,
-				colors.Reset,
-			)
-		} else {
-			fmt.Fprintf(
-				os.Stdout,
-				"Found %s and %s %s %s(linted %s %s with %s %s in %s using %s threads)%s\n",
-				errorsSummary,
-				warningsColorFunc("%d", warningsCount),
-				warningsText,
-				colors.DimText(""),
-				colors.BoldText("%d", lintedfileCount),
-				filesText,
-				colors.BoldText("%d", rulesCount),
-				rulesText,
-				colors.BoldText("%v", time.Since(timeBefore).Round(time.Millisecond)),
-				colors.BoldText("%d", threadsCount),
-				colors.Reset,
-			)
-		}
+	report := output.NewReport(allDiags, output.Metadata{
+		Mode:             mode,
+		LintedFiles:      int(lintedfileCount),
+		TypeCheckedFiles: typeCheckedFileCount,
+		Rules:            len(lintResult.ExecutedRules),
+		Threads:          threadsCount,
+		FixedIssues:      fixedCount,
+		StartedAt:        timeBefore,
+	})
+	if err := output.Render(os.Stdout, report, output.Options{
+		Format:       format,
+		ComparePaths: comparePathOptions,
+		Quiet:        quiet,
+		ColorEnabled: colorEnabled,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing lint report: %v\n", err)
+		return 1
 	}
+	counts := report.Counts()
 
-	tooManyWarnings := maxWarnings >= 0 && warningsCount > maxWarnings
+	tooManyWarnings := maxWarnings >= 0 && counts.Warnings > maxWarnings
 
-	if errorsCount == 0 && tooManyWarnings {
+	if counts.Errors == 0 && tooManyWarnings {
 		fmt.Fprintf(os.Stderr, "Rslint found too many warnings (maximum: %d).\n", maxWarnings)
 	}
 
 	// Exit with non-zero status code if errors were found
-	if errorsCount > 0 || tooManyWarnings {
+	if counts.Errors > 0 || tooManyWarnings {
 		return 1
 	}
 	return 0

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -23,6 +22,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/cmd/rslint/internal/output"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -69,8 +69,8 @@ func runLintPipelineForTest(t *testing.T, cwd string, args lintArgs) (int, strin
 	return code, string(stdoutBytes), string(stderrBytes)
 }
 
-// TestPrintDiagnosticUTF8 tests that printDiagnosticDefault correctly renders
-// UTF-8 characters (Chinese, Japanese, Korean, Emoji) in diagnostic output.
+// TestPrintDiagnosticUTF8 tests that the default output renderer correctly
+// handles UTF-8 characters (Chinese, Japanese, Korean, Emoji).
 func TestPrintDiagnosticUTF8(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -164,20 +164,11 @@ func TestPrintDiagnosticUTF8(t *testing.T) {
 				Severity: rule.SeverityWarning,
 			}
 
-			// Capture diagnostic output
-			var buf bytes.Buffer
-			writer := bufio.NewWriter(&buf)
-
 			comparePathOptions := tspath.ComparePathsOptions{
 				CurrentDirectory:          tmpDir,
 				UseCaseSensitiveFileNames: true,
 			}
-
-			// Call the actual function
-			printDiagnosticDefault(diagnostic, writer, comparePathOptions)
-			writer.Flush()
-
-			output := buf.String()
+			output := renderDiagnostic(t, diagnostic, comparePathOptions)
 
 			// Verify expected UTF-8 text is present in output
 			if !strings.Contains(output, tc.expectedText) {
@@ -248,9 +239,17 @@ func createTestDiagnostic(t *testing.T, source string, startOffset, endOffset in
 func renderDiagnostic(t *testing.T, d rule.RuleDiagnostic, opts tspath.ComparePathsOptions) string {
 	t.Helper()
 	var buf bytes.Buffer
-	w := bufio.NewWriter(&buf)
-	printDiagnosticDefault(d, w, opts)
-	w.Flush()
+	report := output.NewReport([]rule.RuleDiagnostic{d}, output.Metadata{
+		Mode:      output.ModeLint,
+		Threads:   1,
+		StartedAt: time.Now(),
+	})
+	if err := output.Render(&buf, report, output.Options{
+		Format:       output.FormatDefault,
+		ComparePaths: opts,
+	}); err != nil {
+		t.Fatalf("render diagnostic: %v", err)
+	}
 	return buf.String()
 }
 
@@ -619,67 +618,6 @@ func TestSyntacticErrorType(t *testing.T) {
 	}
 }
 
-// TestReportSyntacticErrorsPretty tests that reportSyntacticErrors renders
-// syntax errors with code snippets (like tsc --pretty).
-func TestReportSyntacticErrorsPretty(t *testing.T) {
-	tmpDir := t.TempDir()
-	os.WriteFile(filepath.Join(tmpDir, "tsconfig.json"), []byte(`{"include":["./index.ts"]}`), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "index.ts"), []byte("const x = ;\nconst y = 2;\n"), 0644)
-
-	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	host := utils.CreateCompilerHost(tmpDir, fs)
-	_, err := utils.CreateProgram(true, fs, tmpDir, "tsconfig.json", host)
-	if err == nil {
-		t.Fatal("Expected error")
-	}
-
-	comparePathOptions := tspath.ComparePathsOptions{
-		CurrentDirectory:          tmpDir,
-		UseCaseSensitiveFileNames: true,
-	}
-
-	var buf bytes.Buffer
-	w := bufio.NewWriter(&buf)
-	reported := reportSyntacticErrors(err, w, comparePathOptions)
-	if !reported {
-		t.Fatal("reportSyntacticErrors should return true for SyntacticError")
-	}
-
-	output := buf.String()
-
-	// Should render with code snippet box (like rule diagnostics)
-	if !strings.Contains(output, "╭") || !strings.Contains(output, "╰") {
-		t.Errorf("Should render code snippet box.\nOutput:\n%s", output)
-	}
-	// Should show the source code context
-	if !strings.Contains(output, "const x") {
-		t.Errorf("Should show the error line.\nOutput:\n%s", output)
-	}
-	// Rule name should be the TS error code
-	if !strings.Contains(output, "TS") {
-		t.Errorf("Rule name should contain TS error code.\nOutput:\n%s", output)
-	}
-	// Should show file location
-	if !strings.Contains(output, "index.ts:1:") {
-		t.Errorf("Should show file location.\nOutput:\n%s", output)
-	}
-}
-
-// TestReportSyntacticErrorsNonSyntactic tests that reportSyntacticErrors
-// returns false for non-SyntacticError errors.
-func TestReportSyntacticErrorsNonSyntactic(t *testing.T) {
-	err := errors.New("some other error")
-	var buf bytes.Buffer
-	w := bufio.NewWriter(&buf)
-	reported := reportSyntacticErrors(err, w, tspath.ComparePathsOptions{})
-	if reported {
-		t.Fatal("reportSyntacticErrors should return false for non-SyntacticError")
-	}
-	if buf.Len() != 0 {
-		t.Fatal("Should not write anything for non-SyntacticError")
-	}
-}
-
 // ======== groupDiagsByFile tests ========
 
 func TestGroupDiagsByFile_Empty(t *testing.T) {
@@ -832,6 +770,36 @@ func TestValidateTypeCheckOnlyFlags_FixTakesPriority(t *testing.T) {
 	}
 	if !strings.Contains(msg, "--fix") {
 		t.Errorf("expected --fix to take priority in the error message, got %q", msg)
+	}
+}
+
+func TestExecuteLintPipelineRejectsInvalidFormatBeforeWork(t *testing.T) {
+	code, stdout, stderr := runLintPipelineForTest(t, t.TempDir(), lintArgs{
+		Format:         "stylish",
+		NoColor:        true,
+		SingleThreaded: true,
+	})
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2; stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("invalid format wrote stdout: %q", stdout)
+	}
+	if !strings.Contains(stderr, `invalid output format "stylish"`) {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}
+
+func TestExecuteLintPipelineInitIgnoresLintFormat(t *testing.T) {
+	dir := t.TempDir()
+	code, stdout, stderr := runLintPipelineForTest(t, dir, lintArgs{
+		Init:           true,
+		Format:         "stylish",
+		NoColor:        true,
+		SingleThreaded: true,
+	})
+	if code != 0 || strings.Contains(stderr, "invalid output format") {
+		t.Fatalf("init did not retain priority: code=%d stdout=%q stderr=%q", code, stdout, stderr)
 	}
 }
 
@@ -1220,6 +1188,7 @@ func TestPlainLintSkipsProjectResolutionWhenAllTargetsAreIgnored(t *testing.T) {
 
 	code, _, stderr := runLintPipelineForTest(t, dir, lintArgs{
 		Config:         configPath,
+		Format:         "default",
 		AllowFiles:     []string{tspath.NormalizePath(target)},
 		SingleThreaded: true,
 	})
@@ -1229,6 +1198,7 @@ func TestPlainLintSkipsProjectResolutionWhenAllTargetsAreIgnored(t *testing.T) {
 
 	code, _, stderr = runLintPipelineForTest(t, dir, lintArgs{
 		Config:         configPath,
+		Format:         "default",
 		AllowFiles:     []string{tspath.NormalizePath(target)},
 		SingleThreaded: true,
 		TypeCheck:      true,
@@ -1379,10 +1349,10 @@ func findProgramFileForTest(t *testing.T, program *compiler.Program, suffix stri
 // diagnostics still produces a valid (empty) JSON array, not an empty file.
 func TestGitlabReportState_EmptyProducesEmptyArray(t *testing.T) {
 	var buf bytes.Buffer
-	w := bufio.NewWriter(&buf)
-	state := newGitlabReportState()
-	state.finish(w)
-	w.Flush()
+	report := output.NewReport(nil, output.Metadata{})
+	if err := output.Render(&buf, report, output.Options{Format: output.FormatGitLab}); err != nil {
+		t.Fatalf("render empty GitLab report: %v", err)
+	}
 
 	if got := buf.String(); got != "[]\n" {
 		t.Errorf("expected %q, got %q", "[]\n", got)
@@ -1406,12 +1376,13 @@ func TestPrintDiagnosticGitLab(t *testing.T) {
 	diagError.Message = rule.RuleMessage{Id: "test", Description: "Use const."}
 
 	var buf bytes.Buffer
-	w := bufio.NewWriter(&buf)
-	state := newGitlabReportState()
-	printDiagnosticGitLab(diagWarning, w, opts, state)
-	printDiagnosticGitLab(diagError, w, opts, state)
-	state.finish(w)
-	w.Flush()
+	report := output.NewReport([]rule.RuleDiagnostic{diagWarning, diagError}, output.Metadata{})
+	if err := output.Render(&buf, report, output.Options{
+		Format:       output.FormatGitLab,
+		ComparePaths: opts,
+	}); err != nil {
+		t.Fatalf("render GitLab report: %v", err)
+	}
 
 	var issues []struct {
 		Description string `json:"description"`
@@ -1463,27 +1434,6 @@ func TestPrintDiagnosticGitLab(t *testing.T) {
 	}
 }
 
-// TestGitlabFingerprint_CollisionsDeterministicallyDistinguished verifies
-// that two diagnostics with identical inputs (same file, rule, message,
-// position) still get distinct fingerprints, since GitLab's MR widget merges
-// issues sharing a fingerprint into a single entry.
-func TestGitlabFingerprint_CollisionsDeterministicallyDistinguished(t *testing.T) {
-	seen := make(map[string]int)
-	a := gitlabFingerprint(seen, "f.ts", "rule", "msg", 1, 1, 1, 5)
-	b := gitlabFingerprint(seen, "f.ts", "rule", "msg", 1, 1, 1, 5)
-	if a == b {
-		t.Errorf("identical inputs should still produce distinct fingerprints, got %q twice", a)
-	}
-
-	// Same inputs in a fresh run should reproduce the same first fingerprint
-	// (no randomness), so report diffs across CI runs stay stable.
-	seen2 := make(map[string]int)
-	a2 := gitlabFingerprint(seen2, "f.ts", "rule", "msg", 1, 1, 1, 5)
-	if a != a2 {
-		t.Errorf("fingerprint should be deterministic, got %q then %q", a, a2)
-	}
-}
-
 func TestRemapDiagnosticTargetPaths(t *testing.T) {
 	diagnostics := []rule.RuleDiagnostic{
 		{FilePath: "/program/link.ts"},
@@ -1514,6 +1464,7 @@ func TestDeduplicateTypeScriptDiagnosticsAcrossPathAliases(t *testing.T) {
 
 	base := rule.RuleDiagnostic{
 		RuleName: "TypeScript(TS1110)",
+		Origin:   rule.DiagnosticOriginTypeScript,
 		Range:    core.NewTextRange(11, 11),
 		Message:  rule.RuleMessage{Description: "Type expected."},
 	}
@@ -1523,6 +1474,7 @@ func TestDeduplicateTypeScriptDiagnosticsAcrossPathAliases(t *testing.T) {
 	aliasDiagnostic.FilePath = aliasPath
 	nonTypeScriptA := base
 	nonTypeScriptA.RuleName = "some-rule"
+	nonTypeScriptA.Origin = rule.DiagnosticOriginLint
 	nonTypeScriptA.FilePath = realPath
 	nonTypeScriptB := nonTypeScriptA
 	nonTypeScriptB.FilePath = aliasPath
@@ -1556,6 +1508,7 @@ func TestDeduplicateTypeScriptDiagnosticsPrefersCallerTarget(t *testing.T) {
 	}
 	base := rule.RuleDiagnostic{
 		RuleName: "TypeScript(TS1110)",
+		Origin:   rule.DiagnosticOriginTypeScript,
 		Range:    core.NewTextRange(11, 11),
 		Message:  rule.RuleMessage{Description: "Type expected."},
 	}

--- a/cmd/rslint/internal/output/color.go
+++ b/cmd/rslint/internal/output/color.go
@@ -1,0 +1,35 @@
+package output
+
+import "github.com/fatih/color"
+
+type colorScheme struct {
+	RuleName    func(format string, a ...interface{}) string
+	FileName    func(format string, a ...interface{}) string
+	ErrorText   func(format string, a ...interface{}) string
+	SuccessText func(format string, a ...interface{}) string
+	DimText     func(format string, a ...interface{}) string
+	BorderText  func(format string, a ...interface{}) string
+	WarnText    func(format string, a ...interface{}) string
+}
+
+func newPinnedColor(enabled bool, attrs ...color.Attribute) *color.Color {
+	c := color.New(attrs...)
+	if enabled {
+		c.EnableColor()
+	} else {
+		c.DisableColor()
+	}
+	return c
+}
+
+func newColorScheme(enabled bool) colorScheme {
+	return colorScheme{
+		RuleName:    newPinnedColor(enabled, color.FgHiGreen).SprintfFunc(),
+		FileName:    newPinnedColor(enabled, color.FgCyan, color.Italic).SprintfFunc(),
+		ErrorText:   newPinnedColor(enabled, color.FgRed, color.Bold).SprintfFunc(),
+		SuccessText: newPinnedColor(enabled, color.FgGreen, color.Bold).SprintfFunc(),
+		DimText:     newPinnedColor(enabled, color.Faint).SprintfFunc(),
+		BorderText:  newPinnedColor(enabled, color.Faint).SprintfFunc(),
+		WarnText:    newPinnedColor(enabled, color.FgYellow).SprintfFunc(),
+	}
+}

--- a/cmd/rslint/internal/output/default.go
+++ b/cmd/rslint/internal/output/default.go
@@ -45,9 +45,11 @@ func (f *defaultFormatter) finish(w *bufio.Writer, report Report) error {
 }
 
 func renderSummary(w *bufio.Writer, report Report, elapsed time.Duration, colors colorScheme) {
-	errorColor := colors.ErrorText
-	if report.counts.Errors == 0 {
-		errorColor = colors.SuccessText
+	errorCountText := func(count int) string {
+		if count == 0 {
+			return colors.SuccessText("%d", count)
+		}
+		return colors.ErrorText("%d", count)
 	}
 
 	warningColor := colors.WarnText
@@ -59,41 +61,51 @@ func renderSummary(w *bufio.Writer, report Report, elapsed time.Duration, colors
 	switch report.metadata.Mode {
 	case ModeTypeCheckOnly:
 		errorsSummary = fmt.Sprintf("%s %s",
-			errorColor("%d", report.counts.TypeErrors),
+			errorCountText(report.counts.TypeErrors),
 			pluralize(report.counts.TypeErrors, "type error", "type errors"),
 		)
 	case ModeLintAndTypeCheck:
 		errorsSummary = fmt.Sprintf("%s %s, %s %s",
-			errorColor("%d", report.counts.LintErrors),
+			errorCountText(report.counts.LintErrors),
 			pluralize(report.counts.LintErrors, "lint error", "lint errors"),
-			errorColor("%d", report.counts.TypeErrors),
+			errorCountText(report.counts.TypeErrors),
 			pluralize(report.counts.TypeErrors, "type error", "type errors"),
 		)
 	default:
 		errorsSummary = fmt.Sprintf("%s %s",
-			errorColor("%d", report.counts.Errors),
+			errorCountText(report.counts.Errors),
 			pluralize(report.counts.Errors, "error", "errors"),
 		)
 	}
 
 	if report.metadata.Mode == ModeTypeCheckOnly {
-		details := fmt.Sprintf("(type-checked %d %s in %v using %d threads)",
+		details := fmt.Sprintf("(type-checked %d %s in %v using %d %s)",
 			report.metadata.TypeCheckedFiles,
 			pluralize(report.metadata.TypeCheckedFiles, "file", "files"),
 			elapsed,
 			report.metadata.Threads,
+			pluralize(report.metadata.Threads, "thread", "threads"),
 		)
 		fmt.Fprintf(w, "Found %s %s\n", errorsSummary, colors.DimText("%s", details))
 		return
 	}
 
-	details := fmt.Sprintf("(linted %d %s with %d %s in %v using %d threads",
+	details := fmt.Sprintf("(linted %d %s with %d %s",
 		report.metadata.LintedFiles,
 		pluralize(report.metadata.LintedFiles, "file", "files"),
 		report.metadata.Rules,
 		pluralize(report.metadata.Rules, "rule", "rules"),
+	)
+	if report.metadata.Mode == ModeLintAndTypeCheck {
+		details += fmt.Sprintf(", type-checked %d %s",
+			report.metadata.TypeCheckedFiles,
+			pluralize(report.metadata.TypeCheckedFiles, "file", "files"),
+		)
+	}
+	details += fmt.Sprintf(" in %v using %d %s",
 		elapsed,
 		report.metadata.Threads,
+		pluralize(report.metadata.Threads, "thread", "threads"),
 	)
 	if report.metadata.FixedIssues > 0 {
 		details += fmt.Sprintf(", fixed %d %s",

--- a/cmd/rslint/internal/output/default.go
+++ b/cmd/rslint/internal/output/default.go
@@ -1,0 +1,284 @@
+package output
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type defaultFormatter struct {
+	colors colorScheme
+}
+
+func (f *defaultFormatter) begin(w *bufio.Writer, _ Report, hasVisibleDiagnostics bool) error {
+	if hasVisibleDiagnostics {
+		return w.WriteByte('\n')
+	}
+	return nil
+}
+
+func (f *defaultFormatter) diagnostic(w *bufio.Writer, view diagnosticView) error {
+	renderDefaultDiagnostic(w, view, f.colors)
+	return nil
+}
+
+func (f *defaultFormatter) finish(w *bufio.Writer, report Report) error {
+	// Preserve the existing timing boundary: diagnostics are flushed to the
+	// real destination before the summary duration is measured.
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	elapsed := time.Duration(0)
+	if !report.metadata.StartedAt.IsZero() {
+		elapsed = time.Since(report.metadata.StartedAt).Round(time.Millisecond)
+	}
+	renderSummary(w, report, elapsed, f.colors)
+	return nil
+}
+
+func renderSummary(w *bufio.Writer, report Report, elapsed time.Duration, colors colorScheme) {
+	errorColor := colors.ErrorText
+	if report.counts.Errors == 0 {
+		errorColor = colors.SuccessText
+	}
+
+	warningColor := colors.WarnText
+	if report.counts.Warnings == 0 {
+		warningColor = colors.SuccessText
+	}
+
+	var errorsSummary string
+	switch report.metadata.Mode {
+	case ModeTypeCheckOnly:
+		errorsSummary = fmt.Sprintf("%s %s",
+			errorColor("%d", report.counts.TypeErrors),
+			pluralize(report.counts.TypeErrors, "type error", "type errors"),
+		)
+	case ModeLintAndTypeCheck:
+		errorsSummary = fmt.Sprintf("%s %s, %s %s",
+			errorColor("%d", report.counts.LintErrors),
+			pluralize(report.counts.LintErrors, "lint error", "lint errors"),
+			errorColor("%d", report.counts.TypeErrors),
+			pluralize(report.counts.TypeErrors, "type error", "type errors"),
+		)
+	default:
+		errorsSummary = fmt.Sprintf("%s %s",
+			errorColor("%d", report.counts.Errors),
+			pluralize(report.counts.Errors, "error", "errors"),
+		)
+	}
+
+	if report.metadata.Mode == ModeTypeCheckOnly {
+		details := fmt.Sprintf("(type-checked %d %s in %v using %d threads)",
+			report.metadata.TypeCheckedFiles,
+			pluralize(report.metadata.TypeCheckedFiles, "file", "files"),
+			elapsed,
+			report.metadata.Threads,
+		)
+		fmt.Fprintf(w, "Found %s %s\n", errorsSummary, colors.DimText("%s", details))
+		return
+	}
+
+	details := fmt.Sprintf("(linted %d %s with %d %s in %v using %d threads",
+		report.metadata.LintedFiles,
+		pluralize(report.metadata.LintedFiles, "file", "files"),
+		report.metadata.Rules,
+		pluralize(report.metadata.Rules, "rule", "rules"),
+		elapsed,
+		report.metadata.Threads,
+	)
+	if report.metadata.FixedIssues > 0 {
+		details += fmt.Sprintf(", fixed %d %s",
+			report.metadata.FixedIssues,
+			pluralize(report.metadata.FixedIssues, "issue", "issues"),
+		)
+	}
+	details += ")"
+
+	fmt.Fprintf(w, "Found %s and %s %s %s\n",
+		errorsSummary,
+		warningColor("%d", report.counts.Warnings),
+		pluralize(report.counts.Warnings, "warning", "warnings"),
+		colors.DimText("%s", details),
+	)
+}
+
+func pluralize(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}
+
+func renderDefaultDiagnostic(w *bufio.Writer, view diagnosticView, colors colorScheme) {
+	diagnostic := view.raw
+	diagnosticStart := diagnostic.Range.Pos()
+	diagnosticEnd := diagnostic.Range.End()
+	diagnosticStartLine := view.start.line
+	diagnosticStartColumn := view.start.column
+	diagnosticEndLine := view.end.line
+
+	lineMap := scanner.GetECMALineStarts(diagnostic.SourceFile)
+	text := diagnostic.SourceFile.Text()
+
+	codeboxStartLine := max(diagnosticStartLine-1, 0)
+	codeboxEndLine := min(diagnosticEndLine+1, len(lineMap)-1)
+
+	codeboxStart := int(lineMap[codeboxStartLine])
+	var codeboxEnd int
+	if codeboxEndLine == len(lineMap)-1 {
+		codeboxEnd = len(text)
+	} else {
+		codeboxEnd = int(lineMap[codeboxEndLine+1]) - 1
+	}
+
+	w.WriteByte(' ')
+	w.WriteString(colors.RuleName(" %s ", diagnostic.RuleName))
+	w.WriteString(" — ")
+
+	severityColor := colors.WarnText
+	if diagnostic.Severity == rule.SeverityError {
+		severityColor = colors.ErrorText
+	}
+	w.WriteString(severityColor("[%s] ", diagnostic.Severity.String()))
+
+	messageLineStart := 0
+	for i, char := range diagnostic.Message.Description {
+		if char == '\n' {
+			w.WriteString(diagnostic.Message.Description[messageLineStart : i+1])
+			messageLineStart = i + 1
+			if diagnostic.PreFormatted {
+				w.WriteString("  ")
+			} else {
+				w.WriteString("    ")
+				w.WriteString(colors.BorderText("│"))
+				w.WriteString(strings.Repeat(" ", len(diagnostic.RuleName)+1))
+			}
+		}
+	}
+	if messageLineStart <= len(diagnostic.Message.Description) {
+		w.WriteString(diagnostic.Message.Description[messageLineStart:])
+	}
+
+	w.WriteString("\n  ")
+	w.WriteString(colors.BorderText("╭─┴──────────("))
+	w.WriteByte(' ')
+	location := fmt.Sprintf("%s:%d:%d", view.relativePath, diagnosticStartLine+1, diagnosticStartColumn+1)
+	w.WriteString(colors.FileName("%s", location))
+	w.WriteByte(' ')
+	w.WriteString(colors.BorderText(")─────"))
+	w.WriteByte('\n')
+
+	indentSize := math.MaxInt
+	line := codeboxStartLine
+	lineIndentCalculated := false
+	lastNonSpaceByteIndex := -1
+
+	numLines := codeboxEndLine - codeboxStartLine + 1
+	lineStarts := make([]int, numLines)
+	lineEnds := make([]int, numLines)
+
+	codeboxText := text[codeboxStart:codeboxEnd]
+	for i := 0; i < len(codeboxText); {
+		char, size := utf8.DecodeRuneInString(codeboxText[i:])
+		current := codeboxStart + i
+		next := current + size
+		i += size
+
+		if char == '\n' {
+			if line != codeboxEndLine {
+				lineIndentCalculated = false
+				lineEnds[line-codeboxStartLine] = lastNonSpaceByteIndex - int(lineMap[line])
+				lastNonSpaceByteIndex = -1
+				line++
+			}
+			continue
+		}
+
+		if !lineIndentCalculated && !unicode.IsSpace(char) {
+			lineIndentCalculated = true
+			lineStarts[line-codeboxStartLine] = current - int(lineMap[line])
+			indentSize = min(indentSize, lineStarts[line-codeboxStartLine])
+		}
+
+		if lineIndentCalculated && !unicode.IsSpace(char) {
+			lastNonSpaceByteIndex = next
+		}
+	}
+	if line == codeboxEndLine {
+		lineEnds[line-codeboxStartLine] = lastNonSpaceByteIndex - int(lineMap[line])
+	}
+	if indentSize == math.MaxInt {
+		indentSize = 0
+	}
+
+	diagnosticHighlightActive := false
+	lastLineNumber := strconv.Itoa(codeboxEndLine + 1)
+	shouldFold := codeboxEndLine-codeboxStartLine >= 4
+
+	for line := codeboxStartLine; line <= codeboxEndLine; line++ {
+		if shouldFold && codeboxStartLine+1 < line && line < codeboxEndLine-1 {
+			w.WriteString("  ")
+			w.WriteString(colors.BorderText("│ "))
+			foldDots := strings.Repeat(".", len(lastLineNumber))
+			w.WriteString(colors.DimText("%s", foldDots))
+			w.WriteString(colors.BorderText(" │"))
+			w.WriteByte('\n')
+
+			line = codeboxEndLine - 1
+			diagnosticHighlightActive = diagnosticStart < int(lineMap[line]) && diagnosticEnd >= int(lineMap[line])
+		}
+
+		w.WriteString("  ")
+		w.WriteString(colors.BorderText("│ "))
+		if line == codeboxEndLine {
+			w.WriteString(colors.DimText("%s", lastLineNumber))
+		} else {
+			number := strconv.Itoa(line + 1)
+			if len(number) < len(lastLineNumber) {
+				w.WriteByte(' ')
+			}
+			w.WriteString(colors.DimText("%s", number))
+		}
+		w.WriteString(colors.BorderText(" │"))
+		w.WriteString("  ")
+
+		lineTextStart := int(lineMap[line]) + indentSize
+		underlineStart := max(lineTextStart, int(lineMap[line])+lineStarts[line-codeboxStartLine])
+		underlineEnd := underlineStart
+		lineTextEnd := max(int(lineMap[line])+lineEnds[line-codeboxStartLine], lineTextStart)
+
+		if diagnosticHighlightActive {
+			underlineEnd = lineTextEnd
+		} else if int(lineMap[line]) <= diagnosticStart && (line == len(lineMap)-1 || diagnosticStart < int(lineMap[line+1])) {
+			underlineStart = min(max(lineTextStart, diagnosticStart), lineTextEnd)
+			underlineEnd = lineTextEnd
+			diagnosticHighlightActive = true
+		}
+		if int(lineMap[line]) <= diagnosticEnd && (line == len(lineMap)-1 || diagnosticEnd < int(lineMap[line+1])) {
+			underlineEnd = min(max(underlineStart, diagnosticEnd), lineTextEnd)
+			diagnosticHighlightActive = false
+		}
+
+		if underlineStart != underlineEnd {
+			w.WriteString(text[lineTextStart:underlineStart])
+			w.WriteString(severityColor("%s", text[underlineStart:underlineEnd]))
+			w.WriteString(text[underlineEnd:lineTextEnd])
+		} else if lineTextStart != lineTextEnd {
+			w.WriteString(text[lineTextStart:lineTextEnd])
+		}
+
+		w.WriteByte('\n')
+	}
+	w.WriteString("  ")
+	w.WriteString(colors.BorderText("╰────────────────────────────────"))
+	w.WriteString("\n\n")
+}

--- a/cmd/rslint/internal/output/diagnostic.go
+++ b/cmd/rslint/internal/output/diagnostic.go
@@ -1,0 +1,50 @@
+package output
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type location struct {
+	line   int
+	column int
+}
+
+type diagnosticView struct {
+	raw          rule.RuleDiagnostic
+	relativePath string
+	start        location
+	end          location
+}
+
+func newDiagnosticView(diagnostic rule.RuleDiagnostic, paths tspath.ComparePathsOptions) (diagnosticView, error) {
+	if diagnostic.SourceFile == nil {
+		return diagnosticView{}, fmt.Errorf("diagnostic %q for %q has no source file", diagnostic.RuleName, diagnostic.FilePath)
+	}
+
+	start, end := diagnostic.Range.Pos(), diagnostic.Range.End()
+	textLength := len(diagnostic.SourceFile.Text())
+	if start < 0 || end < start || end > textLength {
+		return diagnosticView{}, fmt.Errorf(
+			"diagnostic %q for %q has invalid range [%d,%d) for source length %d",
+			diagnostic.RuleName,
+			diagnostic.FilePath,
+			start,
+			end,
+			textLength,
+		)
+	}
+
+	startLine, startColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(diagnostic.SourceFile, start)
+	endLine, endColumn := scanner.GetECMALineAndUTF16CharacterOfPosition(diagnostic.SourceFile, end)
+
+	return diagnosticView{
+		raw:          diagnostic,
+		relativePath: tspath.ConvertToRelativePath(diagnostic.FilePath, paths),
+		start:        location{line: startLine, column: int(startColumn)},
+		end:          location{line: endLine, column: int(endColumn)},
+	}, nil
+}

--- a/cmd/rslint/internal/output/format.go
+++ b/cmd/rslint/internal/output/format.go
@@ -1,0 +1,47 @@
+package output
+
+import "fmt"
+
+// Format identifies one CLI stdout protocol. Its zero value is the default
+// human-readable format so internal callers that construct options directly
+// retain the CLI default.
+type Format uint8
+
+// Keep this list in sync with OUTPUT_FORMATS in
+// packages/rslint/src/utils/args.ts.
+const (
+	FormatDefault Format = iota
+	FormatJSONLine
+	FormatGitHub
+	FormatGitLab
+)
+
+func ParseFormat(value string) (Format, error) {
+	switch value {
+	case "default":
+		return FormatDefault, nil
+	case "jsonline":
+		return FormatJSONLine, nil
+	case "github":
+		return FormatGitHub, nil
+	case "gitlab":
+		return FormatGitLab, nil
+	default:
+		return FormatDefault, fmt.Errorf("invalid output format %q (expected default, jsonline, github, or gitlab)", value)
+	}
+}
+
+func (f Format) String() string {
+	switch f {
+	case FormatDefault:
+		return "default"
+	case FormatJSONLine:
+		return "jsonline"
+	case FormatGitHub:
+		return "github"
+	case FormatGitLab:
+		return "gitlab"
+	default:
+		return fmt.Sprintf("Format(%d)", f)
+	}
+}

--- a/cmd/rslint/internal/output/github.go
+++ b/cmd/rslint/internal/output/github.go
@@ -1,0 +1,54 @@
+package output
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type githubFormatter struct{}
+
+func (githubFormatter) begin(_ *bufio.Writer, _ Report, _ bool) error { return nil }
+
+func (githubFormatter) diagnostic(w *bufio.Writer, view diagnosticView) error {
+	severity := "notice"
+	switch view.raw.Severity {
+	case rule.SeverityError:
+		severity = "error"
+	case rule.SeverityWarning:
+		severity = "warning"
+	}
+
+	fmt.Fprintf(w,
+		"::%s file=%s,line=%d,endLine=%d,col=%d,endColumn=%d,title=%s::%s\n",
+		severity,
+		escapeProperty(view.relativePath),
+		view.start.line+1,
+		view.end.line+1,
+		view.start.column+1,
+		view.end.column+1,
+		escapeProperty(view.raw.RuleName),
+		escapeData(view.raw.Message.Description),
+	)
+	return nil
+}
+
+func (githubFormatter) finish(_ *bufio.Writer, _ Report) error { return nil }
+
+func escapeData(value string) string {
+	value = strings.ReplaceAll(value, "%", "%25")
+	value = strings.ReplaceAll(value, "\r", "%0D")
+	value = strings.ReplaceAll(value, "\n", "%0A")
+	return value
+}
+
+func escapeProperty(value string) string {
+	value = strings.ReplaceAll(value, "%", "%25")
+	value = strings.ReplaceAll(value, "\r", "%0D")
+	value = strings.ReplaceAll(value, "\n", "%0A")
+	value = strings.ReplaceAll(value, ":", "%3A")
+	value = strings.ReplaceAll(value, ",", "%2C")
+	return value
+}

--- a/cmd/rslint/internal/output/gitlab.go
+++ b/cmd/rslint/internal/output/gitlab.go
@@ -1,0 +1,135 @@
+package output
+
+import (
+	"bufio"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type gitlabFormatter struct {
+	wrote        int
+	fingerprints gitlabFingerprintState
+}
+
+func newGitLabFormatter() *gitlabFormatter {
+	return &gitlabFormatter{fingerprints: newGitLabFingerprintState()}
+}
+
+func (f *gitlabFormatter) begin(w *bufio.Writer, _ Report, _ bool) error {
+	return w.WriteByte('[')
+}
+
+func (f *gitlabFormatter) diagnostic(w *bufio.Writer, view diagnosticView) error {
+	type gitlabPosition struct {
+		Line   int `json:"line"`
+		Column int `json:"column"`
+	}
+	type gitlabPositions struct {
+		Begin gitlabPosition `json:"begin"`
+		End   gitlabPosition `json:"end"`
+	}
+	type gitlabLines struct {
+		Begin int `json:"begin"`
+		End   int `json:"end"`
+	}
+	type gitlabLocation struct {
+		Path      string          `json:"path"`
+		Lines     gitlabLines     `json:"lines"`
+		Positions gitlabPositions `json:"positions"`
+	}
+	type gitlabIssue struct {
+		Description string         `json:"description"`
+		CheckName   string         `json:"check_name"`
+		Fingerprint string         `json:"fingerprint"`
+		Severity    string         `json:"severity"`
+		Location    gitlabLocation `json:"location"`
+	}
+
+	severity := "info"
+	switch view.raw.Severity {
+	case rule.SeverityError:
+		severity = "major"
+	case rule.SeverityWarning:
+		severity = "minor"
+	}
+
+	beginLine, beginColumn := view.start.line+1, view.start.column+1
+	endLine, endColumn := view.end.line+1, view.end.column+1
+	issue := gitlabIssue{
+		Description: view.raw.Message.Description,
+		CheckName:   view.raw.RuleName,
+		Fingerprint: f.fingerprints.fingerprint(view.relativePath, view.raw.RuleName, view.raw.Message.Description, beginLine, beginColumn, endLine, endColumn),
+		Severity:    severity,
+		Location: gitlabLocation{
+			Path:  view.relativePath,
+			Lines: gitlabLines{Begin: beginLine, End: endLine},
+			Positions: gitlabPositions{
+				Begin: gitlabPosition{Line: beginLine, Column: beginColumn},
+				End:   gitlabPosition{Line: endLine, Column: endColumn},
+			},
+		},
+	}
+
+	encoded, err := json.Marshal(issue)
+	if err != nil {
+		return err
+	}
+	if f.wrote > 0 {
+		w.WriteByte(',')
+	}
+	w.Write(encoded)
+	f.wrote++
+	return nil
+}
+
+func (f *gitlabFormatter) finish(w *bufio.Writer, _ Report) error {
+	w.WriteString("]\n")
+	return nil
+}
+
+type gitlabFingerprintState struct {
+	nextSalt map[string]int
+	emitted  map[string]struct{}
+}
+
+func newGitLabFingerprintState() gitlabFingerprintState {
+	return gitlabFingerprintState{
+		nextSalt: make(map[string]int),
+		emitted:  make(map[string]struct{}),
+	}
+}
+
+func (s *gitlabFingerprintState) fingerprint(filePath, ruleName, message string, startLine, startColumn, endLine, endColumn int) string {
+	input := fmt.Sprintf("%s:%s:%s:%d:%d:%d:%d", filePath, ruleName, message, startLine, startColumn, endLine, endColumn)
+	digest := func(value string) string {
+		sum := md5.Sum([]byte(value)) //nolint:gosec // opaque identifier, not a security boundary
+		return hex.EncodeToString(sum[:])
+	}
+
+	// Preserve the historical hash for the first ordinary occurrence and the
+	// historical :1, :2, ... salts for duplicates. Track every fingerprint that
+	// was actually emitted as well: a salted fingerprint can otherwise collide
+	// with another diagnostic whose unsalted tuple contains the same colon-
+	// separated suffix.
+	salt := s.nextSalt[input]
+	for {
+		value := input
+		if salt > 0 {
+			value += ":" + strconv.Itoa(salt)
+		}
+		salt++
+		s.nextSalt[input] = salt
+
+		fingerprint := digest(value)
+		if _, exists := s.emitted[fingerprint]; exists {
+			continue
+		}
+		s.emitted[fingerprint] = struct{}{}
+		return fingerprint
+	}
+}

--- a/cmd/rslint/internal/output/jsonline.go
+++ b/cmd/rslint/internal/output/jsonline.go
@@ -1,0 +1,49 @@
+package output
+
+import (
+	"bufio"
+	"encoding/json"
+)
+
+type jsonLineFormatter struct{}
+
+func (jsonLineFormatter) begin(_ *bufio.Writer, _ Report, _ bool) error { return nil }
+
+func (jsonLineFormatter) diagnostic(w *bufio.Writer, view diagnosticView) error {
+	type jsonLocation struct {
+		Line   int `json:"line"`
+		Column int `json:"column"`
+	}
+	type jsonRange struct {
+		Start jsonLocation `json:"start"`
+		End   jsonLocation `json:"end"`
+	}
+	type jsonDiagnostic struct {
+		RuleName string    `json:"ruleName"`
+		Message  string    `json:"message"`
+		FilePath string    `json:"filePath"`
+		Range    jsonRange `json:"range"`
+		Severity string    `json:"severity"`
+	}
+
+	diagnostic := jsonDiagnostic{
+		RuleName: view.raw.RuleName,
+		Message:  view.raw.Message.Description,
+		FilePath: view.relativePath,
+		Range: jsonRange{
+			Start: jsonLocation{Line: view.start.line + 1, Column: view.start.column + 1},
+			End:   jsonLocation{Line: view.end.line + 1, Column: view.end.column + 1},
+		},
+		Severity: view.raw.Severity.String(),
+	}
+
+	encoded, err := json.Marshal(diagnostic)
+	if err != nil {
+		return err
+	}
+	w.Write(encoded)
+	w.WriteByte('\n')
+	return nil
+}
+
+func (jsonLineFormatter) finish(_ *bufio.Writer, _ Report) error { return nil }

--- a/cmd/rslint/internal/output/output.go
+++ b/cmd/rslint/internal/output/output.go
@@ -1,0 +1,87 @@
+package output
+
+import (
+	"bufio"
+	"errors"
+	"io"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const outputBufferSize = 4096 * 100
+
+type Options struct {
+	Format       Format
+	ComparePaths tspath.ComparePathsOptions
+	Quiet        bool
+	ColorEnabled bool
+}
+
+type formatter interface {
+	begin(w *bufio.Writer, report Report, hasVisibleDiagnostics bool) error
+	diagnostic(w *bufio.Writer, view diagnosticView) error
+	finish(w *bufio.Writer, report Report) error
+}
+
+func Render(dst io.Writer, report Report, options Options) error {
+	selected, err := newFormatter(options)
+	if err != nil {
+		return err
+	}
+
+	// Build and validate every visible view before writing anything. A malformed
+	// diagnostic must not leave a partial machine-readable report (for example,
+	// an unterminated GitLab JSON array) in the destination.
+	views := make([]diagnosticView, 0, len(report.diagnostics))
+	for _, diagnostic := range report.diagnostics {
+		if !isVisible(diagnostic, options.Quiet) {
+			continue
+		}
+		view, err := newDiagnosticView(diagnostic, options.ComparePaths)
+		if err != nil {
+			return err
+		}
+		views = append(views, view)
+	}
+
+	w := bufio.NewWriterSize(dst, outputBufferSize)
+	if err := selected.begin(w, report, len(views) > 0); err != nil {
+		return errors.Join(err, w.Flush())
+	}
+
+	for _, view := range views {
+		if err := selected.diagnostic(w, view); err != nil {
+			return errors.Join(err, w.Flush())
+		}
+		if w.Available() < 4096 {
+			if err := w.Flush(); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := selected.finish(w, report); err != nil {
+		return errors.Join(err, w.Flush())
+	}
+	return w.Flush()
+}
+
+func isVisible(diagnostic rule.RuleDiagnostic, quiet bool) bool {
+	return !quiet || diagnostic.Severity == rule.SeverityError
+}
+
+func newFormatter(options Options) (formatter, error) {
+	switch options.Format {
+	case FormatDefault:
+		return &defaultFormatter{colors: newColorScheme(options.ColorEnabled)}, nil
+	case FormatJSONLine:
+		return jsonLineFormatter{}, nil
+	case FormatGitHub:
+		return githubFormatter{}, nil
+	case FormatGitLab:
+		return newGitLabFormatter(), nil
+	default:
+		return nil, errors.New("unsupported output format " + options.Format.String())
+	}
+}

--- a/cmd/rslint/internal/output/output_test.go
+++ b/cmd/rslint/internal/output/output_test.go
@@ -97,7 +97,7 @@ func TestSummaryText(t *testing.T) {
 			}, Metadata{
 				Mode: ModeLint, LintedFiles: 1, Rules: 1, Threads: 1, FixedIssues: 1,
 			}),
-			expected: "Found 1 error and 1 warning (linted 1 file with 1 rule in 12ms using 1 threads, fixed 1 issue)\n",
+			expected: "Found 1 error and 1 warning (linted 1 file with 1 rule in 12ms using 1 thread, fixed 1 issue)\n",
 		},
 		{
 			name: "lint and type-check",
@@ -105,9 +105,9 @@ func TestSummaryText(t *testing.T) {
 				{RuleName: "no-debugger", Severity: rule.SeverityError},
 				{RuleName: "TypeScript(TS2322)", Severity: rule.SeverityError, Origin: rule.DiagnosticOriginTypeScript},
 			}, Metadata{
-				Mode: ModeLintAndTypeCheck, LintedFiles: 1, Rules: 0, Threads: 2,
+				Mode: ModeLintAndTypeCheck, LintedFiles: 1, TypeCheckedFiles: 2, Rules: 0, Threads: 2,
 			}),
-			expected: "Found 1 lint error, 1 type error and 0 warnings (linted 1 file with 0 rules in 12ms using 2 threads)\n",
+			expected: "Found 1 lint error, 1 type error and 0 warnings (linted 1 file with 0 rules, type-checked 2 files in 12ms using 2 threads)\n",
 		},
 		{
 			name: "type-check only",
@@ -149,6 +149,13 @@ func TestSummaryDetailsAreOneDimSpan(t *testing.T) {
 			details: "(linted 2 files with 3 rules in 12ms using 4 threads, fixed 5 issues)",
 		},
 		{
+			name: "lint and type-check details",
+			report: NewReport(nil, Metadata{
+				Mode: ModeLintAndTypeCheck, LintedFiles: 1, TypeCheckedFiles: 2, Rules: 3, Threads: 1,
+			}),
+			details: "(linted 1 file with 3 rules, type-checked 2 files in 12ms using 1 thread)",
+		},
+		{
 			name: "type-check-only details",
 			report: NewReport(nil, Metadata{
 				Mode: ModeTypeCheckOnly, TypeCheckedFiles: 2, Threads: 4,
@@ -170,6 +177,32 @@ func TestSummaryDetailsAreOneDimSpan(t *testing.T) {
 				t.Fatalf("details are not one dim span:\n%s", buf.String())
 			}
 		})
+	}
+}
+
+func TestMixedSummaryColorsErrorCountsIndependently(t *testing.T) {
+	report := NewReport([]rule.RuleDiagnostic{
+		{Severity: rule.SeverityError, Origin: rule.DiagnosticOriginTypeScript},
+	}, Metadata{
+		Mode: ModeLintAndTypeCheck, LintedFiles: 1, TypeCheckedFiles: 1, Threads: 1,
+	})
+	colors := newColorScheme(true)
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	renderSummary(w, report, 12*time.Millisecond, colors)
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+	if want := colors.SuccessText("%d", 0) + " lint errors"; !strings.Contains(got, want) {
+		t.Fatalf("zero lint-error count is not green:\n%s", got)
+	}
+	if want := colors.ErrorText("%d", 1) + " type error"; !strings.Contains(got, want) {
+		t.Fatalf("non-zero type-error count is not red:\n%s", got)
+	}
+	if unwanted := colors.ErrorText("%d", 0) + " lint errors"; strings.Contains(got, unwanted) {
+		t.Fatalf("zero lint-error count is red:\n%s", got)
 	}
 }
 

--- a/cmd/rslint/internal/output/output_test.go
+++ b/cmd/rslint/internal/output/output_test.go
@@ -1,0 +1,396 @@
+package output
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestParseFormat(t *testing.T) {
+	tests := []struct {
+		value string
+		want  Format
+	}{
+		{"default", FormatDefault},
+		{"jsonline", FormatJSONLine},
+		{"github", FormatGitHub},
+		{"gitlab", FormatGitLab},
+	}
+	for _, test := range tests {
+		got, err := ParseFormat(test.value)
+		if err != nil || got != test.want {
+			t.Errorf("ParseFormat(%q) = %v, %v; want %v", test.value, got, err, test.want)
+		}
+	}
+	if _, err := ParseFormat("stylish"); err == nil {
+		t.Fatal("expected invalid format to fail")
+	}
+	if _, err := ParseFormat(""); err == nil {
+		t.Fatal("expected an explicitly empty format to fail")
+	}
+}
+
+func TestNewReportOwnsDiagnosticSnapshot(t *testing.T) {
+	diagnostics := []rule.RuleDiagnostic{{RuleName: "before", Severity: rule.SeverityError}}
+	report := NewReport(diagnostics, Metadata{Mode: ModeLint})
+	diagnostics[0].Severity = rule.SeverityWarning
+	diagnostics[0].RuleName = "after"
+	if report.diagnostics[0].RuleName != "before" || report.Counts().Errors != 1 {
+		t.Fatalf("report changed after caller mutation: diagnostic=%+v counts=%+v", report.diagnostics[0], report.Counts())
+	}
+}
+
+func TestNewReportCounts(t *testing.T) {
+	diagnostics := []rule.RuleDiagnostic{
+		{RuleName: "no-debugger", Severity: rule.SeverityError},
+		{RuleName: "TypeScript(TS2322)", Severity: rule.SeverityError, Origin: rule.DiagnosticOriginTypeScript},
+		{RuleName: "TypeScript(TS9999)", Severity: rule.SeverityError},
+		{RuleName: "no-console", Severity: rule.SeverityWarning},
+		{RuleName: "off", Severity: rule.SeverityOff},
+	}
+
+	lintCounts := NewReport(diagnostics, Metadata{Mode: ModeLint}).Counts()
+	if lintCounts != (Counts{Errors: 3, Warnings: 1, LintErrors: 3}) {
+		t.Fatalf("lint counts = %+v", lintCounts)
+	}
+
+	typeCheckCounts := NewReport(diagnostics, Metadata{Mode: ModeLintAndTypeCheck}).Counts()
+	if typeCheckCounts != (Counts{Errors: 3, Warnings: 1, LintErrors: 2, TypeErrors: 1}) {
+		t.Fatalf("type-check counts = %+v", typeCheckCounts)
+	}
+}
+
+func TestSummaryText(t *testing.T) {
+	tests := []struct {
+		name     string
+		report   Report
+		expected string
+	}{
+		{
+			name: "lint zero plural",
+			report: NewReport(nil, Metadata{
+				Mode: ModeLint, LintedFiles: 2, Rules: 3, Threads: 4,
+			}),
+			expected: "Found 0 errors and 0 warnings (linted 2 files with 3 rules in 12ms using 4 threads)\n",
+		},
+		{
+			name: "lint singular with fix",
+			report: NewReport([]rule.RuleDiagnostic{
+				{Severity: rule.SeverityError},
+				{Severity: rule.SeverityWarning},
+			}, Metadata{
+				Mode: ModeLint, LintedFiles: 1, Rules: 1, Threads: 1, FixedIssues: 1,
+			}),
+			expected: "Found 1 error and 1 warning (linted 1 file with 1 rule in 12ms using 1 threads, fixed 1 issue)\n",
+		},
+		{
+			name: "lint and type-check",
+			report: NewReport([]rule.RuleDiagnostic{
+				{RuleName: "no-debugger", Severity: rule.SeverityError},
+				{RuleName: "TypeScript(TS2322)", Severity: rule.SeverityError, Origin: rule.DiagnosticOriginTypeScript},
+			}, Metadata{
+				Mode: ModeLintAndTypeCheck, LintedFiles: 1, Rules: 0, Threads: 2,
+			}),
+			expected: "Found 1 lint error, 1 type error and 0 warnings (linted 1 file with 0 rules in 12ms using 2 threads)\n",
+		},
+		{
+			name: "type-check only",
+			report: NewReport([]rule.RuleDiagnostic{
+				{RuleName: "TypeScript(TS2322)", Severity: rule.SeverityError, Origin: rule.DiagnosticOriginTypeScript},
+			}, Metadata{
+				Mode: ModeTypeCheckOnly, TypeCheckedFiles: 1, Threads: 2,
+			}),
+			expected: "Found 1 type error (type-checked 1 file in 12ms using 2 threads)\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := bufio.NewWriter(&buf)
+			renderSummary(w, test.report, 12*time.Millisecond, newColorScheme(false))
+			if err := w.Flush(); err != nil {
+				t.Fatal(err)
+			}
+			if got := buf.String(); got != test.expected {
+				t.Fatalf("summary:\n got: %q\nwant: %q", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestSummaryDetailsAreOneDimSpan(t *testing.T) {
+	tests := []struct {
+		name    string
+		report  Report
+		details string
+	}{
+		{
+			name: "lint and fixed details",
+			report: NewReport(nil, Metadata{
+				Mode: ModeLint, LintedFiles: 2, Rules: 3, Threads: 4, FixedIssues: 5,
+			}),
+			details: "(linted 2 files with 3 rules in 12ms using 4 threads, fixed 5 issues)",
+		},
+		{
+			name: "type-check-only details",
+			report: NewReport(nil, Metadata{
+				Mode: ModeTypeCheckOnly, TypeCheckedFiles: 2, Threads: 4,
+			}),
+			details: "(type-checked 2 files in 12ms using 4 threads)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := bufio.NewWriter(&buf)
+			renderSummary(w, test.report, 12*time.Millisecond, newColorScheme(true))
+			if err := w.Flush(); err != nil {
+				t.Fatal(err)
+			}
+			wantSpan := "\x1b[2m" + test.details + "\x1b[22m"
+			if !strings.Contains(buf.String(), wantSpan) {
+				t.Fatalf("details are not one dim span:\n%s", buf.String())
+			}
+		})
+	}
+}
+
+func TestMachineFormatsHaveNoLeadingBlankLine(t *testing.T) {
+	diagnostic, paths := createOutputTestDiagnostic(t, rule.SeverityWarning)
+	report := NewReport([]rule.RuleDiagnostic{diagnostic}, Metadata{Mode: ModeLint})
+
+	for _, format := range []Format{FormatJSONLine, FormatGitHub, FormatGitLab} {
+		t.Run(format.String(), func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := Render(&buf, report, Options{Format: format, ComparePaths: paths}); err != nil {
+				t.Fatal(err)
+			}
+			if len(buf.Bytes()) == 0 || buf.Bytes()[0] == '\n' {
+				t.Fatalf("unexpected leading blank line: %q", buf.String())
+			}
+			if strings.Contains(buf.String(), "Found ") {
+				t.Fatalf("machine format contains summary: %q", buf.String())
+			}
+		})
+	}
+}
+
+func TestGitHubEscapesEveryWorkflowCommandField(t *testing.T) {
+	diagnostic, paths := createOutputTestDiagnostic(t, rule.SeverityWarning)
+	diagnostic.RuleName = "rule%,:\r\n::warning"
+	diagnostic.Message.Description = "message%\r\n::error"
+
+	var buf bytes.Buffer
+	if err := Render(&buf, NewReport([]rule.RuleDiagnostic{diagnostic}, Metadata{}), Options{
+		Format: FormatGitHub, ComparePaths: paths,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	want := "::warning file=index.ts,line=1,endLine=1,col=7,endColumn=12,title=rule%25%2C%3A%0D%0A%3A%3A" +
+		"warning::message%25%0D%0A::error\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("GitHub output:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestJSONLineProtocol(t *testing.T) {
+	diagnostic, paths := createOutputTestDiagnostic(t, rule.SeverityWarning)
+	var buf bytes.Buffer
+	if err := Render(&buf, NewReport([]rule.RuleDiagnostic{diagnostic}, Metadata{}), Options{
+		Format: FormatJSONLine, ComparePaths: paths,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	want := "{\"ruleName\":\"test-rule\",\"message\":\"test message\",\"filePath\":\"index.ts\",\"range\":{\"start\":{\"line\":1,\"column\":7},\"end\":{\"line\":1,\"column\":12}},\"severity\":\"warn\"}\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("JSON line output:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestQuietFiltersRenderingButNotCounts(t *testing.T) {
+	diagnostic := rule.RuleDiagnostic{Severity: rule.SeverityWarning}
+	report := NewReport([]rule.RuleDiagnostic{diagnostic}, Metadata{
+		Mode: ModeLint, Threads: 1,
+	})
+	if report.Counts().Warnings != 1 {
+		t.Fatalf("warning count = %d", report.Counts().Warnings)
+	}
+
+	for _, test := range []struct {
+		format Format
+		want   string
+	}{
+		{FormatJSONLine, ""},
+		{FormatGitHub, ""},
+		{FormatGitLab, "[]\n"},
+	} {
+		var buf bytes.Buffer
+		if err := Render(&buf, report, Options{Format: test.format, Quiet: true}); err != nil {
+			t.Fatal(err)
+		}
+		if got := buf.String(); got != test.want {
+			t.Fatalf("%s quiet output = %q, want %q", test.format, got, test.want)
+		}
+	}
+
+	var defaultBuf bytes.Buffer
+	if err := Render(&defaultBuf, report, Options{Format: FormatDefault, Quiet: true}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasPrefix(defaultBuf.String(), "\n") {
+		t.Fatalf("quiet warning-only default report has a stray blank line: %q", defaultBuf.String())
+	}
+	if !strings.Contains(defaultBuf.String(), "1 warning") {
+		t.Fatalf("summary lost hidden warning count: %q", defaultBuf.String())
+	}
+}
+
+func TestGitLabEmptyAndFingerprintCollisions(t *testing.T) {
+	var empty bytes.Buffer
+	if err := Render(&empty, NewReport(nil, Metadata{}), Options{Format: FormatGitLab}); err != nil {
+		t.Fatal(err)
+	}
+	if empty.String() != "[]\n" {
+		t.Fatalf("empty GitLab report = %q", empty.String())
+	}
+
+	sequence := func() []string {
+		state := newGitLabFingerprintState()
+		return []string{
+			state.fingerprint("f.ts", "rule", "msg", 1, 1, 1, 5),
+			state.fingerprint("f.ts", "rule", "msg", 1, 1, 1, 5),
+			// Its unsalted tuple equals the previous diagnostic's historical
+			// colon-salted tuple. All emitted fingerprints must still be unique.
+			state.fingerprint("f.ts", "rule", "msg:1", 1, 1, 5, 1),
+		}
+	}
+	fingerprints := sequence()
+	if fingerprints[0] == fingerprints[1] || fingerprints[0] == fingerprints[2] || fingerprints[1] == fingerprints[2] {
+		t.Fatalf("fingerprints are not unique: %q", fingerprints)
+	}
+	if fresh := sequence(); !slices.Equal(fresh, fingerprints) {
+		t.Fatalf("fingerprints are not deterministic: first=%q fresh=%q", fingerprints, fresh)
+	}
+
+	diagnostic, paths := createOutputTestDiagnostic(t, rule.SeverityError)
+	var rendered bytes.Buffer
+	if err := Render(&rendered, NewReport([]rule.RuleDiagnostic{diagnostic}, Metadata{}), Options{
+		Format: FormatGitLab, ComparePaths: paths,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var issues []map[string]any
+	if err := json.Unmarshal(rendered.Bytes(), &issues); err != nil || len(issues) != 1 {
+		t.Fatalf("invalid GitLab JSON: %v, %s", err, rendered.String())
+	}
+}
+
+func TestRenderValidatesAllDiagnosticsBeforeWriting(t *testing.T) {
+	valid, paths := createOutputTestDiagnostic(t, rule.SeverityError)
+	start := valid.Range.Pos()
+	tests := []struct {
+		name   string
+		mutate func(*rule.RuleDiagnostic)
+	}{
+		{name: "missing source", mutate: func(d *rule.RuleDiagnostic) { d.SourceFile = nil }},
+		{name: "negative start", mutate: func(d *rule.RuleDiagnostic) { d.Range = core.NewTextRange(-1, 0) }},
+		{name: "reversed", mutate: func(d *rule.RuleDiagnostic) { d.Range = core.NewTextRange(start+1, start) }},
+		{name: "past source", mutate: func(d *rule.RuleDiagnostic) {
+			d.Range = core.NewTextRange(start, len(d.SourceFile.Text())+1)
+		}},
+	}
+
+	for _, format := range []Format{FormatDefault, FormatJSONLine, FormatGitHub, FormatGitLab} {
+		for _, test := range tests {
+			t.Run(format.String()+"/"+test.name, func(t *testing.T) {
+				bad := valid
+				test.mutate(&bad)
+				var buf bytes.Buffer
+				err := Render(&buf, NewReport([]rule.RuleDiagnostic{valid, bad}, Metadata{}), Options{
+					Format: format, ComparePaths: paths,
+				})
+				if err == nil {
+					t.Fatal("expected invalid diagnostic to fail")
+				}
+				if buf.Len() != 0 {
+					t.Fatalf("invalid report wrote partial output: %q", buf.String())
+				}
+			})
+		}
+	}
+}
+
+func TestRenderReturnsWriterError(t *testing.T) {
+	want := errors.New("write failed")
+	err := Render(failingWriter{err: want}, NewReport(nil, Metadata{}), Options{Format: FormatGitLab})
+	if !errors.Is(err, want) {
+		t.Fatalf("Render error = %v, want %v", err, want)
+	}
+}
+
+func TestRenderRejectsUnknownFormat(t *testing.T) {
+	err := Render(&bytes.Buffer{}, NewReport(nil, Metadata{}), Options{Format: Format(255)})
+	if err == nil || !strings.Contains(err.Error(), "unsupported output format") {
+		t.Fatalf("Render error = %v", err)
+	}
+}
+
+type failingWriter struct{ err error }
+
+func (w failingWriter) Write(_ []byte) (int, error) { return 0, w.err }
+
+func createOutputTestDiagnostic(t *testing.T, severity rule.DiagnosticSeverity) (rule.RuleDiagnostic, tspath.ComparePathsOptions) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte(`{"include":["./index.ts"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	source := "const value = 1;\n"
+	if err := os.WriteFile(filepath.Join(dir, "index.ts"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := utils.CreateCompilerHost(dir, fs)
+	program, err := utils.CreateProgram(true, fs, dir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sourceFile *ast.SourceFile
+	for _, file := range program.GetSourceFiles() {
+		if strings.HasSuffix(file.FileName(), "index.ts") {
+			sourceFile = file
+			break
+		}
+	}
+	if sourceFile == nil {
+		t.Fatal("source file not found")
+	}
+	start := strings.Index(source, "value")
+	return rule.RuleDiagnostic{
+		RuleName:   "test-rule",
+		SourceFile: sourceFile,
+		FilePath:   sourceFile.FileName(),
+		Range:      core.NewTextRange(start, start+len("value")),
+		Message:    rule.RuleMessage{Description: "test message"},
+		Severity:   severity,
+	}, tspath.ComparePathsOptions{CurrentDirectory: dir, UseCaseSensitiveFileNames: true}
+}

--- a/cmd/rslint/internal/output/report.go
+++ b/cmd/rslint/internal/output/report.go
@@ -1,0 +1,73 @@
+package output
+
+import (
+	"slices"
+	"time"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type Mode uint8
+
+const (
+	ModeLint Mode = iota
+	ModeLintAndTypeCheck
+	ModeTypeCheckOnly
+)
+
+// Metadata contains run-level values that cannot be derived from diagnostics.
+// StartedAt is retained instead of a precomputed duration so the default
+// summary preserves the existing end-to-end timing boundary, including
+// diagnostic rendering before the summary is written.
+type Metadata struct {
+	Mode             Mode
+	LintedFiles      int
+	TypeCheckedFiles int
+	Rules            int
+	Threads          int
+	FixedIssues      int
+	StartedAt        time.Time
+}
+
+type Counts struct {
+	Errors     int
+	Warnings   int
+	LintErrors int
+	TypeErrors int
+}
+
+type Report struct {
+	diagnostics []rule.RuleDiagnostic
+	metadata    Metadata
+	counts      Counts
+}
+
+// NewReport snapshots one completed CLI run. Render consumes the report once:
+// the default formatter finalizes elapsed time only after diagnostic output is
+// flushed, preserving the CLI's end-to-end timing boundary.
+func NewReport(diagnostics []rule.RuleDiagnostic, metadata Metadata) Report {
+	counts := Counts{}
+	for _, diagnostic := range diagnostics {
+		switch diagnostic.Severity {
+		case rule.SeverityError:
+			counts.Errors++
+			if (metadata.Mode == ModeLintAndTypeCheck || metadata.Mode == ModeTypeCheckOnly) &&
+				diagnostic.Origin == rule.DiagnosticOriginTypeScript {
+				counts.TypeErrors++
+			}
+		case rule.SeverityWarning:
+			counts.Warnings++
+		}
+	}
+	counts.LintErrors = counts.Errors - counts.TypeErrors
+
+	return Report{
+		diagnostics: slices.Clone(diagnostics),
+		metadata:    metadata,
+		counts:      counts,
+	}
+}
+
+func (r Report) Counts() Counts {
+	return r.counts
+}

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -44,7 +44,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/ipc"
@@ -252,12 +251,6 @@ func runCLI(args []string) int {
 	stdoutDrainDone := make(chan struct{})
 	go drainStdoutToIPC(stdoutR, ch, stdoutDrainDone)
 	os.Stdout = stdoutW
-	// fatih/color captured its package-level Output at init, pointing at the
-	// real fd-1 — which in IPC mode is the frame stream. Re-aim it at the
-	// redirect pipe so a stray color.Print-family call degrades to ordinary
-	// forwarded text instead of corrupting the frame protocol. (color.Error
-	// already points at the inherited stderr; leave it.)
-	color.Output = stdoutW
 	// finalizeStdout flushes + restores stdout before the shutdown handshake.
 	finalizeStdout := func() {
 		os.Stdout = origStdout

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -693,6 +693,7 @@ func collectTargetSyntacticDiagnostics(
 					Range:        loc,
 					Message:      rule.RuleMessage{Description: diagnostic.String()},
 					Severity:     rule.SeverityError,
+					Origin:       rule.DiagnosticOriginTypeScript,
 					PreFormatted: true,
 				})
 			}

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -760,6 +760,9 @@ func TestTypeCheckDeduplicatesSyntaxFromGoverningFallbackAndParentProgram(t *tes
 	if len(diagnostics) != 1 || diagnostics[0].RuleName != "TypeScript(TS1110)" {
 		t.Fatalf("expected one TS1110 diagnostic after cross-phase dedupe, got %+v", diagnostics)
 	}
+	if diagnostics[0].Origin != rule.DiagnosticOriginTypeScript {
+		t.Fatalf("deduplicated TypeScript diagnostic lost its origin: %+v", diagnostics[0])
+	}
 }
 
 func TestCreateProgramSetForConfigs_DeduplicatesSharedTsconfigAndRetainsOwners(t *testing.T) {

--- a/internal/linter/linter_typecheck_test.go
+++ b/internal/linter/linter_typecheck_test.go
@@ -43,6 +43,9 @@ func TestTypeCheck_ReportsSemanticErrors(t *testing.T) {
 	for _, d := range diagnostics {
 		if strings.HasPrefix(d.RuleName, "TypeScript(") {
 			found = true
+			if d.Origin != rule.DiagnosticOriginTypeScript {
+				t.Errorf("TypeScript diagnostic has origin %v, want DiagnosticOriginTypeScript", d.Origin)
+			}
 			break
 		}
 	}

--- a/internal/linter/typecheck.go
+++ b/internal/linter/typecheck.go
@@ -115,6 +115,7 @@ func runTypeCheckForProgram(prog *compiler.Program) []collectedTypeCheckDiagnost
 				SourceFile:   file,
 				FilePath:     file.FileName(),
 				Severity:     rule.SeverityError,
+				Origin:       rule.DiagnosticOriginTypeScript,
 				PreFormatted: true,
 			},
 		})

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -1044,6 +1044,7 @@ func lintSingleFile(
 				Range:        diagnostic.Loc(),
 				Message:      rule.RuleMessage{Description: diagnostic.String()},
 				Severity:     rule.SeverityError,
+				Origin:       rule.DiagnosticOriginTypeScript,
 				PreFormatted: true,
 			})
 		}
@@ -1354,7 +1355,7 @@ func createCodeActionFromSuggestion(ruleDiag rule.RuleDiagnostic, suggestion rul
 
 // Helper function to create disable rule actions for diagnostics without fixes
 func createDisableRuleActions(ruleDiag rule.RuleDiagnostic, uri lsproto.DocumentUri) []lsproto.CommandOrCodeAction {
-	if strings.HasPrefix(ruleDiag.RuleName, "TypeScript(TS") {
+	if ruleDiag.Origin == rule.DiagnosticOriginTypeScript {
 		return nil
 	}
 	var actions []lsproto.CommandOrCodeAction

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -2421,6 +2421,9 @@ func TestRunConfiguredLintForContent_SyntaxErrorSkipsRules(t *testing.T) {
 	if len(result.Diagnostics) == 0 || !strings.HasPrefix(result.Diagnostics[0].RuleName, "TypeScript(TS") {
 		t.Fatalf("expected a TypeScript syntax diagnostic, got %+v", result.Diagnostics)
 	}
+	if result.Diagnostics[0].Origin != rule.DiagnosticOriginTypeScript {
+		t.Fatalf("TypeScript syntax diagnostic has wrong origin: %+v", result.Diagnostics[0])
+	}
 	for _, diagnostic := range result.Diagnostics {
 		if diagnostic.RuleName == "no-debugger" {
 			t.Fatalf("rules ran for malformed file: %+v", result.Diagnostics)

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -195,6 +195,16 @@ func (s RuleSuggestion) Fixes() []RuleFix {
 	return s.FixesArr
 }
 
+// DiagnosticOrigin identifies the subsystem that produced a diagnostic.
+// Its zero value is a lint diagnostic so existing rule and plugin producers
+// remain source-compatible; TypeScript producers must opt in explicitly.
+type DiagnosticOrigin uint8
+
+const (
+	DiagnosticOriginLint DiagnosticOrigin = iota
+	DiagnosticOriginTypeScript
+)
+
 type RuleDiagnostic struct {
 	Range    core.TextRange
 	RuleName string
@@ -215,6 +225,7 @@ type RuleDiagnostic struct {
 	// from SourceFile.FileName(), plugin diagnostics from the wire path.
 	FilePath string
 	Severity DiagnosticSeverity
+	Origin   DiagnosticOrigin
 	// PreFormatted indicates that Message.Description already contains
 	// structured formatting (e.g. indented continuation lines from tsc diagnostics).
 	// The renderer will use a simple 2-space indent instead of the │ border style.

--- a/internal/term/color.go
+++ b/internal/term/color.go
@@ -1,10 +1,8 @@
 // Package term owns the CLI's color-output decision.
 //
 // The decision is made exactly once, at lint-pipeline entry, by
-// ResolveColorEnabled. Nothing else in the process may mutate the resulting
-// color state afterwards; in particular, fatih/color's package-init guess
-// (which keys off the Go process's own stdout — a pipe in IPC mode, never the
-// user's terminal) is unconditionally overwritten by this decision.
+// ResolveColorEnabled. The resulting bool is passed explicitly to the CLI
+// output package; this package neither reads nor mutates formatter globals.
 package term
 
 // ColorInputs carries every signal the color decision consumes. The caller

--- a/internal/term/color_test.go
+++ b/internal/term/color_test.go
@@ -4,9 +4,8 @@ import "testing"
 
 // TestResolveColorEnabled pins every precedence tier and the tier-vs-tier
 // orderings that differ from the pre-refactor behavior. Inputs are fully
-// explicit per case — no t.Setenv, no process env reads, no mutation of
-// fatih/color globals (writing color.NoColor from a test poisons other tests
-// in the same binary).
+// explicit per case — no t.Setenv calls, process-environment reads, or
+// formatter globals.
 func TestResolveColorEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/packages/rslint-test-tools/tests/cli/basic.test.ts
+++ b/packages/rslint-test-tools/tests/cli/basic.test.ts
@@ -76,6 +76,42 @@ describe('CLI Configuration Tests', () => {
     expect(result.exitCode).toBe(0);
   });
 
+  test('should prioritize help over an invalid output format', async () => {
+    const result = await runRslint(['--help', '--format', 'stylish']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('Usage:');
+    expect(result.stderr).not.toContain('invalid output format');
+  });
+
+  test('should prioritize init over an invalid lint output format', async () => {
+    const tempDir = await createTempDir({});
+    try {
+      const result = await runRslint(
+        ['--init', '--format', 'stylish'],
+        tempDir,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toContain('invalid output format');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('should reject an invalid output format before linting', async () => {
+    const tempDir = await createTempDir({
+      'rslint.config.mjs': `throw new Error('config must not be evaluated');`,
+    });
+    try {
+      const result = await runRslint(['--format', 'stylish'], tempDir);
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('invalid output format "stylish"');
+      expect(result.stderr).not.toContain('config must not be evaluated');
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   test('should use default config when no config specified', async () => {
     const tempDir = await createTempDir({
       'rslint.json': JSON.stringify([

--- a/packages/rslint-test-tools/tests/cli/type-check/__snapshots__/type-check-snapshot.test.ts.snap
+++ b/packages/rslint-test-tools/tests/cli/type-check/__snapshots__/type-check-snapshot.test.ts.snap
@@ -9,7 +9,7 @@ exports[`--type-check output snapshots (default format) > --quiet suppresses war
   │ 3 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 1 warning (linted 2 files with 1 rule in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 1 warning (linted 2 files with 1 rule, type-checked 1 file in <TIME> using <N> thread(s))
 "
 `;
 
@@ -28,7 +28,7 @@ exports[`--type-check output snapshots (default format) > both lint error and ty
   │ 3 │  
   ╰────────────────────────────────
 
-Found 1 lint error, 1 type error and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> threads)
+Found 1 lint error, 1 type error and 0 warnings (linted 2 files with 1 rule, type-checked 1 file in <TIME> using <N> thread(s))
 "
 `;
 
@@ -40,7 +40,7 @@ exports[`--type-check output snapshots (default format) > lint error only with -
   │ 2 │  console.log(a);
   ╰────────────────────────────────
 
-Found 1 lint error, 0 type errors and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> threads)
+Found 1 lint error, 0 type errors and 0 warnings (linted 2 files with 1 rule, type-checked 1 file in <TIME> using <N> thread(s))
 "
 `;
 
@@ -52,7 +52,7 @@ exports[`--type-check output snapshots (default format) > lint error without --t
   │ 2 │  console.log(a);
   ╰────────────────────────────────
 
-Found 1 error and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> threads)
+Found 1 error and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> thread(s))
 "
 `;
 
@@ -66,7 +66,7 @@ exports[`--type-check output snapshots (default format) > multi-line lint error 
   │ 6 │  console.log(fn);
   ╰────────────────────────────────
 
-Found 1 error and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> threads)
+Found 1 error and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> thread(s))
 "
 `;
 
@@ -87,7 +87,7 @@ exports[`--type-check output snapshots (default format) > multi-line lint error 
   │ 7 │  
   ╰────────────────────────────────
 
-Found 1 lint error, 1 type error and 0 warnings (linted 2 files with 1 rule in <TIME> using <N> threads)
+Found 1 lint error, 1 type error and 0 warnings (linted 2 files with 1 rule, type-checked 1 file in <TIME> using <N> thread(s))
 "
 `;
 
@@ -100,7 +100,7 @@ exports[`--type-check output snapshots (default format) > multi-line: MessageCha
   │ 2 │  console.log(foo);
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules, type-checked 1 file in <TIME> using <N> thread(s))
 "
 `;
 
@@ -114,7 +114,7 @@ exports[`--type-check output snapshots (default format) > multi-line: RelatedInf
   │ 3 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules, type-checked 1 file in <TIME> using <N> thread(s))
 "
 `;
 
@@ -128,7 +128,7 @@ exports[`--type-check output snapshots (default format) > multi-line: RelatedInf
   │ 3 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules, type-checked 1 file in <TIME> using <N> thread(s))
 "
 `;
 
@@ -143,12 +143,12 @@ exports[`--type-check output snapshots (default format) > multi-line: deep Messa
   │ 4 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules, type-checked 1 file in <TIME> using <N> thread(s))
 "
 `;
 
 exports[`--type-check output snapshots (default format) > no errors with --type-check 1`] = `
-"Found 0 lint errors, 0 type errors and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
+"Found 0 lint errors, 0 type errors and 0 warnings (linted 2 files with 0 rules, type-checked 1 file in <TIME> using <N> thread(s))
 "
 `;
 
@@ -160,7 +160,7 @@ exports[`--type-check output snapshots (default format) > type error only (TS232
   │ 2 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules, type-checked 1 file in <TIME> using <N> thread(s))
 "
 `;
 

--- a/packages/rslint-test-tools/tests/cli/type-check/__snapshots__/type-check-snapshot.test.ts.snap
+++ b/packages/rslint-test-tools/tests/cli/type-check/__snapshots__/type-check-snapshot.test.ts.snap
@@ -165,27 +165,23 @@ Found 0 lint errors, 1 type error and 0 warnings (linted 2 files with 0 rules in
 `;
 
 exports[`--type-check output snapshots (github format) > both lint and type error in github format 1`] = `
-"
-::error file=test.ts,line=1,endLine=1,col=8,endColumn=11,title=@typescript-eslint/no-explicit-any::Unexpected any. Specify a different type.
+"::error file=test.ts,line=1,endLine=1,col=8,endColumn=11,title=@typescript-eslint/no-explicit-any::Unexpected any. Specify a different type.
 ::error file=test.ts,line=2,endLine=2,col=7,endColumn=8,title=TypeScript(TS2322)::Type 'string' is not assignable to type 'number'.
 "
 `;
 
 exports[`--type-check output snapshots (github format) > type error in github format 1`] = `
-"
-::error file=test.ts,line=1,endLine=1,col=7,endColumn=8,title=TypeScript(TS2322)::Type 'string' is not assignable to type 'number'.
+"::error file=test.ts,line=1,endLine=1,col=7,endColumn=8,title=TypeScript(TS2322)::Type 'string' is not assignable to type 'number'.
 "
 `;
 
 exports[`--type-check output snapshots (jsonline format) > both lint and type error in jsonline format 1`] = `
-"
-{"ruleName":"@typescript-eslint/no-explicit-any","message":"Unexpected any. Specify a different type.","filePath":"test.ts","range":{"start":{"line":1,"column":8},"end":{"line":1,"column":11}},"severity":"error"}
+"{"ruleName":"@typescript-eslint/no-explicit-any","message":"Unexpected any. Specify a different type.","filePath":"test.ts","range":{"start":{"line":1,"column":8},"end":{"line":1,"column":11}},"severity":"error"}
 {"ruleName":"TypeScript(TS2322)","message":"Type 'string' is not assignable to type 'number'.","filePath":"test.ts","range":{"start":{"line":2,"column":7},"end":{"line":2,"column":8}},"severity":"error"}
 "
 `;
 
 exports[`--type-check output snapshots (jsonline format) > type error in jsonline format 1`] = `
-"
-{"ruleName":"TypeScript(TS2322)","message":"Type 'string' is not assignable to type 'number'.","filePath":"test.ts","range":{"start":{"line":1,"column":7},"end":{"line":1,"column":8}},"severity":"error"}
+"{"ruleName":"TypeScript(TS2322)","message":"Type 'string' is not assignable to type 'number'.","filePath":"test.ts","range":{"start":{"line":1,"column":7},"end":{"line":1,"column":8}},"severity":"error"}
 "
 `;

--- a/packages/rslint-test-tools/tests/cli/type-check/helpers.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/helpers.ts
@@ -106,8 +106,8 @@ export function normalizeOutput(output: string, tempDir: string): string {
     '<TEMPDIR>',
   );
   result = result.replace(
-    /in [\d.]+m?s using \d+ threads/g,
-    'in <TIME> using <N> threads',
+    /in [\d.]+m?s using \d+ threads?/g,
+    'in <TIME> using <N> thread(s)',
   );
   return result;
 }

--- a/packages/rslint-test-tools/tests/cli/type-check/ignores-suppression.test.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/ignores-suppression.test.ts
@@ -22,9 +22,9 @@ interface Diagnostic {
 /**
  * Run rslint --type-check twice: once with --format jsonline for exact
  * per-file diagnostic parsing, once with the default format for the summary
- * line ("linted N files"). The default format does not emit structured
- * diagnostics, and jsonline suppresses the summary, so both runs are needed
- * for precise assertions.
+ * line ("linted N files, type-checked M files"). The default format does not
+ * emit structured diagnostics, and jsonline suppresses the summary, so both
+ * runs are needed for precise assertions.
  */
 async function lintTypeCheck(
   tempDir: string,
@@ -32,6 +32,7 @@ async function lintTypeCheck(
 ): Promise<{
   diagnostics: Diagnostic[];
   lintedFileCount: number;
+  typeCheckedFileCount: number;
   exitCode: number;
 }> {
   const jsonRun = await runRslint(
@@ -47,15 +48,17 @@ async function lintTypeCheck(
   const summaryRun = await runRslint(['--type-check', ...extraArgs], tempDir);
   const combined = `${summaryRun.stdout}\n${summaryRun.stderr}`;
   const countMatch = combined.match(/linted (\d+) files?/);
-  if (!countMatch) {
+  const typeCheckedCountMatch = combined.match(/type-checked (\d+) files?/);
+  if (!countMatch || !typeCheckedCountMatch) {
     throw new Error(
-      `Could not parse linted-file count from summary output:\nSTDOUT:\n${summaryRun.stdout}\nSTDERR:\n${summaryRun.stderr}`,
+      `Could not parse file counts from summary output:\nSTDOUT:\n${summaryRun.stdout}\nSTDERR:\n${summaryRun.stderr}`,
     );
   }
 
   return {
     diagnostics,
     lintedFileCount: parseInt(countMatch[1]!, 10),
+    typeCheckedFileCount: parseInt(typeCheckedCountMatch[1]!, 10),
     exitCode: jsonRun.exitCode,
   };
 }
@@ -110,6 +113,9 @@ describe('--type-check + config ignores', () => {
       // LintedFileCount counts the lint-rule pass only — ignored files do
       // not contribute. The targets are src/bad.ts and rslint.config.mjs.
       expect(r.lintedFileCount).toBe(2);
+      // TypeCheckedFileCount follows the tsconfig roots, so both TypeScript
+      // files contribute even though one is ignored by the lint phase.
+      expect(r.typeCheckedFileCount).toBe(2);
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint-test-tools/tests/cli/type-check/type-check-only.test.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/type-check-only.test.ts
@@ -115,9 +115,16 @@ describe('--type-check-only basic', () => {
       'a.ts': 'export const ok = 1;\n',
     });
     try {
-      const r = await runRslint(['--type-check-only'], tempDir);
+      const r = await runRslint(
+        ['--type-check-only', '--singleThreaded'],
+        tempDir,
+      );
       expect(r.stdout).toContain('type-checked');
       expect(r.stdout).toContain('type error');
+      expect(r.stdout).toMatch(
+        /Found 0 type errors \(type-checked 1 file in .+ using 1 thread\)\n/,
+      );
+      expect(r.stdout).not.toContain('using 1 threads');
       // The summary line owns "linted N files"; --type-check-only uses a
       // different summary so this phrasing should NOT appear.
       expect(r.stdout).not.toContain('linted');
@@ -254,6 +261,15 @@ describe('--type-check (non-only) does not short-circuit on Phase 2 diagnostics'
       // (non-only) mode — only --type-check-only suppresses it.
       expect(r.stderr).toContain('nonexistent.ts');
       expect(r.stderr).toContain('was not found');
+
+      const summary = await runRslint(
+        ['--type-check', '--singleThreaded', 'nonexistent.ts'],
+        tempDir,
+      );
+      expect(summary.stdout).toMatch(
+        /Found 0 lint errors, 1 type error and 0 warnings \(linted 0 files with 0 rules, type-checked 1 file in .+ using 1 thread\)\n/,
+      );
+      expect(summary.stdout).not.toContain('using 1 threads');
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/packages/rslint/src/cli/cli.ts
+++ b/packages/rslint/src/cli/cli.ts
@@ -5,7 +5,13 @@ import {
   normalizeConfig,
   collectPluginMeta,
 } from '../config/config-loader.js';
-import { parseArgs, classifyArgs, isJSConfigFile } from '../utils/args.js';
+import {
+  OUTPUT_FORMATS,
+  parseArgs,
+  classifyArgs,
+  isJSConfigFile,
+  isOutputFormat,
+} from '../utils/args.js';
 import {
   coalesceCaseAliasedConfigs,
   discoverConfigs,
@@ -239,9 +245,22 @@ export async function run(
 
   // --init: pass through to Go (no config payload — Go writes the default
   // config to disk and prints the "Created …" line, forwarded via `output`).
+  // It intentionally takes priority over unrelated lint flags, matching the
+  // existing fast-path contract.
   if (args.init) {
     const { runEngine } = await import('./engine.js');
     return runEngine({ binPath, goArgs: ['--init'], configs: [], cwd });
+  }
+
+  // Reject an invalid stdout protocol before config discovery/evaluation.
+  // Help retains its existing priority and is forwarded to Go, which owns the
+  // usage text. Go validates format again after the IPC init payload is merged
+  // so direct and older clients receive the same single-error behavior.
+  if (!args.help && args.format !== null && !isOutputFormat(args.format)) {
+    process.stderr.write(
+      `error: invalid output format ${JSON.stringify(args.format)} (expected ${OUTPUT_FORMATS.slice(0, -1).join(', ')}, or ${OUTPUT_FORMATS.at(-1)})\n`,
+    );
+    return 2;
   }
 
   // Validate explicit --config flag

--- a/packages/rslint/src/utils/args.ts
+++ b/packages/rslint/src/utils/args.ts
@@ -2,6 +2,20 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { parseArgs as nodeParseArgs } from 'node:util';
 
+// Keep this list in sync with cmd/rslint/internal/output/format.go.
+export const OUTPUT_FORMATS = [
+  'default',
+  'jsonline',
+  'github',
+  'gitlab',
+] as const;
+
+export type OutputFormat = (typeof OUTPUT_FORMATS)[number];
+
+export function isOutputFormat(value: string): value is OutputFormat {
+  return (OUTPUT_FORMATS as readonly string[]).includes(value);
+}
+
 export function isJSConfigFile(filePath: string): boolean {
   return /\.(ts|mts|cts|js|mjs|cjs)$/.test(filePath);
 }
@@ -14,6 +28,7 @@ export function parseArgs(argv: string[]) {
     options: {
       config: { type: 'string', short: 'c' },
       init: { type: 'boolean' },
+      help: { type: 'boolean', short: 'h' },
       // Detected so the JS host can size the ESLint-plugin worker pool to a
       // single worker. NOT skipped below, so it still forwards to Go in
       // `rest` (Go's native pass honors the same flag independently).
@@ -77,7 +92,11 @@ export function parseArgs(argv: string[]) {
     // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     init: (values.init as boolean) ?? false,
     // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    help: (values.help as boolean) ?? false,
+    // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     singleThreaded: (values.singleThreaded as boolean) ?? false,
+    // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    format: (values.format as string) ?? null,
     rest,
     positionals,
   };

--- a/packages/rslint/tests/args.test.ts
+++ b/packages/rslint/tests/args.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from '@rstest/core';
-import { isJSConfigFile, classifyArgs, parseArgs } from '../src/utils/args.js';
+import {
+  isJSConfigFile,
+  classifyArgs,
+  isOutputFormat,
+  parseArgs,
+} from '../src/utils/args.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -48,6 +53,18 @@ describe('isJSConfigFile', () => {
   test('returns true for explicitly selectable .cjs and .cts configs', () => {
     expect(isJSConfigFile('rslint.config.cjs')).toBe(true);
     expect(isJSConfigFile('rslint.config.cts')).toBe(true);
+  });
+});
+
+describe('isOutputFormat', () => {
+  test('accepts every CLI output protocol', () => {
+    for (const format of ['default', 'jsonline', 'github', 'gitlab']) {
+      expect(isOutputFormat(format)).toBe(true);
+    }
+  });
+
+  test('rejects unknown output protocols', () => {
+    expect(isOutputFormat('stylish')).toBe(false);
   });
 });
 
@@ -152,6 +169,7 @@ describe('parseArgs positionals', () => {
   test('--format jsonline does not pollute positionals', () => {
     const result = parseArgs(['--format', 'jsonline', 'src/a.ts']);
     expect(result.positionals).toEqual(['src/a.ts']);
+    expect(result.format).toBe('jsonline');
   });
 
   test('file before --format', () => {
@@ -192,6 +210,19 @@ describe('parseArgs positionals', () => {
   test('--format=jsonline inline value', () => {
     const result = parseArgs(['--format=jsonline', 'src/a.ts']);
     expect(result.positionals).toEqual(['src/a.ts']);
+    expect(result.format).toBe('jsonline');
+  });
+
+  test('format defaults to null when absent', () => {
+    expect(parseArgs(['src/a.ts']).format).toBeNull();
+  });
+
+  test('help is detected and still forwarded to Go', () => {
+    for (const flag of ['--help', '-h']) {
+      const result = parseArgs([flag, '--format', 'stylish']);
+      expect(result.help).toBe(true);
+      expect(result.rest).toContain(flag);
+    }
   });
 
   test('no positionals with only flags', () => {

--- a/website/docs/en/guide/output-formats.md
+++ b/website/docs/en/guide/output-formats.md
@@ -14,7 +14,7 @@ rslint .
 src/index.ts:5:7
   error  @typescript-eslint/no-unused-vars  'foo' is declared but its value is never read.
 
-Found 1 error and 0 warnings (linted 12 files in 42ms using 8 threads)
+Found 1 error and 0 warnings (linted 12 files with 1 rule in 42ms using 8 threads)
 ```
 
 With `--type-check`, type errors are also included (see [Type Checking](/guide/type-checking) for details):
@@ -30,7 +30,7 @@ src/index.ts:5:7
 src/utils.ts:3:7
   error  TypeScript(TS2322)  Type 'string' is not assignable to type 'number'.
 
-Found 1 lint error, 1 type error and 0 warnings (linted 12 files in 85ms using 8 threads)
+Found 1 lint error, 1 type error and 0 warnings (linted 12 files with 1 rule in 85ms using 8 threads)
 ```
 
 ## jsonline

--- a/website/docs/en/guide/output-formats.md
+++ b/website/docs/en/guide/output-formats.md
@@ -17,6 +17,8 @@ src/index.ts:5:7
 Found 1 error and 0 warnings (linted 12 files with 1 rule in 42ms using 8 threads)
 ```
 
+In color-enabled terminals, the complete parenthesized execution details are rendered dim.
+
 With `--type-check`, type errors are also included (see [Type Checking](/guide/type-checking) for details):
 
 ```bash
@@ -30,8 +32,12 @@ src/index.ts:5:7
 src/utils.ts:3:7
   error  TypeScript(TS2322)  Type 'string' is not assignable to type 'number'.
 
-Found 1 lint error, 1 type error and 0 warnings (linted 12 files with 1 rule in 85ms using 8 threads)
+Found 1 lint error, 1 type error and 0 warnings (linted 12 files with 1 rule, type-checked 14 files in 85ms using 8 threads)
 ```
+
+The two file counts can differ because CLI arguments and rslint ignore patterns restrict the lint phase, while type-check follows each tsconfig's program-wide scope.
+
+The machine-readable formats below emit diagnostics only. They do not include the default summary, timing, thread count, or fixed-issue count.
 
 ## jsonline
 

--- a/website/docs/en/guide/type-checking.md
+++ b/website/docs/en/guide/type-checking.md
@@ -80,7 +80,7 @@ Chained errors indent the TypeScript message chain:
       Type 'number' is not assignable to type 'string'.
 ```
 
-Type errors appear in every output format (`default`, `jsonline`, `github`).
+Type errors appear in every output format (`default`, `jsonline`, `github`, `gitlab`).
 
 ### Summary line
 
@@ -91,11 +91,13 @@ Three templates depending on mode:
 Found 3 errors and 1 warning (linted 42 files with 5 rules in 120ms using 8 threads)
 
 # --type-check
-Found 3 lint errors, 2 type errors and 1 warning (linted 42 files with 5 rules in 120ms using 8 threads)
+Found 3 lint errors, 2 type errors and 1 warning (linted 42 files with 5 rules, type-checked 47 files in 120ms using 8 threads)
 
 # --type-check-only
 Found 2 type errors (type-checked 42 files in 80ms using 8 threads)
 ```
+
+In combined mode, `linted` counts files visited by the lint phase, while `type-checked` counts unique root files across every real tsconfig Program. The counts can differ because lint targets and rslint ignores do not restrict program-wide type-check. In color-enabled terminals, the complete parenthesized execution details are rendered dim.
 
 ### Exit codes
 


### PR DESCRIPTION
## Summary

- Extract CLI output reporting and formatter implementations into `cmd/rslint/internal/output`, keeping `cmd.go` focused on orchestration.
- Build summaries and exit-policy counts from one report model, and render the complete `(linted ...)` / `(type-checked ...)` suffix with dim styling.
- Clarify combined `--type-check` summaries with a separate type-checked root-file count, independent lint/type error colors, and correct singular/plural wording.
- Preserve default, JSON Lines, GitHub, and GitLab output contracts while hardening format validation, annotation escaping, fingerprints, and diagnostic-origin handling.
- Add focused Go and JS coverage, and update the output-format, type-checking, and architecture documentation.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
