### PR TITLE
feat: port rule no-extra-semi

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -54,6 +54,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_bind"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_boolean_cast"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_label"
+	"github.com/web-infra-dev/rslint/internal/rules/no_extra_semi"
 	"github.com/web-infra-dev/rslint/internal/rules/no_fallthrough"
 	"github.com/web-infra-dev/rslint/internal/rules/no_func_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_global_assign"
@@ -239,6 +240,7 @@ func GetAllRules() []rule.Rule {
 		no_useless_concat.NoUselessConcatRule,
 		no_sparse_arrays.NoSparseArraysRule,
 		no_extra_boolean_cast.NoExtraBooleanCastRule,
+		no_extra_semi.NoExtraSemiRule,
 		no_unneeded_ternary.NoUnneededTernaryRule,
 		no_undef.NoUndefRule,
 		no_undef_init.NoUndefInitRule,

--- a/internal/rules/no_extra_semi/no_extra_semi.go
+++ b/internal/rules/no_extra_semi/no_extra_semi.go
@@ -1,0 +1,93 @@
+package no_extra_semi
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// https://eslint.org/docs/latest/rules/no-extra-semi
+var NoExtraSemiRule = rule.Rule{
+	Name: "no-extra-semi",
+	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindEmptyStatement: func(node *ast.Node) {
+				parent := node.Parent
+				if parent != nil {
+					allowedParentTypes := []ast.Kind{
+						ast.KindForStatement,
+						ast.KindForInStatement,
+						ast.KindForOfStatement,
+						ast.KindWhileStatement,
+						ast.KindDoStatement,
+						ast.KindIfStatement,
+						ast.KindLabeledStatement,
+						ast.KindWithStatement,
+					}
+					for _, allowed := range allowedParentTypes {
+						if parent.Kind == allowed {
+							return
+						}
+					}
+				}
+
+				report(ctx, node)
+			},
+			ast.KindSemicolonClassElement: func(node *ast.Node) {
+				report(ctx, node)
+			},
+		}
+	},
+}
+
+func report(ctx rule.RuleContext, node *ast.Node) {
+	msg := rule.RuleMessage{
+		Id:          "unexpected",
+		Description: "Unnecessary semicolon.",
+	}
+
+	if isFixable(ctx, node) {
+		ctx.ReportNodeWithFixes(node, msg, rule.RuleFixRemove(ctx.SourceFile, node))
+	} else {
+		ctx.ReportNode(node, msg)
+	}
+}
+
+func isFixable(ctx rule.RuleContext, node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return true
+	}
+
+	var stmts []*ast.Node
+	if parent.Kind == ast.KindSourceFile {
+		stmts = parent.Statements()
+	} else if parent.Kind == ast.KindBlock {
+		// Only check directives in function bodies (block statements cannot have directives)
+		if parent.Parent != nil && ast.IsFunctionLike(parent.Parent) {
+			stmts = parent.Statements()
+		} else {
+			return true
+		}
+	} else {
+		return true
+	}
+
+	idx := -1
+	for i, s := range stmts {
+		if s == node {
+			idx = i
+			break
+		}
+	}
+	if idx != -1 && idx < len(stmts)-1 {
+		nextStmt := stmts[idx+1]
+		if nextStmt.Kind == ast.KindExpressionStatement {
+			expr := nextStmt.AsExpressionStatement().Expression
+			if expr.Kind == ast.KindStringLiteral {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/rules/no_extra_semi/no_extra_semi.go
+++ b/internal/rules/no_extra_semi/no_extra_semi.go
@@ -60,16 +60,17 @@ func isFixable(ctx rule.RuleContext, node *ast.Node) bool {
 	}
 
 	var stmts []*ast.Node
-	if parent.Kind == ast.KindSourceFile {
+	switch parent.Kind {
+	case ast.KindSourceFile, ast.KindModuleBlock:
 		stmts = parent.Statements()
-	} else if parent.Kind == ast.KindBlock {
+	case ast.KindBlock:
 		// Only check directives in function bodies (block statements cannot have directives)
 		if parent.Parent != nil && ast.IsFunctionLike(parent.Parent) {
 			stmts = parent.Statements()
 		} else {
 			return true
 		}
-	} else {
+	default:
 		return true
 	}
 
@@ -80,14 +81,8 @@ func isFixable(ctx rule.RuleContext, node *ast.Node) bool {
 			break
 		}
 	}
-	if idx != -1 && idx < len(stmts)-1 {
-		nextStmt := stmts[idx+1]
-		if nextStmt.Kind == ast.KindExpressionStatement {
-			expr := nextStmt.AsExpressionStatement().Expression
-			if expr.Kind == ast.KindStringLiteral {
-				return false
-			}
-		}
+	if idx != -1 && idx < len(stmts)-1 && ast.IsPrologueDirective(stmts[idx+1]) {
+		return false
 	}
 	return true
 }

--- a/internal/rules/no_extra_semi/no_extra_semi.md
+++ b/internal/rules/no_extra_semi/no_extra_semi.md
@@ -1,0 +1,50 @@
+# no-extra-semi
+
+Disallow unnecessary semicolons.
+
+## Rule Details
+
+This rule flags semicolons that can be safely removed without changing the semantics of the JavaScript code.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var x = 5;;
+
+function foo(){};
+
+for(;;);;
+
+while(0);;
+
+do;while(0);;
+
+class A {
+  ;
+  field;;
+  a() {};
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var x = 5;
+
+function foo(){}
+
+for(;;);
+
+while(0);
+
+do;while(0);
+
+class A {
+  field;
+  a() {}
+}
+```
+
+## Original Documentation
+
+[ESLint no-extra-semi documentation](https://eslint.org/docs/latest/rules/no-extra-semi)

--- a/internal/rules/no_extra_semi/no_extra_semi_extras_test.go
+++ b/internal/rules/no_extra_semi/no_extra_semi_extras_test.go
@@ -75,6 +75,14 @@ func TestNoExtraSemiExtras(t *testing.T) {
 					{MessageId: "unexpected", Line: 1, Column: 20},
 				},
 			},
+			{
+				// Locks in: TSModuleBlock is a directive-prologue position, same as
+				// Program and function bodies, so this must not be autofixed.
+				Code: "namespace Foo { ; 'use strict'; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
 		},
 	)
 }

--- a/internal/rules/no_extra_semi/no_extra_semi_extras_test.go
+++ b/internal/rules/no_extra_semi/no_extra_semi_extras_test.go
@@ -1,0 +1,80 @@
+// TestNoExtraSemiExtras locks in branches and edge shapes that the upstream test suite doesn't exercise.
+// Each case carries an inline comment pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers.
+package no_extra_semi
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoExtraSemiExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoExtraSemiRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: Class expression inside variable declaration ----
+			{Code: "const x = class { a() {} };"},
+			{Code: "const x = class A { a() {} };"},
+
+			// ---- Dimension 4: Correct TS abstract class and interfaces ----
+			{Code: "abstract class A { abstract foo(): void; }"},
+			{Code: "interface A { foo: string; }"},
+			{Code: "type T = { foo: string; };"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: TS constructs with double semicolons ----
+			{
+				Code:   "(x as any);;",
+				Output: []string{"(x as any);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code:   "x!;;",
+				Output: []string{"x!;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   "(x satisfies any);;",
+				Output: []string{"(x satisfies any);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+
+			// ---- Dimension 4: TS abstract class extra semicolons ----
+			{
+				Code:   "abstract class A { abstract foo();; }",
+				Output: []string{"abstract class A { abstract foo(); }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+
+			// ---- Real-user & Branch locks: Directive hazards ----
+			{
+				// Locks in: string literal directive checking branch when there's an existing prologue directive
+				Code: "'use strict'; ; 'other directive'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			{
+				// Locks in: double semicolon before a string literal that is not a directive
+				Code:   "function foo() { ; ; 'bar'; }",
+				Output: []string{"function foo() {  ; 'bar'; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_extra_semi/no_extra_semi_upstream_test.go
+++ b/internal/rules/no_extra_semi/no_extra_semi_upstream_test.go
@@ -1,0 +1,279 @@
+// TestNoExtraSemiUpstream migrates the full valid/invalid suite from upstream
+// eslint/tests/lib/rules/no-extra-semi.js 1:1. Position assertions cover
+// line/column for every invalid case.
+// rslint-specific lock-in cases live in the no_extra_semi_extras_test.go file.
+package no_extra_semi
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoExtraSemiUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoExtraSemiRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "var x = 5;"},
+			{Code: "function foo(){}"},
+			{Code: "for(;;);"},
+			{Code: "while(0);"},
+			{Code: "do;while(0);"},
+			{Code: "for(a in b);"},
+			{Code: "for(a of b);"},
+			{Code: "if(true);"},
+			{Code: "if(true); else;"},
+			{Code: "foo: ;"},
+			{Code: "with(foo);"},
+
+			// Class body
+			{Code: "class A { }"},
+			{Code: "var A = class { };"},
+			{Code: "class A { a() { this; } }"},
+			{Code: "var A = class { a() { this; } };"},
+			{Code: "class A { } a;"},
+			{Code: "class A { field; }"},
+			{Code: "class A { field = 0; }"},
+			{Code: "class A { static { foo; } }"},
+
+			// modules
+			{Code: "export const x = 42;"},
+			{Code: "export default 42;"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   "var x = 5;;",
+				Output: []string{"var x = 5;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "function foo(){};",
+				Output: []string{"function foo(){}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code:   "for(;;);;",
+				Output: []string{"for(;;);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   "while(0);;",
+				Output: []string{"while(0);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:   "do;while(0);;",
+				Output: []string{"do;while(0);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   "for(a in b);;",
+				Output: []string{"for(a in b);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   "for(a of b);;",
+				Output: []string{"for(a of b);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   "if(true);;",
+				Output: []string{"if(true);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:   "if(true){} else;;",
+				Output: []string{"if(true){} else;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code:   "if(true){;} else {;}",
+				Output: []string{"if(true){} else {}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10},
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code:   "foo:;;",
+				Output: []string{"foo:;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:   "with(foo);;",
+				Output: []string{"with(foo);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "with(foo){;}",
+				Output: []string{"with(foo){}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "class A { static { ; } }",
+				Output: []string{"class A { static {  } }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code:   "class A { static { a;; } }",
+				Output: []string{"class A { static { a; } }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+				},
+			},
+
+			// Class body
+			{
+				Code:   "class A { ; }",
+				Output: []string{"class A {  }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "class A { /*a*/; }",
+				Output: []string{"class A { /*a*/ }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   "class A { ; a() {} }",
+				Output: []string{"class A {  a() {} }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "class A { a() {}; }",
+				Output: []string{"class A { a() {} }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code:   "class A { a() {}; b() {} }",
+				Output: []string{"class A { a() {} b() {} }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code:   "class A {; a() {}; b() {}; }",
+				Output: []string{"class A { a() {} b() {} }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10},
+					{MessageId: "unexpected", Line: 1, Column: 18},
+					{MessageId: "unexpected", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code:   "class A { a() {}; get b() {} }",
+				Output: []string{"class A { a() {} get b() {} }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code:   "class A { field;; }",
+				Output: []string{"class A { field; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code:   "class A { static {}; }",
+				Output: []string{"class A { static {} }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code:   "class A { static { a; }; foo(){} }",
+				Output: []string{"class A { static { a; } foo(){} }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+
+			// Directive hazards
+			{
+				Code: "; 'use strict'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "; ; 'use strict'",
+				Output: []string{" ; 'use strict'"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: "debugger;\n;\n'use strict'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: "function foo() { ; 'bar'; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:   "{ ; 'foo'; }",
+				Output: []string{"{  'foo'; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:   "; ('use strict');",
+				Output: []string{" ('use strict');"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "; 1;",
+				Output: []string{" 1;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/tests/eslint/rules/no-extra-semi.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-extra-semi.test.ts
@@ -1,0 +1,199 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-extra-semi', {
+  valid: [
+    'var x = 5;',
+    'function foo(){}',
+    'for(;;);',
+    'while(0);',
+    'do;while(0);',
+    'for(a in b);',
+    'if(true);',
+    'if(true); else;',
+    'foo: ;',
+    'with(foo);',
+
+    // Class body.
+    'class A { }',
+    'var A = class { };',
+    'class A { a() { this; } }',
+    'var A = class { a() { this; } };',
+    'class A { } a;',
+    'class A { field; }',
+    'class A { field = 0; }',
+    'class A { static { foo; } }',
+
+    // modules
+    {
+      code: 'export const x = 42;',
+      parserOptions: { sourceType: 'module' } as any,
+    },
+    {
+      code: 'export default 42;',
+      parserOptions: { sourceType: 'module' } as any,
+    },
+  ],
+  invalid: [
+    {
+      code: 'var x = 5;;',
+      output: 'var x = 5;',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'function foo(){};',
+      output: 'function foo(){}',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'for(;;);;',
+      output: 'for(;;);',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'while(0);;',
+      output: 'while(0);',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'do;while(0);;',
+      output: 'do;while(0);',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'for(a in b);;',
+      output: 'for(a in b);',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'if(true);;',
+      output: 'if(true);',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'if(true){} else;;',
+      output: 'if(true){} else;',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'if(true){;} else {;}',
+      output: 'if(true){} else {}',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    {
+      code: 'foo:;;',
+      output: 'foo:;',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'with(foo);;',
+      output: 'with(foo);',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'with(foo){;}',
+      output: 'with(foo){}',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { static { ; } }',
+      output: 'class A { static {  } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { static { a;; } }',
+      output: 'class A { static { a; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { ; }',
+      output: 'class A {  }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { /*a*/; }',
+      output: 'class A { /*a*/ }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { ; a() {} }',
+      output: 'class A {  a() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { a() {}; }',
+      output: 'class A { a() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { a() {}; b() {} }',
+      output: 'class A { a() {} b() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A {; a() {}; b() {}; }',
+      output: 'class A { a() {} b() {} }',
+      errors: [
+        { messageId: 'unexpected' },
+        { messageId: 'unexpected' },
+        { messageId: 'unexpected' },
+      ],
+    },
+    {
+      code: 'class A { a() {}; get b() {} }',
+      output: 'class A { a() {} get b() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { field;; }',
+      output: 'class A { field; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { static {}; }',
+      output: 'class A { static {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { static { a; }; foo(){} }',
+      output: 'class A { static { a; } foo(){} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "; 'use strict'",
+      output: "; 'use strict'", // wait, output is null/unchanged
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "; ; 'use strict'",
+      output: " ; 'use strict'",
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    {
+      code: "debugger;\n;\n'use strict'",
+      output: "debugger;\n;\n'use strict'", // output is null/unchanged
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "function foo() { ; 'bar'; }",
+      output: "function foo() { ; 'bar'; }", // output is null/unchanged
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "{ ; 'foo'; }",
+      output: "{  'foo'; }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "; ('use strict');",
+      output: " ('use strict');",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '; 1;',
+      output: ' 1;',
+      errors: [{ messageId: 'unexpected' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-extra-semi` rule from ESLint to rslint.

Disallows unnecessary semicolons.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-extra-semi
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-extra-semi.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).