### PR TITLE
feat: port rule no-buffer-constructor

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -23,6 +23,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_async_promise_executor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_await_in_loop"
 	"github.com/web-infra-dev/rslint/internal/rules/no_bitwise"
+	"github.com/web-infra-dev/rslint/internal/rules/no_buffer_constructor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_caller"
 	"github.com/web-infra-dev/rslint/internal/rules/no_case_declarations"
 	"github.com/web-infra-dev/rslint/internal/rules/no_class_assign"
@@ -169,6 +170,7 @@ func GetAllRules() []rule.Rule {
 		no_await_in_loop.NoAwaitInLoopRule,
 		no_bitwise.NoBitwiseRule,
 		no_caller.NoCallerRule,
+		no_buffer_constructor.NoBufferConstructorRule,
 		no_case_declarations.NoCaseDeclarationsRule,
 		no_class_assign.NoClassAssignRule,
 		no_compare_neg_zero.NoCompareNegZeroRule,

--- a/internal/rules/no_buffer_constructor/no_buffer_constructor.go
+++ b/internal/rules/no_buffer_constructor/no_buffer_constructor.go
@@ -1,0 +1,46 @@
+package no_buffer_constructor
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-buffer-constructor
+var NoBufferConstructorRule = rule.Rule{
+	Name: "no-buffer-constructor",
+	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				callee := utils.SkipAssertionsAndParens(call.Expression)
+				if callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == "Buffer" {
+					if declared, ok := ctx.Globals["Buffer"]; ok && !declared {
+						return
+					}
+					if !utils.IsShadowed(callee, "Buffer") {
+						ctx.ReportNode(node, rule.RuleMessage{
+							Id:          "deprecated",
+							Description: "Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						})
+					}
+				}
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				newExpr := node.AsNewExpression()
+				callee := utils.SkipAssertionsAndParens(newExpr.Expression)
+				if callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == "Buffer" {
+					if declared, ok := ctx.Globals["Buffer"]; ok && !declared {
+						return
+					}
+					if !utils.IsShadowed(callee, "Buffer") {
+						ctx.ReportNode(node, rule.RuleMessage{
+							Id:          "deprecated",
+							Description: "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						})
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_buffer_constructor/no_buffer_constructor.md
+++ b/internal/rules/no_buffer_constructor/no_buffer_constructor.md
@@ -1,0 +1,29 @@
+# no-buffer-constructor
+
+## Rule Details
+
+This rule disallows the use of the `Buffer()` constructor.
+
+In Node.js, the `Buffer` constructor is deprecated because it is a source of security and usability issues. Instead, use `Buffer.from()`, `Buffer.alloc()`, or `Buffer.allocUnsafe()`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+Buffer(5);
+new Buffer(5);
+Buffer([1, 2, 3]);
+new Buffer([1, 2, 3]);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+Buffer.alloc(5);
+Buffer.allocUnsafe(5);
+new Buffer.Foo();
+Buffer.from([1, 2, 3]);
+```
+
+## Original Documentation
+
+[ESLint documentation](https://eslint.org/docs/latest/rules/no-buffer-constructor)

--- a/internal/rules/no_buffer_constructor/no_buffer_constructor_extras_test.go
+++ b/internal/rules/no_buffer_constructor/no_buffer_constructor_extras_test.go
@@ -1,0 +1,118 @@
+// TestNoBufferConstructorExtras locks in branches and edge shapes that the upstream test suite does not cover.
+// Position assertions cover line/column for every invalid case.
+// Upstream-migrated cases live in the no_buffer_constructor_upstream_test.go file.
+package no_buffer_constructor
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoBufferConstructorExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoBufferConstructorRule,
+		// ---- Extras Valid cases ----
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: Access / key forms ----
+			{Code: "new Buffer.from(5)"},
+
+			// ---- Dimension 4: Declaration / container forms (shadowing) ----
+			{Code: "function run(Buffer) { Buffer(5); }"},
+			{Code: "var Buffer = require('buffer'); new Buffer(5);"},
+			{Code: "let Buffer = class {}; new Buffer(5);"},
+			{Code: "const Buffer = 1; Buffer(5);"},
+			{Code: "try {} catch (Buffer) { Buffer(5); }"},
+
+			// ---- Real-user: global override ----
+			{Code: "new Buffer(5);", Globals: map[string]bool{"Buffer": false}},
+		},
+		// ---- Extras Invalid cases ----
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: Receiver / expression wrappers (parentheses) ----
+			{
+				Code: "(Buffer)(5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: "new (Buffer)(5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			// ---- Dimension 4: Receiver / expression wrappers (TS type expressions) ----
+			{
+				Code: "(Buffer as any)(5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: "new (Buffer as any)(5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: "(Buffer satisfies any)(5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: "Buffer!(5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			// ---- Dimension 4: Optional chaining ----
+			{
+				Code: "Buffer?.(5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_buffer_constructor/no_buffer_constructor_upstream_test.go
+++ b/internal/rules/no_buffer_constructor/no_buffer_constructor_upstream_test.go
@@ -1,0 +1,99 @@
+// TestNoBufferConstructorUpstream migrates the full valid/invalid suite from upstream tests/lib/rules/no-buffer-constructor.js 1:1.
+// Position assertions cover line/column for every invalid case.
+// rslint-specific lock-in cases live in the no_buffer_constructor_extras_test.go file.
+package no_buffer_constructor
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoBufferConstructorUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoBufferConstructorRule,
+		// ---- Upstream Valid cases ----
+		[]rule_tester.ValidTestCase{
+			{Code: "Buffer.alloc(5)"},
+			{Code: "Buffer.allocUnsafe(5)"},
+			{Code: "new Buffer.Foo()"},
+			{Code: "Buffer.from([1, 2, 3])"},
+			{Code: "foo(Buffer)"},
+			{Code: "Buffer.alloc(res.body.amount)"},
+			{Code: "Buffer.from(res.body.values)"},
+		},
+		// ---- Upstream Invalid cases ----
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: "Buffer(5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: "new Buffer(5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: "Buffer([1, 2, 3])",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: "new Buffer([1, 2, 3])",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: "new Buffer(res.body.amount)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: "new Buffer(res.body.values)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "deprecated",
+						Message:   "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -92,6 +92,7 @@ export default defineConfig({
     './tests/eslint/rules/no-ex-assign.test.ts',
     './tests/eslint/rules/no-constant-binary-expression.test.ts',
     './tests/eslint/rules/no-caller.test.ts',
+    './tests/eslint/rules/no-buffer-constructor.test.ts',
 
     './tests/eslint/rules/default-case-last.test.ts',
     './tests/eslint/rules/no-extend-native.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-buffer-constructor.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-buffer-constructor.test.ts.snap
@@ -1,0 +1,157 @@
+// Rstest Snapshot v1
+
+exports[`no-buffer-constructor > invalid 1`] = `
+{
+  "code": "Buffer(5)",
+  "diagnostics": [
+    {
+      "message": "Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+      "messageId": "deprecated",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-buffer-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-buffer-constructor > invalid 2`] = `
+{
+  "code": "new Buffer(5)",
+  "diagnostics": [
+    {
+      "message": "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+      "messageId": "deprecated",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-buffer-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-buffer-constructor > invalid 3`] = `
+{
+  "code": "Buffer([1, 2, 3])",
+  "diagnostics": [
+    {
+      "message": "Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+      "messageId": "deprecated",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-buffer-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-buffer-constructor > invalid 4`] = `
+{
+  "code": "new Buffer([1, 2, 3])",
+  "diagnostics": [
+    {
+      "message": "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+      "messageId": "deprecated",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-buffer-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-buffer-constructor > invalid 5`] = `
+{
+  "code": "new Buffer(res.body.amount)",
+  "diagnostics": [
+    {
+      "message": "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+      "messageId": "deprecated",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-buffer-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-buffer-constructor > invalid 6`] = `
+{
+  "code": "new Buffer(res.body.values)",
+  "diagnostics": [
+    {
+      "message": "new Buffer() is deprecated. Use Buffer.from(), Buffer.alloc(), or Buffer.allocUnsafe() instead.",
+      "messageId": "deprecated",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-buffer-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-buffer-constructor.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-buffer-constructor.test.ts
@@ -1,0 +1,41 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-buffer-constructor', {
+  valid: [
+    'Buffer.alloc(5)',
+    'Buffer.allocUnsafe(5)',
+    'new Buffer.Foo()',
+    'Buffer.from([1, 2, 3])',
+    'foo(Buffer)',
+    'Buffer.alloc(res.body.amount)',
+    'Buffer.from(res.body.values)',
+  ],
+  invalid: [
+    {
+      code: 'Buffer(5)',
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: 'new Buffer(5)',
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: 'Buffer([1, 2, 3])',
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: 'new Buffer([1, 2, 3])',
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: 'new Buffer(res.body.amount)',
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: 'new Buffer(res.body.values)',
+      errors: [{ messageId: 'deprecated' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-buffer-constructor` rule from ESLint to rslint.

Disallows use of the `Buffer()` constructor, which is deprecated in Node.js due to security and usability issues. Use `Buffer.from()`, `Buffer.alloc()`, or `Buffer.allocUnsafe()` instead.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-buffer-constructor

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).