### PR TITLE
perf: reduce executed rule collection contention

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"os"
 	"strings"
-	"sync"
-	"sync/atomic"
 
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -73,7 +71,10 @@ type runProgramOptions struct {
 	HasTargetFiles   bool
 	SyntaxErrorFiles map[string]struct{}
 	GetRulesForFile  RuleHandler
-	ExecutedRules    *sync.Map
+	// CollectExecutedRules controls whether runLintRulesInProgram builds the
+	// per-program rule-name set returned in programLintResult. LintSingleFile
+	// leaves this disabled because it does not consume that result.
+	CollectExecutedRules bool
 	// SingleThreaded, when true, lints this program's file shards
 	// sequentially on the calling goroutine instead of in parallel workers.
 	SingleThreaded bool
@@ -82,6 +83,11 @@ type runProgramOptions struct {
 	// and remaining rules receive a nil TypeChecker. nil = no gap distinction.
 	TypeInfoFiles map[string]struct{}
 	OnDiagnostic  DiagnosticHandler
+}
+
+type programLintResult struct {
+	lintedFileCount int32
+	executedRules   map[string]struct{}
 }
 
 // runLintRulesInProgram lints files in a single Program. Files are filtered
@@ -96,13 +102,13 @@ type runProgramOptions struct {
 // This is the post-refactor internal implementation behind both RunLinter and
 // LintSingleFile. It does NOT run type-check — type-check is a program-level
 // concern handled by RunLinter directly.
-func runLintRulesInProgram(opts runProgramOptions) int32 {
+func runLintRulesInProgram(opts runProgramOptions) programLintResult {
 	if opts.OnDiagnostic == nil {
 		opts.OnDiagnostic = func(rule.RuleDiagnostic) {}
 	}
 	getRulesForFile := opts.GetRulesForFile
 	if getRulesForFile == nil {
-		return 0
+		return programLintResult{}
 	}
 
 	// Collect files to lint (applying all filters). Shared with
@@ -110,13 +116,13 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 	// exact same file set as native linting.
 	filesToLint := collectFilesToLint(opts)
 
-	lintedFileCount := int32(len(filesToLint))
+	result := programLintResult{lintedFileCount: int32(len(filesToLint))}
 
 	// Early-out: if every file in this program was filtered, do not pay the
 	// cost of acquiring a TypeChecker (which forces program binding and is
 	// non-trivial when the checker hasn't been created yet).
-	if lintedFileCount == 0 {
-		return 0
+	if result.lintedFileCount == 0 {
+		return result
 	}
 
 	// lintFile lints one file with its already-resolved rules and checker. All per-file state
@@ -390,9 +396,12 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 			file.FileName(),
 			opts.TypeInfoFiles,
 		)
-		if opts.ExecutedRules != nil {
+		if opts.CollectExecutedRules && len(rules) > 0 {
+			if result.executedRules == nil {
+				result.executedRules = make(map[string]struct{}, len(rules))
+			}
 			for _, configuredRule := range rules {
-				opts.ExecutedRules.Store(configuredRule.Name, struct{}{})
+				result.executedRules[configuredRule.Name] = struct{}{}
 			}
 		}
 		rules = filterNativeRules(rules)
@@ -426,7 +435,7 @@ func runLintRulesInProgram(opts runProgramOptions) int32 {
 	}
 	wg.RunAndWait()
 
-	return lintedFileCount
+	return result
 }
 
 // filterNativeRules removes Node-dispatched ESLint plugin placeholders from
@@ -506,12 +515,13 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 		opts.OnDiagnostic = func(rule.RuleDiagnostic) {}
 	}
 
-	var executedRules sync.Map
-	var lintedFileCount atomic.Int32
+	executedRules := make(map[string]struct{})
+	var lintedFileCount int32
 
 	// Phase 1: lint rules per program (parallel). Skipped when no rule
 	// handler was supplied — see doc above.
 	if opts.GetRulesForFile != nil {
+		programResults := make([]programLintResult, len(opts.Programs))
 		wg := core.NewWorkGroup(opts.SingleThreaded)
 		for i, program := range opts.Programs {
 			var perProgramFilter FileFilter
@@ -529,25 +539,32 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 			}
 
 			programOpts := runProgramOptions{
-				Program:          program,
-				Scope:            opts.Scope,
-				ExcludePaths:     opts.ExcludePaths,
-				FileFilter:       filter,
-				TargetFiles:      targetFiles,
-				HasTargetFiles:   opts.TargetFiles != nil,
-				GetRulesForFile:  opts.GetRulesForFile,
-				ExecutedRules:    &executedRules,
-				SyntaxErrorFiles: opts.SyntaxErrorFiles,
-				SingleThreaded:   opts.SingleThreaded,
-				TypeInfoFiles:    opts.TypeInfoFiles,
-				OnDiagnostic:     opts.OnDiagnostic,
+				Program:              program,
+				Scope:                opts.Scope,
+				ExcludePaths:         opts.ExcludePaths,
+				FileFilter:           filter,
+				TargetFiles:          targetFiles,
+				HasTargetFiles:       opts.TargetFiles != nil,
+				GetRulesForFile:      opts.GetRulesForFile,
+				CollectExecutedRules: true,
+				SyntaxErrorFiles:     opts.SyntaxErrorFiles,
+				SingleThreaded:       opts.SingleThreaded,
+				TypeInfoFiles:        opts.TypeInfoFiles,
+				OnDiagnostic:         opts.OnDiagnostic,
 			}
+			programIndex := i
+			programOptions := programOpts
 			wg.Queue(func() {
-				n := runLintRulesInProgram(programOpts)
-				lintedFileCount.Add(n)
+				programResults[programIndex] = runLintRulesInProgram(programOptions)
 			})
 		}
 		wg.RunAndWait()
+		for _, programResult := range programResults {
+			lintedFileCount += programResult.lintedFileCount
+			for name := range programResult.executedRules {
+				executedRules[name] = struct{}{}
+			}
+		}
 	}
 
 	// Phase 2: program-level type-check (tsc-aligned).
@@ -561,8 +578,8 @@ func RunLinter(opts RunLinterOptions) (*LintResult, error) {
 	}
 
 	return &LintResult{
-		LintedFileCount: lintedFileCount.Load(),
-		ExecutedRules:   collectMapKeys(&executedRules),
+		LintedFileCount: lintedFileCount,
+		ExecutedRules:   executedRules,
 	}, nil
 }
 
@@ -768,15 +785,4 @@ func buildOwnedFileSet(program *compiler.Program) map[string]struct{} {
 		owned[fn] = struct{}{}
 	}
 	return owned
-}
-
-func collectMapKeys(m *sync.Map) map[string]struct{} {
-	out := make(map[string]struct{})
-	m.Range(func(k, _ any) bool {
-		if s, ok := k.(string); ok {
-			out[s] = struct{}{}
-		}
-		return true
-	})
-	return out
 }

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -246,6 +246,47 @@ func TestRunLinter_ExecutedRulesPerFile(t *testing.T) {
 	}
 }
 
+func TestRunLinter_ExecutedRulesAcrossPrograms(t *testing.T) {
+	programA, pathsA := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+	})
+	programB, pathsB := createTestProgramWithFiles(t, map[string]string{
+		"b.ts": "const b = 2;",
+	})
+
+	configuredRule := func(name string) ConfiguredRule {
+		return ConfiguredRule{
+			Name:     name,
+			Severity: rule.SeverityWarning,
+			Run:      func(rule.RuleContext) rule.RuleListeners { return nil },
+		}
+	}
+	result, err := RunLinter(RunLinterOptions{
+		Programs:    []*compiler.Program{programA, programB},
+		TargetFiles: [][]string{{pathsA["a.ts"]}, {pathsB["b.ts"]}},
+		GetRulesForFile: func(file *ast.SourceFile) []ConfiguredRule {
+			if file.FileName() == pathsA["a.ts"] {
+				return []ConfiguredRule{configuredRule("shared"), configuredRule("only-a")}
+			}
+			return []ConfiguredRule{configuredRule("shared"), configuredRule("only-b")}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+	if result.LintedFileCount != 2 {
+		t.Fatalf("LintedFileCount = %d, want 2", result.LintedFileCount)
+	}
+	want := map[string]struct{}{
+		"shared": {},
+		"only-a": {},
+		"only-b": {},
+	}
+	if !reflect.DeepEqual(result.ExecutedRules, want) {
+		t.Fatalf("ExecutedRules = %v, want %v", result.ExecutedRules, want)
+	}
+}
+
 func TestRunLinter_ExecutedRulesEmpty(t *testing.T) {
 	program, _ := createTestProgramWithFiles(t, map[string]string{
 		"a.ts": "const a = 1;",
@@ -262,5 +303,8 @@ func TestRunLinter_ExecutedRulesEmpty(t *testing.T) {
 	}
 	if len(result.ExecutedRules) != 0 {
 		t.Errorf("Expected 0 executed rules, got %d", len(result.ExecutedRules))
+	}
+	if result.ExecutedRules == nil {
+		t.Error("ExecutedRules should be a writable, non-nil empty map")
 	}
 }

--- a/internal/linter/linter_typecheck_typeonly_test.go
+++ b/internal/linter/linter_typecheck_typeonly_test.go
@@ -152,6 +152,9 @@ func TestTypeCheckOnly_ExecutedRulesIsEmpty(t *testing.T) {
 	if len(result.ExecutedRules) != 0 {
 		t.Errorf("expected ExecutedRules to be empty when Phase 1 is skipped, got %v", result.ExecutedRules)
 	}
+	if result.ExecutedRules == nil {
+		t.Error("expected ExecutedRules to be a writable, non-nil empty map")
+	}
 }
 
 // TestTypeCheckOnly_BaselineLintWouldFire is a sanity check: with the same

--- a/internal/linter/test_helpers.go
+++ b/internal/linter/test_helpers.go
@@ -110,5 +110,5 @@ func RunLinterInProgram(
 		TypeInfoFiles:    typeInfoFiles,
 		SyntaxErrorFiles: syntaxErrorFiles,
 		OnDiagnostic:     onDiagnostic,
-	})
+	}).lintedFileCount
 }


### PR DESCRIPTION
## Summary

- Replace shared sync.Map and atomic updates in executed-rule collection with per-program local results merged after all workers join.
- Keep collection disabled for direct single-file paths, while preserving rule eligibility, plugin placeholder accounting, syntax-error behavior, linted-file counts, and writable non-nil results.
- Add regression coverage for multi-program rule unions and empty result maps.

### Real-repository validation

| Repository | Files | Rules | Programs | Clean A/B pairs | Measured runs |
| --- | ---: | ---: | ---: | ---: | ---: |
| rslint | 177 | 89 | 8 | 39 | 78 |
| rsbuild | 2,052 | 75 | 20 | 36 | 72 |
| rspack | 478 | 69 | 4 | 39 | 78 |
| **Total** | — | — | — | **114** | **228** |

All three repositories were checked in plain, --type-check, and --type-check-only modes. Baseline and optimized builds had matching exit codes and exact normalized output in every clean pair, with no hangs or residual processes.

### Shape-matched collection benchmark

| Repository | Old time | New time | Mechanism reduction | Allocated bytes per operation | Estimated end-to-end gain |
| --- | ---: | ---: | ---: | ---: | ---: |
| rslint | 0.996 ms | 0.112 ms | 88.77% | 1,020,726 → 36,280 (-96.45%) | ~0.08% |
| rsbuild | 9.760 ms | 0.445 ms | 95.44% | 9,862,647 → 80,249 (-99.19%) | ~0.50% |
| rspack | 2.030 ms | 0.166 ms | 91.81% | 2,122,129 → 21,624 (-98.98%) | ~0.19% |

The mechanism numbers are medians from benchmarks modeled on each real repository shape. Whole-run wall-time differences remain below the local machine noise floor, so the end-to-end figures are conservative estimates rather than claimed direct measurements.

### Validation

- pnpm run check-spell
- pnpm run format:check
- pnpm exec golangci-lint run --new-from-merge-base=origin/main ./internal/linter/...
- go test ./internal/linter -count=1
- go test -race ./internal/linter -run TestRunLinter_ExecutedRulesAcrossPrograms -count=10

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; no user-visible behavior or API change).