### PR TITLE
feat: port no-alert, no-implicit-coercion, no-useless-backreference to ctx.Globals

### DIFF
--- a/internal/rules/no_alert/no_alert.go
+++ b/internal/rules/no_alert/no_alert.go
@@ -18,13 +18,14 @@ func isProhibitedIdentifier(name string) bool {
 const outerExpressionKinds = ast.OEKParentheses | ast.OEKAssertions
 
 // isGlobalThisOrWindow checks if the node is a reference to the global object:
-// - `this` at global scope (not inside any function-like declaration or class)
-// - non-shadowed `window`
-// - non-shadowed `globalThis`
+//   - `this` at global scope (not inside any function-like declaration or class)
+//   - non-shadowed `window`
+//   - non-shadowed `globalThis`, unless configured `off` (ESLint requires the
+//     `globalThis` variable to exist in scope; `window` has no such check)
 //
 // Skips outer expression wrappers (parentheses, type assertions, non-null assertions)
 // so that `(window).alert()` and `window!.alert()` are handled correctly.
-func isGlobalThisOrWindow(node *ast.Node) bool {
+func isGlobalThisOrWindow(node *ast.Node, globals map[string]bool) bool {
 	node = ast.SkipOuterExpressions(node, outerExpressionKinds)
 	if node == nil {
 		return false
@@ -40,6 +41,11 @@ func isGlobalThisOrWindow(node *ast.Node) bool {
 	}
 	if node.Kind == ast.KindIdentifier {
 		name := node.Text()
+		if name == "globalThis" {
+			if declared, ok := globals["globalThis"]; ok && !declared {
+				return false
+			}
+		}
 		if name == "window" || name == "globalThis" {
 			return !utils.IsShadowed(node, name)
 		}
@@ -78,7 +84,7 @@ var NoAlertRule = rule.Rule{
 					if !ok || !isProhibitedIdentifier(name) {
 						return
 					}
-					if !isGlobalThisOrWindow(utils.AccessExpressionObject(callee)) {
+					if !isGlobalThisOrWindow(utils.AccessExpressionObject(callee), ctx.Globals) {
 						return
 					}
 

--- a/internal/rules/no_alert/no_alert_test.go
+++ b/internal/rules/no_alert/no_alert_test.go
@@ -150,6 +150,13 @@ func TestNoAlertRule(t *testing.T) {
 			{Code: `var x = window.alert;`},
 			{Code: `typeof alert;`},
 			{Code: `new alert()`},
+
+			// ================================================================
+			// Config `off` un-declares `globalThis` (only the globalThis
+			// receiver path consults globals in ESLint)
+			// ================================================================
+			{Code: `globalThis.alert("x");`, Globals: map[string]bool{"globalThis": false}},
+			{Code: `globalThis["alert"]("x");`, Globals: map[string]bool{"globalThis": false}},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ================================================================
@@ -551,6 +558,23 @@ func TestNoAlertRule(t *testing.T) {
 			// Type assertion on member callee
 			{
 				Code: `(window.alert as Function)(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Config `off` on `alert` or `window` has no effect in ESLint:
+			// the direct-call path only checks local shadowing, and the
+			// `window` receiver has no existence check (unlike `globalThis`).
+			{
+				Code:    `alert("x");`,
+				Globals: map[string]bool{"alert": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `window.alert("x");`,
+				Globals: map[string]bool{"window": false},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpected", Line: 1, Column: 1},
 				},

--- a/internal/rules/no_implicit_coercion/no_implicit_coercion.go
+++ b/internal/rules/no_implicit_coercion/no_implicit_coercion.go
@@ -93,7 +93,9 @@ var NoImplicitCoercionRule = rule.Rule{
 				return
 			}
 
-			// !!foo → Boolean(foo) — autofix unless `Boolean` is locally shadowed.
+			// !!foo → Boolean(foo) — autofix unless `Boolean` is locally shadowed
+			// or configured `off` (ESLint's `booleanExists` check downgrades the
+			// fix to a suggestion; the report itself is unaffected).
 			// Parens between the two `!`s (e.g. `!(!foo)`) are transparent in
 			// ESLint's AST, so we peel them off to match that behavior.
 			if opts.boolean && !opts.allow.Has("!!") && isDoubleLogicalNegating(pue) {
@@ -101,6 +103,9 @@ var NoImplicitCoercionRule = rule.Rule{
 				target := ast.SkipParentheses(innerPue.Operand)
 				recommendation := "Boolean(" + utils.TrimmedNodeText(ctx.SourceFile, target) + ")"
 				shouldFix := !utils.IsShadowed(node, "Boolean")
+				if declared, ok := ctx.Globals["Boolean"]; ok && !declared {
+					shouldFix = false
+				}
 				report(node, recommendation, true, shouldFix)
 			}
 

--- a/internal/rules/no_implicit_coercion/no_implicit_coercion_test.go
+++ b/internal/rules/no_implicit_coercion/no_implicit_coercion_test.go
@@ -170,6 +170,20 @@ func TestNoImplicitCoercion(t *testing.T) {
 					},
 				},
 			},
+			// Config `off` un-declares `Boolean` — same downgrade to suggestion
+			// (ESLint's `booleanExists` check); the report itself is unaffected.
+			{
+				Code:    `!!foo`,
+				Globals: map[string]bool{"Boolean": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Boolean(foo)`},
+						},
+					},
+				},
+			},
 			// ~foo.indexOf(x) — no fix, no suggestion (reported only).
 			{
 				Code: `~foo.indexOf(1)`,

--- a/internal/rules/no_useless_backreference/no_useless_backreference.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference.go
@@ -119,6 +119,12 @@ func isBuiltinRegExpCallee(ctx rule.RuleContext, callee *ast.Node) bool {
 	if callee == nil {
 		return false
 	}
+	// Config `off` un-declares `RegExp`: the constructor path goes dead and
+	// regex-literal arguments fall back to the plain literal listener, matching
+	// ESLint's ReferenceTracker walk over the global scope.
+	if declared, ok := ctx.Globals["RegExp"]; ok && !declared {
+		return false
+	}
 	if callee.Kind == ast.KindIdentifier {
 		name := callee.AsIdentifier().Text
 		if name == "RegExp" {

--- a/internal/rules/no_useless_backreference/no_useless_backreference_test.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference_test.go
@@ -158,6 +158,10 @@ func TestNoUselessBackreferenceRule(t *testing.T) {
 			{Code: `/(?<日本>a)\k<日本>/u`},
 			// Empty alternative + backref (edge: `(|a)\1` valid because \1 is after group)
 			{Code: `/(|a)\1/`},
+
+			// Config `off` un-declares `RegExp` — the constructor path goes dead
+			{Code: `new RegExp("\\1(a)");`, Globals: map[string]bool{"RegExp": false}},
+			{Code: `RegExp("\\1(a)");`, Globals: map[string]bool{"RegExp": false}},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- full message tests ----
@@ -351,6 +355,16 @@ func TestNoUselessBackreferenceRule(t *testing.T) {
 				Code: `const flags = getFlags(); RegExp(/\1(a)/, flags);`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "forward", Line: 1, Column: 27},
+				},
+			},
+			// Config `off` un-declares `RegExp`: the constructor no longer owns
+			// its regex-literal argument, so the literal is checked standalone
+			// with its own flags and reported at its own position.
+			{
+				Code:    `new RegExp(/\1(a)/, "u");`,
+				Globals: map[string]bool{"RegExp": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward", Line: 1, Column: 12},
 				},
 			},
 


### PR DESCRIPTION
## Summary

Ports the last three implemented rules that consult the globals configuration in ESLint to the `ctx.Globals` API:

- `no-alert`: `globalThis: off` disables the `globalThis.alert()` receiver path (the `window` receiver and direct calls do not consult globals in ESLint)
- `no-implicit-coercion`: `Boolean: off` downgrades the `!!foo` autofix to a suggestion; the report itself is unchanged (ESLint's `booleanExists` check)
- `no-useless-backreference`: `RegExp: off` disables the constructor-call path; a regex-literal argument falls back to the plain literal listener with its own flags

All new test expectations were verified against ESLint 9.39.4.

## Related Links

Part of https://github.com/web-infra-dev/rslint/issues/1239

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
