### PR TITLE
fix: scope gitignore collection to config directories

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -488,13 +488,14 @@ Program identities, not a second config inheritance tree.
 Additional current behaviors:
 
 - `.gitignore` is injected as a global-ignore entry through the shared
-  `ConfigWithGitignore` policy. CLI, including explicit CLI targets, scans from
-  the config directory; explicit API and LSP requests read only the target
-  files' ancestor chains
+  `ConfigWithGitignore` policy. The governing config directory is a hard upper
+  boundary: its own and nested `.gitignore` files apply, while parent
+  `.gitignore` files do not. In multi-config CLI mode, direct child config
+  directories are downward ownership handoff boundaries. Explicit API and LSP
+  requests read only the target's directory chain within the governing config
 - when the client supports dynamic file-watch registration, LSP watches
-  workspace and inherited ancestor `.gitignore` files; create/change/delete
-  events invalidate open-document diagnostics and request a fresh diagnostic
-  pass
+  workspace-descendant `.gitignore` files; create/change/delete events
+  invalidate open-document diagnostics and request a fresh diagnostic pass
 - the VS Code extension preserves last-good JS configs during reloads; a newly
   unavailable config with no usable JS ancestor contributes an empty boundary,
   preventing legacy JSON fallback only in that authored config subtree

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -699,7 +699,7 @@ func TestHandleLint_GitignoredParentBlocksNestedNegation(t *testing.T) {
 	}
 }
 
-func TestHandleLint_AncestorGitignoredConfigRootBlocksOwnNegation(t *testing.T) {
+func TestHandleLint_ParentGitignoreDoesNotSuppressConfigRoot(t *testing.T) {
 	dir := t.TempDir()
 	appDir := filepath.Join(dir, "packages", "app")
 	target := filepath.Join(appDir, "src", "file.js")
@@ -729,18 +729,18 @@ func TestHandleLint_AncestorGitignoredConfigRootBlocksOwnNegation(t *testing.T) 
 	if err != nil {
 		t.Fatalf("HandleLint returned error: %v", err)
 	}
-	if response.FileCount != 0 {
-		t.Fatalf("ancestor-gitignored config root should stay skipped despite own negation, got FileCount=%d", response.FileCount)
+	if response.FileCount != 1 {
+		t.Fatalf("parent .gitignore must not suppress a config-owned file, got FileCount=%d", response.FileCount)
 	}
-	if len(response.LintedFiles) != 0 {
-		t.Fatalf("ancestor-gitignored file must not be in LintedFiles, got %v", response.LintedFiles)
+	if len(response.LintedFiles) != 1 {
+		t.Fatalf("config-owned file must be in LintedFiles, got %v", response.LintedFiles)
 	}
-	if len(response.Diagnostics) != 0 {
-		t.Fatalf("expected no diagnostics for ancestor-gitignored file, got %+v", response.Diagnostics)
+	if len(response.Diagnostics) != 1 || response.Diagnostics[0].RuleName != "no-debugger" {
+		t.Fatalf("expected no-debugger for config-owned file, got %+v", response.Diagnostics)
 	}
 }
 
-func TestHandleLint_AncestorGitignoredIntermediateBlocksNegation(t *testing.T) {
+func TestHandleLint_IntermediateParentGitignoreIsNotRead(t *testing.T) {
 	dir := t.TempDir()
 	appDir := filepath.Join(dir, "packages", "app")
 	target := filepath.Join(appDir, "src", "file.js")
@@ -770,18 +770,18 @@ func TestHandleLint_AncestorGitignoredIntermediateBlocksNegation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("HandleLint returned error: %v", err)
 	}
-	if response.FileCount != 0 {
-		t.Fatalf("ancestor-gitignored intermediate dir should stay skipped despite its negation, got FileCount=%d", response.FileCount)
+	if response.FileCount != 1 {
+		t.Fatalf("parent .gitignore files must not suppress a config-owned file, got FileCount=%d", response.FileCount)
 	}
-	if len(response.LintedFiles) != 0 {
-		t.Fatalf("ancestor-gitignored file must not be in LintedFiles, got %v", response.LintedFiles)
+	if len(response.LintedFiles) != 1 {
+		t.Fatalf("config-owned file must be in LintedFiles, got %v", response.LintedFiles)
 	}
-	if len(response.Diagnostics) != 0 {
-		t.Fatalf("expected no diagnostics for ancestor-gitignored file, got %+v", response.Diagnostics)
+	if len(response.Diagnostics) != 1 || response.Diagnostics[0].RuleName != "no-debugger" {
+		t.Fatalf("expected no-debugger for config-owned file, got %+v", response.Diagnostics)
 	}
 }
 
-func TestHandleLint_AncestorChildWildcardReadsIntermediateGitignore(t *testing.T) {
+func TestHandleLint_ParentWildcardDoesNotReadIntermediateGitignore(t *testing.T) {
 	dir := t.TempDir()
 	appDir := filepath.Join(dir, "packages", "app")
 	target := filepath.Join(appDir, "src", "generated", "file.js")
@@ -811,14 +811,14 @@ func TestHandleLint_AncestorChildWildcardReadsIntermediateGitignore(t *testing.T
 	if err != nil {
 		t.Fatalf("HandleLint returned error: %v", err)
 	}
-	if response.FileCount != 0 {
-		t.Fatalf("intermediate .gitignore should skip generated explicit file, got FileCount=%d", response.FileCount)
+	if response.FileCount != 1 {
+		t.Fatalf("parent intermediate .gitignore must not skip generated explicit file, got FileCount=%d", response.FileCount)
 	}
-	if len(response.LintedFiles) != 0 {
-		t.Fatalf("gitignored generated file must not be in LintedFiles, got %v", response.LintedFiles)
+	if len(response.LintedFiles) != 1 {
+		t.Fatalf("config-owned generated file must be in LintedFiles, got %v", response.LintedFiles)
 	}
-	if len(response.Diagnostics) != 0 {
-		t.Fatalf("expected no diagnostics for gitignored generated file, got %+v", response.Diagnostics)
+	if len(response.Diagnostics) != 1 || response.Diagnostics[0].RuleName != "no-debugger" {
+		t.Fatalf("expected no-debugger for config-owned generated file, got %+v", response.Diagnostics)
 	}
 }
 

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -665,10 +665,9 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			configTargetScopes = payload.ConfigTargetScopes
 
 			// Inject .gitignore patterns as global ignores for each config.
-			// Each config independently reads its own .gitignore tree:
-			// The shared gitignore collector walks UP (ancestor inheritance) and DOWN
-			// (nested .gitignore) from each configDir. Sibling configs are
-			// fully isolated — they never share gitignore patterns.
+			// Each config independently reads from its own directory downward.
+			// Direct child config directories are ownership handoff boundaries, so
+			// parent and child configs never share .gitignore patterns.
 			//
 			// Directories excluded by global config ignores are pruned during
 			// the .gitignore scan because files below them cannot be linted.
@@ -685,9 +684,11 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			)
 			giWG := core.NewWorkGroup(singleThreaded)
 			if needsLintTargets {
+				configResolver := rslintconfig.NewConfigOwnerResolver(configMap, fs)
 				for configDir, entries := range configMap {
+					stopDirs := configResolver.ChildConfigDirs(configDir)
 					giWG.Queue(func() {
-						augmented := rslintconfig.ConfigWithGitignore(entries, configDir, fs, nil)
+						augmented := rslintconfig.ConfigWithGitignoreWithBoundaries(entries, configDir, fs, nil, stopDirs)
 						giMu.Lock()
 						giResults = append(giResults, giResult{configDir, augmented})
 						giMu.Unlock()

--- a/cmd/rslint/ignore_conformance_test.go
+++ b/cmd/rslint/ignore_conformance_test.go
@@ -64,13 +64,14 @@ func TestCLIAndAPIIgnoreConformance(t *testing.T) {
 			},
 		},
 		{
-			name:      "ancestor ignore blocks nested source",
+			name:      "parent ignore does not affect nested config",
 			configDir: "packages/app",
 			relative:  "ignored/keep.ts",
 			gitignores: map[string]string{
 				".gitignore":                      "/packages/app/ignored/\n",
 				"packages/app/ignored/.gitignore": "!keep.ts\n",
 			},
+			wantLinted: true,
 		},
 		{
 			name:     "pruned nested source does not override root negation",
@@ -268,5 +269,93 @@ func TestCLIMultiConfigGitignoreIsolation(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "packages/second/source.ts") {
 		t.Fatalf("second config lost its independently lintable target: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestCLIMultiConfigGitignoreOwnershipBoundaries(t *testing.T) {
+	workspace := t.TempDir()
+	childDir := filepath.Join(workspace, "packages", "app")
+	parentOwnedTarget := filepath.Join(childDir, "parent-owned.ts")
+	parentIgnoredTarget := filepath.Join(childDir, "parent-ignored.ts")
+	childOwnedTarget := filepath.Join(childDir, "child-owned.ts")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, target := range []string{parentOwnedTarget, parentIgnoredTarget, childOwnedTarget} {
+		if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(workspace, ".gitignore"), []byte("child-owned.ts\nparent-ignored.ts\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, ".gitignore"), []byte("parent-owned.ts\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := map[string]any{
+		"files": []string{"**/*.ts"},
+		"rules": map[string]string{"no-debugger": "error"},
+	}
+	payload, err := json.Marshal(map[string]any{
+		"configs": []any{
+			map[string]any{
+				"configDirectory": workspace,
+				"entries":         []any{entry},
+				"targetFiles":     []string{parentOwnedTarget, parentIgnoredTarget},
+				"explicitOnly":    true,
+			},
+			map[string]any{
+				"configDirectory": childDir,
+				"entries":         []any{entry},
+				"targetFiles":     []string{childOwnedTarget},
+				"explicitOnly":    true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payloadPath := filepath.Join(workspace, "config-payload.json")
+	if err := os.WriteFile(payloadPath, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name           string
+		singleThreaded bool
+	}{
+		{name: "single threaded", singleThreaded: true},
+		{name: "concurrent"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stdin, err := os.Open(payloadPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			originalStdin := os.Stdin
+			os.Stdin = stdin
+			t.Cleanup(func() {
+				os.Stdin = originalStdin
+				_ = stdin.Close()
+			})
+
+			code, stdout, stderr := runLintPipelineForTest(t, workspace, lintArgs{
+				ConfigStdin:    true,
+				Format:         "jsonline",
+				NoColor:        true,
+				SingleThreaded: test.singleThreaded,
+			})
+			if code != 1 {
+				t.Fatalf("expected both boundary targets to fail lint: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+			for _, targetName := range []string{"parent-owned.ts", "child-owned.ts"} {
+				if !strings.Contains(stdout, targetName) {
+					t.Fatalf("%s was polluted by another config's .gitignore: stdout=%q stderr=%q", targetName, stdout, stderr)
+				}
+			}
+			if strings.Contains(stdout, "parent-ignored.ts") {
+				t.Fatalf("parent-owned .gitignore did not apply before child boundary: stdout=%q stderr=%q", stdout, stderr)
+			}
+		})
 	}
 }

--- a/internal/config/config_discovery.go
+++ b/internal/config/config_discovery.go
@@ -37,6 +37,16 @@ func (resolver *ConfigOwnerResolver) Resolve(filePath string) (string, RslintCon
 	return configDir, resolver.configMap[configDir]
 }
 
+// ChildConfigDirs returns the direct lexical child config directories that
+// form ownership handoff boundaries for configDir. The returned slice is a
+// copy and may be used concurrently with resolver lookups.
+func (resolver *ConfigOwnerResolver) ChildConfigDirs(configDir string) []string {
+	if resolver == nil || resolver.index == nil {
+		return nil
+	}
+	return append([]string(nil), resolver.index.childConfigDirs(configDir)...)
+}
+
 // ResolveConfigPathSpace returns the physical path pair used for files and
 // ignores matching. It preserves the file's path relative to the authored
 // config directory, then anchors both paths on the config directory's realpath.

--- a/internal/config/config_discovery_test.go
+++ b/internal/config/config_discovery_test.go
@@ -129,6 +129,28 @@ func TestConfigOwnerResolverPrefersLexicalHierarchy(t *testing.T) {
 	}
 }
 
+func TestConfigOwnerResolverChildConfigDirs(t *testing.T) {
+	resolver := NewConfigOwnerResolver(map[string]RslintConfig{
+		"/repo":                  nil,
+		"/repo/packages/app":     nil,
+		"/repo/packages/lib":     nil,
+		"/repo/packages/app/e2e": nil,
+	}, nil)
+
+	children := resolver.ChildConfigDirs("/repo")
+	if len(children) != 2 || children[0] != "/repo/packages/app" || children[1] != "/repo/packages/lib" {
+		t.Fatalf("root child boundaries = %v", children)
+	}
+	if deep := resolver.ChildConfigDirs("/repo/packages/app"); len(deep) != 1 || deep[0] != "/repo/packages/app/e2e" {
+		t.Fatalf("nested child boundaries = %v", deep)
+	}
+
+	children[0] = "/mutated"
+	if fresh := resolver.ChildConfigDirs("/repo"); fresh[0] != "/repo/packages/app" {
+		t.Fatalf("ChildConfigDirs exposed resolver state: %v", fresh)
+	}
+}
+
 func TestConfigOwnerResolverUsesPhysicalFallbackWithoutLexicalOwner(t *testing.T) {
 	fs := &configPathSpaceFS{
 		caseSensitive: true,

--- a/internal/config/gitignore/collector.go
+++ b/internal/config/gitignore/collector.go
@@ -81,14 +81,10 @@ func readGitignoreAsGlobsWithBoundaries(configDir string, fsys vfs.FS, isDirecto
 	return allGlobs
 }
 
-// readGitignoreAsGlobsForFiles reads only .gitignore files on each directory
-// chain from configDir to an explicit target. This is used by API-style calls
-// where the target set is already known; unlike the full collector, it does
-// not scan every descendant of configDir.
-func readGitignoreAsGlobsForFiles(configDir string, fsys vfs.FS, files []string) []string {
-	return readGitignoreAsGlobsForFilesWithBoundaries(configDir, fsys, files, nil)
-}
-
+// readGitignoreAsGlobsForFilesWithBoundaries reads only .gitignore files on
+// each directory chain from configDir to an explicit target. This is used by
+// API-style calls where the target set is already known; unlike the full
+// collector, it does not scan every descendant of configDir.
 func readGitignoreAsGlobsForFilesWithBoundaries(configDir string, fsys vfs.FS, files []string, stopDirs []string) []string {
 	if fsys == nil || len(files) == 0 {
 		return nil

--- a/internal/config/gitignore/collector.go
+++ b/internal/config/gitignore/collector.go
@@ -30,26 +30,31 @@ func isDefaultExcludedDirName(name string, useCaseSensitive bool) bool {
 
 // Collect reads the .gitignore files relevant to one lint invocation. A nil
 // targetFiles slice scans descendants of configDir; a non-nil slice reads only
-// the explicit files' ancestor chains. In full-scan mode, isDirectoryBlocked
-// may prune descendants; its argument is a slash-separated directory path
-// relative to configDir. The callback is not used for explicit target files.
+// the directory chains between configDir and the explicit files. In full-scan
+// mode, isDirectoryBlocked may prune descendants; its argument is a
+// slash-separated directory path relative to configDir. The callback is not
+// used for explicit target files.
 func Collect(configDir string, fsys vfs.FS, targetFiles []string, isDirectoryBlocked func(string) bool) []string {
+	return CollectWithBoundaries(configDir, fsys, targetFiles, isDirectoryBlocked, nil)
+}
+
+// CollectWithBoundaries is Collect with additional descendant handoff
+// boundaries. A boundary directory and everything below it belongs to another
+// config, so none of its .gitignore files participate in this collection.
+func CollectWithBoundaries(configDir string, fsys vfs.FS, targetFiles []string, isDirectoryBlocked func(string) bool, stopDirs []string) []string {
 	if targetFiles == nil {
-		return readGitignoreAsGlobs(configDir, fsys, isDirectoryBlocked)
+		return readGitignoreAsGlobsWithBoundaries(configDir, fsys, isDirectoryBlocked, stopDirs)
 	}
-	return readGitignoreAsGlobsForFiles(configDir, fsys, targetFiles)
+	return readGitignoreAsGlobsForFilesWithBoundaries(configDir, fsys, targetFiles, stopDirs)
 }
 
 // readGitignoreAsGlobs reads .gitignore files relevant to configDir and
 // converts their patterns to rslint glob format suitable for use as global
 // ignore patterns.
 //
-// It collects patterns from two sources:
-//  1. Ancestor .gitignore files: walks UP from configDir to filesystem root,
-//     collecting .gitignore patterns at each level. This implements gitignore
-//     inheritance (root .gitignore affects all subdirectories).
-//  2. Descendant .gitignore files: walks DOWN from configDir, collecting
-//     nested .gitignore with directory-scoped prefixes.
+// It walks DOWN from configDir, collecting its .gitignore and nested
+// .gitignore files with directory-scoped prefixes. configDir is a hard upper
+// boundary: .gitignore files in its parents are never read.
 //
 // isDirectoryBlocked applies the caller's global config ignores. Descendant
 // .gitignore files below a blocked directory are irrelevant because files in
@@ -57,24 +62,18 @@ func Collect(configDir string, fsys vfs.FS, targetFiles []string, isDirectoryBlo
 //
 // Returns nil if no .gitignore files are found.
 func readGitignoreAsGlobs(configDir string, fsys vfs.FS, isDirectoryBlocked func(string) bool) []string {
+	return readGitignoreAsGlobsWithBoundaries(configDir, fsys, isDirectoryBlocked, nil)
+}
+
+func readGitignoreAsGlobsWithBoundaries(configDir string, fsys vfs.FS, isDirectoryBlocked func(string) bool, stopDirs []string) []string {
 	if fsys == nil {
 		return nil
 	}
 	normalizedRoot := normalizeGlobPath(configDir)
+	boundaries := normalizeCollectionBoundaries(normalizedRoot, stopDirs, fsys.UseCaseSensitiveFileNames())
 	var allGlobs []string
 
-	// Phase 1: collect ancestor .gitignore files (walk UP). Their patterns
-	// are interpreted relative to the ancestor .gitignore's directory, then
-	// projected into configDir-relative globs because rslint ignore matching
-	// evaluates paths relative to each configDir.
-	ancestorGlobs, ancestorPruneRules, configRootIgnored := collectAncestorGitignoreGlobs(normalizedRoot, fsys)
-	allGlobs = append(allGlobs, ancestorGlobs...)
-	if configRootIgnored {
-		return allGlobs
-	}
-
-	// Phase 2: collect descendant .gitignore files (walk DOWN from configDir).
-	collectGitignoreGlobs(normalizedRoot, "", fsys, &allGlobs, isDirectoryBlocked, ancestorPruneRules)
+	collectGitignoreGlobs(normalizedRoot, "", fsys, &allGlobs, isDirectoryBlocked, nil, boundaries)
 
 	if len(allGlobs) == 0 {
 		return nil
@@ -82,26 +81,38 @@ func readGitignoreAsGlobs(configDir string, fsys vfs.FS, isDirectoryBlocked func
 	return allGlobs
 }
 
-// readGitignoreAsGlobsForFiles reads only .gitignore files on the ancestor
-// chains of explicit target files. This is used by API-style calls where the
-// target set is already known; unlike the full collector, it does not scan
-// every descendant of configDir.
+// readGitignoreAsGlobsForFiles reads only .gitignore files on each directory
+// chain from configDir to an explicit target. This is used by API-style calls
+// where the target set is already known; unlike the full collector, it does
+// not scan every descendant of configDir.
 func readGitignoreAsGlobsForFiles(configDir string, fsys vfs.FS, files []string) []string {
+	return readGitignoreAsGlobsForFilesWithBoundaries(configDir, fsys, files, nil)
+}
+
+func readGitignoreAsGlobsForFilesWithBoundaries(configDir string, fsys vfs.FS, files []string, stopDirs []string) []string {
 	if fsys == nil || len(files) == 0 {
 		return nil
 	}
 
 	normalizedConfigDir := normalizeGlobPath(configDir)
+	useCaseSensitive := fsys.UseCaseSensitiveFileNames()
+	boundaries := normalizeCollectionBoundaries(normalizedConfigDir, stopDirs, useCaseSensitive)
 	dirSet := make(map[string]struct{})
 	for _, file := range files {
-		current := dirOfPath(normalizeGlobPath(file))
-		for current != "" {
-			dirSet[current] = struct{}{}
-			next := parentDir(current)
-			if next == current {
+		targetDir := dirOfPath(normalizeGlobPath(file))
+		rel, ok := relativeDir(normalizedConfigDir, targetDir, useCaseSensitive)
+		if !ok {
+			continue
+		}
+
+		current := normalizedConfigDir
+		dirSet[current] = struct{}{}
+		for _, component := range splitPathComponents(rel) {
+			current = tspath.CombinePaths(current, component)
+			if isCollectionBoundary(current, boundaries, useCaseSensitive) {
 				break
 			}
-			current = next
+			dirSet[current] = struct{}{}
 		}
 	}
 
@@ -115,14 +126,14 @@ func readGitignoreAsGlobsForFiles(configDir string, fsys vfs.FS, files []string)
 	var pruneRules []gitignorePruneRule
 	var prunedDirs []string
 	for _, dir := range dirs {
-		if isUnderPrunedDir(dir, prunedDirs, fsys.UseCaseSensitiveFileNames()) {
+		if isUnderPrunedDir(dir, prunedDirs, useCaseSensitive) {
 			continue
 		}
 		if isDescendantSymlinkDir(normalizedConfigDir, dir, fsys) {
 			prunedDirs = append(prunedDirs, dir)
 			continue
 		}
-		if isDirIgnoredByPruneRules(dir, pruneRules, fsys.UseCaseSensitiveFileNames()) {
+		if isDirIgnoredByPruneRules(dir, pruneRules, useCaseSensitive) {
 			prunedDirs = append(prunedDirs, dir)
 			continue
 		}
@@ -131,11 +142,8 @@ func readGitignoreAsGlobsForFiles(configDir string, fsys vfs.FS, files []string)
 		if !ok {
 			continue
 		}
-		if rel, ok := relativeDir(normalizedConfigDir, dir, fsys.UseCaseSensitiveFileNames()); ok {
-			allGlobs = append(allGlobs, convertGitignoreToGlobs(content, rel)...)
-		} else {
-			allGlobs = append(allGlobs, convertAncestorGitignoreToGlobs(content, dir, normalizedConfigDir, fsys.UseCaseSensitiveFileNames())...)
-		}
+		rel, _ := relativeDir(normalizedConfigDir, dir, useCaseSensitive)
+		allGlobs = append(allGlobs, convertGitignoreToGlobs(content, rel)...)
 		if rule, ok := newGitignorePruneRule(dir, content); ok {
 			pruneRules = append(pruneRules, rule)
 		}
@@ -144,6 +152,30 @@ func readGitignoreAsGlobsForFiles(configDir string, fsys vfs.FS, files []string)
 		return nil
 	}
 	return allGlobs
+}
+
+func normalizeCollectionBoundaries(configDir string, stopDirs []string, useCaseSensitive bool) []string {
+	boundaries := make([]string, 0, len(stopDirs))
+	for _, stopDir := range stopDirs {
+		stopDir = normalizeGlobPath(stopDir)
+		rel, ok := relativeDir(configDir, stopDir, useCaseSensitive)
+		if !ok || rel == "" {
+			continue
+		}
+		boundaries = append(boundaries, stopDir)
+	}
+	return boundaries
+}
+
+func isCollectionBoundary(dir string, boundaries []string, useCaseSensitive bool) bool {
+	for _, boundary := range boundaries {
+		if tspath.ComparePaths(dir, boundary, tspath.ComparePathsOptions{
+			UseCaseSensitiveFileNames: useCaseSensitive,
+		}) == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func isUnderPrunedDir(dir string, prunedDirs []string, useCaseSensitive bool) bool {
@@ -182,49 +214,6 @@ func isDescendantSymlinkDir(configDir string, dir string, fsys vfs.FS) bool {
 	return tspath.ComparePaths(dirRealPath, expectedRealPath, tspath.ComparePathsOptions{
 		UseCaseSensitiveFileNames: fsys.UseCaseSensitiveFileNames(),
 	}) != 0
-}
-
-// collectAncestorGitignoreGlobs walks UP from configDir to filesystem root,
-// collecting .gitignore patterns from each ancestor directory.
-// Returns patterns in root-first order (outermost ancestor first).
-func collectAncestorGitignoreGlobs(configDir string, fsys vfs.FS) ([]string, []gitignorePruneRule, bool) {
-	// Collect ancestor dirs (from dir's parent up to root)
-	var ancestors []string
-	current := parentDir(configDir)
-	for current != "" && current != configDir {
-		ancestors = append(ancestors, current)
-		next := parentDir(current)
-		if next == current {
-			break
-		}
-		current = next
-	}
-
-	// Reverse to get root-first order
-	for i, j := 0, len(ancestors)-1; i < j; i, j = i+1, j-1 {
-		ancestors[i], ancestors[j] = ancestors[j], ancestors[i]
-	}
-
-	// Read .gitignore from each ancestor
-	var globs []string
-	var pruneRules []gitignorePruneRule
-	configRootIgnored := false
-	for _, ancestor := range ancestors {
-		if isDirIgnoredByPruneRules(ancestor, pruneRules, fsys.UseCaseSensitiveFileNames()) {
-			configRootIgnored = true
-			break
-		}
-		gitignorePath := tspath.CombinePaths(ancestor, ".gitignore")
-		if content, ok := fsys.ReadFile(gitignorePath); ok {
-			converted := convertAncestorGitignoreToGlobs(content, ancestor, configDir, fsys.UseCaseSensitiveFileNames())
-			globs = append(globs, converted...)
-			if rule, ok := newGitignorePruneRule(ancestor, content); ok {
-				pruneRules = append(pruneRules, rule)
-				configRootIgnored = isDirIgnoredByPruneRules(configDir, pruneRules, fsys.UseCaseSensitiveFileNames())
-			}
-		}
-	}
-	return globs, pruneRules, configRootIgnored
 }
 
 type gitignorePruneRule struct {
@@ -471,8 +460,8 @@ func filesystemPathDepth(path string) int {
 // isDirectoryBlocked provides directory-level pruning from the caller's
 // config policy. If it returns true, files below that directory cannot be
 // linted, so nested .gitignore sources there are irrelevant.
-func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule) {
-	collectGitignoreGlobsRecursive(absDir, relDir, fsys, result, isDirectoryBlocked, pruneRules, &gitignoreWalkState{
+func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, boundaries []string) {
+	collectGitignoreGlobsRecursive(absDir, relDir, fsys, result, isDirectoryBlocked, pruneRules, boundaries, &gitignoreWalkState{
 		resolvedPaths: make(map[string]string),
 		visited:       make(map[string]struct{}),
 	})
@@ -492,7 +481,7 @@ func (s *gitignoreWalkState) realpath(path string, fsys vfs.FS) string {
 	return realpath
 }
 
-func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, result *[]string, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, state *gitignoreWalkState) {
+func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, result *[]string, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, boundaries []string, state *gitignoreWalkState) {
 	gitignorePath := tspath.CombinePaths(absDir, ".gitignore")
 	if content, ok := fsys.ReadFile(gitignorePath); ok {
 		localGlobs := convertGitignoreToGlobs(content, relDir)
@@ -514,6 +503,9 @@ func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, r
 		}
 
 		childAbs := tspath.CombinePaths(absDir, dir)
+		if isCollectionBoundary(childAbs, boundaries, fsys.UseCaseSensitiveFileNames()) {
+			continue
+		}
 		childRealPath := ""
 		if entries.Symlinks != nil {
 			if _, isSymlink := entries.Symlinks[dir]; isSymlink {
@@ -550,7 +542,7 @@ func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, r
 			state.visited[childRealPath] = struct{}{}
 		}
 
-		collectGitignoreGlobsRecursive(childAbs, childRel, fsys, result, isDirectoryBlocked, pruneRules, state)
+		collectGitignoreGlobsRecursive(childAbs, childRel, fsys, result, isDirectoryBlocked, pruneRules, boundaries, state)
 	}
 }
 
@@ -596,102 +588,6 @@ func normalizeGitignoreLine(line string) (string, bool) {
 		return "", false
 	}
 	return line, true
-}
-
-func convertAncestorGitignoreToGlobs(content string, ancestorDir string, configDir string, useCaseSensitive bool) []string {
-	configRel, ok := relativeDir(ancestorDir, configDir, useCaseSensitive)
-	if !ok {
-		return nil
-	}
-
-	var globs []string
-	for _, line := range strings.Split(content, "\n") {
-		line, ok := normalizeGitignoreLine(line)
-		if !ok {
-			continue
-		}
-		glob := convertAncestorSinglePattern(line, configRel)
-		if glob != "" {
-			globs = append(globs, glob)
-		}
-	}
-	return globs
-}
-
-func convertAncestorSinglePattern(line string, configRel string) string {
-	negated := false
-	body := line
-	if strings.HasPrefix(body, "!") {
-		negated = true
-		body = body[1:]
-	}
-	body = strings.TrimSuffix(body, "/")
-
-	rooted := strings.HasPrefix(body, "/") || strings.Contains(body, "/")
-	if !rooted {
-		glob := convertSinglePattern(line, "")
-		if configRel != "" && unrootedPatternCoversConfigRel(body, configRel) {
-			if negated {
-				return "!**/*"
-			}
-			return "**/*"
-		}
-		return glob
-	}
-
-	glob := convertSinglePattern(line, "")
-	if glob == "" || configRel == "" {
-		return glob
-	}
-	if negated {
-		glob = strings.TrimPrefix(glob, "!")
-	}
-
-	relGlob, ok := stripAncestorConfigPrefix(glob, configRel)
-	if !ok {
-		return ""
-	}
-	if negated {
-		return "!" + relGlob
-	}
-	return relGlob
-}
-
-func unrootedPatternCoversConfigRel(pattern string, configRel string) bool {
-	for _, part := range splitPathComponents(configRel) {
-		if matchGlob(pattern, part) {
-			return true
-		}
-	}
-	return false
-}
-
-func stripAncestorConfigPrefix(glob string, configRel string) (string, bool) {
-	globParts := splitPathComponents(glob)
-	configParts := splitPathComponents(configRel)
-	if len(globParts) == 0 || len(configParts) == 0 {
-		return glob, true
-	}
-
-	pi := 0
-	for _, configPart := range configParts {
-		if pi >= len(globParts) {
-			return "**/*", true
-		}
-		part := globParts[pi]
-		if part == "**" {
-			return strings.Join(globParts[pi:], "/"), true
-		}
-		if !matchGlob(part, configPart) {
-			return "", false
-		}
-		pi++
-	}
-
-	if pi >= len(globParts) {
-		return "**/*", true
-	}
-	return strings.Join(globParts[pi:], "/"), true
 }
 
 func splitPathComponents(p string) []string {

--- a/internal/config/gitignore/collector_test.go
+++ b/internal/config/gitignore/collector_test.go
@@ -283,9 +283,9 @@ func TestReadGitignoreAsGlobs_PrunesGitignoredDirs(t *testing.T) {
 	}
 }
 
-func TestCollectors_AncestorPatternPrunesDescendantIgnoreSource(t *testing.T) {
+func TestCollectors_ConfigRootPatternPrunesDescendantIgnoreSource(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
-		".gitignore":                        "/packages/app/ignored/\n",
+		"packages/app/.gitignore":           "/ignored/\n",
 		"packages/app/ignored/.gitignore":   "!keep.ts\n",
 		"packages/app/ignored/keep.ts":      "x",
 		"packages/app/ignored/unrelated.ts": "x",
@@ -484,7 +484,7 @@ func TestConvertGitignoreToGlobs_DirOnlySuffixDedup(t *testing.T) {
 	assert.Equal(t, nested[0], "pkg/app/src/**/*")
 }
 
-// --- Ancestor inheritance tests ---
+// --- Path boundary helpers ---
 
 func TestParentDirStopsAtFilesystemRoot(t *testing.T) {
 	tests := []struct {
@@ -554,7 +554,7 @@ func TestSortByPathDepthTreatsUNCShareAsRoot(t *testing.T) {
 	})
 }
 
-func TestReadGitignoreAsGlobs_JoinsFilesystemRoots(t *testing.T) {
+func TestReadGitignoreAsGlobs_StopsAtConfigDirAcrossFilesystemRoots(t *testing.T) {
 	tests := []struct {
 		name         string
 		configDir    string
@@ -571,7 +571,8 @@ func TestReadGitignoreAsGlobs_JoinsFilesystemRoots(t *testing.T) {
 			mock := &gitignoreMockFS{
 				FS: osvfs.FS(),
 				files: map[string]string{
-					test.rootIgnore: "root-cache/\n",
+					test.rootIgnore:   "root-cache/\n",
+					test.configIgnore: "local-cache/\n",
 				},
 				entries: map[string]vfs.Entries{
 					test.configDir: {Symlinks: map[string]struct{}{}},
@@ -580,52 +581,139 @@ func TestReadGitignoreAsGlobs_JoinsFilesystemRoots(t *testing.T) {
 
 			globs := readGitignoreAsGlobs(test.configDir, mock, nil)
 
-			assert.DeepEqual(t, globs, []string{"**/root-cache/**/*"})
-			assert.DeepEqual(t, mock.readFileCalls, []string{test.rootIgnore, test.configIgnore})
+			assert.DeepEqual(t, globs, []string{"**/local-cache/**/*"})
+			assert.DeepEqual(t, mock.readFileCalls, []string{test.configIgnore})
 		})
 	}
 }
 
-func TestConvertAncestorGitignoreToGlobs_IsVolumeAndShareAware(t *testing.T) {
+func TestExplicitCollectorNeverAccessesOutsideConfigDir(t *testing.T) {
+	t.Run("outside target only", func(t *testing.T) {
+		mock := &gitignoreMockFS{
+			FS: osvfs.FS(),
+			files: map[string]string{
+				"/.gitignore":         "global-cache/\n",
+				"/outside/.gitignore": "outside-cache/\n",
+			},
+			caseSensitiveFS: true,
+		}
+
+		globs := Collect("/repo", mock, []string{"/outside/source.ts"}, nil)
+		assert.Assert(t, globs == nil, "outside target produced %v", globs)
+		assert.Assert(t, len(mock.readFileCalls) == 0, "outside target triggered reads: %v", mock.readFileCalls)
+		assert.Assert(t, len(mock.accessedDirs) == 0, "outside target triggered directory access: %v", mock.accessedDirs)
+		assert.Assert(t, len(mock.realpathCalls) == 0, "outside target triggered realpath: %v", mock.realpathCalls)
+	})
+
+	t.Run("mixed targets collect only the valid chain", func(t *testing.T) {
+		mock := &gitignoreMockFS{
+			FS: osvfs.FS(),
+			files: map[string]string{
+				"/repo/.gitignore":     "root-cache/\n",
+				"/repo/src/.gitignore": "generated.ts\n",
+				"/outside/.gitignore":  "outside-cache/\n",
+			},
+			entries: map[string]vfs.Entries{
+				"/repo": {Symlinks: map[string]struct{}{}},
+			},
+			caseSensitiveFS: true,
+		}
+
+		globs := Collect("/repo", mock, []string{
+			"/outside/source.ts",
+			"/repo/src/source.ts",
+		}, nil)
+		assert.DeepEqual(t, globs, []string{
+			"**/root-cache/**/*",
+			"src/**/generated.ts",
+		})
+		assert.DeepEqual(t, mock.readFileCalls, []string{
+			"/repo/.gitignore",
+			"/repo/src/.gitignore",
+		})
+		assert.DeepEqual(t, mock.accessedDirs, []string{"/repo"})
+		assert.Assert(t, len(mock.realpathCalls) == 0, "mixed targets triggered unexpected realpath: %v", mock.realpathCalls)
+	})
+}
+
+func TestCollectionBoundariesAreVolumeAndCaseAware(t *testing.T) {
 	tests := []struct {
-		name      string
-		ancestor  string
-		configDir string
-		content   string
-		expected  []string
+		name             string
+		configDir        string
+		stopDir          string
+		candidate        string
+		useCaseSensitive bool
 	}{
-		{
-			name:      "same drive preserves config base",
-			ancestor:  "C:/repo",
-			configDir: "C:/repo/packages/app",
-			content:   "/packages/app/dist/\n",
-			expected:  []string{"dist/**/*"},
-		},
-		{
-			name:      "same share preserves config base",
-			ancestor:  "//server/share/repo",
-			configDir: "//server/share/repo/packages/app",
-			content:   "/packages/app/dist/\n",
-			expected:  []string{"dist/**/*"},
-		},
-		{
-			name:      "other drive is not ancestor",
-			ancestor:  "D:/repo",
-			configDir: "C:/repo/packages/app",
-			content:   "dist/\n",
-		},
-		{
-			name:      "other share is not ancestor",
-			ancestor:  "//server/other/repo",
-			configDir: "//server/share/repo/packages/app",
-			content:   "dist/\n",
-		},
+		{name: "posix", configDir: "/repo", stopDir: "/repo/packages/app", candidate: "/repo/packages/app", useCaseSensitive: true},
+		{name: "case insensitive", configDir: "/Repo", stopDir: "/repo/Packages/App", candidate: "/REPO/packages/app"},
+		{name: "drive", configDir: "C:/Repo", stopDir: "c:/repo/Packages/App", candidate: "C:/REPO/packages/app"},
+		{name: "unc", configDir: "//server/share/repo", stopDir: "//SERVER/SHARE/REPO/packages/app", candidate: "//server/share/repo/PACKAGES/APP"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := convertAncestorGitignoreToGlobs(test.content, test.ancestor, test.configDir, true)
-			assert.DeepEqual(t, actual, test.expected)
+			boundaries := normalizeCollectionBoundaries(test.configDir, []string{test.stopDir}, test.useCaseSensitive)
+			assert.Equal(t, len(boundaries), 1)
+			assert.Assert(t, isCollectionBoundary(test.candidate, boundaries, test.useCaseSensitive))
 		})
+	}
+
+	assert.Assert(t, len(normalizeCollectionBoundaries("/repo", []string{"/other/app", "/repo"}, true)) == 0)
+}
+
+func TestCollectors_StopAtChildConfigBoundary(t *testing.T) {
+	mock := &gitignoreMockFS{
+		FS: osvfs.FS(),
+		files: map[string]string{
+			"/repo/.gitignore":                    "root-cache/\n",
+			"/repo/packages/.gitignore":           "package-cache/\n",
+			"/repo/packages/app/.gitignore":       "child-cache/\n",
+			"/repo/packages/app/src/.gitignore":   "generated.ts\n",
+			"/repo/packages/other/.gitignore":     "other-cache/\n",
+			"/repo/packages/other/src/.gitignore": "other-generated.ts\n",
+		},
+		entries: map[string]vfs.Entries{
+			"/repo":                    {Directories: []string{"packages"}, Symlinks: map[string]struct{}{}},
+			"/repo/packages":           {Directories: []string{"app", "other"}, Symlinks: map[string]struct{}{}},
+			"/repo/packages/app":       {Directories: []string{"src"}, Symlinks: map[string]struct{}{}},
+			"/repo/packages/app/src":   {Symlinks: map[string]struct{}{}},
+			"/repo/packages/other":     {Directories: []string{"src"}, Symlinks: map[string]struct{}{}},
+			"/repo/packages/other/src": {Symlinks: map[string]struct{}{}},
+		},
+		caseSensitiveFS: true,
+	}
+	boundary := "/repo/packages/app"
+
+	full := CollectWithBoundaries("/repo", mock, nil, nil, []string{boundary})
+	assert.DeepEqual(t, full, []string{
+		"**/root-cache/**/*",
+		"packages/**/package-cache/**/*",
+		"packages/other/**/other-cache/**/*",
+		"packages/other/src/**/other-generated.ts",
+	})
+	for _, path := range append(append([]string(nil), mock.readFileCalls...), mock.accessedDirs...) {
+		if _, ok := relativeDir(boundary, path, true); ok {
+			t.Fatalf("collector crossed child config boundary: %q", path)
+		}
+	}
+
+	mock.readFileCalls = nil
+	mock.accessedDirs = nil
+	mock.realpathCalls = nil
+	explicit := CollectWithBoundaries(
+		"/repo",
+		mock,
+		[]string{"/repo/packages/app/src/file.ts"},
+		nil,
+		[]string{boundary},
+	)
+	assert.DeepEqual(t, explicit, []string{
+		"**/root-cache/**/*",
+		"packages/**/package-cache/**/*",
+	})
+	for _, path := range append(append(append([]string(nil), mock.readFileCalls...), mock.accessedDirs...), mock.realpathCalls...) {
+		if _, ok := relativeDir(boundary, path, true); ok {
+			t.Fatalf("explicit collector crossed child config boundary: %q", path)
+		}
 	}
 }

--- a/internal/config/gitignore/config_integration_test.go
+++ b/internal/config/gitignore/config_integration_test.go
@@ -87,6 +87,35 @@ func TestConfigWithGitignore_DefaultAndExplicitScopes(t *testing.T) {
 	assert.Assert(t, base[0].Ignores == nil, "ConfigWithGitignore mutated its input: %v", base)
 }
 
+func TestConfigWithGitignore_DoesNotReadParentOfConfigDir(t *testing.T) {
+	sandbox := t.TempDir()
+	workspace := filepath.Join(sandbox, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sandbox, ".gitignore"), []byte("/workspace/source.ts\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(workspace, "source.ts")
+	if err := os.WriteFile(target, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}}
+
+	for _, test := range []struct {
+		name        string
+		targetFiles []string
+	}{
+		{name: "default scan"},
+		{name: "explicit file", targetFiles: []string{target}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			effective := config.ConfigWithGitignore(base, workspace, osvfs.FS(), test.targetFiles)
+			assert.Assert(t, !effective.IsFileIgnored(target, workspace), "a .gitignore above configDir must not ignore config-owned files")
+		})
+	}
+}
+
 func TestConfigWithGitignore_ExplicitMatchesDefaultPruning(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                   "dist/\n!dist/types/\n",
@@ -156,7 +185,7 @@ func TestConfigWithGitignore_SymlinkedConfigPathSpace(t *testing.T) {
 	}
 }
 
-func TestConfigWithGitignore_SymlinkedConfigKeepsLexicalAncestors(t *testing.T) {
+func TestConfigWithGitignore_SymlinkedConfigDoesNotReadParents(t *testing.T) {
 	workspace := t.TempDir()
 	externalParent := t.TempDir()
 	realRoot := filepath.Join(externalParent, "real")
@@ -174,7 +203,7 @@ func TestConfigWithGitignore_SymlinkedConfigKeepsLexicalAncestors(t *testing.T) 
 	base := config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}}
 	matchFile, matchDir := config.ResolveConfigPathSpace(target, aliasRoot, osvfs.FS())
 
-	t.Run("lexical ancestor applies", func(t *testing.T) {
+	t.Run("lexical parent does not apply", func(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(workspace, ".gitignore"), []byte("/alias/src/source.ts\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -182,11 +211,11 @@ func TestConfigWithGitignore_SymlinkedConfigKeepsLexicalAncestors(t *testing.T) 
 
 		full := config.ConfigWithGitignore(base, aliasRoot, osvfs.FS(), nil)
 		explicit := config.ConfigWithGitignore(base, aliasRoot, osvfs.FS(), []string{target})
-		assert.Assert(t, full.IsFileIgnored(matchFile, matchDir))
+		assert.Assert(t, !full.IsFileIgnored(matchFile, matchDir))
 		assert.Equal(t, explicit.IsFileIgnored(matchFile, matchDir), full.IsFileIgnored(matchFile, matchDir))
 	})
 
-	t.Run("physical-only ancestor does not apply", func(t *testing.T) {
+	t.Run("physical parent does not apply", func(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(externalParent, ".gitignore"), []byte("/real/src/source.ts\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -217,9 +246,7 @@ func TestConfigWithGitignore_ExplicitSkipsDescendantSymlinkSource(t *testing.T) 
 	assert.Assert(t, !explicit.IsFileIgnored(matchFile, matchDir))
 }
 
-func TestConfigWithGitignore_AncestorInheritance(t *testing.T) {
-	// Root has .gitignore with dist/. configDir is packages/app (child).
-	// A child config should inherit the root .gitignore.
+func TestConfigWithGitignore_ParentIgnoreIsNotInherited(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":            "dist/\n",
 		"packages/app/src/a.ts": "x",
@@ -233,10 +260,10 @@ func TestConfigWithGitignore_AncestorInheritance(t *testing.T) {
 			hasDistGlob = true
 		}
 	}
-	assert.Assert(t, hasDistGlob, "child configDir should inherit root .gitignore dist/ pattern")
+	assert.Assert(t, !hasDistGlob, "configDir must not inherit its parent's dist/ pattern")
 }
 
-func TestConfigWithGitignore_AncestorAnchoredOutsideConfigDoesNotApply(t *testing.T) {
+func TestConfigWithGitignore_ParentAnchoredOutsideConfigDoesNotApply(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                 "/dist/\n",
 		"dist/root-build.js":         "x",
@@ -259,11 +286,11 @@ func TestConfigWithGitignore_AncestorAnchoredOutsideConfigDoesNotApply(t *testin
 	}
 	appDist := tspath.NormalizePath(filepath.Join(appDir, "dist/app.js"))
 	if cfg.GetConfigForFile(appDist, appDir) == nil {
-		t.Fatalf("ancestor /dist/ should not ignore nested config dist file; globs=%v", globs)
+		t.Fatalf("parent /dist/ should not ignore nested config dist file; globs=%v", globs)
 	}
 }
 
-func TestConfigWithGitignore_AncestorAnchoredInsideConfigApplies(t *testing.T) {
+func TestConfigWithGitignore_ParentAnchoredInsideConfigDoesNotApply(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                "/packages/app/dist/\n",
 		"packages/app/dist/app.js":  "x",
@@ -273,23 +300,23 @@ func TestConfigWithGitignore_AncestorAnchoredInsideConfigApplies(t *testing.T) {
 	globs := collectGitignoreGlobsForTest(appDir, osvfs.FS(), nil)
 
 	gs := globSet(globs)
-	assert.Assert(t, gs["dist/**/*"], "ancestor pattern anchored into config should become config-relative dist/**/*, got: %v", globs)
+	assert.Assert(t, !gs["dist/**/*"], "parent pattern must not be projected into configDir, got: %v", globs)
 
 	cfg := config.RslintConfig{
 		{Ignores: globs},
 		{Rules: config.Rules{"no-debugger": "error"}},
 	}
 	appDist := tspath.NormalizePath(filepath.Join(appDir, "dist/app.js"))
-	if cfg.GetConfigForFile(appDist, appDir) != nil {
-		t.Fatalf("ancestor /packages/app/dist/ should ignore app dist; globs=%v", globs)
+	if cfg.GetConfigForFile(appDist, appDir) == nil {
+		t.Fatalf("parent /packages/app/dist/ should not ignore app dist; globs=%v", globs)
 	}
 	srcFile := tspath.NormalizePath(filepath.Join(appDir, "src/index.js"))
 	if cfg.GetConfigForFile(srcFile, appDir) == nil {
-		t.Fatalf("ancestor /packages/app/dist/ must not ignore src; globs=%v", globs)
+		t.Fatalf("parent /packages/app/dist/ must not ignore src; globs=%v", globs)
 	}
 }
 
-func TestConfigWithGitignore_AncestorWildcardInsideConfigApplies(t *testing.T) {
+func TestConfigWithGitignore_ParentWildcardInsideConfigDoesNotApply(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                "/packages/*/dist/\n",
 		"packages/app/dist/app.js":  "x",
@@ -299,10 +326,10 @@ func TestConfigWithGitignore_AncestorWildcardInsideConfigApplies(t *testing.T) {
 	globs := collectGitignoreGlobsForTest(appDir, osvfs.FS(), nil)
 
 	gs := globSet(globs)
-	assert.Assert(t, gs["dist/**/*"], "ancestor wildcard path should be projected under configDir, got: %v", globs)
+	assert.Assert(t, !gs["dist/**/*"], "parent wildcard path must not be projected under configDir, got: %v", globs)
 }
 
-func TestConfigWithGitignore_AncestorAnchoredParentDirCoversConfig(t *testing.T) {
+func TestConfigWithGitignore_ParentAnchoredDirDoesNotCoverConfig(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                "/packages/\n",
 		"packages/app/src/index.js": "x",
@@ -311,18 +338,18 @@ func TestConfigWithGitignore_AncestorAnchoredParentDirCoversConfig(t *testing.T)
 	globs := collectGitignoreGlobsForTest(appDir, osvfs.FS(), nil)
 
 	gs := globSet(globs)
-	assert.Assert(t, gs["**/*"], "ancestor pattern covering configDir should project to **/*, got: %v", globs)
+	assert.Assert(t, !gs["**/*"], "parent pattern covering configDir must not project to **/*, got: %v", globs)
 	cfg := config.RslintConfig{
 		{Ignores: globs},
 		{Rules: config.Rules{"no-debugger": "error"}},
 	}
 	srcFile := tspath.NormalizePath(filepath.Join(appDir, "src/index.js"))
-	if cfg.GetConfigForFile(srcFile, appDir) != nil {
-		t.Fatalf("ancestor /packages/ should ignore all files under packages/app; globs=%v", globs)
+	if cfg.GetConfigForFile(srcFile, appDir) == nil {
+		t.Fatalf("parent /packages/ should not ignore files under packages/app; globs=%v", globs)
 	}
 }
 
-func TestConfigWithGitignore_AncestorUnrootedParentDirCoversConfig(t *testing.T) {
+func TestConfigWithGitignore_ParentUnrootedDirDoesNotCoverConfig(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                "packages/\n",
 		"packages/app/src/index.js": "x",
@@ -331,18 +358,18 @@ func TestConfigWithGitignore_AncestorUnrootedParentDirCoversConfig(t *testing.T)
 	globs := collectGitignoreGlobsForTest(appDir, osvfs.FS(), nil)
 
 	gs := globSet(globs)
-	assert.Assert(t, gs["**/*"], "ancestor unrooted packages/ should cover configDir, got: %v", globs)
+	assert.Assert(t, !gs["**/*"], "parent unrooted packages/ must not cover configDir, got: %v", globs)
 	cfg := config.RslintConfig{
 		{Ignores: globs},
 		{Rules: config.Rules{"no-debugger": "error"}},
 	}
 	srcFile := tspath.NormalizePath(filepath.Join(appDir, "src/index.js"))
-	if cfg.GetConfigForFile(srcFile, appDir) != nil {
-		t.Fatalf("ancestor packages/ should ignore all files under packages/app; globs=%v", globs)
+	if cfg.GetConfigForFile(srcFile, appDir) == nil {
+		t.Fatalf("parent packages/ should not ignore files under packages/app; globs=%v", globs)
 	}
 }
 
-func TestConfigWithGitignore_AncestorIgnoredConfigRootSkipsOwnGitignore(t *testing.T) {
+func TestConfigWithGitignore_ParentCannotSuppressConfigRootGitignore(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                "packages/\n",
 		"packages/app/.gitignore":   "!src/index.js\n",
@@ -351,22 +378,18 @@ func TestConfigWithGitignore_AncestorIgnoredConfigRootSkipsOwnGitignore(t *testi
 	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
 	globs := collectGitignoreGlobsForTest(appDir, osvfs.FS(), nil)
 
-	for _, glob := range globs {
-		if strings.HasPrefix(glob, "!") {
-			t.Fatalf("config root ignored by ancestor must not read own negation .gitignore, got: %v", globs)
-		}
-	}
+	assert.Assert(t, globSet(globs)["!src/index.js"], "configDir must read its own .gitignore, got: %v", globs)
 	cfg := config.RslintConfig{
 		{Ignores: globs},
 		{Rules: config.Rules{"no-debugger": "error"}},
 	}
 	srcFile := tspath.NormalizePath(filepath.Join(appDir, "src/index.js"))
-	if cfg.GetConfigForFile(srcFile, appDir) != nil {
-		t.Fatalf("ancestor packages/ should not be re-included by packages/app/.gitignore; globs=%v", globs)
+	if cfg.GetConfigForFile(srcFile, appDir) == nil {
+		t.Fatalf("parent packages/ must not suppress packages/app/.gitignore; globs=%v", globs)
 	}
 }
 
-func TestConfigWithGitignore_AncestorIgnoredIntermediateSkipsGitignore(t *testing.T) {
+func TestConfigWithGitignore_ParentIntermediateGitignoreIsNotRead(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                "packages/\n",
 		"packages/.gitignore":       "!app/src/index.js\n",
@@ -375,22 +398,18 @@ func TestConfigWithGitignore_AncestorIgnoredIntermediateSkipsGitignore(t *testin
 	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
 	globs := collectGitignoreGlobsForTest(appDir, osvfs.FS(), nil)
 
-	for _, glob := range globs {
-		if strings.HasPrefix(glob, "!") {
-			t.Fatalf("ignored intermediate ancestor must not re-include from its .gitignore, got: %v", globs)
-		}
-	}
+	assert.Assert(t, len(globs) == 0, "parent and intermediate .gitignore files must not be read, got: %v", globs)
 	cfg := config.RslintConfig{
 		{Ignores: globs},
 		{Rules: config.Rules{"no-debugger": "error"}},
 	}
 	srcFile := tspath.NormalizePath(filepath.Join(appDir, "src/index.js"))
-	if cfg.GetConfigForFile(srcFile, appDir) != nil {
-		t.Fatalf("ancestor packages/ should not be re-included by packages/.gitignore; globs=%v", globs)
+	if cfg.GetConfigForFile(srcFile, appDir) == nil {
+		t.Fatalf("parent .gitignore files must not ignore config-owned files; globs=%v", globs)
 	}
 }
 
-func TestConfigWithGitignore_AncestorChildWildcardReadsIntermediateGitignore(t *testing.T) {
+func TestConfigWithGitignore_ParentWildcardDoesNotReadIntermediateGitignore(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                                   "packages/*\n!packages/app/\n",
 		"packages/.gitignore":                          "app/src/generated/\n",
@@ -403,14 +422,14 @@ func TestConfigWithGitignore_AncestorChildWildcardReadsIntermediateGitignore(t *
 	globs := collectGitignoreGlobsForTest(appDir, osvfs.FS(), nil)
 
 	gs := globSet(globs)
-	assert.Assert(t, gs["src/generated/**/*"], "packages/.gitignore should be collected, got: %v", globs)
+	assert.Assert(t, !gs["src/generated/**/*"], "packages/.gitignore must not be collected, got: %v", globs)
 	cfg := config.RslintConfig{
 		{Ignores: globs},
 		{Rules: config.Rules{"no-debugger": "error"}},
 	}
 	generated := tspath.NormalizePath(filepath.Join(appDir, "src/generated/file.js"))
-	if cfg.GetConfigForFile(generated, appDir) != nil {
-		t.Fatalf("intermediate .gitignore should ignore generated file; globs=%v", globs)
+	if cfg.GetConfigForFile(generated, appDir) == nil {
+		t.Fatalf("parent intermediate .gitignore should not ignore generated file; globs=%v", globs)
 	}
 	normal := tspath.NormalizePath(filepath.Join(appDir, "src/not-generated/file.js"))
 	if cfg.GetConfigForFile(normal, appDir) == nil {
@@ -418,7 +437,7 @@ func TestConfigWithGitignore_AncestorChildWildcardReadsIntermediateGitignore(t *
 	}
 }
 
-func TestConfigWithGitignore_Explicit_ChildWildcardReadsIntermediateGitignore(t *testing.T) {
+func TestConfigWithGitignore_ExplicitDoesNotReadIntermediateParentGitignore(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                         "packages/*\n!packages/app/\n",
 		"packages/.gitignore":                "app/src/generated/\n",
@@ -430,13 +449,13 @@ func TestConfigWithGitignore_Explicit_ChildWildcardReadsIntermediateGitignore(t 
 	globs := collectGitignoreGlobsForFilesForTest(appDir, osvfs.FS(), []string{generated})
 
 	gs := globSet(globs)
-	assert.Assert(t, gs["src/generated/**/*"], "explicit-file gitignore chain should include packages/.gitignore, got: %v", globs)
+	assert.Assert(t, !gs["src/generated/**/*"], "explicit-file gitignore chain must stop at configDir, got: %v", globs)
 	cfg := config.RslintConfig{
 		{Ignores: globs},
 		{Rules: config.Rules{"no-debugger": "error"}},
 	}
-	if cfg.GetConfigForFile(generated, appDir) != nil {
-		t.Fatalf("intermediate .gitignore should ignore explicit generated file; globs=%v", globs)
+	if cfg.GetConfigForFile(generated, appDir) == nil {
+		t.Fatalf("parent intermediate .gitignore should not ignore explicit generated file; globs=%v", globs)
 	}
 }
 
@@ -454,8 +473,7 @@ func TestConfigWithGitignore_DescendantChildWildcardReadsIntermediateGitignore(t
 	assert.Assert(t, gs["packages/app/src/generated/**/*"], "root scan should read packages/.gitignore, got: %v", globs)
 }
 
-func TestConfigWithGitignore_AncestorPlusOwn(t *testing.T) {
-	// Root has dist/, child has tmp/. Both should be in globs.
+func TestConfigWithGitignore_ParentExcludedAndOwnIncluded(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":              "dist/\n",
 		"packages/app/.gitignore": "tmp/\n",
@@ -474,7 +492,7 @@ func TestConfigWithGitignore_AncestorPlusOwn(t *testing.T) {
 			hasTmp = true
 		}
 	}
-	assert.Assert(t, hasDist, "should inherit root dist/")
+	assert.Assert(t, !hasDist, "should not inherit parent dist/")
 	assert.Assert(t, hasTmp, "should have own tmp/")
 }
 
@@ -496,7 +514,7 @@ func TestConfigWithGitignore_SiblingIsolation(t *testing.T) {
 			t.Errorf("app globs should NOT contain lib's cache pattern, found: %s", g)
 		}
 	}
-	// Should have dist (inherited) and tmp (own)
+	// Should have tmp (own), but neither dist (parent) nor cache (sibling).
 	hasDist := false
 	hasTmp := false
 	for _, g := range appGlobs {
@@ -507,12 +525,11 @@ func TestConfigWithGitignore_SiblingIsolation(t *testing.T) {
 			hasTmp = true
 		}
 	}
-	assert.Assert(t, hasDist, "should inherit root dist/")
+	assert.Assert(t, !hasDist, "should not inherit parent dist/")
 	assert.Assert(t, hasTmp, "should have own tmp/")
 }
 
-func TestConfigWithGitignore_DeepAncestor(t *testing.T) {
-	// .gitignore at root, configDir at packages/app/sub (3 levels deep)
+func TestConfigWithGitignore_DeepParentIsNotInherited(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":                "dist/\n",
 		"packages/app/sub/src/a.ts": "x",
@@ -526,12 +543,10 @@ func TestConfigWithGitignore_DeepAncestor(t *testing.T) {
 			hasDist = true
 		}
 	}
-	assert.Assert(t, hasDist, "deeply nested configDir should still inherit root .gitignore")
+	assert.Assert(t, !hasDist, "deeply nested configDir must not inherit root .gitignore")
 }
 
-func TestConfigWithGitignore_MultipleAncestors(t *testing.T) {
-	// Root has .gitignore (dist/), packages/ has .gitignore (vendor/),
-	// configDir is packages/app/. Both ancestors should be collected.
+func TestConfigWithGitignore_MultipleParentsAreNotInherited(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":            "dist/\n",
 		"packages/.gitignore":   "vendor/\n",
@@ -550,13 +565,11 @@ func TestConfigWithGitignore_MultipleAncestors(t *testing.T) {
 			hasVendor = true
 		}
 	}
-	assert.Assert(t, hasDist, "should inherit root dist/")
-	assert.Assert(t, hasVendor, "should inherit intermediate packages/ vendor/")
+	assert.Assert(t, !hasDist, "should not inherit root dist/")
+	assert.Assert(t, !hasVendor, "should not inherit intermediate packages/ vendor/")
 }
 
-func TestConfigWithGitignore_AncestorNegationOverride(t *testing.T) {
-	// Root ignores dist/, intermediate packages/.gitignore re-includes with !dist/.
-	// configDir at packages/app should see both patterns (sequential evaluation).
+func TestConfigWithGitignore_ParentNegationSequenceIsNotInherited(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		".gitignore":            "dist/\n",
 		"packages/.gitignore":   "!dist/\n",
@@ -575,8 +588,8 @@ func TestConfigWithGitignore_AncestorNegationOverride(t *testing.T) {
 			hasNegation = true
 		}
 	}
-	assert.Assert(t, hasDist, "should have root dist/")
-	assert.Assert(t, hasNegation, "should have intermediate !dist/ negation")
+	assert.Assert(t, !hasDist, "should not have root dist/")
+	assert.Assert(t, !hasNegation, "should not have intermediate !dist/ negation")
 }
 
 func TestConfigWithGitignore_EmptyFile(t *testing.T) {

--- a/internal/config/gitignore_config.go
+++ b/internal/config/gitignore_config.go
@@ -8,10 +8,17 @@ import (
 
 // ConfigWithGitignore prepends the .gitignore patterns that apply to a lint
 // invocation. A nil targetFiles slice scans the config directory, as the CLI
-// path does; a non-nil slice limits collection to the ancestor chains of those
-// explicit files, as used by API and LSP requests. The input config is never
-// mutated.
+// path does; a non-nil slice limits collection to the directory chains between
+// configDir and those explicit files, as used by API and LSP requests. The
+// input config is never mutated.
 func ConfigWithGitignore(config RslintConfig, configDir string, fsys vfs.FS, targetFiles []string) RslintConfig {
+	return ConfigWithGitignoreWithBoundaries(config, configDir, fsys, targetFiles, nil)
+}
+
+// ConfigWithGitignoreWithBoundaries applies the shared .gitignore policy while
+// excluding descendant directories owned by child configs. A boundary and its
+// subtree are handed off without reading that subtree's .gitignore files.
+func ConfigWithGitignoreWithBoundaries(config RslintConfig, configDir string, fsys vfs.FS, targetFiles []string, stopDirs []string) RslintConfig {
 	collectionFiles := targetFiles
 	var isDirectoryBlocked func(string) bool
 	if targetFiles == nil {
@@ -29,7 +36,7 @@ func ConfigWithGitignore(config RslintConfig, configDir string, fsys vfs.FS, tar
 			}
 		}
 	}
-	globs := gitignore.Collect(configDir, fsys, collectionFiles, isDirectoryBlocked)
+	globs := gitignore.CollectWithBoundaries(configDir, fsys, collectionFiles, isDirectoryBlocked, stopDirs)
 	if len(globs) == 0 {
 		return config
 	}

--- a/internal/lsp/gitignore_watch_test.go
+++ b/internal/lsp/gitignore_watch_test.go
@@ -16,36 +16,21 @@ import (
 
 func TestGitignoreFileWatchers(t *testing.T) {
 	watchers := gitignoreFileWatchers("/workspace/packages/app", true)
-	if len(watchers) != 4 {
-		t.Fatalf("watcher count=%d, want recursive plus three ancestors", len(watchers))
+	if len(watchers) != 1 {
+		t.Fatalf("watcher count=%d, want one config-scoped recursive watcher", len(watchers))
 	}
 	recursive := watchers[0].GlobPattern.RelativePattern
 	if recursive == nil || recursive.BaseUri.URI == nil || string(*recursive.BaseUri.URI) != "file:///workspace/packages/app" || recursive.Pattern != "**/.gitignore" {
 		t.Fatalf("recursive watcher=%+v", watchers[0])
 	}
-	wantBases := []string{"file:///workspace/packages", "file:///workspace", "file:///"}
-	for i, want := range wantBases {
-		relative := watchers[i+1].GlobPattern.RelativePattern
-		if relative == nil || relative.BaseUri.URI == nil || string(*relative.BaseUri.URI) != want || relative.Pattern != ".gitignore" {
-			t.Fatalf("ancestor watcher %d=%+v, want base %q", i, relative, want)
-		}
-	}
-
 	withoutRelativePatterns := gitignoreFileWatchers("/workspace/packages/app", false)
-	if len(withoutRelativePatterns) != 4 {
+	if len(withoutRelativePatterns) != 1 {
 		t.Fatalf("watchers without relative-pattern support=%+v", withoutRelativePatterns)
 	}
-	wantAbsolute := []string{
-		"/workspace/packages/app/**/.gitignore",
-		"/workspace/packages/.gitignore",
-		"/workspace/.gitignore",
-		"/.gitignore",
-	}
-	for i, want := range wantAbsolute {
-		pattern := withoutRelativePatterns[i].GlobPattern.Pattern
-		if pattern == nil || *pattern != want {
-			t.Fatalf("absolute watcher %d=%+v, want %q", i, withoutRelativePatterns[i], want)
-		}
+	pattern := withoutRelativePatterns[0].GlobPattern.Pattern
+	want := "/workspace/packages/app/**/.gitignore"
+	if pattern == nil || *pattern != want {
+		t.Fatalf("absolute watcher=%+v, want %q", withoutRelativePatterns[0], want)
 	}
 }
 

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -163,18 +163,9 @@ func (s *Server) handleInitialized(ctx context.Context, params *lsproto.Initiali
 
 func gitignoreFileWatchers(cwd string, relativePatternSupport bool) []*lsproto.FileSystemWatcher {
 	workspaceRoot := filepath.Clean(cwd)
-	watchers := []*lsproto.FileSystemWatcher{
+	return []*lsproto.FileSystemWatcher{
 		gitignoreFileWatcher(workspaceRoot, "**/.gitignore", relativePatternSupport),
 	}
-	for current := filepath.Dir(workspaceRoot); current != workspaceRoot; {
-		watchers = append(watchers, gitignoreFileWatcher(current, ".gitignore", relativePatternSupport))
-		parent := filepath.Dir(current)
-		if parent == current {
-			break
-		}
-		current = parent
-	}
-	return watchers
 }
 
 func gitignoreFileWatcher(baseDir string, pattern string, relativePatternSupport bool) *lsproto.FileSystemWatcher {

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -3030,7 +3030,7 @@ func TestLSPExplicitTargetIgnoreConformance(t *testing.T) {
 			},
 		},
 		{
-			name:      "ancestor ignore blocks nested source",
+			name:      "parent ignore does not affect nested config",
 			configDir: "packages/app",
 			relative:  "ignored/keep.ts",
 			config:    config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}},
@@ -3038,6 +3038,7 @@ func TestLSPExplicitTargetIgnoreConformance(t *testing.T) {
 				".gitignore":                      "/packages/app/ignored/\n",
 				"packages/app/ignored/.gitignore": "!keep.ts\n",
 			},
+			wantLinted: true,
 		},
 		{
 			name:     "pruned nested source does not override root negation",

--- a/packages/rslint-test-tools/tests/cli/js-config/gitignore-integration.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/gitignore-integration.test.ts
@@ -312,7 +312,7 @@ describe('Gitignore: interaction with config ignores', () => {
 });
 
 describe('Gitignore: monorepo scenarios', () => {
-  test('root .gitignore + multiple package configs', async () => {
+  test('package configs do not inherit root .gitignore', async () => {
     const { diagnostics, cleanup } = await lintJsonline({
       '.gitignore': 'dist/\ncoverage/\n',
       'rslint.config.mjs': `export default [{ files: ["**/*.ts"], rules: { "no-debugger": "error" } }];`,
@@ -330,8 +330,12 @@ describe('Gitignore: monorepo scenarios', () => {
       expect(
         diagsAt(diagnostics, 'packages/lib/src/utils.ts').length,
       ).toBeGreaterThan(0);
-      expect(diagsAt(diagnostics, 'packages/app/dist').length).toBe(0);
-      expect(diagsAt(diagnostics, 'packages/lib/coverage').length).toBe(0);
+      expect(
+        diagsAt(diagnostics, 'packages/app/dist/bundle.ts').length,
+      ).toBeGreaterThan(0);
+      expect(
+        diagsAt(diagnostics, 'packages/lib/coverage/lcov.ts').length,
+      ).toBeGreaterThan(0);
     } finally {
       await cleanup();
     }
@@ -339,7 +343,6 @@ describe('Gitignore: monorepo scenarios', () => {
 
   test('per-package .gitignore — each scoped to own subtree', async () => {
     const { diagnostics, cleanup } = await lintJsonline({
-      '.gitignore': 'dist/\n',
       'packages/app/.gitignore': 'tmp/\n',
       'packages/lib/.gitignore': 'cache/\n',
       'packages/app/rslint.config.mjs': `export default [{ files: ["**/*.ts"], rules: { "no-console": "error" } }];`,
@@ -648,9 +651,7 @@ describe('Gitignore: tsconfig + gitignore interaction', () => {
 });
 
 describe('Gitignore: monorepo gap file interaction', () => {
-  test('root .gitignore prunes gap file discovery in child config', async () => {
-    // Root .gitignore has build/. Child config's gap file discovery
-    // should NOT find files under build/.
+  test('root .gitignore does not prune child config discovery', async () => {
     const { diagnostics, cleanup } = await lintJsonline({
       '.gitignore': 'build/\n',
       'rslint.config.mjs': `export default [{ files: ["*.ts"], rules: { "no-console": "error" } }];`,
@@ -662,8 +663,9 @@ describe('Gitignore: monorepo gap file interaction', () => {
       expect(
         diagsAt(diagnostics, 'packages/app/src/index.ts').length,
       ).toBeGreaterThan(0);
-      // build/ gitignored → not discovered as gap file
-      expect(diagsAt(diagnostics, 'packages/app/build').length).toBe(0);
+      expect(
+        diagsAt(diagnostics, 'packages/app/build/output.ts').length,
+      ).toBeGreaterThan(0);
     } finally {
       await cleanup();
     }

--- a/website/docs/en/config/ignoring-files.md
+++ b/website/docs/en/config/ignoring-files.md
@@ -98,11 +98,12 @@ For directory-level patterns (`dir/**`), `!` negation cannot re-include files be
 
 ## .gitignore integration
 
-The CLI, JavaScript API, and LSP automatically read `.gitignore` files and treat their patterns as additional global ignores. This means files ignored by git (build outputs, coverage reports, etc.) are also ignored without extra configuration. In the editor, saved `.gitignore` changes refresh diagnostics for open files.
+The CLI, JavaScript API, and LSP automatically read `.gitignore` files and treat their patterns as additional global ignores. Collection starts at the directory of the governing rslint config and never searches its parents. In a multi-config repository, a child config starts a new `.gitignore` scope, so put package-specific ignores beside that package's config. In the editor, saved `.gitignore` changes refresh diagnostics for open files.
 
-- **Nested `.gitignore` files** are supported — each one only affects its own directory subtree
-- **Parent patterns cascade** to child directories (e.g., root `dist/` also ignores `packages/app/dist/`)
+- **Nested `.gitignore` files** inside one config-owned tree are supported — each one only affects its own directory subtree
+- **Parent patterns cascade** to child directories within that tree (e.g., root `dist/` also ignores `packages/app/dist/` when both use the root config)
 - **Child `.gitignore` can override** parent patterns with `!` negation
+- **Child configs are boundaries** — they do not inherit `.gitignore` files from a parent config directory
 - Config `!` negation can also override `.gitignore` patterns (they are evaluated sequentially in the same global ignores list)
 
 ```text


### PR DESCRIPTION
## Summary

- Scope automatic `.gitignore` collection to the directory of its governing rslint config, without reading ancestor files outside that boundary.
- Treat direct child config directories as ownership boundaries in multi-config runs while preserving explicit-target behavior for files owned by the parent config.
- Keep CLI, API, and LSP ignore behavior and watcher scope consistent; update architecture, user documentation, and cross-platform path regression coverage.

### Validation

- Focused Go tests for config discovery, gitignore collection, CLI/API conformance, and LSP reload/watch behavior.
- JS config gitignore integration test (31/31 cases).
- `pnpm run check-spell`
- `pnpm run format:check`
- Changed-code-only `golangci-lint` against `origin/main` for the four affected Go packages (`0 issues`).

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
