### PR TITLE
perf: parallelize eslint-plugin pre-pass and cache global ignore patterns in GetConfigForFile

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -708,15 +708,25 @@ func (config RslintConfig) IsFileIgnored(filePath string, cwd string) bool {
 // After global ignore check, entries are merged in order if their files match and ignores don't.
 // cwd is the directory the config lives in; file paths are resolved relative to it.
 func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *MergedConfig {
+	// Collect all global ignore patterns and evaluate once. This allows `!`
+	// negation patterns in separate entries to work correctly, aligned with
+	// ESLint v10 which merges all global ignores before evaluating. Callers
+	// resolving many files against the same config (FileConfigResolver)
+	// should precompute this once via extractConfigIgnores and call
+	// getConfigForFileWithIgnores directly instead of re-parsing every
+	// pattern string on every call.
+	return config.getConfigForFileWithIgnores(filePath, cwd, extractConfigIgnores(config))
+}
+
+// getConfigForFileWithIgnores is GetConfigForFile with the global ignore
+// patterns supplied by the caller, so repeated calls against the same config
+// (one per lint target) don't re-parse the same ignore pattern strings.
+func (config RslintConfig) getConfigForFileWithIgnores(filePath string, cwd string, globalIgnorePatterns []IgnorePattern) *MergedConfig {
 	merged := &MergedConfig{
 		Rules:   make(map[string]*RuleConfig),
 		Plugins: make(map[string]struct{}),
 	}
 
-	// 1. Collect all global ignore patterns and evaluate once.
-	// This allows `!` negation patterns in separate entries to work correctly,
-	// aligned with ESLint v10 which merges all global ignores before evaluating.
-	globalIgnorePatterns := extractConfigIgnores(config)
 	if len(globalIgnorePatterns) > 0 {
 		// Phase 1: directory-level check. Patterns like `dir/**` block the
 		// directory entirely — `!` negation cannot undo this. Aligned with

--- a/internal/config/file_resolver.go
+++ b/internal/config/file_resolver.go
@@ -20,6 +20,11 @@ type FileConfigResolver struct {
 	config         RslintConfig
 	cwd            string
 	enforcePlugins bool
+	// globalIgnorePatterns is parsed once per run instead of per file: the
+	// config's global `ignores` set is fixed for the whole run, so
+	// re-deriving it (string parsing + allocation) on every ConfigForFile
+	// call is pure waste at thousands-of-files scale.
+	globalIgnorePatterns []IgnorePattern
 
 	mu          sync.RWMutex
 	configCache map[string]cachedMergedConfig
@@ -29,11 +34,12 @@ type FileConfigResolver struct {
 // NewFileConfigResolver creates a per-run resolver for one config root.
 func NewFileConfigResolver(config RslintConfig, cwd string, enforcePlugins bool) *FileConfigResolver {
 	return &FileConfigResolver{
-		config:         config,
-		cwd:            cwd,
-		enforcePlugins: enforcePlugins,
-		configCache:    make(map[string]cachedMergedConfig),
-		rulesCache:     make(map[string]cachedEnabledRules),
+		config:               config,
+		cwd:                  cwd,
+		enforcePlugins:       enforcePlugins,
+		globalIgnorePatterns: extractConfigIgnores(config),
+		configCache:          make(map[string]cachedMergedConfig),
+		rulesCache:           make(map[string]cachedEnabledRules),
 	}
 }
 
@@ -46,7 +52,7 @@ func (r *FileConfigResolver) ConfigForFile(filePath string) *MergedConfig {
 	}
 	r.mu.RUnlock()
 
-	merged := r.config.GetConfigForFile(filePath, r.cwd)
+	merged := r.config.getConfigForFileWithIgnores(filePath, r.cwd, r.globalIgnorePatterns)
 
 	r.mu.Lock()
 	if cached, ok := r.configCache[filePath]; ok {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -731,7 +731,7 @@ func collectLintTargetsForFiles(opts RunLinterOptions, program *compiler.Program
 	shardResults := make([][]LintTarget, shardCount)
 
 	wg := core.NewWorkGroup(opts.SingleThreaded)
-	for shard := 0; shard < shardCount; shard++ {
+	for shard := range shardCount {
 		start := shard * chunkSize
 		end := min(start+chunkSize, len(files))
 		if start >= end {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -721,8 +721,10 @@ func collectLintTargetsForFiles(opts RunLinterOptions, program *compiler.Program
 		return nil
 	}
 	shardCount := runtime.GOMAXPROCS(0)
-	if opts.SingleThreaded || shardCount > len(files) {
+	if opts.SingleThreaded {
 		shardCount = 1
+	} else if shardCount > len(files) {
+		shardCount = len(files)
 	}
 	if shardCount < 1 {
 		shardCount = 1

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -3,6 +3,7 @@ package linter
 import (
 	"context"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -704,19 +705,64 @@ func CollectLintTargets(opts RunLinterOptions) []LintTarget {
 			SyntaxErrorFiles: opts.SyntaxErrorFiles,
 			TypeInfoFiles:    opts.TypeInfoFiles,
 		})
-		for _, file := range files {
-			if shouldSkipRulesForSyntax(runProgramOptions{
-				Program:          program,
-				SyntaxErrorFiles: opts.SyntaxErrorFiles,
-			}, file, context.Background()) {
-				continue
-			}
-			rules := filterRulesForTypeInfo(opts.GetRulesForFile(file), file.FileName(), opts.TypeInfoFiles)
-			if len(rules) == 0 {
-				continue
-			}
-			targets = append(targets, LintTarget{File: file, Rules: rules})
+		targets = append(targets, collectLintTargetsForFiles(opts, program, files)...)
+	}
+	return targets
+}
+
+// collectLintTargetsForFiles resolves rules for one program's lint target
+// files in parallel. Unlike the real lint pass, this has no type-checker
+// affinity to preserve, so files are simply chunked evenly across goroutines.
+// This is what turns the serial per-file config/glob resolution — the
+// dominant cost on large repos with many ignore/files patterns — into a
+// wall-clock win before the real, already-parallel lint pass even starts.
+func collectLintTargetsForFiles(opts RunLinterOptions, program *compiler.Program, files []*ast.SourceFile) []LintTarget {
+	if len(files) == 0 {
+		return nil
+	}
+	shardCount := runtime.GOMAXPROCS(0)
+	if opts.SingleThreaded || shardCount > len(files) {
+		shardCount = 1
+	}
+	if shardCount < 1 {
+		shardCount = 1
+	}
+	chunkSize := (len(files) + shardCount - 1) / shardCount
+	shardResults := make([][]LintTarget, shardCount)
+
+	wg := core.NewWorkGroup(opts.SingleThreaded)
+	for shard := 0; shard < shardCount; shard++ {
+		start := shard * chunkSize
+		end := min(start+chunkSize, len(files))
+		if start >= end {
+			continue
 		}
+		shardIndex := shard
+		shardFiles := files[start:end]
+		wg.Queue(func() {
+			ctx := context.Background()
+			var result []LintTarget
+			for _, file := range shardFiles {
+				if shouldSkipRulesForSyntax(runProgramOptions{
+					Program:          program,
+					SyntaxErrorFiles: opts.SyntaxErrorFiles,
+				}, file, ctx) {
+					continue
+				}
+				rules := filterRulesForTypeInfo(opts.GetRulesForFile(file), file.FileName(), opts.TypeInfoFiles)
+				if len(rules) == 0 {
+					continue
+				}
+				result = append(result, LintTarget{File: file, Rules: rules})
+			}
+			shardResults[shardIndex] = result
+		})
+	}
+	wg.RunAndWait()
+
+	var targets []LintTarget
+	for _, result := range shardResults {
+		targets = append(targets, result...)
 	}
 	return targets
 }


### PR DESCRIPTION
## Summary

- Parallelize `CollectLintTargets`'s per-file rule resolution across goroutines via `core.NewWorkGroup`, matching the parallelism the real lint pass already uses. This function is only reached from the eslint-plugin dispatch pre-pass (`buildPluginFileInputs`, gated on `hasEslintPlugins`), so the win is scoped to configs that mount ESLint plugins.
- Cache each config's parsed global ignore patterns once per `FileConfigResolver` run instead of re-parsing them (`extractConfigIgnores`/`ParseIgnorePatterns`) on every file's `GetConfigForFile` call. This is a general `GetConfigForFile` fix, not eslint-plugin-specific — it also speeds up the native lint pass's own rule resolution.

**Benchmark** ([swwind/bench-linter](https://github.com/swwind/bench-linter), vscode 1.128.0 + ESLint-plugin config, 11832 files, 22-core machine): the single-threaded pre-pass (`buildPluginFileInputs` → `CollectLintTargets`) drops from **5.73s to 0.84s** (~6.8x).

## Related Links

Fixes #1256

## Checklist

- [x] Tests updated (or not required) — pure perf/caching change with no behavior change; covered by existing `internal/linter`/`internal/config`/`cmd` suites (all pass).
- [x] Documentation updated (or not required) — internal implementation detail, no user-facing surface changed.