### PR TITLE
fix: naming-convention `class` selector must not infer names from anonymous class expressions

### DIFF
--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.go
@@ -1503,8 +1503,10 @@ func getIdentifierFromNode(ctx rule.RuleContext, node *ast.Node) []identifierInf
 		return getIdentifiersFromFunctionExpression(node)
 	case ast.KindParameter:
 		return getIdentifiersFromParameter(ctx, node)
-	case ast.KindClassDeclaration, ast.KindClassExpression:
+	case ast.KindClassDeclaration:
 		return getIdentifiersFromClassDeclaration(node)
+	case ast.KindClassExpression:
+		return getIdentifiersFromClassExpression(node)
 	case ast.KindInterfaceDeclaration:
 		return getIdentifiersFromInterfaceDeclaration(node)
 	case ast.KindTypeAliasDeclaration:
@@ -1707,6 +1709,25 @@ func getIdentifiersFromParameter(ctx rule.RuleContext, node *ast.Node) []identif
 
 func getIdentifiersFromClassDeclaration(node *ast.Node) []identifierInfo {
 	nameNode := ast.GetNameOfDeclaration(node)
+	if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+		return nil
+	}
+	return []identifierInfo{{
+		name:     nameNode.AsIdentifier().Text,
+		node:     nameNode,
+		selector: selectorClass,
+	}}
+}
+
+func getIdentifiersFromClassExpression(node *ast.Node) []identifierInfo {
+	// Only named class expressions have a name to check.
+	// Use the class expression's own Name() rather than GetNameOfDeclaration(),
+	// because GetNameOfDeclaration() for anonymous class expressions returns the
+	// parent assignment target (e.g., the variable name), which would incorrectly
+	// apply the `class` selector to variable-inferred names such as
+	// `const clz = class extends Base {}` (real @typescript-eslint/naming-convention
+	// never flags this — it only validates the class's own identifier, if any).
+	nameNode := node.AsClassExpression().Name()
 	if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
 		return nil
 	}

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
@@ -193,6 +193,13 @@ func TestNamingConventionRule(t *testing.T) {
 		// Accessor
 		{Code: `class Foo { get myProp() { return 1; } set myProp(v: number) {} }`},
 
+		// Anonymous class expression: the `class` selector must not infer a
+		// name from the enclosing variable declarator (real
+		// @typescript-eslint/naming-convention only checks the class's own
+		// identifier, which is absent here; `clz` is a variable name, not a
+		// class name).
+		{Code: `const clz = class extends Object {};`},
+
 		// Strict camelCase
 		{
 			Code: `const myId = 1;`,
@@ -251,6 +258,15 @@ func TestNamingConventionRule(t *testing.T) {
 			Code: `class myClass {}`,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "doesNotMatchFormat", Line: 1, Column: 7},
+			},
+		},
+
+		// Named class expression violating PascalCase: the class's own
+		// identifier is still checked by the `class` selector.
+		{
+			Code: `const x = class myClass {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "doesNotMatchFormat", Line: 1, Column: 17},
 			},
 		},
 


### PR DESCRIPTION
## Summary

- `getIdentifierFromNode`'s `class` selector reused `getIdentifiersFromClassDeclaration` (which calls `GetNameOfDeclaration()`) for `ClassExpression` nodes too. For an anonymous class expression like `const clz = class extends Base {}`, `GetNameOfDeclaration()` returns the enclosing variable's identifier, so the rule incorrectly validated `clz` as the class's own name against the `class` selector's format.
- Real `@typescript-eslint/naming-convention` never does this — it only checks a class expression's own identifier when one is present (e.g. `const x = class Named {}`), matching the pattern already used for `FunctionExpression` in this same file.
- Split `ClassExpression` into its own handler (`getIdentifiersFromClassExpression`) that reads the node's own `Name()` instead, which is `nil` for anonymous expressions (skipped) and still validates named ones.

Found while investigating a real-world false positive on vscode's codebase (`const clz = class extends PromptElement {...}` patterns flagged as violating PascalCase, which real ESLint does not flag).

### Validation

- `go test ./internal/plugins/typescript/rules/naming_convention/...` — added a valid case (anonymous class expression) and an invalid case (named class expression still checked)
- Locally ran the full official naming-convention conformance suite ported in `packages/rslint-test-tools` (all 16 per-selector case files under `tests/typescript-eslint/rules/naming-convention/cases/`, 7098 generated cases covering every selector) — 0 failures. These files are currently commented out of `rstest.config.mts`; happy to send that as a separate follow-up PR if useful.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).