### PR TITLE
test(vscode): harden extension CI against code-action races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,10 +165,12 @@ jobs:
       - name: VSCode Test Cache
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
-          path: packages/vscode-extension/.vscode-test
-          key: vscode-test-${{ matrix.os }}
+          # Cache only immutable VS Code distributions. The v2 namespace keeps
+          # legacy archives containing user data/extensions from being restored.
+          path: packages/vscode-extension/.vscode-test/vscode-*
+          key: vscode-distributions-v2-${{ matrix.os }}
           restore-keys: |
-            vscode-test-${{ matrix.os }}-
+            vscode-distributions-v2-${{ matrix.os }}-
 
       - name: Test
         run: xvfb-run -a pnpm run test
@@ -260,10 +262,12 @@ jobs:
       - name: VSCode Test Cache
         uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
         with:
-          path: packages/vscode-extension/.vscode-test
-          key: vscode-test-windows
+          # Cache only immutable VS Code distributions. The v2 namespace keeps
+          # legacy archives containing user data/extensions from being restored.
+          path: packages/vscode-extension/.vscode-test/vscode-*
+          key: vscode-distributions-v2-windows
           restore-keys: |
-            vscode-test-windows-
+            vscode-distributions-v2-windows-
 
       - name: Test
         run: pnpm --filter rslint test

--- a/packages/vscode-extension/__tests__/runSuite.ts
+++ b/packages/vscode-extension/__tests__/runSuite.ts
@@ -1,9 +1,14 @@
 import fastGlob from 'fast-glob';
+import fs from 'node:fs';
 import path from 'node:path';
 import Mocha from 'mocha';
 import * as vscode from 'vscode';
+import { isCodeActionCancellation } from './utils/codeActionRegistry';
+import { runBeforeDeadline } from './utils/deadline';
 
 const extensionId = 'rstack.rslint';
+const workspaceMarkerFile = '.rslint-vscode-test-sandbox.json';
+const startupTimeoutMs = 60_000;
 const typescriptCodeActionProbeSource = `interface RslintCodeActionProbe {
   value: number;
 }
@@ -25,6 +30,11 @@ async function activateAndRun(
   callback: (error: unknown, failures?: number) => void,
 ): Promise<void> {
   try {
+    // This deadline starts before any extension activation. Mocha has not been
+    // created yet, so every asynchronous startup step must be independently
+    // bounded instead of relying on a per-test timeout that does not exist yet.
+    const startupDeadline = Date.now() + startupTimeoutMs;
+    verifyIsolatedWorkspace();
     const extension = vscode.extensions.getExtension(extensionId);
     if (!extension) {
       throw new Error(`Extension ${extensionId} is unavailable`);
@@ -33,8 +43,13 @@ async function activateAndRun(
     // Extension.activate() is the public readiness contract. Await it before
     // loading any tests so cold-start saves and code-action requests cannot run
     // while the language client and workspace configuration are still starting.
-    await extension.activate();
-    await waitForTypeScriptCodeActionProviders();
+    await runBeforeDeadline(
+      () => extension.activate(),
+      startupDeadline,
+      `activation of ${extensionId}`,
+    );
+    await activateBuiltInCodeActionExtensions(startupDeadline);
+    await waitForTypeScriptCodeActionProviders(startupDeadline);
 
     const files = fastGlob.sync('**/*.test.js', { cwd: testPath }).sort();
     if (files.length === 0) {
@@ -48,6 +63,75 @@ async function activateAndRun(
   }
 }
 
+function canonicalPath(filePath: string): string {
+  const realPath = fs.realpathSync.native(filePath);
+  return process.platform === 'win32' ? realPath.toLowerCase() : realPath;
+}
+
+function verifyIsolatedWorkspace(): void {
+  const folders = vscode.workspace.workspaceFolders;
+  if (folders?.length !== 1) {
+    throw new Error(
+      `Expected exactly one isolated workspace folder, got ${folders?.length ?? 0}`,
+    );
+  }
+
+  const actualPath = canonicalPath(folders[0].uri.fsPath);
+  const markerPath = path.join(actualPath, workspaceMarkerFile);
+  let marker: unknown;
+  try {
+    marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+  } catch (error) {
+    throw new Error(
+      `Could not read isolated workspace marker ${markerPath}: ${String(error)}`,
+    );
+  }
+  if (
+    typeof marker !== 'object' ||
+    marker === null ||
+    !('version' in marker) ||
+    marker.version !== 1 ||
+    !('nonce' in marker) ||
+    typeof marker.nonce !== 'string' ||
+    !/^[0-9a-f-]{36}$/i.test(marker.nonce) ||
+    !('expectedWorkspace' in marker) ||
+    typeof marker.expectedWorkspace !== 'string' ||
+    !('sourceWorkspace' in marker) ||
+    typeof marker.sourceWorkspace !== 'string'
+  ) {
+    throw new Error(`Invalid isolated workspace marker ${markerPath}`);
+  }
+
+  const expectedPath = canonicalPath(marker.expectedWorkspace);
+  const sourcePath = canonicalPath(marker.sourceWorkspace);
+  if (actualPath !== expectedPath) {
+    throw new Error(
+      `VS Code opened ${actualPath} instead of isolated workspace ${expectedPath}`,
+    );
+  }
+  if (actualPath === sourcePath) {
+    throw new Error(
+      'VS Code tests must not run against tracked source fixtures',
+    );
+  }
+}
+
+async function activateBuiltInCodeActionExtensions(
+  startupDeadline: number,
+): Promise<void> {
+  for (const id of ['vscode.typescript-language-features', 'vscode.git']) {
+    const extension = vscode.extensions.getExtension(id);
+    if (!extension) {
+      throw new Error(`Built-in extension ${id} is unavailable`);
+    }
+    await runBeforeDeadline(
+      () => extension.activate(),
+      startupDeadline,
+      `activation of built-in extension ${id}`,
+    );
+  }
+}
+
 /**
  * VS Code's built-in TypeScript extension activates lazily. Its activation
  * function returns before tsserver is ready, then four modules asynchronously
@@ -55,14 +139,22 @@ async function activateAndRun(
  * code actions on save are running cancels that save in VS Code 1.128.
  *
  * Probe the public behavior of the quick-fix, refactor, organize-imports, and
- * fix-all providers on a controlled untitled document. This is a readiness
- * barrier only: the save assertions themselves remain single-shot.
+ * fix-all providers on a controlled untitled document. This eagerly resolves
+ * known lazy registrations; the generic registry-quiescence sentinel still
+ * runs immediately before every save. Save assertions remain single-shot.
  */
-async function waitForTypeScriptCodeActionProviders(): Promise<void> {
-  const document = await vscode.workspace.openTextDocument({
-    content: typescriptCodeActionProbeSource,
-    language: 'typescript',
-  });
+async function waitForTypeScriptCodeActionProviders(
+  startupDeadline: number,
+): Promise<void> {
+  const document = await runBeforeDeadline(
+    () =>
+      vscode.workspace.openTextDocument({
+        content: typescriptCodeActionProbeSource,
+        language: 'typescript',
+      }),
+    startupDeadline,
+    'the TypeScript code-action probe document to open',
+  );
 
   const quickFixRange = document.lineAt(3).range;
   const refactorLine = document.lineAt(5);
@@ -106,20 +198,16 @@ async function waitForTypeScriptCodeActionProviders(): Promise<void> {
     ],
   ]);
 
-  const timeoutMs = 60_000;
-  const deadline = Date.now() + timeoutMs;
   let lastProbeError: unknown;
 
-  while (Date.now() < deadline) {
+  while (Date.now() < startupDeadline) {
     for (const [name, probe] of probes) {
       try {
-        const actions = await vscode.commands.executeCommand<
-          vscode.CodeAction[]
-        >(
-          'vscode.executeCodeActionProvider',
-          document.uri,
-          probe.range,
-          probe.kind.value,
+        const actions = await executeCodeActionProbeBeforeDeadline(
+          document,
+          probe,
+          name,
+          startupDeadline,
         );
         if (
           actions?.some(
@@ -129,9 +217,9 @@ async function waitForTypeScriptCodeActionProviders(): Promise<void> {
           probes.delete(name);
         }
       } catch (error) {
-        // A provider registering during this non-mutating probe cancels it.
-        // Keep waiting for the complete provider set, but fail closed on
-        // timeout.
+        // Only the known cancellation caused by an in-flight provider
+        // registration is retryable. Unexpected command failures fail fast.
+        if (!isCodeActionCancellation(error)) throw error;
         lastProbeError = error;
       }
     }
@@ -139,14 +227,41 @@ async function waitForTypeScriptCodeActionProviders(): Promise<void> {
     if (probes.size === 0) {
       return;
     }
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) =>
+      setTimeout(
+        resolve,
+        Math.min(100, Math.max(0, startupDeadline - Date.now())),
+      ),
+    );
   }
 
   throw new Error(
-    `Timed out after ${timeoutMs}ms waiting for TypeScript code-action providers` +
+    `Timed out after ${startupTimeoutMs}ms during VS Code test startup while waiting for TypeScript code-action providers` +
       (probes.size > 0
         ? `; missing actions: ${[...probes.keys()].join(', ')}`
         : '') +
       (lastProbeError ? `; last probe error: ${String(lastProbeError)}` : ''),
+  );
+}
+
+async function executeCodeActionProbeBeforeDeadline(
+  document: vscode.TextDocument,
+  probe: {
+    kind: vscode.CodeActionKind;
+    range: vscode.Range | vscode.Selection;
+  },
+  name: string,
+  deadline: number,
+): Promise<vscode.CodeAction[] | undefined> {
+  return runBeforeDeadline(
+    () =>
+      vscode.commands.executeCommand<vscode.CodeAction[]>(
+        'vscode.executeCodeActionProvider',
+        document.uri,
+        probe.range,
+        probe.kind.value,
+      ),
+    deadline,
+    `the TypeScript ${name} code-action probe to settle`,
   );
 }

--- a/packages/vscode-extension/__tests__/runTest.ts
+++ b/packages/vscode-extension/__tests__/runTest.ts
@@ -1,201 +1,189 @@
-import * as path from 'path';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import { runTests } from '@vscode/test-electron';
+
+interface TestSuite {
+  name: string;
+  workspace: string;
+  tests: string;
+}
+
+const workspaceMarkerFile = '.rslint-vscode-test-sandbox.json';
 
 function resolveFixture(name: string): string {
   return path.resolve(require.resolve('@rslint/core'), '../..', name);
 }
 
-function copyToIsolatedWorkspace(source: string): {
-  workspace: string;
-  userDataDir: string;
-  extensionsDir: string;
-  dispose(): void;
-} {
-  // Go discovery intentionally searches strict cwd ancestors. Keeping an E2E
-  // fixture under this repository would therefore inherit the repository's
-  // root config (whose global ignores exclude __tests__) and correctly prune
-  // the fixture config. A physical temp copy gives the fixture the same clean
-  // ancestry as a real standalone user workspace.
-  // VS Code and the language client create Unix sockets below these paths.
-  // macOS's os.tmpdir() is already long enough to exceed the 103-byte socket
-  // limit once VS Code appends its own names, so keep every test-owned path
-  // directly below a short /tmp container. Windows has no Unix socket limit.
+async function findPackageRoot(startPath: string): Promise<string> {
+  let current = path.resolve(startPath);
+  while (true) {
+    try {
+      await fs.promises.access(path.join(current, 'package.json'));
+      return current;
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        throw new Error(`Could not find a package boundary above ${startPath}`);
+      }
+      current = parent;
+    }
+  }
+}
+
+async function runIsolatedSuite(
+  extensionDevelopmentPath: string,
+  suite: TestSuite,
+): Promise<void> {
+  // Go discovery intentionally searches strict cwd ancestors, so keep each
+  // fixture in a clean physical workspace outside this repository. Use short
+  // paths on Unix as VS Code and the language client append socket names that
+  // can otherwise exceed macOS's Unix-domain socket path limit.
   const tempRoot = process.platform === 'win32' ? os.tmpdir() : '/tmp';
-  const container = fs.mkdtempSync(path.join(tempRoot, 'rsv-'));
-  const workspace = path.join(container, 'w');
-  const userDataDir = path.join(container, 'u');
-  const extensionsDir = path.join(container, 'e');
-  try {
-    fs.cpSync(source, workspace, { recursive: true });
-    fs.mkdirSync(userDataDir);
-    fs.mkdirSync(extensionsDir);
-  } catch (error) {
-    fs.rmSync(container, { recursive: true, force: true });
-    throw error;
-  }
-  return {
-    workspace,
-    userDataDir,
-    extensionsDir,
-    dispose() {
-      fs.rmSync(container, { recursive: true, force: true });
-    },
-  };
-}
+  const profileRoot = await fs.promises.mkdtemp(path.join(tempRoot, 'rsv-'));
+  const userDataDir = path.join(profileRoot, 'u');
+  const extensionsDir = path.join(profileRoot, 'e');
+  const workspaceCopy = path.join(profileRoot, 'w');
 
-async function runIsolatedFixtureTests(options: {
-  source: string;
-  name: string;
-  extensionDevelopmentPath: string;
-  extensionTestsPath: string;
-}): Promise<boolean> {
-  let isolatedWorkspace: ReturnType<typeof copyToIsolatedWorkspace> | undefined;
+  let testError: unknown;
   try {
-    isolatedWorkspace = copyToIsolatedWorkspace(options.source);
-    await runTests({
-      extensionDevelopmentPath: options.extensionDevelopmentPath,
-      extensionTestsPath: options.extensionTestsPath,
-      launchArgs: [
-        '--disable-extensions',
-        `--user-data-dir=${isolatedWorkspace.userDataDir}`,
-        `--extensions-dir=${isolatedWorkspace.extensionsDir}`,
-        isolatedWorkspace.workspace,
-      ],
-      version: 'stable',
+    // Suites intentionally create, rewrite, and delete config files. Run them
+    // against a private copy so even an Extension Host crash cannot mutate a
+    // tracked fixture in the checkout.
+    await fs.promises.cp(suite.workspace, workspaceCopy, {
+      recursive: true,
+      force: false,
+      errorOnExist: true,
     });
-    return true;
-  } catch (err) {
-    console.error(`${options.name} failed:`, err);
-    return false;
-  } finally {
-    isolatedWorkspace?.dispose();
+    await fs.promises.writeFile(
+      path.join(workspaceCopy, workspaceMarkerFile),
+      JSON.stringify({
+        version: 1,
+        nonce: randomUUID(),
+        sourceWorkspace: await fs.promises.realpath(suite.workspace),
+        expectedWorkspace: await fs.promises.realpath(workspaceCopy),
+      }),
+      { encoding: 'utf8', flag: 'wx', mode: 0o600 },
+    );
+
+    // Preserve the source workspace's package boundary and dependency lookup
+    // without placing a writable node_modules link inside the test workspace.
+    const packageRoot = await findPackageRoot(suite.workspace);
+    await fs.promises.copyFile(
+      path.join(packageRoot, 'package.json'),
+      path.join(profileRoot, 'package.json'),
+    );
+    await fs.promises.symlink(
+      path.join(packageRoot, 'node_modules'),
+      path.join(profileRoot, 'node_modules'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
+
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath: suite.tests,
+      launchArgs: [
+        workspaceCopy,
+        '--disable-extensions',
+        '--disable-updates',
+        '--disable-workspace-trust',
+        '--force-disable-user-env',
+        '--skip-release-notes',
+        '--skip-welcome',
+        `--user-data-dir=${userDataDir}`,
+        `--extensions-dir=${extensionsDir}`,
+      ],
+      // Omit `version`: @vscode/test-electron resolves the current stable
+      // release on every run instead of pinning a VS Code build.
+    });
+  } catch (error) {
+    testError = error;
   }
+
+  let cleanupError: unknown;
+  try {
+    await fs.promises.rm(profileRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 200,
+    });
+  } catch (error) {
+    cleanupError = error;
+  }
+
+  if (testError && cleanupError) {
+    throw new AggregateError(
+      [testError, cleanupError],
+      `${suite.name} failed and its isolated sandbox could not be removed`,
+    );
+  }
+  if (testError) throw testError;
+  if (cleanupError) throw cleanupError;
 }
 
-async function main() {
+async function main(): Promise<void> {
   const extensionDevelopmentPath = path.resolve(__dirname, '../..');
-  let failed = false;
-
-  // --- Existing tests (JSON config workspace) ---
-  const extensionTestsPath = path.resolve(__dirname, './suite');
-  if (
-    !(await runIsolatedFixtureTests({
-      source: resolveFixture('fixtures'),
-      name: 'JSON config tests (stable)',
-      extensionDevelopmentPath,
-      extensionTestsPath,
-    }))
-  ) {
-    failed = true;
-  }
-
-  // try {
-  //   await runTests({
-  //     extensionDevelopmentPath,
-  //     extensionTestsPath,
-  //     launchArgs: ['--disable-extensions', testWorkspace],
-  //     version: '1.106.3',
-  //   });
-  // } catch (err) {
-  //   console.error('JSON config tests (1.106.3) failed:', err);
-  //   failed = true;
-  // }
-
-  // --- JS config tests ---
   const testsSourceDir = path.resolve(extensionDevelopmentPath, '__tests__');
-  const jsConfigTestsPath = path.resolve(__dirname, './suite-jsconfig');
-  if (
-    !(await runIsolatedFixtureTests({
-      source: path.resolve(testsSourceDir, 'fixtures-jsconfig'),
+  const suites: TestSuite[] = [
+    {
+      name: 'JSON config tests',
+      workspace: resolveFixture('fixtures'),
+      tests: path.resolve(__dirname, './suite'),
+    },
+    {
       name: 'JS config tests',
-      extensionDevelopmentPath,
-      extensionTestsPath: jsConfigTestsPath,
-    }))
-  ) {
-    failed = true;
-  }
-
-  // --- Monorepo multi-config tests ---
-  const monorepoTestsPath = path.resolve(__dirname, './suite-monorepo');
-  if (
-    !(await runIsolatedFixtureTests({
-      source: path.resolve(testsSourceDir, 'fixtures-monorepo'),
+      workspace: path.resolve(testsSourceDir, 'fixtures-jsconfig'),
+      tests: path.resolve(__dirname, './suite-jsconfig'),
+    },
+    {
       name: 'Monorepo config tests',
-      extensionDevelopmentPath,
-      extensionTestsPath: monorepoTestsPath,
-    }))
-  ) {
-    failed = true;
-  }
-
-  // --- No config fallback tests ---
-  const noConfigTestsPath = path.resolve(__dirname, './suite-noconfig');
-  if (
-    !(await runIsolatedFixtureTests({
-      source: path.resolve(testsSourceDir, 'fixtures-noconfig'),
+      workspace: path.resolve(testsSourceDir, 'fixtures-monorepo'),
+      tests: path.resolve(__dirname, './suite-monorepo'),
+    },
+    {
       name: 'No config tests',
-      extensionDevelopmentPath,
-      extensionTestsPath: noConfigTestsPath,
-    }))
-  ) {
-    failed = true;
-  }
-
-  // --- Type-aware rule scope tests ---
-  const typeAwareScopeTestsPath = path.resolve(
-    __dirname,
-    './suite-type-aware-scope',
-  );
-  if (
-    !(await runIsolatedFixtureTests({
-      source: path.resolve(testsSourceDir, 'fixtures-type-aware-scope'),
+      workspace: path.resolve(testsSourceDir, 'fixtures-noconfig'),
+      tests: path.resolve(__dirname, './suite-noconfig'),
+    },
+    {
       name: 'Type-aware scope tests',
-      extensionDevelopmentPath,
-      extensionTestsPath: typeAwareScopeTestsPath,
-    }))
-  ) {
-    failed = true;
-  }
-
-  // --- projectService type-aware scope tests ---
-  const projectServiceScopeTestsPath = path.resolve(
-    __dirname,
-    './suite-project-service-scope',
-  );
-  if (
-    !(await runIsolatedFixtureTests({
-      source: path.resolve(testsSourceDir, 'fixtures-project-service-scope'),
+      workspace: path.resolve(testsSourceDir, 'fixtures-type-aware-scope'),
+      tests: path.resolve(__dirname, './suite-type-aware-scope'),
+    },
+    {
       name: 'projectService scope tests',
-      extensionDevelopmentPath,
-      extensionTestsPath: projectServiceScopeTestsPath,
-    }))
-  ) {
-    failed = true;
-  }
-
-  // --- eslintPlugins reverse-dispatch tests ---
-  const eslintPluginsTestsPath = path.resolve(
-    __dirname,
-    './suite-eslint-plugins',
-  );
-  if (
-    !(await runIsolatedFixtureTests({
-      source: path.resolve(testsSourceDir, 'fixtures-eslint-plugins'),
+      workspace: path.resolve(testsSourceDir, 'fixtures-project-service-scope'),
+      tests: path.resolve(__dirname, './suite-project-service-scope'),
+    },
+    {
       name: 'eslintPlugins tests',
-      extensionDevelopmentPath,
-      extensionTestsPath: eslintPluginsTestsPath,
-    }))
-  ) {
-    failed = true;
+      workspace: path.resolve(testsSourceDir, 'fixtures-eslint-plugins'),
+      tests: path.resolve(__dirname, './suite-eslint-plugins'),
+    },
+  ];
+
+  const failures: unknown[] = [];
+  for (const suite of suites) {
+    try {
+      await runIsolatedSuite(extensionDevelopmentPath, suite);
+    } catch (error) {
+      console.error(`${suite.name} failed:`, error);
+      failures.push(error);
+    }
   }
 
-  if (failed) {
-    console.error('Some test suites failed');
-    process.exit(1);
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `${failures.length} VS Code suite(s) failed`,
+    );
   }
 }
 
-main();
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/vscode-extension/__tests__/suite-eslint-plugins/eslint-plugins.test.ts
+++ b/packages/vscode-extension/__tests__/suite-eslint-plugins/eslint-plugins.test.ts
@@ -3,6 +3,13 @@ import * as vscode from 'vscode';
 import fs from 'node:fs';
 import path from 'node:path';
 import { waitForContentChange } from '../suite/fixall-helpers';
+import { saveDocumentOnce } from '../utils/codeActionRegistry';
+import { withCodeActionsOnSave } from '../utils/configuration';
+import { waitForRslintDiagnostics } from '../utils/diagnostics';
+import {
+  closeAndDeleteTemporaryDocument,
+  temporaryFilePath,
+} from '../utils/documents';
 
 // End-to-end VS Code coverage for the object-form `plugins` reverse-dispatch
 // path: the LSP server lints natively but dispatches rules mounted via a
@@ -17,7 +24,9 @@ suite('rslint object-form plugins integration', function () {
   this.timeout(120000);
 
   function workspaceRoot(): string {
-    return vscode.workspace.workspaceFolders![0].uri.fsPath;
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) throw new Error('Test workspace is unavailable');
+    return workspaceFolder.uri.fsPath;
   }
 
   // LSP diagnostic messages are formatted as `[<ruleName>] <description>`
@@ -26,103 +35,84 @@ suite('rslint object-form plugins integration', function () {
     return diags.map((d) => d.message).join(' | ');
   }
 
-  async function waitForDiagnostics(
-    doc: vscode.TextDocument,
-    predicate?: (diags: vscode.Diagnostic[]) => boolean,
-  ): Promise<vscode.Diagnostic[]> {
-    for (let i = 0; i < 20; i++) {
-      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
-      if (predicate ? predicate(diagnostics) : diagnostics.length > 0) {
-        return diagnostics;
-      }
-      await new Promise((resolve) => {
-        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          for (const uri of e.uris) {
-            if (uri.toString() === doc.uri.toString()) {
-              disposable.dispose();
-              resolve(void 0);
-              return;
-            }
-          }
-        });
-        setTimeout(() => {
-          disposable.dispose();
-          resolve(void 0);
-        }, 1500);
-      });
-    }
-    return vscode.languages.getDiagnostics(doc.uri);
-  }
-
   // Keep the original flaky scenario first: no preceding test may warm the
   // diagnostics or code-action-on-save path in this fresh extension host.
   test('plugin auto-fix participates in source.fixAll on save', async () => {
-    const tmpFile = path.join(
-      workspaceRoot(),
-      'src',
-      `_fixall_plugin_${Date.now()}.ts`,
+    const tmpFile = temporaryFilePath(
+      path.join(workspaceRoot(), 'src'),
+      '_fixall_plugin_',
     );
     fs.writeFileSync(tmpFile, '// placeholder\n', 'utf-8');
 
-    const editorConfig = vscode.workspace.getConfiguration('editor');
-    const previous = editorConfig.get('codeActionsOnSave');
+    let doc: vscode.TextDocument | undefined;
+    let testError: unknown;
     try {
-      await editorConfig.update(
-        'codeActionsOnSave',
+      const openedDocument = await vscode.workspace.openTextDocument(tmpFile);
+      doc = openedDocument;
+      const editor = await vscode.window.showTextDocument(openedDocument);
+      await withCodeActionsOnSave(
+        openedDocument,
         { 'source.fixAll': 'explicit' },
-        vscode.ConfigurationTarget.Workspace,
-      );
+        async () => {
+          await editor.edit((b) =>
+            b.replace(
+              new vscode.Range(
+                openedDocument.positionAt(0),
+                openedDocument.positionAt(openedDocument.getText().length),
+              ),
+              'const numbers = [1, 2, 3];\nconst ok = numbers.filter((n) => n > 0).length > 0;\nexport { ok };\n',
+            ),
+          );
 
-      const doc = await vscode.workspace.openTextDocument(tmpFile);
-      const editor = await vscode.window.showTextDocument(doc);
-      await editor.edit((b) =>
-        b.replace(
-          new vscode.Range(
-            doc.positionAt(0),
-            doc.positionAt(doc.getText().length),
-          ),
-          'const numbers = [1, 2, 3];\nconst ok = numbers.filter((n) => n > 0).length > 0;\nexport { ok };\n',
-        ),
-      );
+          const diagnostics = await waitForRslintDiagnostics(
+            openedDocument,
+            (diags) =>
+              diags.some((d) => d.message.includes('local/prefer-array-some')),
+          );
+          assert.ok(
+            diagnostics.some((d) =>
+              d.message.includes('local/prefer-array-some'),
+            ),
+            `prefer-array-some did not appear; cannot exercise fixAll. Got: ${messages(diagnostics)}`,
+          );
 
-      const diagnostics = await waitForDiagnostics(doc, (diags) =>
-        diags.some((d) => d.message.includes('local/prefer-array-some')),
-      );
-      assert.ok(
-        diagnostics.some((d) => d.message.includes('local/prefer-array-some')),
-        `prefer-array-some did not appear; cannot exercise fixAll. Got: ${messages(diagnostics)}`,
-      );
+          await saveDocumentOnce(
+            openedDocument,
+            'Document should complete the plugin code-action-on-save pipeline',
+          );
+          await waitForContentChange(
+            openedDocument,
+            (content) => !content.includes('.filter('),
+            60000,
+          );
 
-      assert.ok(
-        await doc.save(),
-        'Document should complete the plugin code-action-on-save pipeline',
+          assert.ok(
+            !openedDocument.getText().includes('.filter('),
+            `Plugin fix (filter -> some) should apply via source.fixAll on save.\nContent: ${openedDocument.getText()}`,
+          );
+          assert.ok(
+            openedDocument.getText().includes('.some('),
+            `Expected '.some(' after fixAll.\nContent: ${openedDocument.getText()}`,
+          );
+        },
       );
-      await waitForContentChange(
-        doc,
-        (content) => !content.includes('.filter('),
-        60000,
-      );
+    } catch (error) {
+      testError = error;
+    }
 
-      assert.ok(
-        !doc.getText().includes('.filter('),
-        `Plugin fix (filter -> some) should apply via source.fixAll on save.\nContent: ${doc.getText()}`,
+    const errors: unknown[] = [];
+    if (testError) errors.push(testError);
+    try {
+      await closeAndDeleteTemporaryDocument(doc, tmpFile);
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) {
+      throw new AggregateError(
+        errors,
+        'Plugin on-save test and temporary-file cleanup failed',
       );
-      assert.ok(
-        doc.getText().includes('.some('),
-        `Expected '.some(' after fixAll.\nContent: ${doc.getText()}`,
-      );
-    } finally {
-      await editorConfig.update(
-        'codeActionsOnSave',
-        previous,
-        vscode.ConfigurationTarget.Workspace,
-      );
-      if (vscode.window.activeTextEditor?.document.uri.fsPath === tmpFile) {
-        await vscode.commands.executeCommand(
-          'workbench.action.closeActiveEditor',
-        );
-      }
-      if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
     }
   });
 
@@ -131,7 +121,7 @@ suite('rslint object-form plugins integration', function () {
     const doc = await vscode.workspace.openTextDocument(filePath);
     await vscode.window.showTextDocument(doc);
 
-    const diagnostics = await waitForDiagnostics(doc, (diags) =>
+    const diagnostics = await waitForRslintDiagnostics(doc, (diags) =>
       diags.some((d) => d.message.includes('local/no-null')),
     );
     const msgs = messages(diagnostics);

--- a/packages/vscode-extension/__tests__/suite-jsconfig/jsconfig.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/jsconfig.test.ts
@@ -2,69 +2,14 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
 import fs from 'node:fs';
+import { waitForRslintDiagnostics as waitForDiagnostics } from '../utils/diagnostics';
+import { closeTextEditor, revertTextDocument } from '../utils/documents';
 
 suite('rslint JS config support', function () {
   this.timeout(120_000);
 
   function getWorkspaceRoot(): string {
     return vscode.workspace.workspaceFolders![0].uri.fsPath;
-  }
-
-  /**
-   * Race-free `onDidChangeDiagnostics` waiter.
-   *
-   * Compared to a polling `getDiagnostics` + `setTimeout` loop, this
-   * subscribes BEFORE checking the initial state, eliminating the
-   * subscribe-after-check window where an event fired between the
-   * synchronous read and the listener registration would be lost.
-   *
-   * The waiter returns as soon as `predicate` accepts a snapshot — no
-   * file edits, no nudges, no sleeps. It relies on the server's own
-   * push channel: a committed config-discovery transaction refreshes open
-   * document diagnostics, so tests only need to listen for that publication.
-   *
-   * Default 60s timeout (vs the older helper's 30s × 20 polling
-   * budget) gives headroom for slow CI runners where the JS-config
-   * reload chain (ESM dynamic import + IO) can take 10s+.
-   */
-  function waitForDiagnostics(
-    doc: vscode.TextDocument,
-    predicate?: (diags: vscode.Diagnostic[]) => boolean,
-    timeoutMs = 60_000,
-  ): Promise<vscode.Diagnostic[]> {
-    const matches = predicate ?? ((ds) => ds.length > 0);
-    return new Promise<vscode.Diagnostic[]>((resolve, reject) => {
-      let done = false;
-      const finish = (
-        value: vscode.Diagnostic[] | undefined,
-        err?: Error,
-      ): void => {
-        if (done) return;
-        done = true;
-        sub.dispose();
-        clearTimeout(timer);
-        if (err) reject(err);
-        else resolve(value!);
-      };
-      const sub = vscode.languages.onDidChangeDiagnostics((e) => {
-        if (!e.uris.some((u) => u.toString() === doc.uri.toString())) return;
-        const ds = vscode.languages.getDiagnostics(doc.uri);
-        if (matches(ds)) finish(ds);
-      });
-      const timer = setTimeout(
-        () =>
-          finish(
-            undefined,
-            new Error('waitForDiagnostics: timeout waiting for predicate'),
-          ),
-        timeoutMs,
-      );
-      // Check current state in case the matching publish already
-      // happened before subscription. Safe because finish() is
-      // idempotent.
-      const initial = vscode.languages.getDiagnostics(doc.uri);
-      if (matches(initial)) finish(initial);
-    });
   }
 
   async function openFixture(filename: string): Promise<vscode.TextDocument> {
@@ -76,6 +21,44 @@ suite('rslint JS config support', function () {
     const editor = await vscode.window.showTextDocument(doc);
     await editor.edit((edit) => edit.insert(new vscode.Position(0, 0), ' '));
     await editor.edit((edit) => edit.delete(new vscode.Range(0, 0, 0, 1)));
+  }
+
+  async function waitForFile(filePath: string, timeoutMs = 10_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (fs.existsSync(filePath)) return;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error(`Timed out waiting for file: ${filePath}`);
+  }
+
+  async function withFailClosedCleanup(
+    testFn: () => Promise<void>,
+    cleanupFn: () => Promise<void>,
+    description: string,
+  ): Promise<void> {
+    let testError: unknown;
+    try {
+      await testFn();
+    } catch (error) {
+      testError = error;
+    }
+
+    let cleanupError: unknown;
+    try {
+      await cleanupFn();
+    } catch (error) {
+      cleanupError = error;
+    }
+
+    if (testError && cleanupError) {
+      throw new AggregateError(
+        [testError, cleanupError],
+        `${description}: test and cleanup both failed`,
+      );
+    }
+    if (testError) throw testError;
+    if (cleanupError) throw cleanupError;
   }
 
   test('JS config should produce diagnostics', async () => {
@@ -149,29 +132,36 @@ suite('rslint JS config support', function () {
   },
 ];
 `;
-    const reloaded = waitForDiagnostics(
-      doc,
-      (diags) =>
-        diags.some((d) => d.message.includes('no-explicit-any')) &&
-        !diags.some((d) => d.message.includes('no-unsafe-member-access')),
+    await withFailClosedCleanup(
+      async () => {
+        const reloaded = waitForDiagnostics(
+          doc,
+          (diags) =>
+            diags.some((d) => d.message.includes('no-explicit-any')) &&
+            !diags.some((d) => d.message.includes('no-unsafe-member-access')),
+        );
+        fs.writeFileSync(configPath, newConfig, 'utf8');
+        const updatedDiags = await reloaded;
+        assert.ok(
+          updatedDiags.some((d) => d.message.includes('no-explicit-any')),
+          'After hot reload, diagnostics should include no-explicit-any',
+        );
+        assert.ok(
+          !updatedDiags.some((d) =>
+            d.message.includes('no-unsafe-member-access'),
+          ),
+          'After hot reload, no-unsafe-member-access should be gone',
+        );
+      },
+      async () => {
+        const restored = waitForDiagnostics(doc, (diags) =>
+          diags.some((d) => d.message.includes('no-unsafe-member-access')),
+        );
+        fs.writeFileSync(configPath, originalConfig, 'utf8');
+        await restored;
+      },
+      'Config hot-reload test',
     );
-
-    try {
-      fs.writeFileSync(configPath, newConfig, 'utf8');
-      const updatedDiags = await reloaded;
-      assert.ok(
-        updatedDiags.some((d) => d.message.includes('no-explicit-any')),
-        'After hot reload, diagnostics should include no-explicit-any',
-      );
-      assert.ok(
-        !updatedDiags.some((d) =>
-          d.message.includes('no-unsafe-member-access'),
-        ),
-        'After hot reload, no-unsafe-member-access should be gone',
-      );
-    } finally {
-      fs.writeFileSync(configPath, originalConfig, 'utf8');
-    }
   });
 
   test('one workspace config edit evaluates exactly one transaction', async () => {
@@ -200,34 +190,43 @@ export default [{
 }];
 `;
 
-    const reloaded = waitForDiagnostics(
-      doc,
-      (diags) =>
-        diags.some((d) => d.message.includes('no-explicit-any')) &&
-        !diags.some((d) => d.message.includes('no-unsafe-member-access')),
-    );
+    await withFailClosedCleanup(
+      async () => {
+        const reloaded = waitForDiagnostics(
+          doc,
+          (diags) =>
+            diags.some((d) => d.message.includes('no-explicit-any')) &&
+            !diags.some((d) => d.message.includes('no-unsafe-member-access')),
+        );
+        fs.rmSync(markerPath, { force: true });
+        fs.writeFileSync(configPath, countedConfig, 'utf8');
+        await reloaded;
 
-    try {
-      fs.rmSync(markerPath, { force: true });
-      fs.writeFileSync(configPath, countedConfig, 'utf8');
-      await reloaded;
-      // A duplicate didChangeWatchedFiles transaction used to race the direct
-      // watcher. Let any queued 300ms debounce complete before inspecting
-      // the config module's observable evaluation count.
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-      assert.strictEqual(
-        fs.readFileSync(markerPath, 'utf8'),
-        'x',
-        'one edit must evaluate one config-discovery transaction',
-      );
-    } finally {
-      const restored = waitForDiagnostics(doc, (diags) =>
-        diags.some((d) => d.message.includes('no-unsafe-member-access')),
-      ).catch(() => undefined);
-      fs.writeFileSync(configPath, originalConfig, 'utf8');
-      await restored;
-      fs.rmSync(markerPath, { force: true });
-    }
+        // A duplicate didChangeWatchedFiles transaction used to race the
+        // direct watcher. Let any queued 300ms debounce finish before reading
+        // the config module's observable evaluation count.
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        assert.strictEqual(
+          fs.readFileSync(markerPath, 'utf8'),
+          'x',
+          'one edit must evaluate one config-discovery transaction',
+        );
+      },
+      async () => {
+        await withFailClosedCleanup(
+          async () => {
+            const restored = waitForDiagnostics(doc, (diags) =>
+              diags.some((d) => d.message.includes('no-unsafe-member-access')),
+            );
+            fs.writeFileSync(configPath, originalConfig, 'utf8');
+            await restored;
+          },
+          async () => fs.rmSync(markerPath, { force: true }),
+          'Config-transaction cleanup',
+        );
+      },
+      'Config-transaction test',
+    );
   });
 
   test('deleting JS config should clear diagnostics', async () => {
@@ -241,30 +240,32 @@ export default [{
     const configPath = path.join(getWorkspaceRoot(), 'rslint.config.js');
     const originalConfig = fs.readFileSync(configPath, 'utf8');
 
-    const cleared = waitForDiagnostics(
-      doc,
-      (diags) =>
-        !diags.some((d) => d.message.includes('no-unsafe-member-access')),
+    await withFailClosedCleanup(
+      async () => {
+        const cleared = waitForDiagnostics(
+          doc,
+          (diags) =>
+            !diags.some((d) => d.message.includes('no-unsafe-member-access')),
+        );
+        fs.unlinkSync(configPath);
+        const afterDeleteDiags = await cleared;
+        assert.ok(
+          !afterDeleteDiags.some((d) =>
+            d.message.includes('no-unsafe-member-access'),
+          ),
+          'After deleting JS config, no-unsafe-member-access should be gone',
+        );
+      },
+      async () => {
+        // Subscribe before restoring so the next test starts from a known state.
+        const restored = waitForDiagnostics(doc, (diags) =>
+          diags.some((d) => d.message.includes('no-unsafe-member-access')),
+        );
+        fs.writeFileSync(configPath, originalConfig, 'utf8');
+        await restored;
+      },
+      'JS-config deletion test',
     );
-
-    try {
-      fs.unlinkSync(configPath);
-      const afterDeleteDiags = await cleared;
-      assert.ok(
-        !afterDeleteDiags.some((d) =>
-          d.message.includes('no-unsafe-member-access'),
-        ),
-        'After deleting JS config, no-unsafe-member-access should be gone',
-      );
-    } finally {
-      // Restore config and wait for the reload to settle so the next
-      // test starts from a known state. Subscribe first, then write.
-      const restored = waitForDiagnostics(doc, (diags) =>
-        diags.some((d) => d.message.includes('no-unsafe-member-access')),
-      ).catch(() => undefined);
-      fs.writeFileSync(configPath, originalConfig, 'utf8');
-      await restored;
-    }
   });
 
   test('creating a new JS config should load it and produce diagnostics', async () => {
@@ -273,16 +274,23 @@ export default [{
     const doc = await openFixture('index.ts');
     await vscode.window.showTextDocument(doc);
 
-    // Step 1: delete existing config and wait until its diagnostics drop.
-    const cleared = waitForDiagnostics(doc, (diags) =>
-      diags.every((d) => !d.message.includes('no-unsafe-member-access')),
+    // Establish a positive publication first, so clearing cannot pass on the
+    // document's not-yet-linted initial empty snapshot.
+    await waitForDiagnostics(doc, (diags) =>
+      diags.some((d) => d.message.includes('no-unsafe-member-access')),
     );
-    fs.unlinkSync(configPath);
-    await cleared;
 
-    try {
-      // Step 2: subscribe for the new rule, then create the file.
-      const newConfig = `export default [
+    await withFailClosedCleanup(
+      async () => {
+        // Step 1: delete existing config and observe its diagnostics drop.
+        const cleared = waitForDiagnostics(doc, (diags) =>
+          diags.every((d) => !d.message.includes('no-unsafe-member-access')),
+        );
+        fs.unlinkSync(configPath);
+        await cleared;
+
+        // Step 2: subscribe for the new rule, then create the file.
+        const newConfig = `export default [
   {
     files: ['**/*.ts'],
     languageOptions: {
@@ -298,22 +306,25 @@ export default [{
   },
 ];
 `;
-      const created = waitForDiagnostics(doc, (diags) =>
-        diags.some((d) => d.message.includes('no-explicit-any')),
-      );
-      fs.writeFileSync(configPath, newConfig, 'utf8');
-      const afterCreateDiags = await created;
-      assert.ok(
-        afterCreateDiags.some((d) => d.message.includes('no-explicit-any')),
-        'After creating new JS config, should see no-explicit-any diagnostic',
-      );
-    } finally {
-      const restored = waitForDiagnostics(doc, (diags) =>
-        diags.some((d) => d.message.includes('no-unsafe-member-access')),
-      ).catch(() => undefined);
-      fs.writeFileSync(configPath, originalConfig, 'utf8');
-      await restored;
-    }
+        const created = waitForDiagnostics(doc, (diags) =>
+          diags.some((d) => d.message.includes('no-explicit-any')),
+        );
+        fs.writeFileSync(configPath, newConfig, 'utf8');
+        const afterCreateDiags = await created;
+        assert.ok(
+          afterCreateDiags.some((d) => d.message.includes('no-explicit-any')),
+          'After creating new JS config, should see no-explicit-any diagnostic',
+        );
+      },
+      async () => {
+        const restored = waitForDiagnostics(doc, (diags) =>
+          diags.some((d) => d.message.includes('no-unsafe-member-access')),
+        );
+        fs.writeFileSync(configPath, originalConfig, 'utf8');
+        await restored;
+      },
+      'JS-config creation test',
+    );
   });
 
   test('a newly discovered broken nested config keeps valid ancestor config active', async () => {
@@ -323,7 +334,11 @@ export default [{
     const nestedDir = path.join(root, 'broken-nested-config');
     const nestedFilePath = path.join(nestedDir, 'index.ts');
     const nestedConfigPath = path.join(nestedDir, 'rslint.config.js');
+    const attemptedLoadPath = path.join(nestedDir, 'config-load-attempted');
+    const postFailureFilePath = path.join(nestedDir, 'post-failure.ts');
     const rootDoc = await openFixture('index.ts');
+    let nestedDoc: vscode.TextDocument | undefined;
+    let postFailureDoc: vscode.TextDocument | undefined;
 
     const rootConfigWithMarker = `export default [{
   files: ['**/*.ts'],
@@ -331,58 +346,114 @@ export default [{
     parserOptions: { projectService: false, project: ['./tsconfig.json'] },
   },
   rules: {
-    '@typescript-eslint/no-unsafe-member-access': 'error',
+    '@typescript-eslint/no-unsafe-member-access': 'warn',
     'no-debugger': 'error',
   },
   plugins: ['@typescript-eslint'],
 }];
 `;
 
-    try {
-      fs.mkdirSync(nestedDir, { recursive: true });
-      fs.writeFileSync(nestedFilePath, 'debugger;\n', 'utf8');
-      fs.writeFileSync(rootConfigPath, rootConfigWithMarker, 'utf8');
+    await withFailClosedCleanup(
+      async () => {
+        fs.mkdirSync(nestedDir, { recursive: true });
+        fs.writeFileSync(nestedFilePath, 'debugger;\n', 'utf8');
+        fs.writeFileSync(rootConfigPath, rootConfigWithMarker, 'utf8');
 
-      await vscode.window.showTextDocument(rootDoc);
-      const nestedDoc = await vscode.workspace.openTextDocument(nestedFilePath);
-      await vscode.window.showTextDocument(nestedDoc);
-      await waitForDiagnostics(nestedDoc, (diags) =>
-        diags.some((d) => d.message.includes('no-debugger')),
-      );
+        await vscode.window.showTextDocument(rootDoc);
+        await waitForDiagnostics(rootDoc, (diags) =>
+          diags.some(
+            (diagnostic) =>
+              diagnostic.message.includes('no-unsafe-member-access') &&
+              diagnostic.severity === vscode.DiagnosticSeverity.Warning,
+          ),
+        );
+        nestedDoc = await vscode.workspace.openTextDocument(nestedFilePath);
+        await vscode.window.showTextDocument(nestedDoc);
+        await waitForDiagnostics(nestedDoc, (diags) =>
+          diags.some(
+            (diagnostic) =>
+              diagnostic.message.includes('no-debugger') &&
+              diagnostic.severity === vscode.DiagnosticSeverity.Error,
+          ),
+        );
+        await closeTextEditor(nestedDoc);
+        nestedDoc = undefined;
 
-      fs.writeFileSync(
-        nestedConfigPath,
-        'export default [BROKEN SYNTAX;',
-        'utf8',
-      );
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-      await triggerRelint(nestedDoc);
+        fs.writeFileSync(
+          nestedConfigPath,
+          `import fs from 'node:fs';
+fs.writeFileSync(${JSON.stringify(attemptedLoadPath)}, 'attempted', 'utf8');
+throw new Error('intentional broken nested config');
+export default [];
+`,
+          'utf8',
+        );
+        await waitForFile(attemptedLoadPath);
+        assert.strictEqual(
+          fs.readFileSync(attemptedLoadPath, 'utf8'),
+          'attempted',
+          'The broken nested config must be evaluated before fallback is asserted',
+        );
 
-      const nestedDiagnostics = await waitForDiagnostics(nestedDoc, (diags) =>
-        diags.some((d) => d.message.includes('no-debugger')),
-      );
-      assert.ok(
-        nestedDiagnostics.some((d) => d.message.includes('no-debugger')),
-        'The broken nested config should be skipped so the root config remains active',
-      );
-
-      const rootDiagnostics = await waitForDiagnostics(rootDoc, (diags) =>
-        diags.some((d) => d.message.includes('no-unsafe-member-access')),
-      );
-      assert.ok(
-        rootDiagnostics.some((d) =>
-          d.message.includes('no-unsafe-member-access'),
-        ),
-        'The valid root config must remain active outside the broken nested config',
-      );
-    } finally {
-      const rootRestored = waitForDiagnostics(rootDoc, (diags) =>
-        diags.some((d) => d.message.includes('no-unsafe-member-access')),
-      ).catch(() => undefined);
-      fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
-      fs.rmSync(nestedDir, { recursive: true, force: true });
-      await rootRestored;
-    }
+        // This URI does not exist until after the broken module has executed,
+        // so its diagnostics cannot be a stale snapshot from before the failed
+        // refresh. Its first lint must run after the blocking config transaction
+        // and resolve through the still-valid ancestor config.
+        fs.writeFileSync(postFailureFilePath, 'debugger;\n', 'utf8');
+        postFailureDoc =
+          await vscode.workspace.openTextDocument(postFailureFilePath);
+        await vscode.window.showTextDocument(postFailureDoc);
+        const postFailureDiagnostics = await waitForDiagnostics(
+          postFailureDoc,
+          (diags) =>
+            diags.some(
+              (diagnostic) =>
+                diagnostic.message.includes('no-debugger') &&
+                diagnostic.severity === vscode.DiagnosticSeverity.Error,
+            ),
+        );
+        assert.deepStrictEqual(
+          postFailureDiagnostics
+            .filter((diagnostic) => diagnostic.message.includes('no-debugger'))
+            .map((diagnostic) => diagnostic.severity),
+          [vscode.DiagnosticSeverity.Error],
+          'The valid ancestor must lint a file opened after the broken child was evaluated',
+        );
+      },
+      async () => {
+        const temporaryDocuments = [nestedDoc, postFailureDoc].filter(
+          (document): document is vscode.TextDocument => document !== undefined,
+        );
+        await withFailClosedCleanup(
+          async () => {
+            await Promise.all(
+              temporaryDocuments.map((document) => closeTextEditor(document)),
+            );
+          },
+          async () => {
+            // The temporary root config deliberately lowers this rule to a
+            // warning. Waiting for Error makes restoration an observable
+            // config-transaction barrier before the next test starts.
+            const rootRestored = waitForDiagnostics(rootDoc, (diags) =>
+              diags.some(
+                (diagnostic) =>
+                  diagnostic.message.includes('no-unsafe-member-access') &&
+                  diagnostic.severity === vscode.DiagnosticSeverity.Error,
+              ),
+            );
+            fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
+            fs.rmSync(nestedDir, { recursive: true, force: true });
+            assert.ok(
+              !fs.existsSync(nestedDir),
+              'Broken nested-config fixtures must be deleted during cleanup',
+            );
+            await rootRestored;
+          },
+          'Broken nested-config resource cleanup',
+        );
+      },
+      'Broken nested-config test',
+    );
   });
 
   test('parent global ignores remove nested configs from the effective catalog', async () => {
@@ -405,71 +476,76 @@ export default [{
         "'@typescript-eslint/no-explicit-any': 'warn'",
       );
 
-    try {
-      fs.mkdirSync(nestedDir, { recursive: true });
-      fs.writeFileSync(nestedFilePath, 'console.log("nested");\n', 'utf8');
-      fs.writeFileSync(
-        nestedConfigPath,
-        `import fs from 'node:fs';
+    await withFailClosedCleanup(
+      async () => {
+        fs.mkdirSync(nestedDir, { recursive: true });
+        fs.writeFileSync(nestedFilePath, 'console.log("nested");\n', 'utf8');
+        fs.writeFileSync(
+          nestedConfigPath,
+          `import fs from 'node:fs';
 fs.appendFileSync(${JSON.stringify(loadMarkerPath)}, 'x');
 export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
 `,
-        'utf8',
-      );
+          'utf8',
+        );
 
-      const nestedDoc = await vscode.workspace.openTextDocument(nestedFilePath);
-      await vscode.window.showTextDocument(nestedDoc);
-      await waitForDiagnostics(nestedDoc, (diagnostics) =>
-        diagnostics.some((diagnostic) =>
-          diagnostic.message.includes('Unexpected console statement'),
-        ),
-      );
-
-      await vscode.window.showTextDocument(rootDoc);
-      const parentApplied = waitForDiagnostics(rootDoc, (diagnostics) =>
-        diagnostics.some((diagnostic) =>
-          diagnostic.message.includes('no-explicit-any'),
-        ),
-      );
-      const nestedCleared = waitForDiagnostics(
-        nestedDoc,
-        (diagnostics) =>
-          !diagnostics.some((diagnostic) =>
-            diagnostic.message.includes('Unexpected console statement'),
-          ),
-      );
-
-      fs.writeFileSync(rootConfigPath, ignoredRootConfig, 'utf8');
-      await Promise.all([parentApplied, nestedCleared]);
-
-      assert.strictEqual(
-        fs.readFileSync(loadMarkerPath, 'utf8'),
-        'x',
-        'The ignored nested candidate must not be evaluated again',
-      );
-      assert.ok(
-        !vscode.languages
-          .getDiagnostics(nestedDoc.uri)
-          .some((diagnostic) =>
-            diagnostic.message.includes('Unexpected console statement'),
-          ),
-        'The ignored nested config must not be sent in the effective catalog',
-      );
-    } finally {
-      const restored = waitForDiagnostics(
-        rootDoc,
-        (diagnostics) =>
+        const nestedDoc =
+          await vscode.workspace.openTextDocument(nestedFilePath);
+        await vscode.window.showTextDocument(nestedDoc);
+        await waitForDiagnostics(nestedDoc, (diagnostics) =>
           diagnostics.some((diagnostic) =>
-            diagnostic.message.includes('no-unsafe-member-access'),
-          ) &&
-          !diagnostics.some((diagnostic) =>
+            diagnostic.message.includes('Unexpected console statement'),
+          ),
+        );
+
+        await vscode.window.showTextDocument(rootDoc);
+        const parentApplied = waitForDiagnostics(rootDoc, (diagnostics) =>
+          diagnostics.some((diagnostic) =>
             diagnostic.message.includes('no-explicit-any'),
           ),
-      ).catch(() => undefined);
-      fs.rmSync(nestedDir, { recursive: true, force: true });
-      fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
-      await restored;
-    }
+        );
+        const nestedCleared = waitForDiagnostics(
+          nestedDoc,
+          (diagnostics) =>
+            !diagnostics.some((diagnostic) =>
+              diagnostic.message.includes('Unexpected console statement'),
+            ),
+        );
+
+        fs.writeFileSync(rootConfigPath, ignoredRootConfig, 'utf8');
+        await Promise.all([parentApplied, nestedCleared]);
+
+        assert.strictEqual(
+          fs.readFileSync(loadMarkerPath, 'utf8'),
+          'x',
+          'The ignored nested candidate must not be evaluated again',
+        );
+        assert.ok(
+          !vscode.languages
+            .getDiagnostics(nestedDoc.uri)
+            .some((diagnostic) =>
+              diagnostic.message.includes('Unexpected console statement'),
+            ),
+          'The ignored nested config must not be sent in the effective catalog',
+        );
+      },
+      async () => {
+        const restored = waitForDiagnostics(
+          rootDoc,
+          (diagnostics) =>
+            diagnostics.some((diagnostic) =>
+              diagnostic.message.includes('no-unsafe-member-access'),
+            ) &&
+            !diagnostics.some((diagnostic) =>
+              diagnostic.message.includes('no-explicit-any'),
+            ),
+        );
+        fs.rmSync(nestedDir, { recursive: true, force: true });
+        fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
+        await restored;
+      },
+      'Parent-ignore catalog test',
+    );
   });
 
   test('config search excludes node_modules and .git', async () => {
@@ -489,55 +565,59 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
       "'@typescript-eslint/no-explicit-any': 'warn'",
     );
 
-    try {
-      for (let index = 0; index < probes.length; index++) {
-        fs.mkdirSync(probes[index], { recursive: true });
-        fs.writeFileSync(
-          path.join(probes[index], 'rslint.config.mjs'),
-          `import fs from 'node:fs'; fs.writeFileSync(${JSON.stringify(markerPaths[index])}, 'loaded'); export default [];`,
-          'utf8',
-        );
-      }
+    await withFailClosedCleanup(
+      async () => {
+        for (let index = 0; index < probes.length; index++) {
+          fs.mkdirSync(probes[index], { recursive: true });
+          fs.writeFileSync(
+            path.join(probes[index], 'rslint.config.mjs'),
+            `import fs from 'node:fs'; fs.writeFileSync(${JSON.stringify(markerPaths[index])}, 'loaded'); export default [];`,
+            'utf8',
+          );
+        }
 
-      await vscode.window.showTextDocument(rootDoc);
-      const reloaded = waitForDiagnostics(rootDoc, (diagnostics) =>
-        diagnostics.some((diagnostic) =>
-          diagnostic.message.includes('no-explicit-any'),
-        ),
-      );
-      fs.writeFileSync(rootConfigPath, changedRootConfig, 'utf8');
-      await reloaded;
-
-      for (const markerPath of markerPaths) {
-        assert.ok(
-          !fs.existsSync(markerPath),
-          `Excluded config was unexpectedly loaded: ${markerPath}`,
-        );
-      }
-    } finally {
-      const restored = waitForDiagnostics(
-        rootDoc,
-        (diagnostics) =>
+        await vscode.window.showTextDocument(rootDoc);
+        const reloaded = waitForDiagnostics(rootDoc, (diagnostics) =>
           diagnostics.some((diagnostic) =>
-            diagnostic.message.includes('no-unsafe-member-access'),
-          ) &&
-          !diagnostics.some((diagnostic) =>
             diagnostic.message.includes('no-explicit-any'),
           ),
-      ).catch(() => undefined);
-      for (const probe of probes) {
-        fs.rmSync(probe, { recursive: true, force: true });
-      }
-      if (!gitDirectoryExisted) {
-        try {
-          fs.rmdirSync(gitDirectory);
-        } catch {
-          // Leave a concurrently populated directory intact.
+        );
+        fs.writeFileSync(rootConfigPath, changedRootConfig, 'utf8');
+        await reloaded;
+
+        for (const markerPath of markerPaths) {
+          assert.ok(
+            !fs.existsSync(markerPath),
+            `Excluded config was unexpectedly loaded: ${markerPath}`,
+          );
         }
-      }
-      fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
-      await restored;
-    }
+      },
+      async () => {
+        const restored = waitForDiagnostics(
+          rootDoc,
+          (diagnostics) =>
+            diagnostics.some((diagnostic) =>
+              diagnostic.message.includes('no-unsafe-member-access'),
+            ) &&
+            !diagnostics.some((diagnostic) =>
+              diagnostic.message.includes('no-explicit-any'),
+            ),
+        );
+        for (const probe of probes) {
+          fs.rmSync(probe, { recursive: true, force: true });
+        }
+        if (!gitDirectoryExisted) {
+          try {
+            fs.rmdirSync(gitDirectory);
+          } catch {
+            // Leave a concurrently populated directory intact.
+          }
+        }
+        fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
+        await restored;
+      },
+      'Excluded-config search test',
+    );
   });
 
   test('same-directory configs use .js > .mjs > .ts > .mts priority', async () => {
@@ -572,14 +652,19 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
 ];
 `;
 
-    const expectWarning = async (ruleName: string): Promise<void> => {
-      const diagnostics = await waitForDiagnostics(doc, (diags) =>
+    const mutateAndExpectWarning = async (
+      ruleName: string,
+      mutate: () => void,
+    ): Promise<void> => {
+      const result = waitForDiagnostics(doc, (diags) =>
         diags.some(
           (d) =>
             d.message.includes(ruleName) &&
             d.severity === vscode.DiagnosticSeverity.Warning,
         ),
       );
+      mutate();
+      const diagnostics = await result;
       const diagnostic = diagnostics.find((d) => d.message.includes(ruleName));
       assert.strictEqual(
         diagnostic?.severity,
@@ -588,62 +673,65 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
       );
     };
 
-    try {
-      fs.writeFileSync(
-        mjsPath,
-        configFor('@typescript-eslint/no-explicit-any'),
-        'utf8',
-      );
-      fs.writeFileSync(
-        tsPath,
-        configFor('@typescript-eslint/no-unsafe-member-access'),
-        'utf8',
-      );
-      fs.writeFileSync(
-        mtsPath,
-        configFor('@typescript-eslint/no-explicit-any'),
-        'utf8',
-      );
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+    await waitForDiagnostics(doc, (diags) =>
+      diags.some(
+        (diagnostic) =>
+          diagnostic.message.includes('no-unsafe-member-access') &&
+          diagnostic.severity === vscode.DiagnosticSeverity.Error,
+      ),
+    );
 
-      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
-      assert.ok(
-        diagnostics.some(
-          (d) =>
-            d.message.includes('no-unsafe-member-access') &&
-            d.severity === vscode.DiagnosticSeverity.Error,
-        ),
-        '.js should remain selected while lower-priority configs coexist',
-      );
+    await withFailClosedCleanup(
+      async () => {
+        fs.writeFileSync(
+          mjsPath,
+          configFor('@typescript-eslint/no-explicit-any'),
+          'utf8',
+        );
+        fs.writeFileSync(
+          tsPath,
+          configFor('@typescript-eslint/no-unsafe-member-access'),
+          'utf8',
+        );
+        fs.writeFileSync(
+          mtsPath,
+          configFor('@typescript-eslint/no-explicit-any'),
+          'utf8',
+        );
 
-      fs.unlinkSync(jsPath);
-      await expectWarning('no-explicit-any');
-
-      fs.unlinkSync(mjsPath);
-      await expectWarning('no-unsafe-member-access');
-
-      fs.unlinkSync(tsPath);
-      await expectWarning('no-explicit-any');
-    } finally {
-      const restored = waitForDiagnostics(doc, (diags) =>
-        diags.some(
-          (d) =>
-            d.message.includes('no-unsafe-member-access') &&
-            d.severity === vscode.DiagnosticSeverity.Error,
-        ),
-      ).catch(() => undefined);
-      fs.writeFileSync(jsPath, originalJS, 'utf8');
-      fs.rmSync(mjsPath, { force: true });
-      fs.rmSync(tsPath, { force: true });
-      fs.rmSync(mtsPath, { force: true });
-      await restored;
-    }
+        await mutateAndExpectWarning('no-explicit-any', () =>
+          fs.unlinkSync(jsPath),
+        );
+        await mutateAndExpectWarning('no-unsafe-member-access', () =>
+          fs.unlinkSync(mjsPath),
+        );
+        await mutateAndExpectWarning('no-explicit-any', () =>
+          fs.unlinkSync(tsPath),
+        );
+      },
+      async () => {
+        const restored = waitForDiagnostics(doc, (diags) =>
+          diags.some(
+            (d) =>
+              d.message.includes('no-unsafe-member-access') &&
+              d.severity === vscode.DiagnosticSeverity.Error,
+          ),
+        );
+        fs.writeFileSync(jsPath, originalJS, 'utf8');
+        fs.rmSync(mjsPath, { force: true });
+        fs.rmSync(tsPath, { force: true });
+        fs.rmSync(mtsPath, { force: true });
+        await restored;
+      },
+      'Same-directory config-priority test',
+    );
   });
 
   test('broken higher-priority config preserves last-good and does not load a lower variant', async () => {
     const root = getWorkspaceRoot();
     const jsPath = path.join(root, 'rslint.config.js');
     const mjsPath = path.join(root, 'rslint.config.mjs');
+    const attemptedLoadPath = path.join(root, 'broken-config-attempted.txt');
     const originalJS = fs.readFileSync(jsPath, 'utf8');
     const doc = await openFixture('index.ts');
     await vscode.window.showTextDocument(doc);
@@ -661,30 +749,77 @@ export default [{ files: ['**/*.ts'], rules: { 'no-console': 'error' } }];
 }];
 `;
 
-    try {
-      fs.writeFileSync(mjsPath, lowerPriorityConfig, 'utf8');
-      fs.writeFileSync(jsPath, 'export default [BROKEN SYNTAX;', 'utf8');
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      await triggerRelint(doc);
+    await withFailClosedCleanup(
+      async () => {
+        fs.writeFileSync(mjsPath, lowerPriorityConfig, 'utf8');
+        fs.writeFileSync(
+          jsPath,
+          `import fs from 'node:fs';
+fs.writeFileSync(${JSON.stringify(attemptedLoadPath)}, 'attempted');
+throw new Error('intentional broken higher-priority config');
+export default [];
+`,
+          'utf8',
+        );
+        await waitForFile(attemptedLoadPath);
 
-      const diagnostics = await waitForDiagnostics(doc, (diags) =>
-        diags.some((d) => d.message.includes('no-unsafe-member-access')),
-      );
-      assert.ok(
-        diagnostics.some((d) => d.message.includes('no-unsafe-member-access')),
-        'The last-good .js config should remain active',
-      );
-      assert.ok(
-        !diagnostics.some((d) => d.message.includes('no-explicit-any')),
-        'A broken .js must not fall through to .mjs or JSON',
-      );
-    } finally {
-      const restored = waitForDiagnostics(doc, (diags) =>
-        diags.some((d) => d.message.includes('no-unsafe-member-access')),
-      ).catch(() => undefined);
-      fs.writeFileSync(jsPath, originalJS, 'utf8');
-      fs.rmSync(mjsPath, { force: true });
-      await restored;
-    }
+        // Request fresh diagnostics only after the failing module was actually
+        // evaluated. A stale pre-reload snapshot cannot satisfy both content
+        // transitions, and falling through to .mjs would report another rule.
+        const originalContent = doc.getText();
+        const editor = await vscode.window.showTextDocument(doc);
+        const cleared = waitForDiagnostics(
+          doc,
+          (diagnostics) => diagnostics.length === 0,
+        );
+        assert.ok(
+          await editor.edit((edit) => {
+            edit.replace(
+              new vscode.Range(
+                doc.positionAt(0),
+                doc.positionAt(doc.getText().length),
+              ),
+              'const safe = 1;\n',
+            );
+          }),
+          'Editing the last-good config probe to clean content should succeed',
+        );
+        await cleared;
+
+        const lastGoodApplied = waitForDiagnostics(doc, (diagnostics) =>
+          diagnostics.some((diagnostic) =>
+            diagnostic.message.includes('no-unsafe-member-access'),
+          ),
+        );
+        assert.ok(
+          await editor.edit((edit) => {
+            edit.replace(
+              new vscode.Range(
+                doc.positionAt(0),
+                doc.positionAt(doc.getText().length),
+              ),
+              originalContent,
+            );
+          }),
+          'Restoring the last-good config probe content should succeed',
+        );
+        const diagnostics = await lastGoodApplied;
+        assert.ok(
+          !diagnostics.some((d) => d.message.includes('no-explicit-any')),
+          'A broken .js must not fall through to .mjs or JSON',
+        );
+      },
+      async () => {
+        await revertTextDocument(doc);
+        const restored = waitForDiagnostics(doc, (diags) =>
+          diags.some((d) => d.message.includes('no-unsafe-member-access')),
+        );
+        fs.writeFileSync(jsPath, originalJS, 'utf8');
+        fs.rmSync(mjsPath, { force: true });
+        fs.rmSync(attemptedLoadPath, { force: true });
+        await restored;
+      },
+      'Broken higher-priority config test',
+    );
   });
 });

--- a/packages/vscode-extension/__tests__/suite-monorepo/monorepo.test.ts
+++ b/packages/vscode-extension/__tests__/suite-monorepo/monorepo.test.ts
@@ -2,42 +2,14 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
 import fs from 'node:fs';
+import { waitForRslintDiagnostics as waitForDiagnostics } from '../utils/diagnostics';
+import { revertTextDocument } from '../utils/documents';
 
 suite('rslint monorepo multi-config support', function () {
-  this.timeout(60000);
+  this.timeout(120000);
 
   function getWorkspaceRoot(): string {
     return vscode.workspace.workspaceFolders![0].uri.fsPath;
-  }
-
-  async function waitForDiagnostics(
-    doc: vscode.TextDocument,
-    predicate?: (diags: vscode.Diagnostic[]) => boolean,
-  ): Promise<vscode.Diagnostic[]> {
-    for (let i = 0; i < 20; i++) {
-      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
-      if (predicate ? predicate(diagnostics) : diagnostics.length > 0) {
-        return diagnostics;
-      }
-
-      await new Promise((resolve) => {
-        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          for (const uri of e.uris) {
-            if (uri.toString() === doc.uri.toString()) {
-              disposable.dispose();
-              resolve(void 0);
-              return;
-            }
-          }
-        });
-        setTimeout(() => {
-          disposable.dispose();
-          resolve(void 0);
-        }, 1500);
-      });
-    }
-
-    return vscode.languages.getDiagnostics(doc.uri);
   }
 
   async function openFile(relativePath: string): Promise<vscode.TextDocument> {
@@ -386,8 +358,11 @@ suite('rslint monorepo multi-config support', function () {
 
     const fooDoc = await openFile('packages/foo/src/index.ts');
     await vscode.window.showTextDocument(fooDoc);
+    const barDoc = await openFile('packages/bar/src/index.ts');
+    await vscode.window.showTextDocument(barDoc);
 
-    // 1. Verify initial: foo uses its own config
+    // 1. Establish positive publications for both configs. Any later empty bar
+    // snapshot is therefore a real transition, not a not-yet-linted default.
     const initialFooDiags = await waitForDiagnostics(fooDoc, (diags) =>
       diags.some((d) => d.message.includes('no-unsafe-member-access')),
     );
@@ -397,44 +372,97 @@ suite('rslint monorepo multi-config support', function () {
       ),
       'Initial: foo file should have no-unsafe-member-access from foo config',
     );
+    await waitForDiagnostics(barDoc, (diags) =>
+      diags.some((d) => d.message.includes('no-explicit-any')),
+    );
 
+    let testError: unknown;
     try {
       // 2. Delete root config
-      fs.unlinkSync(rootConfigPath);
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-
-      // 3. Foo should still work with its own config
-      const fooEditor = await vscode.window.showTextDocument(fooDoc);
-      await triggerRelint(fooEditor);
-
-      const fooDiagsAfter = await waitForDiagnostics(fooDoc, (diags) =>
-        diags.some((d) => d.message.includes('no-unsafe-member-access')),
-      );
-      assert.ok(
-        fooDiagsAfter.some((d) =>
-          d.message.includes('no-unsafe-member-access'),
-        ),
-        'After root delete: foo file should still use foo config',
-      );
-
-      // 4. Bar (no sub-config) should lose diagnostics
-      const barDoc = await openFile('packages/bar/src/index.ts');
-      const barEditor = await vscode.window.showTextDocument(barDoc);
-      await triggerRelint(barEditor);
-
-      const barDiags = await waitForDiagnostics(
+      const barCleared = waitForDiagnostics(
         barDoc,
-        (diags) => diags.filter((d) => d.source === 'rslint').length === 0,
+        (diagnostics) => diagnostics.length === 0,
       );
+      fs.unlinkSync(rootConfigPath);
+      await triggerRelint(await vscode.window.showTextDocument(fooDoc));
+      await triggerRelint(await vscode.window.showTextDocument(barDoc));
+
+      // 3. Bar has no sub-config, so the observed root-config diagnostic must
+      // transition to an explicit empty publication.
+      const barDiags = await barCleared;
       assert.strictEqual(
-        barDiags.filter((d) => d.source === 'rslint').length,
+        barDiags.length,
         0,
         'After root delete: bar file should have no rslint diagnostics (no config)',
       );
-    } finally {
-      fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      // 4. Prove foo's surviving sub-config still evaluates new content after
+      // the root deletion transaction, rather than accepting a stale snapshot.
+      const originalFooContent = fooDoc.getText();
+      const fooEditor = await vscode.window.showTextDocument(fooDoc);
+      const fooCleared = waitForDiagnostics(
+        fooDoc,
+        (diagnostics) => diagnostics.length === 0,
+      );
+      assert.ok(
+        await fooEditor.edit((edit) => {
+          edit.replace(
+            new vscode.Range(
+              fooDoc.positionAt(0),
+              fooDoc.positionAt(fooDoc.getText().length),
+            ),
+            'const safe = 1;\n',
+          );
+        }),
+        'Editing foo to a clean state should succeed',
+      );
+      await fooCleared;
+
+      const fooRestored = waitForDiagnostics(fooDoc, (diagnostics) =>
+        diagnostics.some((diagnostic) =>
+          diagnostic.message.includes('no-unsafe-member-access'),
+        ),
+      );
+      assert.ok(
+        await fooEditor.edit((edit) => {
+          edit.replace(
+            new vscode.Range(
+              fooDoc.positionAt(0),
+              fooDoc.positionAt(fooDoc.getText().length),
+            ),
+            originalFooContent,
+          );
+        }),
+        'Restoring foo content should succeed',
+      );
+      await fooRestored;
+    } catch (error) {
+      testError = error;
     }
+
+    let restoreError: unknown;
+    try {
+      await revertTextDocument(fooDoc);
+      const rootRestored = waitForDiagnostics(barDoc, (diagnostics) =>
+        diagnostics.some((diagnostic) =>
+          diagnostic.message.includes('no-explicit-any'),
+        ),
+      );
+      fs.writeFileSync(rootConfigPath, originalRootConfig, 'utf8');
+      await triggerRelint(await vscode.window.showTextDocument(barDoc));
+      await rootRestored;
+    } catch (error) {
+      restoreError = error;
+    }
+
+    if (testError && restoreError) {
+      throw new AggregateError(
+        [testError, restoreError],
+        'Root-config deletion test and restoration both failed',
+      );
+    }
+    if (testError) throw testError;
+    if (restoreError) throw restoreError;
   });
 
   test('changing root config should update bar file diagnostics (no sub-config)', async () => {

--- a/packages/vscode-extension/__tests__/suite-noconfig/noconfig.test.ts
+++ b/packages/vscode-extension/__tests__/suite-noconfig/noconfig.test.ts
@@ -2,9 +2,10 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
 import fs from 'node:fs';
+import { waitForRslintDiagnostics as waitForDiagnostics } from '../utils/diagnostics';
 
 suite('rslint no config fallback', function () {
-  this.timeout(60000);
+  this.timeout(120000);
 
   function getWorkspaceRoot(): string {
     return vscode.workspace.workspaceFolders![0].uri.fsPath;
@@ -15,34 +16,63 @@ suite('rslint no config fallback', function () {
     return vscode.workspace.openTextDocument(filePath);
   }
 
-  async function waitForDiagnostics(
-    doc: vscode.TextDocument,
-    predicate?: (diags: vscode.Diagnostic[]) => boolean,
-  ): Promise<vscode.Diagnostic[]> {
-    for (let i = 0; i < 20; i++) {
-      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
-      if (predicate ? predicate(diagnostics) : diagnostics.length > 0) {
-        return diagnostics;
-      }
+  const jsonConfig = JSON.stringify(
+    [
+      {
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
+          },
+        },
+        rules: {
+          '@typescript-eslint/no-explicit-any': 'error',
+          '@typescript-eslint/no-unsafe-member-access': 'off',
+        },
+        plugins: ['@typescript-eslint'],
+      },
+    ],
+    null,
+    2,
+  );
 
-      await new Promise((resolve) => {
-        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          for (const uri of e.uris) {
-            if (uri.toString() === doc.uri.toString()) {
-              disposable.dispose();
-              resolve(void 0);
-              return;
-            }
-          }
-        });
-        setTimeout(() => {
-          disposable.dispose();
-          resolve(void 0);
-        }, 1500);
-      });
+  async function withConfigFilesAbsent(
+    testFn: (paths: { json: string; js: string }) => Promise<void>,
+  ): Promise<void> {
+    const paths = {
+      json: path.join(getWorkspaceRoot(), 'rslint.json'),
+      js: path.join(getWorkspaceRoot(), 'rslint.config.js'),
+    };
+    const removeConfigs = (): void => {
+      fs.rmSync(paths.json, { force: true });
+      fs.rmSync(paths.js, { force: true });
+      if (fs.existsSync(paths.json) || fs.existsSync(paths.js)) {
+        throw new Error('No-config fixture cleanup left a config file behind');
+      }
+    };
+
+    let testError: unknown;
+    try {
+      removeConfigs();
+      await testFn(paths);
+    } catch (error) {
+      testError = error;
     }
 
-    return vscode.languages.getDiagnostics(doc.uri);
+    let cleanupError: unknown;
+    try {
+      removeConfigs();
+    } catch (error) {
+      cleanupError = error;
+    }
+    if (testError && cleanupError) {
+      throw new AggregateError(
+        [testError, cleanupError],
+        'No-config test and config cleanup both failed',
+      );
+    }
+    if (testError) throw testError;
+    if (cleanupError) throw cleanupError;
   }
 
   /**
@@ -60,92 +90,63 @@ suite('rslint no config fallback', function () {
     });
   }
 
-  test('extension should start without config file and produce no diagnostics', async () => {
-    const doc = await openFixture('index.ts');
-    await vscode.window.showTextDocument(doc);
+  test('removing the last config reaches an observed no-config state', async () => {
+    await withConfigFilesAbsent(async ({ json }) => {
+      const doc = await openFixture('index.ts');
+      await vscode.window.showTextDocument(doc);
 
-    // Wait a reasonable time for diagnostics to appear (they shouldn't)
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+      // Establish a positive rslint publication first. The subsequent empty
+      // snapshot therefore cannot be the document's not-yet-linted state.
+      const configured = waitForDiagnostics(doc, (diagnostics) =>
+        diagnostics.some((diagnostic) =>
+          diagnostic.message.includes('no-explicit-any'),
+        ),
+      );
+      fs.writeFileSync(json, jsonConfig, 'utf8');
+      await triggerDiagnosticRefresh(doc);
+      await configured;
 
-    const diagnostics = vscode.languages.getDiagnostics(doc.uri);
-
-    // Without any config, no rslint rules are enabled, so no diagnostics
-    assert.strictEqual(
-      diagnostics.filter((d) => d.source === 'rslint').length,
-      0,
-      'Should have no rslint diagnostics when no config file exists',
-    );
+      const cleared = waitForDiagnostics(
+        doc,
+        (diagnostics) => diagnostics.length === 0,
+      );
+      fs.rmSync(json);
+      await triggerDiagnosticRefresh(doc);
+      const diagnostics = await cleared;
+      assert.strictEqual(
+        diagnostics.length,
+        0,
+        'Removing the last config should publish an empty rslint snapshot',
+      );
+    });
   });
 
   test('config lifecycle: no config → JSON → JS override → delete JS → delete JSON', async () => {
-    const root = getWorkspaceRoot();
-    const jsonConfigPath = path.join(root, 'rslint.json');
-    const jsConfigPath = path.join(root, 'rslint.config.js');
-
-    // Ensure clean state — remove any leftover config files
-    try {
-      fs.unlinkSync(jsonConfigPath);
-    } catch {
-      /* ignore */
-    }
-    try {
-      fs.unlinkSync(jsConfigPath);
-    } catch {
-      /* ignore */
-    }
-
-    const doc = await openFixture('index.ts');
-    await vscode.window.showTextDocument(doc);
-
-    try {
-      // ── Step 1: No config → no diagnostics ──
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-      let diags = vscode.languages.getDiagnostics(doc.uri);
-      assert.strictEqual(
-        diags.filter((d) => d.source === 'rslint').length,
-        0,
-        'Step 1: Should have no rslint diagnostics without config',
+    await withConfigFilesAbsent(async ({ json, js }) => {
+      const doc = await openFixture('index.ts');
+      await vscode.window.showTextDocument(doc);
+      assert.ok(
+        !fs.existsSync(json) && !fs.existsSync(js),
+        'The lifecycle must start with no config files',
       );
 
-      // ── Step 2: Create rslint.json → no-explicit-any diagnostics ──
-      const jsonConfig = JSON.stringify(
-        [
-          {
-            languageOptions: {
-              parserOptions: {
-                projectService: false,
-                project: ['./tsconfig.json'],
-              },
-            },
-            rules: {
-              '@typescript-eslint/no-explicit-any': 'error',
-              '@typescript-eslint/no-unsafe-member-access': 'off',
-            },
-            plugins: ['@typescript-eslint'],
-          },
-        ],
-        null,
-        2,
-      );
-      fs.writeFileSync(jsonConfigPath, jsonConfig, 'utf8');
-
-      // Wait for file watcher to detect JSON config creation
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-      await triggerDiagnosticRefresh(doc);
-
-      diags = await waitForDiagnostics(doc, (ds) =>
+      // ── Step 1: Create rslint.json → no-explicit-any diagnostics ──
+      let transition = waitForDiagnostics(doc, (ds) =>
         ds.some((d) => d.message.includes('no-explicit-any')),
       );
+      fs.writeFileSync(json, jsonConfig, 'utf8');
+      await triggerDiagnosticRefresh(doc);
+      let diags = await transition;
       assert.ok(
         diags.some((d) => d.message.includes('no-explicit-any')),
-        'Step 2: Should see no-explicit-any after JSON config created',
+        'Step 1: Should see no-explicit-any after JSON config created',
       );
       assert.ok(
         !diags.some((d) => d.message.includes('no-unsafe-member-access')),
-        'Step 2: Should NOT see no-unsafe-member-access (turned off in JSON)',
+        'Step 1: Should NOT see no-unsafe-member-access (turned off in JSON)',
       );
 
-      // ── Step 3: Create rslint.config.js → JS overrides JSON ──
+      // ── Step 2: Create rslint.config.js → JS overrides JSON ──
       const jsConfig = `export default [
   {
     languageOptions: {
@@ -162,94 +163,79 @@ suite('rslint no config fallback', function () {
   },
 ];
 `;
-      fs.writeFileSync(jsConfigPath, jsConfig, 'utf8');
-
-      // Wait for config discovery to detect and commit the JS config.
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-      await triggerDiagnosticRefresh(doc);
-
-      diags = await waitForDiagnostics(doc, (ds) =>
-        ds.some((d) => d.message.includes('no-unsafe-member-access')),
+      transition = waitForDiagnostics(
+        doc,
+        (ds) =>
+          ds.some((d) => d.message.includes('no-unsafe-member-access')) &&
+          !ds.some((d) => d.message.includes('no-explicit-any')),
       );
+      fs.writeFileSync(js, jsConfig, 'utf8');
+      await triggerDiagnosticRefresh(doc);
+      diags = await transition;
       assert.ok(
         diags.some((d) => d.message.includes('no-unsafe-member-access')),
-        'Step 3: Should see no-unsafe-member-access from JS config',
+        'Step 2: Should see no-unsafe-member-access from JS config',
       );
       assert.ok(
         !diags.some((d) => d.message.includes('no-explicit-any')),
-        'Step 3: JS config should override JSON — no-explicit-any should be off',
+        'Step 2: JS config should override JSON — no-explicit-any should be off',
       );
 
-      // ── Step 4: Delete JS config → JSON config restored ──
-      fs.unlinkSync(jsConfigPath);
-
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      // ── Step 3: Delete JS config → JSON config restored ──
+      transition = waitForDiagnostics(
+        doc,
+        (ds) =>
+          ds.some((d) => d.message.includes('no-explicit-any')) &&
+          !ds.some((d) => d.message.includes('no-unsafe-member-access')),
+      );
+      fs.rmSync(js);
       await triggerDiagnosticRefresh(doc);
-
-      diags = await waitForDiagnostics(doc, (ds) =>
-        ds.some((d) => d.message.includes('no-explicit-any')),
-      );
+      diags = await transition;
       assert.ok(
         diags.some((d) => d.message.includes('no-explicit-any')),
-        'Step 4: After deleting JS config, JSON config should restore no-explicit-any',
+        'Step 3: After deleting JS config, JSON config should restore no-explicit-any',
       );
       assert.ok(
         !diags.some((d) => d.message.includes('no-unsafe-member-access')),
-        'Step 4: no-unsafe-member-access should be gone (JS config deleted)',
+        'Step 3: no-unsafe-member-access should be gone (JS config deleted)',
       );
 
-      // ── Step 5: Broken JS with no last-good → explicit no-lint state ──
+      // ── Step 4: Broken JS with no last-good → explicit no-lint state ──
       const disabledByBrokenJS = waitForDiagnostics(
         doc,
-        (ds) => ds.filter((d) => d.source === 'rslint').length === 0,
+        (ds) => ds.length === 0,
       );
-      fs.writeFileSync(jsConfigPath, 'export default [BROKEN SYNTAX;', 'utf8');
+      fs.writeFileSync(js, 'export default [BROKEN SYNTAX;', 'utf8');
+      await triggerDiagnosticRefresh(doc);
       diags = await disabledByBrokenJS;
       assert.strictEqual(
-        diags.filter((d) => d.source === 'rslint').length,
+        diags.length,
         0,
-        'Step 5: A broken discovered JS config must not fall back to JSON',
+        'Step 4: A broken discovered JS config must not fall back to JSON',
       );
 
-      // ── Step 6: Delete broken JS → legitimate deletion restores JSON ──
+      // ── Step 5: Delete broken JS → legitimate deletion restores JSON ──
       const jsonRestored = waitForDiagnostics(doc, (ds) =>
         ds.some((d) => d.message.includes('no-explicit-any')),
       );
-      fs.unlinkSync(jsConfigPath);
+      fs.rmSync(js);
+      await triggerDiagnosticRefresh(doc);
       diags = await jsonRestored;
       assert.ok(
         diags.some((d) => d.message.includes('no-explicit-any')),
-        'Step 6: Deleting all JS configs should restore the JSON fallback',
+        'Step 5: Deleting all JS configs should restore the JSON fallback',
       );
 
-      // ── Step 7: Delete JSON config → no diagnostics ──
-      fs.unlinkSync(jsonConfigPath);
-
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      // ── Step 6: Delete JSON config → no diagnostics ──
+      const cleared = waitForDiagnostics(doc, (ds) => ds.length === 0);
+      fs.rmSync(json);
       await triggerDiagnosticRefresh(doc);
-
-      // Wait for diagnostics to clear
-      diags = await waitForDiagnostics(
-        doc,
-        (ds) => ds.filter((d) => d.source === 'rslint').length === 0,
-      );
+      diags = await cleared;
       assert.strictEqual(
-        diags.filter((d) => d.source === 'rslint').length,
+        diags.length,
         0,
-        'Step 7: After deleting all configs, should have no rslint diagnostics',
+        'Step 6: After deleting all configs, should have no rslint diagnostics',
       );
-    } finally {
-      // Clean up — ensure no config files remain for other test runs
-      try {
-        fs.unlinkSync(jsonConfigPath);
-      } catch {
-        /* ignore */
-      }
-      try {
-        fs.unlinkSync(jsConfigPath);
-      } catch {
-        /* ignore */
-      }
-    }
+    });
   });
 });

--- a/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
+++ b/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
 import { findFixAllAction, requestFixAll } from '../suite/fixall-helpers';
+import { waitForRslintDiagnostics as waitForDiagnostics } from '../utils/diagnostics';
 
 // Type-aware rule scope when parserOptions uses `projectService: true`
 // (the shape `ts.configs.recommended` exports) without an explicit
@@ -24,35 +25,10 @@ import { findFixAllAction, requestFixAll } from '../suite/fixall-helpers';
 //                                    should NOT fire, while native no-var should
 //                                    diagnose and participate in fixAll.
 suite('rslint projectService type-aware scope', function () {
-  this.timeout(60000);
+  this.timeout(120000);
 
   function workspaceRoot(): string {
     return vscode.workspace.workspaceFolders![0].uri.fsPath;
-  }
-
-  async function waitForDiagnostics(
-    doc: vscode.TextDocument,
-    predicate: (diags: vscode.Diagnostic[]) => boolean,
-  ): Promise<vscode.Diagnostic[]> {
-    for (let i = 0; i < 20; i++) {
-      const current = vscode.languages.getDiagnostics(doc.uri);
-      if (predicate(current)) return current;
-      await new Promise((resolve) => {
-        let timer: ReturnType<typeof setTimeout>;
-        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          if (e.uris.some((uri) => uri.toString() === doc.uri.toString())) {
-            clearTimeout(timer);
-            disposable.dispose();
-            resolve(void 0);
-          }
-        });
-        timer = setTimeout(() => {
-          disposable.dispose();
-          resolve(void 0);
-        }, 1500);
-      });
-    }
-    return vscode.languages.getDiagnostics(doc.uri);
   }
 
   // Only inspect rslint-originated diagnostics — TS's own 6133 ("declared but

--- a/packages/vscode-extension/__tests__/suite-type-aware-scope/type-aware-scope.test.ts
+++ b/packages/vscode-extension/__tests__/suite-type-aware-scope/type-aware-scope.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
+import { waitForRslintDiagnostics as waitForDiagnostics } from '../utils/diagnostics';
 
 // Tests that type-aware rules (e.g. require-await) only run on files covered
 // by parserOptions.project, matching CLI behavior.
@@ -9,38 +10,10 @@ import path from 'node:path';
 // - packages/core/src/index.ts: IN tsconfig, require-await SHOULD fire
 // - packages/cli/src/preview.ts: NOT in tsconfig, require-await should NOT fire
 suite('rslint type-aware rule scope', function () {
-  this.timeout(60000);
+  this.timeout(120000);
 
   function getWorkspaceRoot(): string {
     return vscode.workspace.workspaceFolders![0].uri.fsPath;
-  }
-
-  async function waitForDiagnostics(
-    doc: vscode.TextDocument,
-    predicate?: (diags: vscode.Diagnostic[]) => boolean,
-  ): Promise<vscode.Diagnostic[]> {
-    for (let i = 0; i < 20; i++) {
-      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
-      if (predicate ? predicate(diagnostics) : diagnostics.length > 0) {
-        return diagnostics;
-      }
-      await new Promise((resolve) => {
-        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          for (const uri of e.uris) {
-            if (uri.toString() === doc.uri.toString()) {
-              disposable.dispose();
-              resolve(void 0);
-              return;
-            }
-          }
-        });
-        setTimeout(() => {
-          disposable.dispose();
-          resolve(void 0);
-        }, 1500);
-      });
-    }
-    return vscode.languages.getDiagnostics(doc.uri);
   }
 
   test('file IN parserOptions.project tsconfig should get type-aware rules', async () => {

--- a/packages/vscode-extension/__tests__/suite/extension.test.ts
+++ b/packages/vscode-extension/__tests__/suite/extension.test.ts
@@ -1,151 +1,54 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
-import { executeCodeActionProvider } from './fixall-helpers';
+import { executeCodeActionProvider, getFixturesDir } from './fixall-helpers';
+import {
+  getRslintDiagnostics,
+  waitForRslintDiagnostics as waitForDiagnostics,
+  waitForRslintDiagnosticsCount as waitForDiagnosticsCount,
+  waitForRslintDiagnosticsToChange as waitForDiagnosticsToChange,
+} from '../utils/diagnostics';
+import { closeTextEditor, revertTextDocument } from '../utils/documents';
 
 suite('rslint extension', function () {
   this.timeout(90000);
 
-  // Helper function to wait for diagnostics.
-  // On CI (especially Windows), the LSP server may take longer to start up,
-  // load config, type-check, and push initial diagnostics. Use generous
-  // iteration count (15) and per-iteration timeout (2s) to avoid flaky failures.
-  async function waitForDiagnostics(
-    doc: vscode.TextDocument,
-  ): Promise<vscode.Diagnostic[]> {
-    for (let i = 0; i < 15; i++) {
-      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
-      if (diagnostics.length > 0) {
-        return diagnostics;
-      }
-
-      await new Promise((resolve) => {
-        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          for (const uri of e.uris) {
-            if (uri.toString() === doc.uri.toString()) {
-              disposable.dispose();
-              resolve(void 0);
-              return;
-            }
-          }
-        });
-        setTimeout(() => {
-          disposable.dispose();
-          resolve(void 0);
-        }, 2000);
-      });
+  teardown(async () => {
+    const fixturesSource = path.resolve(getFixturesDir(), 'src');
+    const dirtyFixtures = vscode.workspace.textDocuments.filter((document) => {
+      if (document.uri.scheme !== 'file') return false;
+      const relative = path.relative(fixturesSource, document.uri.fsPath);
+      return (
+        document.isDirty &&
+        relative !== '' &&
+        !relative.startsWith(`..${path.sep}`) &&
+        !path.isAbsolute(relative)
+      );
+    });
+    for (const document of dirtyFixtures) {
+      await revertTextDocument(document);
     }
+  });
 
-    return vscode.languages.getDiagnostics(doc.uri);
-  }
-
-  async function waitForDiagnosticsToChange(
-    doc: vscode.TextDocument,
-    previousCount: number,
-    timeoutMs = 30000,
-  ): Promise<vscode.Diagnostic[]> {
-    const startTime = Date.now();
-
-    while (Date.now() - startTime < timeoutMs) {
-      const current = vscode.languages.getDiagnostics(doc.uri);
-      if (current.length !== previousCount) {
-        return current;
-      }
-
-      // Wait for diagnostics change event or short timeout
-      await new Promise((resolve) => {
-        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          for (const uri of e.uris) {
-            if (uri.toString() === doc.uri.toString()) {
-              disposable.dispose();
-              resolve(void 0);
-              return;
-            }
-          }
-        });
-        setTimeout(() => {
-          disposable.dispose();
-          resolve(void 0);
-        }, 500);
-      });
-    }
-
-    return vscode.languages.getDiagnostics(doc.uri);
-  }
-
-  async function waitForDiagnosticsCount(
-    doc: vscode.TextDocument,
-    expectedCount: number,
-    timeoutMs = 30000,
-  ): Promise<vscode.Diagnostic[]> {
-    const startTime = Date.now();
-
-    while (Date.now() - startTime < timeoutMs) {
-      const current = vscode.languages.getDiagnostics(doc.uri);
-      if (current.length === expectedCount) {
-        return current;
-      }
-
-      await new Promise((resolve) => {
-        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          for (const uri of e.uris) {
-            if (uri.toString() === doc.uri.toString()) {
-              disposable.dispose();
-              resolve(void 0);
-              return;
-            }
-          }
-        });
-        setTimeout(() => {
-          disposable.dispose();
-          resolve(void 0);
-        }, 500);
-      });
-    }
-
-    return vscode.languages.getDiagnostics(doc.uri);
-  }
-
-  async function waitForDiagnosticsWithMessage(
+  function waitForDiagnosticsWithMessage(
     doc: vscode.TextDocument,
     messageSubstring: string,
     timeoutMs = 30000,
   ): Promise<vscode.Diagnostic[]> {
-    const startTime = Date.now();
-
-    while (Date.now() - startTime < timeoutMs) {
-      const current = vscode.languages.getDiagnostics(doc.uri);
-      if (current.some((d) => d.message.includes(messageSubstring))) {
-        return current;
-      }
-
-      // Wait for diagnostics change event or short timeout
-      await new Promise((resolve) => {
-        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          for (const uri of e.uris) {
-            if (uri.toString() === doc.uri.toString()) {
-              disposable.dispose();
-              resolve(void 0);
-              return;
-            }
-          }
-        });
-        setTimeout(() => {
-          disposable.dispose();
-          resolve(void 0);
-        }, 500);
-      });
-    }
-
-    return vscode.languages.getDiagnostics(doc.uri);
+    return waitForDiagnostics(
+      doc,
+      (diagnostics) =>
+        diagnostics.some((diagnostic) =>
+          diagnostic.message.includes(messageSubstring),
+        ),
+      timeoutMs,
+    );
   }
 
   // Helper function to open a test fixture
   async function openFixture(filename: string): Promise<vscode.TextDocument> {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    assert.ok(workspaceFolder, 'Expected an isolated fixture workspace');
     return vscode.workspace.openTextDocument(
-      path.resolve(workspaceFolder.uri.fsPath, 'src', filename),
+      path.resolve(getFixturesDir(), 'src', filename),
     );
   }
 
@@ -204,35 +107,41 @@ suite('rslint extension', function () {
         d.message.includes('no-unnecessary-type-assertion') ||
         (d.source === 'rslint' && d.message.includes('assertion')),
     );
+    assert.ok(
+      typeAssertionDiag,
+      `Expected a no-unnecessary-type-assertion diagnostic. Got: ${diagnostics
+        .map((diagnostic) => diagnostic.message)
+        .join(' | ')}`,
+    );
 
-    if (typeAssertionDiag) {
-      // Request code actions for the diagnostic range
-      const codeActions = await executeCodeActionProvider(
-        doc.uri,
-        typeAssertionDiag.range,
-      );
+    // Request code actions for the diagnostic range
+    const codeActions = await executeCodeActionProvider(
+      doc.uri,
+      typeAssertionDiag.range,
+    );
 
-      assert.ok(
-        codeActions && codeActions.length > 0,
-        'Should have code actions',
-      );
+    assert.ok(codeActions.length > 0, 'Should have code actions');
 
-      // Look for auto fix action
-      const autoFixAction = codeActions.find(
-        (action) =>
-          action.title.toLowerCase().includes('fix') &&
-          action.kind?.value === vscode.CodeActionKind.QuickFix.value,
-      );
+    // Look for auto fix action
+    const autoFixAction = codeActions.find(
+      (action) =>
+        action.title.toLowerCase().includes('fix') &&
+        action.kind?.value === vscode.CodeActionKind.QuickFix.value,
+    );
 
-      assert.ok(autoFixAction, 'Should have auto fix action');
-      assert.ok(
-        autoFixAction.isPreferred,
-        'Auto fix should be marked as preferred',
-      );
+    assert.ok(autoFixAction, 'Should have auto fix action');
+    assert.ok(
+      autoFixAction.isPreferred,
+      'Auto fix should be marked as preferred',
+    );
 
-      // Verify the action has an edit
-      assert.ok(autoFixAction.edit, 'Auto fix action should have an edit');
-    }
+    // Verify the action has an edit
+    assert.ok(autoFixAction.edit, 'Auto fix action should have an edit');
+    const autoFixEdits = autoFixAction.edit.get(doc.uri);
+    assert.ok(
+      autoFixEdits && autoFixEdits.length > 0,
+      'Auto fix edit should not be empty',
+    );
   });
 
   test('code actions - disable rule for line', async () => {
@@ -246,46 +155,49 @@ suite('rslint extension', function () {
     const unsafeDiag = diagnostics.find(
       (d) => d.message.includes('unsafe') || d.message.includes('Unsafe'),
     );
+    assert.ok(
+      unsafeDiag,
+      `Expected an unsafe diagnostic. Got: ${diagnostics
+        .map((diagnostic) => diagnostic.message)
+        .join(' | ')}`,
+    );
 
-    if (unsafeDiag) {
-      // Request code actions for the diagnostic range
-      const codeActions = await executeCodeActionProvider(
-        doc.uri,
-        unsafeDiag.range,
-      );
+    // Request code actions for the diagnostic range
+    const codeActions = await executeCodeActionProvider(
+      doc.uri,
+      unsafeDiag.range,
+    );
 
-      assert.ok(
-        codeActions && codeActions.length > 0,
-        'Should have code actions',
-      );
+    assert.ok(codeActions.length > 0, 'Should have code actions');
 
-      // Look for disable rule for line action
-      const disableLineAction = codeActions.find(
-        (action) =>
-          action.title.toLowerCase().includes('disable') &&
-          action.title.toLowerCase().includes('line'),
-      );
+    // Look for disable rule for line action
+    const disableLineAction = codeActions.find(
+      (action) =>
+        action.title.toLowerCase().includes('disable') &&
+        action.title.toLowerCase().includes('line'),
+    );
 
-      assert.ok(disableLineAction, 'Should have disable rule for line action');
-      assert.ok(
-        !disableLineAction.isPreferred,
-        'Disable action should not be marked as preferred',
-      );
+    assert.ok(disableLineAction, 'Should have disable rule for line action');
+    assert.ok(
+      !disableLineAction.isPreferred,
+      'Disable action should not be marked as preferred',
+    );
 
-      // Verify the action has an edit
-      assert.ok(disableLineAction.edit, 'Disable action should have an edit');
+    // Verify the action has an edit
+    assert.ok(disableLineAction.edit, 'Disable action should have an edit');
 
-      // Verify the edit contains rslint-disable-next-line
-      const workspaceEdit = disableLineAction.edit;
-      const edits = workspaceEdit.get(doc.uri);
-      if (edits && edits.length > 0) {
-        const editText = edits[0].newText;
-        assert.ok(
-          editText.includes('rslint-disable-next-line'),
-          'Edit should contain rslint-disable-next-line comment',
-        );
-      }
-    }
+    // Verify the edit contains rslint-disable-next-line
+    const workspaceEdit = disableLineAction.edit;
+    const edits = workspaceEdit.get(doc.uri);
+    assert.ok(
+      edits && edits.length > 0,
+      'Disable-line edit should not be empty',
+    );
+    const editText = edits[0].newText;
+    assert.ok(
+      editText.includes('rslint-disable-next-line'),
+      'Edit should contain rslint-disable-next-line comment',
+    );
   });
 
   test('code actions - disable rule for file', async () => {
@@ -299,47 +211,49 @@ suite('rslint extension', function () {
     const unsafeDiag = diagnostics.find(
       (d) => d.message.includes('unsafe') || d.message.includes('Unsafe'),
     );
+    assert.ok(
+      unsafeDiag,
+      `Expected an unsafe diagnostic. Got: ${diagnostics
+        .map((diagnostic) => diagnostic.message)
+        .join(' | ')}`,
+    );
 
-    if (unsafeDiag) {
-      // Request code actions for the diagnostic range
-      const codeActions = await executeCodeActionProvider(
-        doc.uri,
-        unsafeDiag.range,
-      );
+    // Request code actions for the diagnostic range
+    const codeActions = await executeCodeActionProvider(
+      doc.uri,
+      unsafeDiag.range,
+    );
 
-      assert.ok(
-        codeActions && codeActions.length > 0,
-        'Should have code actions',
-      );
+    assert.ok(codeActions.length > 0, 'Should have code actions');
 
-      // Look for disable rule for file action
-      const disableFileAction = codeActions.find(
-        (action) =>
-          action.title.toLowerCase().includes('disable') &&
-          action.title.toLowerCase().includes('file'),
-      );
+    // Look for disable rule for file action
+    const disableFileAction = codeActions.find(
+      (action) =>
+        action.title.toLowerCase().includes('disable') &&
+        action.title.toLowerCase().includes('file'),
+    );
 
-      assert.ok(disableFileAction, 'Should have disable rule for file action');
-      assert.ok(
-        !disableFileAction.isPreferred,
-        'Disable action should not be marked as preferred',
-      );
+    assert.ok(disableFileAction, 'Should have disable rule for file action');
+    assert.ok(
+      !disableFileAction.isPreferred,
+      'Disable action should not be marked as preferred',
+    );
 
-      // Verify the action has an edit
-      assert.ok(disableFileAction.edit, 'Disable action should have an edit');
+    // Verify the action has an edit
+    assert.ok(disableFileAction.edit, 'Disable action should have an edit');
 
-      // Verify the edit contains rslint-disable comment
-      const workspaceEdit = disableFileAction.edit;
-      const edits = workspaceEdit.get(doc.uri);
-      if (edits && edits.length > 0) {
-        const editText = edits[0].newText;
-        assert.ok(
-          editText.includes('rslint-disable') &&
-            !editText.includes('-next-line'),
-          'Edit should contain rslint-disable comment for entire file',
-        );
-      }
-    }
+    // Verify the edit contains rslint-disable comment
+    const workspaceEdit = disableFileAction.edit;
+    const edits = workspaceEdit.get(doc.uri);
+    assert.ok(
+      edits && edits.length > 0,
+      'Disable-file edit should not be empty',
+    );
+    const editText = edits[0].newText;
+    assert.ok(
+      editText.includes('rslint-disable') && !editText.includes('-next-line'),
+      'Edit should contain rslint-disable comment for entire file',
+    );
   });
 
   test('code actions - range overlap', async () => {
@@ -390,12 +304,14 @@ suite('rslint extension', function () {
       editBuilder.replace(fullRange, '// no lint errors\nexport {};\n');
     });
 
-    // 3. Wait for diagnostics to update (should decrease)
-    const updatedDiags = await waitForDiagnosticsToChange(doc, initialCount);
+    // 3. Wait for the exact final state; accepting the first smaller
+    // intermediate publication could hide diagnostics that never clear.
+    const updatedDiags = await waitForDiagnosticsCount(doc, 0);
 
-    assert.ok(
-      updatedDiags.length < initialCount,
-      `Expected fewer diagnostics after removing errors. Before: ${initialCount}, After: ${updatedDiags.length}`,
+    assert.strictEqual(
+      updatedDiags.length,
+      0,
+      `Expected zero diagnostics after removing errors. Before: ${initialCount}, After: ${updatedDiags.length}`,
     );
   });
 
@@ -457,11 +373,12 @@ suite('rslint extension', function () {
     );
 
     // 3. Wait for diagnostics to settle — should reflect the error-free final state
-    const finalDiags = await waitForDiagnosticsToChange(doc, initialCount);
+    const finalDiags = await waitForDiagnosticsCount(doc, 0);
 
-    assert.ok(
-      finalDiags.length < initialCount,
-      `After rapid edits ending with clean code, expected fewer diagnostics. Before: ${initialCount}, After: ${finalDiags.length}`,
+    assert.strictEqual(
+      finalDiags.length,
+      0,
+      `After rapid edits ending with clean code, expected zero diagnostics. Before: ${initialCount}, After: ${finalDiags.length}`,
     );
   });
 
@@ -500,12 +417,16 @@ suite('rslint extension', function () {
     const fullRange = () =>
       new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length));
 
+    // Start from a published non-empty snapshot, so the following zero cannot
+    // be the document's not-yet-linted initial state.
+    await waitForDiagnostics(doc);
+
     // Step 1: start from clean state to establish baseline
     await editor.edit((b) =>
       b.replace(fullRange(), '// no errors\nexport {};\n'),
     );
     await waitForDiagnosticsCount(doc, 0, 10000);
-    const cleanCount = vscode.languages.getDiagnostics(doc.uri).length;
+    const cleanCount = getRslintDiagnostics(doc).length;
 
     // Step 2: introduce errors
     await editor.edit((b) =>
@@ -540,15 +461,21 @@ suite('rslint extension', function () {
     const fullRange = () =>
       new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length));
 
+    // Establish a published non-empty baseline first, so waiting for zero
+    // cannot pass on the clean document's not-yet-linted initial state.
+    await editor.edit((b) =>
+      b.replace(
+        fullRange(),
+        'const baseline: any = {};\nbaseline.member;\nexport {};\n',
+      ),
+    );
+    await waitForDiagnosticsWithMessage(doc, 'no-unsafe-member-access');
+
     // Step 1: Start with clean code — should have zero diagnostics
     await editor.edit((b) =>
       b.replace(fullRange(), '// no errors\nexport {};\n'),
     );
-    // -1 as previousCount ensures the condition (current.length !== -1) is always
-    // true on the first check, effectively meaning "wait for any diagnostics event".
-    await waitForDiagnosticsToChange(doc, -1, 5000);
-    await new Promise((r) => setTimeout(r, 1000));
-    const cleanDiags = vscode.languages.getDiagnostics(doc.uri);
+    const cleanDiags = await waitForDiagnosticsCount(doc, 0, 30_000);
     assert.strictEqual(
       cleanDiags.length,
       0,
@@ -622,6 +549,7 @@ suite('rslint extension', function () {
 
     const diagnostics = await waitForDiagnostics(doc);
 
+    let comparedAutoFixAndDisable = false;
     for (const diagnostic of diagnostics) {
       // Filter quick fixes
       const codeActions = (
@@ -643,6 +571,7 @@ suite('rslint extension', function () {
 
       // If both auto fix and disable actions exist, auto fix should be preferred
       if (autoFixActions.length > 0 && disableActions.length > 0) {
+        comparedAutoFixAndDisable = true;
         assert.ok(
           autoFixActions.some((action) => action.isPreferred),
           'Auto fix actions should be marked as preferred',
@@ -653,13 +582,18 @@ suite('rslint extension', function () {
         );
       }
     }
+    assert.ok(
+      comparedAutoFixAndDisable,
+      `Expected at least one diagnostic with both auto-fix and disable actions. Diagnostics: ${diagnostics
+        .map((diagnostic) => diagnostic.message)
+        .join(' | ')}`,
+    );
   });
 
-  test('diagnostics correct after close and reopen cycle', async () => {
-    // Note: VSCode's test framework caches documents from openTextDocument,
-    // so didClose is not reliably sent when editors close. Instead, we test
-    // the full lifecycle: open → edit to clean → close → reopen original →
-    // verify diagnostics reappear (server state is consistent).
+  test('diagnostics correct after reverting and reopening the editor tab', async () => {
+    // VS Code may retain a TextDocument model after its last editor closes, so
+    // this test deliberately covers editor-tab lifecycle rather than claiming
+    // an LSP didClose cycle: edit → revert → close tab → reopen.
     const doc = await openFixture('close-test.ts');
     const editor = await vscode.window.showTextDocument(doc);
 
@@ -677,29 +611,21 @@ suite('rslint extension', function () {
       doc.positionAt(doc.getText().length),
     );
     await editor.edit((b) => b.replace(fullRange, '// clean\nexport {};\n'));
-    const cleanDiags = await waitForDiagnosticsToChange(doc, initialCount);
+    const cleanDiags = await waitForDiagnosticsCount(doc, 0);
     assert.strictEqual(
       cleanDiags.length,
       0,
       `Expected 0 diagnostics after cleaning, got ${cleanDiags.length}`,
     );
 
-    // 3. Close editor and reopen with original error content
-    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+    // 3. Revert the dirty overlay and close the exact editor tab before
+    // reopening the original error content from disk.
+    await closeTextEditor(doc);
     const doc2 = await openFixture('close-test.ts');
-    const editor2 = await vscode.window.showTextDocument(doc2);
+    await vscode.window.showTextDocument(doc2);
 
-    // 4. Restore original error content
-    const fullRange2 = new vscode.Range(
-      doc2.positionAt(0),
-      doc2.positionAt(doc2.getText().length),
-    );
-    await editor2.edit((b) =>
-      b.replace(fullRange2, 'const unsafeVal: any = 42;\nunsafeVal.prop;\n'),
-    );
-
-    // 5. Diagnostics should reappear — server correctly handles the cycle
-    const reopenDiags = await waitForDiagnosticsToChange(doc2, 0);
+    // 4. Diagnostics should reappear — server correctly handles the cycle
+    const reopenDiags = await waitForDiagnostics(doc2);
     assert.ok(
       reopenDiags.length > 0,
       `Expected diagnostics after restoring errors, got ${reopenDiags.length}`,
@@ -713,7 +639,7 @@ suite('rslint extension', function () {
     // Wait a reasonable amount of time — diagnostics should NOT appear
     await new Promise((r) => setTimeout(r, 3000));
 
-    const diagnostics = vscode.languages.getDiagnostics(doc.uri);
+    const diagnostics = getRslintDiagnostics(doc);
     assert.strictEqual(
       diagnostics.length,
       0,

--- a/packages/vscode-extension/__tests__/suite/fixall-cascade.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-cascade.test.ts
@@ -8,6 +8,7 @@ import {
   withTmpFile,
   withOnSaveFixAll,
   replaceAll,
+  saveDocumentOnce,
 } from './fixall-helpers';
 
 suite('rslint fixAll - cascade (multi-pass)', function () {
@@ -75,7 +76,7 @@ suite('rslint fixAll - cascade (multi-pass)', function () {
           .join(' | ')}`,
       );
 
-      assert.ok(await doc.save(), 'Cascade document should save');
+      await saveDocumentOnce(doc, 'Cascade document should save');
 
       // Event-driven wait: resolves the moment the on-save fixAll edit
       // lands on the document, instead of polling on a 500ms interval.

--- a/packages/vscode-extension/__tests__/suite/fixall-error.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-error.test.ts
@@ -8,6 +8,7 @@ import {
   withTmpFile,
   withOnSaveFixAll,
   replaceAll,
+  saveDocumentOnce,
 } from './fixall-helpers';
 
 suite('rslint fixAll - error flows', function () {
@@ -63,7 +64,7 @@ suite('rslint fixAll - error flows', function () {
           .map((d) => d.message)
           .join(' | ')}`,
       );
-      assert.ok(await doc.save(), 'Syntax-error probe should save');
+      await saveDocumentOnce(doc, 'Syntax-error probe should save');
       await waitForContentChange(
         doc,
         (content) => !content.includes('pVal as string'),
@@ -72,7 +73,7 @@ suite('rslint fixAll - error flows', function () {
 
       const brokenContent = 'const x = \nfunction {\nexport {\n';
       await replaceAll(editor, brokenContent);
-      assert.ok(await doc.save(), 'Broken document should save');
+      await saveDocumentOnce(doc, 'Broken document should save');
 
       await new Promise((r) => setTimeout(r, 3000));
 

--- a/packages/vscode-extension/__tests__/suite/fixall-helpers.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-helpers.ts
@@ -2,11 +2,28 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import path from 'node:path';
 import fs from 'node:fs';
-import { isDeepStrictEqual } from 'node:util';
+import {
+  waitForRslintDiagnostics,
+  waitForRslintDiagnosticsCount,
+  waitForRslintDiagnosticsToChange,
+} from '../utils/diagnostics';
+import { withCodeActionsOnSave } from '../utils/configuration';
+import {
+  closeAndDeleteTemporaryDocument,
+  temporaryFilePath,
+} from '../utils/documents';
+import { waitForCodeActionRegistryQuiescence } from '../utils/codeActionRegistry';
+
+export { saveDocumentOnce } from '../utils/codeActionRegistry';
+
+export const waitForDiagnostics = waitForRslintDiagnostics;
+export const waitForDiagnosticsCount = waitForRslintDiagnosticsCount;
+export const waitForDiagnosticsToChange = waitForRslintDiagnosticsToChange;
 
 export function getFixturesDir(): string {
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-  assert.ok(workspaceFolder, 'Expected an isolated fixture workspace');
+  if (!workspaceFolder)
+    throw new Error('VS Code test workspace is unavailable');
   return workspaceFolder.uri.fsPath;
 }
 
@@ -16,96 +33,6 @@ export async function openFixture(
   return vscode.workspace.openTextDocument(
     path.resolve(getFixturesDir(), 'src/', filename),
   );
-}
-
-export async function waitForDiagnostics(
-  doc: vscode.TextDocument,
-): Promise<vscode.Diagnostic[]> {
-  // On CI (especially Windows), the LSP server may take longer to start up,
-  // load config, type-check, and push initial diagnostics. Use generous
-  // iteration count (15) and per-iteration timeout (2s) to avoid flaky failures.
-  for (let i = 0; i < 15; i++) {
-    const diagnostics = vscode.languages.getDiagnostics(doc.uri);
-    if (diagnostics.length > 0) {
-      return diagnostics;
-    }
-    await new Promise((resolve) => {
-      const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-        for (const uri of e.uris) {
-          if (uri.toString() === doc.uri.toString()) {
-            disposable.dispose();
-            resolve(void 0);
-            return;
-          }
-        }
-      });
-      setTimeout(() => {
-        disposable.dispose();
-        resolve(void 0);
-      }, 2000);
-    });
-  }
-  return vscode.languages.getDiagnostics(doc.uri);
-}
-
-export async function waitForDiagnosticsToChange(
-  doc: vscode.TextDocument,
-  previousCount: number,
-  timeoutMs = 30000,
-): Promise<vscode.Diagnostic[]> {
-  const startTime = Date.now();
-  while (Date.now() - startTime < timeoutMs) {
-    const current = vscode.languages.getDiagnostics(doc.uri);
-    if (current.length !== previousCount) {
-      return current;
-    }
-    await new Promise((resolve) => {
-      const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-        for (const uri of e.uris) {
-          if (uri.toString() === doc.uri.toString()) {
-            disposable.dispose();
-            resolve(void 0);
-            return;
-          }
-        }
-      });
-      setTimeout(() => {
-        disposable.dispose();
-        resolve(void 0);
-      }, 500);
-    });
-  }
-  return vscode.languages.getDiagnostics(doc.uri);
-}
-
-export async function waitForDiagnosticsCount(
-  doc: vscode.TextDocument,
-  expectedCount: number,
-  timeoutMs = 30000,
-): Promise<vscode.Diagnostic[]> {
-  const startTime = Date.now();
-  while (Date.now() - startTime < timeoutMs) {
-    const current = vscode.languages.getDiagnostics(doc.uri);
-    if (current.length === expectedCount) {
-      return current;
-    }
-    await new Promise((resolve) => {
-      const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-        for (const uri of e.uris) {
-          if (uri.toString() === doc.uri.toString()) {
-            disposable.dispose();
-            resolve(void 0);
-            return;
-          }
-        }
-      });
-      setTimeout(() => {
-        disposable.dispose();
-        resolve(void 0);
-      }, 500);
-    });
-  }
-  return vscode.languages.getDiagnostics(doc.uri);
 }
 
 export function findFixAllAction(
@@ -123,6 +50,7 @@ export async function executeCodeActionProvider(
   range: vscode.Range,
   kind?: string,
 ): Promise<vscode.CodeAction[]> {
+  await waitForCodeActionRegistryQuiescence();
   const args: unknown[] = ['vscode.executeCodeActionProvider', uri, range];
   if (kind !== undefined) args.push(kind);
   const result = await vscode.commands.executeCommand<vscode.CodeAction[]>(
@@ -151,26 +79,21 @@ export async function withTmpFile(
     editor: vscode.TextEditor,
   ) => Promise<void>,
 ): Promise<void> {
-  const tmpFile = path.join(
-    getFixturesDir(),
-    'src',
-    `_fixall_tmp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}.ts`,
+  const tmpFile = temporaryFilePath(
+    path.join(getFixturesDir(), 'src'),
+    '_fixall_tmp_',
   );
   fs.writeFileSync(tmpFile, content, 'utf-8');
+  let doc: vscode.TextDocument | undefined;
+  let testError: unknown;
   try {
-    const doc = await vscode.workspace.openTextDocument(tmpFile);
+    doc = await vscode.workspace.openTextDocument(tmpFile);
     const editor = await vscode.window.showTextDocument(doc);
     await testFn(doc, editor);
-  } finally {
-    // Close the editor tab so VSCode sends a synchronous didClose to the LSP,
-    // which cleans up the session overlay. Without this, the file deletion
-    // triggers an async didClose via the file watcher, which can race with
-    // the next test's LSP requests (all blocking methods are serialized).
-    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-    if (fs.existsSync(tmpFile)) {
-      fs.unlinkSync(tmpFile);
-    }
+  } catch (error) {
+    testError = error;
   }
+  await finishTemporaryDocument(testError, doc, tmpFile);
 }
 
 /**
@@ -239,50 +162,43 @@ export async function withOnSaveFixAll(
     'source.fixAll.rslint': 'explicit',
   },
 ): Promise<void> {
-  const fixturesDir = getFixturesDir();
-  const tmpFile = path.join(
-    fixturesDir,
-    'src',
-    `_fixall_test_${Date.now()}.ts`,
+  const tmpFile = temporaryFilePath(
+    path.join(getFixturesDir(), 'src'),
+    '_fixall_test_',
   );
   fs.writeFileSync(tmpFile, '// placeholder\n', 'utf-8');
 
+  let doc: vscode.TextDocument | undefined;
+  let testError: unknown;
   try {
-    const config = vscode.workspace.getConfiguration('editor');
-    const previousValue = config.get('codeActionsOnSave');
-    const configurationChanged = !isDeepStrictEqual(
-      previousValue,
-      codeActionsOnSave,
-    );
-    if (configurationChanged) {
-      await config.update(
-        'codeActionsOnSave',
-        codeActionsOnSave,
-        vscode.ConfigurationTarget.Workspace,
-      );
-    }
+    const openedDocument = await vscode.workspace.openTextDocument(tmpFile);
+    doc = openedDocument;
+    const editor = await vscode.window.showTextDocument(openedDocument);
+    await withCodeActionsOnSave(openedDocument, codeActionsOnSave, async () => {
+      await testFn(openedDocument, editor);
+    });
+  } catch (error) {
+    testError = error;
+  }
+  await finishTemporaryDocument(testError, doc, tmpFile);
+}
 
-    try {
-      const doc = await vscode.workspace.openTextDocument(tmpFile);
-      const editor = await vscode.window.showTextDocument(doc);
-      await testFn(doc, editor);
-    } finally {
-      if (configurationChanged) {
-        await config.update(
-          'codeActionsOnSave',
-          previousValue,
-          vscode.ConfigurationTarget.Workspace,
-        );
-      }
-    }
-  } finally {
-    // Close the editor tab so VSCode sends a synchronous didClose to the LSP,
-    // which cleans up the session overlay. Without this, the file deletion
-    // triggers an async didClose via the file watcher, which can race with
-    // the next test's LSP requests (all blocking methods are serialized).
-    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-    if (fs.existsSync(tmpFile)) {
-      fs.unlinkSync(tmpFile);
-    }
+async function finishTemporaryDocument(
+  testError: unknown,
+  document: vscode.TextDocument | undefined,
+  filePath: string,
+): Promise<void> {
+  const errors: unknown[] = [];
+  if (testError) errors.push(testError);
+
+  try {
+    await closeAndDeleteTemporaryDocument(document, filePath);
+  } catch (error) {
+    errors.push(error);
+  }
+
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'Test and temporary-file cleanup failed');
   }
 }

--- a/packages/vscode-extension/__tests__/suite/fixall-onsave.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-onsave.test.ts
@@ -1,11 +1,14 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
+import { getRslintDiagnostics } from '../utils/diagnostics';
+import { waitForCodeActionRegistryQuiescence } from '../utils/codeActionRegistry';
 import {
   waitForDiagnostics,
   waitForDiagnosticsCount,
   waitForContentChange,
   withOnSaveFixAll,
   replaceAll,
+  saveDocumentOnce,
 } from './fixall-helpers';
 
 function assertHasFixableDiagnostic(
@@ -36,8 +39,8 @@ suite('rslint fixAll - on-save', function () {
         const diags = await waitForDiagnostics(doc);
         assertHasFixableDiagnostic(diags, 'generic source.fixAll setup');
 
-        assert.ok(
-          await doc.save(),
+        await saveDocumentOnce(
+          doc,
           'Document should complete the generic source.fixAll save pipeline',
         );
         await waitForContentChange(
@@ -67,7 +70,7 @@ suite('rslint fixAll - on-save', function () {
       const diags = await waitForDiagnostics(doc);
       assertHasFixableDiagnostic(diags, 'fixable on-save setup');
 
-      assert.ok(await doc.save(), 'Fixable document should save');
+      await saveDocumentOnce(doc, 'Fixable document should save');
       await waitForContentChange(
         doc,
         (content) => !content.includes('saveVal as string'),
@@ -90,7 +93,7 @@ suite('rslint fixAll - on-save', function () {
       );
       const probeDiags = await waitForDiagnostics(doc);
       assertHasFixableDiagnostic(probeDiags, 'clean-file probe setup');
-      assert.ok(await doc.save(), 'Clean-file probe should save');
+      await saveDocumentOnce(doc, 'Clean-file probe should save');
       await waitForContentChange(
         doc,
         (content) => !content.includes('probeVal as string'),
@@ -107,7 +110,7 @@ suite('rslint fixAll - on-save', function () {
       await replaceAll(editor, cleanContent);
       await new Promise((r) => setTimeout(r, 3000));
 
-      assert.ok(await doc.save(), 'Clean document should save');
+      await saveDocumentOnce(doc, 'Clean document should save');
       await new Promise((r) => setTimeout(r, 2000));
 
       assert.strictEqual(
@@ -127,7 +130,7 @@ suite('rslint fixAll - on-save', function () {
       );
       const probeDiags = await waitForDiagnostics(doc);
       assertHasFixableDiagnostic(probeDiags, 'non-fixable probe setup');
-      assert.ok(await doc.save(), 'Non-fixable probe should save');
+      await saveDocumentOnce(doc, 'Non-fixable probe should save');
       await waitForContentChange(
         doc,
         (content) => !content.includes('probeVal2 as string'),
@@ -145,7 +148,7 @@ suite('rslint fixAll - on-save', function () {
       const diags = await waitForDiagnostics(doc);
       assert.ok(diags.length > 0, 'Should have non-fixable diagnostics');
 
-      assert.ok(await doc.save(), 'Non-fixable document should save');
+      await saveDocumentOnce(doc, 'Non-fixable document should save');
       await new Promise((r) => setTimeout(r, 2000));
 
       assert.strictEqual(
@@ -154,7 +157,7 @@ suite('rslint fixAll - on-save', function () {
         'Non-fixable file content should not change after on-save',
       );
 
-      const diagsAfter = vscode.languages.getDiagnostics(doc.uri);
+      const diagsAfter = getRslintDiagnostics(doc);
       assert.ok(
         diagsAfter.length > 0,
         'Non-fixable diagnostics should remain after save',
@@ -165,7 +168,7 @@ suite('rslint fixAll - on-save', function () {
   test('edit then immediately save (debounce not fired)', async () => {
     await withOnSaveFixAll(async (doc, editor) => {
       await replaceAll(editor, '// clean start\nexport {};\n');
-      assert.ok(await doc.save(), 'Initial clean document should save');
+      await saveDocumentOnce(doc, 'Initial clean document should save');
       const cleanDiagnostics = await waitForDiagnosticsCount(doc, 0);
       assert.strictEqual(
         cleanDiagnostics.length,
@@ -175,14 +178,21 @@ suite('rslint fixAll - on-save', function () {
           .join(' | ')}`,
       );
 
+      // Put the readiness delay before the edit. The save below intentionally
+      // follows the edit immediately, so this test cannot pass merely because
+      // the normal 1.5s registry barrier allowed the diagnostics debounce to
+      // fire. Any registry mutation in this tiny edit/save gap still makes the
+      // one-shot save fail rather than retrying it.
+      await waitForCodeActionRegistryQuiescence();
       await replaceAll(
         editor,
         "const quickVal: string = 'x';\nconst quickRes = (quickVal as string).trim();\n",
       );
 
-      assert.ok(
-        await doc.save(),
+      await saveDocumentOnce(
+        doc,
         'Edited document should complete the code-action-on-save pipeline',
+        async () => {},
       );
 
       // Event-driven wait — Windows CI needs more headroom than the previous

--- a/packages/vscode-extension/__tests__/suite/fixall.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall.test.ts
@@ -7,6 +7,7 @@ import {
   openFixture,
   findFixAllAction,
   requestFixAll,
+  replaceAll,
   withTmpFile,
 } from './fixall-helpers';
 
@@ -71,9 +72,42 @@ suite('rslint fixAll - code actions', function () {
   // ======== Tests that modify content (use tmp files) ========
 
   test('no action for clean file', async () => {
+    const fixableContent =
+      "const cleanProbe: string = 'hello';\nconst cleanResult = (cleanProbe as string).toUpperCase();\n";
     const cleanContent = '// no lint errors\nexport {};\n';
-    await withTmpFile(cleanContent, async (doc) => {
-      await waitForDiagnosticsCount(doc, 0);
+    await withTmpFile(fixableContent, async (doc, editor) => {
+      const initialDiagnostics = await waitForDiagnostics(doc, (diagnostics) =>
+        diagnostics.some((diagnostic) =>
+          diagnostic.message.includes('no-unnecessary-type-assertion'),
+        ),
+      );
+      assert.ok(
+        initialDiagnostics.some((diagnostic) =>
+          diagnostic.message.includes('no-unnecessary-type-assertion'),
+        ),
+        `Expected a fixable control diagnostic. Got: ${initialDiagnostics
+          .map((diagnostic) => diagnostic.message)
+          .join(' | ')}`,
+      );
+
+      const controlAction = findFixAllAction(await requestFixAll(doc));
+      assert.ok(
+        controlAction?.edit,
+        'Control state should provide fixAll edits',
+      );
+      const controlEdits = controlAction.edit.get(doc.uri);
+      assert.ok(
+        controlEdits && controlEdits.length > 0,
+        'Control state fixAll edit should not be empty',
+      );
+
+      await replaceAll(editor, cleanContent);
+      const cleanDiagnostics = await waitForDiagnosticsCount(doc, 0);
+      assert.strictEqual(
+        cleanDiagnostics.length,
+        0,
+        `Expected clean state to publish zero diagnostics, got ${cleanDiagnostics.length}`,
+      );
 
       const fixAllAction = findFixAllAction(await requestFixAll(doc));
 

--- a/packages/vscode-extension/__tests__/suite/registry-harness.test.ts
+++ b/packages/vscode-extension/__tests__/suite/registry-harness.test.ts
@@ -1,0 +1,280 @@
+import * as assert from 'assert';
+import { randomUUID } from 'node:crypto';
+import * as vscode from 'vscode';
+import {
+  CodeActionRegistryProbe,
+  saveDocumentOnce,
+  waitForConsecutiveSuccessfulProbeWindows,
+} from '../utils/codeActionRegistry';
+import { runBeforeDeadline } from '../utils/deadline';
+
+suite('VS Code test harness fail-closed guards', function () {
+  this.timeout(15_000);
+
+  test('an interrupted window resets consecutive readiness', async () => {
+    const outcomes = [true, false, true, true];
+    const result = await waitForConsecutiveSuccessfulProbeWindows(
+      async (attempt) => outcomes[attempt - 1] ?? false,
+      {
+        consecutiveSuccessfulWindows: 2,
+        timeoutMs: 1_000,
+        retryDelayMs: 0,
+        description: 'the injected readiness sequence',
+      },
+    );
+
+    assert.deepStrictEqual(result, {
+      attempts: 4,
+      interruptedWindows: 1,
+    });
+  });
+
+  test('continuous interruption times out instead of passing partially', async () => {
+    let attempts = 0;
+    await assert.rejects(
+      waitForConsecutiveSuccessfulProbeWindows(
+        async () => {
+          attempts += 1;
+          return false;
+        },
+        {
+          consecutiveSuccessfulWindows: 2,
+          timeoutMs: 50,
+          retryDelayMs: 5,
+          description: 'the continuously interrupted injected probe',
+        },
+      ),
+      /Timed out.*interruptedWindows=/,
+    );
+    assert.ok(attempts > 1, 'The probe should retry readiness windows');
+  });
+
+  test('a non-settling probe window is bounded by the hard deadline', async () => {
+    let attempts = 0;
+    let saveCalls = 0;
+    await assert.rejects(
+      saveDocumentOnce(
+        {
+          save: async () => {
+            saveCalls += 1;
+            return true;
+          },
+        },
+        'non-settling readiness failure',
+        () =>
+          waitForConsecutiveSuccessfulProbeWindows(
+            () => {
+              attempts += 1;
+              return new Promise<boolean>(() => {});
+            },
+            {
+              consecutiveSuccessfulWindows: 2,
+              timeoutMs: 50,
+              retryDelayMs: 0,
+              description: 'the non-settling injected probe',
+            },
+          ),
+      ),
+      /Timed out.*attempts=1/,
+    );
+    assert.strictEqual(attempts, 1);
+    assert.strictEqual(saveCalls, 0, 'A timed-out probe must block the save');
+  });
+
+  test('an unexpected probe error fails immediately and blocks save', async () => {
+    let attempts = 0;
+    let saveCalls = 0;
+    const readiness = () =>
+      waitForConsecutiveSuccessfulProbeWindows(
+        async () => {
+          attempts += 1;
+          throw new Error('unexpected probe failure');
+        },
+        {
+          consecutiveSuccessfulWindows: 2,
+          timeoutMs: 1_000,
+          retryDelayMs: 0,
+          description: 'the unexpectedly failing probe',
+        },
+      );
+
+    await assert.rejects(
+      saveDocumentOnce(
+        {
+          save: async () => {
+            saveCalls += 1;
+            return true;
+          },
+        },
+        'unexpected readiness failure',
+        readiness,
+      ),
+      /unexpected probe failure/,
+    );
+    assert.strictEqual(attempts, 1, 'Unexpected errors must not be retried');
+    assert.strictEqual(saveCalls, 0, 'An unexpected error must block the save');
+  });
+
+  test('a never-settling startup operation is bounded by its shared deadline', async () => {
+    let attempts = 0;
+    await assert.rejects(
+      runBeforeDeadline(
+        () => {
+          attempts += 1;
+          return new Promise<void>(() => {});
+        },
+        Date.now() + 50,
+        'the injected startup operation',
+      ),
+      /Timed out waiting for the injected startup operation.*shared startup deadline/,
+    );
+    assert.strictEqual(
+      attempts,
+      1,
+      'The startup operation must not be retried',
+    );
+  });
+
+  test('an expired startup deadline prevents the operation from starting', async () => {
+    let attempts = 0;
+    await assert.rejects(
+      runBeforeDeadline(
+        () => {
+          attempts += 1;
+        },
+        Date.now() - 1,
+        'the expired injected startup operation',
+      ),
+      /shared startup deadline has expired/,
+    );
+    assert.strictEqual(attempts, 0, 'Expired startup work must not begin');
+  });
+
+  test('readiness failure blocks save and a false save is never retried', async () => {
+    let saveCalls = 0;
+    const document = {
+      save: async () => {
+        saveCalls += 1;
+        return false;
+      },
+    };
+
+    await assert.rejects(
+      saveDocumentOnce(document, 'injected save failure', async () => {
+        throw new Error('injected readiness failure');
+      }),
+      /injected readiness failure/,
+    );
+    assert.strictEqual(
+      saveCalls,
+      0,
+      'A failed readiness probe must block save',
+    );
+
+    await assert.rejects(
+      saveDocumentOnce(document, 'injected save failure', async () => {}),
+      /returned false; the real save was not retried/,
+    );
+    assert.strictEqual(
+      saveCalls,
+      1,
+      'The real save must be invoked exactly once',
+    );
+  });
+
+  test('an unrelated delayed provider mutation interrupts vulnerable VS Code', async () => {
+    const probe = new CodeActionRegistryProbe();
+    let injected = false;
+    let unrelatedProvider: vscode.Disposable | undefined;
+    let resolveMutation: (() => void) | undefined;
+    const mutationCompleted = new Promise<void>((resolve) => {
+      resolveMutation = resolve;
+    });
+
+    try {
+      const result = await probe.wait({
+        quietWindowMs: 100,
+        consecutiveSuccessfulWindows: 2,
+        timeoutMs: 5_000,
+        retryDelayMs: 5,
+        onAttemptStarted: (attempt) => {
+          if (attempt !== 1 || injected) return;
+          injected = true;
+          setTimeout(() => {
+            unrelatedProvider = vscode.languages.registerCodeActionsProvider(
+              { scheme: `rslint-unrelated-${randomUUID()}` },
+              { provideCodeActions: () => [] },
+            );
+            setTimeout(() => {
+              unrelatedProvider?.dispose();
+              unrelatedProvider = undefined;
+              resolveMutation?.();
+            }, 10);
+          }, 20);
+        },
+      });
+      await mutationCompleted;
+
+      assert.ok(injected, 'The provider mutation must be injected in-flight');
+      if (result.interruptedWindows > 0) {
+        assert.ok(
+          result.attempts >= 3,
+          'A cancelled window must reset the two-window readiness sequence',
+        );
+      } else {
+        // Forward-compatible path: once VS Code fixes the registry comparison,
+        // unrelated providers no longer cancel the filtered request.
+        assert.strictEqual(result.attempts, 2);
+      }
+    } finally {
+      unrelatedProvider?.dispose();
+      probe.dispose();
+    }
+  });
+
+  test('a relevant delayed provider mutation always resets readiness', async () => {
+    const probe = new CodeActionRegistryProbe();
+    let relevantProvider: vscode.Disposable | undefined;
+    let mutationCompleted: Promise<void> | undefined;
+
+    try {
+      const result = await probe.wait({
+        quietWindowMs: 100,
+        consecutiveSuccessfulWindows: 2,
+        timeoutMs: 5_000,
+        retryDelayMs: 5,
+        onAttemptStarted: (attempt, probeUri) => {
+          if (attempt !== 1 || mutationCompleted) return;
+          mutationCompleted = new Promise<void>((resolve) => {
+            setTimeout(() => {
+              // No kind metadata means this provider is part of the filtered
+              // request on both vulnerable and fixed VS Code versions.
+              relevantProvider = vscode.languages.registerCodeActionsProvider(
+                { scheme: probeUri.scheme },
+                { provideCodeActions: () => [] },
+              );
+              setTimeout(() => {
+                relevantProvider?.dispose();
+                relevantProvider = undefined;
+                resolve();
+              }, 10);
+            }, 20);
+          });
+        },
+      });
+      await mutationCompleted;
+
+      assert.ok(
+        result.interruptedWindows > 0,
+        'A relevant registry mutation must interrupt an in-flight probe',
+      );
+      assert.ok(
+        result.attempts >= 3,
+        'The interrupted window must reset the two-window readiness sequence',
+      );
+    } finally {
+      relevantProvider?.dispose();
+      probe.dispose();
+    }
+  });
+});

--- a/packages/vscode-extension/__tests__/utils/codeActionRegistry.ts
+++ b/packages/vscode-extension/__tests__/utils/codeActionRegistry.ts
@@ -1,0 +1,304 @@
+import { randomUUID } from 'node:crypto';
+import * as vscode from 'vscode';
+
+const defaultQuietWindowMs = 750;
+const defaultSuccessfulWindows = 2;
+const defaultTimeoutMs = 60_000;
+const defaultRetryDelayMs = 25;
+
+export interface CodeActionRegistryProbeOptions {
+  quietWindowMs?: number;
+  consecutiveSuccessfulWindows?: number;
+  timeoutMs?: number;
+  retryDelayMs?: number;
+  /** Test-only hook. It runs after the probe provider receives the request. */
+  onAttemptStarted?: (attempt: number, probeUri: vscode.Uri) => void;
+}
+
+export interface CodeActionRegistryProbeResult {
+  attempts: number;
+  interruptedWindows: number;
+}
+
+interface ProbeLoopOptions {
+  consecutiveSuccessfulWindows: number;
+  timeoutMs: number;
+  retryDelayMs: number;
+  description: string;
+}
+
+interface SaveableDocument {
+  save(): Thenable<boolean>;
+}
+
+function delay(timeoutMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeoutMs));
+}
+
+export function isCodeActionCancellation(error: unknown): boolean {
+  return (
+    error instanceof vscode.CancellationError ||
+    (error instanceof Error &&
+      error.name === 'Canceled' &&
+      error.message === 'Canceled')
+  );
+}
+
+/**
+ * Require N consecutive successful readiness windows. A failed or cancelled
+ * window resets the count; timeout rejects instead of accepting a partial run.
+ * The executor is injectable so the fail-closed state machine can be tested
+ * without relying on a particular VS Code release's cancellation behavior.
+ */
+export async function waitForConsecutiveSuccessfulProbeWindows(
+  executeWindow: (attempt: number) => Promise<boolean>,
+  options: ProbeLoopOptions,
+): Promise<CodeActionRegistryProbeResult> {
+  if (options.consecutiveSuccessfulWindows < 1) {
+    throw new Error('consecutiveSuccessfulWindows must be at least 1');
+  }
+  if (options.timeoutMs < 1) {
+    throw new Error('timeoutMs must be at least 1');
+  }
+
+  const deadline = Date.now() + options.timeoutMs;
+  let attempts = 0;
+  let interruptedWindows = 0;
+  let successfulWindows = 0;
+
+  const timeoutError = (): Error =>
+    new Error(
+      `Timed out after ${options.timeoutMs}ms waiting for ${options.description}; ` +
+        `attempts=${attempts}, interruptedWindows=${interruptedWindows}`,
+    );
+
+  while (Date.now() < deadline) {
+    attempts += 1;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const remainingMs = Math.max(1, deadline - Date.now());
+    const hardTimeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => reject(timeoutError()), remainingMs);
+    });
+    let completed: boolean;
+    try {
+      completed = await Promise.race([executeWindow(attempts), hardTimeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+    if (Date.now() >= deadline) throw timeoutError();
+
+    if (completed) {
+      successfulWindows += 1;
+      if (successfulWindows >= options.consecutiveSuccessfulWindows) {
+        return { attempts, interruptedWindows };
+      }
+      continue;
+    }
+
+    interruptedWindows += 1;
+    successfulWindows = 0;
+    if (options.retryDelayMs > 0) {
+      await delay(
+        Math.min(options.retryDelayMs, Math.max(0, deadline - Date.now())),
+      );
+    }
+  }
+
+  throw timeoutError();
+}
+
+/**
+ * Public-API sentinel for VS Code's code-action provider registry.
+ *
+ * VS Code versions affected by microsoft/vscode's filtered-provider comparison
+ * bug cancel an in-flight source action whenever any provider is registered or
+ * disposed. Two providers match this private URI scheme, but only one matches
+ * the requested kind. That makes an unrelated registry mutation cancel this
+ * harmless request in exactly the same way it cancels code actions on save.
+ *
+ * Providers remain registered for the lifetime of the probe so their own
+ * disposal cannot race the real save. They match only a randomized private URI
+ * scheme and therefore never participate in normal test documents.
+ */
+export class CodeActionRegistryProbe implements vscode.Disposable {
+  private readonly probeKind: vscode.CodeActionKind;
+  private readonly documentPromise: Thenable<vscode.TextDocument>;
+  private readonly disposables: vscode.Disposable[];
+  private queue: Promise<void> = Promise.resolve();
+  private disposed = false;
+  private activeQuietWindowMs = defaultQuietWindowMs;
+  private activeAttempt = 0;
+  private activeAttemptHook:
+    | ((attempt: number, probeUri: vscode.Uri) => void)
+    | undefined;
+
+  constructor() {
+    const id = randomUUID().replaceAll('-', '');
+    const scheme = `rslint-registry-probe-${id}`;
+    const selector: vscode.DocumentSelector = { scheme };
+    this.probeKind = vscode.CodeActionKind.Source.append(
+      `rslintTest.registryProbe.${id}`,
+    );
+    const excludedKind = vscode.CodeActionKind.QuickFix.append(
+      `rslintTest.registryProbe.${id}`,
+    );
+
+    const contentProvider =
+      vscode.workspace.registerTextDocumentContentProvider(scheme, {
+        provideTextDocumentContent: () => '// registry probe\n',
+      });
+    const includedProvider = vscode.languages.registerCodeActionsProvider(
+      selector,
+      {
+        provideCodeActions: (document, _range, _context, token) =>
+          this.provideProbeAction(document.uri, token),
+      },
+      { providedCodeActionKinds: [this.probeKind] },
+    );
+    // This provider deliberately matches the document but not the requested
+    // kind. It exposes VS Code's filtered-vs-unfiltered registry comparison.
+    const excludedProvider = vscode.languages.registerCodeActionsProvider(
+      selector,
+      { provideCodeActions: () => [] },
+      { providedCodeActionKinds: [excludedKind] },
+    );
+
+    this.disposables = [excludedProvider, includedProvider, contentProvider];
+    this.documentPromise = vscode.workspace.openTextDocument(
+      vscode.Uri.parse(`${scheme}:/probe.ts`),
+    );
+  }
+
+  wait(
+    options: CodeActionRegistryProbeOptions = {},
+  ): Promise<CodeActionRegistryProbeResult> {
+    if (this.disposed) {
+      return Promise.reject(new Error('CodeActionRegistryProbe is disposed'));
+    }
+
+    const execution = this.queue.then(() => this.waitUnqueued(options));
+    this.queue = execution.then(
+      () => undefined,
+      () => undefined,
+    );
+    return execution;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const disposable of this.disposables) disposable.dispose();
+  }
+
+  private async waitUnqueued(
+    options: CodeActionRegistryProbeOptions,
+  ): Promise<CodeActionRegistryProbeResult> {
+    if (this.disposed) {
+      throw new Error('CodeActionRegistryProbe is disposed');
+    }
+
+    const document = await this.documentPromise;
+    const quietWindowMs = options.quietWindowMs ?? defaultQuietWindowMs;
+    if (quietWindowMs < 1) {
+      throw new Error('quietWindowMs must be at least 1');
+    }
+
+    this.activeQuietWindowMs = quietWindowMs;
+    this.activeAttemptHook = options.onAttemptStarted;
+    try {
+      return await waitForConsecutiveSuccessfulProbeWindows(
+        async (attempt) => {
+          this.activeAttempt = attempt;
+          let actions: vscode.CodeAction[] | undefined;
+          try {
+            actions = await vscode.commands.executeCommand<vscode.CodeAction[]>(
+              'vscode.executeCodeActionProvider',
+              document.uri,
+              new vscode.Range(0, 0, 0, 0),
+              this.probeKind.value,
+            );
+          } catch (error) {
+            if (isCodeActionCancellation(error)) return false;
+            throw error;
+          }
+          return Boolean(
+            actions?.some(
+              (action) => action.kind?.value === this.probeKind.value,
+            ),
+          );
+        },
+        {
+          consecutiveSuccessfulWindows:
+            options.consecutiveSuccessfulWindows ?? defaultSuccessfulWindows,
+          timeoutMs: options.timeoutMs ?? defaultTimeoutMs,
+          retryDelayMs: options.retryDelayMs ?? defaultRetryDelayMs,
+          description: 'the VS Code code-action registry to become quiescent',
+        },
+      );
+    } finally {
+      this.activeAttempt = 0;
+      this.activeAttemptHook = undefined;
+    }
+  }
+
+  private provideProbeAction(
+    probeUri: vscode.Uri,
+    token: vscode.CancellationToken,
+  ): Promise<vscode.CodeAction[]> {
+    const attempt = this.activeAttempt;
+    this.activeAttemptHook?.(attempt, probeUri);
+
+    return new Promise<vscode.CodeAction[]>((resolve, reject) => {
+      let settled = false;
+      let cancellation: vscode.Disposable | undefined;
+      const finish = (
+        actions: vscode.CodeAction[] | undefined,
+        error?: unknown,
+      ): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        cancellation?.dispose();
+        if (error) reject(error);
+        else resolve(actions ?? []);
+      };
+      const timer = setTimeout(() => {
+        finish([
+          new vscode.CodeAction('rslint test registry probe', this.probeKind),
+        ]);
+      }, this.activeQuietWindowMs);
+      cancellation = token.onCancellationRequested(() =>
+        finish(undefined, new vscode.CancellationError()),
+      );
+      if (token.isCancellationRequested) {
+        finish(undefined, new vscode.CancellationError());
+      }
+    });
+  }
+}
+
+let sharedProbe: CodeActionRegistryProbe | undefined;
+
+export function waitForCodeActionRegistryQuiescence(): Promise<CodeActionRegistryProbeResult> {
+  sharedProbe ??= new CodeActionRegistryProbe();
+  return sharedProbe.wait();
+}
+
+/**
+ * Wait for readiness, then invoke the real save exactly once. A false result is
+ * surfaced as a failure and is never retried, preventing a cancelled first save
+ * from being hidden by a successful second save.
+ */
+export async function saveDocumentOnce(
+  document: SaveableDocument,
+  failureMessage: string,
+  waitForReadiness: () => Promise<unknown> = waitForCodeActionRegistryQuiescence,
+): Promise<void> {
+  await waitForReadiness();
+  const saved = await document.save();
+  if (!saved) {
+    throw new Error(
+      `${failureMessage}: TextDocument.save() returned false; the real save was not retried`,
+    );
+  }
+}

--- a/packages/vscode-extension/__tests__/utils/configuration.ts
+++ b/packages/vscode-extension/__tests__/utils/configuration.ts
@@ -1,0 +1,213 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
+import * as vscode from 'vscode';
+
+type CodeActionsOnSave = Record<string, 'always' | 'explicit' | 'never'>;
+
+interface EventWaiter {
+  promise: Promise<boolean>;
+  dispose(): void;
+}
+
+interface WorkspaceSettingsSnapshot {
+  directoryPath: string;
+  directoryExisted: boolean;
+  filePath: string;
+  content: Buffer | undefined;
+}
+
+function captureWorkspaceSettings(
+  document: vscode.TextDocument,
+): WorkspaceSettingsSnapshot {
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+  if (!workspaceFolder) {
+    throw new Error(`No workspace folder contains ${document.uri.toString()}`);
+  }
+  const directoryPath = path.join(workspaceFolder.uri.fsPath, '.vscode');
+  const filePath = path.join(directoryPath, 'settings.json');
+  return {
+    directoryPath,
+    directoryExisted: fs.existsSync(directoryPath),
+    filePath,
+    content: fs.existsSync(filePath) ? fs.readFileSync(filePath) : undefined,
+  };
+}
+
+function restoreWorkspaceSettings(snapshot: WorkspaceSettingsSnapshot): void {
+  if (snapshot.content) {
+    fs.mkdirSync(snapshot.directoryPath, { recursive: true });
+    fs.writeFileSync(snapshot.filePath, snapshot.content);
+    if (!fs.readFileSync(snapshot.filePath).equals(snapshot.content)) {
+      throw new Error(
+        `Could not restore workspace settings: ${snapshot.filePath}`,
+      );
+    }
+    return;
+  }
+
+  if (fs.existsSync(snapshot.filePath)) fs.unlinkSync(snapshot.filePath);
+  if (!snapshot.directoryExisted && fs.existsSync(snapshot.directoryPath)) {
+    const entries = fs.readdirSync(snapshot.directoryPath);
+    if (entries.length === 0) fs.rmdirSync(snapshot.directoryPath);
+  }
+  if (fs.existsSync(snapshot.filePath)) {
+    throw new Error(
+      `Could not remove generated settings: ${snapshot.filePath}`,
+    );
+  }
+}
+
+function configurationEventWaiter(
+  section: string,
+  scope: vscode.ConfigurationScope,
+  timeoutMs = 10_000,
+): EventWaiter {
+  let finish: (observed: boolean) => void;
+  let settled = false;
+  const promise = new Promise<boolean>((resolve) => {
+    finish = (observed) => {
+      if (settled) return;
+      settled = true;
+      subscription.dispose();
+      clearTimeout(timer);
+      resolve(observed);
+    };
+  });
+  const subscription = vscode.workspace.onDidChangeConfiguration((event) => {
+    if (event.affectsConfiguration(section, scope)) finish(true);
+  });
+  const timer = setTimeout(() => finish(false), timeoutMs);
+  return { promise, dispose: () => finish(false) };
+}
+
+async function updateWorkspaceLanguageValue(
+  document: vscode.TextDocument,
+  value: CodeActionsOnSave | undefined,
+): Promise<void> {
+  const section = 'editor.codeActionsOnSave';
+  const scope = { uri: document.uri, languageId: document.languageId };
+  const configuration = vscode.workspace.getConfiguration('editor', scope);
+  if (
+    isDeepStrictEqual(
+      configuration.inspect<CodeActionsOnSave>('codeActionsOnSave')
+        ?.workspaceLanguageValue,
+      value,
+    )
+  ) {
+    return;
+  }
+
+  const waiter = configurationEventWaiter(section, scope);
+  try {
+    await configuration.update(
+      'codeActionsOnSave',
+      value,
+      vscode.ConfigurationTarget.Workspace,
+      true,
+    );
+    if (!(await waiter.promise)) {
+      throw new Error(`No configuration change event received for ${section}`);
+    }
+  } finally {
+    waiter.dispose();
+  }
+}
+
+/**
+ * Set the resource/language-specific on-save value and restore the exact prior
+ * workspace-language value. Never writes an inherited effective value back to
+ * workspace settings.
+ */
+export async function withCodeActionsOnSave<T>(
+  document: vscode.TextDocument,
+  value: CodeActionsOnSave,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const scope = { uri: document.uri, languageId: document.languageId };
+  const configuration = vscode.workspace.getConfiguration('editor', scope);
+  const inspection =
+    configuration.inspect<CodeActionsOnSave>('codeActionsOnSave');
+  if (!inspection) {
+    throw new Error('editor.codeActionsOnSave is unavailable');
+  }
+
+  const previousEffective =
+    configuration.get<CodeActionsOnSave>('codeActionsOnSave');
+  const previousWorkspaceLanguageValue = inspection.workspaceLanguageValue;
+  const changed = !isDeepStrictEqual(previousEffective, value);
+  const settingsSnapshot = changed
+    ? captureWorkspaceSettings(document)
+    : undefined;
+
+  let result: T | undefined;
+  let callbackCompleted = false;
+  let callbackError: unknown;
+  try {
+    if (changed) {
+      await updateWorkspaceLanguageValue(document, value);
+      const effective = vscode.workspace
+        .getConfiguration('editor', scope)
+        .get<CodeActionsOnSave>('codeActionsOnSave');
+      if (!isDeepStrictEqual(effective, value)) {
+        throw new Error(
+          'editor.codeActionsOnSave did not resolve to the requested test value',
+        );
+      }
+    }
+    result = await callback();
+    callbackCompleted = true;
+  } catch (error) {
+    callbackError = error;
+  }
+
+  const restoreErrors: unknown[] = [];
+  if (changed) {
+    try {
+      await updateWorkspaceLanguageValue(
+        document,
+        previousWorkspaceLanguageValue,
+      );
+      const restored = vscode.workspace
+        .getConfiguration('editor', scope)
+        .get<CodeActionsOnSave>('codeActionsOnSave');
+      if (!isDeepStrictEqual(restored, previousEffective)) {
+        throw new Error(
+          'editor.codeActionsOnSave was not restored to its prior effective value',
+        );
+      }
+    } catch (error) {
+      restoreErrors.push(error);
+    }
+    if (!settingsSnapshot) {
+      restoreErrors.push(new Error('Workspace settings snapshot is missing'));
+    } else {
+      try {
+        restoreWorkspaceSettings(settingsSnapshot);
+      } catch (error) {
+        restoreErrors.push(error);
+      }
+    }
+  }
+
+  const restoreError =
+    restoreErrors.length > 1
+      ? new AggregateError(
+          restoreErrors,
+          'Multiple editor.codeActionsOnSave restoration steps failed',
+        )
+      : restoreErrors[0];
+
+  if (callbackError && restoreError) {
+    throw new AggregateError(
+      [callbackError, restoreError],
+      'Test callback and editor.codeActionsOnSave restoration both failed',
+    );
+  }
+  if (callbackError) throw callbackError;
+  if (restoreError) throw restoreError;
+  if (!callbackCompleted) {
+    throw new Error('editor.codeActionsOnSave callback did not complete');
+  }
+  return result as T;
+}

--- a/packages/vscode-extension/__tests__/utils/deadline.ts
+++ b/packages/vscode-extension/__tests__/utils/deadline.ts
@@ -1,0 +1,37 @@
+/**
+ * Run one asynchronous startup step within a shared absolute deadline.
+ * A never-settling operation rejects at the deadline instead of hanging the
+ * Extension Host before Mocha (and its per-test timeouts) has started.
+ */
+export async function runBeforeDeadline<T>(
+  operation: () => T | PromiseLike<T>,
+  deadline: number,
+  description: string,
+): Promise<T> {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) {
+    throw new Error(
+      `Timed out waiting for ${description}: the shared startup deadline has expired`,
+    );
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve().then(operation),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `Timed out waiting for ${description} before the shared startup deadline`,
+              ),
+            ),
+          remainingMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/vscode-extension/__tests__/utils/diagnostics.ts
+++ b/packages/vscode-extension/__tests__/utils/diagnostics.ts
@@ -1,0 +1,98 @@
+import * as vscode from 'vscode';
+
+export const rslintDiagnosticSource = 'rslint';
+
+export function getRslintDiagnostics(
+  documentOrUri: vscode.TextDocument | vscode.Uri,
+): vscode.Diagnostic[] {
+  const uri =
+    documentOrUri instanceof vscode.Uri ? documentOrUri : documentOrUri.uri;
+  return vscode.languages
+    .getDiagnostics(uri)
+    .filter((diagnostic) => diagnostic.source === rslintDiagnosticSource);
+}
+
+function describeDiagnostics(
+  diagnostics: readonly vscode.Diagnostic[],
+): string {
+  if (diagnostics.length === 0) return '<none>';
+  return diagnostics
+    .map(
+      (diagnostic) =>
+        `${diagnostic.source ?? '<no source>'}: ${diagnostic.message}`,
+    )
+    .join(' | ');
+}
+
+/** Subscribe before the initial read, filter by source, and reject on timeout. */
+export function waitForRslintDiagnostics(
+  document: vscode.TextDocument,
+  predicate: (diagnostics: vscode.Diagnostic[]) => boolean = (diagnostics) =>
+    diagnostics.length > 0,
+  timeoutMs = 60_000,
+): Promise<vscode.Diagnostic[]> {
+  return new Promise<vscode.Diagnostic[]>((resolve, reject) => {
+    const uriString = document.uri.toString();
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (
+      diagnostics: vscode.Diagnostic[] | undefined,
+      error?: unknown,
+    ): void => {
+      if (settled) return;
+      settled = true;
+      subscription.dispose();
+      if (timer) clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(diagnostics ?? []);
+    };
+    const check = (): void => {
+      const diagnostics = getRslintDiagnostics(document);
+      try {
+        if (predicate(diagnostics)) finish(diagnostics);
+      } catch (error) {
+        finish(undefined, error);
+      }
+    };
+    const subscription = vscode.languages.onDidChangeDiagnostics((event) => {
+      if (event.uris.some((uri) => uri.toString() === uriString)) check();
+    });
+
+    timer = setTimeout(() => {
+      const diagnostics = getRslintDiagnostics(document);
+      finish(
+        undefined,
+        new Error(
+          `Timed out after ${timeoutMs}ms waiting for rslint diagnostics for ${document.uri.toString()}. ` +
+            `Last rslint diagnostics: ${describeDiagnostics(diagnostics)}`,
+        ),
+      );
+    }, timeoutMs);
+    check();
+  });
+}
+
+export function waitForRslintDiagnosticsToChange(
+  document: vscode.TextDocument,
+  previousCount: number,
+  timeoutMs = 30_000,
+): Promise<vscode.Diagnostic[]> {
+  return waitForRslintDiagnostics(
+    document,
+    (diagnostics) => diagnostics.length !== previousCount,
+    timeoutMs,
+  );
+}
+
+export function waitForRslintDiagnosticsCount(
+  document: vscode.TextDocument,
+  expectedCount: number,
+  timeoutMs = 30_000,
+): Promise<vscode.Diagnostic[]> {
+  return waitForRslintDiagnostics(
+    document,
+    (diagnostics) => diagnostics.length === expectedCount,
+    timeoutMs,
+  );
+}

--- a/packages/vscode-extension/__tests__/utils/documents.ts
+++ b/packages/vscode-extension/__tests__/utils/documents.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import * as vscode from 'vscode';
+
+export function temporaryFilePath(
+  directory: string,
+  prefix: string,
+  extension = '.ts',
+): string {
+  return path.join(directory, `${prefix}${randomUUID()}${extension}`);
+}
+
+async function focusTextDocument(document: vscode.TextDocument): Promise<void> {
+  await vscode.window.showTextDocument(document, {
+    preview: false,
+    preserveFocus: false,
+  });
+  if (
+    vscode.window.activeTextEditor?.document.uri.toString() !==
+    document.uri.toString()
+  ) {
+    throw new Error(`Could not focus document: ${document.uri}`);
+  }
+}
+
+export async function revertTextDocument(
+  document: vscode.TextDocument | undefined,
+): Promise<void> {
+  if (!document || document.isClosed) return;
+  if (!document.isDirty) return;
+  await focusTextDocument(document);
+  await vscode.commands.executeCommand('workbench.action.files.revert');
+  if (document.isDirty) {
+    throw new Error(`Could not revert dirty document: ${document.uri}`);
+  }
+}
+
+/** Close the exact editor tab. VS Code may retain its TextDocument model. */
+export async function closeTextEditor(
+  document: vscode.TextDocument | undefined,
+): Promise<void> {
+  if (!document || document.isClosed) return;
+  await focusTextDocument(document);
+  await revertTextDocument(document);
+  await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+  if (
+    vscode.window.activeTextEditor?.document.uri.toString() ===
+    document.uri.toString()
+  ) {
+    throw new Error(`Could not close editor tab: ${document.uri}`);
+  }
+}
+
+export function deleteTemporaryFile(filePath: string): void {
+  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+}
+
+/** Close/revert the exact tab, delete its unique file, and verify deletion. */
+export async function closeAndDeleteTemporaryDocument(
+  document: vscode.TextDocument | undefined,
+  filePath: string,
+): Promise<void> {
+  const errors: unknown[] = [];
+  try {
+    await closeTextEditor(document);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    deleteTemporaryFile(filePath);
+  } catch (error) {
+    errors.push(error);
+  }
+  if (fs.existsSync(filePath)) {
+    errors.push(
+      new Error(`Temporary file still exists after delete: ${filePath}`),
+    );
+  }
+
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'Temporary document cleanup failed');
+  }
+}


### PR DESCRIPTION
## Summary

- Stabilize VS Code integration tests against lazy code-action provider registration without pinning a VS Code version.
- Activate and probe required providers before tests, wait for registry quiescence, and keep real saves single-shot so cancellation or `save() === false` fails instead of being retried.
- Add shared startup deadlines and fault-injection coverage for cancellation, registry churn, never-settling operations, and expired deadlines.
- Run every suite with isolated workspace/profile state, restore settings and fixtures exactly, and cache only immutable VS Code distributions.
- Tighten diagnostics and code-action assertions so empty initial states, intermediate states, missing actions, and cleanup failures cannot produce a false green.

Validation:
- `pnpm --filter rslint test` — 82 passing
- `pnpm check-spell`
- `pnpm format:check`
- scoped `lint:go` — no changed Go files relative to `origin/main`
- `pnpm typecheck`, `pnpm lint`, and `git diff --check`

## Related Links

- Follow-up to #1266

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
