### PR TITLE
feat(eslint-plugin-jest): add `no-interpolation-in-snapshots` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -16,6 +16,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_focused_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_hooks"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_identical_title"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_interpolation_in_snapshots"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_jasmine_globals"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_mocks_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_restricted_jest_methods"
@@ -62,6 +63,7 @@ func GetAllRules() []rule.Rule {
 		no_focused_tests.NoFocusedTestsRule,
 		no_hooks.NoHooksRule,
 		no_identical_title.NoIdenticalTitleRule,
+		no_interpolation_in_snapshots.NoInterpolationInSnapshotsRule,
 		no_jasmine_globals.NoJasmineGlobalsRule,
 		no_mocks_import.NoMocksImportRule,
 		no_restricted_jest_methods.NoRestrictedJestMethodsRule,

--- a/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
+++ b/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
@@ -19,16 +19,15 @@ var NoInterpolationInSnapshotsRule = rule.Rule{
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
 				jestFnCall := utils.ParseJestFnCall(node, ctx)
-				if jestFnCall == nil || jestFnCall.Kind != utils.JestFnTypeExpect {
-					return
-				}
 
-				if !utils.INLINE_SNAPSHOT_MATCHERS[jestFnCall.Matcher] {
+				if jestFnCall == nil ||
+					jestFnCall.Kind != utils.JestFnTypeExpect ||
+					!utils.INLINE_SNAPSHOT_MATCHERS[jestFnCall.Matcher] {
 					return
 				}
 
 				for _, arg := range node.Arguments() {
-					if arg != nil && arg.Kind == ast.KindTemplateExpression {
+					if arg := ast.SkipParentheses(arg); arg != nil && arg.Kind == ast.KindTemplateExpression {
 						ctx.ReportNode(arg, buildNoInterpolationMessage())
 					}
 				}

--- a/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
+++ b/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
@@ -1,0 +1,38 @@
+package no_interpolation_in_snapshots
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func buildNoInterpolationMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noInterpolation",
+		Description: "Do not use string interpolation inside of snapshots",
+	}
+}
+
+var NoInterpolationInSnapshotsRule = rule.Rule{
+	Name: "jest/no-interpolation-in-snapshots",
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				jestFnCall := utils.ParseJestFnCall(node, ctx)
+				if jestFnCall == nil || jestFnCall.Kind != utils.JestFnTypeExpect {
+					return
+				}
+
+				if !utils.INLINE_SNAPSHOT_MATCHERS[jestFnCall.Matcher] {
+					return
+				}
+
+				for _, arg := range node.Arguments() {
+					if arg != nil && arg.Kind == ast.KindTemplateExpression {
+						ctx.ReportNode(arg, buildNoInterpolationMessage())
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
+++ b/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.md
@@ -1,0 +1,56 @@
+# no-interpolation-in-snapshots
+
+## Rule Details
+
+Disallow string interpolation inside inline snapshots. Interpolation prevents Jest from updating snapshots; instead, overload dynamic properties with a matcher via [property matchers](https://jestjs.io/docs/snapshot-testing#property-matchers).
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+expect(something).toMatchInlineSnapshot(
+  `Object {
+    property: ${interpolated}
+  }`,
+);
+
+expect(something).toMatchInlineSnapshot(
+  { other: expect.any(Number) },
+  `Object {
+    other: Any<Number>,
+    property: ${interpolated}
+  }`,
+);
+
+expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
+  `${interpolated}`,
+);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+expect(something).toMatchInlineSnapshot();
+
+expect(something).toMatchInlineSnapshot(
+  `Object {
+    property: 1
+  }`,
+);
+
+expect(something).toMatchInlineSnapshot(
+  { property: expect.any(Date) },
+  `Object {
+    property: Any<Date>
+  }`,
+);
+
+expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot();
+
+expect(errorThrowingFunction).toThrowErrorMatchingInlineSnapshot(
+  `Error Message`,
+);
+```
+
+## Original Documentation
+
+- [jest/no-interpolation-in-snapshots](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md)

--- a/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots_test.go
+++ b/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots_test.go
@@ -1,0 +1,120 @@
+package no_interpolation_in_snapshots_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_interpolation_in_snapshots"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoInterpolationInSnapshotsRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_interpolation_in_snapshots.NoInterpolationInSnapshotsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect("something").toEqual("else");`},
+			{Code: `expect(something).toMatchInlineSnapshot();`},
+			{Code: "expect(something).toMatchInlineSnapshot(`No interpolation`);"},
+			{Code: "expect(something).toMatchInlineSnapshot({}, `No interpolation`);"},
+			{Code: `expect(something);`},
+			{Code: `expect(something).not;`},
+			{Code: `expect.toHaveAssertions();`},
+			{Code: "myObjectWants.toMatchInlineSnapshot({}, `${interpolated}`);"},
+			{Code: "myObjectWants.toMatchInlineSnapshot({}, `${interpolated1} ${interpolated2}`);"},
+			{Code: "toMatchInlineSnapshot({}, `${interpolated}`);"},
+			{Code: "toMatchInlineSnapshot({}, `${interpolated1} ${interpolated2}`);"},
+			{Code: `expect(something).toThrowErrorMatchingInlineSnapshot();`},
+			{Code: "expect(something).toThrowErrorMatchingInlineSnapshot(`No interpolation`);"},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: "expect(something).toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    41,
+						EndColumn: 58,
+					},
+				},
+			},
+			{
+				Code: "expect(something).not.toMatchInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    45,
+						EndColumn: 62,
+					},
+				},
+			},
+			{
+				Code: "expect(something).toMatchInlineSnapshot({}, `${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    45,
+						EndColumn: 62,
+					},
+				},
+			},
+			{
+				Code: "expect(something).not.toMatchInlineSnapshot({}, `${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    49,
+						EndColumn: 66,
+					},
+				},
+			},
+			{
+				Code: "expect(something).toThrowErrorMatchingInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    54,
+						EndColumn: 71,
+					},
+				},
+			},
+			{
+				Code: "expect(something).not.toThrowErrorMatchingInlineSnapshot(`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    58,
+						EndColumn: 75,
+					},
+				},
+			},
+			{
+				Code: "expect(something).toMatchInlineSnapshot(`${first}`, `${second}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    41,
+						EndColumn: 51,
+					},
+					{
+						MessageId: "noInterpolation",
+						Column:    53,
+						EndColumn: 64,
+					},
+				},
+			},
+			{
+				Code: "expect(something)[\"toMatchInlineSnapshot\"](`${interpolated}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noInterpolation",
+						Column:    44,
+						EndColumn: 61,
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/jest/utils/jest.go
+++ b/internal/plugins/jest/utils/jest.go
@@ -56,6 +56,11 @@ var EQUALITY_METHOD_NAMES = map[string]bool{
 	"toStrictEqual": true,
 }
 
+var INLINE_SNAPSHOT_MATCHERS = map[string]bool{
+	"toMatchInlineSnapshot":              true,
+	"toThrowErrorMatchingInlineSnapshot": true,
+}
+
 var EXPECT_MODIFIER_NAMES = map[string]bool{
 	"not":      true,
 	"rejects":  true,

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -502,6 +502,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/no-focused-tests.test.ts',
     './tests/eslint-plugin-jest/rules/no-hooks.test.ts',
     './tests/eslint-plugin-jest/rules/no-identical-title.test.ts',
+    './tests/eslint-plugin-jest/rules/no-interpolation-in-snapshots.test.ts',
     './tests/eslint-plugin-jest/rules/no-jasmine-globals.test.ts',
     './tests/eslint-plugin-jest/rules/no-mocks-import.test.ts',
     './tests/eslint-plugin-jest/rules/no-restricted-jest-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-interpolation-in-snapshots.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/no-interpolation-in-snapshots.test.ts
@@ -1,0 +1,91 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-interpolation-in-snapshots', {} as never, {
+  valid: [
+    { code: 'expect("something").toEqual("else");' },
+    { code: 'expect(something).toMatchInlineSnapshot();' },
+    { code: 'expect(something).toMatchInlineSnapshot(`No interpolation`);' },
+    {
+      code: 'expect(something).toMatchInlineSnapshot({}, `No interpolation`);',
+    },
+    { code: 'expect(something);' },
+    { code: 'expect(something).not;' },
+    { code: 'expect.toHaveAssertions();' },
+    { code: 'myObjectWants.toMatchInlineSnapshot({}, `${interpolated}`);' },
+    {
+      code: 'myObjectWants.toMatchInlineSnapshot({}, `${interpolated1} ${interpolated2}`);',
+    },
+    { code: 'toMatchInlineSnapshot({}, `${interpolated}`);' },
+    {
+      code: 'toMatchInlineSnapshot({}, `${interpolated1} ${interpolated2}`);',
+    },
+    { code: 'expect(something).toThrowErrorMatchingInlineSnapshot();' },
+    {
+      code: 'expect(something).toThrowErrorMatchingInlineSnapshot(`No interpolation`);',
+    },
+  ],
+  invalid: [
+    {
+      code: 'expect(something).toMatchInlineSnapshot(`${interpolated}`);',
+      errors: [
+        {
+          endColumn: 58,
+          column: 41,
+          messageId: 'noInterpolation',
+        },
+      ],
+    },
+    {
+      code: 'expect(something).not.toMatchInlineSnapshot(`${interpolated}`);',
+      errors: [
+        {
+          endColumn: 62,
+          column: 45,
+          messageId: 'noInterpolation',
+        },
+      ],
+    },
+    {
+      code: 'expect(something).toMatchInlineSnapshot({}, `${interpolated}`);',
+      errors: [
+        {
+          endColumn: 62,
+          column: 45,
+          messageId: 'noInterpolation',
+        },
+      ],
+    },
+    {
+      code: 'expect(something).not.toMatchInlineSnapshot({}, `${interpolated}`);',
+      errors: [
+        {
+          endColumn: 66,
+          column: 49,
+          messageId: 'noInterpolation',
+        },
+      ],
+    },
+    {
+      code: 'expect(something).toThrowErrorMatchingInlineSnapshot(`${interpolated}`);',
+      errors: [
+        {
+          endColumn: 71,
+          column: 54,
+          messageId: 'noInterpolation',
+        },
+      ],
+    },
+    {
+      code: 'expect(something).not.toThrowErrorMatchingInlineSnapshot(`${interpolated}`);',
+      errors: [
+        {
+          endColumn: 75,
+          column: 58,
+          messageId: 'noInterpolation',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/rslint/src/config/presets/jest.ts
+++ b/packages/rslint/src/config/presets/jest.ts
@@ -15,7 +15,7 @@ const recommended: RslintConfigEntry = {
     'jest/no-export': 'error',
     'jest/no-focused-tests': 'error',
     'jest/no-identical-title': 'error',
-    // 'jest/no-interpolation-in-snapshots': 'error', // not implemented
+    'jest/no-interpolation-in-snapshots': 'error',
     'jest/no-jasmine-globals': 'error',
     'jest/no-mocks-import': 'error',
     'jest/no-standalone-expect': 'error',


### PR DESCRIPTION
## Summary

Port `no-interpolation-in-snapshots` from eslint-plugin-jest to rslint

## Related Links

<!--- Provide links of related issues or pages -->
Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/no-interpolation-in-snapshots [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-interpolation-in-snapshots.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/no-interpolation-in-snapshots.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
