### PR TITLE
refactor: remove duplicate JS config filename list

### DIFF
--- a/packages/rslint/src/config/config-file-loader.ts
+++ b/packages/rslint/src/config/config-file-loader.ts
@@ -4,14 +4,6 @@ import { pathToFileURL } from 'node:url';
 import { NATIVE_PLUGIN_RESERVED_NAMES } from './define-config.js';
 import { selectPluginSource, unwrapPluginModule } from './plugin-source.js';
 
-/** Config basenames eligible for automatic discovery. */
-export const JS_CONFIG_FILES = [
-  'rslint.config.js',
-  'rslint.config.mjs',
-  'rslint.config.ts',
-  'rslint.config.mts',
-] as const;
-
 let freshConfigLoadNonce = 0;
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/rslint/src/config/config-loader.ts
+++ b/packages/rslint/src/config/config-loader.ts
@@ -5,7 +5,6 @@
  * helpers directly so this facade can expose both APIs without an ESM cycle.
  */
 export {
-  JS_CONFIG_FILES,
   collectPluginMeta,
   loadConfigFile,
   loadConfigFileFresh,

--- a/packages/vscode-extension/__tests__/suite-jsconfig/config-transaction.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/config-transaction.test.ts
@@ -223,7 +223,11 @@ function loadRequest(transactionId = 'tx-1'): LoadConfigsRequest {
 
 suite('LSP config discovery transactions', () => {
   test('the extension watcher leaves gitignore ownership to Go', () => {
+    assert.match(CONFIG_REFRESH_WATCH_GLOB, /rslint\.config\.js/);
     assert.match(CONFIG_REFRESH_WATCH_GLOB, /rslint\.config\.mjs/);
+    assert.match(CONFIG_REFRESH_WATCH_GLOB, /rslint\.config\.ts/);
+    assert.match(CONFIG_REFRESH_WATCH_GLOB, /rslint\.config\.mts/);
+    assert.doesNotMatch(CONFIG_REFRESH_WATCH_GLOB, /rslint\.config\.\*/);
     assert.match(CONFIG_REFRESH_WATCH_GLOB, /rslint\.jsonc/);
     assert.match(CONFIG_REFRESH_WATCH_GLOB, /pnpm-lock\.yaml/);
     assert.doesNotMatch(CONFIG_REFRESH_WATCH_GLOB, /\.gitignore/);

--- a/packages/vscode-extension/src/Rslint.ts
+++ b/packages/vscode-extension/src/Rslint.ts
@@ -25,7 +25,6 @@ import fs from 'node:fs';
 import {
   CONFIG_DISCOVERY_PROTOCOL_VERSION,
   ConfigModuleHost,
-  JS_CONFIG_FILES,
   type ActivateConfigsRequest,
   type ConfigModuleActivationPlan,
   type LoadConfigsRequest,
@@ -48,12 +47,7 @@ const LOCKFILE_NAMES = [
   'yarn.lock',
 ] as const;
 
-export const CONFIG_REFRESH_WATCH_GLOB = `**/{${[
-  ...JS_CONFIG_FILES,
-  'rslint.json',
-  'rslint.jsonc',
-  ...LOCKFILE_NAMES,
-].join(',')}}`;
+export const CONFIG_REFRESH_WATCH_GLOB = `**/{rslint.config.js,rslint.config.mjs,rslint.config.ts,rslint.config.mts,rslint.json,rslint.jsonc,${LOCKFILE_NAMES.join(',')}}`;
 
 export type ConfigRefreshReason =
   | 'initial'


### PR DESCRIPTION
## Summary

- Keep automatic JS/TS config filename discovery authoritative in Go and remove the unused JS_CONFIG_FILES export.
- Keep the VS Code config refresh watcher scoped to the exact supported .js, .mjs, .ts, and .mts config filenames.
- Add regression assertions for every supported filename and guard against a broad rslint.config.* watcher.

Validation:
- pnpm run check-spell
- pnpm run format:check
- Scoped Go lint: no changed Go files relative to origin/main
- pnpm --filter @rslint/core run build:js
- pnpm typecheck
- pnpm --filter ./packages/vscode-extension test — 98 passing

## Related Links

- Follow-up to #1276

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).