### PR TITLE
fix: align import preset with upstream

### DIFF
--- a/packages/rslint/src/config/presets/import.ts
+++ b/packages/rslint/src/config/presets/import.ts
@@ -8,13 +8,13 @@ const recommended: RslintConfigEntry = {
     // errors
     // 'import/no-unresolved': 'error', // not implemented
     // 'import/named': 'error', // not implemented
-    // 'import/namespace': 'error', // not implemented
-    // 'import/default': 'error', // not implemented
+    'import/namespace': 'error',
+    'import/default': 'error',
     // 'import/export': 'error', // not implemented
     // warnings
     // 'import/no-named-as-default': 'warn', // not implemented
     // 'import/no-named-as-default-member': 'warn', // not implemented
-    // 'import/no-duplicates': 'warn', // not implemented
+    'import/no-duplicates': 'warn',
   },
 };
 


### PR DESCRIPTION
## Summary

- Enable three eslint-plugin-import recommended rules that are now available in rslint.
- Keep the upstream severities for namespace, default, and no-duplicates.

## Related Links

- https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/config/recommended.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).