### PR TITLE
fix(vscode): complete multi-root lifecycle ownership

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -549,9 +549,42 @@ The transport and target phase differ by surface:
   do not require that handler. Every long-lived API call uses a
   fresh entry-module load so rewritten config bytes cannot be paired with stale
   normalized exports or a newer plugin-worker topology.
-- The extension binds each language client and its document selectors to one VS
-  Code workspace folder, starts `rslint/configRefresh`, and Go scans that
-  process cwd with a transaction-scoped cached VFS. Go sends
+- The extension owns shared UI, commands, and output channels once. Its
+  `WorkspaceRslintCoordinator` keys desired and active roots by workspace-folder
+  URI (not display name), subscribes to folder changes before awaiting any root,
+  and independently starts or closes one `Rslint` runtime per URI generation.
+  One slow or failed root therefore cannot serialize healthy roots; terminal
+  shutdown still attempts every per-root close before releasing shared
+  resources. If an old generation does not confirm that it closed, its URI slot
+  remains quarantined: no replacement starts, and the retained error is
+  included in terminal shutdown. Each runtime owns its native server children,
+  config watcher, transaction adapter, plugin pool, request handlers, and
+  workspace logger. A process owner covers automatic LanguageClient restarts,
+  terminates any still-live prior child before a restart spawn, blocks new
+  spawns once closing begins, and awaits stdio close after bounded forced
+  termination of any child that survives protocol shutdown. A closing-aware
+  client error handler forbids restart, and per-root close waits for the pending
+  initialize/state tail before extension-wide channels are released.
+- Every runtime keeps a workspace-relative document selector, while
+  `WorkspaceDocumentRouter` is the single authority for overlapping selectors.
+  Among ready roots it assigns an open supported document to the longest
+  matching URI root. A root activation or removal performs an ordered
+  `didClose`/diagnostic-clear/`didOpen` handoff using the document's current
+  in-memory text, without requiring the editor to close. Middleware admits
+  changes, saves, diagnostics, and code actions only for the exact active
+  runtime that currently owns the server-open document. Exact runtime identity
+  rejects diagnostics from a replaced same-URI client, while a document epoch
+  rejects code actions that finish after an ownership change. When the
+  LanguageClient automatically restarts a native server, the router invalidates
+  every recorded server-open session for that runtime—including documents that
+  closed during the feature-listener gap—before LanguageClient replays
+  `didOpen`, so the replacement process receives every still-open document
+  exactly once and a later same-URI reopen cannot inherit stale ownership. The
+  reset is queued as soon as a running transport exits and repeated at the next
+  `Running` transition; root removal also drains any exact-runtime session that
+  disappeared from VS Code's open-document list during that gap.
+- Each root starts `rslint/configRefresh`, and Go scans that process cwd with a
+  transaction-scoped cached VFS. Go sends
   `rslint/loadConfigs` and
   `rslint/activateConfigs`, then commits or aborts the matching plugin-host state
   through `rslint/commitConfigs` / `rslint/abortConfigs`. `fresh` loads cache-bust the config entry
@@ -1054,11 +1087,14 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 │                                LSP PATH                                      │
 ├──────────────────────────────────────────────────────────────────────────────┤
 │                                                                              │
-│  VS Code Extension                                                           │
-│     └───────────────► rslint/configRefresh ────────────────┐                 │
+│  VS Code Extension (shared UI / channels)                                   │
+│     ├── WorkspaceRslintCoordinator (URI identity + generations)             │
+│     ├── WorkspaceDocumentRouter (longest-ready-root ownership)               │
+│     └── Rslint runtime per active root                                       │
+│             └──────── rslint/configRefresh ────────────────┐                 │
 │             ◄──────── load / activate / commit / abort     │                 │
 │                                                            ▼                 │
-│                                                   cmd/rslint --lsp            │
+│                                             cmd/rslint --lsp per root         │
 │     │                                                                        │
 │     ▼                                                                        │
 │  internal/lsp + ts-go project.Session                                        │

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/multiroot.code-workspace
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/multiroot.code-workspace
@@ -1,0 +1,8 @@
+{
+  "folders": [
+    { "path": "parent" },
+    { "path": "sentinel" },
+    { "name": "app", "path": "twins/left/app" },
+    { "name": "app", "path": "twins/right/app" },
+  ],
+}

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/nested-initial.code-workspace
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/nested-initial.code-workspace
@@ -1,0 +1,7 @@
+{
+  "folders": [
+    { "path": "parent" },
+    { "path": "parent/nested" },
+    { "path": "sentinel" },
+  ],
+}

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/parent/nested/rslint.config.js
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/parent/nested/rslint.config.js
@@ -1,0 +1,9 @@
+export default [
+  {
+    files: ['**/*.ts'],
+    plugins: ['@typescript-eslint'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
+];

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/parent/nested/src/index.ts
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/parent/nested/src/index.ts
@@ -1,0 +1,2 @@
+let nestedValue: any = 1;
+void nestedValue;

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/parent/rslint.config.js
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/parent/rslint.config.js
@@ -1,0 +1,9 @@
+export default [
+  {
+    files: ['**/*.ts'],
+    plugins: ['@typescript-eslint'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
+];

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/parent/src/index.ts
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/parent/src/index.ts
@@ -1,0 +1,2 @@
+let parentValue: any = 1;
+void parentValue;

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/sentinel/rslint.config.js
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/sentinel/rslint.config.js
@@ -1,0 +1,9 @@
+export default [
+  {
+    files: ['**/*.ts'],
+    plugins: ['@typescript-eslint'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
+];

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/sentinel/src/index.ts
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/sentinel/src/index.ts
@@ -1,0 +1,2 @@
+let sentinelValue: any = 1;
+void sentinelValue;

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/twins/left/app/rslint.config.js
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/twins/left/app/rslint.config.js
@@ -1,0 +1,9 @@
+export default [
+  {
+    files: ['**/*.ts'],
+    plugins: ['@typescript-eslint'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
+];

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/twins/left/app/src/index.ts
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/twins/left/app/src/index.ts
@@ -1,0 +1,2 @@
+let leftValue: any = 1;
+void leftValue;

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/twins/right/app/rslint.config.js
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/twins/right/app/rslint.config.js
@@ -1,0 +1,9 @@
+export default [
+  {
+    files: ['**/*.ts'],
+    plugins: ['@typescript-eslint'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
+];

--- a/packages/vscode-extension/__tests__/fixtures-multiroot/twins/right/app/src/index.ts
+++ b/packages/vscode-extension/__tests__/fixtures-multiroot/twins/right/app/src/index.ts
@@ -1,0 +1,2 @@
+let rightValue: any = 1;
+void rightValue;

--- a/packages/vscode-extension/__tests__/runSuite.ts
+++ b/packages/vscode-extension/__tests__/runSuite.ts
@@ -68,16 +68,53 @@ function canonicalPath(filePath: string): string {
   return process.platform === 'win32' ? realPath.toLowerCase() : realPath;
 }
 
+function isPathWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === '' ||
+    (relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function findWorkspaceMarker(startPath: string): string {
+  let current = startPath;
+  while (true) {
+    const candidate = path.join(current, workspaceMarkerFile);
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(
+        `Could not find isolated workspace marker above ${startPath}`,
+      );
+    }
+    current = parent;
+  }
+}
+
 function verifyIsolatedWorkspace(): void {
   const folders = vscode.workspace.workspaceFolders;
-  if (folders?.length !== 1) {
-    throw new Error(
-      `Expected exactly one isolated workspace folder, got ${folders?.length ?? 0}`,
-    );
+  if (!folders || folders.length === 0) {
+    throw new Error('Expected at least one isolated workspace folder, got 0');
   }
 
-  const actualPath = canonicalPath(folders[0].uri.fsPath);
-  const markerPath = path.join(actualPath, workspaceMarkerFile);
+  const actualPaths = folders
+    .map((folder) => canonicalPath(folder.uri.fsPath))
+    .sort();
+  const markerPaths = new Set(
+    actualPaths.map((actualPath) =>
+      canonicalPath(findWorkspaceMarker(actualPath)),
+    ),
+  );
+  if (markerPaths.size !== 1) {
+    throw new Error(
+      `Workspace folders do not share one isolated sandbox marker: ${[
+        ...markerPaths,
+      ].join(', ')}`,
+    );
+  }
+  const markerPath = [...markerPaths][0];
   let marker: unknown;
   try {
     marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
@@ -90,12 +127,18 @@ function verifyIsolatedWorkspace(): void {
     typeof marker !== 'object' ||
     marker === null ||
     !('version' in marker) ||
-    marker.version !== 1 ||
+    marker.version !== 2 ||
     !('nonce' in marker) ||
     typeof marker.nonce !== 'string' ||
     !/^[0-9a-f-]{36}$/i.test(marker.nonce) ||
     !('expectedWorkspace' in marker) ||
     typeof marker.expectedWorkspace !== 'string' ||
+    !('expectedWorkspaceFolders' in marker) ||
+    !Array.isArray(marker.expectedWorkspaceFolders) ||
+    marker.expectedWorkspaceFolders.length === 0 ||
+    !marker.expectedWorkspaceFolders.every(
+      (folder): folder is string => typeof folder === 'string',
+    ) ||
     !('sourceWorkspace' in marker) ||
     typeof marker.sourceWorkspace !== 'string'
   ) {
@@ -104,12 +147,35 @@ function verifyIsolatedWorkspace(): void {
 
   const expectedPath = canonicalPath(marker.expectedWorkspace);
   const sourcePath = canonicalPath(marker.sourceWorkspace);
-  if (actualPath !== expectedPath) {
+  const expectedPaths = marker.expectedWorkspaceFolders
+    .map((folder) => canonicalPath(folder))
+    .sort();
+  if (canonicalPath(path.dirname(markerPath)) !== expectedPath) {
     throw new Error(
-      `VS Code opened ${actualPath} instead of isolated workspace ${expectedPath}`,
+      `Isolated workspace marker is outside its declared sandbox ${expectedPath}`,
     );
   }
-  if (actualPath === sourcePath) {
+  if (
+    expectedPaths.some(
+      (expectedFolder) => !isPathWithin(expectedPath, expectedFolder),
+    )
+  ) {
+    throw new Error(
+      'An expected workspace folder escapes its isolated sandbox',
+    );
+  }
+  if (
+    actualPaths.length !== expectedPaths.length ||
+    actualPaths.some((actualPath, index) => actualPath !== expectedPaths[index])
+  ) {
+    throw new Error(
+      `VS Code opened workspace folders ${JSON.stringify(actualPaths)} instead of ${JSON.stringify(expectedPaths)}`,
+    );
+  }
+  if (
+    expectedPath === sourcePath ||
+    actualPaths.some((actualPath) => isPathWithin(sourcePath, actualPath))
+  ) {
     throw new Error(
       'VS Code tests must not run against tracked source fixtures',
     );

--- a/packages/vscode-extension/__tests__/runTest.ts
+++ b/packages/vscode-extension/__tests__/runTest.ts
@@ -9,12 +9,27 @@ interface TestSuite {
   name: string;
   workspace: string;
   tests: string;
+  workspaceEntry?: string;
+  workspaceFolders?: string[];
 }
 
 const workspaceMarkerFile = '.rslint-vscode-test-sandbox.json';
 
 function resolveFixture(name: string): string {
   return path.resolve(require.resolve('@rslint/core'), '../..', name);
+}
+
+function resolveSandboxEntry(workspaceRoot: string, entry: string): string {
+  const resolved = path.resolve(workspaceRoot, entry);
+  const relative = path.relative(workspaceRoot, resolved);
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(`Workspace entry escapes its isolated sandbox: ${entry}`);
+  }
+  return resolved;
 }
 
 async function findPackageRoot(startPath: string): Promise<string> {
@@ -57,13 +72,19 @@ async function runIsolatedSuite(
       force: false,
       errorOnExist: true,
     });
+    const expectedWorkspaceFolders = await Promise.all(
+      (suite.workspaceFolders ?? ['.']).map((folder) =>
+        fs.promises.realpath(resolveSandboxEntry(workspaceCopy, folder)),
+      ),
+    );
     await fs.promises.writeFile(
       path.join(workspaceCopy, workspaceMarkerFile),
       JSON.stringify({
-        version: 1,
+        version: 2,
         nonce: randomUUID(),
         sourceWorkspace: await fs.promises.realpath(suite.workspace),
         expectedWorkspace: await fs.promises.realpath(workspaceCopy),
+        expectedWorkspaceFolders,
       }),
       { encoding: 'utf8', flag: 'wx', mode: 0o600 },
     );
@@ -85,7 +106,9 @@ async function runIsolatedSuite(
       extensionDevelopmentPath,
       extensionTestsPath: suite.tests,
       launchArgs: [
-        workspaceCopy,
+        suite.workspaceEntry
+          ? resolveSandboxEntry(workspaceCopy, suite.workspaceEntry)
+          : workspaceCopy,
         '--disable-extensions',
         '--disable-updates',
         '--disable-workspace-trust',
@@ -142,6 +165,25 @@ async function main(): Promise<void> {
       name: 'Monorepo config tests',
       workspace: path.resolve(testsSourceDir, 'fixtures-monorepo'),
       tests: path.resolve(__dirname, './suite-monorepo'),
+    },
+    {
+      name: 'Multi-root dynamic ownership tests',
+      workspace: path.resolve(testsSourceDir, 'fixtures-multiroot'),
+      tests: path.resolve(__dirname, './suite-multiroot'),
+      workspaceEntry: 'multiroot.code-workspace',
+      workspaceFolders: [
+        'parent',
+        'sentinel',
+        'twins/left/app',
+        'twins/right/app',
+      ],
+    },
+    {
+      name: 'Multi-root initial parent-child tests',
+      workspace: path.resolve(testsSourceDir, 'fixtures-multiroot'),
+      tests: path.resolve(__dirname, './suite-multiroot'),
+      workspaceEntry: 'nested-initial.code-workspace',
+      workspaceFolders: ['parent', 'parent/nested', 'sentinel'],
     },
     {
       name: 'No config tests',

--- a/packages/vscode-extension/__tests__/suite-jsconfig/rslint-lifecycle.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/rslint-lifecycle.test.ts
@@ -1,0 +1,192 @@
+import * as assert from 'node:assert';
+import { window } from 'vscode';
+import { CloseAction, ErrorAction, State } from 'vscode-languageclient/node';
+import { LanguageServerProcessOwner } from '../../src/LanguageServerProcessOwner';
+import {
+  disposeLanguageClient,
+  ManagedLanguageClient,
+  shouldResetDocumentSessionOnServerState,
+  waitForPromiseSettlement,
+} from '../../src/Rslint';
+
+const FORCE_KILL_CHILD =
+  "process.on('SIGTERM', () => undefined); setTimeout(() => process.stdout.write('ready\\n'), 20); setInterval(() => undefined, 1_000)";
+
+function processOwner(source = FORCE_KILL_CHILD): LanguageServerProcessOwner {
+  return new LanguageServerProcessOwner(
+    process.execPath,
+    ['-e', source],
+    process.cwd(),
+    { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+  );
+}
+
+async function waitForOutput(
+  stream: NodeJS.ReadableStream,
+  expected: string,
+): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const onData = (chunk: Buffer): void => {
+      if (!chunk.toString().includes(expected)) return;
+      stream.removeListener('data', onData);
+      resolve();
+    };
+    stream.on('data', onData);
+  });
+}
+
+suite('Rslint lifecycle', () => {
+  test('disposes diagnostics without waiting for a Starting client handshake', async () => {
+    let clientDisposeCalls = 0;
+    let diagnosticDisposeCalls = 0;
+
+    await disposeLanguageClient({
+      state: State.Starting,
+      diagnostics: {
+        dispose() {
+          diagnosticDisposeCalls++;
+        },
+      },
+      async dispose() {
+        clientDisposeCalls++;
+        throw new Error('client is still starting');
+      },
+    });
+
+    assert.strictEqual(clientDisposeCalls, 1);
+    assert.strictEqual(diagnosticDisposeCalls, 1);
+  });
+
+  test('reports a Running client disposal failure after disposing diagnostics', async () => {
+    let diagnosticDisposeCalls = 0;
+
+    await assert.rejects(
+      disposeLanguageClient({
+        state: State.Running,
+        diagnostics: {
+          dispose() {
+            diagnosticDisposeCalls++;
+          },
+        },
+        async dispose() {
+          throw new Error('shutdown failed');
+        },
+      }),
+      /shutdown failed/,
+    );
+
+    assert.strictEqual(diagnosticDisposeCalls, 1);
+  });
+
+  test('awaits native child termination and rejects later restarts', async () => {
+    const owner = processOwner();
+    const child = await owner.start();
+    await waitForOutput(child.stdout, 'ready');
+
+    await owner.close();
+
+    assert.ok(
+      child.exitCode !== null || child.signalCode !== null,
+      'close should resolve only after the child exits',
+    );
+    if (process.platform !== 'win32') {
+      assert.strictEqual(child.signalCode, 'SIGKILL');
+    }
+    await assert.rejects(owner.start(), /process owner is closing/);
+  });
+
+  test('terminates the prior child before an automatic restart spawn', async () => {
+    const owner = processOwner();
+    const first = await owner.start();
+    await waitForOutput(first.stdout, 'ready');
+
+    const second = await owner.start();
+
+    assert.notStrictEqual(first.pid, second.pid);
+    assert.ok(
+      first.exitCode !== null || first.signalCode !== null,
+      'the old child must close before start returns its replacement',
+    );
+    await waitForOutput(second.stdout, 'ready');
+    await owner.close();
+  });
+
+  test('settles a hung initialize tail after forced transport close', async () => {
+    const source =
+      "process.on('SIGTERM', () => undefined); process.stdin.on('data', () => process.stderr.write('initialize-request\\n')); setTimeout(() => process.stderr.write('ready\\n'), 20); setInterval(() => undefined, 1_000)";
+    const owner = processOwner(source);
+    const outputChannel = window.createOutputChannel(
+      `Rslint lifecycle hang ${Date.now()}`,
+    );
+    let closing = false;
+    let spawnCount = 0;
+    let initializeReceived!: () => void;
+    const receivedInitialize = new Promise<void>((resolve) => {
+      initializeReceived = resolve;
+    });
+    const client = new ManagedLanguageClient(
+      `rslint-lifecycle-hang-${Date.now()}`,
+      'Rslint lifecycle hang probe',
+      async () => {
+        const child = await owner.start();
+        spawnCount++;
+        child.stderr.on('data', (chunk: Buffer) => {
+          if (chunk.toString().includes('initialize-request')) {
+            initializeReceived();
+          }
+        });
+        await waitForOutput(child.stderr, 'ready');
+        return child;
+      },
+      {
+        documentSelector: [],
+        outputChannel,
+        errorHandler: {
+          error: () => ({ action: ErrorAction.Shutdown }),
+          closed: () => ({
+            action: closing ? CloseAction.DoNotRestart : CloseAction.Restart,
+            handled: closing,
+          }),
+        },
+      },
+    );
+
+    const startPromise = client.start();
+    void startPromise.catch(() => undefined);
+    await waitForPromiseSettlement(
+      receivedInitialize,
+      2_000,
+      'initialize request probe',
+    );
+    assert.strictEqual(client.state, State.Starting);
+
+    closing = true;
+    owner.beginClose();
+    await disposeLanguageClient(client);
+    await owner.close();
+    await waitForPromiseSettlement(
+      startPromise,
+      2_000,
+      'hung language client start',
+    );
+
+    assert.strictEqual(client.state, State.Stopped);
+    assert.strictEqual(spawnCount, 1, 'closing must suppress restart');
+    outputChannel.dispose();
+  });
+
+  test('resets document sessions as soon as a Running server exits', () => {
+    assert.strictEqual(
+      shouldResetDocumentSessionOnServerState(State.Running, State.Stopped),
+      true,
+    );
+    assert.strictEqual(
+      shouldResetDocumentSessionOnServerState(State.Stopped, State.Starting),
+      false,
+    );
+    assert.strictEqual(
+      shouldResetDocumentSessionOnServerState(State.Starting, State.Running),
+      false,
+    );
+  });
+});

--- a/packages/vscode-extension/__tests__/suite-jsconfig/workspace-coordinator.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/workspace-coordinator.test.ts
@@ -1,0 +1,336 @@
+import * as assert from 'node:assert';
+import {
+  Uri,
+  type TextDocument,
+  type WorkspaceFolder,
+  type WorkspaceFoldersChangeEvent,
+} from 'vscode';
+import {
+  WorkspaceRslintCoordinator,
+  workspaceRootKey,
+  type WorkspaceCoordinatorLogger,
+  type WorkspaceRootRouter,
+  type WorkspaceRuntime,
+} from '../../src/WorkspaceRslintCoordinator';
+
+type StartMode = 'ready' | 'fail' | 'pending' | 'factory-fail';
+
+class FakeRuntime implements WorkspaceRuntime {
+  readonly opened: string[] = [];
+  readonly closedDocuments: string[] = [];
+  closeCalls = 0;
+  failClose = false;
+
+  constructor(
+    readonly workspaceFolder: WorkspaceFolder,
+    readonly rootKey: string,
+    private readonly startMode: StartMode,
+  ) {}
+
+  async start(signal: AbortSignal): Promise<void> {
+    if (this.startMode === 'ready') return;
+    if (this.startMode === 'fail') throw new Error(`failed ${this.rootKey}`);
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => reject(signal.reason);
+      signal.addEventListener('abort', onAbort, { once: true });
+      void resolve;
+    });
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls++;
+    if (this.failClose) throw new Error(`close failed ${this.rootKey}`);
+  }
+
+  async sendDocumentOpen(document: TextDocument): Promise<void> {
+    this.opened.push(document.uri.toString());
+  }
+
+  async sendDocumentClose(document: TextDocument): Promise<void> {
+    this.closedDocuments.push(document.uri.toString());
+  }
+
+  clearDocumentDiagnostics(): void {}
+}
+
+class FakeRouter implements WorkspaceRootRouter {
+  readonly active = new Map<string, WorkspaceRuntime>();
+
+  async activate(runtime: WorkspaceRuntime): Promise<void> {
+    this.active.set(runtime.rootKey, runtime);
+  }
+
+  async deactivate(rootKey: string): Promise<void> {
+    this.active.delete(rootKey);
+  }
+
+  async closeAll(): Promise<void> {
+    this.active.clear();
+  }
+}
+
+const silentLogger: WorkspaceCoordinatorLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function folder(fsPath: string, name = 'app', index = 0): WorkspaceFolder {
+  return { uri: Uri.file(fsPath), name, index };
+}
+
+function changeEvent(
+  added: readonly WorkspaceFolder[],
+  removed: readonly WorkspaceFolder[],
+): WorkspaceFoldersChangeEvent {
+  return { added, removed };
+}
+
+async function eventually(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.fail(message);
+}
+
+function coordinatorHarness(
+  modeFor: (rootKey: string) => StartMode = () => 'ready',
+) {
+  const router = new FakeRouter();
+  const runtimes: FakeRuntime[] = [];
+  const coordinator = new WorkspaceRslintCoordinator(
+    router,
+    (workspaceFolder, rootKey) => {
+      const mode = modeFor(rootKey);
+      if (mode === 'factory-fail') {
+        throw new Error(`factory failed ${rootKey}`);
+      }
+      const runtime = new FakeRuntime(workspaceFolder, rootKey, mode);
+      runtimes.push(runtime);
+      return runtime;
+    },
+    silentLogger,
+  );
+  return { coordinator, router, runtimes };
+}
+
+suite('workspace runtime coordinator', () => {
+  test('uses URI identity for same-name roots', async () => {
+    const first = folder('/workspace/first/app', 'app', 0);
+    const second = folder('/workspace/second/app', 'app', 1);
+    const { coordinator, router, runtimes } = coordinatorHarness();
+
+    await coordinator.initialize([first, second]);
+    await eventually(
+      () => router.active.size === 2,
+      'both same-name roots should become active',
+    );
+
+    assert.notStrictEqual(workspaceRootKey(first), workspaceRootKey(second));
+    assert.strictEqual(runtimes.length, 2);
+    await coordinator.close();
+  });
+
+  test('isolates initial root failures', async () => {
+    const broken = folder('/workspace/broken', 'broken', 0);
+    const healthy = folder('/workspace/healthy', 'healthy', 1);
+    const { coordinator, router } = coordinatorHarness((key) =>
+      key === workspaceRootKey(broken) ? 'fail' : 'ready',
+    );
+
+    await coordinator.initialize([broken, healthy]);
+    await eventually(
+      () => router.active.has(workspaceRootKey(healthy)),
+      'healthy root should remain active',
+    );
+    assert.strictEqual(router.active.has(workspaceRootKey(broken)), false);
+    await coordinator.close();
+  });
+
+  test('isolates runtime factory failures', async () => {
+    const broken = folder('/workspace/broken', 'broken', 0);
+    const healthy = folder('/workspace/healthy', 'healthy', 1);
+    const { coordinator, router } = coordinatorHarness((key) =>
+      key === workspaceRootKey(broken) ? 'factory-fail' : 'ready',
+    );
+
+    await coordinator.initialize([broken, healthy]);
+    await eventually(
+      () => router.active.has(workspaceRootKey(healthy)),
+      'healthy root should survive a sibling factory failure',
+    );
+    await coordinator.close();
+  });
+
+  test('does not let a pending root block another root or removal', async () => {
+    const pending = folder('/workspace/pending', 'pending', 0);
+    const healthy = folder('/workspace/healthy', 'healthy', 1);
+    const { coordinator, router, runtimes } = coordinatorHarness((key) =>
+      key === workspaceRootKey(pending) ? 'pending' : 'ready',
+    );
+
+    await coordinator.initialize([pending, healthy]);
+    coordinator.handleWorkspaceFoldersChanged(changeEvent([], [pending]), [
+      healthy,
+    ]);
+    await eventually(
+      () =>
+        runtimes.find(
+          (runtime) => runtime.rootKey === workspaceRootKey(pending),
+        )?.closeCalls === 1,
+      'removed pending root should close',
+    );
+    assert.strictEqual(router.active.has(workspaceRootKey(healthy)), true);
+    await coordinator.close();
+  });
+
+  test('follows a topology replacement while activation is still pending', async () => {
+    const pending = folder('/workspace/pending', 'pending', 0);
+    const replacement = folder('/workspace/replacement', 'replacement', 0);
+    const { coordinator, router } = coordinatorHarness((key) =>
+      key === workspaceRootKey(pending) ? 'pending' : 'ready',
+    );
+
+    const initializing = coordinator.initialize([pending]);
+    coordinator.handleWorkspaceFoldersChanged(
+      changeEvent([replacement], [pending]),
+      [replacement],
+    );
+    await initializing;
+
+    assert.strictEqual(router.active.has(workspaceRootKey(pending)), false);
+    assert.strictEqual(router.active.has(workspaceRootKey(replacement)), true);
+    await coordinator.close();
+  });
+
+  test('lets an added healthy root unblock a pending initial root', async () => {
+    const pending = folder('/workspace/pending', 'pending', 0);
+    const healthy = folder('/workspace/healthy', 'healthy', 1);
+    const { coordinator, router } = coordinatorHarness((key) =>
+      key === workspaceRootKey(pending) ? 'pending' : 'ready',
+    );
+
+    const initializing = coordinator.initialize([pending]);
+    coordinator.handleWorkspaceFoldersChanged(changeEvent([healthy], []), [
+      pending,
+      healthy,
+    ]);
+    await initializing;
+
+    assert.strictEqual(router.active.has(workspaceRootKey(healthy)), true);
+    await coordinator.close();
+  });
+
+  test('replaces a renamed root even when its URI is unchanged', async () => {
+    const original = folder('/workspace/app', 'old-name', 0);
+    const renamed = folder('/workspace/app', 'new-name', 0);
+    const { coordinator, router, runtimes } = coordinatorHarness();
+    await coordinator.initialize([original]);
+
+    coordinator.handleWorkspaceFoldersChanged(
+      changeEvent([renamed], [original]),
+      [renamed],
+    );
+    await eventually(
+      () => runtimes.length === 2 && runtimes[0].closeCalls === 1,
+      'rename should replace and close the old runtime',
+    );
+    assert.strictEqual(
+      router.active.get(workspaceRootKey(renamed))?.workspaceFolder.name,
+      'new-name',
+    );
+    await coordinator.close();
+  });
+
+  test('quarantines a close-failed runtime instead of overlapping its replacement', async () => {
+    const original = folder('/workspace/app', 'old-name', 0);
+    const renamed = folder('/workspace/app', 'new-name', 0);
+    const { coordinator, router, runtimes } = coordinatorHarness();
+    await coordinator.initialize([original]);
+    runtimes[0].failClose = true;
+
+    coordinator.handleWorkspaceFoldersChanged(
+      changeEvent([renamed], [original]),
+      [renamed],
+    );
+    await eventually(
+      () => runtimes[0].closeCalls === 1,
+      'replacement should attempt to close the old runtime',
+    );
+
+    assert.strictEqual(runtimes.length, 1, 'replacement must not overlap');
+    assert.strictEqual(router.active.has(workspaceRootKey(original)), false);
+    await assert.rejects(
+      coordinator.close(),
+      /failed to close workspace coordinator/,
+    );
+    assert.strictEqual(
+      runtimes[0].closeCalls,
+      2,
+      'terminal close should retry',
+    );
+  });
+
+  test('does not restart a root when only its positional index changes', async () => {
+    const original = folder('/workspace/app', 'app', 0);
+    const shifted = folder('/workspace/app', 'app', 1);
+    const inserted = folder('/workspace/inserted', 'inserted', 0);
+    const { coordinator, router, runtimes } = coordinatorHarness();
+    await coordinator.initialize([original]);
+
+    coordinator.handleWorkspaceFoldersChanged(changeEvent([inserted], []), [
+      inserted,
+      shifted,
+    ]);
+    await eventually(
+      () => router.active.size === 2,
+      'new root should become active',
+    );
+    assert.strictEqual(
+      runtimes.filter(
+        (runtime) => runtime.rootKey === workspaceRootKey(original),
+      ).length,
+      1,
+    );
+    await coordinator.close();
+  });
+
+  test('rejects activation when every root fails', async () => {
+    const first = folder('/workspace/first', 'first', 0);
+    const second = folder('/workspace/second', 'second', 1);
+    const { coordinator } = coordinatorHarness(() => 'fail');
+
+    await assert.rejects(
+      coordinator.initialize([first, second]),
+      /All Rslint workspace roots failed/,
+    );
+    await coordinator.close();
+  });
+
+  test('closes every root and reports terminal close failures', async () => {
+    const first = folder('/workspace/first', 'first', 0);
+    const second = folder('/workspace/second', 'second', 1);
+    const { coordinator, router, runtimes } = coordinatorHarness();
+    await coordinator.initialize([first, second]);
+    await eventually(
+      () => router.active.size === 2,
+      'both roots should become active',
+    );
+    runtimes[0].failClose = true;
+
+    await assert.rejects(
+      coordinator.close(),
+      /failed to close workspace coordinator/,
+    );
+    assert.deepStrictEqual(
+      runtimes.map((runtime) => runtime.closeCalls),
+      [1, 1],
+    );
+  });
+});

--- a/packages/vscode-extension/__tests__/suite-jsconfig/workspace-router.test.ts
+++ b/packages/vscode-extension/__tests__/suite-jsconfig/workspace-router.test.ts
@@ -1,0 +1,441 @@
+import * as assert from 'node:assert';
+import {
+  commands,
+  Range,
+  Uri,
+  window,
+  workspace,
+  type TextDocument,
+  type TextDocumentChangeEvent,
+  type WorkspaceFolder,
+} from 'vscode';
+import {
+  WorkspaceDocumentRouter,
+  type DocumentRoutingRuntime,
+} from '../../src/WorkspaceDocumentRouter';
+
+class FakeRoutingRuntime implements DocumentRoutingRuntime {
+  readonly events: string[] = [];
+  failOpen = false;
+
+  constructor(
+    readonly rootKey: string,
+    readonly workspaceFolder: WorkspaceFolder,
+  ) {}
+
+  async sendDocumentOpen(document: TextDocument): Promise<void> {
+    this.events.push(`open:${document.uri}:${document.getText()}`);
+    if (this.failOpen) throw new Error(`open failed for ${this.rootKey}`);
+  }
+
+  async sendDocumentClose(document: TextDocument): Promise<void> {
+    this.events.push(`close:${document.uri}`);
+  }
+
+  clearDocumentDiagnostics(uri: Uri): void {
+    this.events.push(`clear:${uri}`);
+  }
+}
+
+function detachedDocument(uri: Uri): TextDocument {
+  return {
+    uri,
+    languageId: 'typescript',
+    getText: () => 'const stale = 1;\n',
+  } as TextDocument;
+}
+
+suite('workspace document router', () => {
+  let document: TextDocument;
+  let parentFolder: WorkspaceFolder;
+  let childFolder: WorkspaceFolder;
+  let testDirectory: Uri;
+
+  suiteSetup(async () => {
+    const workspaceFolder = workspace.workspaceFolders?.[0];
+    assert.ok(workspaceFolder, 'test requires a workspace folder');
+    parentFolder = workspaceFolder;
+    testDirectory = Uri.joinPath(
+      workspaceFolder.uri,
+      `.router-test-${Date.now()}`,
+    );
+    await workspace.fs.createDirectory(testDirectory);
+    const file = Uri.joinPath(testDirectory, 'nested.ts');
+    await workspace.fs.writeFile(file, Buffer.from('const value = 1;\n'));
+    document = await workspace.openTextDocument(file);
+    childFolder = {
+      uri: testDirectory,
+      name: 'nested',
+      index: workspaceFolder.index + 1,
+    };
+  });
+
+  suiteTeardown(async () => {
+    await window.showTextDocument(document, { preview: false });
+    await commands.executeCommand('workbench.action.closeActiveEditor');
+    await workspace.fs.delete(testDirectory, { recursive: true });
+  });
+
+  test('hands an open document to the longest active root', async () => {
+    const router = new WorkspaceDocumentRouter();
+    const parent = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    const child = new FakeRoutingRuntime(
+      childFolder.uri.toString(),
+      childFolder,
+    );
+
+    await router.activate(parent);
+    assert.strictEqual(router.getServerOpenOwner(document), parent.rootKey);
+    parent.events.length = 0;
+
+    await router.activate(child);
+    assert.strictEqual(router.getServerOpenOwner(document), child.rootKey);
+    assert.deepStrictEqual(
+      parent.events.filter((event) => event.includes(document.uri.toString())),
+      [`close:${document.uri}`, `clear:${document.uri}`],
+    );
+    assert.ok(
+      child.events.some((event) =>
+        event.startsWith(`open:${document.uri}:const value = 1;`),
+      ),
+    );
+
+    child.events.length = 0;
+    parent.events.length = 0;
+    await router.deactivate(child.rootKey);
+    assert.strictEqual(router.getServerOpenOwner(document), parent.rootKey);
+    assert.deepStrictEqual(
+      child.events.filter((event) => event.includes(document.uri.toString())),
+      [`close:${document.uri}`, `clear:${document.uri}`],
+    );
+    assert.ok(
+      parent.events.some((event) =>
+        event.startsWith(`open:${document.uri}:const value = 1;`),
+      ),
+    );
+    await router.closeAll();
+  });
+
+  test('forwards text changes only through the server-open owner', async () => {
+    const router = new WorkspaceDocumentRouter();
+    const parent = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    const child = new FakeRoutingRuntime(
+      childFolder.uri.toString(),
+      childFolder,
+    );
+    await router.activate(parent);
+    await router.activate(child);
+
+    const event: TextDocumentChangeEvent = {
+      document,
+      reason: undefined,
+      contentChanges: [
+        {
+          range: new Range(0, 0, 0, 0),
+          rangeOffset: 0,
+          rangeLength: 0,
+          text: 'x',
+        },
+      ],
+    };
+    let parentChanges = 0;
+    let childChanges = 0;
+    await Promise.all([
+      router.createMiddleware(parent).didChange?.(event, async () => {
+        parentChanges++;
+      }),
+      router.createMiddleware(child).didChange?.(event, async () => {
+        childChanges++;
+      }),
+    ]);
+    assert.strictEqual(parentChanges, 0);
+    assert.strictEqual(childChanges, 1);
+    await router.closeAll();
+  });
+
+  test('does not duplicate didOpen after a topology handoff opened the document', async () => {
+    const router = new WorkspaceDocumentRouter();
+    const parent = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    await router.activate(parent);
+
+    let forwarded = 0;
+    await router.createMiddleware(parent).didOpen?.(document, async () => {
+      forwarded++;
+    });
+
+    assert.strictEqual(forwarded, 0);
+    assert.strictEqual(
+      parent.events.filter((event) => event.startsWith(`open:${document.uri}:`))
+        .length,
+      1,
+    );
+    await router.closeAll();
+  });
+
+  test('clears ownership and diagnostics when a normal didClose fails', async () => {
+    const router = new WorkspaceDocumentRouter();
+    const parent = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    await router.activate(parent);
+    parent.events.length = 0;
+
+    const didClose = router.createMiddleware(parent).didClose;
+    assert.ok(didClose);
+    await assert.rejects(
+      didClose(document, async () => {
+        throw new Error('server close failed');
+      }),
+      /server close failed/,
+    );
+
+    assert.deepStrictEqual(parent.events, [`clear:${document.uri}`]);
+    assert.strictEqual(router.getServerOpenOwner(document), undefined);
+    await router.closeAll();
+  });
+
+  test('resets a restarted server session before its didOpen replay', async () => {
+    const router = new WorkspaceDocumentRouter();
+    const parent = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    await router.activate(parent);
+    parent.events.length = 0;
+
+    const didOpen = router.createMiddleware(parent).didOpen;
+    assert.ok(didOpen);
+    const reset = router.resetServerSession(parent);
+    const replay = didOpen(document, async () => {
+      parent.events.push(`replay-open:${document.uri}`);
+    });
+    await Promise.all([reset, replay]);
+
+    assert.deepStrictEqual(
+      parent.events.filter((event) => event.includes(document.uri.toString())),
+      [`clear:${document.uri}`, `replay-open:${document.uri}`],
+    );
+    assert.strictEqual(router.getServerOpenOwner(document), parent.rootKey);
+    await router.closeAll();
+  });
+
+  test('lets a nested root activate during the restart gap after early reset', async () => {
+    const router = new WorkspaceDocumentRouter();
+    const parent = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    const child = new FakeRoutingRuntime(
+      childFolder.uri.toString(),
+      childFolder,
+    );
+    await router.activate(parent);
+    await router.resetServerSession(parent);
+    parent.events.length = 0;
+
+    await router.activate(child);
+
+    assert.strictEqual(router.getServerOpenOwner(document), child.rootKey);
+    assert.strictEqual(
+      parent.events.some((event) => event === `close:${document.uri}`),
+      false,
+      'a cleared old transport must not receive didClose',
+    );
+    assert.ok(
+      child.events.some((event) =>
+        event.startsWith(`open:${document.uri}:const value = 1;`),
+      ),
+    );
+    await router.closeAll();
+  });
+
+  test('forgets a document closed during restart before the same URI reopens', async () => {
+    const file = Uri.joinPath(testDirectory, 'restart-closed.ts');
+    const staleDocument = detachedDocument(file);
+    const router = new WorkspaceDocumentRouter();
+    const parent = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    await router.activate(parent);
+    const didOpen = router.createMiddleware(parent).didOpen;
+    assert.ok(didOpen);
+    await didOpen(staleDocument, async () => undefined);
+    assert.strictEqual(
+      router.getServerOpenOwner(staleDocument),
+      parent.rootKey,
+    );
+
+    // Simulate the LanguageClient feature-listener gap: VS Code closes the
+    // document, but this router never receives that generation's didClose. A
+    // detached TextDocument models the retained old session while the URI is
+    // absent from workspace.textDocuments.
+    assert.strictEqual(
+      workspace.textDocuments.some(
+        (candidate) => candidate.uri.toString() === file.toString(),
+      ),
+      false,
+    );
+
+    parent.events.length = 0;
+    await router.resetServerSession(parent);
+    assert.deepStrictEqual(
+      parent.events.filter((event) => event.includes(file.toString())),
+      [`clear:${file}`],
+    );
+
+    const reopenedDocument = detachedDocument(file);
+    let forwarded = 0;
+    await didOpen(reopenedDocument, async () => {
+      forwarded++;
+    });
+    assert.strictEqual(forwarded, 1);
+    assert.strictEqual(
+      router.getServerOpenOwner(reopenedDocument),
+      parent.rootKey,
+    );
+
+    await router.closeAll();
+  });
+
+  test('drains a closed restart-gap session when its root is removed', async () => {
+    const file = Uri.joinPath(testDirectory, 'removed-root-stale.ts');
+    const staleDocument = detachedDocument(file);
+    const router = new WorkspaceDocumentRouter();
+    const parent = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    await router.activate(parent);
+    const firstDidOpen = router.createMiddleware(parent).didOpen;
+    assert.ok(firstDidOpen);
+    await firstDidOpen(staleDocument, async () => undefined);
+    assert.strictEqual(
+      workspace.textDocuments.some(
+        (candidate) => candidate.uri.toString() === file.toString(),
+      ),
+      false,
+    );
+
+    parent.events.length = 0;
+    await router.deactivate(parent.rootKey);
+    assert.deepStrictEqual(
+      parent.events.filter((event) => event.includes(file.toString())),
+      [`clear:${file}`],
+    );
+
+    await router.activate(parent);
+    const reopenedDocument = detachedDocument(file);
+    const didOpen = router.createMiddleware(parent).didOpen;
+    assert.ok(didOpen);
+    let forwarded = 0;
+    await didOpen(reopenedDocument, async () => {
+      forwarded++;
+    });
+    assert.strictEqual(forwarded, 1);
+    assert.strictEqual(
+      router.getServerOpenOwner(reopenedDocument),
+      parent.rootKey,
+    );
+
+    await router.closeAll();
+  });
+
+  test('rejects diagnostics from a replaced runtime with the same root URI', async () => {
+    const router = new WorkspaceDocumentRouter();
+    const oldRuntime = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    const replacement = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    const oldMiddleware = router.createMiddleware(oldRuntime);
+    const replacementMiddleware = router.createMiddleware(replacement);
+    await router.activate(oldRuntime);
+    await router.deactivate(oldRuntime.rootKey);
+    await router.activate(replacement);
+
+    let oldDiagnostics = 0;
+    let replacementDiagnostics = 0;
+    oldMiddleware.handleDiagnostics?.(document.uri, [], () => {
+      oldDiagnostics++;
+    });
+    replacementMiddleware.handleDiagnostics?.(document.uri, [], () => {
+      replacementDiagnostics++;
+    });
+
+    assert.strictEqual(oldDiagnostics, 0);
+    assert.strictEqual(replacementDiagnostics, 1);
+    await router.closeAll();
+  });
+
+  test('drops a code action whose ownership changes while awaiting', async () => {
+    const router = new WorkspaceDocumentRouter();
+    const parent = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    const child = new FakeRoutingRuntime(
+      childFolder.uri.toString(),
+      childFolder,
+    );
+    await router.activate(parent);
+
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const action = router.createMiddleware(parent).provideCodeActions?.(
+      document,
+      new Range(0, 0, 0, 0),
+      { diagnostics: [], only: undefined, triggerKind: 1 },
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: () => ({ dispose() {} }),
+      },
+      async () => {
+        await pending;
+        return [];
+      },
+    );
+
+    await router.activate(child);
+    release();
+    assert.strictEqual(await Promise.resolve(action), undefined);
+    await router.closeAll();
+  });
+
+  test('rolls back to the prior owner when a new owner cannot open', async () => {
+    const router = new WorkspaceDocumentRouter();
+    const parent = new FakeRoutingRuntime(
+      parentFolder.uri.toString(),
+      parentFolder,
+    );
+    const child = new FakeRoutingRuntime(
+      childFolder.uri.toString(),
+      childFolder,
+    );
+    child.failOpen = true;
+    await router.activate(parent);
+
+    await assert.rejects(
+      router.activate(child),
+      /failed to activate document owner/,
+    );
+    assert.strictEqual(router.getServerOpenOwner(document), parent.rootKey);
+    assert.strictEqual(router.ownerKeyForDocument(document), parent.rootKey);
+    await router.closeAll();
+  });
+});

--- a/packages/vscode-extension/__tests__/suite-multiroot/index.ts
+++ b/packages/vscode-extension/__tests__/suite-multiroot/index.ts
@@ -1,0 +1,1 @@
+export { run } from '../runSuite';

--- a/packages/vscode-extension/__tests__/suite-multiroot/multiroot.test.ts
+++ b/packages/vscode-extension/__tests__/suite-multiroot/multiroot.test.ts
@@ -1,0 +1,201 @@
+import * as assert from 'node:assert';
+import path from 'node:path';
+import * as vscode from 'vscode';
+
+function workspaceFolder(name: string): vscode.WorkspaceFolder {
+  const folder = vscode.workspace.workspaceFolders?.find(
+    (candidate) => candidate.name === name,
+  );
+  assert.ok(folder, `workspace folder ${name} is unavailable`);
+  return folder;
+}
+
+async function openWorkspaceFile(
+  folder: vscode.WorkspaceFolder,
+  relativePath: string,
+): Promise<vscode.TextDocument> {
+  return vscode.workspace.openTextDocument(
+    path.join(folder.uri.fsPath, relativePath),
+  );
+}
+
+function rslintDiagnostics(document: vscode.TextDocument): vscode.Diagnostic[] {
+  return vscode.languages
+    .getDiagnostics(document.uri)
+    .filter((diagnostic) => diagnostic.source === 'rslint');
+}
+
+async function waitForSingleRslintDiagnostic(
+  document: vscode.TextDocument,
+): Promise<vscode.Diagnostic[]> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const diagnostics = rslintDiagnostics(document);
+    if (
+      diagnostics.length === 1 &&
+      diagnostics[0].message.includes('no-explicit-any')
+    ) {
+      // Do not accept a transient single result while a duplicate owner is
+      // still publishing its first diagnostics.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      const stable = rslintDiagnostics(document);
+      if (stable.length === 1) return stable;
+    }
+    await new Promise<void>((resolve) => {
+      const listener = vscode.languages.onDidChangeDiagnostics((event) => {
+        if (
+          event.uris.some((uri) => uri.toString() === document.uri.toString())
+        ) {
+          listener.dispose();
+          resolve();
+        }
+      });
+      setTimeout(() => {
+        listener.dispose();
+        resolve();
+      }, 500);
+    });
+  }
+  return rslintDiagnostics(document);
+}
+
+suite('VS Code multi-root ownership', function () {
+  this.timeout(60_000);
+
+  test('keeps same-name roots independent', async function () {
+    const appFolders = (vscode.workspace.workspaceFolders ?? []).filter(
+      (folder) => folder.name === 'app',
+    );
+    if (appFolders.length === 0) this.skip();
+    assert.strictEqual(appFolders.length, 2);
+    assert.notStrictEqual(
+      appFolders[0].uri.toString(),
+      appFolders[1].uri.toString(),
+    );
+
+    for (const folder of appFolders) {
+      const document = await openWorkspaceFile(folder, 'src/index.ts');
+      const diagnostics = await waitForSingleRslintDiagnostic(document);
+      assert.strictEqual(
+        diagnostics.length,
+        1,
+        `${folder.uri} should have exactly one Rslint owner`,
+      );
+    }
+  });
+
+  test('routes an initial parent-child overlap to only the child', async function () {
+    const folders = vscode.workspace.workspaceFolders ?? [];
+    const parent = folders.find((folder) => folder.name === 'parent');
+    const nested = folders.find((folder) => folder.name === 'nested');
+    if (!parent || !nested) this.skip();
+
+    const document = await openWorkspaceFile(nested, 'src/index.ts');
+    const diagnostics = await waitForSingleRslintDiagnostic(document);
+    assert.strictEqual(diagnostics.length, 1);
+  });
+
+  test('hands a document parent → child → parent without reopening it', async function () {
+    const folders = vscode.workspace.workspaceFolders ?? [];
+    if (folders.some((folder) => folder.name === 'nested')) this.skip();
+    // Keep the first root and a sentinel throughout the test. VS Code may
+    // restart the extension host for first-root or single↔multi transitions.
+    assert.ok(folders.length >= 2);
+    const parent = workspaceFolder('parent');
+    workspaceFolder('sentinel');
+    const nestedUri = vscode.Uri.joinPath(parent.uri, 'nested');
+    const document = await vscode.workspace.openTextDocument(
+      vscode.Uri.joinPath(nestedUri, 'src/index.ts'),
+    );
+    assert.strictEqual(
+      (await waitForSingleRslintDiagnostic(document)).length,
+      1,
+    );
+
+    await expectDiagnosticHandoff(document, async () => {
+      const added = vscode.workspace.updateWorkspaceFolders(
+        vscode.workspace.workspaceFolders?.length ?? 0,
+        0,
+        { uri: nestedUri, name: 'nested' },
+      );
+      assert.strictEqual(added, true);
+      await waitForWorkspaceFolder(nestedUri, true);
+    });
+    assert.strictEqual(
+      (await waitForSingleRslintDiagnostic(document)).length,
+      1,
+    );
+
+    const nestedIndex = vscode.workspace.workspaceFolders?.findIndex(
+      (folder) => folder.uri.toString() === nestedUri.toString(),
+    );
+    assert.notStrictEqual(nestedIndex, undefined);
+    assert.ok(nestedIndex !== undefined && nestedIndex >= 0);
+    await expectDiagnosticHandoff(document, async () => {
+      const removed = vscode.workspace.updateWorkspaceFolders(nestedIndex, 1);
+      assert.strictEqual(removed, true);
+      await waitForWorkspaceFolder(nestedUri, false);
+    });
+    assert.strictEqual(
+      (await waitForSingleRslintDiagnostic(document)).length,
+      1,
+    );
+  });
+});
+
+async function expectDiagnosticHandoff(
+  document: vscode.TextDocument,
+  changeTopology: () => Promise<void>,
+): Promise<void> {
+  let events = 0;
+  let maximumDiagnosticCount = rslintDiagnostics(document).length;
+  const listener = vscode.languages.onDidChangeDiagnostics((event) => {
+    if (event.uris.some((uri) => uri.toString() === document.uri.toString())) {
+      events++;
+      maximumDiagnosticCount = Math.max(
+        maximumDiagnosticCount,
+        rslintDiagnostics(document).length,
+      );
+    }
+  });
+  try {
+    await changeTopology();
+    const deadline = Date.now() + 30_000;
+    // VS Code may coalesce the old collection's delete with the new
+    // collection's publication into one aggregate diagnostic event.
+    while (events < 1 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    assert.ok(
+      events >= 1,
+      'expected diagnostics to change during ownership handoff',
+    );
+    assert.strictEqual(
+      (await waitForSingleRslintDiagnostic(document)).length,
+      1,
+    );
+    assert.ok(
+      maximumDiagnosticCount <= 1,
+      `ownership handoff published ${maximumDiagnosticCount} diagnostics`,
+    );
+  } finally {
+    listener.dispose();
+  }
+}
+
+async function waitForWorkspaceFolder(
+  uri: vscode.Uri,
+  present: boolean,
+): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const found = vscode.workspace.workspaceFolders?.some(
+      (folder) => folder.uri.toString() === uri.toString(),
+    );
+    if (found === present) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.fail(
+    `workspace folder ${uri} did not become ${present ? 'present' : 'absent'}`,
+  );
+}

--- a/packages/vscode-extension/src/Extension.ts
+++ b/packages/vscode-extension/src/Extension.ts
@@ -1,163 +1,140 @@
 import {
-  ExtensionContext,
-  Disposable,
-  workspace,
-  WorkspaceFolder,
-  ExtensionMode,
-  OutputChannel,
   window,
+  workspace,
+  type Disposable,
+  type ExtensionContext,
+  type OutputChannel,
 } from 'vscode';
-import { State } from 'vscode-languageclient/node';
-import { LogLevel, Logger } from './logger';
+import { Logger } from './logger';
 import { Rslint } from './Rslint';
 import { setupStatusBar } from './statusBar';
-import { RegisterCommands } from './commands';
+import { registerCommands } from './commands';
+import { WorkspaceDocumentRouter } from './WorkspaceDocumentRouter';
+import { WorkspaceRslintCoordinator } from './WorkspaceRslintCoordinator';
 
-export class Extension implements Disposable {
-  private readonly rslintInstances = new Map<string, Rslint>();
-  private disposables: Disposable[] = [];
+/** Extension-wide owner for shared UI, channels and workspace runtimes. */
+export class Extension {
   private readonly logger: Logger;
-  public context: ExtensionContext;
+  private readonly globalDisposables: Disposable[] = [];
+  private outputChannel: OutputChannel | undefined;
+  private lspOutputChannel: OutputChannel | undefined;
+  private workspaceFolderListener: Disposable | undefined;
+  private router: WorkspaceDocumentRouter | undefined;
+  private coordinator: WorkspaceRslintCoordinator | undefined;
+  private closePromise: Promise<void> | undefined;
+  private activated = false;
 
-  constructor(context: ExtensionContext) {
+  constructor(private readonly context: ExtensionContext) {
     Logger.setDefaultLogLevel(context);
-    this.context = context;
     this.logger = new Logger('Rslint (extension)').useDefaultLogLevel();
   }
 
   public async activate(): Promise<void> {
+    if (this.activated) return;
+    this.activated = true;
     this.logger.info('Rslint extension activating...');
 
-    const folders = workspace.workspaceFolders ?? [];
-    const outputChannel = window.createOutputChannel(
+    const outputChannel = (this.outputChannel = window.createOutputChannel(
       'Rslint Language Server',
       'log',
+    ));
+    const lspOutputChannel = (this.lspOutputChannel =
+      window.createOutputChannel('Rslint Language Server(LSP)'));
+
+    const router = new WorkspaceDocumentRouter();
+    const coordinator = new WorkspaceRslintCoordinator(
+      router,
+      (workspaceFolder, rootKey) =>
+        new Rslint({
+          rootKey,
+          extensionUri: this.context.extensionUri,
+          workspaceFolder,
+          outputChannel,
+          lspOutputChannel,
+          router,
+        }),
+      this.logger,
     );
-    const lspOutputChannel = window.createOutputChannel(
-      'Rslint Language Server(LSP)',
+    this.router = router;
+    this.coordinator = coordinator;
+
+    // Install every global facility before awaiting a root. A slow or broken
+    // config must not create an event-listener gap or hide commands/channels.
+    this.globalDisposables.push(setupStatusBar());
+    this.globalDisposables.push(
+      ...registerCommands(outputChannel, lspOutputChannel),
+    );
+    this.workspaceFolderListener = workspace.onDidChangeWorkspaceFolders(
+      (event) => {
+        coordinator.handleWorkspaceFoldersChanged(
+          event,
+          workspace.workspaceFolders ?? [],
+        );
+      },
     );
 
-    for (const folder of folders) {
-      const workspaceRslint = this.createRslintInstance(
-        folder.name,
-        folder,
-        outputChannel,
-        lspOutputChannel,
-      );
-      await workspaceRslint.start();
-      this.setupStateChangeMonitoring(workspaceRslint, folder.name);
-    }
-    setupStatusBar(this.context);
-    RegisterCommands(this.context, outputChannel, lspOutputChannel);
+    await coordinator.initialize(workspace.workspaceFolders ?? []);
     this.logger.info('Rslint extension activated successfully');
   }
 
   public async deactivate(): Promise<void> {
-    this.logger.info('Rslint extension deactivating...');
+    await this.close();
+  }
 
-    const stopPromises = Array.from(this.rslintInstances.values()).map(
-      async (instance) => instance.stop(),
-    );
+  public async close(): Promise<void> {
+    await (this.closePromise ??= this.closeImpl());
+  }
+
+  private async closeImpl(): Promise<void> {
+    this.logger.info('Rslint extension deactivating...');
+    const errors: unknown[] = [];
+    // Stop accepting topology changes before withdrawing any active root.
+    try {
+      this.workspaceFolderListener?.dispose();
+    } catch (error) {
+      errors.push(error);
+    }
+    this.workspaceFolderListener = undefined;
 
     try {
-      await Promise.all(stopPromises);
-      this.logger.info('All Rslint instances stopped');
-    } catch (err: unknown) {
-      this.logger.error('Error stopping some Rslint instances', err);
+      await this.coordinator?.close();
+    } catch (error) {
+      errors.push(error);
     }
 
-    this.dispose();
-    this.logger.info('Rslint extension deactivated');
-  }
-
-  public createRslintInstance(
-    id: string,
-    workspaceFolder: WorkspaceFolder,
-    outputChannel: OutputChannel,
-    lspOutputChannel: OutputChannel,
-  ): Rslint {
-    if (this.rslintInstances.has(id)) {
-      this.logger.warn(`Rslint instance with id '${id}' already exists`);
-      return this.rslintInstances.get(id)!;
-    }
-
-    // TODO: single file mode
-    const rslint = new Rslint(
-      this,
-      workspaceFolder,
-      outputChannel,
-      lspOutputChannel,
-    );
-    this.rslintInstances.set(id, rslint);
-    this.logger.debug(`Created Rslint instance with id: ${id}`);
-    return rslint;
-  }
-
-  public getRslintInstance(id: string): Rslint | undefined {
-    return this.rslintInstances.get(id);
-  }
-
-  public async removeRslintInstance(id: string): Promise<void> {
-    const instance = this.rslintInstances.get(id);
-    if (!instance) {
-      this.logger.warn(`Rslint instance with id '${id}' not found`);
-      return;
-    }
-
-    await instance.stop();
-    instance.dispose();
-    this.rslintInstances.delete(id);
-
-    this.logger.debug(`Removed Rslint instance with id: ${id}`);
-  }
-
-  public getAllRslintInstances(): Map<string, Rslint> {
-    return new Map(this.rslintInstances);
-  }
-
-  public dispose(): void {
-    this.rslintInstances.forEach((instance) => {
-      instance.dispose();
-    });
-    this.rslintInstances.clear();
-
-    this.disposables.forEach((disposable) => {
-      disposable.dispose();
-    });
-    this.disposables = [];
-
-    this.logger.dispose();
-  }
-
-  private setupLogging(): void {
-    this.logger.setLogLevel(
-      this.context.extensionMode === ExtensionMode.Development
-        ? LogLevel.DEBUG
-        : LogLevel.INFO,
-    );
-  }
-
-  private setupStateChangeMonitoring(rslint: Rslint, instanceId: string): void {
-    const stateChangeDisposable = rslint.onDidChangeState((event) => {
-      this.logger.debug(
-        `Rslint client state changed for instance '${instanceId}':`,
-        event.oldState,
-        '->',
-        event.newState,
-      );
-
-      if (event.newState === State.Running) {
-        this.logger.info(
-          `Rslint language server started for instance '${instanceId}'`,
-        );
-      } else if (event.newState === State.Stopped) {
-        this.logger.info(
-          `Rslint language server stopped for instance '${instanceId}'`,
-        );
+    for (const disposable of this.globalDisposables.splice(0).reverse()) {
+      try {
+        disposable.dispose();
+      } catch (error) {
+        errors.push(error);
       }
-    });
+    }
+    try {
+      this.outputChannel?.dispose();
+    } catch (error) {
+      errors.push(error);
+    }
+    this.outputChannel = undefined;
+    try {
+      this.lspOutputChannel?.dispose();
+    } catch (error) {
+      errors.push(error);
+    }
+    this.lspOutputChannel = undefined;
+    this.coordinator = undefined;
+    this.router = undefined;
 
-    this.disposables.push(stateChangeDisposable);
-    this.context.subscriptions.push(stateChangeDisposable);
+    for (const error of errors) {
+      this.logger.error('Failed to close an extension resource', error);
+    }
+    this.logger.info('Rslint extension deactivated');
+    try {
+      this.logger.dispose();
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'failed to deactivate Rslint extension');
+    }
   }
 }

--- a/packages/vscode-extension/src/LanguageServerProcessOwner.ts
+++ b/packages/vscode-extension/src/LanguageServerProcessOwner.ts
@@ -1,0 +1,178 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+
+const GRACEFUL_EXIT_TIMEOUT_MS = 500;
+const FORCED_EXIT_TIMEOUT_MS = 1_500;
+
+function hasExited(process: ChildProcessWithoutNullStreams): boolean {
+  return process.exitCode !== null || process.signalCode !== null;
+}
+
+async function waitForClose(
+  closed: Promise<void>,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (closedInTime: boolean): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(closedInTime);
+    };
+    const timer = setTimeout(() => {
+      finish(false);
+    }, timeoutMs);
+    void closed.then(() => {
+      finish(true);
+    });
+  });
+}
+
+async function terminateProcess(
+  process: ChildProcessWithoutNullStreams,
+  closed: Promise<void>,
+): Promise<void> {
+  if (!hasExited(process)) {
+    try {
+      process.kill('SIGTERM');
+    } catch {
+      // The close check below distinguishes a process that raced to completion
+      // from one that still needs a forced termination attempt.
+    }
+  }
+  if (await waitForClose(closed, GRACEFUL_EXIT_TIMEOUT_MS)) return;
+
+  if (!hasExited(process)) {
+    try {
+      process.kill('SIGKILL');
+    } catch {
+      // Report only if the transport remains open after the bounded wait.
+    }
+  }
+  if (await waitForClose(closed, FORCED_EXIT_TIMEOUT_MS)) return;
+
+  throw new Error(
+    `language server process ${String(process.pid)} did not close its transports after SIGKILL`,
+  );
+}
+
+/**
+ * Owns every native server child created for one workspace runtime, including
+ * children created by vscode-languageclient's automatic restart path.
+ */
+export class LanguageServerProcessOwner {
+  private readonly processes = new Map<
+    ChildProcessWithoutNullStreams,
+    Promise<void>
+  >();
+  private startTail: Promise<void> = Promise.resolve();
+  private closePromise: Promise<void> | undefined;
+  private closing = false;
+
+  public constructor(
+    private readonly command: string,
+    private readonly args: readonly string[],
+    private readonly cwd: string,
+    private readonly env?: NodeJS.ProcessEnv,
+  ) {}
+
+  public beginClose(): void {
+    this.closing = true;
+  }
+
+  public async start(): Promise<ChildProcessWithoutNullStreams> {
+    const operation = this.startTail.then(
+      async () => this.startImpl(),
+      async () => this.startImpl(),
+    );
+    this.startTail = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    const child = await operation;
+    return child;
+  }
+
+  private async startImpl(): Promise<ChildProcessWithoutNullStreams> {
+    if (this.closing) {
+      throw new Error('language server process owner is closing');
+    }
+
+    // A transport can close before its process exits. Automatic restart must
+    // never create a second native generation while that old child is alive.
+    await this.terminateTrackedProcesses();
+    if (this.closing) {
+      throw new Error('language server process owner is closing');
+    }
+
+    const child = spawn(this.command, [...this.args], {
+      cwd: this.cwd,
+      env: this.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const closed = new Promise<void>((resolve) => {
+      child.once('close', () => {
+        resolve();
+      });
+    });
+    this.processes.set(child, closed);
+    void closed.then(() => {
+      this.processes.delete(child);
+    });
+
+    let spawned = false;
+    let resolveStarted!: () => void;
+    let rejectStarted!: (error: unknown) => void;
+    const started = new Promise<void>((resolve, reject) => {
+      resolveStarted = resolve;
+      rejectStarted = reject;
+    });
+
+    child.once('spawn', () => {
+      spawned = true;
+      if (this.closing) {
+        rejectStarted(new Error('language server process owner is closing'));
+      } else {
+        resolveStarted();
+      }
+    });
+    child.on('error', (error) => {
+      if (spawned) return;
+      rejectStarted(error);
+    });
+
+    await started;
+    return child;
+  }
+
+  public async close(): Promise<void> {
+    await (this.closePromise ??= this.closeImpl());
+  }
+
+  private async closeImpl(): Promise<void> {
+    this.beginClose();
+    await this.startTail;
+    await this.terminateTrackedProcesses();
+  }
+
+  private async terminateTrackedProcesses(): Promise<void> {
+    const results = await Promise.allSettled(
+      [...this.processes].map(async ([process, closed]) => {
+        await terminateProcess(process, closed);
+      }),
+    );
+    const errors: unknown[] = [];
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        const reason: unknown = result.reason;
+        errors.push(reason);
+      }
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(
+        errors,
+        'failed to terminate language server processes',
+      );
+    }
+  }
+}

--- a/packages/vscode-extension/src/Rslint.ts
+++ b/packages/vscode-extension/src/Rslint.ts
@@ -6,19 +6,23 @@ import {
   RelativePattern,
   WorkspaceFolder,
   OutputChannel,
+  TextDocument,
   type CancellationToken,
-  type DocumentFilter,
 } from 'vscode';
 import {
-  Executable,
+  CloseAction,
+  DidCloseTextDocumentNotification,
+  DidOpenTextDocumentNotification,
+  ErrorAction,
   LanguageClient,
   LanguageClientOptions,
+  type ErrorHandler,
+  type Middleware,
   ServerOptions,
   State,
   Trace,
 } from 'vscode-languageclient/node';
 import { Logger } from './logger';
-import type { Extension } from './Extension';
 import { fileExists, getPlatformBinRequests, RslintBinPath } from './utils';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -36,6 +40,11 @@ import {
   LspConfigTransactionAdapter,
   type ConfigTransactionControlRequest,
 } from './ConfigTransactionAdapter';
+import {
+  createWorkspaceDocumentSelector,
+  type WorkspaceDocumentRouter,
+} from './WorkspaceDocumentRouter';
+import { LanguageServerProcessOwner } from './LanguageServerProcessOwner';
 
 /**
  * Workspace-relative lockfiles whose individual metadata feeds the
@@ -86,34 +95,20 @@ export function recoverConfigDiscoveryOnServerState(
   );
 }
 
+export function shouldResetDocumentSessionOnServerState(
+  oldState: State,
+  newState: State,
+): boolean {
+  return oldState === State.Running && newState !== State.Running;
+}
+
 /** Bind each language client to the workspace whose Go process owns discovery. */
 export function createLanguageClientOptions(
   workspaceFolder: WorkspaceFolder,
   outputChannel: OutputChannel | undefined,
+  middleware?: Middleware,
 ): LanguageClientOptions {
-  const workspacePattern = new RelativePattern(workspaceFolder, '**/*');
-  const documentSelector = [
-    {
-      scheme: 'file',
-      language: 'typescript',
-      pattern: workspacePattern,
-    },
-    {
-      scheme: 'file',
-      language: 'typescriptreact',
-      pattern: workspacePattern,
-    },
-    {
-      scheme: 'file',
-      language: 'javascript',
-      pattern: workspacePattern,
-    },
-    {
-      scheme: 'file',
-      language: 'javascriptreact',
-      pattern: workspacePattern,
-    },
-  ] satisfies DocumentFilter[];
+  const documentSelector = createWorkspaceDocumentSelector(workspaceFolder);
   return {
     workspaceFolder,
     // languageclient v9 types this client-only selector as the LSP shape,
@@ -124,6 +119,7 @@ export function createLanguageClientOptions(
       // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       documentSelector as unknown as LanguageClientOptions['documentSelector'],
     outputChannel,
+    middleware,
   };
 }
 
@@ -180,85 +176,276 @@ async function withCancellationSignal<T>(
   }
 }
 
+function abortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) return signal.reason;
+  const error = new Error('Rslint workspace start was cancelled');
+  error.name = 'AbortError';
+  return error;
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw abortError(signal);
+}
+
+async function raceWithAbort<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      reject(abortError(signal));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    operation.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export interface LanguageClientCloseTarget {
+  readonly state: State;
+  readonly diagnostics: Disposable | undefined;
+  dispose(): Promise<void>;
+}
+
+/**
+ * vscode-languageclient calls stop() without observing its promise when an
+ * initialize request fails. Its base stop rejects for non-Running states; the
+ * process owner handles those states, so normalize only that inactive case and
+ * preserve actionable failures from a Running shutdown.
+ */
+export class ManagedLanguageClient extends LanguageClient {
+  public override async stop(timeout?: number): Promise<void> {
+    const stateBeforeStop = this.state;
+    try {
+      await super.stop(timeout);
+    } catch (error) {
+      if (stateBeforeStop === State.Running) throw error;
+    }
+  }
+}
+
+/**
+ * Disposes a LanguageClient without waiting for a possibly hung initialize
+ * request. Its outer LanguageServerProcessOwner blocks restarts and terminates
+ * the callback-owned child after an inactive-state rejection; failures from a
+ * Running client remain independently actionable.
+ */
+export async function disposeLanguageClient(
+  client: LanguageClientCloseTarget,
+): Promise<void> {
+  const diagnostics = client.diagnostics;
+  const reportDisposeFailure = client.state === State.Running;
+  const errors: unknown[] = [];
+  try {
+    await client.dispose();
+  } catch (error) {
+    if (reportDisposeFailure) errors.push(error);
+  }
+  try {
+    diagnostics?.dispose();
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'failed to dispose language client');
+  }
+}
+
+export async function waitForPromiseSettlement(
+  promise: Promise<unknown>,
+  timeoutMs: number,
+  description: string,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const settled = await Promise.race([
+      promise.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => {
+          resolve(false);
+        }, timeoutMs);
+      }),
+    ]);
+    if (!settled) {
+      throw new Error(`${description} did not settle within ${timeoutMs}ms`);
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface ClientStoppedObservation {
+  readonly promise: Promise<void>;
+  dispose(): void;
+}
+
+function observeClientStopped(
+  client: LanguageClient,
+): ClientStoppedObservation {
+  if (client.state === State.Stopped) {
+    return { promise: Promise.resolve(), dispose: () => undefined };
+  }
+  let subscription: Disposable | undefined;
+  const promise = new Promise<void>((resolve) => {
+    subscription = client.onDidChangeState((event) => {
+      if (event.newState === State.Stopped) resolve();
+    });
+  });
+  return {
+    promise,
+    dispose() {
+      subscription?.dispose();
+      subscription = undefined;
+    },
+  };
+}
+
+export interface RslintOptions {
+  readonly rootKey: string;
+  readonly extensionUri: Uri;
+  readonly workspaceFolder: WorkspaceFolder;
+  readonly outputChannel: OutputChannel;
+  readonly lspOutputChannel: OutputChannel;
+  readonly router: WorkspaceDocumentRouter;
+}
+
 export class Rslint implements Disposable {
   private client: LanguageClient | undefined;
   private readonly logger: Logger;
-  private readonly extension: Extension;
-  private readonly workspaceFolder: WorkspaceFolder;
+  public readonly rootKey: string;
+  public readonly workspaceFolder: WorkspaceFolder;
+  private readonly extensionUri: Uri;
+  private readonly router: WorkspaceDocumentRouter;
   private readonly lspOutputChannel: OutputChannel | undefined;
   private readonly outputChannel: OutputChannel | undefined;
   private configWatcher: FileSystemWatcher | undefined;
   private configReloadTimer: ReturnType<typeof setTimeout> | undefined;
   private configReloadChain: Promise<void> = Promise.resolve();
   private serverRestartWatcher: Disposable | undefined;
+  private serverProcessOwner: LanguageServerProcessOwner | undefined;
+  private stateWatcher: Disposable | undefined;
+  private readonly requestHandlers: Disposable[] = [];
   private lifecycleEpoch = 0;
   private pluginDependencyRevision = 0;
   private pluginLintPoolDisposed = false;
   private configTransactionAdapter: LspConfigTransactionAdapter | undefined;
+  private startPromise: Promise<void> | undefined;
+  private startOperation: Promise<void> | undefined;
+  private clientStartPromise: Promise<void> | undefined;
+  private closePromise: Promise<void> | undefined;
+  private closing = false;
   /**
    * Hosts the in-process WorkerPool that answers Go's reverse
    * `rslint/pluginLint` requests for rules mounted via a config's
    * object-form `plugins`. It stays uninitialized until a config actually
    * mounts plugins.
    */
-  private pluginLintPool: PluginLintPool;
+  private readonly pluginLintPool: PluginLintPool;
 
-  constructor(
-    extension: Extension,
-    workspaceFolder: WorkspaceFolder,
-    outputChannel: OutputChannel,
-    lspOutputChannel: OutputChannel,
-  ) {
-    this.extension = extension;
-    this.workspaceFolder = workspaceFolder;
-    this.logger = new Logger('Rslint (workspace)').useDefaultLogLevel();
-    this.lspOutputChannel = lspOutputChannel;
-    this.outputChannel = outputChannel;
-    this.pluginLintPool = new PluginLintPool(this.logger);
+  constructor(options: RslintOptions) {
+    this.rootKey = options.rootKey;
+    this.extensionUri = options.extensionUri;
+    this.workspaceFolder = options.workspaceFolder;
+    this.router = options.router;
+    const logger = new Logger(
+      `Rslint (${options.workspaceFolder.name}: ${options.workspaceFolder.uri.fsPath})`,
+    ).useDefaultLogLevel();
+    this.logger = logger;
+    this.lspOutputChannel = options.lspOutputChannel;
+    this.outputChannel = options.outputChannel;
+    try {
+      this.pluginLintPool = new PluginLintPool(logger);
+    } catch (error) {
+      logger.dispose();
+      throw error;
+    }
   }
 
-  public async start(): Promise<void> {
-    if (this.client) {
-      this.logger.warn('Rslint client is already running');
+  public async start(signal: AbortSignal): Promise<void> {
+    if (this.startPromise) {
+      await this.startPromise;
       return;
     }
-
-    if (this.pluginLintPoolDisposed) {
-      this.pluginLintPool = new PluginLintPool(this.logger);
-      this.pluginLintPoolDisposed = false;
+    if (this.closing || signal.aborted) {
+      throw abortError(signal);
     }
+    this.startOperation = this.startImpl(signal);
+    // The abort facade releases the per-URI coordinator even when JavaScript
+    // module evaluation itself cannot be interrupted. startImpl retains its
+    // own rejection handler and epoch checks so a late completion is harmless.
+    this.startPromise = raceWithAbort(this.startOperation, signal);
+    void this.startOperation.catch(() => undefined);
+    await this.startPromise;
+  }
+
+  private async startImpl(signal: AbortSignal): Promise<void> {
     this.configReloadChain = Promise.resolve();
-    this.serverRestartWatcher?.dispose();
-    this.serverRestartWatcher = undefined;
     this.lifecycleEpoch++;
+    const epoch = this.lifecycleEpoch;
     const pluginLintPool = this.pluginLintPool;
     this.pluginDependencyRevision = 0;
-    this.configTransactionAdapter?.dispose();
-    this.configTransactionAdapter = undefined;
 
     const binPath = await this.getBinaryPath();
+    this.assertStartCurrent(epoch, signal);
     this.logger.info('Rslint binary path:', binPath);
 
-    const run: Executable = {
-      command: binPath,
-      args: ['--lsp'],
-    };
-
-    const serverOptions: ServerOptions = {
-      run,
-      debug: run,
+    const serverProcessOwner = new LanguageServerProcessOwner(
+      binPath,
+      ['--lsp'],
+      this.workspaceFolder.uri.fsPath,
+    );
+    this.serverProcessOwner = serverProcessOwner;
+    const serverOptions: ServerOptions = async () => {
+      const process = await serverProcessOwner.start();
+      return process;
     };
 
     // Check if LSP tracing is enabled
     const traceServer = workspace
-      .getConfiguration('rslint')
+      .getConfiguration('rslint', this.workspaceFolder.uri)
       .get<string>('trace.server', 'off');
     const traceEnabled = traceServer !== 'off';
 
     const clientOptions = createLanguageClientOptions(
       this.workspaceFolder,
       this.outputChannel,
+      this.router.createMiddleware(this),
     );
+    const errorHandlerHolder: { current?: ErrorHandler } = {};
+    clientOptions.errorHandler = {
+      error: async (error, message, count) => {
+        const result = await Promise.resolve(
+          errorHandlerHolder.current?.error(error, message, count) ?? {
+            action: ErrorAction.Shutdown,
+          },
+        );
+        return result;
+      },
+      closed: async () => {
+        if (this.closing) {
+          return { action: CloseAction.DoNotRestart, handled: true };
+        }
+        const result = await Promise.resolve(
+          errorHandlerHolder.current?.closed() ?? {
+            action: CloseAction.DoNotRestart,
+          },
+        );
+        return result;
+      },
+    };
 
     if (traceEnabled) {
       clientOptions.traceOutputChannel = this.lspOutputChannel;
@@ -269,15 +456,25 @@ export class Rslint implements Disposable {
       this.logger.debug('LSP tracing disabled by configuration');
     }
 
-    this.client = new LanguageClient(
+    const client = new ManagedLanguageClient(
       'rslint',
-      'Rslint Language Server',
+      `Rslint Language Server (${this.workspaceFolder.name})`,
       serverOptions,
       clientOptions,
     );
+    errorHandlerHolder.current = client.createDefaultErrorHandler();
+    this.client = client;
+    this.stateWatcher = client.onDidChangeState((event) => {
+      this.logger.debug(
+        `Language client state ${event.oldState} -> ${event.newState}`,
+      );
+    });
 
     try {
-      await this.client.start();
+      const clientStartPromise = client.start();
+      this.clientStartPromise = clientStartPromise;
+      await clientStartPromise;
+      this.assertStartCurrent(epoch, signal, client);
 
       const adapter = new LspConfigTransactionAdapter(
         new ConfigModuleHost(),
@@ -286,29 +483,37 @@ export class Rslint implements Disposable {
       );
       this.configTransactionAdapter = adapter;
 
-      this.client.onRequest(
-        'rslint/loadConfigs',
-        async (params: LoadConfigsRequest, token: CancellationToken) =>
-          withCancellationSignal(token, async (signal) =>
-            adapter.loadConfigs(params, signal),
-          ),
+      this.requestHandlers.push(
+        client.onRequest(
+          'rslint/loadConfigs',
+          async (params: LoadConfigsRequest, token: CancellationToken) =>
+            withCancellationSignal(token, async (requestSignal) =>
+              adapter.loadConfigs(params, requestSignal),
+            ),
+        ),
       );
-      this.client.onRequest(
-        'rslint/activateConfigs',
-        async (params: ActivateConfigsRequest, token: CancellationToken) =>
-          withCancellationSignal(token, async (signal) =>
-            adapter.activateConfigs(params, signal),
-          ),
+      this.requestHandlers.push(
+        client.onRequest(
+          'rslint/activateConfigs',
+          async (params: ActivateConfigsRequest, token: CancellationToken) =>
+            withCancellationSignal(token, async (requestSignal) =>
+              adapter.activateConfigs(params, requestSignal),
+            ),
+        ),
       );
-      this.client.onRequest(
-        'rslint/commitConfigs',
-        async (params: ConfigTransactionControlRequest) =>
-          adapter.commitConfigs(params),
+      this.requestHandlers.push(
+        client.onRequest(
+          'rslint/commitConfigs',
+          async (params: ConfigTransactionControlRequest) =>
+            adapter.commitConfigs(params),
+        ),
       );
-      this.client.onRequest(
-        'rslint/abortConfigs',
-        async (params: ConfigTransactionControlRequest) =>
-          adapter.abortConfigs(params),
+      this.requestHandlers.push(
+        client.onRequest(
+          'rslint/abortConfigs',
+          async (params: ConfigTransactionControlRequest) =>
+            adapter.abortConfigs(params),
+        ),
       );
 
       // Answer Go's reverse `rslint/pluginLint` requests: Go lints
@@ -319,16 +524,56 @@ export class Rslint implements Disposable {
       // $/cancelRequest for a superseded keystroke / closed document — is
       // threaded through to the pool, which bridges it to an AbortSignal and
       // cancels the in-flight worker tasks.
-      this.client.onRequest(
-        'rslint/pluginLint',
-        async (params: EslintPluginLintRequest, token: CancellationToken) =>
-          pluginLintPool.lint(params, token),
+      this.requestHandlers.push(
+        client.onRequest(
+          'rslint/pluginLint',
+          async (params: EslintPluginLintRequest, token: CancellationToken) =>
+            pluginLintPool.lint(params, token),
+        ),
       );
+
+      // client.start() has already emitted the initial Running transition. Any
+      // later Running event belongs to an automatic native-server restart.
+      // Reset router-side server-open state before LanguageClient replays open
+      // documents, then rebuild the replacement Go process's config catalog.
+      this.serverRestartWatcher = client.onDidChangeState((event) => {
+        if (
+          shouldResetDocumentSessionOnServerState(
+            event.oldState,
+            event.newState,
+          )
+        ) {
+          this.router.resetServerSession(this).catch((error: unknown) => {
+            this.logger.error(
+              'Failed to reset documents after server exit',
+              error,
+            );
+          });
+        }
+        const recovery = recoverConfigDiscoveryOnServerState(
+          event.newState,
+          async (reason, beforeRequest) => {
+            await this.router.resetServerSession(this);
+            await this.requestConfigRefresh(reason, beforeRequest);
+          },
+        );
+        recovery?.then(
+          () => {
+            this.logger.info(
+              'Documents and config discovery recovered after server restart',
+            );
+          },
+          (error: unknown) => {
+            this.logger.error('Failed to recover after server restart', error);
+          },
+        );
+      });
 
       if (traceEnabled) {
         const traceLevel =
           traceServer === 'verbose' ? Trace.Verbose : Trace.Messages;
-        await this.client.setTrace(traceLevel);
+        await client.setTrace(traceLevel);
+        this.assertStartCurrent(epoch, signal, client);
         this.logger.info(`LSP trace level set to: ${traceServer}`);
       }
 
@@ -347,47 +592,32 @@ export class Rslint implements Disposable {
           await this.requestConfigRefresh('config-change');
         },
       );
+      this.assertStartCurrent(epoch, signal, client);
       if (retried) {
         this.logger.warn(
           'Config changed during initial activation; discovery recovered on retry',
         );
       }
 
-      // client.start() has already emitted the initial Running transition. Any
-      // later Running event belongs to an automatic native-server restart and
-      // needs a fresh Go catalog; request handlers and the plugin pool survive on
-      // the extension side.
-      this.serverRestartWatcher = this.client.onDidChangeState((event) => {
-        const recovery = recoverConfigDiscoveryOnServerState(
-          event.newState,
-          async (reason, beforeRequest) =>
-            this.requestConfigRefresh(reason, beforeRequest),
-        );
-        recovery?.then(
-          () => {
-            this.logger.info('Config discovery recovered after server restart');
-          },
-          (error: unknown) => {
-            this.logger.error(
-              'Failed to recover config discovery after server restart',
-              error,
-            );
-          },
-        );
-      });
-
       this.logger.info('Rslint language client started successfully');
     } catch (err: unknown) {
       this.logger.error('Failed to start Rslint language client', err);
-      try {
-        await this.stop();
-      } catch (cleanupError: unknown) {
-        this.logger.error(
-          'Failed to clean up a partial Rslint start',
-          cleanupError,
-        );
-      }
       throw err;
+    }
+  }
+
+  private assertStartCurrent(
+    epoch: number,
+    signal: AbortSignal,
+    client?: LanguageClient,
+  ): void {
+    throwIfAborted(signal);
+    if (
+      this.closing ||
+      epoch !== this.lifecycleEpoch ||
+      (client !== undefined && client !== this.client)
+    ) {
+      throw abortError(signal);
     }
   }
 
@@ -464,7 +694,8 @@ export class Rslint implements Disposable {
       epoch === this.lifecycleEpoch &&
       client === this.client &&
       pluginLintPool === this.pluginLintPool &&
-      !this.pluginLintPoolDisposed
+      !this.pluginLintPoolDisposed &&
+      !this.closing
     );
   }
 
@@ -521,80 +752,179 @@ export class Rslint implements Disposable {
     return parts.join('|');
   }
 
-  public async stop(): Promise<void> {
+  public async close(): Promise<void> {
+    await (this.closePromise ??= this.closeImpl());
+  }
+
+  private async closeImpl(): Promise<void> {
+    const errors: unknown[] = [];
+    const disposeSafely = (resource: Disposable | undefined): void => {
+      if (!resource) return;
+      try {
+        resource.dispose();
+      } catch (error) {
+        errors.push(error);
+      }
+    };
+
+    this.closing = true;
     this.lifecycleEpoch++;
     clearTimeout(this.configReloadTimer);
-    this.serverRestartWatcher?.dispose();
+    this.configReloadTimer = undefined;
+    disposeSafely(this.serverRestartWatcher);
     this.serverRestartWatcher = undefined;
-    this.configWatcher?.dispose();
+    disposeSafely(this.configWatcher);
     this.configWatcher = undefined;
-    this.configTransactionAdapter?.dispose();
+    disposeSafely(this.configTransactionAdapter);
     this.configTransactionAdapter = undefined;
-    // Do not await configReloadChain: user config evaluation can contain a
-    // non-settling top-level await. The epoch above makes any late completion
-    // side-effect free, while resetting the chain keeps a future start usable.
+    for (const handler of this.requestHandlers.splice(0)) {
+      disposeSafely(handler);
+    }
+    disposeSafely(this.stateWatcher);
+    this.stateWatcher = undefined;
+    // Do not await startOperation/configReloadChain: user module evaluation can
+    // contain a non-settling top-level await. Epoch/closing checks fence every
+    // late continuation from publishing resources or state.
     this.configReloadChain = Promise.resolve();
+    this.pluginLintPoolDisposed = true;
 
     const client = this.client;
     this.client = undefined;
-    const pluginLintPool = this.pluginLintPool;
-    this.pluginLintPoolDisposed = true;
-
-    const [poolResult, clientResult] = await Promise.allSettled([
-      pluginLintPool.dispose(),
-      client ? client.stop() : Promise.resolve(),
-    ]);
-    if (!client) {
-      this.logger.debug('Rslint client is not running');
-    } else if (clientResult.status === 'fulfilled') {
-      this.logger.info('Rslint language client stopped');
+    const clientStartPromise = this.clientStartPromise;
+    this.clientStartPromise = undefined;
+    const clientStopped =
+      client?.state === State.Starting
+        ? observeClientStopped(client)
+        : undefined;
+    const serverProcessOwner = this.serverProcessOwner;
+    this.serverProcessOwner = undefined;
+    // Block vscode-languageclient's automatic restart callback before its
+    // graceful client shutdown begins. The owner force-terminates and awaits
+    // any surviving child after the bounded protocol shutdown finishes.
+    serverProcessOwner?.beginClose();
+    const asynchronousCleanups: Promise<void>[] = [
+      (async () => {
+        await this.pluginLintPool.dispose();
+      })(),
+    ];
+    if (client) {
+      asynchronousCleanups.push(
+        (async () => {
+          const clientErrors: unknown[] = [];
+          try {
+            await disposeLanguageClient(client);
+          } catch (error) {
+            clientErrors.push(error);
+          }
+          try {
+            await serverProcessOwner?.close();
+          } catch (error) {
+            clientErrors.push(error);
+          }
+          if (clientStartPromise) {
+            try {
+              await waitForPromiseSettlement(
+                clientStartPromise,
+                2_000,
+                'language client start',
+              );
+            } catch (error) {
+              clientErrors.push(error);
+            }
+          }
+          if (clientStopped) {
+            try {
+              await waitForPromiseSettlement(
+                clientStopped.promise,
+                2_000,
+                'language client terminal state',
+              );
+            } catch (error) {
+              clientErrors.push(error);
+            } finally {
+              clientStopped.dispose();
+            }
+          }
+          if (clientErrors.length > 0) {
+            throw new AggregateError(
+              clientErrors,
+              'failed to close language client resources',
+            );
+          }
+        })(),
+      );
+    } else if (serverProcessOwner) {
+      asynchronousCleanups.push(
+        (async () => {
+          await serverProcessOwner.close();
+        })(),
+      );
     }
+    const results = await Promise.allSettled(asynchronousCleanups);
     this.pluginDependencyRevision = 0;
-    if (poolResult.status === 'rejected') throw poolResult.reason;
-    if (clientResult.status === 'rejected') throw clientResult.reason;
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        const reason: unknown = result.reason;
+        errors.push(reason);
+      }
+    }
+    try {
+      for (const error of errors) {
+        this.logger.error('Failed to close Rslint workspace resource', error);
+      }
+      if (errors.length === 0) {
+        this.logger.info('Rslint language client closed');
+      }
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      this.logger.dispose();
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'failed to close Rslint workspace');
+    }
   }
 
   public isRunning(): boolean {
     return this.client?.state === State.Running;
   }
 
-  public getClient(): LanguageClient | undefined {
-    return this.client;
+  public async sendDocumentOpen(document: TextDocument): Promise<void> {
+    const provider = this.client
+      ?.getFeature(DidOpenTextDocumentNotification.method)
+      .getProvider(document);
+    if (!provider) {
+      throw new Error(`didOpen provider is unavailable for ${document.uri}`);
+    }
+    await provider.send(document);
   }
 
-  public onDidChangeState(listener: (event: any) => void): Disposable {
-    if (!this.client) {
-      throw new Error('Client is not initialized');
+  public async sendDocumentClose(document: TextDocument): Promise<void> {
+    const provider = this.client
+      ?.getFeature(DidCloseTextDocumentNotification.method)
+      .getProvider(document);
+    if (!provider) {
+      throw new Error(`didClose provider is unavailable for ${document.uri}`);
     }
-    return this.client.onDidChangeState(listener);
+    await provider.send(document);
+  }
+
+  public clearDocumentDiagnostics(uri: Uri): void {
+    this.client?.diagnostics?.delete(uri);
   }
 
   public dispose(): void {
-    this.lifecycleEpoch++;
-    clearTimeout(this.configReloadTimer);
-    this.serverRestartWatcher?.dispose();
-    this.serverRestartWatcher = undefined;
-    this.configReloadChain = Promise.resolve();
-    this.pluginLintPoolDisposed = true;
-    this.configTransactionAdapter?.dispose();
-    this.configTransactionAdapter = undefined;
-    void this.pluginLintPool.dispose();
-    const client = this.client;
-    this.client = undefined;
-    if (client) {
-      client.stop().catch((err: unknown) => {
-        this.logger.error('Error disposing Rslint client', err);
-      });
-    }
-    this.configWatcher?.dispose();
-    this.configWatcher = undefined;
-    this.lspOutputChannel?.dispose();
+    void this.close().catch(() => undefined);
   }
 
   private async findBinaryFromUserSettings(): Promise<string | null> {
     const customBinPathConfig = workspace
-      .getConfiguration()
-      .get<string>('rslint.customBinPath')
+      .getConfiguration('rslint', this.workspaceFolder.uri)
+      .get<string>('customBinPath')
       ?.trim();
 
     if (!customBinPathConfig) {
@@ -720,7 +1050,7 @@ export class Rslint implements Disposable {
 
   private findBinaryFromBuiltIn(): string {
     const builtInBinPath = Uri.joinPath(
-      this.extension.context.extensionUri,
+      this.extensionUri,
       'dist',
       'rslint',
     ).fsPath;
@@ -733,8 +1063,8 @@ export class Rslint implements Disposable {
 
   private async getBinaryPath(): Promise<string> {
     const binPathConfig = workspace
-      .getConfiguration()
-      .get<RslintBinPath>('rslint.binPath');
+      .getConfiguration('rslint', this.workspaceFolder.uri)
+      .get<RslintBinPath>('binPath');
 
     let finalBinPath: string | null = null;
     if (binPathConfig === 'local') {
@@ -761,7 +1091,10 @@ export class Rslint implements Disposable {
       }
     }
 
+    if (!finalBinPath) {
+      throw new Error(`Unsupported rslint.binPath setting: ${binPathConfig}`);
+    }
     this.logger.debug('Final Rslint binary path:', finalBinPath);
-    return finalBinPath!;
+    return finalBinPath;
   }
 }

--- a/packages/vscode-extension/src/WorkspaceDocumentRouter.ts
+++ b/packages/vscode-extension/src/WorkspaceDocumentRouter.ts
@@ -1,0 +1,504 @@
+import {
+  languages,
+  workspace,
+  RelativePattern,
+  type CodeAction,
+  type Command,
+  type DocumentFilter,
+  type TextDocument,
+  type Uri,
+  type WorkspaceFolder,
+} from 'vscode';
+import type { Middleware } from 'vscode-languageclient/node';
+
+const SUPPORTED_LANGUAGE_IDS = new Set([
+  'typescript',
+  'typescriptreact',
+  'javascript',
+  'javascriptreact',
+]);
+
+export interface DocumentRoutingRuntime {
+  readonly rootKey: string;
+  readonly workspaceFolder: WorkspaceFolder;
+  sendDocumentOpen(document: TextDocument): Promise<void>;
+  sendDocumentClose(document: TextDocument): Promise<void>;
+  clearDocumentDiagnostics(uri: Uri): void;
+}
+
+interface ActiveRuntime {
+  readonly runtime: DocumentRoutingRuntime;
+  readonly selector: DocumentFilter[];
+}
+
+interface ServerOpenDocumentSession {
+  readonly runtime: DocumentRoutingRuntime;
+  readonly document: TextDocument;
+}
+
+type TextSyncKind = 'open' | 'close';
+
+function documentKey(document: TextDocument): string {
+  return document.uri.toString();
+}
+
+function permitKey(kind: TextSyncKind, document: TextDocument): string {
+  return `${kind}\0${documentKey(document)}`;
+}
+
+function errorList(error: unknown): unknown[] {
+  if (!(error instanceof AggregateError)) return [error];
+  const errors: readonly unknown[] = error.errors;
+  return [...errors];
+}
+
+function throwCollectedErrors(errors: unknown[], message: string): void {
+  if (errors.length === 0) return;
+  if (errors.length === 1) throw errors[0];
+  throw new AggregateError(errors, message);
+}
+
+export function createWorkspaceDocumentSelector(
+  workspaceFolder: WorkspaceFolder,
+): DocumentFilter[] {
+  const workspacePattern = new RelativePattern(workspaceFolder, '**/*');
+  return [...SUPPORTED_LANGUAGE_IDS].map((language) => ({
+    scheme: 'file',
+    language,
+    pattern: workspacePattern,
+  }));
+}
+
+export function isSupportedWorkspaceDocument(
+  document: Pick<TextDocument, 'languageId' | 'uri'>,
+): boolean {
+  return (
+    document.uri.scheme === 'file' &&
+    SUPPORTED_LANGUAGE_IDS.has(document.languageId)
+  );
+}
+
+/**
+ * Owns document-to-root routing independently from root process lifecycle.
+ *
+ * Root start/config evaluation never runs on this queue. The queue contains
+ * only bounded document notification handoffs and middleware gates, so a
+ * non-settling user config cannot block unrelated workspace lifecycle work.
+ */
+export class WorkspaceDocumentRouter {
+  private activeRoots = new Map<string, ActiveRuntime>();
+  private readonly serverOpenDocuments = new Map<
+    string,
+    ServerOpenDocumentSession
+  >();
+  private readonly documentEpochs = new WeakMap<TextDocument, number>();
+  private readonly transferPermits = new Map<
+    DocumentRoutingRuntime,
+    Set<string>
+  >();
+  private operationTail: Promise<void> = Promise.resolve();
+
+  public createMiddleware(runtime: DocumentRoutingRuntime): Middleware {
+    return {
+      didOpen: async (document, next) => {
+        if (this.hasTransferPermit('open', runtime, document)) {
+          return next(document);
+        }
+        return this.enqueue(async () => {
+          const uri = documentKey(document);
+          if (
+            this.ownerForDocument(document) !== runtime ||
+            this.serverOpenDocuments.has(uri)
+          ) {
+            return;
+          }
+          await next(document);
+          this.serverOpenDocuments.set(uri, { runtime, document });
+          this.bumpDocumentEpoch(document);
+        });
+      },
+      didChange: async (event, next) =>
+        this.enqueue(async () => {
+          if (!this.isServerOpenOwner(runtime, event.document)) return;
+          await next(event);
+        }),
+      didSave: async (document, next) =>
+        this.enqueue(async () => {
+          if (!this.isServerOpenOwner(runtime, document)) return;
+          await next(document);
+        }),
+      didClose: async (document, next) => {
+        if (this.hasTransferPermit('close', runtime, document)) {
+          return next(document);
+        }
+        return this.enqueue(async () => {
+          const uri = documentKey(document);
+          if (this.serverOpenDocuments.get(uri)?.runtime !== runtime) return;
+          const errors: unknown[] = [];
+          try {
+            await next(document);
+          } catch (error) {
+            errors.push(...errorList(error));
+          }
+          this.releaseDocumentSession(runtime, document, errors);
+          throwCollectedErrors(errors, 'failed to close routed document');
+        });
+      },
+      provideCodeActions: async (
+        document,
+        range,
+        context,
+        token,
+        next,
+      ): Promise<(Command | CodeAction)[] | null | undefined> => {
+        if (!this.isServerOpenOwner(runtime, document)) return undefined;
+        const epoch = this.documentEpoch(document);
+        const result = await Promise.resolve(
+          next(document, range, context, token),
+        );
+        if (
+          epoch !== this.documentEpoch(document) ||
+          !this.isServerOpenOwner(runtime, document)
+        ) {
+          return undefined;
+        }
+        return result;
+      },
+      handleDiagnostics: (uri, diagnostics, next) => {
+        const document = workspace.textDocuments.find(
+          (candidate) => candidate.uri.toString() === uri.toString(),
+        );
+        if (!document || !this.isServerOpenOwner(runtime, document)) return;
+        next(uri, diagnostics);
+      },
+    };
+  }
+
+  public async activate(runtime: DocumentRoutingRuntime): Promise<void> {
+    return this.enqueue(async () => {
+      const existing = this.activeRoots.get(runtime.rootKey);
+      if (existing?.runtime === runtime) return;
+      if (existing) {
+        throw new Error(
+          `workspace root ${JSON.stringify(runtime.rootKey)} is already active`,
+        );
+      }
+
+      const before = this.activeRoots;
+      const after = new Map(before);
+      after.set(runtime.rootKey, {
+        runtime,
+        selector: createWorkspaceDocumentSelector(runtime.workspaceFolder),
+      });
+      await this.transferDocuments(before, after, true);
+    });
+  }
+
+  public async deactivate(rootKey: string): Promise<void> {
+    return this.enqueue(async () => {
+      const removed = this.activeRoots.get(rootKey);
+      if (!removed) return;
+      const before = this.activeRoots;
+      const after = new Map(before);
+      after.delete(rootKey);
+      const errors: unknown[] = [];
+      try {
+        await this.transferDocuments(before, after, false);
+      } catch (error) {
+        errors.push(...errorList(error));
+      }
+
+      // Removal is forward-only. Drain sessions that no longer appear in
+      // workspace.textDocuments (for example, a close during a restart
+      // listener gap) by exact runtime identity before forgetting the root.
+      this.activeRoots = after;
+      for (const session of [...this.serverOpenDocuments.values()]) {
+        if (session.runtime !== removed.runtime) continue;
+        this.releaseDocumentSession(removed.runtime, session.document, errors);
+      }
+      throwCollectedErrors(errors, 'failed to deactivate document owner');
+    });
+  }
+
+  /**
+   * Invalidates the document session owned by a native process that exited.
+   * The LanguageClient re-registers didOpen after its replacement reaches
+   * Running; those callbacks share this queue and therefore run after reset.
+   */
+  public async resetServerSession(
+    runtime: DocumentRoutingRuntime,
+  ): Promise<void> {
+    return this.enqueue(() => {
+      if (this.activeRoots.get(runtime.rootKey)?.runtime !== runtime) return;
+      const errors: unknown[] = [];
+      for (const session of [...this.serverOpenDocuments.values()]) {
+        if (session.runtime !== runtime) continue;
+        this.releaseDocumentSession(runtime, session.document, errors);
+      }
+      throwCollectedErrors(errors, 'failed to reset routed server session');
+    });
+  }
+
+  public async closeAll(): Promise<void> {
+    return this.enqueue(async () => {
+      const errors: unknown[] = [];
+      for (const session of [...this.serverOpenDocuments.values()]) {
+        try {
+          await this.sendClose(session.runtime, session.document);
+        } catch (error) {
+          errors.push(...errorList(error));
+        }
+        this.releaseDocumentSession(session.runtime, session.document, errors);
+      }
+      this.serverOpenDocuments.clear();
+      this.activeRoots = new Map();
+      throwCollectedErrors(errors, 'failed to close routed documents');
+    });
+  }
+
+  public getServerOpenOwner(document: TextDocument): string | undefined {
+    return this.serverOpenDocuments.get(documentKey(document))?.runtime.rootKey;
+  }
+
+  public ownerKeyForDocument(document: TextDocument): string | undefined {
+    return this.ownerKeyForDocumentIn(this.activeRoots, document);
+  }
+
+  private async transferDocuments(
+    before: Map<string, ActiveRuntime>,
+    after: Map<string, ActiveRuntime>,
+    rollbackOnFailure: boolean,
+  ): Promise<void> {
+    const transfers = workspace.textDocuments
+      .filter(isSupportedWorkspaceDocument)
+      .map((document) => ({
+        document,
+        oldOwnerKey: this.ownerKeyForDocumentIn(before, document),
+        newOwnerKey: this.ownerKeyForDocumentIn(after, document),
+      }))
+      .filter(({ oldOwnerKey, newOwnerKey }) => oldOwnerKey !== newOwnerKey);
+
+    const closedOld: typeof transfers = [];
+    const openedNew: typeof transfers = [];
+    const errors: unknown[] = [];
+
+    for (const transfer of transfers) {
+      if (!transfer.oldOwnerKey) continue;
+      const oldOwner = before.get(transfer.oldOwnerKey);
+      if (!oldOwner) continue;
+      const uri = documentKey(transfer.document);
+      if (this.serverOpenDocuments.get(uri)?.runtime !== oldOwner.runtime) {
+        continue;
+      }
+      // A rejected notification promise does not prove that no bytes reached
+      // the server. Treat every attempted close as needing compensation.
+      closedOld.push(transfer);
+      try {
+        await this.sendClose(oldOwner.runtime, transfer.document);
+      } catch (error) {
+        errors.push(...errorList(error));
+      }
+      this.releaseDocumentSession(oldOwner.runtime, transfer.document, errors);
+    }
+
+    if (errors.length > 0 && rollbackOnFailure) {
+      await this.restoreOldOwners(before, closedOld, errors);
+      throw new AggregateError(
+        errors,
+        'failed to close previous document owners',
+      );
+    }
+
+    this.activeRoots = after;
+
+    for (const transfer of transfers) {
+      if (!transfer.newOwnerKey) continue;
+      const newOwner = after.get(transfer.newOwnerKey);
+      if (!newOwner) continue;
+      try {
+        await this.sendOpen(newOwner.runtime, transfer.document);
+        this.serverOpenDocuments.set(documentKey(transfer.document), {
+          runtime: newOwner.runtime,
+          document: transfer.document,
+        });
+        this.bumpDocumentEpoch(transfer.document);
+        openedNew.push(transfer);
+      } catch (error) {
+        errors.push(...errorList(error));
+      }
+    }
+
+    if (errors.length === 0) return;
+    if (!rollbackOnFailure) {
+      throw new AggregateError(
+        errors,
+        'failed to open fallback document owners',
+      );
+    }
+
+    for (const transfer of openedNew.reverse()) {
+      if (!transfer.newOwnerKey) continue;
+      const newOwner = after.get(transfer.newOwnerKey);
+      if (!newOwner) continue;
+      try {
+        await this.sendClose(newOwner.runtime, transfer.document);
+      } catch (error) {
+        errors.push(...errorList(error));
+      }
+      this.releaseDocumentSession(newOwner.runtime, transfer.document, errors);
+    }
+    this.activeRoots = before;
+    await this.restoreOldOwners(before, closedOld, errors);
+    throw new AggregateError(errors, 'failed to activate document owner');
+  }
+
+  private async restoreOldOwners(
+    before: Map<string, ActiveRuntime>,
+    transfers: ReadonlyArray<{
+      document: TextDocument;
+      oldOwnerKey: string | undefined;
+    }>,
+    errors: unknown[],
+  ): Promise<void> {
+    this.activeRoots = before;
+    for (const transfer of transfers) {
+      if (!transfer.oldOwnerKey) continue;
+      const oldOwner = before.get(transfer.oldOwnerKey);
+      if (!oldOwner) continue;
+      try {
+        await this.sendOpen(oldOwner.runtime, transfer.document);
+        this.serverOpenDocuments.set(documentKey(transfer.document), {
+          runtime: oldOwner.runtime,
+          document: transfer.document,
+        });
+        this.bumpDocumentEpoch(transfer.document);
+      } catch (error) {
+        errors.push(...errorList(error));
+      }
+    }
+  }
+
+  private ownerKeyForDocumentIn(
+    roots: ReadonlyMap<string, ActiveRuntime>,
+    document: TextDocument,
+  ): string | undefined {
+    if (!isSupportedWorkspaceDocument(document)) return undefined;
+    let best: { key: string; depth: number } | undefined;
+    for (const [key, entry] of roots) {
+      if (languages.match(entry.selector, document) <= 0) continue;
+      const depth = entry.runtime.workspaceFolder.uri.path
+        .split('/')
+        .filter(Boolean).length;
+      if (
+        !best ||
+        depth > best.depth ||
+        (depth === best.depth && key.localeCompare(best.key) < 0)
+      ) {
+        best = { key, depth };
+      }
+    }
+    return best?.key;
+  }
+
+  private ownerForDocument(
+    document: TextDocument,
+  ): DocumentRoutingRuntime | undefined {
+    const ownerKey = this.ownerKeyForDocument(document);
+    return ownerKey ? this.activeRoots.get(ownerKey)?.runtime : undefined;
+  }
+
+  private isServerOpenOwner(
+    runtime: DocumentRoutingRuntime,
+    document: TextDocument,
+  ): boolean {
+    const session = this.serverOpenDocuments.get(documentKey(document));
+    return (
+      this.ownerForDocument(document) === runtime &&
+      session?.runtime === runtime &&
+      session.document === document
+    );
+  }
+
+  private releaseDocumentSession(
+    runtime: DocumentRoutingRuntime,
+    document: TextDocument,
+    errors: unknown[],
+  ): void {
+    const uri = documentKey(document);
+    try {
+      runtime.clearDocumentDiagnostics(document.uri);
+    } catch (error) {
+      errors.push(...errorList(error));
+    } finally {
+      if (this.serverOpenDocuments.get(uri)?.runtime === runtime) {
+        this.serverOpenDocuments.delete(uri);
+      }
+      this.bumpDocumentEpoch(document);
+    }
+  }
+
+  private async sendOpen(
+    runtime: DocumentRoutingRuntime,
+    document: TextDocument,
+  ): Promise<void> {
+    const key = permitKey('open', document);
+    const permits = this.transferPermits.get(runtime) ?? new Set<string>();
+    permits.add(key);
+    this.transferPermits.set(runtime, permits);
+    let send: Promise<void>;
+    try {
+      // getProvider().send() enters middleware synchronously before returning
+      // its promise, so the narrowly-scoped permit cannot leak across awaits.
+      send = runtime.sendDocumentOpen(document);
+    } finally {
+      permits.delete(key);
+      if (permits.size === 0) this.transferPermits.delete(runtime);
+    }
+    await send;
+  }
+
+  private async sendClose(
+    runtime: DocumentRoutingRuntime,
+    document: TextDocument,
+  ): Promise<void> {
+    const key = permitKey('close', document);
+    const permits = this.transferPermits.get(runtime) ?? new Set<string>();
+    permits.add(key);
+    this.transferPermits.set(runtime, permits);
+    let send: Promise<void>;
+    try {
+      send = runtime.sendDocumentClose(document);
+    } finally {
+      permits.delete(key);
+      if (permits.size === 0) this.transferPermits.delete(runtime);
+    }
+    await send;
+  }
+
+  private hasTransferPermit(
+    kind: TextSyncKind,
+    runtime: DocumentRoutingRuntime,
+    document: TextDocument,
+  ): boolean {
+    return (
+      this.transferPermits.get(runtime)?.has(permitKey(kind, document)) ?? false
+    );
+  }
+
+  private documentEpoch(document: TextDocument): number {
+    return this.documentEpochs.get(document) ?? 0;
+  }
+
+  private bumpDocumentEpoch(document: TextDocument): void {
+    this.documentEpochs.set(document, this.documentEpoch(document) + 1);
+  }
+
+  private async enqueue<T>(operation: () => Promise<T> | T): Promise<T> {
+    const run = this.operationTail.then(operation, operation);
+    this.operationTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+}

--- a/packages/vscode-extension/src/WorkspaceRslintCoordinator.ts
+++ b/packages/vscode-extension/src/WorkspaceRslintCoordinator.ts
@@ -1,0 +1,486 @@
+import type { WorkspaceFolder, WorkspaceFoldersChangeEvent } from 'vscode';
+import type { DocumentRoutingRuntime } from './WorkspaceDocumentRouter';
+
+export interface WorkspaceRuntime extends DocumentRoutingRuntime {
+  start(signal: AbortSignal): Promise<void>;
+  close(): Promise<void>;
+}
+
+export type WorkspaceRuntimeFactory = (
+  folder: WorkspaceFolder,
+  rootKey: string,
+) => WorkspaceRuntime;
+
+export interface WorkspaceRootRouter {
+  activate(runtime: DocumentRoutingRuntime): Promise<void>;
+  deactivate(rootKey: string): Promise<void>;
+  closeAll(): Promise<void>;
+}
+
+export interface WorkspaceCoordinatorLogger {
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, error?: unknown, ...args: unknown[]): void;
+}
+
+interface DesiredRoot {
+  readonly folder: WorkspaceFolder;
+  readonly generation: number;
+  readonly readiness: Deferred<void>;
+}
+
+interface CurrentRuntime {
+  readonly generation: number;
+  readonly runtime: WorkspaceRuntime;
+  readonly abortController: AbortController;
+  phase: 'starting' | 'active' | 'closing' | 'close-failed';
+  closeError?: unknown;
+  closeFailureRecorded?: boolean;
+}
+
+interface RootSlot {
+  readonly key: string;
+  current?: CurrentRuntime;
+  failedGeneration?: number;
+  worker?: Promise<void>;
+  rerun: boolean;
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+  reject(reason?: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise!: (value: T | PromiseLike<T>) => void;
+  let rejectPromise!: (reason?: unknown) => void;
+  let settled = false;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  // Root readiness is also observed by dynamic fire-and-forget reconciliation.
+  // Keep a rejection handler attached even when no activation caller awaits it.
+  void promise.catch(() => undefined);
+  return {
+    promise,
+    resolve(value) {
+      if (settled) return;
+      settled = true;
+      resolvePromise(value);
+    },
+    reject(reason) {
+      if (settled) return;
+      settled = true;
+      rejectPromise(reason);
+    },
+  };
+}
+
+function cancellationError(rootKey: string): Error {
+  const error = new Error(
+    `workspace root ${JSON.stringify(rootKey)} was superseded`,
+  );
+  error.name = 'AbortError';
+  return error;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function errorReasons(error: unknown): unknown[] {
+  if (!(error instanceof AggregateError)) return [error];
+  const reasons: readonly unknown[] = error.errors;
+  return [...reasons];
+}
+
+function folderMetadataChanged(
+  previous: WorkspaceFolder,
+  next: WorkspaceFolder,
+): boolean {
+  // index is positional metadata and routinely changes when an unrelated root
+  // is inserted before this one. It is neither identity nor a restart reason.
+  return previous.name !== next.name;
+}
+
+export function workspaceRootKey(folder: WorkspaceFolder): string {
+  return folder.uri.toString();
+}
+
+/**
+ * Reconciles VS Code workspace-folder identity with independently-lived root
+ * runtimes. It never serializes different roots behind config evaluation or
+ * worker shutdown; only each URI slot is ordered.
+ */
+export class WorkspaceRslintCoordinator {
+  private readonly desiredRoots = new Map<string, DesiredRoot>();
+  private readonly slots = new Map<string, RootSlot>();
+  private readonly generations = new Map<string, number>();
+  private readonly terminalCloseErrors: unknown[] = [];
+  private topologyChanged = deferred<void>();
+  private closePromise: Promise<void> | undefined;
+  private closing = false;
+
+  public constructor(
+    private readonly router: WorkspaceRootRouter,
+    private readonly runtimeFactory: WorkspaceRuntimeFactory,
+    private readonly logger: WorkspaceCoordinatorLogger,
+  ) {}
+
+  public async initialize(folders: readonly WorkspaceFolder[]): Promise<void> {
+    this.reconcile(folders);
+    await this.waitForAnyDesiredRoot();
+  }
+
+  public handleWorkspaceFoldersChanged(
+    event: WorkspaceFoldersChangeEvent,
+    folders: readonly WorkspaceFolder[],
+  ): void {
+    if (this.closing) return;
+    const removedKeys = new Set<string>();
+    for (const folder of event.removed) {
+      removedKeys.add(workspaceRootKey(folder));
+    }
+    const forceReplace = new Set<string>();
+    for (const folder of event.added) {
+      const key = workspaceRootKey(folder);
+      // A rename/remove+add replacement can preserve the URI. A plain added
+      // event for a URI already captured by the activation snapshot is not a
+      // replacement and must not abort that in-flight initial generation.
+      if (removedKeys.has(key)) forceReplace.add(key);
+    }
+    this.reconcile(folders, forceReplace);
+  }
+
+  public async close(): Promise<void> {
+    await (this.closePromise ??= this.closeImpl());
+  }
+
+  private reconcile(
+    folders: readonly WorkspaceFolder[],
+    forceReplace: ReadonlySet<string> = new Set(),
+  ): void {
+    if (this.closing) return;
+    const nextFolders = new Map(
+      folders.map((folder) => [workspaceRootKey(folder), folder]),
+    );
+    const changedKeys = new Set<string>();
+
+    for (const [key, desired] of this.desiredRoots) {
+      const next = nextFolders.get(key);
+      if (!next) {
+        this.desiredRoots.delete(key);
+        this.nextGeneration(key);
+        desired.readiness.reject(cancellationError(key));
+        changedKeys.add(key);
+        this.slots
+          .get(key)
+          ?.current?.abortController.abort(cancellationError(key));
+        continue;
+      }
+      if (
+        forceReplace.has(key) ||
+        folderMetadataChanged(desired.folder, next)
+      ) {
+        desired.readiness.reject(cancellationError(key));
+        const replacement = this.createDesiredRoot(next);
+        this.desiredRoots.set(key, replacement);
+        changedKeys.add(key);
+        this.slots
+          .get(key)
+          ?.current?.abortController.abort(cancellationError(key));
+      }
+      nextFolders.delete(key);
+    }
+
+    for (const [key, folder] of nextFolders) {
+      this.desiredRoots.set(key, this.createDesiredRoot(folder));
+      changedKeys.add(key);
+    }
+
+    for (const key of changedKeys) this.kick(key);
+    if (changedKeys.size > 0) this.signalTopologyChanged();
+  }
+
+  private createDesiredRoot(folder: WorkspaceFolder): DesiredRoot {
+    return {
+      folder,
+      generation: this.nextGeneration(workspaceRootKey(folder)),
+      readiness: deferred<void>(),
+    };
+  }
+
+  private async waitForAnyDesiredRoot(): Promise<void> {
+    for (;;) {
+      const snapshot = [...this.desiredRoots.entries()];
+      if (snapshot.length === 0) return;
+      // Resolve as soon as one independent root is usable. A pending root
+      // cannot undo another root's successful activation.
+      const readiness: Promise<void>[] = [];
+      for (const [, desired] of snapshot) {
+        readiness.push(desired.readiness.promise);
+      }
+      const result = await Promise.race([
+        Promise.any(readiness).then(
+          () => ({ kind: 'ready' as const }),
+          (error: unknown) => ({ kind: 'failed' as const, error }),
+        ),
+        this.topologyChanged.promise.then(() => ({
+          kind: 'topology' as const,
+        })),
+      ]);
+      if (result.kind === 'topology') continue;
+      if (result.kind === 'ready') {
+        return;
+      }
+      if (this.closing) throw result.error;
+      const topologyChanged =
+        snapshot.length !== this.desiredRoots.size ||
+        snapshot.some(
+          ([key, desired]) =>
+            this.desiredRoots.get(key)?.generation !== desired.generation,
+        );
+      // Folder events are installed before initialization. If that topology
+      // superseded every promise in this snapshot, observe the new desired
+      // generations instead of treating cancellation as an activation
+      // failure.
+      if (topologyChanged) continue;
+
+      const reasons = errorReasons(result.error);
+      throw new AggregateError(
+        reasons,
+        `All Rslint workspace roots failed: ${reasons
+          .map((reason) =>
+            reason instanceof Error ? reason.message : String(reason),
+          )
+          .join('; ')}`,
+      );
+    }
+  }
+
+  private signalTopologyChanged(): void {
+    const previous = this.topologyChanged;
+    this.topologyChanged = deferred<void>();
+    previous.resolve(undefined);
+  }
+
+  private nextGeneration(rootKey: string): number {
+    const generation = (this.generations.get(rootKey) ?? 0) + 1;
+    this.generations.set(rootKey, generation);
+    return generation;
+  }
+
+  private kick(rootKey: string): void {
+    let slot = this.slots.get(rootKey);
+    if (!slot) {
+      slot = { key: rootKey, rerun: false };
+      this.slots.set(rootKey, slot);
+    }
+    slot.rerun = true;
+    if (slot.worker) return;
+    slot.worker = this.runSlot(slot).finally(() => {
+      slot.worker = undefined;
+      if (slot.rerun && !this.closing) {
+        this.kick(rootKey);
+      } else if (!slot.current && !this.desiredRoots.has(rootKey)) {
+        this.slots.delete(rootKey);
+        this.generations.delete(rootKey);
+      }
+    });
+  }
+
+  private async runSlot(slot: RootSlot): Promise<void> {
+    while (slot.rerun || this.slotNeedsReconcile(slot)) {
+      slot.rerun = false;
+      const desired = this.desiredRoots.get(slot.key);
+      const current = slot.current;
+
+      if (
+        current &&
+        (!desired || desired.generation !== current.generation || this.closing)
+      ) {
+        if (!(await this.closeCurrent(slot, current))) return;
+        continue;
+      }
+
+      if (!current && desired && !this.closing) {
+        if (slot.failedGeneration === desired.generation) return;
+        if (!(await this.startDesired(slot, desired))) return;
+        continue;
+      }
+
+      return;
+    }
+  }
+
+  private slotNeedsReconcile(slot: RootSlot): boolean {
+    const desired = this.desiredRoots.get(slot.key);
+    const current = slot.current;
+    if (this.closing) return current !== undefined;
+    if (!current) {
+      return !!desired && slot.failedGeneration !== desired.generation;
+    }
+    return !desired || desired.generation !== current.generation;
+  }
+
+  private async startDesired(
+    slot: RootSlot,
+    desired: DesiredRoot,
+  ): Promise<boolean> {
+    const abortController = new AbortController();
+    let runtime: WorkspaceRuntime;
+    try {
+      runtime = this.runtimeFactory(desired.folder, slot.key);
+    } catch (error) {
+      slot.failedGeneration = desired.generation;
+      desired.readiness.reject(error);
+      this.logger.error(`Failed to create Rslint workspace ${slot.key}`, error);
+      return true;
+    }
+    const current: CurrentRuntime = {
+      generation: desired.generation,
+      runtime,
+      abortController,
+      phase: 'starting',
+    };
+    slot.current = current;
+    this.logger.debug(
+      `Starting Rslint workspace ${slot.key} generation ${desired.generation}`,
+    );
+
+    try {
+      await runtime.start(abortController.signal);
+      if (
+        this.closing ||
+        abortController.signal.aborted ||
+        this.desiredRoots.get(slot.key)?.generation !== desired.generation
+      ) {
+        throw cancellationError(slot.key);
+      }
+      await this.router.activate(runtime);
+      if (
+        this.closing ||
+        abortController.signal.aborted ||
+        this.desiredRoots.get(slot.key)?.generation !== desired.generation
+      ) {
+        await this.router.deactivate(slot.key).catch((error: unknown) => {
+          this.logger.error(
+            `Failed to withdraw stale workspace ${slot.key}`,
+            error,
+          );
+        });
+        throw cancellationError(slot.key);
+      }
+      current.phase = 'active';
+      desired.readiness.resolve(undefined);
+      this.logger.info(`Rslint workspace ready: ${slot.key}`);
+      return true;
+    } catch (error) {
+      const stale =
+        isAbortError(error) ||
+        abortController.signal.aborted ||
+        this.desiredRoots.get(slot.key)?.generation !== desired.generation ||
+        this.closing;
+      if (!stale) {
+        slot.failedGeneration = desired.generation;
+        desired.readiness.reject(error);
+        this.logger.error(
+          `Failed to start Rslint workspace ${slot.key}`,
+          error,
+        );
+      } else {
+        desired.readiness.reject(cancellationError(slot.key));
+      }
+      return this.closeCurrent(slot, current);
+    }
+  }
+
+  private async closeCurrent(
+    slot: RootSlot,
+    current: CurrentRuntime,
+  ): Promise<boolean> {
+    if (slot.current !== current) return true;
+    current.abortController.abort(cancellationError(slot.key));
+    if (current.phase === 'active') {
+      try {
+        await this.router.deactivate(slot.key);
+      } catch (error) {
+        this.logger.error(
+          `Failed to transfer documents away from ${slot.key}`,
+          error,
+        );
+      }
+    }
+    current.phase = 'closing';
+    try {
+      await current.runtime.close();
+    } catch (error) {
+      current.phase = 'close-failed';
+      current.closeError = error;
+      this.logger.error(`Failed to close Rslint workspace ${slot.key}`, error);
+      if (!current.closeFailureRecorded) {
+        current.closeFailureRecorded = true;
+        this.terminalCloseErrors.push(error);
+      }
+
+      // A runtime whose resources did not close remains the sole owner of its
+      // URI slot. Starting a replacement here could overlap native processes,
+      // workers, watchers, and diagnostics for one workspace. Quarantine it
+      // until an explicit later reconciliation (or terminal close) retries.
+      const replacement = this.desiredRoots.get(slot.key);
+      if (replacement && replacement.generation !== current.generation) {
+        slot.failedGeneration = replacement.generation;
+        replacement.readiness.reject(
+          new Error(
+            `Could not replace Rslint workspace ${JSON.stringify(slot.key)} because the previous runtime failed to close`,
+            { cause: error },
+          ),
+        );
+      }
+      return false;
+    }
+    if (slot.current === current) slot.current = undefined;
+    this.logger.debug(`Closed Rslint workspace ${slot.key}`);
+    return true;
+  }
+
+  private async closeImpl(): Promise<void> {
+    if (this.closing) return;
+    this.closing = true;
+    for (const [key, desired] of this.desiredRoots) {
+      desired.readiness.reject(cancellationError(key));
+    }
+    this.desiredRoots.clear();
+    for (const slot of this.slots.values()) {
+      slot.current?.abortController.abort(cancellationError(slot.key));
+      slot.rerun = true;
+    }
+
+    const routerResult = await Promise.allSettled([
+      Promise.resolve().then(async () => {
+        await this.router.closeAll();
+      }),
+    ]);
+    for (const slot of this.slots.values()) this.kick(slot.key);
+    const slotPromises: Promise<void>[] = [];
+    for (const slot of this.slots.values()) {
+      slotPromises.push(slot.worker ?? Promise.resolve());
+    }
+    const slotResults = await Promise.allSettled(slotPromises);
+    this.slots.clear();
+
+    const errors = this.terminalCloseErrors.splice(0);
+    for (const result of [...routerResult, ...slotResults]) {
+      if (result.status === 'rejected') {
+        const reason: unknown = result.reason;
+        errors.push(reason);
+      }
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'failed to close workspace coordinator');
+    }
+  }
+}

--- a/packages/vscode-extension/src/commands.ts
+++ b/packages/vscode-extension/src/commands.ts
@@ -1,25 +1,31 @@
 import * as vscode from 'vscode';
-export function RegisterCommands(
-  context: vscode.ExtensionContext,
+export function registerCommands(
   outputChannel: vscode.OutputChannel,
   traceOutputChannel: vscode.OutputChannel,
-) {
-  context.subscriptions.push(
-    vscode.commands.registerCommand('rslint.showMenu', showCommands),
-  );
-  // context.subscriptions.push(vscode.commands.registerCommand('rslint.restart', async () => {
-  //     await vscode.commands.executeCommand('rslint.restart');
-  // }));
-  context.subscriptions.push(
-    vscode.commands.registerCommand('rslint.output.focus', () => {
-      outputChannel.show();
-    }),
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('rslint.lsp-trace.focus', () => {
-      traceOutputChannel.show();
-    }),
-  );
+): vscode.Disposable[] {
+  const disposables: vscode.Disposable[] = [];
+  try {
+    disposables.push(
+      vscode.commands.registerCommand('rslint.showMenu', showCommands),
+    );
+    // vscode.commands.registerCommand('rslint.restart', async () => {
+    //   await vscode.commands.executeCommand('rslint.restart');
+    // }),
+    disposables.push(
+      vscode.commands.registerCommand('rslint.output.focus', () => {
+        outputChannel.show();
+      }),
+    );
+    disposables.push(
+      vscode.commands.registerCommand('rslint.lsp-trace.focus', () => {
+        traceOutputChannel.show();
+      }),
+    );
+    return disposables;
+  } catch (error) {
+    for (const disposable of disposables.reverse()) disposable.dispose();
+    throw error;
+  }
 }
 
 async function showCommands(): Promise<void> {

--- a/packages/vscode-extension/src/logger.ts
+++ b/packages/vscode-extension/src/logger.ts
@@ -12,6 +12,7 @@ export class Logger {
   static defaultLogLevel: LogLevel = LogLevel.INFO;
   private readonly outputChannel: OutputChannel;
   private logLevel: LogLevel = LogLevel.INFO;
+  private disposed = false;
 
   static setDefaultLogLevel(context: { extensionMode: ExtensionMode }): void {
     Logger.defaultLogLevel =
@@ -69,11 +70,13 @@ export class Logger {
   }
 
   public dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
     this.outputChannel.dispose();
   }
 
   private log(level: LogLevel, message: string, ...args: unknown[]): void {
-    if (level < this.logLevel) {
+    if (this.disposed || level < this.logLevel) {
       return;
     }
 

--- a/packages/vscode-extension/src/main.ts
+++ b/packages/vscode-extension/src/main.ts
@@ -1,22 +1,33 @@
 import { ExtensionContext } from 'vscode';
 import { Extension } from './Extension';
 
-let extension: Extension;
+let extension: Extension | undefined;
 
 export async function activate(context: ExtensionContext): Promise<void> {
   extension = new Extension(context);
 
   try {
     await extension.activate();
-    context.subscriptions.push(extension);
-  } catch (error) {
-    extension?.dispose();
-    throw error;
+  } catch (activationError) {
+    let closeError: unknown;
+    try {
+      await extension.close();
+    } catch (error) {
+      closeError = error;
+    }
+    extension = undefined;
+    if (closeError !== undefined) {
+      throw new AggregateError(
+        [activationError, closeError],
+        'Rslint activation and partial-start cleanup both failed',
+      );
+    }
+    throw activationError;
   }
 }
 
 export async function deactivate(): Promise<void> {
-  if (extension) {
-    await extension.deactivate();
-  }
+  const activeExtension = extension;
+  extension = undefined;
+  await activeExtension?.deactivate();
 }

--- a/packages/vscode-extension/src/statusBar.ts
+++ b/packages/vscode-extension/src/statusBar.ts
@@ -1,17 +1,17 @@
 import * as vscode from 'vscode';
-import { RslintBinPath } from './utils';
-export function setupStatusBar(context: vscode.ExtensionContext) {
+export function setupStatusBar(): vscode.StatusBarItem {
   const statusBar = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Right,
     100,
   );
-  const binPathConfig = vscode.workspace
-    .getConfiguration()
-    .get<RslintBinPath>('rslint.binPath')!;
-  statusBar.text = `$(wrench) Rslint`;
-  statusBar.tooltip = `Rslint Language Server (${binPathConfig})`;
-  statusBar.command = 'rslint.showMenu';
-  statusBar.show();
-
-  context.subscriptions.push(statusBar);
+  try {
+    statusBar.text = `$(wrench) Rslint`;
+    statusBar.tooltip = 'Rslint Language Server';
+    statusBar.command = 'rslint.showMenu';
+    statusBar.show();
+    return statusBar;
+  } catch (error) {
+    statusBar.dispose();
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary

- key VS Code workspace runtimes by folder URI and coordinate dynamic add, remove, rename, failed-start isolation, and close-failed quarantine
- route overlapping workspace documents to the longest ready root with ordered ownership handoffs, restart-session invalidation, and runtime/epoch gates for diagnostics and code actions
- make per-workspace `Rslint` instances own their client, watcher, plugin pool, logger, and every native child while the extension exclusively owns shared UI and output channels
- cover same-name roots, parent/child roots, dynamic topology changes, automatic restarts, hung initialization, forced process termination, and fail-closed multi-root test sandboxes; document the resulting architecture

## Related Links

- Follow-up to https://github.com/web-infra-dev/rslint/pull/1276

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
