### PR TITLE
fix: align promise preset with upstream

### DIFF
--- a/packages/rslint/src/config/presets/promise.ts
+++ b/packages/rslint/src/config/presets/promise.ts
@@ -10,12 +10,12 @@ const recommended: RslintConfigEntry = {
     'promise/param-names': 'error',
     'promise/catch-or-return': 'error',
     // 'promise/no-native': 'off', // not implemented
-    // 'promise/no-nesting': 'warn', // not implemented
+    'promise/no-nesting': 'warn',
     'promise/no-promise-in-callback': 'warn',
-    // 'promise/no-callback-in-promise': 'warn', // not implemented
+    'promise/no-callback-in-promise': 'warn',
     'promise/avoid-new': 'off',
-    // 'promise/no-new-statics': 'error', // not implemented
-    // 'promise/no-return-in-finally': 'warn', // not implemented
+    'promise/no-new-statics': 'error',
+    'promise/no-return-in-finally': 'warn',
     'promise/valid-params': 'warn',
   },
 };


### PR DESCRIPTION
## Summary

- Enable four eslint-plugin-promise recommended rules that are now available in rslint.
- Keep each rule at its upstream recommended severity.

## Related Links

- https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/index.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).