### PR TITLE
fix: align React preset with upstream

### DIFF
--- a/packages/rslint/src/config/presets/react.ts
+++ b/packages/rslint/src/config/presets/react.ts
@@ -6,7 +6,7 @@ const recommended: RslintConfigEntry = {
   files: ['**/*.jsx', '**/*.tsx'],
   plugins: ['react'],
   rules: {
-    // 'react/display-name': 'error', // not implemented
+    'react/display-name': 'error',
     'react/jsx-key': 'error',
     'react/jsx-no-comment-textnodes': 'error',
     'react/jsx-no-duplicate-props': 'error',


### PR DESCRIPTION
## Summary

- Enable react/display-name in the React recommended preset.
- Match the upstream recommended error severity now that the rule is available in rslint.

## Related Links

- https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/index.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).