### PR TITLE
fix(website): correct rule manifest identity and test status

### DIFF
--- a/internal/plugins/react/plugin.go
+++ b/internal/plugins/react/plugin.go
@@ -1,1 +1,3 @@
 package react_plugin
+
+const PLUGIN_NAME = "eslint-plugin-react"

--- a/scripts/gen-rule-manifest.js
+++ b/scripts/gen-rule-manifest.js
@@ -78,10 +78,19 @@ function groupToTestDir(group) {
   return group.replace(/^@/, '');
 }
 
-function getIncludedRuleTests() {
+// Canonical manifest key. The whole file uses the `group` namespace so a
+// lookup can never accidentally mix `group` and `testDir` spellings.
+function ruleKey(group, rule) {
+  return `${group}:${rule}`;
+}
+
+function getIncludedRuleTests(groups) {
   // Parse rstest.config.mts include list and associate each rule with its
   // enabled test files, including tests nested under a rule directory.
   const config = fs.readFileSync(TEST_CONFIG_PATH, 'utf-8');
+  // Translate the on-disk test directory back to its manifest group once here,
+  // so the returned map lives entirely in the `group` namespace.
+  const testDirToGroup = new Map(groups.map((g) => [groupToTestDir(g), g]));
   // Match uncommented flat and nested paths:
   //   ./tests/{testDir}/rules/{rule}.test.ts
   //   ./tests/{testDir}/rules/{rule}/{test-file}.test.ts
@@ -90,11 +99,11 @@ function getIncludedRuleTests() {
   const included = new Map();
   let match;
   while ((match = includeRegex.exec(config))) {
+    const group = testDirToGroup.get(match[2]);
+    if (!group) continue; // test dir with no matching plugin group
     const testPath = path.resolve(path.dirname(TEST_CONFIG_PATH), match[1]);
-    const testDir = match[2];
     const rule = match[3].replace(/-/g, '_');
-    // Key by test-dir + rule so same-named rules in different plugins stay distinct.
-    const key = `${testDir}:${rule}`;
+    const key = ruleKey(group, rule);
     if (!included.has(key)) included.set(key, new Set());
     included.get(key).add(testPath);
   }
@@ -286,14 +295,15 @@ function getDocPath(rule, pluginDir) {
 }
 
 function buildManifest() {
-  const included = getIncludedRuleTests();
   const ruleEntries = [...getPluginRuleEntries(), ...getCoreRuleEntries()];
   // Deduplicate by group + rule name, keeping first entry.
   const seen = new Map();
   for (const e of ruleEntries) {
-    const key = `${e.group}:${e.rule}`;
+    const key = ruleKey(e.group, e.rule);
     if (!seen.has(key)) seen.set(key, e);
   }
+  const groups = [...new Set(ruleEntries.map((e) => e.group))];
+  const included = getIncludedRuleTests(groups);
   const rules = Array.from(seen.values())
     .sort(
       (a, b) => a.rule.localeCompare(b.rule) || a.group.localeCompare(b.group),
@@ -303,7 +313,7 @@ function buildManifest() {
       let status = 'full';
       let failing_case = [];
       const group = entry.group;
-      const testFiles = included.get(`${groupToTestDir(group)}:${rule}`);
+      const testFiles = included.get(ruleKey(group, rule));
       if (!testFiles) {
         status = 'partial-test';
       } else {

--- a/scripts/gen-rule-manifest.js
+++ b/scripts/gen-rule-manifest.js
@@ -91,6 +91,19 @@ function getIncludedRuleTests(groups) {
   // Translate the on-disk test directory back to its manifest group once here,
   // so the returned map lives entirely in the `group` namespace.
   const testDirToGroup = new Map(groups.map((g) => [groupToTestDir(g), g]));
+  // Fail loudly if a group's expected test directory is missing: otherwise
+  // every rule in that group silently degrades to partial-test, and because
+  // the manifest is gitignored and built at site-build time the flip would
+  // never surface in a diff.
+  for (const [testDir] of testDirToGroup) {
+    const dir = path.join(TESTS_BASE_DIR, testDir);
+    if (!fs.existsSync(dir)) {
+      throw new Error(
+        `Expected test directory not found: ${path.relative(REPO_ROOT, dir)} ` +
+          `(group "${testDirToGroup.get(testDir)}"). Update groupToTestDir or the test layout.`,
+      );
+    }
+  }
   // Match uncommented flat and nested paths:
   //   ./tests/{testDir}/rules/{rule}.test.ts
   //   ./tests/{testDir}/rules/{rule}/{test-file}.test.ts
@@ -106,6 +119,14 @@ function getIncludedRuleTests(groups) {
     const key = ruleKey(group, rule);
     if (!included.has(key)) included.set(key, new Set());
     included.get(key).add(testPath);
+  }
+  // A non-empty include list that parses to zero entries means the regex or
+  // the config quoting drifted (e.g. a formatter switched to double quotes).
+  if (included.size === 0) {
+    throw new Error(
+      `No rule tests parsed from ${path.relative(REPO_ROOT, TEST_CONFIG_PATH)}; ` +
+        `the include-path regex is likely out of sync with the config format.`,
+    );
   }
   return included;
 }

--- a/scripts/gen-rule-manifest.js
+++ b/scripts/gen-rule-manifest.js
@@ -73,8 +73,6 @@ function getPluginRuleEntries() {
 
 // Map group name to test directory name: "@typescript-eslint" -> "typescript-eslint", etc.
 function groupToTestDir(group) {
-  // The manifest uses "react", while its tests live under "eslint-plugin-react".
-  if (group === 'react') return 'eslint-plugin-react';
   return group.replace(/^@/, '');
 }
 

--- a/scripts/gen-rule-manifest.js
+++ b/scripts/gen-rule-manifest.js
@@ -3,6 +3,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const REPO_ROOT = path.join(__dirname, '..');
+
 // Plugins root directory
 const PLUGINS_DIR = path.join(__dirname, '../internal/plugins');
 const CORE_RULES_DIR = path.join(__dirname, '../internal/rules');
@@ -76,19 +78,25 @@ function groupToTestDir(group) {
   return group.replace(/^@/, '');
 }
 
-function getIncludedRules() {
-  // Parse rstest.config.mts include list, extract rule names from all test directories
+function getIncludedRuleTests() {
+  // Parse rstest.config.mts include list and associate each rule with its
+  // enabled test files, including tests nested under a rule directory.
   const config = fs.readFileSync(TEST_CONFIG_PATH, 'utf-8');
-  // Match any uncommented test path: ./tests/{any-group}/rules/{rule}.test.ts
+  // Match uncommented flat and nested paths:
+  //   ./tests/{testDir}/rules/{rule}.test.ts
+  //   ./tests/{testDir}/rules/{rule}/{test-file}.test.ts
   const includeRegex =
-    /^\s*'\.(?:\/|\\)tests\/([\w-]+)\/rules\/([\w-]+)\.test\.ts'/gm;
-  const included = new Set();
+    /^\s*'(\.(?:\/|\\)tests\/([\w-]+)\/rules\/([\w-]+)(?:\/[^']+)?\.test\.ts)'/gm;
+  const included = new Map();
   let match;
   while ((match = includeRegex.exec(config))) {
-    const testDir = match[1];
-    const rule = match[2].replace(/-/g, '_');
+    const testPath = path.resolve(path.dirname(TEST_CONFIG_PATH), match[1]);
+    const testDir = match[2];
+    const rule = match[3].replace(/-/g, '_');
     // Key by test-dir + rule so same-named rules in different plugins stay distinct.
-    included.add(`${testDir}:${rule}`);
+    const key = `${testDir}:${rule}`;
+    if (!included.has(key)) included.set(key, new Set());
+    included.get(key).add(testPath);
   }
   return included;
 }
@@ -229,29 +237,37 @@ function getStatementLevelSkipCases(content, relPath) {
   return skipCases;
 }
 
-function getSkipCases(rule, group) {
-  // Return skip cases as [{name, url}]
-  const testDir = groupToTestDir(group);
-  const testsDir = path.join(TESTS_BASE_DIR, testDir, 'rules');
-  const testFile = path.join(testsDir, `${rule.replace(/_/g, '-')}.test.ts`);
+function getObjectSkipCases(content, relPath) {
+  // Match statement-level `skip: true` test-case objects, whether or not they
+  // carry a `name` property; unnamed cases get a line-based placeholder.
+  const skipCases = [];
+  const skipRegex = /\bskip\s*:\s*true\b/g;
+  const state = createParserState();
+  let cursor = 0;
+  let match;
+
+  while ((match = skipRegex.exec(content))) {
+    advanceParserState(state, content, cursor, match.index);
+    if (isStatementLevel(state)) {
+      const line = content.slice(0, match.index).split('\n').length;
+      skipCases.push({
+        name: `Skipped test case at line ${line}`,
+        url: `${relPath}#L${line}`,
+      });
+    }
+    cursor = skipRegex.lastIndex;
+  }
+
+  return skipCases;
+}
+
+function getSkipCases(testFile) {
+  // Return skip cases as [{name, url}] for a single enabled test file.
   if (!fs.existsSync(testFile)) return [];
   const content = fs.readFileSync(testFile, 'utf-8');
-  const relPath = `packages/rslint-test-tools/tests/${testDir}/rules/${rule.replace(/_/g, '-')}.test.ts`;
-  const skipCases = [];
-  // 1. Object case: { ..., skip: true, name: 'xxx' }
-  const objCaseRegex =
-    /\{[^}]*skip\s*:\s*true[^}]*name\s*:\s*['"]([^'"]+)['"][^}]*}/g;
-  let m;
-  while ((m = objCaseRegex.exec(content))) {
-    const idx = m.index;
-    const before = content.slice(0, idx);
-    const line = before.split('\n').length;
-    skipCases.push({
-      name: m[1],
-      url: `${relPath}#L${line}`,
-    });
-  }
-  // 2. Top-level it.skip('name', ...) / describe.skip('name', ...)
+  const relPath = path.relative(REPO_ROOT, testFile).split(path.sep).join('/');
+  const skipCases = getObjectSkipCases(content, relPath);
+  // Also collect top-level it.skip('name', ...) / describe.skip('name', ...).
   skipCases.push(...getStatementLevelSkipCases(content, relPath));
   return skipCases;
 }
@@ -270,7 +286,7 @@ function getDocPath(rule, pluginDir) {
 }
 
 function buildManifest() {
-  const included = getIncludedRules();
+  const included = getIncludedRuleTests();
   const ruleEntries = [...getPluginRuleEntries(), ...getCoreRuleEntries()];
   // Deduplicate by group + rule name, keeping first entry.
   const seen = new Map();
@@ -287,10 +303,11 @@ function buildManifest() {
       let status = 'full';
       let failing_case = [];
       const group = entry.group;
-      if (!included.has(`${groupToTestDir(group)}:${rule}`)) {
+      const testFiles = included.get(`${groupToTestDir(group)}:${rule}`);
+      if (!testFiles) {
         status = 'partial-test';
       } else {
-        const skipCases = getSkipCases(rule, group);
+        const skipCases = Array.from(testFiles).flatMap(getSkipCases);
         if (skipCases.length > 0) {
           status = 'partial-impl';
           failing_case = skipCases;

--- a/scripts/gen-rule-manifest.js
+++ b/scripts/gen-rule-manifest.js
@@ -73,6 +73,8 @@ function getPluginRuleEntries() {
 
 // Map group name to test directory name: "@typescript-eslint" -> "typescript-eslint", etc.
 function groupToTestDir(group) {
+  // The manifest uses "react", while its tests live under "eslint-plugin-react".
+  if (group === 'react') return 'eslint-plugin-react';
   return group.replace(/^@/, '');
 }
 
@@ -85,8 +87,10 @@ function getIncludedRules() {
   const included = new Set();
   let match;
   while ((match = includeRegex.exec(config))) {
+    const testDir = match[1];
     const rule = match[2].replace(/-/g, '_');
-    included.add(rule);
+    // Key by test-dir + rule so same-named rules in different plugins stay distinct.
+    included.add(`${testDir}:${rule}`);
   }
   return included;
 }
@@ -270,19 +274,22 @@ function getDocPath(rule, pluginDir) {
 function buildManifest() {
   const included = getIncludedRules();
   const ruleEntries = [...getPluginRuleEntries(), ...getCoreRuleEntries()];
-  // Deduplicate by rule name, keeping first entry
+  // Deduplicate by group + rule name, keeping first entry.
   const seen = new Map();
   for (const e of ruleEntries) {
-    if (!seen.has(e.rule)) seen.set(e.rule, e);
+    const key = `${e.group}:${e.rule}`;
+    if (!seen.has(key)) seen.set(key, e);
   }
-  const rules = Array.from(seen.keys())
-    .sort((a, b) => a.localeCompare(b))
-    .map((rule) => {
-      const entry = seen.get(rule);
+  const rules = Array.from(seen.values())
+    .sort(
+      (a, b) => a.rule.localeCompare(b.rule) || a.group.localeCompare(b.group),
+    )
+    .map((entry) => {
+      const rule = entry.rule;
       let status = 'full';
       let failing_case = [];
       const group = entry.group;
-      if (!included.has(rule)) {
+      if (!included.has(`${groupToTestDir(group)}:${rule}`)) {
         status = 'partial-test';
       } else {
         const skipCases = getSkipCases(rule, group);

--- a/website/theme/components/RuleStates/rule.tsx
+++ b/website/theme/components/RuleStates/rule.tsx
@@ -237,7 +237,10 @@ const RuleImplementationStatus: React.FC = () => {
               </TableHeader>
               <TableBody>
                 {filteredRules.map((rule) => (
-                  <TableRow key={rule.name} className="transition-colors">
+                  <TableRow
+                    key={`${rule.group}:${rule.name}`}
+                    className="transition-colors"
+                  >
                     <TableCell className="truncate">
                       <Button
                         variant="link"

--- a/website/theme/plugin-registry.ts
+++ b/website/theme/plugin-registry.ts
@@ -67,7 +67,7 @@ export const PLUGIN_REGISTRY: PluginMeta[] = [
   },
   {
     prefix: 'react',
-    group: 'react',
+    group: 'eslint-plugin-react',
     importName: 'reactPlugin',
     presets: [
       {


### PR DESCRIPTION
## Summary

Fix rule manifest generation so implementation status is tracked using the complete rule identity, and close the robustness gaps raised in review.

- Use a single `group:rule` key (via a `ruleKey` helper) for dedup and test-status lookup, so same-named rules from different plugins (e.g. `eslint/no-shadow` and `@typescript-eslint/no-shadow`) are no longer collapsed to one entry.
- Give the `react` plugin a `PLUGIN_NAME = "eslint-plugin-react"` constant (mirroring `react-hooks`) instead of special-casing the directory name in the generator; the registry `group` is updated to match. Route slugs come from `prefix`, so `/rules/react/` URLs and preset mapping are unaffected.
- Match nested / multi-file rule test paths (`tests/{dir}/rules/{rule}/*.test.ts`) and associate every enabled test file with its rule.
- Scan those test files for skip cases, including statement-level `skip: true` objects that have no `name` (line-based placeholder), so surfacing nested files cannot silently hide their skipped cases.
- Fail the build when a group's test directory is missing or the include list parses to zero entries, since the manifest is gitignored and built at site-build time.
- Update the frontend rule-status table row key to `group:rule`.

## Implementation Overview

Measured against `main` by regenerating `rule-manifest.json` before and after:

| Status | Before | After | Change |
| --- | ---: | ---: | ---: |
| Fully Implemented | 402 | 403 | +1 |
| Partial Implemented | 1 | 18 | +17 |
| Partial Tested | 45 | 42 | -3 |
| Total Rules | 448 | 463 | +15 |

The large `partial-impl` increase is expected: nested test files and unnamed `skip: true` cases are now scanned, so rules that were previously reported as `full` (or hidden entirely) now correctly report their skipped cases.

## Rule Changes

Rules restored after replacing bare-name deduplication with complete rule identities (previously dropped because a same-named rule in another plugin won the dedup):

- `eslint/max-params` → `full`
- `eslint/no-dupe-class-members` → `full`
- `eslint/no-empty-function` → `full`
- `eslint/no-implied-eval` → `full`
- `eslint/no-loop-func` → `full`
- `eslint/no-redeclare` → `partial-impl`
- `eslint/no-restricted-imports` → `full`
- `eslint/no-shadow` → `full`
- `eslint/no-unused-expressions` → `partial-impl`
- `eslint/no-unused-private-class-members` → `full`
- `eslint/no-useless-constructor` → `full`
- `eslint/prefer-destructuring` → `full`
- `eslint/prefer-promise-reject-errors` → `full`
- `eslint/require-await` → `full`
- `@typescript-eslint/no-deprecated` → `partial-impl`

Existing rules whose status is corrected once they are keyed and scanned by their own identity:

- `@typescript-eslint/class-methods-use-this`: `partial-test` → `full`
- `@typescript-eslint/prefer-optional-chain`: `partial-test` → `full`
- `@typescript-eslint/naming-convention`: `partial-test` → `partial-impl`
- `@typescript-eslint/no-unused-vars`: `partial-test` → `partial-impl`
- `@typescript-eslint/no-shadow`: `full` → `partial-impl`
- `@typescript-eslint/prefer-promise-reject-errors`: `full` → `partial-test`
- `@typescript-eslint/no-confusing-void-expression`, `no-duplicate-type-constituents`, `no-redeclare`, `no-unnecessary-boolean-literal-compare`, `no-unnecessary-condition`, `prefer-nullish-coalescing`, `strict-boolean-expressions`: `full` → `partial-impl`
- `eslint/no-invalid-regexp`, `no-loss-of-precision`, `prefer-exponentiation-operator`, `prefer-regex-literals`: `full` → `partial-impl`
