### PR TITLE
feat(rstest): add no-mocks-import rule

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	promisePlugin "github.com/web-infra-dev/rslint/internal/plugins/promise"
 	reactPlugin "github.com/web-infra-dev/rslint/internal/plugins/react"
 	reactHooksPlugin "github.com/web-infra-dev/rslint/internal/plugins/react_hooks"
+	rstestPlugin "github.com/web-infra-dev/rslint/internal/plugins/rstest"
 	typescriptPlugin "github.com/web-infra-dev/rslint/internal/plugins/typescript"
 	unicornPlugin "github.com/web-infra-dev/rslint/internal/plugins/unicorn"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -464,6 +465,11 @@ var KnownPlugins = []PluginInfo{
 		getAllRules: func() []rule.Rule { return reactHooksPlugin.GetAllRules() },
 	},
 	{
+		RulePrefix:  "rstest",
+		DeclNames:   []string{"rstest"},
+		getAllRules: func() []rule.Rule { return rstestPlugin.GetAllRules() },
+	},
+	{
 		RulePrefix:  "unicorn",
 		DeclNames:   []string{"eslint-plugin-unicorn", "unicorn"},
 		getAllRules: func() []rule.Rule { return unicornPlugin.GetAllRules() },
@@ -598,6 +604,7 @@ func RegisterAllRules() {
 		registerAllReactPluginRules()
 		registerAllReactHooksPluginRules()
 		registerAllJestPluginRules()
+		registerAllRstestPluginRules()
 		registerAllJsxA11yPluginRules()
 		registerAllPromisePluginRules()
 		registerAllUnicornPluginRules()
@@ -619,6 +626,12 @@ func registerAllReactHooksPluginRules() {
 
 func registerAllJestPluginRules() {
 	for _, rule := range jestPlugin.GetAllRules() {
+		GlobalRuleRegistry.Register(rule.Name, rule)
+	}
+}
+
+func registerAllRstestPluginRules() {
+	for _, rule := range rstestPlugin.GetAllRules() {
 		GlobalRuleRegistry.Register(rule.Name, rule)
 	}
 }

--- a/internal/plugins/jest/rules/no_mocks_import/no_mocks_import.go
+++ b/internal/plugins/jest/rules/no_mocks_import/no_mocks_import.go
@@ -13,10 +13,10 @@ var mocksDirName = "__mocks__"
 
 // Message Builder
 
-func buildNoManualImportErrorMessage() rule.RuleMessage {
+func buildNoManualImportErrorMessage(mockFunction string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "noManualImport",
-		Description: fmt.Sprintf("Mocks should not be manually imported from a %s directory. Instead use `jest.mock` and import from the original module path", mocksDirName),
+		Description: fmt.Sprintf("Mocks should not be manually imported from a %s directory. Instead use `%s` and import from the original module path", mocksDirName, mockFunction),
 	}
 }
 
@@ -28,36 +28,41 @@ func isStringNode(node *ast.Node) bool {
 	return node.Kind == ast.KindStringLiteral || node.Kind == ast.KindNoSubstitutionTemplateLiteral
 }
 
-var NoMocksImportRule = rule.Rule{
-	Name: "jest/no-mocks-import",
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		return rule.RuleListeners{
-			ast.KindImportDeclaration: func(node *ast.Node) {
-				if isMocksImportPath(node.AsImportDeclaration().ModuleSpecifier.Text()) {
-					ctx.ReportNode(node, buildNoManualImportErrorMessage())
-				}
-			},
-			ast.KindCallExpression: func(node *ast.Node) {
-				callExpr := node.AsCallExpression().Expression
-				if callExpr.Kind != ast.KindIdentifier {
-					return
-				}
+// NewRule creates a no-mocks-import rule for a test framework.
+func NewRule(name string, mockFunction string) rule.Rule {
+	return rule.Rule{
+		Name: name,
+		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+			return rule.RuleListeners{
+				ast.KindImportDeclaration: func(node *ast.Node) {
+					if isMocksImportPath(node.AsImportDeclaration().ModuleSpecifier.Text()) {
+						ctx.ReportNode(node, buildNoManualImportErrorMessage(mockFunction))
+					}
+				},
+				ast.KindCallExpression: func(node *ast.Node) {
+					callExpr := node.AsCallExpression().Expression
+					if callExpr.Kind != ast.KindIdentifier {
+						return
+					}
 
-				callee := callExpr.AsIdentifier()
-				if callee == nil || callee.Text != "require" {
-					return
-				}
+					callee := callExpr.AsIdentifier()
+					if callee == nil || callee.Text != "require" {
+						return
+					}
 
-				arguments := node.Arguments()
-				if len(arguments) == 0 {
-					return
-				}
+					arguments := node.Arguments()
+					if len(arguments) == 0 {
+						return
+					}
 
-				firstArg := arguments[0]
-				if firstArg != nil && isStringNode(firstArg) && isMocksImportPath(firstArg.Text()) {
-					ctx.ReportNode(firstArg, buildNoManualImportErrorMessage())
-				}
-			},
-		}
-	},
+					firstArg := arguments[0]
+					if firstArg != nil && isStringNode(firstArg) && isMocksImportPath(firstArg.Text()) {
+						ctx.ReportNode(firstArg, buildNoManualImportErrorMessage(mockFunction))
+					}
+				},
+			}
+		},
+	}
 }
+
+var NoMocksImportRule = NewRule("jest/no-mocks-import", "jest.mock")

--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -1,0 +1,12 @@
+package rstest
+
+import (
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func GetAllRules() []rule.Rule {
+	return []rule.Rule{
+		no_mocks_import.NoMocksImportRule,
+	}
+}

--- a/internal/plugins/rstest/fixtures/fixtures.go
+++ b/internal/plugins/rstest/fixtures/fixtures.go
@@ -1,0 +1,11 @@
+package fixtures
+
+import (
+	"path"
+	"runtime"
+)
+
+func GetRootDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return path.Dir(filename)
+}

--- a/internal/plugins/rstest/fixtures/tsconfig.json
+++ b/internal/plugins/rstest/fixtures/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"]
+  }
+}

--- a/internal/plugins/rstest/rules/no_mocks_import/no_mocks_import.go
+++ b/internal/plugins/rstest/rules/no_mocks_import/no_mocks_import.go
@@ -1,0 +1,5 @@
+package no_mocks_import
+
+import jestNoMocksImport "github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_mocks_import"
+
+var NoMocksImportRule = jestNoMocksImport.NewRule("rstest/no-mocks-import", "rs.mock")

--- a/internal/plugins/rstest/rules/no_mocks_import/no_mocks_import.md
+++ b/internal/plugins/rstest/rules/no_mocks_import/no_mocks_import.md
@@ -1,0 +1,21 @@
+# no-mocks-import
+
+## Rule Details
+
+When using `rs.mock`, tests should import from the original module path, not directly from a `__mocks__` directory. Directly importing a manual mock can create a separate module instance and make assertions behave unexpectedly.
+
+This rule reports `import` declarations and `require()` calls whose module specifier contains a `__mocks__` path segment.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+import thing from './__mocks__/thing';
+require('./__mocks__/thing');
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+rs.mock('./thing');
+import thing from './thing';
+```

--- a/internal/plugins/rstest/rules/no_mocks_import/no_mocks_import_test.go
+++ b/internal/plugins/rstest/rules/no_mocks_import/no_mocks_import_test.go
@@ -1,0 +1,81 @@
+package no_mocks_import_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoMocksImport(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_mocks_import.NoMocksImportRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `import something from "something"`},
+			{Code: `require("somethingElse")`},
+			{Code: `require("./__mocks__.js")`},
+			{Code: `require("./__mocks__x")`},
+			{Code: `require("./__mocks__x/x")`},
+			{Code: `require("./x__mocks__")`},
+			{Code: `require("./x__mocks__/x")`},
+			{Code: `require()`},
+			{Code: `var path = "./__mocks__.js"; require(path)`},
+			{Code: `entirelyDifferent(fn)`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `require("./__mocks__")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "noManualImport",
+						Message:   "Mocks should not be manually imported from a __mocks__ directory. Instead use `rs.mock` and import from the original module path",
+						Line:      1,
+						Column:    9,
+						EndLine:   1,
+						EndColumn: 22,
+					},
+				},
+			},
+			{
+				Code: `require("./__mocks__/")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noManualImport", Line: 1, Column: 9, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code: `require("./__mocks__/index")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noManualImport", Line: 1, Column: 9, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				Code: `require("__mocks__")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noManualImport", Line: 1, Column: 9, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				Code: `require("__mocks__/")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noManualImport", Line: 1, Column: 9, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code: `require("__mocks__/index")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noManualImport", Line: 1, Column: 9, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code: `import thing from "./__mocks__/index"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noManualImport", Line: 1, Column: 1, EndLine: 1, EndColumn: 38},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -533,6 +533,9 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/valid-expect.test.ts',
     './tests/eslint-plugin-jest/rules/valid-title.test.ts',
 
+    // rstest
+    './tests/rstest/rules/no-mocks-import.test.ts',
+
     // eslint-plugin-promise
     './tests/eslint-plugin-promise/rules/always-return.test.ts',
     './tests/eslint-plugin-promise/rules/avoid-new.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -1,6 +1,13 @@
 import { describe, test, expect } from '@rstest/core';
 import { normalizeConfig } from '@rslint/core/config-loader';
-import { defineConfig, ts, js, reactPlugin, importPlugin } from '@rslint/core';
+import {
+  defineConfig,
+  ts,
+  js,
+  reactPlugin,
+  importPlugin,
+  rstestPlugin,
+} from '@rslint/core';
 
 describe('defineConfig and config presets', () => {
   test('defineConfig should be importable and return input as-is', () => {
@@ -20,10 +27,12 @@ describe('defineConfig and config presets', () => {
     expect(reactPlugin.configs.recommended).toBeDefined();
     expect(importPlugin).toBeDefined();
     expect(importPlugin.configs.recommended).toBeDefined();
+    expect(rstestPlugin).toBeDefined();
+    expect(rstestPlugin.configs.recommended).toBeDefined();
   });
 
   test('config presets should be valid config entries', () => {
-    for (const plugin of [ts, js, reactPlugin, importPlugin]) {
+    for (const plugin of [ts, js, reactPlugin, importPlugin, rstestPlugin]) {
       const rec = plugin.configs.recommended;
       expect(typeof rec).toBe('object');
       expect(rec).not.toBeNull();
@@ -59,5 +68,14 @@ describe('defineConfig and config presets', () => {
     const rec = importPlugin.configs.recommended;
     expect(rec.plugins).toBeDefined();
     expect(rec.plugins).toContain('eslint-plugin-import');
+  });
+
+  test('rstestPlugin.configs.recommended should declare rstest plugin and rule', () => {
+    const rec = rstestPlugin.configs.recommended;
+    expect(rec.plugins).toBeDefined();
+    expect(rec.plugins).toContain('rstest');
+    expect(rec.rules).toEqual({
+      'rstest/no-mocks-import': 'error',
+    });
   });
 });

--- a/packages/rslint-test-tools/tests/rstest/rslint.config.mjs
+++ b/packages/rslint-test-tools/tests/rstest/rslint.config.mjs
@@ -1,0 +1,12 @@
+export default [
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: ['./tsconfig.files.json', './tsconfig.virtual.json'],
+      },
+    },
+    rules: {},
+    plugins: ['rstest'],
+  },
+];

--- a/packages/rslint-test-tools/tests/rstest/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/rstest/rule-tester.ts
@@ -1,0 +1,239 @@
+import path from 'node:path';
+import util from 'node:util';
+
+import { lint } from '@rslint/core/internal';
+
+import { buildConfigForSettings } from '../src/util/load-test-config';
+
+interface SuggestionOutput {
+  messageId?: string;
+  desc?: string;
+  data?: Record<string, unknown> | undefined;
+  output: string;
+}
+
+interface TestCaseError {
+  message?: string | RegExp;
+  messageId?: string;
+  /**
+   * @deprecated `type` is deprecated and will be removed in the next major version.
+   */
+  type?: string | undefined;
+  data?: any;
+  line?: number | undefined;
+  column?: number | undefined;
+  endLine?: number | undefined;
+  endColumn?: number | undefined;
+  suggestions?: SuggestionOutput[] | undefined;
+}
+
+// Port from 'eslint'
+export interface ValidTestCase {
+  name?: string;
+  code: string;
+  options?: any;
+  filename?: string | undefined;
+  only?: boolean;
+  settings?: Record<string, any> | undefined;
+}
+
+export interface InvalidTestCase extends ValidTestCase {
+  errors: number | (TestCaseError | string)[];
+  output?: string | null | undefined;
+}
+
+export class RuleTester {
+  run(
+    ruleName: string,
+    rule: never,
+    cases: {
+      valid: ValidTestCase[];
+      invalid: InvalidTestCase[];
+    },
+  ) {
+    ruleName = 'rstest/' + ruleName;
+    describe(ruleName, () => {
+      const cwd = process.cwd();
+      const config = path.resolve(import.meta.dirname, './rslint.config.mjs');
+
+      // test whether case has only
+      let hasOnly =
+        cases.valid.some((x) => {
+          if (typeof x === 'object' && x.only) {
+            return true;
+          } else {
+            return false;
+          }
+        }) || cases.invalid.some((x) => x.only);
+
+      test('valid', async () => {
+        for (const validCase of cases.valid) {
+          if (hasOnly) {
+            if (typeof validCase === 'string') {
+              continue;
+            }
+            if (!validCase.only) {
+              continue;
+            }
+          }
+          const code =
+            typeof validCase === 'string' ? validCase : validCase.code;
+
+          const options =
+            typeof validCase === 'string' ? [] : validCase.options || [];
+          const settings =
+            typeof validCase === 'string' ? undefined : validCase.settings;
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof validCase === 'string'
+              ? defaultFilename
+              : (validCase.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+
+          const { config: resolvedConfig, configDirectory } =
+            await buildConfigForSettings(config, settings);
+          const diags = await lint({
+            config: [
+              ...resolvedConfig,
+              {
+                rules: {
+                  [ruleName]:
+                    Array.isArray(options) && options.length > 0
+                      ? ['error', ...options]
+                      : 'error',
+                },
+              },
+            ],
+            configDirectory,
+            workingDirectory: cwd,
+            fileContents: {
+              [absoluteFilename]: code,
+            },
+          });
+
+          assert(
+            diags.diagnostics?.length === 0,
+            `Expected no diagnostics for valid case, but got: ${JSON.stringify(diags)}\nCode: ${code}`,
+          );
+        }
+      });
+      test('invalid', async (t) => {
+        for (const item of cases.invalid) {
+          assert.ok(
+            item.errors || item.errors === 0,
+            `Did not specify errors for an invalid test of ${ruleName}`,
+          );
+          if (Array.isArray(item.errors) && item.errors.length === 0) {
+            assert.fail('Invalid cases must have at least one error');
+          }
+
+          const { code, only = false, options = [], settings } = item;
+          if (hasOnly && !only) {
+            continue;
+          }
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof item === 'string'
+              ? defaultFilename
+              : (item.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+          const { config: resolvedConfig, configDirectory } =
+            await buildConfigForSettings(config, settings);
+          const diags = await lint({
+            config: [
+              ...resolvedConfig,
+              {
+                rules: {
+                  [ruleName]:
+                    Array.isArray(options) && options.length > 0
+                      ? ['error', ...options]
+                      : 'error',
+                },
+              },
+            ],
+            configDirectory,
+            workingDirectory: cwd,
+            fileContents: {
+              [absoluteFilename]: code,
+            },
+          });
+
+          if (typeof item.errors === 'number') {
+            if (item.errors === 0) {
+              assert.fail(
+                "Invalid cases must have 'error' value greater than 0",
+              );
+            }
+
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors,
+                item.errors === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+          } else {
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors.length,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors.length,
+                item.errors.length === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+
+            const hasMessageOfThisRule = diags.diagnostics.some(
+              (d) => d.ruleName === ruleName,
+            );
+
+            for (let i = 0, l = item.errors.length; i < l; i++) {
+              const error = item.errors[i];
+              const message = diags.diagnostics[i];
+
+              assert(
+                hasMessageOfThisRule,
+                'Error rule name should be the same as the name of the rule being tested',
+              );
+              if (typeof error === 'string' || error instanceof RegExp) {
+                // Just an error message.
+                assertMessageMatches(message.message, error);
+                assert.ok(
+                  message.suggestions === void 0,
+                  `Error at index ${i} has suggestions. Please convert the test error into an object and specify 'suggestions' property on it to test suggestions.`,
+                );
+              } else if (typeof error === 'object' && error !== null) {
+                if (typeof error.message === 'string') {
+                  assertMessageMatches(message.message, error.message);
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  }
+}
+
+/**
+ * Asserts that the message matches its expected value. If the expected
+ * value is a regular expression, it is checked against the actual
+ * value.
+ */
+function assertMessageMatches(actual: string, expected: string | RegExp): void {
+  if (expected instanceof RegExp) {
+    // assert.js doesn't have a built-in RegExp match function
+    assert.ok(
+      expected.test(actual),
+      `Expected '${actual}' to match ${expected}`,
+    );
+  } else {
+    assert.strictEqual(actual, expected);
+  }
+}

--- a/packages/rslint-test-tools/tests/rstest/rules/no-mocks-import.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-mocks-import.test.ts
@@ -1,0 +1,69 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-mocks-import', {} as never, {
+  valid: [
+    { code: 'import something from "something"' },
+    { code: 'require("somethingElse")' },
+    { code: 'require("./__mocks__.js")' },
+    { code: 'require("./__mocks__x")' },
+    { code: 'require("./__mocks__x/x")' },
+    { code: 'require("./x__mocks__")' },
+    { code: 'require("./x__mocks__/x")' },
+    { code: 'require()' },
+    { code: 'var path = "./__mocks__.js"; require(path)' },
+    { code: 'entirelyDifferent(fn)' },
+  ],
+  invalid: [
+    {
+      code: 'require("./__mocks__")',
+      errors: [
+        {
+          line: 1,
+          column: 9,
+          endColumn: 22,
+          messageId: 'noManualImport',
+          message:
+            'Mocks should not be manually imported from a __mocks__ directory. Instead use `rs.mock` and import from the original module path',
+        },
+      ],
+    },
+    {
+      code: 'require("./__mocks__/")',
+      errors: [
+        { line: 1, column: 9, endColumn: 23, messageId: 'noManualImport' },
+      ],
+    },
+    {
+      code: 'require("./__mocks__/index")',
+      errors: [
+        { line: 1, column: 9, endColumn: 28, messageId: 'noManualImport' },
+      ],
+    },
+    {
+      code: 'require("__mocks__")',
+      errors: [
+        { line: 1, column: 9, endColumn: 20, messageId: 'noManualImport' },
+      ],
+    },
+    {
+      code: 'require("__mocks__/")',
+      errors: [
+        { line: 1, column: 9, endColumn: 21, messageId: 'noManualImport' },
+      ],
+    },
+    {
+      code: 'require("__mocks__/index")',
+      errors: [
+        { line: 1, column: 9, endColumn: 26, messageId: 'noManualImport' },
+      ],
+    },
+    {
+      code: 'import thing from "./__mocks__/index"',
+      errors: [
+        { line: 1, column: 1, endColumn: 38, messageId: 'noManualImport' },
+      ],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/rstest/tsconfig.files.json
+++ b/packages/rslint-test-tools/tests/rstest/tsconfig.files.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
+    "allowJs": true
+  },
+  "include": ["files/**/*"]
+}

--- a/packages/rslint-test-tools/tests/rstest/tsconfig.virtual.json
+++ b/packages/rslint-test-tools/tests/rstest/tsconfig.virtual.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"]
+  },
+  "include": ["src/virtual.tsx", "src/virtual.ts"]
+}

--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -20,6 +20,7 @@ const NATIVE_PLUGINS = [
   'promise',
   'react',
   'react-hooks',
+  'rstest',
   'unicorn',
 ] as const;
 

--- a/packages/rslint/src/config/presets/index.ts
+++ b/packages/rslint/src/config/presets/index.ts
@@ -5,6 +5,7 @@ import { recommended as reactHooksRecommended } from './react-hooks.js';
 import { recommended as importRecommended } from './import.js';
 import { recommended as promiseRecommended } from './promise.js';
 import { recommended as jestRecommended, style as jestStyle } from './jest.js';
+import { recommended as rstestRecommended } from './rstest.js';
 import { recommended as unicornRecommended } from './unicorn.js';
 import { recommended as jsxA11yRecommended } from './jsx-a11y.js';
 
@@ -34,6 +35,10 @@ export const promisePlugin = {
 
 export const jestPlugin = {
   configs: { recommended: jestRecommended, style: jestStyle },
+};
+
+export const rstestPlugin = {
+  configs: { recommended: rstestRecommended },
 };
 
 export const unicornPlugin = {

--- a/packages/rslint/src/config/presets/rstest.ts
+++ b/packages/rslint/src/config/presets/rstest.ts
@@ -1,0 +1,10 @@
+import type { RslintConfigEntry } from '../define-config.js';
+
+const recommended: RslintConfigEntry = {
+  plugins: ['rstest'],
+  rules: {
+    'rstest/no-mocks-import': 'error',
+  },
+};
+
+export { recommended };

--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -12,6 +12,7 @@ export {
   importPlugin,
   promisePlugin,
   jestPlugin,
+  rstestPlugin,
   unicornPlugin,
   jsxA11yPlugin,
 } from './config/presets/index.js';

--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -156,7 +156,7 @@ Plugins enabled for this entry, in one of two forms.
 
 **Array of names** — built-in (native) plugins. A name declares a rule namespace; its rules become available under the `<plugin>/<rule>` prefix inside `rules`.
 
-Built-in plugin names: `@typescript-eslint`, `import`, `jest`, `jsx-a11y`, `promise`, `react`, `react-hooks`, `unicorn`.
+Built-in plugin names: `@typescript-eslint`, `import`, `jest`, `jsx-a11y`, `promise`, `react`, `react-hooks`, `rstest`, `unicorn`.
 
 ```ts
 {

--- a/website/theme/plugin-registry.ts
+++ b/website/theme/plugin-registry.ts
@@ -125,6 +125,17 @@ export const PLUGIN_REGISTRY: PluginMeta[] = [
     ],
   },
   {
+    prefix: 'rstest',
+    group: 'rstest',
+    importName: 'rstestPlugin',
+    presets: [
+      {
+        name: 'rstestPlugin.configs.recommended',
+        description: 'Rstest rules',
+      },
+    ],
+  },
+  {
     prefix: 'unicorn',
     group: 'eslint-plugin-unicorn',
     importName: 'unicornPlugin',


### PR DESCRIPTION
## Summary

Add the first native Rstest rule, `rstest/no-mocks-import`, which reports direct imports from `__mocks__` and recommends using `rs.mock` instead.

The rule reuses the existing Jest implementation while keeping the Rstest registration, documentation, configuration preset, and tests independent.

## Related Links

<!--- Provide links of related issues or pages -->
Related https://github.com/web-infra-dev/rslint/issues/935

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
