### PR TITLE
test: stabilize flaky CI tests

### DIFF
--- a/packages/rslint/rstest.config.ts
+++ b/packages/rslint/rstest.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from '@rstest/core';
 export default defineConfig({
   testEnvironment: 'node',
   globals: true,
+  // Each eslint-plugin test process can spawn up to eight Worker threads.
+  // Run Windows test files serially so Rstest's CPU-count process pool cannot
+  // multiply that inner concurrency and starve Worker startup/shutdown. Keep
+  // the existing per-test timeouts as real hang sentinels.
+  pool: process.platform === 'win32' ? { maxWorkers: 1 } : undefined,
   // The self-hosted Windows runner can stall under concurrent main CI. Keep
   // ordinary async tests from tripping Rstest's 5s default.
   testTimeout: 30_000,

--- a/packages/vscode-extension/__tests__/runTest.ts
+++ b/packages/vscode-extension/__tests__/runTest.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { runTests } from '@vscode/test-electron';
+import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
 
 interface TestSuite {
   name: string;
@@ -50,6 +50,7 @@ async function findPackageRoot(startPath: string): Promise<string> {
 
 async function runIsolatedSuite(
   extensionDevelopmentPath: string,
+  vscodeExecutablePath: string,
   suite: TestSuite,
 ): Promise<void> {
   // Go discovery intentionally searches strict cwd ancestors, so keep each
@@ -105,6 +106,7 @@ async function runIsolatedSuite(
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath: suite.tests,
+      vscodeExecutablePath,
       launchArgs: [
         suite.workspaceEntry
           ? resolveSandboxEntry(workspaceCopy, suite.workspaceEntry)
@@ -118,8 +120,6 @@ async function runIsolatedSuite(
         `--user-data-dir=${userDataDir}`,
         `--extensions-dir=${extensionsDir}`,
       ],
-      // Omit `version`: @vscode/test-electron resolves the current stable
-      // release on every run instead of pinning a VS Code build.
     });
   } catch (error) {
     testError = error;
@@ -149,6 +149,12 @@ async function runIsolatedSuite(
 
 async function main(): Promise<void> {
   const extensionDevelopmentPath = path.resolve(__dirname, '../..');
+  // Resolve the compatible stable release once so every suite explicitly uses
+  // the same executable and repeated runTests() calls avoid redundant
+  // compatibility/cache resolution.
+  const vscodeExecutablePath = await downloadAndUnzipVSCode({
+    extensionDevelopmentPath,
+  });
   const testsSourceDir = path.resolve(extensionDevelopmentPath, '__tests__');
   const suites: TestSuite[] = [
     {
@@ -210,7 +216,11 @@ async function main(): Promise<void> {
   const failures: unknown[] = [];
   for (const suite of suites) {
     try {
-      await runIsolatedSuite(extensionDevelopmentPath, suite);
+      await runIsolatedSuite(
+        extensionDevelopmentPath,
+        vscodeExecutablePath,
+        suite,
+      );
     } catch (error) {
       console.error(`${suite.name} failed:`, error);
       failures.push(error);

--- a/packages/vscode-extension/__tests__/utils/diagnostics.ts
+++ b/packages/vscode-extension/__tests__/utils/diagnostics.ts
@@ -24,7 +24,17 @@ function describeDiagnostics(
     .join(' | ');
 }
 
-/** Subscribe before the initial read, filter by source, and reject on timeout. */
+const diagnosticsPollIntervalMs = 100;
+
+/**
+ * Wait for matching rslint diagnostics.
+ *
+ * VS Code may coalesce diagnostic-change notifications when multiple documents
+ * are updated in one language-server publish cycle. Keep the event subscription
+ * for the fast path, but also sample the authoritative diagnostics collection so
+ * a missed notification cannot turn an already-satisfied predicate into a
+ * timeout. The timeout performs one final read for the same reason.
+ */
 export function waitForRslintDiagnostics(
   document: vscode.TextDocument,
   predicate: (diagnostics: vscode.Diagnostic[]) => boolean = (diagnostics) =>
@@ -35,6 +45,8 @@ export function waitForRslintDiagnostics(
     const uriString = document.uri.toString();
     let settled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let poller: ReturnType<typeof setInterval> | undefined;
+    let subscription: vscode.Disposable | undefined;
 
     const finish = (
       diagnostics: vscode.Diagnostic[] | undefined,
@@ -42,24 +54,32 @@ export function waitForRslintDiagnostics(
     ): void => {
       if (settled) return;
       settled = true;
-      subscription.dispose();
+      subscription?.dispose();
       if (timer) clearTimeout(timer);
+      if (poller) clearInterval(poller);
       if (error) reject(error);
       else resolve(diagnostics ?? []);
     };
-    const check = (): void => {
+    const check = (): boolean => {
+      if (settled) return true;
       const diagnostics = getRslintDiagnostics(document);
       try {
-        if (predicate(diagnostics)) finish(diagnostics);
+        if (predicate(diagnostics)) {
+          finish(diagnostics);
+          return true;
+        }
       } catch (error) {
         finish(undefined, error);
+        return true;
       }
+      return false;
     };
-    const subscription = vscode.languages.onDidChangeDiagnostics((event) => {
+    subscription = vscode.languages.onDidChangeDiagnostics((event) => {
       if (event.uris.some((uri) => uri.toString() === uriString)) check();
     });
 
     timer = setTimeout(() => {
+      if (check()) return;
       const diagnostics = getRslintDiagnostics(document);
       finish(
         undefined,
@@ -69,6 +89,7 @@ export function waitForRslintDiagnostics(
         ),
       );
     }, timeoutMs);
+    poller = setInterval(check, diagnosticsPollIntervalMs);
     check();
   });
 }


### PR DESCRIPTION
## Summary

- Limit Windows Rstest file-process concurrency to one so Worker-heavy test files cannot multiply the CPU-count process pool by up to eight inner Worker threads. Existing per-test timeout sentinels and all WorkerPool runtime behavior remain unchanged.
- Resolve VS Code once per test run and reuse the same executable across isolated suites, preventing repeated version resolution and per-run executable drift.
- Keep diagnostic-change events as the fast path, while sampling the authoritative VS Code diagnostics collection and checking it once more at timeout. The original predicate and timeout still decide success, so this cannot turn an unmet condition green.

## Related Links

- https://github.com/web-infra-dev/rslint/actions/runs/29396300339/job/87290465970?pr=1292
- https://github.com/web-infra-dev/rslint/actions/runs/29396119310/job/87289917984?pr=1288
- https://github.com/web-infra-dev/rslint/actions/runs/29396180952/job/87290109708?pr=1290

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; test infrastructure only, with no runtime, API, or user configuration changes).