### PR TITLE
refactor: clean up config discovery internals

### DIFF
--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -1472,21 +1472,6 @@ func (s *Server) tsConfigPathsForURI(uri lsproto.DocumentUri) []string {
 	return s.tsConfigPaths
 }
 
-// uriDirname returns the parent directory of a URI string.
-// e.g. "file:///project/src/index.ts" → "file:///project/src"
-func uriDirname(uri string) string {
-	// Find the last '/' after the scheme (file://)
-	idx := strings.LastIndex(uri, "/")
-	if idx <= 0 {
-		return uri
-	}
-	// Don't strip past the authority part (file:///)
-	if strings.HasPrefix(uri, "file:///") && idx < len("file:///") {
-		return uri
-	}
-	return uri[:idx]
-}
-
 // pushDiagnostics runs the linter for the given URI and pushes results to the client.
 // Must be called synchronously from the LSP message loop (not from a goroutine)
 // because session is not goroutine-safe.

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -1196,31 +1196,6 @@ func TestUriToPath(t *testing.T) {
 	}
 }
 
-// ======== uriDirname tests ========
-
-func TestUriDirname(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"file:///project/src/index.ts", "file:///project/src"},
-		{"file:///project/index.ts", "file:///project"},
-		{"file:///project", "file:///project"}, // stops at authority
-		{"file:///C:/Users/project/src", "file:///C:/Users/project"},
-		{"file:///C:/Users", "file:///C:"},
-		{"file:///C:", "file:///C:"}, // stops at authority
-		{"", ""},                     // empty string
-		{"file:///", "file:///"},     // root URI
-	}
-
-	for _, tt := range tests {
-		got := uriDirname(tt.input)
-		if got != tt.want {
-			t.Errorf("uriDirname(%q) = %q, want %q", tt.input, got, tt.want)
-		}
-	}
-}
-
 func TestCloseAndReopen(t *testing.T) {
 	s := newTestServer()
 	ctx := context.Background()

--- a/packages/rslint/src/api/native-config-activation.ts
+++ b/packages/rslint/src/api/native-config-activation.ts
@@ -1,0 +1,159 @@
+import {
+  ConfigModuleHost,
+  type ActivateConfigsRequest,
+  type ActivateConfigsResponse,
+} from '../config/config-loader.js';
+
+export interface PluginLintHost {
+  lint(request: unknown): Promise<unknown>;
+  shutdown(): Promise<void>;
+}
+
+type CreatePluginLintHost = (
+  configs: Array<{ configPath: string; configDirectory: string }>,
+  onLog?: (record: { level: string; source: string; text: string }) => void,
+) => Promise<PluginLintHost>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isPluginHostFactoryModule(
+  value: unknown,
+): value is { createPluginLintHost: CreatePluginLintHost } {
+  return isRecord(value) && typeof value.createPluginLintHost === 'function';
+}
+
+function isPluginLintHost(value: unknown): value is PluginLintHost {
+  return (
+    isRecord(value) &&
+    typeof value.lint === 'function' &&
+    typeof value.shutdown === 'function'
+  );
+}
+
+let pluginHostFactoryPromise: Promise<CreatePluginLintHost> | undefined;
+
+export async function loadPluginHostFactory(): Promise<CreatePluginLintHost> {
+  pluginHostFactoryPromise ??= (async () => {
+    // A package self-reference resolves to src under the test condition and to
+    // dist/eslint-plugin in published builds. Keep it runtime-only: the library
+    // declaration build deliberately excludes the worker implementation.
+    const pluginEntry: string = '@rslint/core/eslint-plugin';
+    const module: unknown = await import(/* webpackIgnore: true */ pluginEntry);
+    if (!isPluginHostFactoryModule(module)) {
+      throw new Error(
+        'rslint ESLint-plugin entry does not export createPluginLintHost',
+      );
+    }
+    return module.createPluginLintHost;
+  })();
+  const factory = await pluginHostFactoryPromise;
+  return factory;
+}
+
+/** @internal Resource registry shared by activation and API close tests. */
+export class PluginHostLifecycle {
+  readonly #pendingBuilds = new Set<Promise<unknown>>();
+  readonly #staged = new Set<PluginLintHost>();
+  readonly #active = new Set<PluginLintHost>();
+  readonly #shutdowns = new WeakMap<PluginLintHost, Promise<void>>();
+
+  async trackBuild<T>(build: Promise<T>): Promise<T> {
+    this.#pendingBuilds.add(build);
+    void build.then(
+      () => this.#pendingBuilds.delete(build),
+      () => this.#pendingBuilds.delete(build),
+    );
+    const result = await build;
+    return result;
+  }
+
+  stage(host: PluginLintHost): void {
+    this.#staged.add(host);
+  }
+
+  publish(host: PluginLintHost): void {
+    this.#staged.delete(host);
+    this.#active.add(host);
+  }
+
+  async shutdown(host: PluginLintHost): Promise<void> {
+    this.#staged.delete(host);
+    this.#active.delete(host);
+    let shutdown = this.#shutdowns.get(host);
+    if (!shutdown) {
+      shutdown = host.shutdown();
+      this.#shutdowns.set(host, shutdown);
+    }
+    await shutdown;
+  }
+
+  async shutdownAll(): Promise<void> {
+    while (this.#pendingBuilds.size > 0) {
+      await Promise.allSettled([...this.#pendingBuilds]);
+    }
+    const shutdowns: Promise<void>[] = [];
+    for (const host of new Set([...this.#staged, ...this.#active])) {
+      shutdowns.push(this.shutdown(host));
+    }
+    await Promise.allSettled(shutdowns);
+  }
+}
+
+/**
+ * Stage one native-discovery activation without exposing a worker imported
+ * from config bytes that differ from Go's normalized entries.
+ *
+ * @internal Exported from this internal module for lifecycle regression tests;
+ * the module is intentionally not exposed through the package exports.
+ */
+export async function stageNativeConfigActivation(
+  configHost: ConfigModuleHost,
+  request: ActivateConfigsRequest,
+  getPluginHostFactory: () => Promise<CreatePluginLintHost>,
+  onLog: (record: { level: string; source: string; text: string }) => void,
+  isClosing: () => boolean,
+  lifecycle?: PluginHostLifecycle,
+): Promise<{
+  activation: ActivateConfigsResponse;
+  pluginHost: PluginLintHost | null;
+}> {
+  let pluginHost: PluginLintHost | null = null;
+  try {
+    const activation = await configHost.activateConfigs(
+      request,
+      undefined,
+      async (candidate) => {
+        if (candidate.pluginConfigs.length === 0) return;
+        if (isClosing()) throw new Error('rslint service is closing');
+        const createPluginLintHost = await getPluginHostFactory();
+        if (isClosing()) throw new Error('rslint service is closing');
+        const build = (async () => {
+          const host = await createPluginLintHost(
+            candidate.pluginConfigs,
+            onLog,
+          );
+          lifecycle?.stage(host);
+          return host;
+        })();
+        pluginHost = await (lifecycle?.trackBuild(build) ?? build);
+        if (isClosing()) throw new Error('rslint service is closing');
+      },
+    );
+    // close() can start while the post-prepare fingerprint read is pending.
+    if (isClosing()) throw new Error('rslint service is closing');
+    return { activation, pluginHost };
+  } catch (error) {
+    try {
+      const createdHost: unknown = pluginHost;
+      if (isPluginLintHost(createdHost)) {
+        await (lifecycle?.shutdown(createdHost) ?? createdHost.shutdown());
+      }
+    } catch {
+      // Preserve the activation error: the source mismatch is what Go must
+      // receive, while the host has still been asked to terminate.
+    }
+    throw error;
+  }
+}

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -20,17 +20,18 @@ import picomatch from 'picomatch';
 
 import { RSLintService } from '../service/service.js';
 import { NodeRslintService } from '../internal/node.js';
-import {
-  ConfigModuleHost,
-  normalizeConfig,
-  type ActivateConfigsRequest,
-  type ActivateConfigsResponse,
-} from '../config/config-loader.js';
+import { ConfigModuleHost, normalizeConfig } from '../config/config-loader.js';
 import {
   nativePathIdentity,
   RunPathResolver,
   type ResolvedFilesystemPath,
 } from './path-identity.js';
+import {
+  loadPluginHostFactory,
+  PluginHostLifecycle,
+  stageNativeConfigActivation,
+  type PluginLintHost,
+} from './native-config-activation.js';
 import type { RslintConfigEntry } from '../config/define-config.js';
 import type {
   Diagnostic,
@@ -105,60 +106,6 @@ export interface LintResult {
   output?: string; // present only when fix:true changed the file
 }
 
-interface PluginLintHost {
-  lint(request: unknown): Promise<unknown>;
-  shutdown(): Promise<void>;
-}
-
-/** @internal Resource registry shared by activation and API close tests. */
-export class PluginHostLifecycle {
-  readonly #pendingBuilds = new Set<Promise<unknown>>();
-  readonly #staged = new Set<PluginLintHost>();
-  readonly #active = new Set<PluginLintHost>();
-  readonly #shutdowns = new WeakMap<PluginLintHost, Promise<void>>();
-
-  async trackBuild<T>(build: Promise<T>): Promise<T> {
-    this.#pendingBuilds.add(build);
-    void build.then(
-      () => this.#pendingBuilds.delete(build),
-      () => this.#pendingBuilds.delete(build),
-    );
-    const result = await build;
-    return result;
-  }
-
-  stage(host: PluginLintHost): void {
-    this.#staged.add(host);
-  }
-
-  publish(host: PluginLintHost): void {
-    this.#staged.delete(host);
-    this.#active.add(host);
-  }
-
-  async shutdown(host: PluginLintHost): Promise<void> {
-    this.#staged.delete(host);
-    this.#active.delete(host);
-    let shutdown = this.#shutdowns.get(host);
-    if (!shutdown) {
-      shutdown = host.shutdown();
-      this.#shutdowns.set(host, shutdown);
-    }
-    await shutdown;
-  }
-
-  async shutdownAll(): Promise<void> {
-    while (this.#pendingBuilds.size > 0) {
-      await Promise.allSettled([...this.#pendingBuilds]);
-    }
-    const shutdowns: Promise<void>[] = [];
-    for (const host of new Set([...this.#staged, ...this.#active])) {
-      shutdowns.push(this.shutdown(host));
-    }
-    await Promise.allSettled(shutdowns);
-  }
-}
-
 interface PluginLintSession {
   host: PluginLintHost;
 }
@@ -166,102 +113,6 @@ interface PluginLintSession {
 interface NativeConfigDiscoverySession {
   handlers: LintInboundHandlers;
   shutdown(): Promise<void>;
-}
-
-type CreatePluginLintHost = (
-  configs: Array<{ configPath: string; configDirectory: string }>,
-  onLog?: (record: { level: string; source: string; text: string }) => void,
-) => Promise<PluginLintHost>;
-
-function isPluginHostFactoryModule(
-  value: unknown,
-): value is { createPluginLintHost: CreatePluginLintHost } {
-  return isRecord(value) && typeof value.createPluginLintHost === 'function';
-}
-
-function isPluginLintHost(value: unknown): value is PluginLintHost {
-  return (
-    isRecord(value) &&
-    typeof value.lint === 'function' &&
-    typeof value.shutdown === 'function'
-  );
-}
-
-let pluginHostFactoryPromise: Promise<CreatePluginLintHost> | undefined;
-
-async function loadPluginHostFactory(): Promise<CreatePluginLintHost> {
-  pluginHostFactoryPromise ??= (async () => {
-    // A package self-reference resolves to src under the test condition and to
-    // dist/eslint-plugin in published builds. Keep it runtime-only: the library
-    // declaration build deliberately excludes the worker implementation.
-    const pluginEntry: string = '@rslint/core/eslint-plugin';
-    const module: unknown = await import(/* webpackIgnore: true */ pluginEntry);
-    if (!isPluginHostFactoryModule(module)) {
-      throw new Error(
-        'rslint ESLint-plugin entry does not export createPluginLintHost',
-      );
-    }
-    return module.createPluginLintHost;
-  })();
-  const factory = await pluginHostFactoryPromise;
-  return factory;
-}
-
-/**
- * Stage one native-discovery activation without exposing a worker imported
- * from config bytes that differ from Go's normalized entries.
- *
- * @internal Exported from this source module for lifecycle regression tests;
- * it is intentionally not re-exported from the package root.
- */
-export async function stageNativeConfigActivation(
-  configHost: ConfigModuleHost,
-  request: ActivateConfigsRequest,
-  getPluginHostFactory: () => Promise<CreatePluginLintHost>,
-  onLog: (record: { level: string; source: string; text: string }) => void,
-  isClosing: () => boolean,
-  lifecycle?: PluginHostLifecycle,
-): Promise<{
-  activation: ActivateConfigsResponse;
-  pluginHost: PluginLintHost | null;
-}> {
-  let pluginHost: PluginLintHost | null = null;
-  try {
-    const activation = await configHost.activateConfigs(
-      request,
-      undefined,
-      async (candidate) => {
-        if (candidate.pluginConfigs.length === 0) return;
-        if (isClosing()) throw new Error('rslint service is closing');
-        const createPluginLintHost = await getPluginHostFactory();
-        if (isClosing()) throw new Error('rslint service is closing');
-        const build = (async () => {
-          const host = await createPluginLintHost(
-            candidate.pluginConfigs,
-            onLog,
-          );
-          lifecycle?.stage(host);
-          return host;
-        })();
-        pluginHost = await (lifecycle?.trackBuild(build) ?? build);
-        if (isClosing()) throw new Error('rslint service is closing');
-      },
-    );
-    // close() can start while the post-prepare fingerprint read is pending.
-    if (isClosing()) throw new Error('rslint service is closing');
-    return { activation, pluginHost };
-  } catch (error) {
-    try {
-      const createdHost: unknown = pluginHost;
-      if (isPluginLintHost(createdHost)) {
-        await (lifecycle?.shutdown(createdHost) ?? createdHost.shutdown());
-      }
-    } catch {
-      // Preserve the activation error: the source mismatch is what Go must
-      // receive, while the host has still been asked to terminate.
-    }
-    throw error;
-  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/rslint/tests/native-config-activation.test.ts
+++ b/packages/rslint/tests/native-config-activation.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import {
   PluginHostLifecycle,
   stageNativeConfigActivation,
-} from '../src/api/rslint.js';
+} from '../src/api/native-config-activation.js';
 import {
   CONFIG_DISCOVERY_PROTOCOL_VERSION,
   ConfigModuleHost,


### PR DESCRIPTION
## Summary

- Remove the unused LSP `uriDirname` helper and its isolated unit test now that config ownership routes exclusively through normalized filesystem paths.
- Move API plugin-host activation, factory loading, and lifecycle bookkeeping into an API-local internal module without changing the package exports.
- Keep the activation race and staged-close regression coverage pointed at the new internal module.

Validation:

- `go test ./internal/lsp`
- `pnpm --filter @rslint/core exec rstest tests/native-config-activation.test.ts`
- `pnpm --filter @rslint/core run build:js`
- `pnpm typecheck`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/lsp`
- `pnpm run lint`

## Related Links

- Follow-up to https://github.com/web-infra-dev/rslint/pull/1276

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
