### PR TITLE
perf: collect source comments lazily

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -220,7 +220,7 @@ Important characteristics:
 - **Node Objects**: `*ast.Node` and `*ast.SourceFile`
 - **Traversal Style**: `ForEachChild(...)` with depth-first recursion
 - **Source Locations**: node ranges and source-file-aware line/column conversion via scanner helpers
-- **Comments**: collected separately and used for directives and comment-based rules
+- **Comments**: exposed through one lazy per-file store for directives and comment-based rules
 
 ### Key AST Properties
 
@@ -271,6 +271,7 @@ type RuleContext struct {
     ConfigGlobals              map[string]bool
     InlineGlobals              []InlineGlobal
     Globals                    map[string]bool
+    Comments                   *CommentStore
     Program                    *compiler.Program
     TypeChecker                *checker.Checker
     DisableManager             *DisableManager
@@ -283,7 +284,12 @@ type RuleContext struct {
 }
 ```
 
-The linter parses `/* global */` comments once per file before rules run.
+The linter creates one short-lived `CommentStore` per file. `Comments.All()`
+materializes the scanner-backed, source-ordered, deduplicated comment list only
+for the first consumer; later consumers share that list. A source without `//`
+or `/*` takes a cheap byte-scan fast path. Inline-global parsing first checks
+for an exact raw-text directive candidate, so ordinary files do not force
+comment collection.
 `ConfigGlobals` preserves the effective `languageOptions.globals` source,
 `InlineGlobals` preserves ordered comment name ranges, and `Globals` is the
 resolved map after inline settings override configuration. Rules consume this
@@ -723,7 +729,10 @@ Rslint supports inline directives with both `rslint-` and `eslint-` prefixes:
 - `/* rslint-disable @typescript-eslint/no-unsafe-assignment */`
 - `// eslint-disable-next-line`
 
-The `DisableManager` in `internal/rule/disable_manager.go` parses and applies these directives before diagnostics are emitted.
+The `DisableManager` in `internal/rule/disable_manager.go` applies these
+directives before diagnostics are emitted. It defers parsing until the first
+disable check and uses an exact directive-text candidate check, so files without a
+supported directive retain an empty manager without scanning comments.
 
 ## 9. CLI Flow
 
@@ -886,6 +895,7 @@ goroutines remain outside that guarantee.
 - **Gap-File Degradation**: fallback gap-file Programs skip type-aware rules and semantic diagnostics instead of paying unreliable semantic costs
 - **Buffered Diagnostic Collection**: CLI mode funnels diagnostics through a buffered channel before formatting, which reduces contention between lint workers and output handling
 - **On-Demand AST Encoding**: API/WASM responses only include encoded source files when `IncludeEncodedSourceFiles` is requested
+- **Lazy Shared Comments**: each file owns one `CommentStore`; directive consumers and comment-aware rules materialize its canonical comment list only when needed and reuse the result. Rule-specific text checks avoid scanner work when their comment syntax cannot occur
 
 ### Caching Strategy
 
@@ -901,7 +911,7 @@ goroutines remain outside that guarantee.
 ### Memory Management
 
 - **ts-go Owns the Heavy Graphs**: AST nodes, checker state, `Program` graphs, and session state are primarily owned by ts-go; rslint adds listener maps, diagnostics, and config-derived rule lists on top
-- **Short-Lived Per-File Structures**: comment slices, disable managers, and registered listener maps are allocated per file and dropped after traversal; `clear(registeredListeners)` helps release references promptly
+- **Short-Lived Per-File Structures**: comment stores, disable managers, and registered listener maps are allocated per file and dropped after traversal. A comment slice is allocated only if requested; `clear(registeredListeners)` helps release references promptly
 - **Source Snapshot Ownership**: snapshot entries hold an immutable source string plus its 128-bit hash without explicitly copying source bytes; on an AST miss, that string is passed directly to the parser. After generation replacement, a retained unchanged AST may still hold the prior equal string while the fresh snapshot owns the new read. Replaced generations are reclaimed after any in-flight lookup releases them. AST retention and source-generation retention remain deliberately separate lifecycles.
 - **Fix Application Uses Linear Rebuilds**: `ApplyRuleFixes` sorts fixes, skips overlapping edits, and rebuilds the output with `strings.Builder` rather than mutating source buffers in place
 - **Bounded Queues**: CLI diagnostics use a buffered channel of 4096 items; LSP request/outgoing queues are buffered to 100, and debounce/refresh signals are single-slot channels
@@ -1129,6 +1139,7 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 
 - **AST**: Abstract Syntax Tree produced directly by ts-go
 - **Code Action**: LSP action derived from diagnostics, suggestions, or bulk-fix operations such as quick fix and fix all
+- **Comment Store**: short-lived per-file provider that lazily computes and shares the canonical source comment list
 - **Config Entry**: One flat-config object whose `files`, `ignores`, `settings`, and `rules` participate in per-file config merging
 - **ConfiguredRule**: Rule implementation plus resolved severity, settings, options, and type-info requirement
 - **Diagnostic**: A lint finding reported by a rule or by TypeScript semantic diagnostics

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"os"
 	"runtime"
-	"slices"
-	"sort"
 	"strings"
 
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -136,27 +134,15 @@ func runLintRulesInProgram(opts runProgramOptions) programLintResult {
 	lintFile := func(file *ast.SourceFile, rules []ConfiguredRule, chk *checker.Checker) {
 		registeredListeners := make(map[ast.Kind][](func(node *ast.Node)), 20)
 
-		// Computed once per file and shared via ctx.Comments so
-		// rules that need every comment in the file (directive scanning,
-		// max-lines, etc.) don't each repeat this same token-tree walk.
-		comments := make([]*ast.CommentRange, 0)
-		utils.ForEachComment(&file.Node, func(comment *ast.CommentRange) { comments = append(comments, comment) }, file)
-		// ForEachComment can surface the same physical comment twice (once as
-		// a token's trailing range, once as the next token's leading range)
-		// and isn't guaranteed strictly ordered. Sort and dedup once here so
-		// every downstream consumer can rely on a clean, ordered list instead
-		// of each re-deriving it.
-		sort.Slice(comments, func(i, j int) bool { return comments[i].Pos() < comments[j].Pos() })
-		comments = slices.CompactFunc(comments, func(a, b *ast.CommentRange) bool {
-			return a.Pos() == b.Pos() && a.End() == b.End()
-		})
+		// One lazy store is shared by directives, inline globals, and every
+		// comment-aware rule in this file. Most files never materialize it.
+		comments := rule.NewCommentStore(file)
 
-		// Create disable manager for this file
+		// Directive parsing is itself lazy and only runs when a rule reports.
 		disableManager := rule.NewDisableManager(file, comments)
 
-		// Parse inline `/* global */` comments once per file, same as
-		// DisableManager above. Rules receive both declaration metadata and the
-		// merged result instead of parsing comments or config themselves.
+		// A cheap source-text check inside ParseInlineGlobals avoids asking
+		// the store for all comments unless an inline directive is possible.
 		inlineGlobals, inlineGlobalDeclarations := rule.ParseInlineGlobals(file, comments)
 		fileChecker := chk
 		if opts.TypeInfoFiles != nil {

--- a/internal/linter/types.go
+++ b/internal/linter/types.go
@@ -11,9 +11,10 @@ type ConfiguredRule struct {
 	Settings map[string]interface{}
 	// Globals is the config-declared `languageOptions.globals` for this file
 	// (name → declared). The linter merges this with inline `/* global */`
-	// comments (parsed once per file, same as DisableManager) before exposing
-	// the combined result to rules as ctx.Globals — rules never parse either
-	// source themselves. Nil when the config declares none.
+	// comments before exposing the combined result to rules as ctx.Globals.
+	// Inline globals and disable directives use candidate-gated lazy comment
+	// collection, so rules never parse either source themselves. Nil when the
+	// config declares none.
 	Globals          map[string]bool
 	Severity         rule.DiagnosticSeverity
 	RequiresTypeInfo bool

--- a/internal/plugins/jest/rules/no_commented_out_tests/no_commented_out_tests.go
+++ b/internal/plugins/jest/rules/no_commented_out_tests/no_commented_out_tests.go
@@ -46,7 +46,7 @@ var NoCommentedOutTestsRule = rule.Rule{
 	Name: "jest/no-commented-out-tests",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		text := ctx.SourceFile.Text()
-		for _, comment := range ctx.Comments {
+		for _, comment := range ctx.Comments.All() {
 			if comment == nil {
 				continue
 			}

--- a/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.go
+++ b/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.go
@@ -48,6 +48,11 @@ var BanTsCommentRule = rule.CreateRule(rule.Rule{
 })
 
 func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
+	text := ctx.SourceFile.Text()
+	if !strings.Contains(text, "@ts-") {
+		return rule.RuleListeners{}
+	}
+
 	options := rule.LegacyUnwrapOptions(_options)
 	opts := BanTsCommentOptions{
 		TsExpectError:            "allow-with-description",
@@ -106,7 +111,7 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		firstStatementPos = scanner.GetTokenPosOfNode(ctx.SourceFile.Statements.Nodes[0], ctx.SourceFile, false)
 	}
 
-	processComments(ctx, ctx.SourceFile.Text(), configs, opts.MinimumDescriptionLength, firstStatementPos)
+	processComments(ctx, text, configs, opts.MinimumDescriptionLength, firstStatementPos)
 
 	return rule.RuleListeners{}
 }
@@ -137,7 +142,7 @@ func parseDirectiveConfig(value interface{}) *DirectiveConfig {
 
 // processComments scans real comment trivia and checks for banned directives.
 func processComments(ctx rule.RuleContext, text string, configs map[string]*DirectiveConfig, minDescLength int, firstStatementPos int) {
-	for _, comment := range ctx.Comments {
+	for _, comment := range ctx.Comments.All() {
 		if comment == nil {
 			continue
 		}

--- a/internal/plugins/typescript/rules/ban_tslint_comment/ban_tslint_comment.go
+++ b/internal/plugins/typescript/rules/ban_tslint_comment/ban_tslint_comment.go
@@ -23,8 +23,11 @@ var BanTslintCommentRule = rule.CreateRule(rule.Rule{
 
 func run(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 	text := ctx.SourceFile.Text()
+	if !strings.Contains(text, "tslint:") {
+		return rule.RuleListeners{}
+	}
 
-	for _, comment := range ctx.Comments {
+	for _, comment := range ctx.Comments.All() {
 		commentValue := extractCommentValue(text, comment)
 		if !enableDisableRegex.MatchString(commentValue) {
 			continue

--- a/internal/plugins/typescript/rules/prefer_ts_expect_error/prefer_ts_expect_error.go
+++ b/internal/plugins/typescript/rules/prefer_ts_expect_error/prefer_ts_expect_error.go
@@ -109,7 +109,10 @@ var PreferTsExpectErrorRule = rule.CreateRule(rule.Rule{
 	Name: "prefer-ts-expect-error",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		fullText := ctx.SourceFile.Text()
-		for _, comment := range ctx.Comments {
+		if !strings.Contains(fullText, tsIgnoreDirective) {
+			return rule.RuleListeners{}
+		}
+		for _, comment := range ctx.Comments.All() {
 			if comment == nil {
 				continue
 			}

--- a/internal/rule/comment_store.go
+++ b/internal/rule/comment_store.go
@@ -1,0 +1,80 @@
+package rule
+
+import (
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// CommentStore owns the canonical comment list for one linted source file.
+//
+// Collection is lazy because most rule/file pairs never inspect comments.
+// All returns the same read-only, source-ordered slice after the first call.
+// A CommentStore belongs to one lintFile invocation and is therefore used
+// serially by that file's rule initializers and listeners.
+type CommentStore struct {
+	sourceFile *ast.SourceFile
+	comments   []*ast.CommentRange
+	scanned    bool
+}
+
+func NewCommentStore(sourceFile *ast.SourceFile) *CommentStore {
+	return &CommentStore{sourceFile: sourceFile}
+}
+
+// All returns every real line or block comment in the source file, ordered by
+// source position and deduplicated. Treat the returned slice as read-only.
+func (s *CommentStore) All() []*ast.CommentRange {
+	if s == nil || s.scanned {
+		if s == nil {
+			return nil
+		}
+		return s.comments
+	}
+	s.scanned = true
+
+	if s.sourceFile == nil {
+		return nil
+	}
+	text := s.sourceFile.Text()
+	// Every comment recognized by the TypeScript scanner starts with one of
+	// these byte pairs. False positives in strings, templates, regexes, or JSX
+	// only take the established slow path; an absence proves there is no
+	// comment and avoids materializing the file's token tree.
+	if !mayContainComment(text) {
+		return nil
+	}
+
+	utils.ForEachComment(s.sourceFile.AsNode(), func(comment *ast.CommentRange) {
+		s.comments = append(s.comments, comment)
+	}, s.sourceFile)
+
+	// ForEachComment can surface the same physical comment twice (once as a
+	// token's trailing range, once as the next token's leading range) and does
+	// not guarantee source order.
+	sort.Slice(s.comments, func(i, j int) bool {
+		return s.comments[i].Pos() < s.comments[j].Pos()
+	})
+	s.comments = slices.CompactFunc(s.comments, func(a, b *ast.CommentRange) bool {
+		return a.Pos() == b.Pos() && a.End() == b.End()
+	})
+	return s.comments
+}
+
+func mayContainComment(text string) bool {
+	for searchStart := 0; searchStart < len(text); {
+		offset := strings.IndexByte(text[searchStart:], '/')
+		if offset < 0 {
+			return false
+		}
+		slash := searchStart + offset
+		if slash+1 < len(text) && (text[slash+1] == '/' || text[slash+1] == '*') {
+			return true
+		}
+		searchStart = slash + 1
+	}
+	return false
+}

--- a/internal/rule/comment_store_test.go
+++ b/internal/rule/comment_store_test.go
@@ -1,0 +1,114 @@
+package rule
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+)
+
+func parseCommentStoreSource(t *testing.T, source string) *ast.SourceFile {
+	t.Helper()
+	return parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, source, core.ScriptKindTS)
+}
+
+func TestCommentStoreCollectsOnceInSourceOrder(t *testing.T) {
+	source := "const fake = '/* not a comment */';\n" +
+		"const other = '// still not a comment'; // first\n" +
+		"/* second */ const value = 1;\n"
+	store := NewCommentStore(parseCommentStoreSource(t, source))
+	if store.scanned {
+		t.Fatal("new comment store was already scanned")
+	}
+
+	comments := store.All()
+	if !store.scanned {
+		t.Fatal("comment store did not record its scan")
+	}
+	var texts []string
+	for _, comment := range comments {
+		texts = append(texts, source[comment.Pos():comment.End()])
+	}
+	if want := []string{"// first", "/* second */"}; !reflect.DeepEqual(texts, want) {
+		t.Fatalf("comments = %#v, want %#v", texts, want)
+	}
+
+	again := store.All()
+	if len(again) != len(comments) || (len(again) > 0 && again[0] != comments[0]) {
+		t.Fatal("second All call did not reuse the cached comment list")
+	}
+}
+
+func TestCommentStoreWithoutCommentsFastPath(t *testing.T) {
+	store := NewCommentStore(parseCommentStoreSource(t, "const quotient = 8 / 2;\nconst value = 'plain';\n"))
+	if comments := store.All(); len(comments) != 0 {
+		t.Fatalf("comments = %#v, want none", comments)
+	}
+	if !store.scanned {
+		t.Fatal("fast path for a file without comments did not cache its result")
+	}
+}
+
+func TestDisableManagerDefersOrdinaryComments(t *testing.T) {
+	source := "// an ordinary comment\nalert('hello')\n"
+	sourceFile := parseCommentStoreSource(t, source)
+	store := NewCommentStore(sourceFile)
+	manager := NewDisableManager(sourceFile, store)
+	if store.scanned {
+		t.Fatal("constructing DisableManager scanned comments")
+	}
+
+	if manager.IsRuleDisabled("no-alert", strings.Index(source, "alert")) {
+		t.Fatal("ordinary comment disabled a rule")
+	}
+	if store.scanned {
+		t.Fatal("ordinary comment caused the comment store to scan")
+	}
+}
+
+func TestDisableManagerLazilyParsesDirective(t *testing.T) {
+	source := "// eslint-disable-next-line no-alert\nalert('hello')\n"
+	sourceFile := parseCommentStoreSource(t, source)
+	store := NewCommentStore(sourceFile)
+	manager := NewDisableManager(sourceFile, store)
+	if store.scanned {
+		t.Fatal("constructing DisableManager scanned comments")
+	}
+
+	if !manager.IsRuleDisabled("no-alert", strings.LastIndex(source, "alert")) {
+		t.Fatal("disable-next-line directive was not applied")
+	}
+	if !store.scanned {
+		t.Fatal("disable check did not lazily scan directive comments")
+	}
+}
+
+func TestMayContainDisableDirective(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "rslint disable", text: "// rslint-disable no-alert", want: true},
+		{name: "rslint enable", text: "/* rslint-enable */", want: true},
+		{name: "eslint disable", text: "// eslint-disable-next-line no-alert", want: true},
+		{name: "eslint enable", text: "/* eslint-enable no-alert */", want: true},
+		{name: "unsupported prefix", text: "// lint-disable no-alert"},
+		{name: "wrong case", text: "// ESLint-disable no-alert"},
+		{name: "ordinary comment", text: "// lint rules are useful"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := mayContainDisableDirective(test.text); got != test.want {
+				t.Fatalf("mayContainDisableDirective(%q) = %v, want %v", test.text, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/rule/disable_manager.go
+++ b/internal/rule/disable_manager.go
@@ -19,10 +19,10 @@ type directiveKind int
 
 const (
 	directiveNone     directiveKind = iota
-	directiveBlock                        // rslint-disable / eslint-disable (block)
-	directiveEnable                       // rslint-enable / eslint-enable
-	directiveLine                         // rslint-disable-line / eslint-disable-line
-	directiveNextLine                     // rslint-disable-next-line / eslint-disable-next-line
+	directiveBlock                  // rslint-disable / eslint-disable (block)
+	directiveEnable                 // rslint-enable / eslint-enable
+	directiveLine                   // rslint-disable-line / eslint-disable-line
+	directiveNextLine               // rslint-disable-next-line / eslint-disable-next-line
 )
 
 // directivePrefix defines the comment prefixes for disable/enable directives.
@@ -41,21 +41,52 @@ var directivePrefixes = []directivePrefix{
 // DisableManager tracks which rules are disabled at different locations in a file
 type DisableManager struct {
 	sourceFile            *ast.SourceFile
+	comments              *CommentStore
+	parsed                bool
 	blockDirectives       []blockDirective // block disable/enable events in source order
 	lineDisabledRules     map[int][]string // Rules disabled for specific lines
 	nextLineDisabledRules map[int][]string // Rules disabled for the next line
 }
 
-// NewDisableManager creates a new DisableManager for the given source file
-func NewDisableManager(sourceFile *ast.SourceFile, comments []*ast.CommentRange) *DisableManager {
-	dm := &DisableManager{
-		sourceFile:            sourceFile,
-		lineDisabledRules:     make(map[int][]string),
-		nextLineDisabledRules: make(map[int][]string),
+// NewDisableManager creates a manager whose directives are parsed on the first
+// disable check. The manager does not materialize comments without a directive.
+func NewDisableManager(sourceFile *ast.SourceFile, comments *CommentStore) *DisableManager {
+	return &DisableManager{
+		sourceFile: sourceFile,
+		comments:   comments,
 	}
+}
 
-	dm.parseDirectives(comments)
-	return dm
+func (dm *DisableManager) ensureParsed() {
+	if dm == nil || dm.parsed {
+		return
+	}
+	dm.parsed = true
+	if dm.sourceFile == nil || !mayContainDisableDirective(dm.sourceFile.Text()) {
+		return
+	}
+	dm.parseDirectives(dm.comments.All())
+}
+
+func mayContainDisableDirective(text string) bool {
+	const marker = "lint-"
+	for searchStart := 0; searchStart < len(text); {
+		offset := strings.Index(text[searchStart:], marker)
+		if offset < 0 {
+			return false
+		}
+		start := searchStart + offset
+		if start >= 2 {
+			prefix := text[start-2 : start]
+			rest := text[start+len(marker):]
+			if (prefix == "rs" || prefix == "es") &&
+				(strings.HasPrefix(rest, "disable") || strings.HasPrefix(rest, "enable")) {
+				return true
+			}
+		}
+		searchStart = start + len(marker)
+	}
+	return false
 }
 
 // parseDirectives parses disable/enable directive comments from the source text.
@@ -87,6 +118,9 @@ func (dm *DisableManager) parseDirectives(comments []*ast.CommentRange) {
 
 		switch kind {
 		case directiveLine:
+			if dm.lineDisabledRules == nil {
+				dm.lineDisabledRules = make(map[int][]string)
+			}
 			if len(rules) == 0 {
 				dm.lineDisabledRules[lineNum] = append(dm.lineDisabledRules[lineNum], "*")
 			} else {
@@ -94,6 +128,9 @@ func (dm *DisableManager) parseDirectives(comments []*ast.CommentRange) {
 			}
 		case directiveNextLine:
 			nextLineNum := lineNum + 1
+			if dm.nextLineDisabledRules == nil {
+				dm.nextLineDisabledRules = make(map[int][]string)
+			}
 			if len(rules) == 0 {
 				dm.nextLineDisabledRules[nextLineNum] = append(dm.nextLineDisabledRules[nextLineNum], "*")
 			} else {
@@ -162,6 +199,14 @@ func parseRuleNames(rulesStr string) []string {
 
 // IsRuleDisabled checks if a rule is disabled at the given position
 func (dm *DisableManager) IsRuleDisabled(ruleName string, pos int) bool {
+	if dm == nil || dm.sourceFile == nil {
+		return false
+	}
+	dm.ensureParsed()
+	if len(dm.blockDirectives) == 0 && len(dm.lineDisabledRules) == 0 && len(dm.nextLineDisabledRules) == 0 {
+		return false
+	}
+
 	line, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(dm.sourceFile, pos)
 
 	// Check block disable/enable directives (range-based)

--- a/internal/rule/inline_globals.go
+++ b/internal/rule/inline_globals.go
@@ -31,27 +31,31 @@ type inlineGlobalName struct {
 	nameRange core.TextRange
 }
 
-// ParseInlineGlobals scans `/* global ... */` / `/* globals ... */` block
-// comments once and returns both the final name -> declared map and ordered
-// declaration metadata for rules that need to distinguish comment globals
-// from configured globals.
+// ParseInlineGlobals returns both the final name -> declared map and ordered
+// declaration metadata for `/* global ... */` / `/* globals ... */` comments.
+// A source-text candidate check keeps the shared comment store lazy unless such a
+// directive may be present.
 //
 // Only real block-comment ranges supplied by the TypeScript scanner are read,
 // so lookalike text in strings, templates, regexes, or line comments is ignored.
 // Within a comment, duplicate names use the last setting and retain the first
 // name range. Across comments, the last setting wins and every comment range is
 // preserved. As in the existing globals API, only "off" un-declares a name.
-func ParseInlineGlobals(sourceFile *ast.SourceFile, comments []*ast.CommentRange) (map[string]bool, []InlineGlobal) {
-	if sourceFile == nil || sourceFile.Text() == "" || len(comments) == 0 {
+func ParseInlineGlobals(sourceFile *ast.SourceFile, comments *CommentStore) (map[string]bool, []InlineGlobal) {
+	if sourceFile == nil || sourceFile.Text() == "" || !mayContainInlineGlobalDirective(sourceFile.Text()) {
 		return nil, nil
 	}
 
 	text := sourceFile.Text()
+	sourceComments := comments.All()
+	if len(sourceComments) == 0 {
+		return nil, nil
+	}
 	var values map[string]bool
 	var globals []InlineGlobal
 	var globalIndexes map[string]int
 
-	for _, comment := range comments {
+	for _, comment := range sourceComments {
 		entries := parseInlineGlobalComment(text, comment)
 		if len(entries) == 0 {
 			continue
@@ -93,6 +97,34 @@ func ParseInlineGlobals(sourceFile *ast.SourceFile, comments []*ast.CommentRange
 	}
 
 	return values, globals
+}
+
+func mayContainInlineGlobalDirective(text string) bool {
+	for searchStart := 0; searchStart < len(text); {
+		markerOffset := strings.Index(text[searchStart:], "/*")
+		if markerOffset < 0 {
+			return false
+		}
+
+		contentStart := searchStart + markerOffset + len("/*")
+		contentStart, _ = trimECMAScriptWhitespaceRange(text, contentStart, len(text))
+		for _, keyword := range inlineGlobalsKeywords {
+			if !strings.HasPrefix(text[contentStart:], keyword) {
+				continue
+			}
+			restStart := contentStart + len(keyword)
+			if restStart == len(text) || strings.HasPrefix(text[restStart:], "*/") {
+				return true
+			}
+			r, _ := utf8.DecodeRuneInString(text[restStart:])
+			if isECMAScriptWhitespace(r) {
+				return true
+			}
+		}
+
+		searchStart = contentStart
+	}
+	return false
 }
 
 func parseInlineGlobalComment(text string, comment *ast.CommentRange) []inlineGlobalName {

--- a/internal/rule/inline_globals_test.go
+++ b/internal/rule/inline_globals_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/parser"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func parseInlineGlobalsForTest(t *testing.T, source string) (map[string]bool, []InlineGlobal) {
@@ -18,11 +17,7 @@ func parseInlineGlobalsForTest(t *testing.T, source string) (map[string]bool, []
 		Path:     "/test.ts",
 	}, source, core.ScriptKindTS)
 
-	var comments []*ast.CommentRange
-	utils.ForEachComment(sourceFile.AsNode(), func(comment *ast.CommentRange) {
-		comments = append(comments, comment)
-	}, sourceFile)
-	return ParseInlineGlobals(sourceFile, comments)
+	return ParseInlineGlobals(sourceFile, NewCommentStore(sourceFile))
 }
 
 func assertInlineGlobals(t *testing.T, source string, got []InlineGlobal, want []struct {
@@ -76,6 +71,23 @@ func TestParseInlineGlobals_MetadataAndSourceFiltering(t *testing.T) {
 		{name: "Array", declared: true, positions: []int{strings.Index(source, "Array:readonly")}},
 		{name: "offName", declared: true, positions: []int{strings.Index(source, "offName:off"), strings.LastIndex(source, "offName, foo")}},
 	})
+}
+
+func TestParseInlineGlobalsKeepsOrdinaryCommentsLazy(t *testing.T) {
+	source := "// ordinary comment\nconst value = 1;\n"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, source, core.ScriptKindTS)
+	store := NewCommentStore(sourceFile)
+
+	values, globals := ParseInlineGlobals(sourceFile, store)
+	if values != nil || globals != nil {
+		t.Fatalf("ParseInlineGlobals returned (%#v, %#v), want nil results", values, globals)
+	}
+	if store.scanned {
+		t.Fatal("ordinary comment caused inline-global parsing to scan comments")
+	}
 }
 
 func TestParseInlineGlobals_DuplicateAndOverrideSemantics(t *testing.T) {

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -262,18 +262,16 @@ type RuleContext struct {
 	InlineGlobals []InlineGlobal
 	// Globals is the fully resolved set of declared global names for this
 	// file — config `languageOptions.globals` merged with inline
-	// `/* global */` comments, computed once per file by the linter (see
-	// DisableManager, built the same way). Rules should read this instead of
-	// parsing comments or config themselves. Nil only when neither source
-	// mentions any globals; a name maps to false when its final setting is "off".
+	// `/* global */` comments, resolved once per file by the linter. Rules
+	// should read this instead of parsing comments or config themselves. Nil
+	// only when neither source mentions any globals; a name maps to false when
+	// its final setting is "off".
 	Globals map[string]bool
-	// Comments holds every comment in SourceFile, in source order,
-	// computed once per file by the linter (see DisableManager, built the
-	// same way). Rules that need all of a file's comments should read this
-	// instead of walking the token tree again with utils.ForEachComment —
-	// several rules doing that independently once dominated per-file lint
-	// time (each repeats the same full tokenization the parser already did).
-	Comments                   []*ast.CommentRange
+	// Comments lazily provides every comment in SourceFile, in source order.
+	// Rules should call Comments.All instead of walking the token tree with
+	// utils.ForEachComment. The first consumer computes the list and every
+	// later consumer for this file reuses it.
+	Comments                   *CommentStore
 	Program                    *compiler.Program
 	TypeChecker                *checker.Checker
 	DisableManager             *DisableManager

--- a/internal/rules/max_lines/max_lines.go
+++ b/internal/rules/max_lines/max_lines.go
@@ -2,7 +2,6 @@ package max_lines
 
 import (
 	"fmt"
-	"sort"
 	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -104,7 +103,7 @@ func checkMaxLines(ctx rule.RuleContext, options any) {
 	}
 
 	if opts.skipComments {
-		for line := range commentOnlyLines(ctx.Comments, text, lineStarts) {
+		for line := range commentOnlyLines(ctx.Comments.All(), text, lineStarts) {
 			idx := line - 1
 			if idx >= 0 && idx < nLines {
 				keep[idx] = false
@@ -158,13 +157,8 @@ func commentOnlyLines(sourceComments []*ast.CommentRange, text string, lineStart
 	if len(comments) == 0 {
 		return nil
 	}
-	// ForEachComment may surface a comment twice (once as a token's trailing
-	// range, once as the next token's leading range) and not strictly in source
-	// order. Duplicates are harmless for this algorithm, but advancing
-	// commentIdx linearly requires sorted input.
-	sort.Slice(comments, func(i, j int) bool {
-		return comments[i].Pos() < comments[j].Pos()
-	})
+	// CommentStore guarantees that sourceComments is ordered and deduplicated;
+	// the optional synthesized hashbang is at position zero.
 
 	nLines := len(lineStarts)
 	// minCodePos[line] / maxCodeEnd[line] bound the non-comment,

--- a/internal/rules/max_lines_per_function/max_lines_per_function.go
+++ b/internal/rules/max_lines_per_function/max_lines_per_function.go
@@ -2,7 +2,6 @@ package max_lines_per_function
 
 import (
 	"fmt"
-	"sort"
 	"unicode"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -19,7 +18,11 @@ var MaxLinesPerFunctionRule = rule.Rule{
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
 		opts := parseOptions(options)
-		state := newLineState(ctx.SourceFile, ctx.Comments)
+		var comments []*ast.CommentRange
+		if opts.skipComments {
+			comments = ctx.Comments.All()
+		}
+		state := newLineState(ctx.SourceFile, comments, opts.skipComments)
 
 		process := func(node *ast.Node) {
 			// Overload signatures, abstract / declare members, and TS interface
@@ -177,13 +180,22 @@ type lineState struct {
 	lineComment []*ast.CommentRange
 }
 
-func newLineState(sourceFile *ast.SourceFile, sourceComments []*ast.CommentRange) *lineState {
+func newLineState(sourceFile *ast.SourceFile, sourceComments []*ast.CommentRange, includeComments bool) *lineState {
 	text := sourceFile.Text()
 	lineStarts := scanner.GetECMALineStarts(sourceFile)
 	if len(lineStarts) == 0 {
 		lineStarts = []core.TextPos{0}
 	}
 	nLines := len(lineStarts)
+	state := &lineState{
+		sourceFile: sourceFile,
+		text:       text,
+		lineStarts: lineStarts,
+		nLines:     nLines,
+	}
+	if !includeComments {
+		return state
+	}
 
 	var comments []*ast.CommentRange
 	// ESLint's sourceCode.getAllComments() includes the hashbang (`#!`) line,
@@ -196,13 +208,8 @@ func newLineState(sourceFile *ast.SourceFile, sourceComments []*ast.CommentRange
 		})
 	}
 	comments = append(comments, sourceComments...)
-	// ForEachComment may surface a comment twice (once as a token's trailing
-	// range, once as the next token's leading range) and not strictly in source
-	// order. Sort so a deterministic "last write wins" assignment to
-	// lineComment matches ESLint's iteration order.
-	sort.Slice(comments, func(i, j int) bool {
-		return comments[i].Pos() < comments[j].Pos()
-	})
+	// CommentStore guarantees that sourceComments is ordered and deduplicated;
+	// the optional synthesized hashbang is at position zero.
 
 	// nLines lines (0-indexed) → store at index = line. We use 0-indexed lines
 	// throughout this rule for consistency with scanner.ComputeLineOfPosition.
@@ -220,13 +227,8 @@ func newLineState(sourceFile *ast.SourceFile, sourceComments []*ast.CommentRange
 		}
 	}
 
-	return &lineState{
-		sourceFile:  sourceFile,
-		text:        text,
-		lineStarts:  lineStarts,
-		nLines:      nLines,
-		lineComment: lineComment,
-	}
+	state.lineComment = lineComment
+	return state
 }
 
 // nodeLineRange returns the inclusive 0-indexed line range of the node,

--- a/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.go
+++ b/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.go
@@ -273,7 +273,7 @@ func buildNegationFix(ctx rule.RuleContext, outerUnary *ast.Node) []rule.RuleFix
 	}
 
 	replaceRange := utils.TrimNodeTextRange(ctx.SourceFile, outerUnary)
-	if utils.HasCommentInSpan(ctx.Comments, replaceRange.Pos(), replaceRange.End()) {
+	if utils.HasCommentInSpan(ctx.Comments.All(), replaceRange.Pos(), replaceRange.End()) {
 		return nil
 	}
 
@@ -311,13 +311,13 @@ func buildCallFix(ctx rule.RuleContext, callNode *ast.Node) []rule.RuleFix {
 		if parent != nil && parent.Kind == ast.KindPrefixUnaryExpression &&
 			parent.AsPrefixUnaryExpression().Operator == ast.KindExclamationToken {
 			parentRange := utils.TrimNodeTextRange(ctx.SourceFile, parent)
-			if utils.HasCommentInSpan(ctx.Comments, parentRange.Pos(), parentRange.End()) {
+			if utils.HasCommentInSpan(ctx.Comments.All(), parentRange.Pos(), parentRange.End()) {
 				return nil
 			}
 			return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, parent, maybePrefixSpace(ctx.SourceFile, parentRange, "true"))}
 		}
 
-		if utils.HasCommentInSpan(ctx.Comments, callRange.Pos(), callRange.End()) {
+		if utils.HasCommentInSpan(ctx.Comments.All(), callRange.Pos(), callRange.End()) {
 			return nil
 		}
 		return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, callNode, maybePrefixSpace(ctx.SourceFile, callRange, "false"))}
@@ -328,7 +328,7 @@ func buildCallFix(ctx rule.RuleContext, callNode *ast.Node) []rule.RuleFix {
 		if ast.IsSpreadElement(arg) {
 			return nil
 		}
-		if utils.HasCommentInSpan(ctx.Comments, callRange.Pos(), callRange.End()) {
+		if utils.HasCommentInSpan(ctx.Comments.All(), callRange.Pos(), callRange.End()) {
 			return nil
 		}
 		// Peel parens to match ESLint's paren-less AST; see buildNegationFix.

--- a/internal/rules/no_irregular_whitespace/no_irregular_whitespace.go
+++ b/internal/rules/no_irregular_whitespace/no_irregular_whitespace.go
@@ -243,7 +243,7 @@ func collectExemptRanges(ctx rule.RuleContext, opts irregularWhitespaceOptions, 
 	if opts.skipComments {
 		nodeFactory := ast.NewNodeFactory(ast.NodeFactoryHooks{})
 		text := sf.Text()
-		for _, comment := range ctx.Comments {
+		for _, comment := range ctx.Comments.All() {
 			*ranges = append(*ranges, errorInfo{pos: comment.Pos(), end: comment.End()})
 		}
 		// Also check for leading comments at position 0 which ForEachComment may miss.

--- a/internal/rules/no_unused_labels/no_unused_labels.go
+++ b/internal/rules/no_unused_labels/no_unused_labels.go
@@ -68,10 +68,11 @@ func hasCommentBetweenLabelAndBody(ctx rule.RuleContext, node *ast.Node) bool {
 	bodyStart := scanner.SkipTrivia(ctx.SourceFile.Text(), ls.Statement.Pos())
 	colon, ok := labelSeparatorRange(ctx, labelToken.End(), bodyStart)
 	if !ok {
-		return utils.HasCommentInSpan(ctx.Comments, labelToken.End(), bodyStart)
+		return utils.HasCommentInSpan(ctx.Comments.All(), labelToken.End(), bodyStart)
 	}
-	return utils.HasCommentInSpan(ctx.Comments, labelToken.End(), colon.Pos()) ||
-		utils.HasCommentInSpan(ctx.Comments, colon.End(), bodyStart)
+	comments := ctx.Comments.All()
+	return utils.HasCommentInSpan(comments, labelToken.End(), colon.Pos()) ||
+		utils.HasCommentInSpan(comments, colon.End(), bodyStart)
 }
 
 func isFixable(ctx rule.RuleContext, node *ast.Node) bool {

--- a/internal/rules/no_unused_private_class_members/no_unused_private_class_members.go
+++ b/internal/rules/no_unused_private_class_members/no_unused_private_class_members.go
@@ -41,7 +41,7 @@ var NoUnusedPrivateClassMembersRule = rule.Rule{
 
 		getSourceItems := func() []sourceItem {
 			if sourceItems == nil {
-				sourceItems = collectSourceItems(ctx.SourceFile, ctx.Comments)
+				sourceItems = collectSourceItems(ctx.SourceFile, ctx.Comments.All())
 			}
 			return sourceItems
 		}
@@ -56,7 +56,7 @@ var NoUnusedPrivateClassMembersRule = rule.Rule{
 			}
 			current := stack[len(stack)-1]
 			stack = stack[:len(stack)-1]
-			reportUnusedMembers(ctx, current, getSourceItems())
+			reportUnusedMembers(ctx, current, getSourceItems)
 		}
 
 		handlePrivateIdentifier := func(node *ast.Node) {
@@ -213,7 +213,7 @@ func isExpressionStatementParent(parent *ast.Node) bool {
 	return parent != nil && parent.Kind == ast.KindExpressionStatement
 }
 
-func reportUnusedMembers(ctx rule.RuleContext, classInfo *classMembers, items []sourceItem) {
+func reportUnusedMembers(ctx rule.RuleContext, classInfo *classMembers, getItems func() []sourceItem) {
 	for _, name := range classInfo.order {
 		member := classInfo.members[name]
 		if member == nil || member.isUsed {
@@ -226,6 +226,7 @@ func reportUnusedMembers(ctx rule.RuleContext, classInfo *classMembers, items []
 			continue
 		}
 
+		items := getItems()
 		fixes := []rule.RuleFix{
 			rule.RuleFixReplaceRange(memberRemovalRange(ctx.SourceFile, member.declNode, items), ""),
 		}

--- a/internal/rules/prefer_arrow_callback/prefer_arrow_callback.go
+++ b/internal/rules/prefer_arrow_callback/prefer_arrow_callback.go
@@ -460,13 +460,13 @@ func buildFixes(ctx rule.RuleContext, node *ast.Node, scope scopeInfo, info call
 		object := info.bindMember.AsPropertyAccessExpression().Expression
 		removeStart := scanner.SkipTrivia(text, object.End())
 		removeEnd := utils.TrimNodeTextRange(sf, info.bindCall).End()
-		if removeStart < 0 || removeStart >= removeEnd || utils.HasCommentInSpan(ctx.Comments, removeStart, removeEnd) {
+		if removeStart < 0 || removeStart >= removeEnd || utils.HasCommentInSpan(ctx.Comments.All(), removeStart, removeEnd) {
 			return nil
 		}
 		fixes = append(fixes, rule.RuleFixRemoveRange(core.NewTextRange(removeStart, removeEnd)))
 	}
 
-	if utils.HasCommentInSpan(ctx.Comments, functionToken.End(), leftParenToken.Pos()) {
+	if utils.HasCommentInSpan(ctx.Comments.All(), functionToken.End(), leftParenToken.Pos()) {
 		fixes = append(fixes, rule.RuleFixRemoveRange(functionToken))
 		if name := node.Name(); name != nil {
 			fixes = append(fixes, rule.RuleFixRemove(sf, name))

--- a/internal/utils/for_each_comment_test.go
+++ b/internal/utils/for_each_comment_test.go
@@ -145,7 +145,7 @@ func TestHasCommentInSpan(t *testing.T) {
 	}
 
 	// HasCommentInSpan takes the file's pre-collected, sorted comment list
-	// (what ctx.Comments holds in production) rather than the source file
+	// (what ctx.Comments.All() returns in production) rather than the source file
 	// itself — mirrors how linter.go builds it once per file.
 	var comments []*ast.CommentRange
 	ForEachComment(sf.AsNode(), func(comment *ast.CommentRange) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -126,7 +126,7 @@ func HasCommentInsideNode(sourceFile *ast.SourceFile, node *ast.Node) bool {
 
 // HasCommentInSpan reports whether any comment in sourceComments overlaps the
 // half-open source span [start, end). sourceComments must be sorted by
-// position — pass ctx.Comments, which the linter already builds
+// position — pass ctx.Comments.All(), which the linter builds lazily
 // once per file. Runs in O(log k) via binary search over the (typically
 // small) comment list, the same technique ESLint's TokenStore uses for
 // commentsExistBetween, instead of re-walking the whole file's token tree on

--- a/packages/rslint/src/config/config-discovery-protocol.ts
+++ b/packages/rslint/src/config/config-discovery-protocol.ts
@@ -61,8 +61,7 @@ export interface FailedConfigModuleResult {
 }
 
 export type ConfigModuleLoadResult =
-  | LoadedConfigModuleResult
-  | FailedConfigModuleResult;
+  LoadedConfigModuleResult | FailedConfigModuleResult;
 
 export interface LoadConfigsResponse {
   transactionId: string;

--- a/packages/vscode-extension/__tests__/utils/codeActionRegistry.ts
+++ b/packages/vscode-extension/__tests__/utils/codeActionRegistry.ts
@@ -129,8 +129,7 @@ export class CodeActionRegistryProbe implements vscode.Disposable {
   private activeQuietWindowMs = defaultQuietWindowMs;
   private activeAttempt = 0;
   private activeAttemptHook:
-    | ((attempt: number, probeUri: vscode.Uri) => void)
-    | undefined;
+    ((attempt: number, probeUri: vscode.Uri) => void) | undefined;
 
   constructor() {
     const id = randomUUID().replaceAll('-', '');

--- a/packages/vscode-extension/src/Rslint.ts
+++ b/packages/vscode-extension/src/Rslint.ts
@@ -59,9 +59,7 @@ const LOCKFILE_NAMES = [
 export const CONFIG_REFRESH_WATCH_GLOB = `**/{rslint.config.js,rslint.config.mjs,rslint.config.ts,rslint.config.mts,rslint.json,rslint.jsonc,${LOCKFILE_NAMES.join(',')}}`;
 
 export type ConfigRefreshReason =
-  | 'initial'
-  | 'config-change'
-  | 'dependency-change';
+  'initial' | 'config-change' | 'dependency-change';
 
 interface ConfigRefreshRequest {
   protocolVersion: typeof CONFIG_DISCOVERY_PROTOCOL_VERSION;


### PR DESCRIPTION
## Summary

- add a per-source-file `CommentStore` that collects, orders, deduplicates, and caches comments only when a consumer requests them
- defer disable-directive parsing until the first reported diagnostic and gate inline globals and comment rules with safe source-text candidate checks
- avoid comment work in rules unless their options or fix paths require it, while preserving comment-sensitive diagnostics and fixes
- document the lazy comment lifecycle and apply the formatting required by Prettier 3.9.4

Performance from 10 alternating paired runs:

- rspack: median wall time 0.66s → 0.64s, CPU time 1.885s → 1.580s, peak RSS 434 MiB → 362 MiB
- rsbuild: median CPU time 3.645s → 3.425s and peak RSS 829 MiB → 792 MiB; wall time remained effectively flat at 1.15s → 1.16s

Validation:

- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run` on the 14 changed Go packages
- targeted Go tests for the comment store, linter integration, and affected comment-aware rules

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
