### PR TITLE
perf: prune gitignored directories during config discovery

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -573,10 +573,10 @@ The transport and target phase differ by surface:
   do not require that handler. Every long-lived API call uses a
   fresh entry-module load so rewritten config bytes cannot be paired with stale
   normalized exports or a newer plugin-worker topology. API `overrideConfig`
-  entries are validated before that load and attached at the loader boundary as
-  the final suffix of every successful config. Their global ignores and
-  negations therefore participate in staged reachability and are published
-  exactly once; an empty catalog uses the same override directly.
+  entries are structurally validated before that load and attached at the
+  loader boundary as the final suffix of every successful config. Their global
+  ignores and negations therefore participate in staged reachability and are
+  published exactly once; an empty catalog uses the same override directly.
 - The extension owns shared UI, commands, and output channels once. Its
   `WorkspaceRslintCoordinator` keys desired and active roots by workspace-folder
   URI (not display name), subscribes to folder changes before awaiting any root,

--- a/architecture.md
+++ b/architecture.md
@@ -109,8 +109,8 @@ The directory map below folds the high-level module relationships into the packa
 | `cmd/tsgo/`                    | ts-go semantic inspection/export tool                                                                                                       | Talks directly to `typescript-go` and bypasses the lint framework; consumed by `packages/tsgo` and `crates/tsgo-client`                                                                                                                                                                |
 | `internal/api/`                | stdio IPC protocol and service types for JS/WASM integration                                                                                | Shared protocol layer for `cmd/rslint --api`; used by `packages/rslint`, `packages/rslint-wasm`, `internal/linter`, and `internal/inspector`                                                                                                                                           |
 | `internal/config/`             | Configuration models, JSON loading, matching/merging, runtime ownership resolution, lint-target planning, and centralized rule registration | Owns the shared authored-global-ignore matcher consumed by both discovery phases. `RegisterAllRules()` orchestrates rule registration; `rule_registry.go` implements registry/query logic used by `cmd/rslint/programs.go` and `internal/linter`                                       |
-| `internal/config/discovery/`   | Go-owned JS/TS config candidate discovery and immutable catalog construction                                                                | Imports the parent config model/matching policy, batches exact candidates to a host-supplied Node loader, and returns configs/scopes/failures/effective IDs. CLI, API, and LSP call its one-shot `Build`; the parent package never imports this child package                          |
-| `internal/config/gitignore/`   | Config-scoped `.gitignore` source discovery and pattern conversion                                                                          | Shared by lint-target admission across CLI, IPC API, and LSP; collection starts at the governing config directory, stops at automatic ownership handoff boundaries (or the exact literal chain for an explicit-only config), and never participates in config candidate discovery      |
+| `internal/config/discovery/`   | Go-owned JS/TS config candidate discovery and immutable catalog construction                                                                | Imports the parent config model/matching policy, batches exact candidates to a host-supplied Node loader, and returns configs/scopes/failures/effective IDs. CLI, API, and LSP call `DiscoverAutomatic` or `LoadExplicitConfig`; the parent package never imports this child package   |
+| `internal/config/gitignore/`   | Config-scoped `.gitignore` parsing, directory reachability, and pattern projection                                                          | Automatic catalog discovery carries a filesystem-independent cursor through its existing walk, pruning Git-inaccessible config subtrees and freezing observed patterns for lint-target admission; explicit/JSON fallback paths reuse the standalone collector                          |
 | `internal/inspector/`          | AST/type/symbol/signature/flow inspection for Playground                                                                                    | Auxiliary backend used mainly by website Playground inspect panels; builds rich semantic data from `typescript-go` programs                                                                                                                                                            |
 | `internal/linter/`             | Core lint engine, traversal, and fix application                                                                                            | Consumes rules from `internal/rule`, file config from `internal/config`, and `Program` / `TypeChecker` data from `typescript-go`; also serves `internal/api` and `internal/lsp`                                                                                                        |
 | `internal/lsp/`                | Language Server Protocol implementation                                                                                                     | Wraps `typescript-go project.Session`, owns transactional config discovery and last-good commit state with `packages/vscode-extension` as the module/plugin host, and invokes `internal/linter` on session-backed programs                                                             |
@@ -450,12 +450,14 @@ The loading flow differs by config type:
 **JS/TS staged catalog discovery**:
 
 CLI, the native JavaScript API path, and transactional LSP refreshes reuse
-the one-shot `internal/config/discovery.Build` operation. It builds an immutable
-config/ownership catalog; it does not collect lint targets or read `.gitignore`.
-Go owns candidate discovery, default exclusions, config hierarchy, authored
-global-ignore reachability, and final effective IDs. Node only executes the
-exact JS/TS modules requested by Go, normalizes their entries, retains live
-third-party plugin objects, and returns serializable entries. Source
+the one-shot `internal/config/discovery.DiscoverAutomatic` operation (or
+`LoadExplicitConfig` for an exact path). Automatic discovery builds an immutable
+config/ownership catalog and observes `.gitignore` sources during the same
+directory walk; it does not collect lint targets. Go owns candidate discovery,
+default exclusions, config hierarchy, authored and Git directory reachability,
+the frozen Git projection for each owner, and final effective IDs. Node only
+executes the exact JS/TS modules requested by Go, normalizes their entries,
+retains live third-party plugin objects, and returns serializable entries. Source
 fingerprints stay in the Node transaction session; after Go selects the final
 effective IDs, activation revalidates those fingerprints and returns only the
 effective plugin metadata.
@@ -464,10 +466,11 @@ The package boundary is deliberate: `internal/config/discovery` imports the
 parent `internal/config` model and its narrow authored-global-ignore matcher;
 the parent never imports discovery. Runtime file routing stays in the parent
 `ConfigOwnerResolver`, while CLI/API/LSP adapters own transport, commit/abort,
-and last-good lifecycle. `Build` has no reusable session, mutex, or generation
-state because every production request is one transaction; a process-random
-nonce plus atomic sequence allocates IDs that cannot collide with a stale host
-session after a native-process restart. The returned catalog
+and last-good lifecycle. Discovery has no cross-transaction session,
+synchronization, or generation state because every production request is one
+transaction; request-local coordination only freezes concurrent observations.
+A process-random nonce plus atomic sequence allocates IDs that cannot collide
+with a stale host session after a native-process restart. The returned catalog
 publishes final configs, scopes, failures, effective IDs, plugin metadata, and
 whether the invocation used an explicit config. Candidate fingerprints and
 plugin-aggregation scratch remain private to the Node transaction session;
@@ -477,17 +480,27 @@ Automatic discovery uses these rules:
 
 1. `.git` and `node_modules` are default discovery boundaries. Within one
    directory, automatic filename priority is `.js` → `.mjs` → `.ts` → `.mts`.
-   `.gitignore` is deliberately not consulted: a config candidate is discovered
-   and loaded even when its directory or filename is gitignored. When a requested
-   directory root is itself default-excluded, Go skips downward traversal but
-   still resolves reachable ancestors outside the boundary.
+   After the first successful JS/TS owner, Git-inaccessible directory nodes are
+   config-discovery boundaries. Git never filters a candidate filename, so a
+   local or ancestor pattern naming `rslint.config.js` does not change priority
+   or fall through to `.mjs`. A directly supplied directory/static-glob root
+   reopens that root's inherited Git gate, but not hidden intermediate configs;
+   overlapping supplied roots retain independent reachability. When a requested
+   root is default-excluded, Go skips downward traversal but still resolves
+   reachable ancestors outside the boundary.
 2. A directory target's config ancestry is evaluated outer-to-inner. The
    current successful ancestor's standalone global ignores can therefore stop
    a nested config before it executes. An absolute directory cover such as
    `dir/**` prunes the frontier. A file cover such as `dir/**/*` keeps the
-   directory traversable for later negations, but an automatic config candidate
-   that still matches that cover is not executed; filename priority falls
-   through to the first non-ignored candidate. CLI/LSP directory roots (including mixed
+   directory traversable for later authored negations, but an automatic config
+   candidate that still matches that authored cover is not executed; filename
+   priority falls through to the first non-ignored candidate. Ordered authored
+   patterns may reopen a Git-blocked node when they match that exact directory:
+   `!dir`, `!dir/`, and `!dir/**` reopen `dir`, while `!dir/**/*` and
+   `!dir/file.ts` do not. Descendant patterns such as `!dir/*` can reopen a
+   child node they directly match, and a later matching positive pattern closes
+   the node again.
+   CLI/LSP directory roots (including mixed
    CLI file-and-directory input) recursively scan reachable sibling frontiers
    with a bounded worker pool. When the native API supplies an already-expanded
    exact file set plus static glob roots, Go builds a lexical target-ancestor
@@ -499,7 +512,8 @@ Automatic discovery uses these rules:
    fails. Lexical ancestry is authoritative; canonical ancestry is consulted
    only when the complete lexical ancestry has no candidate. A default-excluded
    literal file is not lintable and cannot escape through canonical fallback.
-   `.gitignore` is applied only after ownership is known. A config reached only
+   Git is not used to choose that literal's owner; `.gitignore` is applied after
+   ownership is known. A config reached only
    through the literal exception is marked explicit-only: it owns its
    discovery-scoped literal files and uses its directory as the `.gitignore`
    source boundary for that scope, but is excluded from automatic lint-target
@@ -525,7 +539,12 @@ Automatic discovery uses these rules:
    rechecks the same effective sources before publishing the activation. This
    prevents a worker re-import during preparation from observing different
    config bytes than the normalized entries Go is about to commit.
-5. A failed candidate is recorded and discovery continues with the last
+5. A successful child config resets Git scope at its own directory: parent Git
+   rules stop at that ownership handoff, then the child's local `.gitignore` is
+   read. A failed child does not form a boundary and inherits the parent cursor.
+   Config evaluation always precedes reading that directory's local Git source,
+   and a Git-inaccessible branch's nested `.gitignore` is never read.
+6. A failed candidate is recorded and discovery continues with the last
    reachable successful owner. If candidates existed but none loaded,
    discovery returns `ErrAllConfigsFailed` and does not activate Node state.
    Partial failures remain in `catalog.Failures`: CLI and native API emit
@@ -537,11 +556,10 @@ The transport and target phase differ by surface:
 
 - CLI sends `loadConfigs` / `activateConfigs` as reverse framed-IPC requests
   during initialization. The resulting catalog and the later Go lint-target
-  walker are separate traversals, but they share the catalog and the same
-  run-scoped cached VFS.
-  File-only invocations first resolve provisional owners and collect only the
-  `.gitignore` sources on each owner's exact target chains, avoiding an eager
-  subtree scan in lint-staged-style runs.
+  walker are separate traversals, but config discovery already freezes the Git
+  sources observed on its reachable frontier. There is no second per-owner
+  directory sweep. Literal-only and mixed literal targets contribute only their
+  exact owner-to-target source chains to the same source-keyed projection.
 - `Rslint.lintFiles()` still expands target globs with `tinyglobby`, preserves
   literal provenance and canonical identities, and sends the resulting files
   plus their static config-scan roots in one API lint request. Go bounds catalog
@@ -554,7 +572,11 @@ The transport and target phase differ by surface:
   `reversePluginLint` capability at the request boundary; plugin-free catalogs
   do not require that handler. Every long-lived API call uses a
   fresh entry-module load so rewritten config bytes cannot be paired with stale
-  normalized exports or a newer plugin-worker topology.
+  normalized exports or a newer plugin-worker topology. API `overrideConfig`
+  entries are validated before that load and attached at the loader boundary as
+  the final suffix of every successful config. Their global ignores and
+  negations therefore participate in staged reachability and are published
+  exactly once; an empty catalog uses the same override directly.
 - The extension owns shared UI, commands, and output channels once. Its
   `WorkspaceRslintCoordinator` keys desired and active roots by workspace-folder
   URI (not display name), subscribes to folder changes before awaiting any root,
@@ -623,8 +645,10 @@ diagnostics after edits, closes, or config commits.
 
 An explicit JS/TS `--config` or API `overrideConfigFile` bypasses automatic
 candidate selection and loads the exact module. The invocation cwd remains its
-matching directory. Automatic and explicit config modules are both independent
-of `.gitignore`; lint targets are filtered only after the catalog is established.
+matching directory. The exact config path is never gated by `.gitignore`;
+lint targets are filtered afterward with the existing invocation-scoped
+collector. Automatic candidates instead use the Git directory reachability
+rules above.
 
 No-candidate behavior is surface-specific. CLI performs no Node activation and
 continues through its normal JSON fallback. Native API discovery performs no
@@ -677,10 +701,13 @@ allowed alias.
 Additional current behaviors:
 
 - `.gitignore` is injected as a global-ignore entry through the shared
-  `ConfigWithGitignore` policy. The governing config directory is a hard upper
-  boundary: its own and nested `.gitignore` files apply, while parent
-  `.gitignore` files do not. In multi-config CLI mode, direct automatically
-  reachable child config directories are downward ownership handoff boundaries.
+  `ConfigWithCollectedGitignore`/`ConfigWithGitignore` policy. The governing
+  config directory is a hard upper boundary: its own and nested `.gitignore`
+  files apply, while parent `.gitignore` files do not. In automatic catalogs,
+  the staged walk records sources by owner and case-aware source identity,
+  orders them parent-before-child, and materializes the synthetic Git entry
+  before publishing. Direct automatically reachable child config directories
+  are downward ownership handoff boundaries.
   Configs loaded only for explicit targets bound only their literal target
   chains, so adding a literal cannot truncate an ancestor-owned automatic
   target's `.gitignore` sources. This preserves ESLint v10's per-target global
@@ -701,9 +728,9 @@ Additional current behaviors:
 - the VS Code extension preserves last-good JS configs during reloads; a newly
   unavailable config with no usable JS ancestor contributes an empty boundary,
   preventing JSON fallback only in that authored config subtree. A normal
-  transactional refresh prepares all successful and unavailable boundaries
-  before collecting config-scoped `.gitignore` sources, then freezes and commits
-  the Go catalog and Node plugin host under one transaction ID. Failures preserve
+  transactional refresh receives successful entries with their Git projection
+  already frozen, adds unavailable boundaries, then freezes and commits the Go
+  catalog and Node plugin host under one transaction ID. Failures preserve
   a usable last-good catalog and ignore view together; the first-start all-broken
   recovery instead commits unavailable boundaries.
   If the first valid catalog cannot initialize its optional community-plugin
@@ -715,10 +742,10 @@ Additional current behaviors:
 - native and third-party plugin rules are gated by their normalized prefixes for JS/TS configs; third-party rules use process-wide Go registry placeholders, but LSP additionally filters those placeholders through the exact rule-name set committed for the current Node generation so metadata retained from an older generation cannot be dispatched to a newer worker
 - CLI/API lint target selection is independent from TypeScript `Program` membership and considers only rslint-supported script extensions. The `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.tsx`, `.mts`, and `.cts` default baseline is always selected; explicit config `files` contributes candidates only within the supported set. Global ignores and `.gitignore` remove targets, while an entry-level ignore prevents only its own selector/config contribution
 - selected CLI/API targets can still appear as 0-rule lint results when no config entry contributes rules; this applies to default-baseline directory discovery and explicit supported files, and syntax diagnostics remain available in that state
-- under automatic discovery, each selected file is governed by its nearest loadable config; explicit config modes use the selected config directly. In either mode, a target can bind only to a tsconfig declared by its governing config, and the first declared project containing the file wins
+- under automatic discovery, each selected file is governed by its nearest loadable config; an explicitly selected config is used directly. In either case, a target can bind only to a tsconfig declared by its governing config, and the first declared project containing the file wins
 - `files`/`ignores` matching uses the stable target path in the governing config's path space; a Program source alias is used only to locate the AST and type information, so moving a target into or out of a tsconfig cannot change its rule configuration
 - within each Program-registry build, normalized declared tsconfig paths are deduplicated across config associations; CLI fix passes create a new registry build. File-symlink declarations remain distinct because TypeScript resolves relative paths from the declared location. Selected files outside the governing config's Programs receive a non-project-backed fallback Program, and targets whose names collide under a case-insensitive ts-go path key are partitioned across fallback Programs so distinct physical files remain distinct
-- `--type-check` and `--type-check-only` build every real tsconfig declared by the effective loaded config catalog. Once that catalog is established, program-wide checking is not filtered by lint targets, config `files`/`ignores`, `.gitignore`, or CLI file/directory arguments; synthetic fallback Programs never participate. `--type-check-only` skips lint-target and `.gitignore` collection.
+- `--type-check` and `--type-check-only` build every real tsconfig declared by the effective loaded config catalog. Git reachability may change which automatic configs enter that catalog; once it is established, program-wide checking is not filtered by lint targets, config `files`/`ignores`, `.gitignore`, or CLI file/directory arguments. Synthetic fallback Programs never participate, and `--type-check-only` skips the separate lint-target walk.
 - for LSP, an open supported script is a per-file target independent of Program membership. Global config ignores, `.gitignore`, default-excluded paths, and unavailable config boundaries suppress native rules, plugin rules, and fixes; an available zero-rule config still parses the target and can report syntax diagnostics
 
 ### Inline Directives
@@ -747,7 +774,7 @@ rslint [options] [files...]
 The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cli/cli.ts`) and the Go binary (`cmd/rslint/`).
 
 1. **Node.js Wrapper**: parses args, starts the Go engine, and hosts JS/TS module evaluation plus live third-party plugin objects
-2. **Config Catalog**: for automatic or explicit JS/TS config mode, Go builds the staged catalog and batches exact module-evaluation requests to Node. If automatic discovery finds no candidate, or a non-JS config was explicitly selected, the existing Go JSON loader path remains in control
+2. **Config Catalog**: for automatic JS/TS discovery or an explicitly selected JS/TS config, Go builds the staged catalog and batches exact module-evaluation requests to Node. If automatic discovery finds no candidate, or a non-JS config was explicitly selected, the existing Go JSON loader path remains in control
 3. **Mode Selection**:
    - `--lsp`: starts the LSP server
    - `--api`: starts the IPC API server
@@ -786,10 +813,11 @@ collection, and plugin dispatch may still use infrastructure goroutines.
      result, so only sibling branches leading to supplied files enter those
      frontiers. CLI/LSP directory roots, including CLI mixed file+directory
      invocations, remain recursively unbounded within ignore boundaries.
-   - Directory-root ancestry is loaded outer-to-inner before the root frontier;
-     each successful owner's authored global ignores control continuation below
-     that boundary. `.gitignore` is not read during this phase. Literal files use
-     the separate nearest-first exception described above.
+   - Directory-root ancestry is loaded outer-to-inner before the root frontier.
+     Each successful owner's authored global ignores and Git cursor control
+     continuation below that boundary; local Git sources are observed only after
+     the directory's config decision. Literal files use the separate
+     nearest-first ownership exception described above.
    - Discovery commits only the config catalog in stable order. Plain lint then
      runs the separate lint-target walker and constructs Programs only for
      represented configs. `--type-check` and `--type-check-only` construct

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -61,7 +61,8 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 }
 
 type apiConfigModuleLoader struct {
-	requester api.Requester
+	requester      api.Requester
+	overrideConfig rslintconfig.RslintConfig
 }
 
 func (loader *apiConfigModuleLoader) LoadConfigs(ctx context.Context, request discovery.ConfigLoadBatchRequest) (discovery.ConfigLoadBatchResponse, error) {
@@ -75,6 +76,22 @@ func (loader *apiConfigModuleLoader) LoadConfigs(ctx context.Context, request di
 	var response discovery.ConfigLoadBatchResponse
 	if err := msg.Decode(&response); err != nil {
 		return discovery.ConfigLoadBatchResponse{}, fmt.Errorf("decode loadConfigs result: %w", err)
+	}
+	// API override entries are the final suffix of every loaded config. Attach
+	// them at the loader boundary so discovery reachability and the published
+	// catalog observe the same effective config; callers must not append them a
+	// second time after discovery.
+	if len(loader.overrideConfig) > 0 {
+		for index := range response.Results {
+			result := &response.Results[index]
+			if result.Status != "loaded" {
+				continue
+			}
+			effective := make(rslintconfig.RslintConfig, 0, len(result.Entries)+len(loader.overrideConfig))
+			effective = append(effective, result.Entries...)
+			effective = append(effective, loader.overrideConfig...)
+			result.Entries = effective
+		}
 	}
 	return response, nil
 }
@@ -238,22 +255,29 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 		if len(configDiscovery.ExplicitFiles) > 0 && len(configDiscovery.ExplicitFiles) != len(req.Files) {
 			return nil, errors.New("configDiscovery.explicitFiles must be parallel to files")
 		}
-
+		var overrideConfig rslintconfig.RslintConfig
+		if len(configDiscovery.OverrideConfig) > 0 {
+			if err := json.Unmarshal(configDiscovery.OverrideConfig, &overrideConfig); err != nil {
+				return nil, fmt.Errorf("invalid configDiscovery.overrideConfig: %w", err)
+			}
+			if err := rslintconfig.ValidateConfig(overrideConfig); err != nil {
+				return nil, fmt.Errorf("invalid configDiscovery.overrideConfig: %w", err)
+			}
+			// Reject invalid native-rule options before evaluating any user
+			// config module. Besides failing earlier, this guarantees a malformed
+			// request cannot trigger load/activation side effects. The resolved
+			// catalog is still validated below so options from loaded modules are
+			// covered as well.
+			if messages := validateResolvedRuleOptions(nil, overrideConfig); len(messages) > 0 {
+				return nil, fmt.Errorf("invalid rule options:\n%s", strings.Join(messages, "\n"))
+			}
+		}
 		discoveryRequest := discovery.ConfigDiscoveryRequest{
 			CWD:                       currentDirectory,
 			Fresh:                     true,
 			LimitDirectoryWalkToFiles: len(configDiscovery.Directories) > 0,
 			ImplicitCWD:               len(req.Files) == 0 && len(configDiscovery.Directories) == 0,
 			SingleThreaded:            false,
-		}
-		switch configDiscovery.Mode {
-		case "", "auto":
-			discoveryRequest.Mode = discovery.ConfigDiscoveryAuto
-		case "explicit":
-			discoveryRequest.Mode = discovery.ConfigDiscoveryExplicit
-			discoveryRequest.ExplicitConfigPath = resolveRequestPath(configDiscovery.ExplicitConfigPath)
-		default:
-			return nil, fmt.Errorf("invalid configDiscovery mode %q", configDiscovery.Mode)
 		}
 		for _, directory := range configDiscovery.Directories {
 			discoveryRequest.Directories = append(discoveryRequest.Directories, resolveRequestPath(directory))
@@ -274,12 +298,26 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 			})
 		}
 
-		catalog, err := discovery.Build(
-			ctx,
-			fs,
-			&apiConfigModuleLoader{requester: requester},
-			discoveryRequest,
-		)
+		loader := &apiConfigModuleLoader{
+			requester:      requester,
+			overrideConfig: overrideConfig,
+		}
+		var catalog *discovery.ConfigCatalog
+		var err error
+		if configDiscovery.ExplicitConfigPath != "" {
+			catalog, err = discovery.LoadExplicitConfig(
+				ctx,
+				fs,
+				loader,
+				discovery.ExplicitConfigRequest{
+					CWD:        currentDirectory,
+					ConfigPath: resolveRequestPath(configDiscovery.ExplicitConfigPath),
+					Fresh:      true,
+				},
+			)
+		} else {
+			catalog, err = discovery.DiscoverAutomatic(ctx, fs, loader, discoveryRequest)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("discover config catalog: %w", err)
 		}
@@ -293,16 +331,6 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 			}
 		}
 
-		var overrideConfig rslintconfig.RslintConfig
-		if len(configDiscovery.OverrideConfig) > 0 {
-			if err := json.Unmarshal(configDiscovery.OverrideConfig, &overrideConfig); err != nil {
-				return nil, fmt.Errorf("invalid configDiscovery.overrideConfig: %w", err)
-			}
-			if err := rslintconfig.ValidateConfig(overrideConfig); err != nil {
-				return nil, fmt.Errorf("invalid configDiscovery.overrideConfig: %w", err)
-			}
-		}
-
 		if len(catalog.Configs) > 0 {
 			configDirectories := catalog.ConfigDirectories()
 			if len(configDirectories) == 1 && catalog.Explicit {
@@ -312,7 +340,6 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 				// the selected module governs the complete supplied target set.
 				configDirectory = configDirectories[0]
 				rslintConfig = append(rslintconfig.RslintConfig(nil), catalog.Configs[configDirectory]...)
-				rslintConfig = append(rslintConfig, overrideConfig...)
 				pluginConfigDirByOwner = map[string]string{configDirectory: configDirectory}
 			} else {
 				configMap = make(map[string]rslintconfig.RslintConfig, len(catalog.Configs))
@@ -322,52 +349,11 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 				if configMap == nil {
 					continue
 				}
-				effective := make(rslintconfig.RslintConfig, 0, len(entries)+len(overrideConfig))
-				effective = append(effective, entries...)
-				effective = append(effective, overrideConfig...)
-				configMap[ownerDirectory] = effective
+				configMap[ownerDirectory] = append(rslintconfig.RslintConfig(nil), entries...)
 				pluginConfigDirByOwner[ownerDirectory] = ownerDirectory
 			}
 			if configMap != nil {
 				configTargetScopes = catalog.Scopes
-				// The API already has an exact target set. Resolve provisional owners
-				// with authored config ignores first, then read only each owner's
-				// target ancestor chains. Configs loaded only for explicit files are
-				// boundaries for those literal scopes, not for ancestor-owned automatic
-				// siblings.
-				filesByOwner := configTargetFilesByOwner(
-					configMap,
-					configTargetScopes,
-					fs,
-					allowedFiles,
-					false,
-				)
-				automaticResolver := rslintconfig.NewConfigOwnerResolverForAutomaticTargets(
-					configMap,
-					configTargetScopes,
-					fs,
-				)
-				completeResolver := rslintconfig.NewConfigOwnerResolver(configMap, fs)
-				for ownerDirectory, entries := range configMap {
-					ownerFiles := filesByOwner[ownerDirectory]
-					if ownerFiles == nil {
-						ownerFiles = []string{}
-					}
-					// An ExplicitOnly config is a boundary only for its literal
-					// scope. Automatic siblings remain owned by the ancestor and
-					// must continue reading nested .gitignore sources below it.
-					resolver := automaticResolver
-					if configTargetScopes[ownerDirectory].ExplicitOnly {
-						resolver = completeResolver
-					}
-					configMap[ownerDirectory] = rslintconfig.ConfigWithGitignoreWithBoundaries(
-						entries,
-						ownerDirectory,
-						fs,
-						ownerFiles,
-						resolver.ChildConfigDirs(ownerDirectory),
-					)
-				}
 			}
 		} else {
 			// No JS candidate is a valid API state: lint with override entries (or

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -263,14 +263,6 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 			if err := rslintconfig.ValidateConfig(overrideConfig); err != nil {
 				return nil, fmt.Errorf("invalid configDiscovery.overrideConfig: %w", err)
 			}
-			// Reject invalid native-rule options before evaluating any user
-			// config module. Besides failing earlier, this guarantees a malformed
-			// request cannot trigger load/activation side effects. The resolved
-			// catalog is still validated below so options from loaded modules are
-			// covered as well.
-			if messages := validateResolvedRuleOptions(nil, overrideConfig); len(messages) > 0 {
-				return nil, fmt.Errorf("invalid rule options:\n%s", strings.Join(messages, "\n"))
-			}
 		}
 		discoveryRequest := discovery.ConfigDiscoveryRequest{
 			CWD:                       currentDirectory,

--- a/cmd/rslint/api_rule_options_test.go
+++ b/cmd/rslint/api_rule_options_test.go
@@ -83,7 +83,7 @@ func TestHandleLintDiscoveredConfigValidatesRuleOptions(t *testing.T) {
 	_, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
 		Files:            []string{filepath.Join(root, "input.js")},
 		WorkingDirectory: root,
-		ConfigDiscovery:  &api.ConfigDiscoveryRequest{Mode: "auto"},
+		ConfigDiscovery:  &api.ConfigDiscoveryRequest{},
 	}, requester)
 	if err == nil || !strings.Contains(err.Error(), `invalid options for rule "no-console"`) {
 		t.Fatalf("discovered config did not validate rule options: %v", err)
@@ -104,11 +104,37 @@ func TestHandleLintDiscoveryOverrideValidatesRuleOptionsWithoutCandidate(t *test
 		Files:            []string{target},
 		WorkingDirectory: root,
 		ConfigDiscovery: &api.ConfigDiscoveryRequest{
-			Mode:           "auto",
 			OverrideConfig: json.RawMessage(`[{"rules":{"no-console":["error",{"allow":"warn"}]}}]`),
 		},
 	}, requester)
 	if err == nil || !strings.Contains(err.Error(), `invalid options for rule "no-console"`) {
 		t.Fatalf("discovery override did not validate rule options: %v", err)
+	}
+}
+
+func TestHandleLintDiscoveryInvalidOverrideDoesNotLoadCandidate(t *testing.T) {
+	root := t.TempDir()
+	writeProgramTestFiles(t, root, map[string]string{
+		"rslint.config.js": "export default [];\n",
+		"input.js":         "console.log('test');\n",
+	})
+	reverseCalls := 0
+	requester := apiRequesterFunc(func(context.Context, ipc.MessageKind, any) (*ipc.Message, error) {
+		reverseCalls++
+		return nil, errors.New("invalid override must fail before reverse config loading")
+	})
+
+	_, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
+		Files:            []string{filepath.Join(root, "input.js")},
+		WorkingDirectory: root,
+		ConfigDiscovery: &api.ConfigDiscoveryRequest{
+			OverrideConfig: json.RawMessage(`[{"rules":{"no-console":["error",{"allow":"warn"}]}}]`),
+		},
+	}, requester)
+	if err == nil || !strings.Contains(err.Error(), `invalid options for rule "no-console"`) {
+		t.Fatalf("discovery override did not validate rule options: %v", err)
+	}
+	if reverseCalls != 0 {
+		t.Fatalf("invalid override issued %d reverse calls", reverseCalls)
 	}
 }

--- a/cmd/rslint/api_rule_options_test.go
+++ b/cmd/rslint/api_rule_options_test.go
@@ -111,30 +111,3 @@ func TestHandleLintDiscoveryOverrideValidatesRuleOptionsWithoutCandidate(t *test
 		t.Fatalf("discovery override did not validate rule options: %v", err)
 	}
 }
-
-func TestHandleLintDiscoveryInvalidOverrideDoesNotLoadCandidate(t *testing.T) {
-	root := t.TempDir()
-	writeProgramTestFiles(t, root, map[string]string{
-		"rslint.config.js": "export default [];\n",
-		"input.js":         "console.log('test');\n",
-	})
-	reverseCalls := 0
-	requester := apiRequesterFunc(func(context.Context, ipc.MessageKind, any) (*ipc.Message, error) {
-		reverseCalls++
-		return nil, errors.New("invalid override must fail before reverse config loading")
-	})
-
-	_, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
-		Files:            []string{filepath.Join(root, "input.js")},
-		WorkingDirectory: root,
-		ConfigDiscovery: &api.ConfigDiscoveryRequest{
-			OverrideConfig: json.RawMessage(`[{"rules":{"no-console":["error",{"allow":"warn"}]}}]`),
-		},
-	}, requester)
-	if err == nil || !strings.Contains(err.Error(), `invalid options for rule "no-console"`) {
-		t.Fatalf("discovery override did not validate rule options: %v", err)
-	}
-	if reverseCalls != 0 {
-		t.Fatalf("invalid override issued %d reverse calls", reverseCalls)
-	}
-}

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -1509,7 +1509,7 @@ func TestHandleLint_ConfigDiscoveryLoadsActivatesAndRoutesNestedOwners(t *testin
 	response, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
 		Files:            []string{rootTarget, nestedTarget},
 		WorkingDirectory: root,
-		ConfigDiscovery:  &api.ConfigDiscoveryRequest{Mode: "auto"},
+		ConfigDiscovery:  &api.ConfigDiscoveryRequest{},
 	}, requester)
 	if err != nil {
 		t.Fatalf("HandleLintWithContext: %v", err)
@@ -1610,7 +1610,7 @@ func TestHandleLint_ConfigDiscoveryRequiresPluginCapabilityOnlyWhenDiscovered(t 
 			response, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
 				Files:            []string{target},
 				WorkingDirectory: root,
-				ConfigDiscovery:  &api.ConfigDiscoveryRequest{Mode: "auto"},
+				ConfigDiscovery:  &api.ConfigDiscoveryRequest{},
 			}, requester)
 			if test.wantCapErr {
 				if err == nil || !strings.Contains(err.Error(), "does not advertise reversePluginLint capability required by discovered ESLint plugins") {
@@ -1684,7 +1684,6 @@ func TestHandleLint_ConfigDiscoveryDirectoriesOnlyLoadTargetAncestorBranches(t *
 		Files:            []string{target},
 		WorkingDirectory: root,
 		ConfigDiscovery: &api.ConfigDiscoveryRequest{
-			Mode:          "auto",
 			Directories:   []string{root},
 			ExplicitFiles: []bool{false},
 		},
@@ -1744,7 +1743,6 @@ func TestHandleLint_ConfigDiscoveryConfigNegationOverridesGitignore(t *testing.T
 			Files:            files,
 			WorkingDirectory: root,
 			ConfigDiscovery: &api.ConfigDiscoveryRequest{
-				Mode:          "auto",
 				Directories:   []string{root},
 				ExplicitFiles: make([]bool, len(files)),
 			},
@@ -1763,6 +1761,80 @@ func TestHandleLint_ConfigDiscoveryConfigNegationOverridesGitignore(t *testing.T
 	if withBar.FileCount != 1 || len(withBar.Diagnostics) != 1 ||
 		withBar.Diagnostics[0].FilePath != "foo.js" || withBar.Diagnostics[0].RuleName != "no-debugger" {
 		t.Fatalf("config negation restored the wrong gitignored target: %+v", withBar)
+	}
+}
+
+func TestHandleLint_ConfigDiscoveryOverrideNegationReopensGitHiddenConfig(t *testing.T) {
+	root := t.TempDir()
+	ignoredDir := filepath.Join(root, "ignored")
+	rootConfigPath := filepath.Join(root, "rslint.config.js")
+	nestedConfigPath := filepath.Join(ignoredDir, "rslint.config.js")
+	target := filepath.Join(ignoredDir, "index.js")
+	writeProgramTestFiles(t, root, map[string]string{
+		"rslint.config.js":         "export default [];\n",
+		".gitignore":               "ignored/\n",
+		"ignored/rslint.config.js": "export default [];\n",
+		"ignored/index.js":         "debugger;\n",
+	})
+
+	rootEntries := mustAPIConfig(t, `[{"rules":{"no-console":"error"}}]`)
+	nestedEntries := mustAPIConfig(t, `[{"rules":{"no-debugger":"error"}}]`)
+	var requestedPaths []string
+	requester := apiRequesterFunc(func(_ context.Context, kind ipc.MessageKind, payload any) (*ipc.Message, error) {
+		switch kind {
+		case api.KindLoadConfigs:
+			request := payload.(discovery.ConfigLoadBatchRequest)
+			response := discovery.ConfigLoadBatchResponse{TransactionID: request.TransactionID}
+			for _, candidate := range request.Candidates {
+				requestedPaths = append(requestedPaths, filepath.Clean(candidate.ConfigPath))
+				result := discovery.ConfigLoadResult{
+					ID:     candidate.ID,
+					Status: "loaded",
+				}
+				switch filepath.Clean(candidate.ConfigPath) {
+				case filepath.Clean(rootConfigPath):
+					result.Entries = rootEntries
+				case filepath.Clean(nestedConfigPath):
+					result.Entries = nestedEntries
+				default:
+					return nil, fmt.Errorf("unexpected config candidate %q", candidate.ConfigPath)
+				}
+				response.Results = append(response.Results, result)
+			}
+			return ipc.NewMessage(ipc.KindResponse, 1, response)
+		case api.KindActivateConfigs:
+			request := payload.(discovery.ConfigActivationRequest)
+			return ipc.NewMessage(ipc.KindResponse, 1, discovery.ConfigActivationResponse{
+				TransactionID: request.TransactionID,
+			})
+		default:
+			return nil, fmt.Errorf("unexpected reverse request kind %q", kind)
+		}
+	})
+
+	response, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
+		Files:            []string{target},
+		WorkingDirectory: root,
+		ConfigDiscovery: &api.ConfigDiscoveryRequest{
+			Directories:    []string{root},
+			ExplicitFiles:  []bool{false},
+			OverrideConfig: json.RawMessage(`[{"ignores":["!ignored/**"]}]`),
+		},
+	}, requester)
+	if err != nil {
+		t.Fatalf("HandleLintWithContext: %v", err)
+	}
+	wantRequestedPaths := []string{
+		filepath.Clean(rootConfigPath),
+		filepath.Clean(nestedConfigPath),
+	}
+	if !reflect.DeepEqual(requestedPaths, wantRequestedPaths) {
+		t.Fatalf("requested config paths = %v, want %v", requestedPaths, wantRequestedPaths)
+	}
+	if response.FileCount != 1 || len(response.Diagnostics) != 1 ||
+		response.Diagnostics[0].FilePath != filepath.ToSlash(filepath.Join("ignored", "index.js")) ||
+		response.Diagnostics[0].RuleName != "no-debugger" {
+		t.Fatalf("override negation did not restore the nested config owner: %+v", response)
 	}
 }
 
@@ -1831,7 +1903,6 @@ func TestHandleLint_ConfigDiscoveryExplicitOnlyOwnerDoesNotBlockParentGitignore(
 			Files:            files,
 			WorkingDirectory: root,
 			ConfigDiscovery: &api.ConfigDiscoveryRequest{
-				Mode:          "auto",
 				Directories:   []string{ignoredDir},
 				ExplicitFiles: explicitFiles,
 			},
@@ -1898,7 +1969,6 @@ func TestHandleLint_ExplicitConfigGovernsTargetOutsideWorkingDirectory(t *testin
 		Files:            []string{targetPath},
 		WorkingDirectory: workingDirectory,
 		ConfigDiscovery: &api.ConfigDiscoveryRequest{
-			Mode:               "explicit",
 			ExplicitConfigPath: configPath,
 			ExplicitFiles:      []bool{true},
 		},
@@ -1920,7 +1990,7 @@ func TestHandleLint_ConfigAndConfigDiscoveryAreMutuallyExclusive(t *testing.T) {
 
 	_, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
 		Config:           json.RawMessage(`[]`),
-		ConfigDiscovery:  &api.ConfigDiscoveryRequest{Mode: "auto"},
+		ConfigDiscovery:  &api.ConfigDiscoveryRequest{},
 		WorkingDirectory: t.TempDir(),
 	}, requester)
 	if err == nil || !strings.Contains(err.Error(), "config and configDiscovery are mutually exclusive") {
@@ -1943,7 +2013,6 @@ func TestHandleLint_ConfigDiscoveryExplicitFilesMustMatchFiles(t *testing.T) {
 		Files:            []string{filepath.Join(dir, "a.js"), filepath.Join(dir, "b.js")},
 		WorkingDirectory: dir,
 		ConfigDiscovery: &api.ConfigDiscoveryRequest{
-			Mode:          "auto",
 			ExplicitFiles: []bool{true},
 		},
 	}, requester)
@@ -1992,7 +2061,6 @@ func TestHandleLint_ConfigDiscoveryWithoutCandidateUsesOverrideOrSyntaxOnly(t *t
 				Files:            []string{target},
 				WorkingDirectory: dir,
 				ConfigDiscovery: &api.ConfigDiscoveryRequest{
-					Mode:           "auto",
 					OverrideConfig: test.override,
 				},
 			}, requester)
@@ -2045,7 +2113,7 @@ func TestHandleLint_ConfigDiscoveryAllCandidatesFail(t *testing.T) {
 	_, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
 		Files:            []string{filepath.Join(dir, "input.js")},
 		WorkingDirectory: dir,
-		ConfigDiscovery:  &api.ConfigDiscoveryRequest{Mode: "auto"},
+		ConfigDiscovery:  &api.ConfigDiscoveryRequest{},
 	}, requester)
 	if !errors.Is(err, discovery.ErrAllConfigsFailed) {
 		t.Fatalf("error = %v, want ErrAllConfigsFailed", err)

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
-	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
@@ -650,7 +649,6 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// that govern at least one selected target.
 	var realProgramSet lintProgramSet
 	buildAllPrograms := typeCheck || typeCheckOnly
-	needsLintTargets := !typeCheckOnly
 
 	if usesJSConfig {
 		configDirectories := configCatalog.ConfigDirectories()
@@ -690,88 +688,12 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 				}
 			}
 
-			// Inject .gitignore patterns as global ignores for each config.
-			// Each config independently reads from its own directory downward.
-			// Direct automatically reachable child configs are ownership handoff
-			// boundaries, so parent and child owners never share .gitignore patterns.
-			// A config loaded only for a literal target is a boundary for that scope,
-			// while automatic siblings keep their ancestor's complete ignore chain.
-			//
-			// Directories excluded by global config ignores are pruned during
-			// the .gitignore scan because files below them cannot be linted.
-			// File-only invocations collect only the exact target ancestry for each
-			// provisional owner instead of sweeping the owner's complete subtree.
-			//
-			// configMap is not mutated by gitignore workers. Results are collected
-			// and merged on this goroutine before target discovery.
-			type giResult struct {
-				configDir string
-				config    rslintconfig.RslintConfig
-			}
-			var (
-				giResults []giResult
-				giMu      sync.Mutex
-			)
-			fileOnlyTargets := len(allowFiles) > 0 && len(allowDirs) == 0
-			var targetFilesByOwner map[string][]string
-			if needsLintTargets && fileOnlyTargets {
-				targetFilesByOwner = configTargetFilesByOwner(
-					configMap,
-					configTargetScopes,
-					fs,
-					allowFiles,
-					singleThreaded,
-				)
-			}
-			giWG := core.NewWorkGroup(singleThreaded)
-			if needsLintTargets {
-				automaticResolver := rslintconfig.NewConfigOwnerResolverForAutomaticTargets(
-					configMap,
-					configTargetScopes,
-					fs,
-				)
-				completeResolver := rslintconfig.NewConfigOwnerResolver(configMap, fs)
-				for configDir, entries := range configMap {
-					scope := configTargetScopes[configDir]
-					resolver := automaticResolver
-					if scope.ExplicitOnly {
-						resolver = completeResolver
-					}
-					stopDirs := resolver.ChildConfigDirs(configDir)
-					giWG.Queue(func() {
-						var ownerFiles []string
-						if fileOnlyTargets {
-							ownerFiles = targetFilesByOwner[configDir]
-							if ownerFiles == nil {
-								ownerFiles = []string{}
-							}
-						} else if scope.ExplicitOnly {
-							// Mixed file+directory invocations must not turn a config
-							// loaded only for a literal into a full subtree scan.
-							ownerFiles = append([]string{}, scope.Files...)
-						}
-						augmented := rslintconfig.ConfigWithGitignoreWithBoundaries(entries, configDir, fs, ownerFiles, stopDirs)
-						giMu.Lock()
-						giResults = append(giResults, giResult{configDir, augmented})
-						giMu.Unlock()
-					})
-				}
-			}
-
-			var programErr error
 			if buildAllPrograms {
-				realProgramSet, programErr = createProgramSetForConfigs(configMap, singleThreaded, fs, parseCache)
-			}
-
-			// Join the gitignore reads and merge into configMap. Must complete
-			// before target discovery, which relies on the augmented configMap.
-			giWG.RunAndWait()
-			for _, r := range giResults {
-				configMap[r.configDir] = r.config
-			}
-			if programErr != nil {
-				fmt.Fprintf(os.Stderr, "error: %v\n", programErr)
-				return 1
+				realProgramSet, err = createProgramSetForConfigs(configMap, singleThreaded, fs, parseCache)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "error: %v\n", err)
+					return 1
+				}
 			}
 		}
 	} else {

--- a/cmd/rslint/ignore_conformance_test.go
+++ b/cmd/rslint/ignore_conformance_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	api "github.com/web-infra-dev/rslint/internal/api"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/config/discovery"
@@ -225,8 +226,18 @@ func TestCLIMultiConfigGitignoreIsolation(t *testing.T) {
 	}}
 	catalog := &discovery.ConfigCatalog{
 		Configs: map[string]rslintconfig.RslintConfig{
-			tspath.NormalizePath(firstDir):  entry,
-			tspath.NormalizePath(secondDir): entry,
+			tspath.NormalizePath(firstDir): rslintconfig.ConfigWithGitignore(
+				entry,
+				tspath.NormalizePath(firstDir),
+				osvfs.FS(),
+				[]string{tspath.NormalizePath(firstTarget)},
+			),
+			tspath.NormalizePath(secondDir): rslintconfig.ConfigWithGitignore(
+				entry,
+				tspath.NormalizePath(secondDir),
+				osvfs.FS(),
+				[]string{tspath.NormalizePath(secondTarget)},
+			),
 		},
 		Scopes: map[string]rslintconfig.LintDiscoveryScope{
 			tspath.NormalizePath(firstDir):  {Files: []string{tspath.NormalizePath(firstTarget)}, ExplicitOnly: true},
@@ -271,8 +282,18 @@ func TestCLIExplicitOnlyConfigDoesNotBlockParentGitignore(t *testing.T) {
 
 	catalog := &discovery.ConfigCatalog{
 		Configs: map[string]rslintconfig.RslintConfig{
-			tspath.NormalizePath(workspace):  {{Rules: rslintconfig.Rules{"no-console": "error"}}},
-			tspath.NormalizePath(ignoredDir): {{Rules: rslintconfig.Rules{"no-debugger": "error"}}},
+			tspath.NormalizePath(workspace): rslintconfig.ConfigWithGitignore(
+				rslintconfig.RslintConfig{{Rules: rslintconfig.Rules{"no-console": "error"}}},
+				tspath.NormalizePath(workspace),
+				osvfs.FS(),
+				nil,
+			),
+			tspath.NormalizePath(ignoredDir): rslintconfig.ConfigWithGitignore(
+				rslintconfig.RslintConfig{{Rules: rslintconfig.Rules{"no-debugger": "error"}}},
+				tspath.NormalizePath(ignoredDir),
+				osvfs.FS(),
+				[]string{tspath.NormalizePath(explicitTarget)},
+			),
 		},
 		Scopes: map[string]rslintconfig.LintDiscoveryScope{
 			tspath.NormalizePath(ignoredDir): {
@@ -327,8 +348,22 @@ func TestCLIMultiConfigGitignoreOwnershipBoundaries(t *testing.T) {
 	}}
 	catalog := &discovery.ConfigCatalog{
 		Configs: map[string]rslintconfig.RslintConfig{
-			tspath.NormalizePath(workspace): entry,
-			tspath.NormalizePath(childDir):  entry,
+			tspath.NormalizePath(workspace): rslintconfig.ConfigWithGitignoreWithBoundaries(
+				entry,
+				tspath.NormalizePath(workspace),
+				osvfs.FS(),
+				[]string{
+					tspath.NormalizePath(parentOwnedTarget),
+					tspath.NormalizePath(parentIgnoredTarget),
+				},
+				[]string{tspath.NormalizePath(childDir)},
+			),
+			tspath.NormalizePath(childDir): rslintconfig.ConfigWithGitignore(
+				entry,
+				tspath.NormalizePath(childDir),
+				osvfs.FS(),
+				[]string{tspath.NormalizePath(childOwnedTarget)},
+			),
 		},
 		Scopes: map[string]rslintconfig.LintDiscoveryScope{
 			tspath.NormalizePath(workspace): {

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -87,7 +87,6 @@ type initPayload struct {
 }
 
 type configDiscoveryPayload struct {
-	Mode               string `json:"mode"`
 	ExplicitConfigPath string `json:"explicitConfigPath,omitempty"`
 }
 
@@ -277,7 +276,7 @@ func runCLI(args []string) int {
 	// frontier, asks Node to evaluate exact candidates, and converts the final
 	// catalog into the shared lint pipeline input. Help/init and an
 	// explicit JSON --config do not need the JavaScript module host.
-	if !help && !baseArgs.Init && payload.ConfigDiscovery != nil && payload.ConfigDiscovery.Mode != "disabled" {
+	if !help && !baseArgs.Init && payload.ConfigDiscovery != nil {
 		if err := discoverCLIConfigCatalog(lintCtx, &baseArgs, payload, ch); err != nil {
 			// Discovery now includes the potentially long Go walk and reverse
 			// Node loads. A signal can cancel either before the mirror goroutine
@@ -431,22 +430,22 @@ func discoverCLIConfigCatalog(
 			Explicit: true,
 		})
 	}
-	switch payload.ConfigDiscovery.Mode {
-	case "auto", "":
-		request.Mode = discovery.ConfigDiscoveryAuto
-	case "explicit":
-		request.Mode = discovery.ConfigDiscoveryExplicit
-		request.ExplicitConfigPath = payload.ConfigDiscovery.ExplicitConfigPath
-	default:
-		return fmt.Errorf("unsupported config discovery mode %q", payload.ConfigDiscovery.Mode)
+	loader := &ipcConfigModuleLoader{channel: channel}
+	var catalog *discovery.ConfigCatalog
+	if payload.ConfigDiscovery.ExplicitConfigPath != "" {
+		catalog, err = discovery.LoadExplicitConfig(
+			ctx,
+			args.FS,
+			loader,
+			discovery.ExplicitConfigRequest{
+				CWD:            cwd,
+				ConfigPath:     payload.ConfigDiscovery.ExplicitConfigPath,
+				SingleThreaded: args.SingleThreaded,
+			},
+		)
+	} else {
+		catalog, err = discovery.DiscoverAutomatic(ctx, args.FS, loader, request)
 	}
-
-	catalog, err := discovery.Build(
-		ctx,
-		args.FS,
-		&ipcConfigModuleLoader{channel: channel},
-		request,
-	)
 	if err != nil {
 		var allFailed *discovery.AllConfigsFailedError
 		if errors.As(err, &allFailed) {

--- a/cmd/rslint/ipc_cli_test.go
+++ b/cmd/rslint/ipc_cli_test.go
@@ -174,7 +174,7 @@ func TestRunCLIRejectsPayloadFormatBeforeConfigDiscovery(t *testing.T) {
 	code, output := runCLIInitForTest(t, map[string]any{
 		"workingDirectory": dir,
 		"format":           "stylish",
-		"configDiscovery":  map[string]any{"mode": "auto"},
+		"configDiscovery":  map[string]any{},
 	}, false)
 	if code != 2 {
 		t.Fatalf("exit code = %d, want 2; output=%q", code, output)

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -604,30 +604,6 @@ func discoverLintFilesMultiConfig(
 	return rslintconfig.DiscoverLintTargetsMultiConfig(configMap, configTargetScopes, fs, allowFiles, allowDirs, singleThreaded)
 }
 
-func configTargetFilesByOwner(
-	configMap map[string]rslintconfig.RslintConfig,
-	scopes map[string]rslintconfig.LintDiscoveryScope,
-	fs vfs.FS,
-	allowedFiles []string,
-	singleThreaded bool,
-) map[string][]string {
-	filesByOwner := make(map[string][]string, len(configMap))
-	for _, target := range discoverLintFilesMultiConfig(
-		configMap,
-		scopes,
-		fs,
-		allowedFiles,
-		nil,
-		singleThreaded,
-	) {
-		filesByOwner[target.ConfigDirectory] = append(
-			filesByOwner[target.ConfigDirectory],
-			target.Path,
-		)
-	}
-	return filesByOwner
-}
-
 // buildTypeCheckSkipMask returns a parallel-to-programs []bool marking which
 // programs must be excluded from the type-check phase. A program is skipped
 // when it was NOT built from a real tsconfig on disk — i.e. its CompilerOptions

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -125,7 +125,6 @@ type LintRequest struct {
 // ConfigDiscoveryRequest is the API-facing scope for Go's shared staged
 // discovery coordinator. Files themselves remain in LintRequest.Files.
 type ConfigDiscoveryRequest struct {
-	Mode               string `json:"mode"`
 	ExplicitConfigPath string `json:"explicitConfigPath,omitempty"`
 	// Directories are static roots for the already-expanded Files set. Go limits
 	// config discovery below them to branches that can govern those files.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -361,7 +361,7 @@ func TestService_ConfigDiscoveryRequiresAdvertisedCapability(t *testing.T) {
 			}
 
 			_, err := pair.peer.SendRequest(ctx, KindLint, LintRequest{
-				ConfigDiscovery: &ConfigDiscoveryRequest{Mode: "auto"},
+				ConfigDiscovery: &ConfigDiscoveryRequest{},
 			})
 			if test.wantError == "" {
 				if err != nil {

--- a/internal/config/discovery/catalog.go
+++ b/internal/config/discovery/catalog.go
@@ -22,13 +22,6 @@ var AutoJSConfigFileNames = []string{
 	"rslint.config.mts",
 }
 
-type ConfigDiscoveryMode uint8
-
-const (
-	ConfigDiscoveryAuto ConfigDiscoveryMode = iota
-	ConfigDiscoveryExplicit
-)
-
 // DiscoveryFile is a file target that may participate in config discovery.
 // CanonicalPath is consulted only when the complete lexical ancestry contains
 // no config candidate.
@@ -46,11 +39,9 @@ type DiscoveryFile struct {
 // bounds them to an already-expanded target set. When ImplicitCWD is true and
 // no files or directories are supplied, CWD is used as the sole directory root.
 type ConfigDiscoveryRequest struct {
-	CWD                string
-	Mode               ConfigDiscoveryMode
-	ExplicitConfigPath string
-	Files              []DiscoveryFile
-	Directories        []string
+	CWD         string
+	Files       []DiscoveryFile
+	Directories []string
 	// LimitDirectoryWalkToFiles is used when a host has already expanded its
 	// directory/glob inputs to an exact target set. Only target-ancestor branches
 	// can govern that request. CLI/LSP directory roots leave this false and retain
@@ -59,6 +50,17 @@ type ConfigDiscoveryRequest struct {
 	ImplicitCWD               bool
 	Fresh                     bool
 	SingleThreaded            bool
+}
+
+// ExplicitConfigRequest loads one invocation-wide JS/TS config. It is a
+// separate operation from automatic discovery: absence of this request means
+// automatic discovery, while absence of config discovery at the adapter means
+// the low-level/JSON path.
+type ExplicitConfigRequest struct {
+	CWD            string
+	ConfigPath     string
+	Fresh          bool
+	SingleThreaded bool
 }
 
 type configSource struct {
@@ -84,7 +86,9 @@ type ConfigDiscoveryStats struct {
 // ConfigCatalog is the deterministic snapshot produced by one build. Configs
 // contains only effective, successfully loaded ownership boundaries. Requested
 // failures remain in Failures/Stats; ignored or unreachable candidates are
-// omitted because their modules are never requested.
+// omitted because their modules are never requested. Automatic catalogs freeze
+// each owner's observed Git projection into Configs before publication;
+// explicit catalogs leave invocation-scoped Git collection to their adapter.
 type ConfigCatalog struct {
 	TransactionID      string
 	Configs            map[string]rslintconfig.RslintConfig
@@ -156,12 +160,34 @@ func nextConfigDiscoveryTransactionID() string {
 	)
 }
 
-// Build discovers and loads one immutable config catalog. Transaction IDs are
-// unique across concurrent builds and native-process restarts so adapters can
-// stage load/activate/commit as one operation. The operation itself is
-// intentionally stateless; long-lived lifecycle and rollback belong to the
-// CLI/API/LSP adapters that own the transport.
-func Build(ctx context.Context, fsys vfs.FS, loader ConfigModuleLoader, request ConfigDiscoveryRequest) (*ConfigCatalog, error) {
+// DiscoverAutomatic discovers and loads one immutable hierarchical config
+// catalog. Transaction IDs are unique across concurrent builds and native
+// process restarts so adapters can stage load/activate/commit as one operation.
+func DiscoverAutomatic(ctx context.Context, fsys vfs.FS, loader ConfigModuleLoader, request ConfigDiscoveryRequest) (*ConfigCatalog, error) {
+	return buildConfigCatalog(ctx, fsys, loader, request, "")
+}
+
+// LoadExplicitConfig loads one exact invocation-wide config path. Automatic
+// candidate discovery and Git reachability never participate in this operation.
+func LoadExplicitConfig(ctx context.Context, fsys vfs.FS, loader ConfigModuleLoader, request ExplicitConfigRequest) (*ConfigCatalog, error) {
+	if request.ConfigPath == "" {
+		return nil, errors.New("explicit config discovery requires a config path")
+	}
+	automatic := ConfigDiscoveryRequest{
+		CWD:            request.CWD,
+		Fresh:          request.Fresh,
+		SingleThreaded: request.SingleThreaded,
+	}
+	return buildConfigCatalog(ctx, fsys, loader, automatic, request.ConfigPath)
+}
+
+func buildConfigCatalog(
+	ctx context.Context,
+	fsys vfs.FS,
+	loader ConfigModuleLoader,
+	request ConfigDiscoveryRequest,
+	explicitConfigPath string,
+) (*ConfigCatalog, error) {
 	if fsys == nil {
 		return nil, errors.New("config discovery requires a filesystem")
 	}
@@ -172,6 +198,7 @@ func Build(ctx context.Context, fsys vfs.FS, loader ConfigModuleLoader, request 
 		fs:                  fsys,
 		loader:              loader,
 		request:             request,
+		explicitConfigPath:  explicitConfigPath,
 		transactionID:       transactionID,
 		loadStates:          make(map[string]*configLoadState),
 		loadStateByIdentity: make(map[tspath.Path]*configLoadState),

--- a/internal/config/discovery/discovery.go
+++ b/internal/config/discovery/discovery.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
+	"github.com/web-infra-dev/rslint/internal/config/gitignore"
 )
 
 type configCandidate struct {
@@ -38,6 +39,9 @@ type discoverySeed struct {
 	explicitFile       bool
 	ownerDir           string
 	ownerPath          string
+	gitDirectory       string
+	gitCursor          gitignore.Cursor
+	gitActive          bool
 	done               bool
 }
 
@@ -46,6 +50,9 @@ type discoveryWalkNode struct {
 	canonicalDirectory string
 	ownerDir           string
 	ownerPath          string
+	gitDirectory       string
+	gitCursor          gitignore.Cursor
+	gitActive          bool
 	targets            *discoveryTargetTrie
 }
 
@@ -63,37 +70,58 @@ type suspendedDiscoveryNode struct {
 }
 
 type discoveryWalkResult struct {
-	children            []discoveryWalkNode
-	pending             *suspendedDiscoveryNode
-	activation          *configLoadState
-	directoriesVisited  int
-	directoriesPruned   int
-	discoveredCandidate bool
-	err                 error
+	children             []discoveryWalkNode
+	pending              *suspendedDiscoveryNode
+	activation           *configLoadState
+	gitignoreObservation *gitignoreObservation
+	directoriesVisited   int
+	directoriesPruned    int
+	discoveredCandidate  bool
+	err                  error
 }
 
 type directorySeedResolution struct {
-	seed       *discoverySeed
-	candidates []configCandidate
-	next       int
+	seed            *discoverySeed
+	candidates      []configCandidate
+	next            int
+	gitDirectory    string
+	gitCursor       gitignore.Cursor
+	gitActive       bool
+	configReachable bool
+}
+
+type gitignoreObservation struct {
+	ownerDirectory  string
+	sourceDirectory string
+	globs           []string
+}
+
+type gitignoreReadResult struct {
+	content string
+	exists  bool
 }
 
 type configCatalogBuilder struct {
-	ctx           context.Context
-	fs            vfs.FS
-	loader        ConfigModuleLoader
-	request       ConfigDiscoveryRequest
-	transactionID string
+	ctx                context.Context
+	fs                 vfs.FS
+	loader             ConfigModuleLoader
+	request            ConfigDiscoveryRequest
+	explicitConfigPath string
+	transactionID      string
 
-	loadStates          map[string]*configLoadState
-	loadStateByIdentity map[tspath.Path]*configLoadState
-	configs             map[string]rslintconfig.RslintConfig
-	sources             map[string]configSource
-	scopes              map[string]rslintconfig.LintDiscoveryScope
-	failureByPath       map[string]ConfigFailure
-	hadCandidates       bool
-	nextRequestID       int
-	stats               ConfigDiscoveryStats
+	loadStates           map[string]*configLoadState
+	loadStateByIdentity  map[tspath.Path]*configLoadState
+	configs              map[string]rslintconfig.RslintConfig
+	sources              map[string]configSource
+	scopes               map[string]rslintconfig.LintDiscoveryScope
+	failureByPath        map[string]ConfigFailure
+	gitignoreSources     map[string]map[tspath.Path]gitignoreObservation
+	gitignoreReadMu      sync.Mutex
+	gitignoreReadCache   map[tspath.Path]gitignoreReadResult
+	gitignoreReadPending map[tspath.Path]chan struct{}
+	hadCandidates        bool
+	nextRequestID        int
+	stats                ConfigDiscoveryStats
 }
 
 func (builder *configCatalogBuilder) build() (*ConfigCatalog, error) {
@@ -107,12 +135,9 @@ func (builder *configCatalogBuilder) build() (*ConfigCatalog, error) {
 	cwd = tspath.NormalizePath(cwd)
 	builder.request.CWD = cwd
 
-	if builder.request.Mode == ConfigDiscoveryExplicit {
-		if builder.request.ExplicitConfigPath == "" {
-			return nil, errors.New("explicit config discovery requires a config path")
-		}
+	if builder.explicitConfigPath != "" {
 		candidate := configCandidate{
-			path: normalizeDiscoveryPath(builder.request.ExplicitConfigPath, cwd),
+			path: normalizeDiscoveryPath(builder.explicitConfigPath, cwd),
 			// Explicit flat configs resolve files/ignores/projects from the
 			// invocation cwd, not the module's physical directory.
 			directory: cwd,
@@ -239,6 +264,7 @@ func (builder *configCatalogBuilder) build() (*ConfigCatalog, error) {
 		scope.Files = appendUniqueSortedPath(scope.Files, seed.path)
 		builder.scopes[seed.ownerDir] = scope
 	}
+	builder.collectExplicitSeedGitignore(explicitSeeds)
 
 	walkRoots := make([]discoveryWalkNode, 0, len(directorySeedByPath))
 	for _, directory := range directoryRoots {
@@ -251,6 +277,9 @@ func (builder *configCatalogBuilder) build() (*ConfigCatalog, error) {
 			canonicalDirectory: seed.canonicalWalkDir,
 			ownerDir:           seed.ownerDir,
 			ownerPath:          seed.ownerPath,
+			gitDirectory:       seed.gitDirectory,
+			gitCursor:          seed.gitCursor,
+			gitActive:          seed.gitActive,
 			targets:            targetsByRoot[directory],
 		})
 	}
@@ -269,37 +298,21 @@ func (builder *configCatalogBuilder) normalizedDirectoryRoots() []string {
 	if len(raw) == 0 && len(builder.request.Files) == 0 && builder.request.ImplicitCWD {
 		raw = []string{builder.request.CWD}
 	}
-	seen := make(map[string]struct{}, len(raw))
-	roots := make([]string, 0, len(raw))
+	useCaseSensitive := builder.fs.UseCaseSensitiveFileNames()
+	byIdentity := make(map[tspath.Path]string, len(raw))
 	for _, directory := range raw {
 		directory = normalizeDiscoveryPath(directory, builder.request.CWD)
-		if _, exists := seen[directory]; exists {
-			continue
+		identity := tspath.ToPath(directory, "", useCaseSensitive)
+		if current, exists := byIdentity[identity]; !exists || directory < current {
+			byIdentity[identity] = directory
 		}
-		seen[directory] = struct{}{}
+	}
+	roots := make([]string, 0, len(byIdentity))
+	for _, directory := range byIdentity {
 		roots = append(roots, directory)
 	}
-	sort.Slice(roots, func(i, j int) bool {
-		if len(roots[i]) != len(roots[j]) {
-			return len(roots[i]) < len(roots[j])
-		}
-		return roots[i] < roots[j]
-	})
-	compact := roots[:0]
-	for _, root := range roots {
-		covered := false
-		for _, parent := range compact {
-			if discoveryPathsEqual(root, parent, builder.fs.UseCaseSensitiveFileNames()) ||
-				tspath.StartsWithDirectory(root, parent, builder.fs.UseCaseSensitiveFileNames()) {
-				covered = true
-				break
-			}
-		}
-		if !covered {
-			compact = append(compact, root)
-		}
-	}
-	return compact
+	sort.Strings(roots)
+	return roots
 }
 
 func (builder *configCatalogBuilder) normalizedFiles() []DiscoveryFile {
@@ -324,7 +337,7 @@ func (builder *configCatalogBuilder) normalizedFiles() []DiscoveryFile {
 	return files
 }
 
-// targetAncestorTries maps each compact directory root to the lexical paths
+// targetAncestorTries maps each directory root to the lexical paths
 // that can govern a supplied target. Native API callers have already expanded
 // their globs, so configs in every other subtree cannot affect this request and
 // must not be evaluated. Directory-only CLI/LSP requests have no files and keep
@@ -363,9 +376,6 @@ func (builder *configCatalogBuilder) targetAncestorTries(
 				}
 				trie = child
 			}
-			// normalizedDirectoryRoots removes overlapping roots, so a file can
-			// belong to at most one retained lexical root.
-			break
 		}
 	}
 	return tries
@@ -410,7 +420,11 @@ func (builder *configCatalogBuilder) resolveDirectorySeedOwners(seeds []*discove
 			seed.usingCanonical = true
 			candidates = builder.findCandidateChain(seed.canonicalSearchDir)
 		}
-		resolutions = append(resolutions, directorySeedResolution{seed: seed, candidates: candidates})
+		resolutions = append(resolutions, directorySeedResolution{
+			seed:            seed,
+			candidates:      candidates,
+			configReachable: true,
+		})
 	}
 
 	for {
@@ -423,15 +437,32 @@ func (builder *configCatalogBuilder) resolveDirectorySeedOwners(seeds []*discove
 			resolution := &resolutions[index]
 			for resolution.next < len(resolution.candidates) {
 				candidateDirectory := resolution.candidates[resolution.next].directory
-				if resolution.seed.ownerPath != "" && builder.isGloballyIgnoredDirectory(
-					resolution.seed.ownerPath,
-					candidateDirectory,
-					candidateDirectory,
-				) {
-					// An authored absolute directory ignore is a permanent traversal
-					// boundary, so every deeper candidate in this ancestry is unreachable.
-					resolution.next = len(resolution.candidates)
-					break
+				if resolution.gitActive {
+					rootDirectory := resolution.seed.searchDir
+					if resolution.seed.usingCanonical {
+						rootDirectory = resolution.seed.canonicalSearchDir
+					}
+					reachable, authoredBlocked := builder.advanceDirectorySeedGit(
+						resolution,
+						candidateDirectory,
+						discoveryPathsEqual(
+							candidateDirectory,
+							rootDirectory,
+							builder.fs.UseCaseSensitiveFileNames(),
+						),
+					)
+					if authoredBlocked {
+						resolution.gitActive = false
+						resolution.next = len(resolution.candidates)
+						break
+					}
+					if !reachable {
+						// Only the supplied root itself may reopen an inherited
+						// Git-inaccessible ancestry. Hidden intermediate configs are
+						// never evaluated.
+						resolution.next++
+						continue
+					}
 				}
 				candidate, found := builder.findCandidateForOwner(
 					candidateDirectory,
@@ -457,7 +488,7 @@ func (builder *configCatalogBuilder) resolveDirectorySeedOwners(seeds []*discove
 			}
 		}
 		if len(candidates) == 0 {
-			return nil
+			break
 		}
 		if err := builder.ensureCandidates(candidates); err != nil {
 			return err
@@ -468,10 +499,106 @@ func (builder *configCatalogBuilder) resolveDirectorySeedOwners(seeds []*discove
 			if state != nil && state.failure == nil {
 				resolution.seed.ownerDir = state.candidate.directory
 				resolution.seed.ownerPath = state.candidate.path
+				resolution.gitCursor = gitignore.NewCursor(
+					state.candidate.directory,
+					builder.fs.UseCaseSensitiveFileNames(),
+				)
+				resolution.gitDirectory = state.candidate.directory
+				resolution.gitActive = true
+				resolution.configReachable = true
 			}
 			resolution.next++
 		}
 	}
+
+	for index := range resolutions {
+		resolution := &resolutions[index]
+		if !resolution.gitActive {
+			continue
+		}
+		rootDirectory := resolution.seed.searchDir
+		if resolution.seed.usingCanonical {
+			rootDirectory = resolution.seed.canonicalSearchDir
+		}
+		_, authoredBlocked := builder.advanceDirectorySeedGit(resolution, rootDirectory, true)
+		if authoredBlocked {
+			continue
+		}
+		resolution.seed.gitDirectory = resolution.gitDirectory
+		resolution.seed.gitCursor = resolution.gitCursor
+		resolution.seed.gitActive = true
+	}
+	return nil
+}
+
+// advanceDirectorySeedGit advances one requested directory root through the
+// current owner's Git path space without reading the destination's local
+// .gitignore. A candidate in the destination is therefore evaluated first; a
+// successful candidate can reset ownership before that source is observed.
+func (builder *configCatalogBuilder) advanceDirectorySeedGit(
+	resolution *directorySeedResolution,
+	destination string,
+	reopenDestination bool,
+) (reachable bool, authoredBlocked bool) {
+	if resolution == nil || !resolution.gitActive {
+		return true, false
+	}
+	useCaseSensitive := builder.fs.UseCaseSensitiveFileNames()
+	destination = tspath.NormalizePath(destination)
+	if discoveryPathsEqual(resolution.gitDirectory, destination, useCaseSensitive) {
+		if reopenDestination {
+			resolution.configReachable = true
+		}
+		return resolution.configReachable, false
+	}
+	relative, within := rslintconfig.RelativePathWithinConfigRoot(
+		destination,
+		resolution.gitDirectory,
+		useCaseSensitive,
+	)
+	if !within {
+		resolution.gitCursor, _ = resolution.gitCursor.Enter(destination)
+		resolution.gitDirectory = destination
+		resolution.configReachable = false
+		return false, false
+	}
+
+	current := resolution.gitDirectory
+	for _, component := range splitDiscoveryPath(relative) {
+		resolution.gitCursor = builder.observeGitignoreSource(
+			resolution.seed.ownerDir,
+			current,
+			current,
+			resolution.gitCursor,
+		)
+
+		nextDirectory := tspath.CombinePaths(current, component)
+		var gitBlocked bool
+		resolution.gitCursor, gitBlocked = resolution.gitCursor.Enter(nextDirectory)
+		resolution.gitDirectory = nextDirectory
+
+		if builder.isGloballyIgnoredDirectory(
+			resolution.seed.ownerPath,
+			nextDirectory,
+			nextDirectory,
+		) {
+			resolution.configReachable = false
+			return false, true
+		}
+		if gitBlocked && !builder.reopensGitignoredDirectory(
+			resolution.seed.ownerPath,
+			nextDirectory,
+			nextDirectory,
+		) {
+			resolution.configReachable = false
+		}
+		if reopenDestination &&
+			discoveryPathsEqual(nextDirectory, destination, useCaseSensitive) {
+			resolution.configReachable = true
+		}
+		current = nextDirectory
+	}
+	return resolution.configReachable, false
 }
 
 func (builder *configCatalogBuilder) findCandidateChain(startDirectory string) []configCandidate {
@@ -823,6 +950,9 @@ func (builder *configCatalogBuilder) walkDirectories(roots []discoveryWalkNode) 
 					return err
 				}
 			}
+			if result.gitignoreObservation != nil {
+				builder.recordGitignoreObservation(*result.gitignoreObservation)
+			}
 			next = append(next, result.children...)
 			if result.pending != nil {
 				suspended = append(suspended, *result.pending)
@@ -841,11 +971,21 @@ func (builder *configCatalogBuilder) walkDirectories(roots []discoveryWalkNode) 
 					}
 					item.node.ownerDir = state.candidate.directory
 					item.node.ownerPath = state.candidate.path
+					item.node.gitCursor = gitignore.NewCursor(
+						state.candidate.directory,
+						builder.fs.UseCaseSensitiveFileNames(),
+					)
+					item.node.gitDirectory = state.candidate.directory
+					item.node.gitActive = true
 				}
 				next = append(next, item.node)
 			}
 		}
-		queue = deduplicateWalkNodes(next)
+		// Overlapping requested roots are intentionally independent routes. The
+		// same lexical directory can carry inherited Git state on one route and
+		// explicit-root reachability on another, so directory-only deduplication
+		// would be incorrect.
+		queue = next
 	}
 	return nil
 }
@@ -912,9 +1052,25 @@ func (builder *configCatalogBuilder) processWalkNode(node discoveryWalkNode) dis
 			result.activation = state
 			node.ownerDir = state.candidate.directory
 			node.ownerPath = state.candidate.path
+			node.gitCursor = gitignore.NewCursor(
+				state.candidate.directory,
+				builder.fs.UseCaseSensitiveFileNames(),
+			)
+			node.gitDirectory = state.candidate.directory
+			node.gitActive = true
 		}
 	}
 	result.directoriesVisited = 1
+	if node.gitActive {
+		nextCursor, observation := builder.readGitignoreSource(
+			node.ownerDir,
+			node.directory,
+			node.gitDirectory,
+			node.gitCursor,
+		)
+		node.gitCursor = nextCursor
+		result.gitignoreObservation = observation
+	}
 	if node.targets != nil && len(node.targets.children) == 0 {
 		return result
 	}
@@ -922,6 +1078,10 @@ func (builder *configCatalogBuilder) processWalkNode(node discoveryWalkNode) dis
 	entries := builder.fs.GetAccessibleEntries(node.directory)
 	directories := append([]string(nil), entries.Directories...)
 	sort.Strings(directories)
+	parentRealPath := ""
+	if entries.Symlinks == nil && len(directories) > 0 {
+		parentRealPath = builder.fs.Realpath(node.directory)
+	}
 	children := make([]discoveryWalkNode, 0, len(directories))
 	for _, name := range directories {
 		var childTargets *discoveryTargetTrie
@@ -934,10 +1094,8 @@ func (builder *configCatalogBuilder) processWalkNode(node discoveryWalkNode) dis
 		if rslintconfig.IsDefaultExcludedPath(name, "", builder.fs.UseCaseSensitiveFileNames()) {
 			continue
 		}
-		if entries.Symlinks != nil {
-			if _, symlink := entries.Symlinks[name]; symlink {
-				continue
-			}
+		if builder.isSymlinkDirectoryChild(node.directory, parentRealPath, name, entries) {
+			continue
 		}
 		child := tspath.CombinePaths(node.directory, name)
 		canonicalChild := ""
@@ -948,11 +1106,31 @@ func (builder *configCatalogBuilder) processWalkNode(node discoveryWalkNode) dis
 			result.directoriesPruned++
 			continue
 		}
+		childGitDirectory := ""
+		childGitCursor := gitignore.Cursor{}
+		childGitActive := false
+		if node.gitActive {
+			childGitDirectory = tspath.CombinePaths(node.gitDirectory, name)
+			nextCursor, gitBlocked := node.gitCursor.Enter(childGitDirectory)
+			if gitBlocked && !builder.reopensGitignoredDirectory(
+				node.ownerPath,
+				child,
+				canonicalChild,
+			) {
+				result.directoriesPruned++
+				continue
+			}
+			childGitCursor = nextCursor
+			childGitActive = true
+		}
 		children = append(children, discoveryWalkNode{
 			directory:          child,
 			canonicalDirectory: canonicalChild,
 			ownerDir:           node.ownerDir,
 			ownerPath:          node.ownerPath,
+			gitDirectory:       childGitDirectory,
+			gitCursor:          childGitCursor,
+			gitActive:          childGitActive,
 			targets:            childTargets,
 		})
 	}
@@ -963,6 +1141,11 @@ func (builder *configCatalogBuilder) processWalkNode(node discoveryWalkNode) dis
 func (builder *configCatalogBuilder) isGloballyIgnoredDirectory(ownerPath string, directory string, canonicalDirectory string) bool {
 	matcher, ok := builder.globalIgnoreMatcher(ownerPath)
 	return ok && matcher.BlocksDirectory(directory, canonicalDirectory)
+}
+
+func (builder *configCatalogBuilder) reopensGitignoredDirectory(ownerPath string, directory string, canonicalDirectory string) bool {
+	matcher, ok := builder.globalIgnoreMatcher(ownerPath)
+	return ok && matcher.ReopensDirectoryNode(directory, canonicalDirectory)
 }
 
 func (builder *configCatalogBuilder) isGloballyIgnoredCandidate(ownerPath string, candidatePath string, canonicalPath string) bool {
@@ -979,6 +1162,281 @@ func (builder *configCatalogBuilder) globalIgnoreMatcher(ownerPath string) (rsli
 		return rslintconfig.GlobalIgnoreMatcher{}, false
 	}
 	return state.ignoreMatcher, true
+}
+
+func (builder *configCatalogBuilder) readGitignoreSource(
+	ownerDirectory string,
+	sourceDirectory string,
+	matchDirectory string,
+	cursor gitignore.Cursor,
+) (gitignore.Cursor, *gitignoreObservation) {
+	if ownerDirectory == "" || sourceDirectory == "" || matchDirectory == "" || !cursor.SourceReachable() {
+		return cursor, nil
+	}
+	content := builder.readGitignoreFile(sourceDirectory)
+	if !content.exists {
+		return cursor, nil
+	}
+	next, globs := cursor.AppendSource(matchDirectory, content.content)
+	if len(globs) == 0 {
+		return next, nil
+	}
+	return next, &gitignoreObservation{
+		ownerDirectory:  ownerDirectory,
+		sourceDirectory: matchDirectory,
+		globs:           globs,
+	}
+}
+
+// readGitignoreFile freezes each lexical source for one catalog generation.
+// Config modules can have side effects, and overlapping discovery routes may
+// reach the same source on different frontiers; rereading would let one
+// transaction make ownership decisions from different bytes. Different source
+// paths still read concurrently; only duplicate in-flight reads wait for the
+// first route, including a cached miss.
+func (builder *configCatalogBuilder) readGitignoreFile(sourceDirectory string) gitignoreReadResult {
+	path := tspath.CombinePaths(sourceDirectory, ".gitignore")
+	identity := tspath.ToPath(
+		tspath.NormalizePath(path),
+		"",
+		builder.fs.UseCaseSensitiveFileNames(),
+	)
+	for {
+		builder.gitignoreReadMu.Lock()
+		if builder.gitignoreReadCache == nil {
+			builder.gitignoreReadCache = make(map[tspath.Path]gitignoreReadResult)
+		}
+		if builder.gitignoreReadPending == nil {
+			builder.gitignoreReadPending = make(map[tspath.Path]chan struct{})
+		}
+		if result, exists := builder.gitignoreReadCache[identity]; exists {
+			builder.gitignoreReadMu.Unlock()
+			return result
+		}
+		if wait, pending := builder.gitignoreReadPending[identity]; pending {
+			if wait == nil {
+				wait = make(chan struct{})
+				builder.gitignoreReadPending[identity] = wait
+			}
+			builder.gitignoreReadMu.Unlock()
+			<-wait
+			continue
+		}
+		builder.gitignoreReadPending[identity] = nil
+		builder.gitignoreReadMu.Unlock()
+		break
+	}
+
+	content, exists := builder.fs.ReadFile(path)
+	result := gitignoreReadResult{content: content, exists: exists}
+	builder.gitignoreReadMu.Lock()
+	builder.gitignoreReadCache[identity] = result
+	wait := builder.gitignoreReadPending[identity]
+	delete(builder.gitignoreReadPending, identity)
+	if wait != nil {
+		close(wait)
+	}
+	builder.gitignoreReadMu.Unlock()
+	return result
+}
+
+func (builder *configCatalogBuilder) observeGitignoreSource(
+	ownerDirectory string,
+	sourceDirectory string,
+	matchDirectory string,
+	cursor gitignore.Cursor,
+) gitignore.Cursor {
+	next, observation := builder.readGitignoreSource(
+		ownerDirectory,
+		sourceDirectory,
+		matchDirectory,
+		cursor,
+	)
+	if observation != nil {
+		builder.recordGitignoreObservation(*observation)
+	}
+	return next
+}
+
+func (builder *configCatalogBuilder) recordGitignoreObservation(observation gitignoreObservation) {
+	if observation.ownerDirectory == "" || observation.sourceDirectory == "" || len(observation.globs) == 0 {
+		return
+	}
+	if builder.gitignoreSources == nil {
+		builder.gitignoreSources = make(map[string]map[tspath.Path]gitignoreObservation)
+	}
+	sources := builder.gitignoreSources[observation.ownerDirectory]
+	if sources == nil {
+		sources = make(map[tspath.Path]gitignoreObservation)
+		builder.gitignoreSources[observation.ownerDirectory] = sources
+	}
+	identity := tspath.ToPath(
+		tspath.NormalizePath(observation.sourceDirectory),
+		"",
+		builder.fs.UseCaseSensitiveFileNames(),
+	)
+	if _, exists := sources[identity]; exists {
+		return
+	}
+	observation.globs = append([]string(nil), observation.globs...)
+	sources[identity] = observation
+}
+
+func splitDiscoveryPath(path string) []string {
+	path = strings.ReplaceAll(tspath.NormalizePath(path), "\\", "/")
+	var components []string
+	for _, component := range strings.Split(path, "/") {
+		if component == "" || component == "." {
+			continue
+		}
+		components = append(components, component)
+	}
+	return components
+}
+
+// collectExplicitSeedGitignore records the exact directory chain for a literal
+// target. Literal files bypass Git only while choosing their nearest config;
+// the resulting target still uses that config owner's ordinary Git ignores.
+// Keeping these observations source-scoped lets mixed directory+literal input
+// merge them with the automatic walk without duplicating parent patterns.
+func (builder *configCatalogBuilder) collectExplicitSeedGitignore(seeds []*discoverySeed) {
+	useCaseSensitive := builder.fs.UseCaseSensitiveFileNames()
+	cursorByOwnerAndDirectory := make(map[string]map[tspath.Path]gitignore.Cursor)
+	barrierByOwnerAndDirectory := make(map[string]map[tspath.Path]struct{})
+	for _, seed := range seeds {
+		if seed == nil || seed.ownerDir == "" {
+			continue
+		}
+		ownerCursors := cursorByOwnerAndDirectory[seed.ownerDir]
+		if ownerCursors == nil {
+			ownerCursors = make(map[tspath.Path]gitignore.Cursor)
+			cursorByOwnerAndDirectory[seed.ownerDir] = ownerCursors
+		}
+		ownerBarriers := barrierByOwnerAndDirectory[seed.ownerDir]
+		if ownerBarriers == nil {
+			ownerBarriers = make(map[tspath.Path]struct{})
+			barrierByOwnerAndDirectory[seed.ownerDir] = ownerBarriers
+		}
+		builder.collectExplicitSeedGitignoreChain(
+			seed,
+			ownerCursors,
+			ownerBarriers,
+			useCaseSensitive,
+		)
+	}
+}
+
+func (builder *configCatalogBuilder) collectExplicitSeedGitignoreChain(
+	seed *discoverySeed,
+	cursorByDirectory map[tspath.Path]gitignore.Cursor,
+	barriers map[tspath.Path]struct{},
+	useCaseSensitive bool,
+) {
+	targetDirectory := tspath.GetDirectoryPath(seed.path)
+	matchDirectory := targetDirectory
+	if _, within := rslintconfig.RelativePathWithinConfigRoot(
+		matchDirectory,
+		seed.ownerDir,
+		useCaseSensitive,
+	); !within {
+		matchDirectory = seed.canonicalSearchDir
+		if matchDirectory == "" {
+			return
+		}
+		if _, within = rslintconfig.RelativePathWithinConfigRoot(
+			matchDirectory,
+			seed.ownerDir,
+			useCaseSensitive,
+		); !within {
+			return
+		}
+	}
+
+	relative, within := rslintconfig.RelativePathWithinConfigRoot(
+		matchDirectory,
+		seed.ownerDir,
+		useCaseSensitive,
+	)
+	if !within {
+		return
+	}
+	cursor := gitignore.NewCursor(seed.ownerDir, useCaseSensitive)
+	currentMatch := seed.ownerDir
+	currentSource := seed.ownerDir
+	components := splitDiscoveryPath(relative)
+	for index := 0; ; index++ {
+		identity := tspath.ToPath(currentMatch, "", useCaseSensitive)
+		if cached, exists := cursorByDirectory[identity]; exists {
+			cursor = cached
+		} else {
+			cursor = builder.observeGitignoreSource(
+				seed.ownerDir,
+				currentSource,
+				currentMatch,
+				cursor,
+			)
+			cursorByDirectory[identity] = cursor
+		}
+		if index == len(components) || !cursor.SourceReachable() {
+			return
+		}
+		component := components[index]
+		nextSource := tspath.CombinePaths(currentSource, component)
+		nextMatch := tspath.CombinePaths(currentMatch, component)
+		nextIdentity := tspath.ToPath(nextMatch, "", useCaseSensitive)
+		if _, blocked := barriers[nextIdentity]; blocked {
+			return
+		}
+		if cached, exists := cursorByDirectory[nextIdentity]; exists {
+			currentSource = nextSource
+			currentMatch = nextMatch
+			cursor = cached
+			continue
+		}
+		entries := builder.fs.GetAccessibleEntries(currentSource)
+		parentRealPath := ""
+		if entries.Symlinks == nil {
+			parentRealPath = builder.fs.Realpath(currentSource)
+		}
+		if builder.isSymlinkDirectoryChild(currentSource, parentRealPath, component, entries) {
+			barriers[nextIdentity] = struct{}{}
+			return
+		}
+		currentSource = nextSource
+		currentMatch = nextMatch
+		next, blocked := cursor.Enter(currentMatch)
+		cursor = next
+		if blocked {
+			barriers[nextIdentity] = struct{}{}
+			return
+		}
+	}
+}
+
+func (builder *configCatalogBuilder) isSymlinkDirectoryChild(
+	parentDirectory string,
+	parentRealPath string,
+	name string,
+	entries vfs.Entries,
+) bool {
+	if entries.Symlinks != nil {
+		for symlink := range entries.Symlinks {
+			if symlink == name ||
+				(!builder.fs.UseCaseSensitiveFileNames() && strings.EqualFold(symlink, name)) {
+				return true
+			}
+		}
+		return false
+	}
+	childDirectory := tspath.CombinePaths(parentDirectory, name)
+	childRealPath := builder.fs.Realpath(childDirectory)
+	if parentRealPath == "" || childRealPath == "" {
+		return false
+	}
+	expectedRealPath := tspath.CombinePaths(parentRealPath, name)
+	return tspath.ComparePaths(childRealPath, expectedRealPath, tspath.ComparePathsOptions{
+		UseCaseSensitiveFileNames: builder.fs.UseCaseSensitiveFileNames(),
+	}) != 0
 }
 
 func (builder *configCatalogBuilder) activate(state *configLoadState, explicitOnly bool) error {
@@ -1030,6 +1488,9 @@ func (builder *configCatalogBuilder) catalog() (*ConfigCatalog, error) {
 	if err := builder.validateConfigDirectoryIdentities(); err != nil {
 		return nil, err
 	}
+	if builder.explicitConfigPath == "" {
+		builder.materializeGitignoreConfigs()
+	}
 	// ExplicitOnly is derived from every activation path, not just from the
 	// explicit-file scope itself. Publish the final source value with the scope
 	// so target discovery can keep this config out of automatic ownership and
@@ -1072,8 +1533,60 @@ func (builder *configCatalogBuilder) catalog() (*ConfigCatalog, error) {
 		Scopes:             builder.scopes,
 		Failures:           failures,
 		Stats:              builder.stats,
-		Explicit:           builder.request.Mode == ConfigDiscoveryExplicit,
+		Explicit:           builder.explicitConfigPath != "",
 	}, nil
+}
+
+func (builder *configCatalogBuilder) materializeGitignoreConfigs() {
+	caseInsensitive := !builder.fs.UseCaseSensitiveFileNames()
+	for ownerDirectory, entries := range builder.configs {
+		sources := builder.gitignoreSources[ownerDirectory]
+		if len(sources) == 0 {
+			continue
+		}
+		observations := make([]gitignoreObservation, 0, len(sources))
+		for _, observation := range sources {
+			observations = append(observations, observation)
+		}
+		sort.Slice(observations, func(i, j int) bool {
+			leftDepth := builder.gitignoreSourceDepth(ownerDirectory, observations[i].sourceDirectory)
+			rightDepth := builder.gitignoreSourceDepth(ownerDirectory, observations[j].sourceDirectory)
+			if leftDepth != rightDepth {
+				return leftDepth < rightDepth
+			}
+			left := observations[i].sourceDirectory
+			right := observations[j].sourceDirectory
+			if caseInsensitive {
+				leftFolded := strings.ToLower(left)
+				rightFolded := strings.ToLower(right)
+				if leftFolded != rightFolded {
+					return leftFolded < rightFolded
+				}
+			}
+			return left < right
+		})
+		var globs []string
+		for _, observation := range observations {
+			globs = append(globs, observation.globs...)
+		}
+		builder.configs[ownerDirectory] = rslintconfig.ConfigWithCollectedGitignore(
+			entries,
+			globs,
+			caseInsensitive,
+		)
+	}
+}
+
+func (builder *configCatalogBuilder) gitignoreSourceDepth(ownerDirectory string, sourceDirectory string) int {
+	relative, within := rslintconfig.RelativePathWithinConfigRoot(
+		sourceDirectory,
+		ownerDirectory,
+		builder.fs.UseCaseSensitiveFileNames(),
+	)
+	if !within || relative == "" {
+		return 0
+	}
+	return len(splitDiscoveryPath(relative))
 }
 
 // validateConfigDirectoryIdentities rejects ambiguous ownership before Node
@@ -1157,18 +1670,6 @@ func appendUniqueSortedPath(paths []string, path string) []string {
 	paths = append(paths, path)
 	sort.Strings(paths)
 	return paths
-}
-
-func deduplicateWalkNodes(nodes []discoveryWalkNode) []discoveryWalkNode {
-	sort.Slice(nodes, func(i, j int) bool { return nodes[i].directory < nodes[j].directory })
-	result := nodes[:0]
-	for _, node := range nodes {
-		if len(result) > 0 && result[len(result)-1].directory == node.directory {
-			continue
-		}
-		result = append(result, node)
-	}
-	return result
 }
 
 func isDefaultDiscoveryExcluded(path string, cwd string, useCaseSensitive bool) bool {

--- a/internal/config/discovery/discovery.go
+++ b/internal/config/discovery/discovery.go
@@ -179,14 +179,9 @@ func (builder *configCatalogBuilder) build() (*ConfigCatalog, error) {
 			// A default-excluded directory is a downward traversal boundary, not a
 			// reason to discard still-reachable configuration outside it. Skip the
 			// root and every default-excluded ancestor, then resolve normally.
-			searchDirectory = tspath.GetDirectoryPath(directory)
+			searchDirectory = configDiscoveryParent(directory)
 			for searchDirectory != "" && isDefaultDiscoveryExcluded(searchDirectory, cwd, useCaseSensitive) {
-				parent := tspath.GetDirectoryPath(searchDirectory)
-				if parent == searchDirectory {
-					searchDirectory = ""
-					break
-				}
-				searchDirectory = parent
+				searchDirectory = configDiscoveryParent(searchDirectory)
 			}
 			if searchDirectory == "" {
 				continue
@@ -573,8 +568,23 @@ func (builder *configCatalogBuilder) advanceDirectorySeedGit(
 		)
 
 		nextDirectory := tspath.CombinePaths(current, component)
-		var gitBlocked bool
-		resolution.gitCursor, gitBlocked = resolution.gitCursor.Enter(nextDirectory)
+		nextCursor, gitBlocked := resolution.gitCursor.Enter(nextDirectory)
+		if nextCursor.SourceReachable() {
+			entries := builder.fs.GetAccessibleEntries(current)
+			parentRealPath := ""
+			if entries.Symlinks == nil {
+				parentRealPath = builder.fs.Realpath(current)
+			}
+			if builder.isSymlinkDirectoryChild(
+				current,
+				parentRealPath,
+				component,
+				entries,
+			) {
+				nextCursor = nextCursor.BlockSourceTraversal()
+			}
+		}
+		resolution.gitCursor = nextCursor
 		resolution.gitDirectory = nextDirectory
 
 		if builder.isGloballyIgnoredDirectory(
@@ -601,17 +611,32 @@ func (builder *configCatalogBuilder) advanceDirectorySeedGit(
 	return resolution.configReachable, false
 }
 
+// configDiscoveryParent returns the lexical filesystem parent without walking
+// above a UNC share. tspath's generic root parser treats only the server as the
+// root, which is appropriate for URLs but not for filesystem config discovery.
+func configDiscoveryParent(directory string) string {
+	directory = tspath.NormalizePath(directory)
+	if strings.HasPrefix(directory, "//") {
+		serverAndRest := strings.Trim(directory[2:], "/")
+		serverEnd := strings.IndexByte(serverAndRest, '/')
+		if serverEnd < 0 || !strings.Contains(serverAndRest[serverEnd+1:], "/") {
+			return ""
+		}
+	}
+	parent := tspath.GetDirectoryPath(directory)
+	if parent == directory {
+		return ""
+	}
+	return parent
+}
+
 func (builder *configCatalogBuilder) findCandidateChain(startDirectory string) []configCandidate {
 	var reverse []configCandidate
 	for directory := tspath.NormalizePath(startDirectory); directory != ""; {
 		if candidate, ok := builder.findCandidate(directory); ok {
 			reverse = append(reverse, candidate)
 		}
-		parent := tspath.GetDirectoryPath(directory)
-		if parent == directory {
-			break
-		}
-		directory = parent
+		directory = configDiscoveryParent(directory)
 	}
 	candidates := make([]configCandidate, len(reverse))
 	for index := range reverse {
@@ -671,8 +696,8 @@ func (builder *configCatalogBuilder) resolveSeedOwners(seeds []*discoverySeed) e
 				seed.done = true
 				continue
 			}
-			seed.searchDir = tspath.GetDirectoryPath(candidate.directory)
-			if seed.searchDir == candidate.directory || seed.searchDir == "" {
+			seed.searchDir = configDiscoveryParent(candidate.directory)
+			if seed.searchDir == "" {
 				seed.done = true
 			}
 		}
@@ -684,11 +709,7 @@ func (builder *configCatalogBuilder) findCandidateUp(startDirectory string) (con
 		if candidate, ok := builder.findCandidate(directory); ok {
 			return candidate, true
 		}
-		parent := tspath.GetDirectoryPath(directory)
-		if parent == directory {
-			break
-		}
-		directory = parent
+		directory = configDiscoveryParent(directory)
 	}
 	return configCandidate{}, false
 }

--- a/internal/config/discovery/discovery_test.go
+++ b/internal/config/discovery/discovery_test.go
@@ -45,16 +45,22 @@ type configDiscoveryCaseSensitivityFS struct {
 	caseSensitive bool
 }
 
+type configDiscoveryNoSymlinkMetadataFS struct {
+	vfs.FS
+}
+
 type configDiscoveryReadSpyFS struct {
 	vfs.FS
 	mu             sync.Mutex
 	gitignoreReads int
+	gitignorePaths []string
 }
 
 func (fs *configDiscoveryReadSpyFS) ReadFile(path string) (string, bool) {
 	if strings.EqualFold(tspath.GetBaseFileName(path), ".gitignore") {
 		fs.mu.Lock()
 		fs.gitignoreReads++
+		fs.gitignorePaths = append(fs.gitignorePaths, tspath.NormalizePath(path))
 		fs.mu.Unlock()
 	}
 	return fs.FS.ReadFile(path)
@@ -62,6 +68,12 @@ func (fs *configDiscoveryReadSpyFS) ReadFile(path string) (string, bool) {
 
 func (fs *configDiscoveryCaseSensitivityFS) UseCaseSensitiveFileNames() bool {
 	return fs.caseSensitive
+}
+
+func (fs *configDiscoveryNoSymlinkMetadataFS) GetAccessibleEntries(path string) vfs.Entries {
+	entries := fs.FS.GetAccessibleEntries(path)
+	entries.Symlinks = nil
+	return entries
 }
 
 func (fs *configDiscoveryRealpathFS) Realpath(path string) string {
@@ -242,7 +254,7 @@ func TestConfigDiscoveryPriorityDoesNotConsultGitignore(t *testing.T) {
 		loader.configs[mjsPath] = namedConfig("lower-priority")
 
 		catalog := buildFixtureCatalog(t, root, loader, ConfigDiscoveryRequest{CWD: root, ImplicitCWD: true})
-		if got := catalog.Configs[tspath.NormalizePath(root)][0].Name; got != "selected" {
+		if got := namedConfigEntry(catalog.Configs[tspath.NormalizePath(root)]).Name; got != "selected" {
 			t.Fatalf("selected config %q, want highest-priority .js config", got)
 		}
 		if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{jsPath}) {
@@ -251,7 +263,7 @@ func TestConfigDiscoveryPriorityDoesNotConsultGitignore(t *testing.T) {
 	})
 }
 
-func TestConfigDiscoveryDoesNotReadGitignore(t *testing.T) {
+func TestConfigDiscoveryReadsGitignoreAndPrunesHiddenConfig(t *testing.T) {
 	root := t.TempDir()
 	writeDiscoveryFixture(t, root, ".gitignore", "ignored/\nrslint.config.js\n")
 	configPath := writeConfigCandidate(t, root, "rslint.config.js")
@@ -261,17 +273,457 @@ func TestConfigDiscoveryDoesNotReadGitignore(t *testing.T) {
 	loader.configs[tspath.CombinePaths(root, "ignored/rslint.config.js")] = namedConfig("nested")
 	fsys := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
 
-	_, err := Build(context.Background(), fsys, loader, ConfigDiscoveryRequest{
+	catalog, err := DiscoverAutomatic(context.Background(), fsys, loader, ConfigDiscoveryRequest{
 		CWD:         root,
 		ImplicitCWD: true,
 	})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
+	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{tspath.NormalizePath(root)}) {
+		t.Fatalf("Git-hidden config directories = %v", got)
+	}
+	if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{configPath}) {
+		t.Fatalf("Git-hidden config was evaluated: %v", got)
+	}
 	fsys.mu.Lock()
-	defer fsys.mu.Unlock()
-	if fsys.gitignoreReads != 0 {
-		t.Fatalf("config discovery read .gitignore %d times", fsys.gitignoreReads)
+	reads := fsys.gitignoreReads
+	fsys.mu.Unlock()
+	if reads == 0 {
+		t.Fatal("config discovery did not read the owner .gitignore")
+	}
+}
+
+func TestConfigDiscoveryGitignoreDirectoryNegation(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		gitignore  string
+		wantNested bool
+	}{
+		{
+			name:       "exact directory negation reopens",
+			gitignore:  "ignored/\n!ignored/\n",
+			wantNested: true,
+		},
+		{
+			name:       "file negation does not reopen",
+			gitignore:  "ignored/\n!ignored/keep.ts\n",
+			wantNested: false,
+		},
+		{
+			name:       "descendant negation does not reopen",
+			gitignore:  "ignored/\n!ignored/**/*\n",
+			wantNested: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+			nestedConfig := writeConfigCandidate(t, root, "ignored/rslint.config.js")
+			writeDiscoveryFixture(t, root, ".gitignore", test.gitignore)
+			loader := newFixtureConfigLoader()
+			loader.configs[rootConfig] = namedConfig("root")
+			loader.configs[nestedConfig] = namedConfig("nested")
+
+			catalog := buildFixtureCatalog(t, root, loader, ConfigDiscoveryRequest{
+				CWD:         root,
+				ImplicitCWD: true,
+			})
+			wantDirectories := []string{tspath.NormalizePath(root)}
+			wantRequests := []string{rootConfig}
+			if test.wantNested {
+				wantDirectories = append(wantDirectories, tspath.CombinePaths(root, "ignored"))
+				wantRequests = append(wantRequests, nestedConfig)
+			}
+			if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, wantDirectories) {
+				t.Fatalf("config directories = %v, want %v", got, wantDirectories)
+			}
+			if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, wantRequests) {
+				t.Fatalf("requested configs = %v, want %v", got, wantRequests)
+			}
+		})
+	}
+}
+
+func TestConfigDiscoveryAuthoredNegationReopensMatchingGitDirectory(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		negation   string
+		wantNested bool
+	}{
+		{name: "bare directory node", negation: "!ignored", wantNested: true},
+		{name: "directory node", negation: "!ignored/", wantNested: true},
+		{name: "directory and contents", negation: "!ignored/**", wantNested: true},
+		{name: "contents only", negation: "!ignored/**/*", wantNested: false},
+		{name: "one file", negation: "!ignored/keep.ts", wantNested: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+			nestedConfig := writeConfigCandidate(t, root, "ignored/rslint.config.js")
+			writeDiscoveryFixture(t, root, ".gitignore", "ignored/\n")
+			loader := newFixtureConfigLoader()
+			loader.configs[rootConfig] = rslintconfig.RslintConfig{
+				{Ignores: []string{test.negation}},
+				{Name: "root", Rules: rslintconfig.Rules{}},
+			}
+			loader.configs[nestedConfig] = namedConfig("nested")
+
+			catalog := buildFixtureCatalog(t, root, loader, ConfigDiscoveryRequest{
+				CWD:         root,
+				ImplicitCWD: true,
+			})
+			gotNested := slices.Contains(
+				catalog.ConfigDirectories(),
+				tspath.CombinePaths(root, "ignored"),
+			)
+			if gotNested != test.wantNested {
+				t.Fatalf("nested config loaded = %v, want %v", gotNested, test.wantNested)
+			}
+		})
+	}
+}
+
+func TestConfigDiscoveryGitignoreDoesNotFilterCandidateFilename(t *testing.T) {
+	root := t.TempDir()
+	rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+	jsConfig := writeConfigCandidate(t, root, "packages/app/rslint.config.js")
+	mjsConfig := writeConfigCandidate(t, root, "packages/app/rslint.config.mjs")
+	writeDiscoveryFixture(t, root, ".gitignore", "packages/app/rslint.config.js\n")
+	loader := newFixtureConfigLoader()
+	loader.configs[rootConfig] = namedConfig("root")
+	loader.configs[jsConfig] = namedConfig("selected-js")
+	loader.configs[mjsConfig] = namedConfig("must-not-fall-through")
+
+	catalog := buildFixtureCatalog(t, root, loader, ConfigDiscoveryRequest{
+		CWD:         root,
+		ImplicitCWD: true,
+	})
+	appDirectory := tspath.CombinePaths(root, "packages/app")
+	if got := namedConfigEntry(catalog.Configs[appDirectory]).Name; got != "selected-js" {
+		t.Fatalf("selected config = %q, want highest-priority JS candidate", got)
+	}
+	if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{rootConfig, jsConfig}) {
+		t.Fatalf("Git filtered a config filename or changed priority: %v", got)
+	}
+}
+
+func TestConfigDiscoveryGitignoreOwnerBoundary(t *testing.T) {
+	t.Run("successful child resets inherited Git and applies its own source", func(t *testing.T) {
+		root := t.TempDir()
+		rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+		childConfig := writeConfigCandidate(t, root, "packages/app/rslint.config.js")
+		reachableConfig := writeConfigCandidate(t, root, "packages/app/parent-only/rslint.config.js")
+		hiddenConfig := writeConfigCandidate(t, root, "packages/app/child-only/rslint.config.js")
+		writeDiscoveryFixture(t, root, ".gitignore", "packages/app/parent-only/\n")
+		writeDiscoveryFixture(t, root, "packages/app/.gitignore", "child-only/\n")
+		loader := newFixtureConfigLoader()
+		loader.configs[rootConfig] = namedConfig("root")
+		loader.configs[childConfig] = namedConfig("child")
+		loader.configs[reachableConfig] = namedConfig("reachable-after-reset")
+		loader.configs[hiddenConfig] = namedConfig("must-not-load")
+
+		catalog := buildFixtureCatalog(t, root, loader, ConfigDiscoveryRequest{
+			CWD:         root,
+			ImplicitCWD: true,
+		})
+		wantDirectories := []string{
+			tspath.NormalizePath(root),
+			tspath.CombinePaths(root, "packages/app"),
+			tspath.CombinePaths(root, "packages/app/parent-only"),
+		}
+		if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, wantDirectories) {
+			t.Fatalf("owner-boundary directories = %v, want %v", got, wantDirectories)
+		}
+		if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{rootConfig, childConfig, reachableConfig}) {
+			t.Fatalf("owner-boundary requests = %v", got)
+		}
+	})
+
+	t.Run("failed child inherits parent Git", func(t *testing.T) {
+		root := t.TempDir()
+		rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+		failedConfig := writeConfigCandidate(t, root, "packages/app/rslint.config.js")
+		hiddenConfig := writeConfigCandidate(t, root, "packages/app/deep/rslint.config.js")
+		writeDiscoveryFixture(t, root, "packages/app/.gitignore", "deep/\n")
+		loader := newFixtureConfigLoader()
+		loader.configs[rootConfig] = namedConfig("root")
+		loader.failures[failedConfig] = ConfigModuleError{Code: "ERR", Message: "broken"}
+		loader.configs[hiddenConfig] = namedConfig("must-not-load")
+
+		catalog := buildFixtureCatalog(t, root, loader, ConfigDiscoveryRequest{
+			CWD:         root,
+			ImplicitCWD: true,
+		})
+		if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{tspath.NormalizePath(root)}) {
+			t.Fatalf("failed-boundary directories = %v", got)
+		}
+		if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{rootConfig, failedConfig}) {
+			t.Fatalf("failed child did not inherit parent Git: %v", got)
+		}
+	})
+}
+
+func TestConfigDiscoveryDoesNotReadGitignoreBelowBlockedDirectory(t *testing.T) {
+	root := t.TempDir()
+	rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+	hiddenConfig := writeConfigCandidate(t, root, "ignored/deep/rslint.config.js")
+	rootGitignore := writeDiscoveryFixture(t, root, ".gitignore", "ignored/\n")
+	hiddenGitignore := writeDiscoveryFixture(t, root, "ignored/.gitignore", "!deep/\n")
+	loader := newFixtureConfigLoader()
+	loader.configs[rootConfig] = namedConfig("root")
+	loader.configs[hiddenConfig] = namedConfig("must-not-load")
+	fsys := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+
+	_, err := DiscoverAutomatic(context.Background(), fsys, loader, ConfigDiscoveryRequest{
+		CWD:         root,
+		ImplicitCWD: true,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverAutomatic: %v", err)
+	}
+	fsys.mu.Lock()
+	paths := append([]string(nil), fsys.gitignorePaths...)
+	fsys.mu.Unlock()
+	if !slices.Contains(paths, rootGitignore) {
+		t.Fatalf("root .gitignore was not read: %v", paths)
+	}
+	if slices.Contains(paths, hiddenGitignore) {
+		t.Fatalf("blocked nested .gitignore was read: %v", paths)
+	}
+	if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{rootConfig}) {
+		t.Fatalf("nested source revived a hidden config: %v", got)
+	}
+}
+
+func TestConfigDiscoveryOverlappingRootsPreserveExplicitOrigin(t *testing.T) {
+	root := t.TempDir()
+	ignoredDirectory := tspath.CombinePaths(root, "ignored")
+	rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+	childConfig := writeConfigCandidate(t, root, "ignored/rslint.config.js")
+	writeDiscoveryFixture(t, root, ".gitignore", "ignored/\n")
+	loader := newFixtureConfigLoader()
+	loader.configs[rootConfig] = namedConfig("root")
+	loader.configs[childConfig] = namedConfig("child")
+
+	catalog := buildFixtureCatalog(t, root, loader, ConfigDiscoveryRequest{
+		CWD:         root,
+		Directories: []string{root, ignoredDirectory},
+	})
+	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{tspath.NormalizePath(root), ignoredDirectory}) {
+		t.Fatalf("overlapping-root config directories = %v", got)
+	}
+	if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{rootConfig, childConfig}) {
+		t.Fatalf("overlapping roots executed duplicate or hidden configs: %v", got)
+	}
+}
+
+func TestConfigDiscoveryCatalogFreezesCollectedGitignore(t *testing.T) {
+	root := t.TempDir()
+	rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+	target := writeDiscoveryFixture(t, root, "dist/index.ts", "export {}\n")
+	reincludedTarget := writeDiscoveryFixture(t, root, "dist/keep.ts", "export {}\n")
+	writeDiscoveryFixture(t, root, ".gitignore", "dist/\n")
+	loader := newFixtureConfigLoader()
+	loader.configs[rootConfig] = rslintconfig.RslintConfig{
+		{Ignores: []string{"!dist/keep.ts"}},
+		{Name: "root", Rules: rslintconfig.Rules{}},
+	}
+
+	catalog := buildFixtureCatalog(t, root, loader, ConfigDiscoveryRequest{
+		CWD:         root,
+		ImplicitCWD: true,
+	})
+	root = tspath.NormalizePath(root)
+	if !catalog.Configs[root].IsFileIgnored(target, root) {
+		t.Fatal("catalog did not materialize the discovered Git source")
+	}
+	if catalog.Configs[root].IsFileIgnored(reincludedTarget, root) {
+		t.Fatal("authored negation did not follow and override the Git projection")
+	}
+	writeDiscoveryFixture(t, root, ".gitignore", "")
+	if !catalog.Configs[root].IsFileIgnored(target, root) {
+		t.Fatal("published catalog changed after .gitignore mutation")
+	}
+	if catalog.Configs[root].IsFileIgnored(reincludedTarget, root) {
+		t.Fatal("published Git-to-authored ordering changed after source mutation")
+	}
+}
+
+func TestConfigDiscoveryMergesLiteralGitignoreChainIntoAutomaticOwner(t *testing.T) {
+	root := t.TempDir()
+	rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+	automaticTarget := writeDiscoveryFixture(t, root, "automatic/index.ts", "export {}\n")
+	reincludedLiteral := writeDiscoveryFixture(t, root, "outside/keep.tmp", "export {}\n")
+	ignoredLiteral := writeDiscoveryFixture(t, root, "outside/drop.tmp", "export {}\n")
+	writeDiscoveryFixture(t, root, ".gitignore", "*.tmp\n")
+	writeDiscoveryFixture(t, root, "outside/.gitignore", "!keep.tmp\n")
+	loader := newFixtureConfigLoader()
+	loader.configs[rootConfig] = namedConfig("root")
+
+	catalog := buildFixtureCatalog(t, root, loader, ConfigDiscoveryRequest{
+		CWD:         root,
+		Directories: []string{tspath.GetDirectoryPath(automaticTarget)},
+		Files: []DiscoveryFile{
+			{Path: automaticTarget, Explicit: false},
+			{Path: reincludedLiteral, Explicit: true},
+			{Path: ignoredLiteral, Explicit: true},
+		},
+	})
+	root = tspath.NormalizePath(root)
+	effective := catalog.Configs[root]
+	if effective.IsFileIgnored(reincludedLiteral, root) {
+		t.Fatal("nested literal-chain negation was lost or parent Git source was duplicated")
+	}
+	if !effective.IsFileIgnored(ignoredLiteral, root) {
+		t.Fatal("automatic owner did not include the literal target's Git chain")
+	}
+}
+
+func TestConfigDiscoveryCachesLiteralGitignoreSourceChains(t *testing.T) {
+	root := t.TempDir()
+	rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+	writeDiscoveryFixture(t, root, ".gitignore", "*.tmp\n")
+	writeDiscoveryFixture(t, root, "outside/.gitignore", "!keep.tmp\n")
+	loader := newFixtureConfigLoader()
+	loader.configs[rootConfig] = namedConfig("root")
+	var files []DiscoveryFile
+	for _, name := range []string{"keep.tmp", "drop.tmp", "nested/one.tmp", "nested/two.tmp"} {
+		files = append(files, DiscoveryFile{
+			Path:     writeDiscoveryFixture(t, root, "outside/"+name, "export {}\n"),
+			Explicit: true,
+		})
+	}
+	fsys := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+
+	_, err := DiscoverAutomatic(context.Background(), fsys, loader, ConfigDiscoveryRequest{
+		CWD:   root,
+		Files: files,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverAutomatic: %v", err)
+	}
+	fsys.mu.Lock()
+	reads := append([]string(nil), fsys.gitignorePaths...)
+	fsys.mu.Unlock()
+	counts := make(map[string]int)
+	for _, path := range reads {
+		counts[path]++
+	}
+	for _, path := range []string{
+		tspath.CombinePaths(root, ".gitignore"),
+		tspath.CombinePaths(root, "outside/.gitignore"),
+		tspath.CombinePaths(root, "outside/nested/.gitignore"),
+	} {
+		if got := counts[path]; got != 1 {
+			t.Fatalf(".gitignore reads for %q = %d, want 1; all reads: %v", path, got, reads)
+		}
+	}
+}
+
+func TestConfigDiscoveryFreezesGitignoreBytesAcrossOverlappingRoutes(t *testing.T) {
+	root := t.TempDir()
+	directDirectory := tspath.CombinePaths(root, "direct")
+	rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+	directConfig := writeConfigCandidate(t, root, "direct/rslint.config.js")
+	hiddenConfig := writeConfigCandidate(t, root, "hidden/rslint.config.js")
+	hiddenTarget := writeDiscoveryFixture(t, root, "hidden/index.ts", "export {}\n")
+	gitignorePath := writeDiscoveryFixture(t, root, ".gitignore", "hidden/\n")
+	loader := newFixtureConfigLoader()
+	loader.configs[rootConfig] = namedConfig("root")
+	loader.configs[directConfig] = namedConfig("direct")
+	loader.configs[hiddenConfig] = namedConfig("must-not-load")
+	mutated := false
+	loader.mutate = func(request ConfigLoadBatchRequest, response ConfigLoadBatchResponse) ConfigLoadBatchResponse {
+		if mutated {
+			return response
+		}
+		for _, candidate := range request.Candidates {
+			if candidate.ConfigPath == directConfig {
+				if err := os.WriteFile(filepath.FromSlash(gitignorePath), nil, 0o644); err != nil {
+					t.Fatalf("mutate .gitignore: %v", err)
+				}
+				mutated = true
+				break
+			}
+		}
+		return response
+	}
+	fsys := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+
+	catalog, err := DiscoverAutomatic(context.Background(), fsys, loader, ConfigDiscoveryRequest{
+		CWD:         root,
+		Directories: []string{root, directDirectory},
+	})
+	if err != nil {
+		t.Fatalf("DiscoverAutomatic: %v", err)
+	}
+	if !mutated {
+		t.Fatal("fixture did not mutate .gitignore during config evaluation")
+	}
+	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{
+		tspath.NormalizePath(root),
+		directDirectory,
+	}) {
+		t.Fatalf("catalog used post-mutation Git bytes: %v", got)
+	}
+	if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{rootConfig, directConfig}) {
+		t.Fatalf("post-mutation route loaded a hidden config: %v", got)
+	}
+	if !catalog.Configs[tspath.NormalizePath(root)].IsFileIgnored(hiddenTarget, root) {
+		t.Fatal("published Git projection differs from discovery reachability")
+	}
+	fsys.mu.Lock()
+	reads := slices.Clone(fsys.gitignorePaths)
+	fsys.mu.Unlock()
+	count := 0
+	for _, path := range reads {
+		if path == gitignorePath {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("root .gitignore reads = %d, want one frozen read; all reads: %v", count, reads)
+	}
+}
+
+func TestConfigDiscoverySkipsDescendantSymlinkWithoutMetadata(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+	writeDiscoveryFixture(t, external, ".gitignore", "deep/\n")
+	writeConfigCandidate(t, external, "rslint.config.js")
+	alias := filepath.Join(root, "linked")
+	if err := os.Symlink(external, alias); err != nil {
+		t.Skipf("symlink fixture unavailable: %v", err)
+	}
+	aliasConfig := tspath.CombinePaths(alias, "rslint.config.js")
+	aliasGitignore := tspath.CombinePaths(alias, ".gitignore")
+	loader := newFixtureConfigLoader()
+	loader.configs[rootConfig] = namedConfig("root")
+	loader.configs[aliasConfig] = namedConfig("must-not-load")
+	fsys := &configDiscoveryReadSpyFS{
+		FS: &configDiscoveryNoSymlinkMetadataFS{FS: discoveryTestFS()},
+	}
+
+	catalog, err := DiscoverAutomatic(context.Background(), fsys, loader, ConfigDiscoveryRequest{
+		CWD:         root,
+		ImplicitCWD: true,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverAutomatic: %v", err)
+	}
+	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{tspath.NormalizePath(root)}) {
+		t.Fatalf("descendant symlink config was loaded: %v", got)
+	}
+	if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{rootConfig}) {
+		t.Fatalf("descendant symlink candidate was evaluated: %v", got)
+	}
+	fsys.mu.Lock()
+	reads := slices.Clone(fsys.gitignorePaths)
+	fsys.mu.Unlock()
+	if slices.Contains(reads, aliasGitignore) {
+		t.Fatalf("descendant symlink .gitignore was read: %v", reads)
 	}
 }
 
@@ -497,6 +949,20 @@ func TestConfigDiscoveryGitignoredDirectoryStillLoadsNearestConfig(t *testing.T)
 				return ConfigDiscoveryRequest{CWD: target, ImplicitCWD: true}
 			},
 		},
+		{
+			name: "bounded static glob root",
+			request: func(root string, target string) ConfigDiscoveryRequest {
+				return ConfigDiscoveryRequest{
+					CWD:                       root,
+					Directories:               []string{target},
+					LimitDirectoryWalkToFiles: true,
+					Files: []DiscoveryFile{{
+						Path:     tspath.CombinePaths(target, "index.ts"),
+						Explicit: false,
+					}},
+				}
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			root := t.TempDir()
@@ -515,7 +981,7 @@ func TestConfigDiscoveryGitignoredDirectoryStillLoadsNearestConfig(t *testing.T)
 			if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{nearestDir}) {
 				t.Fatalf("gitignored directory owner = %v, want nearest config", got)
 			}
-			wantRequested := []string{rootConfig, ignoredConfig, ignoredNestedConfig}
+			wantRequested := []string{rootConfig, ignoredNestedConfig}
 			if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, wantRequested) {
 				t.Fatalf("gitignored directory requested configs = %v, want %v", got, wantRequested)
 			}
@@ -630,7 +1096,7 @@ func TestConfigDiscoveryBoundsExpandedTargetWalkToAncestorTrie(t *testing.T) {
 		}
 	})
 
-	t.Run("gitignore does not prune a target branch before its config", func(t *testing.T) {
+	t.Run("gitignore prunes a target branch before its config", func(t *testing.T) {
 		root := t.TempDir()
 		writeDiscoveryFixture(t, root, ".gitignore", "target/deep/\n")
 		loader := newFixtureConfigLoader()
@@ -646,12 +1112,12 @@ func TestConfigDiscoveryBoundsExpandedTargetWalkToAncestorTrie(t *testing.T) {
 			LimitDirectoryWalkToFiles: true,
 			Files:                     []DiscoveryFile{{Path: target, Explicit: false}},
 		})
-		wantDirs := []string{tspath.NormalizePath(root), tspath.CombinePaths(root, "target/deep")}
+		wantDirs := []string{tspath.NormalizePath(root)}
 		if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, wantDirs) {
 			t.Fatalf("gitignore catalog = %v, want %v", got, wantDirs)
 		}
-		if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{rootConfig, nestedConfig}) {
-			t.Fatalf("gitignore must not hide nested config: %v", got)
+		if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{rootConfig}) {
+			t.Fatalf("gitignore-hidden config was evaluated: %v", got)
 		}
 	})
 
@@ -702,11 +1168,15 @@ func TestConfigDiscoveryExplicitConfigDoesNotConsultGitignore(t *testing.T) {
 	configPath := writeConfigCandidate(t, root, "ignored/custom.config.cjs")
 	loader.configs[configPath] = namedConfig("explicit")
 
-	catalog := buildFixtureCatalog(t, root, loader, ConfigDiscoveryRequest{
-		CWD:                root,
-		Mode:               ConfigDiscoveryExplicit,
-		ExplicitConfigPath: configPath,
-	})
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		discoveryTestFS(),
+		loader,
+		ExplicitConfigRequest{CWD: root, ConfigPath: configPath},
+	)
+	if err != nil {
+		t.Fatalf("LoadExplicitConfig: %v", err)
+	}
 	root = tspath.NormalizePath(root)
 	if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{root}) {
 		t.Fatalf("explicit config should be anchored at cwd: %v", got)
@@ -965,7 +1435,7 @@ func TestConfigDiscoveryUsesCanonicalOwnerOnlyAfterLexicalAncestryIsEmpty(t *tes
 			},
 		}
 
-		catalog, err := Build(context.Background(), fsys, loader, ConfigDiscoveryRequest{
+		catalog, err := DiscoverAutomatic(context.Background(), fsys, loader, ConfigDiscoveryRequest{
 			CWD:                       lexicalRoot,
 			Directories:               []string{lexicalRoot},
 			LimitDirectoryWalkToFiles: true,
@@ -983,6 +1453,57 @@ func TestConfigDiscoveryUsesCanonicalOwnerOnlyAfterLexicalAncestryIsEmpty(t *tes
 		}
 		if got := fsys.realpathCallCount(lexicalRoot); got != 1 {
 			t.Fatalf("lexical directory realpath calls = %d, want 1", got)
+		}
+	})
+
+	t.Run("directory reads lexical Git source in canonical matching space", func(t *testing.T) {
+		lexicalRoot := t.TempDir()
+		physicalRoot := t.TempDir()
+		loader := newFixtureConfigLoader()
+		configPath := writeConfigCandidate(t, physicalRoot, "rslint.config.js")
+		lexicalIgnored := writeDiscoveryFixture(t, lexicalRoot, "lexical-hidden/index.ts", "export {}\n")
+		physicalOnly := writeDiscoveryFixture(t, lexicalRoot, "physical-hidden/index.ts", "export {}\n")
+		lexicalGitignore := writeDiscoveryFixture(t, lexicalRoot, ".gitignore", "lexical-hidden/\n")
+		physicalGitignore := writeDiscoveryFixture(t, physicalRoot, ".gitignore", "physical-hidden/\n")
+		loader.configs[configPath] = namedConfig("physical-directory")
+		fsys := &configDiscoveryReadSpyFS{FS: &configDiscoveryRealpathFS{
+			FS: discoveryTestFS(),
+			realPaths: map[string]string{
+				tspath.NormalizePath(lexicalRoot): tspath.NormalizePath(physicalRoot),
+			},
+		}}
+
+		catalog, err := DiscoverAutomatic(context.Background(), fsys, loader, ConfigDiscoveryRequest{
+			CWD:                       lexicalRoot,
+			Directories:               []string{lexicalRoot},
+			LimitDirectoryWalkToFiles: true,
+			Files: []DiscoveryFile{
+				{Path: lexicalIgnored, Explicit: false},
+				{Path: physicalOnly, Explicit: false},
+			},
+		})
+		if err != nil {
+			t.Fatalf("DiscoverAutomatic: %v", err)
+		}
+		physicalRoot = tspath.NormalizePath(physicalRoot)
+		effective := catalog.Configs[physicalRoot]
+		if !effective.IsFileIgnored(
+			tspath.CombinePaths(physicalRoot, "lexical-hidden/index.ts"),
+			physicalRoot,
+		) {
+			t.Fatal("lexical .gitignore was not projected into canonical owner space")
+		}
+		if effective.IsFileIgnored(
+			tspath.CombinePaths(physicalRoot, "physical-hidden/index.ts"),
+			physicalRoot,
+		) {
+			t.Fatal("canonical-root .gitignore replaced the lexical walk source")
+		}
+		fsys.mu.Lock()
+		reads := slices.Clone(fsys.gitignorePaths)
+		fsys.mu.Unlock()
+		if !slices.Contains(reads, lexicalGitignore) || slices.Contains(reads, physicalGitignore) {
+			t.Fatalf("Git source IO paths = %v, want lexical root only", reads)
 		}
 	})
 
@@ -1016,6 +1537,29 @@ func TestConfigDiscoveryUsesCanonicalOwnerOnlyAfterLexicalAncestryIsEmpty(t *tes
 	})
 }
 
+func TestConfigDiscoveryCaseInsensitiveRootsChooseStableRepresentative(t *testing.T) {
+	fsys := &configDiscoveryCaseSensitivityFS{
+		FS:            discoveryTestFS(),
+		caseSensitive: false,
+	}
+	build := func(directories []string) []string {
+		builder := configCatalogBuilder{
+			fs: fsys,
+			request: ConfigDiscoveryRequest{
+				CWD:         "C:/repo",
+				Directories: directories,
+			},
+		}
+		return builder.normalizedDirectoryRoots()
+	}
+	first := build([]string{"c:/repo", "C:/Repo"})
+	second := build([]string{"C:/Repo", "c:/repo"})
+	want := []string{"C:/Repo"}
+	if !reflect.DeepEqual(first, want) || !reflect.DeepEqual(second, want) {
+		t.Fatalf("case-insensitive roots depend on input order: first=%v second=%v", first, second)
+	}
+}
+
 func TestConfigDiscoveryValidatesPhysicalConfigDirectoryIdentityBeforeActivation(t *testing.T) {
 	t.Run("distinct symlink aliases are rejected", func(t *testing.T) {
 		root := t.TempDir()
@@ -1036,7 +1580,7 @@ func TestConfigDiscoveryValidatesPhysicalConfigDirectoryIdentityBeforeActivation
 		loader.configs[aliasAConfig] = namedConfig("owner-a")
 		loader.configs[aliasBConfig] = namedConfig("owner-b")
 
-		catalog, err := Build(context.Background(), discoveryTestFS(), loader, ConfigDiscoveryRequest{
+		catalog, err := DiscoverAutomatic(context.Background(), discoveryTestFS(), loader, ConfigDiscoveryRequest{
 			CWD:         root,
 			Directories: []string{aliasA, aliasB},
 		})
@@ -1072,7 +1616,7 @@ func TestConfigDiscoveryValidatesPhysicalConfigDirectoryIdentityBeforeActivation
 		loader.configs[tspath.CombinePaths(upperAlias, filepath.Base(configPath))] = namedConfig("upper")
 		loader.configs[tspath.CombinePaths(lowerAlias, filepath.Base(configPath))] = namedConfig("lower")
 
-		catalog, err := Build(context.Background(), fsys, loader, ConfigDiscoveryRequest{
+		catalog, err := DiscoverAutomatic(context.Background(), fsys, loader, ConfigDiscoveryRequest{
 			CWD:         root,
 			Directories: []string{upperAlias, lowerAlias},
 		})
@@ -1106,7 +1650,7 @@ func TestConfigDiscoveryValidatesPhysicalConfigDirectoryIdentityBeforeActivation
 		}
 		fsys := &configDiscoveryCaseSensitivityFS{FS: realpathFS, caseSensitive: false}
 
-		catalog, err := Build(context.Background(), fsys, loader, ConfigDiscoveryRequest{
+		catalog, err := DiscoverAutomatic(context.Background(), fsys, loader, ConfigDiscoveryRequest{
 			CWD:         root,
 			Directories: []string{upperRoot, lowerRoot},
 		})
@@ -1209,7 +1753,7 @@ func TestConfigDiscoveryWalksSiblingFrontierConcurrentlyWithStableOutput(t *test
 	parallelLoader := newFixtureConfigLoader()
 	parallelLoader.configs[rootConfig] = namedConfig("root")
 	probeFS := newConfigDiscoveryConcurrencyFS(discoveryTestFS(), aDir, bDir)
-	parallelCatalog, err := Build(context.Background(), probeFS, parallelLoader, ConfigDiscoveryRequest{
+	parallelCatalog, err := DiscoverAutomatic(context.Background(), probeFS, parallelLoader, ConfigDiscoveryRequest{
 		CWD:         root,
 		ImplicitCWD: true,
 	})
@@ -1269,7 +1813,7 @@ func TestConfigDiscoveryTransactionIDsAreUniqueAcrossBuilds(t *testing.T) {
 	for range builds {
 		go func() {
 			defer waitGroup.Done()
-			catalog, err := Build(context.Background(), discoveryTestFS(), nil, ConfigDiscoveryRequest{CWD: root})
+			catalog, err := DiscoverAutomatic(context.Background(), discoveryTestFS(), nil, ConfigDiscoveryRequest{CWD: root})
 			if err != nil {
 				results <- result{err: err}
 				return
@@ -1354,7 +1898,7 @@ func TestConfigDiscoveryAllBrokenDoesNotSilentlyProduceEmptyCatalog(t *testing.T
 	nestedConfigPath := writeConfigCandidate(t, root, "packages/app/rslint.config.js")
 	loader.failures[configPath] = ConfigModuleError{Code: "ERR", Message: "nope"}
 	loader.failures[nestedConfigPath] = ConfigModuleError{Code: "ERR_NESTED", Message: "nested nope"}
-	_, err := Build(context.Background(), discoveryTestFS(), loader, ConfigDiscoveryRequest{
+	_, err := DiscoverAutomatic(context.Background(), discoveryTestFS(), loader, ConfigDiscoveryRequest{
 		CWD:         root,
 		ImplicitCWD: true,
 	})
@@ -1378,7 +1922,7 @@ func TestConfigDiscoveryAllBrokenDoesNotSilentlyProduceEmptyCatalog(t *testing.T
 	invalidLoader := newFixtureConfigLoader()
 	invalidLoader.failures[configPath] = ConfigModuleError{Code: "invalid", Message: "not an array"}
 	invalidLoader.failures[nestedConfigPath] = ConfigModuleError{Code: "invalid", Message: "nested not an array"}
-	_, err = Build(context.Background(), discoveryTestFS(), invalidLoader, ConfigDiscoveryRequest{
+	_, err = DiscoverAutomatic(context.Background(), discoveryTestFS(), invalidLoader, ConfigDiscoveryRequest{
 		CWD:         root,
 		ImplicitCWD: true,
 	})
@@ -1400,7 +1944,7 @@ func buildFixtureCatalog(t *testing.T, root string, loader ConfigModuleLoader, r
 	if request.CWD == "" {
 		request.CWD = root
 	}
-	catalog, err := Build(context.Background(), discoveryTestFS(), loader, request)
+	catalog, err := DiscoverAutomatic(context.Background(), discoveryTestFS(), loader, request)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -1413,6 +1957,15 @@ func discoveryTestFS() vfs.FS {
 
 func namedConfig(name string) rslintconfig.RslintConfig {
 	return rslintconfig.RslintConfig{{Name: name, Rules: rslintconfig.Rules{}}}
+}
+
+func namedConfigEntry(entries rslintconfig.RslintConfig) rslintconfig.ConfigEntry {
+	for _, entry := range entries {
+		if entry.Name != "" {
+			return entry
+		}
+	}
+	return rslintconfig.ConfigEntry{}
 }
 
 func writeConfigCandidate(t *testing.T, root string, relativePath string) string {

--- a/internal/config/discovery/discovery_test.go
+++ b/internal/config/discovery/discovery_test.go
@@ -56,6 +56,16 @@ type configDiscoveryReadSpyFS struct {
 	gitignorePaths []string
 }
 
+type configDiscoveryCandidateFS struct {
+	vfs.FS
+	files map[string]struct{}
+}
+
+func (fs *configDiscoveryCandidateFS) FileExists(path string) bool {
+	_, exists := fs.files[tspath.NormalizePath(path)]
+	return exists
+}
+
 func (fs *configDiscoveryReadSpyFS) ReadFile(path string) (string, bool) {
 	if strings.EqualFold(tspath.GetBaseFileName(path), ".gitignore") {
 		fs.mu.Lock()
@@ -725,6 +735,208 @@ func TestConfigDiscoverySkipsDescendantSymlinkWithoutMetadata(t *testing.T) {
 	if slices.Contains(reads, aliasGitignore) {
 		t.Fatalf("descendant symlink .gitignore was read: %v", reads)
 	}
+}
+
+func TestConfigDiscoveryDirectorySymlinkRootPreservesGitSourceBoundary(t *testing.T) {
+	for _, withoutMetadata := range []bool{false, true} {
+		name := "symlink metadata"
+		if withoutMetadata {
+			name = "realpath fallback"
+		}
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			external := t.TempDir()
+			rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+			rootGitignore := writeDiscoveryFixture(t, root, ".gitignore", "linked/scope/parent-hidden/\n")
+			writeDiscoveryFixture(t, external, ".gitignore", "scope/target-hidden/\n")
+			writeDiscoveryFixture(t, external, "scope/parent-hidden/index.ts", "export {}\n")
+			writeDiscoveryFixture(t, external, "scope/target-hidden/index.ts", "export {}\n")
+			alias := filepath.Join(root, "linked")
+			if err := os.Symlink(external, alias); err != nil {
+				t.Skipf("directory symlink unavailable: %v", err)
+			}
+			aliasGitignore := tspath.CombinePaths(alias, ".gitignore")
+			requestDirectory := tspath.CombinePaths(alias, "scope")
+			loader := newFixtureConfigLoader()
+			loader.configs[rootConfig] = namedConfig("root")
+			fsys := discoveryTestFS()
+			if withoutMetadata {
+				fsys = &configDiscoveryNoSymlinkMetadataFS{FS: fsys}
+			}
+			spy := &configDiscoveryReadSpyFS{FS: fsys}
+
+			catalog, err := DiscoverAutomatic(context.Background(), spy, loader, ConfigDiscoveryRequest{
+				CWD:         root,
+				Directories: []string{requestDirectory},
+			})
+			if err != nil {
+				t.Fatalf("DiscoverAutomatic: %v", err)
+			}
+			root = tspath.NormalizePath(root)
+			alias = tspath.NormalizePath(alias)
+			if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{root}) {
+				t.Fatalf("symlink-root owner = %v, want ancestor %q", got, root)
+			}
+			effective := catalog.Configs[root]
+			if !effective.IsFileIgnored(tspath.CombinePaths(alias, "scope/parent-hidden/index.ts"), root) {
+				t.Fatal("ancestor .gitignore rule was lost at the symlink boundary")
+			}
+			if effective.IsFileIgnored(tspath.CombinePaths(alias, "scope/target-hidden/index.ts"), root) {
+				t.Fatal("target-side .gitignore crossed the symlink boundary")
+			}
+			spy.mu.Lock()
+			reads := slices.Clone(spy.gitignorePaths)
+			spy.mu.Unlock()
+			if !slices.Contains(reads, rootGitignore) {
+				t.Fatalf("ancestor .gitignore was not read: %v", reads)
+			}
+			if slices.Contains(reads, aliasGitignore) {
+				t.Fatalf("target-side .gitignore was read through the symlink: %v", reads)
+			}
+		})
+	}
+
+	t.Run("config at the symlink root starts a new source boundary", func(t *testing.T) {
+		root := t.TempDir()
+		external := t.TempDir()
+		rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+		writeConfigCandidate(t, external, "rslint.config.js")
+		writeDiscoveryFixture(t, external, ".gitignore", "hidden/\n")
+		writeDiscoveryFixture(t, external, "hidden/index.ts", "export {}\n")
+		alias := filepath.Join(root, "linked")
+		if err := os.Symlink(external, alias); err != nil {
+			t.Skipf("directory symlink unavailable: %v", err)
+		}
+		alias = tspath.NormalizePath(alias)
+		aliasConfig := tspath.CombinePaths(alias, "rslint.config.js")
+		aliasGitignore := tspath.CombinePaths(alias, ".gitignore")
+		loader := newFixtureConfigLoader()
+		loader.configs[rootConfig] = namedConfig("root")
+		loader.configs[aliasConfig] = namedConfig("alias")
+		spy := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+
+		catalog, err := DiscoverAutomatic(context.Background(), spy, loader, ConfigDiscoveryRequest{
+			CWD:         root,
+			Directories: []string{alias},
+		})
+		if err != nil {
+			t.Fatalf("DiscoverAutomatic: %v", err)
+		}
+		if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{alias}) {
+			t.Fatalf("symlink-root config did not become the owner: %v", got)
+		}
+		if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{
+			rootConfig,
+			aliasConfig,
+		}) {
+			t.Fatalf("config requests = %v", got)
+		}
+		spy.mu.Lock()
+		reads := slices.Clone(spy.gitignorePaths)
+		spy.mu.Unlock()
+		if !slices.Contains(reads, aliasGitignore) {
+			t.Fatalf("symlink-root config did not start a Git source boundary: %v", reads)
+		}
+	})
+
+	t.Run("successful child config starts a new source boundary", func(t *testing.T) {
+		root := t.TempDir()
+		external := t.TempDir()
+		rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+		writeDiscoveryFixture(t, external, ".gitignore", "child/\n")
+		writeConfigCandidate(t, external, "child/rslint.config.js")
+		writeDiscoveryFixture(t, external, "child/.gitignore", "hidden/\n")
+		writeDiscoveryFixture(t, external, "child/hidden/index.ts", "export {}\n")
+		alias := filepath.Join(root, "linked")
+		if err := os.Symlink(external, alias); err != nil {
+			t.Skipf("directory symlink unavailable: %v", err)
+		}
+		aliasGitignore := tspath.CombinePaths(alias, ".gitignore")
+		aliasChild := tspath.CombinePaths(alias, "child")
+		aliasChildConfig := tspath.CombinePaths(aliasChild, "rslint.config.js")
+		aliasChildGitignore := tspath.CombinePaths(aliasChild, ".gitignore")
+		loader := newFixtureConfigLoader()
+		loader.configs[rootConfig] = namedConfig("root")
+		loader.configs[aliasChildConfig] = namedConfig("child")
+		spy := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+
+		catalog, err := DiscoverAutomatic(context.Background(), spy, loader, ConfigDiscoveryRequest{
+			CWD:         root,
+			Directories: []string{alias},
+		})
+		if err != nil {
+			t.Fatalf("DiscoverAutomatic: %v", err)
+		}
+		if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{
+			tspath.NormalizePath(root),
+			aliasChild,
+		}) {
+			t.Fatalf("child config did not reopen its Git source boundary: %v", got)
+		}
+		if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{
+			rootConfig,
+			aliasChildConfig,
+		}) {
+			t.Fatalf("config requests = %v", got)
+		}
+		spy.mu.Lock()
+		reads := slices.Clone(spy.gitignorePaths)
+		spy.mu.Unlock()
+		if slices.Contains(reads, aliasGitignore) {
+			t.Fatalf("pre-config target .gitignore crossed the symlink boundary: %v", reads)
+		}
+		if !slices.Contains(reads, aliasChildGitignore) {
+			t.Fatalf("successful child config did not start a new Git source boundary: %v", reads)
+		}
+	})
+
+	t.Run("failed child config keeps the source boundary closed", func(t *testing.T) {
+		root := t.TempDir()
+		external := t.TempDir()
+		rootConfig := writeConfigCandidate(t, root, "rslint.config.js")
+		failedConfig := writeConfigCandidate(t, external, "child/rslint.config.js")
+		writeDiscoveryFixture(t, external, "child/.gitignore", "hidden/\n")
+		writeConfigCandidate(t, external, "child/hidden/rslint.config.js")
+		alias := filepath.Join(root, "linked")
+		if err := os.Symlink(external, alias); err != nil {
+			t.Skipf("directory symlink unavailable: %v", err)
+		}
+		aliasChildConfig := tspath.CombinePaths(alias, "child/rslint.config.js")
+		aliasChildGitignore := tspath.CombinePaths(alias, "child/.gitignore")
+		aliasHiddenConfig := tspath.CombinePaths(alias, "child/hidden/rslint.config.js")
+		loader := newFixtureConfigLoader()
+		loader.configs[rootConfig] = namedConfig("root")
+		loader.failures[aliasChildConfig] = ConfigModuleError{Code: "ERR", Message: "broken"}
+		loader.configs[aliasHiddenConfig] = namedConfig("visible-through-failed-boundary")
+		spy := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+
+		catalog, err := DiscoverAutomatic(context.Background(), spy, loader, ConfigDiscoveryRequest{
+			CWD:         root,
+			Directories: []string{alias},
+		})
+		if err != nil {
+			t.Fatalf("DiscoverAutomatic: %v", err)
+		}
+		if got := catalog.ConfigDirectories(); !reflect.DeepEqual(got, []string{
+			tspath.NormalizePath(root),
+			tspath.GetDirectoryPath(aliasHiddenConfig),
+		}) {
+			t.Fatalf("failed child unexpectedly changed Git source reachability: %v", got)
+		}
+		if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{
+			rootConfig,
+			aliasChildConfig,
+			aliasHiddenConfig,
+		}) {
+			t.Fatalf("config requests = %v, physical failed config %q", got, failedConfig)
+		}
+		spy.mu.Lock()
+		reads := slices.Clone(spy.gitignorePaths)
+		spy.mu.Unlock()
+		if slices.Contains(reads, aliasChildGitignore) {
+			t.Fatalf("failed child config reopened Git source traversal: %v", reads)
+		}
+	})
 }
 
 func TestConfigDiscoveryParentGlobalIgnorePrunesNestedConfig(t *testing.T) {
@@ -1558,6 +1770,94 @@ func TestConfigDiscoveryCaseInsensitiveRootsChooseStableRepresentative(t *testin
 	if !reflect.DeepEqual(first, want) || !reflect.DeepEqual(second, want) {
 		t.Fatalf("case-insensitive roots depend on input order: first=%v second=%v", first, second)
 	}
+}
+
+func TestConfigDiscoveryCandidateSearchStopsAtUNCShareRoot(t *testing.T) {
+	shareConfig := "//server/share/rslint.config.js"
+	serverConfig := "//server/rslint.config.js"
+
+	t.Run("parent traversal", func(t *testing.T) {
+		for _, test := range []struct {
+			directory string
+			parent    string
+		}{
+			{directory: "/repo/pkg", parent: "/repo"},
+			{directory: "/", parent: ""},
+			{directory: "C:/repo", parent: "C:/"},
+			{directory: "C:/", parent: ""},
+			{directory: "//server/share/repo", parent: "//server/share"},
+			{directory: "//server/share", parent: ""},
+			{directory: "//server/share/", parent: ""},
+			{directory: "//server", parent: ""},
+		} {
+			if got := configDiscoveryParent(test.directory); got != test.parent {
+				t.Fatalf("configDiscoveryParent(%q) = %q, want %q", test.directory, got, test.parent)
+			}
+		}
+	})
+
+	t.Run("ancestor chain includes the share root but not the server", func(t *testing.T) {
+		fsys := &configDiscoveryCandidateFS{
+			FS: discoveryTestFS(),
+			files: map[string]struct{}{
+				shareConfig:  {},
+				serverConfig: {},
+			},
+		}
+		builder := configCatalogBuilder{
+			fs:      fsys,
+			request: ConfigDiscoveryRequest{CWD: "//server/share/repo"},
+		}
+
+		candidates := builder.findCandidateChain("//server/share/repo")
+		if len(candidates) != 1 || candidates[0].path != shareConfig {
+			t.Fatalf("UNC ancestor candidates = %+v, want share root only", candidates)
+		}
+	})
+
+	t.Run("nearest search cannot escape to the server", func(t *testing.T) {
+		fsys := &configDiscoveryCandidateFS{
+			FS: discoveryTestFS(),
+			files: map[string]struct{}{
+				serverConfig: {},
+			},
+		}
+		builder := configCatalogBuilder{
+			fs:      fsys,
+			request: ConfigDiscoveryRequest{CWD: "//server/share/repo"},
+		}
+
+		if candidate, found := builder.findCandidateUp("//server/share/repo"); found {
+			t.Fatalf("UNC nearest search escaped its share: %+v", candidate)
+		}
+	})
+
+	t.Run("failed share candidate cannot fall back to the server", func(t *testing.T) {
+		fsys := &configDiscoveryCandidateFS{
+			FS: discoveryTestFS(),
+			files: map[string]struct{}{
+				shareConfig:  {},
+				serverConfig: {},
+			},
+		}
+		loader := newFixtureConfigLoader()
+		loader.failures[shareConfig] = ConfigModuleError{Code: "ERR", Message: "broken"}
+		loader.configs[serverConfig] = namedConfig("outside-share")
+
+		_, err := DiscoverAutomatic(context.Background(), fsys, loader, ConfigDiscoveryRequest{
+			CWD: "//server/share/repo",
+			Files: []DiscoveryFile{{
+				Path:     "//server/share/repo/src/index.ts",
+				Explicit: true,
+			}},
+		})
+		if !errors.Is(err, ErrAllConfigsFailed) {
+			t.Fatalf("failed share config error = %v, want ErrAllConfigsFailed", err)
+		}
+		if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{shareConfig}) {
+			t.Fatalf("requested configs = %v, want failed share config only", got)
+		}
+	})
 }
 
 func TestConfigDiscoveryValidatesPhysicalConfigDirectoryIdentityBeforeActivation(t *testing.T) {

--- a/internal/config/gitignore/collector.go
+++ b/internal/config/gitignore/collector.go
@@ -229,6 +229,120 @@ type gitignorePrunePattern struct {
 	pattern string
 }
 
+// Cursor is an immutable, filesystem-independent view of the .gitignore
+// sources on one config owner's directory chain. It deliberately
+// separates two questions:
+//
+//   - Enter reports whether the already-observed Git patterns ignore one
+//     directory node. Config discovery may still reopen that node with a later
+//     authored global-ignore negation.
+//   - SourceReachable reports whether raw Git traversal can read the current
+//     directory's .gitignore. Authored config never changes this state; only a
+//     successfully loaded child config creates a new cursor/root.
+//
+// Values are safe to copy between discovery workers. Enter only changes scalar
+// state; AppendSource clones the rule slice before extending it, so siblings
+// never share a writable backing array.
+type Cursor struct {
+	rootDir          string
+	useCaseSensitive bool
+	sourceReachable  bool
+	rules            []gitignorePruneRule
+}
+
+// NewCursor starts a config-scoped Git view. The owner directory itself is
+// always source-reachable; parent .gitignore files are intentionally excluded.
+func NewCursor(ownerRoot string, useCaseSensitive bool) Cursor {
+	ownerRoot = normalizeGlobPath(ownerRoot)
+	return Cursor{
+		rootDir:          ownerRoot,
+		useCaseSensitive: useCaseSensitive,
+		sourceReachable:  ownerRoot != "",
+	}
+}
+
+// SourceReachable reports whether raw Git traversal permits reading the
+// current directory's .gitignore.
+func (cursor Cursor) SourceReachable() bool {
+	return cursor.sourceReachable
+}
+
+// Enter advances to directory and reports whether the already-observed raw Git
+// patterns ignore that exact directory node. The returned cursor keeps raw
+// source reachability monotonic: a negation below an ignored parent cannot make
+// nested .gitignore sources visible.
+func (cursor Cursor) Enter(directory string) (Cursor, bool) {
+	directory = normalizeGlobPath(directory)
+	if _, ok := relativeDir(cursor.rootDir, directory, cursor.useCaseSensitive); !ok {
+		next := cursor
+		next.sourceReachable = false
+		return next, true
+	}
+	blocked := cursor.blocksDirectoryNode(directory)
+	next := cursor
+	next.sourceReachable = cursor.sourceReachable && !blocked
+	return next, blocked
+}
+
+// AppendSource extends the cursor with directory's .gitignore and returns the
+// source projected into the config owner's target path space. Callers keep the
+// source IO path separate and pass the matching-space directory explicitly so
+// lexical and canonical discovery routes cannot be mixed accidentally.
+func (cursor Cursor) AppendSource(directory string, content string) (Cursor, []string) {
+	if !cursor.sourceReachable {
+		return cursor, nil
+	}
+	directory = normalizeGlobPath(directory)
+	relative, ok := relativeDir(cursor.rootDir, directory, cursor.useCaseSensitive)
+	if !ok {
+		next := cursor
+		next.sourceReachable = false
+		return next, nil
+	}
+
+	next := cursor
+	if rule, ok := newGitignorePruneRule(directory, content); ok {
+		next.rules = append(append([]gitignorePruneRule(nil), cursor.rules...), rule)
+	}
+	globs := convertGitignoreToGlobs(content, relative)
+	return next, globs
+}
+
+func (cursor Cursor) blocksDirectoryNode(directory string) bool {
+	if cursor.rootDir == "" || directory == "" {
+		return false
+	}
+	ignored := false
+	for _, rule := range cursor.rules {
+		relative, ok := relativeDir(rule.baseDir, directory, cursor.useCaseSensitive)
+		if !ok || relative == "" {
+			continue
+		}
+		for _, pattern := range rule.patterns {
+			if gitignorePrunePatternMatchesDirectoryNode(pattern, relative, cursor.useCaseSensitive) {
+				ignored = !pattern.negated
+			}
+		}
+	}
+	return ignored
+}
+
+// gitignorePrunePatternMatchesDirectoryNode matches only the current directory
+// node. The existing collector predicate additionally checks ancestors because
+// a raw Git walk can never enter an ignored parent; config discovery cannot use
+// that shortcut because a later authored `!dir/` may reopen the parent node
+// while raw nested-source reachability remains blocked.
+func gitignorePrunePatternMatchesDirectoryNode(pattern gitignorePrunePattern, relative string, useCaseSensitive bool) bool {
+	if pattern.rooted {
+		return matchGitignoreGlob(pattern.pattern, relative, useCaseSensitive)
+	}
+	parts := splitPathComponents(relative)
+	if len(parts) == 0 {
+		return false
+	}
+	return matchGitignoreGlob(pattern.pattern, parts[len(parts)-1], useCaseSensitive)
+}
+
 func newGitignorePruneRule(baseDir string, content string) (gitignorePruneRule, bool) {
 	patterns := parseGitignorePrunePatterns(content)
 	if len(patterns) == 0 {

--- a/internal/config/gitignore/collector.go
+++ b/internal/config/gitignore/collector.go
@@ -267,6 +267,15 @@ func (cursor Cursor) SourceReachable() bool {
 	return cursor.sourceReachable
 }
 
+// BlockSourceTraversal preserves already-observed matching rules while making
+// .gitignore sources at the current directory and its descendants unreachable.
+// A successfully loaded child config starts a new cursor and therefore a new
+// source boundary.
+func (cursor Cursor) BlockSourceTraversal() Cursor {
+	cursor.sourceReachable = false
+	return cursor
+}
+
 // Enter advances to directory and reports whether the already-observed raw Git
 // patterns ignore that exact directory node. The returned cursor keeps raw
 // source reachability monotonic: a negation below an ignored parent cannot make

--- a/internal/config/gitignore/collector_test.go
+++ b/internal/config/gitignore/collector_test.go
@@ -564,6 +564,68 @@ func TestSortByPathDepthTreatsUNCShareAsRoot(t *testing.T) {
 	})
 }
 
+func TestCursorDirectoryReachability(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		content     string
+		directory   string
+		wantBlocked bool
+	}{
+		{
+			name:        "directory remains ignored",
+			content:     "ignored/\n",
+			directory:   "C:/repo/ignored",
+			wantBlocked: true,
+		},
+		{
+			name:        "exact directory negation reopens",
+			content:     "ignored/\n!ignored/\n",
+			directory:   "C:/repo/ignored",
+			wantBlocked: false,
+		},
+		{
+			name:        "file negation does not reopen directory",
+			content:     "ignored/\n!ignored/keep.ts\n",
+			directory:   "C:/repo/ignored",
+			wantBlocked: true,
+		},
+		{
+			name:        "descendant negation does not reopen directory",
+			content:     "ignored/\n!ignored/**/*\n",
+			directory:   "C:/repo/ignored",
+			wantBlocked: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cursor := NewCursor("c:/REPO", false)
+			cursor, _ = cursor.AppendSource("C:/repo", test.content)
+			_, blocked := cursor.Enter(test.directory)
+			assert.Equal(t, blocked, test.wantBlocked)
+		})
+	}
+}
+
+func TestCursorRejectsPathsOutsideOwnerVolume(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		root      string
+		directory string
+	}{
+		{name: "different drive", root: "C:/repo", directory: "D:/repo"},
+		{name: "different UNC share", root: "//server/share/repo", directory: "//server/other/repo"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cursor := NewCursor(test.root, false)
+			next, blocked := cursor.Enter(test.directory)
+			assert.Assert(t, blocked)
+			assert.Assert(t, !next.SourceReachable())
+			next, globs := cursor.AppendSource(test.directory, "ignored/\n")
+			assert.Equal(t, len(globs), 0)
+			assert.Assert(t, !next.SourceReachable())
+		})
+	}
+}
+
 func TestReadGitignoreAsGlobs_StopsAtConfigDirAcrossFilesystemRoots(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/config/gitignore/collector_test.go
+++ b/internal/config/gitignore/collector_test.go
@@ -605,6 +605,22 @@ func TestCursorDirectoryReachability(t *testing.T) {
 	}
 }
 
+func TestCursorBlockSourceTraversalPreservesInheritedRules(t *testing.T) {
+	cursor := NewCursor("/repo", true)
+	cursor, _ = cursor.AppendSource("/repo", "ignored/\n")
+	cursor = cursor.BlockSourceTraversal()
+
+	next, blocked := cursor.Enter("/repo/ignored")
+	assert.Assert(t, blocked)
+	assert.Assert(t, !next.SourceReachable())
+
+	next, globs := cursor.AppendSource("/repo", "must-not-apply/\n")
+	assert.Assert(t, !next.SourceReachable())
+	assert.Equal(t, len(globs), 0)
+	_, blocked = next.Enter("/repo/must-not-apply")
+	assert.Assert(t, !blocked)
+}
+
 func TestCursorRejectsPathsOutsideOwnerVolume(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/config/gitignore_config.go
+++ b/internal/config/gitignore_config.go
@@ -38,12 +38,20 @@ func ConfigWithGitignoreWithBoundaries(config RslintConfig, configDir string, fs
 		}
 	}
 	globs := gitignore.CollectWithBoundaries(configDir, fsys, collectionFiles, isDirectoryBlocked, stopDirs)
+	caseInsensitive := fsys != nil && !fsys.UseCaseSensitiveFileNames()
+	return ConfigWithCollectedGitignore(config, globs, caseInsensitive)
+}
+
+// ConfigWithCollectedGitignore prepends one already-collected Git projection
+// without retaining a filesystem. Both the standalone collector path and
+// staged config discovery use this constructor so private Git matching metadata
+// cannot diverge between them.
+func ConfigWithCollectedGitignore(config RslintConfig, globs []string, caseInsensitive bool) RslintConfig {
 	if len(globs) == 0 {
 		return config
 	}
-	caseInsensitive := fsys != nil && !fsys.UseCaseSensitiveFileNames()
 	gitignoreEntry := ConfigEntry{
-		Ignores:                  globs,
+		Ignores:                  append([]string(nil), globs...),
 		gitignoreSemantics:       true,
 		gitignoreCaseInsensitive: caseInsensitive,
 	}

--- a/internal/config/ignore_pattern.go
+++ b/internal/config/ignore_pattern.go
@@ -33,6 +33,30 @@ func (matcher GlobalIgnoreMatcher) BlocksDirectory(directory string, canonicalDi
 	return ok && len(matcher.patterns) > 0 && isDirAbsolutelyBlocked(relative, matcher.patterns)
 }
 
+// ReopensDirectoryNode reports whether the ordered authored global-ignore
+// patterns leave directory itself re-included. A pattern must match the current
+// node: `!dir`, `!dir/`, and `!dir/**` reopen dir, while `!dir/**/*` and
+// `!dir/file.ts` do not. Descendant patterns can still reopen a matching child.
+//
+// Positive authored directory blocks remain absolute under rslint's existing
+// semantics and are checked by BlocksDirectory before callers consult this
+// method.
+func (matcher GlobalIgnoreMatcher) ReopensDirectoryNode(directory string, canonicalDirectory string) bool {
+	relative, ok := matcher.relativePath(directory, canonicalDirectory)
+	if !ok || len(matcher.patterns) == 0 {
+		return false
+	}
+	relative = strings.TrimSuffix(relative, "/")
+	reopened := false
+	for _, pattern := range matcher.patterns {
+		if ignorePatternMatches(pattern, relative) ||
+			ignorePatternMatches(pattern, relative+"/") {
+			reopened = pattern.Negated
+		}
+	}
+	return reopened
+}
+
 // IgnoresPath reports whether global ignores exclude a config candidate.
 func (matcher GlobalIgnoreMatcher) IgnoresPath(filePath string, canonicalPath string) bool {
 	relative, ok := matcher.relativePath(filePath, canonicalPath)

--- a/internal/config/ignore_pattern_test.go
+++ b/internal/config/ignore_pattern_test.go
@@ -203,6 +203,51 @@ func TestCanPruneDir(t *testing.T) {
 	}
 }
 
+func TestGlobalIgnoreMatcherReopensMatchingDirectoryNode(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		pattern string
+		want    bool
+	}{
+		{name: "bare directory node", pattern: "!ignored", want: true},
+		{name: "rooted directory does not match relative node", pattern: "!/ignored", want: false},
+		{name: "directory-only node", pattern: "!ignored/", want: true},
+		{name: "directory and contents", pattern: "!ignored/**", want: true},
+		{name: "directory files", pattern: "!ignored/**/*", want: false},
+		{name: "one file", pattern: "!ignored/keep.ts", want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			matcher := NewGlobalIgnoreMatcher(
+				RslintConfig{{Ignores: []string{test.pattern}}},
+				"/repo",
+				nil,
+			)
+			assert.Equal(t, matcher.ReopensDirectoryNode("/repo/ignored", ""), test.want)
+		})
+	}
+
+	for _, test := range []struct {
+		name     string
+		patterns []string
+		want     bool
+	}{
+		{name: "single-level descendant", patterns: []string{"!dir/*"}, want: true},
+		{name: "recursive descendant", patterns: []string{"!dir/**/*"}, want: true},
+		{name: "exact descendant", patterns: []string{"!dir/child"}, want: true},
+		{name: "later positive wins", patterns: []string{"!dir/child/", "dir/*"}, want: false},
+		{name: "later negation wins", patterns: []string{"dir/*", "!dir/child/"}, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			matcher := NewGlobalIgnoreMatcher(
+				RslintConfig{{Ignores: test.patterns}},
+				"/repo",
+				nil,
+			)
+			assert.Equal(t, matcher.ReopensDirectoryNode("/repo/dir/child", ""), test.want)
+		})
+	}
+}
+
 // --- Unit: ParseIgnorePattern remaining switch-arm inputs ---
 // TestParseIgnorePattern_Classification already pins braces/`**`/`./`/`//`. This
 // fills the glob-metachar and rooted/trailing forms the task flags: `?`,

--- a/internal/lsp/config_discovery.go
+++ b/internal/lsp/config_discovery.go
@@ -319,9 +319,8 @@ func (s *Server) handleConfigRefresh(ctx context.Context, params any) (configRef
 	// generation's path identity snapshot.
 	snapshotFS := newConfigSnapshotFS(bundled.WrapFS(cachedvfs.From(s.fs)))
 	loader := &lspConfigModuleLoader{server: s}
-	catalog, err := discovery.Build(ctx, snapshotFS, loader, discovery.ConfigDiscoveryRequest{
+	catalog, err := discovery.DiscoverAutomatic(ctx, snapshotFS, loader, discovery.ConfigDiscoveryRequest{
 		CWD:         tspath.NormalizePath(s.cwd),
-		Mode:        discovery.ConfigDiscoveryAuto,
 		ImplicitCWD: true,
 		Fresh:       true,
 	})
@@ -526,22 +525,11 @@ func (s *Server) prepareDiscoveredConfigSnapshot(
 		snapshot.tsConfigPaths[configDir] = nil
 		snapshot.unavailableConfigs[configDir] = struct{}{}
 	}
-	// Build all ownership and unavailable boundaries before collecting any
-	// .gitignore source. This prevents a parent config from reading into a child
-	// boundary merely because that child happened to be processed later.
-	boundaryResolver := config.NewConfigOwnerResolver(snapshot.configs, fsys)
-	for configDir, entries := range snapshot.configs {
-		snapshot.configs[configDir] = config.ConfigWithGitignoreWithBoundaries(
-			entries,
-			configDir,
-			fsys,
-			nil,
-			boundaryResolver.ChildConfigDirs(configDir),
-		)
-	}
 	// ConfigOwnerResolver snapshots both the path index and config values. Build
-	// the committed resolver only after ignore injection so Resolve never returns
-	// a pre-snapshot config that differs from snapshot.configs.
+	// it only after all successful and unavailable boundaries are present.
+	// Successful automatic catalog entries already contain the Git sources read
+	// by their discovery generation; unavailable boundaries intentionally remain
+	// empty and only stop JSON fallback ownership.
 	snapshot.ownerResolver = config.NewConfigOwnerResolver(snapshot.configs, fsys)
 
 	jsonConfig, jsonPath, jsonTsConfigs, err := loadJSONConfigFallbackWithFS(s.cwd, fsys)

--- a/internal/lsp/config_discovery_test.go
+++ b/internal/lsp/config_discovery_test.go
@@ -346,8 +346,19 @@ func TestPrepareDiscoveredConfigSnapshotUsesChildGitignoreSourceBoundaries(t *te
 	catalog := &discovery.ConfigCatalog{
 		TransactionID: "snapshot-boundaries",
 		Configs: map[string]config.RslintConfig{
-			root:  {{Rules: config.Rules{"no-console": "error"}}},
-			child: {{Rules: config.Rules{"no-debugger": "error"}}},
+			root: config.ConfigWithGitignoreWithBoundaries(
+				config.RslintConfig{{Rules: config.Rules{"no-console": "error"}}},
+				root,
+				fsys,
+				nil,
+				[]string{child},
+			),
+			child: config.ConfigWithGitignore(
+				config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}},
+				child,
+				fsys,
+				nil,
+			),
 		},
 	}
 	s := newTestServer()

--- a/packages/rslint-test-tools/tests/cli/js-config/gitignore-integration.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/gitignore-integration.test.ts
@@ -701,6 +701,54 @@ describe('Gitignore: tsconfig + gitignore interaction', () => {
 });
 
 describe('Gitignore: monorepo gap file interaction', () => {
+  test('automatic discovery prunes a Git-hidden child config, while an explicit directory root reopens it', async () => {
+    const tempDir = await createTempDir({
+      '.gitignore': 'packages/ignored/\n',
+      'rslint.config.mjs': CONFIG_NO_CONSOLE,
+      'packages/ignored/rslint.config.mjs': `
+        import { writeFileSync } from 'node:fs';
+        writeFileSync(new URL('./config-loaded.marker', import.meta.url), 'loaded');
+        ${CONFIG_NO_CONSOLE}
+      `,
+      'packages/ignored/index.ts': 'console.log("test");\n',
+    });
+    const marker = path.join(tempDir, 'packages/ignored/config-loaded.marker');
+    try {
+      await runRslint(['--format', 'jsonline'], tempDir);
+      expect(fs.existsSync(marker)).toBe(false);
+
+      await runRslint(['--format', 'jsonline', 'packages/ignored'], tempDir);
+      expect(fs.existsSync(marker)).toBe(true);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('an authored directory-matching negation reopens Git-hidden config discovery', async () => {
+    const tempDir = await createTempDir({
+      '.gitignore': 'packages/ignored/\n',
+      'rslint.config.mjs': `
+        export default [
+          { ignores: ["!packages/ignored/**"] },
+          { rules: { "no-console": "error" } },
+        ];
+      `,
+      'packages/ignored/rslint.config.mjs': `
+        import { writeFileSync } from 'node:fs';
+        writeFileSync(new URL('./config-loaded.marker', import.meta.url), 'loaded');
+        ${CONFIG_NO_CONSOLE}
+      `,
+      'packages/ignored/index.ts': 'console.log("test");\n',
+    });
+    const marker = path.join(tempDir, 'packages/ignored/config-loaded.marker');
+    try {
+      await runRslint(['--format', 'jsonline'], tempDir);
+      expect(fs.existsSync(marker)).toBe(true);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   test('root .gitignore does not prune child config discovery', async () => {
     const { diagnostics, cleanup } = await lintJsonline({
       '.gitignore': 'build/\n',

--- a/packages/rslint-test-tools/tests/cli/type-check/type-check-only.test.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/type-check-only.test.ts
@@ -133,7 +133,7 @@ describe('--type-check-only basic', () => {
     }
   });
 
-  test('gitignored nested config still contributes a type-check Program', async () => {
+  test('gitignored nested config does not contribute a type-check Program', async () => {
     const tempDir = await createTempDir({
       '.gitignore': 'packages/ignored/\n',
       'rslint.config.mjs': makeConfigPlain(),
@@ -176,7 +176,7 @@ describe('--type-check-only basic', () => {
             diagnostic.filePath?.includes('packages/ignored/bad.ts') &&
             diagnostic.ruleName.includes('TS2322'),
         ),
-      ).toBe(true);
+      ).toBe(false);
       expect(r.exitCode).not.toBe(0);
     } finally {
       await cleanupTempDir(tempDir);

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -153,27 +153,14 @@ function staticGlobRoot(pattern: string, cwd: string): string {
   return current || cwd;
 }
 
-function compactScanDirectories(directories: Iterable<string>): string[] {
+function deduplicateScanDirectories(directories: Iterable<string>): string[] {
   const byIdentity = new Map<string, string>();
   for (const directory of directories) {
     const normalized = path.normalize(directory);
     const key = nativePathIdentity.key(normalized);
     if (!byIdentity.has(key)) byIdentity.set(key, normalized);
   }
-  const sorted = [...byIdentity.values()].sort(
-    (a, b) => a.length - b.length || nativePathIdentity.compare(a, b),
-  );
-  const compact: string[] = [];
-  for (const directory of sorted) {
-    if (
-      !compact.some((parent) =>
-        nativePathIdentity.isSameOrChild(parent, directory),
-      )
-    ) {
-      compact.push(directory);
-    }
-  }
-  return compact;
+  return [...byIdentity.values()].sort(nativePathIdentity.compare);
 }
 
 function normalizeGlobPatternForCwd(pattern: string, cwd: string): string {
@@ -262,7 +249,7 @@ async function classifyLintPatterns(
   return {
     literalFilePatterns,
     literalDirectorySymlinks,
-    scanDirectories: compactScanDirectories(scanDirectories),
+    scanDirectories: deduplicateScanDirectories(scanDirectories),
   };
 }
 
@@ -319,10 +306,6 @@ export class Rslint {
           config: usesNativeDiscovery ? undefined : overrideConfig,
           configDiscovery: usesNativeDiscovery
             ? {
-                mode:
-                  typeof this.#overrideConfigFile === 'string'
-                    ? 'explicit'
-                    : 'auto',
                 explicitConfigPath:
                   typeof this.#overrideConfigFile === 'string'
                     ? path.resolve(this.#cwd, this.#overrideConfigFile)
@@ -459,10 +442,6 @@ export class Rslint {
           config: usesNativeDiscovery ? undefined : overrideConfig,
           configDiscovery: usesNativeDiscovery
             ? {
-                mode:
-                  typeof this.#overrideConfigFile === 'string'
-                    ? 'explicit'
-                    : 'auto',
                 explicitConfigPath:
                   typeof this.#overrideConfigFile === 'string'
                     ? path.resolve(this.#cwd, this.#overrideConfigFile)

--- a/packages/rslint/src/cli/cli.ts
+++ b/packages/rslint/src/cli/cli.ts
@@ -76,16 +76,14 @@ export async function run(
     cwd,
     runtime: { singleThreaded: args.singleThreaded },
     extraInit: {
-      configDiscovery: {
-        mode: usesExplicitJSConfig
-          ? 'explicit'
-          : args.config
-            ? 'disabled'
-            : 'auto',
-        explicitConfigPath: usesExplicitJSConfig
-          ? explicitConfigPath
-          : undefined,
-      },
+      configDiscovery:
+        args.config && !usesExplicitJSConfig
+          ? undefined
+          : {
+              explicitConfigPath: usesExplicitJSConfig
+                ? explicitConfigPath
+                : undefined,
+            },
     },
   });
 }

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -82,7 +82,6 @@ export interface LintOptions {
    * backends intentionally do not advertise this host-filesystem capability.
    */
   configDiscovery?: {
-    mode: 'auto' | 'explicit';
     explicitConfigPath?: string;
     /** Static glob roots; Go visits only branches leading to the supplied files. */
     directories?: string[];

--- a/packages/rslint/tests/rslint.test.mjs
+++ b/packages/rslint/tests/rslint.test.mjs
@@ -1214,7 +1214,7 @@ module.exports = config;`
     }
   });
 
-  test('lintFiles scopes .gitignore to config ownership boundaries', async () => {
+  test('lintFiles lets a literal target bypass Git-hidden config discovery but prunes a glob target', async () => {
     const tmp = await mkdtemp(path.join(os.tmpdir(), 'rslint-api-gitignore-'));
     try {
       await writeFile(
@@ -1238,10 +1238,16 @@ module.exports = config;`
           path.join('ignored', 'index.ts'),
         );
 
+        const rootedGlob = await rslint.lintFiles('ignored/**/*.ts');
+        expect(rootedGlob).toHaveLength(1);
+        expect(path.relative(tmp, rootedGlob[0].filePath)).toBe(
+          path.join('ignored', 'index.ts'),
+        );
+
         const results = await rslint.lintFiles('**/*.ts');
         expect(
           results.map((result) => path.relative(tmp, result.filePath)).sort(),
-        ).toEqual([path.join('ignored', 'index.ts'), 'visible.ts'].sort());
+        ).toEqual(['visible.ts']);
       } finally {
         await rslint.close();
       }

--- a/packages/rslint/tests/service.test.ts
+++ b/packages/rslint/tests/service.test.ts
@@ -206,7 +206,7 @@ describe('RSLintService reverse lint request scoping', () => {
 
     await expect(
       service.lint(
-        { configDiscovery: { mode: 'auto' } },
+        { configDiscovery: {} },
         {
           loadConfigs: (request) => ({ loaded: request }),
           activateConfigs: (request) => ({ activated: request }),
@@ -238,7 +238,7 @@ describe('RSLintService reverse lint request scoping', () => {
     const service = new RSLintService(backend);
     await expect(
       service.lint(
-        { configDiscovery: { mode: 'auto' } },
+        { configDiscovery: {} },
         {
           loadConfigs: () => ({ results: [] }),
           activateConfigs: () => ({ eslintPluginEntries: [] }),
@@ -252,7 +252,7 @@ describe('RSLintService reverse lint request scoping', () => {
     const service = new RSLintService(new ReverseConfigBackend());
     await expect(
       service.lint(
-        { configDiscovery: { mode: 'auto' } },
+        { configDiscovery: {} },
         { loadConfigs: () => ({ results: [] }) },
       ),
     ).rejects.toThrow(/loadConfigs and activateConfigs handlers together/);


### PR DESCRIPTION
## Summary

- Integrate config-scoped `.gitignore` reachability only into automatic JavaScript/TypeScript config discovery, while preserving explicit-config/file behavior, static scan roots, authored negations, and config-owner boundaries.
- Freeze the observed Git-ignore projection into each automatic config catalog and reuse it across CLI, API, and LSP flows, removing the later per-owner directory sweep.
- Apply API override entries exactly once at the loader boundary so automatic-discovery reachability and the published catalog observe the same effective config, including override global-ignore negations.
- Keep filesystem boundaries lexical and volume-aware: config lookup stops at POSIX/drive/UNC-share roots, target-side `.gitignore` sources are not read past a directory-symlink boundary unless a successfully loaded config starts a new Git source boundary, and inherited rules remain active.

### Real-repository validation

Compared the final branch (`ffbc3d733daead8359147a7e5a39d30691d1dca1`), the latest `main` (`23f7d10a0f86e92b6dd571d4e247a4253dc68150`), and npm `@rslint/core@0.7.0` on unchanged local checkouts of `rsbuild` (`3c4f7aaa740ba0caf786bdb7281e0b4113afb3bb`) and `rspack` (`51cfa011c9f0b0666a56f96626077341a78f4900`). All three artifacts used Node.js 22.18.0 and byte-identical neutral CLI-wrapper/runtime dependency trees.

Every repository/mode combination produced equivalent normalized diagnostic blocks, identical summary counts, byte-identical stderr, and identical exit status across all rounds. The run also verified no hangs, no residual rslint processes, and byte-identical repository status/diffs before and after.

Each scenario used 12 interleaved measured rounds: all six execution orders of 0.7.0, `main`, and the current branch, repeated twice. Times below are wall-time medians; percentage deltas are medians of same-round paired comparisons, and negative values mean the current branch is faster.

| Repository | Mode | 0.7.0 median | `main` median | Current median | Current vs 0.7.0 | Current vs `main` |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `rsbuild` | plain | 1132.5 ms | 1077.5 ms | 1005.0 ms | -10.6% | -6.8% |
| `rsbuild` | `--type-check` | 1759.5 ms | 1705.5 ms | 1735.5 ms | -0.6% | +0.6% |
| `rsbuild` | `--type-check-only` | 1328.0 ms | 1328.5 ms | 1341.0 ms | +1.1% | +1.2% |
| `rsbuild` | explicit `--config` | 1229.5 ms | 1172.5 ms | 1180.0 ms | -4.1% | +1.0% |
| `rspack` | plain | 1416.5 ms | 1371.0 ms | 507.5 ms | -64.1% | -61.3% |
| `rspack` | `--type-check` | 1503.0 ms | 1433.0 ms | 615.0 ms | -58.9% | -57.7% |
| `rspack` | `--type-check-only` | 1284.0 ms | 1237.5 ms | 488.0 ms | -62.4% | -61.1% |
| `rspack` | explicit `--config` | 787.5 ms | 705.5 ms | 717.0 ms | -7.3% | +1.5% |

The automatic-discovery improvement is large and consistent on `rspack` and visible in `rsbuild` plain mode. `rsbuild` typed modes and both explicit-config controls are effectively neutral against `main`, with paired interquartile ranges crossing zero.

- Validation: `go test ./internal/config/discovery ./internal/config/gitignore -count=1`; focused config-discovery tests in `./cmd/rslint` and `./internal/lsp`; `golangci-lint run --timeout=15m --new-from-rev=origin/main ./internal/config/discovery ./internal/config/gitignore`; `pnpm check-spell`; `pnpm format:check`.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
