### PR TITLE
perf: reuse staged gitignore projection for explicit config

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -110,7 +110,7 @@ The directory map below folds the high-level module relationships into the packa
 | `internal/api/`                | stdio IPC protocol and service types for JS/WASM integration                                                                                | Shared protocol layer for `cmd/rslint --api`; used by `packages/rslint`, `packages/rslint-wasm`, `internal/linter`, and `internal/inspector`                                                                                                                                           |
 | `internal/config/`             | Configuration models, JSON loading, matching/merging, runtime ownership resolution, lint-target planning, and centralized rule registration | Owns the shared authored-global-ignore matcher consumed by both discovery phases. `RegisterAllRules()` orchestrates rule registration; `rule_registry.go` implements registry/query logic used by `cmd/rslint/programs.go` and `internal/linter`                                       |
 | `internal/config/discovery/`   | Go-owned JS/TS config candidate discovery and immutable catalog construction                                                                | Imports the parent config model/matching policy, batches exact candidates to a host-supplied Node loader, and returns configs/scopes/failures/effective IDs. CLI, API, and LSP call `DiscoverAutomatic` or `LoadExplicitConfig`; the parent package never imports this child package   |
-| `internal/config/gitignore/`   | Config-scoped `.gitignore` parsing, directory reachability, and pattern projection                                                          | Automatic catalog discovery carries a filesystem-independent cursor through its existing walk, pruning Git-inaccessible config subtrees and freezing observed patterns for lint-target admission; explicit/JSON fallback paths reuse the standalone collector                          |
+| `internal/config/gitignore/`   | Config-scoped `.gitignore` parsing, directory reachability, and pattern projection                                                          | Staged JS/TS catalogs carry a filesystem-independent cursor through their existing walk, pruning Git-inaccessible subtrees and freezing observed patterns for lint-target admission; JSON/JSONC and low-level fallback paths reuse the standalone collector                            |
 | `internal/inspector/`          | AST/type/symbol/signature/flow inspection for Playground                                                                                    | Auxiliary backend used mainly by website Playground inspect panels; builds rich semantic data from `typescript-go` programs                                                                                                                                                            |
 | `internal/linter/`             | Core lint engine, traversal, and fix application                                                                                            | Consumes rules from `internal/rule`, file config from `internal/config`, and `Program` / `TypeChecker` data from `typescript-go`; also serves `internal/api` and `internal/lsp`                                                                                                        |
 | `internal/lsp/`                | Language Server Protocol implementation                                                                                                     | Wraps `typescript-go project.Session`, owns transactional config discovery and last-good commit state with `packages/vscode-extension` as the module/plugin host, and invokes `internal/linter` on session-backed programs                                                             |
@@ -453,9 +453,12 @@ CLI, the native JavaScript API path, and transactional LSP refreshes reuse
 the one-shot `internal/config/discovery.DiscoverAutomatic` operation (or
 `LoadExplicitConfig` for an exact path). Automatic discovery builds an immutable
 config/ownership catalog and observes `.gitignore` sources during the same
-directory walk; it does not collect lint targets. Go owns candidate discovery,
-default exclusions, config hierarchy, authored and Git directory reachability,
-the frozen Git projection for each owner, and final effective IDs. Node only
+directory walk. Explicit loading first selects the exact module unconditionally,
+then freezes that invocation-wide owner's Git projection with the same frontier
+without probing nested config candidates. Neither path collects lint targets.
+Go owns candidate discovery, default exclusions, config hierarchy, authored and
+Git directory reachability, the frozen Git projection for each owner, and final
+effective IDs. Node only
 executes the exact JS/TS modules requested by Go, normalizes their entries,
 retains live third-party plugin objects, and returns serializable entries. Source
 fingerprints stay in the Node transaction session; after Go selects the final
@@ -556,10 +559,11 @@ The transport and target phase differ by surface:
 
 - CLI sends `loadConfigs` / `activateConfigs` as reverse framed-IPC requests
   during initialization. The resulting catalog and the later Go lint-target
-  walker are separate traversals, but config discovery already freezes the Git
-  sources observed on its reachable frontier. There is no second per-owner
-  directory sweep. Literal-only and mixed literal targets contribute only their
-  exact owner-to-target source chains to the same source-keyed projection.
+  walker are separate traversals, but the staged catalog already freezes the
+  Git sources observed on its reachable frontier. There is no second per-owner
+  directory sweep. Automatic literal scopes and explicit file-only invocations
+  contribute only their exact owner-to-target source chains to the same
+  source-keyed projection.
 - `Rslint.lintFiles()` still expands target globs with `tinyglobby`, preserves
   literal provenance and canonical identities, and sends the resulting files
   plus their static config-scan roots in one API lint request. Go bounds catalog
@@ -646,9 +650,10 @@ diagnostics after edits, closes, or config commits.
 An explicit JS/TS `--config` or API `overrideConfigFile` bypasses automatic
 candidate selection and loads the exact module. The invocation cwd remains its
 matching directory. The exact config path is never gated by `.gitignore`;
-lint targets are filtered afterward with the existing invocation-scoped
-collector. Automatic candidates instead use the Git directory reachability
-rules above.
+only after it loads does a fixed-owner frontier freeze the invocation-scoped
+Git projection used to filter lint targets. That frontier never probes or
+activates nested config candidates. Automatic candidates instead use Git
+directory reachability while selecting ownership.
 
 No-candidate behavior is surface-specific. CLI performs no Node activation and
 continues through its normal JSON fallback. Native API discovery performs no
@@ -703,11 +708,12 @@ Additional current behaviors:
 - `.gitignore` is injected as a global-ignore entry through the shared
   `ConfigWithCollectedGitignore`/`ConfigWithGitignore` policy. The governing
   config directory is a hard upper boundary: its own and nested `.gitignore`
-  files apply, while parent `.gitignore` files do not. In automatic catalogs,
-  the staged walk records sources by owner and case-aware source identity,
-  orders them parent-before-child, and materializes the synthetic Git entry
-  before publishing. Direct automatically reachable child config directories
-  are downward ownership handoff boundaries.
+  files apply, while parent `.gitignore` files do not. In staged JS/TS catalogs,
+  the walk records sources by owner and case-aware source identity, orders them
+  parent-before-child, and materializes the synthetic Git entry before
+  publishing. Direct automatically reachable child config directories are
+  downward ownership handoff boundaries; an explicitly selected config remains
+  the fixed invocation-wide owner and never creates nested handoffs.
   Configs loaded only for explicit targets bound only their literal target
   chains, so adding a literal cannot truncate an ancestor-owned automatic
   target's `.gitignore` sources. This preserves ESLint v10's per-target global

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -247,6 +247,7 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 		configTargetScopes     map[string]rslintconfig.LintDiscoveryScope
 		catalogPlugins         []rslintconfig.EslintPluginEntry
 		pluginConfigDirByOwner map[string]string
+		configGitignoreFrozen  bool
 	)
 	if configDiscovery := req.ConfigDiscovery; configDiscovery != nil {
 		if requester == nil {
@@ -297,14 +298,25 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 		var catalog *discovery.ConfigCatalog
 		var err error
 		if configDiscovery.ExplicitConfigPath != "" {
+			var targetFiles []discovery.DiscoveryFile
+			if allowedFiles != nil {
+				targetFiles = make([]discovery.DiscoveryFile, 0, len(allowedFiles))
+				for _, filePath := range allowedFiles {
+					targetFiles = append(targetFiles, discovery.DiscoveryFile{
+						Path:          filePath,
+						CanonicalPath: canonicalPaths[exactFilesystemPathID(filePath)],
+					})
+				}
+			}
 			catalog, err = discovery.LoadExplicitConfig(
 				ctx,
 				fs,
 				loader,
 				discovery.ExplicitConfigRequest{
-					CWD:        currentDirectory,
-					ConfigPath: resolveRequestPath(configDiscovery.ExplicitConfigPath),
-					Fresh:      true,
+					CWD:         currentDirectory,
+					ConfigPath:  resolveRequestPath(configDiscovery.ExplicitConfigPath),
+					TargetFiles: targetFiles,
+					Fresh:       true,
 				},
 			)
 		} else {
@@ -333,6 +345,7 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 				configDirectory = configDirectories[0]
 				rslintConfig = append(rslintconfig.RslintConfig(nil), catalog.Configs[configDirectory]...)
 				pluginConfigDirByOwner = map[string]string{configDirectory: configDirectory}
+				configGitignoreFrozen = true
 			} else {
 				configMap = make(map[string]rslintconfig.RslintConfig, len(catalog.Configs))
 				pluginConfigDirByOwner = make(map[string]string, len(catalog.Configs))
@@ -357,7 +370,7 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 		catalogPlugins = catalog.EslintPlugins
 	}
 
-	if configMap == nil {
+	if configMap == nil && !configGitignoreFrozen {
 		rslintConfig = rslintconfig.ConfigWithGitignore(rslintConfig, configDirectory, fs, allowedFiles)
 	}
 	if messages := validateResolvedRuleOptions(configMap, rslintConfig); len(messages) > 0 {

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -1930,15 +1930,21 @@ func TestHandleLint_ConfigDiscoveryExplicitOnlyOwnerDoesNotBlockParentGitignore(
 	}
 }
 
-func TestHandleLint_ExplicitConfigGovernsTargetOutsideWorkingDirectory(t *testing.T) {
+func TestHandleLint_ExplicitConfigUsesOnlyWorkingDirectoryGitignore(t *testing.T) {
 	workingDirectory := t.TempDir()
 	targetDirectory := t.TempDir()
 	configPath := filepath.Join(workingDirectory, "custom.config.mjs")
 	targetPath := filepath.Join(targetDirectory, "outside.js")
+	insideIgnoredPath := filepath.Join(workingDirectory, "src/ignored.js")
 	writeProgramTestFiles(t, workingDirectory, map[string]string{
 		"custom.config.mjs": "export default [];\n",
+		".gitignore":        "src/ignored.js\n",
+		"src/ignored.js":    "debugger;\n",
 	})
 	if err := os.WriteFile(targetPath, []byte("debugger;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDirectory, ".gitignore"), []byte("outside.js\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1966,18 +1972,21 @@ func TestHandleLint_ExplicitConfigGovernsTargetOutsideWorkingDirectory(t *testin
 	})
 
 	response, err := (&IPCHandler{}).HandleLintWithContext(context.Background(), api.LintRequest{
-		Files:            []string{targetPath},
+		Files:            []string{targetPath, insideIgnoredPath},
 		WorkingDirectory: workingDirectory,
 		ConfigDiscovery: &api.ConfigDiscoveryRequest{
 			ExplicitConfigPath: configPath,
-			ExplicitFiles:      []bool{true},
+			ExplicitFiles:      []bool{true, true},
 		},
 	}, requester)
 	if err != nil {
 		t.Fatalf("HandleLintWithContext: %v", err)
 	}
-	if response.FileCount != 1 || len(response.Diagnostics) != 1 || response.Diagnostics[0].RuleName != "no-debugger" {
-		t.Fatalf("explicit config did not govern outside target: %+v", response)
+	if response.FileCount != 1 ||
+		len(response.Diagnostics) != 1 ||
+		response.Diagnostics[0].RuleName != "no-debugger" ||
+		filepath.Base(response.Diagnostics[0].FilePath) != "outside.js" {
+		t.Fatalf("explicit config Git projection crossed its working-directory boundary: %+v", response)
 	}
 }
 

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -659,19 +659,8 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			}
 			currentDirectory = configDirectories[0]
 			rslintConfig = slices.Clone(configCatalog.Configs[currentDirectory])
-
-			var exactTargetFiles []string
-			if len(allowFiles) > 0 && len(allowDirs) == 0 {
-				exactTargetFiles = allowFiles
-			}
-			if typeCheckOnly {
+			if buildAllPrograms {
 				realProgramSet, err = createProgramSetForConfig(currentDirectory, rslintConfig, singleThreaded, fs, parseCache)
-			} else if buildAllPrograms {
-				rslintConfig, realProgramSet, err = parallelGitignoreAndPrograms(
-					rslintConfig, currentDirectory, fs, exactTargetFiles, singleThreaded, parseCache,
-				)
-			} else {
-				rslintConfig = rslintconfig.ConfigWithGitignore(rslintConfig, currentDirectory, fs, exactTargetFiles)
 			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -433,6 +433,13 @@ func discoverCLIConfigCatalog(
 	loader := &ipcConfigModuleLoader{channel: channel}
 	var catalog *discovery.ConfigCatalog
 	if payload.ConfigDiscovery.ExplicitConfigPath != "" {
+		var targetFiles []discovery.DiscoveryFile
+		switch {
+		case args.TypeCheckOnly:
+			targetFiles = []discovery.DiscoveryFile{}
+		case len(args.AllowFiles) > 0 && len(args.AllowDirs) == 0:
+			targetFiles = append([]discovery.DiscoveryFile(nil), request.Files...)
+		}
 		catalog, err = discovery.LoadExplicitConfig(
 			ctx,
 			args.FS,
@@ -440,6 +447,7 @@ func discoverCLIConfigCatalog(
 			discovery.ExplicitConfigRequest{
 				CWD:            cwd,
 				ConfigPath:     payload.ConfigDiscovery.ExplicitConfigPath,
+				TargetFiles:    targetFiles,
 				SingleThreaded: args.SingleThreaded,
 			},
 		)

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -146,7 +146,8 @@ func createProgramSetForConfig(
 }
 
 // parallelGitignoreAndPrograms reads gitignore state and builds the Program
-// registry for an invocation-wide config (explicit JS/TS and JSON/JSONC).
+// registry for an invocation-wide JSON/JSONC config. Staged JS/TS catalogs
+// already contain their frozen Git projection before the lint pipeline starts.
 //
 // When singleThreaded is true, both run sequentially in the calling goroutine
 // — honoring the user's --singleThreaded flag (no concurrency at all).

--- a/internal/config/discovery/catalog.go
+++ b/internal/config/discovery/catalog.go
@@ -23,8 +23,11 @@ var AutoJSConfigFileNames = []string{
 }
 
 // DiscoveryFile is a file target that may participate in config discovery.
-// CanonicalPath is consulted only when the complete lexical ancestry contains
-// no config candidate.
+// CanonicalPath supplies an optional physical identity for path-space
+// resolution. Automatic ownership falls back to canonical ancestry only when
+// the complete lexical ancestry contains no candidate; fixed-owner exact Git
+// projection may use it directly to map the target into the owner's lexical
+// space.
 type DiscoveryFile struct {
 	Path          string
 	CanonicalPath string
@@ -57,8 +60,13 @@ type ConfigDiscoveryRequest struct {
 // automatic discovery, while absence of config discovery at the adapter means
 // the low-level/JSON path.
 type ExplicitConfigRequest struct {
-	CWD            string
-	ConfigPath     string
+	CWD        string
+	ConfigPath string
+	// TargetFiles limits Git projection to the directory chains between CWD
+	// and an exact target set. A nil slice projects the complete CWD-owned
+	// subtree; a non-nil empty slice projects nothing, as used by
+	// --type-check-only.
+	TargetFiles    []DiscoveryFile
 	Fresh          bool
 	SingleThreaded bool
 }
@@ -86,9 +94,10 @@ type ConfigDiscoveryStats struct {
 // ConfigCatalog is the deterministic snapshot produced by one build. Configs
 // contains only effective, successfully loaded ownership boundaries. Requested
 // failures remain in Failures/Stats; ignored or unreachable candidates are
-// omitted because their modules are never requested. Automatic catalogs freeze
-// each owner's observed Git projection into Configs before publication;
-// explicit catalogs leave invocation-scoped Git collection to their adapter.
+// omitted because their modules are never requested. Every staged catalog
+// freezes each owner's invocation-scoped Git projection into Configs before
+// publication, so automatic and explicit JS/TS adapters consume the same
+// finalized-config contract.
 type ConfigCatalog struct {
 	TransactionID      string
 	Configs            map[string]rslintconfig.RslintConfig
@@ -167,14 +176,17 @@ func DiscoverAutomatic(ctx context.Context, fsys vfs.FS, loader ConfigModuleLoad
 	return buildConfigCatalog(ctx, fsys, loader, request, "")
 }
 
-// LoadExplicitConfig loads one exact invocation-wide config path. Automatic
-// candidate discovery and Git reachability never participate in this operation.
+// LoadExplicitConfig loads one exact invocation-wide config path. Git
+// reachability never gates that exact source and automatic candidates are not
+// discovered. After the source loads, its invocation-scoped Git projection is
+// frozen into the returned catalog.
 func LoadExplicitConfig(ctx context.Context, fsys vfs.FS, loader ConfigModuleLoader, request ExplicitConfigRequest) (*ConfigCatalog, error) {
 	if request.ConfigPath == "" {
 		return nil, errors.New("explicit config discovery requires a config path")
 	}
 	automatic := ConfigDiscoveryRequest{
 		CWD:            request.CWD,
+		Files:          request.TargetFiles,
 		Fresh:          request.Fresh,
 		SingleThreaded: request.SingleThreaded,
 	}

--- a/internal/config/discovery/discovery.go
+++ b/internal/config/discovery/discovery.go
@@ -153,6 +153,9 @@ func (builder *configCatalogBuilder) build() (*ConfigCatalog, error) {
 		if err := builder.activate(state, false); err != nil {
 			return nil, err
 		}
+		if err := builder.projectExplicitConfigGitignore(state); err != nil {
+			return nil, err
+		}
 		return builder.catalog()
 	}
 
@@ -259,7 +262,7 @@ func (builder *configCatalogBuilder) build() (*ConfigCatalog, error) {
 		scope.Files = appendUniqueSortedPath(scope.Files, seed.path)
 		builder.scopes[seed.ownerDir] = scope
 	}
-	builder.collectExplicitSeedGitignore(explicitSeeds)
+	builder.collectExactTargetGitignore(explicitSeeds)
 
 	walkRoots := make([]discoveryWalkNode, 0, len(directorySeedByPath))
 	for _, directory := range directoryRoots {
@@ -286,6 +289,51 @@ func (builder *configCatalogBuilder) build() (*ConfigCatalog, error) {
 		return nil, builder.allConfigsFailedError()
 	}
 	return builder.catalog()
+}
+
+// projectExplicitConfigGitignore freezes the invocation-scoped Git projection
+// after the exact config has loaded. Config selection is already complete:
+// full-subtree projection uses the catalog's bounded parallel frontier with one
+// fixed owner, while exact targets reuse the source-chain path used by literal
+// automatic targets. Neither path performs automatic candidate discovery.
+func (builder *configCatalogBuilder) projectExplicitConfigGitignore(state *configLoadState) error {
+	if state == nil || state.failure != nil {
+		return nil
+	}
+	if builder.request.Files != nil {
+		files := builder.normalizedFiles()
+		seeds := make([]*discoverySeed, 0, len(files))
+		for _, file := range files {
+			seed := &discoverySeed{
+				path: rslintconfig.ResolveGitignoreCollectionPath(
+					file.Path,
+					file.CanonicalPath,
+					state.candidate.directory,
+					builder.fs,
+				),
+				ownerDir:  state.candidate.directory,
+				ownerPath: state.candidate.path,
+			}
+			seeds = append(seeds, seed)
+		}
+		builder.collectExactTargetGitignore(seeds)
+		return builder.ctx.Err()
+	}
+
+	root := state.candidate.directory
+	canonicalRoot := builder.fs.Realpath(root)
+	if discoveryPathsEqual(root, canonicalRoot, builder.fs.UseCaseSensitiveFileNames()) {
+		canonicalRoot = ""
+	}
+	return builder.walkDirectories([]discoveryWalkNode{{
+		directory:          root,
+		canonicalDirectory: canonicalRoot,
+		ownerDir:           root,
+		ownerPath:          state.candidate.path,
+		gitDirectory:       root,
+		gitCursor:          gitignore.NewCursor(root, builder.fs.UseCaseSensitiveFileNames()),
+		gitActive:          true,
+	}})
 }
 
 func (builder *configCatalogBuilder) normalizedDirectoryRoots() []string {
@@ -1058,27 +1106,29 @@ func (builder *configCatalogBuilder) processWalkNode(node discoveryWalkNode) dis
 	}
 	result := discoveryWalkResult{}
 
-	if candidate, found := builder.findCandidateForOwner(
-		node.directory,
-		node.ownerPath,
-		node.canonicalDirectory,
-	); found && candidate.directory != node.ownerDir {
-		result.discoveredCandidate = true
-		state, resolved := builder.loadStates[candidate.path]
-		if !resolved {
-			result.pending = &suspendedDiscoveryNode{node: node, candidate: candidate}
-			return result
-		}
-		if state.failure == nil {
-			result.activation = state
-			node.ownerDir = state.candidate.directory
-			node.ownerPath = state.candidate.path
-			node.gitCursor = gitignore.NewCursor(
-				state.candidate.directory,
-				builder.fs.UseCaseSensitiveFileNames(),
-			)
-			node.gitDirectory = state.candidate.directory
-			node.gitActive = true
+	if builder.explicitConfigPath == "" {
+		if candidate, found := builder.findCandidateForOwner(
+			node.directory,
+			node.ownerPath,
+			node.canonicalDirectory,
+		); found && candidate.directory != node.ownerDir {
+			result.discoveredCandidate = true
+			state, resolved := builder.loadStates[candidate.path]
+			if !resolved {
+				result.pending = &suspendedDiscoveryNode{node: node, candidate: candidate}
+				return result
+			}
+			if state.failure == nil {
+				result.activation = state
+				node.ownerDir = state.candidate.directory
+				node.ownerPath = state.candidate.path
+				node.gitCursor = gitignore.NewCursor(
+					state.candidate.directory,
+					builder.fs.UseCaseSensitiveFileNames(),
+				)
+				node.gitDirectory = state.candidate.directory
+				node.gitActive = true
+			}
 		}
 	}
 	result.directoriesVisited = 1
@@ -1315,12 +1365,13 @@ func splitDiscoveryPath(path string) []string {
 	return components
 }
 
-// collectExplicitSeedGitignore records the exact directory chain for a literal
-// target. Literal files bypass Git only while choosing their nearest config;
-// the resulting target still uses that config owner's ordinary Git ignores.
-// Keeping these observations source-scoped lets mixed directory+literal input
-// merge them with the automatic walk without duplicating parent patterns.
-func (builder *configCatalogBuilder) collectExplicitSeedGitignore(seeds []*discoverySeed) {
+// collectExactTargetGitignore records the exact directory chain for targets
+// whose owner is already known. Automatic literal files bypass Git only while
+// choosing their nearest config, while explicit-config targets start with their
+// fixed invocation-wide owner. Both still use that owner's ordinary Git
+// ignores. Keeping observations source-scoped lets exact chains merge with a
+// directory walk without duplicating parent patterns.
+func (builder *configCatalogBuilder) collectExactTargetGitignore(seeds []*discoverySeed) {
 	useCaseSensitive := builder.fs.UseCaseSensitiveFileNames()
 	cursorByOwnerAndDirectory := make(map[string]map[tspath.Path]gitignore.Cursor)
 	barrierByOwnerAndDirectory := make(map[string]map[tspath.Path]struct{})
@@ -1338,7 +1389,7 @@ func (builder *configCatalogBuilder) collectExplicitSeedGitignore(seeds []*disco
 			ownerBarriers = make(map[tspath.Path]struct{})
 			barrierByOwnerAndDirectory[seed.ownerDir] = ownerBarriers
 		}
-		builder.collectExplicitSeedGitignoreChain(
+		builder.collectExactTargetGitignoreChain(
 			seed,
 			ownerCursors,
 			ownerBarriers,
@@ -1347,7 +1398,7 @@ func (builder *configCatalogBuilder) collectExplicitSeedGitignore(seeds []*disco
 	}
 }
 
-func (builder *configCatalogBuilder) collectExplicitSeedGitignoreChain(
+func (builder *configCatalogBuilder) collectExactTargetGitignoreChain(
 	seed *discoverySeed,
 	cursorByDirectory map[tspath.Path]gitignore.Cursor,
 	barriers map[tspath.Path]struct{},
@@ -1509,9 +1560,7 @@ func (builder *configCatalogBuilder) catalog() (*ConfigCatalog, error) {
 	if err := builder.validateConfigDirectoryIdentities(); err != nil {
 		return nil, err
 	}
-	if builder.explicitConfigPath == "" {
-		builder.materializeGitignoreConfigs()
-	}
+	builder.materializeGitignoreConfigs()
 	// ExplicitOnly is derived from every activation path, not just from the
 	// explicit-file scope itself. Publish the final source value with the scope
 	// so target discovery can keep this config out of automatic ownership and

--- a/internal/config/discovery/discovery_test.go
+++ b/internal/config/discovery/discovery_test.go
@@ -1373,8 +1373,10 @@ func TestConfigDiscoveryBoundsExpandedTargetWalkToAncestorTrie(t *testing.T) {
 	})
 }
 
-func TestConfigDiscoveryExplicitConfigDoesNotConsultGitignore(t *testing.T) {
+func TestConfigDiscoveryExplicitConfigLoadsBeforeProjectingGitignore(t *testing.T) {
 	root := t.TempDir()
+	ignoredTarget := writeDiscoveryFixture(t, root, "ignored/index.ts", "export {};\n")
+	visibleTarget := writeDiscoveryFixture(t, root, "src/index.ts", "export {};\n")
 	writeDiscoveryFixture(t, root, ".gitignore", "ignored/\n")
 	loader := newFixtureConfigLoader()
 	configPath := writeConfigCandidate(t, root, "ignored/custom.config.cjs")
@@ -1401,6 +1403,307 @@ func TestConfigDiscoveryExplicitConfigDoesNotConsultGitignore(t *testing.T) {
 	}
 	if got := loader.batches[0].Candidates[0].ConfigDirectory; got != root {
 		t.Fatalf("wire configDirectory = %q, want cwd %q", got, root)
+	}
+	config := catalog.Configs[root]
+	if got := config.GetConfigForFile(ignoredTarget, root); got != nil {
+		t.Fatalf("Git-ignored target received explicit config: %+v", got)
+	}
+	if got := config.GetConfigForFile(visibleTarget, root); got == nil {
+		t.Fatal("visible target did not receive explicit config")
+	}
+}
+
+func TestConfigDiscoveryExplicitConfigDoesNotDiscoverNestedCandidates(t *testing.T) {
+	root := t.TempDir()
+	loader := newFixtureConfigLoader()
+	configPath := writeConfigCandidate(t, root, "custom.config.cjs")
+	nestedConfigPath := writeConfigCandidate(t, root, "nested/rslint.config.js")
+	loader.configs[configPath] = namedConfig("explicit")
+	loader.configs[nestedConfigPath] = namedConfig("must-not-load")
+	writeDiscoveryFixture(t, root, "nested/.gitignore", "generated.ts\n")
+	ignoredTarget := writeDiscoveryFixture(t, root, "nested/generated.ts", "export {};\n")
+
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		discoveryTestFS(),
+		loader,
+		ExplicitConfigRequest{CWD: root, ConfigPath: configPath},
+	)
+	if err != nil {
+		t.Fatalf("LoadExplicitConfig: %v", err)
+	}
+	if got := requestedConfigPaths(loader); !reflect.DeepEqual(got, []string{configPath}) {
+		t.Fatalf("explicit projection requested nested configs: %v", got)
+	}
+	root = tspath.NormalizePath(root)
+	if got := catalog.Configs[root].GetConfigForFile(ignoredTarget, root); got != nil {
+		t.Fatalf("nested Git-ignored target received explicit config: %+v", got)
+	}
+}
+
+func TestConfigDiscoveryExplicitConfigTargetFileProjection(t *testing.T) {
+	root := t.TempDir()
+	loader := newFixtureConfigLoader()
+	configPath := writeConfigCandidate(t, root, "custom.config.cjs")
+	loader.configs[configPath] = namedConfig("explicit")
+	target := writeDiscoveryFixture(t, root, "src/index.ts", "export {};\n")
+	writeDiscoveryFixture(t, root, "src/.gitignore", "index.ts\n")
+	writeDiscoveryFixture(t, root, "unrelated/.gitignore", "other.ts\n")
+
+	spyFS := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		spyFS,
+		loader,
+		ExplicitConfigRequest{
+			CWD:         root,
+			ConfigPath:  configPath,
+			TargetFiles: []DiscoveryFile{{Path: target}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("LoadExplicitConfig: %v", err)
+	}
+	root = tspath.NormalizePath(root)
+	if got := catalog.Configs[root].GetConfigForFile(target, root); got != nil {
+		t.Fatalf("target-chain Git ignore was not projected: %+v", got)
+	}
+	wantReads := []string{
+		tspath.CombinePaths(root, ".gitignore"),
+		tspath.CombinePaths(root, "src/.gitignore"),
+	}
+	if got := spyFS.gitignorePaths; !reflect.DeepEqual(got, wantReads) {
+		t.Fatalf("exact projection Git reads = %v, want %v", got, wantReads)
+	}
+}
+
+func TestConfigDiscoveryExplicitConfigTargetProjectionUsesConfigPathSpace(t *testing.T) {
+	physicalRoot := t.TempDir()
+	writeConfigCandidate(t, physicalRoot, "custom.config.cjs")
+	writeDiscoveryFixture(t, physicalRoot, ".gitignore", "src/index.ts\n")
+	physicalTarget := writeDiscoveryFixture(t, physicalRoot, "src/index.ts", "export {};\n")
+	aliasRoot := filepath.Join(t.TempDir(), "workspace-alias")
+	if err := os.Symlink(physicalRoot, aliasRoot); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	aliasRoot = tspath.NormalizePath(aliasRoot)
+	aliasTarget := tspath.CombinePaths(aliasRoot, "src/index.ts")
+	externalSpelling := writeDiscoveryFixture(t, t.TempDir(), "index.ts", "export {};\n")
+	canonicalTarget := discoveryTestFS().Realpath(physicalTarget)
+
+	for _, test := range []struct {
+		name      string
+		cwd       string
+		target    string
+		canonical string
+	}{
+		{name: "aliased CWD and physical target", cwd: aliasRoot, target: physicalTarget},
+		{name: "physical CWD and aliased target", cwd: physicalRoot, target: aliasTarget},
+		{
+			name:      "canonical target hint maps an external spelling",
+			cwd:       physicalRoot,
+			target:    externalSpelling,
+			canonical: canonicalTarget,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			configPath := tspath.CombinePaths(test.cwd, "custom.config.cjs")
+			loader := newFixtureConfigLoader()
+			loader.configs[configPath] = namedConfig("explicit")
+			spyFS := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+
+			catalog, err := LoadExplicitConfig(
+				context.Background(),
+				spyFS,
+				loader,
+				ExplicitConfigRequest{
+					CWD:        test.cwd,
+					ConfigPath: configPath,
+					TargetFiles: []DiscoveryFile{{
+						Path:          test.target,
+						CanonicalPath: test.canonical,
+					}},
+				},
+			)
+			if err != nil {
+				t.Fatalf("LoadExplicitConfig: %v", err)
+			}
+			cwd := tspath.NormalizePath(test.cwd)
+			matchFile, matchDir := rslintconfig.ResolveConfigPathSpaceWithCanonical(
+				test.target,
+				test.canonical,
+				cwd,
+				spyFS,
+			)
+			if got := catalog.Configs[cwd].GetConfigForFile(matchFile, matchDir); got != nil {
+				t.Fatalf(
+					"path-space Git ignore was not projected: config=%+v match=(%q,%q) reads=%v",
+					catalog.Configs[cwd],
+					matchFile,
+					matchDir,
+					spyFS.gitignorePaths,
+				)
+			}
+			wantReads := []string{
+				tspath.CombinePaths(cwd, ".gitignore"),
+				tspath.CombinePaths(cwd, "src/.gitignore"),
+			}
+			if got := spyFS.gitignorePaths; !reflect.DeepEqual(got, wantReads) {
+				t.Fatalf("path-space Git reads = %v, want %v", got, wantReads)
+			}
+		})
+	}
+}
+
+func TestConfigDiscoveryExplicitConfigEmptyTargetSetSkipsGitProjection(t *testing.T) {
+	root := t.TempDir()
+	loader := newFixtureConfigLoader()
+	configPath := writeConfigCandidate(t, root, "custom.config.cjs")
+	loader.configs[configPath] = namedConfig("explicit")
+	writeDiscoveryFixture(t, root, ".gitignore", "*.ts\n")
+
+	spyFS := &configDiscoveryReadSpyFS{FS: discoveryTestFS()}
+	catalog, err := LoadExplicitConfig(
+		context.Background(),
+		spyFS,
+		loader,
+		ExplicitConfigRequest{
+			CWD:         root,
+			ConfigPath:  configPath,
+			TargetFiles: []DiscoveryFile{},
+		},
+	)
+	if err != nil {
+		t.Fatalf("LoadExplicitConfig: %v", err)
+	}
+	if spyFS.gitignoreReads != 0 {
+		t.Fatalf("empty target projection read %d .gitignore files: %v", spyFS.gitignoreReads, spyFS.gitignorePaths)
+	}
+	root = tspath.NormalizePath(root)
+	if got := namedConfigEntry(catalog.Configs[root]).Name; got != "explicit" {
+		t.Fatalf("explicit config missing after empty projection: %q", got)
+	}
+}
+
+func TestConfigDiscoveryExplicitGitProjectionMatchesStandalonePolicy(t *testing.T) {
+	tests := []struct {
+		name          string
+		files         map[string]string
+		configIgnores []string
+		exactTargets  []string
+		exact         bool
+		check         []string
+	}{
+		{
+			name: "full nested sources and Git negation",
+			files: map[string]string{
+				".gitignore":              "*.generated.ts\n",
+				"src/.gitignore":          "ignored.ts\n!keep.generated.ts\n",
+				"src/index.ts":            "export {};\n",
+				"src/ignored.ts":          "export {};\n",
+				"src/drop.generated.ts":   "export {};\n",
+				"src/keep.generated.ts":   "export {};\n",
+				"other/keep.generated.ts": "export {};\n",
+			},
+			check: []string{
+				"src/index.ts",
+				"src/ignored.ts",
+				"src/drop.generated.ts",
+				"src/keep.generated.ts",
+				"other/keep.generated.ts",
+			},
+		},
+		{
+			name: "authored global negation after Git projection",
+			files: map[string]string{
+				".gitignore":    "dist/\n",
+				"dist/index.ts": "export {};\n",
+				"src/index.ts":  "export {};\n",
+			},
+			configIgnores: []string{"!dist/**"},
+			check:         []string{"dist/index.ts", "src/index.ts"},
+		},
+		{
+			name: "exact chains exclude unrelated sources",
+			files: map[string]string{
+				".gitignore":              "*.generated.ts\n",
+				"src/.gitignore":          "index.ts\n",
+				"src/index.ts":            "export {};\n",
+				"unrelated/.gitignore":    "index.ts\n",
+				"unrelated/index.ts":      "export {};\n",
+				"unrelated/generated.ts":  "export {};\n",
+				"outside-target/index.ts": "export {};\n",
+			},
+			exactTargets: []string{"src/index.ts"},
+			exact:        true,
+			check: []string{
+				"src/index.ts",
+				"unrelated/index.ts",
+				"unrelated/generated.ts",
+				"outside-target/index.ts",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			for relativePath, content := range test.files {
+				writeDiscoveryFixture(t, root, relativePath, content)
+			}
+			configPath := writeConfigCandidate(t, root, "custom.config.cjs")
+			entries := rslintconfig.RslintConfig{}
+			if test.configIgnores != nil {
+				entries = append(entries, rslintconfig.ConfigEntry{
+					Ignores: append([]string(nil), test.configIgnores...),
+				})
+			}
+			entries = append(entries, namedConfig("explicit")...)
+			loader := newFixtureConfigLoader()
+			loader.configs[configPath] = entries
+
+			var requestTargets []DiscoveryFile
+			var standaloneTargets []string
+			if test.exact {
+				requestTargets = make([]DiscoveryFile, 0, len(test.exactTargets))
+				standaloneTargets = make([]string, 0, len(test.exactTargets))
+				for _, relativePath := range test.exactTargets {
+					path := tspath.NormalizePath(filepath.Join(root, filepath.FromSlash(relativePath)))
+					requestTargets = append(requestTargets, DiscoveryFile{Path: path})
+					standaloneTargets = append(standaloneTargets, path)
+				}
+			}
+			fsys := discoveryTestFS()
+			catalog, err := LoadExplicitConfig(
+				context.Background(),
+				fsys,
+				loader,
+				ExplicitConfigRequest{
+					CWD:         root,
+					ConfigPath:  configPath,
+					TargetFiles: requestTargets,
+				},
+			)
+			if err != nil {
+				t.Fatalf("LoadExplicitConfig: %v", err)
+			}
+			root = tspath.NormalizePath(root)
+			projected := catalog.Configs[root]
+			standalone := rslintconfig.ConfigWithGitignore(entries, root, fsys, standaloneTargets)
+			for _, relativePath := range test.check {
+				path := tspath.NormalizePath(filepath.Join(root, filepath.FromSlash(relativePath)))
+				gotSelected := projected.GetConfigForFile(path, root) != nil
+				wantSelected := standalone.GetConfigForFile(path, root) != nil
+				if gotSelected != wantSelected {
+					t.Errorf(
+						"%s selected by staged projection = %t, standalone policy = %t",
+						relativePath,
+						gotSelected,
+						wantSelected,
+					)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/config/gitignore_config.go
+++ b/internal/config/gitignore_config.go
@@ -34,7 +34,7 @@ func ConfigWithGitignoreWithBoundaries(config RslintConfig, configDir string, fs
 	} else if fsys != nil && len(targetFiles) > 0 {
 		collectionFiles = make([]string, len(targetFiles))
 		for i, file := range targetFiles {
-			collectionFiles[i] = gitignoreCollectionFilePath(file, configDir, fsys)
+			collectionFiles[i] = ResolveGitignoreCollectionPath(file, "", configDir, fsys)
 		}
 	}
 	globs := gitignore.CollectWithBoundaries(configDir, fsys, collectionFiles, isDirectoryBlocked, stopDirs)
@@ -100,9 +100,12 @@ func parseCollectedGitignorePatterns(globs []string, caseInsensitive bool) []Ign
 	return patterns
 }
 
-func gitignoreCollectionFilePath(filePath string, configDir string, fsys vfs.FS) string {
+// ResolveGitignoreCollectionPath maps one exact target into the config root's
+// lexical path space. This keeps Git source lookup stable when the config root
+// and target use different symlink, casing, or canonical spellings.
+func ResolveGitignoreCollectionPath(filePath string, canonicalPath string, configDir string, fsys vfs.FS) string {
 	filePath = tspath.NormalizePath(filePath)
-	matchFile, matchDir := ResolveConfigPathSpace(filePath, configDir, fsys)
+	matchFile, matchDir := ResolveConfigPathSpaceWithCanonical(filePath, canonicalPath, configDir, fsys)
 	if relative, ok := RelativePathWithinConfigRoot(matchFile, matchDir, true); ok {
 		return tspath.ResolvePath(configDir, relative)
 	}

--- a/packages/rslint-test-tools/tests/cli/js-config/gitignore-integration.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/gitignore-integration.test.ts
@@ -555,6 +555,41 @@ describe('Gitignore: edge cases', () => {
     }
   });
 
+  test('explicit config projects nested gitignore without discovering nested configs', async () => {
+    const tempDir = await createTempDir({
+      'custom.config.mjs': CONFIG_NO_CONSOLE,
+      'nested/.gitignore': 'ignored.ts\n',
+      'nested/rslint.config.mjs': `
+        import { writeFileSync } from 'node:fs';
+        writeFileSync(new URL('./nested-config-loaded.marker', import.meta.url), 'loaded');
+        ${CONFIG_NO_CONSOLE}
+      `,
+      'nested/visible.ts': 'console.log("visible");\n',
+      'nested/ignored.ts': 'console.log("ignored");\n',
+    });
+    const marker = path.join(tempDir, 'nested/nested-config-loaded.marker');
+    try {
+      const result = await runRslint(
+        ['--config', 'custom.config.mjs', '--format', 'jsonline'],
+        tempDir,
+      );
+      const diagnostics = result.stdout
+        .trim()
+        .split('\n')
+        .filter((line) => line.trim().startsWith('{'))
+        .map((line) => JSON.parse(line) as Diagnostic);
+      expect(fs.existsSync(marker)).toBe(false);
+      expect(
+        diagsAt(diagnostics, 'nested/visible.ts').some(
+          (diagnostic) => diagnostic.ruleName === 'no-console',
+        ),
+      ).toBe(true);
+      expect(diagsAt(diagnostics, 'nested/ignored.ts')).toHaveLength(0);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   test('trailing whitespace in patterns is stripped', async () => {
     const { diagnostics, cleanup } = await lintJsonline({
       // Leading whitespace is significant in Git patterns. Exercise only


### PR DESCRIPTION
## Summary

- Freeze explicit JS/TS config `.gitignore` projection into the staged config catalog, reusing the existing bounded parallel directory frontier with the invocation CWD as the fixed owner.
- Keep the exact config source unconditional and structurally disable nested config probing during projection, preserving explicit flat-config semantics.
- Preserve the existing collection scopes:
  - no args / directory / mixed targets: full CWD projection
  - file-only targets: exact owner-to-target source chains
  - `--type-check-only`: no Git projection
- Share lexical/canonical target mapping with the standalone collector, and let CLI/API consume the finalized staged catalog without a second Gitignore sweep. JSON/JSONC, low-level API, and LSP fallback paths remain unchanged.
- Add focused coverage for nested configs, exact target chains, config/Git negations, symlink/canonical path spaces, API boundaries, and the CLI integration path.

Related follow-up: https://github.com/web-infra-dev/rslint/pull/1305

### Performance

Historical `0.7.0` and merged-#1305 baselines are reused from the previous verified run; they were not rerun. Only this branch's artifact was measured again.

Explicit `--config` wall-clock median:

| Repository | 0.7.0 (historical) | merged #1305 artifact (historical) | this branch | vs merged #1305 |
| --- | ---: | ---: | ---: | ---: |
| rsbuild | 1229.5 ms | 1180.0 ms | 1024.5 ms | -155.5 ms (-13.2%) |
| rspack | 787.5 ms | 717.0 ms | 611.0 ms | -106.0 ms (-14.8%) |

Candidate-only, same-run plain/explicit comparison (20 adjacent AB/BA pairs):

| Repository | plain median | explicit median | paired explicit - plain median (Q1, Q3) |
| --- | ---: | ---: | ---: |
| rsbuild | 1039.0 ms | 1024.5 ms | +7.0 ms (-27.5, +30.0) |
| rspack | 627.0 ms | 611.0 ms | +1.0 ms (-18.0, +35.25) |

The former explicit-config overhead is no longer distinguishable from noise.

Candidate-only type-check control (12 adjacent AB/BA pairs):

| Repository | automatic `--type-check` | explicit `--config --type-check` | paired explicit - automatic median (Q1, Q3) |
| --- | ---: | ---: | ---: |
| rsbuild | 1786.0 ms | 1718.5 ms | -42.5 ms (-120.5, +18.25) |
| rspack | 609.0 ms | 619.5 ms | +13.5 ms (-7.0, +41.0) |

There is no type-check regression signal. For every measured pair, normalized stdout, stderr, and exit codes matched. The explicit-config diagnostics also matched the previous verified artifact byte-for-byte after normalizing the summary timing. Both real repositories remained byte-for-byte unchanged, and no candidate process remained.

### Validation

- `go test ./internal/config/discovery -run 'TestConfigDiscoveryExplicit' -count=1`
- `go test ./internal/config/gitignore -run '^TestConfigWithGitignore_(SymlinkedConfigPathSpace|ExplicitTargetOutsideConfigTreeDoesNotReadExternalGitignore|ExplicitSkipsDescendantSymlinkSource)$' -count=1`
- focused `go test ./cmd/rslint` coverage for config discovery and explicit Gitignore behavior
- focused Rstest coverage for ignored explicit config loading and nested Gitignore projection
- `pnpm check-spell`
- `pnpm format:check`
- `golangci-lint run ./cmd/rslint ./internal/config ./internal/config/discovery`

No full repository test suite was run.

## Related Links

- https://github.com/web-infra-dev/rslint/pull/1305

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
