### PR TITLE
fix: triple-slash-reference false positives on lookalike text in strings/templates

### DIFF
--- a/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.go
+++ b/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.go
@@ -58,30 +58,35 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		}
 	}
 
-	// Get the full text of the source file
 	text := ctx.SourceFile.Text()
-
-	// Split into lines to check for triple-slash references
-	lines := strings.Split(text, "\n")
 
 	// Check if file has imports
 	hasImport := hasImportStatements(ctx.SourceFile)
 
-	for lineNum, line := range lines {
-		trimmed := strings.TrimSpace(line)
+	// Only real single-line comment tokens can be triple-slash directives, so
+	// this walks the linter's precomputed comment list instead of scanning
+	// raw source text/lines. That avoids matching text that merely looks like
+	// a reference comment inside a string, template literal, or block comment.
+	for _, comment := range ctx.Comments.All() {
+		if comment.Kind != ast.KindSingleLineCommentTrivia {
+			continue
+		}
+		if comment.Pos() < 0 || comment.End() > len(text) {
+			continue
+		}
 
-		// Check if this is a triple-slash reference
-		if !tripleSlashRegex.MatchString(trimmed) {
+		commentText := text[comment.Pos():comment.End()]
+		if !tripleSlashRegex.MatchString(commentText) {
 			continue
 		}
 
 		// Determine the type of reference
 		var refType string
-		if strings.Contains(trimmed, `path=`) {
+		if strings.Contains(commentText, `path=`) {
 			refType = "path"
-		} else if strings.Contains(trimmed, `types=`) {
+		} else if strings.Contains(commentText, `types=`) {
 			refType = "types"
-		} else if strings.Contains(trimmed, `lib=`) {
+		} else if strings.Contains(commentText, `lib=`) {
 			refType = "lib"
 		}
 
@@ -97,14 +102,8 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		}
 
 		if shouldReport {
-			// Calculate position (approximate - this is simplified)
-			pos := 0
-			for i := range lineNum {
-				pos += len(lines[i]) + 1 // +1 for newline
-			}
-
 			ctx.ReportRange(
-				core.NewTextRange(pos, pos+len(line)),
+				core.NewTextRange(comment.Pos(), comment.End()),
 				rule.RuleMessage{
 					Id:          "tripleSlashReference",
 					Description: "Do not use a triple slash reference for " + refType + ", use `import` style instead.",

--- a/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference_test.go
+++ b/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference_test.go
@@ -62,6 +62,47 @@ import * as foo from 'foo';
 					"types": "never",
 				},
 			},
+			// Reference-directive-looking text inside a multi-line block comment
+			{
+				Code: `
+/*
+/// <reference types="foo" />
+*/
+import * as foo from 'foo';
+`,
+				Options: map[string]interface{}{
+					"lib":   "never",
+					"path":  "never",
+					"types": "never",
+				},
+			},
+			// Reference-directive-looking text inside a template literal (not a real comment)
+			{
+				Code: "const content = `/// <reference types=\"foo\" />`;\nimport * as foo from 'foo';\n",
+				Options: map[string]interface{}{
+					"lib":   "never",
+					"path":  "never",
+					"types": "never",
+				},
+			},
+			// Reference-directive-looking text inside a tagged template literal
+			{
+				Code: "const content = dedent`/// <reference types=\"foo\" />`;\nimport * as foo from 'foo';\n",
+				Options: map[string]interface{}{
+					"lib":   "never",
+					"path":  "never",
+					"types": "never",
+				},
+			},
+			// Reference-directive-looking text inside a regular string literal
+			{
+				Code: `const content = '/// <reference path="foo" />';`,
+				Options: map[string]interface{}{
+					"lib":   "never",
+					"path":  "never",
+					"types": "never",
+				},
+			},
 		},
 		[]rule_tester.InvalidTestCase{
 			// Triple-slash types with prefer-import (ES6 import)
@@ -114,6 +155,21 @@ import * as foo from 'foo';
 				Code: `/// <reference lib="foo" />`,
 				Options: map[string]interface{}{
 					"lib": "never",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "tripleSlashReference",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			// A real triple-slash reference is still reported when a lookalike
+			// string literal appears elsewhere in the same file.
+			{
+				Code: "/// <reference path=\"foo\" />\nconst content = '/// <reference path=\"bar\" />';\n",
+				Options: map[string]interface{}{
+					"path": "never",
 				},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{


### PR DESCRIPTION
## Summary

Fix `@typescript-eslint/triple-slash-reference` false positives, reported against text inside string/template literals that merely looks like a reference directive.

| Case | Expected | rslint before fix |
| --- | ---: | ---: |
| Real `/// <reference .../>` comment | 1 error | 1 error |
| Lookalike text inside a template literal (e.g. `` dedent`/// <reference types="pkg"/>...` ``) | 0 errors | 1 error (false positive) |
| Lookalike text inside a regular string literal | 0 errors | 1 error (false positive) |
| Lookalike text inside a multi-line `/* ... */` block comment | 0 errors | 1 error (false positive) |
| Real directive + lookalike string elsewhere in the same file | 1 error | 2 errors (false positive) |

Root cause: the rule scanned the whole file's raw text line-by-line with a regex instead of checking actual comment tokens, so any line whose trimmed text happened to start with `/// <reference ...=` was flagged regardless of whether it was really a comment. Now it iterates `ctx.Comments.All()` and only considers real single-line comment tokens, matching the pattern already used by `ban-tslint-comment`.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).