### PR TITLE
fix: no-unused-vars false positives on loop/closure self-referencing accumulators

### DIFF
--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -254,10 +254,45 @@ func hasAssignment(definition *ast.Node, sym *ast.Symbol, writeRefs map[*ast.Sym
 	return false
 }
 
+// isInsideLoop checks whether node is lexically inside a loop construct (for,
+// for-in, for-of, while, do-while) without crossing a function boundary first.
+// Mirrors ESLint's astUtils.isInLoop, used to decide whether a self-referencing
+// accumulator assignment (`x = f(x)` inside a loop) can still be observed on a
+// later iteration — and so counts as a real use rather than self-modification.
+func isInsideLoop(node *ast.Node) bool {
+	for current := node; current != nil && !ast.IsFunctionLike(current); current = current.Parent {
+		switch current.Kind {
+		case ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement,
+			ast.KindWhileStatement, ast.KindDoStatement:
+			return true
+		}
+	}
+	return false
+}
+
+// nearestVariableScope returns the nearest enclosing function-like node containing
+// node, or nil if node sits at the top level (module/global scope). Blocks don't
+// introduce a new variable scope, matching escope's notion of a "variable scope".
+func nearestVariableScope(node *ast.Node) *ast.Node {
+	for current := node.Parent; current != nil; current = current.Parent {
+		if ast.IsFunctionLike(current) {
+			return current
+		}
+	}
+	return nil
+}
+
 // isSelfModifyingReference checks if a read reference to a variable is ONLY
 // used to modify the same variable, with the result not used elsewhere.
 // Examples: `a = a + 1;`, `a++;`, `a += 1;` (as statements, not sub-expressions).
-func isSelfModifyingReference(node *ast.Node, sym *ast.Symbol, checker *checker.Checker) bool {
+//
+// declNode anchors the variable's own declaration site. A self-referencing
+// assignment (`x = f(x)`) does NOT count as self-modification — i.e. it IS a
+// real use — when the assignment happens in a different function scope than
+// the declaration, or inside a loop: the written value can be observed later
+// (a closure capturing it, or the next loop iteration), so it's a genuine
+// read-modify-write accumulator rather than a discarded self-reference.
+func isSelfModifyingReference(node *ast.Node, sym *ast.Symbol, checker *checker.Checker, declNode *ast.Node) bool {
 	if node == nil || node.Parent == nil {
 		return false
 	}
@@ -309,6 +344,9 @@ func isSelfModifyingReference(node *ast.Node, sym *ast.Symbol, checker *checker.
 			if bin != nil && ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
 				lhsSym := checker.GetSymbolAtLocation(bin.Left)
 				if lhsSym == sym {
+					if declNode != nil && (nearestVariableScope(p) != nearestVariableScope(declNode) || isInsideLoop(p)) {
+						return false
+					}
 					return isUnusedExpression(p)
 				}
 				break
@@ -1696,7 +1734,7 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 			filteredUsages := []*ast.Node{}
 			for _, usage := range usageNodes {
 				if usage.Pos() != varInfo.Variable.Pos() &&
-					!isSelfModifyingReference(usage, sym, ctx.TypeChecker) &&
+					!isSelfModifyingReference(usage, sym, ctx.TypeChecker, nameNode) &&
 					!isInsideAnyOwnDeclaration(usage, allDecls) {
 					filteredUsages = append(filteredUsages, usage)
 				}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_assignments_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_assignments_test.go
@@ -88,6 +88,39 @@ for (var prop in box) {
 		{Code: `let a: any = null; a ??= 1; console.log(a);`},
 		{Code: `let a: any = ""; a ||= "default"; console.log(a);`},
 		{Code: `let a: any = true; a &&= false; console.log(a);`},
+
+		// --- accumulator pattern: self-referencing assignment inside a loop is a
+		// real use, since the value can be observed on the next iteration ---
+		{Code: `
+let x: any = 0;
+for (let i = 0; i < 10; i++) {
+  x = foo(x);
+}
+`},
+		{Code: `
+let x: any = 0;
+for (const item of [1, 2, 3]) {
+  x = foo(x, item);
+}
+`},
+
+		// --- accumulator pattern: self-referencing assignment inside a nested
+		// closure is a real use, since the value can be observed after the
+		// closure runs (e.g. read by another call, or captured state) ---
+		{Code: `
+let x: any = 0;
+function run() {
+  x = foo(x);
+}
+run();
+`},
+		{Code: `
+let found: any = false;
+declare function forEachItem(cb: (item: any) => void): void;
+forEachItem(item => {
+  found = found || item;
+});
+`},
 	}
 
 	invalidTestCases := []rule_tester.InvalidTestCase{
@@ -349,6 +382,25 @@ let x = null;
 x = foo(x);
 `,
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 3, Column: 1}},
+		},
+		// self-referencing logical assignment, same scope, no loop: still self-modifying
+		{
+			Code: `
+let x: any = false;
+x = x || true;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 3, Column: 1}},
+		},
+		// self-referencing accumulator, same function scope, no loop: still self-modifying
+		{
+			Code: `
+function run() {
+  let x: any = 0;
+  x = foo(x);
+}
+run();
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 4, Column: 3}},
 		},
 
 		// --- sequence expression: self-modification (comma operator) ---

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -144,6 +144,7 @@ errchkjson
 errgroup
 errrr
 esbuild
+escope
 ESLint
 esmodule
 espree


### PR DESCRIPTION
## Summary

Fix `@typescript-eslint/no-unused-vars` false positives on the read-modify-write accumulator pattern (`x = f(..., x, ...)`), verified against upstream ESLint (v10.7.0 + `@typescript-eslint` v8.59.0, matching this repo's own toolchain in packages/rslint-test-tools).

`isSelfModifyingReference` treated any read of `x` inside `x = f(...x...)` as self-modifying purely by AST shape, regardless of *where* the assignment lives. Upstream only excludes such reads when the assignment is in the same function scope as the declaration and not inside a loop — otherwise the accumulated value can be observed later (next loop iteration, or after the closure runs), so it's a real use. Found via false positives in TypeScript's own compiler source (`pollIndex` in sys.ts, `serialized` in watchUtils.ts, `inheritedIndentation` in formatting.ts, `importedFileFromNodeModules` in moduleSpecifiers.ts).

| Case | Upstream ESLint | rslint before fix |
| --- | ---: | ---: |
| `for (...) { x = f(x); }` (loop accumulator) | 0 errors | 1 error (false positive) |
| `for (const item of ...) { x = f(x, item); }` | 0 errors | 1 error (false positive) |
| `function run() { x = f(x); } run();` (closure accumulator) | 0 errors | 1 error (false positive) |
| `cb(item => { found = found \|\| item; })` (closure, logical self-ref) | 0 errors | 1 error (false positive) |
| `x = x \|\| true;` (same scope, no loop — unaffected) | 1 error | 1 error (unchanged) |
| `function run() { let x = 0; x = f(x); }` (same scope, no loop — unaffected) | 1 error | 1 error (unchanged) |

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
