### PR TITLE
fix: no-constant-binary-expression false positive on ?? over ||/&& chains

### DIFF
--- a/internal/rules/no_constant_binary_expression/no_constant_binary_expression.go
+++ b/internal/rules/no_constant_binary_expression/no_constant_binary_expression.go
@@ -622,6 +622,12 @@ func hasConstantNullishness(ctx *rule.RuleContext, node *ast.Node, nonNullish bo
 			return hasConstantNullishness(ctx, binary.Right, true)
 		}
 
+		// Logical && / ||: mirrors upstream ESLint, which only special-cases ??
+		// here and treats any other logical operator as not constant nullishness.
+		if op == ast.KindBarBarToken || op == ast.KindAmpersandAmpersandToken {
+			return false
+		}
+
 		// Comma: check last expression
 		if op == ast.KindCommaToken {
 			return hasConstantNullishness(ctx, binary.Right, nonNullish)
@@ -642,7 +648,7 @@ func hasConstantNullishness(ctx *rule.RuleContext, node *ast.Node, nonNullish bo
 			return true
 		}
 
-		// All remaining binary operators (comparison, arithmetic, bitwise, instanceof, in)
+		// All remaining binary operators (comparison, instanceof, in)
 		// produce non-nullish values (numbers, booleans, or strings)
 		return true
 

--- a/internal/rules/no_constant_binary_expression/no_constant_binary_expression_test.go
+++ b/internal/rules/no_constant_binary_expression/no_constant_binary_expression_test.go
@@ -47,6 +47,18 @@ func TestNoConstantBinaryExpressionRule(t *testing.T) {
 			// --- Nullish coalescing edge cases ---
 			{Code: `foo ?? null ?? bar`},
 
+			// --- ?? over a ||/&& chain: never constant, matching upstream ESLint,
+			// which only special-cases the "??" operator in hasConstantNullishness
+			// and treats any other logical operator as not constant, regardless of
+			// operands (regression: this used to fall through to "always
+			// non-nullish" for any &&/|| operator) ---
+			{Code: `(a || b || c) ?? fallback`},
+			{Code: `(a && b) ?? fallback`},
+			{Code: `(a && b.x) ?? fallback`},
+			{Code: `((a || b) && (c || d)) ?? fallback`},
+			{Code: `(a || b || "literal") ?? fallback`},
+			{Code: `(String(x) && Number(x)) ?? fallback`},
+
 			// --- Shadowed built-in functions ---
 			{Code: `function Boolean(n: any) { return n; } Boolean(x) ?? foo`},
 			{Code: `function Boolean(n: any) { return n; } Boolean(x) && foo`},

--- a/packages/rslint-test-tools/tests/eslint/rules/no-constant-binary-expression.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-constant-binary-expression.test.ts
@@ -34,6 +34,17 @@ ruleTester.run('no-constant-binary-expression', {
     // --- Nullish coalescing edge cases ---
     'foo ?? null ?? bar',
 
+    // --- ?? over a ||/&& chain: never constant, matching upstream ESLint,
+    // which only special-cases the "??" operator in hasConstantNullishness
+    // and treats any other logical operator as not constant, regardless of
+    // operands ---
+    '(a || b || c) ?? fallback',
+    '(a && b) ?? fallback',
+    '(a && b.x) ?? fallback',
+    '((a || b) && (c || d)) ?? fallback',
+    '(a || b || "literal") ?? fallback',
+    '(String(x) && Number(x)) ?? fallback',
+
     // --- Shadowed built-in functions ---
     'function Boolean(n: any) { return n; } Boolean(x) ?? foo',
     'function Boolean(n: any) { return n; } Boolean(x) && foo',


### PR DESCRIPTION
## Summary

Fix `no-constant-binary-expression` false positives, verified against upstream ESLint (v10.6.0).

| Case | Upstream ESLint | rslint before fix |
| --- | ---: | ---: |
| `(a \|\| b \|\| c) ?? fallback` | 0 errors | 1 error (false positive) |
| `(a && b) ?? fallback` | 0 errors | 1 error (false positive) |
| `(a && b.x) ?? fallback` | 0 errors | 1 error (false positive) |
| `((a \|\| b) && (c \|\| d)) ?? fallback` | 0 errors | 1 error (false positive) |
| `(a \|\| b \|\| "literal") ?? fallback` | 0 errors | 1 error (false positive) |
| `(String(x) && Number(x)) ?? fallback` | 0 errors | 1 error (false positive) |

`hasConstantNullishness` had no explicit case for `&&`/`||`, so any such expression fell through to the catch-all `return true` meant only for comparison/instanceof/in operators. This made any `?? ` whose left operand was a multi-operand `||`/`&&` chain (e.g. `(a || b || c) ?? fallback`) get flagged as redundant, even when each operand is independently optional.

Fixed to match upstream ESLint, which only special-cases the `??` operator in this check and treats any other logical operator as not having constant nullishness, regardless of its operands.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).