### PR TITLE
fix: naming-convention false positive on type-only signature parameters

### DIFF
--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.go
@@ -1696,6 +1696,14 @@ func getIdentifiersFromFunctionExpression(node *ast.Node) []identifierInfo {
 }
 
 func getIdentifiersFromParameter(ctx rule.RuleContext, node *ast.Node) []identifierInfo {
+	// Parameters of type-only signatures (function types, call/construct/method
+	// signatures, index signatures, ...) create no binding, so real
+	// @typescript-eslint/naming-convention never validates their names. Only
+	// parameters of an actual function-like declaration/expression are checked.
+	if !ast.IsFunctionLikeDeclaration(node.Parent) {
+		return nil
+	}
+
 	// Check if this is a parameter property (constructor parameter with access modifier, readonly, or override)
 	isParamProp := ast.IsParameterPropertyDeclaration(node, node.Parent)
 

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
@@ -174,6 +174,66 @@ func TestNamingConventionRule(t *testing.T) {
 		// Parameter
 		{Code: `function fn(myParam: string) {}`},
 
+		// Regression: parameter names inside type-only signatures create no
+		// binding, so the "parameter" selector must not validate them — matches
+		// the real-world false positive where `System` in
+		// `as (System: any, ...globalArgs: any[]) => void` (a cast, not a real
+		// function declaration) was incorrectly flagged.
+		{
+			Code: `const evaluateThunk = (0, eval)("") as (System: any, ...globalArgs: any[]) => void;`,
+			Options: []interface{}{
+				map[string]interface{}{
+					"selector": "parameter",
+					"format":   []interface{}{"camelCase"},
+				},
+			},
+		},
+		{
+			Code: `type Cast = (System: any) => void;`,
+			Options: []interface{}{
+				map[string]interface{}{
+					"selector": "parameter",
+					"format":   []interface{}{"camelCase"},
+				},
+			},
+		},
+		{
+			Code: `interface Foo { method(System: any): void; }`,
+			Options: []interface{}{
+				map[string]interface{}{
+					"selector": "parameter",
+					"format":   []interface{}{"camelCase"},
+				},
+			},
+		},
+		{
+			Code: `interface Foo { (System: any): void; }`,
+			Options: []interface{}{
+				map[string]interface{}{
+					"selector": "parameter",
+					"format":   []interface{}{"camelCase"},
+				},
+			},
+		},
+		{
+			Code: `interface Foo { new (System: any): void; }`,
+			Options: []interface{}{
+				map[string]interface{}{
+					"selector": "parameter",
+					"format":   []interface{}{"camelCase"},
+				},
+			},
+		},
+		{
+			Code: `interface Foo { [System: string]: any; }`,
+			Options: []interface{}{
+				map[string]interface{}{
+					"selector": "parameter",
+					"format":   []interface{}{"camelCase"},
+				},
+			},
+		},
+
 		// Destructured variable
 		{
 			Code: `const { myProp } = ({} as any);`,

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/naming-convention/naming-convention.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/naming-convention/naming-convention.test.ts
@@ -2378,6 +2378,36 @@ ruleTester.run('naming-convention', {
         },
       ],
     },
+
+    // Regression: parameter names inside type-only signatures create no
+    // binding, so the `parameter` selector must not validate them — matches
+    // the real-world false positive where `System` in
+    // `as (System: any, ...globalArgs: any[]) => void` (a cast, not a real
+    // function declaration) was incorrectly flagged.
+    {
+      code: 'const evaluateThunk = (0, eval)("") as (System: any, ...globalArgs: any[]) => void;',
+      options: [{ format: ['camelCase'], selector: 'parameter' }],
+    },
+    {
+      code: 'type Cast = (System: any) => void;',
+      options: [{ format: ['camelCase'], selector: 'parameter' }],
+    },
+    {
+      code: 'interface Foo { method(System: any): void; }',
+      options: [{ format: ['camelCase'], selector: 'parameter' }],
+    },
+    {
+      code: 'interface Foo { (System: any): void; }',
+      options: [{ format: ['camelCase'], selector: 'parameter' }],
+    },
+    {
+      code: 'interface Foo { new (System: any): void; }',
+      options: [{ format: ['camelCase'], selector: 'parameter' }],
+    },
+    {
+      code: 'interface Foo { [System: string]: any; }',
+      options: [{ format: ['camelCase'], selector: 'parameter' }],
+    },
   ],
 });
 


### PR DESCRIPTION
## Summary

Fix `naming-convention` false positives on parameter names inside type-only signatures, verified against upstream ESLint 10.5.0 + `@typescript-eslint/eslint-plugin` 8.62.0.

Parameters of function types, call/construct/method signatures, and index signatures create no binding, so real `@typescript-eslint/naming-convention` never validates their names — it only checks parameters of `FunctionDeclaration`/`FunctionExpression`/`ArrowFunctionExpression`/etc. rslint's reimplementation applied the `parameter` selector unconditionally to every `ast.KindParameter` node regardless of its parent, so a name like `System` in `as (System: any, ...globalArgs: any[]) => void` (a cast, not a real function declaration) was incorrectly flagged.

| Case | Upstream ESLint | rslint before fix |
| --- | ---: | ---: |
| Cast: `x as (System: any, ...globalArgs: any[]) => void` | 0 errors | 1 error (false positive) |
| Function-type alias: `type Cast = (System: any) => void` | 0 errors | 1 error (false positive) |
| Interface method signature: `{ method(System: any): void }` | 0 errors | 1 error (false positive) |
| Interface call signature: `{ (System: any): void }` | 0 errors | 1 error (false positive) |
| Interface construct signature: `{ new (System: any): void }` | 0 errors | 1 error (false positive) |
| Interface index signature: `{ [System: string]: any }` | 0 errors | 1 error (false positive) |
| Real function: `function fn(System: any) {}` | 1 error | 1 error (unchanged, still flagged) |

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).