### PR TITLE
perf: prefilter identifiers before checker lookup in no-var reference collection

### DIFF
--- a/internal/rules/no_var/no_var.go
+++ b/internal/rules/no_var/no_var.go
@@ -383,11 +383,16 @@ func findBlockScope(node *ast.Node) *ast.Node {
 }
 
 // collectReferences walks the enclosing scope and collects all identifier references
-// to any of the given variables, grouped by symbol.
+// to any of the given variables, grouped by symbol. Identifiers are pre-filtered by
+// name and by position before consulting the checker: GetSymbolAtLocation is expensive
+// (it can trigger lazy type checking of whole expressions), and for a top-level var the
+// scope is the entire file.
 func collectReferences(scope *ast.Node, vars []varInfo, ctx *rule.RuleContext) map[*ast.Symbol][]*ast.Node {
 	symSet := make(map[*ast.Symbol]bool, len(vars))
+	nameSet := make(map[string]bool, len(vars))
 	for _, v := range vars {
 		symSet[v.sym] = true
+		nameSet[v.nameNode.Text()] = true
 	}
 
 	result := make(map[*ast.Symbol][]*ast.Node)
@@ -396,13 +401,13 @@ func collectReferences(scope *ast.Node, vars []varInfo, ctx *rule.RuleContext) m
 		if n == nil {
 			return
 		}
-		if n.Kind == ast.KindIdentifier {
+		// Skip declaration names (never counted as references) and positions that
+		// can never be a variable reference, e.g. the `b` in `a.b` or `{b: x}`.
+		if n.Kind == ast.KindIdentifier && nameSet[n.Text()] &&
+			!ast.IsDeclarationName(n) && !isNonReferencePosition(n) {
 			sym := ctx.TypeChecker.GetSymbolAtLocation(n)
 			if sym != nil && symSet[sym] {
-				// Skip if this is the declaration name itself
-				if !ast.IsDeclarationName(n) {
-					result[sym] = append(result[sym], n)
-				}
+				result[sym] = append(result[sym], n)
 			}
 		}
 		n.ForEachChild(func(child *ast.Node) bool {
@@ -412,6 +417,27 @@ func collectReferences(scope *ast.Node, vars []varInfo, ctx *rule.RuleContext) m
 	}
 	walk(scope)
 	return result
+}
+
+// isNonReferencePosition reports whether an identifier occupies a position that can
+// never reference a variable: the name of a property access / qualified name, or a
+// property name in an object literal / destructuring pattern.
+func isNonReferencePosition(n *ast.Node) bool {
+	p := n.Parent
+	if p == nil {
+		return false
+	}
+	switch p.Kind {
+	case ast.KindPropertyAccessExpression:
+		return p.AsPropertyAccessExpression().Name() == n
+	case ast.KindQualifiedName:
+		return p.AsQualifiedName().Right == n
+	case ast.KindPropertyAssignment:
+		return p.AsPropertyAssignment().Name() == n
+	case ast.KindBindingElement:
+		return p.AsBindingElement().PropertyName == n
+	}
+	return false
 }
 
 type varInfo struct {


### PR DESCRIPTION
## Summary

- `no-var`'s `collectReferences` walked the entire enclosing scope (the whole file for top-level `var`s) and called `checker.GetSymbolAtLocation` on **every identifier** to find references to the declared variables — O(declarations × file size) checker calls. Each failed lookup could also trigger the checker's spelling-suggestion path (`levenshteinWithMax`), and lookups on property-access names triggered lazy type checking of whole expressions.
- Now the walk consults the checker only for identifiers that can actually be a reference:
  - text matches one of the declared variable names;
  - not a declaration name;
  - not in a position that can never reference a variable (property access name `a.b`, qualified name right side, object-literal property name, destructuring property name).
- Behavior-preserving: name/position mismatches could never pass the existing symbol-set check; they were pure wasted checker work.

## Benchmark

Linting the TypeScript repo (v6.0.3, 746 files, 152 rules, fully type-aware via `parserOptions.project`) once before/after on a 22-core machine — `checker.ts` (3 MB, hundreds of top-level `var`s) is the worst-case input for the old code path:

| | before | after |
|---|---|---|
| wall time | 13.7s | **5.8s** |
| Go CPU profile samples | 29.26s | 19.23s |
| `GetSymbolAtLocation` CPU attributed to `no_var.collectReferences` | 7.8s | ~0 (gone from the caller list) |

The remaining `no-var` cost is ~1.2s of pure AST walking. The win exceeds the 7.8s direct attribution because eliminating the failed lookups also removes the spelling-suggestion (levenshtein) and lazy type-checking work they cascaded into.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required) — behavior-preserving; existing `internal/rules/no_var` test suite passes unchanged.
- [x] Documentation updated (or not required).
