### PR TITLE
perf: prefilter identifiers before checker lookup in no-unused-vars usage collection

### DIFF
--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -1439,14 +1439,24 @@ func isPropertyNameLikePosition(node *ast.Node) bool {
 //   - unresolvedRefs: maps identifier text to nodes where GetSymbolAtLocation returns nil
 //
 // After the walk, it calls markJsxFactoryUsed to handle JSX factory implicit usage.
+//
+// The maps are only ever queried for symbols (and, for unresolvedRefs, names) of
+// declarations the rule's listeners process, and any reference resolving to such a
+// symbol is an identifier with the same text as the declared name. So identifiers
+// whose text matches no candidate declaration name are skipped without consulting
+// the checker — GetSymbolAtLocation is expensive (property accesses trigger lazy
+// type checking of the whole expression; failed resolutions trigger spelling
+// suggestions), and most identifiers in a file don't refer to checked declarations.
 func collectSymbolUsages(ctx rule.RuleContext, sourceFile *ast.Node, usages map[*ast.Symbol][]*ast.Node, writeRefs map[*ast.Symbol][]*ast.Node, unresolvedRefs map[string][]*ast.Node) {
+	candidateNames := collectCandidateNames(sourceFile)
+
 	var walk func(*ast.Node)
 	walk = func(node *ast.Node) {
 		if node == nil {
 			return
 		}
 
-		if ast.IsIdentifier(node) && !isDeclarationName(node) {
+		if ast.IsIdentifier(node) && !isDeclarationName(node) && candidateNames[node.AsIdentifier().Text] {
 			// Track write-only references separately for report position.
 			// Simple assignments (=) are write-only and don't count as usage.
 			if isPartOfAssignment(node) {
@@ -1460,16 +1470,13 @@ func collectSymbolUsages(ctx rule.RuleContext, sourceFile *ast.Node, usages map[
 				})
 				return
 			}
+			sym := ctx.TypeChecker.GetSymbolAtLocation(node)
 			// Compound assignments (+=, -=, etc.) and update expressions (++, --)
 			// are both read and write. Track as writeRef for report position,
-			// but don't return early — the node is still recorded as a usage below.
-			if isCompoundAssignmentTarget(node) || isUpdateTarget(node) {
-				sym := ctx.TypeChecker.GetSymbolAtLocation(node)
-				if sym != nil {
-					writeRefs[sym] = append(writeRefs[sym], node)
-				}
+			// and still record the node as a usage below.
+			if sym != nil && (isCompoundAssignmentTarget(node) || isUpdateTarget(node)) {
+				writeRefs[sym] = append(writeRefs[sym], node)
 			}
-			sym := ctx.TypeChecker.GetSymbolAtLocation(node)
 			if sym != nil {
 				// Store usage under both the original symbol and the resolved alias.
 				// This ensures import specifiers match correctly: the declaration site
@@ -1526,6 +1533,46 @@ func collectSymbolUsages(ctx rule.RuleContext, sourceFile *ast.Node, usages map[
 	// matching @typescript-eslint/parser's `jsxPragma` behavior (the factory
 	// is considered used whenever the file contains JSX, in any runtime).
 	markJsxFactoryUsed(ctx, sourceFile, usages)
+}
+
+// collectCandidateNames walks the source file and gathers the name texts of every
+// declaration kind the rule's listeners process (variables, parameters, functions,
+// classes, interfaces, type aliases, enums, namespaces, type parameters, and all
+// import forms). Only identifiers matching one of these names can ever resolve to
+// a symbol the rule queries, so collectSymbolUsages uses this set to pre-filter
+// before calling into the checker.
+func collectCandidateNames(sourceFile *ast.Node) map[string]bool {
+	names := make(map[string]bool)
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		switch node.Kind {
+		case ast.KindVariableDeclaration:
+			// Covers catch clause variables and destructuring patterns.
+			utils.CollectBindingNames(node.AsVariableDeclaration().Name(), func(_ *ast.Node, name string) {
+				names[name] = true
+			})
+		case ast.KindParameter:
+			utils.CollectBindingNames(node.AsParameterDeclaration().Name(), func(_ *ast.Node, name string) {
+				names[name] = true
+			})
+		case ast.KindFunctionDeclaration, ast.KindClassDeclaration, ast.KindInterfaceDeclaration,
+			ast.KindTypeAliasDeclaration, ast.KindEnumDeclaration, ast.KindModuleDeclaration,
+			ast.KindTypeParameter, ast.KindImportSpecifier, ast.KindImportClause,
+			ast.KindNamespaceImport, ast.KindImportEqualsDeclaration:
+			if name := node.Name(); name != nil && ast.IsIdentifier(name) {
+				names[name.AsIdentifier().Text] = true
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(sourceFile)
+	return names
 }
 
 // markJsxFactoryUsed checks if the source file contains JSX and, if so, marks


### PR DESCRIPTION
## Summary

Stacked on #1321 (same fix pattern, next rule from the same profile).

- `no-unused-vars`'s `collectSymbolUsages` walked the entire source file and called `checker.GetSymbolAtLocation` on **every identifier** to build its usage/write-reference maps. Most identifiers in a file never refer to a declaration the rule checks, and each wasted lookup could cascade into lazy type checking (property accesses) or alias resolution.
- Now `collectCandidateNames` first gathers, in one pure-syntax pass, the name texts of every declaration kind the rule processes (variables incl. destructuring/catch, parameters, functions, classes, interfaces, type aliases, enums, namespaces, type parameters, all import forms). The usage walk then consults the checker only for identifiers whose text matches a candidate name.
- Correctness: the maps are only ever queried for symbols (or, for the `unresolvedRefs` fallback, names) of those processed declarations, and any reference resolving to such a symbol is an identifier with the same text as the declared name — so skipped identifiers could never have contributed a queryable entry.
- Also merges the duplicated back-to-back `GetSymbolAtLocation` calls for compound-assignment/update targets into one.

## Benchmark

Linting the TypeScript repo (v6.0.3, 746 files, 152 rules, fully type-aware) on a 22-core machine, measured on top of #1321:

| | before | after |
|---|---|---|
| `GetSymbolAtLocation` CPU attributed to `no_unused_vars.collectSymbolUsages` | 3.16s | **1.76s** (−44%) |
| wall time | 5.8s | 5.9s (unchanged) |

Wall time doesn't move yet: a profile diff shows much of the eliminated cost was *first-touch lazy checker work* (property-access checking, import alias resolution, spelling suggestions) that is now paid by the next caller (`prefer-const` +0.5s, `naming-convention`). Those two rules have the same brute-force pattern and are queued for the same fix; the wall-time win lands once no rule triggers these lazy paths.

## Related Links

- #1321

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required) — behavior-preserving; existing `no_unused_vars` test suite passes unchanged.
- [x] Documentation updated (or not required).
