### PR TITLE
perf: skip naming-convention reference collection unless a selector checks unused

### DIFF
--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.go
@@ -114,11 +114,12 @@ const (
 	selectorMemberLike   = selectorClassProperty | selectorObjectLiteralProperty | selectorTypeProperty |
 		selectorParameterProperty | selectorEnumMember | selectorClassMethod | selectorObjectLiteralMethod |
 		selectorTypeMethod | selectorClassicAccessor | selectorAutoAccessor
-	selectorTypeLike = selectorClass | selectorInterface | selectorTypeAlias | selectorEnum | selectorTypeParameter
-	selectorMethod   = selectorClassMethod | selectorObjectLiteralMethod | selectorTypeMethod
-	selectorProperty = selectorClassProperty | selectorObjectLiteralProperty | selectorTypeProperty
-	selectorAccessor = selectorClassicAccessor | selectorAutoAccessor
-	selectorDefault  = selectorVariableLike | selectorMemberLike | selectorTypeLike | selectorImport
+	selectorTypeLike        = selectorClass | selectorInterface | selectorTypeAlias | selectorEnum | selectorTypeParameter
+	selectorMethod          = selectorClassMethod | selectorObjectLiteralMethod | selectorTypeMethod
+	selectorProperty        = selectorClassProperty | selectorObjectLiteralProperty | selectorTypeProperty
+	selectorAccessor        = selectorClassicAccessor | selectorAutoAccessor
+	selectorDefault         = selectorVariableLike | selectorMemberLike | selectorTypeLike | selectorImport
+	selectorUnusedSupported = selectorVariableLike | selectorTypeLike
 )
 
 func parseSelectorKind(s string) (selectorKind, bool) {
@@ -1236,10 +1237,11 @@ func getModifiers(ctx rule.RuleContext, node *ast.Node, nameNode *ast.Node, sel 
 		mods |= modifierDestructured
 	}
 
-	// Unused check - exported symbols are never considered unused.
+	// Unused check - exported symbols are never considered unused, and only
+	// scope-participating declarations (not members or imports) can be unused.
 	// Use nameNode (the specific identifier) for symbol lookup, not the declaration node,
 	// so that individual destructured bindings are correctly detected as unused.
-	if mods&modifierExported == 0 && isUnusedByNameNode(ctx, nameNode, refInfo) {
+	if sel&selectorUnusedSupported != 0 && mods&modifierExported == 0 && isUnusedByNameNode(ctx, nameNode, refInfo) {
 		mods |= modifierUnused
 	}
 

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.go
@@ -1359,12 +1359,49 @@ type referencedInfo struct {
 	shorthandNames map[string]bool // names used in shorthand property assignments
 }
 
+// needsUnusedInfo reports whether any selector checks the "unused" modifier.
+// Only then is the referenced-symbols collection needed — isUnusedByNameNode
+// treats a nil referencedInfo as "not unused", and the unused bit in the
+// computed modifiers is only ever consumed by selectors that require it.
+func needsUnusedInfo(selectors []normalizedSelector) bool {
+	for _, sel := range selectors {
+		if sel.modifiers&modifierUnused != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // collectReferencedSymbols walks the source file and collects all symbols that are referenced
 // (i.e., used in a non-declaration context). This is used to detect the "unused" modifier.
+//
+// The symbol set is only ever queried for symbols of declaration names in this file,
+// and any reference resolving to such a symbol is an identifier with the same text as
+// the declared name. So the walk first gathers all declaration-name texts in one
+// pure-syntax pass, then consults the checker only for identifiers matching one of
+// them — GetSymbolAtLocation is expensive (property accesses trigger lazy type
+// checking; failed resolutions trigger spelling suggestions).
 func collectReferencedSymbols(ctx rule.RuleContext) *referencedInfo {
 	if ctx.TypeChecker == nil {
 		return nil
 	}
+
+	declNames := make(map[string]bool)
+	var collectDeclNames func(node *ast.Node)
+	collectDeclNames = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node.Kind == ast.KindIdentifier && node.Parent != nil &&
+			ast.GetNameOfDeclaration(node.Parent) == node {
+			declNames[node.AsIdentifier().Text] = true
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			collectDeclNames(child)
+			return false
+		})
+	}
+	collectDeclNames(&ctx.SourceFile.Node)
 
 	info := &referencedInfo{
 		symbols:        make(map[*ast.Symbol]bool),
@@ -1379,7 +1416,7 @@ func collectReferencedSymbols(ctx rule.RuleContext) *referencedInfo {
 		if node.Kind == ast.KindIdentifier {
 			parent := node.Parent
 			isDeclarationName := parent != nil && ast.GetNameOfDeclaration(parent) == node
-			if !isDeclarationName {
+			if !isDeclarationName && declNames[node.AsIdentifier().Text] {
 				sym := ctx.TypeChecker.GetSymbolAtLocation(node)
 				if sym != nil {
 					info.symbols[sym] = true
@@ -2116,7 +2153,10 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 	}
 
 	reExportedNames := collectReExportedNames(ctx)
-	refInfo := collectReferencedSymbols(ctx)
+	var refInfo *referencedInfo
+	if needsUnusedInfo(selectors) {
+		refInfo = collectReferencedSymbols(ctx)
+	}
 
 	handleNode := func(node *ast.Node) {
 		identifiers := getIdentifierFromNode(ctx, node)

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
@@ -297,6 +297,25 @@ func TestNamingConventionRule(t *testing.T) {
 			},
 		},
 
+		// Unused modifier never applies to members: a type property read via
+		// property access must keep the base format, and even an unreferenced
+		// member stays on the base format (typescript-eslint only computes
+		// `unused` for scope-participating declarations).
+		{
+			Code: "type foo_type = {\n  used_prop: string;\n  extra_prop: number;\n};\nexport declare const foo_var: foo_type;\nexport const prop_value = foo_var.used_prop;",
+			Options: []interface{}{
+				map[string]interface{}{
+					"format":   []interface{}{"snake_case"},
+					"selector": "default",
+				},
+				map[string]interface{}{
+					"format":    []interface{}{"PascalCase"},
+					"modifiers": []interface{}{"unused"},
+					"selector":  "default",
+				},
+			},
+		},
+
 		// A `filter` on an earlier, less-specific selector (memberLike) must
 		// not defeat a later, more specific selector (property) that has no
 		// filter at all — the more specific selector should still win.
@@ -318,6 +337,27 @@ func TestNamingConventionRule(t *testing.T) {
 			},
 		},
 	}, []rule_tester.InvalidTestCase{
+		// Members never get the `unused` modifier: an unreferenced type
+		// property is still checked against the base format, not the
+		// unused override.
+		{
+			Code: "export type foo_type = {\n  ExtraProp: string;\n};",
+			Options: []interface{}{
+				map[string]interface{}{
+					"format":   []interface{}{"snake_case"},
+					"selector": "default",
+				},
+				map[string]interface{}{
+					"format":    []interface{}{"PascalCase"},
+					"modifiers": []interface{}{"unused"},
+					"selector":  "default",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "doesNotMatchFormat", Line: 2, Column: 3},
+			},
+		},
+
 		// Variable violating camelCase
 		{
 			Code: `const my_variable = 1;`,


### PR DESCRIPTION
## Summary

Stacked on #1322 (same profile, next rule).

- `naming-convention`'s `collectReferencedSymbols` walked the entire source file calling `checker.GetSymbolAtLocation` on every non-declaration identifier — but its result is only ever consumed by the `unused` modifier check (`isUnusedByNameNode`, which already treats a nil `referencedInfo` as "not unused").
- Now `needsUnusedInfo` checks the normalized selectors first: if no selector requires the `unused` modifier (the common case — e.g. the TypeScript repo's config has none), the collection is skipped entirely.
- When a selector does need it, the walk pre-filters like #1321/#1322: one pure-syntax pass gathers all declaration-name texts, then only identifiers matching one of them consult the checker. The symbol set is only queried for symbols of declaration names in this file, and any reference resolving to such a symbol shares the declared name's text, so skipped identifiers could never contribute a queryable entry.

## Benchmark

Linting the TypeScript repo (v6.0.3, 746 files, 152 rules, fully type-aware) on a 22-core machine, measured on top of #1322:

| | before | after |
|---|---|---|
| `GetSymbolAtLocation` CPU attributed to `naming_convention.collectReferencedSymbols` | 2.85s | **0** (gone from the caller list) |
| wall time | 5.9s | **5.45s** |
| Go CPU profile samples | 19.27s | 18.05s |

## Fixed false positives

Also fixes a pre-existing `unused` modifier false positive (present on main, not introduced by the prefilter): the `unused` modifier was computed for every selector, but typescript-eslint only computes it for scope-participating declarations (variable, function, parameter, class, interface, typeAlias, enum, typeParameter) — never for members or imports. Since the reference collector skips property-access name positions, members could look permanently unreferenced and picked up `unused`-only overrides. Found with:

```jsonc
[
  { "selector": "default", "format": ["snake_case"] },
  { "selector": "default", "modifiers": ["unused"], "format": ["PascalCase"] }
]
```

- ``Type Property name `used_prop` must match one of the following formats: PascalCase`` — reported on a type property that is read via `foo_var.used_prop`.

Now `unused` is gated to the scope-participating selectors above. Verified against ESLint 10.6.0 + typescript-eslint 8.62.1: a used or unreferenced member keeps the base format (`snake_case`) and never matches the `unused` override.

## Related Links

- #1321, #1322

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required) — behavior-preserving; existing `naming_convention` suite (which covers the `unused` modifier, exercising both paths) passes unchanged.
- [x] Documentation updated (or not required).

