### PR TITLE
perf: prefilter identifiers before checker lookup in prefer-const write scans

### DIFF
--- a/internal/rules/prefer_const/prefer_const.go
+++ b/internal/rules/prefer_const/prefer_const.go
@@ -267,9 +267,11 @@ func countWriteReferences(sym *ast.Symbol, declName string, declNode *ast.Node, 
 			return
 		}
 
-		if n.Kind == ast.KindIdentifier && !isPartOfDeclaration(n, declNode) {
-			refSym := ctx.TypeChecker.GetSymbolAtLocation(n)
-			if refSym == sym && utils.IsWriteReference(n) {
+		// Cheap syntax checks (name match, write position) come first so the
+		// expensive checker lookup only runs for genuine write candidates.
+		if n.Kind == ast.KindIdentifier && n.Text() == declName &&
+			utils.IsWriteReference(n) && !isPartOfDeclaration(n, declNode) {
+			if ctx.TypeChecker.GetSymbolAtLocation(n) == sym {
 				count++
 			}
 		}
@@ -340,8 +342,10 @@ func isReadBeforeFirstAssign(sym *ast.Symbol, declName string, declNode *ast.Nod
 			return done
 		}
 
-		// After declaration, check for reads and writes
-		if n.Kind == ast.KindIdentifier {
+		// After declaration, check for reads and writes. Only identifiers with
+		// the declared name can resolve to the target symbol — skip the rest
+		// without consulting the checker.
+		if n.Kind == ast.KindIdentifier && n.Text() == declName {
 			refSym := ctx.TypeChecker.GetSymbolAtLocation(n)
 			if refSym == sym {
 				if utils.IsWriteReference(n) {
@@ -475,9 +479,9 @@ func findWriteInSameBlock(sym *ast.Symbol, declName string, declNode *ast.Node, 
 			return
 		}
 
-		if n.Kind == ast.KindIdentifier && !isPartOfDeclaration(n, declNode) {
-			refSym := ctx.TypeChecker.GetSymbolAtLocation(n)
-			if refSym == sym && utils.IsWriteReference(n) {
+		if n.Kind == ast.KindIdentifier && n.Text() == declName &&
+			utils.IsWriteReference(n) && !isPartOfDeclaration(n, declNode) {
+			if ctx.TypeChecker.GetSymbolAtLocation(n) == sym {
 				writeNode = n
 				return
 			}


### PR DESCRIPTION
## Summary

Stacked on #1324 — last of the four brute-force reference-collection rules from the same profile (see #1321).

- `prefer-const`'s `countWriteReferences` and `findWriteInSameBlock` walked the enclosing scope calling `checker.GetSymbolAtLocation` on every identifier before checking anything else. Now the cheap syntax checks come first — name match and `utils.IsWriteReference` (write positions are rare) — so the checker lookup only runs for genuine write candidates. This mirrors the existing `countWritesBySym` in the same file, which already checks name and write position before resolving.
- `isReadBeforeFirstAssign` gets the name pre-filter too (it needs read references, so no write-position condition).

## Benchmark

Linting the TypeScript repo (v6.0.3, 746 files, 152 rules, fully type-aware) on a 22-core machine, measured on top of #1324:

| | before | after |
|---|---|---|
| `GetSymbolAtLocation` CPU attributed to `prefer_const` | 1.63s | **0.02s** |
| wall time | 5.45s | **5.23s** |
| Go CPU profile samples | 18.05s | 17.31s |

Cumulative for the whole stack (#1321 → this PR): wall time 13.7s → 5.23s, Go CPU 29.3s → 17.3s on this benchmark.

## Related Links

- #1321, #1322, #1324

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required) — behavior-preserving; existing `prefer_const` suite passes unchanged.
- [x] Documentation updated (or not required).
