### PR TITLE
fix(tsgo): record import module specifier symbols

### DIFF
--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -181,6 +181,18 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 			End:          nodePositionMap.UTF8ToUTF16(node.End()),
 		}
 	}
+	isImportModuleSpecifier := func(node *ast.Node) bool {
+		if node == nil || node.Parent == nil {
+			return false
+		}
+		switch node.Parent.Kind {
+		case ast.KindImportDeclaration, ast.KindJSImportDeclaration, ast.KindExportDeclaration:
+			moduleSpecifier := node.Parent.ModuleSpecifier()
+			return moduleSpecifier != nil && moduleSpecifier.AsNode() == node
+		default:
+			return false
+		}
+	}
 
 	recordType := func(ty *checker.Type) checker.TypeId {
 		if ty == nil {
@@ -239,11 +251,9 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 			}
 
 			if symbol := tc.GetSymbolAtLocation(node); symbol != nil {
-
 				if ty := tc.GetTypeOfSymbol(symbol); ty != nil {
 					typeID := recordType(ty)
 					sym_id := ast.GetSymbolId(symbol)
-
 					declRef := nodeReference(symbol.ValueDeclaration)
 
 					semantic.Symtab[sym_id] = SymbolInfo{
@@ -254,7 +264,7 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 						Decl:       declRef,
 					}
 					semantic.Sym2type[sym_id] = typeID
-					(semantic.Node2sym)[key] = sym_id
+					semantic.Node2sym[key] = sym_id
 					semantic.Node2type[key] = typeID
 
 					// Resolve alias symbol if this is an alias
@@ -266,9 +276,19 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 							}
 						}
 					}
+				} else if isImportModuleSpecifier(node) {
+					sym_id := ast.GetSymbolId(symbol)
+					declRef := nodeReference(symbol.ValueDeclaration)
 
+					semantic.Symtab[sym_id] = SymbolInfo{
+						Id:         sym_id,
+						Name:       sanitizeSymbolName(symbol.Name),
+						Flags:      int(symbol.Flags),
+						CheckFlags: int(symbol.CheckFlags),
+						Decl:       declRef,
+					}
+					semantic.Node2sym[key] = sym_id
 				}
-
 			}
 
 			// Collect shorthand assignment value symbol


### PR DESCRIPTION
## Summary

Side-effect imports such as import "./side-effect.js" have no import binding, so rslim depends on the module specifier symbol to discover the target module. TypeScript's checker returns an external module symbol for that string literal, but the semantic collector only recorded symbols when GetTypeOfSymbol returned a type. External module symbols can have no ordinary value type, so node2sym missed the import edge.

Keep the existing type-backed symbol path unchanged, and only allow import/export module specifier nodes to be recorded without a type. This gives consumers the symbol declaration module while avoiding broad exposure of no-type symbols to downstream sym2type users.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
