### PR TITLE
feat(react-hooks): declare options JSON Schema for react-hooks/ rules

### DIFF
--- a/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
+++ b/internal/plugins/react_hooks/react_hooksutil/react_hooksutil.go
@@ -841,10 +841,10 @@ func IsInsideComponentOrHook(node *ast.Node) bool {
 	return false
 }
 
-// AdditionalHooksFromSettings reads
-// `settings['react-hooks'].<key>` (typically `additionalHooks` for
-// exhaustive-deps, or `additionalEffectHooks` for rules-of-hooks)
-// and compiles it as a regex. Returns nil when the setting is absent
+// AdditionalHooksFromSettings reads `settings['react-hooks'].<key>`
+// (`additionalEffectHooks`, the key upstream's shared
+// getAdditionalEffectHooksFromSettings uses for both rules) and
+// compiles it as a regex. Returns nil when the setting is absent
 // or the pattern fails to compile — mirroring upstream's lenient
 // behavior of silently ignoring malformed regex strings.
 func AdditionalHooksFromSettings(settings map[string]interface{}, key string) *regexp.Regexp {

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
@@ -372,27 +372,27 @@ type Options struct {
 
 // parseOptions parses the rule's options object.
 func parseOptions(options []any, settings map[string]interface{}) Options {
-	opts := Options{}
-	var optsMap map[string]interface{}
-	if len(options) > 0 {
-		optsMap, _ = options[0].(map[string]interface{})
+	opts := Options{
+		AutoDepsHooks:   map[string]bool{},
+		AdditionalHooks: react_hooksutil.AdditionalHooksFromSettings(settings, "additionalEffectHooks"),
 	}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]interface{})
 	opts.EnableDangerousAutofixThisMayCauseInfiniteLoops, _ = optsMap["enableDangerousAutofixThisMayCauseInfiniteLoops"].(bool)
 	opts.RequireExplicitEffectDeps, _ = optsMap["requireExplicitEffectDeps"].(bool)
-	opts.AutoDepsHooks = map[string]bool{}
 	for _, h := range utils.ToStringSlice(optsMap["experimental_autoDependenciesHooks"]) {
 		opts.AutoDepsHooks[h] = true
 	}
 	// Mirrors upstream's `rawOptions.additionalHooks` truthiness check: a
-	// non-empty rule-level pattern wins (even when it fails to compile —
-	// no settings fallback then); an absent or empty one falls back to
-	// `settings['react-hooks'].additionalHooks` via react_hooksutil.
+	// non-empty rule-level pattern replaces the settings fallback even when
+	// it fails to compile; absent or empty keeps the settings-derived value.
 	if raw, _ := optsMap["additionalHooks"].(string); raw != "" {
+		opts.AdditionalHooks = nil
 		if re, err := regexp.Compile(raw); err == nil {
 			opts.AdditionalHooks = re
 		}
-	} else {
-		opts.AdditionalHooks = react_hooksutil.AdditionalHooksFromSettings(settings, "additionalHooks")
 	}
 	return opts
 }

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
@@ -377,40 +377,21 @@ func parseOptions(options []any, settings map[string]interface{}) Options {
 	if len(options) > 0 {
 		optsMap, _ = options[0].(map[string]interface{})
 	}
-	// `addlSet` tracks whether the rule-level `additionalHooks` field was
-	// PRESENT in options (even as empty string). Mirrors upstream's
-	// `rawOptions.additionalHooks` truthiness check — falsy values fall
-	// back to the settings entry, so we record presence here and only
-	// fall back when the rule-level option is absent or empty.
-	addlSet := false
-	if optsMap != nil {
-		if raw, ok := optsMap["additionalHooks"].(string); ok {
-			addlSet = raw != ""
-			if raw != "" {
-				if re, err := regexp.Compile(raw); err == nil {
-					opts.AdditionalHooks = re
-				}
-			}
-		}
-		if v, ok := optsMap["enableDangerousAutofixThisMayCauseInfiniteLoops"].(bool); ok {
-			opts.EnableDangerousAutofixThisMayCauseInfiniteLoops = v
-		}
-		if v, ok := optsMap["requireExplicitEffectDeps"].(bool); ok {
-			opts.RequireExplicitEffectDeps = v
-		}
-		if raw, ok := optsMap["experimental_autoDependenciesHooks"].([]interface{}); ok {
-			opts.AutoDepsHooks = map[string]bool{}
-			for _, item := range raw {
-				if s, ok := item.(string); ok {
-					opts.AutoDepsHooks[s] = true
-				}
-			}
-		}
+	opts.EnableDangerousAutofixThisMayCauseInfiniteLoops, _ = optsMap["enableDangerousAutofixThisMayCauseInfiniteLoops"].(bool)
+	opts.RequireExplicitEffectDeps, _ = optsMap["requireExplicitEffectDeps"].(bool)
+	opts.AutoDepsHooks = map[string]bool{}
+	for _, h := range utils.ToStringSlice(optsMap["experimental_autoDependenciesHooks"]) {
+		opts.AutoDepsHooks[h] = true
 	}
-	// Settings fallback for additionalHooks (matches upstream's
-	// `getAdditionalEffectHooksFromSettings`, but only when the rule-level
-	// option is absent OR empty). Delegates to react_hooksutil.
-	if !addlSet && opts.AdditionalHooks == nil {
+	// Mirrors upstream's `rawOptions.additionalHooks` truthiness check: a
+	// non-empty rule-level pattern wins (even when it fails to compile —
+	// no settings fallback then); an absent or empty one falls back to
+	// `settings['react-hooks'].additionalHooks` via react_hooksutil.
+	if raw, _ := optsMap["additionalHooks"].(string); raw != "" {
+		if re, err := regexp.Compile(raw); err == nil {
+			opts.AdditionalHooks = re
+		}
+	} else {
 		opts.AdditionalHooks = react_hooksutil.AdditionalHooksFromSettings(settings, "additionalHooks")
 	}
 	return opts

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.go
@@ -370,11 +370,13 @@ type Options struct {
 	AutoDepsHooks map[string]bool
 }
 
-// parseOptions parses the rule's options object. Both array and bare-object
-// shapes are supported via `utils.GetOptionsMap`.
-func parseOptions(options any, settings map[string]interface{}) Options {
+// parseOptions parses the rule's options object.
+func parseOptions(options []any, settings map[string]interface{}) Options {
 	opts := Options{}
-	optsMap := utils.GetOptionsMap(options)
+	var optsMap map[string]interface{}
+	if len(options) > 0 {
+		optsMap, _ = options[0].(map[string]interface{})
+	}
 	// `addlSet` tracks whether the rule-level `additionalHooks` field was
 	// PRESENT in options (even as empty string). Mirrors upstream's
 	// `rawOptions.additionalHooks` truthiness check — falsy values fall

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.md
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.md
@@ -104,7 +104,7 @@ The rule accepts a single options object:
   bare-identifier callees — `Foo.useBar` and `React.useBar` are NOT
   matched even if the identifier suffix is in the regex (mirrors
   upstream's `node === calleeNode` gate). Falls back to
-  `settings['react-hooks'].additionalHooks` when omitted or empty.
+  `settings['react-hooks'].additionalEffectHooks` when omitted or empty.
   ```json
   { "react-hooks/exhaustive-deps": ["error", { "additionalHooks": "(useMyEffect|useAsync)" }] }
   ```

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.schema.json
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.schema.json
@@ -1,0 +1,29 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "enableDangerousAutofixThisMayCauseInfiniteLoops": false,
+      "properties": {
+        "additionalHooks": {
+          "type": "string"
+        },
+        "enableDangerousAutofixThisMayCauseInfiniteLoops": {
+          "type": "boolean"
+        },
+        "experimental_autoDependenciesHooks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requireExplicitEffectDeps": {
+          "type": "boolean"
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.schema.json
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.schema.json
@@ -4,22 +4,26 @@
     {
       "type": "object",
       "additionalProperties": false,
-      "enableDangerousAutofixThisMayCauseInfiniteLoops": false,
       "properties": {
         "additionalHooks": {
-          "type": "string"
+          "type": "string",
+          "format": "regex",
+          "default": ""
         },
         "enableDangerousAutofixThisMayCauseInfiniteLoops": {
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "experimental_autoDependenciesHooks": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "default": []
         },
         "requireExplicitEffectDeps": {
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.schema.json
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps.schema.json
@@ -7,23 +7,19 @@
       "properties": {
         "additionalHooks": {
           "type": "string",
-          "format": "regex",
-          "default": ""
+          "format": "regex"
         },
         "enableDangerousAutofixThisMayCauseInfiniteLoops": {
-          "type": "boolean",
-          "default": false
+          "type": "boolean"
         },
         "experimental_autoDependenciesHooks": {
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "default": []
+          }
         },
         "requireExplicitEffectDeps": {
-          "type": "boolean",
-          "default": false
+          "type": "boolean"
         }
       }
     }

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_boundary_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_boundary_test.go
@@ -202,7 +202,7 @@ var boundaryInvalid = []rule_tester.InvalidTestCase{
 		`,
 		Tsx:      true,
 		Options:  map[string]interface{}{"additionalHooks": ""},
-		Settings: map[string]interface{}{"react-hooks": map[string]interface{}{"additionalHooks": "(useTracked)"}},
+		Settings: map[string]interface{}{"react-hooks": map[string]interface{}{"additionalEffectHooks": "(useTracked)"}},
 		Errors: []rule_tester.InvalidTestCaseError{
 			{
 				Message: "React Hook useTracked has a missing dependency: 'id'. Either include it or remove the dependency array.",

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_extras_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_extras_test.go
@@ -268,7 +268,7 @@ var extrasValid = []rule_tester.ValidTestCase{
 			}
 		`,
 		Tsx:      true,
-		Settings: map[string]interface{}{"react-hooks": map[string]interface{}{"additionalHooks": "(useTrackedEffect)"}},
+		Settings: map[string]interface{}{"react-hooks": map[string]interface{}{"additionalEffectHooks": "(useTrackedEffect)"}},
 	},
 
 	// Lock-in: `Namespace.useFoo` is NOT recognized as a hook by the
@@ -494,7 +494,7 @@ var extrasInvalid = []rule_tester.InvalidTestCase{
 			}
 		`,
 		Tsx:      true,
-		Settings: map[string]interface{}{"react-hooks": map[string]interface{}{"additionalHooks": "(useTrackedEffect)"}},
+		Settings: map[string]interface{}{"react-hooks": map[string]interface{}{"additionalEffectHooks": "(useTrackedEffect)"}},
 		Errors: []rule_tester.InvalidTestCaseError{
 			{Message: "React Hook useTrackedEffect has a missing dependency: 'id'. Either include it or remove the dependency array.",
 				Suggestions: []rule_tester.InvalidTestCaseSuggestion{{Output: `

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_nil_tc_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_nil_tc_test.go
@@ -71,10 +71,10 @@ function MyComponent({theme}) {
 		return
 	}
 
-	// Settings include `additionalHooks` so the additional-hooks code
-	// path is also exercised under nil TC.
+	// Settings include `additionalEffectHooks` so the additional-hooks
+	// code path is also exercised under nil TC.
 	settings := map[string]interface{}{
-		"react-hooks": map[string]interface{}{"additionalHooks": "(useTrackedEffect)"},
+		"react-hooks": map[string]interface{}{"additionalEffectHooks": "(useTrackedEffect)"},
 	}
 
 	ctx := rule.RuleContext{

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/rule.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/rule.go
@@ -1,6 +1,7 @@
 package exhaustive_deps
 
 import (
+	_ "embed"
 	"fmt"
 	"sort"
 	"strings"
@@ -11,6 +12,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed exhaustive_deps.schema.json
+var schemaJSON []byte
 
 // runCaches holds per-Run (per-file lint pass) memoization tables.
 //
@@ -46,9 +50,9 @@ type runCaches struct {
 //
 // Diagnostics intentionally mirror upstream wording for switchover parity.
 var ExhaustiveDepsRule = rule.Rule{
-	Name: "react-hooks/exhaustive-deps",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "react-hooks/exhaustive-deps",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options, ctx.Settings)
 		sf := ctx.SourceFile
 		tc := ctx.TypeChecker

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.go
@@ -15,9 +15,10 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// The schema declares `additionalHooks` exactly as upstream does, but — also
-// exactly as upstream — the implementation never reads it: upstream's create()
-// only consults `settings['react-hooks'].additionalEffectHooks`.
+// The schema declares `additionalHooks` exactly as upstream does. Since
+// facebook/react#37085 upstream's create() reads it: the rule-level option
+// takes precedence, `settings['react-hooks'].additionalEffectHooks` is the
+// fallback.
 //
 //go:embed rules_of_hooks.schema.json
 var schemaJSON []byte
@@ -556,6 +557,28 @@ func getAdditionalEffectHooks(settings map[string]interface{}) *regexp.Regexp {
 	return react_hooksutil.AdditionalHooksFromSettings(settings, "additionalEffectHooks")
 }
 
+// parseAdditionalHooks resolves the additional-effect-hooks regex: the
+// rule-level `additionalHooks` option takes precedence, with
+// `settings['react-hooks'].additionalEffectHooks` as the fallback —
+// mirroring upstream's create() since facebook/react#37085.
+func parseAdditionalHooks(options []any, settings map[string]interface{}) *regexp.Regexp {
+	re := getAdditionalEffectHooks(settings)
+	if len(options) == 0 {
+		return re
+	}
+	optsMap, _ := options[0].(map[string]interface{})
+	// Mirrors upstream's `rawOptions.additionalHooks` truthiness check: a
+	// non-empty rule-level pattern replaces the settings fallback even when
+	// it fails to compile; absent or empty keeps the settings-derived value.
+	if raw, _ := optsMap["additionalHooks"].(string); raw != "" {
+		re = nil
+		if compiled, err := regexp.Compile(raw); err == nil {
+			re = compiled
+		}
+	}
+	return re
+}
+
 // eeRegistry tracks `const X = useEffectEvent(...)` declarations per enclosing
 // function-like, used as the fallback when TypeChecker symbol resolution is
 // unavailable. The TypeChecker path takes precedence whenever
@@ -821,7 +844,7 @@ var RulesOfHooksRule = rule.Rule{
 	Name:   "react-hooks/rules-of-hooks",
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		additionalRe := getAdditionalEffectHooks(ctx.Settings)
+		additionalRe := parseAdditionalHooks(options, ctx.Settings)
 		sf := ctx.SourceFile
 		registry := collectEffectEventBindings(sf)
 		tc := ctx.TypeChecker

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.go
@@ -1,6 +1,7 @@
 package rules_of_hooks
 
 import (
+	_ "embed"
 	"fmt"
 	"regexp"
 	"strings"
@@ -13,6 +14,13 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+// The schema declares `additionalHooks` exactly as upstream does, but — also
+// exactly as upstream — the implementation never reads it: upstream's create()
+// only consults `settings['react-hooks'].additionalEffectHooks`.
+//
+//go:embed rules_of_hooks.schema.json
+var schemaJSON []byte
 
 // flowSuppressionRegex matches `$FlowFixMe[react-rule-hook]` comments. Used to
 // gate `hasFlowSuppression`, which mirrors upstream's same-named helper —
@@ -810,7 +818,8 @@ var _ core.TextRange
 // `$FlowFixMe[react-rule-hook]` suppression on the preceding line is
 // honored, mirroring upstream's `hasFlowSuppression` byte-for-byte.
 var RulesOfHooksRule = rule.Rule{
-	Name: "react-hooks/rules-of-hooks",
+	Name:   "react-hooks/rules-of-hooks",
+	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		additionalRe := getAdditionalEffectHooks(ctx.Settings)
 		sf := ctx.SourceFile

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md
@@ -86,14 +86,19 @@ function App() {
 
 ## Options
 
-> **Warning**: options passed to this rule are ignored. The rule's schema
-> accepts `{ "additionalHooks": "..." }` — exactly as upstream
-> `eslint-plugin-react-hooks` declares it — but, also exactly as upstream, the
-> implementation never reads it: upstream added the schema entry and the
-> settings-based implementation in the same commit
-> ([facebook/react#34497](https://github.com/facebook/react/pull/34497)) and
-> only ever wired up the latter. Configure extra effect hooks through the
-> `additionalEffectHooks` **setting** below instead.
+`additionalHooks` is a regex of extra hook names to treat as effect hooks
+(functions created with `useEffectEvent` may be called inside them):
+
+```json
+{
+  "rules": {
+    "react-hooks/rules-of-hooks": ["error", { "additionalHooks": "(useMyEffect|useServerEffect)" }]
+  }
+}
+```
+
+When set, the rule-level option takes precedence over the
+`additionalEffectHooks` setting below.
 
 ## Settings
 

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md
@@ -84,6 +84,17 @@ function App() {
 }
 ```
 
+## Options
+
+> **Warning**: options passed to this rule are ignored. The rule's schema
+> accepts `{ "additionalHooks": "..." }` — exactly as upstream
+> `eslint-plugin-react-hooks` declares it — but, also exactly as upstream, the
+> implementation never reads it: upstream added the schema entry and the
+> settings-based implementation in the same commit
+> ([facebook/react#34497](https://github.com/facebook/react/pull/34497)) and
+> only ever wired up the latter. Configure extra effect hooks through the
+> `additionalEffectHooks` **setting** below instead.
+
 ## Settings
 
 ```json

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.schema.json
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.schema.json
@@ -6,7 +6,8 @@
       "additionalProperties": false,
       "properties": {
         "additionalHooks": {
-          "type": "string"
+          "type": "string",
+          "format": "regex"
         }
       }
     }

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.schema.json
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "additionalHooks": {
+          "type": "string"
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_upstream_test.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_upstream_test.go
@@ -368,6 +368,40 @@ var rulesOfHooksUpstreamValid = []rule_tester.ValidTestCase{
 				"additionalEffectHooks": "(useMyEffect|useServerEffect)",
 			},
 		}},
+		// Valid: useEffectEvent can be called in custom effect hooks
+		// configured via rule options (facebook/react#37085).
+		{Code: `
+			function MyComponent({ theme }) {
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+				useMyEffect(() => {
+					onClick();
+				});
+				useServerEffect(() => {
+					onClick();
+				});
+			}
+		`, Tsx: true, Options: map[string]interface{}{
+			"additionalHooks": "(useMyEffect|useServerEffect)",
+		}},
+		// Valid: rule-level additionalHooks takes precedence over settings.
+		{Code: `
+			function MyComponent({ theme }) {
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+				useMyEffect(() => {
+					onClick();
+				});
+			}
+		`, Tsx: true, Options: map[string]interface{}{
+			"additionalHooks": "useMyEffect",
+		}, Settings: map[string]interface{}{
+			"react-hooks": map[string]interface{}{
+				"additionalEffectHooks": "useServerEffect",
+			},
+		}},
 		// SKIP: rslint does not parse Flow `component` syntax.
 		{Skip: true, Code: `
 			component MyComponent(theme: any) {
@@ -1459,6 +1493,49 @@ var rulesOfHooksUpstreamInvalid = []rule_tester.InvalidTestCase{
 			Settings: map[string]interface{}{
 				"react-hooks": map[string]interface{}{
 					"additionalEffectHooks": "useMyEffect",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component."},
+			},
+		},
+		// Invalid: useEffectEvent should not be callable in hooks not
+		// matching the options regex (facebook/react#37085).
+		{
+			Code: `
+				function MyComponent({ theme }) {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme);
+					});
+					useWrongHook(() => {
+						onClick();
+					});
+				}
+			`,
+			Tsx:     true,
+			Options: map[string]interface{}{"additionalHooks": "useMyEffect"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component."},
+			},
+		},
+		// Invalid: rule-level additionalHooks takes precedence over settings,
+		// so a hook matched only by the settings regex is not an effect hook.
+		{
+			Code: `
+				function MyComponent({ theme }) {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme);
+					});
+					useWrongHook(() => {
+						onClick();
+					});
+				}
+			`,
+			Tsx:     true,
+			Options: map[string]interface{}{"additionalHooks": "useMyEffect"},
+			Settings: map[string]interface{}{
+				"react-hooks": map[string]interface{}{
+					"additionalEffectHooks": "useWrongHook",
 				},
 			},
 			Errors: []rule_tester.InvalidTestCaseError{


### PR DESCRIPTION
## Summary

- Declare option JSON Schemas for both `react-hooks/` rules; options are validated instead of manually unwrapped. `additionalHooks` uses `format: "regex"`, so an invalid pattern fails config validation.
- `rules-of-hooks`: read the `additionalHooks` option — rule-level takes precedence, `settings['react-hooks'].additionalEffectHooks` is the fallback. Upstream declared the option in its schema but never read it; this bug has been reported to upstream, and we adopt the fix here first.
- `exhaustive-deps`: `parseOptions` takes the validated options array directly; the settings fallback now reads `additionalEffectHooks` instead of `additionalHooks`, matching upstream's shared settings reader.

## Related Links

- https://github.com/web-infra-dev/rslint/pull/1303

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
