### PR TITLE
chore: remove stale rstest include entries for deleted js-config tests

### DIFF
--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -10,8 +10,6 @@ export default defineConfig({
     './tests/cli/color-matrix.test.ts',
     './tests/cli/file-args.test.ts',
     './tests/cli/disable-comments.test.ts',
-    './tests/cli/js-config/normalize-config.test.ts',
-    './tests/cli/js-config/load-config.test.ts',
     './tests/cli/js-config/cli-integration.test.ts',
     './tests/cli/js-config/plugin-enforcement.test.ts',
     './tests/cli/js-config/presets.test.ts',


### PR DESCRIPTION
`load-config.test.ts` and `normalize-config.test.ts` were deleted in #1035 but left in the explicit `include` list of `packages/rslint-test-tools/rstest.config.mts`. `@rstest/core` 0.9.2 silently ignores missing include entries, but 0.11.x generates entries for them and fails at runtime with `Cannot find module`, which blocks the rstest upgrade in #1262. This removes the two stale entries.