### PR TITLE
fix(tsgo): preserve merged local value symbols

### DIFF
--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -267,8 +267,9 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 					semantic.Node2sym[key] = sym_id
 					semantic.Node2type[key] = typeID
 
-					// Resolve alias symbol if this is an alias
-					if symbol.Flags&ast.SymbolFlagsAlias != 0 {
+					// A merged symbol can contain both a local value and an imported type.
+					// Value references must keep the local symbol instead of resolving the alias.
+					if symbol.Flags&ast.SymbolFlagsAlias != 0 && symbol.Flags&ast.SymbolFlagsValue == 0 {
 						if aliasedSymbol := getAliasedSymbol(tc, symbol); aliasedSymbol != nil {
 							aliased_id := ast.GetSymbolId(aliasedSymbol)
 							if aliased_id != sym_id {

--- a/cmd/tsgo/semantic_test.go
+++ b/cmd/tsgo/semantic_test.go
@@ -228,6 +228,45 @@ func TestSemanticSnapshot_NonBMPCharPositions(t *testing.T) {
 	}
 }
 
+func TestSemanticAliasDoesNotReplaceMergedLocalValue(t *testing.T) {
+	tmpDir := t.TempDir()
+	tsconfigPath := filepath.Join(tmpDir, "tsconfig.json")
+	modulePath := filepath.Join(tmpDir, "module.ts")
+	indexPath := filepath.Join(tmpDir, "index.ts")
+
+	if err := os.WriteFile(tsconfigPath, []byte(`{"include":["./*.ts"]}`), 0o644); err != nil {
+		t.Fatalf("Failed to write tsconfig: %v", err)
+	}
+	if err := os.WriteFile(modulePath, []byte("export interface SymbolLinks {}"), 0o644); err != nil {
+		t.Fatalf("Failed to write module: %v", err)
+	}
+	source := "import { SymbolLinks } from './module';\nconst SymbolLinks = class implements SymbolLinks {};\nnew SymbolLinks();"
+	if err := os.WriteFile(indexPath, []byte(source), 0o644); err != nil {
+		t.Fatalf("Failed to write index: %v", err)
+	}
+
+	t.Chdir(tmpDir)
+	program, err := CreateProgram("tsconfig.json")
+	if err != nil {
+		t.Fatalf("Failed to create program: %v", err)
+	}
+
+	semantic := CollectSemantic(program)
+	var localValueID ast.SymbolId
+	for symbolID, symbol := range semantic.Symtab {
+		if string(symbol.Name) == "SymbolLinks" && symbol.Flags&int(ast.SymbolFlagsValue) != 0 {
+			localValueID = symbolID
+			break
+		}
+	}
+	if localValueID == 0 {
+		t.Fatal("local SymbolLinks value symbol not found")
+	}
+	if target, exists := semantic.AliasSymbols[localValueID]; exists {
+		t.Fatalf("local value symbol %d was incorrectly aliased to %d", localValueID, target)
+	}
+}
+
 func TestSemanticSnapshot_InternalSymbolNameSanitized(t *testing.T) {
 	// Arrow functions produce an internal symbol with name "\xFEfunction".
 	// Verify that the \xFE prefix is sanitized to "__" in the output.


### PR DESCRIPTION
## Summary

A symbol can merge an imported type alias with a local runtime value, as in an imported interface and a same-named local class. Recording every Alias-flagged symbol in alias_symbols redirected runtime references to the imported type and caused the local value implementation to be tree-shaken.

Resolve only pure aliases that do not also carry a runtime Value flag. Merged local values keep their own symbol identity, while normal imports and re-exports continue to use alias resolution.

The semantic regression imports a SymbolLinks interface, declares a same-named local class, and constructs it at runtime. Applied to the parent, it fails with `local value symbol ... was incorrectly aliased`; it passes with this change, as does the cmd/tsgo test suite.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
