### PR TITLE
feat(tsgo): expose runtime module exports

### DIFF
--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -23,6 +23,7 @@ type CheckResult = struct {
 	ModuleList      []string            `json:"module_list"`
 	SourceFiles     []EncodedSourceFile `json:"source_files"`
 	RootFiles       []string            `json:"root_files"`
+	ModuleExports   [][]ast.SymbolId    `json:"module_exports"`
 	Semantic        Semantic            `json:"semantic"`
 	Diagnostics     []Diagnostics       `json:"diagnostics"`
 	SourceFileExtra []SourceFileExtra   `json:"source_file_extra"`
@@ -206,6 +207,24 @@ func runMain() int {
 		checkResult.SourceFiles = append(checkResult.SourceFiles, encodedSourceFile)
 
 		CollectSemanticInFile(tc, file, &checkResult.Semantic, sourcefileId, sourceFileIds)
+		exports := []ast.SymbolId{}
+		if sourceFile.Symbol != nil {
+			for _, symbol := range tc.GetExportsOfModule(sourceFile.Symbol) {
+				if symbol.Flags&ast.SymbolFlagsAlias != 0 {
+					if tc.GetTypeOnlyAliasDeclaration(symbol) != nil {
+						continue
+					}
+					if target, ok := tc.ResolveAlias(symbol); ok {
+						symbol = target
+					}
+				}
+				if symbol.Flags&ast.SymbolFlagsValue == 0 {
+					continue
+				}
+				exports = append(exports, ast.GetSymbolId(symbol))
+			}
+		}
+		checkResult.ModuleExports = append(checkResult.ModuleExports, exports)
 	}
 	checkResult.Diagnostics = getDiagnostics(diagnostics, &fileMap)
 

--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -267,8 +267,9 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 					semantic.Node2sym[key] = sym_id
 					semantic.Node2type[key] = typeID
 
-					// Resolve alias symbol if this is an alias
-					if symbol.Flags&ast.SymbolFlagsAlias != 0 {
+					// A merged symbol can contain both a local value and an imported type.
+					// Value references must keep the local symbol instead of resolving the alias.
+					if symbol.Flags&ast.SymbolFlagsAlias != 0 && symbol.Flags&ast.SymbolFlagsValue == 0 {
 						if aliasedSymbol := getAliasedSymbol(tc, symbol); aliasedSymbol != nil {
 							aliased_id := ast.GetSymbolId(aliasedSymbol)
 							if aliased_id != sym_id {

--- a/cmd/tsgo/semantic_test.go
+++ b/cmd/tsgo/semantic_test.go
@@ -228,6 +228,45 @@ func TestSemanticSnapshot_NonBMPCharPositions(t *testing.T) {
 	}
 }
 
+func TestSemanticAliasDoesNotReplaceMergedLocalValue(t *testing.T) {
+	tmpDir := t.TempDir()
+	tsconfigPath := filepath.Join(tmpDir, "tsconfig.json")
+	modulePath := filepath.Join(tmpDir, "module.ts")
+	indexPath := filepath.Join(tmpDir, "index.ts")
+
+	if err := os.WriteFile(tsconfigPath, []byte(`{"include":["./*.ts"]}`), 0o644); err != nil {
+		t.Fatalf("Failed to write tsconfig: %v", err)
+	}
+	if err := os.WriteFile(modulePath, []byte("export interface SymbolLinks {}"), 0o644); err != nil {
+		t.Fatalf("Failed to write module: %v", err)
+	}
+	source := "import { SymbolLinks } from './module';\nconst SymbolLinks = class implements SymbolLinks {};\nnew SymbolLinks();"
+	if err := os.WriteFile(indexPath, []byte(source), 0o644); err != nil {
+		t.Fatalf("Failed to write index: %v", err)
+	}
+
+	t.Chdir(tmpDir)
+	program, err := CreateProgram("tsconfig.json")
+	if err != nil {
+		t.Fatalf("Failed to create program: %v", err)
+	}
+
+	semantic := CollectSemantic(program)
+	var localValueID ast.SymbolId
+	for symbolID, symbol := range semantic.Symtab {
+		if string(symbol.Name) == "SymbolLinks" && symbol.Flags&int(ast.SymbolFlagsValue) != 0 {
+			localValueID = symbolID
+			break
+		}
+	}
+	if localValueID == 0 {
+		t.Fatal("local SymbolLinks value symbol not found")
+	}
+	if target, exists := semantic.AliasSymbols[localValueID]; exists {
+		t.Fatalf("local value symbol %d was incorrectly aliased to %d", localValueID, target)
+	}
+}
+
 func TestSemanticSnapshot_InternalSymbolNameSanitized(t *testing.T) {
 	// Arrow functions produce an internal symbol with name "\xFEfunction".
 	// Verify that the \xFE prefix is sanitized to "__" in the output.

--- a/crates/tsgo-client/src/proto.rs
+++ b/crates/tsgo-client/src/proto.rs
@@ -10,6 +10,8 @@ pub struct ProjectResponse<'base> {
     pub root_files: Vec<&'base str>,
     pub source_files: Vec<&'base Bytes>,
     pub module_list: Vec<&'base str>,
+    #[serde(default)]
+    pub module_exports: Vec<Vec<u32>>,
     pub semantic: Semantic,
     pub diagnostics: Vec<Diagnostic>,
     pub source_file_extra: Vec<SourceFileExtra>,

--- a/crates/tsgo-client/tests/fixtures/module-exports/src/index.ts
+++ b/crates/tsgo-client/tests/fixtures/module-exports/src/index.ts
@@ -1,0 +1,10 @@
+export function directValue() {
+  return 'direct';
+}
+
+export interface DirectType {
+  value: string;
+}
+
+export { barrelValue as renamedBarrelValue, otherBarrelValue } from './values';
+export type { BarrelType, RuntimeTypeOnly } from './values';

--- a/crates/tsgo-client/tests/fixtures/module-exports/src/values.ts
+++ b/crates/tsgo-client/tests/fixtures/module-exports/src/values.ts
@@ -1,0 +1,13 @@
+export function barrelValue() {
+  return 'barrel';
+}
+
+export const otherBarrelValue = 'other';
+
+export interface BarrelType {
+  value: string;
+}
+
+export class RuntimeTypeOnly {
+  value = 'runtime';
+}

--- a/crates/tsgo-client/tests/fixtures/module-exports/tsconfig.json
+++ b/crates/tsgo-client/tests/fixtures/module-exports/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*"]
+}

--- a/crates/tsgo-client/tests/integration_test.rs
+++ b/crates/tsgo-client/tests/integration_test.rs
@@ -109,6 +109,11 @@ fn test_tsgo_integration_simple_project() {
         !project.module_list.is_empty(),
         "Expected at least one module"
     );
+    assert_eq!(
+        project.module_exports.len(),
+        project.module_list.len(),
+        "Expected exports for every module"
+    );
 
     // Check semantic data exists
     assert!(
@@ -125,10 +130,75 @@ fn test_tsgo_integration_simple_project() {
     assert_ne!(project.semantic.primtypes.number, 0);
     assert_ne!(project.semantic.primtypes.any, 0);
 
+    let index_module = project
+        .module_list
+        .iter()
+        .position(|path| path.ends_with("/src/index.ts"))
+        .expect("Expected index.ts module");
+    let export_names = project.module_exports[index_module]
+        .iter()
+        .filter_map(|symbol_id| {
+            project
+                .semantic
+                .symtab
+                .iter()
+                .find(|(id, _)| id == symbol_id)
+                .map(|(_, data)| String::from_utf8_lossy(&data.name).into_owned())
+        })
+        .collect::<Vec<_>>();
+    assert!(export_names.iter().any(|name| name == "greet"));
+    assert!(export_names.iter().any(|name| name == "add"));
+    assert!(export_names.iter().any(|name| name == "Calculator"));
+    assert!(!export_names.iter().any(|name| name == "Person"));
+
     println!("\n✓ Integration test passed!");
     println!("  - Loaded {} source files", project.source_files.len());
     println!("  - Found {} symbols", project.semantic.symtab.len());
     println!("  - Found {} types", project.semantic.typetab.len());
+}
+
+#[test]
+fn test_runtime_module_exports() {
+    let tsgo_path = get_tsgo_path().expect("Could not find tsgo executable");
+    let fixture_dir = get_fixtures_dir().join("module-exports");
+    let config_file = fixture_dir.join("tsconfig.json");
+    let options = Options {
+        cwd: Some(fixture_dir),
+        log_file: None,
+        config_file: config_file.to_string_lossy().to_string(),
+    };
+    let client = Client::builder(OsStr::new(&tsgo_path), options)
+        .build()
+        .expect("Failed to build client");
+    let api = Api::with_uninitialized_client(client).expect("Failed to initialize API");
+    let mut buffer = Vec::new();
+    let project = api
+        .load_project(&mut buffer)
+        .expect("Failed to load project");
+    let index_module = project
+        .module_list
+        .iter()
+        .position(|path| path.ends_with("/src/index.ts"))
+        .expect("Expected index.ts module");
+    let export_names = project.module_exports[index_module]
+        .iter()
+        .map(|symbol_id| {
+            project
+                .semantic
+                .symtab
+                .iter()
+                .find(|(id, _)| id == symbol_id)
+                .map(|(_, data)| String::from_utf8_lossy(&data.name).into_owned())
+                .expect("Expected exported symbol in semantic table")
+        })
+        .collect::<Vec<_>>();
+
+    assert!(export_names.iter().any(|name| name == "directValue"));
+    assert!(export_names.iter().any(|name| name == "barrelValue"));
+    assert!(export_names.iter().any(|name| name == "otherBarrelValue"));
+    assert!(!export_names.iter().any(|name| name == "DirectType"));
+    assert!(!export_names.iter().any(|name| name == "BarrelType"));
+    assert!(!export_names.iter().any(|name| name == "RuntimeTypeOnly"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Rslim application builds root only symbols reachable from entry top-level execution. Library builds additionally need the runtime values exported by each entry module, but the tsgo protocol previously exposed only source files and semantic tables, leaving rslim unable to distinguish public runtime exports from internal declarations.

Collect every source module public export, exclude type-only aliases, resolve remaining aliases, and then require the target Value flag before returning runtime SymbolIds in a module-aligned protocol table. This preserves direct exports and barrel re-exports while excluding interfaces, type aliases, and runtime declarations exported through `export type`. The tsgo-client field is defaulted for protocol compatibility; application roots remain unchanged.

The integration fixture checks a direct exported function, renamed and direct barrel values, interface exclusion, and exclusion of a runtime class re-exported with `export type`. Applied to the parent, the test fails to compile because module_exports is absent. With this change, all six tsgo-client integration tests and the cmd/tsgo suite pass.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
