### PR TITLE
test: make nil guard control flow explicit

### DIFF
--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -1206,6 +1206,7 @@ func TestHandleLint_SuggestionsConverted(t *testing.T) {
 	}
 	if anyDiag == nil {
 		t.Fatalf("expected a no-explicit-any diagnostic, got %+v", resp.Diagnostics)
+		return
 	}
 	if anyDiag.MessageId != "unexpectedAny" {
 		t.Fatalf("expected messageId unexpectedAny, got %q", anyDiag.MessageId)
@@ -1263,6 +1264,7 @@ func TestHandleLint_SuggestionDataConverted(t *testing.T) {
 	}
 	if diag == nil {
 		t.Fatalf("expected a no-restricted-types diagnostic, got %+v", resp.Diagnostics)
+		return
 	}
 	if len(diag.Suggestions) != 1 {
 		t.Fatalf("expected 1 suggestion, got %d: %+v", len(diag.Suggestions), diag.Suggestions)

--- a/internal/config/eslint_plugin_test.go
+++ b/internal/config/eslint_plugin_test.go
@@ -241,6 +241,7 @@ func TestGetConfigForFile_SplitEntry_ProjectFromNativeEntrySurvives(t *testing.T
 	merged := cfg.GetConfigForFile("/proj/a.ts", "/proj")
 	if merged == nil {
 		t.Fatal("merged config should not be nil")
+		return
 	}
 	if merged.LanguageOptions == nil || merged.LanguageOptions.ParserOptions == nil {
 		t.Fatal("merged languageOptions/parserOptions must survive from the native entry")

--- a/internal/config/parse_array_rule_test.go
+++ b/internal/config/parse_array_rule_test.go
@@ -78,6 +78,7 @@ func TestParseArrayRuleConfig_OptionShapes(t *testing.T) {
 			rc := parseArrayRuleConfig(tt.in)
 			if rc == nil {
 				t.Fatal("parseArrayRuleConfig returned nil")
+				return
 			}
 			if rc.Level != tt.wantLevel {
 				t.Errorf("Level = %q, want %q", rc.Level, tt.wantLevel)

--- a/internal/lsp/eslint_plugin_test.go
+++ b/internal/lsp/eslint_plugin_test.go
@@ -854,6 +854,7 @@ func TestHandleCodeAction_NativeFixAndPluginSuggestionCoexist(t *testing.T) {
 	nat := byTitle["Fix: native msg"]
 	if nat == nil {
 		t.Fatalf("missing native fix action; got titles %v", titleSet(byTitle))
+		return
 	}
 	if nat.IsPreferred == nil || !*nat.IsPreferred {
 		t.Error("native autofix must be IsPreferred=true")
@@ -861,6 +862,7 @@ func TestHandleCodeAction_NativeFixAndPluginSuggestionCoexist(t *testing.T) {
 	sug := byTitle["Suggestion: use baz"]
 	if sug == nil {
 		t.Fatalf("missing plugin suggestion action; got titles %v", titleSet(byTitle))
+		return
 	}
 	if sug.IsPreferred == nil || *sug.IsPreferred {
 		t.Error("plugin suggestion must be IsPreferred=false")


### PR DESCRIPTION
## Summary

- Make nil-guard control flow explicit in tests by returning after `t.Fatal`/`t.Fatalf`.
- Prevent intermittent `staticcheck` SA5011 false positives when golangci-lint restores cached package facts.
- Verified `pnpm check-spell`, `pnpm format:check`, and incremental Go lint for the changed packages.

## Related Links

- https://github.com/golangci/golangci-lint/issues/5979
- https://github.com/golangci/golangci-lint/pull/6649

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).