### PR TITLE
feat(eslint-plugin-jest): add `require-hook` rule

### DIFF
--- a/internal/plugins/jest/all.go
+++ b/internal/plugins/jest/all.go
@@ -40,6 +40,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_have_been_called_times"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_have_length"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_todo"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/require_hook"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/valid_describe_callback"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/valid_expect"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/valid_title"
@@ -87,6 +88,7 @@ func GetAllRules() []rule.Rule {
 		prefer_to_have_been_called.PreferToHaveBeenCalledRule,
 		prefer_to_have_length.PreferToHaveLengthRule,
 		prefer_todo.PreferTodoRule,
+		require_hook.RequireHookRule,
 		valid_describe_callback.ValidDescribeCallbackRule,
 		valid_expect.ValidExpectRule,
 		valid_title.ValidTitleRule,

--- a/internal/plugins/jest/rules/require_hook/require_hook.go
+++ b/internal/plugins/jest/rules/require_hook/require_hook.go
@@ -92,16 +92,25 @@ func shouldBeInHook(node *ast.Node, ctx rule.RuleContext, allowedFunctionCalls [
 
 	switch node.Kind {
 	case ast.KindExpressionStatement:
-		return shouldBeInHook(node.AsExpressionStatement().Expression, ctx, allowedFunctionCalls)
+		return shouldBeInHook(ast.SkipParentheses(node.AsExpressionStatement().Expression), ctx, allowedFunctionCalls)
 	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		if call.Expression.Kind == ast.KindImportKeyword ||
+			call.QuestionDotToken != nil ||
+			ast.IsOptionalChain(node) {
+			return false
+		}
 		if isJestFnCall(node, ctx) {
 			return false
 		}
 		name := utils.CalleeChainName(node)
 		return !containsString(allowedFunctionCalls, name)
 	case ast.KindVariableStatement:
+		if ast.HasSyntacticModifier(node, ast.ModifierFlagsExport) {
+			return false
+		}
 		declList := node.AsVariableStatement().DeclarationList
-		if declList == nil || declList.Flags&ast.NodeFlagsConst != 0 {
+		if declList == nil || declList.Flags&ast.NodeFlagsBlockScoped == ast.NodeFlagsConst {
 			return false
 		}
 		decls := declList.AsVariableDeclarationList().Declarations
@@ -138,9 +147,21 @@ func getFunctionBodyBlock(fn *ast.Node) *ast.Node {
 	return nil
 }
 
+func hasCallExpressionParent(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	parent := node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parent = parent.Parent
+	}
+	return parent != nil && parent.Kind == ast.KindCallExpression
+}
+
 func describeCallbackBody(call *ast.Node, ctx rule.RuleContext) *ast.Node {
 	if call == nil ||
 		call.Kind != ast.KindCallExpression ||
+		hasCallExpressionParent(call) ||
 		!utils.IsTypeOfJestFnCall(call, ctx, utils.JestFnTypeDescribe) {
 		return nil
 	}

--- a/internal/plugins/jest/rules/require_hook/require_hook.go
+++ b/internal/plugins/jest/rules/require_hook/require_hook.go
@@ -1,0 +1,183 @@
+package require_hook
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func buildUseHookMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "useHook",
+		Description: "This should be done within a hook",
+	}
+}
+
+type Options struct {
+	AllowedFunctionCalls []string
+}
+
+func parseAllowedFunctionCalls(raw any) []string {
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func parseOptions(options any) Options {
+	opts := Options{AllowedFunctionCalls: nil}
+	if options == nil {
+		return opts
+	}
+
+	optArray := rule.NormalizeOptions(options)
+	if len(optArray) == 0 {
+		return opts
+	}
+	optsMap, ok := optArray[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if raw, ok := optsMap["allowedFunctionCalls"]; ok {
+		opts.AllowedFunctionCalls = parseAllowedFunctionCalls(raw)
+	}
+	return opts
+}
+
+func isNullOrUndefined(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindNullKeyword:
+		return true
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text == "undefined"
+	default:
+		return false
+	}
+}
+
+func isJestFnCall(node *ast.Node, ctx rule.RuleContext) bool {
+	if utils.ParseJestFnCall(node, ctx) != nil {
+		return true
+	}
+	name := utils.CalleeChainName(node)
+	return strings.HasPrefix(name, "jest.")
+}
+
+func containsString(list []string, target string) bool {
+	for _, item := range list {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldBeInHook(node *ast.Node, ctx rule.RuleContext, allowedFunctionCalls []string) bool {
+	if node == nil {
+		return false
+	}
+
+	switch node.Kind {
+	case ast.KindExpressionStatement:
+		return shouldBeInHook(node.AsExpressionStatement().Expression, ctx, allowedFunctionCalls)
+	case ast.KindCallExpression:
+		if isJestFnCall(node, ctx) {
+			return false
+		}
+		name := utils.CalleeChainName(node)
+		return !containsString(allowedFunctionCalls, name)
+	case ast.KindVariableStatement:
+		declList := node.AsVariableStatement().DeclarationList
+		if declList == nil || declList.Flags&ast.NodeFlagsConst != 0 {
+			return false
+		}
+		decls := declList.AsVariableDeclarationList().Declarations
+		if decls == nil {
+			return false
+		}
+		for _, decl := range decls.Nodes {
+			vd := decl.AsVariableDeclaration()
+			if vd.Initializer != nil && !isNullOrUndefined(vd.Initializer) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func getFunctionBodyBlock(fn *ast.Node) *ast.Node {
+	if fn == nil || !utils.IsFunction(fn) {
+		return nil
+	}
+	switch fn.Kind {
+	case ast.KindArrowFunction:
+		body := fn.AsArrowFunction().Body
+		if body != nil && body.Kind == ast.KindBlock {
+			return body
+		}
+	case ast.KindFunctionExpression:
+		return fn.AsFunctionExpression().Body
+	case ast.KindFunctionDeclaration:
+		return fn.AsFunctionDeclaration().Body
+	}
+	return nil
+}
+
+func describeCallbackBody(call *ast.Node, ctx rule.RuleContext) *ast.Node {
+	if call == nil ||
+		call.Kind != ast.KindCallExpression ||
+		!utils.IsTypeOfJestFnCall(call, ctx, utils.JestFnTypeDescribe) {
+		return nil
+	}
+
+	args := call.AsCallExpression().Arguments
+	if args == nil || len(args.Nodes) < 2 {
+		return nil
+	}
+	return getFunctionBodyBlock(args.Nodes[1])
+}
+
+func checkBlockBody(ctx rule.RuleContext, body []*ast.Node, allowedFunctionCalls []string) {
+	for _, statement := range body {
+		if shouldBeInHook(statement, ctx, allowedFunctionCalls) {
+			ctx.ReportNode(statement, buildUseHookMessage())
+		}
+	}
+}
+
+var RequireHookRule = rule.Rule{
+	Name: "jest/require-hook",
+	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
+		options := rule.LegacyUnwrapOptions(_options)
+		opts := parseOptions(options)
+
+		if ctx.SourceFile != nil && ctx.SourceFile.Statements != nil {
+			checkBlockBody(ctx, ctx.SourceFile.Statements.Nodes, opts.AllowedFunctionCalls)
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				block := describeCallbackBody(node, ctx)
+				if block == nil || block.AsBlock().Statements == nil {
+					return
+				}
+				checkBlockBody(ctx, block.AsBlock().Statements.Nodes, opts.AllowedFunctionCalls)
+			},
+		}
+	},
+}

--- a/internal/plugins/jest/rules/require_hook/require_hook.md
+++ b/internal/plugins/jest/rules/require_hook/require_hook.md
@@ -1,0 +1,174 @@
+# require-hook
+
+## Rule Details
+
+Require setup and teardown code to be within a Jest lifecycle hook (`beforeEach`, `afterEach`, `beforeAll`, `afterAll`).
+
+It's common when writing tests to need setup work before tests run and cleanup afterward. Because Jest executes all `describe` handlers in a test file **before** any of the actual tests, setup and teardown done directly in a `describe` body (or at the top level of the file) can run at the wrong time or leak across suites. This rule pushes that work into the lifecycle hooks instead.
+
+This rule checks direct statements at the top level of a test file and direct statements within the body of each `describe` callback. It does not inspect arbitrary statements nested inside control-flow statements or other function callbacks.
+
+It flags expressions in those scopes **except** for:
+
+- `import` statements
+- `const` variable declarations, including declarations with initializers
+- Uninitialized `let` and `var` declarations
+- `let` and `var` declarations initialized directly with `null` or `undefined`
+- Classes
+- Types
+- Calls to recognized Jest APIs, such as `describe`, `test` / `it`, lifecycle hooks, `expect`, and `jest.*`
+
+For variable declarations, a declaration containing any other initializer is reported as a whole. For example:
+
+```javascript
+let spy;                 // valid
+let empty = null;        // valid
+let notEmpty = create(); // incorrect
+const value = create();  // valid
+```
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+import { database, isCity } from '../database';
+import { loadCities } from '../api';
+
+jest.mock('../api');
+
+const initializeCityDatabase = () => {
+  database.addCity('Vienna');
+  database.addCity('San Juan');
+  database.addCity('Wellington');
+};
+
+const clearCityDatabase = () => {
+  database.clear();
+};
+
+initializeCityDatabase();
+
+test('that persists cities', () => {
+  expect(database.cities.length).toHaveLength(3);
+});
+
+test('city database has Vienna', () => {
+  expect(isCity('Vienna')).toBeTruthy();
+});
+
+test('city database has San Juan', () => {
+  expect(isCity('San Juan')).toBeTruthy();
+});
+
+describe('when loading cities from the api', () => {
+  let consoleWarnSpy = jest.spyOn(console, 'warn');
+
+  loadCities.mockResolvedValue(['Wellington', 'London']);
+
+  it('does not duplicate cities', async () => {
+    await database.loadCities();
+
+    expect(database.cities).toHaveLength(4);
+  });
+
+  it('logs any duplicates', async () => {
+    await database.loadCities();
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Ignored duplicate cities: Wellington',
+    );
+  });
+});
+
+clearCityDatabase();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+import { database, isCity } from '../database';
+import { loadCities } from '../api';
+
+jest.mock('../api');
+
+const initializeCityDatabase = () => {
+  database.addCity('Vienna');
+  database.addCity('San Juan');
+  database.addCity('Wellington');
+};
+
+const clearCityDatabase = () => {
+  database.clear();
+};
+
+beforeEach(() => {
+  initializeCityDatabase();
+});
+
+test('that persists cities', () => {
+  expect(database.cities.length).toHaveLength(3);
+});
+
+test('city database has Vienna', () => {
+  expect(isCity('Vienna')).toBeTruthy();
+});
+
+test('city database has San Juan', () => {
+  expect(isCity('San Juan')).toBeTruthy();
+});
+
+describe('when loading cities from the api', () => {
+  let consoleWarnSpy;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn');
+    loadCities.mockResolvedValue(['Wellington', 'London']);
+  });
+
+  it('does not duplicate cities', async () => {
+    await database.loadCities();
+
+    expect(database.cities).toHaveLength(4);
+  });
+
+  it('logs any duplicates', async () => {
+    await database.loadCities();
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Ignored duplicate cities: Wellington',
+    );
+  });
+});
+
+afterEach(() => {
+  clearCityDatabase();
+});
+```
+
+## Options
+
+- First argument (optional): object with `allowedFunctionCalls`
+  - `allowedFunctionCalls`: array of exact callee names that are allowed outside hooks. Names are matched against the full dotted callee name, so `helper.setup` matches `helper.setup()` but `setup` does not.
+
+```json
+{ "jest/require-hook": ["error", { "allowedFunctionCalls": ["enableAutoDestroy"] }] }
+```
+
+```javascript
+import { enableAutoDestroy } from '@vue/test-utils';
+import { initDatabase, tearDownDatabase } from './databaseUtils';
+
+enableAutoDestroy(afterEach);
+
+beforeEach(initDatabase);
+afterEach(tearDownDatabase);
+
+describe('Foo', () => {
+  test('always returns 42', () => {
+    expect(global.getAnswer()).toBe(42);
+  });
+});
+```
+
+## Original Documentation
+
+- [jest/require-hook](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/require-hook.md)

--- a/internal/plugins/jest/rules/require_hook/require_hook_extras_test.go
+++ b/internal/plugins/jest/rules/require_hook/require_hook_extras_test.go
@@ -15,7 +15,10 @@ func TestRequireHookExtras(t *testing.T) {
 		t,
 		&require_hook.RequireHookRule,
 		[]rule_tester.ValidTestCase{
-			{Code: `(setup());`},
+			{Code: `setup?.();`},
+			{Code: `foo?.bar();`},
+			{Code: `import('x');`},
+			{Code: `export let value = setup();`},
 			{Code: `jest['mock']('../api');`},
 			{Code: `describe('a test', () => setup());`},
 			{Code: `describe.only('suite', () => {
@@ -47,7 +50,6 @@ func TestRequireHookExtras(t *testing.T) {
 }));`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "useHook", Line: 1, Column: 1},
-					{MessageId: "useHook", Line: 2, Column: 3},
 				},
 			},
 			{
@@ -69,7 +71,19 @@ func TestRequireHookExtras(t *testing.T) {
 				},
 			},
 			{
-				Code: `setup?.();`,
+				Code: `(setup());`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `await using value = setup();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(foo?.bar)();`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "useHook", Line: 1, Column: 1},
 				},

--- a/internal/plugins/jest/rules/require_hook/require_hook_extras_test.go
+++ b/internal/plugins/jest/rules/require_hook/require_hook_extras_test.go
@@ -1,0 +1,98 @@
+package require_hook_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/require_hook"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRequireHookExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&require_hook.RequireHookRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `(setup());`},
+			{Code: `jest['mock']('../api');`},
+			{Code: `describe('a test', () => setup());`},
+			{Code: `describe.only('suite', () => {
+  beforeEach(() => setup());
+});`},
+			{
+				Code: `helper.setup();`,
+				Options: []interface{}{
+					map[string]interface{}{
+						"allowedFunctionCalls": []interface{}{"helper.setup"},
+					},
+				},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `function register() {
+  describe('suite', () => {
+    setup();
+  });
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 3, Column: 5},
+				},
+			},
+			{
+				Code: `foo(describe('suite', () => {
+  setup();
+}));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 1, Column: 1},
+					{MessageId: "useHook", Line: 2, Column: 3},
+				},
+			},
+			{
+				Code: `if (condition) {
+ describe('suite', () => {
+  setup();
+ });
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 3, Column: 3},
+				},
+			},
+			{
+				Code: `const suite = describe('suite', () => {
+  setup();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 2, Column: 3},
+				},
+			},
+			{
+				Code: `setup?.();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `helper.setup();`,
+				Options: []interface{}{
+					map[string]interface{}{
+						"allowedFunctionCalls": []interface{}{"setup"},
+					},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `new NodeExtensionTester()
+  .shouldMatch()
+  .runTests();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/jest/rules/require_hook/require_hook_upstream_test.go
+++ b/internal/plugins/jest/rules/require_hook/require_hook_upstream_test.go
@@ -1,0 +1,90 @@
+package require_hook_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/require_hook"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRequireHookUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&require_hook.RequireHookRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `function helper() { setup(); }
+test('x', () => {});`},
+			{Code: `let x;
+x = 1;
+test('x', () => {});`},
+			{Code: `new Helper();
+test('x', () => {});`},
+			{Code: `describe('empty', () => {});`},
+			{Code: `var x;
+test('x', () => {});`},
+			{Code: `let x = (null);
+test('x', () => {});`},
+			{Code: `let x = (undefined);
+test('x', () => {});`},
+			{Code: `type T = number;
+interface I { x: number }
+test('x', () => {});`},
+			{Code: `jest.anythingCustom();`},
+			{Code: `const utils = require('./utils');
+test('x', () => {});`},
+			{Code: `describe('title only');`},
+			{Code: `describe('title', 'not a function');`},
+			{
+				Code: `enableAutoDestroy(afterEach);
+test('x', () => {});`,
+				Options: []interface{}{
+					map[string]interface{}{
+						"allowedFunctionCalls": []interface{}{"enableAutoDestroy"},
+					},
+				},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `describe('suite', function () {
+  setup();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 2, Column: 3},
+				},
+			},
+			{
+				Code: `var value = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `foo.bar();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `describe.only('suite', () => {
+  setup();
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 2, Column: 3},
+				},
+			},
+			{
+				Code: `test('x', () => {
+  setup();
+});
+setup();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useHook", Line: 4, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -529,6 +529,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/prefer-to-have-been-called.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-to-have-length.test.ts',
     './tests/eslint-plugin-jest/rules/prefer-todo.test.ts',
+    './tests/eslint-plugin-jest/rules/require-hook.test.ts',
     './tests/eslint-plugin-jest/rules/valid-describe-callback.test.ts',
     './tests/eslint-plugin-jest/rules/valid-expect.test.ts',
     './tests/eslint-plugin-jest/rules/valid-title.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rule-tester.ts
@@ -47,7 +47,7 @@ export class RuleTester {
     ruleName: string,
     rule: never,
     cases: {
-      valid: ValidTestCase[];
+      valid: (ValidTestCase | string)[];
       invalid: InvalidTestCase[];
     },
   ) {

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/require-hook.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/require-hook.test.ts
@@ -1,0 +1,440 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('require-hook', {} as never, {
+  valid: [
+    'describe()',
+    'describe("just a title")',
+    `
+      describe('a test', () =>
+        test('something', () => {
+          expect(true).toBe(true);
+        }));
+    `,
+    `
+      test('it', () => {
+        //
+      });
+    `,
+    `
+      const { myFn } = require('../functions');
+
+      test('myFn', () => {
+        expect(myFn()).toBe(1);
+      });
+    `,
+    {
+      code: `
+        import { myFn } from '../functions';
+
+        test('myFn', () => {
+          expect(myFn()).toBe(1);
+        });
+      `,
+    },
+    `
+      class MockLogger {
+        log() {}
+      }
+
+      test('myFn', () => {
+        expect(myFn()).toBe(1);
+      });
+    `,
+    `
+      const { myFn } = require('../functions');
+
+      describe('myFn', () => {
+        it('returns one', () => {
+          expect(myFn()).toBe(1);
+        });
+      });
+    `,
+    `
+      describe('some tests', () => {
+        it('is true', () => {
+          expect(true).toBe(true);
+        });
+      });
+    `,
+    `
+      describe('some tests', () => {
+        it('is true', () => {
+          expect(true).toBe(true);
+        });
+
+        describe('more tests', () => {
+          it('is false', () => {
+            expect(true).toBe(false);
+          });
+        });
+      });
+    `,
+    `
+      describe('some tests', () => {
+        let consoleLogSpy;
+
+        beforeEach(() => {
+          consoleLogSpy = jest.spyOn(console, 'log');
+        });
+
+        it('prints a message', () => {
+          printMessage('hello world');
+
+          expect(consoleLogSpy).toHaveBeenCalledWith('hello world');
+        });
+      });
+    `,
+    `
+      let consoleErrorSpy = null;
+
+      beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error');
+      });
+    `,
+    `
+      let consoleErrorSpy = undefined;
+
+      beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error');
+      });
+    `,
+    `
+      describe('some tests', () => {
+        beforeEach(() => {
+          setup();
+        });
+      });
+    `,
+    `
+      beforeEach(() => {
+        initializeCityDatabase();
+      });
+
+      afterEach(() => {
+        clearCityDatabase();
+      });
+
+      test('city database has Vienna', () => {
+        expect(isCity('Vienna')).toBeTruthy();
+      });
+
+      test('city database has San Juan', () => {
+        expect(isCity('San Juan')).toBeTruthy();
+      });
+    `,
+    `
+      describe('cities', () => {
+        beforeEach(() => {
+          initializeCityDatabase();
+        });
+
+        test('city database has Vienna', () => {
+          expect(isCity('Vienna')).toBeTruthy();
+        });
+
+        test('city database has San Juan', () => {
+          expect(isCity('San Juan')).toBeTruthy();
+        });
+
+        afterEach(() => {
+          clearCityDatabase();
+        });
+      });
+    `,
+    {
+      code: `
+        enableAutoDestroy(afterEach);
+
+        describe('some tests', () => {
+          it('is false', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+      options: [{ allowedFunctionCalls: ['enableAutoDestroy'] }],
+    },
+    `
+      import { myFn } from '../functions';
+
+      // todo: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56545
+      declare module 'eslint' {
+        namespace ESLint {
+          interface LintResult {
+            fatalErrorCount: number;
+          }
+        }
+      }
+
+      test('myFn', () => {
+        expect(myFn()).toBe(1);
+      });
+    `,
+  ],
+  invalid: [
+    {
+      code: 'setup();',
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        describe('some tests', () => {
+          setup();
+        });
+      `,
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 2,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        let { setup } = require('./test-utils');
+
+        describe('some tests', () => {
+          setup();
+        });
+      `,
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'useHook',
+          line: 4,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        describe('some tests', () => {
+          setup();
+
+          it('is true', () => {
+            expect(true).toBe(true);
+          });
+
+          describe('more tests', () => {
+            setup();
+
+            it('is false', () => {
+              expect(true).toBe(false);
+            });
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 2,
+          column: 3,
+        },
+        {
+          messageId: 'useHook',
+          line: 9,
+          column: 5,
+        },
+      ],
+    },
+    {
+      code: `
+        let consoleErrorSpy = jest.spyOn(console, 'error');
+
+        describe('when loading cities from the api', () => {
+          let consoleWarnSpy = jest.spyOn(console, 'warn');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'useHook',
+          line: 4,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        let consoleErrorSpy = null;
+
+        describe('when loading cities from the api', () => {
+          let consoleWarnSpy = jest.spyOn(console, 'warn');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 4,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: 'let value = 1',
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: "let consoleErrorSpy, consoleWarnSpy = jest.spyOn(console, 'error');",
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: "let consoleErrorSpy = jest.spyOn(console, 'error'), consoleWarnSpy;",
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        import { database, isCity } from '../database';
+        import { loadCities } from '../api';
+
+        jest.mock('../api');
+
+        const initializeCityDatabase = () => {
+          database.addCity('Vienna');
+          database.addCity('San Juan');
+          database.addCity('Wellington');
+        };
+
+        const clearCityDatabase = () => {
+          database.clear();
+        };
+
+        initializeCityDatabase();
+
+        test('that persists cities', () => {
+          expect(database.cities.length).toHaveLength(3);
+        });
+
+        test('city database has Vienna', () => {
+          expect(isCity('Vienna')).toBeTruthy();
+        });
+
+        test('city database has San Juan', () => {
+          expect(isCity('San Juan')).toBeTruthy();
+        });
+
+        describe('when loading cities from the api', () => {
+          let consoleWarnSpy = jest.spyOn(console, 'warn');
+
+          loadCities.mockResolvedValue(['Wellington', 'London']);
+
+          it('does not duplicate cities', async () => {
+            await database.loadCities();
+
+            expect(database.cities).toHaveLength(4);
+          });
+
+          it('logs any duplicates', async () => {
+            await database.loadCities();
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+              'Ignored duplicate cities: Wellington',
+            );
+          });
+        });
+
+        clearCityDatabase();
+      `,
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 16,
+          column: 1,
+        },
+        {
+          messageId: 'useHook',
+          line: 31,
+          column: 3,
+        },
+        {
+          messageId: 'useHook',
+          line: 33,
+          column: 3,
+        },
+        {
+          messageId: 'useHook',
+          line: 50,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        enableAutoDestroy(afterEach);
+
+        describe('some tests', () => {
+          it('is false', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+      options: [{ allowedFunctionCalls: ['someOtherName'] }],
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        import { setup } from '../test-utils';
+
+        // todo: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56545
+        declare module 'eslint' {
+          namespace ESLint {
+            interface LintResult {
+              fatalErrorCount: number;
+            }
+          }
+        }
+
+        describe('some tests', () => {
+          setup();
+        });
+      `,
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 13,
+          column: 3,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port `require-hook` from eslint-plugin-jest to rslint

## Related Links

<!--- Provide links of related issues or pages -->

Tracking issue: https://github.com/web-infra-dev/rslint/issues/476
eslint-plugin-jest/require-hook [doc](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/require-hook.md) [code](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/rules/require-hook.ts)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
