### PR TITLE
feat(rstest): add no-commented-out-tests rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -1,6 +1,7 @@
 package rstest
 
 import (
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_commented_out_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_identical_title"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -8,6 +9,7 @@ import (
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
+		no_commented_out_tests.NoCommentedOutTestsRule,
 		no_identical_title.NoIdenticalTitleRule,
 		no_mocks_import.NoMocksImportRule,
 	}

--- a/internal/plugins/rstest/rules/no_commented_out_tests/commented_call_analyzer.go
+++ b/internal/plugins/rstest/rules/no_commented_out_tests/commented_call_analyzer.go
@@ -214,20 +214,64 @@ func rootStartsLogicalLine(text string, offset int) bool {
 	return true
 }
 
-func insideMarkdownFence(text string, offset int) bool {
+func opensMarkdownFence(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
+}
+
+// markdownFenceTracker reports whether an offset sits inside a fenced code
+// block. Candidates are visited in ascending order, so the tracker advances a
+// cursor across the text once instead of rescanning from the start for each
+// candidate.
+type markdownFenceTracker struct {
+	cursor int
+	inside bool
+}
+
+func (tracker *markdownFenceTracker) insideAt(text string, offset int) bool {
 	if offset < 0 || offset > len(text) {
 		return false
 	}
-	inFence := false
-	for _, line := range strings.Split(text[:offset], "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
-			inFence = !inFence
-		}
+	if offset < tracker.cursor {
+		tracker.cursor = 0
+		tracker.inside = false
 	}
-	return inFence
+
+	for tracker.cursor < offset {
+		lineEnd := len(text)
+		if newline := strings.IndexByte(text[tracker.cursor:], '\n'); newline >= 0 {
+			lineEnd = tracker.cursor + newline
+		}
+		if lineEnd >= offset {
+			break
+		}
+		if opensMarkdownFence(text[tracker.cursor:lineEnd]) {
+			tracker.inside = !tracker.inside
+		}
+		tracker.cursor = lineEnd + 1
+	}
+
+	// The partial line holding the offset can open a fence too, but the toggle
+	// is not recorded because a later candidate may sit on the same line.
+	if opensMarkdownFence(text[tracker.cursor:offset]) {
+		return !tracker.inside
+	}
+	return tracker.inside
 }
 
+// registrationExpressionStatement returns the ExpressionStatement a registration
+// opens, or nil when the call does not begin a statement of its own.
+//
+// Adjacent line comments are reconstructed into one block before parsing, so a
+// trailing note binds to the call it follows: `test("foo", () => {})` plus a
+// `- flaky` line parses as a BinaryExpression, and a `(fixture)` line as an
+// outer CallExpression. Demanding that the call be the direct child of an
+// ExpressionStatement therefore drops registrations that are complete on their
+// own line, which is the common shape for a disabled test with a note.
+//
+// Walking through parents that start where the call starts accepts those while
+// still rejecting a call nested in a construct opened earlier, such as an array
+// element or an argument, whose parent begins before the call does.
 func registrationExpressionStatement(node *ast.Node) *ast.Node {
 	for node != nil && node.Parent != nil {
 		parent := node.Parent
@@ -241,7 +285,13 @@ func registrationExpressionStatement(node *ast.Node) *ast.Node {
 		case ast.KindExpressionStatement:
 			return parent
 		default:
-			return nil
+			// A node shares its position with its first child, so equal
+			// positions mean the call is the leftmost token of the parent and
+			// whatever follows only trails the completed registration.
+			if parent.Pos() != node.Pos() {
+				return nil
+			}
+			node = parent
 		}
 	}
 	return nil
@@ -277,11 +327,57 @@ func hasDiagnosticInRange(diagnostics []*ast.Diagnostic, start, end int) bool {
 	return false
 }
 
+// lineWindowEnd returns the offset just past the first count lines of text.
+func lineWindowEnd(text string, count int) int {
+	offset := 0
+	for ; count > 0; count-- {
+		newline := strings.IndexByte(text[offset:], '\n')
+		if newline < 0 {
+			return len(text)
+		}
+		offset += newline + 1
+	}
+	return offset
+}
+
+// findRegistrationInCandidate looks for a registration starting at the given
+// root offset, parsing progressively larger slices of text.
+//
+// Candidates are sliced from the start of their line to the end of the comment
+// block, so parsing every candidate in full makes a block of commented-out
+// tests cost one parse of the remaining block per test. Growing the window by
+// doubling the line count keeps a single-line registration at one parse and a
+// multiline one at a logarithmic number, which bounds the total work for a
+// block by its length rather than by its length times the candidate count.
 func findRegistrationInCandidate(text string, expectedRootOffset int, scriptKind core.ScriptKind) (int, bool) {
+	for lines := 1; ; lines *= 2 {
+		end := lineWindowEnd(text, lines)
+		complete := end >= len(text)
+		if end >= expectedRootOffset {
+			if offset, found := findRegistrationInWindow(text[:end], expectedRootOffset, scriptKind, complete); found {
+				return offset, true
+			}
+		}
+		if complete {
+			return 0, false
+		}
+	}
+}
+
+func findRegistrationInWindow(text string, expectedRootOffset int, scriptKind core.ScriptKind, complete bool) (int, bool) {
 	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
 		FileName: "/commented-rstest",
 		Path:     "/commented-rstest",
 	}, text, scriptKind)
+
+	// A window that stops short of the candidate can cut a registration in
+	// half, and the parser recovers such a slice into a complete-looking call
+	// whose only diagnostic sits past the call's end. Trusting a partial window
+	// therefore requires it to have parsed cleanly; otherwise the search grows
+	// and reconsiders the same call with more text.
+	if !complete && len(sourceFile.Diagnostics()) > 0 {
+		return 0, false
+	}
 
 	bestOffset := len(text) + 1
 	var visit func(*ast.Node) bool
@@ -295,7 +391,7 @@ func findRegistrationInCandidate(text string, expectedRootOffset int, scriptKind
 				!strings.Contains(text[expression.rootOffset:expectedRootOffset], "\n") &&
 				expression.rootOffset < bestOffset &&
 				statement != nil &&
-				!hasDiagnosticInRange(sourceFile.Diagnostics(), statement.Pos(), statement.End()) &&
+				!hasDiagnosticInRange(sourceFile.Diagnostics(), node.Pos(), node.End()) &&
 				registrationHasCleanLineEnd(text, node.End()) {
 				bestOffset = expectedRootOffset
 			}
@@ -314,13 +410,14 @@ func findCommentedRstestRegistrations(text string, scriptKind core.ScriptKind) [
 	matches := rstestRootCandidate.FindAllStringSubmatchIndex(text, -1)
 	offsets := make([]int, 0, len(matches))
 	seen := make(map[int]struct{}, len(matches))
+	var fence markdownFenceTracker
 	for _, match := range matches {
 		if len(match) < 4 {
 			continue
 		}
 		candidateStart := match[0]
 		rootOffset := match[2]
-		if insideMarkdownFence(text, rootOffset) {
+		if fence.insideAt(text, rootOffset) {
 			continue
 		}
 		relativeRoot := rootOffset - candidateStart

--- a/internal/plugins/rstest/rules/no_commented_out_tests/commented_call_analyzer.go
+++ b/internal/plugins/rstest/rules/no_commented_out_tests/commented_call_analyzer.go
@@ -1,0 +1,342 @@
+package no_commented_out_tests
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+)
+
+var rstestRootCandidate = regexp.MustCompile(`(?m)^[\t ]*[;(]*[\t ]*(test|it|describe)\b`)
+
+type rstestAPIKind uint8
+
+const (
+	rstestAPIInvalid rstestAPIKind = iota
+	rstestAPITest
+	rstestAPIDescribe
+)
+
+type rstestAPIPhase uint8
+
+const (
+	rstestPhaseInvalid rstestAPIPhase = iota
+	rstestPhaseAPI
+	rstestPhaseConditionalFactory
+	rstestPhaseParameterizedFactory
+	rstestPhaseExtendFactory
+	rstestPhaseRegistrar
+	rstestPhaseRegistered
+)
+
+type rstestExpression struct {
+	kind       rstestAPIKind
+	phase      rstestAPIPhase
+	rootOffset int
+	extendable bool
+}
+
+func invalidRstestExpression() rstestExpression {
+	return rstestExpression{}
+}
+
+func unwrapRstestExpression(node *ast.Node) *ast.Node {
+	for node != nil {
+		switch node.Kind {
+		case ast.KindParenthesizedExpression:
+			node = node.AsParenthesizedExpression().Expression
+		case ast.KindAsExpression:
+			node = node.AsAsExpression().Expression
+		case ast.KindTypeAssertionExpression:
+			node = node.AsTypeAssertion().Expression
+		case ast.KindNonNullExpression:
+			node = node.AsNonNullExpression().Expression
+		case ast.KindSatisfiesExpression:
+			node = node.AsSatisfiesExpression().Expression
+		default:
+			return node
+		}
+	}
+	return nil
+}
+
+func staticRstestMemberName(node *ast.Node) (string, *ast.Node, bool) {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		access := node.AsPropertyAccessExpression()
+		name := access.Name()
+		if name == nil {
+			return "", nil, false
+		}
+		return name.Text(), access.Expression, true
+	case ast.KindElementAccessExpression:
+		access := node.AsElementAccessExpression()
+		argument := unwrapRstestExpression(access.ArgumentExpression)
+		if argument == nil {
+			return "", nil, false
+		}
+		switch argument.Kind {
+		case ast.KindStringLiteral:
+			return argument.AsStringLiteral().Text, access.Expression, true
+		case ast.KindNoSubstitutionTemplateLiteral:
+			return argument.AsNoSubstitutionTemplateLiteral().Text, access.Expression, true
+		default:
+			return "", nil, false
+		}
+	default:
+		return "", nil, false
+	}
+}
+
+func applyRstestMember(receiver rstestExpression, member string) rstestExpression {
+	if receiver.phase != rstestPhaseAPI {
+		return invalidRstestExpression()
+	}
+
+	switch member {
+	case "only", "skip", "todo", "concurrent", "sequential":
+		receiver.extendable = false
+		return receiver
+	case "fails":
+		if receiver.kind != rstestAPITest {
+			return invalidRstestExpression()
+		}
+		receiver.extendable = false
+		return receiver
+	case "runIf", "skipIf":
+		receiver.phase = rstestPhaseConditionalFactory
+		receiver.extendable = false
+		return receiver
+	case "each", "for":
+		receiver.phase = rstestPhaseParameterizedFactory
+		receiver.extendable = false
+		return receiver
+	case "extend":
+		if receiver.kind != rstestAPITest || !receiver.extendable {
+			return invalidRstestExpression()
+		}
+		receiver.phase = rstestPhaseExtendFactory
+		return receiver
+	default:
+		return invalidRstestExpression()
+	}
+}
+
+func evaluateRstestExpression(node *ast.Node) rstestExpression {
+	node = unwrapRstestExpression(node)
+	if node == nil {
+		return invalidRstestExpression()
+	}
+
+	switch node.Kind {
+	case ast.KindIdentifier:
+		name := node.AsIdentifier().Text
+		switch name {
+		case "test", "it":
+			return rstestExpression{
+				kind:       rstestAPITest,
+				phase:      rstestPhaseAPI,
+				rootOffset: node.Loc.Pos(),
+				extendable: true,
+			}
+		case "describe":
+			return rstestExpression{
+				kind:       rstestAPIDescribe,
+				phase:      rstestPhaseAPI,
+				rootOffset: node.Loc.Pos(),
+			}
+		default:
+			return invalidRstestExpression()
+		}
+
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		member, receiverNode, ok := staticRstestMemberName(node)
+		if !ok {
+			return invalidRstestExpression()
+		}
+		return applyRstestMember(evaluateRstestExpression(receiverNode), member)
+
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		expression := evaluateRstestExpression(call.Expression)
+		switch expression.phase {
+		case rstestPhaseAPI, rstestPhaseRegistrar:
+			if call.TypeArguments != nil {
+				return invalidRstestExpression()
+			}
+			expression.phase = rstestPhaseRegistered
+			expression.extendable = false
+			return expression
+		case rstestPhaseConditionalFactory:
+			if call.TypeArguments != nil {
+				return invalidRstestExpression()
+			}
+			expression.phase = rstestPhaseAPI
+			expression.extendable = false
+			return expression
+		case rstestPhaseParameterizedFactory:
+			expression.phase = rstestPhaseRegistrar
+			return expression
+		case rstestPhaseExtendFactory:
+			expression.phase = rstestPhaseAPI
+			expression.extendable = true
+			return expression
+		default:
+			return invalidRstestExpression()
+		}
+
+	case ast.KindTaggedTemplateExpression:
+		tagged := node.AsTaggedTemplateExpression()
+		expression := evaluateRstestExpression(tagged.Tag)
+		if expression.phase != rstestPhaseParameterizedFactory {
+			return invalidRstestExpression()
+		}
+		expression.phase = rstestPhaseRegistrar
+		return expression
+	default:
+		return invalidRstestExpression()
+	}
+}
+
+func rootStartsLogicalLine(text string, offset int) bool {
+	if offset < 0 || offset > len(text) {
+		return false
+	}
+	lineStart := strings.LastIndexByte(text[:offset], '\n') + 1
+	prefix := strings.TrimSpace(text[lineStart:offset])
+	for _, char := range prefix {
+		if char != '(' && char != ';' {
+			return false
+		}
+	}
+	return true
+}
+
+func insideMarkdownFence(text string, offset int) bool {
+	if offset < 0 || offset > len(text) {
+		return false
+	}
+	inFence := false
+	for _, line := range strings.Split(text[:offset], "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+		}
+	}
+	return inFence
+}
+
+func registrationExpressionStatement(node *ast.Node) *ast.Node {
+	for node != nil && node.Parent != nil {
+		parent := node.Parent
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression,
+			ast.KindAsExpression,
+			ast.KindTypeAssertionExpression,
+			ast.KindNonNullExpression,
+			ast.KindSatisfiesExpression:
+			node = parent
+		case ast.KindExpressionStatement:
+			return parent
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+func registrationHasCleanLineEnd(text string, end int) bool {
+	if end < 0 || end > len(text) {
+		return false
+	}
+	lineEnd := len(text)
+	if newline := strings.IndexByte(text[end:], '\n'); newline >= 0 {
+		lineEnd = end + newline
+	}
+	trailing := strings.TrimSpace(text[end:lineEnd])
+	return trailing == "" ||
+		strings.HasPrefix(trailing, ";") ||
+		strings.HasPrefix(trailing, "//") ||
+		strings.HasPrefix(trailing, "/*")
+}
+
+func hasDiagnosticInRange(diagnostics []*ast.Diagnostic, start, end int) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic == nil {
+			continue
+		}
+		// Parser diagnostics for missing tokens have zero-width ranges. Treat
+		// their position as intersecting the statement so parser-recovered
+		// prose such as `test (see docs)` is not reported as code.
+		if diagnostic.Pos() <= end && diagnostic.End() >= start {
+			return true
+		}
+	}
+	return false
+}
+
+func findRegistrationInCandidate(text string, expectedRootOffset int, scriptKind core.ScriptKind) (int, bool) {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/commented-rstest",
+		Path:     "/commented-rstest",
+	}, text, scriptKind)
+
+	bestOffset := len(text) + 1
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindCallExpression {
+			expression := evaluateRstestExpression(node)
+			statement := registrationExpressionStatement(node)
+			if expression.phase == rstestPhaseRegistered &&
+				expression.rootOffset >= 0 &&
+				expression.rootOffset <= expectedRootOffset &&
+				!strings.Contains(text[expression.rootOffset:expectedRootOffset], "\n") &&
+				expression.rootOffset < bestOffset &&
+				statement != nil &&
+				!hasDiagnosticInRange(sourceFile.Diagnostics(), statement.Pos(), statement.End()) &&
+				registrationHasCleanLineEnd(text, node.End()) {
+				bestOffset = expectedRootOffset
+			}
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+
+	if bestOffset > len(text) {
+		return 0, false
+	}
+	return bestOffset, true
+}
+
+func findCommentedRstestRegistrations(text string, scriptKind core.ScriptKind) []int {
+	matches := rstestRootCandidate.FindAllStringSubmatchIndex(text, -1)
+	offsets := make([]int, 0, len(matches))
+	seen := make(map[int]struct{}, len(matches))
+	for _, match := range matches {
+		if len(match) < 4 {
+			continue
+		}
+		candidateStart := match[0]
+		rootOffset := match[2]
+		if insideMarkdownFence(text, rootOffset) {
+			continue
+		}
+		relativeRoot := rootOffset - candidateStart
+		foundOffset, found := findRegistrationInCandidate(text[candidateStart:], relativeRoot, scriptKind)
+		if !found {
+			continue
+		}
+		absoluteOffset := candidateStart + foundOffset
+		if !rootStartsLogicalLine(text, absoluteOffset) {
+			continue
+		}
+		if _, exists := seen[absoluteOffset]; exists {
+			continue
+		}
+		seen[absoluteOffset] = struct{}{}
+		offsets = append(offsets, absoluteOffset)
+	}
+	return offsets
+}

--- a/internal/plugins/rstest/rules/no_commented_out_tests/no_commented_out_tests.go
+++ b/internal/plugins/rstest/rules/no_commented_out_tests/no_commented_out_tests.go
@@ -1,0 +1,235 @@
+package no_commented_out_tests
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type commentBlockSegment struct {
+	start   int
+	comment *ast.CommentRange
+}
+
+type commentBlock struct {
+	text     string
+	segments []commentBlockSegment
+}
+
+func lineTerminatorLength(text string, offset int) int {
+	if offset < 0 || offset >= len(text) {
+		return 0
+	}
+	switch text[offset] {
+	case '\n':
+		return 1
+	case '\r':
+		if offset+1 < len(text) && text[offset+1] == '\n' {
+			return 2
+		}
+		return 1
+	}
+	if strings.HasPrefix(text[offset:], "\u2028") || strings.HasPrefix(text[offset:], "\u2029") {
+		return len("\u2028")
+	}
+	return 0
+}
+
+func normalizeBlockCommentBody(body string) string {
+	var normalized strings.Builder
+	normalized.Grow(len(body))
+
+	for offset := 0; offset < len(body); {
+		lineEnd := offset
+		for lineEnd < len(body) && lineTerminatorLength(body, lineEnd) == 0 {
+			_, size := utf8.DecodeRuneInString(body[lineEnd:])
+			lineEnd += size
+		}
+
+		content := body[offset:lineEnd]
+		leaderEnd := 0
+		for leaderEnd < len(content) && (content[leaderEnd] == ' ' || content[leaderEnd] == '\t') {
+			leaderEnd++
+		}
+		if leaderEnd < len(content) && content[leaderEnd] == '*' {
+			leaderEnd++
+			if leaderEnd < len(content) && (content[leaderEnd] == ' ' || content[leaderEnd] == '\t') {
+				leaderEnd++
+			}
+			content = content[leaderEnd:]
+		}
+		normalized.WriteString(content)
+
+		terminatorLength := lineTerminatorLength(body, lineEnd)
+		if terminatorLength == 0 {
+			break
+		}
+		// The normalized text is synthetic and block comments always map back
+		// to one physical comment. Canonicalizing every ECMAScript line
+		// terminator to LF lets the multiline candidate matcher behave
+		// consistently for CR, CRLF, U+2028, and U+2029.
+		normalized.WriteByte('\n')
+		offset = lineEnd + terminatorLength
+	}
+
+	return normalized.String()
+}
+
+func buildCommentedTestsMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "commentedTests",
+		Description: "Do not comment out tests",
+	}
+}
+
+func commentBody(sourceText string, comment *ast.CommentRange) (string, bool) {
+	if comment == nil || comment.Pos() < 0 || comment.End() > len(sourceText) {
+		return "", false
+	}
+
+	switch comment.Kind {
+	case ast.KindSingleLineCommentTrivia:
+		if comment.Pos()+2 > comment.End() || sourceText[comment.Pos():comment.Pos()+2] != "//" {
+			return "", false
+		}
+		return sourceText[comment.Pos()+2 : comment.End()], true
+	case ast.KindMultiLineCommentTrivia:
+		if comment.Pos()+4 > comment.End() ||
+			sourceText[comment.Pos():comment.Pos()+2] != "/*" ||
+			sourceText[comment.End()-2:comment.End()] != "*/" {
+			return "", false
+		}
+		// Documentation examples are not disabled tests. Regular block comments
+		// remain eligible, including multiline comments containing full test
+		// bodies.
+		if sourceText[comment.Pos():comment.Pos()+3] == "/**" {
+			return "", false
+		}
+		return normalizeBlockCommentBody(sourceText[comment.Pos()+2 : comment.End()-2]), true
+	default:
+		return "", false
+	}
+}
+
+func containsExactlyOneLineTerminator(text string) bool {
+	count := 0
+	for offset := 0; offset < len(text); {
+		if size := lineTerminatorLength(text, offset); size != 0 {
+			count++
+			if count > 1 {
+				return false
+			}
+			offset += size
+			continue
+		}
+
+		r, size := utf8.DecodeRuneInString(text[offset:])
+		if r == utf8.RuneError && size == 1 || !unicode.IsSpace(r) {
+			return false
+		}
+		offset += size
+	}
+	return count == 1
+}
+
+func lineCommentsAreAdjacent(sourceText string, current, next *ast.CommentRange) bool {
+	if current == nil || next == nil ||
+		current.Kind != ast.KindSingleLineCommentTrivia ||
+		next.Kind != ast.KindSingleLineCommentTrivia ||
+		current.End() > next.Pos() {
+		return false
+	}
+
+	between := sourceText[current.End():next.Pos()]
+	return containsExactlyOneLineTerminator(between)
+}
+
+func buildCommentBlocks(sourceText string, comments []*ast.CommentRange) []commentBlock {
+	blocks := make([]commentBlock, 0, len(comments))
+
+	for i := 0; i < len(comments); {
+		comment := comments[i]
+		body, ok := commentBody(sourceText, comment)
+		if !ok {
+			i++
+			continue
+		}
+
+		var text strings.Builder
+		text.Grow(len(body))
+		text.WriteString(body)
+		block := commentBlock{
+			segments: []commentBlockSegment{{
+				start:   0,
+				comment: comment,
+			}},
+		}
+		i++
+
+		if comment.Kind == ast.KindSingleLineCommentTrivia {
+			previous := comment
+			for i < len(comments) && lineCommentsAreAdjacent(sourceText, previous, comments[i]) {
+				next := comments[i]
+				nextBody, nextOK := commentBody(sourceText, next)
+				if !nextOK {
+					break
+				}
+				text.WriteByte('\n')
+				block.segments = append(block.segments, commentBlockSegment{
+					start:   text.Len(),
+					comment: next,
+				})
+				text.WriteString(nextBody)
+				previous = next
+				i++
+			}
+		}
+
+		block.text = text.String()
+		blocks = append(blocks, block)
+	}
+
+	return blocks
+}
+
+func (block commentBlock) commentAt(offset int) *ast.CommentRange {
+	if len(block.segments) == 0 {
+		return nil
+	}
+	for i := len(block.segments) - 1; i >= 0; i-- {
+		if offset >= block.segments[i].start {
+			return block.segments[i].comment
+		}
+	}
+	return block.segments[0].comment
+}
+
+var NoCommentedOutTestsRule = rule.Rule{
+	Name:   "rstest/no-commented-out-tests",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		sourceText := ctx.SourceFile.Text()
+		for _, block := range buildCommentBlocks(sourceText, ctx.Comments.All()) {
+			reportedComments := make(map[*ast.CommentRange]struct{})
+			for _, offset := range findCommentedRstestRegistrations(block.text, ctx.SourceFile.ScriptKind) {
+				comment := block.commentAt(offset)
+				if comment == nil {
+					continue
+				}
+				if _, reported := reportedComments[comment]; reported {
+					continue
+				}
+				reportedComments[comment] = struct{}{}
+				ctx.ReportRange(
+					core.NewTextRange(comment.Pos(), comment.End()),
+					buildCommentedTestsMessage(),
+				)
+			}
+		}
+		return rule.RuleListeners{}
+	},
+}

--- a/internal/plugins/rstest/rules/no_commented_out_tests/no_commented_out_tests.md
+++ b/internal/plugins/rstest/rules/no_commented_out_tests/no_commented_out_tests.md
@@ -1,0 +1,65 @@
+# no-commented-out-tests
+
+## Rule Details
+
+Disallow commented-out Rstest test cases and `describe` blocks. Commented-out tests are easy to overlook during review and can remain disabled indefinitely. Prefer removing dead tests or using an explicit Rstest API such as `.skip` or `.todo` when a disabled test should remain visible.
+
+The rule reconstructs consecutive line comments and parses the text inside regular line and block comments as TypeScript. It reports a comment when a line, after optional whitespace, contains a call rooted at `test`, `it`, or `describe` that ultimately registers a test or suite.
+
+The matcher understands:
+
+- Direct registrations and static dot or bracket member access.
+- The `only`, `skip`, `todo`, `fails`, `concurrent`, and `sequential` modifiers where supported by Rstest.
+- The `runIf` and `skipIf` conditional factories.
+- Array and tagged-template forms of `each` and `for`, including explicit type arguments.
+- Fixture APIs created with `test.extend`, including repeated extension.
+- Parenthesized and optional calls.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+// test('adds two numbers', () => {});
+// it.skip('is temporarily disabled', () => {});
+
+// describe.only.concurrent('focused suite', () => {});
+// test.for([{ value: 1 }])('handles $value', ({ value }) => {});
+// test.extend(fixtures).only('uses fixtures', () => {});
+
+// test.each`
+//   value | expected
+//   ${1}  | ${2}
+// `('returns $expected', ({ value, expected }) => {});
+
+/*
+describe
+  .only
+  .concurrent('math', () => {});
+*/
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+// These calls only create another API or registrar. They do not define a test.
+// test.runIf(condition)
+// test.each(rows)
+// test.for`value | expected`
+// test.extend(fixtures)
+
+// Dynamic, unknown, and non-Rstest APIs are outside this rule's scope.
+// test[modifier]('name', () => {});
+// test.unknown('name', () => {});
+// fit('name', () => {});
+// rstest.test('name', () => {});
+```
+
+## Limitations
+
+The code inside a comment no longer participates in the source file's symbol table. The rule therefore recognizes only the canonical `test`, `it`, and `describe` names. It does not resolve imported aliases, locally renamed APIs, variables returned from `test.extend`, or namespace and in-source forms such as `import.meta.rstest`.
+
+Documentation comments (`/** ... */`) and calls inside Markdown fenced code blocks are ignored to avoid reporting examples as disabled tests. Regular prose must still form a standalone, syntactically valid Rstest registration before it is reported.
+
+## References
+
+- [Rstest `test` API](https://rstest.rs/api/runtime-api/test-api/test)
+- [Rstest `describe` API](https://rstest.rs/api/runtime-api/test-api/describe)

--- a/internal/plugins/rstest/rules/no_commented_out_tests/no_commented_out_tests_test.go
+++ b/internal/plugins/rstest/rules/no_commented_out_tests/no_commented_out_tests_test.go
@@ -1,0 +1,257 @@
+package no_commented_out_tests_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_commented_out_tests"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoCommentedOutTests(t *testing.T) {
+	invalid := func(code string) rule_tester.InvalidTestCase {
+		return rule_tester.InvalidTestCase{
+			Code: code,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "commentedTests", Line: 1, Column: 1},
+			},
+		}
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_commented_out_tests.NoCommentedOutTestsRule,
+		[]rule_tester.ValidTestCase{
+			// Active Rstest calls are not comments.
+			{Code: `test("foo", () => {})`},
+			{Code: `it.skip("foo", () => {})`},
+			{Code: `describe.only("foo", () => {})`},
+			{Code: `it.only.fails("foo", () => {})`},
+			{Code: `describe.only.concurrent("foo", () => {})`},
+			{Code: "test.each`\nvalue\n${1}\n`(\"$value\", ({ value }) => {})"},
+			{Code: `describe.each<Row>(rows)("foo", ({ value }) => {})`},
+
+			// Jest aliases are not part of the Rstest API.
+			{Code: `// fit("foo", () => {})`},
+			{Code: `// xit("foo", () => {})`},
+			{Code: `// xtest("foo", () => {})`},
+			{Code: `// fdescribe("foo", () => {})`},
+			{Code: `// xdescribe("foo", () => {})`},
+
+			// Similar names and APIs outside the supported Rstest roots are ignored.
+			{Code: `// suite("foo", () => {})`},
+			{Code: `// myTest("foo", () => {})`},
+			{Code: `// rstest.test("foo", () => {})`},
+			{Code: `// beforeEach(() => {})`},
+			{Code: `// testSomething()`},
+			{Code: `// latest(items)`},
+			{Code: "// test`not a parameterized Rstest API`"},
+			{Code: `// test.only`},
+			{Code: `// describe.concurrent`},
+
+			// Type arguments are only recognized after each/for, so prose
+			// containing angle brackets is not mistaken for a test call.
+			{Code: `// test <input> (see docs)`},
+			{Code: `// it <-> (x)`},
+			{Code: `// describe <T> (generic explanation)`},
+
+			// Factory calls do not register a test or suite until the returned
+			// API/registrar is invoked.
+			{Code: `// test.runIf(condition)`},
+			{Code: `// test.skipIf(condition).only`},
+			{Code: `// test.each(rows)`},
+			{Code: "// test.for`value | expected`"},
+			{Code: `// describe.each<Row>(rows)`},
+			{Code: `// test.extend(fixtures)`},
+			{Code: `// test.extend(fixtures).only`},
+
+			// These chains are not part of the current Rstest API. In
+			// particular, each/for return a plain registrar rather than an API
+			// carrying trailing modifiers.
+			{Code: `// test.each(rows).only("foo", () => {})`},
+			{Code: `// describe.for(rows).concurrent("foo", () => {})`},
+			{Code: `// test.only.extend(fixtures)("foo", () => {})`},
+			{Code: `// describe.extend(fixtures)("foo", () => {})`},
+			{Code: `// describe.fails("foo", () => {})`},
+			{Code: `// test.unknown("foo", () => {})`},
+			{Code: `// test[modifier]("foo", () => {})`},
+
+			// Documentation and prose are not disabled tests.
+			{Code: `/** test("documented example", () => {}) */`},
+			{Code: "// ```ts\n// test(\"documented example\", () => {})\n// ```"},
+			{Code: `// test("foo") should be preferred in examples`},
+			{Code: "/* `test(\"foo\", () => {})` */"},
+			{Code: `// test (see docs)`},
+			{Code: `// test (foo bar)`},
+			{Code: `// describe (documentation example)`},
+			{
+				Code:     `// test("generic", () => <T>(value: T) => value)`,
+				FileName: "file.tsx",
+			},
+			{
+				Code:     `// test("invalid JSX here", () => <div />)`,
+				FileName: "file.ts",
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Direct test and suite calls.
+			invalid(`// test("foo", () => {})`),
+			invalid(`// it("foo", () => {})`),
+			invalid(`// describe("foo", () => {})`),
+
+			// Every Rstest test modifier.
+			invalid(`// test.only("foo", () => {})`),
+			invalid(`// test.skip("foo", () => {})`),
+			invalid(`// test.todo("foo")`),
+			invalid(`// test.fails("foo", () => {})`),
+			invalid(`// test.concurrent("foo", () => {})`),
+			invalid(`// test.sequential("foo", () => {})`),
+			invalid(`// test.runIf(condition)("foo", () => {})`),
+			invalid(`// test.skipIf(condition)("foo", () => {})`),
+
+			// Every Rstest suite modifier.
+			invalid(`// describe.only("foo", () => {})`),
+			invalid(`// describe.skip("foo", () => {})`),
+			invalid(`// describe.todo("foo")`),
+			invalid(`// describe.concurrent("foo", () => {})`),
+			invalid(`// describe.sequential("foo", () => {})`),
+			invalid(`// describe.runIf(condition)("foo", () => {})`),
+			invalid(`// describe.skipIf(condition)("foo", () => {})`),
+
+			// Getter and conditional modifiers can be chained.
+			invalid(`// it.only.fails("foo", () => {})`),
+			invalid(`// test.skip.concurrent("foo", () => {})`),
+			invalid(`// test.concurrent.only("foo", () => {})`),
+			invalid(`// test.concurrent.runIf(condition)("foo", () => {})`),
+			invalid(`// describe.only.concurrent("foo", () => {})`),
+			invalid(`// describe.concurrent.only("foo", () => {})`),
+			invalid(`// describe.concurrent.skipIf(condition)("foo", () => {})`),
+			invalid(`// describe.skipIf(condition).concurrent("foo", () => {})`),
+
+			// Array-based parameterized tests and suites.
+			invalid(`// test.each(rows)("foo", ({ value }) => {})`),
+			invalid(`// test.for(rows)("foo", ({ value }) => {})`),
+			invalid(`// it.each(rows)("foo", ({ value }) => {})`),
+			invalid(`// it.for(rows)("foo", ({ value }) => {})`),
+			invalid(`// describe.each(rows)("foo", ({ value }) => {})`),
+			invalid(`// describe.for(rows)("foo", ({ value }) => {})`),
+			invalid(`// it.only.each(rows)("foo", ({ value }) => {})`),
+			invalid(`// it.concurrent.for(rows)("foo", ({ value }) => {})`),
+			invalid(`// describe.only.each(rows)("foo", ({ value }) => {})`),
+			invalid(`// describe.skip.for(rows)("foo", ({ value }) => {})`),
+
+			// Explicit type arguments are supported by each and for.
+			invalid(`// test.each<Row>(rows)("foo", ({ value }) => {})`),
+			invalid(`// test.for<Row>(rows)("foo", ({ value }) => {})`),
+			invalid(`// describe.each<Row>(rows)("foo", ({ value }) => {})`),
+			invalid(`// describe.for<Row>(rows)("foo", ({ value }) => {})`),
+			invalid(`// test.for<{ value: Map<string, number> }>(rows)("foo", ({ value }) => {})`),
+
+			// Tagged-template parameterized tests and suites.
+			invalid("// test.each`value | expected`(\"foo\", ({ value }) => {})"),
+			invalid("// test.for`value | expected`(\"foo\", ({ value }) => {})"),
+			invalid("// it.each`value | expected`(\"foo\", ({ value }) => {})"),
+			invalid("// it.for`value | expected`(\"foo\", ({ value }) => {})"),
+			invalid("// describe.each`value | expected`(\"foo\", ({ value }) => {})"),
+			invalid("// describe.for`value | expected`(\"foo\", ({ value }) => {})"),
+			invalid("// test.for<Row>`value | expected`(\"foo\", ({ value }) => {})"),
+			invalid("// describe.each<Row>`value | expected`(\"foo\", ({ value }) => {})"),
+			invalid("// it.concurrent.for<Row>`value | expected`(\"foo\", ({ value }) => {})"),
+
+			// Property and bracket access can be chained.
+			invalid(`// describe['skip']("foo", () => {})`),
+			invalid(`// test["only"]["concurrent"]("foo", () => {})`),
+			invalid(`// describe['only'].each(rows)("foo", ({ value }) => {})`),
+			invalid("// test[\"for\"]`value | expected`(\"foo\", ({ value }) => {})"),
+
+			// Block comments may contain multiline calls and chains.
+			invalid("/*\n  describe(\"foo\", () => {})\n*/"),
+			invalid("/*\n  describe\n    .only\n    .concurrent(\"foo\", () => {})\n*/"),
+			invalid("/*\n  test.for<Row>`\n    value\n    ${1}\n  `(\"$value\", ({ value }) => {})\n*/"),
+			invalid("/*\n * test(\"foo\", () => {})\n */"),
+			invalid("/*\n\t* describe\n\t*   .only(\"foo\", () => {})\n */"),
+			invalid("/*\n * test.each`\n * value | expected\n * ${1} | ${2}\n * `(\"foo\", () => {})\n */"),
+
+			// Conditional factories only become registrations after the
+			// returned API is invoked.
+			invalid(`// test.runIf(condition).only("foo", () => {})`),
+			invalid(`// describe.only.skipIf(condition)("foo", () => {})`),
+			invalid(`// test["runIf"](condition)["concurrent"]("foo", () => {})`),
+
+			// extend creates another test API. A bare extend call above is
+			// valid, while invoking the returned API defines a test.
+			invalid(`// test.extend(fixtures)("foo", () => {})`),
+			invalid(`// it.extend<Fixtures>(fixtures).only("foo", () => {})`),
+			invalid(`// test.extend(a).extend(b)("foo", () => {})`),
+			invalid(`// test.extend(fixtures).each(rows)("foo", () => {})`),
+
+			// Transparent syntax around a canonical Rstest root remains a
+			// commented-out registration.
+			invalid(`// ((test))("foo", () => {})`),
+			invalid(`// test?.("foo", () => {})`),
+			invalid(`// test?.only("foo", () => {})`),
+			invalid("// test[`only`](\"foo\", () => {})"),
+			invalid(`// ;describe("foo", () => {})`),
+
+			// Consecutive line comments are reconstructed before parsing, so
+			// chains and tagged templates may span physical comments.
+			invalid("// test\n//   .only\n//   .concurrent(\"foo\", () => {})"),
+			invalid("// test.each<Row>`\n// value | expected\n// ${1} | ${2}\n// `(\"foo\", () => {})"),
+			invalid("// test.extend({\n//   value: 1,\n// }).only(\"foo\", () => {})"),
+			invalid("// test\r//   .only(\"foo\", () => {})"),
+			invalid("// test\u2028//   .only(\"foo\", () => {})"),
+			invalid("// test\u2029//   .only(\"foo\", () => {})"),
+
+			// Commented code is parsed with the original file's script kind.
+			{
+				Code:     `/* test("renders", () => <div />) */`,
+				FileName: "file.tsx",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:     `// test("generic", () => <T>(value: T) => value)`,
+				FileName: "file.ts",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "// test(\"first\", () => {})\n// test(\"second\", () => {})",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 1, Column: 1},
+					{MessageId: "commentedTests", Line: 2, Column: 1},
+				},
+			},
+			invalid("/*\n * test(\"first\", () => {})\n * test(\"second\", () => {})\n */"),
+			invalid(`// test("first", () => {}); cleanup()`),
+			{
+				Code: "// setup only\n// test(\"foo\", () => {})",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: "// setup only\r\n// describe(\"foo\", () => {})",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: "// test(\"valid\", () => {})\n// test (see docs)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "// test(\"valid\", () => {})\n// unrelated invalid prose here",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/no_commented_out_tests/no_commented_out_tests_test.go
+++ b/internal/plugins/rstest/rules/no_commented_out_tests/no_commented_out_tests_test.go
@@ -84,6 +84,9 @@ func TestNoCommentedOutTests(t *testing.T) {
 			{Code: `// test("foo") should be preferred in examples`},
 			{Code: "/* `test(\"foo\", () => {})` */"},
 			{Code: `// test (see docs)`},
+			// A registration cut short by prose is not code, so the growing
+			// parse window must not accept the parser's recovery of it.
+			{Code: "// test(\"foo\", () => {\n//   prose that is not code !!!"},
 			{Code: `// test (foo bar)`},
 			{Code: `// describe (documentation example)`},
 			{
@@ -248,6 +251,40 @@ func TestNoCommentedOutTests(t *testing.T) {
 			},
 			{
 				Code: "// test(\"valid\", () => {})\n// unrelated invalid prose here",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 1, Column: 1},
+				},
+			},
+
+			// A trailing note that begins with a continuation token still binds
+			// to the call when the block is reconstructed, but the registration
+			// on the first line is complete on its own.
+			{
+				Code: "// test(\"foo\", () => {})\n// - flaky",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "// test(\"foo\", () => {})\n// (fixture)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "// test(\"foo\", () => {})\n// + see #123",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "// test(\"foo\", () => {})\n// `helper` is missing",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "commentedTests", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "// test(\"foo\", () => {\n//   expect(value).toBe(1)\n// })\n// - flaky",
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "commentedTests", Line: 1, Column: 1},
 				},

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -543,6 +543,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/valid-title.test.ts',
 
     // rstest
+    './tests/rstest/rules/no-commented-out-tests.test.ts',
     './tests/rstest/rules/no-identical-title.test.ts',
     './tests/rstest/rules/no-mocks-import.test.ts',
 

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -75,6 +75,7 @@ describe('defineConfig and config presets', () => {
     expect(rec.plugins).toBeDefined();
     expect(rec.plugins).toContain('rstest');
     expect(rec.rules).toEqual({
+      'rstest/no-commented-out-tests': 'warn',
       'rstest/no-identical-title': 'error',
       'rstest/no-mocks-import': 'error',
     });

--- a/packages/rslint-test-tools/tests/rstest/rules/no-commented-out-tests.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-commented-out-tests.test.ts
@@ -1,0 +1,179 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const invalid = (code: string) => ({
+  code,
+  errors: [{ message: 'Do not comment out tests' }],
+});
+
+ruleTester.run('no-commented-out-tests', {} as never, {
+  valid: [
+    // Active Rstest calls are not comments.
+    { code: 'test("foo", () => {})' },
+    { code: 'it.skip("foo", () => {})' },
+    { code: 'describe.only("foo", () => {})' },
+    { code: 'it.only.fails("foo", () => {})' },
+    { code: 'describe.only.concurrent("foo", () => {})' },
+    {
+      code: 'test.each`\nvalue\n${1}\n`("$value", ({ value }) => {})',
+    },
+    { code: 'describe.each<Row>(rows)("foo", ({ value }) => {})' },
+
+    // Jest aliases are not part of the Rstest API.
+    { code: '// fit("foo", () => {})' },
+    { code: '// xit("foo", () => {})' },
+    { code: '// xtest("foo", () => {})' },
+    { code: '// fdescribe("foo", () => {})' },
+    { code: '// xdescribe("foo", () => {})' },
+
+    // Similar names and APIs outside the supported Rstest roots are ignored.
+    { code: '// suite("foo", () => {})' },
+    { code: '// myTest("foo", () => {})' },
+    { code: '// rstest.test("foo", () => {})' },
+    { code: '// beforeEach(() => {})' },
+    { code: '// testSomething()' },
+    { code: '// latest(items)' },
+    { code: '// test`not a parameterized Rstest API`' },
+    { code: '// test.only' },
+    { code: '// describe.concurrent' },
+
+    // Type arguments are only recognized after each/for, so prose
+    // containing angle brackets is not mistaken for a test call.
+    { code: '// test <input> (see docs)' },
+    { code: '// it <-> (x)' },
+    { code: '// describe <T> (generic explanation)' },
+
+    // Factory calls do not register tests until their returned API is invoked.
+    { code: '// test.runIf(condition)' },
+    { code: '// test.skipIf(condition).only' },
+    { code: '// test.each(rows)' },
+    { code: '// test.for`value | expected`' },
+    { code: '// describe.each<Row>(rows)' },
+    { code: '// test.extend(fixtures)' },
+    { code: '// test.extend(fixtures).only' },
+
+    // Unsupported or non-static call chains are ignored.
+    { code: '// test.each(rows).only("foo", () => {})' },
+    { code: '// describe.for(rows).concurrent("foo", () => {})' },
+    { code: '// test.only.extend(fixtures)("foo", () => {})' },
+    { code: '// describe.extend(fixtures)("foo", () => {})' },
+    { code: '// describe.fails("foo", () => {})' },
+    { code: '// test.unknown("foo", () => {})' },
+    { code: '// test[modifier]("foo", () => {})' },
+
+    // Documentation and prose are not disabled tests.
+    { code: '/** test("documented example", () => {}) */' },
+    {
+      code: '// ```ts\n// test("documented example", () => {})\n// ```',
+    },
+    { code: '// test("foo") should be preferred in examples' },
+  ],
+  invalid: [
+    // Direct test and suite calls.
+    invalid('// test("foo", () => {})'),
+    invalid('// it("foo", () => {})'),
+    invalid('// describe("foo", () => {})'),
+
+    // Every Rstest test modifier.
+    invalid('// test.only("foo", () => {})'),
+    invalid('// test.skip("foo", () => {})'),
+    invalid('// test.todo("foo")'),
+    invalid('// test.fails("foo", () => {})'),
+    invalid('// test.concurrent("foo", () => {})'),
+    invalid('// test.sequential("foo", () => {})'),
+    invalid('// test.runIf(condition)("foo", () => {})'),
+    invalid('// test.skipIf(condition)("foo", () => {})'),
+
+    // Every Rstest suite modifier.
+    invalid('// describe.only("foo", () => {})'),
+    invalid('// describe.skip("foo", () => {})'),
+    invalid('// describe.todo("foo")'),
+    invalid('// describe.concurrent("foo", () => {})'),
+    invalid('// describe.sequential("foo", () => {})'),
+    invalid('// describe.runIf(condition)("foo", () => {})'),
+    invalid('// describe.skipIf(condition)("foo", () => {})'),
+
+    // Getter and conditional modifiers can be chained.
+    invalid('// it.only.fails("foo", () => {})'),
+    invalid('// test.skip.concurrent("foo", () => {})'),
+    invalid('// test.concurrent.only("foo", () => {})'),
+    invalid('// test.concurrent.runIf(condition)("foo", () => {})'),
+    invalid('// describe.only.concurrent("foo", () => {})'),
+    invalid('// describe.concurrent.only("foo", () => {})'),
+    invalid('// describe.concurrent.skipIf(condition)("foo", () => {})'),
+    invalid('// describe.skipIf(condition).concurrent("foo", () => {})'),
+
+    // Array-based parameterized tests and suites.
+    invalid('// test.each(rows)("foo", ({ value }) => {})'),
+    invalid('// test.for(rows)("foo", ({ value }) => {})'),
+    invalid('// it.each(rows)("foo", ({ value }) => {})'),
+    invalid('// it.for(rows)("foo", ({ value }) => {})'),
+    invalid('// describe.each(rows)("foo", ({ value }) => {})'),
+    invalid('// describe.for(rows)("foo", ({ value }) => {})'),
+    invalid('// it.only.each(rows)("foo", ({ value }) => {})'),
+    invalid('// it.concurrent.for(rows)("foo", ({ value }) => {})'),
+    invalid('// describe.only.each(rows)("foo", ({ value }) => {})'),
+    invalid('// describe.skip.for(rows)("foo", ({ value }) => {})'),
+
+    // Explicit type arguments are supported by each and for.
+    invalid('// test.each<Row>(rows)("foo", ({ value }) => {})'),
+    invalid('// test.for<Row>(rows)("foo", ({ value }) => {})'),
+    invalid('// describe.each<Row>(rows)("foo", ({ value }) => {})'),
+    invalid('// describe.for<Row>(rows)("foo", ({ value }) => {})'),
+    invalid(
+      '// test.for<{ value: Map<string, number> }>(rows)("foo", ({ value }) => {})',
+    ),
+
+    // Tagged-template parameterized tests and suites.
+    invalid('// test.each`value | expected`("foo", ({ value }) => {})'),
+    invalid('// test.for`value | expected`("foo", ({ value }) => {})'),
+    invalid('// it.each`value | expected`("foo", ({ value }) => {})'),
+    invalid('// it.for`value | expected`("foo", ({ value }) => {})'),
+    invalid('// describe.each`value | expected`("foo", ({ value }) => {})'),
+    invalid('// describe.for`value | expected`("foo", ({ value }) => {})'),
+    invalid('// test.for<Row>`value | expected`("foo", ({ value }) => {})'),
+    invalid(
+      '// describe.each<Row>`value | expected`("foo", ({ value }) => {})',
+    ),
+    invalid(
+      '// it.concurrent.for<Row>`value | expected`("foo", ({ value }) => {})',
+    ),
+
+    // Property and bracket access can be chained.
+    invalid('// describe["skip"]("foo", () => {})'),
+    invalid('// test["only"]["concurrent"]("foo", () => {})'),
+    invalid('// describe["only"].each(rows)("foo", ({ value }) => {})'),
+    invalid('// test["for"]`value | expected`("foo", ({ value }) => {})'),
+
+    // Block comments may contain multiline calls and chains.
+    invalid('/*\n  describe("foo", () => {})\n*/'),
+    invalid('/*\n  describe\n    .only\n    .concurrent("foo", () => {})\n*/'),
+    invalid(
+      '/*\n  test.for<Row>`\n    value\n    ${1}\n  `("$value", ({ value }) => {})\n*/',
+    ),
+
+    // Conditional and extended APIs must eventually register a test.
+    invalid('// test.runIf(condition).only("foo", () => {})'),
+    invalid('// describe.only.skipIf(condition)("foo", () => {})'),
+    invalid('// test.extend(fixtures)("foo", () => {})'),
+    invalid('// it.extend<Fixtures>(fixtures).only("foo", () => {})'),
+    invalid('// test.extend(a).extend(b)("foo", () => {})'),
+    invalid('// test.extend(fixtures).each(rows)("foo", () => {})'),
+
+    // Transparent syntax and static property access.
+    invalid('// ((test))("foo", () => {})'),
+    invalid('// test?.("foo", () => {})'),
+    invalid('// test?.only("foo", () => {})'),
+    invalid('// test[`only`]("foo", () => {})'),
+
+    // Consecutive line comments are parsed as one logical code block.
+    invalid('// test\n//   .only\n//   .concurrent("foo", () => {})'),
+    invalid(
+      '// test.each<Row>`\n// value | expected\n// ${1} | ${2}\n// `("foo", () => {})',
+    ),
+    invalid('// test.extend({\n//   value: 1,\n// }).only("foo", () => {})'),
+    invalid('/* test("renders", () => <div />) */'),
+    invalid('// test("first", () => {}); cleanup()'),
+  ],
+});

--- a/packages/rslint/src/config/presets/rstest.ts
+++ b/packages/rslint/src/config/presets/rstest.ts
@@ -3,6 +3,7 @@ import type { RslintConfigEntry } from '../define-config.js';
 const recommended: RslintConfigEntry = {
   plugins: ['rstest'],
   rules: {
+    'rstest/no-commented-out-tests': 'warn',
     'rstest/no-identical-title': 'error',
     'rstest/no-mocks-import': 'error',
   },

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -446,6 +446,7 @@ reparser
 repoint
 repoints
 reqs
+rescanning
 resolv
 respawn
 respawned


### PR DESCRIPTION
## Summary

Add `rstest/no-commented-out-tests` to report commented-out Rstest tests and suites.

The rule reconstructs consecutive comments, parses candidate snippets with typescript-go, and analyzes Rstest API chains to distinguish factory calls from actual test registrations. It supports modifiers, conditional APIs, `each` / `for`, tagged templates, and `test.extend`.

## Related Links

Related https://github.com/web-infra-dev/rslint/issues/935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).