### PR TITLE
perf: reduce lint listener allocations

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -266,22 +266,25 @@ type RuleListeners map[ast.Kind]func(node *ast.Node)
 
 ```go
 type RuleContext struct {
-    SourceFile                 *ast.SourceFile
-    Settings                   map[string]interface{}
-    ConfigGlobals              map[string]bool
-    InlineGlobals              []InlineGlobal
-    Globals                    map[string]bool
-    Comments                   *CommentStore
-    Program                    *compiler.Program
-    TypeChecker                *checker.Checker
-    DisableManager             *DisableManager
-    ReportRange                func(textRange core.TextRange, msg RuleMessage)
-    ReportRangeWithFixes       func(textRange core.TextRange, msg RuleMessage, fixes ...RuleFix)
-    ReportRangeWithSuggestions func(textRange core.TextRange, msg RuleMessage, suggestions ...RuleSuggestion)
-    ReportNode                 func(node *ast.Node, msg RuleMessage)
-    ReportNodeWithFixes        func(node *ast.Node, msg RuleMessage, fixes ...RuleFix)
-    ReportNodeWithSuggestions  func(node *ast.Node, msg RuleMessage, suggestions ...RuleSuggestion)
+    SourceFile     *ast.SourceFile
+    Settings       map[string]interface{}
+    ConfigGlobals  map[string]bool
+    InlineGlobals  []InlineGlobal
+    Globals        map[string]bool
+    Comments       *CommentStore
+    Program        *compiler.Program
+    TypeChecker    *checker.Checker
+    DisableManager *DisableManager
 }
+
+func (*RuleContext) ReportRange(...)
+func (*RuleContext) ReportRangeWithFixes(...)
+func (*RuleContext) ReportRangeWithSuggestions(...)
+func (*RuleContext) ReportNode(...)
+func (*RuleContext) ReportNodeWithFixes(...)
+func (*RuleContext) ReportNodeWithSuggestions(...)
+func (*RuleContext) ReportNodeWithFixesAndSuggestions(...)
+func (*RuleContext) ReportRangeWithFixesAndSuggestions(...)
 ```
 
 The linter creates one short-lived `CommentStore` per file. `Comments.All()`
@@ -297,6 +300,9 @@ context data instead of scanning comments independently. Configured access
 aliases are normalized consistently: writable and read-only aliases declare a
 name, `null` is read-only, and only `"off"` disables it. The Node plugin scope separately
 preserves writable versus read-only access for ESLint-compatible scope APIs.
+The linter binds immutable rule name, severity, and diagnostic-sink metadata to
+each context once. The reporting methods use that state directly rather than
+allocating bound callback closures for every reporting variant.
 
 ### Listener Registration
 
@@ -306,7 +312,10 @@ Rules do not walk the AST themselves. Instead:
 2. config merge selects enabled rules for a file
 3. each enabled rule runs `Run(ctx)`
 4. `Run(ctx)` returns listeners keyed by `ast.Kind`
-5. the linter aggregates them into a per-file dispatch table
+5. the linter appends them, in rule order, to the checker-shard task's sparse
+   dispatch registry
+6. after traversing a file, the task clears every listener slot and reuses the
+   registry's map and per-kind backing slices for its next serial file
 
 This allows one AST traversal to serve many rules.
 
@@ -927,9 +936,11 @@ goroutines remain outside that guarantee.
 - **Checker Phase Separation**: the checker is released before TypeScript semantic diagnostics run, so `GetSemanticDiagnostics` can reacquire its own checker cleanly
 - **File Filtering**: Skip node_modules and bundled files automatically
 - **Gap-File Degradation**: fallback gap-file Programs skip type-aware rules and semantic diagnostics instead of paying unreliable semantic costs
-- **Buffered Diagnostic Collection**: CLI mode funnels diagnostics through a buffered channel before formatting, which reduces contention between lint workers and output handling
+- **Buffered Diagnostic Collection**: CLI mode funnels diagnostics through a buffered channel before formatting, which reduces contention between lint tasks and output handling
 - **On-Demand AST Encoding**: API/WASM responses only include encoded source files when `IncludeEncodedSourceFiles` is requested
 - **Lazy Shared Comments**: each file owns one `CommentStore`; directive consumers and comment-aware rules materialize its canonical comment list only when needed and reuse the result. Rule-specific text checks avoid scanner work when their comment syntax cannot occur
+- **Task-Local Listener Reuse**: each checker-shard task owns one sparse listener registry and reuses its map and per-kind slice capacity across that task's serial files. Registries are never shared across tasks or requests
+- **Direct Rule Reporting Methods**: each rule context stores one compact immutable reporter state; its reporting methods replace the former family of per-rule bound closures
 
 ### Caching Strategy
 
@@ -945,7 +956,8 @@ goroutines remain outside that guarantee.
 ### Memory Management
 
 - **ts-go Owns the Heavy Graphs**: AST nodes, checker state, `Program` graphs, and session state are primarily owned by ts-go; rslint adds listener maps, diagnostics, and config-derived rule lists on top
-- **Short-Lived Per-File Structures**: comment stores, disable managers, and registered listener maps are allocated per file and dropped after traversal. A comment slice is allocated only if requested; `clear(registeredListeners)` helps release references promptly
+- **Short-Lived Per-File Structures**: comment stores, disable managers, and rule contexts are allocated per file and dropped after traversal. A comment slice is allocated only if requested
+- **Bounded Listener Retention**: a listener registry lives only for one checker-shard task. After each file it clears every function slot before shortening the slices, so backing capacity can be reused without retaining closures, source files, checker state, or rule contexts. The registry is dropped when that task completes and is never pooled across runs or LSP requests
 - **Source Snapshot Ownership**: snapshot entries hold an immutable source string plus its 128-bit hash without explicitly copying source bytes; on an AST miss, that string is passed directly to the parser. After generation replacement, a retained unchanged AST may still hold the prior equal string while the fresh snapshot owns the new read. Replaced generations are reclaimed after any in-flight lookup releases them. AST retention and source-generation retention remain deliberately separate lifecycles.
 - **Fix Application Uses Linear Rebuilds**: `ApplyRuleFixes` sorts fixes, skips overlapping edits, and rebuilds the output with `strings.Builder` rather than mutating source buffers in place
 - **Bounded Queues**: CLI diagnostics use a buffered channel of 4096 items; LSP request/outgoing queues are buffered to 100, and debounce/refresh signals are single-slot channels

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -77,7 +77,7 @@ type runProgramOptions struct {
 	// leaves this disabled because it does not consume that result.
 	CollectExecutedRules bool
 	// SingleThreaded, when true, lints this program's file shards
-	// sequentially on the calling goroutine instead of in parallel workers.
+	// sequentially on the calling goroutine instead of in parallel tasks.
 	SingleThreaded bool
 	// TypeInfoFiles is the set of files with reliable project type information.
 	// Rules that require type information are filtered for every other file,
@@ -91,12 +91,48 @@ type programLintResult struct {
 	executedRules   map[string]struct{}
 }
 
+type listenerRegistry struct {
+	byKind      map[ast.Kind][]func(node *ast.Node)
+	activeKinds []ast.Kind
+}
+
+func newListenerRegistry() listenerRegistry {
+	return listenerRegistry{
+		byKind:      make(map[ast.Kind][]func(node *ast.Node), 20),
+		activeKinds: make([]ast.Kind, 0, 20),
+	}
+}
+
+func (r *listenerRegistry) add(kind ast.Kind, listener func(node *ast.Node)) {
+	listeners := r.byKind[kind]
+	if len(listeners) == 0 {
+		r.activeKinds = append(r.activeKinds, kind)
+	}
+	r.byKind[kind] = append(listeners, listener)
+}
+
+func (r *listenerRegistry) listeners(kind ast.Kind) []func(node *ast.Node) {
+	return r.byKind[kind]
+}
+
+// reset releases every listener closure from the completed file while
+// retaining the sparse registry's backing storage for the next file in the
+// same checker-shard task.
+func (r *listenerRegistry) reset() {
+	for _, kind := range r.activeKinds {
+		listeners := r.byKind[kind]
+		clear(listeners)
+		r.byKind[kind] = listeners[:0]
+	}
+	r.activeKinds = r.activeKinds[:0]
+}
+
 // runLintRulesInProgram lints files in a single Program. Files are filtered
 // through ExcludePaths, Scope (Files+Dirs), and FileFilter before rule
 // execution. Pass FileFilter=nil to disable that layer.
 //
 // Unless SingleThreaded is set, files are linted in parallel shards — one
-// worker per pool checker, each worker owning its checker exclusively and
+// task per pool checker, each task owning its checker exclusively and
 // processing the files associated to it (see the sharding comment in the
 // function body for the invariants this preserves).
 //
@@ -126,13 +162,11 @@ func runLintRulesInProgram(opts runProgramOptions) programLintResult {
 		return result
 	}
 
-	// lintFile lints one file with its already-resolved rules and checker. All per-file state
-	// (listener map, comments, DisableManager, rule contexts) lives inside
-	// this function, so concurrent calls for different files are independent;
-	// the checker is the only shared resource and is owned exclusively by the
-	// calling worker (see the sharding below).
-	lintFile := func(file *ast.SourceFile, rules []ConfiguredRule, chk *checker.Checker) {
-		registeredListeners := make(map[ast.Kind][](func(node *ast.Node)), 20)
+	// lintFile lints one file with its already-resolved rules and checker. Its
+	// comments, DisableManager, and rule contexts are per-file. The listener
+	// registry belongs to the calling checker-shard task and is empty on entry;
+	// reset clears all captured per-file state before the next serial file.
+	lintFile := func(file *ast.SourceFile, rules []ConfiguredRule, chk *checker.Checker, registeredListeners *listenerRegistry) {
 
 		// One lazy store is shared by directives, inline globals, and every
 		// comment-aware rule in this file. Most files never materialize it.
@@ -162,138 +196,16 @@ func runLintRulesInProgram(opts runProgramOptions) programLintResult {
 				Comments:       comments,
 				TypeChecker:    fileChecker,
 				DisableManager: disableManager,
-				ReportRange: func(textRange core.TextRange, msg rule.RuleMessage) {
-					if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
-						return
-					}
-					opts.OnDiagnostic(rule.RuleDiagnostic{
-						RuleName:   r.Name,
-						Range:      textRange,
-						Message:    msg,
-						SourceFile: file,
-						FilePath:   file.FileName(),
-						Severity:   r.Severity,
-					})
-				},
-				ReportRangeWithFixes: func(textRange core.TextRange, msg rule.RuleMessage, fixes ...rule.RuleFix) {
-					if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
-						return
-					}
-					opts.OnDiagnostic(rule.RuleDiagnostic{
-						RuleName:   r.Name,
-						Range:      textRange,
-						Message:    msg,
-						FixesPtr:   &fixes,
-						SourceFile: file,
-						FilePath:   file.FileName(),
-						Severity:   r.Severity,
-					})
-				},
-				ReportRangeWithSuggestions: func(textRange core.TextRange, msg rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
-					if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
-						return
-					}
-					opts.OnDiagnostic(rule.RuleDiagnostic{
-						RuleName:    r.Name,
-						Range:       textRange,
-						Message:     msg,
-						Suggestions: &suggestions,
-						SourceFile:  file,
-						FilePath:    file.FileName(),
-						Severity:    r.Severity,
-					})
-				},
-				ReportNode: func(node *ast.Node, msg rule.RuleMessage) {
-					trimmedRange := utils.TrimNodeTextRange(file, node)
-					if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
-						return
-					}
-					opts.OnDiagnostic(rule.RuleDiagnostic{
-						RuleName:   r.Name,
-						Range:      trimmedRange,
-						Message:    msg,
-						SourceFile: file,
-						FilePath:   file.FileName(),
-						Severity:   r.Severity,
-					})
-				},
-				ReportNodeWithFixes: func(node *ast.Node, msg rule.RuleMessage, fixes ...rule.RuleFix) {
-					trimmedRange := utils.TrimNodeTextRange(file, node)
-					if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
-						return
-					}
-					opts.OnDiagnostic(rule.RuleDiagnostic{
-						RuleName:   r.Name,
-						Range:      trimmedRange,
-						Message:    msg,
-						FixesPtr:   &fixes,
-						SourceFile: file,
-						FilePath:   file.FileName(),
-						Severity:   r.Severity,
-					})
-				},
-				ReportNodeWithSuggestions: func(node *ast.Node, msg rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
-					trimmedRange := utils.TrimNodeTextRange(file, node)
-					if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
-						return
-					}
-					opts.OnDiagnostic(rule.RuleDiagnostic{
-						RuleName:    r.Name,
-						Range:       trimmedRange,
-						Message:     msg,
-						Suggestions: &suggestions,
-						SourceFile:  file,
-						FilePath:    file.FileName(),
-						Severity:    r.Severity,
-					})
-				},
-				ReportNodeWithFixesAndSuggestions: func(node *ast.Node, msg rule.RuleMessage, fixes []rule.RuleFix, suggestions []rule.RuleSuggestion) {
-					trimmedRange := utils.TrimNodeTextRange(file, node)
-					if disableManager.IsRuleDisabled(r.Name, trimmedRange.Pos()) {
-						return
-					}
-					opts.OnDiagnostic(rule.RuleDiagnostic{
-						RuleName:    r.Name,
-						Range:       trimmedRange,
-						Message:     msg,
-						FixesPtr:    &fixes,
-						Suggestions: &suggestions,
-						SourceFile:  file,
-						FilePath:    file.FileName(),
-						Severity:    r.Severity,
-					})
-				},
-				ReportRangeWithFixesAndSuggestions: func(textRange core.TextRange, msg rule.RuleMessage, fixes []rule.RuleFix, suggestions []rule.RuleSuggestion) {
-					if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
-						return
-					}
-					opts.OnDiagnostic(rule.RuleDiagnostic{
-						RuleName:    r.Name,
-						Range:       textRange,
-						Message:     msg,
-						FixesPtr:    &fixes,
-						Suggestions: &suggestions,
-						SourceFile:  file,
-						FilePath:    file.FileName(),
-						Severity:    r.Severity,
-					})
-				},
-			}
+			}.WithReporter(r.Name, r.Severity, opts.OnDiagnostic)
 
 			for kind, listener := range r.Run(ctx) {
-				listeners, ok := registeredListeners[kind]
-				if !ok {
-					listeners = make([](func(node *ast.Node)), 0, len(rules))
-				}
-				registeredListeners[kind] = append(listeners, listener)
+				registeredListeners.add(kind, listener)
 			}
 		}
 
 		runListeners := func(kind ast.Kind, node *ast.Node) {
-			if listeners, ok := registeredListeners[kind]; ok {
-				for _, listener := range listeners {
-					listener(node)
-				}
+			for _, listener := range registeredListeners.listeners(kind) {
+				listener(node)
 			}
 		}
 
@@ -363,17 +275,18 @@ func runLintRulesInProgram(opts runProgramOptions) programLintResult {
 			return false
 		}
 		file.Node.ForEachChild(childVisitor)
-		clear(registeredListeners)
+		registeredListeners.reset()
 	}
 
 	// Phase 1 parallelism is per-file within the program: files are grouped
 	// by the checker the pool associated to them (for the compiler pool this
 	// is the stable index%N mapping built in checkerpool.go), and each group
-	// is linted serially by ONE worker holding that checker exclusively.
+	// is linted serially by one checker-shard task holding that checker
+	// exclusively.
 	// This keeps three invariants:
 	//   - a checker is never used by two goroutines at once (pool contract:
 	//     checkers must not be accessed concurrently);
-	//   - every file's diagnostics are emitted by a single worker, so the
+	//   - every file's diagnostics are emitted by a single task, so the
 	//     file-internal diagnostic order stays deterministic — the fixer's
 	//     tie-breaking and reporters rely on this;
 	//   - Phase 2 type-check visits files through the same association,
@@ -384,7 +297,7 @@ func runLintRulesInProgram(opts runProgramOptions) programLintResult {
 	// to the first checker, so the grouping collapses to a single group
 	// (no intra-program parallelism on that path; today it is only reached
 	// via LintSingleFile, where one file means one group anyway).
-	// Correctness never depends on the grouping: each worker only uses the
+	// Correctness never depends on the grouping: each task only uses the
 	// checker it acquired exclusively for its own shard.
 	ctx := context.Background()
 	rulesByFile := make(map[*ast.SourceFile][]ConfiguredRule, len(filesToLint))
@@ -425,13 +338,14 @@ func runLintRulesInProgram(opts runProgramOptions) programLintResult {
 	wg := core.NewWorkGroup(opts.SingleThreaded)
 	for chk, files := range checkerGroups {
 		wg.Queue(func() {
+			registeredListeners := newListenerRegistry()
 			if chk != nil {
 				var done func()
 				chk, done = opts.Program.GetTypeCheckerForFileExclusive(ctx, files[0])
 				defer done()
 			}
 			for _, file := range files {
-				lintFile(file, rulesByFile[file], chk)
+				lintFile(file, rulesByFile[file], chk, &registeredListeners)
 			}
 		})
 	}
@@ -794,7 +708,7 @@ func LintSingleFile(opts LintSingleFileOptions) {
 		GetRulesForFile:  getRulesForFile,
 		SyntaxErrorFiles: map[string]struct{}{},
 		// A single file is a single shard — run it on the calling goroutine
-		// instead of spawning a worker.
+		// instead of scheduling a background task.
 		SingleThreaded: true,
 		OnDiagnostic:   opts.OnDiagnostic,
 	})

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
@@ -306,5 +307,227 @@ func TestRunLinter_ExecutedRulesEmpty(t *testing.T) {
 	}
 	if result.ExecutedRules == nil {
 		t.Error("ExecutedRules should be a writable, non-nil empty map")
+	}
+}
+
+func TestListenerRegistryResetReleasesAndReusesListeners(t *testing.T) {
+	registry := newListenerRegistry()
+	var calls []string
+
+	registry.add(ast.KindIdentifier, func(*ast.Node) { calls = append(calls, "first") })
+	registry.add(ast.KindIdentifier, func(*ast.Node) { calls = append(calls, "second") })
+	registry.add(rule.ListenerOnExit(ast.KindIdentifier), func(*ast.Node) { calls = append(calls, "exit") })
+
+	if len(registry.activeKinds) != 2 {
+		t.Fatalf("activeKinds has %d entries, want 2", len(registry.activeKinds))
+	}
+	identifierCapacity := cap(registry.byKind[ast.KindIdentifier])
+	registry.reset()
+
+	if len(registry.activeKinds) != 0 {
+		t.Fatalf("activeKinds has %d entries after reset, want 0", len(registry.activeKinds))
+	}
+	for kind, listeners := range registry.byKind {
+		if len(listeners) != 0 {
+			t.Fatalf("listeners for kind %d have length %d after reset, want 0", kind, len(listeners))
+		}
+		for index, listener := range listeners[:cap(listeners)] {
+			if listener != nil {
+				t.Fatalf("listener slot %d for kind %d retained a closure after reset", index, kind)
+			}
+		}
+	}
+
+	registry.add(ast.KindIdentifier, func(*ast.Node) { calls = append(calls, "replacement") })
+	if cap(registry.byKind[ast.KindIdentifier]) != identifierCapacity {
+		t.Fatalf("identifier listener capacity = %d after reuse, want %d", cap(registry.byKind[ast.KindIdentifier]), identifierCapacity)
+	}
+	for _, listener := range registry.listeners(ast.KindIdentifier) {
+		listener(nil)
+	}
+	if !reflect.DeepEqual(calls, []string{"replacement"}) {
+		t.Fatalf("calls after registry reuse = %v, want only the replacement listener", calls)
+	}
+}
+
+func TestListenerRegistryIsolationAndRuleOrderAcrossFiles(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const alpha = 1;",
+		"b.ts": "const beta = 2;",
+	})
+
+	configuredListenerRule := func(kind ast.Kind, name string, severity rule.DiagnosticSeverity) ConfiguredRule {
+		return ConfiguredRule{
+			Name:     name,
+			Severity: severity,
+			Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				return rule.RuleListeners{
+					kind: func(node *ast.Node) {
+						ctx.ReportNode(node, rule.RuleMessage{Id: name, Description: name})
+					},
+				}
+			},
+		}
+	}
+
+	var diagnostics []rule.RuleDiagnostic
+	_, err := RunLinter(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{{paths["a.ts"], paths["b.ts"]}},
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []ConfiguredRule {
+			if sourceFile.FileName() == paths["a.ts"] {
+				return []ConfiguredRule{
+					configuredListenerRule(ast.KindIdentifier, "a-first", rule.SeverityWarning),
+					configuredListenerRule(ast.KindIdentifier, "a-second", rule.SeverityError),
+				}
+			}
+			return []ConfiguredRule{
+				configuredListenerRule(ast.KindNumericLiteral, "b-first", rule.SeverityError),
+				configuredListenerRule(ast.KindNumericLiteral, "b-second", rule.SeverityWarning),
+			}
+		},
+		OnDiagnostic: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+	if len(diagnostics) != 4 {
+		t.Fatalf("got %d diagnostics, want exactly 4 with no listener leaking between files: %#v", len(diagnostics), diagnostics)
+	}
+
+	byFile := make(map[string][]rule.RuleDiagnostic, 2)
+	for _, diagnostic := range diagnostics {
+		byFile[diagnostic.FilePath] = append(byFile[diagnostic.FilePath], diagnostic)
+	}
+	for _, testCase := range []struct {
+		path       string
+		ruleNames  []string
+		severities []rule.DiagnosticSeverity
+	}{
+		{path: paths["a.ts"], ruleNames: []string{"a-first", "a-second"}, severities: []rule.DiagnosticSeverity{rule.SeverityWarning, rule.SeverityError}},
+		{path: paths["b.ts"], ruleNames: []string{"b-first", "b-second"}, severities: []rule.DiagnosticSeverity{rule.SeverityError, rule.SeverityWarning}},
+	} {
+		fileDiagnostics := byFile[testCase.path]
+		if len(fileDiagnostics) != 2 {
+			t.Fatalf("diagnostics for %s = %#v, want 2", testCase.path, fileDiagnostics)
+		}
+		for index, diagnostic := range fileDiagnostics {
+			if diagnostic.RuleName != testCase.ruleNames[index] || diagnostic.Message.Id != testCase.ruleNames[index] || diagnostic.Severity != testCase.severities[index] {
+				t.Errorf("diagnostic %d for %s = (%q, %q, %v), want (%q, %q, %v)", index, testCase.path, diagnostic.RuleName, diagnostic.Message.Id, diagnostic.Severity, testCase.ruleNames[index], testCase.ruleNames[index], testCase.severities[index])
+			}
+		}
+	}
+}
+
+func TestRuleContextReporterPreservesDiagnosticSemantics(t *testing.T) {
+	const source = "// rslint-disable-next-line reporter-semantics\nconst blocked = 0;\n  const target = 1;\n"
+	program, paths := createTestProgramWithFiles(t, map[string]string{"reporter.ts": source})
+	sourceFile := program.GetSourceFile(paths["reporter.ts"])
+	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) != 2 {
+		t.Fatal("reporter fixture did not parse into two statements")
+	}
+
+	blockedNode := sourceFile.Statements.Nodes[0]
+	targetNode := sourceFile.Statements.Nodes[1]
+	nodeRange := utils.TrimNodeTextRange(sourceFile, targetNode)
+	explicitRange := core.NewTextRange(nodeRange.Pos()+len("const "), nodeRange.Pos()+len("const target"))
+	fix := rule.RuleFix{Text: "replacement", Range: explicitRange}
+	suggestion := rule.RuleSuggestion{
+		Message:  rule.RuleMessage{Id: "suggestion", Description: "suggest replacement"},
+		FixesArr: []rule.RuleFix{fix},
+	}
+	emptyFixes := make([]rule.RuleFix, 0)
+	emptySuggestions := make([]rule.RuleSuggestion, 0)
+	message := func(id string) rule.RuleMessage {
+		return rule.RuleMessage{Id: id, Description: "description-" + id, Data: map[string]string{"id": id}}
+	}
+
+	var diagnostics []rule.RuleDiagnostic
+	result, err := RunLinter(RunLinterOptions{
+		Programs:       []*compiler.Program{program},
+		SingleThreaded: true,
+		TargetFiles:    [][]string{{paths["reporter.ts"]}},
+		GetRulesForFile: func(*ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{{
+				Name:     "reporter-semantics",
+				Severity: rule.SeverityWarning,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					ctx.ReportNode(blockedNode, message("disabled"))
+					ctx.ReportRange(explicitRange, message("range"))
+					ctx.ReportRangeWithFixes(explicitRange, message("range-fixes"), fix)
+					ctx.ReportRangeWithSuggestions(explicitRange, message("range-suggestions"), suggestion)
+					ctx.ReportRangeWithFixesAndSuggestions(explicitRange, message("range-combined"), []rule.RuleFix{fix}, []rule.RuleSuggestion{suggestion})
+					ctx.ReportRangeWithFixesAndSuggestions(explicitRange, message("range-empty-combined"), emptyFixes, emptySuggestions)
+					ctx.ReportNode(targetNode, message("node"))
+					ctx.ReportNodeWithFixes(targetNode, message("node-empty-fixes"))
+					ctx.ReportNodeWithSuggestions(targetNode, message("node-empty-suggestions"))
+					ctx.ReportNodeWithFixesAndSuggestions(targetNode, message("node-empty-combined"), nil, nil)
+					return nil
+				},
+			}}
+		},
+		OnDiagnostic: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+	if result.LintedFileCount != 1 {
+		t.Fatalf("LintedFileCount = %d, want 1", result.LintedFileCount)
+	}
+
+	type expectation struct {
+		id             string
+		textRange      core.TextRange
+		hasFixes       bool
+		fixes          []rule.RuleFix
+		hasSuggestions bool
+		suggestions    []rule.RuleSuggestion
+	}
+	expected := []expectation{
+		{id: "range", textRange: explicitRange},
+		{id: "range-fixes", textRange: explicitRange, hasFixes: true, fixes: []rule.RuleFix{fix}},
+		{id: "range-suggestions", textRange: explicitRange, hasSuggestions: true, suggestions: []rule.RuleSuggestion{suggestion}},
+		{id: "range-combined", textRange: explicitRange, hasFixes: true, fixes: []rule.RuleFix{fix}, hasSuggestions: true, suggestions: []rule.RuleSuggestion{suggestion}},
+		{id: "range-empty-combined", textRange: explicitRange, hasFixes: true, fixes: []rule.RuleFix{}, hasSuggestions: true, suggestions: []rule.RuleSuggestion{}},
+		{id: "node", textRange: nodeRange},
+		{id: "node-empty-fixes", textRange: nodeRange, hasFixes: true},
+		{id: "node-empty-suggestions", textRange: nodeRange, hasSuggestions: true},
+		{id: "node-empty-combined", textRange: nodeRange, hasFixes: true, hasSuggestions: true},
+	}
+	if len(diagnostics) != len(expected) {
+		t.Fatalf("got %d diagnostics, want %d (disabled report must be suppressed)", len(diagnostics), len(expected))
+	}
+	for index, want := range expected {
+		got := diagnostics[index]
+		if got.RuleName != "reporter-semantics" || got.Severity != rule.SeverityWarning {
+			t.Errorf("diagnostic %d metadata = (%q, %v), want (reporter-semantics, warning)", index, got.RuleName, got.Severity)
+		}
+		if got.SourceFile != sourceFile || got.FilePath != paths["reporter.ts"] {
+			t.Errorf("diagnostic %d source = (%v, %q), want fixture source and %q", index, got.SourceFile == sourceFile, got.FilePath, paths["reporter.ts"])
+		}
+		if got.Range != want.textRange {
+			t.Errorf("diagnostic %d range = %v, want %v", index, got.Range, want.textRange)
+		}
+		if !reflect.DeepEqual(got.Message, message(want.id)) {
+			t.Errorf("diagnostic %d message = %#v, want %#v", index, got.Message, message(want.id))
+		}
+		if (got.FixesPtr != nil) != want.hasFixes {
+			t.Errorf("diagnostic %d FixesPtr presence = %v, want %v", index, got.FixesPtr != nil, want.hasFixes)
+		} else if want.hasFixes && !reflect.DeepEqual(*got.FixesPtr, want.fixes) {
+			t.Errorf("diagnostic %d fixes = %#v, want %#v", index, *got.FixesPtr, want.fixes)
+		}
+		if (got.Suggestions != nil) != want.hasSuggestions {
+			t.Errorf("diagnostic %d Suggestions presence = %v, want %v", index, got.Suggestions != nil, want.hasSuggestions)
+		} else if want.hasSuggestions && !reflect.DeepEqual(*got.Suggestions, want.suggestions) {
+			t.Errorf("diagnostic %d suggestions = %#v, want %#v", index, *got.Suggestions, want.suggestions)
+		}
+		if got.Origin != rule.DiagnosticOriginLint || got.PreFormatted {
+			t.Errorf("diagnostic %d origin/preformatted = (%v, %v), want lint/false", index, got.Origin, got.PreFormatted)
+		}
 	}
 }

--- a/internal/plugins/react/rules/require_optimization/require_optimization_extra_test.go
+++ b/internal/plugins/react/rules/require_optimization/require_optimization_extra_test.go
@@ -3,8 +3,6 @@ package require_optimization
 import (
 	"testing"
 
-	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
@@ -2502,27 +2500,12 @@ const ArrowComp = (p) => <div />;
 		return
 	}
 
-	ctx := rule.RuleContext{
+	ctx := (rule.RuleContext{
 		SourceFile:  sourceFile,
 		Program:     program,
 		Settings:    map[string]interface{}{},
 		TypeChecker: nil, // explicitly nil — this is the path under test
-		ReportNode: func(node *ast.Node, msg rule.RuleMessage) {
-			// noop — we only care that nothing panics.
-		},
-		ReportRange: func(_ core.TextRange, _ rule.RuleMessage) {
-		},
-		ReportNodeWithFixes: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleFix) {
-		},
-		ReportRangeWithFixes: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleFix) {
-		},
-		ReportNodeWithSuggestions: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
-		},
-		ReportRangeWithSuggestions: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
-		},
-		ReportNodeWithFixesAndSuggestions: func(_ *ast.Node, _ rule.RuleMessage, _ []rule.RuleFix, _ []rule.RuleSuggestion) {
-		},
-	}
+	}).WithReporter("test/require-optimization", rule.SeverityWarning, func(rule.RuleDiagnostic) {})
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_nil_tc_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_nil_tc_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
@@ -77,27 +76,12 @@ function MyComponent({theme}) {
 		"react-hooks": map[string]interface{}{"additionalEffectHooks": "(useTrackedEffect)"},
 	}
 
-	ctx := rule.RuleContext{
+	ctx := (rule.RuleContext{
 		SourceFile:  sourceFile,
 		Program:     program,
 		Settings:    settings,
 		TypeChecker: nil, // explicitly nil — this is the path under test
-		ReportNode: func(node *ast.Node, msg rule.RuleMessage) {
-			// noop — we only care that nothing panics.
-		},
-		ReportRange: func(_ core.TextRange, _ rule.RuleMessage) {
-		},
-		ReportNodeWithFixes: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleFix) {
-		},
-		ReportRangeWithFixes: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleFix) {
-		},
-		ReportNodeWithSuggestions: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
-		},
-		ReportRangeWithSuggestions: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
-		},
-		ReportNodeWithFixesAndSuggestions: func(_ *ast.Node, _ rule.RuleMessage, _ []rule.RuleFix, _ []rule.RuleSuggestion) {
-		},
-	}
+	}).WithReporter("test/exhaustive-deps", rule.SeverityWarning, func(rule.RuleDiagnostic) {})
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/rule.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/rule.go
@@ -78,15 +78,8 @@ var ExhaustiveDepsRule = rule.Rule{
 				// `problem.fix = problem.suggest[0].fix`: promote the
 				// first suggestion's first fix only (singular `.fix`,
 				// not the entire FixesArr), AND keep the suggestions.
-				// `ReportNodeWithFixesAndSuggestions` is the preferred
-				// path; harnesses without it fall back to a fix-only
-				// report.
 				firstFix := []rule.RuleFix{sugs[0].FixesArr[0]}
-				if ctx.ReportNodeWithFixesAndSuggestions != nil {
-					ctx.ReportNodeWithFixesAndSuggestions(node, rule.RuleMessage{Description: msg}, firstFix, sugs)
-					return
-				}
-				ctx.ReportNodeWithFixes(node, rule.RuleMessage{Description: msg}, firstFix...)
+				ctx.ReportNodeWithFixesAndSuggestions(node, rule.RuleMessage{Description: msg}, firstFix, sugs)
 				return
 			}
 			if len(sugs) == 0 {
@@ -1182,7 +1175,7 @@ func parseDeclaredDeps(
 func flushDeferredDiagnostics(ctx rule.RuleContext, deferred []elementDiagnostic, enableDangerous bool) {
 	for _, d := range deferred {
 		if d.suggestion != nil {
-			if enableDangerous && len(d.suggestion.FixesArr) > 0 && ctx.ReportNodeWithFixesAndSuggestions != nil {
+			if enableDangerous && len(d.suggestion.FixesArr) > 0 {
 				firstFix := []rule.RuleFix{d.suggestion.FixesArr[0]}
 				ctx.ReportNodeWithFixesAndSuggestions(
 					d.node,

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_test.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -55,25 +54,12 @@ function MyComponent({ theme }: { theme: string }) {
 		return
 	}
 
-	ctx := rule.RuleContext{
+	ctx := (rule.RuleContext{
 		SourceFile:  sourceFile,
 		Program:     program,
 		Settings:    nil,
 		TypeChecker: nil, // explicitly nil — this is the path under test
-		ReportNode: func(node *ast.Node, msg rule.RuleMessage) {
-			// noop — we only care that nothing panics.
-		},
-		ReportRange: func(_ core.TextRange, _ rule.RuleMessage) {
-		},
-		ReportNodeWithFixes: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleFix) {
-		},
-		ReportRangeWithFixes: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleFix) {
-		},
-		ReportNodeWithSuggestions: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
-		},
-		ReportRangeWithSuggestions: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
-		},
-	}
+	}).WithReporter("test/rules-of-hooks", rule.SeverityWarning, func(rule.RuleDiagnostic) {})
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -99,4 +85,3 @@ function MyComponent({ theme }: { theme: string }) {
 	}
 	walk(sourceFile.AsNode())
 }
-

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -271,28 +271,112 @@ type RuleContext struct {
 	// Rules should call Comments.All instead of walking the token tree with
 	// utils.ForEachComment. The first consumer computes the list and every
 	// later consumer for this file reuses it.
-	Comments                   *CommentStore
-	Program                    *compiler.Program
-	TypeChecker                *checker.Checker
-	DisableManager             *DisableManager
-	ReportRange                func(textRange core.TextRange, msg RuleMessage)
-	ReportRangeWithFixes       func(textRange core.TextRange, msg RuleMessage, fixes ...RuleFix)
-	ReportRangeWithSuggestions func(textRange core.TextRange, msg RuleMessage, suggestions ...RuleSuggestion)
-	ReportNode                 func(node *ast.Node, msg RuleMessage)
-	ReportNodeWithFixes        func(node *ast.Node, msg RuleMessage, fixes ...RuleFix)
-	ReportNodeWithSuggestions  func(node *ast.Node, msg RuleMessage, suggestions ...RuleSuggestion)
-	// ReportNodeWithFixesAndSuggestions emits a single diagnostic carrying
-	// BOTH an autofix and one or more suggestions. Used by rules that follow
-	// upstream's "promote first suggestion to fix while keeping the
-	// suggestion" pattern (e.g., ESLint's
-	// `enableDangerousAutofixThisMayCauseInfiniteLoops` in
-	// react-hooks/exhaustive-deps).
-	ReportNodeWithFixesAndSuggestions func(node *ast.Node, msg RuleMessage, fixes []RuleFix, suggestions []RuleSuggestion)
-	// ReportRangeWithFixesAndSuggestions is the range-keyed twin of
-	// ReportNodeWithFixesAndSuggestions. Same semantics, anchors the
-	// diagnostic at an explicit TextRange instead of a node's trimmed
-	// range.
-	ReportRangeWithFixesAndSuggestions func(textRange core.TextRange, msg RuleMessage, fixes []RuleFix, suggestions []RuleSuggestion)
+	Comments       *CommentStore
+	Program        *compiler.Program
+	TypeChecker    *checker.Checker
+	DisableManager *DisableManager
+	reporter       ruleContextReporter
+}
+
+// ruleContextReporter is immutable after Rule.Run starts. Keeping only the
+// rule-specific metadata here avoids allocating a family of bound reporting
+// closures for every rule context.
+type ruleContextReporter struct {
+	ruleName     string
+	severity     DiagnosticSeverity
+	onDiagnostic func(RuleDiagnostic)
+}
+
+// WithReporter returns a context configured to report diagnostics for one
+// rule. The linter calls it once for each context before invoking Rule.Run.
+func (ctx RuleContext) WithReporter(
+	ruleName string,
+	severity DiagnosticSeverity,
+	onDiagnostic func(RuleDiagnostic),
+) RuleContext {
+	if ctx.SourceFile == nil {
+		panic("rule: reporter requires a source file")
+	}
+	if onDiagnostic == nil {
+		panic("rule: reporter requires a diagnostic handler")
+	}
+	ctx.reporter = ruleContextReporter{
+		ruleName:     ruleName,
+		severity:     severity,
+		onDiagnostic: onDiagnostic,
+	}
+	return ctx
+}
+
+func (ctx *RuleContext) requireReporter() {
+	if ctx.reporter.onDiagnostic == nil {
+		panic("rule: uninitialized RuleContext reporter")
+	}
+}
+
+// reportRange assumes requireReporter has already run. Keeping validation in
+// the public methods makes node reports fail consistently before touching a
+// nil SourceFile while paying only one reporter check per diagnostic.
+func (ctx *RuleContext) reportRange(textRange core.TextRange, msg RuleMessage, fixes *[]RuleFix, suggestions *[]RuleSuggestion) {
+	reporter := &ctx.reporter
+	if ctx.DisableManager.IsRuleDisabled(reporter.ruleName, textRange.Pos()) {
+		return
+	}
+	reporter.onDiagnostic(RuleDiagnostic{
+		RuleName:    reporter.ruleName,
+		Range:       textRange,
+		Message:     msg,
+		FixesPtr:    fixes,
+		Suggestions: suggestions,
+		SourceFile:  ctx.SourceFile,
+		FilePath:    ctx.SourceFile.FileName(),
+		Severity:    reporter.severity,
+	})
+}
+
+func (ctx *RuleContext) ReportRange(textRange core.TextRange, msg RuleMessage) {
+	ctx.requireReporter()
+	ctx.reportRange(textRange, msg, nil, nil)
+}
+
+func (ctx *RuleContext) ReportRangeWithFixes(textRange core.TextRange, msg RuleMessage, fixes ...RuleFix) {
+	ctx.requireReporter()
+	ctx.reportRange(textRange, msg, &fixes, nil)
+}
+
+func (ctx *RuleContext) ReportRangeWithSuggestions(textRange core.TextRange, msg RuleMessage, suggestions ...RuleSuggestion) {
+	ctx.requireReporter()
+	ctx.reportRange(textRange, msg, nil, &suggestions)
+}
+
+func (ctx *RuleContext) ReportNode(node *ast.Node, msg RuleMessage) {
+	ctx.requireReporter()
+	ctx.reportRange(utils.TrimNodeTextRange(ctx.SourceFile, node), msg, nil, nil)
+}
+
+func (ctx *RuleContext) ReportNodeWithFixes(node *ast.Node, msg RuleMessage, fixes ...RuleFix) {
+	ctx.requireReporter()
+	ctx.reportRange(utils.TrimNodeTextRange(ctx.SourceFile, node), msg, &fixes, nil)
+}
+
+func (ctx *RuleContext) ReportNodeWithSuggestions(node *ast.Node, msg RuleMessage, suggestions ...RuleSuggestion) {
+	ctx.requireReporter()
+	ctx.reportRange(utils.TrimNodeTextRange(ctx.SourceFile, node), msg, nil, &suggestions)
+}
+
+// ReportNodeWithFixesAndSuggestions emits a single diagnostic carrying both
+// an autofix and one or more suggestions. It is used by rules that promote a
+// suggestion to an autofix while keeping the suggestion available.
+func (ctx *RuleContext) ReportNodeWithFixesAndSuggestions(node *ast.Node, msg RuleMessage, fixes []RuleFix, suggestions []RuleSuggestion) {
+	ctx.requireReporter()
+	ctx.reportRange(utils.TrimNodeTextRange(ctx.SourceFile, node), msg, &fixes, &suggestions)
+}
+
+// ReportRangeWithFixesAndSuggestions is the range-keyed twin of
+// ReportNodeWithFixesAndSuggestions.
+func (ctx *RuleContext) ReportRangeWithFixesAndSuggestions(textRange core.TextRange, msg RuleMessage, fixes []RuleFix, suggestions []RuleSuggestion) {
+	ctx.requireReporter()
+	ctx.reportRange(textRange, msg, &fixes, &suggestions)
 }
 
 func ReportNodeWithFixesOrSuggestions(ctx RuleContext, node *ast.Node, fix bool, msg RuleMessage, suggestionMsg RuleMessage, fixes ...RuleFix) {

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"reflect"
 	"testing"
+
+	"github.com/microsoft/typescript-go/shim/core"
 )
 
 func TestNormalizeOptions(t *testing.T) {
@@ -44,5 +46,37 @@ func TestNormalizeOptions(t *testing.T) {
 	nested := NormalizeOptions([]interface{}{[]interface{}{"a", "b"}})
 	if len(nested) != 1 || !reflect.DeepEqual(nested[0], []interface{}{"a", "b"}) {
 		t.Errorf("lone array option → [[a,b]], got %v", nested)
+	}
+}
+
+func TestRuleContextReportWithoutReporterPanics(t *testing.T) {
+	textRange := core.NewTextRange(0, 0)
+	message := RuleMessage{Description: "must not be dropped silently"}
+	tests := []struct {
+		name   string
+		report func(*RuleContext)
+	}{
+		{name: "range", report: func(ctx *RuleContext) { ctx.ReportRange(textRange, message) }},
+		{name: "range fixes", report: func(ctx *RuleContext) { ctx.ReportRangeWithFixes(textRange, message) }},
+		{name: "range suggestions", report: func(ctx *RuleContext) { ctx.ReportRangeWithSuggestions(textRange, message) }},
+		{name: "range combined", report: func(ctx *RuleContext) { ctx.ReportRangeWithFixesAndSuggestions(textRange, message, nil, nil) }},
+		{name: "node", report: func(ctx *RuleContext) { ctx.ReportNode(nil, message) }},
+		{name: "node fixes", report: func(ctx *RuleContext) { ctx.ReportNodeWithFixes(nil, message) }},
+		{name: "node suggestions", report: func(ctx *RuleContext) { ctx.ReportNodeWithSuggestions(nil, message) }},
+		{name: "node combined", report: func(ctx *RuleContext) { ctx.ReportNodeWithFixesAndSuggestions(nil, message, nil, nil) }},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			defer func() {
+				got := recover()
+				if got != "rule: uninitialized RuleContext reporter" {
+					t.Fatalf("panic = %v, want uninitialized reporter failure", got)
+				}
+			}()
+
+			var ctx RuleContext
+			testCase.report(&ctx)
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Reuse a task-local sparse listener registry while a checker shard processes files serially, and clear per-file listener closures before the next file.
- Store immutable reporter state directly in `RuleContext` and replace eight bound reporter closures with methods.
- Keep the reuse boundary internal to one lint task: there is no global pool, cross-request sharing, or externally visible CLI/API/LSP behavior change.
- Add semantic coverage for listener ordering, disable directives, ranges, fixes, suggestions, metadata, and update the architecture documentation.

## Performance

Measured on local `rsbuild` and `rspack` checkouts with 30 adjacent old/new pairs per scenario, alternating execution order, 4 warmups, and a gate requiring 6 consecutive machine-idle samples at or above 80%. The benchmark compared `ecdbe149` with the same revision plus this patch; this branch was subsequently rebased onto `9feb899e`.

| Scenario | End-to-end median | Paired median delta |
| --- | ---: | ---: |
| rsbuild plain lint | 1154.5 -> 1114.0 ms | -40.5 ms (-3.5%, p=0.0052) |
| rsbuild explicit config | 1064.5 -> 1049.0 ms | -18.0 ms (-1.7%, p=0.0357) |
| rspack plain lint | 540.5 -> 534.0 ms | -1.5 ms (-0.3%, within startup noise) |
| rspack explicit config | 543.0 -> 535.0 ms | -4.5 ms (-0.8%, within startup noise) |

For rsbuild lint, paired Go CPU time decreased by 6.5% in plain mode and 4.2% with an explicit config; peak RSS decreased by 15.0% and 16.9%, respectively. Type-check-only was neutral, as expected because it bypasses lint rule setup. The mixed rsbuild type-check scenario used 5.3% less CPU but showed 3.2% higher paired peak RSS; GC diagnostics point to collection timing, so this change does not force a GC.

All eight scenario pairs preserved exit codes, ordered output, diagnostic sets, and summaries. The run completed 480 measured invocations with no hangs, orphaned processes, or detected runtime blockers.

## Validation

- `pnpm run check-spell`
- `prettier --check .`
- `pnpm exec golangci-lint run --new-from-rev=origin/main` on the five changed Go packages only
- Real-repository CLI output comparison for rsbuild and rspack across plain lint, explicit config, type-check, and type-check-only modes

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
