### PR TITLE
feat(import): declare options JSON Schema for import/ rules

### DIFF
--- a/internal/plugins/import/rules/default/default.go
+++ b/internal/plugins/import/rules/default/default.go
@@ -13,7 +13,8 @@ import (
 //
 // See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/default.js
 var DefaultRule = rule.Rule{
-	Name: "import/default",
+	Name:   "import/default",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		checkDefault := func(node *ast.Node) {
 			importDecl := node.AsImportDeclaration()

--- a/internal/plugins/import/rules/first/first.go
+++ b/internal/plugins/import/rules/first/first.go
@@ -1,6 +1,7 @@
 package first
 
 import (
+	_ "embed"
 	"slices"
 	"strings"
 	"unicode/utf8"
@@ -11,11 +12,14 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed first.schema.json
+var schemaJSON []byte
+
 // See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/first.js
 var FirstRule = rule.Rule{
-	Name: "import/first",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "import/first",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		// The linter visits SourceFile's children but never fires a KindSourceFile
 		// listener, so run the check eagerly before returning listeners.
 		checkFirst(ctx, options)
@@ -175,7 +179,7 @@ type errorInfo struct {
 	rangeTo   int
 }
 
-func checkFirst(ctx rule.RuleContext, options any) {
+func checkFirst(ctx rule.RuleContext, options []any) {
 	statements := ctx.SourceFile.Statements
 	if statements == nil || len(statements.Nodes) == 0 {
 		return

--- a/internal/plugins/import/rules/first/first.schema.json
+++ b/internal/plugins/import/rules/first/first.schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "string",
+      "enum": ["absolute-first", "disable-absolute-first"]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/import/rules/namespace/namespace.go
+++ b/internal/plugins/import/rules/namespace/namespace.go
@@ -1,6 +1,7 @@
 package namespace
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,9 @@ import (
 	rslint_utils "github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed namespace.schema.json
+var schemaJSON []byte
+
 type ruleOptions struct {
 	allowComputed bool
 }
@@ -18,9 +22,9 @@ type ruleOptions struct {
 //
 // See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/namespace.js
 var NamespaceRule = rule.Rule{
-	Name: "import/namespace",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "import/namespace",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 		namespaces := collectNamespaces(ctx)
 
@@ -41,13 +45,13 @@ var NamespaceRule = rule.Rule{
 	},
 }
 
-func parseOptions(options any) ruleOptions {
+func parseOptions(options []any) ruleOptions {
 	opts := ruleOptions{}
-	if optsMap := rslint_utils.GetOptionsMap(options); optsMap != nil {
-		if allowComputed, ok := optsMap["allowComputed"].(bool); ok {
-			opts.allowComputed = allowComputed
-		}
+	if len(options) == 0 {
+		return opts
 	}
+	optsMap, _ := options[0].(map[string]interface{})
+	opts.allowComputed, _ = optsMap["allowComputed"].(bool)
 	return opts
 }
 

--- a/internal/plugins/import/rules/namespace/namespace.schema.json
+++ b/internal/plugins/import/rules/namespace/namespace.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allowComputed": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/import/rules/newline_after_import/newline_after_import.go
+++ b/internal/plugins/import/rules/newline_after_import/newline_after_import.go
@@ -1,6 +1,7 @@
 package newline_after_import
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -8,8 +9,10 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed newline_after_import.schema.json
+var schemaJSON []byte
 
 type ruleOptions struct {
 	count            int
@@ -17,26 +20,17 @@ type ruleOptions struct {
 	considerComments bool
 }
 
-func parseOptions(options any) ruleOptions {
+func parseOptions(options []any) ruleOptions {
 	opts := ruleOptions{count: 1}
-	optsMap := utils.GetOptionsMap(options)
-	if optsMap != nil {
-		if v, ok := optsMap["count"]; ok {
-			if f, ok := v.(float64); ok && f >= 1 {
-				opts.count = int(f)
-			}
-		}
-		if v, ok := optsMap["exactCount"]; ok {
-			if b, ok := v.(bool); ok {
-				opts.exactCount = b
-			}
-		}
-		if v, ok := optsMap["considerComments"]; ok {
-			if b, ok := v.(bool); ok {
-				opts.considerComments = b
-			}
-		}
+	if len(options) == 0 {
+		return opts
 	}
+	optsMap, _ := options[0].(map[string]interface{})
+	if f, ok := optsMap["count"].(float64); ok && f >= 1 {
+		opts.count = int(f)
+	}
+	opts.exactCount, _ = optsMap["exactCount"].(bool)
+	opts.considerComments, _ = optsMap["considerComments"].(bool)
 	return opts
 }
 
@@ -58,9 +52,9 @@ func makeMessage(typ string, count int) rule.RuleMessage {
 // NewlineAfterImportRule enforces a newline after import/require statements.
 // See: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md
 var NewlineAfterImportRule = rule.Rule{
-	Name: "import/newline-after-import",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "import/newline-after-import",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		// The linter visits SourceFile's children (not the SourceFile node itself),

--- a/internal/plugins/import/rules/newline_after_import/newline_after_import.schema.json
+++ b/internal/plugins/import/rules/newline_after_import/newline_after_import.schema.json
@@ -1,0 +1,23 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "exactCount": {
+          "type": "boolean"
+        },
+        "considerComments": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/import/rules/no_cycle/no_cycle.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle.go
@@ -1,6 +1,7 @@
 package no_cycle
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -10,8 +11,10 @@ import (
 	"github.com/microsoft/typescript-go/shim/scanner"
 	import_utils "github.com/web-infra-dev/rslint/internal/plugins/import/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	rslint_utils "github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_cycle.schema.json
+var schemaJSON []byte
 
 const unlimitedDepth = int(^uint(0) >> 1)
 
@@ -36,42 +39,34 @@ type queuedModule struct {
 //
 // See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-cycle.js
 var NoCycleRule = rule.Rule{
-	Name: "import/no-cycle",
-	Run: func(ctx rule.RuleContext, newOptions []any) rule.RuleListeners {
-		opts := parseOptions(rule.LegacyUnwrapOptions(newOptions))
+	Name:   "import/no-cycle",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 		checkSourceFile(ctx, opts)
 		return rule.RuleListeners{}
 	},
 }
 
-func parseOptions(options any) ruleOptions {
+func parseOptions(options []any) ruleOptions {
 	opts := ruleOptions{
 		maxDepth: unlimitedDepth,
 		moduleReferences: import_utils.ModuleReferenceOptions{
 			ESModule: true,
 		},
 	}
-
-	optsMap := rslint_utils.GetOptionsMap(options)
-	if optsMap == nil {
+	if len(options) == 0 {
 		return opts
 	}
+	optsMap, _ := options[0].(map[string]interface{})
 
 	if maxDepth, ok := parseMaxDepth(optsMap["maxDepth"]); ok {
 		opts.maxDepth = maxDepth
 	}
-	if ignoreExternal, ok := optsMap["ignoreExternal"].(bool); ok {
-		opts.ignoreExternal = ignoreExternal
-	}
-	if allow, ok := optsMap["allowUnsafeDynamicCyclicDependency"].(bool); ok {
-		opts.allowUnsafeDynamicCyclicDependency = allow
-	}
-	if commonJS, ok := optsMap["commonjs"].(bool); ok {
-		opts.moduleReferences.CommonJS = commonJS
-	}
-	if amd, ok := optsMap["amd"].(bool); ok {
-		opts.moduleReferences.AMD = amd
-	}
+	opts.ignoreExternal, _ = optsMap["ignoreExternal"].(bool)
+	opts.allowUnsafeDynamicCyclicDependency, _ = optsMap["allowUnsafeDynamicCyclicDependency"].(bool)
+	opts.moduleReferences.CommonJS, _ = optsMap["commonjs"].(bool)
+	opts.moduleReferences.AMD, _ = optsMap["amd"].(bool)
 	if esmodule, ok := optsMap["esmodule"].(bool); ok {
 		opts.moduleReferences.ESModule = esmodule
 	}

--- a/internal/plugins/import/rules/no_cycle/no_cycle.md
+++ b/internal/plugins/import/rules/no_cycle/no_cycle.md
@@ -81,6 +81,22 @@ dynamic `import()`.
 }
 ```
 
+### `esmodule`
+
+Checks ES module `import`/`export` sources. Defaults to `true`; set to
+`false` to disable them.
+
+```json
+{ "import/no-cycle": ["error", { "esmodule": false }] }
+```
+
+### `disableScc`
+
+Accepted for compatibility with upstream configs. Upstream uses this to skip
+building a strongly-connected-components graph, an internal traversal
+optimization; this rule does not build one either way, so the option has no
+observable effect here.
+
 ## Original Documentation
 
 - [eslint-plugin-import/no-cycle](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md)

--- a/internal/plugins/import/rules/no_cycle/no_cycle.schema.json
+++ b/internal/plugins/import/rules/no_cycle/no_cycle.schema.json
@@ -22,6 +22,9 @@
             {
               "type": "string",
               "enum": ["∞"]
+            },
+            {
+              "type": "null"
             }
           ]
         },

--- a/internal/plugins/import/rules/no_cycle/no_cycle.schema.json
+++ b/internal/plugins/import/rules/no_cycle/no_cycle.schema.json
@@ -1,0 +1,43 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "commonjs": {
+          "type": "boolean"
+        },
+        "amd": {
+          "type": "boolean"
+        },
+        "esmodule": {
+          "type": "boolean"
+        },
+        "maxDepth": {
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 1
+            },
+            {
+              "type": "string",
+              "enum": ["∞"]
+            }
+          ]
+        },
+        "ignoreExternal": {
+          "type": "boolean"
+        },
+        "allowUnsafeDynamicCyclicDependency": {
+          "type": "boolean"
+        },
+        "disableScc": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/import/rules/no_default_export/no_default_export.go
+++ b/internal/plugins/import/rules/no_default_export/no_default_export.go
@@ -29,7 +29,8 @@ func noAliasDefaultMessage(local string) rule.RuleMessage {
 
 // See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-default-export.js
 var NoDefaultExportRule = rule.Rule{
-	Name: "import/no-default-export",
+	Name:   "import/no-default-export",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		reportDefaultExport := func(node *ast.Node) {
 			ctx.ReportRange(defaultKeywordRange(ctx.SourceFile, node), preferNamedMessage())

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.go
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.go
@@ -1,6 +1,7 @@
 package no_duplicates
 
 import (
+	_ "embed"
 	"fmt"
 	"slices"
 	"strings"
@@ -13,34 +14,30 @@ import (
 	rslintUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed no_duplicates.schema.json
+var schemaJSON []byte
+
 type ruleOptions struct {
 	considerQueryString bool
 	preferInline        bool
 }
 
-func parseOptions(options any) ruleOptions {
+func parseOptions(options []any) ruleOptions {
 	opts := ruleOptions{}
-	optsMap := rslintUtils.GetOptionsMap(options)
-	if optsMap != nil {
-		if v, ok := optsMap["considerQueryString"]; ok {
-			if b, ok := v.(bool); ok {
-				opts.considerQueryString = b
-			}
-		}
-		if v, ok := optsMap["prefer-inline"]; ok {
-			if b, ok := v.(bool); ok {
-				opts.preferInline = b
-			}
-		}
+	if len(options) == 0 {
+		return opts
 	}
+	optsMap, _ := options[0].(map[string]interface{})
+	opts.considerQueryString, _ = optsMap["considerQueryString"].(bool)
+	opts.preferInline, _ = optsMap["prefer-inline"].(bool)
 	return opts
 }
 
 // See: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md
 var NoDuplicatesRule = rule.Rule{
-	Name: "import/no-duplicates",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "import/no-duplicates",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		sourceFile := ctx.SourceFile

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.schema.json
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.schema.json
@@ -1,0 +1,19 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "considerQueryString": {
+          "type": "boolean"
+        },
+        "prefer-inline": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports.go
+++ b/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports.go
@@ -10,7 +10,8 @@ import (
 
 // See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-mutable-exports.js
 var NoMutableExportsRule = rule.Rule{
-	Name: "import/no-mutable-exports",
+	Name:   "import/no-mutable-exports",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		// checkDeclarationList reports if the VariableDeclarationList uses `let` or `var`.
 		checkDeclarationList := func(declList *ast.Node) {

--- a/internal/plugins/import/rules/no_self_import/no_self_import.go
+++ b/internal/plugins/import/rules/no_self_import/no_self_import.go
@@ -8,7 +8,8 @@ import (
 
 // See: https://github.com/import-js/eslint-plugin-import/blob/01c9eb04331d2efa8d63f2d7f4bfec3bc44c94f3/src/rules/no-self-import.js
 var NoSelfImportRule = rule.Rule{
-	Name: "import/no-self-import",
+	Name:   "import/no-self-import",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return utils.VisitModules(func(source, node *ast.Node) {
 			isImportingSelf(ctx, source, node)

--- a/internal/plugins/import/rules/no_webpack_loader_syntax/no_webpack_loader_syntax.go
+++ b/internal/plugins/import/rules/no_webpack_loader_syntax/no_webpack_loader_syntax.go
@@ -22,7 +22,8 @@ func buildRuleMessage(modulePath string) rule.RuleMessage {
 
 // See: https://github.com/import-js/eslint-plugin-import/blob/01c9eb04331d2efa8d63f2d7f4bfec3bc44c94f3/src/rules/no-webpack-loader-syntax.js
 var NoWebpackLoaderSyntax = rule.Rule{
-	Name: "import/no-webpack-loader-syntax",
+	Name:   "import/no-webpack-loader-syntax",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindImportDeclaration: func(node *ast.Node) {


### PR DESCRIPTION
## Summary

- Declare option JSON Schemas for all `import/` rules, matching `eslint-plugin-import` upstream, so options are now validated instead of manually unwrapped.
- `no-cycle`'s schema omits upstream's `ignore` option. Upstream exposes it via the shared `moduleVisitor.makeOptionsSchema()` base schema, but this port's `no-cycle` uses a separate traversal path (`import_utils.CollectModuleReferences` / `ModuleReferenceOptions`) that has no ignore-list concept at all, so the option isn't declared. `esmodule` and `disableScc` are documented for the first time.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).