### PR TITLE
fix: isolate rule option validation

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -373,8 +373,10 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	if configMap == nil && !configGitignoreFrozen {
 		rslintConfig = rslintconfig.ConfigWithGitignore(rslintConfig, configDirectory, fs, allowedFiles)
 	}
-	if messages := validateResolvedRuleOptions(configMap, rslintConfig); len(messages) > 0 {
-		return nil, fmt.Errorf("invalid rule options:\n%s", strings.Join(messages, "\n"))
+	var optionsMessages []string
+	configMap, rslintConfig, optionsMessages = validateResolvedRuleOptions(configMap, rslintConfig)
+	if len(optionsMessages) > 0 {
+		return nil, fmt.Errorf("invalid rule options:\n%s", strings.Join(optionsMessages, "\n"))
 	}
 
 	// The plugin registry is process-global, but execution is request-gated by

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -411,26 +411,34 @@ func cloneConfigMap(configMap map[string]rslintconfig.RslintConfig) map[string]r
 // resolved configuration: every configMap config in multi-config mode (each
 // message suffixed with the owning config directory, since the same rule can
 // be misconfigured differently per config), or the single rslintConfig
-// otherwise. Returns one formatted message per failure.
-func validateResolvedRuleOptions(configMap map[string]rslintconfig.RslintConfig, rslintConfig rslintconfig.RslintConfig) []string {
+// otherwise. It returns normalized copies plus one formatted message per
+// failure, leaving the input configs untouched.
+func validateResolvedRuleOptions(
+	configMap map[string]rslintconfig.RslintConfig,
+	rslintConfig rslintconfig.RslintConfig,
+) (map[string]rslintconfig.RslintConfig, rslintconfig.RslintConfig, []string) {
 	var messages []string
 	if configMap == nil {
-		for _, optionsError := range rslintconfig.ValidateRuleOptions(rslintConfig, rslintconfig.GlobalRuleRegistry) {
+		normalized, optionsErrors := rslintconfig.ValidateRuleOptions(rslintConfig, rslintconfig.GlobalRuleRegistry)
+		for _, optionsError := range optionsErrors {
 			messages = append(messages, optionsError.Error())
 		}
-		return messages
+		return nil, normalized, messages
 	}
 	configDirs := make([]string, 0, len(configMap))
 	for dir := range configMap {
 		configDirs = append(configDirs, dir)
 	}
 	slices.Sort(configDirs)
+	normalizedMap := make(map[string]rslintconfig.RslintConfig, len(configMap))
 	for _, dir := range configDirs {
-		for _, optionsError := range rslintconfig.ValidateRuleOptions(configMap[dir], rslintconfig.GlobalRuleRegistry) {
+		normalized, optionsErrors := rslintconfig.ValidateRuleOptions(configMap[dir], rslintconfig.GlobalRuleRegistry)
+		normalizedMap[dir] = normalized
+		for _, optionsError := range optionsErrors {
 			messages = append(messages, fmt.Sprintf("%s (config at %s)", optionsError.Error(), dir))
 		}
 	}
-	return messages
+	return normalizedMap, rslintConfig, messages
 }
 
 // resolveStartTime returns the start time for timing output.
@@ -747,8 +755,10 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 	// a separate step after configuration is fully resolved (including --rule
 	// overrides) and before any linting starts, so a bad config fails fast
 	// with every failure reported at once instead of surfacing mid-lint.
-	if messages := validateResolvedRuleOptions(configMap, rslintConfig); len(messages) > 0 {
-		for _, message := range messages {
+	var optionsMessages []string
+	configMap, rslintConfig, optionsMessages = validateResolvedRuleOptions(configMap, rslintConfig)
+	if len(optionsMessages) > 0 {
+		for _, message := range optionsMessages {
 			fmt.Fprintf(os.Stderr, "error: %s\n", message)
 		}
 		return 1

--- a/cmd/rslint/rule_options_validation_test.go
+++ b/cmd/rslint/rule_options_validation_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 )
 
 // The rule-options validation step runs after configuration is fully
@@ -82,5 +84,59 @@ func TestCLIValidRuleOptionsLintNormally(t *testing.T) {
 	}
 	if code != 1 || !strings.Contains(stdout, "no-debugger") {
 		t.Fatalf("expected the lint itself to run and flag no-debugger, got code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+}
+
+func TestValidateResolvedRuleOptionsReturnsNormalizedSingleConfig(t *testing.T) {
+	inputOptions := map[string]any{"values": []any{"original"}}
+	input := rslintconfig.RslintConfig{{
+		Rules: rslintconfig.Rules{
+			"unknown-rule": []any{"error", inputOptions},
+		},
+	}}
+
+	normalizedMap, normalized, messages := validateResolvedRuleOptions(nil, input)
+	if normalizedMap != nil {
+		t.Fatalf("single-config mode returned a non-nil config map: %#v", normalizedMap)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("unexpected validation messages: %v", messages)
+	}
+
+	normalizedOptions := normalized[0].Rules["unknown-rule"].([]any)[1].(map[string]any)
+	normalizedOptions["values"].([]any)[0] = "changed"
+	if got := inputOptions["values"].([]any)[0]; got != "original" {
+		t.Fatalf("helper returned the input config instead of its normalized copy: %#v", got)
+	}
+}
+
+func TestValidateResolvedRuleOptionsPreservesMultiConfigMode(t *testing.T) {
+	normalizedMap, _, messages := validateResolvedRuleOptions(
+		map[string]rslintconfig.RslintConfig{},
+		rslintconfig.RslintConfig{{Rules: rslintconfig.Rules{"unused": "error"}}},
+	)
+	if normalizedMap == nil || len(normalizedMap) != 0 {
+		t.Fatalf("non-nil empty config map changed mode: %#v", normalizedMap)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("unexpected validation messages: %v", messages)
+	}
+
+	inputOptions := map[string]any{"values": []any{"original"}}
+	inputMap := map[string]rslintconfig.RslintConfig{
+		"/workspace/a": {{
+			Rules: rslintconfig.Rules{
+				"unknown-rule": []any{"error", inputOptions},
+			},
+		}},
+	}
+	normalizedMap, _, messages = validateResolvedRuleOptions(inputMap, nil)
+	if len(messages) != 0 {
+		t.Fatalf("unexpected validation messages: %v", messages)
+	}
+	normalizedOptions := normalizedMap["/workspace/a"][0].Rules["unknown-rule"].([]any)[1].(map[string]any)
+	normalizedOptions["values"].([]any)[0] = "changed"
+	if got := inputOptions["values"].([]any)[0]; got != "original" {
+		t.Fatalf("multi-config helper returned an aliased input value: %#v", got)
 	}
 }

--- a/internal/config/validate_rule_options.go
+++ b/internal/config/validate_rule_options.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"runtime"
+	"slices"
 	"sort"
 	"sync"
 
@@ -22,9 +24,12 @@ func (e RuleOptionsError) Error() string {
 	return fmt.Sprintf("invalid options for rule %q: %v", e.RuleName, e.Err)
 }
 
-// ValidateRuleOptions validates every enabled rule's options in config
-// against the rule's declared schema, in parallel, and returns every failure
-// (not just the first) sorted by rule name for deterministic output.
+// ValidateRuleOptions validates every enabled rule's options in config against
+// the rule's declared schema and returns a normalized config plus every failure
+// (not just the first) sorted by rule name for deterministic output. The input
+// config is never mutated. The returned config owns each entry's Rules map and
+// its JSON-shaped rule values; successful options contain schema defaults,
+// while failed options remain an unmodified copy of their input value.
 //
 // It is meant to run as a separate step right after configuration is
 // resolved and before linting starts, so a bad config fails fast instead of
@@ -37,45 +42,71 @@ func (e RuleOptionsError) Error() string {
 //
 // Each entry's options are validated independently, mirroring ESLint, which
 // validates every config array element's options rather than only the final
-// merged value. The parallel loop leans on [rule.Schema]'s internal
-// sync.Once: racing first uses compile each schema at most once, and a
-// schema shared by many rules (EmptyArraySchema) compiles a single time.
+// merged value. Unique schemas are compiled first with bounded parallelism;
+// options are then normalized and validated by a second bounded worker pool.
+// Separating the phases keeps repeated entries from occupying every worker
+// while they wait on the same [rule.Schema] compile.
 //
 // Validation is also where schema-declared `default` values are filled in,
-// exactly like ajv's `useDefaults` in ESLint: [rule.Schema.Validate] mutates
-// the options' own maps and slices in place, and because each work item's
-// options slice aliases the raw config entry value it was parsed from
-// (parseRuleConfigValue sub-slices, it never copies), the defaults land in
-// the very options the per-file config merge later hands to rules — no
-// write-back needed. The parallel loop stays race-free because every entry's
-// rule value is its own decoded JSON value, never shared with another
-// entry's.
-func ValidateRuleOptions(config RslintConfig, registry *RuleRegistry) []RuleOptionsError {
+// exactly like ajv's `useDefaults` in ESLint. [rule.Schema.Validate] mutates
+// maps and slices in place, so every options-bearing work item receives a deep
+// copy of its complete raw rule value first. This makes arbitrary aliases
+// between entries safe without serializing independent schema validation.
+func ValidateRuleOptions(config RslintConfig, registry *RuleRegistry) (RslintConfig, []RuleOptionsError) {
 	type workItem struct {
-		entryIndex int
-		ruleName   string
-		schema     *rule.Schema
-		options    []any
+		entryIndex  int
+		ruleName    string
+		schema      *rule.Schema
+		schemaIndex int
+		ruleValue   any
+		hasOptions  bool
+	}
+	type workResult struct {
+		ruleValue any
+		err       error
 	}
 
+	normalized := slices.Clone(config)
+	schemaIndexes := make(map[*rule.Schema]int)
+	var schemas []*rule.Schema
+	var schemaNeedsEmptyOptionsValidation []bool
 	var items []workItem
 	for entryIndex, entry := range config {
+		if entry.Rules == nil {
+			continue
+		}
+		normalizedRules := make(Rules, len(entry.Rules))
+		normalized[entryIndex].Rules = normalizedRules
 		for ruleName, ruleValue := range entry.Rules {
-			ruleConfig, _, err := parseRuleConfigValue(ruleValue)
+			ruleConfig, hasOptions, err := parseRuleConfigValue(ruleValue)
 			// Malformed rule values (bad severity etc.) are rejected at config
 			// ingress by ValidateConfig; they are not this step's concern.
 			if err != nil || !ruleConfig.IsEnabled() {
+				normalizedRules[ruleName] = cloneConfigValue(ruleValue)
 				continue
 			}
 			ruleImpl, exists := registry.GetRule(ruleName)
 			if !exists || ruleImpl.Schema == nil {
+				normalizedRules[ruleName] = cloneConfigValue(ruleValue)
 				continue
 			}
+			schemaIndex, exists := schemaIndexes[ruleImpl.Schema]
+			if !exists {
+				schemaIndex = len(schemas)
+				schemaIndexes[ruleImpl.Schema] = schemaIndex
+				schemas = append(schemas, ruleImpl.Schema)
+				schemaNeedsEmptyOptionsValidation = append(schemaNeedsEmptyOptionsValidation, false)
+			}
+			if !hasOptions {
+				schemaNeedsEmptyOptionsValidation[schemaIndex] = true
+			}
 			items = append(items, workItem{
-				entryIndex: entryIndex,
-				ruleName:   ruleName,
-				schema:     ruleImpl.Schema,
-				options:    ruleConfig.Options,
+				entryIndex:  entryIndex,
+				ruleName:    ruleName,
+				schema:      ruleImpl.Schema,
+				schemaIndex: schemaIndex,
+				ruleValue:   ruleValue,
+				hasOptions:  hasOptions,
 			})
 		}
 	}
@@ -89,20 +120,56 @@ func ValidateRuleOptions(config RslintConfig, registry *RuleRegistry) []RuleOpti
 		return items[i].entryIndex < items[j].entryIndex
 	})
 
-	results := make([]error, len(items))
-	var wg sync.WaitGroup
-	for i, item := range items {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			results[i] = item.schema.Validate(item.options)
-		}()
+	compileErrors := make([]error, len(schemas))
+	emptyOptionsErrors := make([]error, len(schemas))
+	parallelRuleOptionsWork(len(schemas), func(index int) {
+		_, compileErrors[index] = schemas[index].Compile()
+		if compileErrors[index] == nil && schemaNeedsEmptyOptionsValidation[index] {
+			emptyOptionsErrors[index] = schemas[index].Validate(nil)
+		}
+	})
+
+	results := make([]workResult, len(items))
+	var optionItemIndexes []int
+	for index, item := range items {
+		if err := compileErrors[item.schemaIndex]; err != nil {
+			results[index].err = err
+			continue
+		}
+		if !item.hasOptions {
+			results[index].err = emptyOptionsErrors[item.schemaIndex]
+			continue
+		}
+		optionItemIndexes = append(optionItemIndexes, index)
 	}
-	wg.Wait()
+	parallelRuleOptionsWork(len(optionItemIndexes), func(workIndex int) {
+		index := optionItemIndexes[workIndex]
+		item := items[index]
+		// hasOptions is only true for array-form rule values with at least one
+		// element after the severity, so the cloned options start at index 1.
+		clonedValue, ok := cloneConfigValue(item.ruleValue).([]any)
+		if !ok {
+			results[index].err = fmt.Errorf("internal error: cloned rule value has unexpected type %T", item.ruleValue)
+			return
+		}
+		results[index].err = item.schema.Validate(clonedValue[1:])
+		if results[index].err == nil {
+			results[index].ruleValue = clonedValue
+		}
+	})
+
+	for index, item := range items {
+		ruleValue := results[index].ruleValue
+		if results[index].err != nil || !item.hasOptions {
+			ruleValue = cloneConfigValue(item.ruleValue)
+		}
+		normalized[item.entryIndex].Rules[item.ruleName] = ruleValue
+	}
 
 	var errs []RuleOptionsError
 	seen := map[string]bool{}
-	for i, err := range results {
+	for i, result := range results {
+		err := result.err
 		if err == nil {
 			continue
 		}
@@ -115,5 +182,35 @@ func ValidateRuleOptions(config RslintConfig, registry *RuleRegistry) []RuleOpti
 		seen[key] = true
 		errs = append(errs, RuleOptionsError{RuleName: items[i].ruleName, Err: err})
 	}
-	return errs
+	return normalized, errs
+}
+
+func parallelRuleOptionsWork(taskCount int, work func(int)) {
+	if taskCount == 0 {
+		return
+	}
+	workerCount := min(runtime.GOMAXPROCS(0), taskCount)
+	if workerCount == 1 {
+		for index := range taskCount {
+			work(index)
+		}
+		return
+	}
+
+	jobs := make(chan int, workerCount)
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for index := range jobs {
+				work(index)
+			}
+		}()
+	}
+	for index := range taskCount {
+		jobs <- index
+	}
+	close(jobs)
+	workers.Wait()
 }

--- a/internal/config/validate_rule_options_test.go
+++ b/internal/config/validate_rule_options_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -52,6 +53,81 @@ func newOptionsTestRegistry() *RuleRegistry {
 	return registry
 }
 
+func newDefaultsOptionsTestRegistry() *RuleRegistry {
+	registry := NewRuleRegistry()
+	noopRun := func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{}
+	}
+	registry.Register("with-defaults", rule.Rule{
+		Name: "with-defaults",
+		Schema: rule.NewSchema([]byte(`{
+			"type": "array",
+			"items": [
+				{
+					"type": "object",
+					"properties": {
+						"allow": { "type": "array", "items": { "type": "string" }, "default": [] },
+						"strict": { "type": "boolean", "default": true }
+					},
+					"additionalProperties": false
+				}
+			],
+			"minItems": 0,
+			"maxItems": 1
+		}`)),
+		Run: noopRun,
+	})
+	registry.Register("with-nested-defaults", rule.Rule{
+		Name: "with-nested-defaults",
+		Schema: rule.NewSchema([]byte(`{
+			"type": "array",
+			"items": [
+				{
+					"type": "object",
+					"properties": {
+						"nested": {
+							"type": "object",
+							"properties": {
+								"enabled": { "type": "boolean", "default": true }
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false
+				}
+			],
+			"minItems": 0,
+			"maxItems": 1
+		}`)),
+		Run: noopRun,
+	})
+	registry.Register("with-tuple-defaults", rule.Rule{
+		Name: "with-tuple-defaults",
+		Schema: rule.NewSchema([]byte(`{
+			"type": "array",
+			"items": [
+				{
+					"type": "object",
+					"default": { "values": [] },
+					"properties": {
+						"values": {
+							"type": "array",
+							"items": [
+								{ "type": "string", "default": "filled" }
+							],
+							"maxItems": 1
+						}
+					},
+					"additionalProperties": false
+				}
+			],
+			"maxItems": 1
+		}`)),
+		Run: noopRun,
+	})
+	return registry
+}
+
 func configWithRules(rules Rules) RslintConfig {
 	return RslintConfig{ConfigEntry{Rules: rules}}
 }
@@ -63,7 +139,7 @@ func TestValidateRuleOptionsAcceptsValidConfig(t *testing.T) {
 		"no-options":  "error",
 		"unmigrated":  []any{"warn", map[string]any{"whatever": true}},
 	})
-	if errs := ValidateRuleOptions(config, registry); len(errs) != 0 {
+	if _, errs := ValidateRuleOptions(config, registry); len(errs) != 0 {
 		t.Errorf("expected no errors, got: %v", errs)
 	}
 }
@@ -76,7 +152,7 @@ func TestValidateRuleOptionsReportsEveryFailure(t *testing.T) {
 		// A no-options rule given an option.
 		"no-options": []any{"error", map[string]any{"unexpected": true}},
 	})
-	errs := ValidateRuleOptions(config, registry)
+	_, errs := ValidateRuleOptions(config, registry)
 	if len(errs) != 2 {
 		t.Fatalf("expected 2 errors, got %d: %v", len(errs), errs)
 	}
@@ -99,20 +175,114 @@ func TestValidateRuleOptionsSkipsDisabledUnknownAndUnmigrated(t *testing.T) {
 		// No schema declared yet: passes through unvalidated.
 		"unmigrated": []any{"error", map[string]any{"whatever": true}},
 	})
-	if errs := ValidateRuleOptions(config, registry); len(errs) != 0 {
+	if _, errs := ValidateRuleOptions(config, registry); len(errs) != 0 {
 		t.Errorf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidateRuleOptionsDetachesSkippedRuleValues(t *testing.T) {
+	registry := newOptionsTestRegistry()
+	sharedOptions := map[string]any{"nested": []any{"original"}}
+	config := configWithRules(Rules{
+		"with-schema": []any{"off", sharedOptions},
+		"no-such-rule": []any{
+			"error",
+			sharedOptions,
+		},
+		"unmigrated": []any{"error", sharedOptions},
+	})
+
+	normalized, errs := ValidateRuleOptions(config, registry)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+
+	disabled := normalized[0].Rules["with-schema"].([]any)[1].(map[string]any)
+	unknown := normalized[0].Rules["no-such-rule"].([]any)[1].(map[string]any)
+	unmigrated := normalized[0].Rules["unmigrated"].([]any)[1].(map[string]any)
+	disabled["nested"].([]any)[0] = "changed"
+	normalized[0].Rules["new-rule"] = "error"
+
+	if got := sharedOptions["nested"].([]any)[0]; got != "original" {
+		t.Fatalf("normalized skipped value still aliases input: got %#v", got)
+	}
+	if got := unknown["nested"].([]any)[0]; got != "original" {
+		t.Fatalf("normalized skipped values still alias each other: got %#v", got)
+	}
+	if got := unmigrated["nested"].([]any)[0]; got != "original" {
+		t.Fatalf("normalized skipped values still alias each other: got %#v", got)
+	}
+	if _, exists := config[0].Rules["new-rule"]; exists {
+		t.Fatal("normalized Rules map still aliases input")
 	}
 }
 
 func TestValidateRuleOptionsSurfacesSchemaCompileError(t *testing.T) {
 	registry := newOptionsTestRegistry()
 	config := configWithRules(Rules{"broken-schema": "error"})
-	errs := ValidateRuleOptions(config, registry)
+	_, errs := ValidateRuleOptions(config, registry)
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
 	}
 	if errs[0].RuleName != "broken-schema" {
 		t.Errorf("expected the compile failure to name the rule, got %q", errs[0].RuleName)
+	}
+}
+
+func TestValidateRuleOptionsReportsSharedSchemaCompileErrorPerRule(t *testing.T) {
+	registry := NewRuleRegistry()
+	sharedBrokenSchema := rule.NewSchema([]byte(`not json`))
+	noopRun := func(rule.RuleContext, []any) rule.RuleListeners {
+		return rule.RuleListeners{}
+	}
+	for _, ruleName := range []string{"alpha", "beta"} {
+		registry.Register(ruleName, rule.Rule{
+			Name:   ruleName,
+			Schema: sharedBrokenSchema,
+			Run:    noopRun,
+		})
+	}
+
+	_, errs := ValidateRuleOptions(configWithRules(Rules{
+		"beta":  "error",
+		"alpha": "error",
+	}), registry)
+	if len(errs) != 2 {
+		t.Fatalf("expected one compile error per rule, got %d: %v", len(errs), errs)
+	}
+	if errs[0].RuleName != "alpha" || errs[1].RuleName != "beta" {
+		t.Fatalf("compile errors are not in rule-name order: %v", errs)
+	}
+}
+
+func TestValidateRuleOptionsReportsSharedEmptyOptionsErrorPerRule(t *testing.T) {
+	registry := NewRuleRegistry()
+	sharedSchema := rule.NewSchema([]byte(`{
+		"type": "array",
+		"items": [{ "type": "string" }],
+		"minItems": 1,
+		"maxItems": 1
+	}`))
+	noopRun := func(rule.RuleContext, []any) rule.RuleListeners {
+		return rule.RuleListeners{}
+	}
+	for _, ruleName := range []string{"alpha", "beta"} {
+		registry.Register(ruleName, rule.Rule{
+			Name:   ruleName,
+			Schema: sharedSchema,
+			Run:    noopRun,
+		})
+	}
+
+	_, errs := ValidateRuleOptions(RslintConfig{
+		{Rules: Rules{"alpha": "error", "beta": []any{"error"}}},
+		{Rules: Rules{"alpha": "error", "beta": []any{"error"}}},
+	}, registry)
+	if len(errs) != 2 {
+		t.Fatalf("expected one empty-options error per rule, got %d: %v", len(errs), errs)
+	}
+	if errs[0].RuleName != "alpha" || errs[1].RuleName != "beta" {
+		t.Fatalf("empty-options errors are not in rule-name order: %v", errs)
 	}
 }
 
@@ -128,7 +298,7 @@ func TestValidateRuleOptionsValidatesEachEntryAndDeduplicates(t *testing.T) {
 		// A valid entry for the same rule doesn't mask the bad ones.
 		ConfigEntry{Rules: Rules{"with-schema": []any{"error", map[string]any{"allow": []any{"warn"}}}}},
 	}
-	errs := ValidateRuleOptions(config, registry)
+	_, errs := ValidateRuleOptions(config, registry)
 	if len(errs) != 2 {
 		t.Fatalf("expected 2 errors (duplicate collapsed, distinct kept), got %d: %v", len(errs), errs)
 	}
@@ -140,41 +310,167 @@ func TestValidateRuleOptionsValidatesEachEntryAndDeduplicates(t *testing.T) {
 }
 
 func TestValidateRuleOptionsFillsSchemaDefaultsIntoConfig(t *testing.T) {
-	// The useDefaults contract: validation mutates the options in place, and
-	// because the validated options slice aliases the raw config entry value,
-	// the defaults are visible to the per-file config merge afterwards.
-	registry := NewRuleRegistry()
-	registry.Register("with-defaults", rule.Rule{
-		Name: "with-defaults",
-		Schema: rule.NewSchema([]byte(`{
-			"type": "array",
-			"items": [
-				{
-					"type": "object",
-					"properties": {
-						"allow": { "type": "array", "items": { "type": "string" }, "default": [] },
-						"strict": { "type": "boolean", "default": true }
-					},
-					"additionalProperties": false
-				}
-			],
-			"minItems": 0,
-			"maxItems": 1
-		}`)),
-		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-			return rule.RuleListeners{}
-		},
-	})
+	registry := newDefaultsOptionsTestRegistry()
 
 	options := map[string]any{"strict": false}
 	config := configWithRules(Rules{"with-defaults": []any{"error", options}})
-	if errs := ValidateRuleOptions(config, registry); len(errs) != 0 {
+	normalized, errs := ValidateRuleOptions(config, registry)
+	if len(errs) != 0 {
 		t.Fatalf("expected no errors, got: %v", errs)
 	}
 
 	want := map[string]any{"allow": []any{}, "strict": false}
-	if !reflect.DeepEqual(options, want) {
-		t.Errorf("expected defaults filled into the config's own options, got %#v, want %#v", options, want)
+	normalizedRule, _, err := parseRuleConfigValue(normalized[0].Rules["with-defaults"])
+	if err != nil {
+		t.Fatalf("parse normalized rule: %v", err)
+	}
+	got := normalizedRule.Options[0].(map[string]any)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected defaults filled into normalized options, got %#v, want %#v", got, want)
+	}
+	if !reflect.DeepEqual(options, map[string]any{"strict": false}) {
+		t.Errorf("expected input options to remain unchanged, got %#v", options)
+	}
+}
+
+func TestValidateRuleOptionsPreservesTopLevelShapeAndNestedTupleDefaults(t *testing.T) {
+	registry := newDefaultsOptionsTestRegistry()
+	nestedValues := []any{}
+	config := RslintConfig{
+		{Rules: Rules{"with-tuple-defaults": "error"}},
+		{Rules: Rules{"with-tuple-defaults": []any{"error"}}},
+		{Rules: Rules{
+			"with-tuple-defaults": []any{
+				"error",
+				map[string]any{"values": nestedValues},
+			},
+		}},
+	}
+
+	normalized, errs := ValidateRuleOptions(config, registry)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+	if normalized[0].Rules["with-tuple-defaults"] != "error" {
+		t.Fatalf("severity-only scalar changed shape: %#v", normalized[0].Rules["with-tuple-defaults"])
+	}
+	severityOnly := normalized[1].Rules["with-tuple-defaults"].([]any)
+	if !reflect.DeepEqual(severityOnly, []any{"error"}) {
+		t.Fatalf("severity-only array changed shape: %#v", severityOnly)
+	}
+
+	ruleConfig, _, err := parseRuleConfigValue(normalized[2].Rules["with-tuple-defaults"])
+	if err != nil {
+		t.Fatalf("parse normalized rule: %v", err)
+	}
+	options := ruleConfig.Options[0].(map[string]any)
+	if got := options["values"]; !reflect.DeepEqual(got, []any{"filled"}) {
+		t.Fatalf("nested tuple default was not published: %#v", got)
+	}
+	if len(nestedValues) != 0 {
+		t.Fatalf("nested tuple default mutated input: %#v", nestedValues)
+	}
+}
+
+func TestValidateRuleOptionsIsolatesNestedAliases(t *testing.T) {
+	registry := newDefaultsOptionsTestRegistry()
+	sharedNested := map[string]any{}
+	config := RslintConfig{
+		{Rules: Rules{
+			"with-nested-defaults": []any{"error", map[string]any{"nested": sharedNested}},
+		}},
+		{Rules: Rules{
+			"with-nested-defaults": []any{"error", map[string]any{"nested": sharedNested}},
+		}},
+	}
+
+	normalized, errs := ValidateRuleOptions(config, registry)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+	if len(sharedNested) != 0 {
+		t.Fatalf("expected shared input to remain unchanged, got %#v", sharedNested)
+	}
+
+	nested := make([]map[string]any, len(normalized))
+	for index, entry := range normalized {
+		ruleConfig, _, err := parseRuleConfigValue(entry.Rules["with-nested-defaults"])
+		if err != nil {
+			t.Fatalf("parse normalized rule at entry %d: %v", index, err)
+		}
+		options := ruleConfig.Options[0].(map[string]any)
+		nested[index] = options["nested"].(map[string]any)
+		if got := nested[index]["enabled"]; got != true {
+			t.Fatalf("entry %d: enabled = %#v, want true", index, got)
+		}
+	}
+	nested[0]["enabled"] = false
+	if got := nested[1]["enabled"]; got != true {
+		t.Fatalf("normalized entries still share nested options: second enabled = %#v", got)
+	}
+}
+
+func TestValidateRuleOptionsDoesNotPublishPartialDefaultsOnError(t *testing.T) {
+	registry := newDefaultsOptionsTestRegistry()
+	options := map[string]any{"strict": "invalid"}
+	config := configWithRules(Rules{
+		"with-defaults": []any{"error", options},
+	})
+
+	normalized, errs := ValidateRuleOptions(config, registry)
+	if len(errs) != 1 {
+		t.Fatalf("expected one validation error, got %d: %v", len(errs), errs)
+	}
+	ruleConfig, _, err := parseRuleConfigValue(normalized[0].Rules["with-defaults"])
+	if err != nil {
+		t.Fatalf("parse normalized rule: %v", err)
+	}
+	got := ruleConfig.Options[0].(map[string]any)
+	if !reflect.DeepEqual(got, options) {
+		t.Fatalf("failed options contain partial defaults: got %#v, want %#v", got, options)
+	}
+	got["strict"] = "changed"
+	if options["strict"] != "invalid" {
+		t.Fatalf("failed normalized options still alias input: input = %#v", options)
+	}
+}
+
+func TestValidateRuleOptionsConcurrentCallsShareInputSafely(t *testing.T) {
+	registry := newDefaultsOptionsTestRegistry()
+	shared := map[string]any{"strict": false}
+	ruleValue := []any{"error", shared}
+	config := RslintConfig{
+		{Rules: Rules{"with-defaults": ruleValue}},
+		{Rules: Rules{"with-defaults": ruleValue}},
+	}
+
+	var waitGroup sync.WaitGroup
+	for call := range 16 {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			normalized, errs := ValidateRuleOptions(config, registry)
+			if len(errs) != 0 {
+				t.Errorf("call %d: expected no errors, got: %v", call, errs)
+				return
+			}
+			for entryIndex, entry := range normalized {
+				ruleConfig, _, err := parseRuleConfigValue(entry.Rules["with-defaults"])
+				if err != nil {
+					t.Errorf("call %d entry %d: parse normalized rule: %v", call, entryIndex, err)
+					continue
+				}
+				options := ruleConfig.Options[0].(map[string]any)
+				if _, ok := options["allow"]; !ok {
+					t.Errorf("call %d entry %d: default was not applied: %#v", call, entryIndex, options)
+				}
+			}
+		}()
+	}
+	waitGroup.Wait()
+
+	if !reflect.DeepEqual(shared, map[string]any{"strict": false}) {
+		t.Fatalf("concurrent validation mutated shared input: %#v", shared)
 	}
 }
 
@@ -186,7 +482,7 @@ func TestValidateRuleOptionsAcceptsSeverityOnlyAndEmptyOptions(t *testing.T) {
 		// Array form with severity only.
 		"no-options": []any{"warn"},
 	})
-	if errs := ValidateRuleOptions(config, registry); len(errs) != 0 {
+	if _, errs := ValidateRuleOptions(config, registry); len(errs) != 0 {
 		t.Errorf("expected no errors, got: %v", errs)
 	}
 }

--- a/internal/lsp/config_discovery.go
+++ b/internal/lsp/config_discovery.go
@@ -491,9 +491,11 @@ func (s *Server) prepareDiscoveredConfigSnapshot(
 		if err := config.ValidateConfig(entries); err != nil {
 			return nil, fmt.Errorf("invalid discovered config for %q: %w", configDir, err)
 		}
-		if err := validateRuleOptionsForConfig(entries, configDir); err != nil {
+		normalizedEntries, err := validateRuleOptionsForConfig(entries, configDir)
+		if err != nil {
 			return nil, err
 		}
+		entries = normalizedEntries
 		configID := lspFilesystemPathID(configDir, fsys)
 		if previous, exists := seenConfigDirs[configID]; exists {
 			return nil, fmt.Errorf(

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -258,16 +258,19 @@ func (s *Server) reloadConfig() error {
 	return nil
 }
 
-func validateRuleOptionsForConfig(entries config.RslintConfig, configDirectory string) error {
-	optionsErrs := config.ValidateRuleOptions(entries, config.GlobalRuleRegistry)
+func validateRuleOptionsForConfig(
+	entries config.RslintConfig,
+	configDirectory string,
+) (config.RslintConfig, error) {
+	normalized, optionsErrs := config.ValidateRuleOptions(entries, config.GlobalRuleRegistry)
 	if len(optionsErrs) == 0 {
-		return nil
+		return normalized, nil
 	}
 	msgs := make([]string, len(optionsErrs))
 	for i, optionsErr := range optionsErrs {
 		msgs[i] = optionsErr.Error()
 	}
-	return fmt.Errorf("invalid rule options for %q:\n%s", configDirectory, strings.Join(msgs, "\n"))
+	return nil, fmt.Errorf("invalid rule options for %q:\n%s", configDirectory, strings.Join(msgs, "\n"))
 }
 
 // handleDidChangeWatchedFiles handles file change notifications from the client.


### PR DESCRIPTION
## Summary

- return a detached normalized rules config so schema defaults never mutate or race on shared input values
- compile unique schemas and validate empty options once with bounded worker pools, keeping startup scalable for 800+ schemas
- use normalized configs in CLI, API, and LSP paths, with race, aliasing, tuple-default, and call-site regressions

## Local Benchmark

Local-only benchmark on Apple M1 Max (`darwin/arm64`, `GOMAXPROCS=8`) with 800 unique schemas. Results are medians from `-benchtime=10x -count=5`. The benchmark source was intentionally not committed.

| Scenario | Legacy | This PR | Delta |
| --- | ---: | ---: | ---: |
| Cold schemas, severity-only, 16 entries | 14.05 ms/op · 16.48 MB/op · 185,808 allocs/op | 7.03 ms/op · 11.36 MB/op · 88,975 allocs/op | -49.9% time · -31.1% bytes · -52.1% allocs |
| Warm schemas, severity-only, 16 entries | 11.86 ms/op · 10.97 MB/op · 115,225 allocs/op | 5.18 ms/op · 5.87 MB/op · 18,537 allocs/op | -56.3% time · -46.5% bytes · -83.9% allocs |
| Warm schemas, fresh default-bearing configs, 8 entries | 6.56 ms/op · 9.77 MB/op · 108,822 allocs/op | 8.12 ms/op · 10.70 MB/op · 128,129 allocs/op | +23.8% time (+1.56 ms) · +9.4% bytes · +17.7% allocs |

The defaults-heavy case measures 6,400 independently owned options graphs. Its additional 1.56 ms is the required cost of keeping input immutable, isolating deep aliases, and publishing defaults in a detached normalized snapshot. Severity-only configurations avoid that copy and benefit from validating empty options once per unique schema instead of once per occurrence.

As a cold-start scaling check for the new implementation (`-benchtime=1x -count=10`, explicit GC before timing), the median was 12.06 ms at `GOMAXPROCS=1` and 7.45 ms at `GOMAXPROCS=8` (-38.2% wall time).

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).