### PR TITLE
fix: preserve gitignore directory negation semantics

### DIFF
--- a/cmd/rslint/ignore_conformance_test.go
+++ b/cmd/rslint/ignore_conformance_test.go
@@ -43,6 +43,14 @@ func TestCLIAndAPIIgnoreConformance(t *testing.T) {
 			gitignores: map[string]string{".gitignore": "ignored.ts\n"},
 		},
 		{
+			name:     "directory negation preserves nested directory ignore",
+			relative: "dist-path/dist/output.ts",
+			gitignores: map[string]string{
+				".gitignore":                "dist/\ndist-*/\n!dist-path/\n",
+				"dist-path/dist/.gitignore": "!output.ts\n",
+			},
+		},
+		{
 			name:          "config negation restores gitignored explicit target",
 			relative:      "dist/important.ts",
 			globalIgnores: []string{"!dist/important.ts"},
@@ -77,13 +85,12 @@ func TestCLIAndAPIIgnoreConformance(t *testing.T) {
 			wantLinted: true,
 		},
 		{
-			name:     "pruned nested source does not override root negation",
+			name:     "excluded parent blocks child negation and nested source",
 			relative: "dist/types/private.ts",
 			gitignores: map[string]string{
 				".gitignore":            "dist/\n!dist/types/\n",
 				"dist/types/.gitignore": "private.ts\n",
 			},
-			wantLinted: true,
 		},
 		{
 			name:       "directory symlink remains lintable without ignore",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,12 +44,15 @@ type ConfigEntry struct {
 	Plugins  []string `json:"plugins,omitempty"`
 	Settings Settings `json:"settings,omitempty"`
 
-	// gitignoreSemantics marks the process-local synthetic entry prepended by
-	// ConfigWithGitignore. Git patterns need slightly different directory
-	// classification from authored flat-config ignores, while remaining in the
-	// same ordered ignore sequence so later config negations can re-include.
-	gitignoreSemantics       bool
-	gitignoreCaseInsensitive bool
+	// collectedGitignore marks the process-local synthetic entry prepended by
+	// ConfigWithGitignore and retains its once-compiled directory-node
+	// matchers. Keeping the uncommon metadata behind one pointer preserves the
+	// original ConfigEntry footprint for every ordinary authored config entry.
+	collectedGitignore *collectedGitignoreMetadata
+}
+
+type collectedGitignoreMetadata struct {
+	ignores []IgnorePattern
 }
 
 func (entry ConfigEntry) MarshalJSON() ([]byte, error) {
@@ -688,8 +691,12 @@ func isDirBlockedByIgnores(filePath string, patterns []IgnorePattern, cwd string
 
 // normalizePath converts file path to be relative to cwd for consistent matching
 func normalizePath(filePath, cwd string) string {
+	return normalizePathWithCaseSensitivity(filePath, cwd, true)
+}
+
+func normalizePathWithCaseSensitivity(filePath, cwd string, useCaseSensitive bool) string {
 	return tspath.NormalizePath(tspath.ConvertToRelativePath(filePath, tspath.ComparePathsOptions{
-		UseCaseSensitiveFileNames: true,
+		UseCaseSensitiveFileNames: useCaseSensitive,
 		CurrentDirectory:          cwd,
 	}))
 }
@@ -708,10 +715,21 @@ func extractConfigIgnores(config RslintConfig) []IgnorePattern {
 		if !isGlobalIgnoreEntry(entry) {
 			continue
 		}
-		if entry.gitignoreSemantics {
-			ignores = append(ignores, parseCollectedGitignorePatterns(entry.Ignores, entry.gitignoreCaseInsensitive)...)
+		var entryIgnores []IgnorePattern
+		if entry.collectedGitignore != nil {
+			entryIgnores = entry.collectedGitignore.ignores
 		} else {
-			ignores = append(ignores, ParseIgnorePatterns(entry.Ignores)...)
+			entryIgnores = ParseIgnorePatterns(entry.Ignores)
+		}
+		if len(entryIgnores) == 0 {
+			continue
+		}
+		if len(ignores) == 0 {
+			// Reuse the first immutable group. Limiting capacity guarantees a
+			// later append cannot mutate its config-owned backing array.
+			ignores = entryIgnores[:len(entryIgnores):len(entryIgnores)]
+		} else {
+			ignores = append(ignores, entryIgnores...)
 		}
 	}
 	return ignores

--- a/internal/config/discovery/discovery.go
+++ b/internal/config/discovery/discovery.go
@@ -93,7 +93,7 @@ type directorySeedResolution struct {
 type gitignoreObservation struct {
 	ownerDirectory  string
 	sourceDirectory string
-	globs           []string
+	patterns        []gitignore.Pattern
 }
 
 type gitignoreReadResult struct {
@@ -1248,14 +1248,14 @@ func (builder *configCatalogBuilder) readGitignoreSource(
 	if !content.exists {
 		return cursor, nil
 	}
-	next, globs := cursor.AppendSource(matchDirectory, content.content)
-	if len(globs) == 0 {
+	next, patterns := cursor.AppendSourcePatterns(matchDirectory, content.content)
+	if len(patterns) == 0 {
 		return next, nil
 	}
 	return next, &gitignoreObservation{
 		ownerDirectory:  ownerDirectory,
 		sourceDirectory: matchDirectory,
-		globs:           globs,
+		patterns:        patterns,
 	}
 }
 
@@ -1330,7 +1330,7 @@ func (builder *configCatalogBuilder) observeGitignoreSource(
 }
 
 func (builder *configCatalogBuilder) recordGitignoreObservation(observation gitignoreObservation) {
-	if observation.ownerDirectory == "" || observation.sourceDirectory == "" || len(observation.globs) == 0 {
+	if observation.ownerDirectory == "" || observation.sourceDirectory == "" || len(observation.patterns) == 0 {
 		return
 	}
 	if builder.gitignoreSources == nil {
@@ -1349,7 +1349,7 @@ func (builder *configCatalogBuilder) recordGitignoreObservation(observation giti
 	if _, exists := sources[identity]; exists {
 		return
 	}
-	observation.globs = append([]string(nil), observation.globs...)
+	observation.patterns = append([]gitignore.Pattern(nil), observation.patterns...)
 	sources[identity] = observation
 }
 
@@ -1635,13 +1635,13 @@ func (builder *configCatalogBuilder) materializeGitignoreConfigs() {
 			}
 			return left < right
 		})
-		var globs []string
+		var patterns []gitignore.Pattern
 		for _, observation := range observations {
-			globs = append(globs, observation.globs...)
+			patterns = append(patterns, observation.patterns...)
 		}
 		builder.configs[ownerDirectory] = rslintconfig.ConfigWithCollectedGitignore(
 			entries,
-			globs,
+			patterns,
 			caseInsensitive,
 		)
 	}

--- a/internal/config/file_discovery_dir_prune_test.go
+++ b/internal/config/file_discovery_dir_prune_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/config/gitignore"
 	"gotest.tools/v3/assert"
 )
 
@@ -144,18 +145,16 @@ func TestDiscoverGapFiles_CaseInsensitiveAnchoredNegationPrunesUnrelatedDir(t *t
 		"scripts/debug/keep.ts",
 		"scripts/other/drop.ts",
 	})
-	config := RslintConfig{
-		{
-			Ignores: []string{
-				"**/target/**/*",
-				"**/scripts/**/*",
-				"!Scripts/**/Debug/**/*",
-			},
-			gitignoreSemantics:       true,
-			gitignoreCaseInsensitive: true,
-		},
+	config := ConfigWithCollectedGitignore(RslintConfig{
 		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
-	}
+	}, []gitignore.Pattern{
+		{Glob: "**/target/**/*", NodeGlob: "**/target", DirectoryOnly: true},
+		// scripts/* ignores each immediate child node without excluding the
+		// scripts parent, so Git permits the later Debug negation to reopen the
+		// matching child.
+		{Glob: "scripts/*", NodeGlob: "scripts/*"},
+		{Glob: "!Scripts/**/Debug/**/*", NodeGlob: "Scripts/**/Debug", Negated: true, DirectoryOnly: true},
+	}, true)
 
 	spy := &caseInsensitiveSpyFS{spyFS: &spyFS{FS: osvfs.FS()}}
 	gapFiles := DiscoverGapFiles(config, configDir, spy, map[string]struct{}{}, nil, nil, true)

--- a/internal/config/gitignore/collector.go
+++ b/internal/config/gitignore/collector.go
@@ -132,14 +132,10 @@ func readGitignoreAsPatternsWithBoundaries(configDir string, fsys vfs.FS, isDire
 	return allPatterns
 }
 
-// readGitignoreAsGlobsForFilesWithBoundaries reads only .gitignore files on
+// readGitignoreAsPatternsForFilesWithBoundaries reads only .gitignore files on
 // each directory chain from configDir to an explicit target. This is used by
 // API-style calls where the target set is already known; unlike the full
 // collector, it does not scan every descendant of configDir.
-func readGitignoreAsGlobsForFilesWithBoundaries(configDir string, fsys vfs.FS, files []string, stopDirs []string) []string {
-	return patternGlobs(readGitignoreAsPatternsForFilesWithBoundaries(configDir, fsys, files, stopDirs))
-}
-
 func readGitignoreAsPatternsForFilesWithBoundaries(configDir string, fsys vfs.FS, files []string, stopDirs []string) []Pattern {
 	if fsys == nil || len(files) == 0 {
 		return nil

--- a/internal/config/gitignore/collector.go
+++ b/internal/config/gitignore/collector.go
@@ -9,6 +9,27 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+// Pattern preserves both views of one collected .gitignore rule:
+//
+//   - Glob is the compatibility projection exposed through the synthetic
+//     config entry and used to derive conservative directory pruning.
+//   - NodeGlob matches the path node named by the Git rule before a trailing
+//     directory slash is expanded to /**/*. Keeping this view is essential for
+//     ordered negations: !dist-path/ re-includes the dist-path node, not every
+//     independently ignored node below it.
+//
+// DirectoryOnly retains Git's trailing-slash restriction. Negated is stored
+// separately because an escaped leading exclamation mark is literal pattern
+// text, not a negation. ContentsOnly distinguishes a genuine trailing "/**"
+// from an unrooted bare "**" whose generated NodeGlob also ends in "/**".
+type Pattern struct {
+	Glob          string
+	NodeGlob      string
+	Negated       bool
+	DirectoryOnly bool
+	ContentsOnly  bool
+}
+
 func normalizeGlobPath(path string) string {
 	return strings.ReplaceAll(tspath.NormalizePath(path), "\\", "/")
 }
@@ -17,10 +38,6 @@ func matchGitignoreGlob(pattern string, path string, useCaseSensitive bool) bool
 	if !useCaseSensitive {
 		pattern = strings.ToLower(pattern)
 		path = strings.ToLower(path)
-	}
-	// Git's trailing /** matches contents, not the directory itself.
-	if strings.HasSuffix(pattern, "/**") && utils.MatchGlob(strings.TrimSuffix(pattern, "/**"), path) {
-		return false
 	}
 	return utils.MatchGlob(pattern, path)
 }
@@ -48,10 +65,34 @@ func Collect(configDir string, fsys vfs.FS, targetFiles []string, isDirectoryBlo
 // boundaries. A boundary directory and everything below it belongs to another
 // config, so none of its .gitignore files participate in this collection.
 func CollectWithBoundaries(configDir string, fsys vfs.FS, targetFiles []string, isDirectoryBlocked func(string) bool, stopDirs []string) []string {
+	return patternGlobs(CollectPatternsWithBoundaries(configDir, fsys, targetFiles, isDirectoryBlocked, stopDirs))
+}
+
+// CollectPatterns is the structured form of Collect. Callers that feed the
+// final ignore matcher must use this form so Git directory-node semantics are
+// not lost in the compatibility glob projection.
+func CollectPatterns(configDir string, fsys vfs.FS, targetFiles []string, isDirectoryBlocked func(string) bool) []Pattern {
+	return CollectPatternsWithBoundaries(configDir, fsys, targetFiles, isDirectoryBlocked, nil)
+}
+
+// CollectPatternsWithBoundaries is the structured form of
+// CollectWithBoundaries.
+func CollectPatternsWithBoundaries(configDir string, fsys vfs.FS, targetFiles []string, isDirectoryBlocked func(string) bool, stopDirs []string) []Pattern {
 	if targetFiles == nil {
-		return readGitignoreAsGlobsWithBoundaries(configDir, fsys, isDirectoryBlocked, stopDirs)
+		return readGitignoreAsPatternsWithBoundaries(configDir, fsys, isDirectoryBlocked, stopDirs)
 	}
-	return readGitignoreAsGlobsForFilesWithBoundaries(configDir, fsys, targetFiles, stopDirs)
+	return readGitignoreAsPatternsForFilesWithBoundaries(configDir, fsys, targetFiles, stopDirs)
+}
+
+func patternGlobs(patterns []Pattern) []string {
+	if len(patterns) == 0 {
+		return nil
+	}
+	globs := make([]string, len(patterns))
+	for index, pattern := range patterns {
+		globs[index] = pattern.Glob
+	}
+	return globs
 }
 
 // readGitignoreAsGlobs reads .gitignore files relevant to configDir and
@@ -72,19 +113,23 @@ func readGitignoreAsGlobs(configDir string, fsys vfs.FS, isDirectoryBlocked func
 }
 
 func readGitignoreAsGlobsWithBoundaries(configDir string, fsys vfs.FS, isDirectoryBlocked func(string) bool, stopDirs []string) []string {
+	return patternGlobs(readGitignoreAsPatternsWithBoundaries(configDir, fsys, isDirectoryBlocked, stopDirs))
+}
+
+func readGitignoreAsPatternsWithBoundaries(configDir string, fsys vfs.FS, isDirectoryBlocked func(string) bool, stopDirs []string) []Pattern {
 	if fsys == nil {
 		return nil
 	}
 	normalizedRoot := normalizeGlobPath(configDir)
 	boundaries := normalizeCollectionBoundaries(normalizedRoot, stopDirs, fsys.UseCaseSensitiveFileNames())
-	var allGlobs []string
+	var allPatterns []Pattern
 
-	collectGitignoreGlobs(normalizedRoot, "", fsys, &allGlobs, isDirectoryBlocked, nil, boundaries)
+	collectGitignorePatterns(normalizedRoot, "", fsys, &allPatterns, isDirectoryBlocked, nil, boundaries)
 
-	if len(allGlobs) == 0 {
+	if len(allPatterns) == 0 {
 		return nil
 	}
-	return allGlobs
+	return allPatterns
 }
 
 // readGitignoreAsGlobsForFilesWithBoundaries reads only .gitignore files on
@@ -92,6 +137,10 @@ func readGitignoreAsGlobsWithBoundaries(configDir string, fsys vfs.FS, isDirecto
 // API-style calls where the target set is already known; unlike the full
 // collector, it does not scan every descendant of configDir.
 func readGitignoreAsGlobsForFilesWithBoundaries(configDir string, fsys vfs.FS, files []string, stopDirs []string) []string {
+	return patternGlobs(readGitignoreAsPatternsForFilesWithBoundaries(configDir, fsys, files, stopDirs))
+}
+
+func readGitignoreAsPatternsForFilesWithBoundaries(configDir string, fsys vfs.FS, files []string, stopDirs []string) []Pattern {
 	if fsys == nil || len(files) == 0 {
 		return nil
 	}
@@ -124,7 +173,7 @@ func readGitignoreAsGlobsForFilesWithBoundaries(configDir string, fsys vfs.FS, f
 	}
 	sortByPathDepth(dirs)
 
-	var allGlobs []string
+	var allPatterns []Pattern
 	var pruneRules []gitignorePruneRule
 	var prunedDirs []string
 	for _, dir := range dirs {
@@ -135,7 +184,8 @@ func readGitignoreAsGlobsForFilesWithBoundaries(configDir string, fsys vfs.FS, f
 			prunedDirs = append(prunedDirs, dir)
 			continue
 		}
-		if isDirIgnoredByPruneRules(dir, pruneRules, useCaseSensitive) {
+		rel, _ := relativeDir(normalizedConfigDir, dir, useCaseSensitive)
+		if isDirIgnoredByPruneRules(rel, pruneRules, useCaseSensitive) {
 			prunedDirs = append(prunedDirs, dir)
 			continue
 		}
@@ -144,16 +194,16 @@ func readGitignoreAsGlobsForFilesWithBoundaries(configDir string, fsys vfs.FS, f
 		if !ok {
 			continue
 		}
-		rel, _ := relativeDir(normalizedConfigDir, dir, useCaseSensitive)
-		allGlobs = append(allGlobs, convertGitignoreToGlobs(content, rel)...)
-		if rule, ok := newGitignorePruneRule(dir, content); ok {
-			pruneRules = append(pruneRules, rule)
+		localPatterns := convertGitignoreToPatterns(content, rel)
+		allPatterns = append(allPatterns, localPatterns...)
+		if len(localPatterns) > 0 {
+			pruneRules = append(pruneRules, gitignorePruneRule{patterns: localPatterns})
 		}
 	}
-	if len(allGlobs) == 0 {
+	if len(allPatterns) == 0 {
 		return nil
 	}
-	return allGlobs
+	return allPatterns
 }
 
 func normalizeCollectionBoundaries(configDir string, stopDirs []string, useCaseSensitive bool) []string {
@@ -219,14 +269,7 @@ func isDescendantSymlinkDir(configDir string, dir string, fsys vfs.FS) bool {
 }
 
 type gitignorePruneRule struct {
-	baseDir  string
-	patterns []gitignorePrunePattern
-}
-
-type gitignorePrunePattern struct {
-	negated bool
-	rooted  bool
-	pattern string
+	patterns []Pattern
 }
 
 // Cursor is an immutable, filesystem-independent view of the .gitignore
@@ -298,6 +341,15 @@ func (cursor Cursor) Enter(directory string) (Cursor, bool) {
 // source IO path separate and pass the matching-space directory explicitly so
 // lexical and canonical discovery routes cannot be mixed accidentally.
 func (cursor Cursor) AppendSource(directory string, content string) (Cursor, []string) {
+	next, patterns := cursor.AppendSourcePatterns(directory, content)
+	return next, patternGlobs(patterns)
+}
+
+// AppendSourcePatterns is the structured form of AppendSource. It keeps the
+// directory-node matcher needed by final file decisions while AppendSource
+// remains available to compatibility callers that only inspect projected
+// globs.
+func (cursor Cursor) AppendSourcePatterns(directory string, content string) (Cursor, []Pattern) {
 	if !cursor.sourceReachable {
 		return cursor, nil
 	}
@@ -310,26 +362,29 @@ func (cursor Cursor) AppendSource(directory string, content string) (Cursor, []s
 	}
 
 	next := cursor
-	if rule, ok := newGitignorePruneRule(directory, content); ok {
-		next.rules = append(append([]gitignorePruneRule(nil), cursor.rules...), rule)
+	patterns := convertGitignoreToPatterns(content, relative)
+	if len(patterns) > 0 {
+		next.rules = append(
+			append([]gitignorePruneRule(nil), cursor.rules...),
+			gitignorePruneRule{patterns: patterns},
+		)
 	}
-	globs := convertGitignoreToGlobs(content, relative)
-	return next, globs
+	return next, patterns
 }
 
 func (cursor Cursor) blocksDirectoryNode(directory string) bool {
 	if cursor.rootDir == "" || directory == "" {
 		return false
 	}
+	relative, ok := relativeDir(cursor.rootDir, directory, cursor.useCaseSensitive)
+	if !ok || relative == "" {
+		return false
+	}
 	ignored := false
 	for _, rule := range cursor.rules {
-		relative, ok := relativeDir(rule.baseDir, directory, cursor.useCaseSensitive)
-		if !ok || relative == "" {
-			continue
-		}
 		for _, pattern := range rule.patterns {
 			if gitignorePrunePatternMatchesDirectoryNode(pattern, relative, cursor.useCaseSensitive) {
-				ignored = !pattern.negated
+				ignored = !pattern.Negated
 			}
 		}
 	}
@@ -337,100 +392,33 @@ func (cursor Cursor) blocksDirectoryNode(directory string) bool {
 }
 
 // gitignorePrunePatternMatchesDirectoryNode matches only the current directory
-// node. The existing collector predicate additionally checks ancestors because
-// a raw Git walk can never enter an ignored parent; config discovery cannot use
-// that shortcut because a later authored `!dir/` may reopen the parent node
-// while raw nested-source reachability remains blocked.
-func gitignorePrunePatternMatchesDirectoryNode(pattern gitignorePrunePattern, relative string, useCaseSensitive bool) bool {
-	if pattern.rooted {
-		return matchGitignoreGlob(pattern.pattern, relative, useCaseSensitive)
+// node. Parent reachability is already enforced by the recursive walk, the
+// explicit-chain prunedDirs set, or Cursor.sourceReachable. Re-evaluating an
+// ancestor here would incorrectly let !parent/ re-include an independently
+// ignored child directory.
+func gitignorePrunePatternMatchesDirectoryNode(pattern Pattern, relative string, useCaseSensitive bool) bool {
+	glob := pattern.NodeGlob
+	if pattern.ContentsOnly {
+		// Git's trailing /** matches only contents. Requiring one final
+		// component keeps the prefix directory itself reachable.
+		glob += "/*"
 	}
-	parts := splitPathComponents(relative)
-	if len(parts) == 0 {
+	return matchGitignoreGlob(glob, relative, useCaseSensitive)
+}
+
+func isDirIgnoredByPruneRules(relative string, rules []gitignorePruneRule, useCaseSensitive bool) bool {
+	if relative == "" {
 		return false
 	}
-	return matchGitignoreGlob(pattern.pattern, parts[len(parts)-1], useCaseSensitive)
-}
-
-func newGitignorePruneRule(baseDir string, content string) (gitignorePruneRule, bool) {
-	patterns := parseGitignorePrunePatterns(content)
-	if len(patterns) == 0 {
-		return gitignorePruneRule{}, false
-	}
-	return gitignorePruneRule{baseDir: baseDir, patterns: patterns}, true
-}
-
-func parseGitignorePrunePatterns(content string) []gitignorePrunePattern {
-	var patterns []gitignorePrunePattern
-	for _, line := range strings.Split(content, "\n") {
-		line, ok := normalizeGitignoreLine(line)
-		if !ok {
-			continue
-		}
-		negated := false
-		if strings.HasPrefix(line, "!") {
-			negated = true
-			line = line[1:]
-		}
-		if containsParentPathComponent(line) {
-			continue
-		}
-		line = strings.TrimSuffix(line, "/")
-		rooted := false
-		if strings.HasPrefix(line, "/") {
-			rooted = true
-			line = strings.TrimPrefix(line, "/")
-		} else if strings.Contains(line, "/") {
-			rooted = true
-		}
-		if line == "" {
-			continue
-		}
-		line = gitignorePatternForConfigGlob(line)
-		patterns = append(patterns, gitignorePrunePattern{
-			negated: negated,
-			rooted:  rooted,
-			pattern: line,
-		})
-	}
-	return patterns
-}
-
-func isDirIgnoredByPruneRules(dir string, rules []gitignorePruneRule, useCaseSensitive bool) bool {
 	ignored := false
 	for _, rule := range rules {
-		rel, ok := relativeDir(rule.baseDir, dir, useCaseSensitive)
-		if !ok || rel == "" {
-			continue
-		}
 		for _, pattern := range rule.patterns {
-			if gitignorePrunePatternCoversDir(pattern, rel, useCaseSensitive) {
-				ignored = !pattern.negated
+			if gitignorePrunePatternMatchesDirectoryNode(pattern, relative, useCaseSensitive) {
+				ignored = !pattern.Negated
 			}
 		}
 	}
 	return ignored
-}
-
-func gitignorePrunePatternCoversDir(pattern gitignorePrunePattern, relDir string, useCaseSensitive bool) bool {
-	for current := relDir; current != ""; current = parentDir(current) {
-		if gitignorePrunePatternMatchesPath(pattern, current, useCaseSensitive) {
-			return true
-		}
-	}
-	return false
-}
-
-func gitignorePrunePatternMatchesPath(pattern gitignorePrunePattern, relPath string, useCaseSensitive bool) bool {
-	if pattern.rooted {
-		return matchGitignoreGlob(pattern.pattern, relPath, useCaseSensitive)
-	}
-	for _, part := range splitPathComponents(relPath) {
-		if matchGitignoreGlob(pattern.pattern, part, useCaseSensitive) {
-			return true
-		}
-	}
-	return false
 }
 
 type filesystemPath struct {
@@ -579,15 +567,15 @@ func filesystemPathDepth(path string) int {
 	return strings.Count(rest, "/") + 1
 }
 
-// collectGitignoreGlobs recursively scans for .gitignore files and converts
-// their patterns to globs. Raw patterns from parent .gitignore files are used
-// to prune directories during scanning.
+// collectGitignorePatterns recursively scans for .gitignore files and converts
+// their rules to structured patterns. Raw patterns from parent .gitignore
+// files are used to prune directories during scanning.
 //
 // isDirectoryBlocked provides directory-level pruning from the caller's
 // config policy. If it returns true, files below that directory cannot be
 // linted, so nested .gitignore sources there are irrelevant.
-func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, boundaries []string) {
-	collectGitignoreGlobsRecursive(absDir, relDir, fsys, result, isDirectoryBlocked, pruneRules, boundaries, &gitignoreWalkState{
+func collectGitignorePatterns(absDir string, relDir string, fsys vfs.FS, result *[]Pattern, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, boundaries []string) {
+	collectGitignorePatternsRecursive(absDir, relDir, fsys, result, isDirectoryBlocked, pruneRules, boundaries, &gitignoreWalkState{
 		resolvedPaths: make(map[string]string),
 		visited:       make(map[string]struct{}),
 	})
@@ -607,13 +595,13 @@ func (s *gitignoreWalkState) realpath(path string, fsys vfs.FS) string {
 	return realpath
 }
 
-func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, result *[]string, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, boundaries []string, state *gitignoreWalkState) {
+func collectGitignorePatternsRecursive(absDir string, relDir string, fsys vfs.FS, result *[]Pattern, isDirectoryBlocked func(string) bool, pruneRules []gitignorePruneRule, boundaries []string, state *gitignoreWalkState) {
 	gitignorePath := tspath.CombinePaths(absDir, ".gitignore")
 	if content, ok := fsys.ReadFile(gitignorePath); ok {
-		localGlobs := convertGitignoreToGlobs(content, relDir)
-		*result = append(*result, localGlobs...)
-		if rule, ok := newGitignorePruneRule(absDir, content); ok {
-			pruneRules = append(pruneRules, rule)
+		localPatterns := convertGitignoreToPatterns(content, relDir)
+		*result = append(*result, localPatterns...)
+		if len(localPatterns) > 0 {
+			pruneRules = append(pruneRules, gitignorePruneRule{patterns: localPatterns})
 		}
 	}
 
@@ -657,7 +645,7 @@ func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, r
 		}
 
 		// Prune directories already ignored by collected .gitignore patterns.
-		if isDirIgnoredByPruneRules(childAbs, pruneRules, fsys.UseCaseSensitiveFileNames()) {
+		if isDirIgnoredByPruneRules(childRel, pruneRules, fsys.UseCaseSensitiveFileNames()) {
 			continue
 		}
 
@@ -668,7 +656,7 @@ func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, r
 			state.visited[childRealPath] = struct{}{}
 		}
 
-		collectGitignoreGlobsRecursive(childAbs, childRel, fsys, result, isDirectoryBlocked, pruneRules, boundaries, state)
+		collectGitignorePatternsRecursive(childAbs, childRel, fsys, result, isDirectoryBlocked, pruneRules, boundaries, state)
 	}
 }
 
@@ -688,18 +676,22 @@ func collectGitignoreGlobsRecursive(absDir string, relDir string, fsys vfs.FS, r
 //
 //	baseDir="pkg/app", "tmp/" → "pkg/app/**/tmp/**/*"
 func convertGitignoreToGlobs(content string, baseDir string) []string {
-	var globs []string
+	return patternGlobs(convertGitignoreToPatterns(content, baseDir))
+}
+
+func convertGitignoreToPatterns(content string, baseDir string) []Pattern {
+	var patterns []Pattern
 	for _, line := range strings.Split(content, "\n") {
 		line, ok := normalizeGitignoreLine(line)
 		if !ok {
 			continue
 		}
-		glob := convertSinglePattern(line, baseDir)
-		if glob != "" {
-			globs = append(globs, glob)
+		pattern, ok := convertSinglePatternToPattern(line, baseDir)
+		if ok {
+			patterns = append(patterns, pattern)
 		}
 	}
-	return globs
+	return patterns
 }
 
 func normalizeGitignoreLine(line string) (string, bool) {
@@ -732,6 +724,7 @@ func trimUnescapedTrailingGitignoreWhitespace(line string) string {
 	}
 	return line
 }
+
 func splitPathComponents(p string) []string {
 	var parts []string
 	for _, part := range strings.Split(p, "/") {
@@ -745,13 +738,21 @@ func splitPathComponents(p string) []string {
 
 // convertSinglePattern converts one gitignore pattern line to a glob.
 func convertSinglePattern(line string, baseDir string) string {
+	pattern, ok := convertSinglePatternToPattern(line, baseDir)
+	if !ok {
+		return ""
+	}
+	return pattern.Glob
+}
+
+func convertSinglePatternToPattern(line string, baseDir string) (Pattern, bool) {
 	negated := false
 	if strings.HasPrefix(line, "!") {
 		negated = true
 		line = line[1:]
 	}
 	if containsParentPathComponent(line) {
-		return ""
+		return Pattern{}, false
 	}
 
 	// Trailing / means directory-only; for glob purposes, we match dir/**
@@ -772,33 +773,43 @@ func convertSinglePattern(line string, baseDir string) string {
 	}
 
 	if line == "" {
-		return ""
+		return Pattern{}, false
 	}
+	contentsOnly := strings.HasSuffix(line, "/**")
 	line = gitignorePatternForConfigGlob(line)
+	baseGlob := gitignoreBaseDirForConfigGlob(baseDir)
 
 	// Build the glob pattern
 	var glob string
 	if rooted {
-		if baseDir != "" {
-			glob = baseDir + "/" + line
+		if baseGlob != "" {
+			glob = baseGlob + "/" + line
 		} else {
 			glob = line
 		}
 	} else {
 		// Unrooted: matches at any depth
-		if baseDir != "" {
-			glob = baseDir + "/**/" + line
+		if baseGlob != "" {
+			glob = baseGlob + "/**/" + line
 		} else {
 			glob = "**/" + line
 		}
 	}
+
+	nodeGlob := glob
 
 	// Append /**/* for directory patterns to match all contents.
 	// Use /**/* (file-level) instead of /** (directory-level) because collected
 	// rules participate in one ordered global-ignore sequence and later
 	// negations must be able to re-include descendants.
 	if dirOnly && !strings.HasSuffix(glob, "/**/*") {
-		glob += "/**/*"
+		if contentsOnly {
+			// A genuine trailing /** already supplies the recursive part; add
+			// one required component so the directory before it is not matched.
+			glob += "/*"
+		} else {
+			glob += "/**/*"
+		}
 	}
 
 	if negated {
@@ -809,7 +820,34 @@ func convertSinglePattern(line string, baseDir string) string {
 		// without changing the matcher.
 		glob = "./" + glob
 	}
-	return glob
+	return Pattern{
+		Glob:          glob,
+		NodeGlob:      nodeGlob,
+		Negated:       negated,
+		DirectoryOnly: dirOnly,
+		ContentsOnly:  contentsOnly,
+	}, true
+}
+
+// gitignoreBaseDirForConfigGlob quotes the real directory names contributed by
+// the filesystem. Unlike the .gitignore rule itself, this prefix is never glob
+// syntax: a repository directory literally named pkg[1] or pkg{a} must remain
+// literal on Unix, Windows, and case-insensitive macOS volumes.
+func gitignoreBaseDirForConfigGlob(baseDir string) string {
+	if !strings.ContainsAny(baseDir, "*?[{}") {
+		return baseDir
+	}
+	var result strings.Builder
+	result.Grow(len(baseDir))
+	for index := range len(baseDir) {
+		character := baseDir[index]
+		if character == '/' {
+			result.WriteByte(character)
+		} else {
+			appendConfigGlobLiteral(&result, character)
+		}
+	}
+	return result.String()
 }
 
 // gitignorePatternForConfigGlob removes Git's backslash quoting before a

--- a/internal/config/gitignore/collector_test.go
+++ b/internal/config/gitignore/collector_test.go
@@ -107,6 +107,44 @@ func TestConvertGitignoreToGlobs_Negation(t *testing.T) {
 	assert.Equal(t, globs[0], "!**/dist/**/*")
 }
 
+func TestConvertGitignoreToPatterns_PreservesDirectoryNode(t *testing.T) {
+	patterns := convertGitignoreToPatterns("!dist-path/\n!dist-path/**/*\n", "")
+	assert.DeepEqual(t, patterns, []Pattern{
+		{
+			Glob:          "!**/dist-path/**/*",
+			NodeGlob:      "**/dist-path",
+			Negated:       true,
+			DirectoryOnly: true,
+		},
+		{
+			Glob:     "!dist-path/**/*",
+			NodeGlob: "dist-path/**/*",
+			Negated:  true,
+		},
+	})
+}
+
+func TestConvertGitignoreToPatterns_DistinguishesBareAndTrailingDoublestar(t *testing.T) {
+	patterns := convertGitignoreToPatterns("**\nfoo/**\nfoo/**/\n", "")
+	assert.DeepEqual(t, patterns, []Pattern{
+		{
+			Glob:     "**/**",
+			NodeGlob: "**/**",
+		},
+		{
+			Glob:         "foo/**",
+			NodeGlob:     "foo/**",
+			ContentsOnly: true,
+		},
+		{
+			Glob:          "foo/**/*",
+			NodeGlob:      "foo/**",
+			DirectoryOnly: true,
+			ContentsOnly:  true,
+		},
+	})
+}
+
 func TestConvertGitignoreToGlobs_CommentsAndBlanks(t *testing.T) {
 	globs := convertGitignoreToGlobs("# comment\n\ndist/\n\n# another\n*.log\n", "")
 	assert.Equal(t, len(globs), 2)
@@ -196,6 +234,14 @@ func TestConvertGitignoreToGlobs_NestedWildcard(t *testing.T) {
 	globs := convertGitignoreToGlobs("*.generated.ts\n", "packages/app")
 	assert.Equal(t, len(globs), 1)
 	assert.Equal(t, globs[0], "packages/app/**/*.generated.ts")
+}
+
+func TestConvertGitignoreToPatterns_QuotesNestedFilesystemDirectory(t *testing.T) {
+	patterns := convertGitignoreToPatterns("ignored.ts\n", "!pkg[1]{x}*")
+	assert.DeepEqual(t, patterns, []Pattern{{
+		Glob:     "./!pkg[[]1][{]x[}][*]/**/ignored.ts",
+		NodeGlob: "!pkg[[]1][{]x[}][*]/**/ignored.ts",
+	}})
 }
 
 // --- Collector integration tests ---
@@ -603,6 +649,16 @@ func TestCursorDirectoryReachability(t *testing.T) {
 			assert.Equal(t, blocked, test.wantBlocked)
 		})
 	}
+}
+
+func TestCursorTrailingDoublestarMatchesNestedRepeatedName(t *testing.T) {
+	cursor := NewCursor("/repo", true)
+	cursor, _ = cursor.AppendSource("/repo", "**/cache/**\n")
+
+	cache, blocked := cursor.Enter("/repo/cache")
+	assert.Assert(t, !blocked, "trailing /** must not match the directory before it")
+	_, blocked = cache.Enter("/repo/cache/cache")
+	assert.Assert(t, blocked, "a repeated name below the matched directory is still its content")
 }
 
 func TestCursorBlockSourceTraversalPreservesInheritedRules(t *testing.T) {

--- a/internal/config/gitignore/config_integration_test.go
+++ b/internal/config/gitignore/config_integration_test.go
@@ -16,10 +16,8 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-// For representative reachable patterns, ConfigWithGitignore should make the
-// same final file decision as Git. Excluded-parent re-inclusion is covered by
-// the product-level ordered-global-ignore tests below instead: once a rule is
-// collected, rslint intentionally lets later negations re-include it.
+// For representative patterns, ConfigWithGitignore should make the same final
+// file decision as Git, including excluded-parent and directory-node ordering.
 func TestConfigWithGitignore_MatchesGitCheckIgnore(t *testing.T) {
 	git, err := exec.LookPath("git")
 	if err != nil {
@@ -51,9 +49,42 @@ func TestConfigWithGitignore_MatchesGitCheckIgnore(t *testing.T) {
 			files:      []string{"cache/deep/file.ts", "build/keep.ts", "build/drop.ts", "build/drop/child.ts"},
 		},
 		{
+			name:       "excluded parent cannot be re-included by child negation",
+			gitignores: map[string]string{".gitignore": "blocked/\n!blocked/keep.ts\n"},
+			files:      []string{"blocked/keep.ts", "blocked/drop.ts"},
+		},
+		{
 			name:       "trailing doublestar remains reversible",
 			gitignores: map[string]string{".gitignore": "build/**\n!build/keep.ts\n"},
 			files:      []string{"build/keep.ts", "build/drop.ts", "build/deep/drop.ts"},
+		},
+		{
+			name:       "bare doublestar",
+			gitignores: map[string]string{".gitignore": "**\n"},
+			files:      []string{"source.ts", "nested/deep/source.ts"},
+		},
+		{
+			name:       "ambiguous trailing doublestar",
+			gitignores: map[string]string{".gitignore": "**/cache/**\n"},
+			files:      []string{"cache.ts", "cache/cache", "cache/deep/cache", "other/cache/cache", "other/source.ts"},
+		},
+		{
+			name: "directory negation does not reinclude nested ignored directory",
+			gitignores: map[string]string{
+				".gitignore":                "dist/\ndist-*/\n!dist-path/\n",
+				"dist-path/dist/.gitignore": "!output.ts\n",
+			},
+			files: []string{"dist-path/src/source.ts", "dist-path/dist/output.ts"},
+		},
+		{
+			name:       "directory negation preserves independent descendant matches",
+			gitignores: map[string]string{".gitignore": "cache-*/\n*.generated.ts\ncache/\n!cache-path/\n"},
+			files:      []string{"cache-path/src/source.ts", "cache-path/src/types.generated.ts", "cache-path/cache/output.ts"},
+		},
+		{
+			name:       "later ancestor ignore overrides earlier descendant negation",
+			gitignores: map[string]string{".gitignore": "!build/keep/\nbuild/\n"},
+			files:      []string{"build/keep/source.ts"},
 		},
 		{
 			name: "reachable nested source overrides ancestor",
@@ -77,6 +108,17 @@ func TestConfigWithGitignore_MatchesGitCheckIgnore(t *testing.T) {
 			},
 		},
 		{
+			name: "nested source directory is literal glob text",
+			gitignores: map[string]string{
+				"!pkg[1]{x}/.gitignore": "ignored.ts\n",
+			},
+			files: []string{
+				"!pkg[1]{x}/ignored.ts",
+				"!pkg[1]{x}/source.ts",
+				"!pkg1x/ignored.ts",
+			},
+		},
+		{
 			name: "ignored nested source is unreachable",
 			gitignores: map[string]string{
 				".gitignore":         "blocked/\n",
@@ -94,12 +136,12 @@ func TestConfigWithGitignore_MatchesGitCheckIgnore(t *testing.T) {
 				t.Fatalf("git init: %v: %s", err, output)
 			}
 			for _, relative := range test.files {
-				// Windows cannot materialize a file whose name contains `*`.
-				// The platform-independent collector unit test still pins the
-				// escaped pattern conversion to `literal[*].ts`; this Git parity
-				// integration case can only exercise the literal filename where
-				// the host filesystem supports it.
-				if runtime.GOOS == "windows" && relative == "literal*.ts" {
+				// Windows cannot materialize `*` or a trailing space in a file
+				// name. Platform-independent collector tests still pin those
+				// conversions; this filesystem parity case skips only the
+				// impossible host paths.
+				if runtime.GOOS == "windows" &&
+					(relative == "literal*.ts" || strings.HasSuffix(relative, " ")) {
 					continue
 				}
 				path := filepath.Join(root, filepath.FromSlash(relative))
@@ -114,7 +156,8 @@ func TestConfigWithGitignore_MatchesGitCheckIgnore(t *testing.T) {
 			base := config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}}
 			full := config.ConfigWithGitignore(base, root, osvfs.FS(), nil)
 			for _, relative := range test.files {
-				if runtime.GOOS == "windows" && relative == "literal*.ts" {
+				if runtime.GOOS == "windows" &&
+					(relative == "literal*.ts" || strings.HasSuffix(relative, " ")) {
 					continue
 				}
 				path := filepath.Join(root, filepath.FromSlash(relative))
@@ -277,7 +320,7 @@ func TestConfigWithGitignore_ExplicitMatchesDefaultPruning(t *testing.T) {
 	full := config.ConfigWithGitignore(base, dir, osvfs.FS(), nil)
 	explicit := config.ConfigWithGitignore(base, dir, osvfs.FS(), []string{target})
 	assert.Equal(t, explicit.IsFileIgnored(target, dir), full.IsFileIgnored(target, dir))
-	assert.Assert(t, !explicit.IsFileIgnored(target, dir))
+	assert.Assert(t, explicit.IsFileIgnored(target, dir))
 }
 
 func TestConfigWithGitignore_FullWalkHonorsOrderedDirectoryReinclude(t *testing.T) {

--- a/internal/config/gitignore_config.go
+++ b/internal/config/gitignore_config.go
@@ -37,23 +37,27 @@ func ConfigWithGitignoreWithBoundaries(config RslintConfig, configDir string, fs
 			collectionFiles[i] = ResolveGitignoreCollectionPath(file, "", configDir, fsys)
 		}
 	}
-	globs := gitignore.CollectWithBoundaries(configDir, fsys, collectionFiles, isDirectoryBlocked, stopDirs)
+	patterns := gitignore.CollectPatternsWithBoundaries(configDir, fsys, collectionFiles, isDirectoryBlocked, stopDirs)
 	caseInsensitive := fsys != nil && !fsys.UseCaseSensitiveFileNames()
-	return ConfigWithCollectedGitignore(config, globs, caseInsensitive)
+	return ConfigWithCollectedGitignore(config, patterns, caseInsensitive)
 }
 
 // ConfigWithCollectedGitignore prepends one already-collected Git projection
 // without retaining a filesystem. Both the standalone collector path and
 // staged config discovery use this constructor so private Git matching metadata
 // cannot diverge between them.
-func ConfigWithCollectedGitignore(config RslintConfig, globs []string, caseInsensitive bool) RslintConfig {
-	if len(globs) == 0 {
+func ConfigWithCollectedGitignore(config RslintConfig, patterns []gitignore.Pattern, caseInsensitive bool) RslintConfig {
+	if len(patterns) == 0 {
 		return config
 	}
 	gitignoreEntry := ConfigEntry{
-		Ignores:                  append([]string(nil), globs...),
-		gitignoreSemantics:       true,
-		gitignoreCaseInsensitive: caseInsensitive,
+		Ignores: make([]string, len(patterns)),
+		collectedGitignore: &collectedGitignoreMetadata{
+			ignores: parseCollectedGitignorePatterns(patterns, caseInsensitive),
+		},
+	}
+	for index, pattern := range patterns {
+		gitignoreEntry.Ignores[index] = pattern.Glob
 	}
 	effective := make(RslintConfig, 0, len(config)+1)
 	effective = append(effective, gitignoreEntry)
@@ -65,37 +69,55 @@ func ConfigWithCollectedGitignore(config RslintConfig, globs []string, caseInsen
 // flat-config matcher without turning them into irreversible ESLint directory
 // blocks. The synthetic patterns still participate in the same ordered list as
 // authored config ignores, so a later config negation can re-include a target.
-func parseCollectedGitignorePatterns(globs []string, caseInsensitive bool) []IgnorePattern {
-	patterns := make([]IgnorePattern, 0, len(globs)*2)
+func parseCollectedGitignorePatterns(collected []gitignore.Pattern, caseInsensitive bool) []IgnorePattern {
+	patterns := make([]IgnorePattern, 0, len(collected))
 	parse := func(raw string) IgnorePattern {
 		pattern := ParseIgnorePattern(raw)
 		pattern.CaseInsensitive = caseInsensitive
 		return pattern
 	}
-	for _, raw := range globs {
-		negated := strings.HasPrefix(raw, "!")
-		body := strings.TrimPrefix(raw, "!")
-		if body == "" {
+	for _, source := range collected {
+		body := source.Glob
+		if source.Negated {
+			body = strings.TrimPrefix(body, "!")
+		}
+		nodeGlob := normalizePattern(source.NodeGlob)
+		if body == "" || nodeGlob == "" {
 			continue
 		}
 
-		prefix := ""
-		if negated {
-			prefix = "!"
+		// Every Git rule can match a directory node, including a rule without a
+		// trailing slash (for example "build"). Keep a subtree projection for
+		// sound walk pruning. The original node matcher remains a prefix of that
+		// projection and GitNodeGlobEnd records its boundary.
+		projection := body
+		if strings.HasSuffix(projection, "/**") && !strings.HasSuffix(projection, "/**/*") {
+			projection += "/*"
+		} else if !strings.HasSuffix(projection, "/**/*") {
+			projection += "/**/*"
 		}
-		if strings.HasSuffix(body, "/**") && !strings.HasSuffix(body, "/**/*") {
-			patterns = append(patterns, parse(prefix+body+"/*"))
+		if source.Negated {
+			projection = "!" + projection
+		}
+		pattern := parse(projection)
+		pattern.GitPattern = true
+		pattern.GitDirectoryOnly = source.DirectoryOnly
+		pattern.GitContentsOnly = source.ContentsOnly
+		if caseInsensitive {
+			// Git patterns are immutable after parsing. Fold them once here;
+			// the per-file matcher then only needs to fold the target path once,
+			// rather than allocating lower-case copies for every pattern/node.
+			pattern.Glob = strings.ToLower(pattern.Glob)
+			nodeGlob = strings.ToLower(nodeGlob)
+		}
+		if !strings.HasPrefix(pattern.Glob, nodeGlob) {
+			// Collected patterns always satisfy this compact-representation
+			// invariant. Reject an inconsistent manually constructed value
+			// instead of slicing an unrelated projection at match time.
 			continue
 		}
-		if strings.HasSuffix(body, "/**/*") {
-			patterns = append(patterns, parse(raw))
-			continue
-		}
-
-		direct := parse(raw)
-		direct.Kind = dirNone
-		patterns = append(patterns, direct)
-		patterns = append(patterns, parse(prefix+body+"/**/*"))
+		pattern.GitNodeGlobEnd = len(nodeGlob)
+		patterns = append(patterns, pattern)
 	}
 	return patterns
 }

--- a/internal/config/ignore_pattern.go
+++ b/internal/config/ignore_pattern.go
@@ -114,14 +114,20 @@ const (
 //   - Kind: the directory role (see dirKind), classified once here instead of
 //     by suffix inspection at each call site.
 //
-// Glob is the normalized, `!`-stripped matcher fed to doublestar — byte-for-byte
-// the same string the old []string pipeline matched against, so file-level
-// matching (isFileIgnored) is unchanged.
+// Glob is the normalized, `!`-stripped matcher fed to doublestar. For collected
+// Git rules, its prefix ending at GitNodeGlobEnd is the original path-node
+// matcher and the complete Glob is its conservative subtree projection. Keeping
+// both views in one string avoids doubling the hot IgnorePattern's string
+// headers. GitDirectoryOnly and GitContentsOnly retain the two Git-only roles.
 type IgnorePattern struct {
-	Glob            string
-	Negated         bool
-	Kind            dirKind
-	CaseInsensitive bool
+	Glob             string
+	GitNodeGlobEnd   int
+	Negated          bool
+	Kind             dirKind
+	CaseInsensitive  bool
+	GitPattern       bool
+	GitDirectoryOnly bool
+	GitContentsOnly  bool
 }
 
 // ParseIgnorePattern parses one raw ignore string (user config or a
@@ -197,18 +203,31 @@ func isFileIgnored(filePath string, patterns []IgnorePattern, cwd string) bool {
 	}
 	normalizedPath := normalizePath(filePath, cwd)
 	unixPath := strings.ReplaceAll(normalizedPath, "\\", "/")
+	if pathEscapesCwd(unixPath) && hasCaseInsensitivePattern(patterns) {
+		// On Windows and case-insensitive macOS volumes, callers may supply a
+		// canonical path whose drive/share or directory casing differs from
+		// cwd. A case-sensitive relative conversion then manufactures ../ even
+		// though both paths name the same tree. Re-resolve only on that uncommon
+		// fallback so the normal hot path pays no extra pattern scan.
+		normalizedPath = normalizePathWithCaseSensitivity(filePath, cwd, false)
+		unixPath = strings.ReplaceAll(normalizedPath, "\\", "/")
+	}
+	return isFileIgnoredNormalized(normalizedPath, unixPath, patterns)
+}
 
-	ignored := false
-	for _, p := range patterns {
-		matched := ignorePatternMatches(p, normalizedPath)
-		if !matched && unixPath != normalizedPath {
-			matched = ignorePatternMatches(p, unixPath)
-		}
-		if matched {
-			ignored = !p.Negated
+func pathEscapesCwd(path string) bool {
+	return path == ".." ||
+		strings.HasPrefix(path, "../") ||
+		tspath.PathIsAbsolute(path)
+}
+
+func hasCaseInsensitivePattern(patterns []IgnorePattern) bool {
+	for _, pattern := range patterns {
+		if pattern.CaseInsensitive {
+			return true
 		}
 	}
-	return ignored
+	return false
 }
 
 // ignorePatternMatches reports whether path matches pattern.Glob, applying the
@@ -224,13 +243,270 @@ func ignorePatternMatches(pattern IgnorePattern, path string) bool {
 
 // isFileIgnoredSimple is the cwd-unavailable fallback (matches the raw path).
 func isFileIgnoredSimple(filePath string, patterns []IgnorePattern) bool {
+	return isFileIgnoredNormalized(filePath, strings.ReplaceAll(filePath, "\\", "/"), patterns)
+}
+
+func isFileIgnoredNormalized(path string, unixPath string, patterns []IgnorePattern) bool {
 	ignored := false
-	for _, p := range patterns {
-		if ignorePatternMatches(p, filePath) {
+	for index := 0; index < len(patterns); {
+		p := patterns[index]
+		if p.GitPattern {
+			end := index + 1
+			for end < len(patterns) && patterns[end].GitPattern {
+				end++
+			}
+			gitState := newGitIgnorePathState(unixPath)
+			groupIgnored := gitState.evaluate(patterns[index:end])
+			if gitState.matched {
+				ignored = groupIgnored
+			}
+			index = end
+			continue
+		}
+		matched := ignorePatternMatches(p, path)
+		if !matched && unixPath != path {
+			matched = ignorePatternMatches(p, unixPath)
+		}
+		if matched {
 			ignored = !p.Negated
 		}
+		index++
 	}
 	return ignored
+}
+
+// gitIgnorePathState evaluates a contiguous group of collected Git rules
+// against every concrete node on one target path. Rules are visited in reverse:
+// the first match for a node is its final Git decision. A negation resolves only
+// the node it actually matches; an unresolved parent can therefore still be
+// ignored by an earlier positive rule. This is the Git distinction erased by
+// the historical !dir/**/* projection.
+//
+// Authored config patterns are evaluated after the complete Git group and may
+// still intentionally override its final decision as a separate config layer.
+type gitIgnorePathState struct {
+	path                   string
+	lowerPath              string
+	fileDepth              int
+	unresolved             int
+	resolvedDepths         uint64
+	resolvedDepthsOverflow []bool
+	matched                bool
+}
+
+func newGitIgnorePathState(path string) gitIgnorePathState {
+	path = strings.Trim(path, "/")
+	if path == "." {
+		path = ""
+	} else if strings.HasPrefix(path, "./") ||
+		strings.Contains(path, "//") ||
+		strings.Contains(path, "/./") ||
+		strings.HasSuffix(path, "/.") {
+		// The normal path enters through normalizePath and never needs this
+		// branch. Keep the cwd-less fallback equivalent to the former
+		// component builder for redundant separators and "." components.
+		parts := strings.Split(path, "/")
+		filtered := parts[:0]
+		for _, part := range parts {
+			if part != "" && part != "." {
+				filtered = append(filtered, part)
+			}
+		}
+		path = strings.Join(filtered, "/")
+	}
+	depth := -1
+	if path != "" {
+		depth = strings.Count(path, "/")
+	}
+	return gitIgnorePathState{
+		path:       path,
+		fileDepth:  depth,
+		unresolved: depth + 1,
+	}
+}
+
+func (state *gitIgnorePathState) evaluate(patterns []IgnorePattern) bool {
+	for index := len(patterns) - 1; index >= 0 && state.unresolved > 0; index-- {
+		if state.apply(patterns[index]) {
+			return true
+		}
+	}
+	return false
+}
+
+// apply reports whether pattern is the final positive decision for any still
+// unresolved path node. That is enough to ignore the target immediately:
+// reverse traversal guarantees no earlier rule can override that node.
+func (state *gitIgnorePathState) apply(pattern IgnorePattern) bool {
+	if state.fileDepth < 0 {
+		return false
+	}
+	path := state.path
+	if pattern.CaseInsensitive {
+		if state.lowerPath == "" {
+			state.lowerPath = strings.ToLower(path)
+		}
+		path = state.lowerPath
+	}
+
+	if basenameGlob, ok := gitIgnoreRootBasenameGlob(pattern); ok {
+		return state.applyRootBasename(pattern, path, basenameGlob)
+	}
+
+	// A non-directory-only rule may name the target file itself. Its subtree
+	// projection separately tells us whether any ancestor can match.
+	if !pattern.GitDirectoryOnly &&
+		!state.depthResolved(state.fileDepth) &&
+		gitIgnorePatternMatchesNode(pattern, path) {
+		if state.applyDepth(state.fileDepth, pattern.Negated) {
+			return true
+		}
+		if state.unresolved == 0 {
+			return false
+		}
+	}
+
+	// Glob is the node pattern's conservative subtree projection. One match
+	// against the complete target cheaply rejects the overwhelmingly common
+	// case where this rule cannot name any ancestor.
+	if !utils.MatchGlob(pattern.Glob, path) {
+		return false
+	}
+
+	end := strings.LastIndexByte(path, '/')
+	for depth := state.fileDepth - 1; depth >= 0 && end >= 0; depth-- {
+		node := path[:end]
+		if !state.depthResolved(depth) &&
+			gitIgnorePatternMatchesNode(pattern, node) {
+			if state.applyDepth(depth, pattern.Negated) {
+				return true
+			}
+			if state.unresolved == 0 {
+				return false
+			}
+		}
+		end = strings.LastIndexByte(node, '/')
+	}
+	return false
+}
+
+// gitIgnoreRootBasenameGlob recognizes the dominant .gitignore shape:
+// an unrooted, single-component rule from the config root. Matching its small
+// basename glob against path components avoids repeatedly running a **/ glob
+// over growing full-path prefixes. A rooted "/**/name" rule has the same
+// config-root semantics and is safe to take through this path too.
+func gitIgnoreRootBasenameGlob(pattern IgnorePattern) (string, bool) {
+	const prefix = "**/"
+	nodeGlob := gitIgnoreNodeGlob(pattern)
+	if !strings.HasPrefix(nodeGlob, prefix) ||
+		strings.HasSuffix(nodeGlob, "/**") {
+		return "", false
+	}
+	glob := strings.TrimPrefix(nodeGlob, prefix)
+	return glob, glob != "" && !strings.Contains(glob, "/")
+}
+
+func (state *gitIgnorePathState) applyRootBasename(pattern IgnorePattern, path string, glob string) bool {
+	var end int
+	depth := state.fileDepth
+	if pattern.GitDirectoryOnly {
+		end = strings.LastIndexByte(path, '/')
+		depth--
+	} else {
+		start := strings.LastIndexByte(path, '/') + 1
+		if !state.depthResolved(depth) &&
+			utils.MatchGlob(glob, path[start:]) {
+			if state.applyDepth(depth, pattern.Negated) {
+				return true
+			}
+			if state.unresolved == 0 {
+				return false
+			}
+		}
+		end = start - 1
+		depth--
+	}
+	if end < 0 {
+		return false
+	}
+
+	// A literal component is common enough to avoid both doublestar and glob
+	// matching entirely. Wildcard components first use the subtree projection
+	// to reject non-matches, then inspect only the candidate's ancestors.
+	literal := !strings.ContainsAny(glob, "*?[{")
+	if !literal && !utils.MatchGlob(pattern.Glob, path) {
+		return false
+	}
+	for depth >= 0 && state.unresolved > 0 {
+		start := strings.LastIndexByte(path[:end], '/') + 1
+		component := path[start:end]
+		if !state.depthResolved(depth) &&
+			((literal && component == glob) || (!literal && utils.MatchGlob(glob, component))) {
+			if state.applyDepth(depth, pattern.Negated) {
+				return true
+			}
+		}
+		if start == 0 {
+			break
+		}
+		end = start - 1
+		depth--
+	}
+	return false
+}
+
+func (state *gitIgnorePathState) applyDepth(depth int, negated bool) bool {
+	state.matched = true
+	if !negated {
+		return true
+	}
+	state.resolveDepth(depth)
+	return false
+}
+
+func (state *gitIgnorePathState) depthResolved(depth int) bool {
+	if depth < 64 {
+		return state.resolvedDepths&(uint64(1)<<uint(depth)) != 0
+	}
+	index := depth - 64
+	return index < len(state.resolvedDepthsOverflow) &&
+		state.resolvedDepthsOverflow[index]
+}
+
+func (state *gitIgnorePathState) resolveDepth(depth int) {
+	if state.depthResolved(depth) {
+		return
+	}
+	state.unresolved--
+	if depth < 64 {
+		state.resolvedDepths |= uint64(1) << uint(depth)
+		return
+	}
+	index := depth - 64
+	if index >= len(state.resolvedDepthsOverflow) {
+		state.resolvedDepthsOverflow = append(
+			state.resolvedDepthsOverflow,
+			make([]bool, index-len(state.resolvedDepthsOverflow)+1)...,
+		)
+	}
+	state.resolvedDepthsOverflow[index] = true
+}
+
+func gitIgnorePatternMatchesNode(pattern IgnorePattern, path string) bool {
+	if pattern.GitContentsOnly {
+		// Glob is NodeGlob with a required final component (/**/*), which
+		// expresses Git's true trailing-/** semantics without ambiguity when
+		// an earlier doublestar can match the same complete path.
+		return utils.MatchGlob(pattern.Glob, path)
+	}
+	return utils.MatchGlob(gitIgnoreNodeGlob(pattern), path)
+}
+
+func gitIgnoreNodeGlob(pattern IgnorePattern) string {
+	if pattern.GitNodeGlobEnd <= 0 || pattern.GitNodeGlobEnd > len(pattern.Glob) {
+		return ""
+	}
+	return pattern.Glob[:pattern.GitNodeGlobEnd]
 }
 
 // isDirAbsolutelyBlocked reports whether dirPath (or an ancestor segment) is

--- a/internal/config/ignore_pattern_test.go
+++ b/internal/config/ignore_pattern_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/web-infra-dev/rslint/internal/config/gitignore"
 	"gotest.tools/v3/assert"
 )
 
@@ -105,6 +107,74 @@ func TestParseIgnorePattern_DotStarDoesNotOverBlock(t *testing.T) {
 	}
 	if cfg.GetConfigForFile("/repo/src/app/main.ts", "/repo") == nil {
 		t.Error(`nested file src/app/main.ts must still be linted under ignores ["./*"]`)
+	}
+}
+
+func TestCollectedGitignoreDirectoryNegationIsNodeScoped(t *testing.T) {
+	patterns := parseCollectedGitignorePatterns([]gitignore.Pattern{
+		{Glob: "**/dist/**/*", NodeGlob: "**/dist", DirectoryOnly: true},
+		{Glob: "**/dist-*/**/*", NodeGlob: "**/dist-*", DirectoryOnly: true},
+		{Glob: "!**/dist-path/**/*", NodeGlob: "**/dist-path", Negated: true, DirectoryOnly: true},
+	}, false)
+
+	assert.Assert(t, !isFileIgnored("dist-path/src/source.ts", patterns, ""))
+	assert.Assert(t, isFileIgnored("dist-path/dist/output.ts", patterns, ""))
+}
+
+func TestCollectedGitignoreDirectoryNegationBeyondBitsetDepth(t *testing.T) {
+	path := "dist-path/" + strings.Repeat("level/", 64) + "dist/output.ts"
+	patterns := parseCollectedGitignorePatterns([]gitignore.Pattern{
+		{Glob: "**/dist/**/*", NodeGlob: "**/dist", DirectoryOnly: true},
+		{Glob: "**/dist-*/**/*", NodeGlob: "**/dist-*", DirectoryOnly: true},
+		{Glob: "!**/dist-path/**/*", NodeGlob: "**/dist-path", Negated: true, DirectoryOnly: true},
+	}, false)
+
+	assert.Assert(t, isFileIgnored(path, patterns, ""), "the descendant match above depth 64 must survive the ancestor negation")
+}
+
+func TestCollectedGitignoreNegationResolvesNodeBeyondBitsetDepth(t *testing.T) {
+	path := strings.Repeat("level/", 65) + "keep.ts"
+	patterns := parseCollectedGitignorePatterns([]gitignore.Pattern{
+		{Glob: path, NodeGlob: path},
+		{Glob: "!" + path, NodeGlob: path, Negated: true},
+	}, false)
+
+	assert.Assert(t, !isFileIgnored(path, patterns, ""), "the final negation must resolve a file node above depth 64")
+}
+
+func TestCollectedGitignoreNegationCannotReincludeBelowIgnoredParent(t *testing.T) {
+	patterns := parseCollectedGitignorePatterns([]gitignore.Pattern{
+		{Glob: "**/blocked/**/*", NodeGlob: "**/blocked", DirectoryOnly: true},
+		{Glob: "!blocked/keep.ts", NodeGlob: "blocked/keep.ts", Negated: true},
+	}, false)
+
+	assert.Assert(t, isFileIgnored("blocked/keep.ts", patterns, ""))
+}
+
+func TestCollectedGitignoreCaseInsensitiveWindowsPathSpace(t *testing.T) {
+	patterns := parseCollectedGitignorePatterns([]gitignore.Pattern{{
+		Glob:     "src/ignored.ts",
+		NodeGlob: "src/ignored.ts",
+	}}, true)
+	for _, test := range []struct {
+		name string
+		file string
+		cwd  string
+	}{
+		{
+			name: "drive letter separators and directory case",
+			file: `c:\REPO\SRC\IGNORED.TS`,
+			cwd:  "C:/repo",
+		},
+		{
+			name: "UNC server share and directory case",
+			file: `//SERVER/Share/REPO/SRC/IGNORED.TS`,
+			cwd:  "//server/share/repo",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Assert(t, isFileIgnored(test.file, patterns, test.cwd))
+		})
 	}
 }
 

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -2353,14 +2353,13 @@ func TestLSPExplicitTargetIgnoreConformance(t *testing.T) {
 			wantLinted: true,
 		},
 		{
-			name:     "pruned nested source does not override root negation",
+			name:     "excluded parent keeps nested source unreachable",
 			relative: "dist/types/private.ts",
 			config:   config.RslintConfig{{Rules: config.Rules{"no-debugger": "error"}}},
 			gitignores: map[string]string{
 				".gitignore":            "dist/\n!dist/types/\n",
 				"dist/types/.gitignore": "private.ts\n",
 			},
-			wantLinted: true,
 		},
 		{
 			name:       "directory symlink remains lintable without ignore",


### PR DESCRIPTION
## Summary

- Preserve directory-only gitignore negations as directory-node rules, so reopening one matched directory does not accidentally reopen independently ignored descendants.
- Share the parsed gitignore representation between complete-path matching and directory-pruning decisions, including nested `.gitignore` base directories and excluded-parent semantics.
- Add focused regression, CLI/API conformance, deep-path, case-insensitive, Windows drive, and UNC-path coverage.

### Gitignore micro-benchmark

`main@7ae12bef` vs this PR at `c6db2b52`, using 40 representative rules, one CPU, 300 ms per benchmark, and the median of 10 serial alternating A/B rounds. Negative time means faster.

| Benchmark | main | This PR | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| Production source append | 15.258 µs | 10.478 µs | -31.3% | 13,928 → 11,296 | 250 → 165 |
| Cursor enter, shallow path | 3.832 µs | 2.139 µs | -44.2% | 2,688 → 0 | 48 → 0 |
| Cursor enter, deep path | 7.131 µs | 4.339 µs | -39.1% | 7,296 → 0 | 72 → 0 |
| Compatibility `AppendSource` | 14.706 µs | 10.492 µs | -28.7% | 13,928 → 12,000 | 250 → 166 |
| Compatibility `convertGitignoreToGlobs` | 8.337 µs | 10.341 µs | +24.0% | 7,592 → 11,976 | 162 → 165 |

The compatibility-only glob projection is slower because it now constructs structured patterns and then projects them back to `[]string`. Production consumers use the structured path directly; its source setup is 31.3% faster, while the directory-matching hot path is 39.1–44.2% faster and allocation-free.

## Related Links

- Fixes #1342

## Testing

- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./cmd/rslint ./internal/config ./internal/config/discovery ./internal/config/gitignore`
- Focused Go tests for gitignore parsing, collection, discovery pruning, config integration, and CLI/API conformance
- Windows/amd64 cross-compilation of the changed collector implementation and tests
- rsbuild and rspack A/B correctness validation against `main` in plain, type-check, type-check-only, and explicit-config modes
- Ten alternating serial A/B performance rounds per mode: the branch was 7.5–13.7% faster on rsbuild wall time and 4.3–9.6% faster on rspack wall time, with matching internal-time direction

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
