### PR TITLE
feat(jsx-a11y): declare options JSON Schema for jsx-a11y/ rules

### DIFF
--- a/internal/plugins/jsx_a11y/rules/alt_text/alt_text.go
+++ b/internal/plugins/jsx_a11y/rules/alt_text/alt_text.go
@@ -1,12 +1,16 @@
 package alt_text
 
 import (
+	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed alt_text.schema.json
+var schemaJSON []byte
 
 // Default DOM elements alt-text validates. Mirrors upstream's `DEFAULT_ELEMENTS`.
 // The order is preserved because option-driven custom-component lookup falls
@@ -53,12 +57,12 @@ type options struct {
 	customComponents map[string][]string // keyed by DOM element name (e.g. "img" / `input[type="image"]`)
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{elements: defaultElements}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 
 	if rawElements, ok := m["elements"]; ok {
 		// Upstream falls through to DEFAULT_ELEMENTS via `||` only when
@@ -82,9 +86,9 @@ func parseOptions(raw any) options {
 }
 
 var AltTextRule = rule.Rule{
-	Name: "jsx-a11y/alt-text",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/alt-text",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		// Precompute the set of nodeType strings that should trigger a check.

--- a/internal/plugins/jsx_a11y/rules/alt_text/alt_text.schema.json
+++ b/internal/plugins/jsx_a11y/rules/alt_text/alt_text.schema.json
@@ -1,0 +1,42 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "elements": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "img": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "object": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "area": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "input[type=\"image\"]": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text.go
@@ -13,6 +13,7 @@
 package anchor_ambiguous_text
 
 import (
+	_ "embed"
 	"fmt"
 	"regexp"
 	"strings"
@@ -22,8 +23,10 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed anchor_ambiguous_text.schema.json
+var schemaJSON []byte
 
 // defaultAmbiguousWords mirrors upstream's `DEFAULT_AMBIGUOUS_WORDS`. Order
 // matters because it surfaces in the user-facing diagnostic via
@@ -242,12 +245,12 @@ type options struct {
 	words []string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{words: defaultAmbiguousWords}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	// Upstream: `const { words = DEFAULT_AMBIGUOUS_WORDS } = options;`. The
 	// destructuring default only kicks in when `words` is `undefined`. An
 	// explicit `[]` REPLACES the defaults and disables the rule for that run
@@ -263,9 +266,9 @@ func parseOptions(raw any) options {
 }
 
 var AnchorAmbiguousTextRule = rule.Rule{
-	Name: "jsx-a11y/anchor-ambiguous-text",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/anchor-ambiguous-text",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		// Pre-build the lookup set so each check is O(1) on the wordlist.

--- a/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text.schema.json
+++ b/internal/plugins/jsx_a11y/rules/anchor_ambiguous_text/anchor_ambiguous_text.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "words": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content.go
@@ -6,14 +6,17 @@
 package anchor_has_content
 
 import (
+	_ "embed"
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed anchor_has_content.schema.json
+var schemaJSON []byte
 
 const errorMessage = "Anchors must have content and the content must be accessible by a screen reader."
 
@@ -25,20 +28,20 @@ type options struct {
 	components []string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	opts.components = jsxa11yutil.StringSliceOption(m["components"])
 	return opts
 }
 
 var AnchorHasContentRule = rule.Rule{
-	Name: "jsx-a11y/anchor-has-content",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/anchor-has-content",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		// Mirrors upstream `typeCheck = ['a'].concat(componentOptions)`.

--- a/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content.schema.json
+++ b/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.go
@@ -16,6 +16,7 @@
 package anchor_is_valid
 
 import (
+	_ "embed"
 	"regexp"
 	"slices"
 
@@ -23,8 +24,10 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed anchor_is_valid.schema.json
+var schemaJSON []byte
 
 const (
 	preferButtonErrorMessage = "Anchor used as a button. Anchors are primarily expected to navigate. Use the button element instead. Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/HEAD/docs/rules/anchor-is-valid.md"
@@ -60,7 +63,7 @@ type options struct {
 	activeAspects map[string]bool
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{
 		activeAspects: map[string]bool{
 			aspectNoHref:       true,
@@ -68,10 +71,10 @@ func parseOptions(raw any) options {
 			aspectPreferButton: true,
 		},
 	}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	opts.components = jsxa11yutil.StringSliceOption(m["components"])
 	opts.specialLink = jsxa11yutil.StringSliceOption(m["specialLink"])
 	if rawAspects, ok := m["aspects"]; ok {
@@ -104,9 +107,9 @@ func parseOptions(raw any) options {
 }
 
 var AnchorIsValidRule = rule.Rule{
-	Name: "jsx-a11y/anchor-is-valid",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/anchor-is-valid",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		// typeCheck = ['a'].concat(componentOptions). Resolved against the
 		// element's effective name via `jsxa11yutil.GetElementType` so both

--- a/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.schema.json
+++ b/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid.schema.json
@@ -1,0 +1,34 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "specialLink": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "aspects": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["noHref", "invalidHref", "preferButton"]
+          },
+          "uniqueItems": true,
+          "additionalItems": false,
+          "minItems": 1
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex.go
+++ b/internal/plugins/jsx_a11y/rules/aria_activedescendant_has_tabindex/aria_activedescendant_has_tabindex.go
@@ -36,7 +36,8 @@ import (
 const errorMessage = "An element that manages focus with `aria-activedescendant` must have a tabindex"
 
 var AriaActivedescendantHasTabindexRule = rule.Rule{
-	Name: "jsx-a11y/aria-activedescendant-has-tabindex",
+	Name:   "jsx-a11y/aria-activedescendant-has-tabindex",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		// sourceText is required by GetTabIndexEx for raw-text template
 		// literal extraction (NoSubstitutionTemplate has no RawText field).

--- a/internal/plugins/jsx_a11y/rules/aria_props/aria_props.go
+++ b/internal/plugins/jsx_a11y/rules/aria_props/aria_props.go
@@ -56,7 +56,8 @@ func errorMessage(name string) string {
 }
 
 var AriaPropsRule = rule.Rule{
-	Name: "jsx-a11y/aria-props",
+	Name:   "jsx-a11y/aria-props",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindJsxAttribute: func(attr *ast.Node) {

--- a/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes.go
+++ b/internal/plugins/jsx_a11y/rules/aria_proptypes/aria_proptypes.go
@@ -211,7 +211,8 @@ func permittedValuesContainsString(values []any, candidate string) bool {
 }
 
 var AriaProptypesRule = rule.Rule{
-	Name: "jsx-a11y/aria-proptypes",
+	Name:   "jsx-a11y/aria-proptypes",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindJsxAttribute: func(attr *ast.Node) {

--- a/internal/plugins/jsx_a11y/rules/aria_role/aria_role.go
+++ b/internal/plugins/jsx_a11y/rules/aria_role/aria_role.go
@@ -37,14 +37,17 @@
 package aria_role
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed aria_role.schema.json
+var schemaJSON []byte
 
 // errorMessage mirrors upstream's exact string. Reproduced verbatim so a
 // future audit can diff against `src/rules/aria-role.js` byte-for-byte.
@@ -55,12 +58,12 @@ type options struct {
 	allowedInvalidRoles map[string]struct{}
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	if v, ok := m["ignoreNonDOM"].(bool); ok {
 		opts.ignoreNonDOM = v
 	}
@@ -98,9 +101,9 @@ func reportIfInvalid(ctx rule.RuleContext, attr *ast.Node, str string, allowed m
 }
 
 var AriaRoleRule = rule.Rule{
-	Name: "jsx-a11y/aria-role",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/aria-role",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		return rule.RuleListeners{
 			ast.KindJsxAttribute: func(attr *ast.Node) {

--- a/internal/plugins/jsx_a11y/rules/aria_role/aria_role.go
+++ b/internal/plugins/jsx_a11y/rules/aria_role/aria_role.go
@@ -67,12 +67,10 @@ func parseOptions(raw []any) options {
 	if v, ok := m["ignoreNonDOM"].(bool); ok {
 		opts.ignoreNonDOM = v
 	}
-	if arr, ok := m["allowedInvalidRoles"].([]interface{}); ok && len(arr) > 0 {
-		opts.allowedInvalidRoles = make(map[string]struct{}, len(arr))
-		for _, v := range arr {
-			if s, ok := v.(string); ok {
-				opts.allowedInvalidRoles[s] = struct{}{}
-			}
+	if roles := jsxa11yutil.StringSliceOption(m["allowedInvalidRoles"]); len(roles) > 0 {
+		opts.allowedInvalidRoles = make(map[string]struct{}, len(roles))
+		for _, s := range roles {
+			opts.allowedInvalidRoles[s] = struct{}{}
 		}
 	}
 	return opts

--- a/internal/plugins/jsx_a11y/rules/aria_role/aria_role.schema.json
+++ b/internal/plugins/jsx_a11y/rules/aria_role/aria_role.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allowedInvalidRoles": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "ignoreNonDOM": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/aria_unsupported_elements/aria_unsupported_elements.go
+++ b/internal/plugins/jsx_a11y/rules/aria_unsupported_elements/aria_unsupported_elements.go
@@ -51,7 +51,8 @@ func errorMessage(invalidProp string) string {
 }
 
 var AriaUnsupportedElementsRule = rule.Rule{
-	Name: "jsx-a11y/aria-unsupported-elements",
+	Name:   "jsx-a11y/aria-unsupported-elements",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		check := func(node *ast.Node) {
 			nodeType := jsxa11yutil.GetElementType(node, ctx.Settings)

--- a/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid.go
+++ b/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid.go
@@ -3,6 +3,7 @@
 package autocomplete_valid
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -11,6 +12,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed autocomplete_valid.schema.json
+var schemaJSON []byte
 
 // failMessage is the message axe-core's `autocomplete-valid` check emits when
 // the autocomplete attribute fails validation. The upstream ESLint rule reads
@@ -163,20 +167,20 @@ type options struct {
 	inputComponents []string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	opts.inputComponents = utils.ToStringSlice(m["inputComponents"])
 	return opts
 }
 
 var AutocompleteValidRule = rule.Rule{
-	Name: "jsx-a11y/autocomplete-valid",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/autocomplete-valid",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		// inputTypes is the union of `["input"]` and the user-provided

--- a/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid.schema.json
+++ b/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "inputComponents": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events.go
+++ b/internal/plugins/jsx_a11y/rules/click_events_have_key_events/click_events_have_key_events.go
@@ -38,7 +38,8 @@ import (
 const errorMessage = "Visible, non-interactive elements with click handlers must have at least one keyboard listener."
 
 var ClickEventsHaveKeyEventsRule = rule.Rule{
-	Name: "jsx-a11y/click-events-have-key-events",
+	Name:   "jsx-a11y/click-events-have-key-events",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		getElementType := func(node *ast.Node) string {
 			return jsxa11yutil.GetElementType(node, ctx.Settings)

--- a/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label.go
+++ b/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label.go
@@ -26,13 +26,16 @@
 package control_has_associated_label
 
 import (
+	_ "embed"
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed control_has_associated_label.schema.json
+var schemaJSON []byte
 
 // errorMessage mirrors upstream's `errorMessage` constant verbatim.
 const errorMessage = "A control must be associated with a text label."
@@ -52,12 +55,12 @@ type options struct {
 	depth             int
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{depth: defaultDepth}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	opts.labelAttributes = jsxa11yutil.StringSliceOption(m["labelAttributes"])
 	opts.controlComponents = jsxa11yutil.StringSliceOption(m["controlComponents"])
 	opts.ignoreElements = jsxa11yutil.StringSliceOption(m["ignoreElements"])
@@ -78,9 +81,9 @@ func parseOptions(raw any) options {
 }
 
 var ControlHasAssociatedLabelRule = rule.Rule{
-	Name: "jsx-a11y/control-has-associated-label",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/control-has-associated-label",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		// Upstream `newIgnoreElements = new Set([].concat(ignoreElements,
 		// ignoreList))` where `ignoreList = ['link']`. The `link` entry is

--- a/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label.schema.json
+++ b/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label.schema.json
@@ -1,0 +1,40 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "labelAttributes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "controlComponents": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "ignoreElements": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "ignoreRoles": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "depth": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/heading_has_content/heading_has_content.go
+++ b/internal/plugins/jsx_a11y/rules/heading_has_content/heading_has_content.go
@@ -6,13 +6,16 @@
 package heading_has_content
 
 import (
+	_ "embed"
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed heading_has_content.schema.json
+var schemaJSON []byte
 
 const errorMessage = "Headings must have content and the content must be accessible by a screen reader."
 
@@ -29,20 +32,20 @@ type options struct {
 	components []string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	opts.components = jsxa11yutil.StringSliceOption(m["components"])
 	return opts
 }
 
 var HeadingHasContentRule = rule.Rule{
-	Name: "jsx-a11y/heading-has-content",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/heading-has-content",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		// Mirrors upstream `typeCheck = headings.concat(componentOptions)`.

--- a/internal/plugins/jsx_a11y/rules/heading_has_content/heading_has_content.schema.json
+++ b/internal/plugins/jsx_a11y/rules/heading_has_content/heading_has_content.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/html_has_lang/html_has_lang.go
+++ b/internal/plugins/jsx_a11y/rules/html_has_lang/html_has_lang.go
@@ -13,7 +13,8 @@ import (
 const errorMessage = "<html> elements must have the lang prop."
 
 var HtmlHasLangRule = rule.Rule{
-	Name: "jsx-a11y/html-has-lang",
+	Name:   "jsx-a11y/html-has-lang",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		elementType := func(node *ast.Node) string {
 			return jsxa11yutil.GetElementType(node, ctx.Settings)

--- a/internal/plugins/jsx_a11y/rules/iframe_has_title/iframe_has_title.go
+++ b/internal/plugins/jsx_a11y/rules/iframe_has_title/iframe_has_title.go
@@ -14,7 +14,8 @@ import (
 const errorMessage = "<iframe> elements must have a unique title property."
 
 var IframeHasTitleRule = rule.Rule{
-	Name: "jsx-a11y/iframe-has-title",
+	Name:   "jsx-a11y/iframe-has-title",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		elementType := func(node *ast.Node) string {
 			return jsxa11yutil.GetElementType(node, ctx.Settings)

--- a/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.go
+++ b/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.go
@@ -1,14 +1,17 @@
 package img_redundant_alt
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed img_redundant_alt.schema.json
+var schemaJSON []byte
 
 // errorMessage mirrors upstream's `errorMessage` constant verbatim — including
 // the curly-quote in `don’t` and the trailing comma after `photo,` inside
@@ -23,12 +26,12 @@ type options struct {
 	words      []string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	if rawComponents, ok := m["components"]; ok {
 		if arr, ok := rawComponents.([]interface{}); ok {
 			for _, v := range arr {
@@ -51,9 +54,9 @@ func parseOptions(raw any) options {
 }
 
 var ImgRedundantAltRule = rule.Rule{
-	Name: "jsx-a11y/img-redundant-alt",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/img-redundant-alt",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		// Upstream: `typesToValidate = ['img'].concat(componentOptions)`.

--- a/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.go
+++ b/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.go
@@ -32,24 +32,8 @@ func parseOptions(raw []any) options {
 		return opts
 	}
 	m, _ := raw[0].(map[string]interface{})
-	if rawComponents, ok := m["components"]; ok {
-		if arr, ok := rawComponents.([]interface{}); ok {
-			for _, v := range arr {
-				if s, ok := v.(string); ok {
-					opts.components = append(opts.components, s)
-				}
-			}
-		}
-	}
-	if rawWords, ok := m["words"]; ok {
-		if arr, ok := rawWords.([]interface{}); ok {
-			for _, v := range arr {
-				if s, ok := v.(string); ok {
-					opts.words = append(opts.words, s)
-				}
-			}
-		}
-	}
+	opts.components = jsxa11yutil.StringSliceOption(m["components"])
+	opts.words = jsxa11yutil.StringSliceOption(m["words"])
 	return opts
 }
 

--- a/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.schema.json
+++ b/internal/plugins/jsx_a11y/rules/img_redundant_alt/img_redundant_alt.schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "words": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus.go
+++ b/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus.go
@@ -42,6 +42,7 @@
 package interactive_supports_focus
 
 import (
+	_ "embed"
 	"fmt"
 	"slices"
 
@@ -49,8 +50,10 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed interactive_supports_focus.schema.json
+var schemaJSON []byte
 
 const (
 	// suggestionInsertTabIndexZeroDesc mirrors upstream's `tabIndex=0`
@@ -68,20 +71,20 @@ type options struct {
 	Tabbable []string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	opts.Tabbable = jsxa11yutil.StringSliceOption(m["tabbable"])
 	return opts
 }
 
 var InteractiveSupportsFocusRule = rule.Rule{
-	Name: "jsx-a11y/interactive-supports-focus",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/interactive-supports-focus",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		sourceText := ctx.SourceFile.Text()
 

--- a/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus.schema.json
+++ b/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus.schema.json
@@ -1,0 +1,56 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "tabbable": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "button",
+              "checkbox",
+              "columnheader",
+              "combobox",
+              "grid",
+              "gridcell",
+              "link",
+              "listbox",
+              "menu",
+              "menubar",
+              "menuitem",
+              "menuitemcheckbox",
+              "menuitemradio",
+              "option",
+              "progressbar",
+              "radio",
+              "radiogroup",
+              "row",
+              "rowheader",
+              "scrollbar",
+              "searchbox",
+              "slider",
+              "spinbutton",
+              "switch",
+              "tab",
+              "tablist",
+              "textbox",
+              "tree",
+              "treegrid",
+              "treeitem",
+              "doc-backlink",
+              "doc-biblioref",
+              "doc-glossref",
+              "doc-noteref"
+            ]
+          },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/label_has_associated_control/label_has_associated_control.go
+++ b/internal/plugins/jsx_a11y/rules/label_has_associated_control/label_has_associated_control.go
@@ -40,14 +40,17 @@
 package label_has_associated_control
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed label_has_associated_control.schema.json
+var schemaJSON []byte
 
 // Message strings mirror upstream's `errorMessages` constant verbatim.
 const (
@@ -98,15 +101,15 @@ type options struct {
 	depth             int
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{
 		assert: defaultAssert,
 		depth:  defaultDepth,
 	}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	opts.labelComponents = jsxa11yutil.StringSliceOption(m["labelComponents"])
 	opts.labelAttributes = jsxa11yutil.StringSliceOption(m["labelAttributes"])
 	opts.controlComponents = jsxa11yutil.StringSliceOption(m["controlComponents"])
@@ -156,9 +159,9 @@ func parseOptions(raw any) options {
 // plugin registry. The Name matches the rslint convention — the
 // `jsx-a11y/` prefix is part of the registered key.
 var LabelHasAssociatedControlRule = rule.Rule{
-	Name: "jsx-a11y/label-has-associated-control",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/label-has-associated-control",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		// `labelComponentNames = ['label'].concat(labelComponents)` upstream.

--- a/internal/plugins/jsx_a11y/rules/label_has_associated_control/label_has_associated_control.go
+++ b/internal/plugins/jsx_a11y/rules/label_has_associated_control/label_has_associated_control.go
@@ -313,20 +313,13 @@ func resolveHtmlForAttributes(settings map[string]interface{}) []string {
 		return defaultHtmlForAttributes
 	}
 	raw, ok := attrs["for"]
-	if !ok || raw == nil {
-		return defaultHtmlForAttributes
-	}
-	arr, ok := raw.([]interface{})
 	if !ok {
 		return defaultHtmlForAttributes
 	}
-	out := make([]string, 0, len(arr))
-	for _, item := range arr {
-		if s, ok := item.(string); ok {
-			out = append(out, s)
-		}
+	if out := jsxa11yutil.StringSliceOption(raw); out != nil {
+		return out
 	}
-	return out
+	return defaultHtmlForAttributes
 }
 
 // validateHtmlFor mirrors upstream's `validateHtmlFor`:

--- a/internal/plugins/jsx_a11y/rules/label_has_associated_control/label_has_associated_control.schema.json
+++ b/internal/plugins/jsx_a11y/rules/label_has_associated_control/label_has_associated_control.schema.json
@@ -1,0 +1,38 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "labelComponents": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "labelAttributes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "controlComponents": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "assert": {
+          "type": "string",
+          "enum": ["htmlFor", "nesting", "both", "either"]
+        },
+        "depth": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/lang/lang.go
+++ b/internal/plugins/jsx_a11y/rules/lang/lang.go
@@ -16,7 +16,8 @@ import (
 const errorMessage = "lang attribute must have a valid value."
 
 var LangRule = rule.Rule{
-	Name: "jsx-a11y/lang",
+	Name:   "jsx-a11y/lang",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindJsxAttribute: func(attr *ast.Node) {

--- a/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption.go
+++ b/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption.go
@@ -9,6 +9,7 @@
 package media_has_caption
 
 import (
+	_ "embed"
 	"slices"
 	"strings"
 
@@ -16,8 +17,10 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed media_has_caption.schema.json
+var schemaJSON []byte
 
 const errorMessage = "Media elements such as <audio> and <video> must have a <track> for captions."
 
@@ -37,12 +40,12 @@ type options struct {
 	track []string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	opts.audio = jsxa11yutil.StringSliceOption(m["audio"])
 	opts.video = jsxa11yutil.StringSliceOption(m["video"])
 	opts.track = jsxa11yutil.StringSliceOption(m["track"])
@@ -50,9 +53,9 @@ func parseOptions(raw any) options {
 }
 
 var MediaHasCaptionRule = rule.Rule{
-	Name: "jsx-a11y/media-has-caption",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/media-has-caption",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		// Mirrors upstream's `isMediaType`:

--- a/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption.schema.json
+++ b/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption.schema.json
@@ -1,0 +1,30 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "audio": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "video": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "track": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events.go
+++ b/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events.go
@@ -41,12 +41,16 @@
 package mouse_events_have_key_events
 
 import (
+	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed mouse_events_have_key_events.schema.json
+var schemaJSON []byte
 
 // defaultHoverInHandlers / defaultHoverOutHandlers mirror upstream's
 // `DEFAULT_HOVER_IN_HANDLERS` / `DEFAULT_HOVER_OUT_HANDLERS`. Used when
@@ -65,15 +69,15 @@ type options struct {
 	HoverOutHandlers []string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{
 		HoverInHandlers:  defaultHoverInHandlers,
 		HoverOutHandlers: defaultHoverOutHandlers,
 	}
-	optsMap := utils.GetOptionsMap(raw)
-	if optsMap == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	optsMap, _ := raw[0].(map[string]interface{})
 	// Explicit empty array stays empty; a non-array / missing key falls
 	// back to the upstream defaults via `??`. StringSliceOption returns
 	// nil for non-`[]interface{}` inputs and a non-nil zero-length slice
@@ -139,9 +143,9 @@ func pairAttributeIsMissing(attrs []*ast.Node, pairName string) bool {
 }
 
 var MouseEventsHaveKeyEventsRule = rule.Rule{
-	Name: "jsx-a11y/mouse-events-have-key-events",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/mouse-events-have-key-events",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		check := func(node *ast.Node) {

--- a/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events.schema.json
+++ b/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events.schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "hoverInHandlers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "hoverOutHandlers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key.go
+++ b/internal/plugins/jsx_a11y/rules/no_access_key/no_access_key.go
@@ -22,7 +22,8 @@ import (
 const errorMessage = "No access key attribute allowed. Inconsistencies between keyboard shortcuts and keyboard commands used by screen readers and keyboard-only users create a11y complications."
 
 var NoAccessKeyRule = rule.Rule{
-	Name: "jsx-a11y/no-access-key",
+	Name:   "jsx-a11y/no-access-key",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		check := func(node *ast.Node) {
 			attrs := reactutil.GetJsxElementAttributes(node)

--- a/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable.go
+++ b/internal/plugins/jsx_a11y/rules/no_aria_hidden_on_focusable/no_aria_hidden_on_focusable.go
@@ -44,7 +44,8 @@ import (
 const errorMessage = `aria-hidden="true" must not be set on focusable elements.`
 
 var NoAriaHiddenOnFocusableRule = rule.Rule{
-	Name: "jsx-a11y/no-aria-hidden-on-focusable",
+	Name:   "jsx-a11y/no-aria-hidden-on-focusable",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		sourceText := ctx.SourceFile.Text()
 

--- a/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus.go
+++ b/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus.go
@@ -25,12 +25,16 @@
 package no_autofocus
 
 import (
+	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_autofocus.schema.json
+var schemaJSON []byte
 
 // errorMessage mirrors upstream's `errorMessage` string verbatim.
 const errorMessage = "The autoFocus prop should not be enabled, as it can reduce usability and accessibility for users."
@@ -42,12 +46,12 @@ type options struct {
 	IgnoreNonDOM bool
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	optsMap := utils.GetOptionsMap(raw)
-	if optsMap == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	optsMap, _ := raw[0].(map[string]interface{})
 	if v, ok := optsMap["ignoreNonDOM"].(bool); ok {
 		opts.IgnoreNonDOM = v
 	}
@@ -55,9 +59,9 @@ func parseOptions(raw any) options {
 }
 
 var NoAutofocusRule = rule.Rule{
-	Name: "jsx-a11y/no-autofocus",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/no-autofocus",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		return rule.RuleListeners{
 			ast.KindJsxAttribute: func(attr *ast.Node) {

--- a/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus.schema.json
+++ b/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "ignoreNonDOM": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements.go
+++ b/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements.go
@@ -12,13 +12,16 @@
 package no_distracting_elements
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_distracting_elements.schema.json
+var schemaJSON []byte
 
 // errorMessage mirrors upstream's `errorMessage(element)` template literal
 // verbatim. The element name is interpolated into the diagnostic so a
@@ -37,12 +40,12 @@ type options struct {
 	elements []string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{elements: defaultElements}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	// Upstream: `const elementOptions = options.elements || DEFAULT_ELEMENTS`.
 	// `||` only falls through when the LHS is JS-falsy (undefined / null /
 	// "" / 0 / NaN). An EXPLICITLY empty array is JS-truthy so it replaces
@@ -59,9 +62,9 @@ func parseOptions(raw any) options {
 }
 
 var NoDistractingElementsRule = rule.Rule{
-	Name: "jsx-a11y/no-distracting-elements",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/no-distracting-elements",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		// Empty element list — rule is effectively disabled for this run.

--- a/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements.schema.json
+++ b/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "elements": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["marquee", "blink"]
+          },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role.go
+++ b/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role.go
@@ -51,14 +51,17 @@
 package no_interactive_element_to_noninteractive_role
 
 import (
+	_ "embed"
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_interactive_element_to_noninteractive_role.schema.json
+var schemaJSON []byte
 
 // errorMessage mirrors upstream's `errorMessage` string verbatim.
 const errorMessage = "Interactive elements should not be assigned non-interactive roles."
@@ -72,12 +75,12 @@ type options struct {
 	allowedRoles map[string][]string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	for key, v := range m {
 		if parsed := jsxa11yutil.StringSliceOption(v); parsed != nil {
 			if opts.allowedRoles == nil {
@@ -90,9 +93,9 @@ func parseOptions(raw any) options {
 }
 
 var NoInteractiveElementToNoninteractiveRoleRule = rule.Rule{
-	Name: "jsx-a11y/no-interactive-element-to-noninteractive-role",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/no-interactive-element-to-noninteractive-role",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		return rule.RuleListeners{

--- a/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role.schema.json
+++ b/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role.schema.json
@@ -1,0 +1,15 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" },
+        "uniqueItems": true
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.go
@@ -44,14 +44,17 @@
 package no_noninteractive_element_interactions
 
 import (
+	_ "embed"
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_noninteractive_element_interactions.schema.json
+var schemaJSON []byte
 
 // errorMessage mirrors upstream's `errorMessage` string verbatim.
 const errorMessage = "Non-interactive elements should not be assigned mouse or keyboard event listeners."
@@ -92,12 +95,12 @@ var defaultInteractiveProps = func() []string {
 	return out
 }()
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	if rawHandlers, ok := m["handlers"]; ok {
 		// Upstream `config.handlers || defaultInteractiveProps`. JS arrays
 		// (including empty) are truthy, so we treat any present `[]string`
@@ -123,9 +126,9 @@ func parseOptions(raw any) options {
 }
 
 var NoNoninteractiveElementInteractionsRule = rule.Rule{
-	Name: "jsx-a11y/no-noninteractive-element-interactions",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/no-noninteractive-element-interactions",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		interactiveProps := defaultInteractiveProps
 		if opts.Handlers != nil {

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.schema.json
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "handlers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role.go
@@ -57,14 +57,17 @@
 package no_noninteractive_element_to_interactive_role
 
 import (
+	_ "embed"
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_noninteractive_element_to_interactive_role.schema.json
+var schemaJSON []byte
 
 // errorMessage mirrors upstream's `errorMessage` string verbatim.
 const errorMessage = "Non-interactive elements should not be assigned interactive roles."
@@ -78,12 +81,12 @@ type options struct {
 	allowedRoles map[string][]string
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	for key, v := range m {
 		if parsed := jsxa11yutil.StringSliceOption(v); parsed != nil {
 			if opts.allowedRoles == nil {
@@ -96,9 +99,9 @@ func parseOptions(raw any) options {
 }
 
 var NoNoninteractiveElementToInteractiveRoleRule = rule.Rule{
-	Name: "jsx-a11y/no-noninteractive-element-to-interactive-role",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/no-noninteractive-element-to-interactive-role",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		return rule.RuleListeners{

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role.schema.json
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role.schema.json
@@ -1,0 +1,15 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" },
+        "uniqueItems": true
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex.go
@@ -30,14 +30,17 @@
 package no_noninteractive_tabindex
 
 import (
+	_ "embed"
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_noninteractive_tabindex.schema.json
+var schemaJSON []byte
 
 // errorMessage mirrors upstream's `errorMessage` string verbatim.
 const errorMessage = "`tabIndex` should only be declared on interactive elements."
@@ -53,12 +56,12 @@ type options struct {
 	AllowExpressionValues bool
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	opts.Tags = jsxa11yutil.StringSliceOption(m["tags"])
 	opts.Roles = jsxa11yutil.StringSliceOption(m["roles"])
 	if v, ok := m["allowExpressionValues"].(bool); ok {
@@ -68,9 +71,9 @@ func parseOptions(raw any) options {
 }
 
 var NoNoninteractiveTabindexRule = rule.Rule{
-	Name: "jsx-a11y/no-noninteractive-tabindex",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/no-noninteractive-tabindex",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		// sourceText is required by GetTabIndexEx for raw-text template
 		// literal extraction (NoSubstitutionTemplate has no RawText field).

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex.schema.json
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex.schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "roles": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/no_redundant_roles/no_redundant_roles.go
+++ b/internal/plugins/jsx_a11y/rules/no_redundant_roles/no_redundant_roles.go
@@ -32,14 +32,17 @@
 package no_redundant_roles
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_redundant_roles.schema.json
+var schemaJSON []byte
 
 // Implicit-role lookup (`getImplicitRole`, `getExplicitRole`, and the
 // per-element `implicitRoleFor*` helpers) lives in
@@ -79,8 +82,11 @@ func errorMessage(element, implicitRole string) string {
 // and `options = [{}]` both yield an empty allowedRedundantRoles
 // object, and `hasOwn({}, 'nav')` is `false`, so DEFAULT_ROLE_EXCEPTIONS
 // is consulted in both cases.
-func parseOptions(raw any) map[string][]string {
-	m := utils.GetOptionsMap(raw)
+func parseOptions(raw []any) map[string][]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	m, _ := raw[0].(map[string]interface{})
 	if m == nil {
 		return nil
 	}
@@ -92,9 +98,9 @@ func parseOptions(raw any) map[string][]string {
 }
 
 var NoRedundantRolesRule = rule.Rule{
-	Name: "jsx-a11y/no-redundant-roles",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/no-redundant-roles",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		check := func(node *ast.Node) {

--- a/internal/plugins/jsx_a11y/rules/no_redundant_roles/no_redundant_roles.schema.json
+++ b/internal/plugins/jsx_a11y/rules/no_redundant_roles/no_redundant_roles.schema.json
@@ -1,0 +1,15 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" },
+        "uniqueItems": true
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions.go
+++ b/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions.go
@@ -40,14 +40,17 @@
 package no_static_element_interactions
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jsx_a11y/jsxa11yutil"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_static_element_interactions.schema.json
+var schemaJSON []byte
 
 // errorMessage mirrors upstream's `errorMessage` string verbatim.
 const errorMessage = "Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element."
@@ -64,12 +67,12 @@ type options struct {
 	AllowExpressionValues bool
 }
 
-func parseOptions(raw any) options {
+func parseOptions(raw []any) options {
 	opts := options{}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
 	if v, ok := m["handlers"]; ok {
 		opts.HandlersProvided = true
 		opts.Handlers = jsxa11yutil.StringSliceOption(v)
@@ -127,9 +130,9 @@ func hasNonNullInteractiveHandler(attrs []*ast.Node, handlers []string) bool {
 }
 
 var NoStaticElementInteractionsRule = rule.Rule{
-	Name: "jsx-a11y/no-static-element-interactions",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "jsx-a11y/no-static-element-interactions",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		handlers := opts.Handlers
 		if !opts.HandlersProvided {

--- a/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions.schema.json
+++ b/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "handlers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "additionalItems": false
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role.go
+++ b/internal/plugins/jsx_a11y/rules/prefer_tag_over_role/prefer_tag_over_role.go
@@ -166,7 +166,8 @@ func lastSpaceSeparatedToken(s string) string {
 }
 
 var PreferTagOverRoleRule = rule.Rule{
-	Name: "jsx-a11y/prefer-tag-over-role",
+	Name:   "jsx-a11y/prefer-tag-over-role",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		check := func(node *ast.Node) {
 			attrs := reactutil.GetJsxElementAttributes(node)

--- a/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props.go
+++ b/internal/plugins/jsx_a11y/rules/role_has_required_aria_props/role_has_required_aria_props.go
@@ -172,7 +172,8 @@ func isSemanticRoleElement(elementType string, attrs []*ast.Node, roleAttrValue 
 }
 
 var RoleHasRequiredAriaPropsRule = rule.Rule{
-	Name: "jsx-a11y/role-has-required-aria-props",
+	Name:   "jsx-a11y/role-has-required-aria-props",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindJsxAttribute: func(attr *ast.Node) {

--- a/internal/plugins/jsx_a11y/rules/role_supports_aria_props/role_supports_aria_props.go
+++ b/internal/plugins/jsx_a11y/rules/role_supports_aria_props/role_supports_aria_props.go
@@ -68,7 +68,8 @@ func errorMessage(attr, role, tag string, isImplicit bool) string {
 }
 
 var RoleSupportsAriaPropsRule = rule.Rule{
-	Name: "jsx-a11y/role-supports-aria-props",
+	Name:   "jsx-a11y/role-supports-aria-props",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		check := func(node *ast.Node) {
 			elementType := jsxa11yutil.GetElementType(node, ctx.Settings)

--- a/internal/plugins/jsx_a11y/rules/scope/scope.go
+++ b/internal/plugins/jsx_a11y/rules/scope/scope.go
@@ -44,7 +44,8 @@ import (
 const errorMessage = "The scope prop can only be used on <th> elements."
 
 var ScopeRule = rule.Rule{
-	Name: "jsx-a11y/scope",
+	Name:   "jsx-a11y/scope",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindJsxAttribute: func(attr *ast.Node) {

--- a/internal/plugins/jsx_a11y/rules/tabindex_no_positive/tabindex_no_positive.go
+++ b/internal/plugins/jsx_a11y/rules/tabindex_no_positive/tabindex_no_positive.go
@@ -49,7 +49,8 @@ import (
 const errorMessage = "Avoid positive integer values for tabIndex."
 
 var TabindexNoPositiveRule = rule.Rule{
-	Name: "jsx-a11y/tabindex-no-positive",
+	Name:   "jsx-a11y/tabindex-no-positive",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		// Source text is needed for raw-string extraction on template
 		// literals (NoSubstitutionTemplateLiteral has no RawText field in

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/control-has-associated-label.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/control-has-associated-label.test.ts
@@ -178,11 +178,6 @@ new RuleTester().run('control-has-associated-label', null as never, {
       code: '<button data-label="Save" />',
       options: [{ labelAttributes: ['data-label'] }],
     },
-    // labelAttributes — duplicate entry, defensive.
-    {
-      code: '<button title="Save" />',
-      options: [{ labelAttributes: ['title', 'title'] }],
-    },
 
     // ============================================================
     // ignoreRoles vs case-sensitivity / multi-role

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-distracting-elements.test.ts
@@ -65,11 +65,6 @@ new RuleTester().run('no-distracting-elements', null as never, {
     { code: '<this.Foo />' },
     { code: '<UI.marquee />' }, // type "UI.marquee" ≠ "marquee"
 
-    // ---- options: null elements falls back to default ----
-    { code: '<div />', options: [{ elements: null }] },
-    // rslint extension: array-of-non-strings silences the rule.
-    { code: '<marquee />', options: [{ elements: [123, true] }] },
-
     // ---- Components map: map-to-non-distracting / non-string value ----
     {
       code: '<Foo />',
@@ -198,11 +193,6 @@ new RuleTester().run('no-distracting-elements', null as never, {
     },
 
     // ---- Custom `elements` list ----
-    {
-      code: '<custom />',
-      options: [{ elements: ['custom'] }],
-      errors: [expectedError('custom')],
-    },
     {
       code: '<blink />',
       options: [{ elements: ['blink'] }],
@@ -378,23 +368,6 @@ new RuleTester().run('no-distracting-elements', null as never, {
           polymorphicAllowList: [123 as unknown as string, 'Foo'],
         },
       },
-      errors: [expectedError('marquee')],
-    },
-
-    // ---- rslint-specific options (no schema validation) ----
-    {
-      code: '<marquee />',
-      options: [{ elements: ['marquee', 123] }],
-      errors: [expectedError('marquee')],
-    },
-    {
-      code: '<marquee />',
-      options: [{ elements: ['', 'marquee'] }],
-      errors: [expectedError('marquee')],
-    },
-    {
-      code: '<marquee />',
-      options: [{ elements: ['marquee', 'marquee'] }],
       errors: [expectedError('marquee')],
     },
   ],

--- a/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-tabindex.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jsx-a11y/rules/no-noninteractive-tabindex.test.ts
@@ -278,12 +278,6 @@ new RuleTester().run('no-noninteractive-tabindex', null as never, {
     // Empty option object / array.
     { code: '<div tabIndex={-1} />', options: [{}] },
     { code: '<div tabIndex={-1} />', options: [] },
-    // Malformed option types silently default.
-    {
-      code: '<div tabIndex={-1} />',
-      options: [{ tags: 'not-an-array' }],
-    },
-    { code: '<div tabIndex={-1} />', options: [{ roles: 123 }] },
 
     // ============================================================
     // Custom components (skip via dom.has=false)


### PR DESCRIPTION
## Summary

- Declare option JSON Schemas for all 36 `jsx-a11y/` rules, matching `eslint-plugin-jsx-a11y` upstream.
- Cross-checked against the real npm package at runtime (`rule.meta.schema`, and `eslint`'s `Linter.verify` for accepted/rejected configs), not just by reading source.
- Rules that never read `context.options` use the shared `EmptyArraySchema`, even where upstream's own schema declares a permissive-but-unused object slot.
- `interactive-supports-focus`'s `tabbable` gets the concrete enum of ARIA widget roles (resolved from `aria-query` at runtime) instead of an open string array.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).