### PR TITLE
ci: optimize Windows CI runners

### DIFF
--- a/.github/actions/windows-disable-cpu-hogs/action.yml
+++ b/.github/actions/windows-disable-cpu-hogs/action.yml
@@ -1,0 +1,23 @@
+name: Disable CPU hogs (Windows)
+
+description: Disable Defender realtime monitoring, Windows Update and telemetry to reduce CI flakiness, then log the effective Defender status
+
+runs:
+  using: composite
+  steps:
+    - shell: powershell
+      run: |
+        $ErrorActionPreference = 'SilentlyContinue'
+        Set-MpPreference -DisableRealtimeMonitoring $true -Force
+        Add-MpPreference -ExclusionPath "C:\" -Force
+        Add-MpPreference -ExclusionPath "D:\" -Force
+        sc.exe config wuauserv start= disabled
+        Stop-Service wuauserv
+        reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\wsl.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+        reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\CompatTelRunner.exe" /v Debugger /t REG_SZ /d "block.exe" /f
+        Write-Host "== Windows Defender status (post disable attempt) =="
+        if (Get-Command Get-MpComputerStatus -ErrorAction SilentlyContinue) {
+          Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected, AntivirusEnabled | Format-List
+        } else {
+          Write-Host "Windows Defender is not installed on this runner; the disable steps above are no-ops here."
+        }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           submodules: true
           fetch-depth: 1
+
+      - name: Disable CPU hogs (Windows)
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        uses: ./.github/actions/windows-disable-cpu-hogs
+
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -364,7 +370,7 @@ jobs:
       - test-wasm
       - test-rust
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: rspack-ubuntu-22.04-mini
     name: CI Done
     steps:
       - run: exit 1


### PR DESCRIPTION
## Summary

- Add a best-effort Windows CI action that disables Defender realtime monitoring, Windows Update, and telemetry-related processes, then logs the effective Defender status.
- Run the action before Node and Go setup for the Windows `Test Go` matrix job.
- Move the lightweight `CI Done` aggregation job from `ubuntu-latest` to `rspack-ubuntu-22.04-mini`.
- Verification:
  - `pnpm run check-spell`
  - `pnpm run format:check`
  - Changed-only Go lint: no Go files changed, so no Go packages required linting.

## Related Links

- Reference implementation: https://github.com/web-infra-dev/rspack/pull/14711
- Windows CI timing sample: https://github.com/web-infra-dev/rslint/actions/runs/29984450851/job/89133557378

## Checklist

- [x] Tests updated (not required; CI-only changes).
- [x] Documentation updated (not required).
