### PR TITLE
chore: release npm 0.7.1 and tsgo-client crate 0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "tsgo-client"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "bitflags",
  "cbor4ii",

--- a/crates/tsgo-client/Cargo.toml
+++ b/crates/tsgo-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsgo-client"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 description = "TypeScript Go client library"
 license = "MIT"

--- a/npm/rslint/darwin-arm64/package.json
+++ b/npm/rslint/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-darwin-arm64",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "rslint native binaries for darwin-arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/darwin-x64/package.json
+++ b/npm/rslint/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-darwin-x64",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "rslint native binaries for darwin-x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-arm64-gnu/package.json
+++ b/npm/rslint/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-arm64-gnu",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-arm64-gnu",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-arm64-musl/package.json
+++ b/npm/rslint/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-arm64-musl",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-arm64-musl",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-x64-gnu/package.json
+++ b/npm/rslint/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-x64-gnu",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-x64-gnu",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/linux-x64-musl/package.json
+++ b/npm/rslint/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-linux-x64-musl",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "rslint native binaries for linux-x64-musl",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/win32-arm64-msvc/package.json
+++ b/npm/rslint/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-win32-arm64-msvc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "rslint native binaries for win32-arm64-msvc",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/rslint/win32-x64-msvc/package.json
+++ b/npm/rslint/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/native-win32-x64-msvc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "rslint native binaries for win32-x64-msvc",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/darwin-arm64/package.json
+++ b/npm/tsgo/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-darwin-arm64",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "tsgo binary for darwin arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/darwin-x64/package.json
+++ b/npm/tsgo/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-darwin-x64",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "tsgo binary for darwin x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/linux-arm64/package.json
+++ b/npm/tsgo/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-linux-arm64",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "tsgo binary for linux arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/linux-x64/package.json
+++ b/npm/tsgo/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-linux-x64",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "tsgo binary for linux x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/win32-arm64/package.json
+++ b/npm/tsgo/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-win32-arm64",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "tsgo binary for windows arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/win32-x64/package.json
+++ b/npm/tsgo/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-win32-x64",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "tsgo binary for windows x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rslint-monorepo",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Rslint Monorepo",
   "homepage": "https://github.com/web-infra-dev/rslint#readme",

--- a/packages/rslint-api/package.json
+++ b/packages/rslint-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/api",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Rslint AST library",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/rslint-test-tools/package.json
+++ b/packages/rslint-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/test-tools",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "main": "src/index.ts",
   "private": true,

--- a/packages/rslint-wasm/package.json
+++ b/packages/rslint-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/wasm",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "rslint wasm package",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/rslint/package.json
+++ b/packages/rslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "exports": {
     ".": {
       "@typescript/source": "./src/index.ts",

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript-eslint/rule-tester",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/tsgo/package.json
+++ b/packages/tsgo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "custom tsgo binary",
   "license": "MIT",
   "type": "module",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript-eslint/utils",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "",
   "main": "index.ts",
   "private": true,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "rslint",
   "displayName": "Rslint",
   "description": "Language support for Rslint",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "icon": "images/icon.png",
   "private": true,
   "publisher": "rstack",


### PR DESCRIPTION
## Summary

- npm packages: `0.7.0` → `0.7.1`
- `tsgo-client` crate: `0.0.5` → `0.0.6` (published independently to crates.io via the 📦 Release crates workflow)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).