### PR TITLE
ci: disable CPU hogs in Windows npm tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,11 @@ jobs:
           submodules: true
           fetch-depth: 1
 
+      - name: Disable CPU hogs (Windows)
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        uses: ./.github/actions/windows-disable-cpu-hogs
+
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:


### PR DESCRIPTION
## Summary

- Run the existing best-effort `windows-disable-cpu-hogs` action in the self-hosted Windows npm test job.
- Keep the setup consistent with the Windows `Test Go` matrix job by running it immediately after checkout.
- Verification:
  - `pnpm run check-spell`
  - `pnpm run format:check`
  - Changed-only Go lint: no Go files changed, so no Go packages required linting.

## Related Links

- Follow-up to https://github.com/web-infra-dev/rslint/pull/1348

## Checklist

- [x] Tests updated (not required; CI-only change).
- [x] Documentation updated (not required).
