### PR TITLE
perf: optimize @typescript-eslint/triple-slash-reference

### DIFF
--- a/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.go
+++ b/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.go
@@ -2,130 +2,173 @@ package triple_slash_reference
 
 import (
 	"regexp"
-	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 type TripleSlashReferenceOptions struct {
 	Lib   string `json:"lib"`   // "always" | "never"
-	Path  string `json:"path"`  // "always" | "never" | "prefer-import"
+	Path  string `json:"path"`  // "always" | "never"
 	Types string `json:"types"` // "always" | "never" | "prefer-import"
 }
 
-var tripleSlashRegex = regexp.MustCompile(`^///\s*<reference\s+(path|types|lib)\s*=`)
+type pendingReference struct {
+	textRange core.TextRange
+	module    string
+}
 
-// TripleSlashReferenceRule implements the triple-slash-reference rule
-// Disallow certain triple slash directives
+// ECMAScript's \s includes WhiteSpace and LineTerminator code points. Keep the
+// set explicit: Go regexp's \s is ASCII-only and would not match the upstream
+// rule for comments containing non-ASCII whitespace.
+const ecmascriptWhitespace = `[\t\n\v\f\r \x{00A0}\x{1680}\x{2000}-\x{200A}\x{2028}\x{2029}\x{202F}\x{205F}\x{3000}\x{FEFF}]`
+
+// This is the upstream regexp applied to ESLint's Comment.value. Comment.value
+// omits the leading "//", so a real triple-slash comment starts with "/".
+// Preserve its deliberately permissive details: no required whitespace before
+// the reference kind, "|" is accepted as a quote, and the module capture is
+// greedy and does not require a closing tag.
+var tripleSlashReferencePattern = regexp.MustCompile(
+	`^/` + ecmascriptWhitespace + `*<reference` +
+		ecmascriptWhitespace + `*(types|path|lib)` +
+		ecmascriptWhitespace + `*=` +
+		ecmascriptWhitespace + `*["|'](.*)["|']`,
+)
+
+// GetLeadingCommentRanges only calls NodeFactory.NewCommentRange, which is a
+// pure value constructor. Reuse one hook-free factory instead of allocating
+// the comparatively large NodeFactory once per linted file.
+var tripleSlashReferenceCommentFactory = ast.NewNodeFactory(ast.NodeFactoryHooks{})
+
+// TripleSlashReferenceRule implements the triple-slash-reference rule.
+// Disallow certain triple slash directives in favor of import declarations.
 var TripleSlashReferenceRule = rule.CreateRule(rule.Rule{
 	Name: "triple-slash-reference",
 	Run:  run,
 })
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
-	opts := TripleSlashReferenceOptions{
-		Lib:   "always",
-		Path:  "always",
-		Types: "prefer-import",
-	}
-
-	// Parse options
-	if options != nil {
-		var optsMap map[string]interface{}
-		var ok bool
-
-		// Handle array format: [{ option: value }]
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			optsMap, ok = optArray[0].(map[string]interface{})
-		} else {
-			// Handle direct object format: { option: value }
-			optsMap, ok = options.(map[string]interface{})
-		}
-
-		if ok {
-			if lib, ok := optsMap["lib"].(string); ok {
-				opts.Lib = lib
-			}
-			if path, ok := optsMap["path"].(string); ok {
-				opts.Path = path
-			}
-			if types, ok := optsMap["types"].(string); ok {
-				opts.Types = types
-			}
-		}
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
+	opts := parseOptions(options)
+	if opts.Lib == "always" && opts.Path == "always" && opts.Types == "always" {
+		return rule.RuleListeners{}
 	}
 
 	text := ctx.SourceFile.Text()
+	references := make([]pendingReference, 0)
 
-	// Check if file has imports
-	hasImport := hasImportStatements(ctx.SourceFile)
-
-	// Only real single-line comment tokens can be triple-slash directives, so
-	// this walks the linter's precomputed comment list instead of scanning
-	// raw source text/lines. That avoids matching text that merely looks like
-	// a reference comment inside a string, template literal, or block comment.
-	for _, comment := range ctx.Comments.All() {
-		if comment.Kind != ast.KindSingleLineCommentTrivia {
-			continue
-		}
-		if comment.Pos() < 0 || comment.End() > len(text) {
+	// sourceCode.getCommentsBefore(Program) only exposes the comments in the
+	// file's leading trivia. Scanning that prefix also avoids materializing the
+	// linter's full-file token/comment cache for this rule.
+	for comment := range scanner.GetLeadingCommentRanges(tripleSlashReferenceCommentFactory, text, 0) {
+		if comment.Kind != ast.KindSingleLineCommentTrivia ||
+			comment.Pos() < 0 ||
+			comment.Pos()+2 > comment.End() ||
+			comment.End() > len(text) {
 			continue
 		}
 
-		commentText := text[comment.Pos():comment.End()]
-		if !tripleSlashRegex.MatchString(commentText) {
+		commentValue := text[comment.Pos()+2 : comment.End()]
+		match := tripleSlashReferencePattern.FindStringSubmatchIndex(commentValue)
+		if match == nil {
 			continue
 		}
 
-		// Determine the type of reference
-		var refType string
-		if strings.Contains(commentText, `path=`) {
-			refType = "path"
-		} else if strings.Contains(commentText, `types=`) {
-			refType = "types"
-		} else if strings.Contains(commentText, `lib=`) {
-			refType = "lib"
-		}
+		referenceKind := commentValue[match[2]:match[3]]
+		module := commentValue[match[4]:match[5]]
+		textRange := core.NewTextRange(comment.Pos(), comment.End())
 
-		// Check if this reference should be reported
-		shouldReport := false
-		switch refType {
-		case "path":
-			shouldReport = opts.Path == "never"
-		case "types":
-			shouldReport = opts.Types == "never" || (opts.Types == "prefer-import" && hasImport)
+		switch referenceKind {
 		case "lib":
-			shouldReport = opts.Lib == "never"
-		}
-
-		if shouldReport {
-			ctx.ReportRange(
-				core.NewTextRange(comment.Pos(), comment.End()),
-				rule.RuleMessage{
-					Id:          "tripleSlashReference",
-					Description: "Do not use a triple slash reference for " + refType + ", use `import` style instead.",
-				},
-			)
+			if opts.Lib == "never" {
+				reportReference(&ctx, textRange, module)
+			}
+		case "path":
+			if opts.Path == "never" {
+				reportReference(&ctx, textRange, module)
+			}
+		case "types":
+			switch opts.Types {
+			case "never":
+				reportReference(&ctx, textRange, module)
+			case "prefer-import":
+				references = append(references, pendingReference{
+					textRange: textRange,
+					module:    module,
+				})
+			}
 		}
 	}
 
-	return rule.RuleListeners{}
+	if len(references) == 0 {
+		return rule.RuleListeners{}
+	}
+
+	reportMatchingReferences := func(module string) {
+		for _, reference := range references {
+			if reference.module == module {
+				reportReference(&ctx, reference.textRange, reference.module)
+			}
+		}
+	}
+
+	return rule.RuleListeners{
+		ast.KindImportDeclaration: func(node *ast.Node) {
+			declaration := node.AsImportDeclaration()
+			module, ok := utils.GetStaticStringLiteralValue(declaration.ModuleSpecifier)
+			if ok {
+				reportMatchingReferences(module)
+			}
+		},
+		ast.KindImportEqualsDeclaration: func(node *ast.Node) {
+			declaration := node.AsImportEqualsDeclaration()
+			if declaration.ModuleReference == nil ||
+				declaration.ModuleReference.Kind != ast.KindExternalModuleReference {
+				return
+			}
+
+			externalReference := declaration.ModuleReference.AsExternalModuleReference()
+			module, ok := utils.GetStaticStringLiteralValue(externalReference.Expression)
+			if ok {
+				reportMatchingReferences(module)
+			}
+		},
+	}
 }
 
-// hasImportStatements checks if the source file contains any import statements
-func hasImportStatements(sourceFile *ast.SourceFile) bool {
-	if sourceFile.Statements == nil {
-		return false
+func parseOptions(options []any) TripleSlashReferenceOptions {
+	opts := TripleSlashReferenceOptions{
+		Lib:   "always",
+		Path:  "never",
+		Types: "prefer-import",
 	}
 
-	for _, stmt := range sourceFile.Statements.Nodes {
-		switch stmt.Kind {
-		case ast.KindImportDeclaration, ast.KindImportEqualsDeclaration:
-			return true
+	if optionsMap := utils.GetOptionsMap(options); optionsMap != nil {
+		if lib, ok := optionsMap["lib"].(string); ok {
+			opts.Lib = lib
+		}
+		if path, ok := optionsMap["path"].(string); ok {
+			opts.Path = path
+		}
+		if types, ok := optionsMap["types"].(string); ok {
+			opts.Types = types
 		}
 	}
-	return false
+
+	return opts
+}
+
+func reportReference(ctx *rule.RuleContext, textRange core.TextRange, module string) {
+	ctx.ReportRange(
+		textRange,
+		rule.RuleMessage{
+			Id:          "tripleSlashReference",
+			Description: "Do not use a triple slash reference for " + module + ", use `import` style instead.",
+			Data: map[string]string{
+				"module": module,
+			},
+		},
+	)
 }

--- a/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.md
+++ b/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.md
@@ -4,22 +4,27 @@
 
 Disallow certain triple slash directives in favor of ES6-style import declarations. TypeScript's `/// <reference ... />` triple-slash directives are an older mechanism for including type information. In most modern codebases, ES6-style `import` statements are preferred. This rule can ban `/// <reference path="..." />`, `/// <reference types="..." />`, and `/// <reference lib="..." />` directives.
 
-By default, `types` references are banned when the file already uses `import` statements (the `prefer-import` setting).
+The default options are:
+
+- `lib: "always"`: allow `lib` references.
+- `path: "never"`: disallow `path` references.
+- `types: "prefer-import"`: disallow a `types` reference only when the same module is also imported.
 
 Examples of **incorrect** code for this rule:
 
 ```typescript
 /// <reference types="jest" />
-import { foo } from 'bar';
+import 'jest';
+
+/// <reference path="./types.d.ts" />
 ```
 
 Examples of **correct** code for this rule:
 
 ```typescript
-import { foo } from 'bar';
-
 /// <reference types="jest" />
-// (OK when there are no import statements in the file)
+import { foo } from 'bar';
+// The "jest" reference is allowed because only "bar" is imported.
 ```
 
 ## Original Documentation

--- a/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference_extras_test.go
+++ b/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference_extras_test.go
@@ -1,0 +1,390 @@
+package triple_slash_reference
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestTripleSlashReferenceRuleExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&TripleSlashReferenceRule,
+		[]rule_tester.ValidTestCase{
+			{
+				// getCommentsBefore(Program) does not include comments after the
+				// first syntax token.
+				Code:    "const value = 1;\n/// <reference path=\"foo\" />\n",
+				Options: map[string]interface{}{"path": "never"},
+			},
+			{
+				Code: `
+//// <reference path="four-slashes" />
+/* /// <reference path="block" /> */
+const stringValue = '/// <reference path="string" />';
+const templateValue = ` + "`/// <reference path=\"template\" />`" + `;
+const taggedValue = tag` + "`/// <reference path=\"tagged\" />`" + `;
+`,
+				Options: map[string]interface{}{"path": "never"},
+			},
+			{
+				Code: `
+/// <Reference path="uppercase-tag" />
+/// <reference PATH="uppercase-kind" />
+/// <reference other="first" path="not-first" />
+`,
+				Options: map[string]interface{}{"path": "never"},
+			},
+			{
+				Code: `
+/// <reference types="foo" />
+import foo = ns.foo;
+`,
+				Options: map[string]interface{}{"types": "prefer-import"},
+			},
+			{
+				Code: `
+/// <reference types="foo" />
+import('foo');
+require('foo');
+export * from 'foo';
+`,
+				Options: map[string]interface{}{"types": "prefer-import"},
+			},
+			{
+				Code: `
+/// <reference types=" foo " />
+import 'foo';
+`,
+				Options: map[string]interface{}{"types": "prefer-import"},
+			},
+			{
+				Code: `
+/// <reference types="f\u006fo" />
+import 'foo';
+`,
+				Options: map[string]interface{}{"types": "prefer-import"},
+			},
+			{
+				Code: `
+/// <reference path="foo" />
+/// <reference types="foo" />
+/// <reference lib="foo" />
+import 'foo';
+`,
+				Options: map[string]interface{}{
+					"lib":   "always",
+					"path":  "always",
+					"types": "always",
+				},
+			},
+			{
+				Code: `
+// eslint-disable-next-line
+/// <reference path="disabled" />
+`,
+				Options: map[string]interface{}{"path": "never"},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				// Defaults are lib=always, path=never, types=prefer-import.
+				Code: `
+/// <reference path="path-default" />
+/// <reference lib="lib-default" />
+/// <reference types="same" />
+/// <reference types="different" />
+import 'same';
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					tripleSlashReferenceError(2, 1, "path-default"),
+					tripleSlashReferenceError(4, 1, "same"),
+				},
+			},
+			{
+				// A partial object is merged with the upstream defaults.
+				Code: `
+/// <reference path="path-default" />
+/// <reference lib="lib-never" />
+/// <reference types="types-default" />
+import 'types-default';
+`,
+				Options: map[string]interface{}{"lib": "never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					tripleSlashReferenceError(2, 1, "path-default"),
+					tripleSlashReferenceError(3, 1, "lib-never"),
+					tripleSlashReferenceError(4, 1, "types-default"),
+				},
+			},
+			{
+				Code: `
+/* license */
+// ordinary leading comment
+/// <reference path="foo" />
+const value = 1;
+`,
+				Options: map[string]interface{}{"path": "never"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(4, 1, "foo")},
+			},
+			{
+				Code:    "\ufeff/// <reference path=\"bom\" />\n",
+				Options: map[string]interface{}{"path": "never"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(1, 2, "bom")},
+			},
+			{
+				Code:    "#!/usr/bin/env node\n/// <reference path=\"shebang\" />\n",
+				Options: map[string]interface{}{"path": "never"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(2, 1, "shebang")},
+			},
+			{
+				Code: "\t/// <reference path=\"foo\" />\r\nconst value = 1;\r\n",
+				Options: map[string]interface{}{
+					"path": "never",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "tripleSlashReference",
+					Message:   "Do not use a triple slash reference for foo, use `import` style instead.",
+					Line:      1,
+					Column:    2,
+					EndLine:   1,
+					EndColumn: 30,
+				}},
+			},
+			{
+				Code: "///\v<reference\u00a0path\u000b=\u000c\"unicode-space\"\n",
+				Options: map[string]interface{}{
+					"path": "never",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					tripleSlashReferenceError(1, 1, "unicode-space"),
+				},
+			},
+			{
+				// The upstream capture is greedy and the regexp is not anchored
+				// at the end of the comment.
+				Code:    `/// <reference path="foo" types="bar" /> trailing`,
+				Options: map[string]interface{}{"path": "never"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					tripleSlashReferenceError(1, 1, `foo" types="bar`),
+				},
+			},
+			{
+				Code: `
+/// <reference types="foo" />
+import type { Foo } from 'foo';
+`,
+				Options: map[string]interface{}{"types": "prefer-import"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(2, 1, "foo")},
+			},
+			{
+				Code: `
+/// <reference types="foo" />
+import 'foo';
+`,
+				Options: map[string]interface{}{"types": "prefer-import"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(2, 1, "foo")},
+			},
+			{
+				Code: `
+/// <reference types=" foo " />
+import ' foo ';
+`,
+				Options: map[string]interface{}{"types": "prefer-import"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(2, 1, " foo ")},
+			},
+			{
+				Code: `
+/// <reference types="foo" />
+import 'f\u006fo';
+`,
+				Options: map[string]interface{}{"types": "prefer-import"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(2, 1, "foo")},
+			},
+			{
+				Code: `
+/// <reference types="foo" />
+/// <reference types="foo" />
+import first from 'foo';
+import second from 'foo';
+`,
+				Options: map[string]interface{}{"types": "prefer-import"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					tripleSlashReferenceError(2, 1, "foo"),
+					tripleSlashReferenceError(3, 1, "foo"),
+					tripleSlashReferenceError(2, 1, "foo"),
+					tripleSlashReferenceError(3, 1, "foo"),
+				},
+			},
+		},
+	)
+}
+
+func TestTripleSlashReferenceMatcherParity(t *testing.T) {
+	tests := []struct {
+		name        string
+		source      string
+		wantModules []string
+	}{
+		{
+			name:        "zero whitespace and no closing tag",
+			source:      `/// <reference` + `types="zero-space"`,
+			wantModules: []string{"zero-space"},
+		},
+		{
+			name:        "single quotes",
+			source:      `/// <reference path='single-quote'`,
+			wantModules: []string{"single-quote"},
+		},
+		{
+			name:        "pipe quotes",
+			source:      `/// <reference path=|pipe-quote|`,
+			wantModules: []string{"pipe-quote"},
+		},
+		{
+			name:        "mismatched quotes",
+			source:      `/// <reference path="mismatched'`,
+			wantModules: []string{"mismatched"},
+		},
+		{
+			name:        "empty module",
+			source:      `/// <reference path=""`,
+			wantModules: []string{""},
+		},
+		{
+			name:        "greedy module capture",
+			source:      `/// <reference path="foo" types="bar" />`,
+			wantModules: []string{`foo" types="bar`},
+		},
+		{
+			name:        "ECMAScript whitespace",
+			source:      "///\v<reference\u00a0path\u000b=\u000c\"unicode-space\"",
+			wantModules: []string{"unicode-space"},
+		},
+		{
+			name:   "unquoted module",
+			source: `/// <reference path=unquoted />`,
+		},
+		{
+			name:   "missing closing quote",
+			source: `/// <reference path="unterminated />`,
+		},
+		{
+			name:   "case sensitive tag",
+			source: `/// <Reference path="uppercase" />`,
+		},
+		{
+			name:   "case sensitive kind",
+			source: `/// <reference PATH="uppercase" />`,
+		},
+		{
+			name:   "kind is not first attribute",
+			source: `/// <reference other="first" path="not-first" />`,
+		},
+	}
+
+	options := []any{map[string]interface{}{
+		"lib":   "never",
+		"path":  "never",
+		"types": "never",
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diagnostics := runTripleSlashReferenceDirect(test.source, options)
+			modules := make([]string, 0, len(diagnostics))
+			for _, diagnostic := range diagnostics {
+				modules = append(modules, diagnostic.Message.Data["module"])
+			}
+			if !slices.Equal(modules, test.wantModules) {
+				t.Errorf("reported modules = %q, want %q", modules, test.wantModules)
+			}
+		})
+	}
+}
+
+func TestTripleSlashReferenceDiagnosticDataAndRange(t *testing.T) {
+	source := `/// <reference path="foo" />`
+	diagnostics := runTripleSlashReferenceDirect(
+		source,
+		[]any{map[string]interface{}{"path": "never"}},
+	)
+
+	if len(diagnostics) != 1 {
+		t.Fatalf("got %d diagnostics, want 1", len(diagnostics))
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Range.Pos() != 0 || diagnostic.Range.End() != len(source) {
+		t.Errorf("diagnostic range = [%d,%d), want [0,%d)", diagnostic.Range.Pos(), diagnostic.Range.End(), len(source))
+	}
+	if diagnostic.Message.Description != "Do not use a triple slash reference for foo, use `import` style instead." {
+		t.Errorf("diagnostic message = %q", diagnostic.Message.Description)
+	}
+	if diagnostic.Message.Data["module"] != "foo" {
+		t.Errorf("diagnostic module data = %q, want %q", diagnostic.Message.Data["module"], "foo")
+	}
+}
+
+func TestTripleSlashReferenceDisableDirectives(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		options []any
+	}{
+		{
+			name: "immediate never report",
+			source: "// eslint-disable-next-line @typescript-eslint/triple-slash-reference\n" +
+				"/// <reference path=\"disabled\" />\n",
+			options: []any{map[string]interface{}{"path": "never"}},
+		},
+		{
+			name: "deferred prefer-import report",
+			source: "// eslint-disable-next-line @typescript-eslint/triple-slash-reference\n" +
+				"/// <reference types=\"disabled\" />\n" +
+				"import 'disabled';\n",
+			options: []any{map[string]interface{}{"types": "prefer-import"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if diagnostics := runTripleSlashReferenceDirect(test.source, test.options); len(diagnostics) != 0 {
+				t.Errorf("got %d diagnostics, want none: %v", len(diagnostics), diagnostics)
+			}
+		})
+	}
+}
+
+func runTripleSlashReferenceDirect(source string, options []any) []rule.RuleDiagnostic {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, source, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	diagnostics := make([]rule.RuleDiagnostic, 0, 1)
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithReporter(
+		"@typescript-eslint/triple-slash-reference",
+		rule.SeverityError,
+		func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	)
+
+	listeners := TripleSlashReferenceRule.Run(ctx, options)
+	for _, statement := range sourceFile.Statements.Nodes {
+		if listener := listeners[statement.Kind]; listener != nil {
+			listener(statement)
+		}
+	}
+	return diagnostics
+}

--- a/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference_test.go
+++ b/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference_test.go
@@ -1,68 +1,135 @@
 package triple_slash_reference
 
 import (
+	"testing"
+
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"testing"
 )
 
 func TestTripleSlashReferenceRule(t *testing.T) {
+	always := map[string]interface{}{
+		"lib":   "always",
+		"path":  "always",
+		"types": "always",
+	}
+	never := map[string]interface{}{
+		"lib":   "never",
+		"path":  "never",
+		"types": "never",
+	}
+
 	rule_tester.RunRuleTester(
 		fixtures.GetRootDir(),
 		"tsconfig.json",
 		t,
 		&TripleSlashReferenceRule,
 		[]rule_tester.ValidTestCase{
-			// Double-slash comments with 'never' options
 			{
 				Code: `
 // <reference path="foo" />
 // <reference types="bar" />
 // <reference lib="baz" />
 import * as foo from 'foo';
+import * as bar from 'bar';
+import * as baz from 'baz';
 `,
-				Options: map[string]interface{}{
-					"lib":   "never",
-					"path":  "never",
-					"types": "never",
-				},
+				Options: never,
 			},
-			// Triple-slash comments with 'always' options
+			{
+				Code: `
+// <reference path="foo" />
+// <reference types="bar" />
+// <reference lib="baz" />
+import foo = require('foo');
+import bar = require('bar');
+import baz = require('baz');
+`,
+				Options: never,
+			},
 			{
 				Code: `
 /// <reference path="foo" />
 /// <reference types="bar" />
 /// <reference lib="baz" />
 import * as foo from 'foo';
+import * as bar from 'bar';
+import * as baz from 'baz';
 `,
-				Options: map[string]interface{}{
-					"lib":   "always",
-					"path":  "always",
-					"types": "always",
-				},
+				Options: always,
 			},
-			// Triple-slash with prefer-import when no imports
+			{
+				Code: `
+/// <reference path="foo" />
+/// <reference types="bar" />
+/// <reference lib="baz" />
+import foo = require('foo');
+import bar = require('bar');
+import baz = require('baz');
+`,
+				Options: always,
+			},
+			{
+				Code: `
+/// <reference path="foo" />
+/// <reference types="bar" />
+/// <reference lib="baz" />
+import foo = foo;
+import bar = bar;
+import baz = baz;
+`,
+				Options: always,
+			},
+			{
+				Code: `
+/// <reference path="foo" />
+/// <reference types="bar" />
+/// <reference lib="baz" />
+import foo = foo.foo;
+import bar = bar.bar.bar.bar;
+import baz = baz.baz;
+`,
+				Options: always,
+			},
+			{
+				Code:    "import * as foo from 'foo';",
+				Options: map[string]interface{}{"path": "never"},
+			},
+			{
+				Code:    "import foo = require('foo');",
+				Options: map[string]interface{}{"path": "never"},
+			},
+			{
+				Code:    "import * as foo from 'foo';",
+				Options: map[string]interface{}{"types": "never"},
+			},
+			{
+				Code:    "import foo = require('foo');",
+				Options: map[string]interface{}{"types": "never"},
+			},
+			{
+				Code:    "import * as foo from 'foo';",
+				Options: map[string]interface{}{"lib": "never"},
+			},
+			{
+				Code:    "import foo = require('foo');",
+				Options: map[string]interface{}{"lib": "never"},
+			},
+			{
+				Code:    "import * as foo from 'foo';",
+				Options: map[string]interface{}{"types": "prefer-import"},
+			},
+			{
+				Code:    "import foo = require('foo');",
+				Options: map[string]interface{}{"types": "prefer-import"},
+			},
 			{
 				Code: `
 /// <reference types="foo" />
+import * as bar from 'bar';
 `,
-				Options: map[string]interface{}{
-					"types": "prefer-import",
-				},
+				Options: map[string]interface{}{"types": "prefer-import"},
 			},
-			// Commented-out references
-			{
-				Code: `
-/* /// <reference types="foo" /> */
-import * as foo from 'foo';
-`,
-				Options: map[string]interface{}{
-					"lib":   "never",
-					"path":  "never",
-					"types": "never",
-				},
-			},
-			// Reference-directive-looking text inside a multi-line block comment
 			{
 				Code: `
 /*
@@ -70,115 +137,50 @@ import * as foo from 'foo';
 */
 import * as foo from 'foo';
 `,
-				Options: map[string]interface{}{
-					"lib":   "never",
-					"path":  "never",
-					"types": "never",
-				},
-			},
-			// Reference-directive-looking text inside a template literal (not a real comment)
-			{
-				Code: "const content = `/// <reference types=\"foo\" />`;\nimport * as foo from 'foo';\n",
-				Options: map[string]interface{}{
-					"lib":   "never",
-					"path":  "never",
-					"types": "never",
-				},
-			},
-			// Reference-directive-looking text inside a tagged template literal
-			{
-				Code: "const content = dedent`/// <reference types=\"foo\" />`;\nimport * as foo from 'foo';\n",
-				Options: map[string]interface{}{
-					"lib":   "never",
-					"path":  "never",
-					"types": "never",
-				},
-			},
-			// Reference-directive-looking text inside a regular string literal
-			{
-				Code: `const content = '/// <reference path="foo" />';`,
-				Options: map[string]interface{}{
-					"lib":   "never",
-					"path":  "never",
-					"types": "never",
-				},
+				Options: never,
 			},
 		},
 		[]rule_tester.InvalidTestCase{
-			// Triple-slash types with prefer-import (ES6 import)
 			{
 				Code: `
 /// <reference types="foo" />
 import * as foo from 'foo';
 `,
-				Options: map[string]interface{}{
-					"types": "prefer-import",
-				},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{
-						MessageId: "tripleSlashReference",
-						Line:      2,
-						Column:    1,
-					},
-				},
+				Options: map[string]interface{}{"types": "prefer-import"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(2, 1, "foo")},
 			},
-			// Triple-slash path when never allowed
 			{
-				Code: `/// <reference path="foo" />`,
-				Options: map[string]interface{}{
-					"path": "never",
-				},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{
-						MessageId: "tripleSlashReference",
-						Line:      1,
-						Column:    1,
-					},
-				},
+				Code: `
+/// <reference types="foo" />
+import foo = require('foo');
+`,
+				Options: map[string]interface{}{"types": "prefer-import"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(2, 1, "foo")},
 			},
-			// Triple-slash types when never allowed
 			{
-				Code: `/// <reference types="foo" />`,
-				Options: map[string]interface{}{
-					"types": "never",
-				},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{
-						MessageId: "tripleSlashReference",
-						Line:      1,
-						Column:    1,
-					},
-				},
+				Code:    `/// <reference path="foo" />`,
+				Options: map[string]interface{}{"path": "never"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(1, 1, "foo")},
 			},
-			// Triple-slash lib when never allowed
 			{
-				Code: `/// <reference lib="foo" />`,
-				Options: map[string]interface{}{
-					"lib": "never",
-				},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{
-						MessageId: "tripleSlashReference",
-						Line:      1,
-						Column:    1,
-					},
-				},
+				Code:    `/// <reference types="foo" />`,
+				Options: map[string]interface{}{"types": "never"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(1, 1, "foo")},
 			},
-			// A real triple-slash reference is still reported when a lookalike
-			// string literal appears elsewhere in the same file.
 			{
-				Code: "/// <reference path=\"foo\" />\nconst content = '/// <reference path=\"bar\" />';\n",
-				Options: map[string]interface{}{
-					"path": "never",
-				},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{
-						MessageId: "tripleSlashReference",
-						Line:      1,
-						Column:    1,
-					},
-				},
+				Code:    `/// <reference lib="foo" />`,
+				Options: map[string]interface{}{"lib": "never"},
+				Errors:  []rule_tester.InvalidTestCaseError{tripleSlashReferenceError(1, 1, "foo")},
 			},
 		},
 	)
+}
+
+func tripleSlashReferenceError(line int, column int, module string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "tripleSlashReference",
+		Message:   "Do not use a triple slash reference for " + module + ", use `import` style instead.",
+		Line:      line,
+		Column:    column,
+	}
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -414,7 +414,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/strict-boolean-expressions.test.ts',
     './tests/typescript-eslint/rules/strict-void-return.test.ts',
     // './tests/typescript-eslint/rules/switch-exhaustiveness-check.test.ts',
-    // './tests/typescript-eslint/rules/triple-slash-reference.test.ts',
+    './tests/typescript-eslint/rules/triple-slash-reference.test.ts',
     // './tests/typescript-eslint/rules/typedef.test.ts',
     // './tests/typescript-eslint/rules/unbound-method.test.ts',
     // './tests/typescript-eslint/rules/unified-signatures.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/triple-slash-reference.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/triple-slash-reference.test.ts.snap
@@ -1,0 +1,137 @@
+// Rstest Snapshot v1
+
+exports[`triple-slash-reference > invalid 1`] = `
+{
+  "code": "
+/// <reference types="foo" />
+import * as foo from 'foo';
+      ",
+  "diagnostics": [
+    {
+      "message": "Do not use a triple slash reference for foo, use \`import\` style instead.",
+      "messageId": "tripleSlashReference",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/triple-slash-reference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`triple-slash-reference > invalid 2`] = `
+{
+  "code": "
+/// <reference types="foo" />
+import foo = require('foo');
+      ",
+  "diagnostics": [
+    {
+      "message": "Do not use a triple slash reference for foo, use \`import\` style instead.",
+      "messageId": "tripleSlashReference",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/triple-slash-reference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`triple-slash-reference > invalid 3`] = `
+{
+  "code": "/// <reference path="foo" />",
+  "diagnostics": [
+    {
+      "message": "Do not use a triple slash reference for foo, use \`import\` style instead.",
+      "messageId": "tripleSlashReference",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/triple-slash-reference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`triple-slash-reference > invalid 4`] = `
+{
+  "code": "/// <reference types="foo" />",
+  "diagnostics": [
+    {
+      "message": "Do not use a triple slash reference for foo, use \`import\` style instead.",
+      "messageId": "tripleSlashReference",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/triple-slash-reference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`triple-slash-reference > invalid 5`] = `
+{
+  "code": "/// <reference lib="foo" />",
+  "diagnostics": [
+    {
+      "message": "Do not use a triple slash reference for foo, use \`import\` style instead.",
+      "messageId": "tripleSlashReference",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/triple-slash-reference",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

- Avoid materializing the full-file comment/token tree for `@typescript-eslint/triple-slash-reference` by scanning only leading comments and deferring exact import matching to listeners.
- Align defaults, matching behavior, diagnostics, and import-equals handling with the upstream typescript-eslint rule.
- Add upstream compatibility coverage, adversarial edge cases, documentation updates, and JS integration snapshots.
- Reduce the 64 KiB ordinary-comment rule benchmark from 10.8 ms and 216,810 allocations to 6.4 µs and 9 allocations.

## Related Links

- Rule documentation: https://typescript-eslint.io/rules/triple-slash-reference/
- Upstream source: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/triple-slash-reference.ts
- Upstream tests: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/triple-slash-reference.test.ts

## Verification

- `go test -count=1 ./internal/plugins/typescript/rules/triple_slash_reference`
- `npx rstest run --testTimeout=10000 triple-slash-reference`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m ./internal/plugins/typescript/rules/triple_slash_reference`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
