### PR TITLE
docs: refresh Rstack slogan

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See [Guide](https://rslint.rs/guide/).
 
 ## 🦀 Rstack
 
-Rstack is a unified JavaScript toolchain built around Rspack, with high performance and consistent architecture.
+Rslint is part of Rstack, the fast, unified JavaScript toolchain for developers and agents.
 
 | Name                                                  | Description              | Version                                                                                                                                                                          |
 | ----------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,8 +426,8 @@ importers:
         specifier: ^2.0.15
         version: 2.0.15(@rspress/core@2.0.15(@rspack/core@2.1.5(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))
       '@rstack-dev/doc-ui':
-        specifier: 1.14.2
-        version: 1.14.2(@rspress/core@2.0.15(@rspack/core@2.1.5(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))
+        specifier: 1.14.7
+        version: 1.14.7(@rspress/core@2.0.15(@rspack/core@2.1.5(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -2544,8 +2544,8 @@ packages:
   '@rspress/shared@2.0.15':
     resolution: {integrity: sha512-o8aYwEzNuTmWnmKe91ntPv+34u3RbtAe+rcK9XC5MANOlgncwOaCs3bUa8/B1/llwyLoNgrpi+VB9bEiU11ZRQ==}
 
-  '@rstack-dev/doc-ui@1.14.2':
-    resolution: {integrity: sha512-bnQY2rHLKvqOfEp/fGjEmMM9WTVsLEL9BwaQXN7jnX9zfA1AWx9ic2lBbOEBtuQ3/cg5uTB3pKNukXQTtytKwA==}
+  '@rstack-dev/doc-ui@1.14.7':
+    resolution: {integrity: sha512-PnY2JKleZxQTbSrxRAyG84lBKNwXwB+v05sUOFxF5qD1UPmBn/bzRmL4zNOPq1qG4d0PjTG62weetryub40M2A==}
     peerDependencies:
       '@rspress/core': '>=2.0.0'
     peerDependenciesMeta:
@@ -8427,7 +8427,7 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rstack-dev/doc-ui@1.14.2(@rspress/core@2.0.15(@rspack/core@2.1.5(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rstack-dev/doc-ui@1.14.7(@rspress/core@2.0.15(@rspack/core@2.1.5(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))':
     optionalDependencies:
       '@rspress/core': 2.0.15(@rspack/core@2.1.5(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,8 @@ minimumReleaseAgeExclude:
   - '@rstest/*'
   - '@rsdoctor/*'
   - '@rslint/*'
+  - '@rstackjs/*'
+  - '@rstack-dev/*'
 
 # Prevent un-reviewed build scripts
 strictDepBuilds: true

--- a/website/package.json
+++ b/website/package.json
@@ -31,7 +31,7 @@
     "@rslint/wasm": "workspace:*",
     "@rspress/core": "^2.0.15",
     "@rspress/plugin-sitemap": "^2.0.15",
-    "@rstack-dev/doc-ui": "1.14.2",
+    "@rstack-dev/doc-ui": "1.14.7",
     "@tailwindcss/postcss": "^4.3.0",
     "@types/dagre": "^0.7.53",
     "@types/node": "^22.20.0",


### PR DESCRIPTION
## Summary

This PR refreshes the Rstack slogan in the README to clarify that Rslint is part of the unified toolchain.

It also upgrades `@rstack-dev/doc-ui` to v1.14.7 and exempts Rstack packages from the minimum release age so coordinated website updates can be installed immediately.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8179
- https://github.com/rstackjs/rstack-doc-ui/releases/tag/v1.14.7

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).