### PR TITLE
fix: prevent IPC acknowledgement races

### DIFF
--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -133,8 +133,13 @@ type runtimePayload struct {
 // runCLIState carries the init-handshake outcome from the inbound handler
 // (which runs on the channel's read-loop goroutine) to the runCLI main
 // goroutine, and tracks whether a termination signal fired.
+type initDelivery struct {
+	payload *initPayload
+	reply   *ipc.ResponseReceipt
+}
+
 type runCLIState struct {
-	payloadCh chan *initPayload // 1-buffered; receives at most one payload
+	payloadCh chan initDelivery // 1-buffered; receives at most one result
 	once      sync.Once
 	signalled atomic.Bool // set on SIGINT/SIGTERM/SIGHUP
 }
@@ -165,7 +170,7 @@ func runCLI(args []string) int {
 	origStdout := os.Stdout
 	ch := ipc.NewChannel(os.Stdin, origStdout)
 
-	state := &runCLIState{payloadCh: make(chan *initPayload, 1)}
+	state := &runCLIState{payloadCh: make(chan initDelivery, 1)}
 
 	// Mirror lintCtx cancellation onto state.signalled so the final exit-code
 	// mapping (130 when set) works even when the signal arrives after the
@@ -188,9 +193,12 @@ func runCLI(args []string) int {
 			if err := msg.Decode(&p); err != nil {
 				return nil, fmt.Errorf("decode init: %w", err)
 			}
+			response, receipt := ipc.TrackResponse(map[string]any{"ok": true})
 			// Exactly-once: engine.ts sends one init; defensive vs a buggy peer.
-			state.once.Do(func() { state.payloadCh <- &p })
-			return map[string]any{"ok": true}, nil
+			state.once.Do(func() {
+				state.payloadCh <- initDelivery{payload: &p, reply: receipt}
+			})
+			return response, nil
 		default:
 			return nil, fmt.Errorf("rslint: unsupported inbound kind %q", msg.Kind)
 		}
@@ -205,7 +213,7 @@ func runCLI(args []string) int {
 		<-ch.Done()
 		state.once.Do(func() {
 			select {
-			case state.payloadCh <- nil:
+			case state.payloadCh <- initDelivery{}:
 			default:
 			}
 		})
@@ -218,9 +226,9 @@ func runCLI(args []string) int {
 	initTimer := time.NewTimer(initTimeout)
 	defer initTimer.Stop()
 
-	var payload *initPayload
+	var delivery initDelivery
 	select {
-	case payload = <-state.payloadCh:
+	case delivery = <-state.payloadCh:
 	case <-sigChInit:
 		state.signalled.Store(true)
 		_ = ch.Close()
@@ -230,10 +238,43 @@ func runCLI(args []string) int {
 		_ = ch.Close()
 		return 2
 	}
-	if payload == nil {
+	if delivery.payload == nil {
 		_ = ch.Close() // peer disconnected before init
 		return 2
 	}
+
+	// The handler has decoded and reserved this init, but the application may
+	// not observe it until the complete response frame has reached stdout.
+	// Keep the original signal/timeout progress guarantees while waiting.
+	select {
+	case <-delivery.reply.Done():
+		if delivery.reply.Err() != nil {
+			_ = ch.Close()
+			return 2
+		}
+	case <-sigChInit:
+		state.signalled.Store(true)
+		_ = ch.Close()
+		return 130
+	case <-initTimer.C:
+		fmt.Fprintf(os.Stderr, "rslint: timed out waiting for init after %s\n", initTimeout)
+		_ = ch.Close()
+		return 2
+	case <-ch.Done():
+		// A successful receipt may race a peer EOF. Prefer the committed reply
+		// when both are ready; otherwise the transport ended before the ACK.
+		select {
+		case <-delivery.reply.Done():
+		default:
+			_ = ch.Close()
+			return 2
+		}
+		if delivery.reply.Err() != nil {
+			_ = ch.Close()
+			return 2
+		}
+	}
+	payload := delivery.payload
 
 	// Apply the payload. Working directory and the positional file set are
 	// payload-authoritative; the rest supplement flag values.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/microsoft/typescript-go/shim/api/encoder"
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -269,27 +268,18 @@ type Service struct {
 	handshakeOK      bool
 	peerCapabilities map[string]struct{}
 
-	exitMu        sync.Mutex
-	exitRequestID int
 	exitRequested bool
-	exitAck       chan struct{}
-	exitAckOnce   sync.Once
+	exitReply     chan *ipc.ResponseReceipt
 }
 
 // NewService creates a new IPC service
 func NewService(reader io.Reader, writer io.Writer, handler Handler) *Service {
 	s := &Service{
-		handler: handler,
-		reader:  &observedReader{reader: reader},
-		exitAck: make(chan struct{}),
+		handler:   handler,
+		reader:    &observedReader{reader: reader},
+		exitReply: make(chan *ipc.ResponseReceipt, 1),
 	}
-	observedWriter := &frameObserverWriter{
-		writer:        writer,
-		remaining:     -1,
-		shouldCapture: s.exitHasBeenRequested,
-		onFrame:       s.observeOutboundFrame,
-	}
-	s.channel = ipc.NewChannel(s.reader, observedWriter)
+	s.channel = ipc.NewChannel(s.reader, writer)
 	s.channel.SetInboundHandler(s.handleInbound)
 	return s
 }
@@ -298,22 +288,34 @@ func NewService(reader io.Reader, writer io.Writer, handler Handler) *Service {
 func (s *Service) Start() error {
 	s.channel.Start()
 	select {
-	case <-s.exitAck:
-		// The complete exit response frame has reached the underlying writer.
-		// Closing earlier can race Channel's asynchronous inbound handler and
-		// suppress the ack that legacy Node/browser clients await.
+	case receipt := <-s.exitReply:
+		select {
+		case <-receipt.Done():
+			if err := receipt.Err(); err != nil {
+				_ = s.channel.Close()
+				return fmt.Errorf("api: write exit acknowledgement: %w", err)
+			}
+		case <-s.channel.Done():
+			return s.channelResult()
+		}
+		// A terminal response seals later writes before completing its receipt;
+		// Close now publishes channel shutdown without racing a queued writer.
 		_ = s.channel.Close()
 		return nil
 	case <-s.channel.Done():
-		err := s.reader.Err()
-		if errors.Is(err, io.EOF) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		return errors.New("api: IPC transport closed unexpectedly")
+		return s.channelResult()
 	}
+}
+
+func (s *Service) channelResult() error {
+	err := s.reader.Err()
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return errors.New("api: IPC transport closed unexpectedly")
 }
 
 func (s *Service) handleInbound(ctx context.Context, msg *ipc.Message) (any, error) {
@@ -388,35 +390,17 @@ func (s *Service) handleInbound(ctx context.Context, msg *ipc.Message) (any, err
 		return s.handler.HandleGetAstInfo(req)
 
 	case ipc.KindExit:
-		s.exitMu.Lock()
-		if !s.exitRequested {
-			s.exitRequested = true
-			s.exitRequestID = msg.ID
+		if s.exitRequested {
+			return struct{}{}, nil
 		}
-		s.exitMu.Unlock()
-		return struct{}{}, nil
+		s.exitRequested = true
+		response, receipt := ipc.TrackTerminalResponse(struct{}{})
+		s.exitReply <- receipt
+		return response, nil
 
 	default:
 		return nil, fmt.Errorf("unknown message kind: %s", msg.Kind)
 	}
-}
-
-func (s *Service) observeOutboundFrame(msg *ipc.Message) {
-	if msg.Kind != ipc.KindResponse && msg.Kind != ipc.KindError {
-		return
-	}
-	s.exitMu.Lock()
-	isExitAck := s.exitRequested && msg.ID == s.exitRequestID
-	s.exitMu.Unlock()
-	if isExitAck {
-		s.exitAckOnce.Do(func() { close(s.exitAck) })
-	}
-}
-
-func (s *Service) exitHasBeenRequested() bool {
-	s.exitMu.Lock()
-	defer s.exitMu.Unlock()
-	return s.exitRequested
 }
 
 // observedReader records the terminal read error so Service.Start can retain
@@ -482,90 +466,6 @@ func (r *observedReader) Err() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.err
-}
-
-// frameObserverWriter observes complete outbound frames after their bytes have
-// been accepted by the real writer. It normally tracks lengths only; after an
-// exit request arrives it captures response bodies until the matching ack is
-// seen. Channel serializes all calls into it.
-type frameObserverWriter struct {
-	writer        io.Writer
-	shouldCapture func() bool
-	onFrame       func(*ipc.Message)
-	mu            sync.Mutex
-	header        [4]byte
-	headerLen     int
-	remaining     int
-	capture       bool
-	body          []byte
-}
-
-func (w *frameObserverWriter) Write(p []byte) (int, error) {
-	n, err := w.writer.Write(p)
-	if n != len(p) && err == nil {
-		err = io.ErrShortWrite
-	}
-	if n <= 0 {
-		return n, err
-	}
-
-	w.mu.Lock()
-	var completed []*ipc.Message
-	data := p[:n]
-	for len(data) > 0 {
-		if w.remaining < 0 {
-			headerBytes := min(4-w.headerLen, len(data))
-			copy(w.header[w.headerLen:], data[:headerBytes])
-			w.headerLen += headerBytes
-			data = data[headerBytes:]
-			if w.headerLen < 4 {
-				continue
-			}
-			w.remaining = int(binary.LittleEndian.Uint32(w.header[:]))
-			w.headerLen = 0
-			w.capture = w.shouldCapture()
-			if w.capture {
-				w.body = make([]byte, 0, w.remaining)
-			}
-		}
-
-		bodyBytes := min(w.remaining, len(data))
-		if w.capture {
-			w.body = append(w.body, data[:bodyBytes]...)
-		}
-		w.remaining -= bodyBytes
-		data = data[bodyBytes:]
-		if w.remaining == 0 {
-			if w.capture {
-				var msg ipc.Message
-				if json.Unmarshal(w.body, &msg) == nil {
-					completed = append(completed, &msg)
-				}
-			}
-			w.remaining = -1
-			w.capture = false
-			w.body = nil
-		}
-	}
-	w.mu.Unlock()
-
-	if err == nil {
-		for _, msg := range completed {
-			w.onFrame(msg)
-		}
-	}
-	return n, err
-}
-
-// Preserve Channel's write-deadline support when the underlying writer is an
-// *os.File or net.Conn. Channel intentionally ignores unsupported deadlines.
-func (w *frameObserverWriter) SetWriteDeadline(deadline time.Time) error {
-	if writer, ok := w.writer.(interface {
-		SetWriteDeadline(deadline time.Time) error
-	}); ok {
-		return writer.SetWriteDeadline(deadline)
-	}
-	return nil
 }
 
 // IsIPCMode returns true if the process is in IPC mode

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"io"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -134,6 +136,124 @@ func requestContext(t *testing.T) context.Context {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	t.Cleanup(cancel)
 	return ctx
+}
+
+type gatedAPIWriter struct {
+	mu          sync.Mutex
+	buf         bytes.Buffer
+	calls       int
+	bodyEntered chan struct{}
+	releaseBody chan struct{}
+	releaseOnce sync.Once
+}
+
+func newGatedAPIWriter() *gatedAPIWriter {
+	return &gatedAPIWriter{
+		bodyEntered: make(chan struct{}),
+		releaseBody: make(chan struct{}),
+	}
+}
+
+func (w *gatedAPIWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.calls++
+	call := w.calls
+	w.mu.Unlock()
+	if call == 2 {
+		close(w.bodyEntered)
+		<-w.releaseBody
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *gatedAPIWriter) release() {
+	w.releaseOnce.Do(func() { close(w.releaseBody) })
+}
+
+func (w *gatedAPIWriter) bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return bytes.Clone(w.buf.Bytes())
+}
+
+func TestService_ExitWaitsForCompleteAcknowledgement(t *testing.T) {
+	inR, inW := io.Pipe()
+	t.Cleanup(func() { _ = inW.Close() })
+	writer := newGatedAPIWriter()
+	t.Cleanup(writer.release)
+	service := NewService(inR, writer, &serviceTestHandler{})
+
+	serviceDone := make(chan error, 1)
+	go func() { serviceDone <- service.Start() }()
+
+	request, err := ipc.NewMessage(ipc.KindExit, 17, struct{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ipc.WriteFrame(inW, request); err != nil {
+		t.Fatalf("write exit request: %v", err)
+	}
+	select {
+	case <-writer.bodyEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("exit acknowledgement did not reach the body-write gate")
+	}
+	select {
+	case err := <-serviceDone:
+		t.Fatalf("service returned before the complete exit acknowledgement: %v", err)
+	default:
+	}
+
+	writer.release()
+	select {
+	case err := <-serviceDone:
+		if err != nil {
+			t.Fatalf("service exit: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("service did not return after the complete exit acknowledgement")
+	}
+
+	response, err := ipc.ReadFrame(bufio.NewReader(bytes.NewReader(writer.bytes())))
+	if err != nil {
+		t.Fatalf("read exit acknowledgement: %v", err)
+	}
+	if response.Kind != ipc.KindResponse || response.ID != 17 {
+		t.Fatalf("exit acknowledgement = kind %q id %d", response.Kind, response.ID)
+	}
+}
+
+type failingAPIWriter struct{}
+
+func (failingAPIWriter) Write([]byte) (int, error) {
+	return 0, errors.New("api writer boom")
+}
+
+func TestService_ExitWriteFailureIsNotSuccess(t *testing.T) {
+	inR, inW := io.Pipe()
+	t.Cleanup(func() { _ = inW.Close() })
+	service := NewService(inR, failingAPIWriter{}, &serviceTestHandler{})
+
+	serviceDone := make(chan error, 1)
+	go func() { serviceDone <- service.Start() }()
+	request, err := ipc.NewMessage(ipc.KindExit, 23, struct{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ipc.WriteFrame(inW, request); err != nil {
+		t.Fatalf("write exit request: %v", err)
+	}
+
+	select {
+	case err := <-serviceDone:
+		if err == nil {
+			t.Fatal("exit acknowledgement write failure returned success")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("service hung after the exit acknowledgement write failed")
+	}
 }
 
 func TestService_BidirectionalLintKeepsReadLoopRunning(t *testing.T) {

--- a/internal/ipc/channel.go
+++ b/internal/ipc/channel.go
@@ -17,6 +17,61 @@ import (
 // channel closes.
 type InboundHandler func(ctx context.Context, msg *Message) (any, error)
 
+// ResponseReceipt is completed by Channel after an inbound response reaches a
+// terminal write outcome. A nil Err means the complete intended response frame
+// was accepted by the underlying writer. Call Err only after Done is closed.
+//
+// The receipt is framework-owned: completing it never calls application code,
+// so Channel may safely publish the successful write commit point while holding
+// its write lock.
+type ResponseReceipt struct {
+	done chan struct{}
+	once sync.Once
+	err  error
+}
+
+// Done closes exactly once when the response write succeeds or cannot succeed.
+func (r *ResponseReceipt) Done() <-chan struct{} { return r.done }
+
+// Err returns the response write outcome. It must be called after Done closes.
+func (r *ResponseReceipt) Err() error { return r.err }
+
+func (r *ResponseReceipt) complete(err error) {
+	r.once.Do(func() {
+		r.err = err
+		close(r.done)
+	})
+}
+
+type trackedResponse struct {
+	payload  any
+	receipt  *ResponseReceipt
+	terminal bool
+}
+
+// TrackResponse wraps an inbound handler result and returns a receipt for its
+// response write. The wire payload is unchanged; only Channel sees the wrapper.
+func TrackResponse(payload any) (any, *ResponseReceipt) {
+	return newTrackedResponse(payload, false)
+}
+
+// TrackTerminalResponse is TrackResponse plus a write-side seal: after the
+// complete response frame is accepted, Channel rejects every later frame. This
+// is used by terminal protocol requests whose acknowledgement must be the last
+// outbound frame.
+func TrackTerminalResponse(payload any) (any, *ResponseReceipt) {
+	return newTrackedResponse(payload, true)
+}
+
+func newTrackedResponse(payload any, terminal bool) (any, *ResponseReceipt) {
+	receipt := &ResponseReceipt{done: make(chan struct{})}
+	return &trackedResponse{
+		payload:  payload,
+		receipt:  receipt,
+		terminal: terminal,
+	}, receipt
+}
+
 // NotificationHandler handles an inbound notification (id == 0). No reply.
 type NotificationHandler func(msg *Message)
 
@@ -53,7 +108,12 @@ type Channel struct {
 	nextID   int
 	closed   bool
 	closeErr error
-	started  bool
+	// writeSealed rejects frames that have not yet passed write admission.
+	// It is published while writeMu is held on a terminal response or write
+	// fault, closing the unlock-before-close race for queued writers.
+	writeSealed  bool
+	writeSealErr error
+	started      bool
 
 	notifyHandlers map[MessageKind]NotificationHandler
 	inbound        InboundHandler
@@ -67,6 +127,11 @@ type Channel struct {
 // non-draining) peer can't block a write forever. Re-armed per write in
 // writeFrame; only applies to writers that support SetWriteDeadline.
 const defaultWriteTimeout = 30 * time.Second
+
+var (
+	errTerminalResponse = errors.New("ipc: writes sealed after terminal response")
+	errWriteNotAdmitted = errors.New("ipc: write not admitted")
+)
 
 // NewChannel creates a channel over r (inbound frames) and w (outbound
 // frames). Call SetInboundHandler/RegisterNotification before Start.
@@ -214,18 +279,88 @@ type deadlineWriter interface{ SetWriteDeadline(t time.Time) error }
 // SendRequest wakes via c.done instead of hanging forever. The deadline is
 // re-armed on each write (a stale past-deadline can't linger to a later call).
 func (c *Channel) writeFrame(msg *Message) error {
+	return c.writeFrameTracked(msg, nil, false)
+}
+
+// writeFrameTracked writes one frame and optionally publishes its completion
+// through receipt. Write admission and terminal/failure sealing are serialized
+// by writeMu:
+//
+//   - queued writers check closed/sealed only after acquiring writeMu;
+//   - a write fault seals admission before releasing writeMu, so a partially
+//     written frame can never be followed by another frame;
+//   - a terminal response seals admission before its successful receipt is
+//     completed, so the waiter does not need to win a scheduling race to Close.
+func (c *Channel) writeFrameTracked(msg *Message, receipt *ResponseReceipt, terminal bool) error {
 	c.writeMu.Lock()
+
+	if err := c.writeAdmissionError(); err != nil {
+		c.writeMu.Unlock()
+		if receipt != nil {
+			receipt.complete(err)
+		}
+		return err
+	}
+
+	err := c.writeFrameBytes(msg)
+	if err != nil {
+		c.sealWrites(err)
+	} else if terminal {
+		c.sealWrites(errTerminalResponse)
+	}
+	if err == nil && receipt != nil {
+		// Framework-owned and non-blocking; safe while writeMu establishes the
+		// response-before-application commit point.
+		receipt.complete(nil)
+	}
+	c.writeMu.Unlock()
+
+	if err != nil {
+		c.closeWith(err)
+		if receipt != nil {
+			receipt.complete(err)
+		}
+	}
+	return err
+}
+
+func (c *Channel) writeFrameBytes(msg *Message) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("ipc: writer panicked: %v", recovered)
+		}
+	}()
 	if c.writeTimeout > 0 {
 		if dw, ok := c.writer.(deadlineWriter); ok {
 			_ = dw.SetWriteDeadline(time.Now().Add(c.writeTimeout))
 		}
 	}
-	err := WriteFrame(c.writer, msg)
-	c.writeMu.Unlock()
-	if err != nil {
-		c.closeWith(err)
+	return WriteFrame(c.writer, msg)
+}
+
+// writeAdmissionError is called only while writeMu is held.
+func (c *Channel) writeAdmissionError() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.writeSealed {
+		return fmt.Errorf("%w: %w", errWriteNotAdmitted, c.writeSealErr)
 	}
-	return err
+	if c.closed {
+		return fmt.Errorf("%w: %w", errWriteNotAdmitted, c.closeErr)
+	}
+	return nil
+}
+
+// sealWrites is called only while writeMu is held. The first seal reason wins,
+// giving every queued writer a stable terminal error.
+func (c *Channel) sealWrites(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.writeSealed {
+		return
+	}
+	c.writeSealed = true
+	c.writeSealErr = err
 }
 
 func (c *Channel) readLoop() {
@@ -302,52 +437,110 @@ func (c *Channel) dispatch(msg *Message) {
 		c.sendError(msg.ID, fmt.Sprintf("no inbound handler registered (kind=%s)", msg.Kind))
 		return
 	}
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				c.sendError(msg.ID, fmt.Sprintf("inbound handler panicked: %v", r))
+	go c.handleInboundRequest(h, msg)
+}
+
+func (c *Channel) handleInboundRequest(h InboundHandler, msg *Message) {
+	result, err := callInboundHandler(h, c.inCtx, msg)
+	if err != nil {
+		err = stableInboundError(err)
+		if _, receipt, _, tracked := unwrapTrackedResponse(result); tracked {
+			writeErr := c.sendErrorFrame(msg.ID, err.Error(), true)
+			if writeErr != nil {
+				err = errors.Join(err, writeErr)
+				if !errors.Is(writeErr, errWriteNotAdmitted) {
+					fmt.Fprintf(os.Stderr, "rslint: write error (id=%d): %v\n", msg.ID, writeErr)
+				}
 			}
-		}()
-		result, err := h(c.inCtx, msg)
-		if err != nil {
-			c.sendError(msg.ID, err.Error())
+			receipt.complete(err)
 			return
 		}
-		c.sendResponse(msg.ID, result)
+		c.sendError(msg.ID, err.Error())
+		return
+	}
+	c.sendResponse(msg.ID, result)
+}
+
+// callInboundHandler scopes panic recovery to application code. Response
+// writing happens afterward, so a post-handler transport failure can never be
+// mistaken for a handler panic and produce a second response for the same ID.
+func callInboundHandler(h InboundHandler, ctx context.Context, msg *Message) (result any, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result = nil
+			err = fmt.Errorf("inbound handler panicked: %v", recovered)
+		}
 	}()
+	return h(ctx, msg)
+}
+
+func stableInboundError(err error) (stable error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			stable = fmt.Errorf("inbound handler error panicked: %v", recovered)
+		}
+	}()
+	return errors.New(err.Error())
 }
 
 func (c *Channel) sendResponse(id int, payload any) {
-	if c.isClosed() {
-		return
-	}
-	msg, err := NewMessage(KindResponse, id, payload)
+	payload, receipt, terminal, _ := unwrapTrackedResponse(payload)
+
+	msg, err := newResponseMessage(id, payload)
 	if err != nil {
-		c.sendError(id, fmt.Sprintf("marshal response failed: %v", err))
+		// The intended response was not written. A tracked lifecycle response
+		// seals after its fallback error frame so its waiter can abort without
+		// another writer overtaking the eventual Close.
+		writeErr := c.sendErrorFrame(
+			id,
+			fmt.Sprintf("marshal response failed: %v", err),
+			receipt != nil || terminal,
+		)
+		if receipt != nil {
+			if writeErr != nil {
+				err = errors.Join(err, writeErr)
+			}
+			receipt.complete(err)
+		}
 		return
 	}
-	if err := c.writeFrame(msg); err != nil {
+	if err := c.writeFrameTracked(msg, receipt, terminal); err != nil &&
+		!errors.Is(err, errWriteNotAdmitted) {
 		fmt.Fprintf(os.Stderr, "rslint: write response (id=%d): %v\n", id, err)
 	}
 }
 
+func unwrapTrackedResponse(payload any) (any, *ResponseReceipt, bool, bool) {
+	tracked, ok := payload.(*trackedResponse)
+	if !ok {
+		return payload, nil, false, false
+	}
+	return tracked.payload, tracked.receipt, tracked.terminal, true
+}
+
 func (c *Channel) sendError(id int, message string) {
-	if c.isClosed() {
-		return
-	}
-	msg := &Message{Kind: KindError, ID: id}
-	if raw, err := marshalJSON(ErrorResponseData{Message: message}); err == nil {
-		msg.Data = raw
-	}
-	if err := c.writeFrame(msg); err != nil {
+	if err := c.sendErrorFrame(id, message, false); err != nil &&
+		!errors.Is(err, errWriteNotAdmitted) {
 		fmt.Fprintf(os.Stderr, "rslint: write error (id=%d): %v\n", id, err)
 	}
 }
 
-func (c *Channel) isClosed() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.closed
+func (c *Channel) sendErrorFrame(id int, message string, terminal bool) error {
+	msg := &Message{Kind: KindError, ID: id}
+	if raw, err := marshalJSON(ErrorResponseData{Message: message}); err == nil {
+		msg.Data = raw
+	}
+	return c.writeFrameTracked(msg, nil, terminal)
+}
+
+func newResponseMessage(id int, payload any) (msg *Message, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			msg = nil
+			err = fmt.Errorf("ipc: marshal response payload panicked: %v", recovered)
+		}
+	}()
+	return NewMessage(KindResponse, id, payload)
 }
 
 // closeWith shuts the channel down: marks closed, records the cause, cancels
@@ -382,6 +575,10 @@ func (c *Channel) closeWith(cause error) {
 		c.closeErr = errors.New("ipc: channel closed (peer EOF)")
 	} else {
 		c.closeErr = fmt.Errorf("ipc: channel closed: %w", cause)
+	}
+	if !c.writeSealed {
+		c.writeSealed = true
+		c.writeSealErr = c.closeErr
 	}
 	c.pending = make(map[int]chan *Message) // drop refs; waiters wake via c.done
 	c.mu.Unlock()

--- a/internal/ipc/channel_test.go
+++ b/internal/ipc/channel_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -193,6 +194,55 @@ func TestFrame_RoundTrip(t *testing.T) {
 	}
 }
 
+type shortWriteWriter struct {
+	failCall int
+	failN    func(int) int
+	failErr  error
+	calls    int
+}
+
+func (w *shortWriteWriter) Write(p []byte) (int, error) {
+	w.calls++
+	if w.calls == w.failCall {
+		return w.failN(len(p)), w.failErr
+	}
+	return len(p), nil
+}
+
+func TestWriteFrame_RejectsShortWrites(t *testing.T) {
+	msg, err := NewMessage("hello", 7, map[string]int{"x": 42})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeBoom := errors.New("write boom")
+	tests := []struct {
+		name     string
+		failCall int
+		failN    func(int) int
+		failErr  error
+		want     error
+	}{
+		{"header partial nil", 1, func(n int) int { return n - 1 }, nil, io.ErrShortWrite},
+		{"header zero nil", 1, func(int) int { return 0 }, nil, io.ErrShortWrite},
+		{"body partial nil", 2, func(n int) int { return n - 1 }, nil, io.ErrShortWrite},
+		{"body zero nil", 2, func(int) int { return 0 }, nil, io.ErrShortWrite},
+		{"body full with error", 2, func(n int) int { return n }, writeBoom, writeBoom},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			writer := &shortWriteWriter{
+				failCall: test.failCall,
+				failN:    test.failN,
+				failErr:  test.failErr,
+			}
+			err := WriteFrame(writer, msg)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("WriteFrame error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
 // TestNewMessage_NilContainerPayloadOmitted pins the wire-parity fix: a nil
 // map/slice/pointer (and untyped nil) is "no payload" → the data field is
 // omitted, matching Node where `undefined` is dropped by JSON.stringify. An
@@ -263,6 +313,375 @@ func TestChannel_RegisterAfterStartPanics(t *testing.T) {
 type failWriter struct{}
 
 func (failWriter) Write([]byte) (int, error) { return 0, errors.New("write boom") }
+
+type gatedFrameWriter struct {
+	mu          sync.Mutex
+	buf         bytes.Buffer
+	calls       int
+	bodyEntered chan struct{}
+	releaseBody chan struct{}
+	releaseOnce sync.Once
+}
+
+func newGatedFrameWriter() *gatedFrameWriter {
+	return &gatedFrameWriter{
+		bodyEntered: make(chan struct{}),
+		releaseBody: make(chan struct{}),
+	}
+}
+
+func (w *gatedFrameWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.calls++
+	call := w.calls
+	w.mu.Unlock()
+	if call == 2 {
+		close(w.bodyEntered)
+		<-w.releaseBody
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *gatedFrameWriter) release() {
+	w.releaseOnce.Do(func() { close(w.releaseBody) })
+}
+
+func (w *gatedFrameWriter) bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return bytes.Clone(w.buf.Bytes())
+}
+
+func writeInboundRequest(t *testing.T, w io.Writer, kind MessageKind, id int) {
+	t.Helper()
+	msg, err := NewMessage(kind, id, struct{}{})
+	if err != nil {
+		t.Fatalf("NewMessage: %v", err)
+	}
+	if err := WriteFrame(w, msg); err != nil {
+		t.Fatalf("WriteFrame: %v", err)
+	}
+}
+
+func TestChannel_ResponseReceiptWaitsForCompleteFrame(t *testing.T) {
+	inR, inW := io.Pipe()
+	t.Cleanup(func() { _ = inW.Close() })
+	writer := newGatedFrameWriter()
+	t.Cleanup(writer.release)
+
+	receiptCh := make(chan *ResponseReceipt, 1)
+	c := NewChannel(inR, writer)
+	c.SetInboundHandler(func(context.Context, *Message) (any, error) {
+		response, receipt := TrackResponse(map[string]any{"ok": true})
+		receiptCh <- receipt
+		return response, nil
+	})
+	c.Start()
+	t.Cleanup(func() { _ = c.Close() })
+
+	writeInboundRequest(t, inW, "init", 1)
+	receipt := <-receiptCh
+	select {
+	case <-writer.bodyEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("response body write did not reach the gate")
+	}
+	select {
+	case <-receipt.Done():
+		t.Fatal("receipt completed before the response body write returned")
+	default:
+	}
+
+	writer.release()
+	select {
+	case <-receipt.Done():
+		if err := receipt.Err(); err != nil {
+			t.Fatalf("response receipt: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("receipt did not complete after the full response write")
+	}
+
+	msg, err := ReadFrame(bufio.NewReader(bytes.NewReader(writer.bytes())))
+	if err != nil {
+		t.Fatalf("read committed response: %v", err)
+	}
+	if msg.Kind != KindResponse || msg.ID != 1 {
+		t.Fatalf("committed frame = kind %q id %d, want response id 1", msg.Kind, msg.ID)
+	}
+}
+
+func TestChannel_ResponseReceiptReportsMarshalFailure(t *testing.T) {
+	inR, inW := io.Pipe()
+	t.Cleanup(func() { _ = inW.Close() })
+	var output bytes.Buffer
+
+	receiptCh := make(chan *ResponseReceipt, 1)
+	c := NewChannel(inR, &output)
+	c.SetInboundHandler(func(context.Context, *Message) (any, error) {
+		response, receipt := TrackResponse(func() {})
+		receiptCh <- receipt
+		return response, nil
+	})
+	c.Start()
+	t.Cleanup(func() { _ = c.Close() })
+
+	writeInboundRequest(t, inW, "init", 1)
+	receipt := <-receiptCh
+	select {
+	case <-receipt.Done():
+		if err := receipt.Err(); err == nil || !strings.Contains(err.Error(), "unsupported type") {
+			t.Fatalf("receipt error = %v, want marshal failure", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("marshal failure did not complete the response receipt")
+	}
+
+	msg, err := ReadFrame(bufio.NewReader(bytes.NewReader(output.Bytes())))
+	if err != nil {
+		t.Fatalf("read fallback error response: %v", err)
+	}
+	if msg.Kind != KindError || msg.ID != 1 {
+		t.Fatalf("fallback frame = kind %q id %d, want error id 1", msg.Kind, msg.ID)
+	}
+	if err := c.SendNotification("late", nil); err == nil {
+		t.Fatal("tracked marshal failure did not seal later writes")
+	}
+}
+
+func TestChannel_TrackedHandlerErrorCompletesReceipt(t *testing.T) {
+	inR, inW := io.Pipe()
+	t.Cleanup(func() { _ = inW.Close() })
+	var output bytes.Buffer
+	receiptCh := make(chan *ResponseReceipt, 1)
+
+	c := NewChannel(inR, &output)
+	c.SetInboundHandler(func(context.Context, *Message) (any, error) {
+		response, receipt := TrackResponse(map[string]any{"ignored": true})
+		receiptCh <- receipt
+		return response, errors.New("handler failed")
+	})
+	c.Start()
+	t.Cleanup(func() { _ = c.Close() })
+
+	writeInboundRequest(t, inW, "init", 1)
+	receipt := <-receiptCh
+	select {
+	case <-receipt.Done():
+		if err := receipt.Err(); err == nil || !strings.Contains(err.Error(), "handler failed") {
+			t.Fatalf("receipt error = %v, want handler failure", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("tracked handler error did not complete the response receipt")
+	}
+
+	msg, err := ReadFrame(bufio.NewReader(bytes.NewReader(output.Bytes())))
+	if err != nil {
+		t.Fatalf("read handler error response: %v", err)
+	}
+	if msg.Kind != KindError || msg.ID != 1 {
+		t.Fatalf("handler error frame = kind %q id %d, want error id 1", msg.Kind, msg.ID)
+	}
+	var responseErr ErrorResponseData
+	if err := msg.Decode(&responseErr); err != nil {
+		t.Fatalf("decode handler error: %v", err)
+	}
+	if responseErr.Message != "handler failed" {
+		t.Fatalf("handler error message = %q, want %q", responseErr.Message, "handler failed")
+	}
+	if err := c.SendNotification("late", nil); !errors.Is(err, errTerminalResponse) {
+		t.Fatalf("late write error = %v, want %v", err, errTerminalResponse)
+	}
+}
+
+func TestChannel_ResponseReceiptReportsCloseBeforeWrite(t *testing.T) {
+	inR, inW := io.Pipe()
+	t.Cleanup(func() { _ = inW.Close() })
+	var output bytes.Buffer
+	handlerRelease := make(chan struct{})
+
+	receiptCh := make(chan *ResponseReceipt, 1)
+	c := NewChannel(inR, &output)
+	c.SetInboundHandler(func(context.Context, *Message) (any, error) {
+		response, receipt := TrackResponse(map[string]any{"ok": true})
+		receiptCh <- receipt
+		<-handlerRelease
+		return response, nil
+	})
+	c.Start()
+	t.Cleanup(func() { _ = c.Close() })
+
+	writeInboundRequest(t, inW, "init", 1)
+	receipt := <-receiptCh
+	_ = c.Close()
+	close(handlerRelease)
+	select {
+	case <-receipt.Done():
+		if err := receipt.Err(); err == nil {
+			t.Fatal("receipt reported success after the channel closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("closed channel did not complete the response receipt")
+	}
+	if output.Len() != 0 {
+		t.Fatalf("closed channel wrote %d unexpected bytes", output.Len())
+	}
+}
+
+type panicWriter struct{}
+
+func (panicWriter) Write([]byte) (int, error) { panic("writer boom") }
+
+func TestChannel_ResponseReceiptReportsWriterPanic(t *testing.T) {
+	inR, inW := io.Pipe()
+	t.Cleanup(func() { _ = inW.Close() })
+	receiptCh := make(chan *ResponseReceipt, 1)
+
+	c := NewChannel(inR, panicWriter{})
+	c.SetInboundHandler(func(context.Context, *Message) (any, error) {
+		response, receipt := TrackResponse(map[string]any{"ok": true})
+		receiptCh <- receipt
+		return response, nil
+	})
+	c.Start()
+	t.Cleanup(func() { _ = c.Close() })
+
+	writeInboundRequest(t, inW, "init", 1)
+	receipt := <-receiptCh
+	select {
+	case <-receipt.Done():
+		if err := receipt.Err(); err == nil || !strings.Contains(err.Error(), "writer panicked") {
+			t.Fatalf("receipt error = %v, want writer panic", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer panic did not complete the response receipt")
+	}
+	select {
+	case <-c.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer panic did not close the channel")
+	}
+}
+
+func TestChannel_TerminalResponseSealsLaterWrites(t *testing.T) {
+	inR, inW := io.Pipe()
+	t.Cleanup(func() { _ = inW.Close() })
+	writer := newGatedFrameWriter()
+	t.Cleanup(writer.release)
+	receiptCh := make(chan *ResponseReceipt, 1)
+
+	c := NewChannel(inR, writer)
+	c.SetInboundHandler(func(context.Context, *Message) (any, error) {
+		response, receipt := TrackTerminalResponse(struct{}{})
+		receiptCh <- receipt
+		return response, nil
+	})
+	c.Start()
+	t.Cleanup(func() { _ = c.Close() })
+
+	writeInboundRequest(t, inW, KindExit, 1)
+	receipt := <-receiptCh
+	select {
+	case <-writer.bodyEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminal response body write did not reach the gate")
+	}
+
+	lateResult := make(chan error, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go func() {
+		_, err := c.SendRequest(ctx, "late", nil)
+		lateResult <- err
+	}()
+
+	pendingDeadline := time.After(2 * time.Second)
+	for {
+		c.mu.Lock()
+		pending := len(c.pending)
+		c.mu.Unlock()
+		if pending == 1 {
+			break
+		}
+		select {
+		case <-pendingDeadline:
+			t.Fatal("late writer did not queue behind the terminal response")
+		default:
+			runtime.Gosched()
+		}
+	}
+	select {
+	case err := <-lateResult:
+		t.Fatalf("queued writer returned before terminal response was released: %v", err)
+	default:
+	}
+
+	writer.release()
+	select {
+	case <-receipt.Done():
+		if err := receipt.Err(); err != nil {
+			t.Fatalf("terminal response receipt: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminal response receipt did not complete")
+	}
+
+	select {
+	case err := <-lateResult:
+		if !errors.Is(err, errTerminalResponse) {
+			t.Fatalf("queued write error = %v, want %v", err, errTerminalResponse)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued writer did not observe the terminal write seal")
+	}
+	reader := bufio.NewReader(bytes.NewReader(writer.bytes()))
+	if _, err := ReadFrame(reader); err != nil {
+		t.Fatalf("read terminal response: %v", err)
+	}
+	if _, err := ReadFrame(reader); !errors.Is(err, io.EOF) {
+		t.Fatalf("unexpected frame after terminal response: %v", err)
+	}
+
+	_ = c.Close()
+	c.writeMu.Lock()
+	admissionErr := c.writeAdmissionError()
+	c.writeMu.Unlock()
+	if !errors.Is(admissionErr, errTerminalResponse) {
+		t.Fatalf("post-close admission error = %v, want first seal reason %v", admissionErr, errTerminalResponse)
+	}
+}
+
+type panickingError struct{}
+
+func (panickingError) Error() string { panic("error boom") }
+
+func TestChannel_HandlerErrorPanicRecovered(t *testing.T) {
+	a, b := newChannelPair(t)
+	b.SetInboundHandler(func(context.Context, *Message) (any, error) {
+		return nil, panickingError{}
+	})
+	a.Start()
+	b.Start()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	for range 2 {
+		_, err := a.SendRequest(ctx, "x", nil)
+		if err == nil {
+			t.Fatal("expected peer error")
+		}
+		if !strings.Contains(err.Error(), "inbound handler error panicked: error boom") {
+			t.Fatalf("unexpected peer error: %v", err)
+		}
+		select {
+		case <-b.Done():
+			t.Fatal("panicking error stringer closed the channel")
+		default:
+		}
+	}
+}
 
 func TestChannel_WriteErrorCascades(t *testing.T) {
 	pr, pw := io.Pipe()

--- a/internal/ipc/frame.go
+++ b/internal/ipc/frame.go
@@ -165,11 +165,28 @@ func WriteFrame(w io.Writer, msg *Message) error {
 	if len(body) > maxFrameSize {
 		return fmt.Errorf("ipc: frame body %d exceeds cap %d", len(body), maxFrameSize)
 	}
-	if err := binary.Write(w, binary.LittleEndian, uint32(len(body))); err != nil {
+	var header [4]byte
+	binary.LittleEndian.PutUint32(header[:], uint32(len(body)))
+	if err := writeExact(w, header[:]); err != nil {
 		return fmt.Errorf("ipc: write frame length: %w", err)
 	}
-	if _, err := w.Write(body); err != nil {
+	if err := writeExact(w, body); err != nil {
 		return fmt.Errorf("ipc: write frame body: %w", err)
+	}
+	return nil
+}
+
+// writeExact treats any short write as terminal, even when a broken Writer
+// returns a nil error. Retrying would be unsafe for framing: the peer has
+// already received a prefix, and a Writer returning (0, nil) could otherwise
+// spin forever.
+func writeExact(w io.Writer, p []byte) error {
+	n, err := w.Write(p)
+	if err != nil {
+		return err
+	}
+	if n != len(p) {
+		return io.ErrShortWrite
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Fix the IPC init acknowledgement race observed in the [failed Linux Go CI job](https://github.com/web-infra-dev/rslint/actions/runs/29991569014/job/89155406417), where `TestRunCLIRejectsPayloadFormatBeforeConfigDiscovery` received 0 init replies after the response writer had already been closed.
- Make the IPC channel report when a complete response frame reaches the underlying writer.
- Wait for CLI init and API exit acknowledgements before shutdown, while sealing terminal responses against queued writes.
- Treat short writes and transport or marshal panics as deterministic failures without changing wire payloads or successful-path user behavior.
- Add deterministic regression and fault-injection coverage for the handshake race.

## Related Links

- Flaky CI: [run 29991569014, attempt 1 — Test Go (rspack-ubuntu-22.04-large, Go 1.26.0)](https://github.com/web-infra-dev/rslint/actions/runs/29991569014/job/89155406417)

## Testing

- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./cmd/rslint ./internal/api ./internal/ipc` (0 issues)
- `go test ./internal/ipc ./internal/api ./cmd/rslint`
- `go test -race ./internal/ipc ./internal/api`
- Ubuntu 22.04 / Go 1.26.0: original flaky test repeated 10,000 times with 0 failures

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).