### PR TITLE
fix: flush forwarded stdout before timing output

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -803,7 +803,8 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
 10. **Fix Passes**: CLI multi-pass `--fix` applies fixes, rebuilds real Programs, and rebinds the unchanged target plan after each pass; a file may move between a real Program and fallback as its import graph changes
 11. **Report Assembly**: the CLI builds one output report from the final post-fix diagnostics plus run metadata. Diagnostics carry an explicit lint or TypeScript origin, and the report computes error/warning/type-error counts once so the summary and exit policy use the same values; `--quiet` filters rendering only.
 12. **Output Formatting**: the CLI-private output subsystem renders `default`, JSON line, GitHub workflow command, or GitLab Code Quality formats. Only `default` emits a summary; machine-readable formats never emit ANSI styling or a summary.
-13. **Exit Code**: depends on the report counts, `--max-warnings`, and fix outcomes
+13. **Output Synchronization**: in the default IPC CLI, Go drains all report text into ordered `output` notifications and then sends its terminal `shutdown` request. Node seals forwarding and waits for every real-stdout write callback before acknowledging; only after Go receives that acknowledgement does it emit deferred stderr (currently the `--timing` table), so merged `2>&1` output cannot place the table before or inside the report.
+14. **Exit Code**: depends on the report counts, `--max-warnings`, and fix outcomes
 
 ### Concurrency Model
 

--- a/cmd/rslint/ipc_cli.go
+++ b/cmd/rslint/ipc_cli.go
@@ -341,8 +341,9 @@ func runCLI(args []string) int {
 	// The peer holds the real stdout for IPC frames, so any plain-text write
 	// (usage banner, "Created rslint.config.*", lint output) would corrupt the
 	// frame stream if it shared the fd. Redirect through `output`
-	// notifications, which the peer concatenates into its real stdout. stderr
-	// is untouched (inherited end-to-end).
+	// notifications, which the peer concatenates into its real stdout. Ordinary
+	// stderr stays inherited; deferred final stderr waits for Node's shutdown
+	// acknowledgement before using that inherited stream.
 	stdoutR, stdoutW, err := os.Pipe()
 	if err != nil {
 		_ = ch.Close()
@@ -386,19 +387,19 @@ func runCLI(args []string) int {
 		return &res, nil
 	}
 
-	// Hold the --timing table back until finalizeStdout has drained the
-	// async stdout forwarding: stderr is inherited and would otherwise
-	// surface the table before (or inside) the still-in-flight lint report.
+	// Hold the --timing table until Node confirms that its real stdout sink has
+	// completed every forwarded write. Draining the Go pipe alone is not a
+	// sufficient ordering edge because Node's Writable writes are asynchronous.
 	var timingTable string
 	baseArgs.DeferTimingTable = func(table string) { timingTable = table }
 
 	exitCode := executeLintPipeline(baseArgs, lintCtx, dispatch)
 
 	finalizeStdout()
-	if timingTable != "" {
+	stdoutFlushed := shutdownPeer(ch, state)
+	if stdoutFlushed && !state.signalled.Load() && timingTable != "" {
 		fmt.Fprint(os.Stderr, timingTable)
 	}
-	shutdownPeer(ch, state)
 	_ = ch.Close()
 
 	if state.signalled.Load() {
@@ -418,17 +419,19 @@ func markCLIInterrupted(ctx context.Context, state *runCLIState) bool {
 	return interrupted
 }
 
-// shutdownPeer best-effort tells the peer we're done so it drains its worker
-// pool and exits cleanly. Skipped if a signal already fired: the peer sees its
-// own stdin disconnect anyway, and pushing another frame races the closing
-// pipe.
-func shutdownPeer(ch *ipc.Channel, state *runCLIState) {
+// shutdownPeer tells the peer we're done and waits for its acknowledgement.
+// The Node peer sends that acknowledgement only after forwarded stdout has
+// flushed, so a true result is the ordering barrier for deferred stderr.
+// Skipped if a signal already fired: the peer sees its own stdin disconnect
+// anyway, and pushing another frame races the closing pipe.
+func shutdownPeer(ch *ipc.Channel, state *runCLIState) bool {
 	if state != nil && state.signalled.Load() {
-		return
+		return false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, _ = ch.SendRequest(ctx, kindShutdown, struct{}{})
+	_, err := ch.SendRequest(ctx, kindShutdown, struct{}{})
+	return err == nil
 }
 
 // classifyPaths splits a path slice into (files, dirs) by stat'ing each entry,

--- a/cmd/rslint/ipc_cli_test.go
+++ b/cmd/rslint/ipc_cli_test.go
@@ -79,6 +79,51 @@ func TestMarkCLIInterruptedUsesCanceledDiscoveryContext(t *testing.T) {
 	}
 }
 
+func TestShutdownPeerWaitsForAcknowledgement(t *testing.T) {
+	cli, peer := newCLIChannelPair(t)
+	requestSeen := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	peer.SetInboundHandler(func(_ context.Context, msg *ipc.Message) (any, error) {
+		if msg.Kind != kindShutdown {
+			return nil, fmt.Errorf("request kind = %q, want %q", msg.Kind, kindShutdown)
+		}
+		var payload struct{}
+		if err := msg.Decode(&payload); err != nil {
+			return nil, fmt.Errorf("decode shutdown payload: %w", err)
+		}
+		close(requestSeen)
+		<-releaseResponse
+		return map[string]any{"ok": true}, nil
+	})
+	cli.Start()
+	peer.Start()
+
+	shutdownDone := make(chan bool, 1)
+	go func() {
+		shutdownDone <- shutdownPeer(cli, &runCLIState{})
+	}()
+
+	select {
+	case <-requestSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("peer did not receive shutdown request")
+	}
+	select {
+	case <-shutdownDone:
+		t.Fatal("shutdownPeer returned before the peer acknowledged")
+	default:
+	}
+	close(releaseResponse)
+	select {
+	case acknowledged := <-shutdownDone:
+		if !acknowledged {
+			t.Fatal("shutdownPeer did not report the acknowledgement")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdownPeer did not return after the acknowledgement")
+	}
+}
+
 // TestDrainStdoutToIPC_DiscardsOnClosedPeer pins #4: once the channel is
 // closed (peer gone) the drain stops forwarding but keeps reading r — so the
 // lint pipeline never blocks on a full stdout pipe — and exits cleanly on EOF.
@@ -384,6 +429,10 @@ func serveCLITestPeer(fromCLI io.Reader, toCLI io.Writer) cliTestPeerResult {
 				recordError(errors.New("received duplicate shutdown request"))
 			}
 			shutdownSeen = true
+			var payload struct{}
+			if err := msg.Decode(&payload); err != nil {
+				recordError(fmt.Errorf("decode shutdown payload: %w", err))
+			}
 			response, err := ipc.NewMessage(ipc.KindResponse, msg.ID, map[string]any{"ok": true})
 			if err != nil {
 				recordError(fmt.Errorf("build shutdown response: %w", err))

--- a/packages/rslint/src/cli/engine.ts
+++ b/packages/rslint/src/cli/engine.ts
@@ -76,6 +76,126 @@ function isActivateConfigsRequest(
   );
 }
 
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+/**
+ * Tracks completion callbacks, rather than `write()` return values: a false
+ * return means the chunk was accepted under backpressure, not that it was
+ * flushed. The tracker retains no report text or Promise array; under sustained
+ * backpressure the Writable owns one small completion callback per roughly
+ * 8 KiB IPC output chunk alongside the chunks it already buffers.
+ */
+class StdoutWriteBarrier {
+  private accepting = true;
+  private closed = false;
+  private pendingWrites = 0;
+  private failure: Error | null = null;
+  private readonly waiters = new Set<() => void>();
+
+  constructor(private readonly stream: NodeJS.WritableStream) {
+    // Writable failures also emit `error`; handling the event prevents EPIPE
+    // from becoming an uncaught exception and covers streams that omit a write
+    // callback after failing.
+    stream.on('error', this.onError);
+    stream.on('close', this.onClose);
+    stream.on('finish', this.onClose);
+  }
+
+  write(text: string): void {
+    if (!this.accepting || this.closed) {
+      this.recordFailure(
+        new Error(
+          `engine: stdout write after ${
+            this.closed ? 'stream close' : 'flush began'
+          }`,
+        ),
+      );
+      return;
+    }
+
+    this.pendingWrites++;
+    let completed = false;
+    const complete = (error?: Error | null): void => {
+      if (completed) return;
+      completed = true;
+      this.pendingWrites--;
+      if (error) {
+        this.recordFailure(asError(error));
+      } else {
+        this.wakeWaiters();
+      }
+    };
+
+    try {
+      this.stream.write(text, complete);
+    } catch (error) {
+      if (completed) {
+        this.recordFailure(asError(error));
+      } else {
+        complete(asError(error));
+      }
+    }
+  }
+
+  async sealAndFlush(): Promise<void> {
+    this.accepting = false;
+
+    // IpcClient dispatches all complete frames in one input chunk
+    // synchronously. Yield once so an illegal output notification following
+    // shutdown in that same chunk is observed before shutdown is acknowledged.
+    await Promise.resolve();
+
+    while (!this.failure && this.pendingWrites > 0) {
+      await new Promise<void>((resolve) => {
+        this.waiters.add(resolve);
+      });
+    }
+    if (this.failure) {
+      throw new Error(
+        `engine: stdout forwarding failed: ${this.failure.message}`,
+      );
+    }
+  }
+
+  dispose(): void {
+    this.stream.off('error', this.onError);
+    this.stream.off('close', this.onClose);
+    this.stream.off('finish', this.onClose);
+    if (this.pendingWrites > 0 && !this.failure) {
+      this.recordFailure(
+        new Error(`engine stopped with ${this.pendingWrites} pending write(s)`),
+      );
+    }
+  }
+
+  private readonly onError = (error: Error): void => {
+    this.recordFailure(asError(error));
+  };
+
+  private readonly onClose = (): void => {
+    this.closed = true;
+    if (this.pendingWrites > 0) {
+      this.recordFailure(
+        new Error(
+          `engine: stdout stream closed with ${this.pendingWrites} pending write(s)`,
+        ),
+      );
+    }
+  };
+
+  private recordFailure(error: Error): void {
+    if (!this.failure) this.failure = error;
+    this.wakeWaiters();
+  }
+
+  private wakeWaiters(): void {
+    for (const resolve of this.waiters) resolve();
+    this.waiters.clear();
+  }
+}
+
 // POSIX: a process killed by signal N exits 128+N. Node reports the signal
 // NAME, so map the ones we can receive; collapsing all to 130 would mislabel
 // a SIGTERM/SIGKILL teardown as a Ctrl-C.
@@ -272,6 +392,7 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
     process.off('SIGTERM', onSignal);
     process.off('SIGHUP', onSignal);
   };
+  const forwardedStdout = new StdoutWriteBarrier(stdout);
 
   // try/finally so the worker pool is always drained — every exit path
   // (init failure as well as normal completion) runs the `finally`, which
@@ -327,9 +448,15 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
             throw error;
           }
         }
-        case 'shutdown':
-          // Go signals it's done; teardown happens via the 'exit' event below.
+        case 'shutdown': {
+          // Go sends shutdown only after its last output notification. Seal
+          // forwarding and wait for the actual destination callbacks. The
+          // response is Go's barrier: only after receiving it may Go write
+          // deferred stderr (the timing table).
+          await forwardedStdout.sealAndFlush();
+          // Teardown happens via the child 'exit' event below.
           return { ok: true };
+        }
         case 'pluginLint':
           // Go dispatched a plugin-lint batch in parallel with native linting.
           // Go only dispatches after activation returned plugin metadata, so a
@@ -349,7 +476,7 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
       'output',
       (msg: IpcMessage<{ stream?: string; text?: string }>) => {
         const text = msg.data?.text;
-        if (text != null) stdout.write(text);
+        if (text != null) forwardedStdout.write(text);
       },
     );
     ipc.start();
@@ -421,6 +548,7 @@ export async function runEngine(opts: EngineRunOptions): Promise<number> {
     for (const transactionId of configTransactions) {
       configModuleHost.deleteSession(transactionId);
     }
+    forwardedStdout.dispose();
   }
 }
 

--- a/packages/rslint/tests/engine.test.ts
+++ b/packages/rslint/tests/engine.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from '@rstest/core';
 import fs from 'node:fs';
 import os from 'node:os';
-import { PassThrough } from 'node:stream';
+import { PassThrough, Writable } from 'node:stream';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runEngine } from '../src/cli/engine.js';
@@ -52,6 +52,97 @@ describe('runEngine init payload TTY fact', () => {
     const { exitCode, payload } = await runWithSink(new PassThrough());
     expect(exitCode).toBe(0);
     expect(payload.runtime?.stdoutIsTTY).toBe(false);
+  });
+});
+
+describe('runEngine output shutdown barrier', () => {
+  test('waits for stdout under backpressure before acknowledging shutdown', async () => {
+    const events: string[] = [];
+    let releaseFirstWrite!: () => void;
+    let markFirstWriteStarted!: () => void;
+    const firstWriteStarted = new Promise<void>((resolve) => {
+      markFirstWriteStarted = resolve;
+    });
+    const firstWriteGate = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let stdoutWrites = 0;
+    const stdout = new Writable({
+      highWaterMark: 1,
+      write(_chunk, _encoding, callback) {
+        stdoutWrites++;
+        const write = stdoutWrites;
+        events.push(`stdout:${write}:start`);
+        if (write === 1) {
+          markFirstWriteStarted();
+          void firstWriteGate.then(() => {
+            events.push(`stdout:${write}:done`);
+            callback();
+          });
+          return;
+        }
+        events.push(`stdout:${write}:done`);
+        callback();
+      },
+    });
+    let settled = false;
+    const run = runEngine({
+      binPath: process.execPath,
+      goArgs: [FAKE_BIN],
+      stdout,
+      stderr: new PassThrough(),
+    }).then((code) => {
+      settled = true;
+      return code;
+    });
+
+    try {
+      await firstWriteStarted;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+    } finally {
+      releaseFirstWrite();
+    }
+
+    expect(await run).toBe(0);
+    expect(events).toEqual([
+      'stdout:1:start',
+      'stdout:1:done',
+      'stdout:2:start',
+      'stdout:2:done',
+    ]);
+  });
+
+  test('rejects shutdown when stdout forwarding fails', async () => {
+    const stdout = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback(new Error('injected stdout failure'));
+      },
+    });
+    const exitCode = await runEngine({
+      binPath: process.execPath,
+      goArgs: [FAKE_BIN],
+      stdout,
+      stderr: new PassThrough(),
+    });
+
+    expect(exitCode).toBe(2);
+  });
+
+  test('rejects shutdown without hanging when stdout closes mid-write', async () => {
+    const stdout = new Writable({
+      write() {
+        stdout.destroy();
+      },
+    });
+    const exitCode = await runEngine({
+      binPath: process.execPath,
+      goArgs: [FAKE_BIN],
+      stdout,
+      stderr: new PassThrough(),
+    });
+
+    expect(exitCode).toBe(2);
   });
 });
 

--- a/packages/rslint/tests/fixtures/fake-ipc-binary.cjs
+++ b/packages/rslint/tests/fixtures/fake-ipc-binary.cjs
@@ -2,8 +2,9 @@
 // Minimal Go-binary stand-in for engine tests, speaking the IPC frame
 // protocol ([4-byte u32 LE length][JSON {kind,id,data}]) over stdio:
 //   1. expects an `init` request → replies `response {ok:true}`,
-//   2. echoes the received init payload back as an `output` notification,
-//   3. sends a `shutdown` request and exits 0 once the peer acks it.
+//   2. echoes the received init payload back as two `output` notifications,
+//   3. sends a `shutdown` request,
+//   4. exits 0 on an acknowledgement or 2 if the peer rejects shutdown.
 // This mirrors the real binary's happy-path frame sequence so runEngine can
 // be exercised end-to-end without Go.
 
@@ -19,14 +20,21 @@ function send(msg) {
 function onMessage(msg) {
   if (msg.kind === 'init') {
     send({ kind: 'response', id: msg.id, data: { ok: true } });
+    const text = JSON.stringify(msg.data);
+    const split = Math.ceil(text.length / 2);
     send({
       kind: 'output',
       id: 0,
-      data: { stream: 'stdout', text: JSON.stringify(msg.data) },
+      data: { stream: 'stdout', text: text.slice(0, split) },
+    });
+    send({
+      kind: 'output',
+      id: 0,
+      data: { stream: 'stdout', text: text.slice(split) },
     });
     send({ kind: 'shutdown', id: 1000, data: {} });
-  } else if (msg.kind === 'response' && msg.id === 1000) {
-    process.exit(0);
+  } else if (msg.id === 1000) {
+    process.exit(msg.kind === 'response' ? 0 : 2);
   }
 }
 


### PR DESCRIPTION
## Summary

- Make the Node shutdown acknowledgement an explicit barrier that waits for every forwarded stdout write to complete before Go emits the deferred `--timing` table.
- Handle stdout backpressure, synchronous/asynchronous write failures, clean stream closure, and output arriving after shutdown without serializing the normal output path.
- Add Go and Node regression tests for acknowledgement ordering and failure paths, and document the IPC output synchronization flow.

## Related Links

- Follow-up to #1334

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
