### PR TITLE
fix: exclude import attribute names from RefStore

### DIFF
--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -121,6 +121,10 @@ func isReferencePosition(n *ast.Node) bool {
 		return p.AsPropertyAssignment().Name() != n
 	case ast.KindBindingElement:
 		return p.AsBindingElement().PropertyName != n
+	case ast.KindImportAttribute:
+		// Import attribute keys (`type` in `with { type: "json" }`) are
+		// syntactic names, not references to same-named variables.
+		return p.AsImportAttribute().Name() != n
 	case ast.KindImportSpecifier, ast.KindExportSpecifier, ast.KindNamespaceImport,
 		ast.KindImportClause, ast.KindNamespaceExport:
 		// Import/export bindings resolve through module/alias machinery the

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -134,6 +134,31 @@ func TestRefStoreMetaPropertyExcluded(t *testing.T) {
 	}
 }
 
+func TestRefStoreImportAttributeNameExcluded(t *testing.T) {
+	// `type` in an import attribute is a syntactic key, not a reference to a
+	// same-named variable.
+	sourceFile, refs := newBoundRefStore(t, "/import-attribute.ts", core.ScriptKindTS,
+		`import data from "pkg" with { type: "json" }; var type = 1; type++;`)
+
+	occurrences := identifiers(sourceFile.AsNode(), "type")
+	if len(occurrences) != 3 {
+		t.Fatalf("expected 3 occurrences of type, got %d", len(occurrences))
+	}
+	attributeIdent, declIdent, useIdent := occurrences[0], occurrences[1], occurrences[2]
+	if attributeIdent.Parent == nil || attributeIdent.Parent.Kind != ast.KindImportAttribute {
+		t.Fatalf("expected the first `type` to be an ImportAttribute name, got parent kind %v", attributeIdent.Parent.Kind)
+	}
+	sym := declIdent.Parent.Symbol()
+	if sym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	got := refs.References(sym)
+	if len(got) != 1 || got[0] != useIdent {
+		t.Fatalf("References = %v, want [%v] (the import attribute key must be excluded)", got, useIdent)
+	}
+}
+
 func TestRefStoreJsxNamespacedNameExcluded(t *testing.T) {
 	// `bar` in the namespaced JSX tag name `<bar:qux />` is syntactic, not a
 	// reference to a same-named variable.

--- a/internal/rules/no_var/no_var_test.go
+++ b/internal/rules/no_var/no_var_test.go
@@ -87,6 +87,14 @@ func TestNoVarRule(t *testing.T) {
 					{MessageId: "unexpectedVar"},
 				},
 			},
+			// Import attribute keys are syntax names, not variable references.
+			{
+				Code:   `import data from "pkg" with { type: "json" }; var type = 1;`,
+				Output: []string{`import data from "pkg" with { type: "json" }; let type = 1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedVar"},
+				},
+			},
 			// Multiple var statements, both fixable
 			{
 				Code:   `export {}; var foo = 1; var bar = 2;`,


### PR DESCRIPTION
## Summary

- Exclude import attribute keys such as `type` in `with` clauses from RefStore references.
- Restore the safe no-var `var` to `let` autofix when a same-named import attribute precedes the declaration.
- Add RefStore unit coverage and a no-var integration regression case.

Validation:

- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/rule ./internal/rules/no_var`
- `go test ./internal/rule -run ^TestRefStore -count=1`
- `go test ./internal/rules/no_var -run ^TestNoVarRule$/^invalid-9$ -count=1`

## Related Links

- Follow-up to #1335

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).