### PR TITLE
perf: port no-class-assign, no-func-assign, no-ex-assign to RefStore

### DIFF
--- a/internal/rules/no_class_assign/no_class_assign.go
+++ b/internal/rules/no_class_assign/no_class_assign.go
@@ -14,317 +14,19 @@ func buildClassReassignmentMessage(className string) rule.RuleMessage {
 	}
 }
 
-// getIdentifierName extracts the name from an identifier node
-func getIdentifierName(node *ast.Node) string {
-	if node == nil || node.Kind != ast.KindIdentifier {
-		return ""
-	}
-	return node.Text()
-}
-
-// isWriteReference checks if a node is a write reference (assignment target)
-func isWriteReference(node *ast.Node) bool {
-	if node == nil || node.Parent == nil {
-		return false
-	}
-
-	parent := node.Parent
-
-	switch parent.Kind {
-	case ast.KindBinaryExpression:
-		binary := parent.AsBinaryExpression()
-		if binary == nil || binary.OperatorToken == nil {
-			return false
-		}
-
-		// Check if it's an assignment operator and node is on the left side
-		switch binary.OperatorToken.Kind {
-		case ast.KindEqualsToken,
-			ast.KindPlusEqualsToken,
-			ast.KindMinusEqualsToken,
-			ast.KindAsteriskAsteriskEqualsToken,
-			ast.KindAsteriskEqualsToken,
-			ast.KindSlashEqualsToken,
-			ast.KindPercentEqualsToken,
-			ast.KindLessThanLessThanEqualsToken,
-			ast.KindGreaterThanGreaterThanEqualsToken,
-			ast.KindGreaterThanGreaterThanGreaterThanEqualsToken,
-			ast.KindAmpersandEqualsToken,
-			ast.KindBarEqualsToken,
-			ast.KindCaretEqualsToken,
-			ast.KindBarBarEqualsToken,
-			ast.KindAmpersandAmpersandEqualsToken,
-			ast.KindQuestionQuestionEqualsToken:
-			return binary.Left == node
-		}
-
-	case ast.KindPostfixUnaryExpression:
-		postfix := parent.AsPostfixUnaryExpression()
-		if postfix == nil {
-			return false
-		}
-		// ++ and -- are write operations
-		switch postfix.Operator {
-		case ast.KindPlusPlusToken, ast.KindMinusMinusToken:
-			return postfix.Operand == node
-		}
-
-	case ast.KindPrefixUnaryExpression:
-		prefix := parent.AsPrefixUnaryExpression()
-		if prefix == nil {
-			return false
-		}
-		// ++ and -- are write operations
-		switch prefix.Operator {
-		case ast.KindPlusPlusToken, ast.KindMinusMinusToken:
-			return prefix.Operand == node
-		}
-
-	case ast.KindObjectBindingPattern:
-		// In destructuring like {A} = obj, A is a write reference
-		// ObjectBindingPattern is used in destructuring assignments
-		// Check if this pattern is on the left side of an assignment
-		return isBindingPatternInAssignment(parent)
-
-	case ast.KindArrayBindingPattern:
-		// In array destructuring like [A] = arr, A is a write reference
-		return isBindingPatternInAssignment(parent)
-
-	case ast.KindBindingElement:
-		// Check if the binding element is part of a write context
-		return isWriteReference(parent)
-
-	case ast.KindShorthandPropertyAssignment:
-		// In destructuring like {A} = obj or ({A} = obj), A is a write reference
-		shorthand := parent.AsShorthandPropertyAssignment()
-		if shorthand != nil && shorthand.Name() == node {
-			return isInDestructuringAssignment(parent)
-		}
-
-	case ast.KindPropertyAssignment:
-		// In destructuring like {b: A} = obj, A is a write reference
-		propAssignment := parent.AsPropertyAssignment()
-		if propAssignment != nil && propAssignment.Initializer == node {
-			return isInDestructuringAssignment(parent)
-		}
-
-	case ast.KindArrayLiteralExpression:
-		// In array destructuring like [A] = arr, A is a write reference
-		return isInDestructuringAssignment(parent)
-
-	case ast.KindObjectLiteralExpression:
-		// In object destructuring like {A} = obj, A is a write reference
-		return isInDestructuringAssignment(parent)
-
-	case ast.KindParenthesizedExpression:
-		// Unwrap parentheses and check the parent context
-		return isWriteReference(parent)
-
-	case ast.KindAsExpression, ast.KindTypeAssertionExpression:
-		// Type assertions like (A as any) = 0
-		// The type assertion wraps the identifier, check if the assertion is a write target
-		return isWriteReference(parent)
-	}
-
-	return false
-}
-
-// isBindingPatternInAssignment checks if a binding pattern is the left side of an assignment
-func isBindingPatternInAssignment(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-
-	// The binding pattern's parent might be wrapped in parentheses
-	parent := node.Parent
-
-	// Unwrap parentheses
-	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-		parent = parent.Parent
-	}
-
-	// Check if the parent is a binary expression with = operator
-	if parent != nil && parent.Kind == ast.KindBinaryExpression {
-		binary := parent.AsBinaryExpression()
-		if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
-			// Check if the binding pattern is on the left side
-			leftNode := binary.Left
-			// Unwrap parentheses on the left side
-			for leftNode != nil && leftNode.Kind == ast.KindParenthesizedExpression {
-				parenExpr := leftNode.AsParenthesizedExpression()
-				if parenExpr != nil {
-					leftNode = parenExpr.Expression
-				} else {
-					break
-				}
-			}
-			return leftNode == node
-		}
-	}
-
-	return false
-}
-
-// isInDestructuringAssignment checks if a node is part of a destructuring assignment pattern
-func isInDestructuringAssignment(node *ast.Node) bool {
-	current := node
-	for current != nil {
-		if current.Kind == ast.KindObjectLiteralExpression || current.Kind == ast.KindArrayLiteralExpression {
-			// Check if this literal is the left side of an assignment
-			// May be wrapped in parentheses
-			parent := current.Parent
-
-			// Unwrap parentheses
-			for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-				parent = parent.Parent
-			}
-
-			if parent != nil && parent.Kind == ast.KindBinaryExpression {
-				binary := parent.AsBinaryExpression()
-				if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
-					// Check if the literal (or its parent parenthesized expression) is on the left
-					leftNode := binary.Left
-					// Unwrap parentheses on left side
-					for leftNode != nil && leftNode.Kind == ast.KindParenthesizedExpression {
-						parenExpr := leftNode.AsParenthesizedExpression()
-						if parenExpr != nil {
-							leftNode = parenExpr.Expression
-						} else {
-							break
-						}
-					}
-					if leftNode == current {
-						return true
-					}
-				}
-			}
-			return false
-		}
-		current = current.Parent
-	}
-	return false
-}
-
-// getClassSymbol gets the symbol for a class node
-func getClassSymbol(classNode *ast.Node, ctx *rule.RuleContext) *ast.Symbol {
-	if ctx.TypeChecker == nil {
-		return nil
-	}
-
-	switch classNode.Kind {
-	case ast.KindClassDeclaration:
-		classDecl := classNode.AsClassDeclaration()
-		if classDecl != nil && classDecl.Name() != nil {
-			return ctx.TypeChecker.GetSymbolAtLocation(classDecl.Name())
-		}
-	case ast.KindClassExpression:
-		classExpr := classNode.AsClassExpression()
-		if classExpr != nil && classExpr.Name() != nil {
-			return ctx.TypeChecker.GetSymbolAtLocation(classExpr.Name())
-		}
-	}
-
-	return nil
-}
-
-// isNameShadowed checks if an identifier references a different variable due to shadowing
-func isNameShadowed(node *ast.Node, className string, classNode *ast.Node, ctx *rule.RuleContext) bool {
-	if node == nil || ctx.TypeChecker == nil {
-		return false
-	}
-
-	// Get the symbol at the identifier location
-	symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
-	if symbol == nil {
-		return false
-	}
-
-	// Get the symbol of the class declaration
-	var classSymbol = getClassSymbol(classNode, ctx)
-
-	// If symbols are different, the name is shadowed
-	if classSymbol != nil {
-		return symbol != classSymbol
-	}
-
-	// Fallback: check if the identifier is within a scope that shadows the
-	// class name. Walks only up to classNode (not to SourceFile).
-	return utils.IsNameShadowedBetween(node, classNode, className)
-}
-
-// checkClassReassignments finds all reassignments to the class name
-func checkClassReassignments(classNode *ast.Node, className string, ctx *rule.RuleContext) {
-	if className == "" {
+// checkClassReassignments reports every write-reference to classNode's own
+// symbol. RefStore resolution is scope-correct by construction, so a local
+// binding that shadows the class name is never returned as a reference here.
+func checkClassReassignments(classNode *ast.Node, ctx *rule.RuleContext) {
+	sym := classNode.Symbol()
+	if sym == nil {
 		return
 	}
-
-	// Find the scope to search - for class declarations, we need to search the parent scope
-	// For class expressions, we only search within the class itself
-	var searchRoot *ast.Node
-	if classNode.Kind == ast.KindClassDeclaration {
-		// For class declarations, search the enclosing block or source file
-		searchRoot = findEnclosingScope(classNode)
-	} else {
-		// For class expressions, search within the class only
-		searchRoot = classNode
-	}
-
-	if searchRoot == nil {
-		return
-	}
-
-	// Walk the tree to find all identifiers with the class name
-	var walk func(*ast.Node)
-	walk = func(node *ast.Node) {
-		if node == nil {
-			return
+	for _, ref := range ctx.Refs.References(sym) {
+		if utils.IsWriteReference(ref) {
+			ctx.ReportNode(ref, buildClassReassignmentMessage(sym.Name))
 		}
-
-		if node.Kind == ast.KindIdentifier && getIdentifierName(node) == className {
-			// Skip if this is the class name declaration itself
-			if node.Parent == classNode {
-				// Continue walking children
-				node.ForEachChild(func(child *ast.Node) bool {
-					walk(child)
-					return false
-				})
-				return
-			}
-
-			// Check if this is a write reference
-			if isWriteReference(node) {
-				// Check if the name is shadowed by a local variable
-				if !isNameShadowed(node, className, classNode, ctx) {
-					ctx.ReportNode(node, buildClassReassignmentMessage(className))
-				}
-			}
-		}
-
-		// Recursively check children
-		node.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
 	}
-
-	walk(searchRoot)
-}
-
-// findEnclosingScope finds the enclosing block or source file for a node
-func findEnclosingScope(node *ast.Node) *ast.Node {
-	current := node.Parent
-	for current != nil {
-		switch current.Kind {
-		case ast.KindSourceFile:
-			return current
-		case ast.KindBlock:
-			return current
-		case ast.KindModuleBlock:
-			return current
-		}
-		current = current.Parent
-	}
-	return nil
 }
 
 // NoClassAssignRule disallows reassigning class declarations
@@ -334,26 +36,20 @@ var NoClassAssignRule = rule.Rule{
 		return rule.RuleListeners{
 			// Check class declarations
 			ast.KindClassDeclaration: func(node *ast.Node) {
-				classDecl := node.AsClassDeclaration()
-				if classDecl == nil || classDecl.Name() == nil {
+				if node.AsClassDeclaration().Name() == nil {
 					return
 				}
-
-				className := getIdentifierName(classDecl.Name())
-				checkClassReassignments(node, className, &ctx)
+				checkClassReassignments(node, &ctx)
 			},
 
-			// Check named class expressions
+			// Check named class expressions. The name is only visible inside
+			// the class body, which RefStore's scope-aware resolution
+			// enforces on its own.
 			ast.KindClassExpression: func(node *ast.Node) {
-				classExpr := node.AsClassExpression()
-				if classExpr == nil || classExpr.Name() == nil {
+				if node.AsClassExpression().Name() == nil {
 					return
 				}
-
-				// Only check named class expressions
-				// For `let A = class A { ... }`, we need to check reassignments inside the class
-				className := getIdentifierName(classExpr.Name())
-				checkClassReassignments(node, className, &ctx)
+				checkClassReassignments(node, &ctx)
 			},
 		}
 	},

--- a/internal/rules/no_class_assign/no_class_assign_test.go
+++ b/internal/rules/no_class_assign/no_class_assign_test.go
@@ -60,13 +60,12 @@ func TestNoClassAssignRule(t *testing.T) {
 			},
 
 			// Destructuring assignment with class name
-			// TODO: This test case is not working yet - needs investigation of AST structure
-			// {
-			// 	Code: `class A { } ({A} = 0);`,
-			// 	Errors: []rule_tester.InvalidTestCaseError{
-			// 		{MessageId: "classReassignment", Line: 1, Column: 15},
-			// 	},
-			// },
+			{
+				Code: `class A { } ({A} = 0);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "classReassignment", Line: 1, Column: 15},
+				},
+			},
 
 			// Destructuring assignment with default value
 			{

--- a/internal/rules/no_ex_assign/no_ex_assign.go
+++ b/internal/rules/no_ex_assign/no_ex_assign.go
@@ -1,8 +1,6 @@
 package no_ex_assign
 
 import (
-	"slices"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -16,274 +14,43 @@ func buildExAssignMessage() rule.RuleMessage {
 	}
 }
 
-func collectCatchBindingNamesAndSymbols(node *ast.Node, ctx rule.RuleContext) ([]string, []*ast.Symbol) {
-	if node == nil {
-		return nil, nil
-	}
-	if ast.IsIdentifier(node) {
-		var sym *ast.Symbol
-		if ctx.TypeChecker != nil {
-			sym = ctx.TypeChecker.GetSymbolAtLocation(node)
-		}
-		return []string{node.Text()}, []*ast.Symbol{sym}
-	}
-	if ast.IsBindingPattern(node) {
-		var names []string
-		var symbols []*ast.Symbol
-		for _, elem := range node.Elements() {
-			if elem == nil || !ast.IsBindingElement(elem) {
-				continue
-			}
-			be := elem.AsBindingElement()
-			if be == nil || be.Name() == nil {
-				continue
-			}
-			utils.CollectBindingNames(be.Name(), func(ident *ast.Node, name string) {
-				names = append(names, name)
-				var sym *ast.Symbol
-				if ctx.TypeChecker != nil {
-					sym = ctx.TypeChecker.GetSymbolAtLocation(ident)
-				}
-				symbols = append(symbols, sym)
-			})
-		}
-		return names, symbols
-	}
-	return nil, nil
-}
-
-func isBindingPatternInAssignment(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-
-	parent := node.Parent
-
-	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-		parent = parent.Parent
-	}
-
-	if parent == nil || parent.Kind != ast.KindBinaryExpression {
-		return false
-	}
-
-	binary := parent.AsBinaryExpression()
-	if binary == nil || binary.OperatorToken == nil {
-		return false
-	}
-
-	switch binary.OperatorToken.Kind {
-	case ast.KindEqualsToken:
-		return binary.Left == node
-	}
-
-	return false
-}
-
-func isInDestructuringAssignment(node *ast.Node) bool {
-	current := node
-	for current != nil {
-		parent := current.Parent
-		if parent == nil {
-			return false
-		}
-
-		switch parent.Kind {
-		case ast.KindBinaryExpression:
-			binary := parent.AsBinaryExpression()
-			if binary != nil && binary.OperatorToken != nil &&
-				binary.OperatorToken.Kind == ast.KindEqualsToken {
-				return binary.Left == current
-			}
-			return false
-		case ast.KindParenthesizedExpression,
-			ast.KindObjectLiteralExpression,
-			ast.KindArrayLiteralExpression,
-			ast.KindPropertyAssignment,
-			ast.KindShorthandPropertyAssignment,
-			ast.KindSpreadAssignment:
-			current = parent
-		default:
-			return false
-		}
-	}
-	return false
-}
-
-func isWriteReference(node *ast.Node) bool {
-	if node == nil || node.Parent == nil {
-		return false
-	}
-
-	parent := node.Parent
-
-	switch parent.Kind {
-	case ast.KindBinaryExpression:
-		binary := parent.AsBinaryExpression()
-		if binary == nil || binary.OperatorToken == nil {
-			return false
-		}
-
-		switch binary.OperatorToken.Kind {
-		case ast.KindEqualsToken,
-			ast.KindPlusEqualsToken,
-			ast.KindMinusEqualsToken,
-			ast.KindAsteriskAsteriskEqualsToken,
-			ast.KindAsteriskEqualsToken,
-			ast.KindSlashEqualsToken,
-			ast.KindPercentEqualsToken,
-			ast.KindLessThanLessThanEqualsToken,
-			ast.KindGreaterThanGreaterThanEqualsToken,
-			ast.KindGreaterThanGreaterThanGreaterThanEqualsToken,
-			ast.KindAmpersandEqualsToken,
-			ast.KindBarEqualsToken,
-			ast.KindCaretEqualsToken,
-			ast.KindBarBarEqualsToken,
-			ast.KindAmpersandAmpersandEqualsToken,
-			ast.KindQuestionQuestionEqualsToken:
-			return binary.Left == node
-		}
-	case ast.KindPostfixUnaryExpression:
-		postfix := parent.AsPostfixUnaryExpression()
-		if postfix == nil {
-			return false
-		}
-		switch postfix.Operator {
-		case ast.KindPlusPlusToken, ast.KindMinusMinusToken:
-			return postfix.Operand == node
-		}
-	case ast.KindPrefixUnaryExpression:
-		prefix := parent.AsPrefixUnaryExpression()
-		if prefix == nil {
-			return false
-		}
-		switch prefix.Operator {
-		case ast.KindPlusPlusToken, ast.KindMinusMinusToken:
-			return prefix.Operand == node
-		}
-	case ast.KindForInStatement:
-		forIn := parent.AsForInOrOfStatement()
-		if forIn == nil {
-			return false
-		}
-		return forIn.Initializer == node
-	case ast.KindForOfStatement:
-		forOf := parent.AsForInOrOfStatement()
-		if forOf == nil {
-			return false
-		}
-		return forOf.Initializer == node
-	case ast.KindObjectBindingPattern:
-		return isBindingPatternInAssignment(parent)
-	case ast.KindArrayBindingPattern:
-		return isBindingPatternInAssignment(parent)
-	case ast.KindBindingElement:
-		return isWriteReference(parent)
-	case ast.KindShorthandPropertyAssignment:
-		shorthand := parent.AsShorthandPropertyAssignment()
-		if shorthand != nil && shorthand.Name() == node {
-			return isInDestructuringAssignment(parent)
-		}
-	case ast.KindPropertyAssignment:
-		propAssignment := parent.AsPropertyAssignment()
-		if propAssignment != nil && propAssignment.Initializer == node {
-			return isInDestructuringAssignment(parent)
-		}
-	case ast.KindObjectLiteralExpression:
-		return isInDestructuringAssignment(parent)
-	case ast.KindArrayLiteralExpression:
-		return isInDestructuringAssignment(parent)
-	case ast.KindParenthesizedExpression:
-		return isWriteReference(parent)
-	case ast.KindAsExpression, ast.KindTypeAssertionExpression:
-		return isWriteReference(parent)
-	}
-
-	return false
-}
-
-func isNameShadowed(node *ast.Node, symbols []*ast.Symbol, ctx rule.RuleContext) bool {
-	if node == nil || ctx.TypeChecker == nil || len(symbols) == 0 {
-		return false
-	}
-
-	symbol := utils.GetReferenceSymbol(node, ctx.TypeChecker)
-	if symbol == nil {
-		return false
-	}
-
-	for _, s := range symbols {
-		if s == symbol {
-			return false
-		}
-	}
-	return true
-}
-
-func getIdentifierName(node *ast.Node) string {
-	if node == nil || node.Kind != ast.KindIdentifier {
-		return ""
-	}
-	return node.Text()
-}
-
-func checkReassignments(block *ast.Node, names []string, symbols []*ast.Symbol, ctx rule.RuleContext) {
-	if block == nil || ctx.TypeChecker == nil || len(names) == 0 || len(symbols) == 0 {
+// checkBindingReassignments reports every write-reference to ident's own
+// declared symbol. RefStore resolution is scope-correct by construction, so a
+// local binding that shadows the catch parameter is never returned as a
+// reference here.
+func checkBindingReassignments(ident *ast.Node, ctx *rule.RuleContext) {
+	decl := ident.Parent
+	if decl == nil || decl.Name() != ident {
 		return
 	}
-
-	var walk func(*ast.Node)
-	walk = func(block *ast.Node) {
-		if block == nil {
-			return
-		}
-
-		block.ForEachChild(func(child *ast.Node) bool {
-			if child == nil {
-				return false
-			}
-
-			childName := getIdentifierName(child)
-			if child.Kind == ast.KindIdentifier && slices.Contains(names, childName) {
-				if isWriteReference(child) {
-					shadowed := isNameShadowed(child, symbols, ctx)
-					if !shadowed {
-						ctx.ReportNode(child, buildExAssignMessage())
-					}
-				}
-			} else {
-				walk(child)
-			}
-
-			return false
-		})
+	sym := decl.Symbol()
+	if sym == nil {
+		return
 	}
-
-	walk(block)
+	for _, ref := range ctx.Refs.References(sym) {
+		if utils.IsWriteReference(ref) {
+			ctx.ReportNode(ref, buildExAssignMessage())
+		}
+	}
 }
 
 var NoExAssignRule = rule.Rule{
-	Name:             "no-ex-assign",
-	RequiresTypeInfo: true,
+	Name: "no-ex-assign",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCatchClause: func(node *ast.Node) {
-				if node.AsCatchClause().VariableDeclaration == nil {
+				varDeclNode := node.AsCatchClause().VariableDeclaration
+				if varDeclNode == nil {
 					return
 				}
-
-				varDecl := node.AsCatchClause().VariableDeclaration.AsVariableDeclaration()
+				varDecl := varDeclNode.AsVariableDeclaration()
 				if varDecl == nil || varDecl.Name() == nil {
 					return
 				}
 
-				block := node.AsCatchClause().Block
-				if block == nil {
-					return
-				}
-
-				names, symbols := collectCatchBindingNamesAndSymbols(varDecl.Name(), ctx)
-				checkReassignments(block, names, symbols, ctx)
+				utils.CollectBindingNames(varDecl.Name(), func(ident *ast.Node, _ string) {
+					checkBindingReassignments(ident, &ctx)
+				})
 			},
 		}
 	},

--- a/internal/rules/no_func_assign/no_func_assign.go
+++ b/internal/rules/no_func_assign/no_func_assign.go
@@ -13,86 +13,19 @@ func buildMessage(name string) rule.RuleMessage {
 	}
 }
 
-// isNameShadowed checks whether the identifier at `node` refers to a different
-// binding than `declNode`'s name, i.e. a local variable/parameter/catch binding
-// that shadows the function name.
-//
-// When a TypeChecker is available, symbol identity is checked first (fast path).
-// Because the TypeChecker sometimes resolves shorthand-property identifiers in
-// destructuring assignments to a *property* symbol rather than the variable
-// symbol, a positive result is confirmed by a scope-based walk before we
-// declare the name shadowed.
-func isNameShadowed(node *ast.Node, name string, declNode *ast.Node, ctx *rule.RuleContext) bool {
-	if node == nil || ctx.TypeChecker == nil {
-		return false
-	}
-
-	identSymbol := ctx.TypeChecker.GetSymbolAtLocation(node)
-	if identSymbol == nil {
-		return false
-	}
-
-	// Get the symbol at the declaration's name.
-	declName := declNode.Name()
-	if declName == nil {
-		return false
-	}
-	declSymbol := ctx.TypeChecker.GetSymbolAtLocation(declName)
-
-	if declSymbol != nil {
-		if identSymbol == declSymbol {
-			return false // same binding — not shadowed
-		}
-		// Different symbol — confirm with scope analysis before concluding,
-		// because some AST positions (e.g. shorthand destructuring) resolve
-		// to a property symbol rather than the variable symbol.
-		return isInShadowingScope(node, name, declNode)
-	}
-
-	return isInShadowingScope(node, name, declNode)
-}
-
-// isInShadowingScope walks from `node` up to (but not including) `declNode`,
-// returning true if any intermediate scope introduces a binding with the given
-// name. Also treats `declNode`'s own parameters as shadowing
-// (e.g. `function foo(foo) { foo = bar; }`).
-func isInShadowingScope(node *ast.Node, name string, declNode *ast.Node) bool {
-	if utils.IsNameShadowedBetween(node, declNode, name) {
-		return true
-	}
-	return declNode != nil && utils.HasShadowingParameter(declNode, name)
-}
-
-// checkReassignments walks `searchRoot` and reports every write-reference to `name`
-// that targets the same binding as `declNode`.
-func checkReassignments(searchRoot *ast.Node, name string, declNode *ast.Node, ctx *rule.RuleContext) {
-	if name == "" {
+// checkReassignments reports every write-reference to declNode's own symbol.
+// RefStore resolution is scope-correct by construction, so a local binding
+// that shadows the function name is never returned as a reference here.
+func checkReassignments(declNode *ast.Node, ctx *rule.RuleContext) {
+	sym := declNode.Symbol()
+	if sym == nil {
 		return
 	}
-
-	var walk func(*ast.Node)
-	walk = func(node *ast.Node) {
-		if node == nil {
-			return
+	for _, ref := range ctx.Refs.References(sym) {
+		if utils.IsWriteReference(ref) {
+			ctx.ReportNode(ref, buildMessage(sym.Name))
 		}
-
-		if node.Kind == ast.KindIdentifier && node.Text() == name {
-			// Skip the declaration's own name node.
-			if node.Parent == declNode {
-				return
-			}
-			if utils.IsWriteReference(node) && !isNameShadowed(node, name, declNode, ctx) {
-				ctx.ReportNode(node, buildMessage(name))
-			}
-		}
-
-		node.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
 	}
-
-	walk(searchRoot)
 }
 
 // NoFuncAssignRule disallows reassigning function declarations.
@@ -105,31 +38,18 @@ var NoFuncAssignRule = rule.Rule{
 				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
 					return
 				}
-				funcName := nameNode.Text()
-				if funcName == "" {
-					return
-				}
-
-				searchRoot := ast.GetEnclosingBlockScopeContainer(node)
-				if searchRoot == nil {
-					return
-				}
-
-				checkReassignments(searchRoot, funcName, node, &ctx)
+				checkReassignments(node, &ctx)
 			},
 
-			// Named function expressions: the name is only visible inside the body.
+			// Named function expressions: the name is only visible inside the
+			// body, which RefStore's scope-aware resolution enforces on its
+			// own.
 			ast.KindFunctionExpression: func(node *ast.Node) {
 				nameNode := node.Name()
 				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
 					return
 				}
-				funcName := nameNode.Text()
-				if funcName == "" {
-					return
-				}
-
-				checkReassignments(node, funcName, node, &ctx)
+				checkReassignments(node, &ctx)
 			},
 		}
 	},


### PR DESCRIPTION
## Summary

- Port `no-class-assign`, `no-func-assign`, and `no-ex-assign` to `ctx.Refs`, replacing their manual whole-scope AST walks, name-string matching, and TypeChecker-based shadow detection with `ctx.Refs.References(sym)`, following the pattern the no-var rule already uses.
- `no-ex-assign` no longer requires a TypeChecker (drops `RequiresTypeInfo: true`); reference resolution is now binder-based like the other two.
- Fixes false positives in `no-class-assign` and `no-func-assign` where a shadowing local was still reported when `ctx.TypeChecker` was nil (their old shadow check silently no-opped in that case).
- Re-enables a previously-disabled `no-class-assign` test case for shorthand destructuring assignment (`({A} = 0)`), which now passes correctly.

## Validation

- `go test ./internal/rules/no_class_assign/...`
- `go test ./internal/rules/no_func_assign/...`
- `go test ./internal/rules/no_ex_assign/...`
- `go vet` on the three changed packages
- `internal/config` TypeChecker-nil-safety guard tests (`TestAllRules_SilentOnNilTypeCheckerImpliesRequiresTypeInfo`, `TestAllRules_NilTypeCheckerEarlyReturnImpliesRequiresTypeInfo`, `TestAllRules_DeclaredSchemasCompile`)

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).