### PR TITLE
perf: port no-shadow-restricted-names and no-const-assign to ctx.Refs

### DIFF
--- a/internal/rules/no_const_assign/no_const_assign.go
+++ b/internal/rules/no_const_assign/no_const_assign.go
@@ -1,11 +1,14 @@
 package no_const_assign
 
 import (
+	"sort"
+
 	"github.com/microsoft/typescript-go/shim/ast"
+
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// Message builder
 func buildConstMessage(name string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "const",
@@ -13,361 +16,82 @@ func buildConstMessage(name string) rule.RuleMessage {
 	}
 }
 
-// isConstBinding checks if a variable declaration is a const binding
-func isConstBinding(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindVariableDeclarationList {
-		return false
-	}
-
-	varDeclList := node.AsVariableDeclarationList()
-	if varDeclList == nil {
-		return false
-	}
-
-	// Check if the declaration is const (or using/await using in the future)
-	// In TypeScript AST, const declarations have flags
-	return (varDeclList.Flags & ast.NodeFlagsConst) != 0
-}
-
-// getIdentifierName gets the name of an identifier node
-func getIdentifierName(node *ast.Node) string {
-	if node == nil || node.Kind != ast.KindIdentifier {
-		return ""
-	}
-
-	return node.Text()
-}
-
-// isWriteReference checks if a reference is a write operation (assignment, increment, decrement, etc.)
-func isWriteReference(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-
-	parent := node.Parent
-	if parent == nil {
-		return false
-	}
-
-	switch parent.Kind {
-	case ast.KindBinaryExpression:
-		// Check if this is an assignment operation
-		binary := parent.AsBinaryExpression()
-		if binary == nil {
-			return false
-		}
-
-		// Check if the node is on the left side of an assignment
-		if binary.Left != node {
-			return false
-		}
-
-		// Check for all assignment operators
-		switch binary.OperatorToken.Kind {
-		case ast.KindEqualsToken, // =
-			ast.KindPlusEqualsToken,                              // +=
-			ast.KindMinusEqualsToken,                             // -=
-			ast.KindAsteriskEqualsToken,                          // *=
-			ast.KindSlashEqualsToken,                             // /=
-			ast.KindPercentEqualsToken,                           // %=
-			ast.KindAsteriskAsteriskEqualsToken,                  // **=
-			ast.KindLessThanLessThanEqualsToken,                  // <<=
-			ast.KindGreaterThanGreaterThanEqualsToken,            // >>=
-			ast.KindGreaterThanGreaterThanGreaterThanEqualsToken, // >>>=
-			ast.KindAmpersandEqualsToken,                         // &=
-			ast.KindBarEqualsToken,                               // |=
-			ast.KindCaretEqualsToken,                             // ^=
-			ast.KindQuestionQuestionEqualsToken,                  // ??=
-			ast.KindAmpersandAmpersandEqualsToken,                // &&=
-			ast.KindBarBarEqualsToken:                            // ||=
-			return true
-		}
-
-	case ast.KindPrefixUnaryExpression:
-		// Check for ++ and -- prefix operators
-		prefix := parent.AsPrefixUnaryExpression()
-		if prefix == nil {
-			return false
-		}
-
-		switch prefix.Operator {
-		case ast.KindPlusPlusToken, // ++
-			ast.KindMinusMinusToken: // --
-			return prefix.Operand == node
-		}
-
-	case ast.KindPostfixUnaryExpression:
-		// Check for ++ and -- postfix operators
-		postfix := parent.AsPostfixUnaryExpression()
-		if postfix == nil {
-			return false
-		}
-
-		switch postfix.Operator {
-		case ast.KindPlusPlusToken, // ++
-			ast.KindMinusMinusToken: // --
-			return postfix.Operand == node
-		}
-
-	case ast.KindObjectBindingPattern:
-		// In destructuring like {x} = obj, x is a write reference
-		return isBindingPatternInAssignment(parent)
-
-	case ast.KindArrayBindingPattern:
-		// In array destructuring like [x] = arr, x is a write reference
-		return isBindingPatternInAssignment(parent)
-
-	case ast.KindBindingElement:
-		// Check if the binding element is part of a write context
-		return isWriteReference(parent)
-
-	case ast.KindShorthandPropertyAssignment:
-		// In destructuring like {x} = obj or ({x} = obj), x is a write reference
-		// Check if the parent shorthand property is in a destructuring assignment
-		return isInDestructuringAssignment(parent)
-
-	case ast.KindPropertyAssignment:
-		// In destructuring like {b: x} = obj, x is a write reference
-		propAssignment := parent.AsPropertyAssignment()
-		if propAssignment != nil && propAssignment.Initializer == node {
-			return isInDestructuringAssignment(parent)
-		}
-
-	case ast.KindObjectLiteralExpression:
-		// In object destructuring like {x} = obj, x is a write reference
-		return isInDestructuringAssignment(parent)
-
-	case ast.KindArrayLiteralExpression:
-		// In array destructuring like [x] = arr, x is a write reference
-		return isInDestructuringAssignment(parent)
-
-	case ast.KindParenthesizedExpression:
-		// Unwrap parentheses and check the parent context
-		return isWriteReference(parent)
-
-	case ast.KindAsExpression, ast.KindTypeAssertionExpression:
-		// Type assertions like (x as any) = 0
-		// The type assertion wraps the identifier, check if the assertion is a write target
-		return isWriteReference(parent)
-	}
-
-	return false
-}
-
-// isBindingPatternInAssignment checks if a binding pattern is the left side of an assignment
-func isBindingPatternInAssignment(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-
-	// The binding pattern's parent might be wrapped in parentheses
-	parent := node.Parent
-
-	// Unwrap parentheses
-	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-		parent = parent.Parent
-	}
-
-	// Check if the parent is a binary expression with = operator
-	if parent != nil && parent.Kind == ast.KindBinaryExpression {
-		binary := parent.AsBinaryExpression()
-		if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
-			// Check if the binding pattern is on the left side
-			leftNode := binary.Left
-			// Unwrap parentheses on the left side
-			for leftNode != nil && leftNode.Kind == ast.KindParenthesizedExpression {
-				parenExpr := leftNode.AsParenthesizedExpression()
-				if parenExpr != nil {
-					leftNode = parenExpr.Expression
-				} else {
-					break
-				}
-			}
-			return leftNode == node
-		}
-	}
-
-	return false
-}
-
-// isInDestructuringAssignment checks if a node is part of a destructuring assignment pattern
-func isInDestructuringAssignment(node *ast.Node) bool {
-	current := node
-	for current != nil {
-		if current.Kind == ast.KindObjectLiteralExpression || current.Kind == ast.KindArrayLiteralExpression {
-			// Check if this literal is the left side of an assignment
-			// May be wrapped in parentheses
-			parent := current.Parent
-
-			// Unwrap parentheses
-			for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-				parent = parent.Parent
-			}
-
-			if parent != nil && parent.Kind == ast.KindBinaryExpression {
-				binary := parent.AsBinaryExpression()
-				if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
-					// Check if the literal (or its parent parenthesized expression) is on the left
-					leftNode := binary.Left
-					// Unwrap parentheses on left side
-					for leftNode != nil && leftNode.Kind == ast.KindParenthesizedExpression {
-						parenExpr := leftNode.AsParenthesizedExpression()
-						if parenExpr != nil {
-							leftNode = parenExpr.Expression
-						} else {
-							break
-						}
-					}
-					if leftNode == current {
-						return true
-					}
-				}
-			}
-			return false
-		}
-		current = current.Parent
-	}
-	return false
-}
-
-// checkIdentifierWrite checks if an identifier is a write reference to a const variable
-func checkIdentifierWrite(node *ast.Node, ctx *rule.RuleContext, constSymbols map[*ast.Symbol]bool) {
-	// Check if this is a write reference (assignment, increment, etc.)
-	if !isWriteReference(node) {
-		return
-	}
-
-	// Get the symbol for this identifier
-	if ctx.TypeChecker == nil {
-		return
-	}
-
-	symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
-	if symbol == nil {
-		return
-	}
-
-	// Check if this symbol refers to a const variable
-	if !constSymbols[symbol] {
-		return
-	}
-
-	// Report the violation
-	identName := getIdentifierName(node)
-	ctx.ReportNode(node, buildConstMessage(identName))
-}
-
 // NoConstAssignRule disallows reassigning const variables
 var NoConstAssignRule = rule.Rule{
 	Name:             "no-const-assign",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		// Track const declarations by their symbol
-		constSymbols := make(map[*ast.Symbol]bool)
+		// Violations are collected per declaration (as the traversal visits each
+		// VariableDeclarationList) but reported only once the whole file has
+		// been walked, sorted back into source order: two separate `const`
+		// declarations of the same name in different scopes are visited in
+		// declaration order, not in the order their writes actually appear.
+		var violations []*ast.Node
 
-		return rule.RuleListeners{
-			// Track const variable declarations
+		flush := func() {
+			sort.Slice(violations, func(i, j int) bool {
+				return violations[i].Pos() < violations[j].Pos()
+			})
+			for _, ref := range violations {
+				ctx.ReportNode(ref, buildConstMessage(ref.Text()))
+			}
+		}
+
+		listeners := rule.RuleListeners{
 			ast.KindVariableDeclarationList: func(node *ast.Node) {
-				if !isConstBinding(node) {
+				if ctx.Refs == nil || node.Flags&ast.NodeFlagsConst == 0 {
+					return
+				}
+				declList := node.AsVariableDeclarationList()
+				if declList == nil || declList.Declarations == nil {
 					return
 				}
 
-				varDeclList := node.AsVariableDeclarationList()
-				if varDeclList == nil || varDeclList.Declarations == nil {
-					return
-				}
-
-				// Track all identifiers declared as const using their symbols
-				for _, decl := range varDeclList.Declarations.Nodes {
+				for _, decl := range declList.Declarations.Nodes {
 					if decl.Kind != ast.KindVariableDeclaration {
 						continue
 					}
-
 					varDecl := decl.AsVariableDeclaration()
 					if varDecl == nil || varDecl.Name() == nil {
 						continue
 					}
 
-					// Collect symbols for all identifiers in the binding name
-					collectSymbols(varDecl.Name(), &ctx, constSymbols)
+					utils.CollectBindingNames(varDecl.Name(), func(ident *ast.Node, _ string) {
+						// The binder attaches the symbol to the enclosing
+						// declaration (VariableDeclaration or BindingElement).
+						bindingDecl := ident.Parent
+						if bindingDecl == nil || bindingDecl.Name() != ident {
+							return
+						}
+						sym := bindingDecl.Symbol()
+						if sym == nil {
+							return
+						}
+						for _, ref := range ctx.Refs.References(sym) {
+							if utils.IsWriteReference(ref) {
+								violations = append(violations, ref)
+							}
+						}
+					})
 				}
-			},
-
-			// Check for reassignments to const variables
-			ast.KindIdentifier: func(node *ast.Node) {
-				checkIdentifierWrite(node, &ctx, constSymbols)
-			},
-
-			// Check shorthand property assignments in destructuring (e.g., {x} = obj)
-			ast.KindShorthandPropertyAssignment: func(node *ast.Node) {
-				shorthand := node.AsShorthandPropertyAssignment()
-				if shorthand == nil || shorthand.Name() == nil {
-					return
-				}
-
-				// Check if this shorthand is in a destructuring assignment
-				if !isInDestructuringAssignment(node) {
-					return
-				}
-
-				// This is a write reference, check if it refers to a const variable
-				if ctx.TypeChecker == nil {
-					return
-				}
-
-				symbol := ctx.TypeChecker.GetSymbolAtLocation(shorthand.Name())
-				if symbol == nil {
-					return
-				}
-
-				// Check if this symbol refers to a const variable
-				if !constSymbols[symbol] {
-					return
-				}
-
-				// Report the violation
-				identName := getIdentifierName(shorthand.Name())
-				ctx.ReportNode(shorthand.Name(), buildConstMessage(identName))
 			},
 		}
+
+		// Flush once the whole file has been walked. The traversal never visits
+		// the SourceFile node itself (only its children), so the hook is the
+		// exit of the last top-level statement, mirroring no_unused_vars.
+		statements := ctx.SourceFile.Statements
+		if statements == nil || len(statements.Nodes) == 0 {
+			flush()
+		} else {
+			lastTopLevelNode := statements.Nodes[len(statements.Nodes)-1]
+			listeners[rule.ListenerOnExit(lastTopLevelNode.Kind)] = func(node *ast.Node) {
+				if node == lastTopLevelNode {
+					flush()
+				}
+			}
+		}
+
+		return listeners
 	},
-}
-
-// collectSymbols recursively collects symbols for all identifiers from a binding pattern
-func collectSymbols(bindingName *ast.Node, ctx *rule.RuleContext, constSymbols map[*ast.Symbol]bool) {
-	if bindingName == nil || ctx.TypeChecker == nil {
-		return
-	}
-
-	switch bindingName.Kind {
-	case ast.KindIdentifier:
-		symbol := ctx.TypeChecker.GetSymbolAtLocation(bindingName)
-		if symbol != nil {
-			constSymbols[symbol] = true
-		}
-
-	case ast.KindObjectBindingPattern:
-		// Walk through child nodes to find binding elements
-		bindingName.ForEachChild(func(child *ast.Node) bool {
-			if child.Kind == ast.KindBindingElement {
-				bindingElem := child.AsBindingElement()
-				if bindingElem != nil && bindingElem.Name() != nil {
-					collectSymbols(bindingElem.Name(), ctx, constSymbols)
-				}
-			}
-			return false
-		})
-
-	case ast.KindArrayBindingPattern:
-		// Walk through child nodes to find binding elements
-		bindingName.ForEachChild(func(child *ast.Node) bool {
-			if child.Kind == ast.KindBindingElement {
-				bindingElem := child.AsBindingElement()
-				if bindingElem != nil && bindingElem.Name() != nil {
-					collectSymbols(bindingElem.Name(), ctx, constSymbols)
-				}
-			}
-			return false
-		})
-	}
 }

--- a/internal/rules/no_const_assign/no_const_assign_test.go
+++ b/internal/rules/no_const_assign/no_const_assign_test.go
@@ -109,13 +109,12 @@ func TestNoConstAssignRule(t *testing.T) {
 			},
 
 			// Assignment via destructuring
-			// TODO: This test case is not working yet - needs investigation of AST structure
-			// {
-			// 	Code: `const x = 0; ({x} = {x: 1});`,
-			// 	Errors: []rule_tester.InvalidTestCaseError{
-			// 		{MessageId: "const", Line: 1, Column: 16},
-			// 	},
-			// },
+			{
+				Code: `const x = 0; ({x} = {x: 1});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "const", Line: 1, Column: 16},
+				},
+			},
 
 			// Compound assignment +=
 			{

--- a/internal/rules/no_shadow_restricted_names/no_shadow_restricted_names.go
+++ b/internal/rules/no_shadow_restricted_names/no_shadow_restricted_names.go
@@ -49,51 +49,19 @@ func isForInOrOfLoopVariable(varDecl *ast.Node) bool {
 	return stmt != nil && stmt.Initializer == list
 }
 
-// collectWrittenUndefinedSymbols walks the source file and collects symbols of
-// every identifier named "undefined" that is written to (assignment target).
-// Symbol-level declaration analysis (init, parameter/class/function/catch/import
-// defs, for-in/of loop) is handled separately via `symbol.Declarations`.
-func collectWrittenUndefinedSymbols(ctx rule.RuleContext) map[*ast.Symbol]bool {
-	written := map[*ast.Symbol]bool{}
-	if ctx.TypeChecker == nil || ctx.SourceFile == nil {
-		return written
-	}
-	tc := ctx.TypeChecker
-
-	var walk func(n *ast.Node)
-	walk = func(n *ast.Node) {
-		if n == nil {
-			return
-		}
-		if ast.IsIdentifier(n) && n.AsIdentifier().Text == "undefined" && utils.IsWriteReference(n) {
-			// GetReferenceSymbol resolves the value-binding symbol for
-			// shorthand destructuring assignments, instead of the property
-			// symbol that GetSymbolAtLocation would otherwise return.
-			if sym := utils.GetReferenceSymbol(n, tc); sym != nil {
-				written[sym] = true
-			}
-		}
-		n.ForEachChild(func(c *ast.Node) bool {
-			walk(c)
-			return false
-		})
-	}
-
-	walk(ctx.SourceFile.AsNode())
-	return written
-}
-
 // isSymbolSafelyShadowingUndefined matches ESLint's safelyShadowsUndefined:
 // every def of the symbol must be a plain VariableDeclaration without an
 // initializer and not a for-in/of loop variable, AND the symbol must have no
 // write references.
-func isSymbolSafelyShadowingUndefined(sym *ast.Symbol, writtenSymbols map[*ast.Symbol]bool) bool {
+func isSymbolSafelyShadowingUndefined(sym *ast.Symbol, refs *rule.RefStore) bool {
 	if sym == nil {
-		// No type info — be permissive, same as when TypeChecker is nil.
+		// No symbol info — be permissive, same as when refs is nil.
 		return true
 	}
-	if writtenSymbols[sym] {
-		return false
+	for _, ref := range refs.References(sym) {
+		if utils.IsWriteReference(ref) {
+			return false
+		}
 	}
 	if len(sym.Declarations) == 0 {
 		return true
@@ -171,16 +139,6 @@ var NoShadowRestrictedNamesRule = rule.Rule{
 			restricted["globalThis"] = true
 		}
 
-		var writtenUndefinedSymbols map[*ast.Symbol]bool
-		undefinedComputed := false
-		ensureUndefinedAnalysis := func() {
-			if undefinedComputed {
-				return
-			}
-			undefinedComputed = true
-			writtenUndefinedSymbols = collectWrittenUndefinedSymbols(ctx)
-		}
-
 		reported := map[*ast.Node]bool{}
 		report := func(ident *ast.Node, name string) {
 			if ident == nil || reported[ident] {
@@ -198,14 +156,16 @@ var NoShadowRestrictedNamesRule = rule.Rule{
 				return
 			}
 			if name == "undefined" && allowSafeUndefined {
-				if ctx.TypeChecker == nil {
-					// No type information: be permissive, matching ESLint's
+				if ctx.Refs == nil {
+					// No reference info: be permissive, matching ESLint's
 					// safelyShadowsUndefined when the declaration has no initializer.
 					return
 				}
-				ensureUndefinedAnalysis()
-				sym := ctx.TypeChecker.GetSymbolAtLocation(ident)
-				if isSymbolSafelyShadowingUndefined(sym, writtenUndefinedSymbols) &&
+				var sym *ast.Symbol
+				if decl := ident.Parent; decl != nil && decl.Name() == ident {
+					sym = decl.Symbol()
+				}
+				if isSymbolSafelyShadowingUndefined(sym, ctx.Refs) &&
 					!hasSameScopeNonVarUndefinedDeclaration(ident) {
 					return
 				}


### PR DESCRIPTION
## Summary

- Port `no-shadow-restricted-names` and `no-const-assign` to `ctx.Refs`, replacing manual whole-file/whole-scope AST walks and `TypeChecker.GetSymbolAtLocation` calls with `ctx.Refs.References(sym)`, following the pattern the no-var rule already uses.
- `no-const-assign`'s violations are now collected per declaration and flushed in source order at the end of the file (mirroring `no-unused-vars`'s pattern), since scanning the whole file in one linear pass no longer happens naturally once lookups are grouped by declaration.
- Re-enables a previously-disabled `no-const-assign` test case for shorthand destructuring writes (`({x} = {x: 1})`), which now passes correctly.

The `prefer-const` port and the `RefStore.Resolve` API addition moved to #1415.

## Validation

- `go build ./internal/rule/... ./internal/rules/...`
- `go test ./internal/rules/no_shadow_restricted_names/...`
- `go test ./internal/rules/no_const_assign/...`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).