### PR TITLE
perf: defer no-duplicates fix construction

### DIFF
--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.go
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.go
@@ -317,14 +317,10 @@ func checkImports(ctx rule.RuleContext, importMap map[string][]*ast.Node, text s
 		first := g.nodes[0]
 		rest := g.nodes[1:]
 
-		fixes := getFix(ctx, first, rest, text, opts)
-
 		firstSource := first.AsImportDeclaration().ModuleSpecifier
-		if fixes != nil {
-			ctx.ReportNodeWithFixes(firstSource, msg, fixes...)
-		} else {
-			ctx.ReportNode(firstSource, msg)
-		}
+		ctx.ReportNodeWithDeferredFixes(firstSource, msg, func() []rule.RuleFix {
+			return getFix(ctx, first, rest, text, opts)
+		})
 
 		for _, node := range rest {
 			ctx.ReportNode(node.AsImportDeclaration().ModuleSpecifier, msg)

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates_test.go
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates_test.go
@@ -1,11 +1,18 @@
 package no_duplicates_test
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_duplicates"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoDuplicatesRule(t *testing.T) {
@@ -708,4 +715,157 @@ func TestNoDuplicatesRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoDuplicatesEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const code = "import { first } from './shared';\nimport { second } from './shared';\n"
+	program, sourceFile := createNoDuplicatesProgram(t, "edit-demand.ts", code)
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:         program,
+			File:            sourceFile.FileName(),
+			HasTypeInfo:     true,
+			GetRulesForFile: noDuplicatesConfiguredRules,
+			ExcludePaths:    []string{},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixes := run(rule.EditDemandAutofix)
+	suggestionsOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	for name, diagnostics := range map[string][]rule.RuleDiagnostic{
+		"diagnostics only": diagnosticsOnly,
+		"autofixes":        autofixes,
+		"suggestions only": suggestionsOnly,
+		"all edits":        allEdits,
+	} {
+		if len(diagnostics) != 2 {
+			t.Fatalf("%s: got %d diagnostics, want 2", name, len(diagnostics))
+		}
+		for i, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil {
+				t.Errorf("%s: diagnostic %d unexpectedly has suggestions", name, i)
+			}
+		}
+	}
+
+	for i := range allEdits {
+		want := diagnosticWithoutEdits(allEdits[i])
+		for name, diagnostics := range map[string][]rule.RuleDiagnostic{
+			"diagnostics only": diagnosticsOnly,
+			"autofixes":        autofixes,
+			"suggestions only": suggestionsOnly,
+		} {
+			if got := diagnosticWithoutEdits(diagnostics[i]); !reflect.DeepEqual(got, want) {
+				t.Errorf("%s: diagnostic %d changed:\ngot  %#v\nwant %#v", name, i, got, want)
+			}
+		}
+	}
+
+	if got := len(autofixes[0].Fixes()); got == 0 {
+		t.Fatal("autofixes: first diagnostic has no merge fix")
+	}
+	if !reflect.DeepEqual(autofixes[0].Fixes(), allEdits[0].Fixes()) {
+		t.Fatalf("autofix and all-edits modes produced different fixes:\nautofix %#v\nall     %#v", autofixes[0].Fixes(), allEdits[0].Fixes())
+	}
+	for name, diagnostics := range map[string][]rule.RuleDiagnostic{
+		"diagnostics only": diagnosticsOnly,
+		"suggestions only": suggestionsOnly,
+	} {
+		for i, diagnostic := range diagnostics {
+			if got := len(diagnostic.Fixes()); got != 0 {
+				t.Errorf("%s: diagnostic %d has %d fixes, want 0", name, i, got)
+			}
+		}
+	}
+	for i := 1; i < len(autofixes); i++ {
+		if got := len(autofixes[i].Fixes()); got != 0 {
+			t.Errorf("autofixes: diagnostic %d has %d fixes, want 0", i, got)
+		}
+	}
+
+	const unfixableCode = "import first from './shared';\nimport second from './shared';\n"
+	unfixableProgram, unfixableSourceFile := createNoDuplicatesProgram(t, "unfixable.ts", unfixableCode)
+	var unfixableDiagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:         unfixableProgram,
+		File:            unfixableSourceFile.FileName(),
+		HasTypeInfo:     true,
+		GetRulesForFile: noDuplicatesConfiguredRules,
+		ExcludePaths:    []string{},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: rule.EditDemandAll,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				unfixableDiagnostics = append(unfixableDiagnostics, diagnostic)
+			},
+		},
+	})
+	if len(unfixableDiagnostics) != 2 {
+		t.Fatalf("unfixable imports: got %d diagnostics, want 2", len(unfixableDiagnostics))
+	}
+	for i, diagnostic := range unfixableDiagnostics {
+		if diagnostic.FixesPtr != nil {
+			t.Errorf("unfixable imports: diagnostic %d has a non-nil fix payload", i)
+		}
+	}
+}
+
+type diagnosticIdentity struct {
+	Range    [2]int
+	RuleName string
+	Message  rule.RuleMessage
+	FilePath string
+	Severity rule.DiagnosticSeverity
+}
+
+func diagnosticWithoutEdits(diagnostic rule.RuleDiagnostic) diagnosticIdentity {
+	return diagnosticIdentity{
+		Range:    [2]int{diagnostic.Range.Pos(), diagnostic.Range.End()},
+		RuleName: diagnostic.RuleName,
+		Message:  diagnostic.Message,
+		FilePath: diagnostic.FilePath,
+		Severity: diagnostic.Severity,
+	}
+}
+
+func createNoDuplicatesProgram(t testing.TB, fileName string, code string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+
+	rootDir := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return program, sourceFile
+}
+
+func noDuplicatesConfiguredRules(*ast.SourceFile) []linter.ConfiguredRule {
+	return []linter.ConfiguredRule{{
+		Name:     no_duplicates.NoDuplicatesRule.Name,
+		Severity: rule.SeverityError,
+		Run: func(ctx rule.RuleContext) rule.RuleListeners {
+			return no_duplicates.NoDuplicatesRule.Run(ctx, nil)
+		},
+	}}
 }


### PR DESCRIPTION
## Summary

- Defer `import/no-duplicates` merge-fix construction until the native diagnostic consumer requests autofixes.
- Keep duplicate detection, diagnostic order, messages, ranges, severities, and all-edits fix output unchanged.
- Add an edit-demand matrix test covering diagnostics-only, autofix, suggestion-only, and all-edits consumers, including the unfixable conflicting-default-import case.
- Benchmark measurements were collected with a temporary local harness; benchmark-only files are intentionally excluded from this PR.

Architecturally, the rule continues to own fix semantics while the framework owns artifact demand and suppression. The rule does not inspect consumer state: it passes a synchronous, non-retained builder to `ReportNodeWithDeferredFixes`. This keeps output-mode concerns out of rule logic and guarantees suppressed or diagnostics-only reports cannot trigger source scanning, import merging, map allocation, or replacement-text construction.

### Benchmark

Apple M1 Max, darwin/arm64. Measurements use the same temporary local harness on the base and PR commits; benchmark-only files are intentionally excluded from the PR. GOMAXPROCS=1, 1 second per sample, 12 samples per revision, measured in both before→after and after→before order. Values are medians; time MAD/median is at most 0.36%.

| Demand | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| diagnostics only | 573,331 → 113,545 (-80.20%) | 835,611 → 57,112 (-93.17%) | 4,521 → 489 (-89.18%) |
| all edits | 573,913 → 577,114 (+0.56%) | 835,611 → 835,611 (0.00%) | 4,521 → 4,521 (0.00%) |

The target diagnostics-only path removes most merge-fix work. All-edits still constructs the same artifacts and retains identical memory and allocation counts; its sub-percent timing delta is the bounded deferred-call cost.

### Adversarial review

- Verified all four edit-demand combinations preserve the same diagnostic identity.
- Verified autofix and all-edits modes produce identical fixes.
- Verified suggestion-only mode does not expose or construct autofixes.
- Verified an unfixable duplicate group retains a nil fix payload rather than an empty fix payload.
- Re-ran the demand test 20 times and ran the affected package under the race detector.

## Related Links

Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).


