### PR TITLE
perf: defer first autofix planning

### DIFF
--- a/internal/plugins/import/rules/first/first.go
+++ b/internal/plugins/import/rules/first/first.go
@@ -187,15 +187,12 @@ func checkFirst(ctx rule.RuleContext, options []any) {
 
 	absoluteFirst := utils.GetOptionsString(options) == "absolute-first"
 	body := statements.Nodes
-	sourceText := ctx.SourceFile.Text()
 
 	nonImportCount := 0
 	anyExpressions := false
 	anyRelative := false
 	var lastLegalImp *ast.Node
 	var errorInfos []errorInfo
-	shouldSort := true
-	lastSortNodesIndex := 0
 
 	for i, node := range body {
 		// Skip directives ('use strict', etc.) that precede any real expression.
@@ -223,19 +220,6 @@ func checkFirst(ctx rule.RuleContext, options []any) {
 			}
 
 			if nonImportCount > 0 {
-				// This import appears after non-import code.
-				// Check if any of its declared names are referenced before it;
-				// if so, moving the import could change evaluation order, so
-				// disable autofix from this point on.
-				if shouldSort {
-					if hasReferenceBeforeImport(ctx, body, i, node) {
-						shouldSort = false
-					}
-				}
-				if shouldSort {
-					lastSortNodesIndex = len(errorInfos)
-				}
-
 				rangeFrom := 0
 				if i > 0 {
 					rangeFrom = body[i-1].End()
@@ -258,23 +242,73 @@ func checkFirst(ctx rule.RuleContext, options []any) {
 		return
 	}
 
-	for i, ei := range errorInfos {
-		if i == lastSortNodesIndex {
-			// The last sortable error carries the combined fix that moves all
-			// sortable imports to the top.
-			sortNodes := errorInfos[:lastSortNodesIndex+1]
-			fixes := buildFix(sourceText, body, lastLegalImp, sortNodes)
-			ctx.ReportNodeWithFixes(ei.node, messageFirst(), fixes...)
-		} else if i < lastSortNodesIndex {
-			// Earlier sortable errors get a no-op fix so the fixer treats them
-			// as already handled (avoids overlapping fix conflicts).
-			ctx.ReportNodeWithFixes(ei.node, messageFirst(), rule.RuleFix{
-				Range: core.NewTextRange(ei.node.End(), ei.node.End()),
-				Text:  "",
-			})
-		} else {
-			ctx.ReportNode(ei.node, messageFirst())
+	var fixPlan firstFixPlan
+	fixPlanBuilt := false
+	getFixes := func(errorIndex int, node *ast.Node) []rule.RuleFix {
+		if !fixPlanBuilt {
+			fixPlan = buildFixPlan(ctx, body, lastLegalImp, errorInfos)
+			fixPlanBuilt = true
 		}
+		return fixPlan.fixesFor(errorIndex, node)
+	}
+
+	for i, ei := range errorInfos {
+		errorIndex := i
+		node := ei.node
+		ctx.ReportNodeWithDeferredFixes(node, messageFirst(), func() []rule.RuleFix {
+			return getFixes(errorIndex, node)
+		})
+	}
+}
+
+type firstFixPlan struct {
+	lastSortNodesIndex int
+	combinedFixes      []rule.RuleFix
+}
+
+func (p firstFixPlan) fixesFor(errorIndex int, node *ast.Node) []rule.RuleFix {
+	switch {
+	case errorIndex == p.lastSortNodesIndex:
+		return p.combinedFixes
+	case errorIndex < p.lastSortNodesIndex:
+		return []rule.RuleFix{{
+			Range: core.NewTextRange(node.End(), node.End()),
+			Text:  "",
+		}}
+	default:
+		return nil
+	}
+}
+
+// buildFixPlan determines which misplaced imports may be safely moved together
+// and builds the per-diagnostic fixes. This work is only needed by consumers
+// that request autofixes.
+func buildFixPlan(ctx rule.RuleContext, body []*ast.Node, lastLegalImp *ast.Node, errorInfos []errorInfo) firstFixPlan {
+	shouldSort := true
+	lastSortNodesIndex := 0
+	bodyIndex := 0
+	for i, ei := range errorInfos {
+		for bodyIndex < len(body) && body[bodyIndex] != ei.node {
+			bodyIndex++
+		}
+		if bodyIndex == len(body) {
+			panic("import/first: misplaced import is not part of the source-file body")
+		}
+		// The first misplaced import remains individually fixable. A reference
+		// only prevents later imports from joining the same batch.
+		if shouldSort && hasReferenceBeforeImport(ctx, body, bodyIndex, ei.node) {
+			shouldSort = false
+		}
+		if shouldSort {
+			lastSortNodesIndex = i
+		}
+	}
+
+	return firstFixPlan{
+		lastSortNodesIndex: lastSortNodesIndex,
+		// The last sortable error carries the combined fix that moves all
+		// sortable imports to the top.
+		combinedFixes: buildFix(ctx.SourceFile.Text(), body, lastLegalImp, errorInfos[:lastSortNodesIndex+1]),
 	}
 }
 

--- a/internal/plugins/import/rules/first/first_test.go
+++ b/internal/plugins/import/rules/first/first_test.go
@@ -1,11 +1,18 @@
 package first_test
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/first"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestFirstRule(t *testing.T) {
@@ -676,4 +683,152 @@ func TestFirstRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestFirstEditDemand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		code           string
+		wantFixPayload []bool
+	}{
+		{
+			name: "all misplaced imports batch together",
+			code: "const before = 1;\n" +
+				"import { first } from './first';\n" +
+				"const between = 2;\n" +
+				"import { second } from './second';\n" +
+				"import { third } from './third';\n",
+			wantFixPayload: []bool{true, true, true},
+		},
+		{
+			name: "reference cuts off the current fix batch",
+			code: "const before = 1;\n" +
+				"import { first } from './first';\n" +
+				"const usedBeforeImport = second;\n" +
+				"import { second } from './second';\n" +
+				"import { third } from './third';\n",
+			wantFixPayload: []bool{true, false, false},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			program, sourceFile := createFirstProgram(t, "edit-demand.ts", test.code)
+			run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+				t.Helper()
+
+				var diagnostics []rule.RuleDiagnostic
+				linter.LintSingleFile(linter.LintSingleFileOptions{
+					Program:         program,
+					File:            sourceFile.FileName(),
+					HasTypeInfo:     true,
+					GetRulesForFile: firstConfiguredRules,
+					ExcludePaths:    []string{},
+					Consumer: rule.DiagnosticConsumer{
+						Demand: demand,
+						Report: func(diagnostic rule.RuleDiagnostic) {
+							diagnostics = append(diagnostics, diagnostic)
+						},
+					},
+				})
+				return diagnostics
+			}
+
+			diagnosticsOnly := run(rule.EditDemandNone)
+			autofixes := run(rule.EditDemandAutofix)
+			suggestionsOnly := run(rule.EditDemandSuggestion)
+			allEdits := run(rule.EditDemandAll)
+
+			for name, diagnostics := range map[string][]rule.RuleDiagnostic{
+				"diagnostics only": diagnosticsOnly,
+				"autofixes":        autofixes,
+				"suggestions only": suggestionsOnly,
+				"all edits":        allEdits,
+			} {
+				if len(diagnostics) != len(test.wantFixPayload) {
+					t.Fatalf("%s: got %d diagnostics, want %d", name, len(diagnostics), len(test.wantFixPayload))
+				}
+				for i, diagnostic := range diagnostics {
+					if diagnostic.Suggestions != nil {
+						t.Errorf("%s: diagnostic %d unexpectedly has suggestions", name, i)
+					}
+				}
+			}
+
+			for i := range allEdits {
+				wantIdentity := firstDiagnosticWithoutEdits(allEdits[i])
+				for name, diagnostics := range map[string][]rule.RuleDiagnostic{
+					"diagnostics only": diagnosticsOnly,
+					"autofixes":        autofixes,
+					"suggestions only": suggestionsOnly,
+				} {
+					if got := firstDiagnosticWithoutEdits(diagnostics[i]); !reflect.DeepEqual(got, wantIdentity) {
+						t.Errorf("%s: diagnostic %d changed:\ngot  %#v\nwant %#v", name, i, got, wantIdentity)
+					}
+				}
+
+				if got := autofixes[i].FixesPtr != nil; got != test.wantFixPayload[i] {
+					t.Errorf("autofixes: diagnostic %d fix-payload presence = %v, want %v", i, got, test.wantFixPayload[i])
+				}
+				if !reflect.DeepEqual(autofixes[i].Fixes(), allEdits[i].Fixes()) {
+					t.Errorf("diagnostic %d differs between autofix and all-edits modes", i)
+				}
+				if diagnosticsOnly[i].FixesPtr != nil {
+					t.Errorf("diagnostics only: diagnostic %d unexpectedly has a fix payload", i)
+				}
+				if suggestionsOnly[i].FixesPtr != nil {
+					t.Errorf("suggestions only: diagnostic %d unexpectedly has a fix payload", i)
+				}
+			}
+		})
+	}
+}
+
+type firstDiagnosticIdentity struct {
+	Range    [2]int
+	RuleName string
+	Message  rule.RuleMessage
+	FilePath string
+	Severity rule.DiagnosticSeverity
+}
+
+func firstDiagnosticWithoutEdits(diagnostic rule.RuleDiagnostic) firstDiagnosticIdentity {
+	return firstDiagnosticIdentity{
+		Range:    [2]int{diagnostic.Range.Pos(), diagnostic.Range.End()},
+		RuleName: diagnostic.RuleName,
+		Message:  diagnostic.Message,
+		FilePath: diagnostic.FilePath,
+		Severity: diagnostic.Severity,
+	}
+}
+
+func createFirstProgram(t testing.TB, fileName string, code string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+
+	rootDir := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return program, sourceFile
+}
+
+func firstConfiguredRules(*ast.SourceFile) []linter.ConfiguredRule {
+	return []linter.ConfiguredRule{{
+		Name:     first.FirstRule.Name,
+		Severity: rule.SeverityError,
+		Run: func(ctx rule.RuleContext) rule.RuleListeners {
+			return first.FirstRule.Run(ctx, nil)
+		},
+	}}
 }


### PR DESCRIPTION
## Summary

- Defer `import/first` autofix safety analysis and replacement construction until the native diagnostic consumer requests autofixes.
- Preserve the rule's existing multi-pass behavior: the first misplaced import remains individually fixable, while an earlier reference only prevents later imports from joining that fix batch.
- Add an edit-demand matrix covering fully batchable imports and a reference-triggered batch cutoff.
- Benchmark measurements were collected with a temporary local harness; benchmark-only files are intentionally excluded from this PR.

Architecturally, diagnostic discovery now records only misplaced imports. A synchronous deferred builder materializes one memoized fix plan on the first requested, non-suppressed autofix. The plan is intentionally compact: it stores the last sortable diagnostic and the single combined replacement, while earlier no-op fixes are generated only when attached. Rules never inspect output mode, and diagnostics-only consumers skip all binding lookup, TypeChecker reference walking, source extraction, sorting, and replacement construction.

The compact plan also preserves the all-edits allocation profile exactly; an intermediate two-dimensional fix table was rejected because it added an unnecessary allocation and memory overhead.

### Benchmark

Apple M1 Max, darwin/arm64. Measurements use the same temporary local harness on the base and PR commits; benchmark-only files are intentionally excluded from the PR. GOMAXPROCS=1, 2 seconds per sample, 8 samples per revision, measured in both before→after and after→before order. Values are medians.

| Demand | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| diagnostics only | 563,846 → 41,334 (-92.67%) | 49,664 → 8,096 (-83.70%) | 146 → 57 (-60.96%) |
| all edits | 562,836 → 561,452 (-0.25%) | 49,664 → 49,664 (0.00%) | 146 → 146 (0.00%) |

Diagnostics-only time MAD/median is 0.12% before and 0.19% after. The all-edits timing difference is smaller than run-to-run variance and is treated as neutral; its memory and allocation counts are exactly unchanged.

### Adversarial review

- Verified diagnostic identity across diagnostics-only, autofix, suggestion-only, and all-edits consumers.
- Verified the all-batchable path retains no-op fixes on earlier diagnostics and the combined fix on the last sortable diagnostic.
- Verified a pre-import reference preserves the first-import-only fix and nil fix payloads on later diagnostics.
- Verified autofix and all-edits payloads are identical.
- Re-ran the demand matrix 20 times, the complete affected rule suite, and the affected package under the race detector.
- Confirmed the final all-edits bytes and allocation counts exactly match the baseline.

## Related Links

Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).


