### PR TITLE
perf: defer unused import edits

### DIFF
--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -1160,6 +1160,37 @@ func getImportRemoveFix(ctx rule.RuleContext, definition *ast.Node, reportedUnus
 	return nil, rule.RuleMessage{}
 }
 
+func reportUnusedImport(
+	ctx rule.RuleContext,
+	reportNode *ast.Node,
+	definition *ast.Node,
+	message rule.RuleMessage,
+	autofix bool,
+	reportedUnused map[*ast.Node]bool,
+) {
+	// Deferred builders execute synchronously when their artifact category is
+	// requested, so they observe the same incremental reportedUnused state as
+	// the former eager path.
+	if autofix {
+		ctx.ReportNodeWithDeferredFixes(reportNode, message, func() []rule.RuleFix {
+			fixes, _ := getImportRemoveFix(ctx, definition, reportedUnused)
+			return fixes
+		})
+		return
+	}
+
+	ctx.ReportNodeWithDeferredSuggestions(reportNode, message, func() []rule.RuleSuggestion {
+		fixes, suggestionMessage := getImportRemoveFix(ctx, definition, reportedUnused)
+		if len(fixes) == 0 {
+			return nil
+		}
+		return []rule.RuleSuggestion{{
+			Message:  suggestionMessage,
+			FixesArr: fixes,
+		}}
+	})
+}
+
 func getImportDeclaration(node *ast.Node) *ast.Node {
 	current := node
 	for current != nil {
@@ -1786,15 +1817,15 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 		// Track unused imports for allImportSpecifiersUnused check
 		if isImport {
 			ac.reportedUnused[definition] = true
-		}
-
-		// Generate import removal fix/suggestion
-		if isImport {
-			fixes, suggestionMsg := getImportRemoveFix(ctx, definition, ac.reportedUnused)
-			if len(fixes) > 0 {
-				rule.ReportNodeWithFixesOrSuggestions(ctx, reportNode, opts.EnableAutofixRemoval.Imports, buildUnusedVarMessage(name, assigned), suggestionMsg, fixes...)
-				return
-			}
+			reportUnusedImport(
+				ctx,
+				reportNode,
+				definition,
+				buildUnusedVarMessage(name, assigned),
+				opts.EnableAutofixRemoval.Imports,
+				ac.reportedUnused,
+			)
+			return
 		}
 		ctx.ReportNode(reportNode, buildUnusedVarMessage(name, assigned))
 	}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_imports_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_imports_test.go
@@ -1,10 +1,17 @@
 package no_unused_vars
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoUnusedVarsImports(t *testing.T) {
@@ -272,4 +279,178 @@ console.log(join("a", "b"));`,
 	}
 
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, validTestCases, invalidTestCases)
+}
+
+func TestNoUnusedVarsImportEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const code = `import DefaultValue, { usedValue, unusedOne, unusedTwo } from './named';
+import * as unusedNamespace from './namespace';
+import unusedEquals = require('./equals');
+console.log(usedValue);
+`
+
+	tests := []struct {
+		name            string
+		options         []any
+		requestedDemand rule.EditDemand
+		otherDemand     rule.EditDemand
+		wantFixes       bool
+	}{
+		{
+			name:            "suggestions",
+			options:         rule.NormalizeOptions(nil),
+			requestedDemand: rule.EditDemandSuggestion,
+			otherDemand:     rule.EditDemandAutofix,
+		},
+		{
+			name: "autofix",
+			options: rule.NormalizeOptions(map[string]interface{}{
+				"enableAutofixRemoval": map[string]interface{}{"imports": true},
+			}),
+			requestedDemand: rule.EditDemandAutofix,
+			otherDemand:     rule.EditDemandSuggestion,
+			wantFixes:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			program, sourceFile := createNoUnusedVarsProgram(t, "edit-demand-"+test.name+".ts", code)
+			run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+				t.Helper()
+
+				var diagnostics []rule.RuleDiagnostic
+				linter.LintSingleFile(linter.LintSingleFileOptions{
+					Program:         program,
+					File:            sourceFile.FileName(),
+					HasTypeInfo:     true,
+					GetRulesForFile: noUnusedVarsConfiguredRules(test.options),
+					ExcludePaths:    []string{},
+					Consumer: rule.DiagnosticConsumer{
+						Demand: demand,
+						Report: func(diagnostic rule.RuleDiagnostic) {
+							diagnostics = append(diagnostics, diagnostic)
+						},
+					},
+				})
+				return diagnostics
+			}
+
+			diagnosticsOnly := run(rule.EditDemandNone)
+			requested := run(test.requestedDemand)
+			otherCategory := run(test.otherDemand)
+			allEdits := run(rule.EditDemandAll)
+
+			const wantDiagnostics = 5
+			for name, diagnostics := range map[string][]rule.RuleDiagnostic{
+				"diagnostics only": diagnosticsOnly,
+				"requested":        requested,
+				"other category":   otherCategory,
+				"all edits":        allEdits,
+			} {
+				if len(diagnostics) != wantDiagnostics {
+					t.Fatalf("%s: got %d diagnostics, want %d", name, len(diagnostics), wantDiagnostics)
+				}
+			}
+
+			for i := range allEdits {
+				wantIdentity := noUnusedVarsDiagnosticWithoutEdits(allEdits[i])
+				for name, diagnostics := range map[string][]rule.RuleDiagnostic{
+					"diagnostics only": diagnosticsOnly,
+					"requested":        requested,
+					"other category":   otherCategory,
+				} {
+					if got := noUnusedVarsDiagnosticWithoutEdits(diagnostics[i]); !reflect.DeepEqual(got, wantIdentity) {
+						t.Errorf("%s: diagnostic %d changed:\ngot  %#v\nwant %#v", name, i, got, wantIdentity)
+					}
+				}
+
+				assertNoUnusedVarsDiagnosticHasNoEdits(t, "diagnostics only", i, diagnosticsOnly[i])
+				assertNoUnusedVarsDiagnosticHasNoEdits(t, "other category", i, otherCategory[i])
+
+				if test.wantFixes {
+					if requested[i].FixesPtr == nil {
+						t.Errorf("requested: diagnostic %d has no autofix payload", i)
+					}
+					if !reflect.DeepEqual(requested[i].Fixes(), allEdits[i].Fixes()) {
+						t.Errorf("diagnostic %d differs between autofix and all-edits modes", i)
+					}
+					if requested[i].Suggestions != nil || allEdits[i].Suggestions != nil {
+						t.Errorf("diagnostic %d unexpectedly has suggestions in autofix configuration", i)
+					}
+				} else {
+					if requested[i].Suggestions == nil {
+						t.Errorf("requested: diagnostic %d has no suggestion payload", i)
+					}
+					if !reflect.DeepEqual(requested[i].Suggestions, allEdits[i].Suggestions) {
+						t.Errorf("diagnostic %d differs between suggestion and all-edits modes", i)
+					}
+					if requested[i].FixesPtr != nil || allEdits[i].FixesPtr != nil {
+						t.Errorf("diagnostic %d unexpectedly has fixes in suggestion configuration", i)
+					}
+				}
+			}
+		})
+	}
+}
+
+func assertNoUnusedVarsDiagnosticHasNoEdits(t *testing.T, mode string, index int, diagnostic rule.RuleDiagnostic) {
+	t.Helper()
+	if diagnostic.FixesPtr != nil {
+		t.Errorf("%s: diagnostic %d unexpectedly has a fix payload", mode, index)
+	}
+	if diagnostic.Suggestions != nil {
+		t.Errorf("%s: diagnostic %d unexpectedly has a suggestion payload", mode, index)
+	}
+}
+
+type noUnusedVarsDiagnosticIdentity struct {
+	Range    [2]int
+	RuleName string
+	Message  rule.RuleMessage
+	FilePath string
+	Severity rule.DiagnosticSeverity
+}
+
+func noUnusedVarsDiagnosticWithoutEdits(diagnostic rule.RuleDiagnostic) noUnusedVarsDiagnosticIdentity {
+	return noUnusedVarsDiagnosticIdentity{
+		Range:    [2]int{diagnostic.Range.Pos(), diagnostic.Range.End()},
+		RuleName: diagnostic.RuleName,
+		Message:  diagnostic.Message,
+		FilePath: diagnostic.FilePath,
+		Severity: diagnostic.Severity,
+	}
+}
+
+func createNoUnusedVarsProgram(t testing.TB, fileName string, code string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+
+	rootDir := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return program, sourceFile
+}
+
+func noUnusedVarsConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
+	return func(*ast.SourceFile) []linter.ConfiguredRule {
+		return []linter.ConfiguredRule{{
+			Name:             NoUnusedVarsRule.Name,
+			Severity:         rule.SeverityError,
+			RequiresTypeInfo: true,
+			Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				return NoUnusedVarsRule.Run(ctx, options)
+			},
+		}}
+	}
 }


### PR DESCRIPTION
## Summary

- Defer unused-import fix construction in `@typescript-eslint/no-unused-vars` until the consumer requests the configured artifact category.
- Preserve all diagnostic-essential symbol, reference, write, export, ignore-pattern, and type analysis on the main rule path.
- Route the default configuration through deferred suggestions and `enableAutofixRemoval.imports` through deferred autofixes without exposing consumer demand to the rule.
- Add a four-mode edit-demand test for both configurations; benchmark measurements were collected with a temporary local harness and benchmark-only files are intentionally excluded.

Architecturally, `reportedUnused` remains diagnostic-side state and is updated before every report. The deferred builder is synchronous and non-retained, so an all-edits consumer observes the same incremental map state as the former eager call to `getImportRemoveFix`. Diagnostics-only or wrong-category consumers skip line expansion, comma scanning, specifier removal ranges, message construction, and suggestion wrapping.

Unsupported or malformed import shapes remain ordinary diagnostics: an empty builder result produces a nil artifact payload, matching the old fallback to `ReportNode`.

### Benchmark

Apple M1 Max, darwin/arm64. Measurements use the same temporary local harness on the base and PR commits; benchmark-only files are intentionally excluded from the PR. GOMAXPROCS=1, 1 second per sample, 10 samples per revision, measured in both before→after and after→before order. Values are medians; time MAD/median ranges from 0.18% to 1.20%.

| Configuration / demand | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| suggestions / diagnostics only | 247,590 → 162,170 (-34.50%) | 152,984 → 109,976 (-28.11%) | 2,084 → 868 (-58.35%) |
| suggestions / all edits | 246,393 → 247,781 (+0.56%) | 152,984 → 152,984 (0.00%) | 2,084 → 2,084 (0.00%) |
| autofix / diagnostics only | 231,449 → 162,812 (-29.66%) | 136,600 → 109,976 (-19.49%) | 1,828 → 868 (-52.52%) |
| autofix / all edits | 232,536 → 230,244 (-0.99%) | 136,600 → 136,600 (0.00%) | 1,828 → 1,828 (0.00%) |

Both diagnostics-only configurations show large, repeatable reductions. The two all-edits timing deltas are within the measured run variance and are treated as neutral; bytes and allocations are exactly unchanged.

### Adversarial review

- Verified diagnostic identity across diagnostics-only, autofix, suggestion-only, and all-edits consumers for both rule configurations.
- Verified wrong-category consumers receive no fix or suggestion payload.
- Verified requested-category payloads exactly match all-edits payloads.
- Exercised default, namespace, import-equals, used, and multiple unused named bindings in the demand matrix.
- Ran the complete affected rule package, the affected package under the race detector, and the parallel demand matrix repeatedly with an independent Program per subtest.
- Confirmed the existing import golden suite still covers whole-declaration removal, partial removal, commas, multiline imports, aliases, CRLF, and autofix/suggestion output.

## Related Links

Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).



