### PR TITLE
feat: defer combined edit artifacts

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -297,6 +297,12 @@ func (*RuleContext) ReportNodeWithDeferredFixes(..., func() []RuleFix)
 func (*RuleContext) ReportRangeWithDeferredFixes(..., func() []RuleFix)
 func (*RuleContext) ReportNodeWithDeferredSuggestions(..., func() []RuleSuggestion)
 func (*RuleContext) ReportRangeWithDeferredSuggestions(..., func() []RuleSuggestion)
+func (*RuleContext) ReportNodeWithDeferredFixesAndSuggestions(
+    ..., func() []RuleFix, func() []RuleSuggestion,
+)
+func (*RuleContext) ReportRangeWithDeferredFixesAndSuggestions(
+    ..., func() []RuleFix, func() []RuleSuggestion,
+)
 ```
 
 The linter creates one short-lived `CommentStore` per file. `Comments.All()`
@@ -329,16 +335,18 @@ This is a reporting-pass capability, not a `Program` property:
 `RunLinter` normalizes it once and passes the same immutable consumer separately
 to every per-Program lint task and then into each rule reporter.
 
-The category-specific deferred reporting methods apply inline-disable
-suppression first, inspect the matching demand bit, and only then invoke the
-builder synchronously. Builders are never retained and must contain only work
-needed to construct their optional artifact; diagnostic detection, message,
-range, and severity are decided before the builder. Keeping the rule API
+The deferred reporting methods apply inline-disable suppression first, inspect
+the matching demand bit, and only then invoke each category-specific builder
+synchronously. Builders are never retained and must contain only work needed
+to construct their optional artifact; diagnostic detection, message, range,
+and severity are decided before the builder. A diagnostic that can carry both
+autofixes and suggestions supplies two independent builders, so a consumer
+requesting one category does not materialize the other. Keeping builders
 category-specific avoids exposing a general callback protocol or a demand
-query that rules could accidentally use to change diagnostic semantics.
-Adding another native optional artifact is additive: define one demand bit and
-one category-specific deferred reporting path. The pass/Program scheduling
-boundary and existing rule APIs do not need to change.
+query that rules could accidentally use to change diagnostic semantics. Adding
+another native optional artifact is additive: define one demand bit and one
+category-specific builder path. The pass/Program scheduling boundary and
+existing rule APIs do not need to change.
 
 Existing eager `Report*WithFixes` and `Report*WithSuggestions` methods remain
 available for gradual rule migration. Their already-built artifacts are
@@ -418,7 +426,10 @@ analysis is expensive should use `ReportRangeWithDeferredFixes(...)` or
 `ReportNodeWithDeferredFixes(...)`, allowing the framework to skip that
 analysis when the current native consumer does not need autofixes. The
 suggestion counterparts provide the same migration path for expensive
-suggestion construction.
+suggestion construction. A single diagnostic with independently expensive
+autofixes and suggestions should use
+`Report*WithDeferredFixesAndSuggestions(...)`; its two builders are gated
+separately while suppression and diagnostic emission still happen once.
 
 Fix application happens in `internal/linter/source_code_fixer.go`:
 

--- a/internal/rule/context.go
+++ b/internal/rule/context.go
@@ -190,6 +190,34 @@ func (ctx *RuleContext) reportRangeWithDeferredSuggestions(textRange core.TextRa
 	ctx.emitRange(textRange, msg, nil, suggestions)
 }
 
+func (ctx *RuleContext) reportRangeWithDeferredFixesAndSuggestions(
+	textRange core.TextRange,
+	msg RuleMessage,
+	buildFixes func() []RuleFix,
+	buildSuggestions func() []RuleSuggestion,
+) {
+	if !ctx.shouldReportRange(textRange) {
+		return
+	}
+
+	var fixes *[]RuleFix
+	if ctx.reporter.consumer.Demand&EditDemandAutofix != 0 {
+		built := buildFixes()
+		if len(built) > 0 {
+			fixes = &built
+		}
+	}
+
+	var suggestions *[]RuleSuggestion
+	if ctx.reporter.consumer.Demand&EditDemandSuggestion != 0 {
+		built := buildSuggestions()
+		if len(built) > 0 {
+			suggestions = &built
+		}
+	}
+	ctx.emitRange(textRange, msg, fixes, suggestions)
+}
+
 func (ctx *RuleContext) ReportRange(textRange core.TextRange, msg RuleMessage) {
 	ctx.requireReporter()
 	ctx.reportRange(textRange, msg, nil, nil)
@@ -227,6 +255,26 @@ func (ctx *RuleContext) ReportRangeWithDeferredSuggestions(textRange core.TextRa
 	ctx.reportRangeWithDeferredSuggestions(textRange, msg, build)
 }
 
+// ReportRangeWithDeferredFixesAndSuggestions reports one diagnostic whose
+// autofixes and suggestions are constructed independently when their matching
+// artifact categories are requested. Each requested builder runs synchronously
+// after suppression and is never retained; empty results attach no artifact.
+func (ctx *RuleContext) ReportRangeWithDeferredFixesAndSuggestions(
+	textRange core.TextRange,
+	msg RuleMessage,
+	buildFixes func() []RuleFix,
+	buildSuggestions func() []RuleSuggestion,
+) {
+	ctx.requireReporter()
+	if buildFixes == nil {
+		panic("rule: deferred fixes require a builder")
+	}
+	if buildSuggestions == nil {
+		panic("rule: deferred suggestions require a builder")
+	}
+	ctx.reportRangeWithDeferredFixesAndSuggestions(textRange, msg, buildFixes, buildSuggestions)
+}
+
 func (ctx *RuleContext) ReportNode(node *ast.Node, msg RuleMessage) {
 	ctx.requireReporter()
 	ctx.reportRange(utils.TrimNodeTextRange(ctx.SourceFile, node), msg, nil, nil)
@@ -260,6 +308,29 @@ func (ctx *RuleContext) ReportNodeWithDeferredSuggestions(node *ast.Node, msg Ru
 		panic("rule: deferred suggestions require a builder")
 	}
 	ctx.reportRangeWithDeferredSuggestions(utils.TrimNodeTextRange(ctx.SourceFile, node), msg, build)
+}
+
+// ReportNodeWithDeferredFixesAndSuggestions is the node-keyed twin of
+// ReportRangeWithDeferredFixesAndSuggestions.
+func (ctx *RuleContext) ReportNodeWithDeferredFixesAndSuggestions(
+	node *ast.Node,
+	msg RuleMessage,
+	buildFixes func() []RuleFix,
+	buildSuggestions func() []RuleSuggestion,
+) {
+	ctx.requireReporter()
+	if buildFixes == nil {
+		panic("rule: deferred fixes require a builder")
+	}
+	if buildSuggestions == nil {
+		panic("rule: deferred suggestions require a builder")
+	}
+	ctx.reportRangeWithDeferredFixesAndSuggestions(
+		utils.TrimNodeTextRange(ctx.SourceFile, node),
+		msg,
+		buildFixes,
+		buildSuggestions,
+	)
 }
 
 // ReportNodeWithFixesAndSuggestions emits a single diagnostic carrying both

--- a/internal/rule/context_test.go
+++ b/internal/rule/context_test.go
@@ -26,6 +26,14 @@ func TestRuleContextReportWithoutReporterPanics(t *testing.T) {
 		{name: "range deferred suggestions", report: func(ctx *RuleContext) {
 			ctx.ReportRangeWithDeferredSuggestions(textRange, message, func() []RuleSuggestion { return nil })
 		}},
+		{name: "range deferred combined", report: func(ctx *RuleContext) {
+			ctx.ReportRangeWithDeferredFixesAndSuggestions(
+				textRange,
+				message,
+				func() []RuleFix { return nil },
+				func() []RuleSuggestion { return nil },
+			)
+		}},
 		{name: "node", report: func(ctx *RuleContext) { ctx.ReportNode(nil, message) }},
 		{name: "node fixes", report: func(ctx *RuleContext) { ctx.ReportNodeWithFixes(nil, message) }},
 		{name: "node suggestions", report: func(ctx *RuleContext) { ctx.ReportNodeWithSuggestions(nil, message) }},
@@ -35,6 +43,14 @@ func TestRuleContextReportWithoutReporterPanics(t *testing.T) {
 		}},
 		{name: "node deferred suggestions", report: func(ctx *RuleContext) {
 			ctx.ReportNodeWithDeferredSuggestions(nil, message, func() []RuleSuggestion { return nil })
+		}},
+		{name: "node deferred combined", report: func(ctx *RuleContext) {
+			ctx.ReportNodeWithDeferredFixesAndSuggestions(
+				nil,
+				message,
+				func() []RuleFix { return nil },
+				func() []RuleSuggestion { return nil },
+			)
 		}},
 	}
 
@@ -120,8 +136,20 @@ func TestDeferredReportsRejectNilBuilder(t *testing.T) {
 	}{
 		{name: "range fixes", report: func() { ctx.ReportRangeWithDeferredFixes(textRange, message, nil) }},
 		{name: "range suggestions", report: func() { ctx.ReportRangeWithDeferredSuggestions(textRange, message, nil) }},
+		{name: "range combined fixes", report: func() {
+			ctx.ReportRangeWithDeferredFixesAndSuggestions(textRange, message, nil, func() []RuleSuggestion { return nil })
+		}},
+		{name: "range combined suggestions", report: func() {
+			ctx.ReportRangeWithDeferredFixesAndSuggestions(textRange, message, func() []RuleFix { return nil }, nil)
+		}},
 		{name: "node fixes", report: func() { ctx.ReportNodeWithDeferredFixes(nil, message, nil) }},
 		{name: "node suggestions", report: func() { ctx.ReportNodeWithDeferredSuggestions(nil, message, nil) }},
+		{name: "node combined fixes", report: func() {
+			ctx.ReportNodeWithDeferredFixesAndSuggestions(nil, message, nil, func() []RuleSuggestion { return nil })
+		}},
+		{name: "node combined suggestions", report: func() {
+			ctx.ReportNodeWithDeferredFixesAndSuggestions(nil, message, func() []RuleFix { return nil }, nil)
+		}},
 	}
 
 	for _, testCase := range tests {
@@ -133,6 +161,153 @@ func TestDeferredReportsRejectNilBuilder(t *testing.T) {
 			}()
 			testCase.report()
 		})
+	}
+}
+
+func TestDeferredFixesAndSuggestionsDemand(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, "const value = 1;", core.ScriptKindTS)
+	textRange := core.NewTextRange(0, 5)
+	message := RuleMessage{Id: "combined", Description: "combined report"}
+	fix := RuleFixReplaceRange(textRange, "let")
+	suggestion := RuleSuggestion{
+		Message:  RuleMessage{Id: "suggestion", Description: "use let"},
+		FixesArr: []RuleFix{fix},
+	}
+
+	tests := []struct {
+		name               string
+		demand             EditDemand
+		wantFixBuilder     int
+		wantSuggestBuilder int
+		wantFixes          bool
+		wantSuggestions    bool
+	}{
+		{name: "diagnostics only", demand: EditDemandNone},
+		{name: "autofix", demand: EditDemandAutofix, wantFixBuilder: 1, wantFixes: true},
+		{name: "suggestions", demand: EditDemandSuggestion, wantSuggestBuilder: 1, wantSuggestions: true},
+		{
+			name:               "all edits",
+			demand:             EditDemandAll,
+			wantFixBuilder:     1,
+			wantSuggestBuilder: 1,
+			wantFixes:          true,
+			wantSuggestions:    true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixBuilderCalls := 0
+			suggestionBuilderCalls := 0
+			var got []RuleDiagnostic
+			ctx := RuleContext{
+				SourceFile:     sourceFile,
+				DisableManager: NewDisableManager(sourceFile, NewCommentStore(sourceFile)),
+			}.WithDiagnosticConsumer("test", SeverityWarning, DiagnosticConsumer{
+				Demand: testCase.demand,
+				Report: func(diagnostic RuleDiagnostic) {
+					got = append(got, diagnostic)
+				},
+			})
+
+			ctx.ReportRangeWithDeferredFixesAndSuggestions(
+				textRange,
+				message,
+				func() []RuleFix {
+					fixBuilderCalls++
+					return []RuleFix{fix}
+				},
+				func() []RuleSuggestion {
+					suggestionBuilderCalls++
+					return []RuleSuggestion{suggestion}
+				},
+			)
+
+			if fixBuilderCalls != testCase.wantFixBuilder {
+				t.Errorf("fix builder calls = %d, want %d", fixBuilderCalls, testCase.wantFixBuilder)
+			}
+			if suggestionBuilderCalls != testCase.wantSuggestBuilder {
+				t.Errorf("suggestion builder calls = %d, want %d", suggestionBuilderCalls, testCase.wantSuggestBuilder)
+			}
+			if len(got) != 1 {
+				t.Fatalf("diagnostics = %d, want 1", len(got))
+			}
+			if got[0].Range != textRange || !reflect.DeepEqual(got[0].Message, message) {
+				t.Errorf("diagnostic identity changed: %#v", got[0])
+			}
+			if (got[0].FixesPtr != nil) != testCase.wantFixes {
+				t.Errorf("fix presence = %v, want %v", got[0].FixesPtr != nil, testCase.wantFixes)
+			} else if testCase.wantFixes && !reflect.DeepEqual(*got[0].FixesPtr, []RuleFix{fix}) {
+				t.Errorf("fixes = %#v, want %#v", *got[0].FixesPtr, []RuleFix{fix})
+			}
+			if (got[0].Suggestions != nil) != testCase.wantSuggestions {
+				t.Errorf("suggestion presence = %v, want %v", got[0].Suggestions != nil, testCase.wantSuggestions)
+			} else if testCase.wantSuggestions && !reflect.DeepEqual(*got[0].Suggestions, []RuleSuggestion{suggestion}) {
+				t.Errorf("suggestions = %#v, want %#v", *got[0].Suggestions, []RuleSuggestion{suggestion})
+			}
+		})
+	}
+}
+
+func TestNodeDeferredFixesAndSuggestionsSkipsSuppressedBuilders(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, "const visible = 1;\n// rslint-disable-next-line test\nconst blocked = 2;\n", core.ScriptKindTS)
+	if sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) != 2 {
+		t.Fatal("suppression fixture did not parse into two statements")
+	}
+
+	fixBuilderCalls := 0
+	suggestionBuilderCalls := 0
+	var got []RuleDiagnostic
+	ctx := RuleContext{
+		SourceFile:     sourceFile,
+		DisableManager: NewDisableManager(sourceFile, NewCommentStore(sourceFile)),
+	}.WithDiagnosticConsumer("test", SeverityWarning, DiagnosticConsumer{
+		Demand: EditDemandAll,
+		Report: func(diagnostic RuleDiagnostic) {
+			got = append(got, diagnostic)
+		},
+	})
+	report := func(node *ast.Node) {
+		ctx.ReportNodeWithDeferredFixesAndSuggestions(
+			node,
+			RuleMessage{Description: "report"},
+			func() []RuleFix {
+				fixBuilderCalls++
+				return nil
+			},
+			func() []RuleSuggestion {
+				suggestionBuilderCalls++
+				return nil
+			},
+		)
+	}
+
+	report(sourceFile.Statements.Nodes[0])
+	report(sourceFile.Statements.Nodes[1])
+
+	if len(got) != 1 {
+		t.Fatalf("diagnostics = %d, want only the unsuppressed diagnostic", len(got))
+	}
+	visibleNode := sourceFile.Statements.Nodes[0]
+	wantRange := core.NewTextRange(visibleNode.Pos(), visibleNode.End())
+	if got[0].Range != wantRange {
+		t.Fatalf("reported range = %v, want visible node range %v", got[0].Range, wantRange)
+	}
+	if fixBuilderCalls != 1 || suggestionBuilderCalls != 1 {
+		t.Fatalf(
+			"builder calls = fixes %d, suggestions %d; want one call each for only the unsuppressed diagnostic",
+			fixBuilderCalls,
+			suggestionBuilderCalls,
+		)
+	}
+	if got[0].FixesPtr != nil || got[0].Suggestions != nil {
+		t.Fatalf("empty builders should attach no artifacts: %#v", got[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add range- and node-keyed deferred reporting APIs for one diagnostic that can carry both autofixes and suggestions.
- Keep the two builders category-specific: autofix-only consumers never construct suggestions, suggestion-only consumers never construct autofixes, and diagnostics-only consumers construct neither.
- Apply inline-disable suppression once before either builder and emit exactly one diagnostic.
- Preserve the existing fixes-only and suggestions-only implementations unchanged, avoiding any regression for already migrated rules.
- Document the combined path in `architecture.md` and add truth-table, validation, suppression, empty-result, node/range, and race coverage.
- Benchmark measurements were collected with a temporary local harness; benchmark-only files are intentionally excluded from this PR.

The new API is:

```go
ReportRangeWithDeferredFixesAndSuggestions(
    textRange,
    message,
    buildFixes,
    buildSuggestions,
)

ReportNodeWithDeferredFixesAndSuggestions(
    node,
    message,
    buildFixes,
    buildSuggestions,
)
```

This remains a reporting-framework concern. It does not expose `EditDemand` queries to rules, attach demand to Program or TypeChecker state, or alter the serialized JavaScript plugin protocol. Each requested builder executes synchronously and is never retained, so callers may safely memoize shared edit-only computation while keeping diagnostic semantics outside the builders.

Both builders are required. A rule with only one artifact category should use the existing category-specific method; a requested builder may return an empty slice to decline that artifact.

### Benchmark

Apple M1 Max, darwin/arm64. A temporary local harness runs paired eager and deferred controls in the same test binary; benchmark-only files are intentionally excluded from the PR. GOMAXPROCS=1, 1 second per sample, 10 samples per control. Values are medians.

| Demand | ns/op eager → deferred | B/op eager → deferred | allocs/op eager → deferred |
| --- | ---: | ---: | ---: |
| diagnostics only | 4,107 → 14.64 (-99.64%) | 4,384 → 0 (-100.00%) | 132 → 0 (-100.00%) |
| autofix | 4,103 → 1,973 (-51.91%) | 4,384 → 1,656 (-62.23%) | 132 → 66 (-50.00%) |
| suggestions | 4,137 → 2,167 (-47.62%) | 4,384 → 2,728 (-37.77%) | 132 → 66 (-50.00%) |
| all edits | 4,102 → 4,110 (+0.20%) | 4,384 → 4,384 (0.00%) | 132 → 132 (0.00%) |

Time MAD/median is 0.17–1.03%. The all-edits delta is below the combined sample variation and is treated as neutral; there is no additional construction, memory, or allocation.

### Adversarial review

- Verified the exact None, Autofix, Suggestion, and All builder-call truth table.
- Verified nil builders fail at the public API boundary even when their category is not requested.
- Verified empty builder results keep artifact pointers nil.
- Verified suppression skips both builders and the diagnostic.
- Verified the node twin reports the trimmed node range.
- Verified one diagnostic carries both exact artifacts under All.
- Ran the framework package and relevant linter integration tests under the race detector.
- Kept existing single-category private paths intact after rejecting a shared implementation that added unnecessary branches to their hot paths.

## Related Links

Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).


