### PR TITLE
perf: defer exhaustive-deps edits

### DIFF
--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_test.go
@@ -1,10 +1,17 @@
 package exhaustive_deps
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // TestExhaustiveDepsRule covers a curated subset of upstream
@@ -439,3 +446,242 @@ var exhaustiveDepsInvalid = []rule_tester.InvalidTestCase{
 	},
 }
 
+func TestExhaustiveDepsEditDemand(t *testing.T) {
+	t.Parallel()
+
+	fixtures := []struct {
+		name              string
+		code              string
+		message           string
+		suggestionMessage string
+		fixTexts          []string
+	}{
+		{
+			name: "dependency array replacement",
+			code: `
+				function Component(props: { value: number }) {
+					useEffect(() => console.log(props.value), []);
+				}
+			`,
+			message:           "React Hook useEffect has a missing dependency: 'props.value'. Either include it or remove the dependency array.",
+			suggestionMessage: "Update the dependencies array to be: [props.value]",
+			fixTexts:          []string{"[props.value]"},
+		},
+		{
+			name: "unresolved callback replacement",
+			code: `function Component() {
+				useEffect(missingCallback, []);
+			}`,
+			message:           "React Hook useEffect has a missing dependency: 'missingCallback'. Either include it or remove the dependency array.",
+			suggestionMessage: "Update the dependencies array to be: [missingCallback]",
+			fixTexts:          []string{"[missingCallback]"},
+		},
+		{
+			name: "setState dependency insertion",
+			code: `function Component(value: number) {
+				const [, setValue] = useState(0);
+				useEffect(() => { setValue(value); });
+			}`,
+			message:           "React Hook useEffect contains a call to 'setValue'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass [value] as a second argument to the useEffect Hook.",
+			suggestionMessage: "Add dependencies array: [value]",
+			fixTexts:          []string{", [value]"},
+		},
+		{
+			name: "construction wrapping",
+			code: `function Component() {
+				const handler = () => {};
+				useEffect(() => handler(), [handler]);
+				handler();
+			}`,
+			message:           "The 'handler' function makes the dependencies of useEffect Hook (at line 3) change on every render. To fix this, wrap the definition of 'handler' in its own useCallback() Hook.",
+			suggestionMessage: "Wrap the definition of 'handler' in its own useCallback() Hook.",
+			fixTexts:          []string{"useCallback(", ")"},
+		},
+		{
+			name: "useEffectEvent removal",
+			code: `
+				function Component(theme: string) {
+					const onClick = useEffectEvent(() => console.log(theme));
+					useEffect(() => onClick(), [onClick]);
+				}
+			`,
+			message:           "Functions returned from `useEffectEvent` must not be included in the dependency array. Remove `onClick` from the list.",
+			suggestionMessage: "Remove the dependency `onClick`",
+			fixTexts:          []string{""},
+		},
+	}
+
+	configs := []struct {
+		name      string
+		options   []any
+		dangerous bool
+	}{
+		{name: "suggestions", options: rule.NormalizeOptions(nil)},
+		{
+			name: "dangerous autofix",
+			options: rule.NormalizeOptions(map[string]interface{}{
+				"enableDangerousAutofixThisMayCauseInfiniteLoops": true,
+			}),
+			dangerous: true,
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			t.Parallel()
+
+			program, sourceFile := createExhaustiveDepsProgram(t, fixture.name+".ts", fixture.code)
+			for _, config := range configs {
+				t.Run(config.name, func(t *testing.T) {
+					diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+					for _, demand := range []rule.EditDemand{
+						rule.EditDemandNone,
+						rule.EditDemandAutofix,
+						rule.EditDemandSuggestion,
+						rule.EditDemandAll,
+					} {
+						got := lintExhaustiveDepsWithDemand(program, sourceFile, config.options, demand)
+						if len(got) != 1 {
+							t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(got))
+						}
+						if got[0].Message.Description != fixture.message {
+							t.Errorf("demand %d: message = %q, want %q", demand, got[0].Message.Description, fixture.message)
+						}
+						diagnostics[demand] = got[0]
+					}
+
+					diagnosticsOnly := diagnostics[rule.EditDemandNone]
+					for demand, diagnostic := range diagnostics {
+						requireSameDiagnosticWithoutEdits(t, diagnosticsOnly, diagnostic, demand)
+					}
+
+					requireNoEdits(t, diagnostics[rule.EditDemandNone], rule.EditDemandNone)
+					if diagnostics[rule.EditDemandAutofix].Suggestions != nil {
+						t.Errorf("autofix-only demand unexpectedly materialized suggestions")
+					}
+					if diagnostics[rule.EditDemandSuggestion].FixesPtr != nil {
+						t.Errorf("suggestion-only demand unexpectedly materialized autofixes")
+					}
+
+					suggestionOnly := diagnostics[rule.EditDemandSuggestion].Suggestions
+					allSuggestions := diagnostics[rule.EditDemandAll].Suggestions
+					if suggestionOnly == nil || allSuggestions == nil || !reflect.DeepEqual(*suggestionOnly, *allSuggestions) {
+						t.Fatalf("suggestion artifacts differ between suggestion-only and all demand")
+					}
+					if len(*suggestionOnly) != 1 {
+						t.Fatalf("suggestions = %#v, want one suggestion", *suggestionOnly)
+					}
+					suggestion := (*suggestionOnly)[0]
+					if suggestion.Message.Description != fixture.suggestionMessage {
+						t.Errorf("suggestion message = %q, want %q", suggestion.Message.Description, fixture.suggestionMessage)
+					}
+					if len(suggestion.FixesArr) != len(fixture.fixTexts) {
+						t.Fatalf("suggestion fixes = %#v, want texts %#v", suggestion.FixesArr, fixture.fixTexts)
+					}
+					for index, fix := range suggestion.FixesArr {
+						if fix.Text != fixture.fixTexts[index] {
+							t.Errorf("suggestion fix %d text = %q, want %q", index, fix.Text, fixture.fixTexts[index])
+						}
+					}
+
+					if !config.dangerous {
+						if diagnostics[rule.EditDemandAutofix].FixesPtr != nil ||
+							diagnostics[rule.EditDemandAll].FixesPtr != nil {
+							t.Errorf("default config unexpectedly materialized a top-level autofix")
+						}
+						return
+					}
+
+					autofixOnly := diagnostics[rule.EditDemandAutofix].FixesPtr
+					allFixes := diagnostics[rule.EditDemandAll].FixesPtr
+					if autofixOnly == nil || allFixes == nil || !reflect.DeepEqual(*autofixOnly, *allFixes) {
+						t.Fatalf("autofix artifacts differ between autofix-only and all demand")
+					}
+					if len(*autofixOnly) != 1 || !reflect.DeepEqual((*autofixOnly)[0], suggestion.FixesArr[0]) {
+						t.Fatalf("dangerous autofix = %#v, want the first suggestion fix %#v", *autofixOnly, suggestion.FixesArr[0])
+					}
+				})
+			}
+		})
+	}
+}
+
+func lintExhaustiveDepsWithDemand(
+	program *compiler.Program,
+	sourceFile *ast.SourceFile,
+	options []any,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:         program,
+		File:            sourceFile.FileName(),
+		HasTypeInfo:     true,
+		GetRulesForFile: exhaustiveDepsConfiguredRules(options),
+		ExcludePaths:    []string{},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	return diagnostics
+}
+
+func requireSameDiagnosticWithoutEdits(
+	t *testing.T,
+	want rule.RuleDiagnostic,
+	got rule.RuleDiagnostic,
+	demand rule.EditDemand,
+) {
+	t.Helper()
+	want.FixesPtr = nil
+	want.Suggestions = nil
+	got.FixesPtr = nil
+	got.Suggestions = nil
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("demand %d changed diagnostic metadata:\ngot:  %#v\nwant: %#v", demand, got, want)
+	}
+}
+
+func requireNoEdits(t *testing.T, diagnostic rule.RuleDiagnostic, demand rule.EditDemand) {
+	t.Helper()
+	if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+		t.Errorf(
+			"demand %d unexpectedly materialized edits: fixes=%#v suggestions=%#v",
+			demand,
+			diagnostic.FixesPtr,
+			diagnostic.Suggestions,
+		)
+	}
+}
+
+func createExhaustiveDepsProgram(t testing.TB, fileName string, code string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+
+	rootDir := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return program, sourceFile
+}
+
+func exhaustiveDepsConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
+	return func(*ast.SourceFile) []linter.ConfiguredRule {
+		return []linter.ConfiguredRule{{
+			Name:     ExhaustiveDepsRule.Name,
+			Severity: rule.SeverityError,
+			Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				return ExhaustiveDepsRule.Run(ctx, options)
+			},
+		}}
+	}
+}

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/rule.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/rule.go
@@ -37,6 +37,94 @@ type runCaches struct {
 	usedOutside   map[*ast.Node]bool
 }
 
+type suggestionBuilder func() []rule.RuleSuggestion
+
+type suggestionReporter struct {
+	ctx              *rule.RuleContext
+	dangerousAutofix bool
+}
+
+// newSuggestionReporter is the rule-local adapter between upstream's
+// suggestion-first reporting model and rslint's independently demanded edit
+// categories. Dangerous autofix mode promotes exactly the first suggestion's
+// first fix while memoizing the shared suggestion build for EditDemandAll.
+func newSuggestionReporter(ctx *rule.RuleContext, dangerousAutofix bool) *suggestionReporter {
+	return &suggestionReporter{
+		ctx:              ctx,
+		dangerousAutofix: dangerousAutofix,
+	}
+}
+
+func (reporter *suggestionReporter) report(
+	node *ast.Node,
+	description string,
+	buildSuggestions suggestionBuilder,
+) {
+	message := rule.RuleMessage{Description: description}
+	if buildSuggestions == nil {
+		reporter.ctx.ReportNode(node, message)
+		return
+	}
+	if !reporter.dangerousAutofix {
+		reporter.ctx.ReportNodeWithDeferredSuggestions(node, message, buildSuggestions)
+		return
+	}
+	reporter.reportDangerous(node, message, buildSuggestions)
+}
+
+func (reporter *suggestionReporter) reportDangerous(
+	node *ast.Node,
+	message rule.RuleMessage,
+	buildSuggestions suggestionBuilder,
+) {
+	var suggestions []rule.RuleSuggestion
+	suggestionsBuilt := false
+	getSuggestions := func() []rule.RuleSuggestion {
+		if !suggestionsBuilt {
+			suggestions = buildSuggestions()
+			suggestionsBuilt = true
+		}
+		return suggestions
+	}
+	reporter.ctx.ReportNodeWithDeferredFixesAndSuggestions(
+		node,
+		message,
+		func() []rule.RuleFix {
+			built := getSuggestions()
+			if len(built) == 0 || len(built[0].FixesArr) == 0 {
+				return nil
+			}
+			// Mirrors upstream's `problem.fix =
+			// problem.suggest[0].fix`: promote the first
+			// suggestion's first fix only (singular `.fix`).
+			return []rule.RuleFix{built[0].FixesArr[0]}
+		},
+		getSuggestions,
+	)
+}
+
+func buildDependencyArraySuggestion(
+	sf *ast.SourceFile,
+	depsNode *ast.Node,
+	suggestedDeps []string,
+	alphabetized bool,
+	optionalChains map[string]bool,
+) []rule.RuleSuggestion {
+	if alphabetized {
+		sort.Strings(suggestedDeps)
+	}
+
+	formatted := make([]string, len(suggestedDeps))
+	for i, key := range suggestedDeps {
+		formatted[i] = formatDependency(key, optionalChains)
+	}
+	suggestionText := "[" + strings.Join(formatted, ", ") + "]"
+	return []rule.RuleSuggestion{{
+		Message:  rule.RuleMessage{Description: "Update the dependencies array to be: " + suggestionText},
+		FixesArr: []rule.RuleFix{rule.RuleFixReplace(sf, depsNode, suggestionText)},
+	}}
+}
+
 // ExhaustiveDepsRule is the rslint port of upstream `react-hooks/exhaustive-deps`.
 //
 // Architectural difference from upstream: instead of relying on ESLint's
@@ -72,26 +160,14 @@ var ExhaustiveDepsRule = rule.Rule{
 		report := func(node *ast.Node, msg string) {
 			ctx.ReportNode(node, rule.RuleMessage{Description: msg})
 		}
-		reportWithSuggestions := func(node *ast.Node, msg string, sugs ...rule.RuleSuggestion) {
-			if opts.EnableDangerousAutofixThisMayCauseInfiniteLoops && len(sugs) > 0 && len(sugs[0].FixesArr) > 0 {
-				// Mirrors upstream's
-				// `problem.fix = problem.suggest[0].fix`: promote the
-				// first suggestion's first fix only (singular `.fix`,
-				// not the entire FixesArr), AND keep the suggestions.
-				firstFix := []rule.RuleFix{sugs[0].FixesArr[0]}
-				ctx.ReportNodeWithFixesAndSuggestions(node, rule.RuleMessage{Description: msg}, firstFix, sugs)
-				return
-			}
-			if len(sugs) == 0 {
-				ctx.ReportNode(node, rule.RuleMessage{Description: msg})
-				return
-			}
-			ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{Description: msg}, sugs...)
-		}
+		suggestionReports := newSuggestionReporter(
+			&ctx,
+			opts.EnableDangerousAutofixThisMayCauseInfiniteLoops,
+		)
 
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
-				visitCall(ctx, sf, tc, opts, caches, node, report, reportWithSuggestions)
+				visitCall(ctx, sf, tc, opts, caches, node, report, suggestionReports)
 			},
 		}
 	},
@@ -109,7 +185,7 @@ func visitCall(
 	caches *runCaches,
 	node *ast.Node,
 	report func(*ast.Node, string),
-	reportWithSuggestions func(*ast.Node, string, ...rule.RuleSuggestion),
+	suggestionReports *suggestionReporter,
 ) {
 	call := node.AsCallExpression()
 	callee := call.Expression
@@ -182,7 +258,7 @@ func visitCall(
 	cb := stripAsExpression(callback)
 	switch cb.Kind {
 	case ast.KindFunctionExpression, ast.KindArrowFunction:
-		visitFunctionWithDependencies(ctx, sf, tc, opts, caches, cb, depsNode, callee, hookName, isEffect, node, reportWithSuggestions)
+		visitFunctionWithDependencies(ctx, sf, tc, opts, caches, cb, depsNode, callee, hookName, isEffect, node, suggestionReports)
 	case ast.KindIdentifier:
 		// useEffect(myFn, deps): try to follow the symbol.
 		// Without a deps array we can't fault anything (effect always runs).
@@ -223,14 +299,14 @@ func visitCall(
 				}
 				switch decl.Kind {
 				case ast.KindFunctionDeclaration:
-					visitFunctionWithDependencies(ctx, sf, tc, opts, caches, decl, depsNode, callee, hookName, isEffect, node, reportWithSuggestions)
+					visitFunctionWithDependencies(ctx, sf, tc, opts, caches, decl, depsNode, callee, hookName, isEffect, node, suggestionReports)
 					return
 				case ast.KindVariableDeclaration:
 					vd := decl.AsVariableDeclaration()
 					if vd.Initializer != nil {
 						init := stripAsExpression(vd.Initializer)
 						if init != nil && (init.Kind == ast.KindArrowFunction || init.Kind == ast.KindFunctionExpression) {
-							visitFunctionWithDependencies(ctx, sf, tc, opts, caches, init, depsNode, callee, hookName, isEffect, node, reportWithSuggestions)
+							visitFunctionWithDependencies(ctx, sf, tc, opts, caches, init, depsNode, callee, hookName, isEffect, node, suggestionReports)
 							return
 						}
 					}
@@ -238,15 +314,18 @@ func visitCall(
 			}
 		}
 		// Fallback: suggest adding the identifier to the deps array.
-		fix := rule.RuleFixReplace(sf, depsNode, "["+cb.AsIdentifier().Text+"]")
-		reportWithSuggestions(callee,
+		callbackName := cb.AsIdentifier().Text
+		suggestionReports.report(callee,
 			fmt.Sprintf(
 				"React Hook %s has a missing dependency: '%s'. Either include it or remove the dependency array.",
-				hookName, cb.AsIdentifier().Text,
+				hookName, callbackName,
 			),
-			rule.RuleSuggestion{
-				Message:  rule.RuleMessage{Description: "Update the dependencies array to be: [" + cb.AsIdentifier().Text + "]"},
-				FixesArr: []rule.RuleFix{fix},
+			func() []rule.RuleSuggestion {
+				suggestionText := "[" + callbackName + "]"
+				return []rule.RuleSuggestion{{
+					Message:  rule.RuleMessage{Description: "Update the dependencies array to be: " + suggestionText},
+					FixesArr: []rule.RuleFix{rule.RuleFixReplace(sf, depsNode, suggestionText)},
+				}}
 			},
 		)
 	default:
@@ -294,7 +373,7 @@ func visitFunctionWithDependencies(
 	hookName string,
 	isEffect bool,
 	hookCall *ast.Node,
-	reportWithSuggestions func(*ast.Node, string, ...rule.RuleSuggestion),
+	suggestionReports *suggestionReporter,
 ) {
 	if isEffect && hasAsyncModifier(callback) {
 		ctx.ReportNode(callback, rule.RuleMessage{Description: "Effect callbacks are synchronous to prevent race conditions. " +
@@ -403,7 +482,7 @@ func visitFunctionWithDependencies(
 	// No deps array case: only emit the setState-without-deps diagnostic.
 	if depsNode == nil {
 		emitSetStateInsideEffectWarning(ctx, sf, tc, hookCall, reactiveHook, hookName, callback,
-			dependencies, setStateCallSites, stableDeps, optionalChains, reportWithSuggestions)
+			dependencies, setStateCallSites, stableDeps, optionalChains, suggestionReports)
 		return
 	}
 
@@ -423,24 +502,12 @@ func visitFunctionWithDependencies(
 
 	rec := collectRecommendations(dependencies, declared, stableDeps, externalDeps, isEffect)
 
-	suggestedDeps := rec.Suggested
 	problemCount := len(rec.Duplicate) + len(rec.Missing) + len(rec.Unnecessary)
 	if problemCount == 0 {
 		// No deps issues: check for constructions that change every render.
-		emitConstructionWarnings(ctx, sf, tc, callback, depsNode, declared, hookName, opts, reportWithSuggestions)
-		flushDeferredDiagnostics(ctx, deferredElementDiags, opts.EnableDangerousAutofixThisMayCauseInfiniteLoops)
+		emitConstructionWarnings(ctx, sf, tc, callback, depsNode, declared, hookName, opts, suggestionReports)
+		flushDeferredDiagnostics(deferredElementDiags, suggestionReports)
 		return
-	}
-
-	// For non-effect hooks with missing deps, recompute suggestions from scratch.
-	if !isEffect && len(rec.Missing) > 0 {
-		rec2 := collectRecommendations(dependencies, []declaredDependency{}, stableDeps, externalDeps, isEffect)
-		suggestedDeps = rec2.Suggested
-	}
-
-	// Alphabetize suggestions iff the originals were alphabetized.
-	if areDeclaredDepsAlphabetized(declared) {
-		sort.Strings(suggestedDeps)
 	}
 
 	// Build the warning message.
@@ -448,22 +515,36 @@ func visitFunctionWithDependencies(
 	msg := buildDepDiagnostic(hookCalleeText, rec, externalDeps, dependencies,
 		hookName, optionalChains, setStateCallSites, stateVariableSymbols, componentFn, tc, callback)
 
-	// Build suggestion text.
-	formatted := make([]string, len(suggestedDeps))
-	for i, k := range suggestedDeps {
-		formatted[i] = formatDependency(k, optionalChains)
+	suggestedDeps := rec.Suggested
+	var buildSuggestions suggestionBuilder
+	if !isEffect && len(rec.Missing) > 0 {
+		// Non-effect hooks intentionally recompute from scratch to mirror
+		// upstream. Keep that less-common edit-only work deferred.
+		buildSuggestions = func() []rule.RuleSuggestion {
+			rec2 := collectRecommendations(dependencies, []declaredDependency{}, stableDeps, externalDeps, isEffect)
+			return buildDependencyArraySuggestion(
+				sf,
+				depsNode,
+				rec2.Suggested,
+				areDeclaredDepsAlphabetized(declared),
+				optionalChains,
+			)
+		}
+	} else {
+		buildSuggestions = func() []rule.RuleSuggestion {
+			return buildDependencyArraySuggestion(
+				sf,
+				depsNode,
+				suggestedDeps,
+				areDeclaredDepsAlphabetized(declared),
+				optionalChains,
+			)
+		}
 	}
-	suggestionText := "[" + strings.Join(formatted, ", ") + "]"
-	fix := rule.RuleFixReplace(sf, depsNode, suggestionText)
-	reportWithSuggestions(depsNode, msg,
-		rule.RuleSuggestion{
-			Message:  rule.RuleMessage{Description: "Update the dependencies array to be: " + suggestionText},
-			FixesArr: []rule.RuleFix{fix},
-		},
-	)
+	suggestionReports.report(depsNode, msg, buildSuggestions)
 	// Flush per-element diagnostics AFTER the main report — upstream's
 	// observable order is missing-dep first, element errors after.
-	flushDeferredDiagnostics(ctx, deferredElementDiags, opts.EnableDangerousAutofixThisMayCauseInfiniteLoops)
+	flushDeferredDiagnostics(deferredElementDiags, suggestionReports)
 }
 
 // buildDepDiagnostic constructs the "React Hook X has a/an missing/unnecessary
@@ -874,7 +955,7 @@ func emitSetStateInsideEffectWarning(
 	setStateCallSites map[*ast.Symbol]*ast.Node,
 	stableDeps map[string]bool,
 	optionalChains map[string]bool,
-	reportWithSuggestions func(*ast.Node, string, ...rule.RuleSuggestion),
+	suggestionReports *suggestionReporter,
 ) {
 	var found string
 	// Iterate dep keys in source order so the "first setState in callback"
@@ -914,24 +995,27 @@ func emitSetStateInsideEffectWarning(
 		formatted[i] = formatDependency(k, optionalChains)
 	}
 	suggestionText := "[" + strings.Join(formatted, ", ") + "]"
-	// Insert AFTER the callback (not after the whole call expression),
-	// matching upstream's `fixer.insertTextAfter(node, ...)`. Using
-	// hookCall.End() would put the deps array INSIDE the closing `)`.
-	fix := rule.RuleFix{
-		Text:  ", " + suggestionText,
-		Range: callback.Loc.WithPos(callback.End()),
-	}
 	_ = sf
 	_ = tc
 	_ = reactiveHook
-	reportWithSuggestions(hookCall,
+	suggestionReports.report(hookCall,
 		fmt.Sprintf(
 			"React Hook %s contains a call to '%s'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass %s as a second argument to the %s Hook.",
 			hookName, found, suggestionText, hookName,
 		),
-		rule.RuleSuggestion{
-			Message:  rule.RuleMessage{Description: "Add dependencies array: " + suggestionText},
-			FixesArr: []rule.RuleFix{fix},
+		func() []rule.RuleSuggestion {
+			return []rule.RuleSuggestion{{
+				Message: rule.RuleMessage{Description: "Add dependencies array: " + suggestionText},
+				FixesArr: []rule.RuleFix{{
+					// Insert AFTER the callback (not after the whole call
+					// expression), matching upstream's
+					// `fixer.insertTextAfter(node, ...)`. Using
+					// hookCall.End() would put the deps array inside the
+					// closing `)`.
+					Text:  ", " + suggestionText,
+					Range: callback.Loc.WithPos(callback.End()),
+				}},
+			}}
 		},
 	)
 }
@@ -949,7 +1033,7 @@ func emitConstructionWarnings(
 	declared []declaredDependency,
 	hookName string,
 	opts Options,
-	reportWithSuggestions func(*ast.Node, string, ...rule.RuleSuggestion),
+	suggestionReports *suggestionReporter,
 ) {
 	componentFn := findEnclosingFunction(callback)
 	if componentFn == nil {
@@ -989,26 +1073,29 @@ func emitConstructionWarnings(
 			"The '%s' %s %s the dependencies of %s Hook (at line %d) change on every render. %s",
 			nameText, c.DepType, causation, hookName, depsLine, advice,
 		)
-		var sugs []rule.RuleSuggestion
+		var buildSuggestions suggestionBuilder
 		if c.IsUsedOutsideHook && c.Decl != nil && c.Decl.Kind == ast.KindVariableDeclaration && c.DepType == "function" {
-			before := "useCallback("
-			after := ")"
-			if wrapper == "useMemo" {
-				before = "useMemo(() => { return "
-				after = "; })"
+			initNode := c.InitNode
+			buildSuggestions = func() []rule.RuleSuggestion {
+				before := "useCallback("
+				after := ")"
+				if wrapper == "useMemo" {
+					before = "useMemo(() => { return "
+					after = "; })"
+				}
+				return []rule.RuleSuggestion{{
+					Message: rule.RuleMessage{Description: fmt.Sprintf(
+						"Wrap the %s of '%s' in its own %s() Hook.",
+						ctype, nameText, wrapper,
+					)},
+					FixesArr: []rule.RuleFix{
+						rule.RuleFixInsertBefore(sf, initNode, before),
+						rule.RuleFixInsertAfter(initNode, after),
+					},
+				}}
 			}
-			sugs = []rule.RuleSuggestion{{
-				Message: rule.RuleMessage{Description: fmt.Sprintf(
-					"Wrap the %s of '%s' in its own %s() Hook.",
-					ctype, nameText, wrapper,
-				)},
-				FixesArr: []rule.RuleFix{
-					rule.RuleFixInsertBefore(sf, c.InitNode, before),
-					rule.RuleFixInsertAfter(c.InitNode, after),
-				},
-			}}
 		}
-		reportWithSuggestions(c.Decl, msg, sugs...)
+		suggestionReports.report(c.Decl, msg, buildSuggestions)
 	}
 	_ = opts
 }
@@ -1029,9 +1116,10 @@ func lineOf(sf *ast.SourceFile, node *ast.Node) (int, error) {
 type elementDiagnostic struct {
 	node    *ast.Node
 	message string
-	// suggestion is non-nil only for the useEffectEvent variant — every
-	// other element diagnostic upstream is suggestion-less.
-	suggestion *rule.RuleSuggestion
+	// suggestionMessage is non-empty only for the useEffectEvent variant.
+	// Its range and edit remain deferred until the runtime requests suggestions
+	// or dangerous autofixes.
+	suggestionMessage string
 }
 
 // parseDeclaredDeps mirrors upstream's loop over the array literal: for
@@ -1089,17 +1177,14 @@ func parseDeclaredDeps(
 		if tc != nil && el.Kind == ast.KindIdentifier {
 			sym := tc.GetSymbolAtLocation(el)
 			if sym != nil && useEffectEventSymbols[sym] {
-				removeRange := utils.TrimNodeTextRange(sf, el)
+				dependencyText := getCalleeText(sf, el)
 				deferred = append(deferred, elementDiagnostic{
 					node: el,
 					message: fmt.Sprintf(
 						"Functions returned from `useEffectEvent` must not be included in the dependency array. Remove `%s` from the list.",
-						getCalleeText(sf, el),
+						dependencyText,
 					),
-					suggestion: &rule.RuleSuggestion{
-						Message:  rule.RuleMessage{Description: fmt.Sprintf("Remove the dependency `%s`", getCalleeText(sf, el))},
-						FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(removeRange)},
-					},
+					suggestionMessage: fmt.Sprintf("Remove the dependency `%s`", dependencyText),
 				})
 			}
 		}
@@ -1166,29 +1251,29 @@ func parseDeclaredDeps(
 // parseDeclaredDeps. Called by the caller AFTER the main missing-dep
 // diagnostic, so the output order matches upstream.
 //
-// `enableDangerous` mirrors upstream's `reportProblem` promotion gate:
-// when `enableDangerousAutofixThisMayCauseInfiniteLoops` is on and the
-// diagnostic carries a suggestion, the first suggestion's first fix is
-// promoted to a top-level autofix while keeping the suggestion array.
-// This applies to every `reportProblem` call in upstream — including
-// the per-element useEffectEvent rejection — so we plumb the flag here.
-func flushDeferredDiagnostics(ctx rule.RuleContext, deferred []elementDiagnostic, enableDangerous bool) {
+// Suggestion construction is routed through the same reporter as the
+// top-level dependency diagnostic. This keeps demand gating and dangerous
+// autofix promotion identical for every upstream `reportProblem` call.
+func flushDeferredDiagnostics(
+	deferred []elementDiagnostic,
+	suggestionReports *suggestionReporter,
+) {
 	for _, d := range deferred {
-		if d.suggestion != nil {
-			if enableDangerous && len(d.suggestion.FixesArr) > 0 {
-				firstFix := []rule.RuleFix{d.suggestion.FixesArr[0]}
-				ctx.ReportNodeWithFixesAndSuggestions(
-					d.node,
-					rule.RuleMessage{Description: d.message},
-					firstFix,
-					[]rule.RuleSuggestion{*d.suggestion},
-				)
-				continue
-			}
-			ctx.ReportNodeWithSuggestions(d.node, rule.RuleMessage{Description: d.message}, *d.suggestion)
-		} else {
-			ctx.ReportNode(d.node, rule.RuleMessage{Description: d.message})
+		node := d.node
+		if d.suggestionMessage == "" {
+			suggestionReports.report(node, d.message, nil)
+			continue
 		}
+
+		suggestionMessage := d.suggestionMessage
+		suggestionReports.report(node, d.message, func() []rule.RuleSuggestion {
+			return []rule.RuleSuggestion{{
+				Message: rule.RuleMessage{Description: suggestionMessage},
+				FixesArr: []rule.RuleFix{
+					rule.RuleFixRemoveRange(utils.TrimNodeTextRange(suggestionReports.ctx.SourceFile, node)),
+				},
+			}}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Defer all native `react-hooks/exhaustive-deps` suggestion/fix construction until the diagnostic consumer requests that edit category.
- Preserve diagnostic detection, messages, ranges, ordering, suggestion shapes, and dangerous-autofix semantics across the main dependency-array path, unresolved callbacks, setState insertion, construction wrapping, and `useEffectEvent` removal.
- Add a demand matrix test for all five suggestion-producing paths. Benchmark measurements were collected with a temporary local harness; benchmark-only files are intentionally excluded.

### Architecture

The rule now has one concrete, rule-local `suggestionReporter` adapter. Analysis produces diagnostics and synchronous suggestion builders; the adapter maps those builders to the native `RuleContext` demand APIs from #1367. This keeps demand policy out of dependency analysis and keeps the optimization independent of `Program`, TypeChecker, and cross-language plugin protocols.

Dangerous autofix mode still derives the top-level fix from the first suggestion fix. A per-report memoized builder guarantees `EditDemandAll` constructs the shared suggestion exactly once. The adapter is a concrete type rather than a function-valued reporter so Go escape analysis keeps per-diagnostic builders on the stack; this removed the all-edits allocation regression found during adversarial review.

### Benchmark

Apple M1 Max, darwin/arm64. Measurements use the same temporary local harness on the #1367 API base (source-identical to latest `main` for this benchmark dependency graph) and the PR commit; benchmark-only files are intentionally excluded from the PR. GOMAXPROCS=1, 1 second per sample, 10 samples per revision, measured in both before→after and after→before order. Values are medians; time MAD/median is at most 0.69%.

| Configuration / demand | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| suggestions / diagnostics only | 730,530 → 654,799 (-10.37%) | 286,307 → 240,962 (-15.84%) | 6,497 → 5,153 (-20.69%) |
| suggestions / all edits | 729,916 → 725,328 (-0.63%) | 286,306 → 286,274 (-0.01%) | 6,497 → 6,497 (0.00%) |
| dangerous autofix / diagnostics only | 733,099 → 654,246 (-10.76%) | 287,459 → 240,962 (-16.18%) | 6,545 → 5,153 (-21.27%) |
| dangerous autofix / all edits | 730,487 → 729,112 (-0.19%) | 287,458 → 287,426 (-0.01%) | 6,545 → 6,545 (0.00%) |

The previous +1.4% and +5.0% all-edits readings do not reproduce under the balanced stable run. Both all-edits paths are neutral to slightly faster with identical allocation counts, while diagnostics-only consistently removes about 16% of bytes and 21% of allocations.

### Adversarial review

- Compared diagnostic identity across `None`, `Autofix`, `Suggestion`, and `All` demand.
- Verified the dangerous option promotes only the first fix while retaining the complete suggestion under all-edit demand.
- Covered a multi-fix construction suggestion to catch accidental promotion of the full fix array.
- Preserved main-before-element diagnostic ordering and deferred `useEffectEvent` ranges without changing dependency analysis.
- Confirmed builders do not escape with compiler escape analysis and ran focused race coverage.

### Validation

- `go test ./internal/plugins/react_hooks/rules/exhaustive_deps -count=1`
- `go test -race ./internal/plugins/react_hooks/rules/exhaustive_deps -run "^(TestExhaustiveDepsEditDemand|TestExhaustiveDepsRule|TestExhaustiveDepsRule_Boundary)$" -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run ./internal/plugins/react_hooks/rules/exhaustive_deps/...`

## Related Links

- Built on #1367 (merged into `main`)
- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).




