### PR TITLE
perf: defer no-restricted-types edits

### DIFF
--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.go
@@ -125,6 +125,29 @@ func customMessageFor(cfg bannedTypeConfig) string {
 	return " " + cfg.Message
 }
 
+func buildReplacementSuggestions(
+	sourceFile *ast.SourceFile,
+	typeNode *ast.Node,
+	name string,
+	replacements []string,
+) []rule.RuleSuggestion {
+	suggestions := make([]rule.RuleSuggestion, 0, len(replacements))
+	for _, replacement := range replacements {
+		suggestions = append(suggestions, rule.RuleSuggestion{
+			Message: rule.RuleMessage{
+				Id:          "bannedTypeReplacement",
+				Description: fmt.Sprintf("Replace `%s` with `%s`.", name, replacement),
+				Data: map[string]string{
+					"name":        name,
+					"replacement": replacement,
+				},
+			},
+			FixesArr: []rule.RuleFix{rule.RuleFixReplace(sourceFile, typeNode, replacement)},
+		})
+	}
+	return suggestions
+}
+
 var NoRestrictedTypesRule = rule.CreateRule(rule.Rule{
 	Name: "no-restricted-types",
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
@@ -164,33 +187,32 @@ var NoRestrictedTypesRule = rule.CreateRule(rule.Rule{
 				},
 			}
 
-			var fixes []rule.RuleFix
-			if cfg.Kind == "object" && cfg.HasFix {
-				fixes = []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, typeNode, cfg.FixWith)}
-			}
-
-			var suggestions []rule.RuleSuggestion
-			for _, replacement := range cfg.Suggest {
-				suggestions = append(suggestions, rule.RuleSuggestion{
-					Message: rule.RuleMessage{
-						Id:          "bannedTypeReplacement",
-						Description: fmt.Sprintf("Replace `%s` with `%s`.", name, replacement),
-						Data: map[string]string{
-							"name":        name,
-							"replacement": replacement,
-						},
-					},
-					FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, typeNode, replacement)},
-				})
-			}
-
+			hasFix := cfg.Kind == "object" && cfg.HasFix
+			hasSuggestions := len(cfg.Suggest) > 0
 			switch {
-			case len(fixes) > 0 && len(suggestions) > 0:
-				ctx.ReportNodeWithFixesAndSuggestions(typeNode, msg, fixes, suggestions)
-			case len(fixes) > 0:
-				ctx.ReportNodeWithFixes(typeNode, msg, fixes...)
-			case len(suggestions) > 0:
-				ctx.ReportNodeWithSuggestions(typeNode, msg, suggestions...)
+			case hasFix && hasSuggestions:
+				fixWith := cfg.FixWith
+				replacements := cfg.Suggest
+				ctx.ReportNodeWithDeferredFixesAndSuggestions(
+					typeNode,
+					msg,
+					func() []rule.RuleFix {
+						return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, typeNode, fixWith)}
+					},
+					func() []rule.RuleSuggestion {
+						return buildReplacementSuggestions(ctx.SourceFile, typeNode, name, replacements)
+					},
+				)
+			case hasFix:
+				fixWith := cfg.FixWith
+				ctx.ReportNodeWithDeferredFixes(typeNode, msg, func() []rule.RuleFix {
+					return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, typeNode, fixWith)}
+				})
+			case hasSuggestions:
+				replacements := cfg.Suggest
+				ctx.ReportNodeWithDeferredSuggestions(typeNode, msg, func() []rule.RuleSuggestion {
+					return buildReplacementSuggestions(ctx.SourceFile, typeNode, name, replacements)
+				})
 			default:
 				ctx.ReportNode(typeNode, msg)
 			}

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
@@ -6,10 +6,18 @@
 package no_restricted_types
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoRestrictedTypesExtras(t *testing.T) {
@@ -918,4 +926,229 @@ func TestNoRestrictedTypesNonFalsePositives(t *testing.T) {
 			}}),
 		},
 	}, []rule_tester.InvalidTestCase{})
+}
+
+func TestNoRestrictedTypesEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const source = "let value: Banned;\n"
+
+	configs := []struct {
+		name            string
+		bannedType      any
+		wantFix         bool
+		fixText         string
+		suggestionTexts []string
+	}{
+		{
+			name:       "diagnostic only",
+			bannedType: true,
+		},
+		{
+			name: "autofix only",
+			bannedType: map[string]interface{}{
+				"fixWith": "Fixed",
+			},
+			wantFix: true,
+			fixText: "Fixed",
+		},
+		{
+			name: "empty autofix replacement",
+			bannedType: map[string]interface{}{
+				"fixWith": "",
+			},
+			wantFix: true,
+		},
+		{
+			name: "suggestions only",
+			bannedType: map[string]interface{}{
+				"suggest": []interface{}{"SuggestedOne", ""},
+			},
+			suggestionTexts: []string{"SuggestedOne", ""},
+		},
+		{
+			name: "autofix and suggestions",
+			bannedType: map[string]interface{}{
+				"fixWith": "Fixed",
+				"suggest": []interface{}{"SuggestedOne", "SuggestedTwo"},
+			},
+			wantFix:         true,
+			fixText:         "Fixed",
+			suggestionTexts: []string{"SuggestedOne", "SuggestedTwo"},
+		},
+	}
+
+	for index, config := range configs {
+		t.Run(config.name, func(t *testing.T) {
+			t.Parallel()
+
+			program, sourceFile := createNoRestrictedTypesProgram(
+				t,
+				fmt.Sprintf("edit-demand-%d.ts", index),
+				source,
+			)
+			options := rule.NormalizeOptions(map[string]interface{}{
+				"types": map[string]interface{}{
+					"Banned": config.bannedType,
+				},
+			})
+			diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+			for _, demand := range []rule.EditDemand{
+				rule.EditDemandNone,
+				rule.EditDemandAutofix,
+				rule.EditDemandSuggestion,
+				rule.EditDemandAll,
+			} {
+				got := lintNoRestrictedTypesWithDemand(program, sourceFile, options, demand)
+				if len(got) != 1 {
+					t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(got))
+				}
+				if got[0].Message.Description != "Don't use `Banned` as a type." {
+					t.Errorf("demand %d: unexpected message %q", demand, got[0].Message.Description)
+				}
+				diagnostics[demand] = got[0]
+			}
+
+			diagnosticsOnly := diagnostics[rule.EditDemandNone]
+			for demand, diagnostic := range diagnostics {
+				requireSameNoRestrictedTypesDiagnostic(t, diagnosticsOnly, diagnostic, demand)
+			}
+			requireNoRestrictedTypeEdits(t, diagnostics[rule.EditDemandNone], rule.EditDemandNone)
+			if diagnostics[rule.EditDemandAutofix].Suggestions != nil {
+				t.Errorf("autofix-only demand unexpectedly materialized suggestions")
+			}
+			if diagnostics[rule.EditDemandSuggestion].FixesPtr != nil {
+				t.Errorf("suggestion-only demand unexpectedly materialized autofixes")
+			}
+
+			autofixOnly := diagnostics[rule.EditDemandAutofix].FixesPtr
+			allFixes := diagnostics[rule.EditDemandAll].FixesPtr
+			if !config.wantFix {
+				if autofixOnly != nil || allFixes != nil {
+					t.Fatalf("unexpected autofixes: autofix=%#v all=%#v", autofixOnly, allFixes)
+				}
+			} else {
+				if autofixOnly == nil || allFixes == nil || !reflect.DeepEqual(*autofixOnly, *allFixes) {
+					t.Fatalf("autofix artifacts differ between autofix-only and all demand")
+				}
+				if len(*autofixOnly) != 1 || (*autofixOnly)[0].Text != config.fixText {
+					t.Fatalf("autofixes = %#v, want replacement %q", *autofixOnly, config.fixText)
+				}
+			}
+
+			suggestionOnly := diagnostics[rule.EditDemandSuggestion].Suggestions
+			allSuggestions := diagnostics[rule.EditDemandAll].Suggestions
+			if len(config.suggestionTexts) == 0 {
+				if suggestionOnly != nil || allSuggestions != nil {
+					t.Fatalf("unexpected suggestions: suggestion=%#v all=%#v", suggestionOnly, allSuggestions)
+				}
+				return
+			}
+			if suggestionOnly == nil || allSuggestions == nil || !reflect.DeepEqual(*suggestionOnly, *allSuggestions) {
+				t.Fatalf("suggestion artifacts differ between suggestion-only and all demand")
+			}
+			if len(*suggestionOnly) != len(config.suggestionTexts) {
+				t.Fatalf("suggestions = %#v, want %d", *suggestionOnly, len(config.suggestionTexts))
+			}
+			for index, suggestion := range *suggestionOnly {
+				replacement := config.suggestionTexts[index]
+				if suggestion.Message.Description != "Replace `Banned` with `"+replacement+"`." {
+					t.Errorf("suggestion %d message = %q", index, suggestion.Message.Description)
+				}
+				if !reflect.DeepEqual(suggestion.Message.Data, map[string]string{
+					"name":        "Banned",
+					"replacement": replacement,
+				}) {
+					t.Errorf("suggestion %d data = %#v", index, suggestion.Message.Data)
+				}
+				if len(suggestion.FixesArr) != 1 || suggestion.FixesArr[0].Text != replacement {
+					t.Errorf("suggestion %d fixes = %#v", index, suggestion.FixesArr)
+				}
+			}
+		})
+	}
+}
+
+func lintNoRestrictedTypesWithDemand(
+	program *compiler.Program,
+	sourceFile *ast.SourceFile,
+	options []any,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:         program,
+		File:            sourceFile.FileName(),
+		HasTypeInfo:     true,
+		GetRulesForFile: noRestrictedTypesConfiguredRules(options),
+		ExcludePaths:    []string{},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	return diagnostics
+}
+
+func requireSameNoRestrictedTypesDiagnostic(
+	t *testing.T,
+	want rule.RuleDiagnostic,
+	got rule.RuleDiagnostic,
+	demand rule.EditDemand,
+) {
+	t.Helper()
+	want.FixesPtr = nil
+	want.Suggestions = nil
+	got.FixesPtr = nil
+	got.Suggestions = nil
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("demand %d changed diagnostic metadata:\ngot:  %#v\nwant: %#v", demand, got, want)
+	}
+}
+
+func requireNoRestrictedTypeEdits(
+	t *testing.T,
+	diagnostic rule.RuleDiagnostic,
+	demand rule.EditDemand,
+) {
+	t.Helper()
+	if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+		t.Errorf(
+			"demand %d unexpectedly materialized edits: fixes=%#v suggestions=%#v",
+			demand,
+			diagnostic.FixesPtr,
+			diagnostic.Suggestions,
+		)
+	}
+}
+
+func createNoRestrictedTypesProgram(t testing.TB, fileName string, code string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+
+	rootDir := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return program, sourceFile
+}
+
+func noRestrictedTypesConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
+	return func(*ast.SourceFile) []linter.ConfiguredRule {
+		return []linter.ConfiguredRule{{
+			Name:     NoRestrictedTypesRule.Name,
+			Severity: rule.SeverityError,
+			Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				return NoRestrictedTypesRule.Run(ctx, options)
+			},
+		}}
+	}
 }


### PR DESCRIPTION
## Summary

- Defer `no-restricted-types` replacement fixes and suggestion payloads until the native diagnostic consumer requests the matching edit category.
- Preserve diagnostic detection, messages, Data maps, ranges, suggestion order, and the distinction between an absent replacement and an explicitly empty replacement.
- Add a demand matrix covering diagnostic-only, fix-only, suggestion-only, and combined rule configurations. Benchmark measurements were collected with a temporary local harness; benchmark-only files are intentionally excluded.

### Architecture

Diagnostic matching and diagnostic metadata remain eager. Optional edit construction is split at the rule boundary: fix-only and suggestion-only configurations use their single-category deferred APIs, while combined configurations use the category-independent API from #1367. No demand state leaks into rule analysis, `Program`, TypeChecker, or plugin protocols.

Suggestion creation is isolated in `buildReplacementSuggestions`, which preserves configured order and preallocates the exact result capacity. The builders are synchronous and non-retained by the framework; compiler escape analysis confirms the per-diagnostic closures remain stack-local.

### Benchmark

Apple M1 Max, darwin/arm64. Measurements use the same temporary local harness on the #1367 API base (source-identical to latest `main` for this benchmark dependency graph) and the PR commit; benchmark-only files are intentionally excluded from the PR. GOMAXPROCS=1, 1 second per sample, 10 samples per revision, measured in both before→after and after→before order. Values are medians; time MAD/median is at most 0.82%.

| Demand | ns/op before → after | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: |
| diagnostics only | 233,174 → 57,566 (-75.31%) | 252,041 → 54,920 (-78.21%) | 2,864 → 624 (-78.21%) |
| autofix only | 235,971 → 69,169 (-70.69%) | 252,041 → 68,232 (-72.93%) | 2,864 → 816 (-71.51%) |
| suggestions only | 235,155 → 211,158 (-10.20%) | 252,041 → 226,441 (-10.16%) | 2,864 → 2,544 (-11.17%) |
| all edits | 234,760 → 222,116 (-5.39%) | 252,041 → 239,753 (-4.88%) | 2,864 → 2,736 (-4.47%) |

Every demand mode improves in the balanced run. The largest gains come from completely skipped categories, while all-edits still benefits from the refactored construction path.

### Adversarial review

- Compared diagnostic identity across `None`, `Autofix`, `Suggestion`, and `All` demand for every reporting branch.
- Verified combined configurations build and expose each category independently.
- Verified multiple suggestions retain order, message IDs, Data, ranges, and replacement text.
- Added explicit empty `fixWith` and empty suggestion replacements so empty artifacts cannot be mistaken for missing artifacts.
- Confirmed listener registration, type-name normalization, and multi-node matching are unchanged.
- Confirmed deferred closures do not escape and ran focused race coverage.

### Validation

- `go test ./internal/plugins/typescript/rules/no_restricted_types -count=1`
- `go test -race ./internal/plugins/typescript/rules/no_restricted_types -run "^TestNoRestrictedTypesEditDemand$" -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run ./internal/plugins/typescript/rules/no_restricted_types/...`

## Related Links

- Built on #1367 (merged into `main`)
- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).



