### PR TITLE
perf: defer no-unused-vars suggestions

### DIFF
--- a/internal/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/rules/no_unused_vars/no_unused_vars.go
@@ -55,45 +55,69 @@ type analysisContext struct {
 	tokens             []utils.SourceToken
 }
 
+func (ac *analysisContext) ensureTokens(sourceFile *ast.SourceFile) {
+	if ac.tokens != nil {
+		return
+	}
+	ac.tokens = utils.TokensOfNode(sourceFile, sourceFile.AsNode())
+}
+
+// coreRemoveSuggestionCandidate is the immutable input needed to construct
+// one optional removal suggestion. Pending diagnostics retain this data rather
+// than a closure so deferring reports does not add per-diagnostic allocations.
+type coreRemoveSuggestionCandidate struct {
+	nameNode   *ast.Node
+	definition *ast.Node
+	symbol     *ast.Symbol
+}
+
 type pendingDiagnostic struct {
-	node        *ast.Node
-	textRange   core.TextRange
-	usesRange   bool
-	message     rule.RuleMessage
-	suggestions []rule.RuleSuggestion
+	node                 *ast.Node
+	textRange            core.TextRange
+	usesRange            bool
+	message              rule.RuleMessage
+	coreRemoveSuggestion coreRemoveSuggestionCandidate
 }
 
 type diagnosticReporter struct {
-	ctx          rule.RuleContext
-	deferReports bool
-	pending      []pendingDiagnostic
+	ctx     rule.RuleContext
+	pending []pendingDiagnostic
 }
 
 func (r *diagnosticReporter) reportNode(node *ast.Node, message rule.RuleMessage) {
-	if !r.deferReports {
-		r.ctx.ReportNode(node, message)
-		return
-	}
 	r.pending = append(r.pending, pendingDiagnostic{node: node, message: message})
 }
 
-func (r *diagnosticReporter) reportNodeWithSuggestions(node *ast.Node, message rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
-	if !r.deferReports {
-		r.ctx.ReportNodeWithSuggestions(node, message, suggestions...)
-		return
+func (r *diagnosticReporter) buildCoreRemoveSuggestions(
+	candidate coreRemoveSuggestionCandidate,
+	analysis *analysisContext,
+) []rule.RuleSuggestion {
+	suggestion, ok := getCoreRemoveSuggestion(
+		r.ctx,
+		candidate.nameNode,
+		candidate.definition,
+		candidate.symbol,
+		analysis,
+	)
+	if !ok {
+		return nil
 	}
+	return []rule.RuleSuggestion{suggestion}
+}
+
+func (r *diagnosticReporter) reportNodeWithDeferredCoreRemoveSuggestion(
+	node *ast.Node,
+	message rule.RuleMessage,
+	candidate coreRemoveSuggestionCandidate,
+) {
 	r.pending = append(r.pending, pendingDiagnostic{
-		node:        node,
-		message:     message,
-		suggestions: suggestions,
+		node:                 node,
+		message:              message,
+		coreRemoveSuggestion: candidate,
 	})
 }
 
 func (r *diagnosticReporter) reportRange(textRange core.TextRange, message rule.RuleMessage) {
-	if !r.deferReports {
-		r.ctx.ReportRange(textRange, message)
-		return
-	}
 	r.pending = append(r.pending, pendingDiagnostic{
 		textRange: textRange,
 		usesRange: true,
@@ -101,32 +125,39 @@ func (r *diagnosticReporter) reportRange(textRange core.TextRange, message rule.
 	})
 }
 
-func (r *diagnosticReporter) reportRangeWithSuggestions(textRange core.TextRange, message rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
-	if !r.deferReports {
-		r.ctx.ReportRangeWithSuggestions(textRange, message, suggestions...)
-		return
-	}
+func (r *diagnosticReporter) reportRangeWithDeferredCoreRemoveSuggestion(
+	textRange core.TextRange,
+	message rule.RuleMessage,
+	candidate coreRemoveSuggestionCandidate,
+) {
 	r.pending = append(r.pending, pendingDiagnostic{
-		textRange:   textRange,
-		usesRange:   true,
-		message:     message,
-		suggestions: suggestions,
+		textRange:            textRange,
+		usesRange:            true,
+		message:              message,
+		coreRemoveSuggestion: candidate,
 	})
 }
 
-func (r *diagnosticReporter) flush() {
+func (r *diagnosticReporter) flush(analysis *analysisContext) {
 	sort.SliceStable(r.pending, func(i, j int) bool {
 		return r.position(r.pending[i]) < r.position(r.pending[j])
 	})
-	for _, diagnostic := range r.pending {
+	for index := range r.pending {
+		diagnostic := &r.pending[index]
 		if diagnostic.usesRange {
-			if len(diagnostic.suggestions) > 0 {
-				r.ctx.ReportRangeWithSuggestions(diagnostic.textRange, diagnostic.message, diagnostic.suggestions...)
+			if diagnostic.coreRemoveSuggestion.nameNode != nil {
+				candidate := diagnostic.coreRemoveSuggestion
+				r.ctx.ReportRangeWithDeferredSuggestions(diagnostic.textRange, diagnostic.message, func() []rule.RuleSuggestion {
+					return r.buildCoreRemoveSuggestions(candidate, analysis)
+				})
 			} else {
 				r.ctx.ReportRange(diagnostic.textRange, diagnostic.message)
 			}
-		} else if len(diagnostic.suggestions) > 0 {
-			r.ctx.ReportNodeWithSuggestions(diagnostic.node, diagnostic.message, diagnostic.suggestions...)
+		} else if diagnostic.coreRemoveSuggestion.nameNode != nil {
+			candidate := diagnostic.coreRemoveSuggestion
+			r.ctx.ReportNodeWithDeferredSuggestions(diagnostic.node, diagnostic.message, func() []rule.RuleSuggestion {
+				return r.buildCoreRemoveSuggestions(candidate, analysis)
+			})
 		} else {
 			r.ctx.ReportNode(diagnostic.node, diagnostic.message)
 		}
@@ -187,19 +218,27 @@ func eslintCoreDefinitionNameRange(sourceFile *ast.SourceFile, nameNode *ast.Nod
 	return core.NewTextRange(nameRange.Pos(), end), true
 }
 
-func reportVariableDiagnostic(ctx rule.RuleContext, reporter *diagnosticReporter, nameNode *ast.Node, reportNode *ast.Node, definition *ast.Node, message rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
+func reportVariableDiagnostic(
+	ctx rule.RuleContext,
+	reporter *diagnosticReporter,
+	nameNode *ast.Node,
+	reportNode *ast.Node,
+	definition *ast.Node,
+	message rule.RuleMessage,
+	suggestionCandidate *coreRemoveSuggestionCandidate,
+) {
 	if reportNode == nameNode {
 		if textRange, extended := eslintCoreDefinitionNameRange(ctx.SourceFile, nameNode, definition); extended {
-			if len(suggestions) > 0 {
-				reporter.reportRangeWithSuggestions(textRange, message, suggestions...)
+			if suggestionCandidate != nil {
+				reporter.reportRangeWithDeferredCoreRemoveSuggestion(textRange, message, *suggestionCandidate)
 			} else {
 				reporter.reportRange(textRange, message)
 			}
 			return
 		}
 	}
-	if len(suggestions) > 0 {
-		reporter.reportNodeWithSuggestions(reportNode, message, suggestions...)
+	if suggestionCandidate != nil {
+		reporter.reportNodeWithDeferredCoreRemoveSuggestion(reportNode, message, *suggestionCandidate)
 	} else {
 		reporter.reportNode(reportNode, message)
 	}
@@ -1467,8 +1506,10 @@ func getCoreRemoveSuggestion(ctx rule.RuleContext, nameNode *ast.Node, definitio
 	)
 	switch definition.Kind {
 	case ast.KindVariableDeclaration:
+		ac.ensureTokens(ctx.SourceFile)
 		fix, ok = fixVariableDeclaration(ctx, definition, ac)
 	case ast.KindBindingElement:
+		ac.ensureTokens(ctx.SourceFile)
 		fix, ok = fixBindingElement(ctx, definition, ac)
 	case ast.KindParameter:
 		if ast.HasSyntacticModifier(definition, ast.ModifierFlagsParameterPropertyModifier) {
@@ -1478,6 +1519,7 @@ func getCoreRemoveSuggestion(ctx rule.RuleContext, nameNode *ast.Node, definitio
 			fixRange, _ := eslintCoreDefinitionNameRange(ctx.SourceFile, nameNode, definition)
 			fix, ok = rule.RuleFixRemoveRange(fixRange), true
 		} else {
+			ac.ensureTokens(ctx.SourceFile)
 			fix, ok = fixFunctionParameter(ctx, definition, ac)
 		}
 	case ast.KindFunctionDeclaration:
@@ -1491,10 +1533,12 @@ func getCoreRemoveSuggestion(ctx rule.RuleContext, nameNode *ast.Node, definitio
 	case ast.KindClassDeclaration:
 		fix, ok = removeNodeRange(ctx.SourceFile, definition), true
 	case ast.KindTypeParameter, ast.KindEnumMember:
+		ac.ensureTokens(ctx.SourceFile)
 		fix, ok = fixCommaSeparatedName(ctx, nameNode, ac), true
 	case ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration, ast.KindModuleDeclaration, ast.KindEnumDeclaration:
 		fix, ok = removeNodeRange(ctx.SourceFile, nameNode), true
 	case ast.KindImportClause, ast.KindImportSpecifier, ast.KindNamespaceImport:
+		ac.ensureTokens(ctx.SourceFile)
 		fix, ok = fixImportBinding(ctx, definition, ac)
 	}
 	if !ok {
@@ -1963,7 +2007,7 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 				}
 			}
 			additional := ignorePatternAdditional(matchedType, opts, true)
-			reportVariableDiagnostic(ctx, ac.reporter, nameNode, reportNode, definition, buildUsedIgnoredVarMessage(name, additional))
+			reportVariableDiagnostic(ctx, ac.reporter, nameNode, reportNode, definition, buildUsedIgnoredVarMessage(name, additional), nil)
 		}
 		return
 	}
@@ -2009,14 +2053,23 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 	usedIgnoredAdditional := ignorePatternAdditional(matchedType, opts, true)
 
 	if matchedPattern && varInfo.Used && opts.ReportUsedIgnorePattern {
-		reportVariableDiagnostic(ctx, ac.reporter, nameNode, varInfo.Variable, definition, buildUsedIgnoredVarMessage(name, usedIgnoredAdditional))
+		reportVariableDiagnostic(ctx, ac.reporter, nameNode, varInfo.Variable, definition, buildUsedIgnoredVarMessage(name, usedIgnoredAdditional), nil)
 	} else if !varInfo.Used {
 		message := buildUnusedVarMessage(name, assigned, unusedAdditional)
-		if suggestion, ok := getCoreRemoveSuggestion(ctx, nameNode, definition, sym, ac); ok {
-			reportVariableDiagnostic(ctx, ac.reporter, nameNode, reportNode, definition, message, suggestion)
-			return
+		suggestionCandidate := coreRemoveSuggestionCandidate{
+			nameNode:   nameNode,
+			definition: definition,
+			symbol:     sym,
 		}
-		reportVariableDiagnostic(ctx, ac.reporter, nameNode, reportNode, definition, message)
+		reportVariableDiagnostic(
+			ctx,
+			ac.reporter,
+			nameNode,
+			reportNode,
+			definition,
+			message,
+			&suggestionCandidate,
+		)
 	}
 }
 
@@ -2032,11 +2085,7 @@ func newRule() rule.Rule {
 				return rule.RuleListeners{}
 			}
 			opts := parseOptions(options)
-			reporter := &diagnosticReporter{
-				ctx:          ctx,
-				deferReports: true,
-			}
-			tokens := utils.TokensOfNode(ctx.SourceFile, ctx.SourceFile.AsNode())
+			reporter := &diagnosticReporter{ctx: ctx}
 
 			ac := &analysisContext{
 				allUsages:          make(map[*ast.Symbol][]*ast.Node),
@@ -2049,7 +2098,6 @@ func newRule() rule.Rule {
 				refIndex:          utils.NewReferenceIndex(ctx.SourceFile, nil),
 				seenMergedSymbols: make(map[*ast.Symbol]bool),
 				reporter:          reporter,
-				tokens:            tokens,
 			}
 			collected := false
 
@@ -2393,12 +2441,12 @@ func newRule() rule.Rule {
 
 			statements := ctx.SourceFile.Statements
 			if statements == nil || len(statements.Nodes) == 0 {
-				reporter.flush()
+				reporter.flush(ac)
 			} else {
 				lastTopLevelNode := statements.Nodes[len(statements.Nodes)-1]
 				listeners[rule.ListenerOnExit(lastTopLevelNode.Kind)] = func(node *ast.Node) {
 					if node == lastTopLevelNode {
-						reporter.flush()
+						reporter.flush(ac)
 					}
 				}
 			}

--- a/internal/rules/no_unused_vars/no_unused_vars_extras_scopes_test.go
+++ b/internal/rules/no_unused_vars/no_unused_vars_extras_scopes_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -758,5 +759,108 @@ consume(data);`,
 				t.Fatalf("unused names = %v, want %v", names, test.wantNames)
 			}
 		})
+	}
+}
+
+func TestNoUnusedVarsEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const code = `const removable = 1;
+let assigned: number;
+assigned = 2;
+`
+	tmpDir := t.TempDir()
+	filePath := tspath.NormalizePath(filepath.Join(tmpDir, "edit-demand.ts"))
+	if err := os.WriteFile(filePath, []byte(code), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := utils.CreateCompilerHost(tmpDir, fs)
+	program, err := utils.CreateProgramFromOptionsLenient(true, &core.CompilerOptions{
+		SkipLibCheck: core.TSTrue,
+		Target:       core.ScriptTargetESNext,
+	}, []string{filePath}, host)
+	if err != nil {
+		t.Fatalf("create program: %v", err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:     program,
+			File:        filePath,
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     NoUnusedVarsRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoUnusedVarsRule.Run(ctx, nil)
+					},
+				}}
+			},
+			ExcludePaths: []string{},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		return diagnostics
+	}
+
+	diagnostics := map[rule.EditDemand][]rule.RuleDiagnostic{}
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		diagnostics[demand] = run(demand)
+		if got := len(diagnostics[demand]); got != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, got)
+		}
+	}
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range diagnostics[rule.EditDemandAll] {
+		want := withoutEdits(diagnostics[rule.EditDemandAll][index])
+		for demand, demandDiagnostics := range diagnostics {
+			if got := withoutEdits(demandDiagnostics[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d: diagnostic %d changed:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+			if demandDiagnostics[index].FixesPtr != nil {
+				t.Errorf("demand %d: diagnostic %d unexpectedly has autofixes", demand, index)
+			}
+		}
+	}
+
+	for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix} {
+		for index, diagnostic := range diagnostics[demand] {
+			if diagnostic.Suggestions != nil {
+				t.Errorf("demand %d: diagnostic %d unexpectedly has suggestions", demand, index)
+			}
+		}
+	}
+
+	suggestionOnly := diagnostics[rule.EditDemandSuggestion]
+	allEdits := diagnostics[rule.EditDemandAll]
+	if suggestionOnly[0].Suggestions == nil ||
+		!reflect.DeepEqual(suggestionOnly[0].Suggestions, allEdits[0].Suggestions) {
+		t.Fatalf("remove suggestions differ between suggestion-only and all demand")
+	}
+	if got := *allEdits[0].Suggestions; len(got) != 1 || got[0].Message.Id != "removeVar" || len(got[0].Fixes()) != 1 {
+		t.Fatalf("unexpected remove suggestions: %#v", got)
+	}
+	if suggestionOnly[1].Suggestions != nil || allEdits[1].Suggestions != nil {
+		t.Fatalf("write-only diagnostic unexpectedly has remove suggestions")
 	}
 }


### PR DESCRIPTION
## Summary

- Keep `no-unused-vars` collection, symbol analysis, diagnostic selection, message/range construction, ordering, and suppression behavior unchanged.
- Retain only immutable removal-suggestion inputs in pending diagnostics, then build the optional `RuleSuggestion` when the native consumer requests suggestions.
- Lazily tokenize the source at most once and only when a requested suggestion kind needs tokens. The reporter does not retain per-diagnostic closures and no longer has an unused immediate-reporting mode or an analysis back-reference.
- Keep this optimization entirely inside the native rule/framework boundary: no `Program`, TypeChecker, JavaScript plugin protocol, or serialized diagnostic changes.
- Add end-to-end demand coverage to the existing rule test file for diagnostics-only, autofix-only, suggestion-only, and all-edit consumers, including exact diagnostic identity and the write-only/no-suggestion case.

### Benchmark

Apple M1 Max (`darwin/arm64`), `GOMAXPROCS=1`, `GOGC=off`, fixed 50 iterations per sample. Diagnostics-only results use 20 samples per side; the adversarial mixed/all check uses 40 samples per side. The temporary benchmark was removed before commit.

| Scenario | Base | This PR | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| clean, diagnostics only | 986.0 µs | 237.0 µs | -75.96% | -97.20% | -97.15% |
| 320 violations, diagnostics only | 968.3 µs | 359.3 µs | -62.89% | -74.77% | -79.45% |
| 320 used + 1 unused, diagnostics only | 1044.6 µs | 294.4 µs | -71.82% | -94.76% | -95.01% |
| 320 used + 1 unused, all edits | 1.063 ms | 1.085 ms | +2.12% | effectively unchanged | unchanged |

The last row is a measured CPU tradeoff, not an allocation regression: when a suggestion is consumed, tokenization moves from rule initialization to the first suggestion builder. Avoiding it would require exposing edit demand or adding an eager preparation hook, which would couple rule execution back to consumer demand and would also give up the clean-file win. The diagnostics-only/native lint path remains the intended optimization target.

## Related Links

Related #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
