### PR TITLE
perf: defer prefer-regex-literals suggestions

### DIFF
--- a/internal/rules/prefer_regex_literals/prefer_regex_literals.go
+++ b/internal/rules/prefer_regex_literals/prefer_regex_literals.go
@@ -113,89 +113,82 @@ func isUnnecessarilyWrappedRegexLiteral(ctx rule.RuleContext, args []*ast.Node) 
 }
 
 func reportStaticStringRegExp(ctx rule.RuleContext, node *ast.Node, args []*ast.Node) {
-	pattern, _ := staticStringValue(ctx, args[0])
-	flags := ""
-	if len(args) == 2 {
-		flags, _ = staticStringValue(ctx, args[1])
-	}
-
 	msg := rule.RuleMessage{
 		Id:          "unexpectedRegExp",
 		Description: "Use a regular expression literal instead of the 'RegExp' constructor.",
 	}
 
-	suggestions := []rule.RuleSuggestion{}
-	if literal, ok := buildLiteralReplacement(pattern, flags); ok && canFixTo(ctx, node, literal) {
-		suggestions = append(suggestions, buildSuggestion(ctx, node, "replaceWithLiteral", "Replace with an equivalent regular expression literal.", literal, nil))
-	}
-	reportWithSuggestions(ctx, node, msg, suggestions)
+	ctx.ReportNodeWithDeferredSuggestions(node, msg, func() []rule.RuleSuggestion {
+		pattern, _ := staticStringValue(ctx, args[0])
+		flags := ""
+		if len(args) == 2 {
+			flags, _ = staticStringValue(ctx, args[1])
+		}
+		if literal, ok := buildLiteralReplacement(pattern, flags); ok && canFixTo(ctx, node, literal) {
+			return []rule.RuleSuggestion{buildSuggestion(ctx, node, "replaceWithLiteral", "Replace with an equivalent regular expression literal.", literal, nil)}
+		}
+		return nil
+	})
 }
 
 func reportRedundantRegExp(ctx rule.RuleContext, node *ast.Node, args []*ast.Node) {
 	regexNode := utils.SkipAssertionsAndParens(args[0])
-	pattern, literalFlags, _ := regexLiteralPatternAndFlags(regexNode)
 
 	if len(args) == 2 {
-		argFlags, _ := staticStringValue(ctx, args[1])
-		suggestions := []rule.RuleSuggestion{}
-
-		replacement := "/" + pattern + "/" + argFlags
-		if canFixTo(ctx, node, replacement) {
-			suggestions = append(suggestions, buildSuggestion(
-				ctx,
-				node,
-				"replaceWithLiteralAndFlags",
-				fmt.Sprintf("Replace with an equivalent regular expression literal with flags '%s'.", argFlags),
-				replacement,
-				map[string]string{"flags": argFlags},
-			))
-		}
-
-		mergedFlags := mergeRegexFlags(literalFlags, argFlags)
-		mergedReplacement := "/" + pattern + "/" + mergedFlags
-		if !areFlagsEqual(mergedFlags, argFlags) && canFixTo(ctx, node, mergedReplacement) {
-			suggestions = append(suggestions, buildSuggestion(
-				ctx,
-				node,
-				"replaceWithIntendedLiteralAndFlags",
-				fmt.Sprintf("Replace with a regular expression literal with flags '%s'.", mergedFlags),
-				mergedReplacement,
-				map[string]string{"flags": mergedFlags},
-			))
-		}
-
-		reportWithSuggestions(ctx, node, rule.RuleMessage{
+		ctx.ReportNodeWithDeferredSuggestions(node, rule.RuleMessage{
 			Id:          "unexpectedRedundantRegExpWithFlags",
 			Description: "Use regular expression literal with flags instead of the 'RegExp' constructor.",
-		}, suggestions)
+		}, func() []rule.RuleSuggestion {
+			pattern, literalFlags, _ := regexLiteralPatternAndFlags(regexNode)
+			argFlags, _ := staticStringValue(ctx, args[1])
+			suggestions := []rule.RuleSuggestion{}
+
+			replacement := "/" + pattern + "/" + argFlags
+			if canFixTo(ctx, node, replacement) {
+				suggestions = append(suggestions, buildSuggestion(
+					ctx,
+					node,
+					"replaceWithLiteralAndFlags",
+					fmt.Sprintf("Replace with an equivalent regular expression literal with flags '%s'.", argFlags),
+					replacement,
+					map[string]string{"flags": argFlags},
+				))
+			}
+
+			mergedFlags := mergeRegexFlags(literalFlags, argFlags)
+			mergedReplacement := "/" + pattern + "/" + mergedFlags
+			if !areFlagsEqual(mergedFlags, argFlags) && canFixTo(ctx, node, mergedReplacement) {
+				suggestions = append(suggestions, buildSuggestion(
+					ctx,
+					node,
+					"replaceWithIntendedLiteralAndFlags",
+					fmt.Sprintf("Replace with a regular expression literal with flags '%s'.", mergedFlags),
+					mergedReplacement,
+					map[string]string{"flags": mergedFlags},
+				))
+			}
+			return suggestions
+		})
 		return
 	}
 
-	suggestions := []rule.RuleSuggestion{}
-	literal := utils.TrimmedNodeText(ctx.SourceFile, regexNode)
-	if canFixTo(ctx, node, literal) {
-		suggestions = append(suggestions, buildSuggestion(
-			ctx,
-			node,
-			"replaceWithLiteral",
-			"Replace with an equivalent regular expression literal.",
-			literal,
-			nil,
-		))
-	}
-
-	reportWithSuggestions(ctx, node, rule.RuleMessage{
+	ctx.ReportNodeWithDeferredSuggestions(node, rule.RuleMessage{
 		Id:          "unexpectedRedundantRegExp",
 		Description: "Regular expression literal is unnecessarily wrapped within a 'RegExp' constructor.",
-	}, suggestions)
-}
-
-func reportWithSuggestions(ctx rule.RuleContext, node *ast.Node, msg rule.RuleMessage, suggestions []rule.RuleSuggestion) {
-	if len(suggestions) == 0 {
-		ctx.ReportNode(node, msg)
-		return
-	}
-	ctx.ReportNodeWithSuggestions(node, msg, suggestions...)
+	}, func() []rule.RuleSuggestion {
+		literal := utils.TrimmedNodeText(ctx.SourceFile, regexNode)
+		if canFixTo(ctx, node, literal) {
+			return []rule.RuleSuggestion{buildSuggestion(
+				ctx,
+				node,
+				"replaceWithLiteral",
+				"Replace with an equivalent regular expression literal.",
+				literal,
+				nil,
+			)}
+		}
+		return nil
+	})
 }
 
 func buildSuggestion(ctx rule.RuleContext, node *ast.Node, messageID string, description string, replacement string, data map[string]string) rule.RuleSuggestion {

--- a/internal/rules/prefer_regex_literals/prefer_regex_literals_extras_test.go
+++ b/internal/rules/prefer_regex_literals/prefer_regex_literals_extras_test.go
@@ -1,9 +1,14 @@
 package prefer_regex_literals
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -293,4 +298,72 @@ func TestPreferRegexLiteralsExtras(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestPreferRegexLiteralsEditDemand(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, `RegExp("item-(a|b)+", "giu");`, core.ScriptKindTS)
+	statement := sourceFile.Statements.Nodes[0].AsExpressionStatement()
+	callNode := statement.Expression
+	args := callNode.AsCallExpression().Arguments.Nodes
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			DisableManager: rule.NewDisableManager(sourceFile, rule.NewCommentStore(sourceFile)),
+		}.WithDiagnosticConsumer(PreferRegexLiteralsRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		})
+		reportStaticStringRegExp(ctx, callNode, args)
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.Suggestions != nil || autofixOnly.Suggestions != nil {
+		t.Fatal("non-suggestion demand materialized suggestions")
+	}
+	if diagnosticsOnly.FixesPtr != nil || autofixOnly.FixesPtr != nil ||
+		suggestionOnly.FixesPtr != nil || allEdits.FixesPtr != nil {
+		t.Fatal("suggestion-only rule materialized autofixes")
+	}
+	if suggestionOnly.Suggestions == nil ||
+		!reflect.DeepEqual(suggestionOnly.Suggestions, allEdits.Suggestions) {
+		t.Fatalf("suggestions differ between suggestion-only and all demand")
+	}
+	if suggestions := *allEdits.Suggestions; len(suggestions) != 1 ||
+		suggestions[0].Message.Id != "replaceWithLiteral" ||
+		len(suggestions[0].Fixes()) != 1 {
+		t.Fatalf("unexpected suggestions: %#v", suggestions)
+	}
 }


### PR DESCRIPTION
## Summary

- Keep built-in `RegExp` resolution, shadowing checks, static-argument detection, redundant-wrapping detection, diagnostic messages, and ranges eager and unchanged.
- Defer only optional suggestion work: extracting replacement pattern/flags, constructing and validating literal replacements, safe-output calculation, and `RuleSuggestion`/fix allocation.
- Use the native deferred-suggestion API directly, with no `Program`, TypeChecker, JavaScript plugin protocol, or serialized diagnostic changes.
- Add demand-mode coverage to the existing rule test file and verify exact diagnostic identity across diagnostics-only, autofix-only, suggestion-only, and all-edit consumers.

### Benchmark

Apple M1 Max (`darwin/arm64`), one core, 300 ms per sample, 10 samples per side. The temporary benchmark was removed before commit.

| Demand | Base | This PR | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| diagnostics only | 17.822 ms | 4.031 ms | -77.38% | -96.68% | -98.83% |
| all edits | — | — | no significant change (`p=0.165`) | unchanged | unchanged |

The diagnostic count and every requested suggestion remain identical.

## Related Links

Related #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
