### PR TITLE
perf: defer no-else-return fixes

### DIFF
--- a/internal/rules/no_else_return/no_else_return.go
+++ b/internal/rules/no_else_return/no_else_return.go
@@ -143,11 +143,9 @@ func checkIfWithElse(ctx rule.RuleContext, node *ast.Node) {
 }
 
 func displayReport(ctx rule.RuleContext, elseNode *ast.Node) {
-	if fixes := buildFixes(ctx, elseNode); len(fixes) > 0 {
-		ctx.ReportNodeWithFixes(elseNode, unexpectedMessage, fixes...)
-		return
-	}
-	ctx.ReportNode(elseNode, unexpectedMessage)
+	ctx.ReportNodeWithDeferredFixes(elseNode, unexpectedMessage, func() []rule.RuleFix {
+		return buildFixes(ctx, elseNode)
+	})
 }
 
 func isStatementListParent(node *ast.Node) bool {

--- a/internal/rules/no_else_return/no_else_return_extras_test.go
+++ b/internal/rules/no_else_return/no_else_return_extras_test.go
@@ -1,9 +1,14 @@
 package no_else_return
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -337,4 +342,80 @@ func TestNoElseReturnExtras(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoElseReturnEditDemand(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, `function f() { if (a) return 1; else return 2; }`, core.ScriptKindTS)
+	var elseNode *ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindIfStatement {
+			elseNode = node.AsIfStatement().ElseStatement
+			return true
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if elseNode == nil {
+		t.Fatal("fixture has no else branch")
+	}
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			DisableManager: rule.NewDisableManager(sourceFile, rule.NewCommentStore(sourceFile)),
+		}.WithDiagnosticConsumer(NoElseReturnRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		})
+		displayReport(ctx, elseNode)
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("non-autofix demand materialized fixes")
+	}
+	if autofixOnly.FixesPtr == nil || !reflect.DeepEqual(autofixOnly.FixesPtr, allEdits.FixesPtr) {
+		t.Fatal("autofix and all-edits demands produced different fixes")
+	}
+	if fixes := *allEdits.FixesPtr; len(fixes) != 2 {
+		t.Fatalf("fixes = %d, want 2", len(fixes))
+	}
+	for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		if diagnostic.Suggestions != nil {
+			t.Fatal("autofix-only rule materialized suggestions")
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Keep control-flow detection, `allowElseIf` behavior, diagnostic selection, message, and range unchanged.
- Defer the complete optional fix path—including collision, ASI, token-boundary, and replacement-text checks—until the native consumer requests autofixes.
- Preserve the existing behavior where an unsafe transformation still reports the diagnostic without a fix.
- Add demand-mode coverage to the existing rule test file, checking exact diagnostic identity and identical two-edit payloads for autofix-only and all-edit consumers.
- This is a native rule-local migration with no `Program`, TypeChecker, plugin protocol, or serialized diagnostic changes.

### Benchmark

Apple M1 Max (`darwin/arm64`), one core, 300 ms per sample, 10 samples per side. The temporary benchmark was removed before commit.

| Demand | Base | This PR | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| diagnostics only | 5438.4 µs | 153.3 µs | -97.18% | -99.10% | -99.20% |
| all edits | — | — | no significant change (`p=0.631`) | unchanged | unchanged |

Diagnostic and requested-fix counts are identical.

## Related Links

Related #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
