### PR TITLE
perf: defer no-unused-private-class-members suggestions

### DIFF
--- a/internal/rules/no_unused_private_class_members/no_unused_private_class_members.go
+++ b/internal/rules/no_unused_private_class_members/no_unused_private_class_members.go
@@ -226,17 +226,19 @@ func reportUnusedMembers(ctx rule.RuleContext, classInfo *classMembers, getItems
 			continue
 		}
 
-		items := getItems()
-		fixes := []rule.RuleFix{
-			rule.RuleFixReplaceRange(memberRemovalRange(ctx.SourceFile, member.declNode, items), ""),
-		}
-		if token, ok := semicolonInsertionToken(ctx.SourceFile, classInfo.classNode, member.declNode, items); ok {
-			fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(token.end, token.end), ";"))
-		}
+		ctx.ReportNodeWithDeferredSuggestions(member.nameNode, message, func() []rule.RuleSuggestion {
+			items := getItems()
+			fixes := []rule.RuleFix{
+				rule.RuleFixReplaceRange(memberRemovalRange(ctx.SourceFile, member.declNode, items), ""),
+			}
+			if token, ok := semicolonInsertionToken(ctx.SourceFile, classInfo.classNode, member.declNode, items); ok {
+				fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(token.end, token.end), ";"))
+			}
 
-		ctx.ReportNodeWithSuggestions(member.nameNode, message, rule.RuleSuggestion{
-			Message:  removeUnusedPrivateClassMemberMessage(member.name),
-			FixesArr: fixes,
+			return []rule.RuleSuggestion{{
+				Message:  removeUnusedPrivateClassMemberMessage(member.name),
+				FixesArr: fixes,
+			}}
 		})
 	}
 }

--- a/internal/rules/no_unused_private_class_members/no_unused_private_class_members_extras_test.go
+++ b/internal/rules/no_unused_private_class_members/no_unused_private_class_members_extras_test.go
@@ -20,9 +20,14 @@
 package no_unused_private_class_members
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -418,4 +423,92 @@ class C {
 			),
 		},
 	)
+}
+
+func TestNoUnusedPrivateClassMembersEditDemand(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, `class C {
+	value = () => 1
+	#unused;
+	[key]() {}
+}`, core.ScriptKindTS)
+	classNode := sourceFile.Statements.Nodes[0]
+	classInfo := collectPrivateMembers(classNode)
+
+	run := func(demand rule.EditDemand) (rule.RuleDiagnostic, int) {
+		t.Helper()
+
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(NoUnusedPrivateClassMembersRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		})
+		itemBuilds := 0
+		reportUnusedMembers(ctx, classInfo, func() []sourceItem {
+			itemBuilds++
+			return collectSourceItems(sourceFile, comments.All())
+		})
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0], itemBuilds
+	}
+
+	diagnosticsOnly, diagnosticsOnlyBuilds := run(rule.EditDemandNone)
+	autofixOnly, autofixOnlyBuilds := run(rule.EditDemandAutofix)
+	suggestionOnly, suggestionOnlyBuilds := run(rule.EditDemandSuggestion)
+	allEdits, allEditsBuilds := run(rule.EditDemandAll)
+
+	if diagnosticsOnlyBuilds != 0 || autofixOnlyBuilds != 0 ||
+		suggestionOnlyBuilds != 1 || allEditsBuilds != 1 {
+		t.Fatalf(
+			"source item builds = none:%d autofix:%d suggestion:%d all:%d",
+			diagnosticsOnlyBuilds,
+			autofixOnlyBuilds,
+			suggestionOnlyBuilds,
+			allEditsBuilds,
+		)
+	}
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.Suggestions != nil || autofixOnly.Suggestions != nil {
+		t.Fatal("non-suggestion demand materialized suggestions")
+	}
+	if suggestionOnly.Suggestions == nil ||
+		!reflect.DeepEqual(suggestionOnly.Suggestions, allEdits.Suggestions) {
+		t.Fatal("suggestion and all-edits demands produced different suggestions")
+	}
+	if suggestions := *allEdits.Suggestions; len(suggestions) != 1 ||
+		suggestions[0].Message.Id != "removeUnusedPrivateClassMember" ||
+		len(suggestions[0].Fixes()) != 2 {
+		t.Fatalf("unexpected suggestions: %#v", suggestions)
+	}
+	for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		if diagnostic.FixesPtr != nil {
+			t.Fatal("suggestion-only rule materialized autofixes")
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Keep class/member tracking, private-name reference analysis, write-only handling, diagnostic selection, messages, ranges, and ordering unchanged.
- Defer source-item/comment collection, member-removal range calculation, semicolon repair, and suggestion allocation until a native consumer requests suggestions.
- Preserve the existing per-file lazy source-item cache, so multiple requested suggestions still scan source structure only once.
- Add demand-mode coverage to the existing rule test file, including an explicit source-item builder count, exact diagnostic identity, and the two-fix semicolon-preservation case.
- This remains native and rule-local, with no `Program`, TypeChecker, plugin protocol, or serialized diagnostic changes.

### Benchmark

Apple M1 Max (`darwin/arm64`), one core, 300 ms per sample, 10 samples per side. The temporary benchmark was removed before commit.

| Demand | Base | This PR | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| diagnostics only | 14086.6 µs | 374.3 µs | -97.34% | -81.28% | -49.78% |
| all edits | — | — | no significant change (`p=0.971`) | unchanged | unchanged |

Diagnostic and requested-suggestion counts are identical.

## Related Links

Related #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
