### PR TITLE
perf: defer arrow-body-style fixes

### DIFF
--- a/internal/rules/arrow_body_style/arrow_body_style.go
+++ b/internal/rules/arrow_body_style/arrow_body_style.go
@@ -149,6 +149,103 @@ func findClosingParenRange(objNode *ast.Node, sf *ast.SourceFile) (int, int, boo
 	return parenEnd - 1, parenEnd, true
 }
 
+func insertFix(pos int, text string) rule.RuleFix {
+	return rule.RuleFixReplaceRange(core.NewTextRange(pos, pos), text)
+}
+
+func removeFix(start int, end int) rule.RuleFix {
+	return rule.RuleFixRemoveRange(core.NewTextRange(start, end))
+}
+
+func positionsOnSameLine(sourceFile *ast.SourceFile, left int, right int) bool {
+	lineStarts := scanner.GetECMALineStarts(sourceFile)
+	return scanner.ComputeLineOfPosition(lineStarts, left) == scanner.ComputeLineOfPosition(lineStarts, right)
+}
+
+func buildBlockBodyFixes(
+	sourceFile *ast.SourceFile,
+	text string,
+	arrowNode *ast.Node,
+	body *ast.Node,
+	blockRange core.TextRange,
+	statementCount int,
+	firstStatement *ast.Node,
+	returnExpression *ast.Node,
+) []rule.RuleFix {
+	if statementCount != 1 ||
+		firstStatement == nil ||
+		firstStatement.Kind != ast.KindReturnStatement ||
+		returnExpression == nil ||
+		hasASIProblemAfter(text, body.End()) {
+		return nil
+	}
+
+	argument := ast.SkipParentheses(returnExpression)
+	braceOpenStart := blockRange.Pos()
+	braceCloseEnd := blockRange.End()
+	braceCloseStart := braceCloseEnd - 1
+	firstValueStart := scanner.SkipTrivia(text, returnExpression.Pos())
+	valueEnd := utils.TrimNodeTextRange(sourceFile, returnExpression).End()
+
+	semicolonStart, semicolonEnd := -1, -1
+	if pos := scanner.SkipTrivia(text, valueEnd); pos < braceCloseStart && pos < len(text) && text[pos] == ';' {
+		semicolonStart, semicolonEnd = pos, pos+1
+	}
+	lastValueEnd := valueEnd
+	if semicolonStart >= 0 {
+		lastValueEnd = semicolonEnd
+	}
+
+	// commentsExistBetween(openingBrace, firstValueToken) ||
+	// commentsExistBetween(lastValueToken, closingBrace). ForEachComment
+	// walks every token's trivia, so it catches a comment sitting after
+	// the `return` keyword too (which a position-anchored scan misses).
+	commentsExist := false
+	utils.ForEachComment(body, func(comment *ast.CommentRange) {
+		if commentsExist {
+			return
+		}
+		if (comment.Pos() >= braceOpenStart+1 && comment.End() <= firstValueStart) ||
+			(comment.Pos() >= lastValueEnd && comment.End() <= braceCloseStart) {
+			commentsExist = true
+		}
+	}, sourceFile)
+
+	var fixes []rule.RuleFix
+	if commentsExist {
+		returnKeywordStart := scanner.SkipTrivia(text, braceOpenStart+1)
+		fixes = append(fixes,
+			removeFix(braceOpenStart, braceOpenStart+1),
+			removeFix(braceCloseStart, braceCloseEnd),
+			removeFix(returnKeywordStart, returnKeywordStart+len("return")),
+		)
+	} else {
+		fixes = append(fixes,
+			removeFix(braceOpenStart, firstValueStart),
+			removeFix(lastValueEnd, braceCloseEnd),
+		)
+	}
+
+	isSequence := argument.Kind == ast.KindBinaryExpression &&
+		argument.AsBinaryExpression() != nil &&
+		argument.AsBinaryExpression().OperatorToken != nil &&
+		argument.AsBinaryExpression().OperatorToken.Kind == ast.KindCommaToken
+	startsWithBrace := firstValueStart < len(text) && text[firstValueStart] == '{'
+	needsParentheses := startsWithBrace || isSequence ||
+		(isInsideForLoopInitializer(arrowNode) && subtreeHasInOperator(arrowNode))
+	if needsParentheses && returnExpression.Kind != ast.KindParenthesizedExpression {
+		fixes = append(fixes,
+			insertFix(firstValueStart, "("),
+			insertFix(lastValueEnd, ")"),
+		)
+	}
+
+	if semicolonStart >= 0 {
+		fixes = append(fixes, removeFix(semicolonStart, semicolonEnd))
+	}
+	return fixes
+}
+
 var ArrowBodyStyleRule = rule.Rule{
 	Name: "arrow-body-style",
 	Run: func(ctx rule.RuleContext, _opts []any) rule.RuleListeners {
@@ -159,17 +256,6 @@ var ArrowBodyStyleRule = rule.Rule{
 		never := o.style == styleNever
 		sf := ctx.SourceFile
 		text := sf.Text()
-
-		sameLine := func(a, b int) bool {
-			lineStarts := scanner.GetECMALineStarts(sf)
-			return scanner.ComputeLineOfPosition(lineStarts, a) == scanner.ComputeLineOfPosition(lineStarts, b)
-		}
-		insertAt := func(pos int, s string) rule.RuleFix {
-			return rule.RuleFixReplaceRange(core.NewTextRange(pos, pos), s)
-		}
-		removeR := func(start, end int) rule.RuleFix {
-			return rule.RuleFixRemoveRange(core.NewTextRange(start, end))
-		}
 
 		validate := func(node *ast.Node) {
 			arrow := node.AsArrowFunction()
@@ -232,81 +318,9 @@ var ArrowBodyStyleRule = rule.Rule{
 					}
 				}
 
-				// Build the autofix. It stays empty when upstream would emit no
-				// fix (more than one statement, no/empty return argument, or an
-				// ASI hazard on the token after the block).
-				var fixes []rule.RuleFix
-				if len(stmts) == 1 && firstStmt.Kind == ast.KindReturnStatement && retExpr != nil && !hasASIProblemAfter(text, body.End()) {
-					argument := ast.SkipParentheses(retExpr)
-
-					braceOpenStart := blockRange.Pos()
-					braceCloseEnd := blockRange.End()
-					braceCloseStart := braceCloseEnd - 1
-					firstValueStart := scanner.SkipTrivia(text, retExpr.Pos())
-					valueEnd := utils.TrimNodeTextRange(sf, retExpr).End()
-
-					semiStart, semiEnd := -1, -1
-					if p := scanner.SkipTrivia(text, valueEnd); p < braceCloseStart && p < len(text) && text[p] == ';' {
-						semiStart, semiEnd = p, p+1
-					}
-					lastValueEnd := valueEnd
-					if semiStart >= 0 {
-						lastValueEnd = semiEnd
-					}
-
-					// commentsExistBetween(openingBrace, firstValueToken) ||
-					// commentsExistBetween(lastValueToken, closingBrace). ForEachComment
-					// walks every token's trivia, so it catches a comment sitting after
-					// the `return` keyword too (which a position-anchored scan misses).
-					commentsExist := false
-					utils.ForEachComment(body, func(c *ast.CommentRange) {
-						if commentsExist {
-							return
-						}
-						if (c.Pos() >= braceOpenStart+1 && c.End() <= firstValueStart) ||
-							(c.Pos() >= lastValueEnd && c.End() <= braceCloseStart) {
-							commentsExist = true
-						}
-					}, sf)
-
-					if commentsExist {
-						returnKwStart := scanner.SkipTrivia(text, braceOpenStart+1)
-						fixes = append(fixes,
-							removeR(braceOpenStart, braceOpenStart+1),
-							removeR(braceCloseStart, braceCloseEnd),
-							removeR(returnKwStart, returnKwStart+len("return")),
-						)
-					} else {
-						fixes = append(fixes,
-							removeR(braceOpenStart, firstValueStart),
-							removeR(lastValueEnd, braceCloseEnd),
-						)
-					}
-
-					isSeq := argument.Kind == ast.KindBinaryExpression &&
-						argument.AsBinaryExpression() != nil &&
-						argument.AsBinaryExpression().OperatorToken != nil &&
-						argument.AsBinaryExpression().OperatorToken.Kind == ast.KindCommaToken
-					startsWithBrace := firstValueStart < len(text) && text[firstValueStart] == '{'
-					needsParens := startsWithBrace || isSeq ||
-						(isInsideForLoopInitializer(node) && subtreeHasInOperator(node))
-					if needsParens && retExpr.Kind != ast.KindParenthesizedExpression {
-						fixes = append(fixes,
-							insertAt(firstValueStart, "("),
-							insertAt(lastValueEnd, ")"),
-						)
-					}
-
-					if semiStart >= 0 {
-						fixes = append(fixes, removeR(semiStart, semiEnd))
-					}
-				}
-
-				if len(fixes) > 0 {
-					ctx.ReportRangeWithFixes(blockRange, msg, fixes...)
-				} else {
-					ctx.ReportRange(blockRange, msg)
-				}
+				ctx.ReportRangeWithDeferredFixes(blockRange, msg, func() []rule.RuleFix {
+					return buildBlockBodyFixes(sf, text, node, body, blockRange, len(stmts), firstStmt, retExpr)
+				})
 				return
 			}
 
@@ -323,47 +337,47 @@ var ArrowBodyStyleRule = rule.Rule{
 				ctx.ReportRange(reportRange, msgExpectedBlock())
 				return
 			}
-			firstTokenStart := scanner.SkipTrivia(text, arrowToken.End())
-			nodeEnd := utils.TrimNodeTextRange(sf, node).End()
-
-			var fixes []rule.RuleFix
-			handled := false
-			if firstTokenStart < len(text) && text[firstTokenStart] == '(' {
-				braceStart := scanner.SkipTrivia(text, firstTokenStart+1)
-				if braceStart < len(text) && text[braceStart] == '{' {
-					objNode := ast.GetNodeAtPosition(sf, braceStart, false)
-					// A `({a} = b)`-style destructuring target parses as an
-					// ObjectLiteralExpression in tsgo but is an ObjectPattern in
-					// ESTree, so exclude assignment targets to match ESLint (which
-					// keeps the forced parens via its else branch).
-					if objNode != nil && objNode.Kind == ast.KindObjectLiteralExpression && !ast.IsAssignmentTarget(objNode) {
-						if cpStart, cpEnd, ok := findClosingParenRange(objNode, sf); ok {
-							openParenStart := firstTokenStart
-							openParenEnd := firstTokenStart + 1
-							if sameLine(openParenStart, braceStart) {
-								fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(openParenStart, openParenEnd), "{return "))
-							} else {
-								// Different lines: keep the `return ` next to the
-								// object so ASI does not split the statement.
-								fixes = append(fixes,
-									rule.RuleFixReplaceRange(core.NewTextRange(openParenStart, openParenEnd), "{"),
-									insertAt(braceStart, "return "),
-								)
+			ctx.ReportRangeWithDeferredFixes(reportRange, msgExpectedBlock(), func() []rule.RuleFix {
+				firstTokenStart := scanner.SkipTrivia(text, arrowToken.End())
+				nodeEnd := utils.TrimNodeTextRange(sf, node).End()
+				var fixes []rule.RuleFix
+				handled := false
+				if firstTokenStart < len(text) && text[firstTokenStart] == '(' {
+					braceStart := scanner.SkipTrivia(text, firstTokenStart+1)
+					if braceStart < len(text) && text[braceStart] == '{' {
+						objectNode := ast.GetNodeAtPosition(sf, braceStart, false)
+						// A `({a} = b)`-style destructuring target parses as an
+						// ObjectLiteralExpression in tsgo but is an ObjectPattern in
+						// ESTree, so exclude assignment targets to match ESLint (which
+						// keeps the forced parens via its else branch).
+						if objectNode != nil && objectNode.Kind == ast.KindObjectLiteralExpression && !ast.IsAssignmentTarget(objectNode) {
+							if closeParenStart, closeParenEnd, ok := findClosingParenRange(objectNode, sf); ok {
+								openParenStart := firstTokenStart
+								openParenEnd := firstTokenStart + 1
+								if positionsOnSameLine(sf, openParenStart, braceStart) {
+									fixes = append(fixes, rule.RuleFixReplaceRange(core.NewTextRange(openParenStart, openParenEnd), "{return "))
+								} else {
+									// Different lines: keep the `return ` next to the
+									// object so ASI does not split the statement.
+									fixes = append(fixes,
+										rule.RuleFixReplaceRange(core.NewTextRange(openParenStart, openParenEnd), "{"),
+										insertFix(braceStart, "return "),
+									)
+								}
+								fixes = append(fixes, removeFix(closeParenStart, closeParenEnd), insertFix(nodeEnd, "}"))
+								handled = true
 							}
-							fixes = append(fixes, removeR(cpStart, cpEnd), insertAt(nodeEnd, "}"))
-							handled = true
 						}
 					}
 				}
-			}
-			if !handled {
-				fixes = append(fixes,
-					insertAt(firstTokenStart, "{return "),
-					insertAt(nodeEnd, "}"),
-				)
-			}
-
-			ctx.ReportRangeWithFixes(reportRange, msgExpectedBlock(), fixes...)
+				if !handled {
+					fixes = append(fixes,
+						insertFix(firstTokenStart, "{return "),
+						insertFix(nodeEnd, "}"),
+					)
+				}
+				return fixes
+			})
 		}
 
 		return rule.RuleListeners{

--- a/internal/rules/arrow_body_style/arrow_body_style_extras_test.go
+++ b/internal/rules/arrow_body_style/arrow_body_style_extras_test.go
@@ -5,9 +5,14 @@
 package arrow_body_style
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -278,4 +283,101 @@ func TestArrowBodyStyleExtras(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestArrowBodyStyleEditDemand(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name    string
+		code    string
+		options []any
+	}{
+		{
+			name:    "remove block",
+			code:    `const value = () => { return result; };`,
+			options: []any{"as-needed"},
+		},
+		{
+			name:    "add block",
+			code:    `const value = () => result;`,
+			options: []any{"always"},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/edit-demand.ts",
+				Path:     "/edit-demand.ts",
+			}, testCase.code, core.ScriptKindTS)
+			var arrowNode *ast.Node
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if node.Kind == ast.KindArrowFunction {
+					arrowNode = node
+					return true
+				}
+				return node.ForEachChild(visit)
+			}
+			sourceFile.AsNode().ForEachChild(visit)
+			if arrowNode == nil {
+				t.Fatal("fixture has no arrow function")
+			}
+
+			run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+				t.Helper()
+
+				comments := rule.NewCommentStore(sourceFile)
+				var diagnostics []rule.RuleDiagnostic
+				ctx := rule.RuleContext{
+					SourceFile:     sourceFile,
+					Comments:       comments,
+					DisableManager: rule.NewDisableManager(sourceFile, comments),
+				}.WithDiagnosticConsumer(ArrowBodyStyleRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+					Demand: demand,
+					Report: func(diagnostic rule.RuleDiagnostic) {
+						diagnostics = append(diagnostics, diagnostic)
+					},
+				})
+				listener := ArrowBodyStyleRule.Run(ctx, testCase.options)[ast.KindArrowFunction]
+				listener(arrowNode)
+				if len(diagnostics) != 1 {
+					t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+				}
+				return diagnostics[0]
+			}
+
+			diagnosticsOnly := run(rule.EditDemandNone)
+			autofixOnly := run(rule.EditDemandAutofix)
+			suggestionOnly := run(rule.EditDemandSuggestion)
+			allEdits := run(rule.EditDemandAll)
+
+			withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+				diagnostic.FixesPtr = nil
+				diagnostic.Suggestions = nil
+				return diagnostic
+			}
+			for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+				rule.EditDemandNone:       diagnosticsOnly,
+				rule.EditDemandAutofix:    autofixOnly,
+				rule.EditDemandSuggestion: suggestionOnly,
+			} {
+				if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+					t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+				}
+			}
+			if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+				t.Fatal("non-autofix demand materialized fixes")
+			}
+			if autofixOnly.FixesPtr == nil || !reflect.DeepEqual(autofixOnly.FixesPtr, allEdits.FixesPtr) {
+				t.Fatal("autofix and all-edits demands produced different fixes")
+			}
+			for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+				if diagnostic.Suggestions != nil {
+					t.Fatal("autofix-only rule materialized suggestions")
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Keep option handling, block/expression classification, diagnostic selection, message IDs, and report ranges eager and unchanged.
- Defer only optional transformation work in both directions: removing a block body and adding a block around an expression body.
- Preserve all existing safety behavior for comments, semicolons/ASI, object literals, sequence expressions, `for` initializers containing `in`, multiline object returns, and destructuring assignment targets.
- Pass the original statement count into the extracted block-fix builder so `never` diagnostics for empty or multi-statement blocks cannot accidentally acquire a fix.
- Add both conversion directions to the existing demand-mode test file and verify exact diagnostic identity and identical autofix payloads.
- No `Program`, TypeChecker, plugin protocol, or serialized diagnostic changes are involved.

### Benchmark

Apple M1 Max (`darwin/arm64`), one core, 300 ms per sample, 10 samples per side. The temporary benchmark was removed before commit.

| Scenario | Base | This PR | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| remove block, diagnostics only | 1084.3 µs | 111.1 µs | -89.75% | -94.99% | -98.01% |
| add block, diagnostics only | 163.45 µs | 99.59 µs | -39.07% | -57.55% | -72.86% |
| remove block, all edits | 1.083 ms | 1.100 ms | no significant change (`p=0.280`) | effectively unchanged | effectively unchanged |
| add block, all edits | 163.4 µs | 163.1 µs | no significant change (`p=0.436`) | slightly lower | slightly lower |

Diagnostic and requested-fix counts are identical.

## Related Links

Related #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
