### PR TITLE
perf: defer prefer-template fixes

### DIFF
--- a/internal/rules/prefer_template/prefer_template.go
+++ b/internal/rules/prefer_template/prefer_template.go
@@ -42,15 +42,16 @@ var PreferTemplateRule = rule.Rule{
 				Description: "Unexpected string concatenation.",
 			}
 
-			// Octal / non-octal-decimal escape sequences can't be represented
-			// in a template literal, so skip the autofix in that case.
-			if hasOctalOrNonOctalDecimalEscape(ctx.SourceFile, top) {
-				ctx.ReportNode(top, msg)
-				return
-			}
+			ctx.ReportNodeWithDeferredFixes(top, msg, func() []rule.RuleFix {
+				// Octal / non-octal-decimal escape sequences can't be represented
+				// in a template literal, so skip the autofix in that case.
+				if hasOctalOrNonOctalDecimalEscape(ctx.SourceFile, top) {
+					return nil
+				}
 
-			fixed := toTemplateLiteral(ctx.SourceFile, top, "", "")
-			ctx.ReportNodeWithFixes(top, msg, rule.RuleFixReplace(ctx.SourceFile, top, fixed))
+				fixed := toTemplateLiteral(ctx.SourceFile, top, "", "")
+				return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, top, fixed)}
+			})
 		}
 
 		return rule.RuleListeners{

--- a/internal/rules/prefer_template/prefer_template_test.go
+++ b/internal/rules/prefer_template/prefer_template_test.go
@@ -1,9 +1,14 @@
 package prefer_template
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -798,4 +803,83 @@ func TestPreferTemplate(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestPreferTemplateEditDemand(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, `const text = "item-" + value + "-done";`, core.ScriptKindTS)
+	var stringNode *ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindStringLiteral {
+			stringNode = node
+			return true
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if stringNode == nil {
+		t.Fatal("fixture has no string literal")
+	}
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(PreferTemplateRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		})
+		listener := PreferTemplateRule.Run(ctx, nil)[ast.KindStringLiteral]
+		listener(stringNode)
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("non-autofix demand materialized fixes")
+	}
+	if autofixOnly.FixesPtr == nil || !reflect.DeepEqual(autofixOnly.FixesPtr, allEdits.FixesPtr) {
+		t.Fatal("autofix and all-edits demands produced different fixes")
+	}
+	if fixes := *allEdits.FixesPtr; len(fixes) != 1 {
+		t.Fatalf("fixes = %d, want 1", len(fixes))
+	}
+	for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		if diagnostic.Suggestions != nil {
+			t.Fatal("autofix-only rule materialized suggestions")
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Keep concatenation detection, top-chain selection, duplicate-report suppression, diagnostic message, and range unchanged.
- Defer only optional autofix work: the octal/non-octal-decimal escape safety scan and recursive template-literal conversion.
- Preserve the existing behavior where unsafe escape sequences still report a diagnostic but do not expose a fix.
- Add demand-mode coverage to the existing main rule test file and verify exact diagnostic identity plus identical autofixes for autofix-only and all-edit consumers.
- No `Program`, TypeChecker, plugin protocol, or serialized diagnostic changes are involved.

### Benchmark

Apple M1 Max (`darwin/arm64`), one core, 300 ms per sample, 10 samples per side. The temporary benchmark was removed before commit.

| Demand | Base | This PR | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| diagnostics only | 814.7 µs | 160.8 µs | -80.27% | -83.12% | -94.19% |
| all edits | 787.9 µs | 779.5 µs | -1.06% | unchanged | unchanged |

Diagnostic and requested-fix counts are identical.

## Related Links

Related #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
