### PR TITLE
perf: defer one-var fixes

### DIFF
--- a/internal/rules/one_var/one_var.go
+++ b/internal/rules/one_var/one_var.go
@@ -730,11 +730,17 @@ var OneVarRule = rule.Rule{
 								prevInitCount, prevUninitCount := countDeclarations(prevDecls)
 								switch {
 								case typeOpts.initialized == modeConsecutive && typeOpts.uninitialized == modeConsecutive:
-									reportRangeWithFixes(ctx, reportRange, msg("combine", kind), fixCombine(view, node, kind, ctx.SourceFile))
+									ctx.ReportRangeWithDeferredFixes(reportRange, msg("combine", kind), func() []rule.RuleFix {
+										return fixCombine(view, node, kind, ctx.SourceFile)
+									})
 								case typeOpts.initialized == modeConsecutive && initCount > 0 && prevInitCount > 0:
-									reportRangeWithFixes(ctx, reportRange, msg("combineInitialized", kind), fixCombine(view, node, kind, ctx.SourceFile))
+									ctx.ReportRangeWithDeferredFixes(reportRange, msg("combineInitialized", kind), func() []rule.RuleFix {
+										return fixCombine(view, node, kind, ctx.SourceFile)
+									})
 								case typeOpts.uninitialized == modeConsecutive && uninitCount > 0 && prevUninitCount > 0:
-									reportRangeWithFixes(ctx, reportRange, msg("combineUninitialized", kind), fixCombine(view, node, kind, ctx.SourceFile))
+									ctx.ReportRangeWithDeferredFixes(reportRange, msg("combineUninitialized", kind), func() []rule.RuleFix {
+										return fixCombine(view, node, kind, ctx.SourceFile)
+									})
 								}
 							}
 						}
@@ -746,16 +752,22 @@ var OneVarRule = rule.Rule{
 			currentScope := getCurrentScope(key)
 			if currentScope != nil && !hasOnlyOneStatement(currentScope, typeOpts, declarations, opts.separateRequires) {
 				if typeOpts.initialized == modeAlways && typeOpts.uninitialized == modeAlways {
-					reportRangeWithFixes(ctx, reportRange, msg("combine", kind), fixCombine(view, node, kind, ctx.SourceFile))
+					ctx.ReportRangeWithDeferredFixes(reportRange, msg("combine", kind), func() []rule.RuleFix {
+						return fixCombine(view, node, kind, ctx.SourceFile)
+					})
 				} else {
 					if typeOpts.initialized == modeAlways && initCount > 0 {
-						reportRangeWithFixes(ctx, reportRange, msg("combineInitialized", kind), fixCombine(view, node, kind, ctx.SourceFile))
+						ctx.ReportRangeWithDeferredFixes(reportRange, msg("combineInitialized", kind), func() []rule.RuleFix {
+							return fixCombine(view, node, kind, ctx.SourceFile)
+						})
 					}
 					if typeOpts.uninitialized == modeAlways && uninitCount > 0 {
 						// for-in/for-of left side: skip combineUninitialized
 						// (mirrors ESLint's `parent.left === node` early return).
 						if !isForInOfInit {
-							reportRangeWithFixes(ctx, reportRange, msg("combineUninitialized", kind), fixCombine(view, node, kind, ctx.SourceFile))
+							ctx.ReportRangeWithDeferredFixes(reportRange, msg("combineUninitialized", kind), func() []rule.RuleFix {
+								return fixCombine(view, node, kind, ctx.SourceFile)
+							})
 						}
 					}
 				}
@@ -766,11 +778,17 @@ var OneVarRule = rule.Rule{
 				totalDecls := initCount + uninitCount
 				if totalDecls > 1 {
 					if typeOpts.initialized == modeNever && typeOpts.uninitialized == modeNever {
-						reportRangeWithFixes(ctx, reportRange, msg("split", kind), fixSplit(view, node, kind, ctx.SourceFile))
+						ctx.ReportRangeWithDeferredFixes(reportRange, msg("split", kind), func() []rule.RuleFix {
+							return fixSplit(view, node, kind, ctx.SourceFile)
+						})
 					} else if typeOpts.initialized == modeNever && initCount > 0 {
-						reportRangeWithFixes(ctx, reportRange, msg("splitInitialized", kind), fixSplit(view, node, kind, ctx.SourceFile))
+						ctx.ReportRangeWithDeferredFixes(reportRange, msg("splitInitialized", kind), func() []rule.RuleFix {
+							return fixSplit(view, node, kind, ctx.SourceFile)
+						})
 					} else if typeOpts.uninitialized == modeNever && uninitCount > 0 {
-						reportRangeWithFixes(ctx, reportRange, msg("splitUninitialized", kind), fixSplit(view, node, kind, ctx.SourceFile))
+						ctx.ReportRangeWithDeferredFixes(reportRange, msg("splitUninitialized", kind), func() []rule.RuleFix {
+							return fixSplit(view, node, kind, ctx.SourceFile)
+						})
 					}
 				}
 			}
@@ -814,12 +832,4 @@ var OneVarRule = rule.Rule{
 			ast.KindVariableDeclarationList: checkDeclList,
 		}
 	},
-}
-
-func reportRangeWithFixes(ctx rule.RuleContext, r core.TextRange, m rule.RuleMessage, fixes []rule.RuleFix) {
-	if len(fixes) > 0 {
-		ctx.ReportRangeWithFixes(r, m, fixes...)
-	} else {
-		ctx.ReportRange(r, m)
-	}
 }

--- a/internal/rules/one_var/one_var_test.go
+++ b/internal/rules/one_var/one_var_test.go
@@ -1,9 +1,13 @@
 package one_var
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -2754,4 +2758,97 @@ var b; // b's purpose`, Options: []interface{}{"never"}},
 			},
 		},
 	)
+}
+
+func TestOneVarEditDemand(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name    string
+		code    string
+		options []any
+	}{
+		{
+			name:    "combine",
+			code:    `let first = 1; let second = 2;`,
+			options: []any{"always"},
+		},
+		{
+			name:    "split",
+			code:    `let first = 1, second = 2;`,
+			options: []any{"never"},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+			program, sourceFile, err := helper.CreateTestProgram(testCase.code, "edit-demand.ts", "tsconfig.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+				t.Helper()
+
+				var diagnostics []rule.RuleDiagnostic
+				linter.LintSingleFile(linter.LintSingleFileOptions{
+					Program:      program,
+					File:         sourceFile.FileName(),
+					HasTypeInfo:  true,
+					ExcludePaths: []string{},
+					GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+						return []linter.ConfiguredRule{{
+							Name:     OneVarRule.Name,
+							Severity: rule.SeverityError,
+							Run: func(ctx rule.RuleContext) rule.RuleListeners {
+								return OneVarRule.Run(ctx, testCase.options)
+							},
+						}}
+					},
+					Consumer: rule.DiagnosticConsumer{
+						Demand: demand,
+						Report: func(diagnostic rule.RuleDiagnostic) {
+							diagnostics = append(diagnostics, diagnostic)
+						},
+					},
+				})
+				if len(diagnostics) != 1 {
+					t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+				}
+				return diagnostics[0]
+			}
+
+			diagnosticsOnly := run(rule.EditDemandNone)
+			autofixOnly := run(rule.EditDemandAutofix)
+			suggestionOnly := run(rule.EditDemandSuggestion)
+			allEdits := run(rule.EditDemandAll)
+
+			withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+				diagnostic.FixesPtr = nil
+				diagnostic.Suggestions = nil
+				return diagnostic
+			}
+			for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+				rule.EditDemandNone:       diagnosticsOnly,
+				rule.EditDemandAutofix:    autofixOnly,
+				rule.EditDemandSuggestion: suggestionOnly,
+			} {
+				if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+					t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+				}
+			}
+			if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+				t.Fatal("non-autofix demand materialized fixes")
+			}
+			if autofixOnly.FixesPtr == nil || !reflect.DeepEqual(autofixOnly.FixesPtr, allEdits.FixesPtr) {
+				t.Fatal("autofix and all-edits demands produced different fixes")
+			}
+			for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+				if diagnostic.Suggestions != nil {
+					t.Fatal("autofix-only rule materialized suggestions")
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Keep scope tracking, declaration grouping, `always`/`never`/`consecutive` decisions, require separation, export-wrapper handling, loop special cases, messages, and ranges unchanged.
- Migrate all combine/split report sites to the native deferred-fix API, so source reconstruction and fix allocation run only for consumers requesting autofixes.
- Remove the eager reporting helper; an empty builder result still emits the same diagnostic without a fix.
- Add end-to-end demand coverage for both combine and split paths to the existing main rule test file.
- No new `Program`, TypeChecker, plugin protocol, or serialized diagnostic coupling is introduced.

### Benchmark

Apple M1 Max (`darwin/arm64`), one core, 300 ms per sample, 10 samples per side. The temporary benchmark was removed before commit.

| Scenario | Base | This PR | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| combine, diagnostics only | 679.7 µs | 470.8 µs | -30.74% | -34.10% | -36.91% |
| split, diagnostics only | 624.9 µs | 503.8 µs | -19.38% | -21.18% | -32.81% |
| combine, all edits | 686.0 µs | 681.8 µs | no significant change (`p=0.739`) | unchanged | unchanged |
| split, all edits | 621.2 µs | 619.4 µs | no significant change (`p=0.529`) | unchanged | unchanged |

Diagnostic and requested-fix counts are identical.

## Related Links

Related #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
