### PR TITLE
perf: defer prefer-object-spread fixes

### DIFF
--- a/internal/rules/prefer_object_spread/prefer_object_spread.go
+++ b/internal/rules/prefer_object_spread/prefer_object_spread.go
@@ -764,7 +764,9 @@ var PreferObjectSpreadRule = rule.Rule{
 					msg = buildUseLiteralMessage()
 				}
 
-				ctx.ReportNodeWithFixes(node, msg, buildFixes(ctx, node, args)...)
+				ctx.ReportNodeWithDeferredFixes(node, msg, func() []rule.RuleFix {
+					return buildFixes(ctx, node, args)
+				})
 			},
 		}
 	},

--- a/internal/rules/prefer_object_spread/prefer_object_spread_extras_test.go
+++ b/internal/rules/prefer_object_spread/prefer_object_spread_extras_test.go
@@ -1,9 +1,13 @@
 package prefer_object_spread
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -516,4 +520,83 @@ func TestPreferObjectSpreadExtras(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestPreferObjectSpreadEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`Object.assign({ first: 1 }, source, { last: 2 });`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     PreferObjectSpreadRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return PreferObjectSpreadRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("non-autofix demand materialized fixes")
+	}
+	if autofixOnly.FixesPtr == nil || !reflect.DeepEqual(autofixOnly.FixesPtr, allEdits.FixesPtr) {
+		t.Fatal("autofix and all-edits demands produced different fixes")
+	}
+	if fixes := *allEdits.FixesPtr; len(fixes) < 3 {
+		t.Fatalf("fixes = %d, want at least 3", len(fixes))
+	}
+	for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		if diagnostic.Suggestions != nil {
+			t.Fatal("autofix-only rule materialized suggestions")
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Keep `Object.assign` identity/global-write tracking, first-argument checks, array-spread/accessor exclusions, diagnostic selection, messages, and ranges unchanged.
- Defer only optional fix construction: comment collection, call/argument token reconstruction, parentheses and ASI handling, `__proto__` safety, and per-argument spread rewrites.
- Add end-to-end demand coverage to the existing rule test file and verify exact diagnostic identity plus identical multi-edit autofixes.
- The rule's existing analysis dependencies are unchanged; this adds no new `Program`, TypeChecker, plugin protocol, or serialized diagnostic coupling.

### Benchmark

Apple M1 Max (`darwin/arm64`), direct rule benchmark, `GOMAXPROCS=1`, `GOGC=off`, fixed one iteration per isolated run, 20 runs per side. Each demand was measured in a separate process because the large AST/fix allocation made the normal mixed benchmark GC-sensitive. The temporary benchmark was removed before commit.

| Demand | Base | This PR | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| diagnostics only | 25.00 ms | 10.06 ms | -59.76% | -99.27% | -99.03% |
| all edits | 25.17 ms | 24.94 ms | no significant change (`p=0.142`) | unchanged | unchanged |

Diagnostic and requested-fix counts are identical.

## Related Links

Related #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
