### PR TITLE
perf: defer no-static-only-class fixes

### DIFF
--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.go
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.go
@@ -530,12 +530,9 @@ var NoStaticOnlyClassRule = rule.Rule{
 			}
 			headRange := classHeadRange(node, ctx.SourceFile)
 
-			fixes := buildFix(node, ctx.SourceFile)
-			if len(fixes) == 0 {
-				ctx.ReportRange(headRange, msg)
-				return
-			}
-			ctx.ReportRangeWithFixes(headRange, msg, fixes...)
+			ctx.ReportRangeWithDeferredFixes(headRange, msg, func() []rule.RuleFix {
+				return buildFix(node, ctx.SourceFile)
+			})
 		}
 
 		return rule.RuleListeners{

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class_test.go
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class_test.go
@@ -1,10 +1,14 @@
 package no_static_only_class_test
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_static_only_class"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -657,4 +661,83 @@ func TestNoStaticOnlyClass(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoStaticOnlyClassEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`class StaticOnly { static value = 1; static method() { return 2; } }`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     no_static_only_class.NoStaticOnlyClassRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return no_static_only_class.NoStaticOnlyClassRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("non-autofix demand materialized fixes")
+	}
+	if autofixOnly.FixesPtr == nil || !reflect.DeepEqual(autofixOnly.FixesPtr, allEdits.FixesPtr) {
+		t.Fatal("autofix and all-edits demands produced different fixes")
+	}
+	if fixes := *allEdits.FixesPtr; len(fixes) == 0 {
+		t.Fatal("all-edits demand produced no fixes")
+	}
+	for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		if diagnostic.Suggestions != nil {
+			t.Fatal("autofix-only rule materialized suggestions")
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Keep class eligibility checks for inheritance, decorators, empty classes, semicolon elements, and non-static members unchanged.
- Keep the diagnostic message and class-head range eager, while deferring only the optional class-to-object rewrite.
- Preserve all existing fix guards and member conversion behavior; an unfixable static-only class still reports without an autofix.
- Add end-to-end demand coverage to the existing rule test file and verify exact diagnostic identity plus identical requested fixes.
- No `Program`, TypeChecker, plugin protocol, or serialized diagnostic changes are involved.

### Benchmark

Apple M1 Max (`darwin/arm64`), one core, 300 ms per sample, 10 samples per side. The temporary benchmark was removed before commit.

| Demand | Base | This PR | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| diagnostics only | 350.6 µs | 162.0 µs | -53.79% | -80.27% | -81.67% |
| all edits | 352.0 µs | 353.1 µs | no significant change (`p=0.353`) | unchanged | unchanged |

Diagnostic and requested-fix counts are identical.

## Related Links

Related #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
