### PR TITLE
test: stabilize debounce close race test

### DIFF
--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -766,15 +766,14 @@ func TestDebounce_CloseRace(t *testing.T) {
 		t.Fatal("URI should be removed from pendingLintURIs after close")
 	}
 
-	// Step 3: wait for the timer to fire
-	time.Sleep(300 * time.Millisecond)
-
-	// debounceCh should have a signal (timer still fires)
+	// Step 3: wait for the timer to fire. Waiting on the signal synchronizes
+	// with the timer callback without assuming it will be scheduled within a
+	// fixed amount of time.
 	select {
 	case <-s.debounceCh:
 		// good — signal received
-	default:
-		t.Fatal("timer should still fire even after close")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timer did not fire after close")
 	}
 
 	// Step 4: simulate what the dispatch loop does — iterate pending URIs


### PR DESCRIPTION
## Summary

- Wait for the debounce timer signal with a bounded timeout instead of sleeping for a fixed duration and checking the channel non-blockingly.
- Avoid flaky failures when the timer callback is delayed under load.
- Verified the targeted test 20 times, check-spell, format:check, and incremental Go lint for internal/lsp.

## Related Links

- Follow-up to #1374
- Failing CI job: https://github.com/web-infra-dev/rslint/actions/runs/30154341157/job/89669833642?pr=1374

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).