### PR TITLE
test: stabilize Windows worker pool isolation

### DIFF
--- a/packages/rslint/tests/eslint-plugin/fixtures/hang-plugin.mjs
+++ b/packages/rslint/tests/eslint-plugin/fixtures/hang-plugin.mjs
@@ -11,6 +11,8 @@
  * up task on the newly respawned worker. Its presence verifies the
  * pool isn't permanently broken after the timeout.
  */
+import fs from 'node:fs';
+
 export default {
   meta: { name: 'hang-plugin', version: '0.0.0' },
   rules: {
@@ -19,6 +21,13 @@ export default {
       create() {
         return {
           Program() {
+            // Process-isolated tests use this explicit cross-thread barrier to
+            // prove the listener entered before they trigger timeout/shutdown.
+            // Ordinary tests leave the env variable unset.
+            const enteredFile = process.env.RSLINT_HANG_ENTERED_FILE;
+            if (enteredFile) {
+              fs.writeFileSync(enteredFile, 'entered');
+            }
             // Spin forever. Worker can only exit via terminate().
             // eslint-disable-next-line no-constant-condition
             while (true) {

--- a/packages/rslint/tests/eslint-plugin/pool-isolation/harness.test.ts
+++ b/packages/rslint/tests/eslint-plugin/pool-isolation/harness.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from '@rstest/core';
 
 import {
   JOURNAL_VERSION,
+  POOL_ISOLATION_AUDIT_PREFIX,
   classifyScenario,
+  formatScenarioAudit,
   parseJournalForTests,
   type ClassificationInput,
   type JournalRecord,
@@ -160,6 +162,46 @@ describe('pool-isolation verdict is fail-closed', () => {
     ).toBe('FAIL');
     expect(classify({ processError: 'orderly failure' })).toBe('FAIL');
     expect(classify({ journalError: 'torn record' })).toBe('FAIL');
+  });
+});
+
+describe('pool-isolation CI audit record', () => {
+  test('is one machine-readable line that exposes clean versus tolerated exit', () => {
+    const line = formatScenarioAudit({
+      scenario: SCENARIO,
+      verdict: 'EXPECTED-NATIVE-ABORT',
+      milestones: [
+        'started',
+        'init-done',
+        'refed-plugin-loaded',
+        'terminate-invoked',
+      ],
+      asserts: [],
+      exitCode: null,
+      signal: 'SIGABRT',
+      timedOut: false,
+      stderr: '',
+      stderrTruncated: false,
+    });
+
+    expect(line.startsWith(POOL_ISOLATION_AUDIT_PREFIX)).toBe(true);
+    expect(line).not.toContain('\n');
+    expect(JSON.parse(line.slice(POOL_ISOLATION_AUDIT_PREFIX.length))).toEqual({
+      version: 1,
+      scenario: SCENARIO,
+      verdict: 'EXPECTED-NATIVE-ABORT',
+      exitCode: null,
+      signal: 'SIGABRT',
+      timedOut: false,
+      lastMilestone: 'terminate-invoked',
+      milestoneCount: 4,
+      assertionCount: 0,
+      failedAssertionCount: 0,
+      journalValid: true,
+      harnessError: false,
+      stderrBytes: 0,
+      stderrTruncated: false,
+    });
   });
 });
 

--- a/packages/rslint/tests/eslint-plugin/pool-isolation/harness.test.ts
+++ b/packages/rslint/tests/eslint-plugin/pool-isolation/harness.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from '@rstest/core';
+
+import {
+  JOURNAL_VERSION,
+  classifyScenario,
+  parseJournalForTests,
+  type ClassificationInput,
+  type JournalRecord,
+} from './harness.js';
+
+const RUN_ID = 'adversarial-run';
+const SCENARIO = 'u11';
+
+function records(
+  ...items: Array<
+    | { kind: 'milestone'; name: string }
+    | { kind: 'assert'; name: string; pass: boolean; detail?: string }
+    | { kind: 'error'; detail: string }
+  >
+): JournalRecord[] {
+  return items.map((item, index) => ({
+    version: JOURNAL_VERSION,
+    runId: RUN_ID,
+    scenario: SCENARIO,
+    seq: index + 1,
+    ...item,
+  }));
+}
+
+const cleanSuccess = (): JournalRecord[] =>
+  records(
+    { kind: 'milestone', name: 'started' },
+    { kind: 'milestone', name: 'init-done' },
+    { kind: 'milestone', name: 'refed-plugin-loaded' },
+    { kind: 'milestone', name: 'terminate-invoked' },
+    { kind: 'assert', name: 'pool-drained', pass: true },
+    { kind: 'milestone', name: 'done' },
+  );
+
+function classify(
+  overrides: Partial<ClassificationInput> = {},
+): ReturnType<typeof classifyScenario> {
+  return classifyScenario({
+    scenario: SCENARIO,
+    records: cleanSuccess(),
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    platform: 'darwin',
+    ...overrides,
+  });
+}
+
+describe('pool-isolation verdict is fail-closed', () => {
+  test('accepts only a complete clean-success journal', () => {
+    expect(classify()).toBe('PASS');
+  });
+
+  test('watchdog timeout wins even if done was already written', () => {
+    expect(classify({ timedOut: true })).toBe('FAIL');
+  });
+
+  test('done cannot hide an abnormal process close', () => {
+    expect(classify({ exitCode: null, signal: 'SIGTERM' })).toBe('FAIL');
+  });
+
+  test('clean exit still requires the exact terminate boundary', () => {
+    expect(
+      classify({
+        records: cleanSuccess().filter(
+          (record) =>
+            !(
+              record.kind === 'milestone' && record.name === 'terminate-invoked'
+            ),
+        ),
+      }),
+    ).toBe('FAIL');
+  });
+
+  test('clean exit still requires every scenario assertion', () => {
+    expect(
+      classify({
+        records: cleanSuccess().filter((record) => record.kind !== 'assert'),
+      }),
+    ).toBe('FAIL');
+  });
+
+  test('milestones must satisfy the scenario contract in order', () => {
+    expect(
+      classify({
+        records: records(
+          { kind: 'milestone', name: 'started' },
+          { kind: 'milestone', name: 'refed-plugin-loaded' },
+          { kind: 'milestone', name: 'init-done' },
+          { kind: 'milestone', name: 'terminate-invoked' },
+          { kind: 'assert', name: 'pool-drained', pass: true },
+          { kind: 'milestone', name: 'done' },
+        ),
+      }),
+    ).toBe('FAIL');
+    expect(classify({ scenario: 'not-an-allowed-scenario' })).toBe('FAIL');
+  });
+
+  test('native abort exception is Windows-only and exact-boundary-only', () => {
+    const nativeAbortRecords = cleanSuccess().slice(0, -2);
+    expect(
+      classify({
+        records: nativeAbortRecords,
+        exitCode: 0,
+        platform: 'win32',
+      }),
+    ).toBe('EXPECTED-NATIVE-ABORT');
+    expect(
+      classify({
+        records: nativeAbortRecords,
+        exitCode: 0,
+        platform: 'linux',
+      }),
+    ).toBe('FAIL');
+    expect(
+      classify({
+        records: records(
+          { kind: 'milestone', name: 'started' },
+          { kind: 'milestone', name: 'init-done' },
+          { kind: 'milestone', name: 'refed-plugin-loaded' },
+          { kind: 'milestone', name: 'terminate-point' },
+        ),
+        platform: 'win32',
+      }),
+    ).toBe('FAIL');
+  });
+
+  test('failed assertion, orderly exit/error, and invalid journal always fail', () => {
+    const failedAssert = cleanSuccess();
+    failedAssert.splice(-1, 0, {
+      version: JOURNAL_VERSION,
+      runId: RUN_ID,
+      scenario: SCENARIO,
+      seq: failedAssert.length,
+      kind: 'assert',
+      name: 'injected-failure',
+      pass: false,
+    });
+    expect(classify({ records: failedAssert })).toBe('FAIL');
+    expect(
+      classify({
+        records: records(
+          { kind: 'milestone', name: 'started' },
+          { kind: 'milestone', name: 'init-done' },
+          { kind: 'milestone', name: 'refed-plugin-loaded' },
+          { kind: 'milestone', name: 'terminate-invoked' },
+          {
+            kind: 'error',
+            detail: 'runner exited through Node before done',
+          },
+        ),
+        exitCode: 0,
+        platform: 'win32',
+      }),
+    ).toBe('FAIL');
+    expect(classify({ processError: 'orderly failure' })).toBe('FAIL');
+    expect(classify({ journalError: 'torn record' })).toBe('FAIL');
+  });
+});
+
+describe('pool-isolation journal parser rejects ambiguous evidence', () => {
+  const expected = { runId: RUN_ID, scenario: SCENARIO };
+  const line = (record: JournalRecord): string => `${JSON.stringify(record)}\n`;
+
+  test('accepts a fully framed, sequential journal', () => {
+    const journal = cleanSuccess().map(line).join('');
+    const result = parseJournalForTests(journal, expected);
+    expect(result.error).toBeUndefined();
+    expect(result.records).toHaveLength(6);
+  });
+
+  test('rejects torn and invalid JSON records instead of ignoring them', () => {
+    const first = cleanSuccess()[0];
+    expect(parseJournalForTests(JSON.stringify(first), expected).error).toMatch(
+      /torn/,
+    );
+    expect(parseJournalForTests('{broken}\n', expected).error).toMatch(
+      /invalid JSON/,
+    );
+  });
+
+  test('rejects stale/forged run identity and sequence gaps', () => {
+    const first = cleanSuccess()[0];
+    expect(
+      parseJournalForTests(
+        line({ ...first, runId: 'some-other-run' }),
+        expected,
+      ).error,
+    ).toMatch(/runId/);
+    expect(
+      parseJournalForTests(line({ ...first, seq: 2 }), expected).error,
+    ).toMatch(/seq/);
+  });
+
+  test('rejects records after done and duplicate assertion names', () => {
+    const afterDone = records(
+      { kind: 'milestone', name: 'done' },
+      { kind: 'milestone', name: 'late' },
+    )
+      .map(line)
+      .join('');
+    expect(parseJournalForTests(afterDone, expected).error).toMatch(
+      /after its terminal/,
+    );
+
+    const duplicate = records(
+      { kind: 'assert', name: 'same', pass: true },
+      { kind: 'assert', name: 'same', pass: true },
+    )
+      .map(line)
+      .join('');
+    expect(parseJournalForTests(duplicate, expected).error).toMatch(
+      /duplicate assertion/,
+    );
+  });
+});

--- a/packages/rslint/tests/eslint-plugin/pool-isolation/harness.ts
+++ b/packages/rslint/tests/eslint-plugin/pool-isolation/harness.ts
@@ -2,10 +2,11 @@
 //
 // rstest tests call `runPoolScenario(name)`, which spawns runner.mjs in a
 // throwaway subprocess, lets it drive the real dist WorkerPool through a
-// terminate-churning scenario, and applies a MILESTONE-DRIVEN verdict. The
-// point: a native napi-terminate abort (Windows) crashes only that subprocess,
-// never this test process.
+// terminate-churning scenario, and applies a milestone-driven verdict. A
+// native napi-terminate abort (Windows) crashes only that subprocess, never
+// the rstest process.
 import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -21,7 +22,120 @@ const DIST_ESLINT_PLUGIN = path.resolve(
   '../../../dist/eslint-plugin/index.js',
 );
 
-export type Verdict = 'PASS' | 'TOLERATED-PASS' | 'FAIL';
+export const JOURNAL_VERSION = 1;
+const STDERR_LIMIT_BYTES = 256 * 1024;
+const JOURNAL_LIMIT_BYTES = 1024 * 1024;
+
+interface ScenarioContract {
+  /**
+   * Ordered state prefix required both for a clean pass and for the narrow
+   * Windows native-abort exception. The final item is always the exact
+   * Worker.prototype.terminate entry observed by runner.mjs.
+   */
+  requiredProgress: readonly string[];
+  requiredSuccessAsserts: readonly string[];
+}
+
+// One fail-closed contract table prevents allowlist, prerequisite, and
+// assertion requirements from drifting apart when a scenario is added.
+const SCENARIO_CONTRACTS = {
+  u11: {
+    requiredProgress: [
+      'started',
+      'init-done',
+      'refed-plugin-loaded',
+      'terminate-invoked',
+    ],
+    requiredSuccessAsserts: ['pool-drained'],
+  },
+  'hang-shutdown': {
+    requiredProgress: [
+      'started',
+      'init-done',
+      'hang-entered',
+      'terminate-invoked',
+    ],
+    requiredSuccessAsserts: [
+      'wedge-shutdown',
+      'pool-drained',
+      'second-shutdown-returned',
+    ],
+  },
+  'worker-exit-race': {
+    requiredProgress: [
+      'started',
+      'init-done',
+      'initial-worker-ready',
+      'respawn-in-flight',
+      'shutdown-started',
+      'terminate-invoked',
+    ],
+    requiredSuccessAsserts: [
+      'one-worker-spawned',
+      'worker-hard-exit',
+      'respawn-in-flight',
+      'closed-before-respawn-release',
+      'pool-drained',
+      'lint-batch-rejects-closed',
+    ],
+  },
+  'task-timeout': {
+    requiredProgress: [
+      'started',
+      'init-done',
+      'hang-entered',
+      'terminate-invoked',
+    ],
+    requiredSuccessAsserts: [
+      'one-task-timeout-captured',
+      'hang-task-timeout',
+      'recovery-ok',
+      'respawn-logged',
+      'pool-drained',
+    ],
+  },
+  'all-degraded': {
+    requiredProgress: [
+      'started',
+      'init-done',
+      'degraded-queue-ready',
+      'terminate-invoked',
+    ],
+    requiredSuccessAsserts: [
+      'queue-enqueued',
+      'degraded-drain',
+      'queue-drained',
+    ],
+  },
+  'lint-batch-after-degraded': {
+    requiredProgress: [
+      'started',
+      'init-done',
+      'degraded-queue-ready',
+      'terminate-invoked',
+    ],
+    requiredSuccessAsserts: [
+      'first-queue-enqueued',
+      'first-degraded',
+      'terminal-state',
+      'second-degraded',
+      'queue-drained',
+    ],
+  },
+} as const satisfies Record<string, ScenarioContract>;
+
+export type Verdict = 'PASS' | 'EXPECTED-NATIVE-ABORT' | 'FAIL';
+
+export interface JournalRecord {
+  version: number;
+  runId: string;
+  scenario: string;
+  seq: number;
+  kind: 'milestone' | 'assert' | 'error';
+  name?: string;
+  pass?: boolean;
+  detail?: string;
+}
 
 export interface ScenarioResult {
   scenario: string;
@@ -29,26 +143,42 @@ export interface ScenarioResult {
   milestones: string[];
   asserts: { name: string; pass: boolean; detail?: string }[];
   error?: string;
+  journalError?: string;
   exitCode: number | null;
   signal: NodeJS.Signals | null;
   timedOut: boolean;
   stderr: string;
+  stderrTruncated: boolean;
 }
 
-interface Rec {
-  kind: 'milestone' | 'assert' | 'error';
-  name?: string;
-  pass?: boolean;
-  detail?: string;
+export interface JournalReadResult {
+  records: JournalRecord[];
+  error?: string;
+}
+
+export interface ClassificationInput {
+  scenario: string;
+  records: JournalRecord[];
+  journalError?: string;
+  processError?: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  platform?: NodeJS.Platform;
 }
 
 export async function runPoolScenario(
   scenario: string,
   opts: { timeoutMs?: number } = {},
 ): Promise<ScenarioResult> {
-  const timeoutMs = opts.timeoutMs ?? 15_000;
+  // This is only a dead-process/deadlock sentinel. Scenario correctness is
+  // established by recorded state transitions, never elapsed wall time.
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const runId = randomUUID();
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rslint-pool-iso-'));
   const milestoneFile = path.join(tmpDir, 'milestones.ndjson');
+  const scenarioTmpDir = path.join(tmpDir, 'scenario');
+  fs.mkdirSync(scenarioTmpDir);
   fs.writeFileSync(milestoneFile, '');
 
   return new Promise<ScenarioResult>((resolve) => {
@@ -58,106 +188,338 @@ export async function runPoolScenario(
         ...process.env,
         RSLINT_MILESTONE_FILE: milestoneFile,
         RSLINT_DIST_ESLINT_PLUGIN: DIST_ESLINT_PLUGIN,
+        RSLINT_RUN_ID: runId,
+        RSLINT_SCENARIO_TMP_DIR: scenarioTmpDir,
       },
     });
-    let stderr = '';
-    child.stderr.on('data', (d) => (stderr += d.toString()));
 
-    let settled = false;
-    const finish = (
-      exitCode: number | null,
-      signal: NodeJS.Signals | null,
-      timedOut: boolean,
-    ): void => {
-      if (settled) return;
-      settled = true;
+    // Never let an unconsumed pipe backpressure the child. Scenario output is
+    // intentionally irrelevant; durable state lives in the journal.
+    child.stdout.resume();
+
+    const stderrChunks: Buffer[] = [];
+    let stderrBytes = 0;
+    let stderrTruncated = false;
+    child.stderr.on('data', (value: Buffer | string) => {
+      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      const remaining = STDERR_LIMIT_BYTES - stderrBytes;
+      if (remaining > 0) {
+        const kept = chunk.subarray(0, remaining);
+        stderrChunks.push(kept);
+        stderrBytes += kept.length;
+      }
+      if (chunk.length > remaining) stderrTruncated = true;
+    });
+
+    let timedOut = false;
+    let spawnError: string | undefined;
+    const timer = setTimeout(() => {
+      // Do not resolve here: the journal and stdio are not final until
+      // ChildProcess emits `close`. A late `done` cannot override timedOut.
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+
+    child.on('error', (err) => {
+      // Node guarantees `close` after `error`; let that single terminal path
+      // collect the complete journal and stream state.
+      spawnError = `failed to run isolated child: ${err.message}`;
+    });
+
+    child.on('close', (exitCode, signal) => {
       clearTimeout(timer);
-      const recs = readMilestones(milestoneFile);
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-      const milestones = recs
+      const journal = readJournal(milestoneFile, { runId, scenario });
+      let cleanupError: string | undefined;
+      try {
+        fs.rmSync(tmpDir, {
+          recursive: true,
+          force: true,
+          maxRetries: 10,
+          retryDelay: 50,
+        });
+      } catch (err) {
+        cleanupError = `failed to remove scenario temp directory: ${String(
+          err,
+        )}`;
+      }
+
+      const milestones = journal.records
         .filter((r) => r.kind === 'milestone')
         .map((r) => r.name!);
-      const asserts = recs
+      const asserts = journal.records
         .filter((r) => r.kind === 'assert')
-        .map((r) => ({ name: r.name!, pass: !!r.pass, detail: r.detail }));
-      const error = recs.find((r) => r.kind === 'error')?.detail;
+        .map((r) => ({ name: r.name!, pass: r.pass!, detail: r.detail }));
+      const reportedError = journal.records.find(
+        (r) => r.kind === 'error',
+      )?.detail;
+      const processError = reportedError ?? spawnError ?? cleanupError;
+      const stderr = Buffer.concat(stderrChunks).toString('utf8');
+
       resolve({
         scenario,
-        verdict: classify(milestones, asserts, error, timedOut),
+        verdict: classifyScenario({
+          scenario,
+          records: journal.records,
+          journalError: journal.error,
+          processError,
+          exitCode,
+          signal,
+          timedOut,
+        }),
         milestones,
         asserts,
-        error,
+        error: processError,
+        journalError: journal.error,
         exitCode,
         signal,
         timedOut,
         stderr,
+        stderrTruncated,
       });
-    };
-    const timer = setTimeout(() => {
-      child.kill('SIGKILL');
-      finish(null, 'SIGKILL', true);
-    }, timeoutMs);
-    child.on('exit', (code, signal) => finish(code, signal, false));
-    child.on('error', () => finish(-1, null, false));
+    });
   });
 }
 
-function readMilestones(file: string): Rec[] {
+function readJournal(
+  file: string,
+  expected: { runId: string; scenario: string },
+): JournalReadResult {
   let text: string;
   try {
-    text = fs.readFileSync(file, 'utf8');
-  } catch {
-    return [];
-  }
-  const out: Rec[] = [];
-  for (const line of text.split('\n')) {
-    if (!line) continue;
-    try {
-      out.push(JSON.parse(line) as Rec);
-    } catch {
-      /* ignore a torn final line (process died mid-write) */
+    const size = fs.statSync(file).size;
+    if (size > JOURNAL_LIMIT_BYTES) {
+      return {
+        records: [],
+        error: `journal exceeds ${JOURNAL_LIMIT_BYTES} byte limit (size=${size})`,
+      };
     }
+    text = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    return {
+      records: [],
+      error: `journal could not be read: ${String(err)}`,
+    };
   }
-  return out;
+  return parseJournalForTests(text, expected);
 }
 
-// MILESTONE-DRIVEN verdict (validated by the spike). Deliberately ignores exit
-// code/signal: a real napi abort on Windows can surface as exit code 0
-// (indistinguishable from a clean exit), and an orderly failure exits non-zero
-// — exit codes cannot tell them apart, but the child's own milestones can.
-function classify(
-  milestones: string[],
-  asserts: { pass: boolean }[],
-  error: string | undefined,
-  timedOut: boolean,
-): Verdict {
-  const reached = (m: string): boolean => milestones.includes(m);
-  if (asserts.some((a) => !a.pass)) return 'FAIL'; // in-child assertion failed
-  if (error) return 'FAIL'; // child reported an orderly error
-  if (reached('done')) return 'PASS'; // explicit success
-  if (timedOut) return 'FAIL'; // pool hung
-  // Silent abnormal exit with no done/error/failed-assert: tolerate ONLY if the
-  // pool provably reached the terminate step — that's the isolated native
-  // abort. Anything earlier is a real crash and must fail.
-  //
-  // Coverage note: a TOLERATED-PASS means the in-child asserts AFTER the
-  // terminate point did not run (the process aborted there). Those business
-  // invariants (drain / respawn / closed-rejection / no-leak) are still fully
-  // verified on mac/linux, where terminate is clean and the child runs through
-  // to `done` (PASS). The Windows abort path only confirms the pool reached the
-  // terminate step and the isolation held — the business assertions are
-  // guaranteed by the non-Windows runners, which is sound because those
-  // invariants are platform-independent.
-  return reached('terminate-point') ? 'TOLERATED-PASS' : 'FAIL';
+/** Pure parser exported for adversarial tests; production code uses readJournal. */
+export function parseJournalForTests(
+  text: string,
+  expected: { runId: string; scenario: string },
+): JournalReadResult {
+  if (text.length === 0) return { records: [] };
+  if (!text.endsWith('\n')) {
+    return {
+      records: [],
+      error: 'journal ended with a torn record (missing newline)',
+    };
+  }
+
+  const records: JournalRecord[] = [];
+  const lines = text.slice(0, -1).split('\n');
+  for (let index = 0; index < lines.length; index++) {
+    const lineNumber = index + 1;
+    if (lines[index].length === 0) {
+      return {
+        records,
+        error: `journal contains an empty record at line ${lineNumber}`,
+      };
+    }
+
+    let value: unknown;
+    try {
+      value = JSON.parse(lines[index]);
+    } catch (err) {
+      return {
+        records,
+        error: `journal contains invalid JSON at line ${lineNumber}: ${String(
+          err,
+        )}`,
+      };
+    }
+
+    const recordError = validateRecord(value, {
+      ...expected,
+      seq: lineNumber,
+    });
+    if (recordError) {
+      return {
+        records,
+        error: `journal record ${lineNumber} is invalid: ${recordError}`,
+      };
+    }
+    records.push(value as JournalRecord);
+  }
+
+  const terminalIndexes = records.flatMap((record, index) =>
+    record.kind === 'error' ||
+    (record.kind === 'milestone' && record.name === 'done')
+      ? [index]
+      : [],
+  );
+  if (terminalIndexes.length > 1) {
+    return {
+      records,
+      error: 'journal contains more than one terminal record',
+    };
+  }
+  if (
+    terminalIndexes.length === 1 &&
+    terminalIndexes[0] !== records.length - 1
+  ) {
+    return {
+      records,
+      error: 'journal contains records after its terminal record',
+    };
+  }
+  const assertionNames = records
+    .filter((record) => record.kind === 'assert')
+    .map((record) => record.name!);
+  if (new Set(assertionNames).size !== assertionNames.length) {
+    return {
+      records,
+      error: 'journal contains duplicate assertion names',
+    };
+  }
+
+  return { records };
+}
+
+function validateRecord(
+  value: unknown,
+  expected: { runId: string; scenario: string; seq: number },
+): string | undefined {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return 'record must be an object';
+  }
+  const record = value as Record<string, unknown>;
+  const allowedKeys = new Set([
+    'version',
+    'runId',
+    'scenario',
+    'seq',
+    'kind',
+    'name',
+    'pass',
+    'detail',
+  ]);
+  const extraKey = Object.keys(record).find((key) => !allowedKeys.has(key));
+  if (extraKey) return `unknown field "${extraKey}"`;
+  if (record.version !== JOURNAL_VERSION) {
+    return `version must be ${JOURNAL_VERSION}`;
+  }
+  if (record.runId !== expected.runId) return 'runId does not match this run';
+  if (record.scenario !== expected.scenario) {
+    return 'scenario does not match this run';
+  }
+  if (record.seq !== expected.seq) {
+    return `seq must be ${expected.seq}`;
+  }
+  if (
+    record.kind !== 'milestone' &&
+    record.kind !== 'assert' &&
+    record.kind !== 'error'
+  ) {
+    return 'kind is not recognized';
+  }
+
+  if (record.kind === 'milestone') {
+    if (typeof record.name !== 'string' || record.name.length === 0) {
+      return 'milestone.name must be a non-empty string';
+    }
+    if (record.pass !== undefined || record.detail !== undefined) {
+      return 'milestone may not contain pass or detail';
+    }
+  } else if (record.kind === 'assert') {
+    if (typeof record.name !== 'string' || record.name.length === 0) {
+      return 'assert.name must be a non-empty string';
+    }
+    if (typeof record.pass !== 'boolean') {
+      return 'assert.pass must be a boolean';
+    }
+    if (record.detail !== undefined && typeof record.detail !== 'string') {
+      return 'assert.detail must be a string when present';
+    }
+  } else {
+    if (record.name !== undefined || record.pass !== undefined) {
+      return 'error may not contain name or pass';
+    }
+    if (typeof record.detail !== 'string' || record.detail.length === 0) {
+      return 'error.detail must be a non-empty string';
+    }
+  }
+  return undefined;
 }
 
 /**
- * Human-readable failure report for a scenario that did not pass. Surfaces the
- * failed in-child assertion(s) (name + detail), the child's error / timeout /
- * exit code, the milestones it reached, and the child stderr — so a CI failure
- * reads like a normal assertion report instead of a JSON blob. Pass it as
- * expect()'s second arg:
- *   expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL')
+ * Strict verdict oracle. Exported only so test code can attack every branch
+ * with synthetic journals without spawning more subprocesses.
+ */
+export function classifyScenario(input: ClassificationInput): Verdict {
+  const platform = input.platform ?? process.platform;
+  const assertions = input.records.filter((r) => r.kind === 'assert');
+  if (input.journalError) return 'FAIL';
+  if (input.records.some((record) => record.kind === 'error')) return 'FAIL';
+  if (assertions.some((record) => record.pass !== true)) return 'FAIL';
+  if (input.processError) return 'FAIL';
+  // A watchdog firing is terminal even if the child managed to write `done`
+  // just before it was killed.
+  if (input.timedOut) return 'FAIL';
+
+  const milestones = input.records
+    .filter((r) => r.kind === 'milestone')
+    .map((r) => r.name!);
+  const last = input.records.at(-1);
+  const contract = Object.prototype.hasOwnProperty.call(
+    SCENARIO_CONTRACTS,
+    input.scenario,
+  )
+    ? SCENARIO_CONTRACTS[input.scenario as keyof typeof SCENARIO_CONTRACTS]
+    : undefined;
+  if (!contract) return 'FAIL';
+  const hasRequiredProgress = containsOrdered(
+    milestones,
+    contract.requiredProgress,
+  );
+  if (last?.kind === 'milestone' && last.name === 'done') {
+    const assertNames = new Set(assertions.map((record) => record.name!));
+    const hasAllSuccessAssertions = contract.requiredSuccessAsserts.every(
+      (name) => assertNames.has(name),
+    );
+    return hasRequiredProgress &&
+      hasAllSuccessAssertions &&
+      input.exitCode === 0 &&
+      input.signal === null
+      ? 'PASS'
+      : 'FAIL';
+  }
+
+  // A native napi teardown abort is tolerated only on Windows, only in an
+  // explicitly enumerated terminate scenario, and only when the last durable
+  // record proves the real Worker.terminate() call was entered. A generic
+  // "about to terminate" marker is not sufficient.
+  const exactNativeAbortBoundary =
+    platform === 'win32' &&
+    hasRequiredProgress &&
+    last?.kind === 'milestone' &&
+    last.name === 'terminate-invoked';
+  return exactNativeAbortBoundary ? 'EXPECTED-NATIVE-ABORT' : 'FAIL';
+}
+
+function containsOrdered(
+  actual: readonly string[],
+  required: readonly string[],
+): boolean {
+  let requiredIndex = 0;
+  for (const value of actual) {
+    if (value === required[requiredIndex]) requiredIndex++;
+  }
+  return requiredIndex === required.length;
+}
+
+/**
+ * Human-readable failure report for a scenario that did not pass.
  */
 export function formatScenarioFailure(r: ScenarioResult): string {
   const lines: string[] = [
@@ -170,17 +532,20 @@ export function formatScenarioFailure(r: ScenarioResult): string {
       lines.push(`    x ${a.name}${a.detail ? ` - ${a.detail}` : ''}`);
     }
   }
-  if (r.error) lines.push(`  child error: ${r.error}`);
+  if (r.journalError) lines.push(`  invalid child journal: ${r.journalError}`);
+  if (r.error) lines.push(`  child/harness error: ${r.error}`);
   if (r.timedOut) {
-    lines.push('  child TIMED OUT - the pool hung and never exited');
+    lines.push('  child TIMED OUT - the scenario deadlocked or never exited');
   }
   lines.push(`  milestones reached: ${r.milestones.join(' > ') || '(none)'}`);
   lines.push(
     `  child exit: code=${r.exitCode ?? 'null'} signal=${r.signal ?? 'null'}`,
   );
   if (r.stderr.trim()) {
-    lines.push('  child stderr:');
-    for (const l of r.stderr.trim().split('\n')) lines.push(`    ${l}`);
+    lines.push(`  child stderr${r.stderrTruncated ? ' (truncated)' : ''}:`);
+    for (const line of r.stderr.trim().split('\n')) {
+      lines.push(`    ${line}`);
+    }
   }
   return lines.join('\n');
 }

--- a/packages/rslint/tests/eslint-plugin/pool-isolation/harness.ts
+++ b/packages/rslint/tests/eslint-plugin/pool-isolation/harness.ts
@@ -23,6 +23,8 @@ const DIST_ESLINT_PLUGIN = path.resolve(
 );
 
 export const JOURNAL_VERSION = 1;
+export const POOL_ISOLATION_AUDIT_PREFIX = '[pool-isolation-audit] ';
+const AUDIT_VERSION = 1;
 const STDERR_LIMIT_BYTES = 256 * 1024;
 const JOURNAL_LIMIT_BYTES = 1024 * 1024;
 
@@ -255,7 +257,7 @@ export async function runPoolScenario(
       const processError = reportedError ?? spawnError ?? cleanupError;
       const stderr = Buffer.concat(stderrChunks).toString('utf8');
 
-      resolve({
+      const result: ScenarioResult = {
         scenario,
         verdict: classifyScenario({
           scenario,
@@ -275,7 +277,14 @@ export async function runPoolScenario(
         timedOut,
         stderr,
         stderrTruncated,
-      });
+      };
+
+      // Emit exactly one parent-authored, machine-readable record per isolated
+      // scenario. Child stdout is discarded, so it cannot forge this success
+      // evidence. In particular, CI logs now distinguish a clean PASS from the
+      // narrowly tolerated Windows EXPECTED-NATIVE-ABORT verdict.
+      process.stdout.write(`${formatScenarioAudit(result)}\n`);
+      resolve(result);
     });
   });
 }
@@ -516,6 +525,29 @@ function containsOrdered(
     if (value === required[requiredIndex]) requiredIndex++;
   }
   return requiredIndex === required.length;
+}
+
+/**
+ * Stable, single-line evidence for auditing green CI runs.
+ */
+export function formatScenarioAudit(r: ScenarioResult): string {
+  return `${POOL_ISOLATION_AUDIT_PREFIX}${JSON.stringify({
+    version: AUDIT_VERSION,
+    scenario: r.scenario,
+    verdict: r.verdict,
+    exitCode: r.exitCode,
+    signal: r.signal,
+    timedOut: r.timedOut,
+    lastMilestone: r.milestones.at(-1) ?? null,
+    milestoneCount: r.milestones.length,
+    assertionCount: r.asserts.length,
+    failedAssertionCount: r.asserts.filter((assertion) => !assertion.pass)
+      .length,
+    journalValid: r.journalError === undefined,
+    harnessError: r.error !== undefined,
+    stderrBytes: Buffer.byteLength(r.stderr),
+    stderrTruncated: r.stderrTruncated,
+  })}`;
 }
 
 /**

--- a/packages/rslint/tests/eslint-plugin/pool-isolation/runner.mjs
+++ b/packages/rslint/tests/eslint-plugin/pool-isolation/runner.mjs
@@ -1,27 +1,16 @@
 // Subprocess entry for process-isolated worker-pool scenarios.
 //
-// Why this exists: the worker-pool e2e scenarios that force a worker
-// `terminate()` can native-abort BELOW the JS layer on Windows — libuv tears
-// down the oxc-napi worker's stdio pipes during terminate and faults. When the
-// pool runs inside the rstest test process, that abort crashes the test process
-// itself ("Rstest exited unexpectedly"). Running the pool in THIS throwaway
-// subprocess confines the abort here; the parent rstest test (harness.ts)
-// observes our outcome via milestones and never crashes.
-//
-// Progress is reported to a milestone FILE (env RSLINT_MILESTONE_FILE) via
-// synchronous appendFileSync: a milestone written immediately before a native
-// abort is already on disk, so the parent can always tell how far the pool got.
-// process.stdout is NOT used for milestones — its userland buffer can be lost
-// when the process aborts.
+// Forced termination of a worker containing the native parser can abort below
+// JavaScript on Windows. This process confines that abort. The parent accepts
+// it only when the last durable journal record is emitted by a wrapper around
+// the real Worker.prototype.terminate call.
 import fs from 'node:fs';
 import path from 'node:path';
-import os from 'node:os';
+import { Worker } from 'node:worker_threads';
 import { pathToFileURL, fileURLToPath } from 'node:url';
 
+const JOURNAL_VERSION = 1;
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-// Shared fixtures live one level up (tests/eslint-plugin/fixtures); the worker
-// imports the config via plugin-loader's pathToFileURL, so absolute paths work
-// cross-platform.
 const FIXTURES = path.resolve(HERE, '../fixtures');
 const LOCAL_CONFIG = {
   configPath: path.join(FIXTURES, 'local.config.mjs'),
@@ -32,39 +21,145 @@ const HANG_CONFIG = {
   configDirectory: FIXTURES,
 };
 
+const SCENARIO = process.argv[2] ?? '';
 const MILESTONE_FILE = process.env.RSLINT_MILESTONE_FILE;
-const report = (obj) => {
-  if (!MILESTONE_FILE) return;
-  try {
-    fs.appendFileSync(MILESTONE_FILE, JSON.stringify(obj) + '\n');
-  } catch {
-    /* parent or disk gone — nothing we can do, and we must not throw */
+const RUN_ID = process.env.RSLINT_RUN_ID;
+const SCENARIO_TMP_DIR = process.env.RSLINT_SCENARIO_TMP_DIR;
+const JOURNAL_RECORD_LIMIT = 1_024;
+let sequence = 0;
+let terminalRecordWritten = false;
+
+const report = (record) => {
+  if (!MILESTONE_FILE || !RUN_ID) {
+    throw new Error('journal environment is incomplete');
   }
+  if (sequence >= JOURNAL_RECORD_LIMIT) {
+    throw new Error(
+      `journal exceeded ${JOURNAL_RECORD_LIMIT} record safety limit`,
+    );
+  }
+  sequence++;
+  fs.appendFileSync(
+    MILESTONE_FILE,
+    `${JSON.stringify({
+      ...record,
+      version: JOURNAL_VERSION,
+      runId: RUN_ID,
+      scenario: SCENARIO,
+      seq: sequence,
+    })}\n`,
+  );
 };
 const milestone = (name) => report({ kind: 'milestone', name });
 const check = (name, pass, detail) =>
-  report({ kind: 'assert', name, pass: !!pass, detail });
+  report({
+    kind: 'assert',
+    name,
+    pass: Boolean(pass),
+    ...(detail === undefined ? {} : { detail }),
+  });
+const terminal = (record) => {
+  report(record);
+  terminalRecordWritten = true;
+};
 
 async function loadWorkerPool() {
   const dist = process.env.RSLINT_DIST_ESLINT_PLUGIN;
   if (!dist) throw new Error('RSLINT_DIST_ESLINT_PLUGIN not set');
   // Production resolution path: WorkerPool resolves its sibling
-  // dist/eslint-plugin/lint-worker.js automatically — no setWorkerEntryForTests.
-  // pathToFileURL is required on Windows: ESM import() rejects a bare absolute
-  // path like `C:\...` (ERR_UNSUPPORTED_ESM_URL_SCHEME) and needs a file:// URL.
+  // dist/eslint-plugin/lint-worker.js automatically. pathToFileURL is required
+  // on Windows because ESM import rejects bare `C:\...` paths.
   const mod = await import(pathToFileURL(dist).href);
   return mod.WorkerPool;
 }
 
+let fixtureIndex = 0;
 const makeFixtureDir = (files) => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rslint-pool-iso-fx-'));
+  if (!SCENARIO_TMP_DIR) {
+    throw new Error('RSLINT_SCENARIO_TMP_DIR not set');
+  }
+  const dir = path.join(SCENARIO_TMP_DIR, `fixture-${++fixtureIndex}`);
+  fs.mkdirSync(dir);
   for (const [name, content] of Object.entries(files)) {
+    if (path.basename(name) !== name) {
+      throw new Error(`fixture name must not escape its directory: ${name}`);
+    }
     fs.writeFileSync(path.join(dir, name), content);
   }
   return dir;
 };
 
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const markerPath = (name) => {
+  if (!SCENARIO_TMP_DIR) {
+    throw new Error('RSLINT_SCENARIO_TMP_DIR not set');
+  }
+  return path.join(SCENARIO_TMP_DIR, name);
+};
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Polling is used only to observe an explicit cross-thread file barrier. The
+// deadline is a deadlock sentinel, never a product performance assertion.
+async function waitForFile(file, description, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!fs.existsSync(file)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for ${description}: ${file}`);
+    }
+    await delay(10);
+  }
+}
+
+// Observe the exact JS entry to Worker.terminate without changing its returned
+// promise, arguments, or production implementation. If native teardown aborts,
+// this is the last record the parent is allowed to accept.
+function observeWorkerTerminate() {
+  const original = Worker.prototype.terminate;
+  const wrapped = function () {
+    milestone('terminate-invoked');
+    return original.call(this);
+  };
+  Worker.prototype.terminate = wrapped;
+  return () => {
+    if (Worker.prototype.terminate === wrapped) {
+      Worker.prototype.terminate = original;
+    }
+  };
+}
+
+// Capture one production timeout callback without waiting for wall-clock time.
+// The WorkerPool schedules it synchronously while lintBatch dispatches. The
+// returned fake handle is only ever passed to clearTimeout.
+function captureTimeout(delayMs, action) {
+  const original = globalThis.setTimeout;
+  const callbacks = [];
+  globalThis.setTimeout = function (callback, delayValue, ...args) {
+    if (delayValue === delayMs) {
+      callbacks.push(() => callback(...args));
+      return Object.create(null);
+    }
+    return original(callback, delayValue, ...args);
+  };
+  let value;
+  try {
+    value = action();
+  } finally {
+    globalThis.setTimeout = original;
+  }
+  return {
+    value,
+    count: callbacks.length,
+    fire() {
+      if (callbacks.length !== 1) {
+        throw new Error(
+          `expected exactly one ${delayMs}ms timeout, got ${callbacks.length}`,
+        );
+      }
+      callbacks[0]();
+    },
+  };
+}
+
 const localTask = (filePath, text, rule = 'local/no-null') => ({
   filePath,
   text,
@@ -74,17 +169,17 @@ const localTask = (filePath, text, rule = 'local/no-null') => ({
   configKey: FIXTURES,
 });
 
-// Each scenario drives the real dist WorkerPool through one forced-terminate
-// flow and reports `check(...)` assertions + an emitted `terminate-point`
-// milestone just before the terminate that can native-abort on Windows.
 const scenarios = {
-  // U11: a refed top-level setInterval keeps the worker event loop alive, so
-  // shutdown must escalate to a forced terminate().
+  // A refed top-level interval keeps the worker event loop alive. Shutdown must
+  // use its existing grace fallback and leave no live worker/handle behind.
   u11: async () => {
     const WorkerPool = await loadWorkerPool();
+    const loadedFile = markerPath('u11-plugin-loaded');
     const dir = makeFixtureDir({
       'plugin.mjs':
-        'const _i = setInterval(() => {}, 60_000);\n' +
+        "import fs from 'node:fs';\n" +
+        `fs.writeFileSync(${JSON.stringify(loadedFile)}, 'loaded');\n` +
+        'const _interval = setInterval(() => {}, 60_000);\n' +
         "export default { meta: { name: 'u11' }, rules: { noop: { meta: {}, create() { return {}; } } } };\n",
       'config.mjs':
         "import plugin from './plugin.mjs';\nexport default [{ plugins: { u11: plugin } }];\n",
@@ -97,11 +192,9 @@ const scenarios = {
     });
     await pool.init();
     milestone('init-done');
-    milestone('terminate-point');
-    const start = Date.now();
+    await waitForFile(loadedFile, 'refed plugin load barrier');
+    milestone('refed-plugin-loaded');
     await pool.shutdown();
-    const elapsed = Date.now() - start;
-    check('shutdown-bounded', elapsed < 8_000, `elapsed=${elapsed}ms`);
     check(
       'pool-drained',
       Array.isArray(pool.workers) && pool.workers.length === 0,
@@ -109,15 +202,15 @@ const scenarios = {
     );
   },
 
-  // sync-wedged: the hang plugin spins forever on Program, so the worker can't
-  // even process the inbound shutdown message — shutdown must escalate to a
-  // forced terminate() after the 5s grace.
+  // The listener proves it entered its synchronous wedge via a file barrier.
+  // Shutdown must then force terminate and settle the in-flight task.
   'hang-shutdown': async () => {
     const WorkerPool = await loadWorkerPool();
+    const enteredFile = markerPath('hang-shutdown-entered');
+    process.env.RSLINT_HANG_ENTERED_FILE = enteredFile;
     const pool = new WorkerPool({
       configs: [HANG_CONFIG],
       workerCount: 1,
-      // 60s so a task_timeout respawn can't preempt the shutdown path.
       taskTimeoutMs: 60_000,
     });
     await pool.init();
@@ -125,16 +218,9 @@ const scenarios = {
     const wedgeP = pool.lintBatch([
       localTask('wedge.ts', 'const x = 1;\n', 'hang/hang'),
     ]);
-    await sleep(200); // let the worker enter the sync hang before shutdown
-    milestone('terminate-point');
-    const start = Date.now();
+    await waitForFile(enteredFile, 'sync listener entry');
+    milestone('hang-entered');
     await pool.shutdown();
-    const elapsed = Date.now() - start;
-    check(
-      'shutdown-bounded',
-      elapsed >= 4_500 && elapsed < 8_000,
-      `elapsed=${elapsed}ms`,
-    );
     const wedge = await wedgeP;
     check(
       'wedge-shutdown',
@@ -146,80 +232,131 @@ const scenarios = {
       pool.workers.length === 0,
       `workers=${pool.workers.length}`,
     );
-    const s2 = Date.now();
-    await pool.shutdown(); // idempotent + instant
-    check(
-      'second-shutdown-fast',
-      Date.now() - s2 < 50,
-      `2nd=${Date.now() - s2}ms`,
-    );
+    await pool.shutdown();
+    check('second-shutdown-returned', pool.closed === true, '');
   },
 
-  // worker-exit-race: directly terminate one worker of a 2-worker pool, then
-  // shutdown. The leaked respawn must not survive; lintBatch after shutdown
-  // rejects /closed/.
+  // Hold a replacement worker inside config import, start shutdown while that
+  // respawn promise is provably in flight, then release it. Shutdown must await
+  // and terminate the replacement rather than leaking it.
   'worker-exit-race': async () => {
     const WorkerPool = await loadWorkerPool();
+    const countFile = markerPath('respawn-import-count');
+    const enteredFile = markerPath('respawn-import-entered');
+    const releaseFile = markerPath('respawn-import-release');
+    const dir = makeFixtureDir({
+      'config.mjs':
+        "import fs from 'node:fs';\n" +
+        `const countFile = ${JSON.stringify(countFile)};\n` +
+        `const enteredFile = ${JSON.stringify(enteredFile)};\n` +
+        `const releaseFile = ${JSON.stringify(releaseFile)};\n` +
+        "const count = fs.existsSync(countFile) ? Number(fs.readFileSync(countFile, 'utf8')) + 1 : 1;\n" +
+        'fs.writeFileSync(countFile, String(count));\n' +
+        'if (count > 1) {\n' +
+        "  fs.writeFileSync(enteredFile, 'entered');\n" +
+        '  while (!fs.existsSync(releaseFile)) {\n' +
+        '    await new Promise((resolve) => setTimeout(resolve, 10));\n' +
+        '  }\n' +
+        '}\n' +
+        "const plugin = { meta: { name: 'respawn-race' }, rules: {\n" +
+        '  noop: { meta: {}, create() { return {}; } },\n' +
+        '  crash: { meta: {}, create() { return { Program() { process.exit(42); } }; } },\n' +
+        '} };\n' +
+        'export default [{ plugins: { race: plugin } }];\n',
+    });
     const pool = new WorkerPool({
-      configs: [LOCAL_CONFIG],
-      workerCount: 2,
+      configs: [
+        { configPath: path.join(dir, 'config.mjs'), configDirectory: dir },
+      ],
+      workerCount: 1,
       taskTimeoutMs: 5_000,
     });
     await pool.init();
     milestone('init-done');
+    milestone('initial-worker-ready');
     check(
-      'workers-spawned',
-      pool.workers.length > 0,
-      `workers=${pool.workers.length}`,
+      'one-worker-spawned',
+      pool.workers.length === 1 && pool.workers[0].ready === true,
+      `workers=${pool.workers.length} ready=${pool.workers[0]?.ready}`,
     );
-    milestone('terminate-point');
-    void pool.workers[0].worker.terminate();
-    const start = Date.now();
-    await pool.shutdown();
+
+    const crashResult = await pool.lintBatch([
+      {
+        ...localTask('crash.ts', 'const x = 1;\n', 'race/crash'),
+        configKey: dir,
+      },
+    ]);
     check(
-      'shutdown-bounded',
-      Date.now() - start < 10_000,
-      `elapsed=${Date.now() - start}ms`,
+      'worker-hard-exit',
+      crashResult.length === 1 &&
+        crashResult[0]?.parseError?.includes('worker_crashed'),
+      JSON.stringify(crashResult[0]),
     );
+    await waitForFile(enteredFile, 'replacement worker import barrier');
+    milestone('respawn-import-entered');
+    check(
+      'respawn-in-flight',
+      pool.workers[0].respawning === true && pool.respawns.size === 1,
+      `respawning=${pool.workers[0].respawning} respawns=${pool.respawns.size}`,
+    );
+    milestone('respawn-in-flight');
+
+    const shutdownP = pool.shutdown();
+    check('closed-before-respawn-release', pool.closed === true, '');
+    milestone('shutdown-started');
+    fs.writeFileSync(releaseFile, 'release');
+    await shutdownP;
+    check(
+      'pool-drained',
+      pool.workers.length === 0 && pool.respawns.size === 0,
+      `workers=${pool.workers.length} respawns=${pool.respawns.size}`,
+    );
+
     let rejectedClosed = false;
     try {
       await pool.lintBatch([localTask('x.ts', 'const x = 1;')]);
-    } catch (e) {
-      rejectedClosed = /closed/.test(String(e?.message ?? e));
+    } catch (err) {
+      rejectedClosed = /closed/.test(String(err?.message ?? err));
     }
     check('lint-batch-rejects-closed', rejectedClosed, '');
-    await sleep(200);
-    check(
-      'pool-drained',
-      pool.workers.length === 0,
-      `workers=${pool.workers.length}`,
-    );
   },
 
-  // task-timeout: the hang plugin trips the 600ms per-task timeout, which
-  // terminates the worker and respawns it; the next batch must succeed on the
-  // replacement.
+  // Capture and fire the exact timeout callback created by dispatch. This pins
+  // timeout → terminate → respawn → recovery without a scheduler-dependent
+  // sleep or a small wall-clock budget.
   'task-timeout': async () => {
     const WorkerPool = await loadWorkerPool();
+    const enteredFile = markerPath('task-timeout-hang-entered');
+    process.env.RSLINT_HANG_ENTERED_FILE = enteredFile;
     const logs = [];
+    const capturedDelay = 86_400_000;
     const pool = new WorkerPool({
       configs: [HANG_CONFIG],
       workerCount: 1,
-      taskTimeoutMs: 600,
-      onLog: (rec) => logs.push(rec),
+      taskTimeoutMs: capturedDelay,
+      onLog: (record) => logs.push(record),
     });
     await pool.init();
     milestone('init-done');
-    milestone('terminate-point'); // the timeout-driven terminate fires below
-    const hangResult = await pool.lintBatch([
-      localTask('wedge.ts', 'const x = 1;\n', 'hang/hang'),
-    ]);
+
+    const captured = captureTimeout(capturedDelay, () =>
+      pool.lintBatch([localTask('wedge.ts', 'const x = 1;\n', 'hang/hang')]),
+    );
+    check(
+      'one-task-timeout-captured',
+      captured.count === 1,
+      `captured=${captured.count}`,
+    );
+    await waitForFile(enteredFile, 'task timeout listener entry');
+    milestone('hang-entered');
+    captured.fire();
+
+    const hangResult = await captured.value;
     check(
       'hang-task-timeout',
       hangResult.length === 1 && hangResult[0]?.parseError === 'task_timeout',
       `len=${hangResult.length} parseError=${hangResult[0]?.parseError}`,
     );
-    await sleep(500);
     const okResult = await pool.lintBatch([
       localTask('ok.ts', 'const TRIGGER = 1;\n', 'hang/noop'),
     ]);
@@ -233,14 +370,15 @@ const scenarios = {
     );
     check(
       'respawn-logged',
-      logs.some((l) => l.text.includes('respawning')),
+      logs.some((record) => record.text.includes('respawning')),
       '',
     );
     await pool.shutdown();
+    check('pool-drained', pool.workers.length === 0, '');
   },
 
-  // all-degraded: drive every slot past its respawn cap (crashCount=cap +
-  // terminate), so the in-flight batch drains as parseError:pool_degraded.
+  // Enqueue is synchronous. Observe the actual queue state before terminating
+  // the exhausted slot; no scheduler delay is needed.
   'all-degraded': async () => {
     const WorkerPool = await loadWorkerPool();
     const pool = new WorkerPool({
@@ -250,12 +388,16 @@ const scenarios = {
     });
     await pool.init();
     milestone('init-done');
-    pool.workers[0].ready = false; // hold non-ready so kickQueue can't dispatch
+    pool.workers[0].ready = false;
     const batchP = pool.lintBatch(
-      [1, 2].map((i) => localTask(`q${i}.ts`, 'const x = null;\n')),
+      [1, 2].map((index) => localTask(`q${index}.ts`, 'const x = null;\n')),
     );
-    await sleep(30);
-    milestone('terminate-point');
+    check(
+      'queue-enqueued',
+      pool.pendingQueue.length === 2,
+      `pending=${pool.pendingQueue.length}`,
+    );
+    milestone('degraded-queue-ready');
     pool.workers[0].crashCount = pool.opts.retryCap;
     await pool.workers[0].worker.terminate();
     const result = await batchP;
@@ -263,13 +405,13 @@ const scenarios = {
       'degraded-drain',
       result.length === 2 &&
         result.every(
-          (r) =>
-            r.parseError === 'pool_degraded' &&
-            r.cancelled === false &&
-            Array.isArray(r.diagnostics) &&
-            r.diagnostics.length === 0,
+          (item) =>
+            item.parseError === 'pool_degraded' &&
+            item.cancelled === false &&
+            Array.isArray(item.diagnostics) &&
+            item.diagnostics.length === 0,
         ),
-      JSON.stringify(result.map((r) => r.parseError)),
+      JSON.stringify(result.map((item) => item.parseError)),
     );
     check(
       'queue-drained',
@@ -279,8 +421,8 @@ const scenarios = {
     await pool.shutdown();
   },
 
-  // lint-batch-after-degraded: like all-degraded, but a SECOND batch issued
-  // AFTER the pool settled terminal must also resolve pool_degraded (not hang).
+  // After the first queue proves terminal degradation, a future batch must be
+  // drained synchronously by lintBatch's terminal-state guard.
   'lint-batch-after-degraded': async () => {
     const WorkerPool = await loadWorkerPool();
     const pool = new WorkerPool({
@@ -294,15 +436,19 @@ const scenarios = {
     const firstBatch = pool.lintBatch([
       localTask('first.ts', 'const x = null;\n'),
     ]);
-    await sleep(30);
-    milestone('terminate-point');
+    check(
+      'first-queue-enqueued',
+      pool.pendingQueue.length === 1,
+      `pending=${pool.pendingQueue.length}`,
+    );
+    milestone('degraded-queue-ready');
     pool.workers[0].crashCount = pool.opts.retryCap;
     await pool.workers[0].worker.terminate();
     const firstResult = await firstBatch;
     check(
       'first-degraded',
       firstResult.length === 1 && firstResult[0].parseError === 'pool_degraded',
-      JSON.stringify(firstResult.map((r) => r.parseError)),
+      JSON.stringify(firstResult.map((item) => item.parseError)),
     );
     check(
       'terminal-state',
@@ -313,25 +459,21 @@ const scenarios = {
         pool.workers[0].exited === true,
       `closed=${pool.closed} ready=${pool.workers[0]?.ready} exited=${pool.workers[0]?.exited}`,
     );
-    const secondBatch = pool.lintBatch([
+    const secondResult = await pool.lintBatch([
       localTask('second-a.ts', 'const y = null;\n'),
       localTask('second-b.ts', 'const z = null;\n'),
     ]);
-    const guard = new Promise((_, rej) =>
-      setTimeout(() => rej(new Error('second lintBatch hung')), 4_000),
-    );
-    const secondResult = await Promise.race([secondBatch, guard]);
     check(
       'second-degraded',
       secondResult.length === 2 &&
         secondResult.every(
-          (r) =>
-            r.parseError === 'pool_degraded' &&
-            r.cancelled === false &&
-            Array.isArray(r.diagnostics) &&
-            r.diagnostics.length === 0,
+          (item) =>
+            item.parseError === 'pool_degraded' &&
+            item.cancelled === false &&
+            Array.isArray(item.diagnostics) &&
+            item.diagnostics.length === 0,
         ),
-      JSON.stringify(secondResult.map((r) => r.parseError)),
+      JSON.stringify(secondResult.map((item) => item.parseError)),
     );
     check(
       'queue-drained',
@@ -342,19 +484,60 @@ const scenarios = {
   },
 };
 
-const name = process.argv[2];
-const fn = scenarios[name];
-if (typeof fn !== 'function') {
-  report({ kind: 'error', detail: `unknown scenario: ${name}` });
-  process.exit(2);
-}
-try {
-  await fn();
-  milestone('done'); // explicit success — the last line on the happy path
-  process.exit(0);
-} catch (err) {
-  // An ORDERLY error (import/init threw) — report it so the parent fails the
-  // test, rather than mistaking a silent exit for a tolerable native abort.
-  report({ kind: 'error', detail: String(err?.stack ?? err) });
-  process.exit(1);
+if (
+  !MILESTONE_FILE ||
+  !RUN_ID ||
+  !SCENARIO_TMP_DIR ||
+  !process.env.RSLINT_DIST_ESLINT_PLUGIN
+) {
+  console.error('isolated runner environment is incomplete');
+  process.exitCode = 2;
+} else {
+  // `beforeExit` is skipped by process.exit(), while the synchronous `exit`
+  // event still runs. Record that orderly early-exit path so an exit code 0
+  // can never masquerade as the known Windows native abort (which bypasses JS
+  // teardown entirely). Natural success writes `done` first; reported errors
+  // also mark the journal terminal and therefore do not get duplicated here.
+  process.once('exit', (code) => {
+    if (terminalRecordWritten) return;
+    try {
+      terminal({
+        kind: 'error',
+        detail: `runner exited through Node before a terminal record (code=${code})`,
+      });
+    } catch (err) {
+      console.error(`could not journal early process exit: ${String(err)}`);
+    }
+  });
+  milestone('started');
+  const scenario = scenarios[SCENARIO];
+  if (typeof scenario !== 'function') {
+    terminal({ kind: 'error', detail: `unknown scenario: ${SCENARIO}` });
+    process.exitCode = 2;
+  } else {
+    const restoreTerminate = observeWorkerTerminate();
+    try {
+      await scenario();
+      process.exitCode = 0;
+      // Write `done` only when Node itself proves the event loop is quiescent.
+      // A leaked Worker/refed handle therefore trips the parent watchdog
+      // instead of being hidden by an eager journal record or process.exit(0).
+      process.once('beforeExit', () => {
+        restoreTerminate();
+        terminal({ kind: 'milestone', name: 'done' });
+      });
+    } catch (err) {
+      restoreTerminate();
+      try {
+        terminal({ kind: 'error', detail: String(err?.stack ?? err) });
+      } catch (reportError) {
+        console.error(
+          `scenario failed and its journal could not be updated: ${String(
+            reportError,
+          )}\noriginal error: ${String(err?.stack ?? err)}`,
+        );
+      }
+      process.exitCode = 1;
+    }
+  }
 }

--- a/packages/rslint/tests/eslint-plugin/regression-coverage.test.ts
+++ b/packages/rslint/tests/eslint-plugin/regression-coverage.test.ts
@@ -2944,7 +2944,7 @@ describe('applyOptionDefaults: schema property defaults fill existing object slo
 // ────────────────────────────────────────────────────────────────────
 
 describe('WorkerPool: worker hard-exit during init rejects (not 60s hang)', () => {
-  test('config that process.exit()s at import → init() rejects fast', async () => {
+  test('config that process.exit()s at import → init() rejects from the exit event', async () => {
     const exitPath = path.resolve(
       __dirname,
       'fixtures',
@@ -2955,27 +2955,24 @@ describe('WorkerPool: worker hard-exit during init rejects (not 60s hang)', () =
       configs: [{ configPath: exitPath, configDirectory: exitDir }],
       workerCount: 1,
       // Long init timeout — the test asserts we DON'T wait for it.
-      workerInitTimeoutMs: 30_000,
+      workerInitTimeoutMs: 60_000,
     });
 
-    const start = Date.now();
     let err: Error | undefined;
     try {
       await pool.init();
     } catch (e) {
       err = e as Error;
     }
-    const elapsed = Date.now() - start;
-
-    // Rejected (not hung) and well under the 30s init timeout.
+    // The error source proves the worker exit event won the race against the
+    // 60s timeout. The outer test timeout remains only a deadlock sentinel.
     expect(err).toBeDefined();
-    expect(elapsed).toBeLessThan(10_000);
     // Message names the exit path, not a misleading "init timed out".
     expect(err!.message).toMatch(/exited during init|init failed/);
     expect(err!.message).not.toMatch(/timed out/);
 
     await pool.shutdown().catch(() => {});
-  }, 35_000);
+  }, 70_000);
 });
 
 // ────────────────────────────────────────────────────────────────────

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-lifecycle.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-lifecycle.test.ts
@@ -163,13 +163,14 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
     // inbound shutdown message, so shutdown must escalate to a forced
     // terminate() after the 5s grace. Terminating an oxc-napi worker can
     // native-abort below the JS layer on Windows — run it isolated (see
-    // ./pool-isolation/runner.mjs). PASS = clean terminate; TOLERATED-PASS =
-    // pool reached terminate then the subprocess aborted; FAIL = hang, failed
-    // in-child assertion, or a crash before the terminate point.
-    test('shutdown drains a sync-wedged worker via terminate fallback within grace', async () => {
+    // ./pool-isolation/runner.mjs). PASS = clean terminate;
+    // EXPECTED-NATIVE-ABORT = Windows reached the exact Worker.terminate call
+    // and then aborted below JS; FAIL = hang, failed state assertion, malformed
+    // journal, or any exit outside that narrow boundary.
+    test('shutdown drains a sync-wedged worker via terminate fallback', async () => {
       const r = await runPoolScenario('hang-shutdown');
       expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
-    }, 20_000);
+    }, 70_000);
 
     // U12: a single WorkerPool instance must support N lintBatch calls
     // in sequence (the CLI's fix-loop and the LSP's continuous edit
@@ -229,14 +230,13 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
     // runs in an isolated subprocess (see ./pool-isolation/runner.mjs): a native
     // abort is confined there, and the pool's outcome comes back via milestones.
     //
-    //   PASS           = clean terminate (mac/linux): shutdown bounded + drained
-    //   TOLERATED-PASS = pool reached terminate, then the subprocess aborted
-    //                    (Windows napi teardown) — the pool still did its job
-    //   FAIL           = hang, failed in-child assertion, or a crash BEFORE the
-    //                    terminate point — a real regression
+    //   PASS                  = exact terminate observed + pool drained
+    //   EXPECTED-NATIVE-ABORT = Windows aborted at the exact terminate call
+    //   FAIL                  = deadlock, failed/missing assertion, invalid
+    //                           journal, or an exit outside that boundary
     test('U11: plugin with a top-level setInterval — shutdown still terminates the worker', async () => {
       const r = await runPoolScenario('u11');
       expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
-    }, 20_000);
+    }, 70_000);
   },
 );

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-queue.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-queue.test.ts
@@ -66,8 +66,10 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
         })),
       );
 
-      // Let the enqueue actually happen before shutting down.
-      await new Promise((r) => setTimeout(r, 30));
+      // lintBatch enqueues synchronously before returning its Promise. Assert
+      // that state directly instead of sleeping and hoping the scheduler ran.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((pool as any).pendingQueue.length).toBe(5);
 
       // Tear down. shutdown() must drain pendingQueue and resolve
       // every queued task with the 'shutdown' marker.
@@ -94,7 +96,7 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
     test('all workers degraded → pendingQueue drains as parseError:pool_degraded (no hang)', async () => {
       const r = await runPoolScenario('all-degraded');
       expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
-    }, 20_000);
+    }, 70_000);
 
     // Queue-model regression suite — five tests pinning the design
     // properties that the Finding 3 refactor introduced.
@@ -227,6 +229,6 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
     test('lintBatch issued AFTER the pool settled into the terminal degraded state resolves as pool_degraded (does not hang)', async () => {
       const r = await runPoolScenario('lint-batch-after-degraded');
       expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
-    }, 20_000);
+    }, 70_000);
   },
 );

--- a/packages/rslint/tests/eslint-plugin/worker-pool-e2e-resilience.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-e2e-resilience.test.ts
@@ -127,7 +127,7 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
     test('worker exit racing shutdown does not leak the respawn', async () => {
       const r = await runPoolScenario('worker-exit-race');
       expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
-    }, 20_000);
+    }, 70_000);
 
     // A hung listener trips the per-task timeout, which terminates the worker
     // and respawns it; the next batch must succeed on the replacement. The
@@ -136,6 +136,6 @@ describe.skipIf(SKIP_WIN32_NAPI_TEARDOWN && process.platform === 'win32')(
     test('hung listener → task_timeout → respawn → next batch succeeds', async () => {
       const r = await runPoolScenario('task-timeout');
       expect(r.verdict, formatScenarioFailure(r)).not.toBe('FAIL');
-    }, 30_000);
+    }, 70_000);
   },
 );

--- a/packages/rslint/tests/eslint-plugin/worker-pool-shutdown-state.test.ts
+++ b/packages/rslint/tests/eslint-plugin/worker-pool-shutdown-state.test.ts
@@ -1,0 +1,268 @@
+import { EventEmitter } from 'node:events';
+
+import { describe, expect, test } from '@rstest/core';
+
+import { WorkerPool } from '../../src/eslint-plugin/worker-pool.js';
+
+class FakePipe {
+  constructor(
+    private readonly name: string,
+    private readonly events: string[],
+  ) {}
+
+  destroy(): void {
+    this.events.push(`${this.name}:destroy`);
+  }
+}
+
+class FakeWorker extends EventEmitter {
+  readonly stdout: FakePipe;
+  readonly stderr: FakePipe;
+  readonly posted: unknown[] = [];
+  terminateCalls = 0;
+  throwOnPost = false;
+  onPostMessage?: () => void;
+
+  constructor(readonly events: string[]) {
+    super();
+    this.stdout = new FakePipe('stdout', events);
+    this.stderr = new FakePipe('stderr', events);
+  }
+
+  postMessage(message: unknown): void {
+    this.events.push('postMessage');
+    if (this.throwOnPost) throw new Error('postMessage failed');
+    this.posted.push(message);
+    this.onPostMessage?.();
+  }
+
+  terminate(): Promise<number> {
+    this.terminateCalls++;
+    this.events.push('terminate');
+    return Promise.resolve(1);
+  }
+}
+
+interface TestSlot {
+  id: number;
+  worker: FakeWorker;
+  ready: boolean;
+  exited: boolean;
+  respawning: boolean;
+  inflight: Map<number, never>;
+  crashCount: number;
+}
+
+interface TestPoolState {
+  opts: { workerCount: number };
+  workers: TestSlot[];
+  closed: boolean;
+}
+
+function makePool(...workers: FakeWorker[]): {
+  pool: WorkerPool;
+  state: TestPoolState;
+  slots: TestSlot[];
+} {
+  // Empty configs ensure construction itself cannot create a real Worker. The
+  // tests then install structurally faithful in-memory slots.
+  const pool = new WorkerPool({ configs: [] });
+  const state = pool as unknown as TestPoolState;
+  const slots = workers.map<TestSlot>((worker, id) => ({
+    id,
+    worker,
+    ready: true,
+    exited: false,
+    respawning: false,
+    inflight: new Map(),
+    crashCount: 0,
+  }));
+  for (const slot of slots) {
+    slot.worker.on('exit', () => {
+      slot.ready = false;
+      slot.exited = true;
+    });
+  }
+  state.opts.workerCount = workers.length;
+  state.workers = slots;
+  return { pool, state, slots };
+}
+
+interface CapturedTimer {
+  delay: number;
+  cleared: boolean;
+  fired: boolean;
+  fire(): void;
+}
+
+function beginShutdownWithCapturedTimers(pool: WorkerPool): {
+  shutdown: Promise<void>;
+  timers: CapturedTimer[];
+  restore(): void;
+} {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const timers: CapturedTimer[] = [];
+
+  globalThis.setTimeout = ((
+    callback: (...args: unknown[]) => void,
+    delay?: number,
+    ...args: unknown[]
+  ) => {
+    const timer: CapturedTimer = {
+      delay: delay ?? 0,
+      cleared: false,
+      fired: false,
+      fire() {
+        if (timer.cleared || timer.fired) return;
+        timer.fired = true;
+        callback(...args);
+      },
+    };
+    timers.push(timer);
+    return timer as unknown as NodeJS.Timeout;
+  }) as typeof setTimeout;
+  globalThis.clearTimeout = ((handle: NodeJS.Timeout) => {
+    const timer = handle as unknown as CapturedTimer;
+    if (timers.includes(timer)) timer.cleared = true;
+  }) as typeof clearTimeout;
+
+  try {
+    const shutdown = pool.shutdown();
+    return {
+      shutdown,
+      timers,
+      restore() {
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+      },
+    };
+  } catch (err) {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+    throw err;
+  }
+}
+
+describe('WorkerPool shutdown state machine (no real Worker)', () => {
+  test('worker exit after waiter registration cancels the fallback', async () => {
+    const events: string[] = [];
+    const worker = new FakeWorker(events);
+    const { pool, state } = makePool(worker);
+    const capture = beginShutdownWithCapturedTimers(pool);
+    try {
+      expect(capture.timers).toHaveLength(1);
+      expect(capture.timers[0].delay).toBe(5_000);
+      expect(worker.posted).toEqual([{ kind: 'shutdown' }]);
+
+      worker.emit('exit', 0);
+      expect(capture.timers[0].cleared).toBe(true);
+    } finally {
+      capture.restore();
+    }
+
+    await capture.shutdown;
+    expect(worker.terminateCalls).toBe(0);
+    expect(state.workers).toEqual([]);
+  });
+
+  test('exit while posting shutdown is observed without arming a stale timer', async () => {
+    const events: string[] = [];
+    const worker = new FakeWorker(events);
+    const { pool, state } = makePool(worker);
+    worker.onPostMessage = () => worker.emit('exit', 0);
+
+    const capture = beginShutdownWithCapturedTimers(pool);
+    capture.restore();
+    await capture.shutdown;
+
+    expect(capture.timers).toEqual([]);
+    expect(worker.terminateCalls).toBe(0);
+    expect(state.workers).toEqual([]);
+  });
+
+  test('fallback fires at the configured grace and closes pipes first', async () => {
+    const events: string[] = [];
+    const worker = new FakeWorker(events);
+    const { pool, state } = makePool(worker);
+    const capture = beginShutdownWithCapturedTimers(pool);
+    try {
+      expect(capture.timers).toHaveLength(1);
+      expect(capture.timers[0].delay).toBe(5_000);
+      capture.timers[0].fire();
+    } finally {
+      capture.restore();
+    }
+
+    await capture.shutdown;
+    expect(events).toEqual([
+      'postMessage',
+      'stdout:destroy',
+      'stderr:destroy',
+      'terminate',
+    ]);
+    expect(worker.terminateCalls).toBe(1);
+    expect(state.workers).toEqual([]);
+  });
+
+  test('postMessage failure still leaves a bounded terminate fallback', async () => {
+    const events: string[] = [];
+    const worker = new FakeWorker(events);
+    worker.throwOnPost = true;
+    const { pool, state } = makePool(worker);
+    const capture = beginShutdownWithCapturedTimers(pool);
+    try {
+      expect(capture.timers).toHaveLength(1);
+      expect(capture.timers[0].delay).toBe(5_000);
+      capture.timers[0].fire();
+    } finally {
+      capture.restore();
+    }
+
+    await capture.shutdown;
+    expect(worker.terminateCalls).toBe(1);
+    expect(state.workers).toEqual([]);
+  });
+
+  test('already-exited slots and repeated shutdown do not arm timers', async () => {
+    const events: string[] = [];
+    const worker = new FakeWorker(events);
+    const { pool, state, slots } = makePool(worker);
+    slots[0].exited = true;
+    slots[0].ready = false;
+
+    const first = beginShutdownWithCapturedTimers(pool);
+    first.restore();
+    await first.shutdown;
+    expect(first.timers).toEqual([]);
+    expect(worker.terminateCalls).toBe(0);
+    expect(state.workers).toEqual([]);
+
+    const second = beginShutdownWithCapturedTimers(pool);
+    second.restore();
+    await second.shutdown;
+    expect(second.timers).toEqual([]);
+    expect(worker.terminateCalls).toBe(0);
+  });
+
+  test('mixed slots wait for graceful exit and forced exit together', async () => {
+    const firstWorker = new FakeWorker([]);
+    const secondWorker = new FakeWorker([]);
+    const { pool, state } = makePool(firstWorker, secondWorker);
+    const capture = beginShutdownWithCapturedTimers(pool);
+    try {
+      expect(capture.timers.map((timer) => timer.delay)).toEqual([
+        5_000, 5_000,
+      ]);
+      firstWorker.emit('exit', 0);
+      capture.timers[1].fire();
+    } finally {
+      capture.restore();
+    }
+
+    await capture.shutdown;
+    expect(firstWorker.terminateCalls).toBe(0);
+    expect(secondWorker.terminateCalls).toBe(1);
+    expect(state.workers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace load-sensitive elapsed-time assertions and fixed sleeps in worker-pool isolation tests with explicit state barriers.
- Harden the process-isolation result oracle with a versioned, run-scoped, sequential journal; ordered scenario contracts; strict terminal handling; bounded diagnostics; and fail-closed classification.
- Narrow the Windows native-abort exception to the exact observed `Worker.prototype.terminate()` boundary after all required state transitions. Orderly early exit, malformed evidence, missing assertions, timeout, and non-Windows silent exit remain failures.
- Add deterministic in-memory shutdown state-machine tests for graceful exit, synchronous exit races, forced fallback, postMessage failure, repeated shutdown, and mixed slots.
- Emit one parent-authored, machine-readable audit record per isolated scenario so full CI logs distinguish clean `PASS` from `EXPECTED-NATIVE-ABORT`.
- Keep the change entirely under `packages/rslint/tests/**`: no production source, workflow, package output, user-visible behavior, or child-process count changes.

Local validation:

- `pnpm run check-spell`
- `pnpm run format:check`
- Changed-scope Go lint: no changed `.go` files, so no full-repository Go lint was run
- `pnpm --filter @rslint/core test` — 767/767 passed
- Three consecutive focused worker-pool E2E runs — 17/17 passed per run
- CI-equivalent dependency-closure test — core passed; rslint-test-tools 4,284 tests with 0 failures
- npm package dry run — 23 entries, no `tests/` or `src/`

## Related Links

- Investigated CI job: `Test npm packages (rspack-windows-2022-large)`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). No documentation change is required for a test-only refactor with unchanged product behavior.

