### PR TITLE
perf: defer prefer-array-flat edits

### DIFF
--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat.go
@@ -396,11 +396,12 @@ var PreferArrayFlatRule = rule.Rule{
 
 				for _, match := range matches {
 					ruleMessage := message(match.description)
-					if canFix(node, match.array, ctx) {
-						ctx.ReportNodeWithFixes(node, ruleMessage, buildFixes(node, match, ctx)...)
-					} else {
-						ctx.ReportNode(node, ruleMessage)
-					}
+					ctx.ReportNodeWithDeferredFixes(node, ruleMessage, func() []rule.RuleFix {
+						if !canFix(node, match.array, ctx) {
+							return nil
+						}
+						return buildFixes(node, match, ctx)
+					})
 				}
 			},
 		}

--- a/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat/prefer_array_flat_extras_test.go
@@ -1,8 +1,14 @@
 package prefer_array_flat_test
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -501,4 +507,83 @@ Array.prototype.concat.call([], item)`,
 	// candidate call by themselves and are ignored by the CallExpression listener.
 
 	suite.run(t)
+}
+
+func TestPreferArrayFlatEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`array.flatMap(value => value);`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     prefer_array_flat.PreferArrayFlatRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return prefer_array_flat.PreferArrayFlatRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("non-autofix demand materialized fixes")
+	}
+	if autofixOnly.FixesPtr == nil || !reflect.DeepEqual(autofixOnly.FixesPtr, allEdits.FixesPtr) {
+		t.Fatal("autofix and all-edits demands produced different fixes")
+	}
+	if fixes := *allEdits.FixesPtr; len(fixes) == 0 {
+		t.Fatal("all-edits demand produced no fixes")
+	}
+	for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		if diagnostic.Suggestions != nil {
+			t.Fatal("autofix-only rule materialized suggestions")
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Defer prefer-array-flat fixability checks and replacement construction until the diagnostic consumer requests autofixes.
- Keep matching, diagnostic messages, and report ranges independent from edit demand.
- Add edit-demand coverage to the existing extras test file, verifying identical diagnostics and fixes across consumer modes.

### Architecture

The rule now follows the native demand-driven reporting boundary: matching remains eager because it defines rule semantics, while comment inspection, source replacement construction, semicolon handling, and keyword-spacing fix planning live inside ReportNodeWithDeferredFixes. A diagnostics-only consumer therefore avoids all optional edit work, while autofix and all-edits consumers execute the existing builders unchanged.

### Benchmark

Apple M1 Max, GOMAXPROCS=1, 256 fixable flatMap diagnostics, Program construction excluded, 300 ms paired base/candidate samples:

| Mode | Base | This PR | Change |
| --- | ---: | ---: | ---: |
| diagnostics-only time | 6.098 ms/op | 0.313 ms/op | -94.9% |
| diagnostics-only memory | 523,370 B/op | 179,304 B/op | -65.7% |
| diagnostics-only allocations | 4,899 allocs/op | 2,083 allocs/op | -57.5% |
| all-edits time | 6.143 ms/op | 6.167 ms/op | +0.4% |
| all-edits memory | 523,370 B/op | 523,370 B/op | unchanged |
| all-edits allocations | 4,899 allocs/op | 4,899 allocs/op | unchanged |

The benchmark source file was temporary and is not included in this PR.

## Related Links

- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
