### PR TITLE
perf: defer no-extra-boolean-cast edits

### DIFF
--- a/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.go
+++ b/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.go
@@ -379,11 +379,9 @@ var NoExtraBooleanCastRule = rule.Rule{
 				if !isInFlaggedContext(node, opts) {
 					return
 				}
-				if fixes := buildNegationFix(ctx, node); fixes != nil {
-					ctx.ReportNodeWithFixes(node, negationMsg, fixes...)
-				} else {
-					ctx.ReportNode(node, negationMsg)
-				}
+				ctx.ReportNodeWithDeferredFixes(node, negationMsg, func() []rule.RuleFix {
+					return buildNegationFix(ctx, node)
+				})
 			},
 
 			// Detect Boolean(expr) in a flagged context.
@@ -402,11 +400,9 @@ var NoExtraBooleanCastRule = rule.Rule{
 				if !isInFlaggedContext(node, opts) {
 					return
 				}
-				if fixes := buildCallFix(ctx, node); fixes != nil {
-					ctx.ReportNodeWithFixes(node, callMsg, fixes...)
-				} else {
-					ctx.ReportNode(node, callMsg)
-				}
+				ctx.ReportNodeWithDeferredFixes(node, callMsg, func() []rule.RuleFix {
+					return buildCallFix(ctx, node)
+				})
 			},
 		}
 	},

--- a/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast_test.go
+++ b/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast_test.go
@@ -1,9 +1,13 @@
 package no_extra_boolean_cast
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -335,4 +339,93 @@ func TestNoExtraBooleanCastRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoExtraBooleanCastEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"if (!!first) {}\nif (Boolean(second)) {}",
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     NoExtraBooleanCastRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoExtraBooleanCastRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got, want := withoutEdits(diagnostics[index]), withoutEdits(allEdits[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d changed diagnostic %d:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		if autofixOnly[index].FixesPtr == nil ||
+			!reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+		if fixes := *allEdits[index].FixesPtr; len(fixes) == 0 {
+			t.Fatalf("diagnostic %d: all-edits demand produced no fixes", index)
+		}
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{
+		diagnosticsOnly,
+		autofixOnly,
+		suggestionOnly,
+		allEdits,
+	} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil {
+				t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Defer redundant-negation and Boolean-call autofix construction until the consumer requests autofixes.
- Preserve context detection, diagnostic messages, and report ranges across every edit-demand mode.
- Add edit-demand coverage to the existing rule test file for both fix shapes.

### Architecture

The rule keeps boolean-context matching eager because it defines whether a diagnostic exists. Comment inspection, source extraction, precedence handling, and replacement construction remain encapsulated in the existing fix builders, which are now invoked through ReportNodeWithDeferredFixes. Diagnostics-only and suggestion-only consumers therefore do not materialize native autofixes, while autofix consumers execute the same builders as before.

### Benchmark

Apple M1 Max, GOMAXPROCS=1, 256 fixable diagnostics per shape, Program construction excluded, 300 ms paired base/candidate samples:

| Shape and mode | Base | This PR | Change |
| --- | ---: | ---: | ---: |
| double-negation diagnostics-only time | 166.3 µs/op | 64.2 µs/op | -61.4% |
| Boolean-call diagnostics-only time | 174.2 µs/op | 66.6 µs/op | -61.7% |
| diagnostics-only memory | 179,344 B/op | 44,176 B/op | -75.4% |
| diagnostics-only allocations | 1,572 allocs/op | 292 allocs/op | -81.4% |
| double-negation all-edits time | 167.2 µs/op | 165.0 µs/op | -1.3% |
| Boolean-call all-edits time | 175.4 µs/op | 175.9 µs/op | +0.3% |
| all-edits memory | 179,344 B/op | 179,344 B/op | unchanged |
| all-edits allocations | 1,572 allocs/op | 1,572 allocs/op | unchanged |

The benchmark source file was temporary and is not included in this PR.

## Related Links

- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
