### PR TITLE
perf: defer TypeScript prefer-destructuring edits

### DIFF
--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.go
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.go
@@ -336,8 +336,19 @@ func shouldFix(leftNode *ast.Node, rightNode *ast.Node) bool {
 	return left.Text() == pae.Name().Text()
 }
 
-// reportWithFix reports the diagnostic with an autofix.
+// reportWithFix reports the diagnostic and defers optional autofix planning.
 func reportWithFix(ctx rule.RuleContext, leftNode *ast.Node, rightNode *ast.Node, reportNode *ast.Node) {
+	ctx.ReportNodeWithDeferredFixes(reportNode, buildPreferDestructuringMessage("object"), func() []rule.RuleFix {
+		return buildObjectDestructuringFix(ctx, leftNode, rightNode, reportNode)
+	})
+}
+
+func buildObjectDestructuringFix(
+	ctx rule.RuleContext,
+	leftNode *ast.Node,
+	rightNode *ast.Node,
+	reportNode *ast.Node,
+) []rule.RuleFix {
 	pae := rightNode.AsPropertyAccessExpression()
 	propName := pae.Name().Text()
 	objectExpr := pae.Expression
@@ -355,8 +366,7 @@ func reportWithFix(ctx rule.RuleContext, leftNode *ast.Node, rightNode *ast.Node
 
 	if utils.HasCommentInSpan(comments, idRange.End(), objRange.Pos()) ||
 		utils.HasCommentInSpan(comments, objRange.End(), nodeRange.End()) {
-		ctx.ReportNode(reportNode, buildPreferDestructuringMessage("object"))
-		return
+		return nil
 	}
 
 	// Get the inner expression text, stripping outer ParenthesizedExpression.
@@ -369,8 +379,7 @@ func reportWithFix(ctx rule.RuleContext, leftNode *ast.Node, rightNode *ast.Node
 	// If stripping parens would lose a comment (e.g., `(/* c */ obj)`), suppress fix.
 	if utils.HasCommentInSpan(comments, objRange.Pos(), innerRange.Pos()) ||
 		utils.HasCommentInSpan(comments, innerRange.End(), objRange.End()) {
-		ctx.ReportNode(reportNode, buildPreferDestructuringMessage("object"))
-		return
+		return nil
 	}
 
 	objectText := text[innerRange.Pos():innerRange.End()]
@@ -386,7 +395,5 @@ func reportWithFix(ctx rule.RuleContext, leftNode *ast.Node, rightNode *ast.Node
 	replacement := "{" + propName + "} = " + objectText
 	fixRange := core.NewTextRange(idRange.Pos(), nodeRange.End())
 
-	ctx.ReportNodeWithFixes(reportNode, buildPreferDestructuringMessage("object"),
-		rule.RuleFixReplaceRange(fixRange, replacement),
-	)
+	return []rule.RuleFix{rule.RuleFixReplaceRange(fixRange, replacement)}
 }

--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring_test.go
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring_test.go
@@ -1,9 +1,13 @@
 package prefer_destructuring
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -1175,4 +1179,96 @@ func TestPreferDestructuringRule(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestPreferDestructuringEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"declare const object: { value: string; kept: string };\n"+
+			"const value = object.value;\n"+
+			"const kept = object /* keep */ .kept;",
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:             PreferDestructuringRule.Name,
+					Severity:         rule.SeverityError,
+					RequiresTypeInfo: PreferDestructuringRule.RequiresTypeInfo,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return PreferDestructuringRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+	wantFix := []bool{true, false}
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got, want := withoutEdits(diagnostics[index]), withoutEdits(allEdits[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d changed diagnostic %d:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		if got := autofixOnly[index].FixesPtr != nil; got != wantFix[index] {
+			t.Fatalf("diagnostic %d: autofix payload presence = %v, want %v", index, got, wantFix[index])
+		}
+		if !reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{
+		diagnosticsOnly,
+		autofixOnly,
+		suggestionOnly,
+		allEdits,
+	} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil {
+				t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Defer TypeScript prefer-destructuring autofix planning until the consumer requests autofixes.
- Separate diagnostic reporting from object-destructuring fix construction.
- Add edit-demand coverage to the existing rule test file, including a comment-preserving diagnostic without a fix.

### Architecture

Type-aware matching and same-name eligibility remain eager because they define the rule diagnostic. reportWithFix now owns only the demand-driven reporting boundary, while buildObjectDestructuringFix owns comment accounting, source extraction, precedence handling, and replacement construction. An unsafe comment layout returns an empty fix list, preserving the prior diagnostic-without-fix behavior without recursively reporting from inside the builder.

### Benchmark

Apple M1 Max, GOMAXPROCS=1, 256 fixable object-destructuring diagnostics, Program construction excluded, 300 ms paired base/candidate samples:

| Mode | Base | This PR | Change |
| --- | ---: | ---: | ---: |
| diagnostics-only time | 271.3 µs/op | 110.0 µs/op | -59.4% |
| diagnostics-only memory | 234,576 B/op | 52,304 B/op | -77.7% |
| diagnostics-only allocations | 2,340 allocs/op | 548 allocs/op | -76.6% |
| all-edits time | 270.3 µs/op | 269.4 µs/op | -0.3% |
| all-edits memory | 234,576 B/op | 234,576 B/op | unchanged |
| all-edits allocations | 2,340 allocs/op | 2,340 allocs/op | unchanged |

The benchmark source file was temporary and is not included in this PR.

## Related Links

- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
