### PR TITLE
perf: defer dot-notation edits

### DIFF
--- a/internal/rules/dot_notation/dot_notation.go
+++ b/internal/rules/dot_notation/dot_notation.go
@@ -142,6 +142,127 @@ func literalKey(n *ast.Node) (value string, formatted string, ok bool) {
 	return "", "", false
 }
 
+// buildUseDotFix constructs the bracket-to-dot replacement after the rule has
+// already decided to report. Keeping token and comment inspection here lets
+// diagnostics-only consumers skip every fix-specific source operation.
+func buildUseDotFix(
+	sourceFile *ast.SourceFile,
+	sourceComments []*ast.CommentRange,
+	node *ast.Node,
+	elem *ast.ElementAccessExpression,
+	value string,
+) []rule.RuleFix {
+	text := sourceFile.Text()
+	nodeRange := utils.TrimNodeTextRange(sourceFile, node)
+	exprRange := utils.TrimNodeTextRange(sourceFile, elem.Expression)
+
+	// Locate the opening `[` via the real token stream (skipping
+	// comments/whitespace, and the "?." operator node when present)
+	// rather than scanning raw bytes for a literal '[' - a byte scan
+	// stops at a '[' that happens to appear inside an intervening
+	// comment, e.g. `foo /* [ */ ['bar']`.
+	hasQuestionDot := elem.QuestionDotToken != nil
+	operatorEnd := exprRange.End()
+	if hasQuestionDot {
+		operatorEnd = utils.TrimNodeTextRange(sourceFile, elem.QuestionDotToken).End()
+	}
+	bracketStart := operatorEnd
+	if bracketTok, ok := utils.TokenAtOrAfter(sourceFile, operatorEnd); ok {
+		bracketStart = bracketTok.Start
+	}
+	bracketEnd := nodeRange.End() - 1
+	for bracketEnd > bracketStart && text[bracketEnd] != ']' {
+		bracketEnd--
+	}
+
+	if utils.HasCommentInSpan(sourceComments, bracketStart+1, bracketEnd) {
+		// A comment lives inside the brackets (anywhere, including inside
+		// nested parens around the key), so replacing the bracket span would
+		// drop it.
+		return nil
+	}
+
+	// Replace only the bracket part `['key']` itself, mirroring upstream's
+	// fixer range [leftBracket, rightBracket]. Everything before `[` (object,
+	// `?.` operator, whitespace, comments) stays untouched, so fixes on nested
+	// accesses like `a['b']['c']` don't overlap and can apply in one pass.
+	var replacement string
+	if hasQuestionDot {
+		// The untouched `?.` operator already supplies the dot:
+		// `a?.['b']` -> `a?.b`.
+		replacement = value
+	} else {
+		sep := "."
+		if isDecimalIntegerLiteral(sourceFile, elem.Expression) {
+			sep = " ."
+		}
+		replacement = sep + value
+	}
+
+	// Guard against the replacement identifier fusing with whatever token
+	// immediately follows the closing bracket, e.g.
+	// `foo['bar']instanceof baz`.
+	nextCharIdx := bracketEnd + 1
+	if nextCharIdx < len(text) && identContinueRE.MatchString(string(text[nextCharIdx])) {
+		replacement += " "
+	}
+
+	return []rule.RuleFix{rule.RuleFixReplaceRange(
+		core.NewTextRange(bracketStart, bracketEnd+1),
+		replacement,
+	)}
+}
+
+// buildUseBracketsFix constructs the dot-to-bracket replacement after the
+// keyword access has been detected. Its inputs are fix-specific, making the
+// reporting path independent of token and comment materialization.
+func buildUseBracketsFix(
+	sourceFile *ast.SourceFile,
+	sourceComments []*ast.CommentRange,
+	pae *ast.PropertyAccessExpression,
+	name string,
+	isOptional bool,
+) []rule.RuleFix {
+	nameRange := utils.TrimNodeTextRange(sourceFile, pae.Name())
+	objRange := utils.TrimNodeTextRange(sourceFile, pae.Expression)
+
+	// Locate the access operator (either `?.` or `.`) via the real token
+	// stream rather than scanning raw bytes for a literal '?' or '.' - a byte
+	// scan stops inside an intervening comment, e.g. `foo /* ? */ .while`.
+	accessStart := objRange.End()
+	opLen := 1
+	if isOptional {
+		qRange := utils.TrimNodeTextRange(sourceFile, pae.QuestionDotToken)
+		accessStart = qRange.Pos()
+		opLen = qRange.End() - qRange.Pos()
+	} else if opTok, ok := utils.TokenAtOrAfter(sourceFile, objRange.End()); ok {
+		accessStart = opTok.Start
+		opLen = opTok.End - opTok.Start
+	}
+	gapStart := accessStart + opLen
+	if gapStart > nameRange.Pos() {
+		gapStart = nameRange.Pos()
+	}
+	if utils.HasCommentInSpan(sourceComments, gapStart, nameRange.Pos()) {
+		// A comment lives between the operator and property name, so replacing
+		// that span would drop it.
+		return nil
+	}
+
+	// Replace only the operator + property name (`.while` / `?.while`),
+	// mirroring upstream's fixer range [dotToken, property]. The object and
+	// trivia before the operator stay untouched, so fixes on nested keyword
+	// accesses like `a.if.while` don't overlap and can apply in one pass.
+	replacement := "[\"" + name + "\"]"
+	if isOptional {
+		replacement = "?.[\"" + name + "\"]"
+	}
+	return []rule.RuleFix{rule.RuleFixReplaceRange(
+		core.NewTextRange(accessStart, nameRange.End()),
+		replacement,
+	)}
+}
+
 // DotNotationRule enforces dot notation whenever possible, matching ESLint
 // core's `dot-notation` rule (eslint/lib/rules/dot-notation.js) 1:1. This is
 // the plain, non-type-aware port; the TypeScript-enhanced variant with
@@ -193,63 +314,9 @@ var DotNotationRule = rule.Rule{
 				}
 			}
 
-			text := sourceFile.Text()
-			nodeRange := utils.TrimNodeTextRange(sourceFile, node)
-			exprRange := utils.TrimNodeTextRange(sourceFile, elem.Expression)
-
-			// Locate the opening `[` via the real token stream (skipping
-			// comments/whitespace, and the "?." operator node when present)
-			// rather than scanning raw bytes for a literal '[' - a byte scan
-			// stops at a '[' that happens to appear inside an intervening
-			// comment, e.g. `foo /* [ */ ['bar']`.
-			hasQuestionDot := elem.QuestionDotToken != nil
-			operatorEnd := exprRange.End()
-			if hasQuestionDot {
-				operatorEnd = utils.TrimNodeTextRange(sourceFile, elem.QuestionDotToken).End()
-			}
-			bracketStart := operatorEnd
-			if bracketTok, ok := utils.TokenAtOrAfter(sourceFile, operatorEnd); ok {
-				bracketStart = bracketTok.Start
-			}
-			bracketEnd := nodeRange.End() - 1
-			for bracketEnd > bracketStart && text[bracketEnd] != ']' {
-				bracketEnd--
-			}
-
-			if utils.HasCommentInSpan(ctx.Comments.All(), bracketStart+1, bracketEnd) {
-				// Report but don't fix: a comment lives inside the brackets
-				// (anywhere, including inside nested parens around the key).
-				ctx.ReportNode(keyNode, buildUseDotMessage(formattedKey))
-				return
-			}
-
-			// Replace only the bracket part `['key']` itself, mirroring
-			// upstream's fixer range [leftBracket, rightBracket]. Everything
-			// before `[` (object, `?.` operator, whitespace, comments) stays
-			// untouched, so fixes on nested accesses like `a['b']['c']` don't
-			// overlap and can both apply in a single pass.
-			var replacement string
-			if hasQuestionDot {
-				// The untouched `?.` operator already supplies the dot:
-				// `a?.['b']` -> `a?.b`.
-				replacement = value
-			} else {
-				sep := "."
-				if isDecimalIntegerLiteral(sourceFile, elem.Expression) {
-					sep = " ."
-				}
-				replacement = sep + value
-			}
-
-			// Guard against the replacement identifier fusing with whatever
-			// token immediately follows the closing bracket (no existing
-			// whitespace between them), e.g. `foo['bar']instanceof baz`.
-			nextCharIdx := bracketEnd + 1
-			if nextCharIdx < len(text) && identContinueRE.MatchString(string(text[nextCharIdx])) {
-				replacement += " "
-			}
-
-			ctx.ReportNodeWithFixes(keyNode, buildUseDotMessage(formattedKey), rule.RuleFixReplaceRange(core.NewTextRange(bracketStart, bracketEnd+1), replacement))
+			ctx.ReportNodeWithDeferredFixes(keyNode, buildUseDotMessage(formattedKey), func() []rule.RuleFix {
+				return buildUseDotFix(sourceFile, ctx.Comments.All(), node, elem, value)
+			})
 		}
 
 		listeners := rule.RuleListeners{}
@@ -300,47 +367,9 @@ var DotNotationRule = rule.Rule{
 				return
 			}
 
-			nameRange := utils.TrimNodeTextRange(sourceFile, pae.Name())
-			objRange := utils.TrimNodeTextRange(sourceFile, pae.Expression)
-
-			// Locate the access operator (either `?.` or `.`) via the real
-			// token stream rather than scanning raw bytes for a literal '?'
-			// or '.' - a byte scan stops at one of those characters if it
-			// happens to appear inside an intervening comment, e.g.
-			// `foo /* ? */ .while`.
-			accessStart := objRange.End()
-			opLen := 1
-			if isOptional {
-				qRange := utils.TrimNodeTextRange(sourceFile, pae.QuestionDotToken)
-				accessStart = qRange.Pos()
-				opLen = qRange.End() - qRange.Pos()
-			} else if opTok, ok := utils.TokenAtOrAfter(sourceFile, objRange.End()); ok {
-				accessStart = opTok.Start
-				opLen = opTok.End - opTok.Start
-			}
-			gapStart := accessStart + opLen
-			if gapStart > nameRange.Pos() {
-				gapStart = nameRange.Pos()
-			}
-			if utils.HasCommentInSpan(ctx.Comments.All(), gapStart, nameRange.Pos()) {
-				// Report but don't fix: a comment lives between the operator
-				// and the property name.
-				ctx.ReportNode(pae.Name(), buildUseBracketsMessage(name))
-				return
-			}
-
-			// Replace only the operator + property name (`.while` / `?.while`),
-			// mirroring upstream's fixer range [dotToken, property]. The object
-			// and any whitespace/comments before the operator stay untouched,
-			// so fixes on nested keyword accesses like `a.if.while` don't
-			// overlap and can both apply in a single pass.
-			var replacement string
-			if isOptional {
-				replacement = "?.[\"" + name + "\"]"
-			} else {
-				replacement = "[\"" + name + "\"]"
-			}
-			ctx.ReportNodeWithFixes(pae.Name(), buildUseBracketsMessage(name), rule.RuleFixReplaceRange(core.NewTextRange(accessStart, nameRange.End()), replacement))
+			ctx.ReportNodeWithDeferredFixes(pae.Name(), buildUseBracketsMessage(name), func() []rule.RuleFix {
+				return buildUseBracketsFix(sourceFile, ctx.Comments.All(), pae, name, isOptional)
+			})
 		}
 
 		return listeners

--- a/internal/rules/dot_notation/dot_notation_extras_test.go
+++ b/internal/rules/dot_notation/dot_notation_extras_test.go
@@ -6,9 +6,13 @@
 package dot_notation
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -234,5 +238,100 @@ func TestDotNotationAllowPatternSchema(t *testing.T) {
 	valid := []any{map[string]any{"allowPattern": "(?<=a)b"}}
 	if err := DotNotationRule.Schema.Validate(valid); err != nil {
 		t.Errorf("expected a valid allowPattern regex to pass schema validation, got: %v", err)
+	}
+}
+
+func TestDotNotationEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`const first = object["property"];
+const second = object.while;
+const third = object[(/* keep */ "property")];
+const fourth = object. /* keep */ while;`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := []any{map[string]any{"allowKeywords": false}}
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     DotNotationRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return DotNotationRule.Run(ctx, options)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 4 {
+			t.Fatalf("demand %d: diagnostics = %d, want 4", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		want := withoutEdits(allEdits[index])
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got := withoutEdits(diagnostics[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("demand %d diagnostic %d changed:\ngot  %#v\nwant %#v", demand, index, got, want)
+			}
+		}
+	}
+
+	wantFixes := []bool{true, true, false, false}
+	for index, wantFix := range wantFixes {
+		if got := autofixOnly[index].FixesPtr != nil; got != wantFix {
+			t.Errorf("autofix diagnostic %d fix presence = %t, want %t", index, got, wantFix)
+		}
+		if !reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Errorf("autofix and all-edits diagnostic %d produced different fixes", index)
+		}
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{diagnosticsOnly, suggestionOnly} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.FixesPtr != nil {
+				t.Errorf("non-autofix diagnostic %d materialized fixes", index)
+			}
+		}
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil {
+				t.Errorf("autofix-only diagnostic %d materialized suggestions", index)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Defer `dot-notation` token lookup, comment inspection, range calculation, and replacement construction until the diagnostic consumer requests autofixes.
- Extract bracket-to-dot and dot-to-bracket fix construction into focused helpers with explicit source/AST/comment inputs, while keeping detection and option semantics in the listeners.
- Add edit-demand coverage to the existing extras test file for both fixer directions, including fixable and comment-blocked diagnostics.

## Architecture

The listeners still eagerly decide whether a diagnostic exists: literal classification, identifier/keyword checks, `allowPattern`, the `let` guard, message, and diagnostic anchor are unchanged. Once a diagnostic is known, `ReportNodeWithDeferredFixes` conditionally invokes a synchronous builder for the optional edit payload.

The extracted builders contain only fix-specific source operations and return either the original fix or no fix. Comment collection remains lazy because `CommentStore.All()` is called inside the deferred callback. This is a native core-rule reporting optimization; it has no dependency on `Program`, `TypeChecker`, or plugin transport and changes no public behavior.

## Benchmark

Paired baseline/candidate benchmark binaries on an Apple M1 Max with Go 1.26.1 and `GOMAXPROCS=1`; 256 violations per case, program construction excluded, median of 10 alternating samples:

| Path | Demand | Baseline | Candidate | Change |
| --- | --- | ---: | ---: | ---: |
| bracket → dot | diagnostics only | 378.2 µs/op | 226.1 µs/op | -40.2% |
| bracket → dot | diagnostics only | 335,115 B/op | 154,889 B/op | -53.8% |
| bracket → dot | diagnostics only | 3,881 allocs/op | 1,833 allocs/op | -52.8% |
| bracket → dot | all edits | 378.6 µs/op | 381.4 µs/op | +0.7% |
| dot → bracket | diagnostics only | 300.0 µs/op | 157.4 µs/op | -47.6% |
| dot → bracket | diagnostics only | 318,728 B/op | 138,504 B/op | -56.5% |
| dot → bracket | diagnostics only | 2,857 allocs/op | 1,065 allocs/op | -62.7% |
| dot → bracket | all edits | 299.3 µs/op | 303.1 µs/op | +1.2% |

All-edits memory and allocation counts are identical. The small all-edits timing delta is approximately 11 ns and 15 ns per violation respectively, the bounded cost of routing requested edits through the synchronous builder; diagnostics-only mode avoids the much larger fix construction cost. The temporary benchmark harness is not included in this PR.

## Related Links

Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; no user-facing or high-level architecture contract changed).
