### PR TITLE
perf: defer consistent-type-assertions edits

### DIFF
--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.go
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.go
@@ -30,6 +30,186 @@ type ConsistentTypeAssertionsOptions struct {
 	ArrayLiteralTypeAssertions  LiteralAssertion `json:"arrayLiteralTypeAssertions"`
 }
 
+const (
+	objectAnnotationSuggestionID       = "replaceObjectTypeAssertionWithAnnotation"
+	objectAnnotationSuggestionTemplate = "Use const x: {{cast}} = { ... } instead."
+	objectSatisfiesSuggestionID        = "replaceObjectTypeAssertionWithSatisfies"
+	objectSatisfiesSuggestionTemplate  = "Use const x = { ... } satisfies {{cast}} instead."
+	arrayAnnotationSuggestionID        = "replaceArrayTypeAssertionWithAnnotation"
+	arrayAnnotationSuggestionTemplate  = "Use const x: {{cast}} = [ ... ] instead."
+	arraySatisfiesSuggestionID         = "replaceArrayTypeAssertionWithSatisfies"
+	arraySatisfiesSuggestionTemplate   = "Use const x = [ ... ] satisfies {{cast}} instead."
+)
+
+var asExpressionPrecedence = ast.GetOperatorPrecedence(
+	ast.KindAsExpression,
+	ast.KindUnknown,
+	ast.OperatorPrecedenceFlagsNone,
+)
+
+type consistentTypeAssertionsEdits struct {
+	sourceFile *ast.SourceFile
+}
+
+// skipParensUp returns the first non-parenthesis ancestor of node. ESTree has
+// no parenthesis nodes, so upstream's node.parent is exactly this.
+func skipParensUp(node *ast.Node) *ast.Node {
+	parent := node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parent = parent.Parent
+	}
+	return parent
+}
+
+func substituteCast(template, cast string) string {
+	return strings.ReplaceAll(template, "{{cast}}", cast)
+}
+
+func wrappedCode(text string, nodePrecedence, parentPrecedence ast.OperatorPrecedence) string {
+	if nodePrecedence > parentPrecedence {
+		return text
+	}
+	return "(" + text + ")"
+}
+
+func (e consistentTypeAssertionsEdits) text(node *ast.Node) string {
+	return utils.TrimmedNodeText(e.sourceFile, node)
+}
+
+// textWithParentheses mirrors upstream getTextWithParentheses: the text of the
+// paren-stripped expression, wrapped in one pair of parentheses when it was
+// parenthesized in source.
+func (e consistentTypeAssertionsEdits) textWithParentheses(expression *ast.Node) string {
+	inner := ast.SkipParentheses(expression)
+	text := e.text(inner)
+	if inner != expression {
+		return "(" + text + ")"
+	}
+	return text
+}
+
+func (e consistentTypeAssertionsEdits) literalSuggestions(
+	node *ast.Node,
+	expression *ast.Node,
+	typeNode *ast.Node,
+	annotationID string,
+	annotationTemplate string,
+	satisfiesID string,
+	satisfiesTemplate string,
+) []rule.RuleSuggestion {
+	typeText := e.text(typeNode)
+	expressionText := e.textWithParentheses(expression)
+	suggestions := make([]rule.RuleSuggestion, 0, 2)
+	if effectiveParent := skipParensUp(node); effectiveParent != nil && effectiveParent.Kind == ast.KindVariableDeclaration {
+		if declaration := effectiveParent.AsVariableDeclaration(); declaration.Type == nil {
+			if name := declaration.Name(); name != nil {
+				suggestions = append(suggestions, rule.RuleSuggestion{
+					Message: rule.RuleMessage{
+						Id:          annotationID,
+						Description: substituteCast(annotationTemplate, typeText),
+						Data:        map[string]string{"cast": typeText},
+					},
+					FixesArr: []rule.RuleFix{
+						rule.RuleFixInsertAfter(name, ": "+typeText),
+						rule.RuleFixReplace(e.sourceFile, node, expressionText),
+					},
+				})
+			}
+		}
+	}
+	suggestions = append(suggestions, rule.RuleSuggestion{
+		Message: rule.RuleMessage{
+			Id:          satisfiesID,
+			Description: substituteCast(satisfiesTemplate, typeText),
+			Data:        map[string]string{"cast": typeText},
+		},
+		FixesArr: []rule.RuleFix{
+			rule.RuleFixReplace(e.sourceFile, node, expressionText),
+			rule.RuleFixInsertAfter(node, " satisfies "+typeText),
+		},
+	})
+	return suggestions
+}
+
+func (e consistentTypeAssertionsEdits) objectLiteralSuggestions(
+	node *ast.Node,
+	expression *ast.Node,
+	typeNode *ast.Node,
+) []rule.RuleSuggestion {
+	return e.literalSuggestions(
+		node,
+		expression,
+		typeNode,
+		objectAnnotationSuggestionID,
+		objectAnnotationSuggestionTemplate,
+		objectSatisfiesSuggestionID,
+		objectSatisfiesSuggestionTemplate,
+	)
+}
+
+func (e consistentTypeAssertionsEdits) arrayLiteralSuggestions(
+	node *ast.Node,
+	expression *ast.Node,
+	typeNode *ast.Node,
+) []rule.RuleSuggestion {
+	return e.literalSuggestions(
+		node,
+		expression,
+		typeNode,
+		arrayAnnotationSuggestionID,
+		arrayAnnotationSuggestionTemplate,
+		arraySatisfiesSuggestionID,
+		arraySatisfiesSuggestionTemplate,
+	)
+}
+
+// angleToAsFix converts an angle-bracket assertion into an as assertion,
+// preserving the same precedence wrapping as the upstream fixer.
+func (e consistentTypeAssertionsEdits) angleToAsFix(
+	node *ast.Node,
+	expression *ast.Node,
+	typeText string,
+) []rule.RuleFix {
+	innerExpression := ast.SkipParentheses(expression)
+	expressionText := wrappedCode(
+		e.text(innerExpression),
+		ast.GetExpressionPrecedence(innerExpression),
+		asExpressionPrecedence,
+	)
+	text := expressionText + " as " + typeText
+
+	parent := node.Parent
+	if parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		return []rule.RuleFix{rule.RuleFixReplace(e.sourceFile, node, text)}
+	}
+
+	parentKind := ast.KindUnknown
+	operatorKind := ast.KindUnknown
+	flags := ast.OperatorPrecedenceFlagsNone
+	if parent != nil {
+		parentKind = parent.Kind
+		switch parent.Kind {
+		case ast.KindBinaryExpression:
+			if operator := parent.AsBinaryExpression().OperatorToken; operator != nil {
+				operatorKind = operator.Kind
+			}
+		case ast.KindNewExpression:
+			newExpression := parent.AsNewExpression()
+			if newExpression.Arguments == nil || len(newExpression.Arguments.Nodes) == 0 {
+				flags = ast.OperatorPrecedenceFlagsNewWithoutArguments
+			}
+		}
+	}
+	parentPrecedence := ast.GetOperatorPrecedence(parentKind, operatorKind, flags)
+	return []rule.RuleFix{
+		rule.RuleFixReplace(
+			e.sourceFile,
+			node,
+			wrappedCode(text, asExpressionPrecedence, parentPrecedence),
+		),
+	}
+}
+
 // ConsistentTypeAssertionsRule is the rslint port of upstream
 // `@typescript-eslint/consistent-type-assertions`. It mirrors upstream v8
 // observably: the same diagnostics (message ids + texts), the same
@@ -64,10 +244,7 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		}
 	}
 
-	src := ctx.SourceFile
-	getText := func(n *ast.Node) string {
-		return utils.TrimmedNodeText(src, n)
-	}
+	edits := consistentTypeAssertionsEdits{sourceFile: ctx.SourceFile}
 
 	// isConst reports whether the assertion target is `const` (the `as const` /
 	// `<const>` assertion). Mirrors upstream `isConst`.
@@ -97,16 +274,6 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		}
 	}
 
-	// skipParensUp returns the first non-parenthesis ancestor of `node`. ESTree
-	// has no parenthesis nodes, so upstream's `node.parent` is exactly this.
-	skipParensUp := func(node *ast.Node) *ast.Node {
-		p := node.Parent
-		for p != nil && p.Kind == ast.KindParenthesizedExpression {
-			p = p.Parent
-		}
-		return p
-	}
-
 	// isAsParameter mirrors upstream `isAsParameter`: the assertion is in a
 	// position where an object/array literal is "passed" rather than assigned to
 	// a typeable binding (call / new / throw arguments, JSX expression
@@ -133,76 +300,6 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		return false
 	}
 
-	// asPrecedence is the precedence of an `x as T` expression — the pivot the
-	// angle-bracket→as autofix uses to decide where wrapping parens are needed.
-	asPrecedence := ast.GetOperatorPrecedence(ast.KindAsExpression, ast.KindUnknown, ast.OperatorPrecedenceFlagsNone)
-
-	// getWrappedCode mirrors upstream's helper of the same name: wrap `text` in
-	// parens unless its precedence is strictly higher than the surrounding
-	// context's.
-	getWrappedCode := func(text string, nodePrec, parentPrec ast.OperatorPrecedence) string {
-		if nodePrec > parentPrec {
-			return text
-		}
-		return "(" + text + ")"
-	}
-
-	subst := func(tmpl, cast string) string {
-		return strings.ReplaceAll(tmpl, "{{cast}}", cast)
-	}
-
-	// textWithParentheses mirrors upstream `getTextWithParentheses`: the text of
-	// the (paren-stripped) expression, wrapped in a single pair of parens when
-	// it was parenthesized in source. ESTree exposes only the inner node, so the
-	// wrapping is always exactly one level regardless of nesting depth.
-	textWithParentheses := func(exprRaw *ast.Node) string {
-		inner := ast.SkipParentheses(exprRaw)
-		t := getText(inner)
-		if inner != exprRaw {
-			return "(" + t + ")"
-		}
-		return t
-	}
-
-	// buildSuggestions mirrors upstream `getSuggestions`: an annotation
-	// suggestion (only when the assertion initializes a variable with no type
-	// annotation) plus a `satisfies` suggestion (always). `exprRaw` is the raw
-	// expression (parens preserved) — upstream uses `getTextWithParentheses`.
-	buildSuggestions := func(node, exprRaw, typeNode *ast.Node, annID, annTmpl, satID, satTmpl string) []rule.RuleSuggestion {
-		typeText := getText(typeNode)
-		exprText := textWithParentheses(exprRaw)
-		suggestions := make([]rule.RuleSuggestion, 0, 2)
-		if eff := skipParensUp(node); eff != nil && eff.Kind == ast.KindVariableDeclaration {
-			if vd := eff.AsVariableDeclaration(); vd.Type == nil {
-				if name := vd.Name(); name != nil {
-					suggestions = append(suggestions, rule.RuleSuggestion{
-						Message: rule.RuleMessage{
-							Id:          annID,
-							Description: subst(annTmpl, typeText),
-							Data:        map[string]string{"cast": typeText},
-						},
-						FixesArr: []rule.RuleFix{
-							rule.RuleFixInsertAfter(name, ": "+typeText),
-							rule.RuleFixReplace(src, node, exprText),
-						},
-					})
-				}
-			}
-		}
-		suggestions = append(suggestions, rule.RuleSuggestion{
-			Message: rule.RuleMessage{
-				Id:          satID,
-				Description: subst(satTmpl, typeText),
-				Data:        map[string]string{"cast": typeText},
-			},
-			FixesArr: []rule.RuleFix{
-				rule.RuleFixReplace(src, node, exprText),
-				rule.RuleFixInsertAfter(node, " satisfies "+typeText),
-			},
-		})
-		return suggestions
-	}
-
 	// checkObject / checkArray mirror upstream's checkExpressionForObjectAssertion
 	// / checkExpressionForArrayAssertion. `exprRaw` is the assertion's raw
 	// expression; the literal check uses the paren-stripped form.
@@ -217,12 +314,12 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 			return
 		}
 		if checkType(typeNode) {
-			ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{
+			ctx.ReportNodeWithDeferredSuggestions(node, rule.RuleMessage{
 				Id:          "unexpectedObjectTypeAssertion",
 				Description: "Always prefer const x: T = { ... }.",
-			}, buildSuggestions(node, exprRaw, typeNode,
-				"replaceObjectTypeAssertionWithAnnotation", "Use const x: {{cast}} = { ... } instead.",
-				"replaceObjectTypeAssertionWithSatisfies", "Use const x = { ... } satisfies {{cast}} instead.")...)
+			}, func() []rule.RuleSuggestion {
+				return edits.objectLiteralSuggestions(node, exprRaw, typeNode)
+			})
 		}
 	}
 
@@ -237,48 +334,13 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 			return
 		}
 		if checkType(typeNode) {
-			ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{
+			ctx.ReportNodeWithDeferredSuggestions(node, rule.RuleMessage{
 				Id:          "unexpectedArrayTypeAssertion",
 				Description: "Always prefer const x: T[] = [ ... ].",
-			}, buildSuggestions(node, exprRaw, typeNode,
-				"replaceArrayTypeAssertionWithAnnotation", "Use const x: {{cast}} = [ ... ] instead.",
-				"replaceArrayTypeAssertionWithSatisfies", "Use const x = [ ... ] satisfies {{cast}} instead.")...)
+			}, func() []rule.RuleSuggestion {
+				return edits.arrayLiteralSuggestions(node, exprRaw, typeNode)
+			})
 		}
-	}
-
-	// buildAngleToAsFix converts an angle-bracket assertion `<T>expr` into
-	// `expr as T`, wrapping the expression and/or the whole assertion in parens
-	// exactly where precedence requires. Mirrors upstream's `as` fixer.
-	buildAngleToAsFix := func(node, exprRaw, typeNode *ast.Node) rule.RuleFix {
-		skipExpr := ast.SkipParentheses(exprRaw)
-		exprText := getWrappedCode(getText(skipExpr), ast.GetExpressionPrecedence(skipExpr), asPrecedence)
-		text := exprText + " as " + getText(typeNode)
-
-		parent := node.Parent
-		if parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-			// Already parenthesized in source — the existing parens suffice.
-			return rule.RuleFixReplace(src, node, text)
-		}
-
-		parentKind := ast.KindUnknown
-		operatorKind := ast.KindUnknown
-		flags := ast.OperatorPrecedenceFlagsNone
-		if parent != nil {
-			parentKind = parent.Kind
-			switch parent.Kind {
-			case ast.KindBinaryExpression:
-				if op := parent.AsBinaryExpression().OperatorToken; op != nil {
-					operatorKind = op.Kind
-				}
-			case ast.KindNewExpression:
-				ne := parent.AsNewExpression()
-				if ne.Arguments == nil || len(ne.Arguments.Nodes) == 0 {
-					flags = ast.OperatorPrecedenceFlagsNewWithoutArguments
-				}
-			}
-		}
-		parentPrec := ast.GetOperatorPrecedence(parentKind, operatorKind, flags)
-		return rule.RuleFixReplace(src, node, getWrappedCode(text, asPrecedence, parentPrec))
 	}
 
 	// reportIncorrectAssertionType handles the assertion-style mismatch reports
@@ -292,17 +354,19 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		}
 		switch style {
 		case AssertionStyleAs:
-			cast := getText(typeNode)
-			ctx.ReportNodeWithFixes(node, rule.RuleMessage{
+			cast := edits.text(typeNode)
+			ctx.ReportNodeWithDeferredFixes(node, rule.RuleMessage{
 				Id:          "as",
-				Description: subst("Use 'as {{cast}}' instead of '<{{cast}}>'.", cast),
+				Description: substituteCast("Use 'as {{cast}}' instead of '<{{cast}}>'.", cast),
 				Data:        map[string]string{"cast": cast},
-			}, buildAngleToAsFix(node, exprRaw, typeNode))
+			}, func() []rule.RuleFix {
+				return edits.angleToAsFix(node, exprRaw, cast)
+			})
 		case AssertionStyleAngleBracket:
-			cast := getText(typeNode)
+			cast := edits.text(typeNode)
 			ctx.ReportNode(node, rule.RuleMessage{
 				Id:          "angle-bracket",
-				Description: subst("Use '<{{cast}}>' instead of 'as {{cast}}'.", cast),
+				Description: substituteCast("Use '<{{cast}}>' instead of 'as {{cast}}'.", cast),
 				Data:        map[string]string{"cast": cast},
 			})
 		case AssertionStyleNever:

--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions_test.go
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions_test.go
@@ -1,9 +1,13 @@
 package consistent_type_assertions
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -419,4 +423,122 @@ func TestConsistentTypeAssertionsRule(t *testing.T) {
 			}},
 		},
 	})
+}
+
+func TestConsistentTypeAssertionsEditDemand(t *testing.T) {
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`const angle = <Shape<number>>source;
+const object = ({ value: source }) as Shape<number>;
+const array = ([source]) as Array<number>;`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := []any{map[string]interface{}{
+		"assertionStyle":              "as",
+		"objectLiteralTypeAssertions": "never",
+		"arrayLiteralTypeAssertions":  "never",
+	}}
+	wantMessageIDs := []string{
+		"as",
+		"unexpectedObjectTypeAssertion",
+		"unexpectedArrayTypeAssertion",
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     ConsistentTypeAssertionsRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return ConsistentTypeAssertionsRule.Run(ctx, options)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != len(wantMessageIDs) {
+			t.Fatalf("demand %d: diagnostics = %d, want %d", demand, len(diagnostics), len(wantMessageIDs))
+		}
+		for index, messageID := range wantMessageIDs {
+			if diagnostics[index].Message.Id != messageID {
+				t.Fatalf(
+					"demand %d diagnostic %d: message id = %q, want %q",
+					demand,
+					index,
+					diagnostics[index].Message.Id,
+					messageID,
+				)
+			}
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index, allEditsDiagnostic := range allEdits {
+		for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly[index],
+			rule.EditDemandAutofix:    autofixOnly[index],
+			rule.EditDemandSuggestion: suggestionOnly[index],
+		} {
+			if got, want := withoutEdits(diagnostic), withoutEdits(allEditsDiagnostic); !reflect.DeepEqual(got, want) {
+				t.Errorf(
+					"diagnostic %d demand %d changed identity:\ngot  %#v\nwant %#v",
+					index,
+					demand,
+					got,
+					want,
+				)
+			}
+		}
+
+		if diagnosticsOnly[index].FixesPtr != nil || diagnosticsOnly[index].Suggestions != nil {
+			t.Errorf("diagnostic %d: diagnostics-only demand materialized edits", index)
+		}
+		if autofixOnly[index].Suggestions != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Errorf("diagnostic %d: demand materialized the wrong edit category", index)
+		}
+	}
+
+	if autofixOnly[0].FixesPtr == nil || !reflect.DeepEqual(autofixOnly[0].FixesPtr, allEdits[0].FixesPtr) {
+		t.Error("angle-bracket autofix differs between autofix and all-edits demands")
+	}
+	if suggestionOnly[0].Suggestions != nil || allEdits[0].Suggestions != nil {
+		t.Error("angle-bracket diagnostic unexpectedly materialized suggestions")
+	}
+
+	for index := 1; index < len(allEdits); index++ {
+		if autofixOnly[index].FixesPtr != nil || allEdits[index].FixesPtr != nil {
+			t.Errorf("literal diagnostic %d unexpectedly materialized autofixes", index)
+		}
+		if suggestionOnly[index].Suggestions == nil ||
+			!reflect.DeepEqual(suggestionOnly[index].Suggestions, allEdits[index].Suggestions) {
+			t.Errorf("literal diagnostic %d differs between suggestion and all-edits demands", index)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- defer angle-bracket autofixes and literal-assertion suggestions until their edit category is requested
- extract source rendering and precedence-sensitive replacement logic into a rule-local edit builder
- add combined autofix/suggestion demand coverage to the existing rule test file

### Architecture

Option parsing, AST matching, literal exemptions, parameter-position checks, and diagnostic messages remain in the rule listeners. `consistentTypeAssertionsEdits` owns only source-derived artifacts: annotation/satisfies suggestions and the precedence-aware angle-bracket-to-`as` replacement.

Each report uses the framework's category-specific deferred API. Suppressed diagnostics and diagnostics-only consumers therefore skip text extraction, replacement strings, maps, fix slices, and suggestion slices. Autofix and suggestion demand remain independent, and the all-edits path produces the same ordered artifacts as before.

This is isolated to the native rule implementation; it adds no `Program`, type-checker, or plugin-protocol coupling.

### Benchmarks

Post-rebase base: `c5de1d62`. Apple M1 Max, Go 1.26.1, `GOMAXPROCS=1`; 256 diagnostics per invocation, program setup excluded. Values are medians from 10 alternating paired samples at 300 ms each.

| Case | Demand | ns/op | B/op | allocs/op |
| --- | --- | ---: | ---: | ---: |
| angle → `as` | diagnostics only | 302,883 → 193,741 (-36.0%) | 331,272 → 187,832 (-43.3%) | 2,866 → 1,325 (-53.8%) |
| angle → `as` | all edits | 301,301 → 277,963 (-7.7%) | 331,272 → 290,152 (-12.4%) | 2,866 → 2,605 (-9.1%) |
| object literal suggestions | diagnostics only | 497,158 → 149,927 (-69.8%) | 495,192 → 44,472 (-91.0%) | 4,658 → 301 (-93.5%) |
| object literal suggestions | all edits | 509,548 → 504,532 (-1.0%) | 495,192 → 495,032 (-0.03%) | 4,658 → 4,653 |

The benchmark harness was temporary and is not included in this PR.

## Related Links

Related to #1336.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
