### PR TITLE
perf: defer prefer-function-type edits

### DIFF
--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.go
@@ -89,9 +89,157 @@ func collectCommentsForward(text string, start, limit int) []core.TextRange {
 	return result
 }
 
+type preferFunctionTypeFixer struct {
+	sourceFile *ast.SourceFile
+	sourceText string
+	lineStarts []core.TextPos
+}
+
+func shouldWrapFunctionTypeSuggestion(parent *ast.Node) bool {
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindUnionType, ast.KindIntersectionType, ast.KindArrayType:
+		return true
+	}
+	return false
+}
+
+// interfaceHeader returns the verbatim Name<TypeParams> text used to prefix
+// the rewritten type alias. Constraints, defaults, and variance markers are
+// preserved by slicing the source.
+func (f preferFunctionTypeFixer) interfaceHeader(
+	declaration *ast.InterfaceDeclaration,
+) string {
+	nameText := utils.TrimmedNodeText(f.sourceFile, declaration.Name())
+	if declaration.TypeParameters == nil || len(declaration.TypeParameters.Nodes) == 0 {
+		return nameText
+	}
+	parameters := declaration.TypeParameters.Nodes
+	lastParameter := parameters[len(parameters)-1]
+	lastParameterEnd := utils.TrimNodeTextRange(f.sourceFile, lastParameter).End()
+	greaterThanPosition := lastParameterEnd
+	for greaterThanPosition < len(f.sourceText) && f.sourceText[greaterThanPosition] != '>' {
+		greaterThanPosition++
+	}
+	if greaterThanPosition < len(f.sourceText) {
+		greaterThanPosition++
+	}
+	nameStart := utils.TrimNodeTextRange(f.sourceFile, declaration.Name()).Pos()
+	return f.sourceText[nameStart:greaterThanPosition]
+}
+
+func (f preferFunctionTypeFixer) fixes(member *ast.Node, node *ast.Node) []rule.RuleFix {
+	var returnType *ast.Node
+	switch member.Kind {
+	case ast.KindCallSignature:
+		returnType = member.AsCallSignatureDeclaration().Type
+	case ast.KindConstructSignature:
+		returnType = member.AsConstructSignatureDeclaration().Type
+	}
+	if returnType == nil {
+		return nil
+	}
+
+	isInterface := node.Kind == ast.KindInterfaceDeclaration
+	hasExport := isInterface && ast.HasSyntacticModifier(node, ast.ModifierFlagsExport)
+
+	memberRange := utils.TrimNodeTextRange(f.sourceFile, member)
+	memberStart := memberRange.Pos()
+	memberEnd := memberRange.End()
+	text := f.sourceText[memberStart:memberEnd]
+
+	returnTypeStart := utils.TrimNodeTextRange(f.sourceFile, returnType).Pos()
+	colonPosition := returnTypeStart - 1
+	for colonPosition >= memberStart && f.sourceText[colonPosition] != ':' {
+		colonPosition--
+	}
+	if colonPosition < memberStart {
+		return nil
+	}
+	colonOffset := colonPosition - memberStart
+
+	suggestion := text[:colonOffset] + " =>" + text[colonOffset+1:]
+	lastCharacter := ""
+	if strings.HasSuffix(suggestion, ";") {
+		lastCharacter = ";"
+		suggestion = suggestion[:len(suggestion)-1]
+	}
+
+	if shouldWrapFunctionTypeSuggestion(node.Parent) {
+		suggestion = "(" + suggestion + ")"
+	}
+
+	if isInterface {
+		declaration := node.AsInterfaceDeclaration()
+		suggestion = "type " + f.interfaceHeader(declaration) + " = " + suggestion + lastCharacter
+	}
+
+	nodeRange := utils.TrimNodeTextRange(f.sourceFile, node)
+	comments := append(
+		collectCommentsForward(f.sourceText, member.Pos(), memberStart),
+		collectCommentsForward(f.sourceText, memberEnd, nodeRange.End())...,
+	)
+	memberLine := scanner.ComputeLineOfPosition(f.lineStarts, memberStart)
+
+	var fixes []rule.RuleFix
+	if isInterface && hasExport {
+		var commentsText strings.Builder
+		for _, comment := range comments {
+			commentsText.WriteString(f.sourceText[comment.Pos():comment.End()])
+			commentsText.WriteByte('\n')
+		}
+		if commentsText.Len() > 0 {
+			fixes = append(fixes, rule.RuleFix{
+				Text:  commentsText.String(),
+				Range: core.NewTextRange(nodeRange.Pos(), nodeRange.Pos()),
+			})
+		}
+	} else {
+		for _, comment := range comments {
+			commentText := f.sourceText[comment.Pos():comment.End()]
+			if scanner.ComputeLineOfPosition(f.lineStarts, comment.Pos()) == memberLine {
+				commentText += " "
+			} else {
+				commentText += "\n"
+			}
+			suggestion = commentText + suggestion
+		}
+	}
+
+	replaceStart := nodeRange.Pos()
+	if isInterface {
+		modifiers := node.AsInterfaceDeclaration().Modifiers()
+		var scanFrom int
+		if modifiers != nil && len(modifiers.Nodes) > 0 {
+			scanFrom = modifiers.Nodes[len(modifiers.Nodes)-1].End()
+		} else {
+			scanFrom = nodeRange.Pos()
+		}
+		sourceScanner := scanner.GetScannerForSourceFile(f.sourceFile, scanFrom)
+		for sourceScanner.TokenStart() < nodeRange.End() {
+			if sourceScanner.Token() == ast.KindInterfaceKeyword {
+				replaceStart = sourceScanner.TokenStart()
+				break
+			}
+			sourceScanner.Scan()
+		}
+	}
+
+	fixes = append(fixes, rule.RuleFix{
+		Text:  suggestion,
+		Range: core.NewTextRange(replaceStart, nodeRange.End()),
+	})
+	return fixes
+}
+
 func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
-	sourceText := ctx.SourceFile.Text()
-	lineStarts := ctx.SourceFile.ECMALineMap()
+	fixer := preferFunctionTypeFixer{
+		sourceFile: ctx.SourceFile,
+		sourceText: ctx.SourceFile.Text(),
+		lineStarts: ctx.SourceFile.ECMALineMap(),
+	}
 
 	// hasOneNonFunctionSupertype mirrors upstream's hasOneSupertype(): an
 	// interface with `extends X[, Y, ...]` is skipped unless the only supertype
@@ -116,17 +264,6 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		}
 		expr := extends[0].AsExpressionWithTypeArguments().Expression
 		if expr == nil || expr.Kind != ast.KindIdentifier || expr.AsIdentifier().Text != "Function" {
-			return true
-		}
-		return false
-	}
-
-	shouldWrapSuggestion := func(parent *ast.Node) bool {
-		if parent == nil {
-			return false
-		}
-		switch parent.Kind {
-		case ast.KindUnionType, ast.KindIntersectionType, ast.KindArrayType:
 			return true
 		}
 		return false
@@ -167,29 +304,6 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return result
 	}
 
-	// buildInterfaceHeader returns the verbatim `Name<TypeParams>` text used to
-	// prefix the rewritten type alias. Includes the angle brackets when type
-	// parameters exist; constraints / defaults / variance markers are picked up
-	// for free because we slice raw source.
-	buildInterfaceHeader := func(iface *ast.InterfaceDeclaration) string {
-		nameText := utils.TrimmedNodeText(ctx.SourceFile, iface.Name())
-		if iface.TypeParameters == nil || len(iface.TypeParameters.Nodes) == 0 {
-			return nameText
-		}
-		params := iface.TypeParameters.Nodes
-		lastParam := params[len(params)-1]
-		lastParamEnd := utils.TrimNodeTextRange(ctx.SourceFile, lastParam).End()
-		gtPos := lastParamEnd
-		for gtPos < len(sourceText) && sourceText[gtPos] != '>' {
-			gtPos++
-		}
-		if gtPos < len(sourceText) {
-			gtPos++
-		}
-		nameStart := utils.TrimNodeTextRange(ctx.SourceFile, iface.Name()).Pos()
-		return sourceText[nameStart:gtPos]
-	}
-
 	checkMember := func(member *ast.Node, node *ast.Node, tsThisTypes []*ast.Node) {
 		var returnType *ast.Node
 		switch member.Kind {
@@ -225,114 +339,9 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 			return
 		}
 
-		memberRange := utils.TrimNodeTextRange(ctx.SourceFile, member)
-		memberStart := memberRange.Pos()
-		memberEnd := memberRange.End()
-		text := sourceText[memberStart:memberEnd]
-
-		// Find the ':' before the return type. The return type node starts at
-		// the type token itself (whitespace skipped); the ':' immediately
-		// precedes it (modulo whitespace).
-		returnTypeStart := utils.TrimNodeTextRange(ctx.SourceFile, returnType).Pos()
-		colonPos := returnTypeStart - 1
-		for colonPos >= memberStart && sourceText[colonPos] != ':' {
-			colonPos--
-		}
-		if colonPos < memberStart {
-			ctx.ReportNode(member, msg)
-			return
-		}
-		colonOffset := colonPos - memberStart
-
-		suggestion := text[:colonOffset] + " =>" + text[colonOffset+1:]
-		lastChar := ""
-		if strings.HasSuffix(suggestion, ";") {
-			lastChar = ";"
-			suggestion = suggestion[:len(suggestion)-1]
-		}
-
-		if shouldWrapSuggestion(node.Parent) {
-			suggestion = "(" + suggestion + ")"
-		}
-
-		if isInterface {
-			suggestion = "type " + buildInterfaceHeader(node.AsInterfaceDeclaration()) + " = " + suggestion + lastChar
-		}
-
-		nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
-
-		// Collect leading and trailing comments by scanning the trivia regions
-		// directly. tsgo's scanner.GetLeadingCommentRanges only collects line-
-		// boundary-adjacent comments, so it misses same-line inline blocks like
-		// `{ /* c */ (): void }` that the upstream rule needs to relocate.
-		// Trailing scan is capped at the containing node's end so comments
-		// outside the type-literal / interface body never leak in.
-		comments := append(
-			collectCommentsForward(sourceText, member.Pos(), memberStart),
-			collectCommentsForward(sourceText, memberEnd, nodeRange.End())...,
-		)
-
-		memberLine := scanner.ComputeLineOfPosition(lineStarts, memberStart)
-
-		var fixes []rule.RuleFix
-
-		// `export interface Foo` has comments moved before `export` so they
-		// don't end up between `export` and the resulting `type` declaration.
-		if isInterface && hasExport && !hasDefault {
-			var commentsText strings.Builder
-			for _, c := range comments {
-				commentsText.WriteString(sourceText[c.Pos():c.End()])
-				commentsText.WriteByte('\n')
-			}
-			if commentsText.Len() > 0 {
-				fixes = append(fixes, rule.RuleFix{
-					Text:  commentsText.String(),
-					Range: core.NewTextRange(nodeRange.Pos(), nodeRange.Pos()),
-				})
-			}
-		} else {
-			for _, c := range comments {
-				cText := sourceText[c.Pos():c.End()]
-				if scanner.ComputeLineOfPosition(lineStarts, c.Pos()) == memberLine {
-					cText += " "
-				} else {
-					cText += "\n"
-				}
-				suggestion = cText + suggestion
-			}
-		}
-
-		// For interfaces, only replace from the `interface` keyword onwards.
-		// Preserving the modifier prefix verbatim avoids dropping any trivia
-		// (e.g. comments) that lives between modifiers, exactly matching
-		// upstream's `replaceTextRange([declaration.range[0], ...])` semantics
-		// — ESTree's `declaration.range[0]` is the `interface` keyword, not
-		// the first modifier.
-		replaceStart := nodeRange.Pos()
-		if isInterface {
-			modifiers := node.AsInterfaceDeclaration().Modifiers()
-			var scanFrom int
-			if modifiers != nil && len(modifiers.Nodes) > 0 {
-				scanFrom = modifiers.Nodes[len(modifiers.Nodes)-1].End()
-			} else {
-				scanFrom = nodeRange.Pos()
-			}
-			s := scanner.GetScannerForSourceFile(ctx.SourceFile, scanFrom)
-			for s.TokenStart() < nodeRange.End() {
-				if s.Token() == ast.KindInterfaceKeyword {
-					replaceStart = s.TokenStart()
-					break
-				}
-				s.Scan()
-			}
-		}
-
-		fixes = append(fixes, rule.RuleFix{
-			Text:  suggestion,
-			Range: core.NewTextRange(replaceStart, nodeRange.End()),
+		ctx.ReportNodeWithDeferredFixes(member, msg, func() []rule.RuleFix {
+			return fixer.fixes(member, node)
 		})
-
-		ctx.ReportNodeWithFixes(member, msg, fixes...)
 	}
 
 	return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_extras_test.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type_extras_test.go
@@ -6,9 +6,13 @@
 package prefer_function_type
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -1208,6 +1212,124 @@ type Foo = () => void;
 				},
 			},
 		},
-
 	})
+}
+
+func TestPreferFunctionTypeEditDemand(t *testing.T) {
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`type Callable = { /* leading */ (value: number): Result<number>; /* trailing */ };
+export interface Exported<T extends number = number> { /* leading */ (value: T): Result<T>; }
+export default interface DefaultCallable { (): void; }
+interface ThisCallable { (): this; }`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantMessageIDs := []string{
+		"functionTypeOverCallableType",
+		"functionTypeOverCallableType",
+		"functionTypeOverCallableType",
+		"unexpectedThisOnFunctionOnlyInterface",
+	}
+	wantFixes := []bool{true, true, false, false}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     PreferFunctionTypeRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return PreferFunctionTypeRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != len(wantMessageIDs) {
+			t.Fatalf("demand %d: diagnostics = %d, want %d", demand, len(diagnostics), len(wantMessageIDs))
+		}
+		for index, messageID := range wantMessageIDs {
+			if diagnostics[index].Message.Id != messageID {
+				t.Fatalf(
+					"demand %d diagnostic %d: message id = %q, want %q",
+					demand,
+					index,
+					diagnostics[index].Message.Id,
+					messageID,
+				)
+			}
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index, allEditsDiagnostic := range allEdits {
+		for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly[index],
+			rule.EditDemandAutofix:    autofixOnly[index],
+			rule.EditDemandSuggestion: suggestionOnly[index],
+		} {
+			if got, want := withoutEdits(diagnostic), withoutEdits(allEditsDiagnostic); !reflect.DeepEqual(got, want) {
+				t.Errorf(
+					"diagnostic %d demand %d changed identity:\ngot  %#v\nwant %#v",
+					index,
+					demand,
+					got,
+					want,
+				)
+			}
+		}
+
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Errorf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		if !reflect.DeepEqual(autofixOnly[index].FixesPtr, allEditsDiagnostic.FixesPtr) {
+			t.Errorf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+		if wantFixes[index] {
+			if allEditsDiagnostic.FixesPtr == nil || len(*allEditsDiagnostic.FixesPtr) == 0 {
+				t.Errorf("diagnostic %d: all-edits demand produced no fixes", index)
+			}
+		} else if allEditsDiagnostic.FixesPtr != nil {
+			t.Errorf("diagnostic %d: non-fixable report materialized fixes", index)
+		}
+	}
+
+	for _, diagnostics := range [][]rule.RuleDiagnostic{
+		diagnosticsOnly,
+		autofixOnly,
+		suggestionOnly,
+		allEdits,
+	} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil {
+				t.Errorf("diagnostic %d: autofix-only rule materialized suggestions", index)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- defer callable-interface/type-literal replacements until autofixes are requested
- extract raw-source rewriting, comment relocation, generic headers, and replacement ranges into a rule-local fixer
- add edit-demand coverage for fixable, multi-fix, `export default`, and `this` diagnostics to the existing extras test file

### Architecture

The listeners retain all product semantics: member-shape matching, supertype handling, `this` diagnostics, message construction, and the `export default` non-fixable exception. `preferFunctionTypeFixer` receives only immutable per-file source handles and owns the expensive artifact path: colon lookup, function-type rendering, precedence wrapping, comment movement, interface-keyword scanning, and fix assembly.

The framework's deferred-fix API invokes that builder only after suppression and autofix-demand checks. Diagnostics-only consumers therefore avoid all source scanning and replacement allocation, while the all-edits path preserves the exact fix order and ranges locked by the upstream and extras suites.

This remains a native rule-local optimization with no `Program`, type-checker, or plugin-protocol coupling.

### Benchmarks

Base: `c5de1d62`. Apple M1 Max, Go 1.26.1, `GOMAXPROCS=1`; 256 diagnostics per invocation, program setup excluded. Values are medians from 10 alternating paired samples at 300 ms each.

| Case | Demand | ns/op | B/op | allocs/op |
| --- | --- | ---: | ---: | ---: |
| commented type literal | diagnostics only | 384,491 → 198,178 (-48.5%) | 343,208 → 150,648 (-56.1%) | 4,392 → 1,063 (-75.8%) |
| commented type literal | all edits | 387,458 → 386,778 (-0.2%) | 343,208 → 343,160 (-0.01%) | 4,392 → 4,391 |
| exported generic interface | diagnostics only | 516,308 → 230,254 (-55.4%) | 494,760 → 150,648 (-69.6%) | 4,648 → 1,063 (-77.1%) |
| exported generic interface | all edits | 508,824 → 498,968 (-1.9%) | 494,760 → 488,568 (-1.3%) | 4,648 → 4,391 (-5.5%) |

The benchmark harness was temporary and is not included in this PR.

## Related Links

Related to #1336.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
