### PR TITLE
perf: defer prefer-exponentiation-operator edits

### DIFF
--- a/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator.go
+++ b/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator.go
@@ -381,7 +381,7 @@ func nextAdjacentTokenText(sf *ast.SourceFile, pos int) (string, bool) {
 	return text[pos:end], true
 }
 
-func buildFix(sf *ast.SourceFile, node *ast.Node) *rule.RuleFix {
+func buildFixes(sf *ast.SourceFile, node *ast.Node) []rule.RuleFix {
 	call := node.AsCallExpression()
 	if call == nil || call.Arguments == nil {
 		return nil
@@ -441,26 +441,29 @@ func buildFix(sf *ast.SourceFile, node *ast.Node) *rule.RuleFix {
 		prefix = ";"
 	}
 
-	fix := rule.RuleFixReplaceRange(core.NewTextRange(nodeRange.Pos(), nodeRange.End()), prefix+replacement+suffix)
-	return &fix
+	return []rule.RuleFix{
+		rule.RuleFixReplaceRange(
+			core.NewTextRange(nodeRange.Pos(), nodeRange.End()),
+			prefix+replacement+suffix,
+		),
+	}
 }
 
 // https://eslint.org/docs/latest/rules/prefer-exponentiation-operator
 var PreferExponentiationOperatorRule = rule.Rule{
 	Name: "prefer-exponentiation-operator",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		sourceFile := ctx.SourceFile
+		message := buildUseExponentiationMessage()
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
 				if !isMathPowCall(node, ctx.Globals) {
 					return
 				}
 
-				if fix := buildFix(ctx.SourceFile, node); fix != nil {
-					ctx.ReportNodeWithFixes(node, buildUseExponentiationMessage(), *fix)
-					return
-				}
-
-				ctx.ReportNode(node, buildUseExponentiationMessage())
+				ctx.ReportNodeWithDeferredFixes(node, message, func() []rule.RuleFix {
+					return buildFixes(sourceFile, node)
+				})
 			},
 		}
 	},

--- a/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator_extras_test.go
+++ b/internal/rules/prefer_exponentiation_operator/prefer_exponentiation_operator_extras_test.go
@@ -1,9 +1,13 @@
 package prefer_exponentiation_operator
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -159,4 +163,110 @@ func TestPreferExponentiationOperatorExtras(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestPreferExponentiationOperatorEditDemand(t *testing.T) {
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`const fixed = left + Math.pow((base + 1), condition ? 2 : 3) * right;
+const kept = Math.pow(base /* keep */, exponent);`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     PreferExponentiationOperatorRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return PreferExponentiationOperatorRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: diagnostics = %d, want 2", demand, len(diagnostics))
+		}
+		for index, diagnostic := range diagnostics {
+			if diagnostic.Message.Id != "useExponentiation" {
+				t.Fatalf(
+					"demand %d diagnostic %d: message id = %q, want useExponentiation",
+					demand,
+					index,
+					diagnostic.Message.Id,
+				)
+			}
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index, allEditsDiagnostic := range allEdits {
+		for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly[index],
+			rule.EditDemandAutofix:    autofixOnly[index],
+			rule.EditDemandSuggestion: suggestionOnly[index],
+		} {
+			if got, want := withoutEdits(diagnostic), withoutEdits(allEditsDiagnostic); !reflect.DeepEqual(got, want) {
+				t.Errorf(
+					"diagnostic %d demand %d changed identity:\ngot  %#v\nwant %#v",
+					index,
+					demand,
+					got,
+					want,
+				)
+			}
+		}
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Errorf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		if !reflect.DeepEqual(autofixOnly[index].FixesPtr, allEditsDiagnostic.FixesPtr) {
+			t.Errorf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+	}
+
+	if allEdits[0].FixesPtr == nil || len(*allEdits[0].FixesPtr) != 1 {
+		t.Error("fixable Math.pow diagnostic did not produce exactly one fix")
+	}
+	if allEdits[1].FixesPtr != nil {
+		t.Error("commented Math.pow diagnostic unexpectedly produced a fix")
+	}
+	for _, diagnostics := range [][]rule.RuleDiagnostic{
+		diagnosticsOnly,
+		autofixOnly,
+		suggestionOnly,
+		allEdits,
+	} {
+		for index, diagnostic := range diagnostics {
+			if diagnostic.Suggestions != nil {
+				t.Errorf("diagnostic %d: autofix-only rule materialized suggestions", index)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- defer `Math.pow` replacement analysis until autofixes are requested
- have the existing precedence/comment-aware builder return the framework's fix slice directly
- add edit-demand coverage for both a complex fixable call and a comment-preserving non-fixable call

### Architecture

Global `Math.pow` recognition and diagnostic reporting remain in the call-expression listener. The existing source-aware builder still owns every fixability and rendering decision: argument/spread checks, comment safety, base/exponent/whole-expression precedence, token adjacency, ASI protection, and replacement range construction.

The listener now reports through the framework's deferred-fix API. Suppressed diagnostics and diagnostics-only consumers skip the entire builder, while autofix consumers receive the same single fix or an empty result for non-fixable calls. No `Program`, type-checker, or plugin-protocol dependency is introduced.

### Benchmarks

Base: `c5de1d62`. Apple M1 Max, Go 1.26.1, `GOMAXPROCS=1`; 256 diagnostics per invocation, program setup excluded. Values are medians from 10 alternating paired samples at 300 ms each.

| Case | Demand | ns/op | B/op | allocs/op |
| --- | --- | ---: | ---: | ---: |
| precedence-heavy fix | diagnostics only | 3,851,564 → 1,012,664 (-73.7%) | 2,552,848 → 44,096 (-98.3%) | 49,956 → 292 (-99.4%) |
| precedence-heavy fix | all edits | 3,880,685 → 3,754,534 (-3.3%) | 2,552,848 → 2,546,752 (-0.24%) | 49,956 → 49,700 (-0.51%) |
| comment-preserving no-fix | diagnostics only | 2,219,487 → 926,260 (-58.3%) | 1,154,064 → 44,096 (-96.2%) | 23,076 → 292 (-98.7%) |
| comment-preserving no-fix | all edits | 2,272,799 → 2,159,618 (-5.0%) | 1,154,064 → 1,160,256 (+0.54%) | 23,076 → 23,332 (+1.1%) |

The no-fix all-edits allocation delta is one 24-byte deferred callback environment per diagnostic. It is only paid when autofixes are requested and the builder must run before determining that an internal comment makes the call non-fixable; diagnostics-only consumers avoid that work entirely.

The benchmark harness was temporary and is not included in this PR.

## Related Links

Related to #1336.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
