### PR TITLE
perf: defer TypeScript dot-notation edits

### DIFF
--- a/internal/plugins/typescript/rules/dot_notation/dot_notation.go
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation.go
@@ -152,6 +152,94 @@ func literalKey(n *ast.Node) (string, bool) {
 	return "", false
 }
 
+type dotNotationFixer struct {
+	sourceFile *ast.SourceFile
+	sourceText string
+}
+
+// buildUseDotFix constructs the bracket-to-dot replacement after the rule has
+// already decided to report. Keeping source ranges, comment inspection, and
+// replacement text construction here lets diagnostics-only consumers skip
+// every fix-specific source operation.
+func (f *dotNotationFixer) buildUseDotFix(
+	node *ast.Node,
+	elem *ast.ElementAccessExpression,
+	propName string,
+) []rule.RuleFix {
+	nodeRange := utils.TrimNodeTextRange(f.sourceFile, node)
+	exprRange := utils.TrimNodeTextRange(f.sourceFile, elem.Expression)
+
+	bracketStart := exprRange.End()
+	for bracketStart < nodeRange.End() && f.sourceText[bracketStart] != '[' {
+		bracketStart++
+	}
+	bracketEnd := nodeRange.End() - 1
+	for bracketEnd > bracketStart && f.sourceText[bracketEnd] != ']' {
+		bracketEnd--
+	}
+
+	insideBrackets := core.NewTextRange(bracketStart+1, bracketEnd)
+	if utils.HasCommentsInRange(f.sourceFile, insideBrackets) {
+		return nil
+	}
+
+	whitespace := ""
+	if bracketStart > exprRange.End() {
+		whitespace = f.sourceText[exprRange.End():bracketStart]
+	}
+	objectText := f.sourceText[exprRange.Pos():exprRange.End()]
+	replacement := objectText + whitespace + "." + propName
+
+	return []rule.RuleFix{rule.RuleFixReplace(f.sourceFile, node, replacement)}
+}
+
+// buildUseBracketsFix constructs the dot-to-bracket replacement after the
+// keyword access has been detected. It deliberately preserves the existing
+// whole-node replacement and trivia behavior; this helper only changes when
+// the work is materialized.
+func (f *dotNotationFixer) buildUseBracketsFix(
+	node *ast.Node,
+	pae *ast.PropertyAccessExpression,
+	name string,
+	isOptional bool,
+) []rule.RuleFix {
+	nameRange := utils.TrimNodeTextRange(f.sourceFile, pae.Name())
+	objRange := utils.TrimNodeTextRange(f.sourceFile, pae.Expression)
+
+	// Locate the start of the access operator — either `?.` (optional
+	// chain) or `.`. Any whitespace between the object end and the
+	// operator belongs to the replacement.
+	accessStart := objRange.End()
+	for accessStart < nameRange.Pos() && f.sourceText[accessStart] != '?' && f.sourceText[accessStart] != '.' {
+		accessStart++
+	}
+
+	// Suppress autofix if a comment lives between the operator and the
+	// property name (ESLint parity). The operator is 1 byte for `.` or
+	// 2 bytes for `?.`.
+	opLen := 1
+	if f.sourceText[accessStart] == '?' {
+		opLen = 2
+	}
+	gapStart := accessStart + opLen
+	if gapStart > nameRange.Pos() {
+		gapStart = nameRange.Pos()
+	}
+	if utils.HasCommentsInRange(f.sourceFile, core.NewTextRange(gapStart, nameRange.Pos())) {
+		return nil
+	}
+
+	objectText := f.sourceText[objRange.Pos():objRange.End()]
+	preOp := f.sourceText[objRange.End():accessStart] // whitespace before operator
+	var replacement string
+	if isOptional {
+		replacement = objectText + preOp + "?.[\"" + name + "\"]"
+	} else {
+		replacement = objectText + preOp + "[\"" + name + "\"]"
+	}
+	return []rule.RuleFix{rule.RuleFixReplace(f.sourceFile, node, replacement)}
+}
+
 // DotNotationRule enforces dot-notation when safe and allowed by options.
 //
 // KNOWN LIMITATION: The test infrastructure in /packages/rule-tester doesn't properly pass
@@ -183,6 +271,10 @@ var DotNotationRule = rule.CreateRule(rule.Rule{
 			_ = ctx.Program.Options()
 		}
 
+		fixer := dotNotationFixer{
+			sourceFile: ctx.SourceFile,
+			sourceText: ctx.SourceFile.Text(),
+		}
 		listeners := rule.RuleListeners{}
 
 		// Compute allowIndexSignaturePropertyAccess once — respects both the
@@ -273,36 +365,9 @@ var DotNotationRule = rule.CreateRule(rule.Rule{
 				}
 			}
 
-			// Build the fix: replace `['prop']` with `.prop`, preserving any
-			// whitespace between the object and the bracket. Skip the fix if a
-			// comment lives inside the brackets (ESLint behavior).
-			text := ctx.SourceFile.Text()
-			nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
-			exprRange := utils.TrimNodeTextRange(ctx.SourceFile, elem.Expression)
-
-			bracketStart := exprRange.End()
-			for bracketStart < nodeRange.End() && text[bracketStart] != '[' {
-				bracketStart++
-			}
-			bracketEnd := nodeRange.End() - 1
-			for bracketEnd > bracketStart && text[bracketEnd] != ']' {
-				bracketEnd--
-			}
-
-			insideBrackets := core.NewTextRange(bracketStart+1, bracketEnd)
-			if utils.HasCommentsInRange(ctx.SourceFile, insideBrackets) {
-				ctx.ReportNode(elem.ArgumentExpression, buildUseDotMessage())
-				return
-			}
-
-			whitespace := ""
-			if bracketStart > exprRange.End() {
-				whitespace = text[exprRange.End():bracketStart]
-			}
-			objectText := text[exprRange.Pos():exprRange.End()]
-			replacement := objectText + whitespace + "." + propName
-
-			ctx.ReportNodeWithFixes(elem.ArgumentExpression, buildUseDotMessage(), rule.RuleFixReplace(ctx.SourceFile, node, replacement))
+			ctx.ReportNodeWithDeferredFixes(elem.ArgumentExpression, buildUseDotMessage(), func() []rule.RuleFix {
+				return fixer.buildUseDotFix(node, elem, propName)
+			})
 		}
 
 		// Handle dot → bracket (PropertyAccessExpression) when keywords are disallowed.
@@ -333,43 +398,9 @@ var DotNotationRule = rule.CreateRule(rule.Rule{
 				return
 			}
 
-			text := ctx.SourceFile.Text()
-			nameRange := utils.TrimNodeTextRange(ctx.SourceFile, pae.Name())
-			objRange := utils.TrimNodeTextRange(ctx.SourceFile, pae.Expression)
-
-			// Locate the start of the access operator — either `?.` (optional
-			// chain) or `.`. Any whitespace between the object end and the
-			// operator belongs to the replacement.
-			accessStart := objRange.End()
-			for accessStart < nameRange.Pos() && text[accessStart] != '?' && text[accessStart] != '.' {
-				accessStart++
-			}
-
-			// Suppress autofix if a comment lives between the operator and the
-			// property name (ESLint parity). The operator is 1 byte for `.` or
-			// 2 bytes for `?.`.
-			opLen := 1
-			if text[accessStart] == '?' {
-				opLen = 2
-			}
-			gapStart := accessStart + opLen
-			if gapStart > nameRange.Pos() {
-				gapStart = nameRange.Pos()
-			}
-			if utils.HasCommentsInRange(ctx.SourceFile, core.NewTextRange(gapStart, nameRange.Pos())) {
-				ctx.ReportNode(pae.Name(), buildUseBracketsMessage(name))
-				return
-			}
-
-			objectText := text[objRange.Pos():objRange.End()]
-			preOp := text[objRange.End():accessStart] // whitespace before operator
-			var replacement string
-			if isOptional {
-				replacement = objectText + preOp + "?.[\"" + name + "\"]"
-			} else {
-				replacement = objectText + preOp + "[\"" + name + "\"]"
-			}
-			ctx.ReportNodeWithFixes(pae.Name(), buildUseBracketsMessage(name), rule.RuleFixReplace(ctx.SourceFile, node, replacement))
+			ctx.ReportNodeWithDeferredFixes(pae.Name(), buildUseBracketsMessage(name), func() []rule.RuleFix {
+				return fixer.buildUseBracketsFix(node, pae, name, isOptional)
+			})
 		}
 
 		return listeners

--- a/internal/plugins/typescript/rules/dot_notation/dot_notation_test.go
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation_test.go
@@ -1,9 +1,14 @@
 package dot_notation
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -79,9 +84,9 @@ func TestDotNotationRule(t *testing.T) {
 		{Code: "a['with-dash'];"},
 		{Code: "a['has space'];"},
 		{Code: "a[''];"},
-		{Code: "a['12valid'];"},       // starts with digit
-		{Code: "a['\\n'];"},            // contains newline
-		{Code: "a['it\\'s'];"},         // contains quote
+		{Code: "a['12valid'];"}, // starts with digit
+		{Code: "a['\\n'];"},     // contains newline
+		{Code: "a['it\\'s'];"},  // contains quote
 		{Code: "a['$ok'];", Options: map[string]interface{}{"allowPattern": "^\\$"}}, // starts with $ but allowPattern matches
 
 		// --- #2 non-ASCII identifier-looking strings (ESLint ASCII-only regex skips them) ---
@@ -316,4 +321,102 @@ func TestDotNotationRule(t *testing.T) {
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
 		},
 	})
+}
+
+func TestDotNotationEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"declare const object: { property: string; commented: string; while: string };\n"+
+			"object['property'];\n"+
+			"object[/* keep */ 'commented'];\n"+
+			"object?.while;\n"+
+			"object./* keep */ while;\n"+
+			"let.if();",
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := []any{map[string]interface{}{"allowKeywords": false}}
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:             DotNotationRule.Name,
+					Severity:         rule.SeverityError,
+					RequiresTypeInfo: DotNotationRule.RequiresTypeInfo,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return DotNotationRule.Run(ctx, options)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 5 {
+			t.Fatalf("demand %d: diagnostics = %d, want 5", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnostics := map[rule.EditDemand][]rule.RuleDiagnostic{
+		rule.EditDemandNone:       run(rule.EditDemandNone),
+		rule.EditDemandAutofix:    run(rule.EditDemandAutofix),
+		rule.EditDemandSuggestion: run(rule.EditDemandSuggestion),
+		rule.EditDemandAll:        run(rule.EditDemandAll),
+	}
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+
+	for index := range diagnostics[rule.EditDemandAll] {
+		want := withoutEdits(diagnostics[rule.EditDemandAll][index])
+		for demand, demandDiagnostics := range diagnostics {
+			if got := withoutEdits(demandDiagnostics[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("diagnostic %d changed for demand %d:\ngot:  %#v\nwant: %#v", index, demand, got, want)
+			}
+			if demandDiagnostics[index].Suggestions != nil {
+				t.Errorf("diagnostic %d demand %d unexpectedly has suggestions", index, demand)
+			}
+		}
+	}
+
+	wantFix := []bool{true, false, true, false, false}
+	wantText := []string{"object.property", "", "object?.[\"while\"]", "", ""}
+	for index, shouldFix := range wantFix {
+		autofix := diagnostics[rule.EditDemandAutofix][index].FixesPtr
+		allEdits := diagnostics[rule.EditDemandAll][index].FixesPtr
+		if (autofix != nil) != shouldFix {
+			t.Errorf("diagnostic %d fix presence = %v, want %v", index, autofix != nil, shouldFix)
+		}
+		if !reflect.DeepEqual(autofix, allEdits) {
+			t.Errorf("diagnostic %d fixes differ between autofix and all-edits demand", index)
+		}
+		if shouldFix {
+			if len(*autofix) != 1 || (*autofix)[0].Text != wantText[index] {
+				t.Errorf("diagnostic %d fixes = %#v, want replacement %q", index, *autofix, wantText[index])
+			}
+		}
+		if diagnostics[rule.EditDemandNone][index].FixesPtr != nil ||
+			diagnostics[rule.EditDemandSuggestion][index].FixesPtr != nil {
+			t.Errorf("diagnostic %d attached fixes without autofix demand", index)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Defer TypeScript `dot-notation` source-range scans, comment checks, and replacement construction until autofixes are requested.
- Preserve every option and TypeChecker gate, diagnostic range/message, comment no-fix guard, `let` guard, optional-chain spelling, whitespace, and whole-node replacement behavior.
- Add edit-demand coverage for fixable and non-fixable bracket/dot reports across all four demand modes.

### Architecture

Detection remains entirely in the existing type-aware listeners. A rule-local, source-only fixer owns the immutable SourceFile/text handles and materializes the two existing replacement algorithms behind `ReportNodeWithDeferredFixes`. It has no Program or TypeChecker dependency; the pre-existing type-aware eligibility checks run exactly as before.

The core and TypeScript `dot-notation` fixers are intentionally not shared: the newly merged core implementation uses token-bounded partial replacements and additional lexical guards, while the TypeScript implementation has an existing whole-node replacement contract. Sharing them in this performance-only PR would change observable fixes and couple two independently registered rules.

This PR is based directly on `main` and is independent of the other rule migrations.

### Benchmarks

Apple M1 Max, GOMAXPROCS=1, 256 diagnostics per invocation, 10 alternating base/candidate samples, 300 ms per sample; values are medians from an uncommitted benchmark run against the rule's pre-change baseline:

| Case | Demand | Base | This PR | Time |
| --- | --- | ---: | ---: | ---: |
| Bracket, fixable | diagnostics | 465.5 us, 597090 B, 5156 allocs | 98.52 us, 44184 B, 293 allocs | -78.8% |
| Bracket, comment/no fix | diagnostics | 395.5 us, 506978 B, 3108 allocs | 113.9 us, 44184 B, 293 allocs | -71.2% |
| Optional keyword, fixable | diagnostics | 435.0 us, 597088 B, 5156 allocs | 67.66 us, 44184 B, 293 allocs | -84.4% |
| Bracket, fixable | all edits | 462.6 us, 597090 B, 5156 allocs | 465.9 us, 597146 B, 5157 allocs | +0.7% |
| Bracket, comment/no fix | all edits | 398.2 us, 506978 B, 3108 allocs | 393.5 us, 507034 B, 3109 allocs | -1.2% |
| Optional keyword, fixable | all edits | 436.8 us, 597088 B, 5156 allocs | 436.2 us, 597144 B, 5157 allocs | -0.1% |

The all-edits path adds only one fixed 56 B allocation per 256-diagnostic rule run; there is no per-diagnostic allocation growth.

## Related Links

- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). The framework contract and external rule behavior are unchanged.