### PR TITLE
perf: defer no-unnecessary-type-conversion suggestions

### DIFF
--- a/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.go
@@ -70,22 +70,79 @@ func wrappedInnerText(sourceFile *ast.SourceFile, innerNode *ast.Node) string {
 	return text
 }
 
-// buildWrappingFix produces the replacement text for `outerNode` constructed
-// from `innerNode`'s text. When `wrap` is nil the inner text replaces the
-// outer node directly; when `wrap` is provided the result is additionally
-// wrapped in parens if the surrounding context could rebind precedence.
-func buildWrappingFix(sourceFile *ast.SourceFile, outerNode *ast.Node, innerNode *ast.Node, wrap func(string) string) rule.RuleFix {
-	innerCode := wrappedInnerText(sourceFile, innerNode)
-	var code string
-	if wrap == nil {
-		code = innerCode
-	} else {
-		code = wrap(innerCode)
-		if typescriptutil.IsWeakPrecedenceParent(outerNode) {
-			code = "(" + code + ")"
-		}
+type conversionSuggestionBuilder struct {
+	sourceFile *ast.SourceFile
+}
+
+func (b *conversionSuggestionBuilder) buildRemoveFix(
+	outerRange core.TextRange,
+	innerCode string,
+	removeNode *ast.Node,
+) rule.RuleFix {
+	removeFix := rule.RuleFixReplaceRange(outerRange, innerCode)
+	if removeNode != nil {
+		removeFix = rule.RuleFixRemoveRange(utils.TrimNodeTextRange(b.sourceFile, removeNode))
 	}
-	return rule.RuleFixReplace(sourceFile, outerNode, code)
+	return removeFix
+}
+
+// build constructs the two suggestions shared by every report in this rule.
+// removeNode is non-nil only for a standalone `value += ”` expression, where
+// the remove suggestion deletes the entire statement instead of replacing the
+// conversion expression with its inner value.
+func (b *conversionSuggestionBuilder) build(
+	outerNode *ast.Node,
+	innerNode *ast.Node,
+	typeName string,
+	removeNode *ast.Node,
+) []rule.RuleSuggestion {
+	innerCode := wrappedInnerText(b.sourceFile, innerNode)
+	outerRange := utils.TrimNodeTextRange(b.sourceFile, outerNode)
+	satisfiesCode := innerCode + " satisfies " + typeName
+	if typescriptutil.IsWeakPrecedenceParent(outerNode) {
+		satisfiesCode = "(" + satisfiesCode + ")"
+	}
+
+	return []rule.RuleSuggestion{
+		{
+			Message: buildSuggestRemoveMessage(),
+			FixesArr: []rule.RuleFix{
+				b.buildRemoveFix(outerRange, innerCode, removeNode),
+			},
+		},
+		{
+			Message: buildSuggestSatisfiesMessage(typeName),
+			FixesArr: []rule.RuleFix{
+				rule.RuleFixReplaceRange(outerRange, satisfiesCode),
+			},
+		},
+	}
+}
+
+func (b *conversionSuggestionBuilder) buildString(
+	outerNode *ast.Node,
+	innerNode *ast.Node,
+	removeNode *ast.Node,
+) []rule.RuleSuggestion {
+	innerCode := wrappedInnerText(b.sourceFile, innerNode)
+	outerRange := utils.TrimNodeTextRange(b.sourceFile, outerNode)
+	satisfiesCode := innerCode + " satisfies string"
+	if typescriptutil.IsWeakPrecedenceParent(outerNode) {
+		satisfiesCode = "(" + satisfiesCode + ")"
+	}
+
+	return []rule.RuleSuggestion{
+		{
+			Message: buildSuggestRemoveMessage(),
+			FixesArr: []rule.RuleFix{
+				b.buildRemoveFix(outerRange, innerCode, removeNode),
+			},
+		},
+		{
+			Message:  buildSuggestSatisfiesMessage("string"),
+			FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(outerRange, satisfiesCode)},
+		},
+	}
 }
 
 // argumentSkippingParens unwraps any ParenthesizedExpression chain so that the
@@ -335,6 +392,7 @@ var NoUnnecessaryTypeConversionRule = rule.CreateRule(rule.Rule{
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		sourceFile := ctx.SourceFile
+		suggestions := conversionSuggestionBuilder{sourceFile: sourceFile}
 
 		// reportUnaryConversion reports unary-operator-style conversions (`+x`,
 		// `!!x`, `~~x`). `outerNode` is the report anchor (the full `!!` /
@@ -344,17 +402,11 @@ var NoUnnecessaryTypeConversionRule = rule.CreateRule(rule.Rule{
 			outerRange := utils.TrimNodeTextRange(sourceFile, outerNode)
 			opStart := utils.TrimNodeTextRange(sourceFile, opStartNode).Pos()
 			reportRange := core.NewTextRange(outerRange.Pos(), opStart+1)
-			ctx.ReportRangeWithSuggestions(reportRange,
+			ctx.ReportRangeWithDeferredSuggestions(
+				reportRange,
 				buildUnnecessaryTypeConversionMessage(violation, typeName),
-				rule.RuleSuggestion{
-					Message:  buildSuggestRemoveMessage(),
-					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, outerNode, innerArgument, nil)},
-				},
-				rule.RuleSuggestion{
-					Message: buildSuggestSatisfiesMessage(typeName),
-					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, outerNode, innerArgument, func(code string) string {
-						return code + " satisfies " + typeName
-					})},
+				func() []rule.RuleSuggestion {
+					return suggestions.build(outerNode, innerArgument, typeName, nil)
 				},
 			)
 		}
@@ -363,17 +415,11 @@ var NoUnnecessaryTypeConversionRule = rule.CreateRule(rule.Rule{
 			typeName := strings.ToLower(fnName)
 			violation := "Passing a " + typeName + " to " + fnName + "()"
 			calleeRange := utils.TrimNodeTextRange(sourceFile, calleeIdentifier)
-			ctx.ReportRangeWithSuggestions(calleeRange,
+			ctx.ReportRangeWithDeferredSuggestions(
+				calleeRange,
 				buildUnnecessaryTypeConversionMessage(violation, typeName),
-				rule.RuleSuggestion{
-					Message:  buildSuggestRemoveMessage(),
-					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, callNode, innerArg, nil)},
-				},
-				rule.RuleSuggestion{
-					Message: buildSuggestSatisfiesMessage(typeName),
-					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, callNode, innerArg, func(code string) string {
-						return code + " satisfies " + typeName
-					})},
+				func() []rule.RuleSuggestion {
+					return suggestions.build(callNode, innerArg, typeName, nil)
 				},
 			)
 		}
@@ -382,17 +428,11 @@ var NoUnnecessaryTypeConversionRule = rule.CreateRule(rule.Rule{
 			propertyRange := utils.TrimNodeTextRange(sourceFile, propertyIdent)
 			callRange := utils.TrimNodeTextRange(sourceFile, callNode)
 			reportRange := core.NewTextRange(propertyRange.Pos(), callRange.End())
-			ctx.ReportRangeWithSuggestions(reportRange,
+			ctx.ReportRangeWithDeferredSuggestions(
+				reportRange,
 				buildUnnecessaryTypeConversionMessage("Calling a string's .toString() method", "string"),
-				rule.RuleSuggestion{
-					Message:  buildSuggestRemoveMessage(),
-					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, callNode, innerObject, nil)},
-				},
-				rule.RuleSuggestion{
-					Message: buildSuggestSatisfiesMessage("string"),
-					FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, callNode, innerObject, func(code string) string {
-						return code + " satisfies string"
-					})},
+				func() []rule.RuleSuggestion {
+					return suggestions.buildString(callNode, innerObject, nil)
 				},
 			)
 		}
@@ -423,22 +463,16 @@ var NoUnnecessaryTypeConversionRule = rule.CreateRule(rule.Rule{
 				}
 
 				inner := argumentSkippingParens(left)
-				removeFix := buildWrappingFix(sourceFile, node, inner, nil)
+				var removeNode *ast.Node
 				if node.Parent != nil && node.Parent.Kind == ast.KindExpressionStatement {
-					removeFix = rule.RuleFixRemoveRange(utils.TrimNodeTextRange(sourceFile, node.Parent))
+					removeNode = node.Parent
 				}
 
-				ctx.ReportNodeWithSuggestions(node,
+				ctx.ReportNodeWithDeferredSuggestions(
+					node,
 					buildUnnecessaryTypeConversionMessage("Concatenating a string with ''", "string"),
-					rule.RuleSuggestion{
-						Message:  buildSuggestRemoveMessage(),
-						FixesArr: []rule.RuleFix{removeFix},
-					},
-					rule.RuleSuggestion{
-						Message: buildSuggestSatisfiesMessage("string"),
-						FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, node, inner, func(code string) string {
-							return code + " satisfies string"
-						})},
+					func() []rule.RuleSuggestion {
+						return suggestions.buildString(node, inner, removeNode)
 					},
 				)
 
@@ -458,17 +492,11 @@ var NoUnnecessaryTypeConversionRule = rule.CreateRule(rule.Rule{
 					nodeRange := utils.TrimNodeTextRange(sourceFile, node)
 					reportRange := core.NewTextRange(innerRange.End(), nodeRange.End())
 
-					ctx.ReportRangeWithSuggestions(reportRange,
+					ctx.ReportRangeWithDeferredSuggestions(
+						reportRange,
 						buildUnnecessaryTypeConversionMessage("Concatenating a string with ''", "string"),
-						rule.RuleSuggestion{
-							Message:  buildSuggestRemoveMessage(),
-							FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, node, inner, nil)},
-						},
-						rule.RuleSuggestion{
-							Message: buildSuggestSatisfiesMessage("string"),
-							FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, node, inner, func(code string) string {
-								return code + " satisfies string"
-							})},
+						func() []rule.RuleSuggestion {
+							return suggestions.buildString(node, inner, nil)
 						},
 					)
 					return
@@ -487,17 +515,11 @@ var NoUnnecessaryTypeConversionRule = rule.CreateRule(rule.Rule{
 					innerRange := utils.TrimNodeTextRange(sourceFile, inner)
 					reportRange := core.NewTextRange(nodeRange.Pos(), innerRange.Pos())
 
-					ctx.ReportRangeWithSuggestions(reportRange,
+					ctx.ReportRangeWithDeferredSuggestions(
+						reportRange,
 						buildUnnecessaryTypeConversionMessage("Concatenating '' with a string", "string"),
-						rule.RuleSuggestion{
-							Message:  buildSuggestRemoveMessage(),
-							FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, node, inner, nil)},
-						},
-						rule.RuleSuggestion{
-							Message: buildSuggestSatisfiesMessage("string"),
-							FixesArr: []rule.RuleFix{buildWrappingFix(sourceFile, node, inner, func(code string) string {
-								return code + " satisfies string"
-							})},
+						func() []rule.RuleSuggestion {
+							return suggestions.buildString(node, inner, nil)
 						},
 					)
 				}

--- a/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion_extras_test.go
@@ -13,9 +13,14 @@
 package no_unnecessary_type_conversion
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -1136,4 +1141,131 @@ t satisfies string;
 			},
 		},
 	)
+}
+
+func TestNoUnnecessaryTypeConversionEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		"String('value');\n"+
+			"'value'.toString();\n"+
+			"'value' + '';\n"+
+			"'' + 'value';\n"+
+			"let value = 'value';\n"+
+			"value += '';\n"+
+			"+1;\n"+
+			"!!true;\n"+
+			"~~1;",
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:             NoUnnecessaryTypeConversionRule.Name,
+					Severity:         rule.SeverityError,
+					RequiresTypeInfo: NoUnnecessaryTypeConversionRule.RequiresTypeInfo,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoUnnecessaryTypeConversionRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 8 {
+			t.Fatalf("demand %d: diagnostics = %d, want 8", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnostics := map[rule.EditDemand][]rule.RuleDiagnostic{
+		rule.EditDemandNone:       run(rule.EditDemandNone),
+		rule.EditDemandAutofix:    run(rule.EditDemandAutofix),
+		rule.EditDemandSuggestion: run(rule.EditDemandSuggestion),
+		rule.EditDemandAll:        run(rule.EditDemandAll),
+	}
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+
+	for index := range diagnostics[rule.EditDemandAll] {
+		want := withoutEdits(diagnostics[rule.EditDemandAll][index])
+		for demand, demandDiagnostics := range diagnostics {
+			if got := withoutEdits(demandDiagnostics[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("diagnostic %d changed for demand %d:\ngot:  %#v\nwant: %#v", index, demand, got, want)
+			}
+			if demandDiagnostics[index].FixesPtr != nil {
+				t.Errorf("diagnostic %d demand %d unexpectedly has autofixes", index, demand)
+			}
+		}
+	}
+
+	wantTexts := [][2]string{
+		{"'value'", "'value' satisfies string"},
+		{"'value'", "'value' satisfies string"},
+		{"'value'", "'value' satisfies string"},
+		{"'value'", "'value' satisfies string"},
+		{"", "value satisfies string"},
+		{"1", "1 satisfies number"},
+		{"true", "true satisfies boolean"},
+		{"1", "1 satisfies number"},
+	}
+	for index, texts := range wantTexts {
+		suggestionOnly := diagnostics[rule.EditDemandSuggestion][index].Suggestions
+		allEdits := diagnostics[rule.EditDemandAll][index].Suggestions
+		if suggestionOnly == nil || !reflect.DeepEqual(suggestionOnly, allEdits) {
+			t.Fatalf("diagnostic %d suggestions differ between suggestion and all-edits demand", index)
+		}
+		if len(*suggestionOnly) != 2 {
+			t.Fatalf("diagnostic %d suggestions = %#v, want 2", index, *suggestionOnly)
+		}
+		for suggestionIndex, suggestion := range *suggestionOnly {
+			wantMessageID := "suggestRemove"
+			if suggestionIndex == 1 {
+				wantMessageID = "suggestSatisfies"
+			}
+			if suggestion.Message.Id != wantMessageID {
+				t.Errorf(
+					"diagnostic %d suggestion %d message = %q, want %q",
+					index,
+					suggestionIndex,
+					suggestion.Message.Id,
+					wantMessageID,
+				)
+			}
+			if len(suggestion.FixesArr) != 1 || suggestion.FixesArr[0].Text != texts[suggestionIndex] {
+				t.Errorf(
+					"diagnostic %d suggestion %d fixes = %#v, want replacement %q",
+					index,
+					suggestionIndex,
+					suggestion.FixesArr,
+					texts[suggestionIndex],
+				)
+			}
+		}
+		if diagnostics[rule.EditDemandNone][index].Suggestions != nil ||
+			diagnostics[rule.EditDemandAutofix][index].Suggestions != nil {
+			t.Errorf("diagnostic %d attached suggestions without suggestion demand", index)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Defer both `no-unnecessary-type-conversion` suggestions until the consumer requests suggestions.
- Centralize suggestion construction while preserving all seven report branches, precedence handling, messages, ranges, and the standalone `+=` statement-removal behavior.
- Reuse the inner source text and outer replacement range across the remove/satisfies pair, improving the all-edits path as well as diagnostics-only linting.
- Add edit-demand coverage for call, `toString`, both binary-plus directions, `+=`, and all unary conversion forms.

### Architecture

Type-aware detection remains in the existing listeners and still performs exactly the same TypeChecker queries and eligibility checks. Once a report is decided, a source-only suggestion builder owns optional message/fix materialization behind `Report*WithDeferredSuggestions`; it has no Program or TypeChecker dependency.

The builder computes immutable inner text, precedence, and the outer range once per requested pair instead of repeating those source operations for each suggestion. Fixed string-conversion branches retain a constant-string construction path so current Go compilers do not introduce a per-diagnostic escaping string header. Diagnostic identity is independent of edit demand.

This PR is based directly on `main` and is independent of #1393 and the other rule migrations.

### Benchmarks

Apple M1 Max, GOMAXPROCS=1, 256 diagnostics per invocation, 10 alternating base/candidate samples, 300 ms per sample; medians from the final uncommitted benchmark run against the rule's pre-change baseline:

| Case | Demand | Base | This PR | Time |
| --- | --- | ---: | ---: | ---: |
| Conversion call | diagnostics | 560.5 us, 500834 B, 5672 allocs | 293.8 us, 171144 B, 2345 allocs | -47.6% |
| Conversion call | all edits | 560.5 us, 500834 B, 5672 allocs | 508.2 us, 418954 B, 5161 allocs | -9.3% |
| Binary plus | diagnostics | 491.2 us, 519186 B, 4648 allocs | 225.8 us, 193673 B, 1577 allocs | -54.0% |
| Binary plus | all edits | 487.4 us, 519186 B, 4648 allocs | 430.6 us, 437306 B, 4137 allocs | -11.7% |
| Unary conversion | diagnostics | 651.4 us, 706635 B, 6752 allocs | 241.1 us, 205961 B, 2089 allocs | -63.0% |
| Unary conversion | all edits | 653.5 us, 706635 B, 6752 allocs | 526.2 us, 538242 B, 5573 allocs | -19.5% |
| `.toString()` | diagnostics | 497.4 us, 523282 B, 4648 allocs | 229.7 us, 197769 B, 1577 allocs | -53.8% |
| `.toString()` | all edits | 493.0 us, 523282 B, 4648 allocs | 440.9 us, 441402 B, 4137 allocs | -10.6% |

No benchmark file is included in the change.

## Related Links

- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). The framework contract and external rule behavior are unchanged.