### PR TITLE
perf: defer method-signature-style edits

### DIFF
--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style.go
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style.go
@@ -54,6 +54,212 @@ func containsThisType(node *ast.Node) bool {
 	return found
 }
 
+type methodSignatureFixer struct {
+	sourceFile *ast.SourceFile
+	sourceText string
+}
+
+// safeSlice returns sourceText[start:end] with bounds clamping.
+func (f *methodSignatureFixer) safeSlice(start, end int) string {
+	if start < 0 {
+		start = 0
+	}
+	if end > len(f.sourceText) {
+		end = len(f.sourceText)
+	}
+	return f.sourceText[start:end]
+}
+
+// getMethodKey returns the key text for a method or property signature,
+// including optional marker and readonly prefix.
+func (f *methodSignatureFixer) getMethodKey(node *ast.Node) string {
+	var nameNode *ast.Node
+	switch node.Kind {
+	case ast.KindMethodSignature:
+		nameNode = node.AsMethodSignatureDeclaration().Name()
+	case ast.KindPropertySignature:
+		nameNode = node.AsPropertySignatureDeclaration().Name()
+	default:
+		return ""
+	}
+
+	// TrimmedNodeText handles computed property names correctly —
+	// ComputedPropertyName nodes already include the surrounding brackets.
+	key := utils.TrimmedNodeText(f.sourceFile, nameNode)
+
+	if ast.HasQuestionToken(node) {
+		key += "?"
+	}
+	if ast.HasSyntacticModifier(node, ast.ModifierFlagsReadonly) {
+		key = "readonly " + key
+	}
+	return key
+}
+
+// getMethodParams returns the type parameters + parameters text.
+// E.g. "<T>(a: T, b: T)" or "()" for no params.
+func (f *methodSignatureFixer) getMethodParams(node *ast.Node) string {
+	var params *ast.NodeList
+	var typeParams *ast.NodeList
+
+	switch node.Kind {
+	case ast.KindMethodSignature:
+		sig := node.AsMethodSignatureDeclaration()
+		params = sig.Parameters
+		typeParams = sig.TypeParameters
+	case ast.KindFunctionType:
+		ft := node.AsFunctionTypeNode()
+		params = ft.Parameters
+		typeParams = ft.TypeParameters
+	default:
+		return "()"
+	}
+
+	paramsText := "()"
+	if params != nil && len(params.Nodes) > 0 {
+		firstRange := utils.TrimNodeTextRange(f.sourceFile, params.Nodes[0])
+		lastRange := utils.TrimNodeTextRange(f.sourceFile, params.Nodes[len(params.Nodes)-1])
+		// Scan backward to find '(' before first param
+		openParen := firstRange.Pos() - 1
+		for openParen > 0 && f.sourceText[openParen] != '(' {
+			openParen--
+		}
+		// Scan forward to find ')' after last param
+		closeParen := lastRange.End()
+		for closeParen < len(f.sourceText) && f.sourceText[closeParen] != ')' {
+			closeParen++
+		}
+		paramsText = f.safeSlice(openParen, closeParen+1)
+	}
+
+	if typeParams != nil && len(typeParams.Nodes) > 0 {
+		firstRange := utils.TrimNodeTextRange(f.sourceFile, typeParams.Nodes[0])
+		lastRange := utils.TrimNodeTextRange(f.sourceFile, typeParams.Nodes[len(typeParams.Nodes)-1])
+		// Scan backward/forward to find '<'/'>' (comments may sit between the bracket and the first/last param)
+		start := firstRange.Pos() - 1
+		for start > 0 && f.sourceText[start] != '<' {
+			start--
+		}
+		end := lastRange.End()
+		for end < len(f.sourceText) && f.sourceText[end] != '>' {
+			end++
+		}
+		paramsText = f.safeSlice(start, end+1) + paramsText
+	}
+
+	return paramsText
+}
+
+// getMethodReturnType returns the return type text, or "any" if omitted.
+func (f *methodSignatureFixer) getMethodReturnType(node *ast.Node) string {
+	var typeNode *ast.Node
+	switch node.Kind {
+	case ast.KindMethodSignature:
+		typeNode = node.AsMethodSignatureDeclaration().Type
+	case ast.KindFunctionType:
+		typeNode = node.AsFunctionTypeNode().Type
+	}
+	if typeNode == nil {
+		return "any"
+	}
+	return utils.TrimmedNodeText(f.sourceFile, typeNode)
+}
+
+// getDelimiter returns the trailing ';' or ',' of a member node, or "".
+func (f *methodSignatureFixer) getDelimiter(node *ast.Node) string {
+	end := utils.TrimNodeTextRange(f.sourceFile, node).End()
+	if end > 0 && end <= len(f.sourceText) {
+		if ch := f.sourceText[end-1]; ch == ';' || ch == ',' {
+			return string(ch)
+		}
+	}
+	return ""
+}
+
+func (f *methodSignatureFixer) buildMethodFixes(node *ast.Node) []rule.RuleFix {
+	signature := node.AsMethodSignatureDeclaration()
+	if containsThisType(signature.Type) ||
+		ast.FindAncestorKind(node, ast.KindModuleDeclaration) != nil {
+		return nil
+	}
+
+	thisKey := f.getMethodKey(node)
+	members := node.Parent.Members()
+
+	// Find overloaded method signatures with the same key.
+	var duplicates []*ast.Node
+	for _, member := range members {
+		if member.Kind == ast.KindMethodSignature && member != node && f.getMethodKey(member) == thisKey {
+			duplicates = append(duplicates, member)
+		}
+	}
+
+	if len(duplicates) > 0 {
+		// Sort all overloads by position; only the first provides the fix.
+		allNodes := append([]*ast.Node{node}, duplicates...)
+		sort.Slice(allNodes, func(i, j int) bool {
+			return allNodes[i].Pos() < allNodes[j].Pos()
+		})
+		if allNodes[0] != node {
+			return nil
+		}
+
+		// Merge overloads into an intersection of function types.
+		typeParts := make([]string, 0, len(allNodes))
+		for _, overload := range allNodes {
+			typeParts = append(
+				typeParts,
+				"("+f.getMethodParams(overload)+" => "+f.getMethodReturnType(overload)+")",
+			)
+		}
+		typeString := strings.Join(typeParts, " & ")
+		replacement := f.getMethodKey(node) + ": " + typeString + f.getDelimiter(node)
+
+		fixes := make([]rule.RuleFix, 0, len(duplicates)+1)
+		fixes = append(fixes, rule.RuleFixReplace(f.sourceFile, node, replacement))
+
+		// Remove each duplicate and its preceding whitespace.
+		for _, duplicate := range duplicates {
+			duplicateRange := utils.TrimNodeTextRange(f.sourceFile, duplicate)
+			start := duplicateRange.Pos()
+			// Consume leading whitespace/newlines back to the previous member's delimiter.
+			for start > 0 &&
+				(f.sourceText[start-1] == ' ' ||
+					f.sourceText[start-1] == '\t' ||
+					f.sourceText[start-1] == '\n' ||
+					f.sourceText[start-1] == '\r') {
+				start--
+			}
+			fixes = append(
+				fixes,
+				rule.RuleFixRemoveRange(duplicateRange.WithPos(start).WithEnd(duplicateRange.End())),
+			)
+		}
+
+		return fixes
+	}
+
+	replacement := f.getMethodKey(node) +
+		": " +
+		f.getMethodParams(node) +
+		" => " +
+		f.getMethodReturnType(node) +
+		f.getDelimiter(node)
+	return []rule.RuleFix{rule.RuleFixReplace(f.sourceFile, node, replacement)}
+}
+
+func (f *methodSignatureFixer) buildPropertyFixes(
+	node *ast.Node,
+	functionType *ast.Node,
+) []rule.RuleFix {
+	replacement := f.getMethodKey(node) +
+		f.getMethodParams(functionType) +
+		": " +
+		f.getMethodReturnType(functionType) +
+		f.getDelimiter(node)
+	return []rule.RuleFix{rule.RuleFixReplace(f.sourceFile, node, replacement)}
+}
+
 func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 	options := rule.LegacyUnwrapOptions(_options)
 	opt := mode(utils.GetOptionsString(options))
@@ -61,194 +267,19 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		opt = modeProperty
 	}
 
-	sourceText := ctx.SourceFile.Text()
-
-	// safeSlice returns sourceText[start:end] with bounds clamping.
-	safeSlice := func(start, end int) string {
-		if start < 0 {
-			start = 0
-		}
-		if end > len(sourceText) {
-			end = len(sourceText)
-		}
-		return sourceText[start:end]
+	fixer := methodSignatureFixer{
+		sourceFile: ctx.SourceFile,
+		sourceText: ctx.SourceFile.Text(),
 	}
-
-	// getMethodKey returns the key text for a method or property signature,
-	// including optional marker and readonly prefix.
-	getMethodKey := func(node *ast.Node) string {
-		var nameNode *ast.Node
-		switch node.Kind {
-		case ast.KindMethodSignature:
-			nameNode = node.AsMethodSignatureDeclaration().Name()
-		case ast.KindPropertySignature:
-			nameNode = node.AsPropertySignatureDeclaration().Name()
-		default:
-			return ""
-		}
-
-		// TrimmedNodeText handles computed property names correctly —
-		// ComputedPropertyName nodes already include the surrounding brackets.
-		key := utils.TrimmedNodeText(ctx.SourceFile, nameNode)
-
-		if ast.HasQuestionToken(node) {
-			key += "?"
-		}
-		if ast.HasSyntacticModifier(node, ast.ModifierFlagsReadonly) {
-			key = "readonly " + key
-		}
-		return key
-	}
-
-	// getMethodParams returns the type parameters + parameters text.
-	// E.g. "<T>(a: T, b: T)" or "()" for no params.
-	getMethodParams := func(node *ast.Node) string {
-		var params *ast.NodeList
-		var typeParams *ast.NodeList
-
-		switch node.Kind {
-		case ast.KindMethodSignature:
-			sig := node.AsMethodSignatureDeclaration()
-			params = sig.Parameters
-			typeParams = sig.TypeParameters
-		case ast.KindFunctionType:
-			ft := node.AsFunctionTypeNode()
-			params = ft.Parameters
-			typeParams = ft.TypeParameters
-		default:
-			return "()"
-		}
-
-		paramsText := "()"
-		if params != nil && len(params.Nodes) > 0 {
-			firstRange := utils.TrimNodeTextRange(ctx.SourceFile, params.Nodes[0])
-			lastRange := utils.TrimNodeTextRange(ctx.SourceFile, params.Nodes[len(params.Nodes)-1])
-			// Scan backward to find '(' before first param
-			openParen := firstRange.Pos() - 1
-			for openParen > 0 && sourceText[openParen] != '(' {
-				openParen--
-			}
-			// Scan forward to find ')' after last param
-			closeParen := lastRange.End()
-			for closeParen < len(sourceText) && sourceText[closeParen] != ')' {
-				closeParen++
-			}
-			paramsText = safeSlice(openParen, closeParen+1)
-		}
-
-		if typeParams != nil && len(typeParams.Nodes) > 0 {
-			firstRange := utils.TrimNodeTextRange(ctx.SourceFile, typeParams.Nodes[0])
-			lastRange := utils.TrimNodeTextRange(ctx.SourceFile, typeParams.Nodes[len(typeParams.Nodes)-1])
-			// Scan backward/forward to find '<'/'>' (comments may sit between the bracket and the first/last param)
-			start := firstRange.Pos() - 1
-			for start > 0 && sourceText[start] != '<' {
-				start--
-			}
-			end := lastRange.End()
-			for end < len(sourceText) && sourceText[end] != '>' {
-				end++
-			}
-			paramsText = safeSlice(start, end+1) + paramsText
-		}
-
-		return paramsText
-	}
-
-	// getMethodReturnType returns the return type text, or "any" if omitted.
-	getMethodReturnType := func(node *ast.Node) string {
-		var typeNode *ast.Node
-		switch node.Kind {
-		case ast.KindMethodSignature:
-			typeNode = node.AsMethodSignatureDeclaration().Type
-		case ast.KindFunctionType:
-			typeNode = node.AsFunctionTypeNode().Type
-		}
-		if typeNode == nil {
-			return "any"
-		}
-		return utils.TrimmedNodeText(ctx.SourceFile, typeNode)
-	}
-
-	// getDelimiter returns the trailing ';' or ',' of a member node, or "".
-	getDelimiter := func(node *ast.Node) string {
-		end := utils.TrimNodeTextRange(ctx.SourceFile, node).End()
-		if end > 0 && end <= len(sourceText) {
-			if ch := sourceText[end-1]; ch == ';' || ch == ',' {
-				return string(ch)
-			}
-		}
-		return ""
-	}
-
 	listeners := rule.RuleListeners{}
 
 	if opt == modeProperty {
 		listeners[ast.KindMethodSignature] = func(node *ast.Node) {
 			// In typescript-go AST, get/set accessors use KindGetAccessor/KindSetAccessor,
 			// so KindMethodSignature always represents an actual method — no kind check needed.
-
-			skipFix := containsThisType(node.AsMethodSignatureDeclaration().Type)
-			isParentModule := ast.FindAncestorKind(node, ast.KindModuleDeclaration) != nil
-			thisKey := getMethodKey(node)
-			members := node.Parent.Members()
-
-			// Find overloaded method signatures with the same key
-			var duplicates []*ast.Node
-			for _, member := range members {
-				if member.Kind == ast.KindMethodSignature && member != node && getMethodKey(member) == thisKey {
-					duplicates = append(duplicates, member)
-				}
-			}
-
-			if len(duplicates) > 0 {
-				if isParentModule || skipFix {
-					ctx.ReportNode(node, messageErrorMethod())
-					return
-				}
-
-				// Sort all overloads by position; only the first provides the fix
-				allNodes := append([]*ast.Node{node}, duplicates...)
-				sort.Slice(allNodes, func(i, j int) bool {
-					return allNodes[i].Pos() < allNodes[j].Pos()
-				})
-				if allNodes[0] != node {
-					ctx.ReportNode(node, messageErrorMethod())
-					return
-				}
-
-				// Merge overloads into an intersection of function types
-				var typeParts []string
-				for _, n := range allNodes {
-					typeParts = append(typeParts, "("+getMethodParams(n)+" => "+getMethodReturnType(n)+")")
-				}
-				typeString := strings.Join(typeParts, " & ")
-				replacement := getMethodKey(node) + ": " + typeString + getDelimiter(node)
-
-				var fixes []rule.RuleFix
-				fixes = append(fixes, rule.RuleFixReplace(ctx.SourceFile, node, replacement))
-
-				// Remove each duplicate and its preceding whitespace
-				for _, dup := range duplicates {
-					dupRange := utils.TrimNodeTextRange(ctx.SourceFile, dup)
-					start := dupRange.Pos()
-					// Consume leading whitespace/newlines back to the previous member's delimiter
-					for start > 0 && (sourceText[start-1] == ' ' || sourceText[start-1] == '\t' || sourceText[start-1] == '\n' || sourceText[start-1] == '\r') {
-						start--
-					}
-					fixes = append(fixes, rule.RuleFixRemoveRange(dupRange.WithPos(start).WithEnd(dupRange.End())))
-				}
-
-				ctx.ReportNodeWithFixes(node, messageErrorMethod(), fixes...)
-				return
-			}
-
-			// Single method signature (no overloads)
-			if isParentModule || skipFix {
-				ctx.ReportNode(node, messageErrorMethod())
-			} else {
-				replacement := getMethodKey(node) + ": " + getMethodParams(node) + " => " + getMethodReturnType(node) + getDelimiter(node)
-				ctx.ReportNodeWithFixes(node, messageErrorMethod(), rule.RuleFixReplace(ctx.SourceFile, node, replacement))
-			}
+			ctx.ReportNodeWithDeferredFixes(node, messageErrorMethod(), func() []rule.RuleFix {
+				return fixer.buildMethodFixes(node)
+			})
 		}
 	}
 
@@ -259,8 +290,9 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 				return
 			}
 
-			replacement := getMethodKey(node) + getMethodParams(propSig.Type) + ": " + getMethodReturnType(propSig.Type) + getDelimiter(node)
-			ctx.ReportNodeWithFixes(node, messageErrorProperty(), rule.RuleFixReplace(ctx.SourceFile, node, replacement))
+			ctx.ReportNodeWithDeferredFixes(node, messageErrorProperty(), func() []rule.RuleFix {
+				return fixer.buildPropertyFixes(node, propSig.Type)
+			})
 		}
 	}
 

--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style_test.go
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style_test.go
@@ -1,9 +1,13 @@
 package method_signature_style
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -811,4 +815,155 @@ func TestMethodSignatureStyleRule(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestMethodSignatureStyleEditDemand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		code         string
+		options      []any
+		wantFixCount []int
+	}{
+		{
+			name: "method to property",
+			code: `interface Test {
+  simple<T>(value: T): Promise<T>;
+  overloaded(value: string): string;
+  overloaded(value: number): number;
+  self(): Promise<this>;
+}
+declare namespace External {
+  interface Nested {
+    ambient(): void;
+  }
+}`,
+			wantFixCount: []int{1, 2, 0, 0, 0},
+		},
+		{
+			name:         "property to method",
+			code:         `interface Test { readonly method?: <T>(value: T) => Promise<T>; }`,
+			options:      []any{"method"},
+			wantFixCount: []int{1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+			program, sourceFile, err := helper.CreateTestProgram(
+				test.code,
+				"method-signature-style-edit-demand.ts",
+				"tsconfig.json",
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+				t.Helper()
+
+				var diagnostics []rule.RuleDiagnostic
+				linter.LintSingleFile(linter.LintSingleFileOptions{
+					Program:      program,
+					File:         sourceFile.FileName(),
+					HasTypeInfo:  true,
+					ExcludePaths: []string{},
+					GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+						return []linter.ConfiguredRule{{
+							Name:     MethodSignatureStyleRule.Name,
+							Severity: rule.SeverityError,
+							Run: func(ctx rule.RuleContext) rule.RuleListeners {
+								return MethodSignatureStyleRule.Run(ctx, test.options)
+							},
+						}}
+					},
+					Consumer: rule.DiagnosticConsumer{
+						Demand: demand,
+						Report: func(diagnostic rule.RuleDiagnostic) {
+							diagnostics = append(diagnostics, diagnostic)
+						},
+					},
+				})
+				if len(diagnostics) != len(test.wantFixCount) {
+					t.Fatalf(
+						"demand %d: diagnostics = %d, want %d",
+						demand,
+						len(diagnostics),
+						len(test.wantFixCount),
+					)
+				}
+				return diagnostics
+			}
+
+			diagnosticsOnly := run(rule.EditDemandNone)
+			autofixOnly := run(rule.EditDemandAutofix)
+			suggestionOnly := run(rule.EditDemandSuggestion)
+			allEdits := run(rule.EditDemandAll)
+
+			withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+				diagnostic.FixesPtr = nil
+				diagnostic.Suggestions = nil
+				return diagnostic
+			}
+
+			for index, wantFixCount := range test.wantFixCount {
+				wantIdentity := withoutEdits(allEdits[index])
+				for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+					rule.EditDemandNone:       diagnosticsOnly,
+					rule.EditDemandAutofix:    autofixOnly,
+					rule.EditDemandSuggestion: suggestionOnly,
+				} {
+					if got := withoutEdits(diagnostics[index]); !reflect.DeepEqual(got, wantIdentity) {
+						t.Errorf(
+							"demand %d changed diagnostic %d:\ngot  %#v\nwant %#v",
+							demand,
+							index,
+							got,
+							wantIdentity,
+						)
+					}
+				}
+
+				if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+					t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+				}
+				if diagnosticsOnly[index].Suggestions != nil ||
+					autofixOnly[index].Suggestions != nil ||
+					suggestionOnly[index].Suggestions != nil ||
+					allEdits[index].Suggestions != nil {
+					t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+				}
+
+				for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+					rule.EditDemandAutofix: autofixOnly,
+					rule.EditDemandAll:     allEdits,
+				} {
+					fixes := diagnostics[index].FixesPtr
+					if wantFixCount == 0 {
+						if fixes != nil {
+							t.Fatalf("demand %d diagnostic %d: unexpected fixes %#v", demand, index, *fixes)
+						}
+						continue
+					}
+					if fixes == nil || len(*fixes) != wantFixCount {
+						t.Fatalf(
+							"demand %d diagnostic %d: fix count = %d, want %d",
+							demand,
+							index,
+							len(diagnostics[index].Fixes()),
+							wantFixCount,
+						)
+					}
+				}
+
+				if !reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+					t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- defer every native `method-signature-style` autofix until the diagnostic consumer requests autofixes
- extract a source-only `methodSignatureFixer` that owns text slicing, signature rendering, overload grouping, and duplicate-removal edits
- preserve listener selection, diagnostic messages/ranges, option semantics, fix text/order, and the existing per-node `this` and module no-fix behavior
- add edit-demand coverage to the existing rule test file for both directions, overload leaders/followers, `this`, modules, and all four edit-demand modes

### Architecture

Detection remains in the rule listeners and is always executed, so diagnostic behavior is unchanged. Only edit construction crosses the deferred boundary. The extracted fixer depends exclusively on the immutable source file/AST and source text; it has no Program, TypeChecker, or plugin-protocol coupling. Expensive method-key extraction, sibling scans, sorting, signature rendering, and fix-slice construction now run only after suppression checks and only for consumers requesting autofixes. Unfixable `this`/module nodes return before the overload scan.

This PR is based directly on `main` and is independent of the other rule migrations.

### Benchmark

Each invocation reports 256 diagnostics. Results are medians from 10 alternating baseline/candidate samples with `GOMAXPROCS=1`, `-cpu=1`, and a 300 ms sample window. The initially noisy overload/all-edits case was additionally rechecked with a 1 s window shown below.

| Scenario | Demand | Before | After | Time | B/op | allocs/op |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| method → property | diagnostics | 9.000 ms | 101.8 µs | -98.9% | 10,887,362 → 44,072 | 69,159 → 291 |
| method → property | all edits | 9.022 ms | 8.996 ms | -0.3% | 10,887,362 → 10,887,210 | 69,159 → 69,155 |
| overloads | diagnostics | 8.994 ms | 68.9 µs | -99.2% | 10,757,320 → 44,072 | 68,647 → 291 |
| overloads | all edits (1 s) | 8.894 ms | 8.731 ms | -1.8% | 10,757,320 → 10,752,560 | 68,647 → 68,515 |
| `this` no-fix | diagnostics | 8.695 ms | 64.9 µs | -99.3% | 10,529,986 → 44,072 | 65,831 → 291 |
| `this` no-fix | all edits | 8.645 ms | 68.3 µs | -99.2% | 10,529,986 → 44,072 | 65,831 → 291 |
| property → method | diagnostics | 412.4 µs | 118.9 µs | -71.2% | 410,800 → 44,072 | 4,135 → 291 |
| property → method | all edits | 410.8 µs | 406.3 µs | -1.1% | 410,800 → 410,664 | 4,135 → 4,131 |

No benchmark file is included in the PR.

## Related Links

- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
