### PR TITLE
perf: defer no-useless-computed-key fixes

### DIFF
--- a/internal/rules/no_useless_computed_key/no_useless_computed_key.go
+++ b/internal/rules/no_useless_computed_key/no_useless_computed_key.go
@@ -261,28 +261,38 @@ var NoUselessComputedKeyRule = rule.Rule{
 			// brackets — preserving comments across a token replacement
 			// would require splicing them back in and isn't worth the
 			// complexity, matching ESLint's behavior.
-			if hasCommentsBetween(sourceText, leftBracketPos+1, endPos-1) {
+			//
+			// The literal itself cannot contain comments. Checking only the
+			// surrounding text both preserves comment-like text inside string
+			// keys and avoids scanning the key again solely to skip over it.
+			leftContentStart := leftBracketPos + 1
+			rightContentEnd := endPos - 1
+			if (leftContentStart < keyStart &&
+				hasCommentsBetween(sourceText, leftContentStart, keyStart)) ||
+				(keyEnd < rightContentEnd &&
+					hasCommentsBetween(sourceText, keyEnd, rightContentEnd)) {
 				ctx.ReportNode(container, msg)
 				return
 			}
 
-			replacement := keyRaw
-			if leftBracketPos > 0 && len(keyRaw) > 0 {
-				prev := sourceText[leftBracketPos-1]
-				// Only add a separator space when the previous token and
-				// the key would fuse into one identifier (e.g. `get` + `2`
-				// → `get2`). `get` + `'foo'` is fine because `'` can't
-				// continue an identifier.
-				if isIdentPart(prev) && isIdentPart(keyRaw[0]) {
-					replacement = " " + keyRaw
+			ctx.ReportNodeWithDeferredFixes(container, msg, func() []rule.RuleFix {
+				replacement := keyRaw
+				if leftBracketPos > 0 && len(keyRaw) > 0 {
+					prev := sourceText[leftBracketPos-1]
+					// Only add a separator space when the previous token and
+					// the key would fuse into one identifier (e.g. `get` + `2`
+					// → `get2`). `get` + `'foo'` is fine because `'` can't
+					// continue an identifier.
+					if isIdentPart(prev) && isIdentPart(keyRaw[0]) {
+						replacement = " " + keyRaw
+					}
 				}
-			}
 
-			fix := rule.RuleFixReplaceRange(
-				core.NewTextRange(leftBracketPos, endPos),
-				replacement,
-			)
-			ctx.ReportNodeWithFixes(container, msg, fix)
+				return []rule.RuleFix{rule.RuleFixReplaceRange(
+					core.NewTextRange(leftBracketPos, endPos),
+					replacement,
+				)}
+			})
 		}
 
 		nameIfComputed := func(n *ast.Node) *ast.Node {

--- a/internal/rules/no_useless_computed_key/no_useless_computed_key_test.go
+++ b/internal/rules/no_useless_computed_key/no_useless_computed_key_test.go
@@ -1,9 +1,13 @@
 package no_useless_computed_key
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -1011,4 +1015,125 @@ func TestNoUselessComputedKeyRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoUselessComputedKeyEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`const object = {
+  ['http://key/* literal text */']: 1,
+  [/* keep */ 'commented']: 2,
+  get[2]() { return 3 },
+};
+const { ['binding']: binding } = input;`,
+		"no-useless-computed-key-edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     NoUselessComputedKeyRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoUselessComputedKeyRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 4 {
+			t.Fatalf("demand %d: diagnostics = %d, want 4", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+	wantFixText := []string{"'http://key/* literal text */'", "", " 2", "'binding'"}
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+
+	for index, wantText := range wantFixText {
+		wantIdentity := withoutEdits(allEdits[index])
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got := withoutEdits(diagnostics[index]); !reflect.DeepEqual(got, wantIdentity) {
+				t.Errorf(
+					"demand %d changed diagnostic %d:\ngot  %#v\nwant %#v",
+					demand,
+					index,
+					got,
+					wantIdentity,
+				)
+			}
+		}
+
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		for _, diagnostics := range [][]rule.RuleDiagnostic{
+			diagnosticsOnly,
+			autofixOnly,
+			suggestionOnly,
+			allEdits,
+		} {
+			if diagnostics[index].Suggestions != nil {
+				t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+			}
+		}
+
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandAutofix: autofixOnly,
+			rule.EditDemandAll:     allEdits,
+		} {
+			fixes := diagnostics[index].FixesPtr
+			if wantText == "" {
+				if fixes != nil {
+					t.Fatalf("demand %d diagnostic %d: unexpected fixes %#v", demand, index, *fixes)
+				}
+				continue
+			}
+			if fixes == nil || len(*fixes) != 1 || (*fixes)[0].Text != wantText {
+				t.Fatalf(
+					"demand %d diagnostic %d: fixes = %#v, want one fix with text %q",
+					demand,
+					index,
+					fixes,
+					wantText,
+				)
+			}
+		}
+
+		if !reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- defer `no-useless-computed-key` replacement, adjacency, range, and fix construction until the native consumer requests autofixes
- keep literal/container eligibility, reserved-name carve-outs, diagnostic messages/ranges, and comment-based fixability classification in the detection path
- scan only the text surrounding the literal for comments, preserving comment-like text inside string keys while avoiding a redundant literal scan
- add edit-demand coverage to the existing rule test file for fixable object and binding keys, token-separating numeric keys, comment-blocked fixes, and all four demand modes

### Architecture

The listener still owns rule semantics: it decides whether a computed key is reportable and whether comments make it unfixable. Only construction of the replacement text and `RuleFix` crosses the deferred boundary. The callback is synchronous and source-only, capturing immutable source text and ranges; it has no Program, TypeChecker, or plugin-protocol dependency.

Keeping comment classification eager avoids paying a deferred callback for diagnostics that can never carry a fix. The tiny builder remains inline at its call site because extracting it introduced measurable call overhead on this unusually cheap fix path.

This PR is based directly on `main` and is independent of the other rule migrations.

### Benchmark

Each invocation reports 256 diagnostics. Results are medians from 10 alternating baseline/candidate samples with alternating execution order, `GOMAXPROCS=1`, `-cpu=1`, and a 500 ms sample window.

| Scenario | Demand | Before | After | Time | B/op | allocs/op |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| object properties | diagnostics | 110.6 µs | 93.4 µs | -15.6% | 75,232 → 62,944 | 1,320 → 808 |
| object properties | all edits | 109.6 µs | 109.2 µs | -0.4% | 75,232 → 75,232 | 1,320 → 1,320 |
| class methods | diagnostics | 109.1 µs | 93.6 µs | -14.2% | 72,736 → 60,448 | 1,320 → 808 |
| class methods | all edits | 109.6 µs | 110.2 µs | +0.5% | 72,736 → 72,736 | 1,320 → 1,320 |
| binding elements | diagnostics | 113.9 µs | 96.5 µs | -15.3% | 75,232 → 62,944 | 1,320 → 808 |
| binding elements | all edits | 113.1 µs | 113.0 µs | -0.1% | 75,232 → 75,232 | 1,320 → 1,320 |
| comment-blocked, no fix | diagnostics | 111.5 µs | 112.0 µs | +0.4% | 62,944 → 62,944 | 808 → 808 |
| comment-blocked, no fix | all edits | 111.1 µs | 112.0 µs | +0.7% | 62,944 → 62,944 | 808 → 808 |

The sub-1% movements have no allocation change and are treated as neutral. The stable gain is the 14–16% diagnostics-only improvement and 512 fewer allocations for every 256 fixable diagnostics. No benchmark file is included in the PR.

## Related Links

- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
