### PR TITLE
perf: defer no-unneeded-ternary fixes

### DIFF
--- a/internal/rules/no_unneeded_ternary/no_unneeded_ternary.go
+++ b/internal/rules/no_unneeded_ternary/no_unneeded_ternary.go
@@ -202,6 +202,7 @@ var NoUnneededTernaryRule = rule.Rule{
 			Id:          "unnecessaryConditionalAssignment",
 			Description: "Unnecessary use of conditional expression for default assignment.",
 		}
+		sourceFile := ctx.SourceFile
 
 		return rule.RuleListeners{
 			ast.KindConditionalExpression: func(node *ast.Node) {
@@ -213,16 +214,21 @@ var NoUnneededTernaryRule = rule.Rule{
 				consVal, consOk := boolKind(cond.WhenTrue)
 				altVal, altOk := boolKind(cond.WhenFalse)
 				if consOk && altOk {
-					if fixes := buildBooleanLiteralFix(ctx.SourceFile, cond, consVal, altVal); fixes != nil {
-						ctx.ReportNodeWithFixes(node, condExprMsg, fixes...)
-					} else {
+					if consVal == altVal &&
+						ast.SkipParentheses(cond.Condition).Kind != ast.KindIdentifier {
 						ctx.ReportNode(node, condExprMsg)
+						return
 					}
+					ctx.ReportNodeWithDeferredFixes(node, condExprMsg, func() []rule.RuleFix {
+						return buildBooleanLiteralFix(sourceFile, cond, consVal, altVal)
+					})
 					return
 				}
 
 				if !opts.defaultAssignment && matchesDefaultAssignment(cond.Condition, cond.WhenTrue) {
-					ctx.ReportNodeWithFixes(node, condAssignMsg, buildDefaultAssignmentFix(ctx.SourceFile, cond)...)
+					ctx.ReportNodeWithDeferredFixes(node, condAssignMsg, func() []rule.RuleFix {
+						return buildDefaultAssignmentFix(sourceFile, cond)
+					})
 				}
 			},
 		}

--- a/internal/rules/no_unneeded_ternary/no_unneeded_ternary_test.go
+++ b/internal/rules/no_unneeded_ternary/no_unneeded_ternary_test.go
@@ -1,9 +1,13 @@
 package no_unneeded_ternary
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -615,4 +619,131 @@ func TestNoUnneededTernaryRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoUnneededTernaryEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`const comparison = left === right ? true : false;
+const inverse = left !== right ? false : true;
+const equalIdentifier = flag ? true : true;
+const equalSideEffect = call() ? true : true;
+const defaultAssignment = value ? value : other ?? fallback;`,
+		"no-unneeded-ternary-edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := []any{map[string]any{"defaultAssignment": false}}
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     NoUnneededTernaryRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoUnneededTernaryRule.Run(ctx, options)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 5 {
+			t.Fatalf("demand %d: diagnostics = %d, want 5", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+	wantFixText := []string{
+		"left === right",
+		"left === right",
+		"true",
+		"",
+		"value || (other ?? fallback)",
+	}
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+
+	for index, wantText := range wantFixText {
+		wantIdentity := withoutEdits(allEdits[index])
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got := withoutEdits(diagnostics[index]); !reflect.DeepEqual(got, wantIdentity) {
+				t.Errorf(
+					"demand %d changed diagnostic %d:\ngot  %#v\nwant %#v",
+					demand,
+					index,
+					got,
+					wantIdentity,
+				)
+			}
+		}
+
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		for _, diagnostics := range [][]rule.RuleDiagnostic{
+			diagnosticsOnly,
+			autofixOnly,
+			suggestionOnly,
+			allEdits,
+		} {
+			if diagnostics[index].Suggestions != nil {
+				t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+			}
+		}
+
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandAutofix: autofixOnly,
+			rule.EditDemandAll:     allEdits,
+		} {
+			fixes := diagnostics[index].FixesPtr
+			if wantText == "" {
+				if fixes != nil {
+					t.Fatalf("demand %d diagnostic %d: unexpected fixes %#v", demand, index, *fixes)
+				}
+				continue
+			}
+			if fixes == nil || len(*fixes) != 1 || (*fixes)[0].Text != wantText {
+				t.Fatalf(
+					"demand %d diagnostic %d: fixes = %#v, want one fix with text %q",
+					demand,
+					index,
+					fixes,
+					wantText,
+				)
+			}
+		}
+
+		if !reflect.DeepEqual(autofixOnly[index].FixesPtr, allEdits[index].FixesPtr) {
+			t.Fatalf("diagnostic %d: autofix and all-edits demands produced different fixes", index)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- defer `no-unneeded-ternary` boolean-literal and default-assignment fix builders until the native consumer requests autofixes
- preserve the existing eager classification for equal boolean branches whose condition can have side effects, so known-unfixable diagnostics do not enter a deferred callback
- keep all precedence, operator inversion, parenthesization, option, diagnostic message/range, and fix text behavior unchanged
- add edit-demand coverage to the existing rule test file for comparison/inversion fixes, equal-literal fixable and unfixable paths, default assignment, and all four demand modes

### Architecture

Detection remains entirely in the conditional-expression listener. Existing source-only builder functions cross the deferred boundary unchanged and receive only the immutable `SourceFile`, AST node, and already-detected boolean values. There is no Program, TypeChecker, or plugin-protocol coupling.

The one known nil-builder case (`exprWithSideEffects ? true : true`) is classified before reporting, exactly matching the builder's prior guard. This keeps its diagnostics and all-edits path free of callback overhead while avoiding all replacement/text/range allocation for fixable diagnostics unless autofixes are requested.

This PR is based directly on `main` and is independent of the other rule migrations.

### Benchmark

Each invocation reports 256 diagnostics. Results are medians from 10 alternating baseline/candidate samples with alternating execution order, `GOMAXPROCS=1`, and `-cpu=1`. The main sample window is 500 ms; the three initially noisy boolean all-edits rows were rechecked with a 1 s window and those longer-window results are shown.

| Scenario | Demand | Before | After | Time | B/op | allocs/op |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| boolean comparison | diagnostics | 197.0 µs | 118.9 µs | -39.7% | 138,328 → 44,120 | 1,314 → 290 |
| boolean comparison | all edits (1 s) | 199.2 µs | 194.5 µs | -2.4% | 138,328 → 138,328 | 1,314 → 1,314 |
| inverse equality | diagnostics | 233.3 µs | 119.3 µs | -48.9% | 185,432 → 44,120 | 1,826 → 290 |
| inverse equality | all edits (1 s) | 237.2 µs | 230.3 µs | -2.9% | 185,432 → 185,432 | 1,826 → 1,826 |
| complex inverse | diagnostics | 210.6 µs | 119.9 µs | -43.0% | 144,472 → 44,120 | 1,570 → 290 |
| complex inverse | all edits (1 s) | 212.2 µs | 208.5 µs | -1.7% | 144,472 → 144,472 | 1,570 → 1,570 |
| default assignment | diagnostics | 260.0 µs | 120.1 µs | -53.8% | 191,416 → 44,120 | 1,826 → 290 |
| default assignment | all edits | 260.8 µs | 252.0 µs | -3.4% | 191,416 → 191,416 | 1,826 → 1,826 |
| equal literals, side effects/no fix | diagnostics | 108.9 µs | 108.1 µs | -0.7% | 44,120 → 44,120 | 290 → 290 |
| equal literals, side effects/no fix | all edits | 109.9 µs | 107.5 µs | -2.2% | 44,120 → 44,120 | 290 → 290 |

No benchmark file is included in the PR.

## Related Links

- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
