### PR TITLE
perf: optimize no-misleading-character-class

### DIFF
--- a/internal/rules/no_misleading_character_class/no_misleading_character_class.go
+++ b/internal/rules/no_misleading_character_class/no_misleading_character_class.go
@@ -32,21 +32,43 @@ var NoMisleadingCharacterClassRule = rule.Rule{
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
 		opts := parseOptions(options)
-		eval := utils.NewStaticStringEvaluatorWithSourceFile(ctx.TypeChecker, ctx.SourceFile)
-		return rule.RuleListeners{
+		listeners := rule.RuleListeners{
 			ast.KindRegularExpressionLiteral: func(node *ast.Node) {
 				handleRegexLiteral(ctx, node, opts)
 			},
-			ast.KindCallExpression: func(node *ast.Node) {
-				call := node.AsCallExpression()
-				handleRegExpConstructor(ctx, node, call.Expression, call.Arguments, opts, eval)
-			},
-			ast.KindNewExpression: func(node *ast.Node) {
-				newExpr := node.AsNewExpression()
-				handleRegExpConstructor(ctx, node, newExpr.Expression, newExpr.Arguments, opts, eval)
-			},
 		}
+		if !sourceMayUseRegExp(ctx.SourceFile) {
+			return listeners
+		}
+		eval := utils.NewStaticStringEvaluatorWithSourceFile(ctx.TypeChecker, ctx.SourceFile)
+		listeners[ast.KindCallExpression] = func(node *ast.Node) {
+			call := node.AsCallExpression()
+			handleRegExpConstructor(ctx, node, call.Expression, call.Arguments, opts, eval)
+		}
+		listeners[ast.KindNewExpression] = func(node *ast.Node) {
+			newExpr := node.AsNewExpression()
+			handleRegExpConstructor(ctx, node, newExpr.Expression, newExpr.Arguments, opts, eval)
+		}
+		return listeners
 	},
+}
+
+func sourceMayUseRegExp(sourceFile *ast.SourceFile) bool {
+	if sourceFile == nil || sourceFile.Identifiers == nil {
+		return true
+	}
+	for _, name := range [...]string{
+		"RegExp",
+		"globalThis",
+		"window",
+		"self",
+		"global",
+	} {
+		if _, ok := sourceFile.Identifiers[name]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 type ruleOptions struct {
@@ -832,17 +854,23 @@ func isIdentityEscapeForm(raw string) bool {
 func emitMatch(ctx rule.RuleContext, m foundMatch, pattern string, makeFixes func() []rule.RuleFix) {
 	msg := rule.RuleMessage{Id: m.kind, Description: messageDescriptionFor(m.kind)}
 	r := core.NewTextRange(m.srcStart, m.srcEnd)
-	if m.kind == "surrogatePairWithoutUFlag" && patternValidWithUFlag(pattern) {
-		fixes := makeFixes()
-		if fixes != nil {
-			ctx.ReportRangeWithSuggestions(r, msg, rule.RuleSuggestion{
-				Message:  rule.RuleMessage{Id: "suggestUnicodeFlag", Description: "Add unicode 'u' flag to regex."},
-				FixesArr: fixes,
-			})
-			return
-		}
+	if m.kind != "surrogatePairWithoutUFlag" {
+		ctx.ReportRange(r, msg)
+		return
 	}
-	ctx.ReportRange(r, msg)
+	ctx.ReportRangeWithDeferredSuggestions(r, msg, func() []rule.RuleSuggestion {
+		if !patternValidWithUFlag(pattern) {
+			return nil
+		}
+		fixes := makeFixes()
+		if fixes == nil {
+			return nil
+		}
+		return []rule.RuleSuggestion{{
+			Message:  rule.RuleMessage{Id: "suggestUnicodeFlag", Description: "Add unicode 'u' flag to regex."},
+			FixesArr: fixes,
+		}}
+	})
 }
 
 func messageDescriptionFor(kind string) string {

--- a/internal/rules/no_misleading_character_class/no_misleading_character_class_test.go
+++ b/internal/rules/no_misleading_character_class/no_misleading_character_class_test.go
@@ -4,7 +4,11 @@ package no_misleading_character_class
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -451,6 +455,26 @@ func TestNoMisleadingCharacterClassRule(t *testing.T) {
 						},
 					},
 				},
+			},
+			{
+				Code: `var r = R\u0065gExp("[👍]", "")`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "surrogatePairWithoutUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestUnicodeFlag",
+						Output:    `var r = R\u0065gExp("[👍]", "u")`,
+					}},
+				}},
+			},
+			{
+				Code: `var r = globalThis["RegExp"]("[👍]", "")`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "surrogatePairWithoutUFlag",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestUnicodeFlag",
+						Output:    `var r = globalThis["RegExp"]("[👍]", "u")`,
+					}},
+				}},
 			},
 			{
 				Code: `var r = new RegExp("[👍]", "")`,
@@ -1214,4 +1238,58 @@ func TestNoMisleadingCharacterClassRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoMisleadingCharacterClassDefersSuggestions(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, `/[\uD83D\uDC4D]/`, core.ScriptKindTS)
+
+	for _, testCase := range []struct {
+		name            string
+		demand          rule.EditDemand
+		wantBuilds      int
+		wantSuggestions bool
+	}{
+		{name: "diagnostics only", demand: rule.EditDemandNone},
+		{name: "autofix only", demand: rule.EditDemandAutofix},
+		{name: "suggestions", demand: rule.EditDemandSuggestion, wantBuilds: 1, wantSuggestions: true},
+		{name: "all edits", demand: rule.EditDemandAll, wantBuilds: 1, wantSuggestions: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			builds := 0
+			var diagnostics []rule.RuleDiagnostic
+			ctx := rule.RuleContext{SourceFile: sourceFile}.WithDiagnosticConsumer(
+				NoMisleadingCharacterClassRule.Name,
+				rule.SeverityError,
+				rule.DiagnosticConsumer{
+					Demand: testCase.demand,
+					Report: func(diagnostic rule.RuleDiagnostic) {
+						diagnostics = append(diagnostics, diagnostic)
+					},
+				},
+			)
+
+			emitMatch(ctx, foundMatch{
+				kind:     "surrogatePairWithoutUFlag",
+				srcStart: 2,
+				srcEnd:   14,
+			}, `[\uD83D\uDC4D]`, func() []rule.RuleFix {
+				builds++
+				return []rule.RuleFix{rule.RuleFixReplaceRange(core.NewTextRange(0, 0), "u")}
+			})
+
+			if len(diagnostics) != 1 {
+				t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+			}
+			if builds != testCase.wantBuilds {
+				t.Fatalf("suggestion builds = %d, want %d", builds, testCase.wantBuilds)
+			}
+			hasSuggestions := diagnostics[0].Suggestions != nil
+			if hasSuggestions != testCase.wantSuggestions {
+				t.Fatalf("suggestions present = %v, want %v", hasSuggestions, testCase.wantSuggestions)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Optimize the common paths of `no-misleading-character-class` without replacing existing framework utilities or changing constructor analysis.

- Always keep the regexp-literal listener active.
- Register the `CallExpression` / `NewExpression` listeners, and allocate the existing `StaticStringEvaluator`, only when the source-file identifier table contains a possible `RegExp` root (`RegExp`, `globalThis`, `window`, `self`, or `global`).
- Keep candidate files on the existing TypeChecker and tsgo-backed `StaticStringEvaluator` paths unchanged.
- Defer unicode-flag safety validation and suggestion-fix construction through the existing `ReportRangeWithDeferredSuggestions` API when the diagnostic consumer does not request suggestions.
- Add regressions for escaped `RegExp` identifiers, computed `globalThis["RegExp"]` access, and edit-demand behavior.

The final diff touches only the rule and its existing test file. It adds no tracker, evaluator, regexp/Unicode utility, shim, or framework API.

## Benchmark

Apple M1 Max, darwin/arm64, Go 1.26.1, `-cpu=1`, `-benchtime=500ms`, `-count=10`. All values below are medians. Temporary benchmark files were deleted and are not committed.

### No-candidate file

The harness generated one TypeScript file containing 1,000 bare calls plus 1,000 ordinary method calls and asserted zero diagnostics on every iteration. Program creation was outside the timer; the benchmark used `LintSingleFile` with `EditDemandNone`. Baseline and final were measured in the exact final worktree by toggling only the candidate gate.

| Revision | Time | Bytes | Allocations |
| --- | ---: | ---: | ---: |
| Gate disabled (`origin/main` behavior) | 546,854 ns/op | 36,836 B/op | 2,072 allocs/op |
| This PR (`27620394`) | 191,544 ns/op | 3,122 B/op | 33 allocs/op |
| Change | **-65.0% (2.85x faster)** | **-91.5%** | **-98.4%** |

This isolates the intended no-candidate hot path; it is not a CLI cold-start measurement. Candidate files continue through the pre-existing implementation.

### Emitted diagnostic without suggestion demand

This microbenchmark isolates one eligible `surrogatePairWithoutUFlag` report with `EditDemandNone`. It measures reporting and optional suggestion construction, not pattern scanning. Baseline and final were measured in the same worktree by toggling only eager versus deferred suggestion construction.

| Revision | Time | Bytes | Allocations |
| --- | ---: | ---: | ---: |
| Eager suggestion construction | 1,708 ns/op | 2,376 B/op | 37 allocs/op |
| Deferred suggestion construction | 22.9 ns/op | 0 B/op | 0 allocs/op |
| Change | **-98.7% (74.6x faster)** | **-100%** | **-100%** |

Suggestion-requesting consumers retain the existing safety validation, suggestion text, fix, and diagnostic range.

## Verification

- `go test ./internal/rules/no_misleading_character_class -count=1`
- `golangci-lint run ./internal/rules/no_misleading_character_class` — 0 issues
- `pnpm run check-spell` — 2,415 files, 0 issues
- `pnpm run format:check`
- `git diff --check`

No full-tree Go test, build, or lint was run.

## Related Links

- [ESLint rule documentation](https://eslint.org/docs/latest/rules/no-misleading-character-class)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
