### PR TITLE
docs: prefer framework APIs in port-rule skill

### DIFF
--- a/.agents/skills/port-rule/SKILL.md
+++ b/.agents/skills/port-rule/SKILL.md
@@ -130,6 +130,25 @@ Determine the mode based on the number of rules:
 - **1 rule** → Single Rule Mode
 - **2+ rules** → Batch Mode
 
+### Framework Performance Defaults
+
+Apply these defaults during every implementation phase. Do not rebuild work
+that the rule framework already shares or can skip:
+
+- **Autofixes and suggestions**: report them with the matching
+  `ReportNodeWithDeferred*` or `ReportRangeWithDeferred*` method. Keep
+  diagnostic detection, message, and report range eager, but move all
+  edit-only source-text, range, string, slice, and suggestion construction into
+  the builder. A builder may return nil when the diagnostic is not fixable.
+- **Declared-symbol references**: translate ESLint `variable.references` to
+  `ctx.Refs.References(decl.Symbol())`. Never walk the file and call
+  `GetSymbolAtLocation` once per identifier.
+- **Whole-file comments**: iterate `ctx.Comments.All()`. Never rescan
+  `ctx.SourceFile.AsNode()` once per rule.
+
+See [AST_PATTERNS.md](references/AST_PATTERNS.md) for the APIs, boundaries, and
+worked examples.
+
 ### Single Rule Mode
 
 Follow the phases in [PORT_RULE.md](references/PORT_RULE.md) sequentially:
@@ -228,6 +247,14 @@ Do NOT include AI-related information in PR title or body. If any rules were ski
 The workflow is complete ONLY when all tasks created during Planning are marked as `completed` (or explicitly skipped due to failure). Do NOT stop or wait for user instructions while there are still pending tasks. If the conversation context was compressed or the session was resumed, call `TaskList` first to check remaining work before continuing.
 
 ## Quick Reference
+
+**Framework defaults**:
+
+| Need                            | Use                                                    |
+| ------------------------------- | ------------------------------------------------------ |
+| Autofixes or suggestions        | `ReportNodeWithDeferred*` / `ReportRangeWithDeferred*` |
+| References to a declared symbol | `ctx.Refs.References(decl.Symbol())`                   |
+| Every comment in the file       | `ctx.Comments.All()`                                   |
 
 **Directory Structure**:
 

--- a/.agents/skills/port-rule/references/AST_PATTERNS.md
+++ b/.agents/skills/port-rule/references/AST_PATTERNS.md
@@ -174,7 +174,7 @@ Prefer:
 - `utils.TrimmedNodeText(sourceFile, node)` — source text over that trimmed range.
 - `ctx.ReportNode(node, msg)` — diagnostic range already uses the trimmed span; no manual adjustment needed.
 
-For fixes:
+For fixes, construct these helpers inside the deferred report builder:
 
 - `rule.RuleFixReplace(sf, node, text)` — replaces the trimmed span.
 - `rule.RuleFixReplaceRange(range, text)` — replaces a specific range (useful for precision edits across multiple nodes).
@@ -298,7 +298,7 @@ if node.Kind == ast.KindPropertyAccessExpression {
     propertyName := propAccess.Name.Text()
 
     if propAccess.Expression.Kind == ast.KindIdentifier {
-        objectName = propAccess.Expression.AsIdentifier().Text()
+        objectName = propAccess.Expression.AsIdentifier().Text
     }
     // objectName = "console", propertyName = "log"
 }
@@ -363,12 +363,11 @@ var MyCoreRule = rule.Rule{
 
 See `typescript-go/_packages/api/src/api.ts` for full API:
 
-| Method                            | Description              |
-| --------------------------------- | ------------------------ |
-| `GetTypeAtLocation(node)`         | Get the type of a node   |
-| `GetSymbolAtLocation(node)`       | Get the symbol of a node |
-| `TypeToString(type)`              | Convert type to string   |
-| `GetSignaturesOfType(type, kind)` | Get function signatures  |
+| Method                            | Description             |
+| --------------------------------- | ----------------------- |
+| `GetTypeAtLocation(node)`         | Get the type of a node  |
+| `TypeToString(type)`              | Convert type to string  |
+| `GetSignaturesOfType(type, kind)` | Get function signatures |
 
 ---
 
@@ -518,7 +517,7 @@ return rule.RuleListeners{
 
 ### Type Annotation Checking
 
-Reference: `internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go`
+Reference: `internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.go`
 
 For rules that check type annotations:
 
@@ -532,7 +531,7 @@ func isAnyType(node *ast.Node) bool {
     if node.Kind == ast.KindTypeReference {
         typeRef := node.AsTypeReferenceNode()
         if typeRef.TypeName.Kind == ast.KindIdentifier {
-            return typeRef.TypeName.AsIdentifier().Text() == "any"
+            return typeRef.TypeName.AsIdentifier().Text == "any"
         }
     }
     return false
@@ -543,7 +542,7 @@ func isAnyType(node *ast.Node) bool {
 
 ## Reporting Functions
 
-`RuleContext` provides multiple reporting methods (defined in `internal/rule/rule.go`):
+`RuleContext` provides reporting methods in `internal/rule/context.go`.
 
 ### Basic Report
 
@@ -560,31 +559,70 @@ ctx.ReportNode(node, rule.RuleMessage{
 ctx.ReportRange(core.TextRange{Pos: start, End: end}, rule.RuleMessage{...})
 ```
 
-### Report with Autofix
+### Reports with Optional Edits
+
+Autofixes and suggestions are optional artifacts. New native rules must defer
+their construction so diagnostics-only consumers and suppressed diagnostics do
+not pay for replacement text, token scans, edit ranges/slices, or suggestion
+messages.
+
+| Artifact                     | Node-keyed method                           | Range-keyed method                           |
+| ---------------------------- | ------------------------------------------- | -------------------------------------------- |
+| Autofixes                    | `ReportNodeWithDeferredFixes`               | `ReportRangeWithDeferredFixes`               |
+| Suggestions                  | `ReportNodeWithDeferredSuggestions`         | `ReportRangeWithDeferredSuggestions`         |
+| Both, independently demanded | `ReportNodeWithDeferredFixesAndSuggestions` | `ReportRangeWithDeferredFixesAndSuggestions` |
+
+The diagnostic decision, message, and report range stay outside the builder and
+must not depend on edit demand. Work needed only to decide whether an edit is
+safe may be deferred too; return nil when the diagnostic has no artifact. Each
+requested builder runs synchronously during the report call, after suppression,
+and is never retained. It must not mutate detection state.
+
+#### Autofix
 
 ```go
-ctx.ReportNodeWithFixes(node, rule.RuleMessage{...},
-    rule.RuleFix{
-        Range: core.TextRange{Pos: start, End: end},
-        Text:  "replacement text",  // Note: field is "Text", not "NewText"
-    },
-)
+ctx.ReportNodeWithDeferredFixes(node, msg, func() []rule.RuleFix {
+    if !canFix(node) {
+        return nil
+    }
+    replacement := buildReplacement(ctx.SourceFile, node)
+    return []rule.RuleFix{
+        rule.RuleFixReplace(ctx.SourceFile, node, replacement),
+    }
+})
 ```
 
-### Report with Suggestions
-
-Suggestions are optional fixes that users can choose to apply:
+#### Suggestion
 
 ```go
-ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{...},
-    rule.RuleSuggestion{
+ctx.ReportNodeWithDeferredSuggestions(node, msg, func() []rule.RuleSuggestion {
+    replacement := buildReplacement(ctx.SourceFile, node)
+    return []rule.RuleSuggestion{{
         Message: rule.RuleMessage{
-            Id:          "suggestRemove",
-            Description: "Remove this statement",
+            Id:          "suggestReplace",
+            Description: "Replace this expression",
         },
-        FixesArr: []rule.RuleFix{  // Note: field is "FixesArr", not "Fixes"
-            {Range: core.TextRange{...}, Text: ""},
+        FixesArr: []rule.RuleFix{
+            rule.RuleFixReplace(ctx.SourceFile, node, replacement),
         },
+    }}
+})
+```
+
+#### Autofix and Suggestion
+
+When one diagnostic exposes both categories, use separate builders so the
+consumer materializes only what it requested:
+
+```go
+ctx.ReportNodeWithDeferredFixesAndSuggestions(
+    node,
+    msg,
+    func() []rule.RuleFix {
+        return buildFixes(ctx.SourceFile, node)
+    },
+    func() []rule.RuleSuggestion {
+        return buildSuggestions(ctx.SourceFile, node)
     },
 )
 ```
@@ -593,7 +631,7 @@ ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{...},
 
 ## Fix Helper Functions
 
-Defined in `internal/rule/rule.go`:
+Defined in `internal/rule/diagnostic.go`:
 
 ```go
 // Insert text before node (requires SourceFile)
@@ -621,10 +659,12 @@ To remove or replace multiple non-contiguous ranges in a single fix, pass multip
 
 ```go
 // Example: remove ".bind" and "(arg)" separately from "fn.bind(arg)"
-ctx.ReportNodeWithFixes(node, msg,
-    rule.RuleFixRemoveRange(core.NewTextRange(dotStart, bindEnd)),   // removes ".bind"
-    rule.RuleFixRemoveRange(core.NewTextRange(parenStart, parenEnd)), // removes "(arg)"
-)
+ctx.ReportNodeWithDeferredFixes(node, msg, func() []rule.RuleFix {
+    return []rule.RuleFix{
+        rule.RuleFixRemoveRange(core.NewTextRange(dotStart, bindEnd)),    // removes ".bind"
+        rule.RuleFixRemoveRange(core.NewTextRange(parenStart, parenEnd)), // removes "(arg)"
+    }
+})
 ```
 
 ---

--- a/.agents/skills/port-rule/references/PORT_RULE.md
+++ b/.agents/skills/port-rule/references/PORT_RULE.md
@@ -18,7 +18,9 @@ Note: `languageOptions.globals` and `/*global ...*/` comments are automatically 
 
 Note: ESLint's scope manager (`sourceCode.getScope()`, `variable.references`) has no direct equivalent, but the common case — "every identifier that references this declared symbol" — is served by `ctx.Refs.References(sym)`, a lazily built per-file reference index keyed by binder symbols (`decl.Symbol()`). Use it instead of walking the AST and calling `ctx.TypeChecker.GetSymbolAtLocation` per identifier, which is a known performance killer. See [AST_PATTERNS.md — Collecting Variable References](./AST_PATTERNS.md#collecting-variable-references-ctxrefs) for semantics and the nil guard.
 
-Note: every comment in the file is already collected once by the linter and exposed through `ctx.Comments` (`[]*ast.CommentRange`, sorted, deduplicated). If your rule needs to scan all of a file's comments (directive comments, "is this line comment-only", etc.), iterate `ctx.Comments` directly — do **not** call `utils.ForEachComment(ctx.SourceFile.AsNode(), ...)`, which re-walks the entire token tree from scratch. See [UTILS_REFERENCE.md](./UTILS_REFERENCE.md#token-and-comment-iteration) for the full comment-handling API and when each function is appropriate.
+Note: every comment in the file is exposed lazily through `ctx.Comments.All()` as a source-ordered, deduplicated `[]*ast.CommentRange`. If your rule needs to scan all comments (directive comments, "is this line comment-only", etc.), iterate that shared slice — do **not** call `utils.ForEachComment(ctx.SourceFile.AsNode(), ...)`, which re-walks the entire token tree from scratch. See [UTILS_REFERENCE.md](./UTILS_REFERENCE.md#token-and-comment-iteration) for the full comment-handling API and when each function is appropriate.
+
+Note: autofixes and suggestions are optional artifacts. New native rules must use the matching `ReportNodeWithDeferred*` or `ReportRangeWithDeferred*` method so diagnostics-only consumers and suppressed diagnostics do not pay to construct replacement text, edit ranges/slices, or suggestions. Detection, message construction, and the diagnostic range remain eager and independent of edit demand; work used only to decide or materialize an edit belongs in the builder, which may return nil. See [AST_PATTERNS.md — Reporting Functions](./AST_PATTERNS.md#reporting-functions).
 
 When an upstream test case depends on other unsupported concepts (like `env` or `/*eslint*/` configurations):
 
@@ -78,7 +80,11 @@ Before starting, familiarize yourself with these key source locations:
 
 | File/Directory                        | Description                                                                                                                                                |
 | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `internal/rule/rule.go`               | **Core rule interface** - `Rule`, `RuleContext`, `RuleListeners`, `RuleMessage`, `RuleFix`, `RuleSuggestion` definitions                                   |
+| `internal/rule/rule.go`               | **Core rule interface** - `Rule` and `RuleListeners`                                                                                                       |
+| `internal/rule/context.go`            | `RuleContext`, edit demand, and diagnostic reporting APIs                                                                                                  |
+| `internal/rule/diagnostic.go`         | `RuleMessage`, `RuleFix`, `RuleSuggestion`, and fix helpers                                                                                                |
+| `internal/rule/ref_store.go`          | Lazy per-file reference index exposed as `ctx.Refs`                                                                                                        |
+| `internal/rule/comment_store.go`      | Lazy canonical comment list exposed as `ctx.Comments`                                                                                                      |
 | `internal/rule/disable_manager.go`    | Logic for handling `// rslint-disable` and `// eslint-disable` comments                                                                                    |
 | `internal/config/config.go`           | Registration orchestration and config loading. Per-rule registration data lives in each group's `all.go` — see Phase 3 Step 4 for where to add a new rule. |
 | `internal/rule_tester/rule_tester.go` | Go test framework - `RunRuleTester`, `ValidTestCase`, `InvalidTestCase`                                                                                    |
@@ -95,12 +101,13 @@ Before starting, familiarize yourself with these key source locations:
 
 ### Example Rules (Recommended Reading)
 
-| Rule                    | Path                                                 | Highlights                              |
-| ----------------------- | ---------------------------------------------------- | --------------------------------------- |
-| `no-debugger`           | `internal/rules/no_debugger/`                        | Simplest rule example                   |
-| `constructor-super`     | `internal/rules/constructor_super/`                  | Complex control flow analysis           |
-| `array-callback-return` | `internal/rules/array_callback_return/`              | Options parsing, function body analysis |
-| `no-explicit-any`       | `internal/plugins/typescript/rules/no_explicit_any/` | TypeScript rule, Fix suggestions        |
+| Rule                    | Path                                                     | Highlights                              |
+| ----------------------- | -------------------------------------------------------- | --------------------------------------- |
+| `no-debugger`           | `internal/rules/no_debugger/`                            | Simplest rule example                   |
+| `constructor-super`     | `internal/rules/constructor_super/`                      | Complex control flow analysis           |
+| `array-callback-return` | `internal/rules/array_callback_return/`                  | Options parsing, function body analysis |
+| `no-var`                | `internal/rules/no_var/`                                 | `ctx.Refs`, deferred autofix            |
+| `no-restricted-types`   | `internal/plugins/typescript/rules/no_restricted_types/` | Deferred fixes and suggestions          |
 
 ---
 
@@ -202,6 +209,8 @@ Before starting, familiarize yourself with these key source locations:
    - Arguments with side effects (should suppress autofix)
    - Parenthesized expressions (multiple levels)
    - Multi-line code with varying whitespace
+   - Diagnostic count, message, and range must be identical for every edit demand
+   - Identify every source-text read, token scan, range calculation, string build, and slice allocation used only by the edit; these belong in a deferred builder
 
    **Dimension 4: Universal edge shapes** — walk this checklist for EVERY port, regardless of what the rule does. Mark rows as N/A when genuinely irrelevant (and briefly note why), and add ≥1 dedicated test for each applicable row. Upstream's own test suite rarely covers all of these; they are the most common source of "looks aligned but silently drifts" regressions:
    - **Receiver / expression wrappers on inputs the rule inspects**:
@@ -371,7 +380,7 @@ var MyCoreRule = rule.Rule{
 **Key Points**:
 
 - `RuleListeners` is a map from `ast.Kind` to a callback function
-- Each callback receives a `*ast.Node` and reports diagnostics via `ctx.ReportNode()`
+- Each callback receives a `*ast.Node` and reports diagnostics through `RuleContext`; reports with optional edits use the deferred methods
 - Options parsing happens inside the `Run` function before returning listeners
 - Use `rule.CreateRule` **ONLY** for `@typescript-eslint` rules (it adds the prefix)
 - **`RequiresTypeInfo`**: If a `@typescript-eslint` rule uses `ctx.TypeChecker`, you **MUST** set `RequiresTypeInfo: true`. This tells the linter to skip the rule on files without a type checker, preventing nil-pointer panics. Core ESLint rules should NOT set this flag — use `ctx.TypeChecker == nil` guards instead (see [AST_PATTERNS.md — Using TypeChecker](AST_PATTERNS.md#using-typechecker)).
@@ -452,6 +461,7 @@ Before moving on, walk through each check. Each one targets a class of AST-shape
 | Handles `foo?.bar` / `foo?.()`                                                  | Use `ast.IsOptionalChain(node)`; don't hand-check node flags.                                                                                                     | [AST_PATTERNS.md § Optional Chain](AST_PATTERNS.md#optional-chain)                   |
 | Compares literal values                                                         | Match the precise `Kind*Literal`; normalize numeric text via `utils.NormalizeNumericLiteral` before value comparison.                                             | [AST_PATTERNS.md § Literal Kinds](AST_PATTERNS.md#literal-kinds)                     |
 | Has separate ESLint listeners for `AssignmentExpression` / `SequenceExpression` | Collapse into one `BinaryExpression` listener and branch on `OperatorToken.Kind`.                                                                                 | [AST_PATTERNS.md § Binary Operator Kinds](AST_PATTERNS.md#binary-operator-kinds)     |
+| Emits autofixes or suggestions                                                  | Use the matching deferred report method. Keep diagnostic identity eager; put all edit-only work in the builder and return nil when no artifact applies.           | [AST_PATTERNS.md § Reporting Functions](AST_PATTERNS.md#reporting-functions)         |
 | Emits fix/suggestion text starting with an identifier                           | Guard against token fusion with the preceding character before emitting (otherwise e.g. `typeof` + `Number(foo)` becomes `typeofNumber(foo)`).                    | —                                                                                    |
 | Checks whether a name resolves to a global                                      | Use `utils.IsShadowed(node, name)`. Note: stricter than ESLint's scope manager on TS type-only bindings — document in the rule's `.md` if the difference matters. | —                                                                                    |
 | Reads source text for recommendation / fix                                      | Prefer `utils.TrimmedNodeText(sf, node)` (skips leading trivia) over raw `node.Pos()/End()`.                                                                      | [AST_PATTERNS.md § Node Text and Positions](AST_PATTERNS.md#node-text-and-positions) |
@@ -574,7 +584,7 @@ rule_tester.InvalidTestCase{
 }
 ```
 
-**Autofix Testing**: If the rule provides autofix, use the `Output` field to verify the fixed code:
+**Optional Edit Testing**: If the rule provides autofix, use the `Output` field to verify the fixed code:
 
 ```go
 // With autofix: provide Output field with the expected fixed code
@@ -590,6 +600,31 @@ rule_tester.InvalidTestCase{
     Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
 }
 ```
+
+For suggestions, assert both their message IDs and applied output on the
+diagnostic:
+
+```go
+rule_tester.InvalidTestCase{
+    Code: `const value = source as Type`,
+    Errors: []rule_tester.InvalidTestCaseError{{
+        MessageId: "unexpectedAssertion",
+        Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+            MessageId: "suggestAnnotation",
+            Output:    `const value: Type = source`,
+        }},
+    }},
+}
+```
+
+`RunRuleTester` requests all edit categories, so `Output` verifies final edit text but does not verify the demand boundary. For every rule with an autofix or suggestion, also add `Test<Rule>EditDemand` to the existing `<rule>_extras_test.go` file. Run the same representative diagnostic with:
+
+- `rule.EditDemandNone`
+- `rule.EditDemandAutofix`
+- `rule.EditDemandSuggestion`
+- `rule.EditDemandAll`
+
+Assert that diagnostic count, message, and range are identical in all four modes; fixes and suggestions appear only under their matching demand; and the requested artifacts equal the all-edits output. Do not create a standalone edit-demand test file. See `internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go` for a combined fix/suggestion example. The framework's own `internal/rule/context_test.go` covers the lower-level guarantee that an unrequested builder is not invoked.
 
 **Test Case Structs**: See `internal/rule_tester/rule_tester.go` for `ValidTestCase`, `InvalidTestCase`, and `InvalidTestCaseError` definitions.
 
@@ -752,6 +787,7 @@ Follow this **strict order** — each step depends on the previous one:
    **Diagnostic contract** (each invalid output is exactly what ESLint emits):
    - [ ] **Message text assertions**: each `messageId` has ≥1 test using the `InvalidTestCaseError.Message` field (exact string match), covering every modifier combination the rule can emit (`static`, `private`, `async`, computed-no-name, etc.).
    - [ ] **Position assertions per container**: for each container the rule emits into (object literal / class / type / descriptor / …), ≥2 cases assert `Line` + `Column` + `EndLine` + `EndColumn`, including one multi-line case.
+   - [ ] **Edit-demand invariance**: rules with autofixes or suggestions have `Test<Rule>EditDemand` in `<rule>_extras_test.go`, covering none/autofix/suggestion/all without changing diagnostic identity.
 
    **Options contract**:
    - [ ] **Schema match**: option names, types, and **defaults** match ESLint's schema exactly. Assert every default by running a case with no options vs. `[{}]` options and confirming identical output.

--- a/.agents/skills/port-rule/references/QUICK_REFERENCE.md
+++ b/.agents/skills/port-rule/references/QUICK_REFERENCE.md
@@ -27,12 +27,26 @@ A quick reference for common commands, file locations, and checklists when porti
 
 ## File Locations
 
-| File Type         | Core Rules                                                     | Plugin Rules                                                     |
-| ----------------- | -------------------------------------------------------------- | ---------------------------------------------------------------- |
-| Go implementation | `internal/rules/<name>/`                                       | `internal/plugins/<plugin>/rules/<name>/`                        |
-| Go tests          | `internal/rules/<name>/<name>_test.go`                         | `internal/plugins/<plugin>/rules/<name>/<name>_test.go`          |
-| Documentation     | `internal/rules/<name>/<name>.md`                              | `internal/plugins/<plugin>/rules/<name>/<name>.md`               |
-| JS tests          | `packages/rslint-test-tools/tests/eslint/rules/<name>.test.ts` | `packages/rslint-test-tools/tests/<plugin>/rules/<name>.test.ts` |
+| File Type         | Core Rules                                                                | Plugin Rules                                                     |
+| ----------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Go implementation | `internal/rules/<name>/`                                                  | `internal/plugins/<plugin>/rules/<name>/`                        |
+| Go tests          | `<name>_upstream_test.go` + `<name>_extras_test.go` in the rule directory | Same two-file split in the plugin rule directory                 |
+| Documentation     | `internal/rules/<name>/<name>.md`                                         | `internal/plugins/<plugin>/rules/<name>/<name>.md`               |
+| JS tests          | `packages/rslint-test-tools/tests/eslint/rules/<name>.test.ts`            | `packages/rslint-test-tools/tests/<plugin>/rules/<name>.test.ts` |
+
+---
+
+## Framework Performance Defaults
+
+| Need                              | Use                                                                     | Avoid                                                                        |
+| --------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Autofixes or suggestions          | Matching `ReportNodeWithDeferred*` or `ReportRangeWithDeferred*` method | Constructing edit-only text, ranges, slices, or suggestions before reporting |
+| References to one declared symbol | `ctx.Refs.References(decl.Symbol())`                                    | Full-file AST walk with one `GetSymbolAtLocation` call per identifier        |
+| Every comment in the file         | `ctx.Comments.All()`                                                    | Calling `ForEachComment` on `ctx.SourceFile.AsNode()`                        |
+
+Deferred edit builders may return nil and run synchronously only when their
+artifact category is requested and the diagnostic is not suppressed. Detection,
+message, and report range must remain independent of edit demand.
 
 ---
 
@@ -109,7 +123,10 @@ import (
 - [ ] Build binary (`cd packages/rslint && pnpm run build:bin`)
 - [ ] JS snapshots generated (`npx rstest run <name> -u`)
 - [ ] JS tests pass (`cd packages/rslint-test-tools && npx rstest run <name>`)
-- [ ] Go/JS test coverage aligned (same invalid cases, including comments/multi-line/nested)
+- [ ] Go/JS test coverage is semantically aligned (`JS ⊆ Go upstream`; extras remain Go-only)
+- [ ] Autofixes/suggestions use deferred report builders and have `Test<Rule>EditDemand` in the existing extras test file
+- [ ] ESLint `variable.references` usage maps to `ctx.Refs` with a binder symbol
+- [ ] Whole-file comment scans use `ctx.Comments.All()`
 - [ ] Type check passes (`pnpm typecheck`)
 - [ ] Lint check passes (`pnpm lint`)
 - [ ] Spell check passes (`pnpm -w run check-spell`)

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
@@ -180,7 +180,7 @@ func TestNoRestrictedTypesExtras(t *testing.T) {
 		// ---- Branch lock-in: object with BOTH fixWith and suggest emits fix + suggestions ----
 		// Upstream `context.report({...fix, suggest})` keeps both; we
 		// match by sending the diagnostic via
-		// ReportNodeWithFixesAndSuggestions.
+		// ReportNodeWithDeferredFixesAndSuggestions.
 		{
 			Code: `let value: Banned;`,
 			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{


### PR DESCRIPTION
## Summary

- make deferred fix and suggestion reporting the default for newly ported native rules, and remove eager edit-report examples from the port-rule guidance
- surface the framework-owned `ctx.Refs` and `ctx.Comments.All()` paths in the top-level skill and quick reference so new rules reuse lazy per-file work
- document the diagnostic/edit boundary, all six deferred report variants, edit-demand validation, and corrected framework source locations
- replace eager example rules with deferred/RefStore examples and fix the remaining stale API reference

### Architecture

The skill now treats diagnostics as the eager semantic contract while fixes and suggestions are demand-driven optional artifacts. Reference lookup and whole-file comment collection likewise route through the framework's shared lazy stores instead of rule-local rescans. These defaults stay entirely within native rule implementation guidance and do not change runtime or product semantics.

### Validation

- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_restricted_types/...`

## Related Links

- Related to #1336

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).