### PR TITLE
perf: optimize new-for-builtins

### DIFF
--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.go
@@ -130,10 +130,60 @@ var globalObjectNames = map[string]bool{
 	"window":     true,
 }
 
+// potentialReferenceRoots is the cheap listener-side gate. Only these global
+// roots, plus names registered in aliasesByID, can ever produce a watched
+// builtin path.
+var potentialReferenceRoots = func() map[string]bool {
+	roots := make(map[string]bool)
+	add := func(names map[string]bool) {
+		for name := range names {
+			root, _, _ := strings.Cut(name, ".")
+			roots[root] = true
+		}
+	}
+	add(enforceNewBuiltins)
+	add(disallowNewBuiltins)
+	add(disallowCallOrNewBuiltins)
+	add(globalObjectNames)
+	return roots
+}()
+
+// Descriptions are immutable and depend only on the builtin name. Keep the
+// per-diagnostic Data map independent, but avoid repeating fmt work for every
+// matching call in large/generated files.
+var (
+	enforceMessageDescriptions = buildMessageDescriptions(enforceNewBuiltins, func(name string) string {
+		return fmt.Sprintf("Use `new %s()` instead of `%s()`.", name, name)
+	})
+	disallowMessageDescriptions = buildMessageDescriptions(disallowNewBuiltins, func(name string) string {
+		return fmt.Sprintf("Use `%s()` instead of `new %s()`.", name, name)
+	})
+	disallowCallOrNewMessageDescriptions = buildMessageDescriptions(disallowCallOrNewBuiltins, func(name string) string {
+		return fmt.Sprintf("`%s` is not a function or constructor.", name)
+	})
+)
+
 type ruleState struct {
-	ctx         rule.RuleContext
-	aliases     map[*ast.Node]aliasInfo
-	aliasesByID map[string][]aliasInfo
+	ctx               rule.RuleContext
+	aliases           map[*ast.Node]aliasInfo
+	aliasesByID       map[string][]aliasInfo
+	collectingAliases bool
+
+	// localRootSymbols is populated during the alias pre-pass without another
+	// AST walk. ctx.Refs resolves these binder symbols to exact reference
+	// identifiers lazily, only if a matching callee actually needs a shadow
+	// decision.
+	localRootSymbols         map[string]map[*ast.Symbol]struct{}
+	incompleteLocalRootNames map[string]bool
+	localRootsCollected      bool
+	indexedLocalRootNames    map[string]bool
+	localRootReferences      map[*ast.Node]struct{}
+
+	// Alias references use the same binder-backed index. Exact-node lookup
+	// replaces repeated TypeChecker and ancestor-scope walks in listeners.
+	indexedAliasNames  map[string]bool
+	completeAliasNames map[string]bool
+	aliasReferences    map[*ast.Node]aliasInfo
 }
 
 type aliasInfo struct {
@@ -162,11 +212,13 @@ type globalReference struct {
 
 func newRuleState(ctx rule.RuleContext) *ruleState {
 	state := &ruleState{
-		ctx:         ctx,
-		aliases:     map[*ast.Node]aliasInfo{},
-		aliasesByID: map[string][]aliasInfo{},
+		ctx:               ctx,
+		aliases:           map[*ast.Node]aliasInfo{},
+		aliasesByID:       map[string][]aliasInfo{},
+		collectingAliases: true,
 	}
 	state.collectAliases()
+	state.collectingAliases = false
 	return state
 }
 
@@ -205,7 +257,9 @@ func (state *ruleState) checkCallExpression(node *ast.Node) {
 		return
 	}
 
-	state.ctx.ReportNodeWithFixes(node, messageEnforce(ref.name), state.enforceNewFix(node))
+	state.ctx.ReportNodeWithDeferredFixes(node, messageEnforce(ref.name), func() []rule.RuleFix {
+		return []rule.RuleFix{state.enforceNewFix(node)}
+	})
 }
 
 func (state *ruleState) checkNewExpression(node *ast.Node) {
@@ -234,28 +288,35 @@ func (state *ruleState) checkNewExpression(node *ast.Node) {
 		return
 	}
 
-	fixes := state.newToCallFixes(node, newExpression)
-	if len(fixes) == 0 {
-		state.ctx.ReportNode(node, message)
-		return
-	}
-	state.ctx.ReportNodeWithFixes(node, message, fixes...)
+	state.ctx.ReportNodeWithDeferredFixes(node, message, func() []rule.RuleFix {
+		return state.newToCallFixes(node, newExpression)
+	})
 }
 
 func (state *ruleState) reportDateCall(node *ast.Node, call *ast.CallExpression) {
 	message := rule.RuleMessage{Id: messageIDErrorDate, Description: messageDateDescription}
-	fix := rule.RuleFixReplaceRange(utils.TrimNodeTextRange(state.ctx.SourceFile, node), state.dateReplacement(node))
 
 	hasArguments := call.Arguments != nil && len(call.Arguments.Nodes) > 0
 	if !hasArguments && !utils.HasCommentInsideNode(state.ctx.SourceFile, node) {
-		state.ctx.ReportNodeWithFixes(node, message, fix)
+		state.ctx.ReportNodeWithDeferredFixes(node, message, func() []rule.RuleFix {
+			return []rule.RuleFix{state.dateFix(node)}
+		})
 		return
 	}
 
-	state.ctx.ReportNodeWithSuggestions(node, message, rule.RuleSuggestion{
-		Message:  rule.RuleMessage{Id: messageIDSuggestionDate, Description: messageDateSuggestion},
-		FixesArr: []rule.RuleFix{fix},
+	state.ctx.ReportNodeWithDeferredSuggestions(node, message, func() []rule.RuleSuggestion {
+		return []rule.RuleSuggestion{{
+			Message:  rule.RuleMessage{Id: messageIDSuggestionDate, Description: messageDateSuggestion},
+			FixesArr: []rule.RuleFix{state.dateFix(node)},
+		}}
 	})
+}
+
+func (state *ruleState) dateFix(node *ast.Node) rule.RuleFix {
+	return rule.RuleFixReplaceRange(
+		utils.TrimNodeTextRange(state.ctx.SourceFile, node),
+		state.dateReplacement(node),
+	)
 }
 
 func (state *ruleState) newToCallFixes(node *ast.Node, newExpression *ast.NewExpression) []rule.RuleFix {
@@ -355,6 +416,15 @@ func (state *ruleState) dateReplacement(node *ast.Node) string {
 }
 
 func (state *ruleState) referenceFromExpression(node *ast.Node) (reference, bool) {
+	root := expressionRootIdentifier(node)
+	if root == nil {
+		return reference{}, false
+	}
+	rootName := root.AsIdentifier().Text
+	if !potentialReferenceRoots[rootName] && len(state.aliasesByID[rootName]) == 0 {
+		return reference{}, false
+	}
+
 	path, ok := state.globalReferencePath(node)
 	if !ok || len(path) == 0 {
 		return reference{}, false
@@ -366,17 +436,35 @@ func (state *ruleState) referenceFromExpression(node *ast.Node) (reference, bool
 	return reference{name: name, path: path}, true
 }
 
+func expressionRootIdentifier(node *ast.Node) *ast.Node {
+	node = utils.SkipAssertionsAndParens(node)
+	for node != nil && ast.IsAccessExpression(node) {
+		node = utils.SkipAssertionsAndParens(utils.AccessExpressionObject(node))
+	}
+	if node == nil || node.Kind != ast.KindIdentifier {
+		return nil
+	}
+	return node
+}
+
 func (state *ruleState) collectAliases() {
 	if state.ctx.SourceFile == nil || state.ctx.SourceFile.AsNode() == nil {
 		return
 	}
+	aliasDeclarations := make([]*ast.Node, 0)
 	var walk func(*ast.Node)
 	walk = func(node *ast.Node) {
 		if node == nil {
 			return
 		}
+		state.collectPotentialLocalRootSymbol(node)
 		if node.Kind == ast.KindVariableDeclaration {
-			state.collectVariableAlias(node)
+			declaration := node.AsVariableDeclaration()
+			if declaration != nil && declaration.Name() != nil && declaration.Initializer != nil &&
+				(declaration.Name().Kind == ast.KindIdentifier || declaration.Name().Kind == ast.KindObjectBindingPattern) &&
+				expressionRootIdentifier(declaration.Initializer) != nil {
+				aliasDeclarations = append(aliasDeclarations, node)
+			}
 		}
 		node.ForEachChild(func(child *ast.Node) bool {
 			walk(child)
@@ -384,6 +472,47 @@ func (state *ruleState) collectAliases() {
 		})
 	}
 	walk(state.ctx.SourceFile.AsNode())
+
+	// Resolve alias initializers only after every local root declaration is
+	// known. This keeps the pre-pass at one AST walk while making RefStore's
+	// negative result authoritative even for declarations that appear later.
+	state.localRootsCollected = true
+	for _, declaration := range aliasDeclarations {
+		state.collectVariableAlias(declaration)
+	}
+}
+
+func (state *ruleState) collectPotentialLocalRootSymbol(node *ast.Node) {
+	if node.Kind != ast.KindIdentifier {
+		return
+	}
+	name := node.AsIdentifier().Text
+	if !potentialReferenceRoots[name] || !ast.IsDeclarationName(node) {
+		return
+	}
+
+	declaration := node.Parent
+	if declaration == nil || declaration.Name() != node {
+		return
+	}
+	symbol := declaration.Symbol()
+	if symbol == nil {
+		if state.incompleteLocalRootNames == nil {
+			state.incompleteLocalRootNames = map[string]bool{}
+		}
+		state.incompleteLocalRootNames[name] = true
+		return
+	}
+
+	if state.localRootSymbols == nil {
+		state.localRootSymbols = map[string]map[*ast.Symbol]struct{}{}
+	}
+	symbols := state.localRootSymbols[name]
+	if symbols == nil {
+		symbols = map[*ast.Symbol]struct{}{}
+		state.localRootSymbols[name] = symbols
+	}
+	symbols[symbol] = struct{}{}
 }
 
 func (state *ruleState) collectVariableAlias(node *ast.Node) {
@@ -493,6 +622,13 @@ func (state *ruleState) globalReferenceInfo(node *ast.Node) (globalReference, bo
 		return globalReference{}, false
 	}
 
+	// A tracked local alias wins even if it reuses one of the conventional
+	// global-object names (for example, `{Array: window}`). ReferenceTracker
+	// follows the binding identity, not its spelling.
+	if aliasPath, ok := state.aliasPathForIdentifier(root); ok {
+		return globalReference{path: appendPath(aliasPath, path[1:]...), source: referenceSourceAlias}, true
+	}
+
 	if globalObjectNames[path[0]] {
 		if state.isLocalNonAliasIdentifier(root) {
 			return globalReference{}, false
@@ -500,8 +636,10 @@ func (state *ruleState) globalReferenceInfo(node *ast.Node) (globalReference, bo
 		return globalReference{path: slices.Clone(path[1:]), source: referenceSourceGlobalObject}, true
 	}
 
-	if aliasPath, ok := state.aliasPathForIdentifier(root); ok {
-		return globalReference{path: appendPath(aliasPath, path[1:]...), source: referenceSourceAlias}, true
+	// A non-global, non-alias root cannot become a watched builtin. This also
+	// keeps alias collection from doing shadow work for ordinary initializers.
+	if !potentialReferenceRoots[path[0]] {
+		return globalReference{}, false
 	}
 
 	if state.isLocalNonAliasIdentifier(root) {
@@ -554,6 +692,20 @@ func (state *ruleState) aliasPathForIdentifier(node *ast.Node) ([]string, bool) 
 	if node == nil || node.Kind != ast.KindIdentifier {
 		return nil, false
 	}
+	name := node.AsIdentifier().Text
+	infos := state.aliasesByID[name]
+	if len(infos) == 0 {
+		return nil, false
+	}
+
+	if !state.collectingAliases && state.ensureAliasReferenceIndex(name) {
+		info, ok := state.aliasReferences[node]
+		if !ok {
+			return nil, false
+		}
+		return slices.Clone(info.path), true
+	}
+
 	if state.ctx.TypeChecker != nil {
 		symbol := utils.GetReferenceSymbol(node, state.ctx.TypeChecker)
 		if symbol != nil {
@@ -564,13 +716,81 @@ func (state *ruleState) aliasPathForIdentifier(node *ast.Node) ([]string, bool) 
 			}
 		}
 	}
-	infos := state.aliasesByID[node.AsIdentifier().Text]
 	for i := len(infos) - 1; i >= 0; i-- {
 		if state.aliasInfoApplies(node, infos[i]) {
 			return slices.Clone(infos[i].path), true
 		}
 	}
 	return nil, false
+}
+
+func (state *ruleState) ensureAliasReferenceIndex(name string) bool {
+	if state.indexedAliasNames != nil && state.indexedAliasNames[name] {
+		return state.completeAliasNames[name]
+	}
+	if state.indexedAliasNames == nil {
+		state.indexedAliasNames = map[string]bool{}
+		state.completeAliasNames = map[string]bool{}
+	}
+	state.indexedAliasNames[name] = true
+
+	if state.ctx.Refs == nil {
+		return false
+	}
+
+	symbols := make(map[*ast.Symbol]aliasInfo)
+	for _, info := range state.aliasesByID[name] {
+		symbol := aliasBindingSymbol(info.binding)
+		if symbol == nil {
+			return false
+		}
+		if _, exists := symbols[symbol]; !exists {
+			resolvedInfo, ok := state.aliasInfoForBinderSymbol(symbol)
+			if !ok {
+				return false
+			}
+			symbols[symbol] = resolvedInfo
+		}
+	}
+
+	if state.aliasReferences == nil {
+		state.aliasReferences = map[*ast.Node]aliasInfo{}
+	}
+	for symbol, info := range symbols {
+		for _, ref := range state.ctx.Refs.References(symbol) {
+			state.aliasReferences[ref] = info
+		}
+	}
+	state.completeAliasNames[name] = true
+	return true
+}
+
+func aliasBindingSymbol(binding *ast.Node) *ast.Symbol {
+	if binding == nil || binding.Kind != ast.KindIdentifier {
+		return nil
+	}
+	declaration := binding.Parent
+	if declaration == nil || declaration.Name() != binding {
+		return nil
+	}
+	return declaration.Symbol()
+}
+
+func (state *ruleState) aliasInfoForBinderSymbol(symbol *ast.Symbol) (aliasInfo, bool) {
+	if symbol == nil {
+		return aliasInfo{}, false
+	}
+	for _, declaration := range symbol.Declarations {
+		if info, ok := state.aliases[declaration]; ok {
+			return info, true
+		}
+	}
+	for _, info := range state.aliasesByID[symbol.Name] {
+		if aliasBindingSymbol(info.binding) == symbol {
+			return info, true
+		}
+	}
+	return aliasInfo{}, false
 }
 
 func (state *ruleState) aliasInfoApplies(node *ast.Node, info aliasInfo) bool {
@@ -708,6 +928,16 @@ func (state *ruleState) isLocalNonAliasIdentifier(node *ast.Node) bool {
 	}
 
 	name := node.AsIdentifier().Text
+	if state.localRootsCollected {
+		if local, known := state.indexedLocalRootReference(node, name); known {
+			return local
+		}
+	}
+
+	// RefStore resolves in the value namespace, so it is authoritative when
+	// its declaration index is complete. Keep the checker as a fallback for
+	// contexts where Refs is unavailable or a declaration had no binder
+	// symbol.
 	if state.ctx.TypeChecker != nil && state.ctx.SourceFile != nil {
 		symbol := utils.GetReferenceSymbol(node, state.ctx.TypeChecker)
 		if utils.IsSymbolDeclaredInFile(symbol, state.ctx.SourceFile) {
@@ -716,6 +946,40 @@ func (state *ruleState) isLocalNonAliasIdentifier(node *ast.Node) bool {
 	}
 
 	return utils.IsShadowed(node, name)
+}
+
+func (state *ruleState) indexedLocalRootReference(node *ast.Node, name string) (local bool, known bool) {
+	if !potentialReferenceRoots[name] || state.incompleteLocalRootNames[name] {
+		return false, false
+	}
+
+	symbols := state.localRootSymbols[name]
+	if len(symbols) == 0 {
+		// The alias pre-pass walked every declaration in the file. With no local
+		// binder symbol for this root, the reference cannot be shadowed.
+		return false, true
+	}
+	if state.ctx.Refs == nil {
+		return false, false
+	}
+
+	if state.indexedLocalRootNames == nil {
+		state.indexedLocalRootNames = map[string]bool{}
+	}
+	if !state.indexedLocalRootNames[name] {
+		if state.localRootReferences == nil {
+			state.localRootReferences = map[*ast.Node]struct{}{}
+		}
+		for symbol := range symbols {
+			for _, ref := range state.ctx.Refs.References(symbol) {
+				state.localRootReferences[ref] = struct{}{}
+			}
+		}
+		state.indexedLocalRootNames[name] = true
+	}
+
+	_, local = state.localRootReferences[node]
+	return local, true
 }
 
 func hasOptionalChain(node *ast.Node) bool {
@@ -767,7 +1031,7 @@ func isStrictObjectComparison(node *ast.Node) bool {
 func messageEnforce(name string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          messageIDEnforce,
-		Description: fmt.Sprintf("Use `new %s()` instead of `%s()`.", name, name),
+		Description: enforceMessageDescriptions[name],
 		Data:        map[string]string{"name": name},
 	}
 }
@@ -775,7 +1039,7 @@ func messageEnforce(name string) rule.RuleMessage {
 func messageDisallow(name string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          messageIDDisallow,
-		Description: fmt.Sprintf("Use `%s()` instead of `new %s()`.", name, name),
+		Description: disallowMessageDescriptions[name],
 		Data:        map[string]string{"name": name},
 	}
 }
@@ -783,9 +1047,17 @@ func messageDisallow(name string) rule.RuleMessage {
 func messageDisallowCallOrNew(name string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          messageIDDisallowCallOrNew,
-		Description: fmt.Sprintf("`%s` is not a function or constructor.", name),
+		Description: disallowCallOrNewMessageDescriptions[name],
 		Data:        map[string]string{"name": name},
 	}
+}
+
+func buildMessageDescriptions(names map[string]bool, build func(string) string) map[string]string {
+	descriptions := make(map[string]string, len(names))
+	for name := range names {
+		descriptions[name] = build(name)
+	}
+	return descriptions
 }
 
 func isWatchedBuiltin(name string) bool {

--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_extras_test.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_extras_test.go
@@ -78,6 +78,42 @@ func TestNewForBuiltinsExtras(t *testing.T) {
 			)),
 			// ---- Dimension 4: local global-object names shadow the real globals ----
 			jsValid("const globalThis = {Array() {}}; globalThis.Array();"),
+			// ---- Adversarial: hoisted declarations shadow calls before their declaration ----
+			jsValid(lines(
+				"function run() {",
+				"\tArray();",
+				"\tvar Array = function() {};",
+				"}",
+			)),
+			// ---- Adversarial: catch and loop bindings are exact lexical shadows ----
+			jsValid("try {} catch (Array) { Array(); }"),
+			jsValid("for (const Map of values) { Map(); }"),
+			// ---- Adversarial: declaration symbols beyond variables shadow builtins ----
+			jsValid("function Array() {} Array();"),
+			jsValid("class Map {} Map();"),
+			jsValid("const holder = function Set() { return Set(); };"),
+			jsValid("const Holder = class WeakMap { method() { return WeakMap(); } };"),
+			// ---- Adversarial: imports using the builtin's exact name are local ----
+			jsValid("import Array from 'array-package'; Array();"),
+			jsValid("import * as Intl from 'intl-package'; Intl.DateTimeFormat();"),
+			// ---- Adversarial: a later local globalThis declaration is still in scope ----
+			jsValid(lines(
+				"function run() {",
+				"\tglobalThis.Array();",
+				"\tconst globalThis = {Array() {}};",
+				"}",
+			)),
+			jsValid(lines(
+				"function run() {",
+				"\tconst {Array: A} = globalThis;",
+				"\tconst globalThis = {Array() {}};",
+				"\tA();",
+				"}",
+			)),
+			tsValid(lines(
+				"namespace Intl { export const local = 1; }",
+				"Intl.DateTimeFormat();",
+			)),
 			// ---- Dimension 4: bare WebAssembly namespace aliases are not tracked by upstream ----
 			jsValid(lines(
 				"const WA = WebAssembly;",
@@ -177,6 +213,18 @@ func TestNewForBuiltinsExtras(t *testing.T) {
 				"const B = A;",
 				"B();",
 			), "B()", "Array"),
+			// ---- Adversarial: an alias may reuse another builtin's name ----
+			enforceInvalid(lines(
+				"const {Map: Array} = globalThis;",
+				"Array();",
+			), "Array()", "Map"),
+			// ---- Adversarial: alias identity wins over a global-object spelling ----
+			enforceInvalid(lines(
+				"const {Array: window} = globalThis;",
+				"window();",
+			), "window()", "Array"),
+			aliasWithInnerShadowInvalid(),
+			disjointAliasPathsInvalid(),
 			// ---- Dimension 4: alias declarations after a use still match upstream scope tracing ----
 			enforceInvalid(lines(
 				"A();",
@@ -242,6 +290,24 @@ func TestNewForBuiltinsExtras(t *testing.T) {
 				"}",
 				"A();",
 			), "A()", "Array"),
+			// ---- Adversarial: type-space declarations do not shadow runtime builtins ----
+			tsEnforceInvalid(lines(
+				"type Array = () => void;",
+				"Array();",
+			), "Array()", "Array"),
+			tsEnforceInvalid(lines(
+				"interface Map {}",
+				"Map();",
+			), "Map()", "Map"),
+			tsEnforceInvalid(lines(
+				"const A = Array;",
+				"interface Array {}",
+				"A();",
+			), "A()", "Array"),
+			tsEnforceInvalid(lines(
+				"namespace Intl { export interface Local {} }",
+				"Intl.DateTimeFormat();",
+			), "Intl.DateTimeFormat()", "Intl.DateTimeFormat"),
 
 			// ---- Real-user: #901 new String('test') reports but has no autofix ----
 			disallowNoFixInvalid("const str = new String('test');", "new String('test')", "String"),
@@ -283,4 +349,67 @@ func tsEnforceInvalid(code string, target string, name string) rule_tester.Inval
 	testCase := enforceInvalid(code, target, name)
 	testCase.FileName = "file.ts"
 	return testCase
+}
+
+func tsValid(code string) rule_tester.ValidTestCase {
+	testCase := jsValid(code)
+	testCase.FileName = "file.ts"
+	return testCase
+}
+
+func aliasWithInnerShadowInvalid() rule_tester.InvalidTestCase {
+	code := lines(
+		"const {Array: A} = globalThis;",
+		"{",
+		"\tconst A = function() {};",
+		"\tA();",
+		"}",
+		"A();",
+	)
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Output: []string{lines(
+			"const {Array: A} = globalThis;",
+			"{",
+			"\tconst A = function() {};",
+			"\tA();",
+			"}",
+			"new A();",
+		)},
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedErrorAfter(code, "}\n", "A()", messageIDEnforce, enforceMessage("Array")),
+		},
+	}
+}
+
+func disjointAliasPathsInvalid() rule_tester.InvalidTestCase {
+	code := lines(
+		"{",
+		"\tconst {Array: A} = globalThis;",
+		"\tA();",
+		"}",
+		"{",
+		"\tconst {Map: A} = globalThis;",
+		"\tA();",
+		"}",
+	)
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Output: []string{lines(
+			"{",
+			"\tconst {Array: A} = globalThis;",
+			"\tnew A();",
+			"}",
+			"{",
+			"\tconst {Map: A} = globalThis;",
+			"\tnew A();",
+			"}",
+		)},
+		Errors: []rule_tester.InvalidTestCaseError{
+			expectedError(code, "A()", messageIDEnforce, enforceMessage("Array")),
+			expectedErrorAfter(code, "const {Map: A}", "A()", messageIDEnforce, enforceMessage("Map")),
+		},
+	}
 }

--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_internal_test.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins_internal_test.go
@@ -1,0 +1,262 @@
+package new_for_builtins
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/binder"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func TestDeferredReportsPreserveDiagnostics(t *testing.T) {
+	source := `Array();
+		new String();
+		new Symbol();
+		Date();
+		Date(1);
+		WebAssembly();`
+
+	withoutEdits := runRuleForTest(t, source, rule.EditDemandNone)
+	withEdits := runRuleForTest(t, source, rule.EditDemandAll)
+	if len(withoutEdits) != len(withEdits) {
+		t.Fatalf("diagnostic count without edits = %d, with edits = %d", len(withoutEdits), len(withEdits))
+	}
+	if len(withEdits) != 6 {
+		t.Fatalf("diagnostic count = %d, want 6", len(withEdits))
+	}
+
+	for index := range withEdits {
+		withoutEdit := withoutEdits[index]
+		withEdit := withEdits[index]
+		if withoutEdit.Range != withEdit.Range ||
+			withoutEdit.Message.Id != withEdit.Message.Id ||
+			withoutEdit.Message.Description != withEdit.Message.Description ||
+			!reflect.DeepEqual(withoutEdit.Message.Data, withEdit.Message.Data) {
+			t.Fatalf("diagnostic %d changed with edit demand", index)
+		}
+		if withoutEdit.FixesPtr != nil || withoutEdit.Suggestions != nil {
+			t.Fatalf("diagnostic %d materialized edits with EditDemandNone", index)
+		}
+	}
+
+	wantAutofix := []bool{true, false, true, true, false, false}
+	wantSuggestion := []bool{false, false, false, false, true, false}
+	for index, diagnostic := range withEdits {
+		if got := diagnostic.FixesPtr != nil; got != wantAutofix[index] {
+			t.Errorf("diagnostic %d autofix presence = %t, want %t", index, got, wantAutofix[index])
+		}
+		if got := diagnostic.Suggestions != nil; got != wantSuggestion[index] {
+			t.Errorf("diagnostic %d suggestion presence = %t, want %t", index, got, wantSuggestion[index])
+		}
+	}
+
+	disabled := runRuleForTest(
+		t,
+		"/* eslint-disable unicorn/new-for-builtins */\nArray();",
+		rule.EditDemandAll,
+	)
+	if len(disabled) != 0 {
+		t.Fatalf("disabled diagnostic count = %d, want 0", len(disabled))
+	}
+}
+
+func TestReferenceResolutionWithAndWithoutRefStore(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "global builtin",
+			source: "Array();",
+			want:   []string{"Array"},
+		},
+		{
+			name:   "local variable",
+			source: "const Array = function() {}; Array();",
+			want:   []string{""},
+		},
+		{
+			name:   "exported local variable",
+			source: "export const Array = function() {}; Array();",
+			want:   []string{""},
+		},
+		{
+			name:   "exported alias",
+			source: "export const A = Array; A();",
+			want:   []string{"Array"},
+		},
+		{
+			name:   "hoisted variable",
+			source: "function run() { Array(); var Array = function() {}; }",
+			want:   []string{""},
+		},
+		{
+			name:   "body var does not shadow parameter initializer",
+			source: "function run(value = Array()) { var Array = function() {}; }",
+			want:   []string{"Array"},
+		},
+		{
+			name:   "destructured parameter",
+			source: "function run({Array}) { Array(); }",
+			want:   []string{""},
+		},
+		{
+			name:   "destructured catch binding",
+			source: "try {} catch ({Array}) { Array(); }",
+			want:   []string{""},
+		},
+		{
+			name:   "switch clauses share lexical scope",
+			source: "switch (value) { case 0: Array(); break; case 1: const Array = function() {}; }",
+			want:   []string{""},
+		},
+		{
+			name:   "local global object",
+			source: "const globalThis = {Array() {}}; globalThis.Array();",
+			want:   []string{""},
+		},
+		{
+			name:   "destructured alias",
+			source: "const {Array: A} = globalThis; A();",
+			want:   []string{"Array"},
+		},
+		{
+			name:   "type-only declaration does not block alias source",
+			source: "const A = Array; interface Array {} A();",
+			want:   []string{"Array"},
+		},
+		{
+			name:   "later local global object blocks alias source",
+			source: "function run() { const {Array: A} = globalThis; const globalThis = {}; A(); }",
+			want:   []string{""},
+		},
+		{
+			name: "inner shadow of alias",
+			source: `const {Array: A} = globalThis;
+				{ const A = function() {}; A(); }
+				A();`,
+			want: []string{"", "Array"},
+		},
+		{
+			name:   "type-only declaration",
+			source: "interface Map {} Map();",
+			want:   []string{"Map"},
+		},
+		{
+			name:   "runtime namespace declaration",
+			source: "namespace Intl { export const local = 1; } Intl.DateTimeFormat();",
+			want:   []string{""},
+		},
+		{
+			name:   "runtime enum declaration",
+			source: "enum Map {} Map();",
+			want:   []string{""},
+		},
+		{
+			name:   "alias named like global object",
+			source: "const {Array: window} = globalThis; window();",
+			want:   []string{"Array"},
+		},
+		{
+			name: "same alias spelling in disjoint scopes",
+			source: `{ const {Array: A} = globalThis; A(); }
+				{ const {Map: A} = globalThis; A(); }`,
+			want: []string{"Array", "Map"},
+		},
+		{
+			name:   "later local global object",
+			source: "function run() { globalThis.Array(); const globalThis = {}; }",
+			want:   []string{""},
+		},
+	}
+
+	for _, testCase := range tests {
+		for _, withRefs := range []bool{false, true} {
+			mode := "fallback"
+			if withRefs {
+				mode = "refs"
+			}
+			t.Run(testCase.name+"/"+mode, func(t *testing.T) {
+				got := resolveCallReferences(t, testCase.source, withRefs)
+				if !slices.Equal(got, testCase.want) {
+					t.Fatalf("resolved references = %q, want %q", got, testCase.want)
+				}
+			})
+		}
+	}
+}
+
+func resolveCallReferences(t *testing.T, source string, withRefs bool) []string {
+	t.Helper()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/new-for-builtins-reference-test.ts",
+		Path:     tspath.Path("/new-for-builtins-reference-test.ts"),
+	}, source, core.ScriptKindTS)
+	binder.BindSourceFile(sourceFile)
+
+	ctx := rule.RuleContext{SourceFile: sourceFile}
+	if withRefs {
+		options := core.CompilerOptions{}
+		ctx.Refs = rule.NewRefStore(sourceFile, &options)
+	}
+	state := newRuleState(ctx)
+
+	references := make([]string, 0)
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindCallExpression {
+			call := node.AsCallExpression()
+			if ref, ok := state.referenceFromExpression(call.Expression); ok {
+				references = append(references, ref.name)
+			} else {
+				references = append(references, "")
+			}
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return references
+}
+
+func runRuleForTest(t *testing.T, source string, demand rule.EditDemand) []rule.RuleDiagnostic {
+	t.Helper()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/new-for-builtins-deferred-report-test.ts",
+		Path:     tspath.Path("/new-for-builtins-deferred-report-test.ts"),
+	}, source, core.ScriptKindTS)
+	binder.BindSourceFile(sourceFile)
+
+	comments := rule.NewCommentStore(sourceFile)
+	diagnostics := make([]rule.RuleDiagnostic, 0)
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(NewForBuiltinsRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+		Demand: demand,
+		Report: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+	options := core.CompilerOptions{}
+	ctx.Refs = rule.NewRefStore(sourceFile, &options)
+
+	listeners := NewForBuiltinsRule.Run(ctx, nil)
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
+}


### PR DESCRIPTION
## Summary

Optimize the Go implementation of `unicorn/new-for-builtins` without changing the rule framework.

- Add a cheap callee-root gate so unrelated calls skip path and scope resolution.
- Use `RuleContext.Refs` to lazily map binder symbols to exact local and alias references, while retaining the existing fallback when refs are unavailable or incomplete.
- Collect local symbols before resolving aliases in the existing single AST pre-pass, preserving later-declaration, TDZ, and type/value-namespace semantics.
- Defer fixes and suggestions until the diagnostic consumer requests them.
- Cache immutable diagnostic descriptions and add adversarial coverage for shadowing, aliases, type-only declarations, edit demand, and disabled diagnostics.

### Performance

Rule-layer benchmark on an Apple M1 Max with 2,000 calls; parsing and binding were outside the timed loop.

| Scenario | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Unrelated `fetch()` calls | ~139 ms | 0.103 ms | ~1,350x |
| Unrelated `console.log()` calls | ~219 ms | 0.154 ms | ~1,420x |

For 2,000 reported `Array()` calls:

| Edit demand | Time | Bytes/op | Allocs/op |
| --- | ---: | ---: | ---: |
| Diagnostics only | 0.800 ms | 1,056,693 | 10,008 |
| All edits | 1.03 ms | 1,472,695 | 16,008 |

Deferring edits saves about 22% runtime, 28% allocated bytes, and 37% allocations for diagnostics-only consumers. CPU profiling moved `utils.IsShadowed` from roughly 81% cumulative CPU before the change to zero samples in the final stress profile.

The benchmark-only test file used to collect these measurements is intentionally not included in this PR.

### Validation

- `pnpm check-spell`
- `pnpm format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/unicorn/rules/new_for_builtins`
- `go test -p=2 ./internal/plugins/unicorn/rules/new_for_builtins -count=1`
- `git diff --check origin/main...HEAD`

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). No user-facing behavior or API changes.
