### PR TITLE
perf: improve no-dupe-class-members performance

### DIFF
--- a/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.go
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.go
@@ -1,27 +1,54 @@
 package no_dupe_class_members
 
 import (
-	"fmt"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+type memberKind uint8
+
+const (
+	memberKindInit memberKind = iota
+	memberKindGet
+	memberKindSet
+)
+
+type memberState uint8
+
+const (
+	memberStateInit memberState = 1 << iota
+	memberStateGet
+	memberStateSet
+)
+
+type stateEntry struct {
+	nonStatic memberState
+	static    memberState
+}
+
+func registerMember(state memberState, kind memberKind) (memberState, bool) {
+	var flag memberState
+	var conflicts memberState
+	switch kind {
+	case memberKindGet:
+		flag = memberStateGet
+		conflicts = memberStateInit | memberStateGet
+	case memberKindSet:
+		flag = memberStateSet
+		conflicts = memberStateInit | memberStateSet
+	default:
+		flag = memberStateInit
+		conflicts = memberStateInit | memberStateGet | memberStateSet
+	}
+	return state | flag, state&conflicts != 0
+}
+
 var NoDupeClassMembersRule = rule.CreateRule(rule.Rule{
 	Name: "no-dupe-class-members",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		checkClass := func(node *ast.Node) {
-			type memberState struct {
-				init bool
-				get  bool
-				set  bool
-			}
-			type stateEntry struct {
-				nonStatic memberState
-				static    memberState
-			}
-			stateMap := make(map[string]*stateEntry)
+			stateMap := make(map[string]stateEntry)
 
 			for _, member := range node.Members() {
 				// Skip the class constructor. In TypeScript-Go's AST, both keyword
@@ -42,17 +69,17 @@ var NoDupeClassMembersRule = rule.CreateRule(rule.Rule{
 
 				// Determine the duplicate-detection category.
 				// get + set for the same name is allowed; any other combination is a duplicate.
-				var kind string
+				var kind memberKind
 				switch {
 				case ast.IsGetAccessorDeclaration(member):
-					kind = "get"
+					kind = memberKindGet
 				case ast.IsSetAccessorDeclaration(member):
-					kind = "set"
+					kind = memberKindSet
 				case ast.IsMethodDeclaration(member), ast.IsPropertyDeclaration(member):
-					kind = "init"
+					kind = memberKindInit
 				case ast.IsConstructorDeclaration(member):
 					// Static constructor — treated as a static method named "constructor".
-					kind = "init"
+					kind = memberKindInit
 				default:
 					continue
 				}
@@ -73,29 +100,14 @@ var NoDupeClassMembersRule = rule.CreateRule(rule.Rule{
 					continue
 				}
 
-				// "$" prefix avoids collisions with built-in object keys like "__proto__".
-				key := "$" + name
-				if stateMap[key] == nil {
-					stateMap[key] = &stateEntry{}
-				}
-
-				state := &stateMap[key].nonStatic
-				if ast.IsStatic(member) {
-					state = &stateMap[key].static
-				}
-
+				entry := stateMap[name]
 				var isDuplicate bool
-				switch kind {
-				case "get":
-					isDuplicate = state.init || state.get
-					state.get = true
-				case "set":
-					isDuplicate = state.init || state.set
-					state.set = true
-				default: // "init"
-					isDuplicate = state.init || state.get || state.set
-					state.init = true
+				if ast.IsStatic(member) {
+					entry.static, isDuplicate = registerMember(entry.static, kind)
+				} else {
+					entry.nonStatic, isDuplicate = registerMember(entry.nonStatic, kind)
 				}
+				stateMap[name] = entry
 
 				if isDuplicate {
 					reportNode := nameNode
@@ -104,7 +116,7 @@ var NoDupeClassMembersRule = rule.CreateRule(rule.Rule{
 					}
 					ctx.ReportNode(reportNode, rule.RuleMessage{
 						Id:          "unexpected",
-						Description: fmt.Sprintf("Duplicate name '%s'.", name),
+						Description: "Duplicate name '" + name + "'.",
 					})
 				}
 			}

--- a/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members_test.go
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members_test.go
@@ -100,6 +100,9 @@ func TestNoDupeClassMembersRule(t *testing.T) {
 
 		// ─── __proto__ as single member (no collision) ───
 		{Code: `class A { __proto__() {} }`},
+		// Go maps do not need the "$" prefix used by the JavaScript
+		// implementation to avoid prototype-key collisions.
+		{Code: `class A { $() {} $$() {} }`},
 
 		// ─── property with function-expression initializer (single, no dup) ───
 		{Code: `class A { foo = () => {} }`},
@@ -136,7 +139,7 @@ func TestNoDupeClassMembersRule(t *testing.T) {
 		{
 			Code: `class A { foo() {} foo() {} }`,
 			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "unexpected", Line: 1, Column: 20},
+				{MessageId: "unexpected", Message: "Duplicate name 'foo'.", Line: 1, Column: 20},
 			},
 		},
 		{
@@ -428,6 +431,12 @@ func TestNoDupeClassMembersRule(t *testing.T) {
 				{MessageId: "unexpected", Line: 1, Column: 26},
 			},
 		},
+		{
+			Code: `class A { $() {} ['$']() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Message: "Duplicate name '$'.", Line: 1, Column: 18},
+			},
+		},
 
 		// ─── class with extends: duplicates in child class still detected ───
 		{
@@ -551,4 +560,63 @@ func TestNoDupeClassMembersRule(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestRegisterMemberExhaustive(t *testing.T) {
+	type referenceState struct {
+		init bool
+		get  bool
+		set  bool
+	}
+
+	registerReference := func(state referenceState, kind memberKind) (referenceState, bool) {
+		var duplicate bool
+		switch kind {
+		case memberKindGet:
+			duplicate = state.init || state.get
+			state.get = true
+		case memberKindSet:
+			duplicate = state.init || state.set
+			state.set = true
+		default:
+			duplicate = state.init || state.get || state.set
+			state.init = true
+		}
+		return state, duplicate
+	}
+
+	toMemberState := func(state referenceState) memberState {
+		var result memberState
+		if state.init {
+			result |= memberStateInit
+		}
+		if state.get {
+			result |= memberStateGet
+		}
+		if state.set {
+			result |= memberStateSet
+		}
+		return result
+	}
+
+	kinds := [...]memberKind{memberKindInit, memberKindGet, memberKindSet}
+	var visit func(memberState, referenceState, []memberKind)
+	visit = func(actual memberState, expected referenceState, sequence []memberKind) {
+		if len(sequence) == 8 {
+			return
+		}
+		for _, kind := range kinds {
+			nextActual, gotDuplicate := registerMember(actual, kind)
+			nextExpected, wantDuplicate := registerReference(expected, kind)
+			nextSequence := append(sequence, kind)
+			if gotDuplicate != wantDuplicate {
+				t.Fatalf("sequence %v: duplicate = %v, want %v", nextSequence, gotDuplicate, wantDuplicate)
+			}
+			if wantState := toMemberState(nextExpected); nextActual != wantState {
+				t.Fatalf("sequence %v: state = %03b, want %03b", nextSequence, nextActual, wantState)
+			}
+			visit(nextActual, nextExpected, nextSequence)
+		}
+	}
+	visit(0, referenceState{}, nil)
 }


### PR DESCRIPTION
## Summary

- Replace per-name pointer/boolean state with compact bit flags stored directly in the map.
- Remove the JavaScript-specific key prefix allocation and avoid `fmt.Sprintf` on the diagnostic path.
- Preserve rule inputs and diagnostics; add exhaustive state-transition and special-key regression coverage.
- Keep the optimization within the rule layer. `ctx.Refs` would add a file-wide reference-index walk for declaration names, while deferred reports only defer fixes or suggestions that this rule does not produce.

### Benchmark

Measured on Apple M1 Max with Go 1.26.1, `-cpu=1`, using the median of five runs. Parsing was excluded. The benchmark called the rule listener directly, used no JSON configuration, and its temporary harness is not committed.

| Corpus | Time before | Time after | Bytes before | Bytes after | Allocs before | Allocs after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 512 unique members | 80.0 µs | 50.5 µs (-36.9%) | 62,696 B | 54,504 B (-13.1%) | 1,043 | 19 (-98.2%) |
| 4,096 unique members | 678.7 µs | 424.9 µs (-37.4%) | 527,064 B | 436,760 B (-17.1%) | 8,242 | 50 (-99.4%) |
| Real repository corpus (1,148 TS-family files, 84 classes, 644 members) | 402.7 µs | 361.0 µs (-10.4%) | 439,360 B | 427,184 B (-2.8%) | 5,694 | 4,682 (-17.8%) |

Correctness was attacked with an exhaustive init/get/set state-machine comparison through sequence length eight and a temporary differential harness generating 2,500 mixed classes. Every diagnostic range, message ID, and message matched the previous implementation. The targeted package also passed under the race detector.

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

### Checks

- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_dupe_class_members`
- `go test ./internal/plugins/typescript/rules/no_dupe_class_members -count=1`
- `go test -race ./internal/plugins/typescript/rules/no_dupe_class_members -count=1`