### PR TITLE
perf: optimize no-import-assign reference lookup

### DIFF
--- a/internal/rules/no_import_assign/no_import_assign.go
+++ b/internal/rules/no_import_assign/no_import_assign.go
@@ -1,6 +1,9 @@
 package no_import_assign
 
 import (
+	"cmp"
+	"slices"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -10,23 +13,52 @@ import (
 type importedBinding struct {
 	name        string
 	isNamespace bool
-	nameNode    *ast.Node
 	symbol      *ast.Symbol
 }
 
-// makeImportedBinding creates an importedBinding, resolving the symbol via the type checker if available.
-func makeImportedBinding(nameNode *ast.Node, isNamespace bool, ctx *rule.RuleContext) importedBinding {
-	name := nameNode.Text()
-	var sym *ast.Symbol
-	if ctx.TypeChecker != nil {
-		sym = ctx.TypeChecker.GetSymbolAtLocation(nameNode)
-	}
+type importedBindingViolationKind uint8
+
+const (
+	importedBindingViolationNone importedBindingViolationKind = iota
+	importedBindingViolationDirect
+	importedBindingViolationMember
+)
+
+type importedBindingViolation struct {
+	node    *ast.Node
+	binding importedBinding
+	kind    importedBindingViolationKind
+}
+
+type noImportAssignRefStoreMode uint8
+
+const (
+	noImportAssignRefStoreAuto noImportAssignRefStoreMode = iota
+	noImportAssignRefStoreDisabled
+	noImportAssignRefStoreEnabled
+)
+
+func makeImportedBinding(nameNode *ast.Node, isNamespace bool, symbol *ast.Symbol) importedBinding {
 	return importedBinding{
-		name:        name,
+		name:        nameNode.Text(),
 		isNamespace: isNamespace,
-		nameNode:    nameNode,
-		symbol:      sym,
+		symbol:      symbol,
 	}
+}
+
+// importBindingSymbol returns the binder-owned alias symbol used by ctx.Refs.
+func importBindingSymbol(nameNode *ast.Node) *ast.Symbol {
+	if nameNode == nil || nameNode.Parent == nil || nameNode.Parent.Name() != nameNode {
+		return nil
+	}
+	return nameNode.Parent.Symbol()
+}
+
+func checkerImportBindingSymbol(nameNode *ast.Node, ctx *rule.RuleContext) *ast.Symbol {
+	if ctx.TypeChecker == nil {
+		return nil
+	}
+	return ctx.TypeChecker.GetSymbolAtLocation(nameNode)
 }
 
 // wellKnownMutationMethods maps global object names to their mutation method names.
@@ -55,7 +87,13 @@ func isArgumentOfWellKnownMutationFunction(node *ast.Node, ctx *rule.RuleContext
 		return false
 	}
 
-	parent := node.Parent
+	// Parentheses do not change the argument's identity, but TypeScript's AST
+	// preserves them between the identifier and the call expression.
+	argument := utils.OutermostParenthesizedExpression(node)
+	if argument == nil || argument.Parent == nil {
+		return false
+	}
+	parent := argument.Parent
 
 	// The parent must be a CallExpression
 	if parent.Kind != ast.KindCallExpression {
@@ -68,32 +106,52 @@ func isArgumentOfWellKnownMutationFunction(node *ast.Node, ctx *rule.RuleContext
 	}
 
 	// The node must be the first argument
-	if callExpr.Arguments.Nodes[0] != node {
+	if callExpr.Arguments.Nodes[0] != argument {
 		return false
 	}
 
 	// The callee must be a PropertyAccessExpression like Object.assign or Reflect.set
 	// Unwrap parentheses: (Object?.defineProperty)(ns, ...) → Object?.defineProperty
-	callee := callExpr.Expression
-	for callee != nil && callee.Kind == ast.KindParenthesizedExpression {
-		callee = callee.AsParenthesizedExpression().Expression
+	callee := ast.SkipParentheses(callExpr.Expression)
+	if callee == nil {
+		return false
 	}
-	if callee == nil || callee.Kind != ast.KindPropertyAccessExpression {
+	var object *ast.Node
+	var methodName string
+	switch callee.Kind {
+	case ast.KindPropertyAccessExpression:
+		propAccess := callee.AsPropertyAccessExpression()
+		if propAccess == nil || propAccess.Expression == nil || propAccess.Name() == nil {
+			return false
+		}
+		object = propAccess.Expression
+		methodName = propAccess.Name().Text()
+	case ast.KindElementAccessExpression:
+		elementAccess := callee.AsElementAccessExpression()
+		if elementAccess == nil || elementAccess.Expression == nil ||
+			elementAccess.ArgumentExpression == nil {
+			return false
+		}
+		var ok bool
+		object = elementAccess.Expression
+		methodName, ok = utils.GetStaticStringLiteralValue(
+			ast.SkipParentheses(elementAccess.ArgumentExpression),
+		)
+		if !ok {
+			return false
+		}
+	default:
 		return false
 	}
 
-	propAccess := callee.AsPropertyAccessExpression()
-	if propAccess == nil || propAccess.Expression == nil || propAccess.Name() == nil {
+	// The object must be a simple identifier (Object or Reflect). Parentheses
+	// around that identifier are transparent, as they are in ESTree.
+	object = ast.SkipParentheses(object)
+	if object == nil || object.Kind != ast.KindIdentifier {
 		return false
 	}
 
-	// The object must be a simple identifier (Object or Reflect)
-	if propAccess.Expression.Kind != ast.KindIdentifier {
-		return false
-	}
-
-	objectName := propAccess.Expression.Text()
-	methodName := propAccess.Name().Text()
+	objectName := object.Text()
 
 	methods, ok := wellKnownMutationMethods[objectName]
 	if !ok {
@@ -105,7 +163,7 @@ func isArgumentOfWellKnownMutationFunction(node *ast.Node, ctx *rule.RuleContext
 
 	// If Object/Reflect is locally shadowed, skip the check (same as no-console pattern).
 	if ctx.TypeChecker != nil {
-		sym := ctx.TypeChecker.GetSymbolAtLocation(propAccess.Expression)
+		sym := ctx.TypeChecker.GetSymbolAtLocation(object)
 		if sym != nil {
 			for _, decl := range sym.Declarations {
 				declSF := ast.GetSourceFileOfNode(decl)
@@ -150,7 +208,9 @@ func isMemberExpressionWrite(memberExpr *ast.Node) bool {
 		return true
 	}
 	// IsWriteReference does not handle delete expressions, so check separately.
-	if memberExpr.Parent != nil && memberExpr.Parent.Kind == ast.KindDeleteExpression {
+	deleteTarget := utils.OutermostParenthesizedExpression(memberExpr)
+	if deleteTarget != nil && deleteTarget.Parent != nil &&
+		deleteTarget.Parent.Kind == ast.KindDeleteExpression {
 		return true
 	}
 	return false
@@ -170,19 +230,25 @@ func isMemberWrite(node *ast.Node, ctx *rule.RuleContext) bool {
 		return false
 	}
 
-	parent := node.Parent
+	// Parentheses around the namespace object are transparent:
+	// `((ns)).prop = value` mutates the same namespace as `ns.prop = value`.
+	reference := utils.OutermostParenthesizedExpression(node)
+	if reference == nil || reference.Parent == nil {
+		return false
+	}
+	parent := reference.Parent
 
 	// Check ns.prop = val, ns.prop++, ns["prop"] = val, delete ns.prop, etc.
 	if parent.Kind == ast.KindPropertyAccessExpression {
 		propAccess := parent.AsPropertyAccessExpression()
-		if propAccess != nil && propAccess.Expression == node {
+		if propAccess != nil && propAccess.Expression == reference {
 			return isMemberExpressionWrite(parent)
 		}
 	}
 
 	if parent.Kind == ast.KindElementAccessExpression {
 		elemAccess := parent.AsElementAccessExpression()
-		if elemAccess != nil && elemAccess.Expression == node {
+		if elemAccess != nil && elemAccess.Expression == reference {
 			return isMemberExpressionWrite(parent)
 		}
 	}
@@ -218,104 +284,253 @@ func isImportBindingName(node *ast.Node) bool {
 	return false
 }
 
+func forEachImportedBindingName(
+	node *ast.Node,
+	visit func(nameNode *ast.Node, isNamespace bool),
+) {
+	importDecl := node.AsImportDeclaration()
+	if importDecl == nil || importDecl.ImportClause == nil {
+		return
+	}
+
+	importClause := importDecl.ImportClause.AsImportClause()
+	if importClause == nil {
+		return
+	}
+
+	// Default import: import foo from "mod"
+	if name := importClause.Name(); name != nil {
+		visit(name, false)
+	}
+
+	if importClause.NamedBindings == nil {
+		return
+	}
+
+	switch importClause.NamedBindings.Kind {
+	case ast.KindNamespaceImport:
+		namespaceImport := importClause.NamedBindings.AsNamespaceImport()
+		if namespaceImport != nil && namespaceImport.Name() != nil {
+			visit(namespaceImport.Name(), true)
+		}
+	case ast.KindNamedImports:
+		namedImports := importClause.NamedBindings.AsNamedImports()
+		if namedImports != nil && namedImports.Elements != nil {
+			for _, element := range namedImports.Elements.Nodes {
+				importSpecifier := element.AsImportSpecifier()
+				if importSpecifier != nil && importSpecifier.Name() != nil {
+					visit(importSpecifier.Name(), false)
+				}
+			}
+		}
+	}
+}
+
+func collectImportedBindings(
+	node *ast.Node,
+	resolveSymbol func(nameNode *ast.Node) *ast.Symbol,
+) []importedBinding {
+	var bindings []importedBinding
+	forEachImportedBindingName(node, func(nameNode *ast.Node, isNamespace bool) {
+		bindings = append(bindings, makeImportedBinding(
+			nameNode,
+			isNamespace,
+			resolveSymbol(nameNode),
+		))
+	})
+	return bindings
+}
+
+func hasMultipleTopLevelImportedBindings(sourceFile *ast.SourceFile) bool {
+	if sourceFile == nil || sourceFile.Statements == nil {
+		return false
+	}
+
+	count := 0
+	for _, statement := range sourceFile.Statements.Nodes {
+		if statement.Kind != ast.KindImportDeclaration {
+			continue
+		}
+		forEachImportedBindingName(statement, func(*ast.Node, bool) {
+			count++
+		})
+		if count >= 2 {
+			return true
+		}
+	}
+	return false
+}
+
+func classifyImportedBindingViolation(
+	node *ast.Node,
+	binding importedBinding,
+	ctx *rule.RuleContext,
+) importedBindingViolationKind {
+	if utils.IsWriteReference(node) {
+		return importedBindingViolationDirect
+	}
+	if binding.isNamespace && isMemberWrite(node, ctx) {
+		return importedBindingViolationMember
+	}
+	return importedBindingViolationNone
+}
+
+func reportImportedBindingViolation(ctx *rule.RuleContext, violation importedBindingViolation) {
+	switch violation.kind {
+	case importedBindingViolationDirect:
+		ctx.ReportNode(violation.node, rule.RuleMessage{
+			Id:          "readonly",
+			Description: "'" + violation.binding.name + "' is read-only.",
+		})
+	case importedBindingViolationMember:
+		ctx.ReportNode(violation.node, rule.RuleMessage{
+			Id:          "readonlyMember",
+			Description: "The members of '" + violation.binding.name + "' are read-only.",
+		})
+	}
+}
+
+func reportImportedBindingGroup(ctx *rule.RuleContext, bindings []importedBinding) {
+	if len(bindings) == 1 {
+		binding := bindings[0]
+		for _, reference := range ctx.Refs.References(binding.symbol) {
+			kind := classifyImportedBindingViolation(reference, binding, ctx)
+			if kind != importedBindingViolationNone {
+				reportImportedBindingViolation(ctx, importedBindingViolation{
+					node:    reference,
+					binding: binding,
+					kind:    kind,
+				})
+			}
+		}
+		return
+	}
+
+	var violations []importedBindingViolation
+	for _, binding := range bindings {
+		for _, reference := range ctx.Refs.References(binding.symbol) {
+			kind := classifyImportedBindingViolation(reference, binding, ctx)
+			if kind != importedBindingViolationNone {
+				violations = append(violations, importedBindingViolation{
+					node:    reference,
+					binding: binding,
+					kind:    kind,
+				})
+			}
+		}
+	}
+
+	// The old implementation walked the source once per import declaration,
+	// checking all of that declaration's bindings at each identifier. Preserve
+	// its diagnostic order after merging the per-symbol reference lists.
+	slices.SortStableFunc(violations, func(a importedBindingViolation, b importedBindingViolation) int {
+		return cmp.Compare(a.node.Pos(), b.node.Pos())
+	})
+	for _, violation := range violations {
+		reportImportedBindingViolation(ctx, violation)
+	}
+}
+
+// walkImportedBindingReferences preserves the pre-RefStore implementation for
+// single-binding files, direct RuleContext callers without a Program/Refs, and
+// imports without binder symbols.
+func walkImportedBindingReferences(ctx *rule.RuleContext, bindings []importedBinding) {
+	if ctx.SourceFile == nil {
+		return
+	}
+
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+
+		if node.Kind == ast.KindIdentifier {
+			for _, binding := range bindings {
+				if node.Text() != binding.name || isImportBindingName(node) {
+					continue
+				}
+
+				// Verify symbol identity when the type checker is available.
+				if binding.symbol != nil && ctx.TypeChecker != nil &&
+					utils.GetReferenceSymbol(node, ctx.TypeChecker) != binding.symbol {
+					continue
+				}
+
+				kind := classifyImportedBindingViolation(node, binding, ctx)
+				if kind != importedBindingViolationNone {
+					reportImportedBindingViolation(ctx, importedBindingViolation{
+						node:    node,
+						binding: binding,
+						kind:    kind,
+					})
+				}
+			}
+		}
+
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(ctx.SourceFile.AsNode())
+}
+
+func allBindingsHaveSymbols(bindings []importedBinding) bool {
+	for _, binding := range bindings {
+		if binding.symbol == nil {
+			return false
+		}
+	}
+	return true
+}
+
+func noImportAssignListeners(
+	ctx rule.RuleContext,
+	refStoreMode noImportAssignRefStoreMode,
+) rule.RuleListeners {
+	refStoreModeResolved := refStoreMode != noImportAssignRefStoreAuto
+	useRefStore := refStoreMode == noImportAssignRefStoreEnabled && ctx.Refs != nil
+
+	return rule.RuleListeners{
+		ast.KindImportDeclaration: func(node *ast.Node) {
+			if !refStoreModeResolved {
+				// One imported binding needs only one compatibility walk, which
+				// avoids materializing RefStore buckets for every unrelated
+				// identifier. At two bindings the shared index already wins,
+				// and its advantage grows with the number of imports. Without a
+				// checker, RefStore is also required for exact shadow resolution.
+				useRefStore = ctx.Refs != nil &&
+					(ctx.TypeChecker == nil ||
+						hasMultipleTopLevelImportedBindings(ctx.SourceFile))
+				refStoreModeResolved = true
+			}
+
+			if useRefStore {
+				bindings := collectImportedBindings(node, importBindingSymbol)
+				if len(bindings) == 0 {
+					return
+				}
+				if allBindingsHaveSymbols(bindings) {
+					reportImportedBindingGroup(&ctx, bindings)
+					return
+				}
+			}
+
+			bindings := collectImportedBindings(node, func(nameNode *ast.Node) *ast.Symbol {
+				return checkerImportBindingSymbol(nameNode, &ctx)
+			})
+			if len(bindings) != 0 {
+				walkImportedBindingReferences(&ctx, bindings)
+			}
+		},
+	}
+}
+
 // NoImportAssignRule disallows assigning to imported bindings.
 var NoImportAssignRule = rule.Rule{
 	Name: "no-import-assign",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		return rule.RuleListeners{
-			ast.KindImportDeclaration: func(node *ast.Node) {
-				importDecl := node.AsImportDeclaration()
-				if importDecl == nil || importDecl.ImportClause == nil {
-					return
-				}
-
-				importClause := importDecl.ImportClause.AsImportClause()
-				if importClause == nil {
-					return
-				}
-
-				var bindings []importedBinding
-
-				// Default import: import foo from 'mod'
-				if importClause.Name() != nil {
-					bindings = append(bindings, makeImportedBinding(importClause.Name(), false, &ctx))
-				}
-
-				// Named or namespace bindings
-				if importClause.NamedBindings != nil {
-					nb := importClause.NamedBindings
-
-					switch nb.Kind {
-					case ast.KindNamespaceImport:
-						nsImport := nb.AsNamespaceImport()
-						if nsImport != nil && nsImport.Name() != nil {
-							bindings = append(bindings, makeImportedBinding(nsImport.Name(), true, &ctx))
-						}
-					case ast.KindNamedImports:
-						namedImports := nb.AsNamedImports()
-						if namedImports != nil && namedImports.Elements != nil {
-							for _, elem := range namedImports.Elements.Nodes {
-								importSpec := elem.AsImportSpecifier()
-								if importSpec != nil && importSpec.Name() != nil {
-									bindings = append(bindings, makeImportedBinding(importSpec.Name(), false, &ctx))
-								}
-							}
-						}
-					}
-				}
-
-				if len(bindings) == 0 {
-					return
-				}
-
-				// Walk the source file looking for write references to the imported bindings.
-				sourceFile := ctx.SourceFile
-				var walk func(*ast.Node)
-				walk = func(n *ast.Node) {
-					if n == nil {
-						return
-					}
-
-					if n.Kind == ast.KindIdentifier {
-						for _, binding := range bindings {
-							if n.Text() != binding.name {
-								continue
-							}
-
-							// Skip the import declaration names themselves
-							if isImportBindingName(n) {
-								continue
-							}
-
-							// Verify symbol identity when type checker is available
-							if binding.symbol != nil && ctx.TypeChecker != nil {
-								refSym := ctx.TypeChecker.GetSymbolAtLocation(n)
-								if refSym != binding.symbol {
-									continue
-								}
-							}
-
-							if utils.IsWriteReference(n) {
-								ctx.ReportNode(n, rule.RuleMessage{
-									Id:          "readonly",
-									Description: "'" + binding.name + "' is read-only.",
-								})
-							} else if binding.isNamespace && isMemberWrite(n, &ctx) {
-								ctx.ReportNode(n, rule.RuleMessage{
-									Id:          "readonlyMember",
-									Description: "The members of '" + binding.name + "' are read-only.",
-								})
-							}
-						}
-					}
-
-					n.ForEachChild(func(child *ast.Node) bool {
-						walk(child)
-						return false
-					})
-				}
-				walk(sourceFile.AsNode())
-			},
-		}
+		return noImportAssignListeners(ctx, noImportAssignRefStoreAuto)
 	},
 }

--- a/internal/rules/no_import_assign/no_import_assign_test.go
+++ b/internal/rules/no_import_assign/no_import_assign_test.go
@@ -3,8 +3,13 @@ package no_import_assign
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoImportAssignRule(t *testing.T) {
@@ -381,4 +386,344 @@ func TestNoImportAssignRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestNoImportAssignRuleAdversarial(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoImportAssignRule,
+		[]rule_tester.ValidTestCase{
+			{
+				Code: `import { a } from "mod";
+				{ let a = 0; a = 1; }
+				const object = { a: 1 };
+				const shorthand = { a };
+				const computed = { [a]: 1 };
+				object.a = 2;
+				export { a };
+				a: for (;;) { break a; }`,
+			},
+			{
+				Code: `import * as ns from "mod";
+					{ const Object = factory; ((Object)).assign(((ns)), source); }
+					Object[method](((ns)), source);`,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				// References from bindings in one declaration must retain source order.
+				Code: `import { a, b } from "mod";
+					b = 1;
+					a = 2;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'b' is read-only.", Line: 2, Column: 6},
+					{MessageId: "readonly", Message: "'a' is read-only.", Line: 3, Column: 6},
+				},
+			},
+			{
+				// Separate declarations retain declaration-grouped report order.
+				Code: `import { a } from "a";
+					import { b } from "b";
+					b = 1;
+					a = 2;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'a' is read-only.", Line: 4, Column: 6},
+					{MessageId: "readonly", Message: "'b' is read-only.", Line: 3, Column: 6},
+				},
+			},
+			{
+				// Import declarations are hoisted, so references before the declaration count.
+				Code: `a = 1;
+					import { a } from "mod";`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'a' is read-only.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `ns.value = 1;
+					import * as ns from "mod";`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonlyMember", Message: "The members of 'ns' are read-only.", Line: 1, Column: 1},
+				},
+			},
+			{
+				// Parentheses around a namespace reference are semantically transparent.
+				Code: `import * as ns from "mod";
+					((ns)).value = 1;
+					Object.assign(((ns)), source);
+					delete (((ns).removed));
+					((Object)).defineProperty(((ns)), key, descriptor);
+					Object["assign"](((ns)), source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonlyMember", Message: "The members of 'ns' are read-only.", Line: 2},
+					{MessageId: "readonlyMember", Message: "The members of 'ns' are read-only.", Line: 3},
+					{MessageId: "readonlyMember", Message: "The members of 'ns' are read-only.", Line: 4},
+					{MessageId: "readonlyMember", Message: "The members of 'ns' are read-only.", Line: 5},
+					{MessageId: "readonlyMember", Message: "The members of 'ns' are read-only.", Line: 6},
+				},
+			},
+			{
+				// RefStore resolves shorthand assignment patterns that the
+				// checker returns as property symbols rather than import aliases.
+				Code: `import { value } from "mod";
+					({ value } = source);
+					({ value = 0 } = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 2},
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 3},
+				},
+			},
+		},
+	)
+}
+
+func TestNoImportAssignRuleWithoutRefStore(t *testing.T) {
+	fallbackRule := NoImportAssignRule
+	fallbackRule.Run = func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		ctx.Refs = nil
+		return NoImportAssignRule.Run(ctx, options)
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&fallbackRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `import { value } from "mod"; { let value = 0; value = 1; }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `import { value } from "mod"; value = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 1, Column: 30},
+				},
+			},
+			{
+				Code: `import * as ns from "mod"; Object.assign(ns, value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonlyMember", Message: "The members of 'ns' are read-only.", Line: 1, Column: 42},
+				},
+			},
+			{
+				Code: `import { value } from "mod"; ({ value = 0 } = source);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 1, Column: 33},
+				},
+			},
+		},
+	)
+}
+
+func TestNoImportAssignRuleWithRefStoreWithoutTypeChecker(t *testing.T) {
+	noCheckerRule := NoImportAssignRule
+	noCheckerRule.Run = func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		ctx.TypeChecker = nil
+		return NoImportAssignRule.Run(ctx, options)
+	}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&noCheckerRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `import { value } from "mod"; { let value = 0; value = 1; }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `import { value } from "mod";
+					{ let value = 0; value = 1; }
+					value = 2;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'value' is read-only.", Line: 3},
+				},
+			},
+		},
+	)
+}
+
+type noImportAssignDiagnosticFingerprint struct {
+	messageID   string
+	description string
+	pos         int
+	end         int
+}
+
+func lintNoImportAssignForComparison(
+	t *testing.T,
+	code string,
+	useRefStore bool,
+) []noImportAssignDiagnosticFingerprint {
+	t.Helper()
+
+	rootDir := fixtures.GetRootDir()
+	fileName := "file.ts"
+	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatal("comparison source file was not loaded")
+	}
+
+	var diagnostics []noImportAssignDiagnosticFingerprint
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:      program,
+		File:         sourceFile.FileName(),
+		HasTypeInfo:  true,
+		ExcludePaths: []string{},
+		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:     NoImportAssignRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					if !useRefStore {
+						ctx.Refs = nil
+						return noImportAssignListeners(ctx, noImportAssignRefStoreDisabled)
+					}
+					return noImportAssignListeners(ctx, noImportAssignRefStoreEnabled)
+				},
+			}}
+		},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: rule.EditDemandNone,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, noImportAssignDiagnosticFingerprint{
+					messageID:   diagnostic.Message.Id,
+					description: diagnostic.Message.Description,
+					pos:         diagnostic.Range.Pos(),
+					end:         diagnostic.Range.End(),
+				})
+			},
+		},
+	})
+	return diagnostics
+}
+
+func TestNoImportAssignRefStoreMatchesFallback(t *testing.T) {
+	testCases := []struct {
+		name string
+		code string
+	}{
+		{
+			name: "direct writes and ordering",
+			code: `before = 0;
+				import before, { first as alpha, second as beta } from "one";
+				beta += 1;
+				[alpha] = source;
+				before++;
+				({ alpha = 0, beta: before } = source);`,
+		},
+		{
+			name: "multiple declaration groups",
+			code: `import { a } from "a";
+				import { b, c } from "bc";
+				b = 1;
+				a = 2;
+				c = 3;`,
+		},
+		{
+			name: "namespace mutations and escapes",
+			code: `ns.value = 1;
+					import * as ns from "mod";
+					ns["element"]++;
+					delete ns.deleted;
+					Object.assign(ns, source);
+					Reflect.set(ns, key, value);
+					((ns)).wrapped = 1;
+					Object.assign(((ns)), source);
+					Object["assign"](((ns)), source);
+					(ns.escaped as any) = 1;
+					ns.deep.value = 1;`,
+		},
+		{
+			name: "local shadows and syntactic names",
+			code: `import { value } from "value";
+				import * as ns from "ns";
+				{ let value = 0; value = 1; }
+				{ let ns = {}; ns.value = 1; }
+				const object = { value: 1 };
+				object.value = 2;
+				value: for (;;) { break value; }
+				value = 3;
+				ns.value = 4;`,
+		},
+		{
+			name: "shadowed mutation globals",
+			code: `import * as ns from "ns";
+				{ const Object = factory; Object.assign(ns, source); }
+				Object.assign(ns, source);
+				function f(Reflect) { Reflect.set(ns, key, value); }
+				Reflect.set(ns, key, value);`,
+		},
+		{
+			name: "type-only imports",
+			code: `import type { T } from "types";
+				import { type U, V } from "mixed";
+				V = 1;
+				T = 2;
+				U = 3;`,
+		},
+		{
+			name: "import attributes",
+			code: `import data from "pkg" with { type: "json" };
+				let type = 0;
+				type = 1;
+				data = replacement;`,
+		},
+		{
+			name: "duplicate aliases in recovered syntax",
+			code: `import { x as duplicate } from "x";
+				import { y as duplicate } from "y";
+				duplicate = 1;`,
+		},
+		{
+			name: "duplicate local binding in recovered syntax",
+			code: `import { x as duplicate } from "x";
+				let duplicate;
+				duplicate = 1;`,
+		},
+		{
+			name: "nested import in recovered syntax",
+			code: `if (condition) {
+					import { nested } from "nested";
+					nested = 1;
+				}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fast := lintNoImportAssignForComparison(t, testCase.code, true)
+			fallback := lintNoImportAssignForComparison(t, testCase.code, false)
+			if len(fast) != len(fallback) {
+				t.Fatalf("diagnostic count differs: RefStore=%+v fallback=%+v", fast, fallback)
+			}
+			for i := range fast {
+				if fast[i] != fallback[i] {
+					t.Fatalf("diagnostic %d differs: RefStore=%+v fallback=%+v", i, fast[i], fallback[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNoImportAssignRefStoreHonorsDisableDirectives(t *testing.T) {
+	diagnostics := lintNoImportAssignForComparison(t, `import { a, b } from "mod";
+		// eslint-disable-next-line no-import-assign
+		a = 1;
+		b = 2;`, true)
+
+	if len(diagnostics) != 1 {
+		t.Fatalf("got diagnostics %+v, want one unsuppressed diagnostic", diagnostics)
+	}
+	if diagnostics[0].description != "'b' is read-only." {
+		t.Fatalf("got diagnostic %+v, want the write to b", diagnostics[0])
+	}
 }


### PR DESCRIPTION
## Summary

- Replace repeated whole-file walks in `no-import-assign` with a rule-local hybrid reference strategy.
- Use `ctx.Refs` for files with multiple imported bindings, while retaining one compatibility walk for single-binding files to avoid unnecessary reference-index allocations. When the type checker is unavailable, use `ctx.Refs` for exact shadow resolution.
- Keep reporting in the `ImportDeclaration` listener and stably merge per-symbol violations so existing diagnostic ordering and disable-directive behavior are preserved.
- Keep the fallback path for contexts without `ctx.Refs`, including shorthand assignment symbol resolution through `GetReferenceSymbol`.
- Fix adversarial namespace-write gaps involving transparent parentheses, parenthesized `delete`, and static computed mutation calls such as `Object["assign"]`.
- Deferred reports are not used because this rule has no fixes or suggestions to materialize lazily.

### Performance

Apple M1 Max, Go 1.26.1, 1,000 non-import statements, parse and program creation outside the timed section, 500 ms benchmark time with 3 runs. Values below are medians.

| Imports | Auto strategy | Compatibility scan | Speedup |
| ---: | ---: | ---: | ---: |
| 1 | 130 µs/op | 128 µs/op | effectively flat |
| 2 | 130 µs/op | 161 µs/op | 1.24x |
| 10 | 138 µs/op | 396 µs/op | 2.9x |
| 100 | 184 µs/op | 3.58 ms/op | 19.4x |

The single-binding guard also avoids the high-allocation edge case from eagerly indexing unrelated references: about 3.2 KB/op with auto versus about 220 KB/op with forced refs in the 1,000-unrelated-reference stress case.

### Validation

- `pnpm check-spell`
- `pnpm format:check`
- `golangci-lint run internal/rules/no_import_assign/no_import_assign.go internal/rules/no_import_assign/no_import_assign_test.go`
- Targeted `no_import_assign` rule tests covering the existing suite, forced refs/fallback differential behavior, nil-checker shadowing, disable directives, recovered syntax, and adversarial namespace mutations.
- No full Go test suite was run.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).