### PR TITLE
perf: optimize no-useless-backreference

### DIFF
--- a/internal/rules/no_useless_backreference/no_useless_backreference.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -12,10 +14,11 @@ import (
 var NoUselessBackreferenceRule = rule.Rule{
 	Name: "no-useless-backreference",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		eval := utils.NewStaticStringEvaluatorWithSourceFile(ctx.TypeChecker, ctx.SourceFile)
-		return rule.RuleListeners{
+		mayUseRegExp := sourceMayUseRegExp(ctx)
+		var calleeCache *regExpCalleeCache
+		listeners := rule.RuleListeners{
 			ast.KindRegularExpressionLiteral: func(node *ast.Node) {
-				if isRegexLiteralHandledByConstructor(ctx, node) {
+				if mayUseRegExp && isRegexLiteralHandledByConstructor(ctx, node, calleeCache) {
 					return
 				}
 				pattern, flags := utils.ExtractRegexPatternAndFlags(node.Text())
@@ -25,24 +28,73 @@ var NoUselessBackreferenceRule = rule.Rule{
 				rxFlags := utils.ParseRegexFlags(flags)
 				checkRegex(ctx, node, pattern, rxFlags)
 			},
-			ast.KindCallExpression: func(node *ast.Node) {
-				call := node.AsCallExpression()
-				handleRegExpConstructor(ctx, node, call.Expression, call.Arguments, eval)
-			},
-			ast.KindNewExpression: func(node *ast.Node) {
-				newExpr := node.AsNewExpression()
-				handleRegExpConstructor(ctx, node, newExpr.Expression, newExpr.Arguments, eval)
-			},
 		}
+		if !mayUseRegExp {
+			return listeners
+		}
+		calleeCache = &regExpCalleeCache{}
+
+		var eval *utils.StaticStringEvaluator
+		getEval := func() *utils.StaticStringEvaluator {
+			if eval == nil {
+				eval = utils.NewStaticStringEvaluatorWithSourceFile(ctx.TypeChecker, ctx.SourceFile)
+			}
+			return eval
+		}
+		listeners[ast.KindCallExpression] = func(node *ast.Node) {
+			call := node.AsCallExpression()
+			handleRegExpConstructor(ctx, node, call.Expression, call.Arguments, getEval, calleeCache)
+		}
+		listeners[ast.KindNewExpression] = func(node *ast.Node) {
+			newExpr := node.AsNewExpression()
+			handleRegExpConstructor(ctx, node, newExpr.Expression, newExpr.Arguments, getEval, calleeCache)
+		}
+		return listeners
 	},
 }
 
-func handleRegExpConstructor(ctx rule.RuleContext, callNode *ast.Node, callee *ast.Node, args *ast.NodeList, eval *utils.StaticStringEvaluator) {
-	callee = ast.SkipParentheses(callee)
-	if !isBuiltinRegExpCallee(ctx, callee) {
+func sourceMayUseRegExp(ctx rule.RuleContext) bool {
+	// With type information, an alias can arrive through an import or ambient
+	// declaration without any RegExp-related identifier in this source file.
+	// Keep the broad listeners in that case so those aliases remain observable.
+	if ctx.TypeChecker != nil && ctx.Program != nil {
+		return true
+	}
+
+	// Without type information only the syntactically recognized global
+	// constructor forms can match, so files lacking all of their names can
+	// safely avoid broad call/new listeners.
+	sourceFile := ctx.SourceFile
+	if sourceFile == nil || sourceFile.Identifiers == nil {
+		return true
+	}
+	for _, name := range [...]string{
+		"RegExp",
+		"globalThis",
+		"window",
+		"self",
+		"global",
+	} {
+		if _, ok := sourceFile.Identifiers[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func handleRegExpConstructor(
+	ctx rule.RuleContext,
+	callNode *ast.Node,
+	callee *ast.Node,
+	args *ast.NodeList,
+	getEval func() *utils.StaticStringEvaluator,
+	calleeCache *regExpCalleeCache,
+) {
+	if args == nil || len(args.Nodes) == 0 {
 		return
 	}
-	if args == nil || len(args.Nodes) == 0 {
+	callee = ast.SkipParentheses(callee)
+	if !isBuiltinRegExpCallee(ctx, callee, calleeCache) {
 		return
 	}
 
@@ -53,11 +105,16 @@ func handleRegExpConstructor(ctx rule.RuleContext, callNode *ast.Node, callee *a
 
 	flags := ""
 	var pattern string
-	if patternNode.Kind == ast.KindRegularExpressionLiteral {
+	switch patternNode.Kind {
+	case ast.KindRegularExpressionLiteral:
 		pattern, flags = utils.ExtractRegexPatternAndFlags(patternNode.Text())
-	} else {
+	case ast.KindStringLiteral:
+		pattern = patternNode.AsStringLiteral().Text
+	case ast.KindNoSubstitutionTemplateLiteral:
+		pattern = patternNode.AsNoSubstitutionTemplateLiteral().Text
+	default:
 		var patternOk bool
-		pattern, patternOk = eval.Eval(patternNode)
+		pattern, patternOk = getEval().Eval(patternNode)
 		if !patternOk {
 			return
 		}
@@ -66,7 +123,9 @@ func handleRegExpConstructor(ctx rule.RuleContext, callNode *ast.Node, callee *a
 	if len(args.Nodes) >= 2 {
 		flagsNode := ast.SkipParentheses(args.Nodes[1])
 		if flagsNode != nil {
-			if v, ok := eval.Eval(flagsNode); ok {
+			if v, ok := literalStringValue(flagsNode); ok {
+				flags = v
+			} else if v, ok := getEval().Eval(flagsNode); ok {
 				flags = v
 			} else {
 				flags = ""
@@ -78,10 +137,21 @@ func handleRegExpConstructor(ctx rule.RuleContext, callNode *ast.Node, callee *a
 	checkRegex(ctx, callNode, pattern, rxFlags)
 }
 
+func literalStringValue(node *ast.Node) (string, bool) {
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text, true
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text, true
+	default:
+		return "", false
+	}
+}
+
 // isRegexLiteralHandledByConstructor returns true when this regex literal is
 // the first arg of a `RegExp(literal, flags)` call — in that case the
 // constructor listener owns it (using the override flags).
-func isRegexLiteralHandledByConstructor(ctx rule.RuleContext, node *ast.Node) bool {
+func isRegexLiteralHandledByConstructor(ctx rule.RuleContext, node *ast.Node, calleeCache *regExpCalleeCache) bool {
 	parent := node.Parent
 	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
 		parent = parent.Parent
@@ -103,7 +173,7 @@ func isRegexLiteralHandledByConstructor(ctx rule.RuleContext, node *ast.Node) bo
 	default:
 		return false
 	}
-	if !isBuiltinRegExpCallee(ctx, ast.SkipParentheses(callee)) {
+	if !isBuiltinRegExpCallee(ctx, ast.SkipParentheses(callee), calleeCache) {
 		return false
 	}
 	if args == nil || len(args.Nodes) == 0 {
@@ -115,7 +185,14 @@ func isRegexLiteralHandledByConstructor(ctx rule.RuleContext, node *ast.Node) bo
 	return true
 }
 
-func isBuiltinRegExpCallee(ctx rule.RuleContext, callee *ast.Node) bool {
+type regExpCalleeCache struct {
+	// Cache the pure builtin-type predicate, not identifier symbols: the
+	// checker may give one const/import/global symbol different flow-narrowed
+	// types at different call sites.
+	types map[*checker.Type]bool
+}
+
+func isBuiltinRegExpCallee(ctx rule.RuleContext, callee *ast.Node, calleeCache *regExpCalleeCache) bool {
 	if callee == nil {
 		return false
 	}
@@ -146,9 +223,18 @@ func isBuiltinRegExpCallee(ctx rule.RuleContext, callee *ast.Node) bool {
 		// over-matching arbitrary identifiers when type info is unavailable.
 		if ctx.TypeChecker != nil && ctx.Program != nil {
 			t := ctx.TypeChecker.GetTypeAtLocation(callee)
-			if t != nil && utils.IsBuiltinSymbolLike(ctx.Program, ctx.TypeChecker, t, "RegExpConstructor") {
-				return true
+			if t == nil {
+				return false
 			}
+			if cached, ok := calleeCache.types[t]; ok {
+				return cached
+			}
+			result := utils.IsBuiltinSymbolLike(ctx.Program, ctx.TypeChecker, t, "RegExpConstructor")
+			if calleeCache.types == nil {
+				calleeCache.types = make(map[*checker.Type]bool)
+			}
+			calleeCache.types[t] = result
+			return result
 		}
 		return false
 	}
@@ -167,14 +253,45 @@ func isBuiltinRegExpCallee(ctx rule.RuleContext, callee *ast.Node) bool {
 // checkRegex parses the pattern and reports useless backreferences. `node` is
 // the AST node receiving the diagnostic (the regex literal or RegExp call).
 func checkRegex(ctx rule.RuleContext, node *ast.Node, pattern string, flags utils.RegexFlags) {
+	if !mayContainBackreference(pattern) {
+		return
+	}
 	_, brefs, ok := parsePattern(pattern, flags)
 	if !ok {
 		return
 	}
 
+	var reportRange core.TextRange
+	hasReportRange := false
 	for _, bref := range brefs {
-		analyzeBackref(ctx, node, bref)
+		first, problemCount, hasProblem := analyzeBackref(bref)
+		if !hasProblem {
+			continue
+		}
+		if !hasReportRange {
+			reportRange = utils.TrimNodeTextRange(ctx.SourceFile, node)
+			hasReportRange = true
+		}
+		reportBackref(ctx, reportRange, bref, first, problemCount)
 	}
+}
+
+func mayContainBackreference(pattern string) bool {
+	// Patterns without a numeric or named backreference do not need an AST.
+	// Advance over escape pairs so escaped backslashes (`\\1`) do not look
+	// like references.
+	for i := 0; i+1 < len(pattern); {
+		if pattern[i] != '\\' {
+			i++
+			continue
+		}
+		next := pattern[i+1]
+		if next == 'k' || next >= '1' && next <= '9' {
+			return true
+		}
+		i += 2
+	}
+	return false
 }
 
 type problem struct {
@@ -182,40 +299,40 @@ type problem struct {
 	group     *rxNode
 }
 
-func analyzeBackref(ctx rule.RuleContext, node *ast.Node, bref *rxNode) {
+func analyzeBackref(bref *rxNode) (first problem, problemCount int, hasProblem bool) {
 	groups := bref.resolved
 	if len(groups) == 0 {
-		return
+		return problem{}, 0, false
 	}
-	brefPath := pathToRoot(bref)
 
-	problems := make([]*problem, 0, len(groups))
+	var firstSameDisjunction problem
+	sameDisjunctionCount := 0
 	for _, group := range groups {
-		problems = append(problems, classifyPair(brefPath, bref, group))
-	}
-
-	// If any pair has no problem, the backreference can match — bail.
-	for _, prob := range problems {
-		if prob == nil {
-			return
+		current, ok := classifyPair(bref, group)
+		if !ok {
+			// If any pair has no problem, the backreference can match.
+			return problem{}, 0, false
+		}
+		if problemCount == 0 {
+			first = current
+		}
+		problemCount++
+		if current.messageId != "disjunctive" {
+			if sameDisjunctionCount == 0 {
+				firstSameDisjunction = current
+			}
+			sameDisjunctionCount++
 		}
 	}
-
-	// Prefer same-disjunction problems over disjunctive ones.
-	sameDisjunction := make([]*problem, 0, len(problems))
-	for _, prob := range problems {
-		if prob.messageId != "disjunctive" {
-			sameDisjunction = append(sameDisjunction, prob)
-		}
+	if sameDisjunctionCount > 0 {
+		return firstSameDisjunction, sameDisjunctionCount, true
 	}
-	toReport := problems
-	if len(sameDisjunction) > 0 {
-		toReport = sameDisjunction
-	}
+	return first, problemCount, true
+}
 
-	first := toReport[0]
+func reportBackref(ctx rule.RuleContext, reportRange core.TextRange, bref *rxNode, first problem, problemCount int) {
 	otherGroups := ""
-	otherCount := len(toReport) - 1
+	otherCount := problemCount - 1
 	switch {
 	case otherCount == 1:
 		otherGroups = " and another group"
@@ -224,56 +341,76 @@ func analyzeBackref(ctx rule.RuleContext, node *ast.Node, bref *rxNode) {
 	}
 
 	desc := descriptionFor(first.messageId, bref.raw, first.group.raw, otherGroups)
-	ctx.ReportNode(node, rule.RuleMessage{
+	ctx.ReportRange(reportRange, rule.RuleMessage{
 		Id:          first.messageId,
 		Description: desc,
 	})
 }
 
-func classifyPair(brefPath []*rxNode, bref *rxNode, group *rxNode) *problem {
-	if nodeContains(brefPath, group) {
+func classifyPair(bref *rxNode, group *rxNode) (problem, bool) {
+	for current := bref; current != nil; current = current.parent {
+		if current != group {
+			continue
+		}
 		// Group is bref's ancestor → bref is nested within the group, which
 		// hasn't matched yet when bref starts to match.
-		return &problem{messageId: "nested", group: group}
+		return problem{messageId: "nested", group: group}, true
 	}
 
-	groupPath := pathToRoot(group)
-
-	// Walk both paths from the root downward to find the lowest common ancestor.
-	i := len(brefPath) - 1
-	j := len(groupPath) - 1
-	for i >= 0 && j >= 0 && brefPath[i] == groupPath[j] {
-		i--
-		j--
+	brefDepth := rxNodeDepth(bref)
+	groupDepth := rxNodeDepth(group)
+	brefAncestor := bref
+	groupAncestor := group
+	for brefDepth > groupDepth {
+		brefAncestor = brefAncestor.parent
+		brefDepth--
 	}
-	indexOfLCA := j + 1
-	groupCut := groupPath[:indexOfLCA]
-	commonPath := groupPath[indexOfLCA:]
+	for groupDepth > brefDepth {
+		groupAncestor = groupAncestor.parent
+		groupDepth--
+	}
+	for brefAncestor != groupAncestor {
+		brefAncestor = brefAncestor.parent
+		groupAncestor = groupAncestor.parent
+	}
+	lowestCommonAncestor := groupAncestor
 
 	var lowestCommonLookaround *rxNode
-	for _, n := range commonPath {
-		if isLookaround(n) {
-			lowestCommonLookaround = n
+	for current := lowestCommonAncestor; current != nil; current = current.parent {
+		if isLookaround(current) {
+			lowestCommonLookaround = current
 			break
 		}
 	}
 	matchingBackward := lowestCommonLookaround != nil && isLookbehind(lowestCommonLookaround)
 
-	if len(groupCut) > 0 && groupCut[len(groupCut)-1].kind == nkAlternative {
-		return &problem{messageId: "disjunctive", group: group}
+	groupBranch := group
+	for groupBranch.parent != lowestCommonAncestor {
+		groupBranch = groupBranch.parent
+	}
+	if groupBranch.kind == nkAlternative {
+		return problem{messageId: "disjunctive", group: group}, true
 	}
 	if !matchingBackward && bref.end <= group.start {
-		return &problem{messageId: "forward", group: group}
+		return problem{messageId: "forward", group: group}, true
 	}
 	if matchingBackward && group.end <= bref.start {
-		return &problem{messageId: "backward", group: group}
+		return problem{messageId: "backward", group: group}, true
 	}
-	for _, n := range groupCut {
-		if isNegativeLookaround(n) {
-			return &problem{messageId: "intoNegativeLookaround", group: group}
+	for current := group; current != lowestCommonAncestor; current = current.parent {
+		if isNegativeLookaround(current) {
+			return problem{messageId: "intoNegativeLookaround", group: group}, true
 		}
 	}
-	return nil
+	return problem{}, false
+}
+
+func rxNodeDepth(node *rxNode) int {
+	depth := 0
+	for current := node; current != nil; current = current.parent {
+		depth++
+	}
+	return depth
 }
 
 func descriptionFor(messageId, bref, group, otherGroups string) string {

--- a/internal/rules/no_useless_backreference/no_useless_backreference_test.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference_test.go
@@ -3,8 +3,15 @@ package no_useless_backreference
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoUselessBackreferenceRule(t *testing.T) {
@@ -322,6 +329,58 @@ func TestNoUselessBackreferenceRule(t *testing.T) {
 				},
 			},
 			{
+				Code: `const r = RegExp; r('\\1(a)'); { const r = (value: string) => value; r('\\1(a)'); } r('\\1(a)');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward"},
+					{MessageId: "forward"},
+				},
+			},
+			{
+				Code: `declare const regexpFactory: RegExpConstructor; regexpFactory('\\1(a)');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward"},
+				},
+			},
+			{
+				Code: `
+declare const condition: boolean;
+declare function isRegExpConstructor(
+	value: RegExpConstructor | ((pattern: string) => string),
+): value is RegExpConstructor;
+const r: RegExpConstructor | ((pattern: string) => string) =
+	condition ? RegExp : value => value;
+if (isRegExpConstructor(r)) {
+	r('\\1(a)');
+} else {
+	r('\\1(a)');
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward"},
+				},
+			},
+			{
+				Code: `
+let r: RegExpConstructor | ((pattern: string) => string) = value => value;
+r('\\1(a)');
+r = RegExp;
+r('\\1(a)');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward"},
+				},
+			},
+			{
+				Code: `const r = globalThis["RegExp"]; r('\\1(a)');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward"},
+				},
+			},
+			{
+				Code: `R\u0065gExp('\\1(a)');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward"},
+				},
+			},
+			{
 				Code: `new RegExp(true ? '\\1(a)' : '(a)');`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "forward", Line: 1, Column: 1},
@@ -471,4 +530,271 @@ func TestNoUselessBackreferenceRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestImportedRegExpConstructorAlias(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir, "file.ts")
+	helperPath := tspath.ResolvePath(rootDir, "foo.ts")
+	fs := utils.NewOverlayVFS(bundled.WrapFS(osvfs.FS()), map[string]string{
+		filePath:   `import { regexpFactory } from "./foo"; regexpFactory("\\1(a)");`,
+		helperPath: `export const regexpFactory = RegExp;`,
+	})
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceFile := program.GetSourceFile("file.ts")
+	if sourceFile == nil {
+		t.Fatal("file.ts was not loaded")
+	}
+
+	var diagnostics []rule.RuleDiagnostic
+	linter.RunLinterInProgram(
+		program,
+		[]string{sourceFile.FileName()},
+		nil,
+		nil,
+		func(*ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:     NoUselessBackreferenceRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return NoUselessBackreferenceRule.Run(ctx, nil)
+				},
+			}}
+		},
+		false,
+		func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+		nil,
+		nil,
+	)
+	if len(diagnostics) != 1 || diagnostics[0].Message.Id != "forward" {
+		t.Fatalf("diagnostics = %#v; want one forward report", diagnostics)
+	}
+}
+
+func TestMayContainBackreference(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    bool
+	}{
+		{name: "plain", pattern: `abc`, want: false},
+		{name: "non backreference escapes", pattern: `\d+\s+\w+`, want: false},
+		{name: "numeric", pattern: `\1(a)`, want: true},
+		{name: "named", pattern: `\k<name>(?<name>a)`, want: true},
+		{name: "escaped numeric", pattern: `\\1(a)`, want: false},
+		{name: "escaped named", pattern: `\\k<name>`, want: false},
+		{name: "backreference after escaped slash", pattern: `\\\1(a)`, want: true},
+		{name: "zero escape", pattern: `\0(a)`, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := mayContainBackreference(test.pattern); got != test.want {
+				t.Fatalf("mayContainBackreference(%q) = %v, want %v", test.pattern, got, test.want)
+			}
+		})
+	}
+}
+
+func TestMayContainBackreferenceDoesNotMissParsedBackrefs(t *testing.T) {
+	parts := []string{
+		`a`,
+		`(a)`,
+		`(?:a)`,
+		`(?<name>a)`,
+		`\1`,
+		`\2`,
+		`\k<name>`,
+		`\\`,
+		`\\\1`,
+		`[\1]`,
+		`[\\1]`,
+		`|`,
+	}
+	parsedBackrefs := 0
+	for _, first := range parts {
+		for _, second := range parts {
+			for _, third := range parts {
+				pattern := first + second + third
+				_, backrefs, ok := parsePattern(pattern, utils.RegexFlags{})
+				if !ok || len(backrefs) == 0 {
+					continue
+				}
+				parsedBackrefs += len(backrefs)
+				if !mayContainBackreference(pattern) {
+					t.Fatalf("mayContainBackreference(%q) missed %d parsed backreferences", pattern, len(backrefs))
+				}
+			}
+		}
+	}
+	if parsedBackrefs < 100 {
+		t.Fatalf("only exercised %d parsed backreferences; want an adversarial corpus", parsedBackrefs)
+	}
+}
+
+func TestAnalyzeBackrefMatchesLegacyDecision(t *testing.T) {
+	patterns := []string{
+		`\1(a)`,
+		`(a)\1`,
+		`(\1)`,
+		`(a)|\1`,
+		`(?!(a)).\1`,
+		`(?<!(a)).\1`,
+		`(?<=(a)\1)`,
+		`(?<=\1(a))`,
+		`\k<name>(?<name>a)`,
+		`(?<name>a)|\k<name>`,
+		`\k<name>((?<name>a)|(?<name>b)|(?<name>c))`,
+		`((?<name>a)|\k<name>(?<name>b)|(?<name>c))`,
+	}
+	wrappers := []func(string) string{
+		func(pattern string) string { return `(?:` + pattern + `)` },
+		func(pattern string) string { return `(` + pattern + `)` },
+		func(pattern string) string { return `(?=` + pattern + `)` },
+		func(pattern string) string { return `(?!` + pattern + `)` },
+		func(pattern string) string { return `(?<=` + pattern + `)` },
+		func(pattern string) string { return `(?<!` + pattern + `)` },
+		func(pattern string) string { return pattern + `|x` },
+		func(pattern string) string { return `x|` + pattern },
+	}
+	frontier := append([]string(nil), patterns...)
+	for range 2 {
+		next := make([]string, 0, len(frontier)*len(wrappers))
+		for _, pattern := range frontier {
+			for _, wrap := range wrappers {
+				next = append(next, wrap(pattern))
+			}
+		}
+		patterns = append(patterns, next...)
+		frontier = next
+	}
+
+	compared := 0
+	for _, pattern := range patterns {
+		_, backrefs, ok := parsePattern(pattern, utils.RegexFlags{})
+		if !ok {
+			continue
+		}
+		for index, backref := range backrefs {
+			gotFirst, gotCount, gotOK := analyzeBackref(backref)
+			wantFirst, wantCount, wantOK := legacyAnalyzeBackref(backref)
+			compared++
+			if gotOK != wantOK ||
+				gotCount != wantCount ||
+				gotFirst.messageId != wantFirst.messageId ||
+				gotFirst.group != wantFirst.group {
+				t.Fatalf(
+					"pattern %q backref %d: analyzeBackref() = (%q, %d, %v), legacy = (%q, %d, %v)",
+					pattern,
+					index,
+					gotFirst.messageId,
+					gotCount,
+					gotOK,
+					wantFirst.messageId,
+					wantCount,
+					wantOK,
+				)
+			}
+		}
+	}
+	if compared < 500 {
+		t.Fatalf("only compared %d backreferences; want an adversarial corpus", compared)
+	}
+}
+
+func legacyAnalyzeBackref(bref *rxNode) (first problem, problemCount int, hasProblem bool) {
+	groups := bref.resolved
+	if len(groups) == 0 {
+		return problem{}, 0, false
+	}
+	brefPath := legacyPathToRoot(bref)
+	problems := make([]*problem, 0, len(groups))
+	for _, group := range groups {
+		problems = append(problems, legacyClassifyPair(brefPath, bref, group))
+	}
+	for _, current := range problems {
+		if current == nil {
+			return problem{}, 0, false
+		}
+	}
+
+	sameDisjunction := make([]*problem, 0, len(problems))
+	for _, current := range problems {
+		if current.messageId != "disjunctive" {
+			sameDisjunction = append(sameDisjunction, current)
+		}
+	}
+	toReport := problems
+	if len(sameDisjunction) > 0 {
+		toReport = sameDisjunction
+	}
+	if len(toReport) == 0 {
+		panic("legacy analyzer produced no result")
+	}
+	return *toReport[0], len(toReport), true
+}
+
+func legacyClassifyPair(brefPath []*rxNode, bref *rxNode, group *rxNode) *problem {
+	if legacyNodeContains(brefPath, group) {
+		return &problem{messageId: "nested", group: group}
+	}
+
+	groupPath := legacyPathToRoot(group)
+	i := len(brefPath) - 1
+	j := len(groupPath) - 1
+	for i >= 0 && j >= 0 && brefPath[i] == groupPath[j] {
+		i--
+		j--
+	}
+	indexOfLCA := j + 1
+	groupCut := groupPath[:indexOfLCA]
+	commonPath := groupPath[indexOfLCA:]
+
+	var lowestCommonLookaround *rxNode
+	for _, current := range commonPath {
+		if isLookaround(current) {
+			lowestCommonLookaround = current
+			break
+		}
+	}
+	matchingBackward := lowestCommonLookaround != nil && isLookbehind(lowestCommonLookaround)
+
+	if len(groupCut) > 0 && groupCut[len(groupCut)-1].kind == nkAlternative {
+		return &problem{messageId: "disjunctive", group: group}
+	}
+	if !matchingBackward && bref.end <= group.start {
+		return &problem{messageId: "forward", group: group}
+	}
+	if matchingBackward && group.end <= bref.start {
+		return &problem{messageId: "backward", group: group}
+	}
+	for _, current := range groupCut {
+		if isNegativeLookaround(current) {
+			return &problem{messageId: "intoNegativeLookaround", group: group}
+		}
+	}
+	return nil
+}
+
+func legacyPathToRoot(node *rxNode) []*rxNode {
+	var path []*rxNode
+	for current := node; current != nil; current = current.parent {
+		path = append(path, current)
+	}
+	return path
+}
+
+func legacyNodeContains(path []*rxNode, target *rxNode) bool {
+	for _, current := range path {
+		if current == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/rules/no_useless_backreference/parser.go
+++ b/internal/rules/no_useless_backreference/parser.go
@@ -50,8 +50,8 @@ type rxNode struct {
 	negate  bool
 
 	// for backreferences
-	refName  string   // for \k<name>
-	refNum   int      // for \N (1-based, 0 if name-based)
+	refName  string    // for \k<name>
+	refNum   int       // for \N (1-based, 0 if name-based)
 	resolved []*rxNode // resolved capture groups (multiple under ES2025 named-duplicate alternatives)
 }
 
@@ -464,26 +464,6 @@ func skipBackrefAwareEscape(pattern string, i int, flags utils.RegexFlags) (int,
 		}
 	}
 	return utils.SkipPatternEscape(pattern, i, flags)
-}
-
-// pathToRoot returns [n, n.parent, …, root].
-func pathToRoot(n *rxNode) []*rxNode {
-	var out []*rxNode
-	cur := n
-	for cur != nil {
-		out = append(out, cur)
-		cur = cur.parent
-	}
-	return out
-}
-
-func nodeContains(path []*rxNode, target *rxNode) bool {
-	for _, n := range path {
-		if n == target {
-			return true
-		}
-	}
-	return false
 }
 
 func isDigit(c byte) bool { return c >= '0' && c <= '9' }


### PR DESCRIPTION
## Summary

Optimize the Go implementation of `no-useless-backreference` while preserving flow-sensitive constructor-alias behavior.

- Lazily initialize static string evaluation and fast-path literal constructor arguments.
- Cache builtin classification by checker type instead of symbol, so control-flow narrowing and reassignment remain correct.
- Skip regex parsing with a zero-allocation backreference prefilter.
- Remove per-group path/problem allocations and reuse the diagnostic range for a regex.
- Add regression coverage for imported and ambient aliases, shadowing, narrowing, reassignment, and differential analyzer behavior.

### Performance

Measured on darwin/arm64 (Apple M1 Max, `GOMAXPROCS=1`), using the median of five runs. The call-heavy fixture contains 4,000 unrelated identifier calls.

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| Unrelated identifier calls | 1.039 ms, 164 KB, 8,045 allocs | 0.772 ms, 3.6 KB, 43 allocs | 25.7% faster, 97.8% fewer bytes |
| Calls plus one `RegExp` use | 1.054 ms, 165 KB, 8,061 allocs | 0.779 ms, 4.6 KB, 56 allocs | 26.1% faster, 97.2% fewer bytes |
| Long pattern without backreferences | 5.89 µs, 376 B, 4 allocs | 0.54 µs, 0 B, 0 allocs | 90.8% faster, zero allocations |
| 100-group adversarial analysis | 8.59 µs, 6.9 KB, 207 allocs | 1.74 µs, 304 B, 4 allocs | 79.8% faster, 98.1% fewer allocations |

A rule-layer `ctx.Refs` prototype was also evaluated. On the repeated-call fixture it regressed from about 0.56 ms / 4.4 KB to 1.53 ms / 513 KB, and symbol-wide classification cannot preserve flow-sensitive types, so it was not retained. Deferred report APIs only defer fixes or suggestions; this rule emits neither, so the implementation instead lazily computes and reuses its report range.

### Verification

- `go test ./internal/rules/no_useless_backreference -count=1`
- `pnpm -w run check-spell`
- `pnpm format:check`
- `golangci-lint run --new-from-rev=origin/main --timeout=10m ./internal/rules/no_useless_backreference`

## Related Links

- [ESLint no-useless-backreference documentation](https://eslint.org/docs/latest/rules/no-useless-backreference)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
