### PR TITLE
perf: binary-search comment getters in JS plugin SourceCode

### DIFF
--- a/packages/rslint/src/eslint-plugin/source-code/source-code-helpers.ts
+++ b/packages/rslint/src/eslint-plugin/source-code/source-code-helpers.ts
@@ -11,7 +11,11 @@ import type {
   TokenCountOpts,
   TokenSkipOpts,
 } from './source-code.js';
-import type { Token } from './token-builder.js';
+import {
+  spanIndexStartingAtOrAfter,
+  spanIndexEndingAtOrBefore,
+  type Token,
+} from './token-builder.js';
 
 // ─────────────────────────────────────────────────────────────────────
 // Line-start offset lookup — shared safe accessor for `lso[line - 1]`
@@ -190,11 +194,11 @@ export function normalizeFilterOpts(
  * this is intentionally NOT passed the comment-merged stream.
  *
  * `getFirstIndex` / `getLastIndex` resolve, for a real boundary loc, to
- * the first/last token fully inside `[startLoc, endLoc]`. The linear
- * scans below compute the same first/last index; when the range
- * contains no token (`firstIdx > lastIdx`) the unpadded slice is empty
- * and padding inflates symmetrically around that gap — matching the
- * cursor's index arithmetic.
+ * the first/last token fully inside `[startLoc, endLoc]`; both are
+ * binary searches over the sorted, non-overlapping token array. When the
+ * range contains no token (`firstIdx > lastIdx`) the unpadded slice is
+ * empty and padding inflates symmetrically around that gap — matching
+ * the cursor's index arithmetic.
  */
 export function paddedTokenSlice(
   tokens: readonly Token[],
@@ -205,22 +209,13 @@ export function paddedTokenSlice(
 ): Token[] {
   const len = tokens.length;
   if (len === 0) return [];
-  // getFirstIndex: first token whose start is at/after startLoc.
-  let firstIdx = len;
-  for (let i = 0; i < len; i++) {
-    if (tokens[i].range[0] >= startLoc) {
-      firstIdx = i;
-      break;
-    }
-  }
-  // getLastIndex: last token whose end is at/before endLoc.
-  let lastIdx = -1;
-  for (let i = len - 1; i >= 0; i--) {
-    if (tokens[i].range[1] <= endLoc) {
-      lastIdx = i;
-      break;
-    }
-  }
+  // getFirstIndex: first token whose start is at/after startLoc. `-1`
+  // (no such token) means the range opens past EOF — keep the `len`
+  // sentinel the padding arithmetic below expects.
+  const firstAtOrAfter = spanIndexStartingAtOrAfter(tokens, startLoc);
+  const firstIdx = firstAtOrAfter < 0 ? len : firstAtOrAfter;
+  // getLastIndex: last token whose end is at/before endLoc (-1 if none).
+  const lastIdx = spanIndexEndingAtOrBefore(tokens, endLoc);
   const start = Math.max(0, firstIdx - beforeCount);
   const end = Math.min(len - 1, lastIdx + afterCount);
   if (start > end) return [];

--- a/packages/rslint/src/eslint-plugin/source-code/source-code.ts
+++ b/packages/rslint/src/eslint-plugin/source-code/source-code.ts
@@ -56,7 +56,7 @@ import {
 } from './source-code-helpers.js';
 import {
   buildTokens,
-  tokenIndexAtOrAfter,
+  spanIndexStartingAtOrAfter,
   type Comment,
   type Token,
 } from './token-builder.js';
@@ -767,7 +767,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       // Binary-search the first token starting at/after `targetStart`;
       // the backward scan starts just before it. Only a token that
       // CONTAINS `targetStart` can still trip the range guard below.
-      const idxAfter = tokenIndexAtOrAfter(stream, targetStart);
+      const idxAfter = spanIndexStartingAtOrAfter(stream, targetStart);
       let skipped = 0;
       for (
         let i = idxAfter < 0 ? stream.length - 1 : idxAfter - 1;
@@ -791,7 +791,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const targetEnd = node.range[1];
       // Binary search guarantees every token from `start` on has
       // `range[0] >= targetEnd`, so no per-token range guard is needed.
-      const start = tokenIndexAtOrAfter(stream, targetEnd);
+      const start = spanIndexStartingAtOrAfter(stream, targetEnd);
       if (start < 0) return null;
       let skipped = 0;
       for (let i = start; i < stream.length; i++) {
@@ -810,7 +810,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const stream = streamFor(includeComments);
       // Binary search to the first token starting inside the node's
       // range; from there every token has `range[0] >= node.range[0]`.
-      const start = tokenIndexAtOrAfter(stream, node.range[0]);
+      const start = spanIndexStartingAtOrAfter(stream, node.range[0]);
       if (start < 0) return null;
       let skipped = 0;
       for (let i = start; i < stream.length; i++) {
@@ -831,7 +831,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       // Binary-search the first token starting at/after the node's end;
       // the backward scan starts just before it. Only a token that
       // straddles `node.range[1]` can still trip the range guard below.
-      const idxAfter = tokenIndexAtOrAfter(stream, node.range[1]);
+      const idxAfter = spanIndexStartingAtOrAfter(stream, node.range[1]);
       let skipped = 0;
       for (
         let i = idxAfter < 0 ? stream.length - 1 : idxAfter - 1;
@@ -879,7 +879,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const out: Token[] = [];
       // Binary search to the node's start; stop once tokens begin at/after
       // the node's end (no non-empty token starting there can be contained).
-      const start = tokenIndexAtOrAfter(stream, node.range[0]);
+      const start = spanIndexStartingAtOrAfter(stream, node.range[0]);
       if (start < 0) return out;
       for (let i = start; i < stream.length; i++) {
         const t = stream[i];
@@ -907,7 +907,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       }
       const stream = streamFor(includeComments);
       const out: Token[] = [];
-      const start = tokenIndexAtOrAfter(stream, left.range[1]);
+      const start = spanIndexStartingAtOrAfter(stream, left.range[1]);
       if (start < 0) return out;
       for (let i = start; i < stream.length; i++) {
         const t = stream[i];
@@ -926,7 +926,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
     getFirstTokenBetween(left, right, opts) {
       const { skip, filter, includeComments } = normalizeSkipOpts(opts);
       const stream = streamFor(includeComments);
-      const start = tokenIndexAtOrAfter(stream, left.range[1]);
+      const start = spanIndexStartingAtOrAfter(stream, left.range[1]);
       if (start < 0) return null;
       let matched = 0;
       for (let i = start; i < stream.length; i++) {
@@ -942,7 +942,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const { count, filter, includeComments } = normalizeCountOpts(opts);
       const stream = streamFor(includeComments);
       const out: Token[] = [];
-      const start = tokenIndexAtOrAfter(stream, left.range[1]);
+      const start = spanIndexStartingAtOrAfter(stream, left.range[1]);
       if (start < 0) return out;
       for (let i = start; i < stream.length; i++) {
         const t = stream[i];
@@ -961,7 +961,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const stream = streamFor(includeComments);
       // Collect all candidates first, then walk from the end.
       const matches: Token[] = [];
-      const start = tokenIndexAtOrAfter(stream, left.range[1]);
+      const start = spanIndexStartingAtOrAfter(stream, left.range[1]);
       if (start < 0) return null;
       for (let i = start; i < stream.length; i++) {
         const t = stream[i];
@@ -976,7 +976,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const { count, filter, includeComments } = normalizeCountOpts(opts);
       const stream = streamFor(includeComments);
       const matches: Token[] = [];
-      const start = tokenIndexAtOrAfter(stream, left.range[1]);
+      const start = spanIndexStartingAtOrAfter(stream, left.range[1]);
       if (start < 0) return matches;
       for (let i = start; i < stream.length; i++) {
         const t = stream[i];
@@ -991,7 +991,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const { count, filter, includeComments } = normalizeCountOpts(opts);
       const stream = streamFor(includeComments);
       const out: Token[] = [];
-      const start = tokenIndexAtOrAfter(stream, node.range[0]);
+      const start = spanIndexStartingAtOrAfter(stream, node.range[0]);
       if (start < 0) return out;
       for (let i = start; i < stream.length; i++) {
         const t = stream[i];
@@ -1009,7 +1009,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const { count, filter, includeComments } = normalizeCountOpts(opts);
       const stream = streamFor(includeComments);
       const out: Token[] = [];
-      const idxAfter = tokenIndexAtOrAfter(stream, node.range[1]);
+      const idxAfter = spanIndexStartingAtOrAfter(stream, node.range[1]);
       for (
         let i = idxAfter < 0 ? stream.length - 1 : idxAfter - 1;
         i >= 0;
@@ -1031,7 +1031,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const { count, filter, includeComments } = normalizeCountOpts(opts);
       const stream = streamFor(includeComments);
       const out: Token[] = [];
-      const idxAfter = tokenIndexAtOrAfter(stream, node.range[0]);
+      const idxAfter = spanIndexStartingAtOrAfter(stream, node.range[0]);
       for (
         let i = idxAfter < 0 ? stream.length - 1 : idxAfter - 1;
         i >= 0;
@@ -1052,7 +1052,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const { count, filter, includeComments } = normalizeCountOpts(opts);
       const stream = streamFor(includeComments);
       const out: Token[] = [];
-      const start = tokenIndexAtOrAfter(stream, node.range[1]);
+      const start = spanIndexStartingAtOrAfter(stream, node.range[1]);
       if (start < 0) return out;
       for (let i = start; i < stream.length; i++) {
         const t = stream[i];
@@ -1076,7 +1076,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       // Stream is sorted by range[0]; binary search to the candidate
       // index, then verify exact match (range[0] could equal `start - 1`
       // if `start` lands in a gap).
-      const idx = tokenIndexAtOrAfter(stream, start);
+      const idx = spanIndexStartingAtOrAfter(stream, start);
       if (idx < 0) return null;
       const t = stream[idx];
       return t.range[0] === start ? t : null;
@@ -1095,33 +1095,62 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
     // The fix walks the code-token stream once to find the
     // immediately-prior/-next CODE token and then bounds the comment
     // filter by the gap between that token and the node.
+    //
+    // All three getters below binary-search `comments` (sorted by
+    // `range[0]`, like the token stream) to the first candidate and then
+    // walk forward only across the comments that can still fall inside
+    // the bound. A `comments.filter(...)` here scanned the WHOLE file's
+    // comment array per call, so a rule asking for the comments before
+    // every declaration (`local/jsdoc-format` in the TypeScript repo, any
+    // JSDoc-driven rule) was quadratic in a JSDoc-heavy file.
     getCommentsBefore(node) {
       const { tokens, comments } = ensureTokens();
       // tokens are sorted by range[0]. The nearest code token *before*
-      // `node` sits at index `tokenIndexAtOrAfter(node.range[0]) - 1`
+      // `node` sits at index `spanIndexStartingAtOrAfter(node.range[0]) - 1`
       // (or the last token if no token starts at/after node).
       let prevTokenEnd = 0;
-      const idxAfter = tokenIndexAtOrAfter(tokens, node.range[0]);
+      const idxAfter = spanIndexStartingAtOrAfter(tokens, node.range[0]);
       const prevIdx = idxAfter < 0 ? tokens.length - 1 : idxAfter - 1;
       if (prevIdx >= 0) prevTokenEnd = tokens[prevIdx].range[1];
-      return comments.filter(
-        (c) => c.range[0] >= prevTokenEnd && c.range[1] <= node.range[0],
-      );
+      const out: Comment[] = [];
+      const start = spanIndexStartingAtOrAfter(comments, prevTokenEnd);
+      if (start < 0) return out;
+      for (let i = start; i < comments.length; i++) {
+        const c = comments[i];
+        // Comments are non-empty and non-overlapping, so once one starts
+        // at/after the node there is no later comment that still ends
+        // at/before it.
+        if (c.range[0] >= node.range[0]) break;
+        if (c.range[1] <= node.range[0]) out.push(c);
+      }
+      return out;
     },
     getCommentsAfter(node) {
       const { tokens, comments } = ensureTokens();
       // First code token whose start >= node.range[1] — binary search.
-      const idx = tokenIndexAtOrAfter(tokens, node.range[1]);
+      const idx = spanIndexStartingAtOrAfter(tokens, node.range[1]);
       const nextTokenStart = idx < 0 ? text.length : tokens[idx].range[0];
-      return comments.filter(
-        (c) => c.range[0] >= node.range[1] && c.range[1] <= nextTokenStart,
-      );
+      const out: Comment[] = [];
+      const start = spanIndexStartingAtOrAfter(comments, node.range[1]);
+      if (start < 0) return out;
+      for (let i = start; i < comments.length; i++) {
+        const c = comments[i];
+        if (c.range[0] >= nextTokenStart) break;
+        if (c.range[1] <= nextTokenStart) out.push(c);
+      }
+      return out;
     },
     getCommentsInside(node) {
       const { comments } = ensureTokens();
-      return comments.filter(
-        (c) => c.range[0] >= node.range[0] && c.range[1] <= node.range[1],
-      );
+      const out: Comment[] = [];
+      const start = spanIndexStartingAtOrAfter(comments, node.range[0]);
+      if (start < 0) return out;
+      for (let i = start; i < comments.length; i++) {
+        const c = comments[i];
+        if (c.range[0] >= node.range[1]) break;
+        if (c.range[1] <= node.range[1]) out.push(c);
+      }
+      return out;
     },
     getAllComments() {
       // Cheap path when `parsedComments` was provided at construction —
@@ -1134,10 +1163,7 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       const { comments } = ensureTokens();
       // comments are sorted by range[0]. Binary search to the first
       // candidate, then O(1) check that it ends before `right`.
-      const idx = tokenIndexAtOrAfter(
-        comments as unknown as readonly Token[],
-        left.range[1],
-      );
+      const idx = spanIndexStartingAtOrAfter(comments, left.range[1]);
       if (idx < 0) return false;
       return comments[idx].range[1] <= right.range[0];
     },
@@ -1178,14 +1204,14 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
       // identity check works because streamFor reuses the live
       // token/comment objects without cloning (starts are unique, so a
       // stream member is found exactly at its own index).
-      let i = tokenIndexAtOrAfter(stream, startAnchor.range[0]);
+      let i = spanIndexStartingAtOrAfter(stream, startAnchor.range[0]);
       if (i < 0 || stream[i] !== startAnchor) {
         // Fallback: if the anchor isn't a tokenizer-emitted object
         // (e.g. the caller passed a raw Token literal we don't know
         // about), binary-search to the last token whose start < the
         // anchor's end — i.e. first index where range[0] >= anchor.end,
         // minus one.
-        const after = tokenIndexAtOrAfter(stream, startAnchor.range[1]);
+        const after = spanIndexStartingAtOrAfter(stream, startAnchor.range[1]);
         i = after < 0 ? stream.length - 1 : after - 1;
         if (i < 0) i = 0;
       }
@@ -1193,6 +1219,12 @@ export function createSourceCode(input: SourceCodeBuildInput): SourceCode {
         const cur = stream[i];
         const next = stream[i + 1];
         if (cur === endAnchor) break;
+        // Positional stop, in case `endAnchor` is not a stream member (the
+        // fallback branch above accepts a caller-built Token literal). The
+        // identity break fires at this same index when the anchor IS in the
+        // stream — starts are unique — so this only bounds the walk that
+        // would otherwise run to the end of the file.
+        if (cur.range[0] >= endAnchor.range[0]) break;
         if (cur.range[1] !== next.range[0]) return true;
         i++;
         if (next === endAnchor) break;

--- a/packages/rslint/src/eslint-plugin/source-code/token-builder.ts
+++ b/packages/rslint/src/eslint-plugin/source-code/token-builder.ts
@@ -191,19 +191,51 @@ function isHexDigit(ch: number): boolean {
 }
 
 /**
- * Index of the first token at or after `offset` (binary search on `range[0]`), or -1 if
- * none. Migrated from the deleted tokenizer; used by the SourceCode token getters.
+ * One entry of a sorted, non-overlapping source stream. The two lookups below run over the
+ * code-token array, the comment array, and the merged tokens+comments stream alike, so they
+ * take this shape rather than `Token`.
  */
-export function tokenIndexAtOrAfter(
-  tokens: readonly Token[],
+export interface Span {
+  range: [number, number];
+}
+
+/**
+ * Index of the first span starting at or after `offset` (binary search on `range[0]`), or
+ * -1 if none. Migrated from the deleted tokenizer; used by the SourceCode token and comment
+ * getters.
+ */
+export function spanIndexStartingAtOrAfter(
+  spans: readonly Span[],
   offset: number,
 ): number {
   let lo = 0;
-  let hi = tokens.length;
+  let hi = spans.length;
   while (lo < hi) {
     const mid = (lo + hi) >> 1;
-    if (tokens[mid].range[0] < offset) lo = mid + 1;
+    if (spans[mid].range[0] < offset) lo = mid + 1;
     else hi = mid;
   }
-  return lo < tokens.length ? lo : -1;
+  return lo < spans.length ? lo : -1;
+}
+
+/**
+ * Index of the LAST span whose `range[1]` is at or before `offset`, or -1 if none. The
+ * end-bounded counterpart to `spanIndexStartingAtOrAfter`.
+ *
+ * Binary search is valid on `range[1]` for the same reason it is on `range[0]`: the stream
+ * is sorted by start and its entries never overlap, so ends are increasing too. Callers
+ * must therefore pass one of those streams and not an arbitrarily-ordered array.
+ */
+export function spanIndexEndingAtOrBefore(
+  spans: readonly Span[],
+  offset: number,
+): number {
+  let lo = 0;
+  let hi = spans.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (spans[mid].range[1] <= offset) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo - 1;
 }

--- a/packages/rslint/tests/eslint-plugin/source-code/comment-lookup.test.ts
+++ b/packages/rslint/tests/eslint-plugin/source-code/comment-lookup.test.ts
@@ -14,8 +14,8 @@
  * The tests below pin that rewrite to the ORIGINAL predicates: each
  * reference implementation here is the pre-change filter, verbatim, and
  * the assertions sweep every interesting offset in a comment-dense
- * fixture (comment/token boundaries and their +-1 neighbourhoods, plus
- * both ends of the file) so boundary-off-by-one is not representable.
+ * fixture (every comment/token boundary and the offsets +-1 around it,
+ * plus both ends of the file) so boundary-off-by-one is not representable.
  */
 
 import { describe, test, expect } from '@rstest/core';
@@ -167,8 +167,8 @@ function refPaddedSlice(
 }
 
 // ────────────────────────────────────────────────────────────────────
-// Probe offsets: every token / comment boundary and its +-1
-// neighbourhood, plus both ends of the file.
+// Probe offsets: every token / comment boundary and the offsets +-1
+// around it, plus both ends of the file.
 // ────────────────────────────────────────────────────────────────────
 
 const OFFSETS: number[] = (() => {

--- a/packages/rslint/tests/eslint-plugin/source-code/comment-lookup.test.ts
+++ b/packages/rslint/tests/eslint-plugin/source-code/comment-lookup.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Differential coverage for the offset-indexed lookups that back
+ * `getCommentsBefore` / `getCommentsAfter` / `getCommentsInside` and the
+ * numeric-padding token slice.
+ *
+ * All four used to compute their bound with a full linear scan of the
+ * file's comment / token array on EVERY call. A rule that asks for the
+ * comments attached to each declaration (`local/jsdoc-format` in the
+ * TypeScript repo, and every JSDoc-driven rule) therefore paid
+ * O(declarations x comments) per file. They now binary-search to the
+ * first candidate and walk forward only across the ones that can still
+ * satisfy the bound.
+ *
+ * The tests below pin that rewrite to the ORIGINAL predicates: each
+ * reference implementation here is the pre-change filter, verbatim, and
+ * the assertions sweep every interesting offset in a comment-dense
+ * fixture (comment/token boundaries and their +-1 neighbourhoods, plus
+ * both ends of the file) so boundary-off-by-one is not representable.
+ */
+
+import { describe, test, expect } from '@rstest/core';
+
+import { parse as nativeParse } from '../../../src/eslint-plugin/native/load-binding.js';
+
+import { createSourceCode } from '../../../src/eslint-plugin/source-code/source-code.js';
+import type { ESTreeNode } from '../../../src/eslint-plugin/source-code/source-code.js';
+import {
+  spanIndexEndingAtOrBefore,
+  type Comment,
+  type Token,
+} from '../../../src/eslint-plugin/source-code/token-builder.js';
+import { paddedTokenSlice } from '../../../src/eslint-plugin/source-code/source-code-helpers.js';
+
+// Same shape as `token-padding.test.ts`'s helper: a real native parse so
+// tokens and comments carry real offsets; only `range` is load-bearing on
+// the probe nodes, since every getter under test resolves purely by offset.
+function mkSC(text: string) {
+  const ast = {
+    type: 'Program',
+    body: [],
+    sourceType: 'module',
+    range: [0, text.length] as [number, number],
+    loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+  } as unknown as ESTreeNode;
+  const parsed = nativeParse('test.ts', text, 'module', false);
+  return createSourceCode({
+    text,
+    ast,
+    scopeManagerFactory: () => ({}),
+    parsedTokens: {
+      types: parsed.tokenTypes,
+      starts: parsed.tokenStarts,
+      ends: parsed.tokenEnds,
+    },
+    parsedComments: parsed.comments as ReadonlyArray<{
+      type: 'Line' | 'Block';
+      value: string;
+      start: number;
+      end: number;
+    }>,
+  });
+}
+
+function mkNode(start: number, end: number): ESTreeNode {
+  return {
+    type: 'Probe',
+    range: [start, end],
+    loc: {
+      start: { line: 1, column: start },
+      end: { line: 1, column: end },
+    },
+    start,
+    end,
+  } as unknown as ESTreeNode;
+}
+
+// A comment-dense fixture: leading comments, trailing comments on the
+// same line, back-to-back comments with no code between them, a comment
+// flush against a token (`a/*x*/b`), comments inside a block, and a
+// comment as the very last thing in the file.
+const TEXT = [
+  '// leading line',
+  '/** jsdoc for f */',
+  '/* extra */',
+  'function f(a /* flush */, b) {',
+  '  // inside',
+  '  return a /*g*/ + b; // trailing',
+  '}',
+  '/* between */',
+  '/** jsdoc for g */',
+  'function g() {}',
+  '// last line of the file',
+].join('\n');
+
+const sc = mkSC(TEXT);
+const PROGRAM = mkNode(0, TEXT.length);
+const ALL_TOKENS = sc.getTokens(PROGRAM) as unknown as Token[];
+const ALL_COMMENTS = sc.getAllComments() as unknown as Comment[];
+
+// ────────────────────────────────────────────────────────────────────
+// Reference implementations — the pre-change bodies, unchanged.
+// ────────────────────────────────────────────────────────────────────
+
+// `spanIndexStartingAtOrAfter` as a scan: first index whose start is at/after
+// `offset`, or -1.
+function refIndexAtOrAfter(
+  stream: ReadonlyArray<{ range: [number, number] }>,
+  offset: number,
+): number {
+  for (let i = 0; i < stream.length; i++) {
+    if (stream[i].range[0] >= offset) return i;
+  }
+  return -1;
+}
+
+function refCommentsBefore(range: [number, number]): Comment[] {
+  let prevTokenEnd = 0;
+  const idxAfter = refIndexAtOrAfter(ALL_TOKENS, range[0]);
+  const prevIdx = idxAfter < 0 ? ALL_TOKENS.length - 1 : idxAfter - 1;
+  if (prevIdx >= 0) prevTokenEnd = ALL_TOKENS[prevIdx].range[1];
+  return ALL_COMMENTS.filter(
+    (c) => c.range[0] >= prevTokenEnd && c.range[1] <= range[0],
+  );
+}
+
+function refCommentsAfter(range: [number, number]): Comment[] {
+  const idx = refIndexAtOrAfter(ALL_TOKENS, range[1]);
+  const nextTokenStart = idx < 0 ? TEXT.length : ALL_TOKENS[idx].range[0];
+  return ALL_COMMENTS.filter(
+    (c) => c.range[0] >= range[1] && c.range[1] <= nextTokenStart,
+  );
+}
+
+function refCommentsInside(range: [number, number]): Comment[] {
+  return ALL_COMMENTS.filter(
+    (c) => c.range[0] >= range[0] && c.range[1] <= range[1],
+  );
+}
+
+function refPaddedSlice(
+  tokens: readonly Token[],
+  startLoc: number,
+  endLoc: number,
+  beforeCount: number,
+  afterCount: number,
+): Token[] {
+  const len = tokens.length;
+  if (len === 0) return [];
+  let firstIdx = len;
+  for (let i = 0; i < len; i++) {
+    if (tokens[i].range[0] >= startLoc) {
+      firstIdx = i;
+      break;
+    }
+  }
+  let lastIdx = -1;
+  for (let i = len - 1; i >= 0; i--) {
+    if (tokens[i].range[1] <= endLoc) {
+      lastIdx = i;
+      break;
+    }
+  }
+  const start = Math.max(0, firstIdx - beforeCount);
+  const end = Math.min(len - 1, lastIdx + afterCount);
+  if (start > end) return [];
+  return tokens.slice(start, end + 1);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Probe offsets: every token / comment boundary and its +-1
+// neighbourhood, plus both ends of the file.
+// ────────────────────────────────────────────────────────────────────
+
+const OFFSETS: number[] = (() => {
+  const set = new Set<number>([0, TEXT.length]);
+  for (const t of [...ALL_TOKENS, ...ALL_COMMENTS]) {
+    for (const base of t.range) {
+      for (const d of [-1, 0, 1]) {
+        const o = base + d;
+        if (o >= 0 && o <= TEXT.length) set.add(o);
+      }
+    }
+  }
+  return [...set].sort((a, b) => a - b);
+})();
+
+const ranges = (): Array<[number, number]> => {
+  const out: Array<[number, number]> = [];
+  for (const a of OFFSETS) {
+    for (const b of OFFSETS) {
+      if (b >= a) out.push([a, b]);
+    }
+  }
+  return out;
+};
+
+const RANGES = ranges();
+
+describe('comment lookups match the pre-binary-search predicates', () => {
+  test('the fixture actually exercises the scan (many comments)', () => {
+    // Guards the whole suite: with a one-comment fixture a broken
+    // binary search would still pass every assertion below.
+    expect(ALL_COMMENTS.length).toBeGreaterThanOrEqual(9);
+    expect(ALL_TOKENS.length).toBeGreaterThanOrEqual(20);
+    expect(RANGES.length).toBeGreaterThan(1000);
+  });
+
+  test('getCommentsBefore over every boundary offset', () => {
+    for (const r of RANGES) {
+      expect(sc.getCommentsBefore(mkNode(r[0], r[1]))).toEqual(
+        refCommentsBefore(r),
+      );
+    }
+  });
+
+  test('getCommentsAfter over every boundary offset', () => {
+    for (const r of RANGES) {
+      expect(sc.getCommentsAfter(mkNode(r[0], r[1]))).toEqual(
+        refCommentsAfter(r),
+      );
+    }
+  });
+
+  test('getCommentsInside over every boundary offset', () => {
+    for (const r of RANGES) {
+      expect(sc.getCommentsInside(mkNode(r[0], r[1]))).toEqual(
+        refCommentsInside(r),
+      );
+    }
+  });
+
+  test('known-good spot checks (ESLint semantics)', () => {
+    // ESLint returns only the comments between the node and the nearest
+    // neighbouring CODE token — not every earlier comment in the file.
+    const fnKeyword = ALL_TOKENS.find((t) => t.value === 'function')!;
+    const before = sc.getCommentsBefore(
+      mkNode(fnKeyword.range[0], fnKeyword.range[1]),
+    );
+    expect(before.map((c) => c.value.trim())).toEqual([
+      'leading line',
+      '* jsdoc for f',
+      'extra',
+    ]);
+
+    // `function f(a /* flush */, b)` — the comment sits in the gap
+    // between `a` and `,`, so it attaches to the `,` and NOT to `b`
+    // (whose nearest preceding code token is the `,` itself).
+    const flushComment = ALL_COMMENTS.find((c) => c.value === ' flush ')!;
+    const comma = ALL_TOKENS.find(
+      (t) => t.value === ',' && t.range[0] >= flushComment.range[1],
+    )!;
+    expect(
+      sc
+        .getCommentsBefore(mkNode(comma.range[0], comma.range[1]))
+        .map((c) => c.value),
+    ).toEqual([' flush ']);
+    const b = ALL_TOKENS.find(
+      (t) => t.value === 'b' && t.range[0] > comma.range[0],
+    )!;
+    expect(sc.getCommentsBefore(mkNode(b.range[0], b.range[1]))).toEqual([]);
+
+    // The trailing `// last line of the file` comment has no code token
+    // after it — the bound falls back to EOF.
+    const closeBrace = ALL_TOKENS[ALL_TOKENS.length - 1];
+    expect(
+      sc
+        .getCommentsAfter(mkNode(closeBrace.range[0], closeBrace.range[1]))
+        .map((c) => c.value.trim()),
+    ).toEqual(['last line of the file']);
+  });
+});
+
+describe('spanIndexEndingAtOrBefore', () => {
+  test('matches a backward scan for every boundary offset', () => {
+    for (const offset of OFFSETS) {
+      let expected = -1;
+      for (let i = ALL_TOKENS.length - 1; i >= 0; i--) {
+        if (ALL_TOKENS[i].range[1] <= offset) {
+          expected = i;
+          break;
+        }
+      }
+      expect(spanIndexEndingAtOrBefore(ALL_TOKENS, offset)).toBe(expected);
+    }
+  });
+
+  test('-1 before the first token end, last index past EOF', () => {
+    expect(spanIndexEndingAtOrBefore(ALL_TOKENS, 0)).toBe(-1);
+    expect(spanIndexEndingAtOrBefore(ALL_TOKENS, TEXT.length)).toBe(
+      ALL_TOKENS.length - 1,
+    );
+    expect(spanIndexEndingAtOrBefore([], 42)).toBe(-1);
+  });
+});
+
+describe('paddedTokenSlice matches the pre-binary-search scans', () => {
+  test('over every boundary offset pair and several padding widths', () => {
+    for (const r of RANGES) {
+      for (const [before, after] of [
+        [0, 0],
+        [1, 1],
+        [2, 0],
+        [0, 3],
+        [100, 100],
+      ]) {
+        expect(paddedTokenSlice(ALL_TOKENS, r[0], r[1], before, after)).toEqual(
+          refPaddedSlice(ALL_TOKENS, r[0], r[1], before, after),
+        );
+      }
+    }
+  });
+});
+
+describe('isSpaceBetween is unaffected by the walk bound', () => {
+  test('comments do not count as space; real whitespace does', () => {
+    const aTok = ALL_TOKENS.find((t) => t.value === 'a')!;
+    const flushComment = ALL_COMMENTS.find((c) => c.value === ' flush ')!;
+    // The `,` sits flush against the comment's end.
+    const comma = ALL_TOKENS.find(
+      (t) => t.value === ',' && t.range[0] >= flushComment.range[1],
+    )!;
+
+    // `a /* flush */,` — whitespace between `a` and the comment.
+    expect(
+      sc.isSpaceBetween(
+        aTok as unknown as ESTreeNode,
+        comma as unknown as ESTreeNode,
+      ),
+    ).toBe(true);
+
+    // `a/*x*/(b)` — a comment flush against both sides is NOT space.
+    const TIGHT = 'a/*x*/(b)';
+    const tight = mkSC(TIGHT);
+    const tightTokens = tight.getTokens(
+      mkNode(0, TIGHT.length),
+    ) as unknown as Token[];
+    expect(
+      tight.isSpaceBetween(
+        tightTokens[0] as unknown as ESTreeNode,
+        tightTokens[1] as unknown as ESTreeNode,
+      ),
+    ).toBe(false);
+
+    // Same shape, with a space on one side → space.
+    const LOOSE = 'a /*x*/(b)';
+    const loose = mkSC(LOOSE);
+    const looseTokens = loose.getTokens(
+      mkNode(0, LOOSE.length),
+    ) as unknown as Token[];
+    expect(
+      loose.isSpaceBetween(
+        looseTokens[0] as unknown as ESTreeNode,
+        looseTokens[1] as unknown as ESTreeNode,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #1351, which binary-searched the token getters and left the comment getters on a linear scan.

`getCommentsBefore` / `getCommentsAfter` / `getCommentsInside` each ran a full `comments.filter()` over the file's whole comment array on every call. A rule that asks for the comments attached to each declaration therefore paid O(declarations × comments) per file. They now binary-search `comments` (sorted by `range[0]`, like the token stream) to the first candidate and walk forward only while the bound can still be met.

`paddedTokenSlice` — the implementation behind the numeric `getTokens(node, before, after)` / `getTokensBetween(left, right, padding)` overloads — ran two full scans of the token array per call, one forward for `firstIdx` and one backward for `lastIdx`. Both are now binary searches, the latter via a new end-bounded `spanIndexEndingAtOrBefore`.

Two smaller items found in the same sweep:

- `tokenIndexAtOrAfter` is renamed to `spanIndexStartingAtOrAfter`, and both lookups are typed over a `Span` shape (anything with a `range`). They run over the code-token array, the comment array and the merged tokens+comments stream alike, so the `token` prefix was misleading; this also drops the `as unknown as readonly Token[]` casts at the comment call sites.
- `isSpaceBetween`'s forward walk only terminated on an identity match against the end anchor. When that anchor is not a stream member — the fallback branch accepts a caller-built `Token` literal — the walk ran to EOF. It now also stops positionally, which fires at the same index whenever the anchor *is* in the stream.

No behavior change is intended in any of these.

### Measurement

TypeScript v6.0.3, 746 files, 155 rules. `local/jsdoc-format` calls `getCommentsBefore` on every declaration node, which is the path this PR changes.

Five interleaved A/B pairs — same Go binary throughout, only `dist/` swapped, before/after alternating so ordering effects cancel:

| pair | `local/jsdoc-format` before | after | wall clock before | after |
| --- | --- | --- | --- | --- |
| 1 | 1535.5 ms | 619.3 ms | 3.734 s | 3.310 s |
| 2 | 1503.5 ms | 632.1 ms | 4.142 s | 3.349 s |
| 3 | 1542.3 ms | 711.6 ms | 3.934 s | 3.479 s |
| 4 | 1667.4 ms | 625.5 ms | 3.811 s | 3.481 s |
| 5 | 1678.2 ms | 582.8 ms | 4.241 s | 3.409 s |
| **median** | **1542 ms** | **625 ms (−59%)** | **3.934 s** | **3.409 s (−13%)** |

Both distributions are disjoint and after wins all five pairs on both measures.

Native (Go) rule timings in the same tables swing by up to ±550 ms run to run. This is a JS-only change and cannot affect them, so that spread is the noise floor rather than a result.

### Verification

New `comment-lookup.test.ts` keeps each pre-change filter predicate verbatim as a reference implementation and diffs the rewrite against it across every interesting offset of a comment-dense fixture: every token/comment boundary and its ±1 neighbourhood, all 1000+ ordered range pairs, plus 5 padding widths for `paddedTokenSlice`. Mutation-checked — reverting the `getCommentsBefore` binary search to a scan from index 0 fails the suite.

`packages/rslint` eslint-plugin suite: 498 passed / 0 failed (489 before + 9 new). `tsc --noEmit` clean.

## Related Links

- #1351

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
