### PR TITLE
perf: optimize no-obj-calls reference tracking

### DIFF
--- a/internal/rules/no_obj_calls/no_obj_calls.go
+++ b/internal/rules/no_obj_calls/no_obj_calls.go
@@ -8,148 +8,696 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-var nonCallableGlobals = map[string]bool{
-	"Math": true, "JSON": true, "Reflect": true, "Atomics": true, "Intl": true,
+var nonCallableGlobalNames = [...]string{
+	"Atomics",
+	"JSON",
+	"Math",
+	"Reflect",
+	"Intl",
+	"Temporal",
+}
+
+var nonCallableGlobals = func() map[string]bool {
+	result := make(map[string]bool, len(nonCallableGlobalNames))
+	for _, name := range nonCallableGlobalNames {
+		result[name] = true
+	}
+	return result
+}()
+
+var globalObjectNames = [...]string{
+	"global",
+	"globalThis",
+	"self",
+	"window",
+}
+
+var globalObjects = func() map[string]bool {
+	result := make(map[string]bool, len(globalObjectNames))
+	for _, name := range globalObjectNames {
+		result[name] = true
+	}
+	return result
+}()
+
+func sourceMayUseNonCallableGlobal(sourceFile *ast.SourceFile) bool {
+	if sourceFile == nil || sourceFile.Identifiers == nil {
+		return true
+	}
+	for _, name := range nonCallableGlobalNames {
+		if _, ok := sourceFile.Identifiers[name]; ok {
+			return true
+		}
+	}
+	// Computed global-object access such as globalThis["Math"] does not put
+	// "Math" in SourceFile.Identifiers.
+	for _, name := range globalObjectNames {
+		if _, ok := sourceFile.Identifiers[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+type traceKind uint8
+
+const (
+	traceNonCallable traceKind = iota
+	traceGlobalObject
+)
+
+// trackedValue is the small trace map this rule needs. A global-object value
+// accepts one of nonCallableGlobalNames as its next static property; a
+// non-callable value accepts only call and construct operations.
+type trackedValue struct {
+	kind       traceKind
+	globalName string
+}
+
+type traceWalk struct {
+	variables map[*ast.Symbol]bool
+	globals   map[string]bool
+}
+
+type ruleState struct {
+	ctx rule.RuleContext
+
+	// Only watched/global-object identifiers are indexed eagerly. Other names
+	// are collected on demand solely for the rare `/* global alias */ alias =
+	// JSON` propagation path.
+	identifiersByName map[string][]*ast.Node
+	indexedNames      map[string]bool
+	allNamesIndexed   bool
+
+	// localSymbols contains raw binder symbols. Requested names are indexed
+	// lazily: files with many declarations but no tracked alias should not pay
+	// for a per-declaration map entry. ctx.Refs also deals in raw symbols, so
+	// expanding an alias never needs the TypeChecker.
+	localSymbols           []*ast.Symbol
+	symbolsByName          map[string][]*ast.Symbol
+	indexedSymbolNames     map[string]bool
+	symbolLookupCount      int
+	allSymbolsIndexed      bool
+	resolvedReferenceNames map[string]bool
+	referenceSymbols       map[*ast.Node]*ast.Symbol
+
+	propertyEvaluator *utils.StaticStringEvaluator
+	calls             map[*ast.Node]string
+	additionalCalls   map[*ast.Node][]string
+}
+
+var lexicalShadowSentinel = &ast.Symbol{}
+
+func newRuleState(ctx rule.RuleContext) *ruleState {
+	state := &ruleState{
+		ctx:                    ctx,
+		identifiersByName:      make(map[string][]*ast.Node),
+		indexedNames:           make(map[string]bool),
+		symbolsByName:          make(map[string][]*ast.Symbol),
+		indexedSymbolNames:     make(map[string]bool),
+		resolvedReferenceNames: make(map[string]bool),
+	}
+	state.collectFileIndex()
+	state.collectCalls()
+	return state
+}
+
+func (state *ruleState) collectFileIndex() {
+	if state.ctx.SourceFile == nil {
+		return
+	}
+
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if symbol := node.Symbol(); isTrackableLocalSymbol(symbol) {
+			state.localSymbols = append(state.localSymbols, symbol)
+		}
+
+		if node.Kind == ast.KindIdentifier {
+			name := node.AsIdentifier().Text
+			if (nonCallableGlobals[name] || globalObjects[name]) &&
+				!utils.IsNonReferenceIdentifier(node) {
+				state.identifiersByName[name] = append(state.identifiersByName[name], node)
+				state.indexedNames[name] = true
+			}
+		}
+
+		node.ForEachChild(visit)
+		return false
+	}
+	visit(state.ctx.SourceFile.AsNode())
+}
+
+func isTrackableLocalSymbol(symbol *ast.Symbol) bool {
+	if symbol == nil {
+		return false
+	}
+	const flags = ast.SymbolFlagsVariable |
+		ast.SymbolFlagsFunction |
+		ast.SymbolFlagsClass |
+		ast.SymbolFlagsEnum |
+		ast.SymbolFlagsModule |
+		ast.SymbolFlagsAlias
+	return symbol.Flags&flags != 0
+}
+
+func (state *ruleState) collectCalls() {
+	for _, name := range nonCallableGlobalNames {
+		if state.isGlobalOff(name) || state.globalIsModified(name) {
+			continue
+		}
+		value := trackedValue{kind: traceNonCallable, globalName: name}
+		for _, identifier := range state.identifiersByName[name] {
+			if state.isGlobalReference(identifier, name) {
+				walk := traceWalk{}
+				state.trackExpression(identifier, value, &walk)
+			}
+		}
+	}
+
+	for _, name := range globalObjectNames {
+		if state.isGlobalOff(name) || state.globalIsModified(name) {
+			continue
+		}
+		value := trackedValue{kind: traceGlobalObject}
+		for _, identifier := range state.identifiersByName[name] {
+			if state.isGlobalReference(identifier, name) {
+				walk := traceWalk{}
+				state.trackExpression(identifier, value, &walk)
+			}
+		}
+	}
+}
+
+func (state *ruleState) isGlobalOff(name string) bool {
+	declared, ok := state.ctx.Globals[name]
+	return ok && !declared
+}
+
+func (state *ruleState) globalIsModified(name string) bool {
+	for _, identifier := range state.identifiersByName[name] {
+		if state.isGlobalReference(identifier, name) && utils.IsWriteReference(identifier) {
+			return true
+		}
+	}
+	return false
+}
+
+func (state *ruleState) isGlobalReference(identifier *ast.Node, name string) bool {
+	if identifier == nil || identifier.Kind != ast.KindIdentifier ||
+		utils.IsNonReferenceIdentifier(identifier) {
+		return false
+	}
+	return state.localReferenceSymbol(identifier) == nil
+}
+
+func (state *ruleState) localReferenceSymbol(identifier *ast.Node) *ast.Symbol {
+	if identifier == nil || identifier.Kind != ast.KindIdentifier {
+		return nil
+	}
+	name := identifier.AsIdentifier().Text
+	if !state.resolvedReferenceNames[name] {
+		state.resolvedReferenceNames[name] = true
+		if state.ctx.Refs != nil {
+			for _, symbol := range state.symbolsForName(name) {
+				for _, reference := range state.ctx.Refs.References(symbol) {
+					if state.referenceSymbols == nil {
+						state.referenceSymbols = make(map[*ast.Node]*ast.Symbol)
+					}
+					state.referenceSymbols[reference] = symbol
+				}
+			}
+		}
+	}
+	if symbol := state.referenceSymbols[identifier]; symbol != nil {
+		return symbol
+	}
+
+	// NamespaceModule symbols do not resolve in RefStore's value lookup even
+	// though ESLint scope analysis treats namespace declarations as bindings.
+	// The same fallback also protects direct/unit callers without a Program.
+	if (state.ctx.Refs == nil || len(state.symbolsForName(name)) != 0) &&
+		utils.IsShadowed(identifier, name) {
+		return lexicalShadowSentinel
+	}
+	return nil
+}
+
+func (state *ruleState) symbolsForName(name string) []*ast.Symbol {
+	if state.allSymbolsIndexed {
+		return state.symbolsByName[name]
+	}
+	if state.indexedSymbolNames[name] {
+		return state.symbolsByName[name]
+	}
+	state.indexedSymbolNames[name] = true
+	state.symbolLookupCount++
+
+	// A few watched-root lookups are cheaper as flat scans and avoid indexing
+	// every declaration in the common case. Assignment-heavy alias chains can
+	// request many distinct names; cap those scans, then build the complete
+	// name index once to keep the tracker linear.
+	if state.symbolLookupCount > 8 {
+		state.symbolsByName = make(map[string][]*ast.Symbol)
+		for _, symbol := range state.localSymbols {
+			state.addSymbolByName(symbol)
+		}
+		state.allSymbolsIndexed = true
+		return state.symbolsByName[name]
+	}
+
+	for _, symbol := range state.localSymbols {
+		if symbol.Name == name {
+			state.addSymbolByName(symbol)
+		}
+	}
+	return state.symbolsByName[name]
+}
+
+func (state *ruleState) addSymbolByName(symbol *ast.Symbol) {
+	for _, existing := range state.symbolsByName[symbol.Name] {
+		if existing == symbol {
+			return
+		}
+	}
+	state.symbolsByName[symbol.Name] = append(state.symbolsByName[symbol.Name], symbol)
+}
+
+func (state *ruleState) trackExpression(node *ast.Node, value trackedValue, walk *traceWalk) {
+	if node == nil {
+		return
+	}
+
+	// ESTree discards parentheses and represents the remaining constructs
+	// below as transparent value-preserving wrappers. tsgo keeps several of
+	// them as nodes, so walk upward through the equivalent shape first.
+	for node.Parent != nil && isPassThrough(node, node.Parent) {
+		node = node.Parent
+	}
+
+	parent := node.Parent
+	if parent == nil {
+		return
+	}
+
+	if ast.IsAccessExpression(parent) && utils.AccessExpressionObject(parent) == node {
+		if value.kind != traceGlobalObject {
+			return
+		}
+		name, ok := state.accessExpressionStaticName(parent)
+		if !ok || !nonCallableGlobals[name] {
+			return
+		}
+		state.trackExpression(parent, trackedValue{
+			kind:       traceNonCallable,
+			globalName: name,
+		}, walk)
+		return
+	}
+
+	switch parent.Kind {
+	case ast.KindCallExpression:
+		if parent.AsCallExpression().Expression == node && value.kind == traceNonCallable {
+			state.addCall(parent, value.globalName)
+		}
+
+	case ast.KindNewExpression:
+		if parent.AsNewExpression().Expression == node && value.kind == traceNonCallable {
+			state.addCall(parent, value.globalName)
+		}
+
+	case ast.KindBinaryExpression:
+		binary := parent.AsBinaryExpression()
+		if binary != nil && binary.Right == node &&
+			binary.OperatorToken != nil && ast.IsAssignmentOperator(binary.OperatorToken.Kind) {
+			state.trackAssignmentTarget(binary.Left, value, walk)
+			// Assignment expressions themselves evaluate to a value and can be
+			// nested in another assignment/declaration.
+			state.trackExpression(parent, value, walk)
+		}
+
+	case ast.KindVariableDeclaration:
+		declaration := parent.AsVariableDeclaration()
+		if declaration != nil && declaration.Initializer == node {
+			state.trackAssignmentTarget(declaration.Name(), value, walk)
+		}
+
+	case ast.KindParameter:
+		parameter := parent.AsParameterDeclaration()
+		if parameter != nil && parameter.Initializer == node {
+			state.trackAssignmentTarget(parameter.Name(), value, walk)
+		}
+
+	case ast.KindBindingElement:
+		element := parent.AsBindingElement()
+		if element != nil && element.Initializer == node {
+			state.trackAssignmentTarget(element.Name(), value, walk)
+		}
+
+	case ast.KindShorthandPropertyAssignment:
+		property := parent.AsShorthandPropertyAssignment()
+		if property != nil && property.ObjectAssignmentInitializer == node {
+			state.trackAssignmentTarget(property.Name(), value, walk)
+		}
+	}
+}
+
+func (state *ruleState) addCall(node *ast.Node, globalName string) {
+	if state.calls == nil {
+		state.calls = make(map[*ast.Node]string)
+	}
+	_, exists := state.calls[node]
+	if !exists {
+		state.calls[node] = globalName
+		return
+	}
+	if state.additionalCalls == nil {
+		state.additionalCalls = make(map[*ast.Node][]string)
+	}
+	state.additionalCalls[node] = append(state.additionalCalls[node], globalName)
+}
+
+func (state *ruleState) accessExpressionStaticName(node *ast.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	if node.Kind == ast.KindElementAccessExpression {
+		access := node.AsElementAccessExpression()
+		if access == nil || access.ArgumentExpression == nil {
+			return "", false
+		}
+		if state.propertyEvaluator == nil {
+			// ReferenceTracker evaluates computed keys without a scope
+			// argument: literal expressions can fold, but identifiers cannot.
+			// A nil-checker evaluator has exactly that property.
+			state.propertyEvaluator = utils.NewStaticStringEvaluatorWithSourceFile(nil, state.ctx.SourceFile)
+		}
+		return state.propertyEvaluator.Eval(access.ArgumentExpression)
+	}
+	return utils.AccessExpressionStaticName(node)
+}
+
+func (state *ruleState) staticPropertyName(node *ast.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	if node.Kind == ast.KindComputedPropertyName {
+		computed := node.AsComputedPropertyName()
+		if computed == nil || computed.Expression == nil {
+			return "", false
+		}
+		if state.propertyEvaluator == nil {
+			state.propertyEvaluator = utils.NewStaticStringEvaluatorWithSourceFile(nil, state.ctx.SourceFile)
+		}
+		return state.propertyEvaluator.Eval(computed.Expression)
+	}
+	return utils.GetStaticPropertyName(node)
+}
+
+func isPassThrough(node *ast.Node, parent *ast.Node) bool {
+	switch parent.Kind {
+	case ast.KindParenthesizedExpression:
+		return parent.AsParenthesizedExpression().Expression == node
+	case ast.KindAsExpression:
+		return parent.AsAsExpression().Expression == node
+	case ast.KindSatisfiesExpression:
+		return parent.AsSatisfiesExpression().Expression == node
+	case ast.KindTypeAssertionExpression:
+		return parent.AsTypeAssertion().Expression == node
+	case ast.KindNonNullExpression:
+		return parent.AsNonNullExpression().Expression == node
+	case ast.KindPartiallyEmittedExpression:
+		return parent.Expression() == node
+	case ast.KindExpressionWithTypeArguments:
+		return parent.AsExpressionWithTypeArguments().Expression == node
+	case ast.KindConditionalExpression:
+		conditional := parent.AsConditionalExpression()
+		return conditional.WhenTrue == node || conditional.WhenFalse == node
+	case ast.KindBinaryExpression:
+		binary := parent.AsBinaryExpression()
+		if binary == nil || binary.OperatorToken == nil {
+			return false
+		}
+		switch binary.OperatorToken.Kind {
+		case ast.KindBarBarToken, ast.KindAmpersandAmpersandToken, ast.KindQuestionQuestionToken:
+			return binary.Left == node || binary.Right == node
+		case ast.KindCommaToken:
+			return binary.Right == node
+		}
+	}
+	return false
+}
+
+func (state *ruleState) trackAssignmentTarget(node *ast.Node, value trackedValue, walk *traceWalk) {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case ast.KindIdentifier:
+		state.trackIdentifierVariable(node, value, walk)
+
+	case ast.KindObjectBindingPattern:
+		pattern := node.AsBindingPattern()
+		if pattern == nil || pattern.Elements == nil || value.kind != traceGlobalObject {
+			return
+		}
+		for _, elementNode := range pattern.Elements.Nodes {
+			element := elementNode.AsBindingElement()
+			if element == nil || element.DotDotDotToken != nil || element.Name() == nil {
+				continue
+			}
+			propertyName := element.PropertyName
+			if propertyName == nil {
+				propertyName = element.Name()
+			}
+			name, ok := state.staticPropertyName(propertyName)
+			if !ok || !nonCallableGlobals[name] {
+				continue
+			}
+			state.trackAssignmentTarget(element.Name(), trackedValue{
+				kind:       traceNonCallable,
+				globalName: name,
+			}, walk)
+		}
+
+	case ast.KindObjectLiteralExpression:
+		if value.kind != traceGlobalObject {
+			return
+		}
+		for _, propertyNode := range node.AsObjectLiteralExpression().Properties.Nodes {
+			switch propertyNode.Kind {
+			case ast.KindPropertyAssignment:
+				property := propertyNode.AsPropertyAssignment()
+				name, ok := state.staticPropertyName(property.Name())
+				if !ok || !nonCallableGlobals[name] {
+					continue
+				}
+				state.trackAssignmentTarget(property.Initializer, trackedValue{
+					kind:       traceNonCallable,
+					globalName: name,
+				}, walk)
+			case ast.KindShorthandPropertyAssignment:
+				property := propertyNode.AsShorthandPropertyAssignment()
+				name, ok := state.staticPropertyName(property.Name())
+				if !ok || !nonCallableGlobals[name] {
+					continue
+				}
+				state.trackAssignmentTarget(property.Name(), trackedValue{
+					kind:       traceNonCallable,
+					globalName: name,
+				}, walk)
+			}
+		}
+
+	case ast.KindBinaryExpression:
+		// Default-value assignment patterns (`x = fallback`) retain the
+		// tracked value on their left-hand binding.
+		binary := node.AsBinaryExpression()
+		if binary != nil && binary.OperatorToken != nil &&
+			binary.OperatorToken.Kind == ast.KindEqualsToken {
+			state.trackAssignmentTarget(binary.Left, value, walk)
+		}
+	}
+}
+
+func (state *ruleState) trackIdentifierVariable(identifier *ast.Node, value trackedValue, walk *traceWalk) {
+	if symbol := bindingSymbol(identifier); symbol != nil {
+		state.trackVariable(symbol, value, walk)
+		return
+	}
+	if symbol := state.localReferenceSymbol(identifier); symbol != nil {
+		state.trackVariable(symbol, value, walk)
+		return
+	}
+
+	name := identifier.AsIdentifier().Text
+	if state.isKnownGlobal(name) && state.isGlobalReference(identifier, name) {
+		state.trackGlobalVariable(name, value, walk)
+	}
+}
+
+func bindingSymbol(identifier *ast.Node) *ast.Symbol {
+	if identifier == nil || identifier.Kind != ast.KindIdentifier || identifier.Parent == nil {
+		return nil
+	}
+	declaration := identifier.Parent
+	if declaration.Name() != identifier {
+		return nil
+	}
+	symbol := declaration.Symbol()
+	if !isTrackableLocalSymbol(symbol) {
+		return nil
+	}
+	return symbol
+}
+
+func (state *ruleState) trackVariable(symbol *ast.Symbol, value trackedValue, walk *traceWalk) {
+	if state.ctx.Refs == nil || symbol == nil ||
+		(walk.variables != nil && walk.variables[symbol]) {
+		return
+	}
+	if walk.variables == nil {
+		walk.variables = make(map[*ast.Symbol]bool)
+	}
+	walk.variables[symbol] = true
+	defer delete(walk.variables, symbol)
+
+	for _, reference := range state.ctx.Refs.References(symbol) {
+		if ast.IsWriteOnlyAccess(reference) {
+			continue
+		}
+		state.trackExpression(reference, value, walk)
+	}
+}
+
+func (state *ruleState) isKnownGlobal(name string) bool {
+	if declared, ok := state.ctx.Globals[name]; ok {
+		return declared
+	}
+	return nonCallableGlobals[name] || globalObjects[name]
+}
+
+func (state *ruleState) trackGlobalVariable(name string, value trackedValue, walk *traceWalk) {
+	if walk.globals != nil && walk.globals[name] {
+		return
+	}
+	if walk.globals == nil {
+		walk.globals = make(map[string]bool)
+	}
+	walk.globals[name] = true
+	defer delete(walk.globals, name)
+
+	for _, reference := range state.identifiersForName(name) {
+		if ast.IsWriteOnlyAccess(reference) || !state.isGlobalReference(reference, name) {
+			continue
+		}
+		state.trackExpression(reference, value, walk)
+	}
+}
+
+func (state *ruleState) identifiersForName(name string) []*ast.Node {
+	if state.indexedNames[name] || state.allNamesIndexed || state.ctx.SourceFile == nil {
+		return state.identifiersByName[name]
+	}
+
+	// Reaching an otherwise unknown name means a configured global is being
+	// used as an assignment alias. Collect every not-already-indexed name in
+	// this rare fallback walk so a chain of configured globals stays linear.
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindIdentifier {
+			identifierName := node.AsIdentifier().Text
+			if !state.indexedNames[identifierName] && !utils.IsNonReferenceIdentifier(node) {
+				state.identifiersByName[identifierName] = append(state.identifiersByName[identifierName], node)
+			}
+		}
+		node.ForEachChild(visit)
+		return false
+	}
+	visit(state.ctx.SourceFile.AsNode())
+	state.allNamesIndexed = true
+	return state.identifiersByName[name]
+}
+
+func getCalleeName(node *ast.Node) string {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return "undefined"
+	}
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		if name := node.AsPropertyAccessExpression().Name(); name != nil {
+			return name.Text()
+		}
+		return "null"
+	case ast.KindElementAccessExpression:
+		argument := ast.SkipParentheses(node.AsElementAccessExpression().ArgumentExpression)
+		if name, ok := utils.GetStaticExpressionValue(argument); ok {
+			return name
+		}
+		// ESLint's reporting helper is deliberately narrower than
+		// ReferenceTracker's computed-key evaluator and returns null for
+		// folded/TS-wrapped keys.
+		return "null"
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text
+	}
+	return "undefined"
+}
+
+func (state *ruleState) report(node *ast.Node, globalName string) {
+	var callee *ast.Node
+	switch node.Kind {
+	case ast.KindCallExpression:
+		callee = node.AsCallExpression().Expression
+	case ast.KindNewExpression:
+		callee = node.AsNewExpression().Expression
+	default:
+		return
+	}
+
+	name := getCalleeName(callee)
+	if name == globalName {
+		state.ctx.ReportNode(node, rule.RuleMessage{
+			Id:          "unexpectedCall",
+			Description: fmt.Sprintf("'%s' is not a function.", name),
+		})
+		return
+	}
+	state.ctx.ReportNode(node, rule.RuleMessage{
+		Id:          "unexpectedRefCall",
+		Description: fmt.Sprintf("'%s' is reference to '%s', which is not a function.", name, globalName),
+	})
 }
 
 // https://eslint.org/docs/latest/rules/no-obj-calls
 var NoObjCallsRule = rule.Rule{
-	Name:             "no-obj-calls",
-	RequiresTypeInfo: true,
+	Name: "no-obj-calls",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		// isGlobalSymbol returns true if the symbol comes from lib.d.ts
-		// (none of its declarations are in the current source file).
-		isGlobalSymbol := func(symbol *ast.Symbol) bool {
-			return !utils.IsSymbolDeclaredInFile(symbol, ctx.SourceFile)
+		if !sourceMayUseNonCallableGlobal(ctx.SourceFile) {
+			return rule.RuleListeners{}
 		}
 
-		// resolveExprToGlobal walks through an expression to find if any
-		// branch resolves to a non-callable global. It handles:
-		// - Identifiers and property access (including multi-hop variable chains)
-		// - Conditional expressions (ternary)
-		// - Logical operators (||, &&, ??)
-		// - Comma operator (last expression)
-		// - TS type assertions (as, satisfies, !, <T>) via SkipOuterExpressions
-		var resolveExprToGlobal func(node *ast.Node) (string, bool)
-		resolveExprToGlobal = func(node *ast.Node) (string, bool) {
-			node = utils.SkipAssertionsAndParens(node)
-			switch node.Kind {
-			case ast.KindIdentifier, ast.KindPropertyAccessExpression:
-				symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
-				if symbol == nil {
-					return "", false
-				}
-				if nonCallableGlobals[symbol.Name] && isGlobalSymbol(symbol) {
-					return symbol.Name, true
-				}
-				// Multi-hop: trace through variable declarations
-				for _, decl := range symbol.Declarations {
-					if ast.IsVariableDeclaration(decl) {
-						varDecl := decl.AsVariableDeclaration()
-						if varDecl.Initializer != nil {
-							if name, ok := resolveExprToGlobal(varDecl.Initializer); ok {
-								return name, true
-							}
-						}
-					}
-				}
-			case ast.KindConditionalExpression:
-				cond := node.AsConditionalExpression()
-				if name, ok := resolveExprToGlobal(cond.WhenTrue); ok {
-					return name, true
-				}
-				return resolveExprToGlobal(cond.WhenFalse)
-			case ast.KindBinaryExpression:
-				bin := node.AsBinaryExpression()
-				switch bin.OperatorToken.Kind {
-				case ast.KindBarBarToken, ast.KindAmpersandAmpersandToken, ast.KindQuestionQuestionToken:
-					if name, ok := resolveExprToGlobal(bin.Left); ok {
-						return name, true
-					}
-					return resolveExprToGlobal(bin.Right)
-				case ast.KindCommaToken:
-					return resolveExprToGlobal(bin.Right)
-				}
-			}
-			return "", false
+		state := newRuleState(ctx)
+		if len(state.calls) == 0 {
+			return rule.RuleListeners{}
 		}
 
-		// getCalleeName returns the display name for the callee expression.
-		// For identifiers, returns the name; for member expressions, the property
-		// name; for anything else (e.g. TS assertions), returns "undefined"
-		// to match ESLint's getReportNodeName behavior.
-		getCalleeName := func(node *ast.Node) string {
-			node = ast.SkipParentheses(node)
-			switch node.Kind {
-			case ast.KindPropertyAccessExpression:
-				propAccess := node.AsPropertyAccessExpression()
-				if propAccess.Name() != nil {
-					return propAccess.Name().Text()
-				}
-			case ast.KindIdentifier:
-				return node.AsIdentifier().Text
-			}
-			return "undefined"
-		}
-
-		checkCallee := func(node *ast.Node, calleeNode *ast.Node) {
-			if ctx.TypeChecker == nil {
+		report := func(node *ast.Node) {
+			globalName, ok := state.calls[node]
+			if !ok {
 				return
 			}
-
-			callee := utils.SkipAssertionsAndParens(calleeNode)
-			symbol := ctx.TypeChecker.GetSymbolAtLocation(callee)
-			if symbol == nil {
-				return
-			}
-
-			name := getCalleeName(calleeNode)
-
-			// Direct or TS-assertion-wrapped callee resolves to a non-callable global.
-			if nonCallableGlobals[symbol.Name] && isGlobalSymbol(symbol) {
-				if name == symbol.Name {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "unexpectedCall",
-						Description: fmt.Sprintf("'%s' is not a function.", name),
-					})
-				} else {
-					// Callee name differs from global (e.g. TS assertion wrapping).
-					// ESLint reports this as an indirect reference.
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "unexpectedRefCall",
-						Description: fmt.Sprintf("'%s' is reference to '%s', which is not a function.", name, symbol.Name),
-					})
-				}
-				return
-			}
-
-			// Indirect: callee is a local variable whose initializer
-			// (possibly through multiple hops) references a non-callable global.
-			for _, decl := range symbol.Declarations {
-				if ast.IsVariableDeclaration(decl) {
-					varDecl := decl.AsVariableDeclaration()
-					if varDecl.Initializer != nil {
-						if globalName, ok := resolveExprToGlobal(varDecl.Initializer); ok {
-							ctx.ReportNode(node, rule.RuleMessage{
-								Id:          "unexpectedRefCall",
-								Description: fmt.Sprintf("'%s' is reference to '%s', which is not a function.", name, globalName),
-							})
-							return
-						}
-					}
-				}
+			state.report(node, globalName)
+			for _, additional := range state.additionalCalls[node] {
+				state.report(node, additional)
 			}
 		}
-
 		return rule.RuleListeners{
-			ast.KindCallExpression: func(node *ast.Node) {
-				callExpr := node.AsCallExpression()
-				checkCallee(node, callExpr.Expression)
-			},
-			ast.KindNewExpression: func(node *ast.Node) {
-				newExpr := node.AsNewExpression()
-				checkCallee(node, newExpr.Expression)
-			},
+			ast.KindCallExpression: report,
+			ast.KindNewExpression:  report,
 		}
 	},
 }

--- a/internal/rules/no_obj_calls/no_obj_calls_test.go
+++ b/internal/rules/no_obj_calls/no_obj_calls_test.go
@@ -3,6 +3,9 @@ package no_obj_calls
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
@@ -32,6 +35,36 @@ func TestNoObjCallsRule(t *testing.T) {
 			{Code: `function f() { var Math = 1; Math(); }`},
 			{Code: `function f(JSON: any) { JSON(); }`},
 			{Code: `function f() { var globalThis = { Math: () => {} }; globalThis.Math(); }`},
+			// A write to the global binding makes ReferenceTracker skip that
+			// global entirely. Writing one of its properties does not.
+			{Code: `Math(); Math = replacement;`},
+			{Code: `Math += replacement; Math();`},
+			{Code: `Math++; Math();`},
+			{Code: `for (Math of values) {} Math();`},
+			{Code: `({ Math } = value); Math();`},
+			// Dynamic global-object properties and array patterns are not
+			// paths represented by this rule's trace map.
+			{Code: `globalThis[name]();`},
+			{Code: `let value; [value] = [JSON]; value();`},
+			{Code: `const { ...value } = globalThis; value();`},
+			{Code: `const root = globalThis; root();`},
+			{Code: `let value = (JSON, fallback); value();`},
+			// Cycles which have no tracked source must terminate silently.
+			{Code: `let a = b; let b = a; a();`},
+			// A closer lexical binding must not inherit an outer alias.
+			{Code: `let value; { let value; value = JSON; } value();`},
+			{Code: `const { JSON: value } = { JSON: () => {} }; value();`},
+			{Code: `function f(JSON = JSON) { JSON(); }`},
+			{Code: `namespace Math {} Math();`},
+			{Code: `enum JSON {} JSON();`},
+			// Explicitly disabling a global removes the direct reference, but
+			// does not remove the same-named property from globalThis.
+			{Code: `Temporal();`, Globals: map[string]bool{"Temporal": false}},
+			{Code: `const value = Temporal; value();`, Globals: map[string]bool{"Temporal": false}},
+			// Property values are not lexical aliases followed by ESLint's
+			// ReferenceTracker.
+			{Code: `const obj = { foo: JSON }; obj.foo();`},
+			{Code: `namespace ns { export const foo = JSON; } ns.foo();`},
 		},
 		// Invalid cases
 		[]rule_tester.InvalidTestCase{
@@ -244,6 +277,269 @@ func TestNoObjCallsRule(t *testing.T) {
 					{MessageId: "unexpectedRefCall", Line: 1, Column: 1},
 				},
 			},
+			// Static computed global-object access.
+			{
+				Code: `globalThis["Math"]();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "globalThis[`JSON`]();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `globalThis["Ma" + "th"]();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedRefCall",
+						Message:   "'null' is reference to 'Math', which is not a function.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: `globalThis[true ? "Math" : "JSON"]();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedRefCall",
+						Message:   "'null' is reference to 'Math', which is not a function.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: `globalThis["Math" as const]();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedRefCall",
+						Message:   "'null' is reference to 'Math', which is not a function.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			// Temporal is non-callable in the current ESLint rule.
+			{
+				Code: `Temporal();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `globalThis.Temporal();`,
+				Globals: map[string]bool{"Temporal": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 1},
+				},
+			},
+			// Assignment aliases, including compound assignment and object
+			// destructuring assignment.
+			{
+				Code: `let value; value = JSON; value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedRefCall",
+						Message:   "'value' is reference to 'JSON', which is not a function.",
+						Line:      1,
+						Column:    26,
+					},
+				},
+			},
+			{
+				Code: `let value; value += JSON; value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `let value; ({ Math: value } = globalThis); new value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedRefCall",
+						Message:   "'value' is reference to 'Math', which is not a function.",
+						Line:      1,
+						Column:    44,
+					},
+				},
+			},
+			{
+				Code: `const { ["JS" + "ON"]: value } = globalThis; value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedRefCall",
+						Message:   "'value' is reference to 'JSON', which is not a function.",
+					},
+				},
+			},
+			{
+				Code: `let value; ({ ["Ma" + "th"]: value } = globalThis); value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedRefCall",
+						Message:   "'value' is reference to 'Math', which is not a function.",
+					},
+				},
+			},
+			// Alias a global object, then destructure a tracked property from
+			// that alias.
+			{
+				Code: `const root = globalThis; const { Reflect: value } = root; value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedRefCall",
+						Message:   "'value' is reference to 'Reflect', which is not a function.",
+						Line:      1,
+						Column:    59,
+					},
+				},
+			},
+			// AssignmentPattern/default-parameter propagation.
+			{
+				Code: `function f(value = JSON) { value(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall", Line: 1, Column: 28},
+				},
+			},
+			// A body-level var does not shadow a global used by a parameter
+			// default.
+			{
+				Code: `function f(value = JSON) { var JSON; value(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall"},
+				},
+			},
+			{
+				Code: `function f({ value = JSON }) { value(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall"},
+				},
+			},
+			{
+				Code: `let value; ({ other: value = JSON } = object); value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall"},
+				},
+			},
+			// ReferenceTracker is intentionally flow-insensitive: later writes
+			// do not erase an alias established by an initializer.
+			{
+				Code: `let value = JSON; value = () => {}; value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall", Line: 1, Column: 37},
+				},
+			},
+			// References are resolved by binder identity, including use before
+			// declaration and closer shadowing.
+			{
+				Code: `value(); var value = JSON;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `const value = JSON; function f() { const value = () => {}; value(); } value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall", Line: 1, Column: 71},
+				},
+			},
+			// A cycle reachable from a tracked source must terminate while
+			// preserving the reachable call.
+			{
+				Code: `let a = JSON; let b = a; a = b; a();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall", Line: 1, Column: 33},
+				},
+			},
+			{
+				Code: `let a, b; a = b = JSON; a(); b();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall"},
+					{MessageId: "unexpectedRefCall"},
+				},
+			},
+			// Multiple tracked writes reach the same call independently, which
+			// matches ReferenceTracker's generator semantics.
+			{
+				Code: `let value; value = JSON; value = JSON; value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall", Line: 1, Column: 40},
+					{MessageId: "unexpectedRefCall", Line: 1, Column: 40},
+				},
+			},
+			// A modified watched global can still be an alias reached from a
+			// different, unmodified watched global.
+			{
+				Code: `Math = JSON; Math();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpectedRefCall",
+						Message:   "'Math' is reference to 'JSON', which is not a function.",
+						Line:      1,
+						Column:    14,
+					},
+				},
+			},
+			// Type-only declarations do not shadow the corresponding runtime
+			// global, while value-space namespace/enum declarations do.
+			{
+				Code: `interface Math {} Math();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall"},
+				},
+			},
+			{
+				Code: `type JSON = {}; JSON();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall"},
+				},
+			},
+			// Global-object aliases retain the global object's trace-map shape.
+			{
+				Code: `const root = globalThis; root.Math();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall"},
+				},
+			},
+			{
+				Code: `const value = JSON<string>; value();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedRefCall"},
+				},
+			},
+			{
+				Code: `Math.member = replacement; Math();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall"},
+				},
+			},
 		},
 	)
+}
+
+func TestSourceMayUseNonCallableGlobal(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		code string
+		want bool
+	}{
+		{name: "ordinary method call", code: `service.method()`, want: false},
+		{name: "global identifier", code: `JSON.parse("{}")`, want: true},
+		{name: "escaped global identifier", code: `M\u0061th()`, want: true},
+		{name: "computed global object access", code: `globalThis["Math"]()`, want: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/source.ts",
+				Path:     "/source.ts",
+			}, testCase.code, core.ScriptKindTS)
+			if got := sourceMayUseNonCallableGlobal(sourceFile); got != testCase.want {
+				t.Fatalf("sourceMayUseNonCallableGlobal() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Replace `no-obj-calls`'s per-call type-checker lookups with rule-local reference propagation built on `ctx.Refs`, including alias assignments, destructuring, member chains, global writes, cycle guards, and static computed properties.
- Remove the type-information prerequisite so the rule can run on every parsed file while preserving runtime shadowing and reassignment semantics.
- Keep reporting immediate: this rule has no fixes or suggestions, and diagnostic work only occurs after a confirmed match, so deferred reporting does not improve its hot path.
- Extend the existing rule test file with correctness and adversarial coverage; no benchmark or temporary attack files are committed.

### Performance data

Measured on the same depth-1 VS Code fixture and lint configuration:

| Implementation | Rule time | Files visited | Profile share |
| --- | ---: | ---: | ---: |
| Before | 18,148.2 ms | 5,733 | 47.9% |
| After, run 1 | 154.9 ms | 7,146 | 2.1% |
| After, run 2 | 148.1 ms | 7,146 | 2.1% |
| After, run 3 | 146.1 ms | 7,146 | 2.1% |

The post-change median is 148.1 ms, about 122x faster than the baseline, even though removing the type-information prerequisite makes the rule visit more files.

### Validation

- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run internal/rules/no_obj_calls/no_obj_calls.go internal/rules/no_obj_calls/no_obj_calls_test.go`
- `go test -buildvcs=false ./internal/rules/no_obj_calls -count=5`
- Targeted config invariant tests for type-information requirements
- Targeted `@rslint/test-tools` ESLint compatibility test for `no-obj-calls`
- Adversarial cases for cyclic aliases, reassignment, destructuring, computed properties, runtime/type-only shadowing, TypeScript instantiation, and a generated 2,000-link assignment chain

## Related Links

- https://eslint.org/docs/latest/rules/no-obj-calls

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
