### PR TITLE
perf: add RefStore.Resolve, port prefer-const to ctx.Refs

### DIFF
--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -75,6 +75,23 @@ func (s *RefStore) References(sym *ast.Symbol) []*ast.Node {
 	return s.refs[sym]
 }
 
+// Resolve returns the symbol that a reference-position identifier resolves
+// to — the forward counterpart to References, for rules that need "what
+// declaration does this identifier refer to" rather than "what identifiers
+// refer to this declaration." It uses the same binder scope walk as
+// References, so it never touches the TypeChecker.
+//
+// Returns nil for identifiers that aren't reference positions (declaration
+// names, property keys, import/export bindings, labels, intrinsic JSX tags —
+// see isReferencePosition) and for names that don't resolve to a symbol
+// bound in this file.
+func (s *RefStore) Resolve(node *ast.Node) *ast.Symbol {
+	if s == nil || node == nil || node.Kind != ast.KindIdentifier || !isReferencePosition(node) {
+		return nil
+	}
+	return s.resolver.Resolve(node, node.Text(), referenceMeaning(node), nil, true /*isUse*/, false /*excludeGlobals*/)
+}
+
 // collectCandidates walks the file once and buckets by name every identifier
 // that occupies a reference position.
 func (s *RefStore) collectCandidates() {

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -159,6 +159,75 @@ func TestRefStoreImportAttributeNameExcluded(t *testing.T) {
 	}
 }
 
+func TestRefStoreResolve(t *testing.T) {
+	// Resolve is the forward counterpart to References: given a reference
+	// identifier, find its declaring symbol.
+	sourceFile, refs := newBoundRefStore(t, "/resolve.ts", core.ScriptKindTS,
+		"export {}; function f() { var x = 1; return x; }")
+
+	occurrences := identifiers(sourceFile.AsNode(), "x")
+	if len(occurrences) != 2 {
+		t.Fatalf("expected 2 occurrences of x, got %d", len(occurrences))
+	}
+	declIdent, useIdent := occurrences[0], occurrences[1]
+	wantSym := declIdent.Parent.Symbol()
+	if wantSym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	if got := refs.Resolve(useIdent); got != wantSym {
+		t.Fatalf("Resolve(use) = %v, want %v", got, wantSym)
+	}
+	// Resolving the declaration name itself is meaningless the same way
+	// References excludes it — declaration names aren't reference positions.
+	if got := refs.Resolve(declIdent); got != nil {
+		t.Fatalf("Resolve(decl) = %v, want nil", got)
+	}
+}
+
+func TestRefStoreResolveShorthandPropertyWrite(t *testing.T) {
+	// Resolve must handle shorthand destructuring writes the same way
+	// References does: the shorthand name is a reference position even
+	// though IsDeclarationName also treats it as one.
+	sourceFile, refs := newBoundRefStore(t, "/resolve-shorthand.ts", core.ScriptKindTS,
+		"export {}; function f() { var x; ({ x } = { y: 1 }); return x; }")
+
+	occurrences := identifiers(sourceFile.AsNode(), "x")
+	if len(occurrences) != 3 {
+		t.Fatalf("expected 3 occurrences of x, got %d", len(occurrences))
+	}
+	declIdent, writeIdent := occurrences[0], occurrences[1]
+	wantSym := declIdent.Parent.Symbol()
+	if wantSym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	if got := refs.Resolve(writeIdent); got != wantSym {
+		t.Fatalf("Resolve(shorthand write) = %v, want %v", got, wantSym)
+	}
+}
+
+func TestRefStoreResolveExcludedPositions(t *testing.T) {
+	// Property names, import bindings, and other non-reference positions
+	// must resolve to nil, matching isReferencePosition's exclusions.
+	sourceFile, refs := newBoundRefStore(t, "/resolve-excluded.ts", core.ScriptKindTS,
+		"export {}; function f() { var x = 1; return { x: x }.x; }")
+
+	occurrences := identifiers(sourceFile.AsNode(), "x")
+	if len(occurrences) != 4 {
+		t.Fatalf("expected 4 occurrences of x, got %d", len(occurrences))
+	}
+	// occurrences: [0] var x decl, [1] property key `x:`, [2] value `x`, [3] `.x` property access
+	propertyKey, propertyAccess := occurrences[1], occurrences[3]
+
+	if got := refs.Resolve(propertyKey); got != nil {
+		t.Fatalf("Resolve(property key) = %v, want nil", got)
+	}
+	if got := refs.Resolve(propertyAccess); got != nil {
+		t.Fatalf("Resolve(property access name) = %v, want nil", got)
+	}
+}
+
 func TestRefStoreJsxNamespacedNameExcluded(t *testing.T) {
 	// `bar` in the namespaced JSX tag name `<bar:qux />` is syntactic, not a
 	// reference to a same-named variable.

--- a/internal/rules/prefer_const/prefer_const.go
+++ b/internal/rules/prefer_const/prefer_const.go
@@ -256,11 +256,12 @@ func isInForInOrOf(node *ast.Node) bool {
 }
 
 // countWriteReferences counts the number of write references among refs (as
-// returned by ctx.Refs.References(sym)). Declaration names are never included
-// in refs, so this naturally excludes the declaration itself; a write inside
-// the same declaration's initializer (e.g. `let x = (x = 1)`) is still a
-// descendant of the initializer rather than of the binding name, so it is
-// still counted.
+// returned by ctx.Refs.References(sym)). Binding names are not reference
+// positions, so refs naturally excludes the declaration itself; the one
+// declaration name refs does keep is the shorthand in `({ x } = obj)`, which
+// is a genuine write. A write inside the same declaration's initializer
+// (e.g. `let x = (x = 1)`) is a descendant of the initializer rather than of
+// the binding name, so it is still counted.
 func countWriteReferences(refs []*ast.Node) int {
 	count := 0
 	for _, ref := range refs {

--- a/internal/rules/prefer_const/prefer_const.go
+++ b/internal/rules/prefer_const/prefer_const.go
@@ -177,19 +177,27 @@ var PreferConstRule = rule.Rule{
 
 // shouldReport determines whether a candidate should be reported as "use const".
 func shouldReport(c *candidateInfo, declNode *ast.Node, ctx *rule.RuleContext, opts preferConstOptions) bool {
-	sym := ctx.TypeChecker.GetSymbolAtLocation(c.nameNode)
+	// The binder attaches the symbol to the enclosing declaration
+	// (VariableDeclaration or BindingElement). ctx.Refs is keyed by that
+	// binder symbol, not by checker.GetSymbolAtLocation results.
+	decl := c.nameNode.Parent
+	if decl == nil || decl.Name() != c.nameNode {
+		return false
+	}
+	sym := decl.Symbol()
 	if sym == nil {
 		return false
 	}
+	refs := ctx.Refs.References(sym)
 
 	if c.hasInitializer {
 		// For initialized candidates: report if 0 writes after declaration (never reassigned)
-		return !isReassigned(sym, c.nameNode.Text(), declNode, ctx)
+		return countWriteReferences(refs) == 0
 	}
 
 	// For uninitialized candidates (let x;):
 	// Count write references (excluding declaration)
-	writeCount := countWriteReferences(sym, c.nameNode.Text(), declNode, ctx)
+	writeCount := countWriteReferences(refs)
 	if writeCount != 1 {
 		// 0 writes: never assigned, "let x;" alone is fine - don't report
 		// 2+ writes: truly reassigned - don't report
@@ -200,13 +208,13 @@ func shouldReport(c *candidateInfo, declNode *ast.Node, ctx *rule.RuleContext, o
 	// But only if the write is at the same block level as the declaration.
 	// If the write is inside a nested block (if, for, try, function, etc.),
 	// we can't safely convert to "const x = ..." because it would change semantics.
-	writeNode := findWriteInSameBlock(sym, c.nameNode.Text(), declNode, ctx)
+	writeNode := findWriteInSameBlock(refs, declNode, ctx)
 	if writeNode == nil {
 		return false
 	}
 	// ESLint reports uninitialized variables at the write location when there's no read
 	// between declaration and write. If there IS a read before write, report at the declaration.
-	readBeforeAssign := isReadBeforeFirstAssign(sym, c.nameNode.Text(), declNode, ctx)
+	readBeforeAssign := isReadBeforeFirstAssign(refs, declNode.Pos())
 	if !readBeforeAssign {
 		c.reportNode = writeNode
 	}
@@ -247,176 +255,39 @@ func isInForInOrOf(node *ast.Node) bool {
 	return node.Parent.Kind == ast.KindForInStatement || node.Parent.Kind == ast.KindForOfStatement
 }
 
-// isReassigned checks if a symbol is ever assigned to after its declaration.
-func isReassigned(sym *ast.Symbol, declName string, declNode *ast.Node, ctx *rule.RuleContext) bool {
-	return countWriteReferences(sym, declName, declNode, ctx) > 0
-}
-
-// countWriteReferences counts the number of write references to a symbol after its declaration.
-func countWriteReferences(sym *ast.Symbol, declName string, declNode *ast.Node, ctx *rule.RuleContext) int {
-	// Find enclosing scope to limit the walk
-	scope := findEnclosingScope(declNode)
-	if scope == nil {
-		scope = ctx.SourceFile.AsNode()
-	}
-
+// countWriteReferences counts the number of write references among refs (as
+// returned by ctx.Refs.References(sym)). Declaration names are never included
+// in refs, so this naturally excludes the declaration itself; a write inside
+// the same declaration's initializer (e.g. `let x = (x = 1)`) is still a
+// descendant of the initializer rather than of the binding name, so it is
+// still counted.
+func countWriteReferences(refs []*ast.Node) int {
 	count := 0
-	var walk func(*ast.Node)
-	walk = func(n *ast.Node) {
-		if n == nil {
-			return
+	for _, ref := range refs {
+		if utils.IsWriteReference(ref) {
+			count++
 		}
-
-		// Cheap syntax checks (name match, write position) come first so the
-		// expensive checker lookup only runs for genuine write candidates.
-		if n.Kind == ast.KindIdentifier && n.Text() == declName &&
-			utils.IsWriteReference(n) && !isPartOfDeclaration(n, declNode) {
-			if ctx.TypeChecker.GetSymbolAtLocation(n) == sym {
-				count++
-			}
-		}
-
-		// Also check ShorthandPropertyAssignment - in ({x} = {x: 2}), the TypeChecker
-		// resolves the shorthand name to the property symbol, not the variable symbol.
-		// Use name-based matching combined with scope check for this case.
-		// To avoid false-matching shadowed variables, verify that the shorthand's
-		// value symbol (obtained via the generated identifier) matches the target.
-		if n.Kind == ast.KindShorthandPropertyAssignment && !isPartOfDeclaration(n, declNode) {
-			shorthand := n.AsShorthandPropertyAssignment()
-			if shorthand != nil && shorthand.Name() != nil && utils.IsInDestructuringAssignment(n) {
-				name := shorthand.Name().Text()
-				if name == declName && isInSameScope(n, declNode) {
-					// Guard against shadowed variables: if the TypeChecker can resolve
-					// the shorthand's value to a different symbol, skip it.
-					valSym := ctx.TypeChecker.GetShorthandAssignmentValueSymbol(n)
-					if valSym == nil || valSym == sym {
-						count++
-						return // Skip children to avoid double-counting the name identifier via Path 1
-					}
-				}
-			}
-		}
-
-		n.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
 	}
-	walk(scope)
 	return count
 }
 
-// isReadBeforeFirstAssign checks if a variable is read between its declaration and first assignment.
-// This is used for uninitialized variables (let x;) when ignoreReadBeforeAssign is true.
-func isReadBeforeFirstAssign(sym *ast.Symbol, declName string, declNode *ast.Node, ctx *rule.RuleContext) bool {
-	scope := findEnclosingScope(declNode)
-	if scope == nil {
-		scope = ctx.SourceFile.AsNode()
-	}
-
-	// Walk the scope in source order; track whether we passed the declaration and found the first write
-	pastDecl := false
+// isReadBeforeFirstAssign checks if a variable is read (among refs occurring
+// at or after declPos) before its first write. This is used for uninitialized
+// variables (let x;) when ignoreReadBeforeAssign is true. refs must be in
+// source order, as returned by ctx.Refs.References(sym).
+func isReadBeforeFirstAssign(refs []*ast.Node, declPos int) bool {
 	foundRead := false
-
-	var walk func(*ast.Node) bool
-	walk = func(n *ast.Node) bool {
-		if n == nil {
-			return false
+	for _, ref := range refs {
+		if ref.Pos() < declPos {
+			continue
 		}
-
-		// Check if we reached the declaration
-		if n == declNode {
-			pastDecl = true
-			return false
+		if utils.IsWriteReference(ref) {
+			// Found the first write at or after the declaration - stop looking.
+			return foundRead
 		}
-
-		if !pastDecl {
-			done := false
-			n.ForEachChild(func(child *ast.Node) bool {
-				if walk(child) {
-					done = true
-					return true
-				}
-				return false
-			})
-			return done
-		}
-
-		// After declaration, check for reads and writes. Only identifiers with
-		// the declared name can resolve to the target symbol — skip the rest
-		// without consulting the checker.
-		if n.Kind == ast.KindIdentifier && n.Text() == declName {
-			refSym := ctx.TypeChecker.GetSymbolAtLocation(n)
-			if refSym == sym {
-				if utils.IsWriteReference(n) {
-					// Found the first write - stop walking
-					return true
-				}
-				// It is a read reference before the first write
-				foundRead = true
-			}
-		}
-
-		// Also detect writes through ShorthandPropertyAssignment in destructuring.
-		// The TypeChecker may resolve shorthand names to property symbols instead of
-		// variable symbols, so we use name-based matching (same as countWriteReferences).
-		if n.Kind == ast.KindShorthandPropertyAssignment && !isPartOfDeclaration(n, declNode) {
-			shorthand := n.AsShorthandPropertyAssignment()
-			if shorthand != nil && shorthand.Name() != nil && utils.IsInDestructuringAssignment(n) {
-				if shorthand.Name().Text() == declName && isInSameScope(n, declNode) {
-					valSym := ctx.TypeChecker.GetShorthandAssignmentValueSymbol(n)
-					if valSym == nil || valSym == sym {
-						// Found the first write via shorthand destructuring - stop walking
-						return true
-					}
-				}
-			}
-		}
-
-		done := false
-		n.ForEachChild(func(child *ast.Node) bool {
-			if walk(child) {
-				done = true
-				return true
-			}
-			return false
-		})
-		return done
+		foundRead = true
 	}
-	walk(scope)
 	return foundRead
-}
-
-// findEnclosingScope delegates to the public utils.FindEnclosingScope.
-func findEnclosingScope(node *ast.Node) *ast.Node {
-	return utils.FindEnclosingScope(node)
-}
-
-// isPartOfDeclaration checks if an identifier node is part of the variable declaration's
-// binding name (not its initializer). This ensures that writes inside the initializer
-// (e.g. `let x = (x = 1)`) are still counted as reassignments.
-func isPartOfDeclaration(identNode *ast.Node, declNode *ast.Node) bool {
-	varDecl := declNode.AsVariableDeclaration()
-	if varDecl == nil || varDecl.Name() == nil {
-		return false
-	}
-	// Check if the identifier is a descendant of the binding name node
-	nameNode := varDecl.Name()
-	return ast.FindAncestorOrQuit(identNode, func(n *ast.Node) ast.FindAncestorResult {
-		if n == nameNode {
-			return ast.FindAncestorTrue
-		}
-		// Stop if we've left the declaration entirely
-		if n == declNode {
-			return ast.FindAncestorQuit
-		}
-		return ast.FindAncestorFalse
-	}) != nil
-}
-
-// isInSameScope checks if two nodes share the same enclosing function/module/source scope.
-func isInSameScope(a *ast.Node, b *ast.Node) bool {
-	return findEnclosingScope(a) == findEnclosingScope(b)
 }
 
 // findContainingBlock finds the nearest Block, SourceFile, ModuleBlock, CaseClause, or DefaultClause ancestor.
@@ -461,52 +332,19 @@ func isDirectChildOfBlock(writeNode *ast.Node, declBlock *ast.Node) bool {
 // ESLint only suggests const for uninitialized variables when the write can be merged
 // into the declaration (i.e., same block level). Writes inside nested blocks (if, for,
 // try, function bodies, etc.) cannot be safely merged.
-func findWriteInSameBlock(sym *ast.Symbol, declName string, declNode *ast.Node, ctx *rule.RuleContext) *ast.Node {
+func findWriteInSameBlock(refs []*ast.Node, declNode *ast.Node, ctx *rule.RuleContext) *ast.Node {
 	declBlock := findContainingBlock(declNode)
 	if declBlock == nil {
 		return nil
 	}
 
-	scope := findEnclosingScope(declNode)
-	if scope == nil {
-		scope = ctx.SourceFile.AsNode()
-	}
-
 	var writeNode *ast.Node
-	var walk func(*ast.Node)
-	walk = func(n *ast.Node) {
-		if n == nil || writeNode != nil {
-			return
+	for _, ref := range refs {
+		if utils.IsWriteReference(ref) {
+			writeNode = ref
+			break
 		}
-
-		if n.Kind == ast.KindIdentifier && n.Text() == declName &&
-			utils.IsWriteReference(n) && !isPartOfDeclaration(n, declNode) {
-			if ctx.TypeChecker.GetSymbolAtLocation(n) == sym {
-				writeNode = n
-				return
-			}
-		}
-
-		if n.Kind == ast.KindShorthandPropertyAssignment && !isPartOfDeclaration(n, declNode) {
-			shorthand := n.AsShorthandPropertyAssignment()
-			if shorthand != nil && shorthand.Name() != nil && utils.IsInDestructuringAssignment(n) {
-				name := shorthand.Name().Text()
-				if name == declName && isInSameScope(n, declNode) {
-					valSym := ctx.TypeChecker.GetShorthandAssignmentValueSymbol(n)
-					if valSym == nil || valSym == sym {
-						writeNode = shorthand.Name()
-						return
-					}
-				}
-			}
-		}
-
-		n.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
 	}
-	walk(scope)
 
 	if writeNode == nil {
 		return nil
@@ -540,8 +378,6 @@ func findWriteInSameBlock(sym *ast.Symbol, declName string, declNode *ast.Node, 
 // destructuring assignment containing writeNode have at most 1 write reference.
 // Used with destructuring: "all" to suppress reporting when not all variables in
 // the destructuring write group can be const.
-// Uses name-based matching because GetSymbolAtLocation on shorthand property names
-// in destructuring assignments resolves to the property symbol, not the variable.
 func allDestructuringWriteTargetsConst(writeNode *ast.Node, ctx *rule.RuleContext) bool {
 	assignExpr := ast.FindAncestor(writeNode, func(n *ast.Node) bool {
 		return ast.IsDestructuringAssignment(n)
@@ -550,71 +386,25 @@ func allDestructuringWriteTargetsConst(writeNode *ast.Node, ctx *rule.RuleContex
 		return true // not in a destructuring, no group constraint
 	}
 
-	scope := findEnclosingScope(writeNode)
-	if scope == nil {
-		scope = ctx.SourceFile.AsNode()
-	}
-
 	left := assignExpr.AsBinaryExpression().Left
 	allConst := true
 	utils.VisitDestructuringIdentifiers(left, func(ident *ast.Node) {
 		if !allConst {
 			return
 		}
-		// Resolve the symbol directly from the identifier node provided by
-		// VisitDestructuringIdentifiers. For shorthand properties, the parent
-		// is a ShorthandPropertyAssignment and GetSymbolAtLocation returns the
-		// property symbol, so use GetShorthandAssignmentValueSymbol instead.
-		var sym *ast.Symbol
-		if ident.Parent != nil && ident.Parent.Kind == ast.KindShorthandPropertyAssignment {
-			sym = ctx.TypeChecker.GetShorthandAssignmentValueSymbol(ident.Parent)
-		} else {
-			sym = ctx.TypeChecker.GetSymbolAtLocation(ident)
-		}
+		// ctx.Refs.Resolve handles shorthand property names the same as
+		// plain identifiers (unlike checker.GetSymbolAtLocation, which
+		// resolves a shorthand name to the property symbol rather than the
+		// variable it reads/writes).
+		sym := ctx.Refs.Resolve(ident)
 		if sym == nil {
 			return
 		}
-		if countWritesBySym(sym, ident.Text(), scope, ctx) > 1 {
+		if countWriteReferences(ctx.Refs.References(sym)) > 1 {
 			allConst = false
 		}
 	})
 	return allConst
-}
-
-// countWritesBySym counts write references to a specific symbol within a scope.
-// Uses symbol comparison for identifiers and GetShorthandAssignmentValueSymbol
-// for shorthand property assignments.
-func countWritesBySym(sym *ast.Symbol, name string, scope *ast.Node, ctx *rule.RuleContext) int {
-	count := 0
-	var walk func(*ast.Node)
-	walk = func(n *ast.Node) {
-		if n == nil {
-			return
-		}
-		if n.Kind == ast.KindIdentifier && n.Text() == name && utils.IsWriteReference(n) {
-			refSym := ctx.TypeChecker.GetSymbolAtLocation(n)
-			if refSym == sym {
-				count++
-			}
-		}
-		if n.Kind == ast.KindShorthandPropertyAssignment {
-			shorthand := n.AsShorthandPropertyAssignment()
-			if shorthand != nil && shorthand.Name() != nil &&
-				shorthand.Name().Text() == name && utils.IsInDestructuringAssignment(n) {
-				valSym := ctx.TypeChecker.GetShorthandAssignmentValueSymbol(n)
-				if valSym == nil || valSym == sym {
-					count++
-					return // avoid double-counting
-				}
-			}
-		}
-		n.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
-	}
-	walk(scope)
-	return count
 }
 
 // hasNonReportableDestructuringTarget checks if a write node is inside a destructuring
@@ -622,7 +412,7 @@ func countWritesBySym(sym *ast.Symbol, name string, scope *ast.Node, ctx *rule.R
 // 1. Member expressions (obj.prop, arr[i]) — can never be const declarations
 // 2. Identifiers whose declaration is in a different block scope — can't safely merge
 // Same-scope identifiers (var, const, import, param, etc.) do NOT suppress reporting.
-// Uses TypeChecker symbol resolution instead of name-set collection to correctly
+// Uses ctx.Refs symbol resolution instead of name-set collection to correctly
 // handle all declaration types (imports, function/class declarations, parameters, etc.).
 func hasNonReportableDestructuringTarget(writeNode *ast.Node, declNode *ast.Node, ctx *rule.RuleContext) bool {
 	assignExpr := ast.FindAncestor(writeNode, func(n *ast.Node) bool {
@@ -642,12 +432,12 @@ func hasNonReportableDestructuringTarget(writeNode *ast.Node, declNode *ast.Node
 
 // hasNonReportableTarget checks if a destructuring pattern contains targets that
 // should suppress reporting: member expressions, or identifiers declared in a
-// different block scope. Uses TypeChecker to resolve each identifier's declaration
+// different block scope. Uses ctx.Refs to resolve each identifier's declaration
 // rather than pre-collecting names, so it correctly handles imports, parameters,
 // function declarations, class declarations, etc.
 func hasNonReportableTarget(node *ast.Node, declBlock *ast.Node, ctx *rule.RuleContext) bool {
 	if node.Kind == ast.KindIdentifier {
-		sym := ctx.TypeChecker.GetSymbolAtLocation(node)
+		sym := ctx.Refs.Resolve(node)
 		if sym == nil || len(sym.Declarations) == 0 {
 			// Can't resolve — treat as non-reportable (conservative)
 			return true
@@ -666,7 +456,7 @@ func hasNonReportableTarget(node *ast.Node, declBlock *ast.Node, ctx *rule.RuleC
 			found = true
 			return true
 		case ast.KindIdentifier:
-			sym := ctx.TypeChecker.GetSymbolAtLocation(child)
+			sym := ctx.Refs.Resolve(child)
 			if sym == nil || len(sym.Declarations) == 0 {
 				found = true
 				return true
@@ -678,7 +468,7 @@ func hasNonReportableTarget(node *ast.Node, declBlock *ast.Node, ctx *rule.RuleC
 		case ast.KindShorthandPropertyAssignment:
 			shorthand := child.AsShorthandPropertyAssignment()
 			if shorthand != nil && shorthand.Name() != nil {
-				valSym := ctx.TypeChecker.GetShorthandAssignmentValueSymbol(child)
+				valSym := ctx.Refs.Resolve(shorthand.Name())
 				if valSym == nil || len(valSym.Declarations) == 0 {
 					found = true
 					return true


### PR DESCRIPTION
## Summary

- Port `prefer-const` to `ctx.Refs`, replacing manual whole-file/whole-scope AST walks and `TypeChecker.GetSymbolAtLocation`/`GetShorthandAssignmentValueSymbol` calls with `ctx.Refs` lookups, following the pattern the no-var rule already uses.
- Add `RefStore.Resolve(node)`, the forward counterpart to `References(sym)` (identifier → symbol instead of symbol → references). It reuses the same binder scope walk, so it never touches the TypeChecker.
- `Resolve` is used for prefer-const's destructuring-target checks (`hasNonReportableTarget`, `hasNonReportableDestructuringTarget`, `allDestructuringWriteTargetsConst`), leaving the rule fully checker-free aside from the `RequiresTypeInfo` gate.

Split out of #1362 because it changes the `RefStore` API.

## Benchmark

Synthetic corpus of 3000 generated `.ts` files (25.7 MiB, 288k `let` bindings) covering
reassignment, uninitialized single/multiple writes, object and array destructuring,
`({ x } = obj)` shorthand writes, nested control flow, and `for...of`. Weighted toward
non-reporting bindings so diagnostic formatting does not dominate. Only `prefer-const`
(`destructuring: "all"`) is enabled; a config enabling only `no-var` on the same corpus
serves as the control, and the rule's own cost is the difference. hyperfine, 10 runs
plus 2 warmups, `--format=jsonline > /dev/null`.

| | wall | user CPU |
| --- | --- | --- |
| base + prefer-const | 1.402 s ± 0.038 s | 4.074 s |
| this PR + prefer-const | 1.242 s ± 0.037 s | 3.359 s |
| base + no-var (control) | 1.016 s ± 0.037 s | 2.854 s |
| this PR + no-var (control) | 0.989 s ± 0.039 s | 2.724 s |

The two control runs agree within one standard deviation, so nothing outside the rule
moved. Subtracting the control, `prefer-const` itself costs:

| | wall | user CPU |
| --- | --- | --- |
| base | 386 ms | 1.220 s |
| this PR | 253 ms | 0.635 s |
| delta | **−34%** | **−48%** |

End-to-end on this corpus the run is 11.4% faster, with no overlap between the two
ranges (1.329–1.455 s vs 1.180–1.296 s). Wall-clock gains less than CPU because the
lint pool runs 4 threads and the rule is not the only cost on the critical path.

## Validation

- `go build ./internal/rule/... ./internal/rules/...`
- `go test ./internal/rule/...`
- `go test ./internal/rules/prefer_const/...`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
