### PR TITLE
perf: optimize no-unassigned-vars reference lookup

### DIFF
--- a/internal/rules/no_unassigned_vars/no_unassigned_vars.go
+++ b/internal/rules/no_unassigned_vars/no_unassigned_vars.go
@@ -1,7 +1,7 @@
 package no_unassigned_vars
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -13,7 +13,7 @@ import (
 func messageUnassigned(name string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unassigned",
-		Description: fmt.Sprintf("'%s' is always 'undefined' because it's never assigned.", name),
+		Description: "'" + name + "' is always 'undefined' because it's never assigned.",
 		Data: map[string]string{
 			"name": name,
 		},
@@ -21,8 +21,31 @@ func messageUnassigned(name string) rule.RuleMessage {
 }
 
 type runState struct {
-	ctx  rule.RuleContext
-	refs *utils.ReferenceIndex
+	ctx                      rule.RuleContext
+	declarationWriteBySymbol map[*ast.Symbol]bool
+	localExportsScanned      bool
+	localExportReadBySym     map[*ast.Symbol]bool
+}
+
+type variableSymbols struct {
+	values [3]*ast.Symbol
+	count  int
+}
+
+func (s *variableSymbols) add(sym *ast.Symbol) {
+	if sym == nil {
+		return
+	}
+	for _, existing := range s.values[:s.count] {
+		if existing == sym {
+			return
+		}
+	}
+	if s.count == len(s.values) {
+		return
+	}
+	s.values[s.count] = sym
+	s.count++
 }
 
 func (s *runState) checkVariableDeclarator(node *ast.Node) {
@@ -31,41 +54,198 @@ func (s *runState) checkVariableDeclarator(node *ast.Node) {
 	}
 
 	nameNode := node.AsVariableDeclaration().Name()
-	sym := utils.GetVariableDeclarationSymbol(node, s.ctx.TypeChecker)
-	if sym == nil {
+	symbols := binderVariableDeclarationSymbols(node)
+	if symbols.count == 0 {
 		return
 	}
 
 	name := nameNode.AsIdentifier().Text
 	hasRead := false
-	hasWrite := false
-	s.refs.ForEachReference(sym, func(refNode *ast.Node) bool {
-		if utils.IsVariableWriteReference(refNode) {
-			hasWrite = true
-			return true
-		}
-		if isReadReference(refNode) {
-			hasRead = true
-		}
-		return false
-	})
-	if !hasWrite {
-		s.refs.ForEachReferenceByName(name, node, func(refNode *ast.Node) bool {
+	hasWrite := s.symbolsHaveDeclarationWrite(symbols)
+	for _, sym := range symbols.values[:symbols.count] {
+		for _, refNode := range s.ctx.Refs.References(sym) {
 			if utils.IsVariableWriteReference(refNode) {
 				hasWrite = true
-				return true
+				break
 			}
 			if isReadReference(refNode) {
 				hasRead = true
 			}
-			return false
-		})
+		}
+		if hasWrite {
+			break
+		}
+	}
+	if !hasRead && !hasWrite {
+		hasRead = s.isLocalExportRead(symbols)
 	}
 	if hasWrite || !hasRead {
 		return
 	}
 
 	s.ctx.ReportNode(node, messageUnassigned(name))
+}
+
+// binderVariableDeclarationSymbols returns every binder representation that
+// can key ctx.Refs for this variable. A directly exported declaration exposes
+// an export symbol on the declaration and a linked local symbol in the nearest
+// Locals table. A lone exported declaration resolves uses to the export symbol,
+// while merged/repeated declarations resolve them to the local symbol, so the
+// rule must query both identities.
+func binderVariableDeclarationSymbols(node *ast.Node) variableSymbols {
+	var result variableSymbols
+	if node == nil || node.Kind != ast.KindVariableDeclaration {
+		return result
+	}
+	nameNode := node.Name()
+	if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+		return result
+	}
+	result.add(node.Symbol())
+	name := nameNode.Text()
+	for current := node.Parent; current != nil; current = current.Parent {
+		if !ast.IsLocalsContainer(current) {
+			continue
+		}
+		sym := ast.GetLocals(current)[name]
+		if symbolOwnsVariableDeclaration(sym, node) {
+			result.add(sym)
+			result.add(sym.ExportSymbol)
+			break
+		}
+	}
+	return result
+}
+
+func symbolOwnsVariableDeclaration(sym *ast.Symbol, node *ast.Node) bool {
+	if sym == nil || node == nil {
+		return false
+	}
+	nodeSymbol := node.Symbol()
+	if nodeSymbol != nil &&
+		(sym == nodeSymbol || sym.ExportSymbol == nodeSymbol || nodeSymbol.ExportSymbol == sym) {
+		return true
+	}
+	root := ast.GetRootDeclaration(node)
+	for _, declaration := range sym.Declarations {
+		if declaration == node || declaration == root ||
+			ast.GetRootDeclaration(declaration) == root {
+			return true
+		}
+	}
+	return false
+}
+
+// symbolsHaveDeclarationWrite covers declaration-position writes that RefStore
+// intentionally omits. Inspect every declaration because repeated `var`
+// declarations share one symbol: an initializer or for-in/of binding on any
+// sibling declaration assigns the variable for all of them.
+func (s *runState) symbolsHaveDeclarationWrite(symbols variableSymbols) bool {
+	for _, sym := range symbols.values[:symbols.count] {
+		if s.symbolHasDeclarationWrite(sym) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *runState) symbolHasDeclarationWrite(sym *ast.Symbol) bool {
+	if sym == nil {
+		return false
+	}
+	declarations := sym.Declarations
+	if len(declarations) > 1 && s.declarationWriteBySymbol != nil {
+		if hasWrite, ok := s.declarationWriteBySymbol[sym]; ok {
+			return hasWrite
+		}
+	}
+
+	hasWrite := false
+	for _, declaration := range declarations {
+		if declaration != nil && declaration.Kind == ast.KindVariableDeclaration &&
+			utils.VariableDeclarationIntroducesWrite(declaration) {
+			hasWrite = true
+			break
+		}
+	}
+	if len(declarations) > 1 {
+		if s.declarationWriteBySymbol == nil {
+			s.declarationWriteBySymbol = make(map[*ast.Symbol]bool)
+		}
+		s.declarationWriteBySymbol[sym] = hasWrite
+	}
+	return hasWrite
+}
+
+// isLocalExportRead supplements ctx.Refs for local named export specifiers.
+// RefStore deliberately excludes import/export bindings because its other
+// consumers do not treat them as references, while ESLint scope-manager marks
+// `export { value }` as a read of value for this rule. The exact binder symbol
+// map preserves shadowing and ignores type-only/source-bearing re-exports.
+func (s *runState) isLocalExportRead(symbols variableSymbols) bool {
+	if !s.localExportsScanned {
+		s.localExportsScanned = true
+		if strings.Contains(s.ctx.SourceFile.Text(), "export") {
+			s.localExportReadBySym = collectLocalExportReads(s.ctx.SourceFile)
+		}
+	}
+	for _, sym := range symbols.values[:symbols.count] {
+		if s.localExportReadBySym[sym] {
+			return true
+		}
+	}
+	return false
+}
+
+func collectLocalExportReads(sourceFile *ast.SourceFile) map[*ast.Symbol]bool {
+	if sourceFile == nil {
+		return nil
+	}
+	var result map[*ast.Symbol]bool
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node.Kind == ast.KindExportSpecifier &&
+			!ast.IsTypeOnlyImportOrExportDeclaration(node) &&
+			!utils.IsReExportSpecifier(node) {
+			specifier := node.AsExportSpecifier()
+			if specifier != nil {
+				localName := specifier.Name()
+				if specifier.PropertyName != nil {
+					localName = specifier.PropertyName
+				}
+				if target := binderLocalExportTarget(localName); target != nil {
+					if result == nil {
+						result = make(map[*ast.Symbol]bool)
+					}
+					result[target] = true
+				}
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(sourceFile.AsNode())
+	return result
+}
+
+func binderLocalExportTarget(localName *ast.Node) *ast.Symbol {
+	if localName == nil || localName.Kind != ast.KindIdentifier {
+		return nil
+	}
+	name := localName.Text()
+	for current := localName.Parent; current != nil; current = current.Parent {
+		if ast.IsLocalsContainer(current) {
+			if sym := ast.GetLocals(current)[name]; sym != nil {
+				return sym
+			}
+		}
+	}
+	return nil
 }
 
 func (s *runState) shouldSkipDeclarator(node *ast.Node) bool {
@@ -109,14 +289,11 @@ var NoUnassignedVarsRule = rule.Rule{
 	Name:             "no-unassigned-vars",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		if ctx.TypeChecker == nil {
+		if ctx.TypeChecker == nil || ctx.Refs == nil {
 			return rule.RuleListeners{}
 		}
 
-		s := &runState{
-			ctx:  ctx,
-			refs: utils.NewReferenceIndex(ctx.SourceFile, ctx.TypeChecker),
-		}
+		s := &runState{ctx: ctx}
 
 		return rule.RuleListeners{ast.KindVariableDeclaration: s.checkVariableDeclarator}
 	},

--- a/internal/rules/no_unassigned_vars/no_unassigned_vars_extras_test.go
+++ b/internal/rules/no_unassigned_vars/no_unassigned_vars_extras_test.go
@@ -306,3 +306,142 @@ export function Input() {
 		},
 	)
 }
+
+// TestNoUnassignedVarsRefStoreEdges targets the semantic boundaries that can
+// regress when reference lookup moves from checker searches to ctx.Refs.
+func TestNoUnassignedVarsRefStoreEdges(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnassignedVarsRule,
+		[]rule_tester.ValidTestCase{
+			// Repeated var declarations share a symbol; a write on either
+			// declaration assigns both.
+			{Code: `var value; var value = 1; consume(value);`},
+			{Code: `var value; for (var value of values) {} consume(value);`},
+			{Code: `var value; if (condition) { var value = 1; } consume(value);`},
+			{Code: `export var value; var value = 1; consume(value);`},
+			{Code: `export var value; for (var value of values) {} consume(value);`},
+
+			// Export modifiers do not themselves read a declaration.
+			{Code: `export let value;`},
+			{Code: `export let value; value = 1; consume(value);`},
+
+			// Type-only and source-bearing exports do not read the local.
+			{Code: `let value; export { type value };`},
+			{Code: `let value; export * as value from "mod";`},
+
+			// Binder identity must keep shadow writes and reads isolated.
+			{Code: `let value; { let value = 1; consume(value); }`},
+			{Code: `let value; function f() { let value; value = 1; consume(value); }`},
+
+			// RefStore omits declaration names, so loop declaration writes
+			// must be recognized directly.
+			{Code: `for (let item of items) consume(item);`},
+			{Code: `for (var key in object) consume(key);`},
+
+			// Runtime-free type queries do not count as reads.
+			{Code: `let value; type Alias = typeof value;`},
+
+			// Same-spelled syntactic names are not variable references.
+			{Code: `let value; const object = { value: 1 }; value: for (;;) { break value; }`},
+			{Code: `let component; const element = <component />;`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `var value; var value; consume(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+					unassignedError("value", 1, 16, 1, 21),
+				},
+			},
+			{
+				Code: `export let value; consume(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 12, 1, 17),
+				},
+			},
+			{
+				Code: `export var value; var value; consume(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 12, 1, 17),
+					unassignedError("value", 1, 23, 1, 28),
+				},
+			},
+			{
+				Code: `let value; export { value as default };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			{
+				Code: `let value; export { value as "public" };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			{
+				Code: `for (let value;;) consume(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 10, 1, 15),
+				},
+			},
+			{
+				Code: `consume(value); var value;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 21, 1, 26),
+				},
+			},
+			{
+				Code: `let name; console.log(name);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("name", 1, 5, 1, 9),
+				},
+			},
+			{
+				Code: `let value; { let value; value = 1; } consume(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			{
+				Code: `var value; function f() { var value = 1; } consume(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			{
+				Code: `var value, other = 1; consume(value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			{
+				Code: `let value; export = value;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			{
+				Code: `let value; consume(typeof value);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 5, 1, 10),
+				},
+			},
+			{
+				Code: `let Component; const element = <Component />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("Component", 1, 5, 1, 14),
+				},
+			},
+			{
+				Code: `namespace Runtime { let value; export { value as alias }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					unassignedError("value", 1, 25, 1, 30),
+				},
+			},
+		},
+	)
+}


### PR DESCRIPTION
## Summary

- replace per-variable TypeScript checker reference searches with the shared per-file `ctx.Refs` index
- preserve exported and repeated declaration semantics by querying linked binder symbol identities
- cache declaration-position writes for repeated declarations and lazily index local runtime exports
- add regression coverage to the existing extras test file for exports, repeated declarations, shadowing, JSX, loops, and type-only references

### Performance

Measured with a local temporary benchmark using one TypeScript file containing uninitialized variables that are read but never written. Each value is the median of five runs at `-benchtime=20x`.

| Variables | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 64 | 0.609 ms | 0.112 ms | 5.44x |
| 256 | 3.598 ms | 0.295 ms | 12.20x |
| 1024 | 37.109 ms | 1.092 ms | 33.97x |

At 1024 variables:

- allocated bytes: 14.41 MB/op -> 0.99 MB/op (-93.1%)
- allocations: 70,783/op -> 6,286/op (-91.1%)

On `rsbuild/packages`, using a JavaScript `.mjs` rslint config with only `no-unassigned-vars` enabled and `--singleThreaded`:

- before: approximately 2.1-2.3 ms of rule time
- after: 0.9-1.0 ms of rule time across three runs
- 152 files applied the rule, with zero diagnostics before and after

### Validation

- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run ./internal/rules/no_unassigned_vars/...`
- `go test ./internal/rules/no_unassigned_vars -count=1`
- targeted race testing and adversarial old/new diagnostic parity checks

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
