### PR TITLE
feat(jest): declare options JSON Schema for jest/ rules

### DIFF
--- a/internal/plugins/jest/rules/expect_expect/expect_expect.go
+++ b/internal/plugins/jest/rules/expect_expect/expect_expect.go
@@ -1,6 +1,7 @@
 package expect_expect
 
 import (
+	_ "embed"
 	"regexp"
 	"slices"
 	"strings"
@@ -8,8 +9,10 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed expect_expect.schema.json
+var schemaJSON []byte
 
 // Message Builder
 
@@ -20,38 +23,33 @@ func buildErrorNoAssertionsMessage() rule.RuleMessage {
 	}
 }
 
-func parseOptions(options any) ([]string, []string) {
+func parseOptions(options []any) ([]string, []string) {
 	assertNames := []string{"expect"}
 	additional := []string{}
 
-	m := internalUtils.GetOptionsMap(options)
-	if m == nil {
+	if len(options) == 0 {
 		return assertNames, additional
 	}
+	optsMap, _ := options[0].(map[string]interface{})
 
-	if raw, ok := m["assertFunctionNames"]; ok && raw != nil {
-		if arr, ok := raw.([]interface{}); ok {
-			out := make([]string, 0, len(arr))
-			for _, v := range arr {
-				if s, ok := v.(string); ok {
-					out = append(out, s)
-				}
-			}
-			assertNames = out
-		}
+	if arr, ok := optsMap["assertFunctionNames"].([]interface{}); ok {
+		assertNames = stringList(arr)
 	}
-
-	if raw, ok := m["additionalTestBlockFunctions"]; ok && raw != nil {
-		if arr, ok := raw.([]interface{}); ok {
-			for _, v := range arr {
-				if s, ok := v.(string); ok {
-					additional = append(additional, s)
-				}
-			}
-		}
+	if arr, ok := optsMap["additionalTestBlockFunctions"].([]interface{}); ok {
+		additional = stringList(arr)
 	}
 
 	return assertNames, additional
+}
+
+func stringList(raw []interface{}) []string {
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func compileAssertPatterns(patterns []string) []*regexp.Regexp {
@@ -178,9 +176,9 @@ func checkCallExpressionUsed(
 }
 
 var ExpectExpectRule = rule.Rule{
-	Name: "jest/expect-expect",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "jest/expect-expect",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		assertNames, additionalTestBlocks := parseOptions(options)
 		compiled := compileAssertPatterns(assertNames)
 		var unchecked []*ast.Node

--- a/internal/plugins/jest/rules/expect_expect/expect_expect.schema.json
+++ b/internal/plugins/jest/rules/expect_expect/expect_expect.schema.json
@@ -1,0 +1,25 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "assertFunctionNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "additionalTestBlockFunctions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/max_expects/max_expects.go
+++ b/internal/plugins/jest/rules/max_expects/max_expects.go
@@ -1,13 +1,18 @@
 package max_expects
 
 import (
+	_ "embed"
 	"fmt"
 	"strconv"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed max_expects.schema.json
+var schemaJSON []byte
 
 const defaultMax = 5
 
@@ -15,35 +20,15 @@ type options struct {
 	Max int
 }
 
-func parseOptions(raw any) options {
+func parseOptions(rawOptions []any) options {
 	opts := options{Max: defaultMax}
-	if raw == nil {
+	if len(rawOptions) == 0 {
 		return opts
 	}
 
-	optArray := rule.NormalizeOptions(raw)
-	if len(optArray) == 0 {
-		return opts
-	}
-
-	optsMap, ok := optArray[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
-
-	switch v := optsMap["max"].(type) {
-	case float64:
-		if v == float64(int(v)) {
-			opts.Max = int(v)
-		}
-	case int:
-		opts.Max = v
-	case int64:
-		opts.Max = int(v)
-	}
-
-	if opts.Max < 1 {
-		return options{Max: defaultMax}
+	optsMap, _ := rawOptions[0].(map[string]interface{})
+	if max, ok := internalUtils.CoerceIntegral(optsMap["max"]); ok && max >= 1 {
+		opts.Max = max
 	}
 
 	return opts
@@ -94,9 +79,9 @@ func maybeResetCountForFunctionLike(node *ast.Node, ctx rule.RuleContext, count 
 }
 
 var MaxExpectsRule = rule.Rule{
-	Name: "jest/max-expects",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "jest/max-expects",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 		count := 0
 

--- a/internal/plugins/jest/rules/max_expects/max_expects.go
+++ b/internal/plugins/jest/rules/max_expects/max_expects.go
@@ -27,8 +27,8 @@ func parseOptions(rawOptions []any) options {
 	}
 
 	optsMap, _ := rawOptions[0].(map[string]interface{})
-	if max, ok := internalUtils.CoerceIntegral(optsMap["max"]); ok && max >= 1 {
-		opts.Max = max
+	if maxVal, ok := internalUtils.CoerceIntegral(optsMap["max"]); ok && maxVal >= 1 {
+		opts.Max = maxVal
 	}
 
 	return opts

--- a/internal/plugins/jest/rules/max_expects/max_expects.schema.json
+++ b/internal/plugins/jest/rules/max_expects/max_expects.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "max": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.go
+++ b/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.go
@@ -1,13 +1,18 @@
 package max_nested_describe
 
 import (
+	_ "embed"
 	"fmt"
 	"strconv"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed max_nested_describe.schema.json
+var schemaJSON []byte
 
 const defaultMax = 5
 
@@ -15,35 +20,15 @@ type options struct {
 	Max int
 }
 
-func parseOptions(raw any) options {
+func parseOptions(rawOptions []any) options {
 	opts := options{Max: defaultMax}
-	if raw == nil {
+	if len(rawOptions) == 0 {
 		return opts
 	}
 
-	optArray := rule.NormalizeOptions(raw)
-	if len(optArray) == 0 {
-		return opts
-	}
-
-	optsMap, ok := optArray[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
-
-	switch v := optsMap["max"].(type) {
-	case float64:
-		if v == float64(int(v)) {
-			opts.Max = int(v)
-		}
-	case int:
-		opts.Max = v
-	case int64:
-		opts.Max = int(v)
-	}
-
-	if opts.Max < 0 {
-		return options{Max: defaultMax}
+	optsMap, _ := rawOptions[0].(map[string]interface{})
+	if max, ok := internalUtils.CoerceIntegral(optsMap["max"]); ok && max >= 0 {
+		opts.Max = max
 	}
 
 	return opts
@@ -61,9 +46,9 @@ func buildErrorExceededMaxDepthMessage(depth, maxAllowed int) rule.RuleMessage {
 }
 
 var MaxNestedDescribeRule = rule.Rule{
-	Name: "jest/max-nested-describe",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "jest/max-nested-describe",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 		describes := make([]*ast.Node, 0, 8)
 

--- a/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.go
+++ b/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.go
@@ -27,8 +27,8 @@ func parseOptions(rawOptions []any) options {
 	}
 
 	optsMap, _ := rawOptions[0].(map[string]interface{})
-	if max, ok := internalUtils.CoerceIntegral(optsMap["max"]); ok && max >= 0 {
-		opts.Max = max
+	if maxVal, ok := internalUtils.CoerceIntegral(optsMap["max"]); ok && maxVal >= 0 {
+		opts.Max = maxVal
 	}
 
 	return opts

--- a/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.schema.json
+++ b/internal/plugins/jest/rules/max_nested_describe/max_nested_describe.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "max": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/no_alias_methods/no_alias_methods.go
+++ b/internal/plugins/jest/rules/no_alias_methods/no_alias_methods.go
@@ -33,7 +33,8 @@ var methodNames = map[string]string{
 }
 
 var NoAliasMethodsRule = rule.Rule{
-	Name: "jest/no-alias-methods",
+	Name:   "jest/no-alias-methods",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/no_commented_out_tests/no_commented_out_tests.go
+++ b/internal/plugins/jest/rules/no_commented_out_tests/no_commented_out_tests.go
@@ -43,7 +43,8 @@ func commentInnerText(sourceText string, comment *ast.CommentRange) string {
 }
 
 var NoCommentedOutTestsRule = rule.Rule{
-	Name: "jest/no-commented-out-tests",
+	Name:   "jest/no-commented-out-tests",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		text := ctx.SourceFile.Text()
 		for _, comment := range ctx.Comments.All() {

--- a/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.go
+++ b/internal/plugins/jest/rules/no_conditional_expect/no_conditional_expect.go
@@ -132,11 +132,9 @@ type callExpressionFrame struct {
 }
 
 var NoConditionalExpectRule = rule.Rule{
-	Name: "jest/no-conditional-expect",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		_ = options
-
+	Name:   "jest/no-conditional-expect",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		testCallbackFunctions := collectTestFunctionCallbacks(ctx)
 		testCaseDepth := 0
 		conditionalDepth := 0

--- a/internal/plugins/jest/rules/no_conditional_in_test/no_conditional_in_test.schema.json
+++ b/internal/plugins/jest/rules/no_conditional_in_test/no_conditional_in_test.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allowOptionalChaining": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/no_conditional_in_test/rule.go
+++ b/internal/plugins/jest/rules/no_conditional_in_test/rule.go
@@ -1,10 +1,15 @@
 package no_conditional_in
 
 import (
+	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_conditional_in_test.schema.json
+var schemaJSON []byte
 
 type options struct {
 	allowOptionalChaining bool
@@ -12,16 +17,11 @@ type options struct {
 
 func parseOptions(rawOptions []any) options {
 	opts := options{allowOptionalChaining: true}
-	raw := rule.LegacyUnwrapOptions(rawOptions)
-	optionArray := rule.NormalizeOptions(raw)
-	if len(optionArray) == 0 {
+	if len(rawOptions) == 0 {
 		return opts
 	}
 
-	optionMap, ok := optionArray[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
+	optionMap, _ := rawOptions[0].(map[string]interface{})
 	if allow, ok := optionMap["allowOptionalChaining"].(bool); ok {
 		opts.allowOptionalChaining = allow
 	}
@@ -58,7 +58,8 @@ func isOutermostOptionalChain(node *ast.Node) bool {
 }
 
 var NoConditionalInTestRule = rule.Rule{
-	Name: "jest/no-conditional-in-test",
+	Name:   "jest/no-conditional-in-test",
+	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		inTestCase := false

--- a/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout.go
+++ b/internal/plugins/jest/rules/no_confusing_set_timeout/no_confusing_set_timeout.go
@@ -70,7 +70,8 @@ func isInGlobalOrModuleScope(node *ast.Node) bool {
 }
 
 var NoConfusingSetTimeoutRule = rule.Rule{
-	Name: "jest/no-confusing-set-timeout",
+	Name:   "jest/no-confusing-set-timeout",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		seenJestTimeout := false
 		shouldEmitOrderSetTimeout := false

--- a/internal/plugins/jest/rules/no_deprecated_functions/no_deprecated_functions.go
+++ b/internal/plugins/jest/rules/no_deprecated_functions/no_deprecated_functions.go
@@ -63,7 +63,8 @@ func bracketStyleCalleeReplacement(replacement string) string {
 }
 
 var NoDeprecatedFunctionsRule = rule.Rule{
-	Name: "jest/no-deprecated-functions",
+	Name:   "jest/no-deprecated-functions",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		depMap := deprecatedFunctions(utils.JestVersionMajor(utils.GetJestVersion(ctx)))
 		if len(depMap) == 0 {

--- a/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.go
@@ -69,7 +69,8 @@ func isPendingCall(node *ast.Node, ctx rule.RuleContext) bool {
 }
 
 var NoDisabledTestsRule = rule.Rule{
-	Name: "jest/no-disabled-tests",
+	Name:   "jest/no-disabled-tests",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/no_done_callback/no_done_callback.go
+++ b/internal/plugins/jest/rules/no_done_callback/no_done_callback.go
@@ -58,7 +58,8 @@ func findCallbackArgument(callExpr *ast.CallExpression, jestFnCall *utils.Parsed
 }
 
 var NoDoneCallbackRule = rule.Rule{
-	Name: "jest/no-done-callback",
+	Name:   "jest/no-done-callback",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/no_duplicate_hooks/no_duplicate_hooks.go
+++ b/internal/plugins/jest/rules/no_duplicate_hooks/no_duplicate_hooks.go
@@ -19,7 +19,8 @@ func buildNoDuplicateHookMessage(hook string) rule.RuleMessage {
 }
 
 var NoDuplicateHooksRule = rule.Rule{
-	Name: "jest/no-duplicate-hooks",
+	Name:   "jest/no-duplicate-hooks",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		hookContexts := []map[string]int{{}}
 

--- a/internal/plugins/jest/rules/no_export/no_export.go
+++ b/internal/plugins/jest/rules/no_export/no_export.go
@@ -61,10 +61,9 @@ func hasExportModifier(node *ast.Node) bool {
 }
 
 var NoExportRule = rule.Rule{
-	Name: "jest/no-export",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		_ = options
+	Name:   "jest/no-export",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		exportNodes := make([]*ast.Node, 0)
 		hasJestBlock := false
 

--- a/internal/plugins/jest/rules/no_focused_tests/no_focused_tests.go
+++ b/internal/plugins/jest/rules/no_focused_tests/no_focused_tests.go
@@ -28,7 +28,8 @@ func buildErrorSuggestRemoveFocusMessage() rule.RuleMessage {
 }
 
 var NoFocusedTestsRule = rule.Rule{
-	Name: "jest/no-focused-tests",
+	Name:   "jest/no-focused-tests",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/no_hooks/no_hooks.go
+++ b/internal/plugins/jest/rules/no_hooks/no_hooks.go
@@ -1,6 +1,7 @@
 package no_hooks
 
 import (
+	_ "embed"
 	"fmt"
 	"slices"
 
@@ -8,6 +9,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_hooks.schema.json
+var schemaJSON []byte
 
 // Message builders
 
@@ -44,21 +48,13 @@ func parseAllowList(raw any) []string {
 	return out
 }
 
-func parseOptions(options any) Options {
+func parseOptions(options []any) Options {
 	opts := Options{Allow: []string{}}
-	if options == nil {
+	if len(options) == 0 {
 		return opts
 	}
 
-	optArray := rule.NormalizeOptions(options)
-	if len(optArray) == 0 {
-		return opts
-	}
-	optsMap, ok := optArray[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
-
+	optsMap, _ := options[0].(map[string]interface{})
 	if raw, ok := optsMap["allow"]; ok {
 		opts.Allow = parseAllowList(raw)
 	}
@@ -66,9 +62,9 @@ func parseOptions(options any) Options {
 }
 
 var NoHooksRule = rule.Rule{
-	Name: "jest/no-hooks",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "jest/no-hooks",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		return rule.RuleListeners{

--- a/internal/plugins/jest/rules/no_hooks/no_hooks.schema.json
+++ b/internal/plugins/jest/rules/no_hooks/no_hooks.schema.json
@@ -6,7 +6,10 @@
       "properties": {
         "allow": {
           "type": "array",
-          "contains": ["beforeAll", "beforeEach", "afterAll", "afterEach"]
+          "items": {
+            "type": "string",
+            "enum": ["beforeAll", "beforeEach", "afterAll", "afterEach"]
+          }
         }
       },
       "additionalProperties": false

--- a/internal/plugins/jest/rules/no_hooks/no_hooks.schema.json
+++ b/internal/plugins/jest/rules/no_hooks/no_hooks.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allow": {
+          "type": "array",
+          "contains": ["beforeAll", "beforeEach", "afterAll", "afterEach"]
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/no_hooks/no_hooks_test.go
+++ b/internal/plugins/jest/rules/no_hooks/no_hooks_test.go
@@ -86,3 +86,21 @@ func TestNoHooksRule(t *testing.T) {
 		},
 	)
 }
+
+// TestNoHooksAllowSchema locks in the divergence from upstream's `meta.schema`,
+// which constrains `allow` with `contains: ["beforeAll", ...]`. `contains` is a
+// draft-6 keyword whose value must be a schema, so under the draft-4 dialect
+// ESLint (and rslint) validate with, it is an unknown keyword and ignored
+// entirely — leaving `allow` to accept any array at all. Every element must be
+// one of the four hook names the rule can act on, which is what `items`/`enum`
+// says, so a typo fails validation instead of silently never matching.
+func TestNoHooksAllowSchema(t *testing.T) {
+	valid := []any{map[string]any{"allow": []any{"beforeEach", "afterAll"}}}
+	if err := no_hooks.NoHooksRule.Schema.Validate(valid); err != nil {
+		t.Errorf("expected hook names to pass schema validation, got: %v", err)
+	}
+	invalid := []any{map[string]any{"allow": []any{"beforeeach"}}}
+	if err := no_hooks.NoHooksRule.Schema.Validate(invalid); err == nil {
+		t.Error("expected a non-hook name to fail schema validation")
+	}
+}

--- a/internal/plugins/jest/rules/no_hooks/no_hooks_test.go
+++ b/internal/plugins/jest/rules/no_hooks/no_hooks_test.go
@@ -99,7 +99,7 @@ func TestNoHooksAllowSchema(t *testing.T) {
 	if err := no_hooks.NoHooksRule.Schema.Validate(valid); err != nil {
 		t.Errorf("expected hook names to pass schema validation, got: %v", err)
 	}
-	invalid := []any{map[string]any{"allow": []any{"beforeeach"}}}
+	invalid := []any{map[string]any{"allow": []any{"beforeeach"}}} // cspell:ignore beforeeach
 	if err := no_hooks.NoHooksRule.Schema.Validate(invalid); err == nil {
 		t.Error("expected a non-hook name to fail schema validation")
 	}

--- a/internal/plugins/jest/rules/no_identical_title/no_identical_title.go
+++ b/internal/plugins/jest/rules/no_identical_title/no_identical_title.go
@@ -51,7 +51,8 @@ func staticJestTitleValue(arg *ast.Node) (string, bool) {
 }
 
 var NoIdenticalTitleRule = rule.Rule{
-	Name: "jest/no-identical-title",
+	Name:   "jest/no-identical-title",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		contexts := []*titleLayer{newTitleLayer()}
 

--- a/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
+++ b/internal/plugins/jest/rules/no_interpolation_in_snapshots/no_interpolation_in_snapshots.go
@@ -14,7 +14,8 @@ func buildNoInterpolationMessage() rule.RuleMessage {
 }
 
 var NoInterpolationInSnapshotsRule = rule.Rule{
-	Name: "jest/no-interpolation-in-snapshots",
+	Name:   "jest/no-interpolation-in-snapshots",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/no_jasmine_globals/no_jasmine_globals.go
+++ b/internal/plugins/jest/rules/no_jasmine_globals/no_jasmine_globals.go
@@ -170,7 +170,8 @@ func reportJasmineAssignedProperty(node *ast.Node, ctx rule.RuleContext) {
 }
 
 var NoJasmineGlobalsRule = rule.Rule{
-	Name: "jest/no-jasmine-globals",
+	Name:   "jest/no-jasmine-globals",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/no_mocks_import/no_mocks_import.go
+++ b/internal/plugins/jest/rules/no_mocks_import/no_mocks_import.go
@@ -31,7 +31,8 @@ func isStringNode(node *ast.Node) bool {
 // NewRule creates a no-mocks-import rule for a test framework.
 func NewRule(name string, mockFunction string) rule.Rule {
 	return rule.Rule{
-		Name: name,
+		Name:   name,
+		Schema: rule.EmptyArraySchema,
 		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 			return rule.RuleListeners{
 				ast.KindImportDeclaration: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/no_restricted_jest_methods/no_restricted_jest_methods.go
+++ b/internal/plugins/jest/rules/no_restricted_jest_methods/no_restricted_jest_methods.go
@@ -1,10 +1,15 @@
 package no_restricted_jest_methods
 
 import (
+	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_restricted_jest_methods.schema.json
+var schemaJSON []byte
 
 type restrictedMethod struct {
 	Message string
@@ -32,13 +37,12 @@ func buildRestrictedJestMethodWithMessage(method string, message string) rule.Ru
 	}
 }
 
-func parseOptions(options any) map[string]restrictedMethod {
-	normalized := rule.NormalizeOptions(options)
-	if len(normalized) == 0 {
+func parseOptions(options []any) map[string]restrictedMethod {
+	if len(options) == 0 {
 		return nil
 	}
 
-	raw, ok := normalized[0].(map[string]interface{})
+	raw, ok := options[0].(map[string]interface{})
 	if !ok {
 		return nil
 	}
@@ -89,9 +93,10 @@ func isNestedJestFnCall(node *ast.Node) bool {
 }
 
 var NoRestrictedJestMethodsRule = rule.Rule{
-	Name: "jest/no-restricted-jest-methods",
-	Run: func(ctx rule.RuleContext, newOptions []any) rule.RuleListeners {
-		restrictedMethods := parseOptions(rule.LegacyUnwrapOptions(newOptions))
+	Name:   "jest/no-restricted-jest-methods",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		restrictedMethods := parseOptions(options)
 		if len(restrictedMethods) == 0 {
 			return rule.RuleListeners{}
 		}

--- a/internal/plugins/jest/rules/no_restricted_jest_methods/no_restricted_jest_methods.schema.json
+++ b/internal/plugins/jest/rules/no_restricted_jest_methods/no_restricted_jest_methods.schema.json
@@ -1,0 +1,13 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "null"]
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/no_restricted_matchers/no_restricted_matchers.go
+++ b/internal/plugins/jest/rules/no_restricted_matchers/no_restricted_matchers.go
@@ -1,6 +1,7 @@
 package no_restricted_matchers
 
 import (
+	_ "embed"
 	"sort"
 	"strings"
 
@@ -8,6 +9,9 @@ import (
 	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_restricted_matchers.schema.json
+var schemaJSON []byte
 
 type restrictedMatcher struct {
 	Chain   string
@@ -36,13 +40,12 @@ func buildRestrictedChainWithMessage(chain string, message string) rule.RuleMess
 	}
 }
 
-func parseOptions(options any) []restrictedMatcher {
-	normalized := rule.NormalizeOptions(options)
-	if len(normalized) == 0 {
+func parseOptions(options []any) []restrictedMatcher {
+	if len(options) == 0 {
 		return nil
 	}
 
-	raw, ok := normalized[0].(map[string]interface{})
+	raw, ok := options[0].(map[string]interface{})
 	if !ok {
 		return nil
 	}
@@ -96,9 +99,9 @@ func isChainRestricted(chain string, restriction restrictedMatcher) bool {
 }
 
 var NoRestrictedMatchersRule = rule.Rule{
-	Name: "jest/no-restricted-matchers",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "jest/no-restricted-matchers",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		restrictedMatchers := parseOptions(options)
 		if len(restrictedMatchers) == 0 {
 			return rule.RuleListeners{}

--- a/internal/plugins/jest/rules/no_restricted_matchers/no_restricted_matchers.schema.json
+++ b/internal/plugins/jest/rules/no_restricted_matchers/no_restricted_matchers.schema.json
@@ -1,0 +1,13 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "null"]
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.go
+++ b/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.go
@@ -1,10 +1,15 @@
 package no_standalone_expect
 
 import (
+	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_standalone_expect.schema.json
+var schemaJSON []byte
 
 type blockType string
 
@@ -35,28 +40,14 @@ func buildUnexpectedExpectMessage() rule.RuleMessage {
 	}
 }
 
-func parseOptions(raw any) options {
+func parseOptions(rawOptions []any) options {
 	opts := options{additionalTestBlockFunctions: map[string]struct{}{}}
-	if raw == nil {
+	if len(rawOptions) == 0 {
 		return opts
 	}
 
-	optArray := rule.NormalizeOptions(raw)
-	if len(optArray) == 0 {
-		return opts
-	}
-
-	optsMap, ok := optArray[0].(map[string]interface{})
-	if !ok {
-		return opts
-	}
-
-	rawFns, ok := optsMap["additionalTestBlockFunctions"]
-	if !ok || rawFns == nil {
-		return opts
-	}
-
-	list, ok := rawFns.([]interface{})
+	optsMap, _ := rawOptions[0].(map[string]interface{})
+	list, ok := optsMap["additionalTestBlockFunctions"].([]interface{})
 	if !ok {
 		return opts
 	}
@@ -154,9 +145,9 @@ func getTemplateScopeRange(node *ast.Node) (int, int, bool) {
 }
 
 var NoStandaloneExpectRule = rule.Rule{
-	Name: "jest/no-standalone-expect",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "jest/no-standalone-expect",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 		scopeStack := make([]scopeEntry, 0, 8)
 

--- a/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.schema.json
+++ b/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect.schema.json
@@ -1,0 +1,19 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "additionalTestBlockFunctions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/no_test_prefixes/no_test_prefixes.go
+++ b/internal/plugins/jest/rules/no_test_prefixes/no_test_prefixes.go
@@ -19,7 +19,8 @@ func buildErrorUsePreferredNameMessage(preferredName string) rule.RuleMessage {
 }
 
 var NoTestPrefixesRule = rule.Rule{
-	Name: "jest/no-test-prefixes",
+	Name:   "jest/no-test-prefixes",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function.go
+++ b/internal/plugins/jest/rules/no_unneeded_async_expect_function/no_unneeded_async_expect_function.go
@@ -88,7 +88,8 @@ func hasPromiseExpectModifier(jestFnCall *jestUtils.ParsedJestFnCall) bool {
 }
 
 var NoUnneededAsyncExpectFunctionRule = rule.Rule{
-	Name: "jest/no-unneeded-async-expect-function",
+	Name:   "jest/no-unneeded-async-expect-function",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_called_with/prefer_called_with.go
+++ b/internal/plugins/jest/rules/prefer_called_with/prefer_called_with.go
@@ -26,7 +26,8 @@ func buildPreferCalledWithMessage(matcherName string) rule.RuleMessage {
 }
 
 var PreferCalledWithRule = rule.Rule{
-	Name: "jest/prefer-called-with",
+	Name:   "jest/prefer-called-with",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
@@ -60,7 +60,8 @@ func buildModifierText(jestFnCall *utils.ParsedJestFnCall) string {
 }
 
 var PreferComparisonMatcherRule = rule.Rule{
-	Name: "jest/prefer-comparison-matcher",
+	Name:   "jest/prefer-comparison-matcher",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_each/prefer_each.go
+++ b/internal/plugins/jest/rules/prefer_each/prefer_each.go
@@ -26,7 +26,8 @@ func recommendFn(jestFnCalls []jestUtils.JestFnType) string {
 }
 
 var PreferEachRule = rule.Rule{
-	Name: "jest/prefer-each",
+	Name:   "jest/prefer-each",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		jestFnCalls := make([]jestUtils.JestFnType, 0, 4)
 		inTestCaseCall := false

--- a/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.go
+++ b/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.go
@@ -55,7 +55,8 @@ func buildModifierText(jestFnCall *utils.ParsedJestFnCall, addNotModifier bool) 
 }
 
 var PreferEqualityMatcherRule = rule.Rule{
-	Name: "jest/prefer-equality-matcher",
+	Name:   "jest/prefer-equality-matcher",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves.go
+++ b/internal/plugins/jest/rules/prefer_expect_resolves/prefer_expect_resolves.go
@@ -18,7 +18,8 @@ func buildExpectResolvesErrorMessage() rule.RuleMessage {
 }
 
 var PreferExpectResolvesRule = rule.Rule{
-	Name: "jest/prefer-expect-resolves",
+	Name:   "jest/prefer-expect-resolves",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_hooks_in_order/prefer_hooks_in_order.go
+++ b/internal/plugins/jest/rules/prefer_hooks_in_order/prefer_hooks_in_order.go
@@ -18,7 +18,8 @@ func buildReorderHooksMessage(currentHook, previousHook string) rule.RuleMessage
 }
 
 var PreferHooksInOrderRule = rule.Rule{
-	Name: "jest/prefer-hooks-in-order",
+	Name:   "jest/prefer-hooks-in-order",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		previousHookIndex := -1
 		inHook := false

--- a/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top.go
+++ b/internal/plugins/jest/rules/prefer_hooks_on_top/prefer_hooks_on_top.go
@@ -14,7 +14,8 @@ func buildNoHookOnTopMessage() rule.RuleMessage {
 }
 
 var PreferHooksOnTopRule = rule.Rule{
-	Name: "jest/prefer-hooks-on-top",
+	Name:   "jest/prefer-hooks-on-top",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		hooksContext := []bool{false}
 

--- a/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.go
+++ b/internal/plugins/jest/rules/prefer_jest_mocked/prefer_jest_mocked.go
@@ -69,7 +69,8 @@ func checkJestMockAssertion(ctx rule.RuleContext, node *ast.Node, typeNode, expr
 }
 
 var PreferJestMockedRule = rule.Rule{
-	Name: "jest/prefer-jest-mocked",
+	Name:   "jest/prefer-jest-mocked",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindAsExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_spy_on/prefer_spy_on.go
+++ b/internal/plugins/jest/rules/prefer_spy_on/prefer_spy_on.go
@@ -148,7 +148,8 @@ func buildSpyOnFixes(ctx rule.RuleContext, left *ast.Node, jestFnCall *ast.Node)
 }
 
 var PreferSpyOnRule = rule.Rule{
-	Name: "jest/prefer-spy-on",
+	Name:   "jest/prefer-spy-on",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindBinaryExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_strict_equal/prefer_strict_equal.go
+++ b/internal/plugins/jest/rules/prefer_strict_equal/prefer_strict_equal.go
@@ -24,7 +24,8 @@ func buildSuggestReplaceWithStrictEqualErrorMessage() rule.RuleMessage {
 }
 
 var PreferStrictEqualRule = rule.Rule{
-	Name: "jest/prefer-strict-equal",
+	Name:   "jest/prefer-strict-equal",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.go
+++ b/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.go
@@ -192,7 +192,8 @@ func reportPreferToBe(ctx rule.RuleContext, kind preferKind, jestFnCall *utils.P
 }
 
 var PreferToBeRule = rule.Rule{
-	Name: "jest/prefer-to-be",
+	Name:   "jest/prefer-to-be",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/jest/rules/prefer_to_contain/prefer_to_contain.go
@@ -48,7 +48,8 @@ func getIncludesCalleeName(callee *ast.Node) (receiver *ast.Node, ok bool) {
 }
 
 var PreferToContainRule = rule.Rule{
-	Name: "jest/prefer-to-contain",
+	Name:   "jest/prefer-to-contain",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_to_have_been_called/prefer_to_have_been_called.go
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called/prefer_to_have_been_called.go
@@ -26,7 +26,8 @@ func isZeroLiteral(node *ast.Node) bool {
 }
 
 var PreferToHaveBeenCalledRule = rule.Rule{
-	Name: "jest/prefer-to-have-been-called",
+	Name:   "jest/prefer-to-have-been-called",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.go
+++ b/internal/plugins/jest/rules/prefer_to_have_been_called_times/prefer_to_have_been_called_times.go
@@ -75,7 +75,8 @@ func unwrapMockCallsAccessProperty(arg *ast.Node) *ast.Node {
 }
 
 var PreferToHaveBeenCalledTimesRule = rule.Rule{
-	Name: "jest/prefer-to-have-been-called-times",
+	Name:   "jest/prefer-to-have-been-called-times",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_to_have_length/prefer_to_have_length.go
+++ b/internal/plugins/jest/rules/prefer_to_have_length/prefer_to_have_length.go
@@ -56,7 +56,8 @@ func unwrapLengthAccessProperty(arg *ast.Node) *ast.Node {
 }
 
 var PreferToHaveLengthRule = rule.Rule{
-	Name: "jest/prefer-to-have-length",
+	Name:   "jest/prefer-to-have-length",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/prefer_todo/prefer_todo.go
+++ b/internal/plugins/jest/rules/prefer_todo/prefer_todo.go
@@ -126,7 +126,8 @@ func buildTodoCallReplacementUnimplemented(ctx rule.RuleContext, callExpr *ast.C
 }
 
 var PreferTodoRule = rule.Rule{
-	Name: "jest/prefer-todo",
+	Name:   "jest/prefer-todo",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/valid_describe_callback/valid_describe_callback.go
+++ b/internal/plugins/jest/rules/valid_describe_callback/valid_describe_callback.go
@@ -54,7 +54,8 @@ func findFirstReturnStatement(nodes []*ast.Node) *ast.Node {
 }
 
 var ValidDescribeCallbackRule = rule.Rule{
-	Name: "jest/valid-describe-callback",
+	Name:   "jest/valid-describe-callback",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/jest/rules/valid_expect/valid_expect.go
+++ b/internal/plugins/jest/rules/valid_expect/valid_expect.go
@@ -1,6 +1,7 @@
 package valid_expect
 
 import (
+	_ "embed"
 	"fmt"
 	"slices"
 	"strconv"
@@ -11,6 +12,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed valid_expect.schema.json
+var schemaJSON []byte
 
 type validExpectOptions struct {
 	AlwaysAwait   bool
@@ -113,7 +117,7 @@ func buildAsyncDescriptorMessage(descriptor asyncDescriptor, alwaysAwait bool) r
 	return buildErrorAsyncMustBeAwaitedMessage(alwaysAwait)
 }
 
-func parseOptions(options any) validExpectOptions {
+func parseOptions(options []any) validExpectOptions {
 	out := validExpectOptions{
 		AlwaysAwait:   false,
 		AsyncMatchers: []string{"toReject", "toResolve"},
@@ -121,10 +125,10 @@ func parseOptions(options any) validExpectOptions {
 		MaxArgs:       1,
 	}
 
-	m := internalUtils.GetOptionsMap(options)
-	if m == nil {
+	if len(options) == 0 {
 		return out
 	}
+	m, _ := options[0].(map[string]interface{})
 
 	if raw, ok := m["alwaysAwait"].(bool); ok {
 		out.AlwaysAwait = raw
@@ -406,9 +410,9 @@ func findTopLevelMemberAccess(node *ast.Node) *ast.Node {
 }
 
 var ValidExpectRule = rule.Rule{
-	Name: "jest/valid-expect",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "jest/valid-expect",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 		arrayExceptions := map[string]bool{}
 		asyncInserted := map[*ast.Node]bool{}

--- a/internal/plugins/jest/rules/valid_expect/valid_expect.schema.json
+++ b/internal/plugins/jest/rules/valid_expect/valid_expect.schema.json
@@ -1,0 +1,31 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "alwaysAwait": {
+          "type": "boolean",
+          "default": false
+        },
+        "asyncMatchers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "minArgs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "maxArgs": {
+          "type": "number",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/valid_title/valid_title.go
+++ b/internal/plugins/jest/rules/valid_title/valid_title.go
@@ -1,6 +1,7 @@
 package valid_title
 
 import (
+	_ "embed"
 	"fmt"
 	"regexp"
 	"strings"
@@ -13,6 +14,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed valid_title.schema.json
+var schemaJSON []byte
 
 type matcherEntry struct {
 	re *regexp2.Regexp
@@ -42,15 +46,11 @@ type invalidPattern struct {
 	err        error
 }
 
-func firstOptionMap(options any) map[string]interface{} {
-	if options == nil {
+func firstOptionMap(options []any) map[string]interface{} {
+	if len(options) == 0 {
 		return nil
 	}
-	arr := rule.NormalizeOptions(options)
-	if len(arr) == 0 {
-		return nil
-	}
-	m, ok := arr[0].(map[string]interface{})
+	m, ok := options[0].(map[string]interface{})
 	if !ok {
 		return nil
 	}
@@ -188,7 +188,7 @@ func fillMatcherField(ms *matchersByFn, key string, raw interface{}, optionPath 
 	return invalids
 }
 
-func parseCompiledOptions(options any) compiledOptions {
+func parseCompiledOptions(options []any) compiledOptions {
 	m := firstOptionMap(options)
 	if m == nil {
 		return compiledOptions{}
@@ -379,9 +379,9 @@ func jestEmptyFunctionName(kind jestUtils.JestFnType) string {
 
 // ValidTitleRule enforces ESLint jest/valid-title.
 var ValidTitleRule = rule.Rule{
-	Name: "jest/valid-title",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "jest/valid-title",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		co := parseCompiledOptions(options)
 		if len(co.invalidPatterns) > 0 {
 			for _, bad := range co.invalidPatterns {

--- a/internal/plugins/jest/rules/valid_title/valid_title.schema.json
+++ b/internal/plugins/jest/rules/valid_title/valid_title.schema.json
@@ -45,19 +45,39 @@
         },
         {
           "type": "object",
-          "propertyNames": {
-            "enum": ["describe", "test", "it"]
+          "properties": {
+            "describe": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/patternWithMessage"
+                }
+              ]
+            },
+            "test": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/patternWithMessage"
+                }
+              ]
+            },
+            "it": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/patternWithMessage"
+                }
+              ]
+            }
           },
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/definitions/patternWithMessage"
-              }
-            ]
-          }
+          "additionalProperties": false
         }
       ]
     },

--- a/internal/plugins/jest/rules/valid_title/valid_title.schema.json
+++ b/internal/plugins/jest/rules/valid_title/valid_title.schema.json
@@ -1,0 +1,71 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "ignoreSpaces": {
+          "type": "boolean",
+          "default": false
+        },
+        "ignoreTypeOfDescribeName": {
+          "type": "boolean",
+          "default": false
+        },
+        "ignoreTypeOfTestName": {
+          "type": "boolean",
+          "default": false
+        },
+        "disallowedWords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "patternProperties": {
+        "^must(?:Not)?Match$": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "maxItems": 2,
+              "additionalItems": false
+            },
+            {
+              "type": "object",
+              "propertyNames": {
+                "enum": ["describe", "test", "it"]
+              },
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "maxItems": 2,
+                    "additionalItems": false
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/jest/rules/valid_title/valid_title.schema.json
+++ b/internal/plugins/jest/rules/valid_title/valid_title.schema.json
@@ -21,51 +21,54 @@
           "items": {
             "type": "string"
           }
-        }
-      },
-      "patternProperties": {
-        "^must(?:Not)?Match$": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "maxItems": 2,
-              "additionalItems": false
-            },
-            {
-              "type": "object",
-              "propertyNames": {
-                "enum": ["describe", "test", "it"]
-              },
-              "additionalProperties": {
-                "oneOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "minItems": 1,
-                    "maxItems": 2,
-                    "additionalItems": false
-                  }
-                ]
-              }
-            }
-          ]
+        },
+        "mustMatch": {
+          "$ref": "#/definitions/matcher"
+        },
+        "mustNotMatch": {
+          "$ref": "#/definitions/matcher"
         }
       },
       "additionalProperties": false
     }
   ],
   "minItems": 0,
-  "maxItems": 1
+  "maxItems": 1,
+  "definitions": {
+    "matcher": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/patternWithMessage"
+        },
+        {
+          "type": "object",
+          "propertyNames": {
+            "enum": ["describe", "test", "it"]
+          },
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/patternWithMessage"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "patternWithMessage": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "maxItems": 2,
+      "additionalItems": false
+    }
+  }
 }

--- a/internal/plugins/jest/rules/valid_title/valid_title_test.go
+++ b/internal/plugins/jest/rules/valid_title/valid_title_test.go
@@ -1079,3 +1079,43 @@ func TestValidTitleRule(t *testing.T) {
 		invalid,
 	)
 }
+
+// TestValidTitleMatcherSchema locks in the shape of the `mustMatch` /
+// `mustNotMatch` options. Upstream's meta.schema reaches them through
+// `patternProperties: {"^must(?:Not)?Match$": ...}`; this schema declares the
+// two names outright, so validating a config never runs a regex, and the two
+// options share one `$ref`'d definition rather than a duplicated branch.
+func TestValidTitleMatcherSchema(t *testing.T) {
+	valid := []any{
+		"^\\d+", // one pattern for every block kind
+		[]any{"^\\d+", "titles must start with a number"},     // pattern with a custom message
+		map[string]any{"describe": "^\\d+", "it": []any{"x"}}, // per-block-kind patterns
+	}
+	for _, matcher := range valid {
+		for _, key := range []string{"mustMatch", "mustNotMatch"} {
+			options := []any{map[string]any{key: matcher}}
+			if err := valid_title.ValidTitleRule.Schema.Validate(options); err != nil {
+				t.Errorf("expected %s: %v to pass schema validation, got: %v", key, matcher, err)
+			}
+		}
+	}
+
+	invalid := []any{
+		42,                             // neither a pattern nor a per-kind map
+		[]any{},                        // a pattern is required
+		[]any{"a", "b", "c"},           // at most a pattern and a message
+		map[string]any{"describe": 42}, // a per-kind value is still a pattern
+	}
+	for _, matcher := range invalid {
+		options := []any{map[string]any{"mustMatch": matcher}}
+		if err := valid_title.ValidTitleRule.Schema.Validate(options); err == nil {
+			t.Errorf("expected mustMatch: %v to fail schema validation", matcher)
+		}
+	}
+
+	// A name the upstream pattern would have rejected too.
+	options := []any{map[string]any{"mustAlsoMatch": "^\\d+"}}
+	if err := valid_title.ValidTitleRule.Schema.Validate(options); err == nil {
+		t.Error("expected an unknown option name to fail schema validation")
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -493,6 +493,25 @@ func CoerceInt(v any) (int, bool) {
 	return 0, false
 }
 
+// CoerceIntegral is [CoerceInt] for options declared as a JSON Schema
+// "integer": a fractional number is rejected rather than truncated, the way
+// ajv rejects it during config validation, so a rule reached through an entry
+// point that does not validate options (the Go rule tester, the library API)
+// falls back to its default instead of silently rounding.
+func CoerceIntegral(v any) (int, bool) {
+	switch n := v.(type) {
+	case float64:
+		if n != math.Trunc(n) {
+			return 0, false
+		}
+	case float32:
+		if float64(n) != math.Trunc(float64(n)) {
+			return 0, false
+		}
+	}
+	return CoerceInt(v)
+}
+
 // GetOptionsString extracts a string option from the weakly-typed options parameter.
 // It handles both direct string format ("value") and array format (["value"]).
 func GetOptionsString(opts any) string {


### PR DESCRIPTION
## Summary

- Declare option JSON Schemas for all `jest/` rules, matching eslint-plugin-jest upstream, so options are validated instead of manually unwrapped. The ten rules that take options embed a `<rule_name>.schema.json`; the rest reference the shared `EmptyArraySchema`.
- `max-expects` / `max-nested-describe` share the new `utils.CoerceIntegral` for their `max` option, which rejects a fractional value rather than truncating it, the way schema validation does.
- `no-hooks` diverges from upstream, which constrains `allow` with `contains: ["beforeAll", ...]`. `contains` is a draft-6 keyword whose value must be a schema, so under the draft-4 dialect ESLint and rslint validate with it is ignored entirely and `allow` accepts any array — including a misspelled hook name that then silently never matches. Declared as `items`/`enum` instead.
- `valid-title` declares `mustMatch` / `mustNotMatch` as named properties instead of upstream's `patternProperties: {"^must(?:Not)?Match$": ...}`, so validating a config never runs that regex against every key.

## Related Links

- https://github.com/web-infra-dev/rslint/pull/1216
- https://github.com/web-infra-dev/rslint/pull/1343

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).