### PR TITLE
feat(unicorn): declare options JSON Schema for unicorn/ rules

### DIFF
--- a/internal/plugins/unicorn/rules/filename_case/filename_case.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.go
@@ -1,6 +1,7 @@
 package filename_case
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 	"unicode"
@@ -11,6 +12,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed filename_case.schema.json
+var schemaJSON []byte
 
 // caseStyle is one of the four supported filename case styles.
 type caseStyle struct {
@@ -71,7 +75,7 @@ type Options struct {
 	MultipleFileExtensions bool
 }
 
-func parseOptions(rawOpts any) Options {
+func parseOptions(rawOpts []any) Options {
 	opts := Options{
 		Cases:                  []caseStyle{caseByKey["kebabCase"]},
 		MultipleFileExtensions: true,
@@ -442,14 +446,14 @@ func backtickList(items []string) []string {
 func isLowerCase(s string) bool { return s == strings.ToLower(s) }
 
 var FilenameCaseRule = rule.Rule{
-	Name: "unicorn/filename-case",
+	Name:   "unicorn/filename-case",
+	Schema: rule.NewSchema(schemaJSON),
 	// The rule is purely filename-driven — it does not inspect any AST node.
 	// `Run` is invoked once per source file, so we do the work here and
 	// return an empty listener map. (The linter's visitor walks SourceFile
 	// children but never the SourceFile node itself, so a
 	// `ast.KindSourceFile` listener would silently never fire.)
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		if ctx.SourceFile == nil {
 			return rule.RuleListeners{}
 		}

--- a/internal/plugins/unicorn/rules/filename_case/filename_case.schema.json
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.schema.json
@@ -2,7 +2,7 @@
   "type": "array",
   "items": [
     {
-      "anyOf": [
+      "oneOf": [
         {
           "properties": {
             "case": {

--- a/internal/plugins/unicorn/rules/filename_case/filename_case.schema.json
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.schema.json
@@ -1,0 +1,65 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "case": {
+              "enum": ["camelCase", "snakeCase", "kebabCase", "pascalCase"],
+              "description": "The filename case style."
+            },
+            "ignore": {
+              "type": "array",
+              "uniqueItems": true,
+              "description": "Patterns to ignore."
+            },
+            "multipleFileExtensions": {
+              "type": "boolean",
+              "description": "Whether to treat additional, dot-separated parts of a filename as file extensions."
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "cases": {
+              "properties": {
+                "camelCase": {
+                  "type": "boolean",
+                  "description": "Whether to allow camelCase filenames."
+                },
+                "snakeCase": {
+                  "type": "boolean",
+                  "description": "Whether to allow snake_case filenames."
+                },
+                "kebabCase": {
+                  "type": "boolean",
+                  "description": "Whether to allow kebab-case filenames."
+                },
+                "pascalCase": {
+                  "type": "boolean",
+                  "description": "Whether to allow PascalCase filenames."
+                }
+              },
+              "additionalProperties": false,
+              "description": "The allowed filename case styles."
+            },
+            "ignore": {
+              "type": "array",
+              "uniqueItems": true,
+              "description": "Patterns to ignore."
+            },
+            "multipleFileExtensions": {
+              "type": "boolean",
+              "description": "Whether to treat additional, dot-separated parts of a filename as file extensions."
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/unicorn/rules/filename_case/filename_case.schema.json
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.schema.json
@@ -2,7 +2,7 @@
   "type": "array",
   "items": [
     {
-      "oneOf": [
+      "anyOf": [
         {
           "properties": {
             "case": {

--- a/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.go
+++ b/internal/plugins/unicorn/rules/new_for_builtins/new_for_builtins.go
@@ -24,7 +24,8 @@ const (
 )
 
 var NewForBuiltinsRule = rule.Rule{
-	Name: "unicorn/new-for-builtins",
+	Name:   "unicorn/new-for-builtins",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		state := newRuleState(ctx)
 

--- a/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins.go
+++ b/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins.go
@@ -1,6 +1,7 @@
 package no_instanceof_builtins
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_instanceof_builtins.schema.json
+var schemaJSON []byte
 
 const (
 	messageIDNoInstanceofBuiltins = "no-instanceof-builtins"
@@ -77,9 +81,9 @@ type options struct {
 
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/no-instanceof-builtins.md
 var NoInstanceofBuiltinsRule = rule.Rule{
-	Name: "unicorn/no-instanceof-builtins",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "unicorn/no-instanceof-builtins",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		return rule.RuleListeners{
@@ -140,7 +144,7 @@ func checkBinaryExpression(ctx rule.RuleContext, node *ast.Node, opts options) {
 	}
 }
 
-func parseOptions(rawOptions any) options {
+func parseOptions(rawOptions []any) options {
 	opts := options{
 		useErrorIsError: false,
 		strategy:        "loose",

--- a/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins.schema.json
+++ b/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins.schema.json
@@ -1,0 +1,31 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "useErrorIsError": {
+          "type": "boolean"
+        },
+        "strategy": {
+          "enum": ["loose", "strict"]
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.go
+++ b/internal/plugins/unicorn/rules/no_static_only_class/no_static_only_class.go
@@ -493,7 +493,8 @@ func getHeritageClauses(node *ast.Node) *ast.NodeList {
 }
 
 var NoStaticOnlyClassRule = rule.Rule{
-	Name: "unicorn/no-static-only-class",
+	Name:   "unicorn/no-static-only-class",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		check := func(node *ast.Node) {
 			// Skip classes that extend another class — the static members

--- a/internal/plugins/unicorn/rules/no_thenable/no_thenable.go
+++ b/internal/plugins/unicorn/rules/no_thenable/no_thenable.go
@@ -32,7 +32,8 @@ var (
 
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-thenable.md
 var NoThenableRule = rule.Rule{
-	Name: "unicorn/no-thenable",
+	Name:   "unicorn/no-thenable",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		state := &ruleState{
 			ctx:           ctx,

--- a/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case.go
+++ b/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case.go
@@ -14,7 +14,8 @@ const (
 )
 
 var NoUselessSwitchCaseRule = rule.Rule{
-	Name: "unicorn/no-useless-switch-case",
+	Name:   "unicorn/no-useless-switch-case",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindSwitchStatement: func(node *ast.Node) {

--- a/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map.go
+++ b/internal/plugins/unicorn/rules/prefer_array_flat_map/prefer_array_flat_map.go
@@ -65,7 +65,8 @@ func buildFixes(sf *ast.SourceFile, flatCall dotMethodCall, mapCall dotMethodCal
 
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-array-flat-map.md
 var PreferArrayFlatMapRule = rule.Rule{
-	Name: "unicorn/prefer-array-flat-map",
+	Name:   "unicorn/prefer-array-flat-map",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/unicorn/rules/prefer_number_properties/prefer_number_properties.go
+++ b/internal/plugins/unicorn/rules/prefer_number_properties/prefer_number_properties.go
@@ -1,12 +1,16 @@
 package prefer_number_properties
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed prefer_number_properties.schema.json
+var schemaJSON []byte
 
 const (
 	messageIDError      = "error"
@@ -43,9 +47,9 @@ var globalObjectNames = map[string]struct{}{
 
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-number-properties.md
 var PreferNumberPropertiesRule = rule.Rule{
-	Name: "unicorn/prefer-number-properties",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "unicorn/prefer-number-properties",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		report := func(ref globalReference) {
@@ -95,7 +99,7 @@ var PreferNumberPropertiesRule = rule.Rule{
 	},
 }
 
-func parseOptions(options any) preferNumberPropertiesOptions {
+func parseOptions(options []any) preferNumberPropertiesOptions {
 	opts := preferNumberPropertiesOptions{
 		checkInfinity: false,
 		checkNaN:      true,

--- a/internal/plugins/unicorn/rules/prefer_number_properties/prefer_number_properties.schema.json
+++ b/internal/plugins/unicorn/rules/prefer_number_properties/prefer_number_properties.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "checkInfinity": {
+          "type": "boolean",
+          "description": "Whether to check usage of the global `Infinity`."
+        },
+        "checkNaN": {
+          "type": "boolean",
+          "description": "Whether to check usage of the global `NaN`."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/unicorn/rules/require_array_join_separator/require_array_join_separator.go
+++ b/internal/plugins/unicorn/rules/require_array_join_separator/require_array_join_separator.go
@@ -81,7 +81,8 @@ func appendSeparatorFix(closing core.TextRange, penultimateKind ast.Kind, isProt
 
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/require-array-join-separator.md
 var RequireArrayJoinSeparatorRule = rule.Rule{
-	Name: "unicorn/require-array-join-separator",
+	Name:   "unicorn/require-array-join-separator",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		zeroArguments := 0
 		oneArgument := 1

--- a/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument.go
+++ b/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument/require_number_to_fixed_digits_argument.go
@@ -55,7 +55,8 @@ func callParenthesesRange(sourceFile *ast.SourceFile, node *ast.Node) (core.Text
 
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/require-number-to-fixed-digits-argument.md
 var RequireNumberToFixedDigitsArgumentRule = rule.Rule{
-	Name: "unicorn/require-number-to-fixed-digits-argument",
+	Name:   "unicorn/require-number-to-fixed-digits-argument",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		zeroArguments := 0
 		return rule.RuleListeners{

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/filename-case.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/filename-case.test.ts
@@ -122,11 +122,6 @@ ruleTester.run('filename-case', {} as never, {
     {
       code: '/* Filename: src/foo/foo-bar.js */',
       filename: 'src/foo/foo-bar.js',
-      options: [{ cases: undefined }],
-    },
-    {
-      code: '/* Filename: src/foo/foo-bar.js */',
-      filename: 'src/foo/foo-bar.js',
       options: [{ cases: {} }],
     },
     validCases('src/foo/fooBar.js', { camelCase: true }),


### PR DESCRIPTION
## Summary

- Declare option JSON Schemas for all `unicorn/` rules, matching `eslint-plugin-unicorn` upstream, so options are validated instead of manually unwrapped. `filename-case`, `no-instanceof-builtins` and `prefer-number-properties` embed a `<rule_name>.schema.json`; the seven rules without options reference the shared `EmptyArraySchema`.
- Schemas are copied from **v64**, the version this port targets (`presets/unicorn.ts` and the rule doc links), not the latest release. v72 has since added `checkDirectories` / `camelCaseWithAcronyms` to `filename-case`, neither of which this port implements.
- `filename-case` therefore keeps v64's `oneOf`, under which an options object carrying only `ignore` or `multipleFileExtensions` matches both branches and is rejected. That is upstream v64 behaviour (verified against `ajv@6`); v67+ relaxed it to `anyOf`.
- Cross-checked against the real npm package: each schema is byte-equal to upstream's `meta.schema` after ESLint's own array-to-tuple wrap, and the seven optionless rules were confirmed to reject configured options through `Linter.verify`.
- Removed the `filename-case` test case `options: [{ cases: undefined }]`: real ESLint accepts it (an own key with an `undefined` value still disambiguates `oneOf`), but that distinction can't survive rslint's JSON-RPC boundary to the Go binary — `JSON.stringify` drops `undefined`-valued keys, so on the wire it's indistinguishable from `{}`, which must be rejected. Not a case rslint can support.

## Related Links

- https://github.com/web-infra-dev/rslint/issues/1216
- https://github.com/web-infra-dev/rslint/pull/1417

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
