### PR TITLE
perf: optimize no-useless-constructor rule

### DIFF
--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.go
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.go
@@ -2,7 +2,10 @@ package no_useless_constructor
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func buildNoUselessConstructorMessage() rule.RuleMessage {
@@ -22,32 +25,17 @@ func buildRemoveConstructorMessage() rule.RuleMessage {
 // checkAccessibility returns true if the constructor should be checked (accessibility
 // does not make it useful). Returns false (skip) for private/protected constructors,
 // and for public constructors in classes that extend another class.
-func checkAccessibility(node *ast.Node, classHasSuperClass bool) bool {
-	if ast.HasSyntacticModifier(node, ast.ModifierFlagsPrivate) {
-		return false
-	}
-	if ast.HasSyntacticModifier(node, ast.ModifierFlagsProtected) {
-		return false
-	}
-	if ast.HasSyntacticModifier(node, ast.ModifierFlagsPublic) {
-		if classHasSuperClass {
-			return false
-		}
-	}
-	return true
+func checkAccessibility(modifierFlags ast.ModifierFlags, classHasSuperClass bool) bool {
+	return modifierFlags&ast.ModifierFlagsNonPublicAccessibilityModifier == 0 &&
+		(!classHasSuperClass || modifierFlags&ast.ModifierFlagsPublic == 0)
 }
 
 // checkParams returns true if the constructor should be checked (no parameter
 // properties or decorators that make it useful).
-func checkParams(node *ast.Node, params []*ast.Node) bool {
+func checkParams(params []*ast.Node) bool {
+	const usefulParameterModifiers = ast.ModifierFlagsParameterPropertyModifier | ast.ModifierFlagsDecorator
 	for _, param := range params {
-		if param.Kind != ast.KindParameter {
-			continue
-		}
-		if ast.IsParameterPropertyDeclaration(param, node) {
-			return false
-		}
-		if ast.HasDecorators(param) {
+		if param.Kind == ast.KindParameter && param.ModifierFlags()&usefulParameterModifiers != 0 {
 			return false
 		}
 	}
@@ -68,32 +56,33 @@ func isSimpleParam(param *ast.Node) bool {
 	if pd.Initializer != nil {
 		return false
 	}
-	// Must be a simple identifier (not destructuring)
-	name := param.Name()
-	if name == nil || name.Kind != ast.KindIdentifier {
-		return false
+	// ESTree represents every rest parameter as a RestElement. Its binding
+	// pattern is checked separately when pairing it with a spread argument.
+	if pd.DotDotDotToken != nil {
+		return true
 	}
-	return true
+	name := param.Name()
+	return name != nil && name.Kind == ast.KindIdentifier
 }
 
-// isSingleSuperCall checks if the body consists of exactly one statement: super(...).
-func isSingleSuperCall(statements []*ast.Node) bool {
+// singleSuperCall returns the only super() call in the body.
+func singleSuperCall(statements []*ast.Node) *ast.CallExpression {
 	if len(statements) != 1 {
-		return false
+		return nil
 	}
 	stmt := statements[0]
 	if stmt.Kind != ast.KindExpressionStatement {
-		return false
+		return nil
 	}
 	expr := stmt.Expression()
-	if expr == nil || expr.Kind != ast.KindCallExpression {
-		return false
+	if expr == nil {
+		return nil
 	}
-	call := expr.AsCallExpression()
-	if call == nil || call.Expression == nil {
-		return false
+	expr = ast.SkipParentheses(expr)
+	if expr == nil || !ast.IsSuperCall(expr) {
+		return nil
 	}
-	return call.Expression.Kind == ast.KindSuperKeyword
+	return expr.AsCallExpression()
 }
 
 // isSpreadArguments checks if the arguments are exactly `...arguments`.
@@ -109,45 +98,43 @@ func isSpreadArguments(args []*ast.Node) bool {
 	if se == nil || se.Expression == nil {
 		return false
 	}
-	return se.Expression.Kind == ast.KindIdentifier && se.Expression.Text() == "arguments"
+	expr := ast.SkipParentheses(se.Expression)
+	return expr != nil && expr.Kind == ast.KindIdentifier && expr.Text() == "arguments"
 }
 
 // isValidIdentifierPair checks if the constructor param and super arg are both identifiers with the same name.
 func isValidIdentifierPair(paramName *ast.Node, superArg *ast.Node) bool {
+	if paramName == nil || superArg == nil {
+		return false
+	}
+	superArg = ast.SkipParentheses(superArg)
 	return paramName.Kind == ast.KindIdentifier &&
+		superArg != nil &&
 		superArg.Kind == ast.KindIdentifier &&
 		paramName.Text() == superArg.Text()
 }
 
 // isValidRestSpreadPair checks if the constructor param is a rest param and
 // the super arg is a spread element with the same identifier.
-func isValidRestSpreadPair(param *ast.Node, superArg *ast.Node) bool {
-	pd := param.AsParameterDeclaration()
-	if pd == nil || pd.DotDotDotToken == nil {
-		return false
-	}
-	if superArg.Kind != ast.KindSpreadElement {
+func isValidRestSpreadPair(paramName *ast.Node, superArg *ast.Node) bool {
+	if superArg == nil || superArg.Kind != ast.KindSpreadElement {
 		return false
 	}
 	se := superArg.AsSpreadElement()
 	if se == nil || se.Expression == nil {
 		return false
 	}
-	paramName := param.Name()
-	if paramName == nil {
-		return false
-	}
 	return isValidIdentifierPair(paramName, se.Expression)
 }
 
-// isPassingThrough checks if constructor params are passed through to super() 1:1.
+// isPassingThrough checks simplicity and 1:1 forwarding in one parameter pass.
 func isPassingThrough(params []*ast.Node, args []*ast.Node) bool {
 	if len(params) != len(args) {
 		return false
 	}
 	for i := range params {
 		pd := params[i].AsParameterDeclaration()
-		if pd == nil {
+		if pd == nil || pd.Initializer != nil {
 			return false
 		}
 		paramName := params[i].Name()
@@ -155,13 +142,11 @@ func isPassingThrough(params []*ast.Node, args []*ast.Node) bool {
 			return false
 		}
 		if pd.DotDotDotToken != nil {
-			if !isValidRestSpreadPair(params[i], args[i]) {
+			if !isValidRestSpreadPair(paramName, args[i]) {
 				return false
 			}
-		} else {
-			if !isValidIdentifierPair(paramName, args[i]) {
-				return false
-			}
+		} else if !isValidIdentifierPair(paramName, args[i]) {
+			return false
 		}
 	}
 	return true
@@ -169,23 +154,94 @@ func isPassingThrough(params []*ast.Node, args []*ast.Node) bool {
 
 // isRedundantSuperCall checks if the constructor body is just a redundant super() call.
 func isRedundantSuperCall(statements []*ast.Node, params []*ast.Node) bool {
-	if !isSingleSuperCall(statements) {
+	call := singleSuperCall(statements)
+	if call == nil {
 		return false
 	}
-	// All params must be simple (identifier or rest, no destructuring/defaults)
-	for _, p := range params {
-		if !isSimpleParam(p) {
-			return false
-		}
-	}
-	// Get the super call arguments
-	expr := statements[0].Expression()
-	call := expr.AsCallExpression()
 	var args []*ast.Node
 	if call.Arguments != nil {
 		args = call.Arguments.Nodes
 	}
-	return isSpreadArguments(args) || isPassingThrough(params, args)
+	if !isSpreadArguments(args) {
+		return isPassingThrough(params, args)
+	}
+	for _, param := range params {
+		if !isSimpleParam(param) {
+			return false
+		}
+	}
+	return true
+}
+
+// constructorRanges returns ESLint's constructor-key diagnostic span and the
+// full constructor span used by its removal suggestion. It avoids allocating a
+// standalone scanner on the normal diagnostic-only path.
+func constructorRanges(sourceText string, node *ast.Node) (core.TextRange, core.TextRange) {
+	start := scanner.SkipTrivia(sourceText, node.Pos())
+	fixRange := core.NewTextRange(start, node.End())
+	keyStart := start
+	if modifiers := node.Modifiers(); modifiers != nil && len(modifiers.Nodes) != 0 {
+		keyStart = scanner.SkipTrivia(sourceText, modifiers.Nodes[len(modifiers.Nodes)-1].End())
+	}
+
+	const constructorKeyword = "constructor"
+	if keyStart >= 0 &&
+		keyStart+len(constructorKeyword) <= node.End() &&
+		keyStart+len(constructorKeyword) <= len(sourceText) &&
+		sourceText[keyStart:keyStart+len(constructorKeyword)] == constructorKeyword {
+		return core.NewTextRange(start, keyStart+len(constructorKeyword)), fixRange
+	}
+
+	// A string-literal key whose cooked value is "constructor" is also parsed
+	// as a constructor. Find its closing quote without materializing a token.
+	if keyStart >= 0 && keyStart < node.End() && keyStart < len(sourceText) &&
+		(sourceText[keyStart] == '\'' || sourceText[keyStart] == '"') {
+		quote := sourceText[keyStart]
+		for pos := keyStart + 1; pos < node.End() && pos < len(sourceText); pos++ {
+			switch sourceText[pos] {
+			case '\\':
+				pos++
+			case quote:
+				return core.NewTextRange(start, pos+1), fixRange
+			}
+		}
+	}
+	return fixRange, fixRange
+}
+
+func needsLeadingSemicolon(sourceFile *ast.SourceFile, classNode *ast.Node, node *ast.Node) bool {
+	sourceText := sourceFile.Text()
+	nextStart := scanner.SkipTrivia(sourceText, node.End())
+	if nextStart >= len(sourceText) {
+		return false
+	}
+
+	var nextToken utils.SourceToken
+	switch sourceText[nextStart] {
+	case '[':
+		nextToken = utils.SourceToken{Kind: ast.KindOpenBracketToken, Start: nextStart, End: nextStart + 1, Text: "["}
+	case '*':
+		nextToken = utils.SourceToken{Kind: ast.KindAsteriskToken, Start: nextStart, End: nextStart + 1, Text: "*"}
+	case 'i':
+		// `in` and `instanceof` are the other expression-continuation
+		// tokens accepted in a class body. Let the scanner distinguish them
+		// from ordinary identifier names only on this rare path.
+		var ok bool
+		nextToken, ok = utils.TokenAtOrAfter(sourceFile, nextStart)
+		if !ok {
+			return false
+		}
+	default:
+		return false
+	}
+
+	return utils.NeedsClassMemberLeadingSemicolon(
+		sourceFile,
+		classNode,
+		node,
+		nextToken,
+		utils.ClassMemberLeadingSemicolonOptions{IncludePropertiesWithoutInitializers: true},
+	)
 }
 
 var NoUselessConstructorRule = rule.CreateRule(rule.Rule{
@@ -211,7 +267,9 @@ var NoUselessConstructorRule = rule.CreateRule(rule.Rule{
 				hasSuper := ast.GetExtendsHeritageClauseElement(classNode) != nil
 
 				// TypeScript-specific: skip if accessibility makes constructor useful
-				if !checkAccessibility(node, hasSuper) {
+				modifierFlags := node.ModifierFlags()
+				if modifierFlags&ast.ModifierFlagsStatic != 0 ||
+					!checkAccessibility(modifierFlags, hasSuper) {
 					return
 				}
 
@@ -220,7 +278,7 @@ var NoUselessConstructorRule = rule.CreateRule(rule.Rule{
 				if constructor.Parameters != nil {
 					params = constructor.Parameters.Nodes
 				}
-				if !checkParams(node, params) {
+				if !checkParams(params) {
 					return
 				}
 
@@ -233,14 +291,25 @@ var NoUselessConstructorRule = rule.CreateRule(rule.Rule{
 					isUseless = len(body) == 0
 				}
 
-				if isUseless {
-					ctx.ReportNodeWithSuggestions(node, buildNoUselessConstructorMessage(),
-						rule.RuleSuggestion{
-							Message:  buildRemoveConstructorMessage(),
-							FixesArr: []rule.RuleFix{rule.RuleFixRemove(ctx.SourceFile, node)},
-						},
-					)
+				if !isUseless {
+					return
 				}
+
+				reportRange, fixRange := constructorRanges(ctx.SourceFile.Text(), node)
+				ctx.ReportRangeWithDeferredSuggestions(
+					reportRange,
+					buildNoUselessConstructorMessage(),
+					func() []rule.RuleSuggestion {
+						replacement := ""
+						if needsLeadingSemicolon(ctx.SourceFile, classNode, node) {
+							replacement = ";"
+						}
+						return []rule.RuleSuggestion{{
+							Message:  buildRemoveConstructorMessage(),
+							FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(fixRange, replacement)},
+						}}
+					},
+				)
 			},
 		}
 	},

--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor_test.go
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor_test.go
@@ -1,9 +1,15 @@
 package no_useless_constructor
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -168,6 +174,10 @@ class A {
 abstract class A {
   constructor();
 }`},
+		// tsgo parses these as constructors, but ESTree exposes methods whose
+		// kind is "method", so the upstream rule ignores them.
+		{Code: `class A { static constructor() {} }`},
+		{Code: `class A extends B { static constructor() {} }`},
 		// Overload + implementation with body
 		{Code: `
 class A {
@@ -475,16 +485,6 @@ class A extends B implements I {
 }`},
 
 		// ============================================================
-		// Rest with destructuring (not simple)
-		// ============================================================
-		{Code: `
-class A extends B {
-  constructor(...[x, y]) {
-    super(...arguments);
-  }
-}`},
-
-		// ============================================================
 		// new.target usage (useful body)
 		// ============================================================
 		{Code: `
@@ -645,7 +645,7 @@ class A {
   constructor() {}
 }`,
 			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, EndLine: 3, EndColumn: 14, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 					{MessageId: "removeConstructor", Output: "\nclass A {\n  \n}"},
 				}},
 			},
@@ -664,6 +664,40 @@ class A extends B {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+		// ESTree erases grouping parentheses around expressions. tsgo keeps
+		// them, so they must not hide the same redundant-super shapes.
+		{
+			Code: `class A extends B { constructor() { (((super()))); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		{
+			Code: `class A extends B { constructor(value) { super((value)); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		{
+			Code: `class A extends B { constructor(...values) { super(...(values)); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		{
+			Code: `class A extends B { constructor() { super(...(arguments)); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
 				}},
 			},
 		},
@@ -737,6 +771,21 @@ class A extends B {
 				}},
 			},
 		},
+		// ESTree treats every RestElement as simple. The binding pattern does
+		// not block a direct ...arguments pass-through.
+		{
+			Code: `
+class A extends B {
+  constructor(...[x, y]) {
+    super(...arguments);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
 		// Rest params matching forward
 		{
 			Code: `
@@ -748,6 +797,48 @@ class A extends B {
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// Removing a constructor must not let a preceding field initializer
+		// consume the next computed member through ASI.
+		{
+			Code: `
+class A {
+  field = 'value'
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  field = 'value'\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		{
+			Code: `
+class A {
+  field = 2
+  constructor() {}
+  *iterator() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  field = 2\n  ;\n  *iterator() {}\n}"},
+				}},
+			},
+		},
+		{
+			Code: `
+class A {
+  method() {}
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  method() {}\n  \n  [0]() {}\n}"},
 				}},
 			},
 		},
@@ -1181,5 +1272,190 @@ class A {
 				}},
 			},
 		},
+		{
+			Code: `class A { "\u0063` + `on` + `struct` + `or" /* before paren */ () {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 11, EndLine: 1, EndColumn: 29, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A {  }"},
+				}},
+			},
+		},
 	})
+}
+
+func TestNoUselessConstructorEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const source = `class A {
+  /* keep */
+  public constructor() {}
+}
+class B extends A {
+  constructor(value: number) {
+    super(value);
+  }
+}
+class C {
+  field = 'value'
+  constructor() {}
+  [0]() {}
+}`
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		source,
+		"no-useless-constructor-edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     NoUselessConstructorRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoUselessConstructorRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 3 {
+			t.Fatalf("demand %d: diagnostics = %d, want 3", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnostics := map[rule.EditDemand][]rule.RuleDiagnostic{
+		rule.EditDemandNone:       run(rule.EditDemandNone),
+		rule.EditDemandAutofix:    run(rule.EditDemandAutofix),
+		rule.EditDemandSuggestion: run(rule.EditDemandSuggestion),
+		rule.EditDemandAll:        run(rule.EditDemandAll),
+	}
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+
+	for index := range diagnostics[rule.EditDemandAll] {
+		want := withoutEdits(diagnostics[rule.EditDemandAll][index])
+		for demand, demandDiagnostics := range diagnostics {
+			if got := withoutEdits(demandDiagnostics[index]); !reflect.DeepEqual(got, want) {
+				t.Errorf("diagnostic %d changed for demand %d:\ngot:  %#v\nwant: %#v", index, demand, got, want)
+			}
+			if demandDiagnostics[index].FixesPtr != nil {
+				t.Errorf("diagnostic %d demand %d unexpectedly has autofixes", index, demand)
+			}
+		}
+
+		if diagnostics[rule.EditDemandNone][index].Suggestions != nil ||
+			diagnostics[rule.EditDemandAutofix][index].Suggestions != nil {
+			t.Fatalf("diagnostic %d materialized suggestions without suggestion demand", index)
+		}
+
+		suggestionOnly := diagnostics[rule.EditDemandSuggestion][index].Suggestions
+		allEdits := diagnostics[rule.EditDemandAll][index].Suggestions
+		if suggestionOnly == nil || !reflect.DeepEqual(suggestionOnly, allEdits) {
+			t.Fatalf("diagnostic %d: suggestion and all-edits demands produced different suggestions", index)
+		}
+		if len(*suggestionOnly) != 1 || len((*suggestionOnly)[0].Fixes()) != 1 {
+			t.Fatalf("diagnostic %d suggestions = %#v, want one suggestion with one fix", index, *suggestionOnly)
+		}
+		fix := (*suggestionOnly)[0].Fixes()[0]
+		wantReportText := []string{"public constructor", "constructor", "constructor"}[index]
+		if got := source[want.Range.Pos():want.Range.End()]; got != wantReportText {
+			t.Fatalf("diagnostic %d report range covers %q, want %q", index, got, wantReportText)
+		}
+		wantFixText := []string{
+			"public constructor() {}",
+			"constructor(value: number) {\n    super(value);\n  }",
+			"constructor() {}",
+		}[index]
+		if got := source[fix.Range.Pos():fix.Range.End()]; got != wantFixText {
+			t.Fatalf("diagnostic %d fix range covers %q, want %q", index, got, wantFixText)
+		}
+		wantReplacement := []string{"", "", ";"}[index]
+		if fix.Text != wantReplacement {
+			t.Fatalf("diagnostic %d replacement = %q, want %q", index, fix.Text, wantReplacement)
+		}
+	}
+}
+
+func TestNoUselessConstructorRecoveryAST(t *testing.T) {
+	t.Parallel()
+
+	for _, source := range []string{
+		`class A extends B { constructor() {`,
+		`class A extends B { constructor(value) { super(`,
+		`class A { public /* between */ constructor /* before paren */ (`,
+		`class A { 'constructor`,
+	} {
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/no-useless-constructor-recovery.ts",
+				Path:     "/no-useless-constructor-recovery.ts",
+			}, source, core.ScriptKindTS)
+			var diagnostics []rule.RuleDiagnostic
+			ctx := rule.RuleContext{
+				SourceFile:     sourceFile,
+				DisableManager: rule.NewDisableManager(sourceFile, rule.NewCommentStore(sourceFile)),
+			}.WithDiagnosticConsumer(
+				NoUselessConstructorRule.Name,
+				rule.SeverityError,
+				rule.DiagnosticConsumer{
+					Demand: rule.EditDemandSuggestion,
+					Report: func(diagnostic rule.RuleDiagnostic) {
+						diagnostics = append(diagnostics, diagnostic)
+					},
+				},
+			)
+			listener := NoUselessConstructorRule.Run(ctx, nil)[ast.KindConstructor]
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if node.Kind == ast.KindConstructor {
+					listener(node)
+				}
+				return node.ForEachChild(visit)
+			}
+			sourceFile.AsNode().ForEachChild(visit)
+
+			for _, diagnostic := range diagnostics {
+				if diagnostic.Range.Pos() < 0 ||
+					diagnostic.Range.End() < diagnostic.Range.Pos() ||
+					diagnostic.Range.End() > len(source) {
+					t.Fatalf("out-of-bounds diagnostic range %#v for source length %d", diagnostic.Range, len(source))
+				}
+				if diagnostic.Suggestions == nil {
+					continue
+				}
+				for _, suggestion := range *diagnostic.Suggestions {
+					for _, fix := range suggestion.Fixes() {
+						if fix.Range.Pos() < 0 ||
+							fix.Range.End() < fix.Range.Pos() ||
+							fix.Range.End() > len(source) {
+							t.Fatalf("out-of-bounds fix range %#v for source length %d", fix.Range, len(source))
+						}
+					}
+				}
+			}
+		})
+	}
 }

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-useless-constructor.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-useless-constructor.test.ts.snap
@@ -13,7 +13,7 @@ class A {
       "messageId": "noUselessConstructor",
       "range": {
         "end": {
-          "column": 19,
+          "column": 14,
           "line": 3,
         },
         "start": {
@@ -45,8 +45,8 @@ class A extends B {
       "messageId": "noUselessConstructor",
       "range": {
         "end": {
-          "column": 4,
-          "line": 5,
+          "column": 14,
+          "line": 3,
         },
         "start": {
           "column": 3,
@@ -77,8 +77,8 @@ class A extends B {
       "messageId": "noUselessConstructor",
       "range": {
         "end": {
-          "column": 4,
-          "line": 5,
+          "column": 14,
+          "line": 3,
         },
         "start": {
           "column": 3,
@@ -109,8 +109,8 @@ class A extends B {
       "messageId": "noUselessConstructor",
       "range": {
         "end": {
-          "column": 4,
-          "line": 5,
+          "column": 14,
+          "line": 3,
         },
         "start": {
           "column": 3,
@@ -141,8 +141,8 @@ class A extends B {
       "messageId": "noUselessConstructor",
       "range": {
         "end": {
-          "column": 4,
-          "line": 5,
+          "column": 14,
+          "line": 3,
         },
         "start": {
           "column": 3,
@@ -173,8 +173,8 @@ class A extends B.C {
       "messageId": "noUselessConstructor",
       "range": {
         "end": {
-          "column": 4,
-          "line": 5,
+          "column": 14,
+          "line": 3,
         },
         "start": {
           "column": 3,
@@ -205,8 +205,8 @@ class A extends B {
       "messageId": "noUselessConstructor",
       "range": {
         "end": {
-          "column": 4,
-          "line": 5,
+          "column": 14,
+          "line": 3,
         },
         "start": {
           "column": 3,
@@ -237,8 +237,8 @@ class A extends B {
       "messageId": "noUselessConstructor",
       "range": {
         "end": {
-          "column": 4,
-          "line": 5,
+          "column": 14,
+          "line": 3,
         },
         "start": {
           "column": 3,
@@ -267,7 +267,7 @@ class A {
       "messageId": "noUselessConstructor",
       "range": {
         "end": {
-          "column": 26,
+          "column": 21,
           "line": 3,
         },
         "start": {


### PR DESCRIPTION
## Summary

- Defers removal suggestions until the consumer requests them and computes diagnostic/fix ranges without allocating a standalone scanner on the normal lint path.
- Reads constructor and parameter modifier flags once and checks exact parameter forwarding in one pass.
- Keeps the rule syntax-only: `ctx.Refs` is intentionally not used because it would build a whole-file reference index and would change the upstream name-pairing semantics.
- Aligns tsgo-specific AST shapes with upstream behavior for grouping parentheses, rest binding patterns, `static constructor`, constructor-key report locations, and ASI-safe removal suggestions.

### Benchmark

Environment: Apple M1 Max, darwin/arm64, Go 1.26.1, `GOMAXPROCS=1`. Each benchmark operation invokes the rule listener for 1,024 matching constructors. Values are medians of five 1-second runs from:

`go test ./internal/plugins/typescript/rules/no_useless_constructor -run '^$' -bench '^BenchmarkNoUselessConstructorReport$' -benchmem -benchtime=1s -count=5`

| Scenario | Before | After | Time | Before allocations | After allocations |
| --- | ---: | ---: | ---: | ---: | ---: |
| Empty / diagnostics only | 335.176 µs/op | 34.091 µs/op | -89.8% | 432 KiB, 5,120 allocs/op | 0 B, 0 allocs/op |
| Empty / suggestions | 344.725 µs/op | 175.440 µs/op | -49.1% | 432 KiB, 5,120 allocs/op | 112 KiB, 3,072 allocs/op |
| Pass-through / diagnostics only | 459.495 µs/op | 116.717 µs/op | -74.6% | 432 KiB, 5,120 allocs/op | 0 B, 0 allocs/op |
| Pass-through / suggestions | 459.404 µs/op | 282.002 µs/op | -38.6% | 432 KiB, 5,120 allocs/op | 112 KiB, 3,072 allocs/op |

The temporary benchmark file was removed before commit.

### Validation

- `go test ./internal/plugins/typescript/rules/no_useless_constructor -run '^TestNoUselessConstructor(Rule|EditDemand|RecoveryAST)$' -count=1`
- The same targeted tests with `-shuffle=on -count=20`
- Real CLI run through an `.mjs` rslint config enabling only `@typescript-eslint/no-useless-constructor`: expected 4 diagnostics, no false positives for a parameter property or `static constructor`, and 0.0 ms rule timing on the targeted corpus.
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_useless_constructor`

## Related Links

- https://typescript-eslint.io/rules/no-useless-constructor/
- https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-useless-constructor.ts
- https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-constructor.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
