### PR TITLE
perf: optimize no-misleading-character-class

### DIFF
--- a/internal/rules/no_misleading_character_class/no_misleading_character_class.go
+++ b/internal/rules/no_misleading_character_class/no_misleading_character_class.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -32,22 +33,27 @@ var NoMisleadingCharacterClassRule = rule.Rule{
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
 		opts := parseOptions(options)
+		mayUseRegExp := sourceMayUseRegExp(ctx.SourceFile)
+		var calleeChecker *regexpCalleeChecker
+		if mayUseRegExp {
+			calleeChecker = &regexpCalleeChecker{ctx: ctx}
+		}
 		listeners := rule.RuleListeners{
 			ast.KindRegularExpressionLiteral: func(node *ast.Node) {
-				handleRegexLiteral(ctx, node, opts)
+				handleRegexLiteral(ctx, node, opts, calleeChecker)
 			},
 		}
-		if !sourceMayUseRegExp(ctx.SourceFile) {
+		if !mayUseRegExp {
 			return listeners
 		}
 		eval := utils.NewStaticStringEvaluatorWithSourceFile(ctx.TypeChecker, ctx.SourceFile)
 		listeners[ast.KindCallExpression] = func(node *ast.Node) {
 			call := node.AsCallExpression()
-			handleRegExpConstructor(ctx, node, call.Expression, call.Arguments, opts, eval)
+			handleRegExpConstructor(ctx, node, call.Expression, call.Arguments, opts, eval, calleeChecker)
 		}
 		listeners[ast.KindNewExpression] = func(node *ast.Node) {
 			newExpr := node.AsNewExpression()
-			handleRegExpConstructor(ctx, node, newExpr.Expression, newExpr.Arguments, opts, eval)
+			handleRegExpConstructor(ctx, node, newExpr.Expression, newExpr.Arguments, opts, eval, calleeChecker)
 		}
 		return listeners
 	},
@@ -111,11 +117,11 @@ type foundMatch struct {
 // Listeners
 // ---------------------------------------------------------------------------
 
-func handleRegexLiteral(ctx rule.RuleContext, node *ast.Node, opts ruleOptions) {
+func handleRegexLiteral(ctx rule.RuleContext, node *ast.Node, opts ruleOptions, calleeChecker *regexpCalleeChecker) {
 	// Skip the regex literal if its immediate context is a RegExp(...)/new RegExp(...)
 	// call with an explicit flags argument — in that case, the constructor
 	// listener will handle it (using the override flags).
-	if isRegexLiteralHandledByConstructor(ctx, node) {
+	if calleeChecker != nil && isRegexLiteralHandledByConstructor(node, calleeChecker) {
 		return
 	}
 	text := node.Text()
@@ -140,9 +146,9 @@ func handleRegexLiteral(ctx rule.RuleContext, node *ast.Node, opts ruleOptions) 
 	}
 }
 
-func handleRegExpConstructor(ctx rule.RuleContext, callNode *ast.Node, callee *ast.Node, args *ast.NodeList, opts ruleOptions, eval *utils.StaticStringEvaluator) {
+func handleRegExpConstructor(ctx rule.RuleContext, callNode *ast.Node, callee *ast.Node, args *ast.NodeList, opts ruleOptions, eval *utils.StaticStringEvaluator, calleeChecker *regexpCalleeChecker) {
 	callee = ast.SkipParentheses(callee)
-	if !isBuiltinRegExpCallee(ctx, callee) {
+	if !calleeChecker.isBuiltin(callee) {
 		return
 	}
 	if args == nil || len(args.Nodes) == 0 {
@@ -247,7 +253,7 @@ func scanStringValueForMatches(ctx rule.RuleContext, reportNode *ast.Node, value
 // defers so we don't double-report. This mirrors ESLint's `checkedPatternNodes`
 // which routes inline regex-literal args through the Program handler so the
 // flag-string-level autofix (inserting `u` into the flags arg) can apply.
-func isRegexLiteralHandledByConstructor(ctx rule.RuleContext, node *ast.Node) bool {
+func isRegexLiteralHandledByConstructor(node *ast.Node, calleeChecker *regexpCalleeChecker) bool {
 	parent := node.Parent
 	// Walk through parenthesized expressions upward.
 	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
@@ -270,7 +276,7 @@ func isRegexLiteralHandledByConstructor(ctx rule.RuleContext, node *ast.Node) bo
 	default:
 		return false
 	}
-	if !isBuiltinRegExpCallee(ctx, ast.SkipParentheses(callee)) {
+	if !calleeChecker.isBuiltin(ast.SkipParentheses(callee)) {
 		return false
 	}
 	if args == nil || len(args.Nodes) < 2 {
@@ -328,32 +334,52 @@ func resolveBindingInitializer(ident *ast.Node, eval *utils.StaticStringEvaluato
 // aliases like `const {RegExp: A} = globalThis; new A()`, and imports of
 // the global. Falls back to a syntactic check (identifier / member access)
 // when no type info is available.
-func isBuiltinRegExpCallee(ctx rule.RuleContext, callee *ast.Node) bool {
+type regexpCalleeChecker struct {
+	ctx         rule.RuleContext
+	typeResults map[*checker.Type]bool
+}
+
+func (c *regexpCalleeChecker) isBuiltin(callee *ast.Node) bool {
 	if callee == nil {
 		return false
 	}
-	if ctx.TypeChecker != nil && ctx.Program != nil {
-		t := ctx.TypeChecker.GetTypeAtLocation(callee)
-		if t != nil && utils.IsBuiltinSymbolLike(ctx.Program, ctx.TypeChecker, t, "RegExpConstructor") {
+	// Keep canonical spellings entirely off the TypeChecker path. This is the
+	// overwhelmingly common constructor form and also preserves the fallback
+	// behavior used when type information is unavailable.
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		if callee.AsIdentifier().Text == "RegExp" {
 			return true
 		}
-		// IsBuiltinSymbolLike can return false for direct `RegExp` reference
-		// depending on how the checker models the global — fall through to
-		// the syntactic fast-path below so we never under-detect the
-		// canonical forms.
-	}
-	// Fallback: recognize only the bare identifier and direct global member
-	// access. This path is used when type info is unavailable (JS-only
-	// files) and still covers the most common syntactic forms.
-	if callee.Kind == ast.KindIdentifier {
-		return callee.AsIdentifier().Text == "RegExp"
-	}
-	if callee.Kind == ast.KindPropertyAccessExpression {
+	case ast.KindPropertyAccessExpression:
 		pae := callee.AsPropertyAccessExpression()
 		if pae.Name() != nil && pae.Name().Kind == ast.KindIdentifier && pae.Name().AsIdentifier().Text == "RegExp" {
 			if pae.Expression != nil && pae.Expression.Kind == ast.KindIdentifier {
 				name := pae.Expression.AsIdentifier().Text
-				return name == "globalThis" || name == "window" || name == "self" || name == "global"
+				if name == "globalThis" || name == "window" || name == "self" || name == "global" {
+					return true
+				}
+			}
+		}
+	}
+
+	ctx := c.ctx
+	if ctx.TypeChecker != nil && ctx.Program != nil {
+		t := ctx.TypeChecker.GetTypeAtLocation(callee)
+		if t != nil {
+			if result, ok := c.typeResults[t]; ok {
+				if result {
+					return true
+				}
+			} else {
+				result := utils.IsBuiltinSymbolLike(ctx.Program, ctx.TypeChecker, t, "RegExpConstructor")
+				if c.typeResults == nil {
+					c.typeResults = make(map[*checker.Type]bool)
+				}
+				c.typeResults[t] = result
+				if result {
+					return true
+				}
 			}
 		}
 	}
@@ -395,7 +421,7 @@ const (
 func scanPatternForMatches(pattern string, flags utils.RegexFlags, opts ruleOptions, srcOffset int) []foundMatch {
 	var matches []foundMatch
 	utils.IterateRegexCharacterClasses(pattern, flags, func(start, end int) {
-		els, _, ok := utils.ParseRegexCharacterClass(pattern, start, flags)
+		els, _, ok := utils.ParseRegexCharacterClassWithEnd(pattern, start, end, flags)
 		if !ok {
 			return
 		}
@@ -465,7 +491,7 @@ func scanLiteralUnitsForMatches(units []utils.StringCodeUnit, nodeText string, f
 
 	var matches []foundMatch
 	utils.IterateRegexCharacterClasses(resolved, flags, func(start, end int) {
-		els, _, ok := utils.ParseRegexCharacterClass(resolved, start, flags)
+		els, _, ok := utils.ParseRegexCharacterClassWithEnd(resolved, start, end, flags)
 		if !ok {
 			return
 		}
@@ -486,7 +512,7 @@ func scanLiteralUnitsForMatches(units []utils.StringCodeUnit, nodeText string, f
 // surrogate-pair regexChars (one element → two units) so the detectors see
 // what the JS regex engine sees.
 func runDetectorsOnElements(els []utils.RegexCharElement, flags utils.RegexFlags, opts ruleOptions, srcOffset int, pattern string) []foundMatch {
-	transformed := make([]regexChar, 0, len(els)*2)
+	transformed := make([]regexChar, 0, transformedElementCapacity(els, !flags.UV()))
 	for _, e := range els {
 		if e.Kind == utils.RegexCharBreaker {
 			transformed = append(transformed, regexChar{
@@ -524,7 +550,7 @@ func runDetectorsOnElements(els []utils.RegexCharElement, flags utils.RegexFlags
 			}
 		}
 	}
-	return runDetectorsOnSequences(splitOnBreaker(transformed), flags, opts)
+	return runDetectorsOnChars(transformed, flags, opts)
 }
 
 func makeRegexChar(value uint32, isUBrace bool, srcStart, srcEnd int, raw string) regexChar {
@@ -544,7 +570,7 @@ func splitSurrogatePair(cp uint32) (hi, lo uint32) {
 // values via the units table. We also recover the raw source text for each
 // element (so allowEscape can compare it to the cooked value).
 func runDetectorsOnLiteralElements(els []utils.RegexCharElement, units []utils.StringCodeUnit, byteToUnit []int, nodeText string, flags utils.RegexFlags, opts ruleOptions, nodeStart int) []foundMatch {
-	transformed := make([]regexChar, 0, len(els)*2)
+	transformed := make([]regexChar, 0, transformedElementCapacity(els, false))
 	for _, e := range els {
 		if e.Kind == utils.RegexCharBreaker {
 			s, en := litElementSourceSpan(e, units, byteToUnit, nodeStart)
@@ -591,14 +617,26 @@ func runDetectorsOnLiteralElements(els []utils.RegexCharElement, units []utils.S
 	if flags.UV() {
 		transformed = collapseSurrogatePairs(transformed)
 	}
-	return runDetectorsOnSequences(splitOnBreaker(transformed), flags, opts)
+	return runDetectorsOnChars(transformed, flags, opts)
+}
+
+func transformedElementCapacity(els []utils.RegexCharElement, splitAstral bool) int {
+	capacity := len(els)
+	for _, element := range els {
+		if element.Kind == utils.RegexCharRange {
+			capacity += 2 // min, boundary, max replace one input element
+		} else if splitAstral && element.Kind == utils.RegexCharSingle && element.Value > 0xFFFF {
+			capacity++ // one astral input expands to a surrogate pair
+		}
+	}
+	return capacity
 }
 
 // collapseSurrogatePairs combines two consecutive non-`\u{}` surrogate-pair
 // regexChars into one astral entry, matching what regexpp does under the
 // u/v flag.
 func collapseSurrogatePairs(chars []regexChar) []regexChar {
-	out := make([]regexChar, 0, len(chars))
+	out := chars[:0]
 	for i := 0; i < len(chars); i++ {
 		c := chars[i]
 		if i+1 < len(chars) {
@@ -637,59 +675,30 @@ func elementUnitRange(e utils.RegexCharElement, byteToUnit []int) (int, int) {
 }
 
 // rangeBoundaryMarker returns a sentinel regexChar that splits sequences but
-// otherwise is invisible to detectors (because nil pointer in the slice
-// signals "skip" which is what we want — but using a marker here is simpler
-// than mutating the slice afterwards).
+// otherwise is invisible to detectors.
 func rangeBoundaryMarker() regexChar {
 	return regexChar{value: sentinelRangeBoundary}
 }
 
-// splitOnBreaker takes a flat regexChar slice and produces sequences split
-// on breaker and range-boundary sentinels — mirroring ESLint's
-// iterateCharacterSequence: a range splits the sequence (prev sub-sequence
-// ends with `min`, next starts with `max`); CharacterSet / nested class /
-// set-op elements simply break the sequence.
-func splitOnBreaker(chars []regexChar) [][]*regexChar {
-	var out [][]*regexChar
-	var seq []*regexChar
-	flush := func() {
-		if len(seq) > 0 {
-			out = append(out, seq)
-			seq = nil
-		}
-	}
-	for i := range chars {
-		c := chars[i]
-		switch c.value {
-		case sentinelBreaker, sentinelRangeBoundary:
-			flush()
-		default:
-			cc := c
-			seq = append(seq, &cc)
-		}
-	}
-	flush()
-	return out
-}
-
-func runDetectorsOnSequences(sequences [][]*regexChar, flags utils.RegexFlags, opts ruleOptions) []foundMatch {
+// runDetectorsOnChars splits a flat character stream at breaker and
+// range-boundary sentinels without materializing per-sequence slices or one
+// heap pointer per character.
+func runDetectorsOnChars(chars []regexChar, flags utils.RegexFlags, opts ruleOptions) []foundMatch {
 	var matches []foundMatch
-	for _, seq := range sequences {
-		if len(seq) == 0 {
-			continue
-		}
-		active := seq
-		if opts.allowEscape {
-			active = make([]*regexChar, len(seq))
-			for k, c := range seq {
-				if c != nil && isAcceptableEscape(c) {
-					active[k] = nil
-				} else {
-					active[k] = c
-				}
+	sequenceStart := 0
+	for i := 0; i <= len(chars); i++ {
+		atEnd := i == len(chars)
+		if !atEnd {
+			switch chars[i].value {
+			case sentinelBreaker, sentinelRangeBoundary:
+			default:
+				continue
 			}
 		}
-		matches = appendDetectorMatches(matches, active, seq, flags)
+		if sequenceStart < i {
+			matches = appendDetectorMatches(matches, chars[sequenceStart:i], flags, opts.allowEscape)
+		}
+		sequenceStart = i + 1
 	}
 	return matches
 }
@@ -698,14 +707,14 @@ func runDetectorsOnSequences(sequences [][]*regexChar, flags utils.RegexFlags, o
 // Detectors
 // ---------------------------------------------------------------------------
 
-func appendDetectorMatches(matches []foundMatch, chars, unfiltered []*regexChar, flags utils.RegexFlags) []foundMatch {
+func appendDetectorMatches(matches []foundMatch, chars []regexChar, flags utils.RegexFlags, allowEscape bool) []foundMatch {
 	uvMode := flags.UV()
 
 	// 1. surrogatePairWithoutUFlag (non-uv only)
 	if !uvMode {
 		for i := 1; i < len(chars); i++ {
-			prev, cur := chars[i-1], chars[i]
-			if prev == nil || cur == nil {
+			prev, cur := &chars[i-1], &chars[i]
+			if !detectorCharActive(prev, allowEscape) || !detectorCharActive(cur, allowEscape) {
 				continue
 			}
 			if isSurrogatePair(prev.value, cur.value) && !prev.isUBrace && !cur.isUBrace {
@@ -716,8 +725,8 @@ func appendDetectorMatches(matches []foundMatch, chars, unfiltered []*regexChar,
 	// 2. surrogatePair (uv only, with at least one \u{...})
 	if uvMode {
 		for i := 1; i < len(chars); i++ {
-			prev, cur := chars[i-1], chars[i]
-			if prev == nil || cur == nil {
+			prev, cur := &chars[i-1], &chars[i]
+			if !detectorCharActive(prev, allowEscape) || !detectorCharActive(cur, allowEscape) {
 				continue
 			}
 			if isSurrogatePair(prev.value, cur.value) && (prev.isUBrace || cur.isUBrace) {
@@ -728,12 +737,8 @@ func appendDetectorMatches(matches []foundMatch, chars, unfiltered []*regexChar,
 	// 3. combiningClass — combining char preceded by a non-combining char.
 	//    Use unfiltered for the previous-char check (allowEscape semantics).
 	for i := 1; i < len(chars); i++ {
-		cur := chars[i]
-		var prev *regexChar
-		if i-1 < len(unfiltered) {
-			prev = unfiltered[i-1]
-		}
-		if prev == nil || cur == nil {
+		prev, cur := &chars[i-1], &chars[i]
+		if !detectorCharActive(cur, allowEscape) {
 			continue
 		}
 		if isCombiningCharacter(cur.value) && !isCombiningCharacter(prev.value) {
@@ -742,8 +747,8 @@ func appendDetectorMatches(matches []foundMatch, chars, unfiltered []*regexChar,
 	}
 	// 4. emojiModifier
 	for i := 1; i < len(chars); i++ {
-		prev, cur := chars[i-1], chars[i]
-		if prev == nil || cur == nil {
+		prev, cur := &chars[i-1], &chars[i]
+		if !detectorCharActive(prev, allowEscape) || !detectorCharActive(cur, allowEscape) {
 			continue
 		}
 		if isEmojiModifier(cur.value) && !isEmojiModifier(prev.value) {
@@ -752,8 +757,8 @@ func appendDetectorMatches(matches []foundMatch, chars, unfiltered []*regexChar,
 	}
 	// 5. regionalIndicatorSymbol — both adjacent chars are RIS.
 	for i := 1; i < len(chars); i++ {
-		prev, cur := chars[i-1], chars[i]
-		if prev == nil || cur == nil {
+		prev, cur := &chars[i-1], &chars[i]
+		if !detectorCharActive(prev, allowEscape) || !detectorCharActive(cur, allowEscape) {
 			continue
 		}
 		if isRegionalIndicatorSymbol(cur.value) && isRegionalIndicatorSymbol(prev.value) {
@@ -763,8 +768,10 @@ func appendDetectorMatches(matches []foundMatch, chars, unfiltered []*regexChar,
 	// 6. zwj — character sequence joined by U+200D, possibly chained.
 	seqStart, seqEnd := -1, -1
 	for i := 1; i < len(chars)-1; i++ {
-		prev, cur, next := chars[i-1], chars[i], chars[i+1]
-		if prev == nil || cur == nil || next == nil {
+		prev, cur, next := &chars[i-1], &chars[i], &chars[i+1]
+		if !detectorCharActive(prev, allowEscape) ||
+			!detectorCharActive(cur, allowEscape) ||
+			!detectorCharActive(next, allowEscape) {
 			continue
 		}
 		if cur.value == 0x200D && prev.value != 0x200D && next.value != 0x200D {
@@ -783,6 +790,10 @@ func appendDetectorMatches(matches []foundMatch, chars, unfiltered []*regexChar,
 		matches = append(matches, foundMatch{kind: "zwj", srcStart: seqStart, srcEnd: seqEnd})
 	}
 	return matches
+}
+
+func detectorCharActive(char *regexChar, allowEscape bool) bool {
+	return !allowEscape || !isAcceptableEscape(char)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rules/no_misleading_character_class/no_misleading_character_class_test.go
+++ b/internal/rules/no_misleading_character_class/no_misleading_character_class_test.go
@@ -2,6 +2,7 @@
 package no_misleading_character_class
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -10,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoMisleadingCharacterClassRule(t *testing.T) {
@@ -58,6 +60,10 @@ func TestNoMisleadingCharacterClassRule(t *testing.T) {
 			{Code: `var r = new RegExp('[🇯🇵]', ` + "`${foo}`" + `)`},
 			{Code: `var r = new RegExp("[👍]", flags)`},
 			{Code: `const args = ['[👍]', 'i']; new RegExp(...args);`},
+			// Keep the constructor gate open while repeatedly exercising a
+			// non-RegExp callee type; cached negative results must stay local
+			// to that type and must not produce diagnostics.
+			{Code: `function fake(pattern: string, flags: string) {} const marker = globalThis; fake("[👍]", ""); fake("[🇯🇵]", "u");`},
 
 			// ---- ES2024 v flag ----
 			{Code: `var r = /[👍]/v`},
@@ -876,6 +882,21 @@ func TestNoMisleadingCharacterClassRule(t *testing.T) {
 					{MessageId: "regionalIndicatorSymbol"},
 				},
 			},
+			{
+				// Interleave cached false and true callee types, then reuse
+				// both. This attacks accidental cache poisoning between an
+				// ordinary function and a destructured built-in alias.
+				Code: `function fake(pattern: string, flags: string) {} const {RegExp: A} = globalThis; fake("[👍]", ""); A("[👍]", ""); fake("[🇯🇵]", "u"); A("[🇯🇵]", "u");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "surrogatePairWithoutUFlag",
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "suggestUnicodeFlag", Output: `function fake(pattern: string, flags: string) {} const {RegExp: A} = globalThis; fake("[👍]", ""); A("[👍]", "u"); fake("[🇯🇵]", "u"); A("[🇯🇵]", "u");`},
+						},
+					},
+					{MessageId: "regionalIndicatorSymbol"},
+				},
+			},
 
 			// ==== Heuristic: pattern validity under u flag ====
 			// `\a` identity-letter → suggestion suppressed
@@ -1292,4 +1313,329 @@ func TestNoMisleadingCharacterClassDefersSuggestions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSourceMayUseRegExp(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		code string
+		want bool
+	}{
+		{name: "ordinary calls", code: `fn(); other();`},
+		// Global-object identifiers deliberately keep the gate open. Their
+		// computed property can be assembled from arbitrary static pieces,
+		// so rejecting the file here could hide a real RegExp reference.
+		{name: "conservative global reference", code: `const value = global; fn();`, want: true},
+		{name: "direct constructor", code: `RegExp("x")`, want: true},
+		{name: "escaped constructor identifier", code: `R\u0065gExp("x")`, want: true},
+		{name: "computed global member", code: `globalThis["RegExp"]("x")`, want: true},
+		{name: "folded computed global member", code: `globalThis["Reg" + "Exp"]("x")`, want: true},
+		{name: "escaped computed global member", code: `globalThis["\u0052egExp"]("x")`, want: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/source-gate.ts",
+				Path:     "/source-gate.ts",
+			}, testCase.code, core.ScriptKindTS)
+			if got := sourceMayUseRegExp(sourceFile); got != testCase.want {
+				t.Fatalf("sourceMayUseRegExp(%q) = %v, want %v", testCase.code, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestRunDetectorsOnCharsParity exhaustively compares the allocation-free
+// detector path with the frozen pre-optimization implementation below. The
+// alphabet covers every detector category, both sequence sentinels, escaped
+// and unescaped forms, and the u-brace discriminator.
+func TestRunDetectorsOnCharsParity(t *testing.T) {
+	const maxLength = 4
+	for length := 0; length <= maxLength; length++ {
+		combinations := 1
+		for range length {
+			combinations *= detectorParityAlphabetSize
+		}
+		for encoded := range combinations {
+			chars := detectorParityChars(encoded, length)
+			for _, flags := range []utils.RegexFlags{
+				{},
+				{Unicode: true},
+				{UnicodeSets: true},
+			} {
+				for _, allowEscape := range []bool{false, true} {
+					assertDetectorParity(t, chars, flags, allowEscape)
+				}
+			}
+		}
+	}
+
+	// Length four covers an individual ZWJ triplet; these explicit inputs
+	// cover chained and interrupted sequences beyond the exhaustive bound.
+	for _, chars := range [][]regexChar{
+		detectorParityCharsFromIndexes(5, 9, 5, 9, 5),
+		detectorParityCharsFromIndexes(5, 9, 5, 10, 5, 9, 5),
+		detectorParityCharsFromIndexes(5, 9, 11, 9, 5),
+		detectorParityCharsFromIndexes(5, 9, 5, 12, 5, 9, 5),
+	} {
+		for _, flags := range []utils.RegexFlags{{}, {Unicode: true}} {
+			for _, allowEscape := range []bool{false, true} {
+				assertDetectorParity(t, chars, flags, allowEscape)
+			}
+		}
+	}
+}
+
+func TestCollapseSurrogatePairsInPlace(t *testing.T) {
+	input := []regexChar{
+		{value: 0xD83D, srcStart: 0, srcEnd: 6, raw: `\uD83D`},
+		{value: 0xDC4D, srcStart: 6, srcEnd: 12, raw: `\uDC4D`},
+		{value: 'A', srcStart: 12, srcEnd: 13, raw: "A"},
+		{value: 0xD83C, srcStart: 13, srcEnd: 19, raw: `\uD83C`},
+		{value: 0xDDEF, srcStart: 19, srcEnd: 25, raw: `\uDDEF`},
+		{value: 0xD83D, srcStart: 25, srcEnd: 34, raw: `\u{D83D}`, isUBrace: true},
+		{value: 0xDC4D, srcStart: 34, srcEnd: 40, raw: `\uDC4D`},
+	}
+	first := &input[0]
+	got := collapseSurrogatePairs(input)
+	want := []regexChar{
+		{value: 0x1F44D, srcStart: 0, srcEnd: 12, raw: `\uD83D\uDC4D`},
+		{value: 'A', srcStart: 12, srcEnd: 13, raw: "A"},
+		{value: 0x1F1EF, srcStart: 13, srcEnd: 25, raw: `\uD83C\uDDEF`},
+		{value: 0xD83D, srcStart: 25, srcEnd: 34, raw: `\u{D83D}`, isUBrace: true},
+		{value: 0xDC4D, srcStart: 34, srcEnd: 40, raw: `\uDC4D`},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("collapsed chars = %+v, want %+v", got, want)
+	}
+	if len(got) > 0 && &got[0] != first {
+		t.Fatal("collapseSurrogatePairs allocated a new backing slice")
+	}
+}
+
+func FuzzRunDetectorsOnCharsParity(f *testing.F) {
+	for _, seed := range [][]byte{
+		nil,
+		{0, 1, 2, 3},
+		{5, 9, 5, 9, 5},
+		{6, 7},
+		{11, 6, 7, 12},
+		{5, 3, 4},
+	} {
+		for mode := range uint8(3) {
+			f.Add(seed, mode, false)
+			f.Add(seed, mode, true)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, input []byte, mode uint8, allowEscape bool) {
+		if len(input) > 256 {
+			t.Skip()
+		}
+		chars := make([]regexChar, len(input))
+		for i, value := range input {
+			chars[i] = detectorParityChar(int(value)%detectorParityAlphabetSize, i)
+		}
+		var flags utils.RegexFlags
+		switch mode % 3 {
+		case 1:
+			flags.Unicode = true
+		case 2:
+			flags.UnicodeSets = true
+		}
+		assertDetectorParity(t, chars, flags, allowEscape)
+	})
+}
+
+func assertDetectorParity(t *testing.T, chars []regexChar, flags utils.RegexFlags, allowEscape bool) {
+	t.Helper()
+	got := runDetectorsOnChars(chars, flags, ruleOptions{allowEscape: allowEscape})
+	want := runDetectorsBeforeOptimization(chars, flags, ruleOptions{allowEscape: allowEscape})
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf(
+			"detector mismatch for chars %+v, flags %+v, allowEscape %v:\ngot  %+v\nwant %+v",
+			chars, flags, allowEscape, got, want,
+		)
+	}
+}
+
+const detectorParityAlphabetSize = 13
+
+func detectorParityChars(encoded, length int) []regexChar {
+	chars := make([]regexChar, length)
+	for i := range chars {
+		chars[i] = detectorParityChar(encoded%detectorParityAlphabetSize, i)
+		encoded /= detectorParityAlphabetSize
+	}
+	return chars
+}
+
+func detectorParityCharsFromIndexes(indexes ...int) []regexChar {
+	chars := make([]regexChar, len(indexes))
+	for i, index := range indexes {
+		chars[i] = detectorParityChar(index, i)
+	}
+	return chars
+}
+
+func detectorParityChar(index, position int) regexChar {
+	char := [...]regexChar{
+		{value: 'A', raw: "A"},
+		{value: 0x0301, raw: "\u0301"},
+		{value: 0x0301, raw: `\u0301`},
+		{value: 0x1F466, raw: "👦"},
+		{value: 0x1F3FB, raw: `\u{1F3FB}`, isUBrace: true},
+		{value: 0x1F1EF, raw: "🇯"},
+		{value: 0xD83D, raw: `\uD83D`},
+		{value: 0xDC4D, raw: `\uDC4D`},
+		{value: 0xD83D, raw: `\u{D83D}`, isUBrace: true},
+		{value: 0x200D, raw: "\u200D"},
+		{value: sentinelBreaker},
+		{value: sentinelRangeBoundary},
+		{value: 0x1F1F5, raw: "🇵"},
+	}[index]
+	char.srcStart = position * 3
+	char.srcEnd = char.srcStart + 2
+	return char
+}
+
+// runDetectorsBeforeOptimization is a frozen copy of the pre-optimization
+// sequence materialization and detector dispatch. It is intentionally kept in
+// test code as an independent behavioral oracle for the flat-slice rewrite.
+func runDetectorsBeforeOptimization(chars []regexChar, flags utils.RegexFlags, opts ruleOptions) []foundMatch {
+	var matches []foundMatch
+	for _, sequence := range splitOnBreakerBeforeOptimization(chars) {
+		active := sequence
+		if opts.allowEscape {
+			active = make([]*regexChar, len(sequence))
+			for i, char := range sequence {
+				if char == nil || isAcceptableEscape(char) {
+					continue
+				}
+				active[i] = char
+			}
+		}
+		matches = appendDetectorMatchesBeforeOptimization(matches, active, sequence, flags)
+	}
+	return matches
+}
+
+func splitOnBreakerBeforeOptimization(chars []regexChar) [][]*regexChar {
+	var sequences [][]*regexChar
+	var sequence []*regexChar
+	flush := func() {
+		if len(sequence) == 0 {
+			return
+		}
+		sequences = append(sequences, sequence)
+		sequence = nil
+	}
+	for _, char := range chars {
+		switch char.value {
+		case sentinelBreaker, sentinelRangeBoundary:
+			flush()
+		default:
+			charCopy := char
+			sequence = append(sequence, &charCopy)
+		}
+	}
+	flush()
+	return sequences
+}
+
+func appendDetectorMatchesBeforeOptimization(matches []foundMatch, chars, unfiltered []*regexChar, flags utils.RegexFlags) []foundMatch {
+	if !flags.UV() {
+		for i := 1; i < len(chars); i++ {
+			previous, current := chars[i-1], chars[i]
+			if previous != nil && current != nil &&
+				isSurrogatePair(previous.value, current.value) &&
+				!previous.isUBrace && !current.isUBrace {
+				matches = append(matches, foundMatch{
+					kind:     "surrogatePairWithoutUFlag",
+					srcStart: previous.srcStart,
+					srcEnd:   current.srcEnd,
+				})
+			}
+		}
+	} else {
+		for i := 1; i < len(chars); i++ {
+			previous, current := chars[i-1], chars[i]
+			if previous != nil && current != nil &&
+				isSurrogatePair(previous.value, current.value) &&
+				(previous.isUBrace || current.isUBrace) {
+				matches = append(matches, foundMatch{
+					kind:     "surrogatePair",
+					srcStart: previous.srcStart,
+					srcEnd:   current.srcEnd,
+				})
+			}
+		}
+	}
+
+	for i := 1; i < len(chars); i++ {
+		previous, current := unfiltered[i-1], chars[i]
+		if previous != nil && current != nil &&
+			isCombiningCharacter(current.value) &&
+			!isCombiningCharacter(previous.value) {
+			matches = append(matches, foundMatch{
+				kind:     "combiningClass",
+				srcStart: previous.srcStart,
+				srcEnd:   current.srcEnd,
+			})
+		}
+	}
+	for i := 1; i < len(chars); i++ {
+		previous, current := chars[i-1], chars[i]
+		if previous != nil && current != nil &&
+			isEmojiModifier(current.value) &&
+			!isEmojiModifier(previous.value) {
+			matches = append(matches, foundMatch{
+				kind:     "emojiModifier",
+				srcStart: previous.srcStart,
+				srcEnd:   current.srcEnd,
+			})
+		}
+	}
+	for i := 1; i < len(chars); i++ {
+		previous, current := chars[i-1], chars[i]
+		if previous != nil && current != nil &&
+			isRegionalIndicatorSymbol(current.value) &&
+			isRegionalIndicatorSymbol(previous.value) {
+			matches = append(matches, foundMatch{
+				kind:     "regionalIndicatorSymbol",
+				srcStart: previous.srcStart,
+				srcEnd:   current.srcEnd,
+			})
+		}
+	}
+
+	sequenceStart, sequenceEnd := -1, -1
+	for i := 1; i < len(chars)-1; i++ {
+		previous, current, next := chars[i-1], chars[i], chars[i+1]
+		if previous == nil || current == nil || next == nil {
+			continue
+		}
+		if current.value == 0x200D && previous.value != 0x200D && next.value != 0x200D {
+			if sequenceStart >= 0 && sequenceEnd == previous.srcEnd {
+				sequenceEnd = next.srcEnd
+			} else {
+				if sequenceStart >= 0 {
+					matches = append(matches, foundMatch{
+						kind:     "zwj",
+						srcStart: sequenceStart,
+						srcEnd:   sequenceEnd,
+					})
+				}
+				sequenceStart = previous.srcStart
+				sequenceEnd = next.srcEnd
+			}
+		}
+	}
+	if sequenceStart >= 0 {
+		matches = append(matches, foundMatch{
+			kind:     "zwj",
+			srcStart: sequenceStart,
+			srcEnd:   sequenceEnd,
+		})
+	}
+	return matches
 }

--- a/internal/utils/regex_charclass.go
+++ b/internal/utils/regex_charclass.go
@@ -289,6 +289,42 @@ func SkipPatternEscape(pattern string, i int, flags RegexFlags) (int, bool) {
 // nested classes should iterate them via IterateRegexCharacterClasses and
 // call ParseRegexCharacterClass on each separately.
 func ParseRegexCharacterClass(pattern string, start int, flags RegexFlags) ([]RegexCharElement, int, bool) {
+	return parseRegexCharacterClass(pattern, start, flags, 0)
+}
+
+// ParseRegexCharacterClassWithEnd is ParseRegexCharacterClass with a
+// previously discovered class end. Non-v callers use the known byte span as
+// an element-capacity hint to avoid repeated slice growth for large classes.
+// Unicode-set classes deliberately skip that preallocation:
+// each nested callback receives the outer span, whose byte length can be much
+// larger than its own flat element count. The cap also bounds over-allocation
+// for escape-heavy and multibyte input, where bytes can outnumber elements.
+func ParseRegexCharacterClassWithEnd(pattern string, start, end int, flags RegexFlags) ([]RegexCharElement, int, bool) {
+	if start < 0 || end <= start || end > len(pattern) || pattern[end-1] != ']' {
+		return nil, start, false
+	}
+	elementCapacity := 0
+	if !flags.UnicodeSets {
+		elementCapacity = end - start - 2
+		if elementCapacity < 0 {
+			elementCapacity = 0
+		} else if elementCapacity > maxRegexCharacterClassPreallocation {
+			elementCapacity = maxRegexCharacterClassPreallocation
+		}
+	}
+	elements, parsedEnd, ok := parseRegexCharacterClass(pattern, start, flags, elementCapacity)
+	if !ok || parsedEnd != end {
+		return nil, start, false
+	}
+	if len(elements) == 0 {
+		elements = nil
+	}
+	return elements, parsedEnd, true
+}
+
+const maxRegexCharacterClassPreallocation = 16 << 10
+
+func parseRegexCharacterClass(pattern string, start int, flags RegexFlags, elementCapacity int) ([]RegexCharElement, int, bool) {
 	if start >= len(pattern) || pattern[start] != '[' {
 		return nil, start, false
 	}
@@ -298,6 +334,9 @@ func ParseRegexCharacterClass(pattern string, start int, flags RegexFlags) ([]Re
 	}
 
 	var out []RegexCharElement
+	if elementCapacity > 0 {
+		out = make([]RegexCharElement, 0, elementCapacity)
+	}
 	pendingIdx := -1 // index into `out` of the last RegexCharSingle (candidate for range start)
 
 	for i < len(pattern) {

--- a/internal/utils/regex_charclass_test.go
+++ b/internal/utils/regex_charclass_test.go
@@ -139,10 +139,10 @@ func TestParseRegexCharacterClass_MultipleRangesAndSets(t *testing.T) {
 	// `[\dA-Z\sa-z]` — alternating sets and ranges.
 	els := parseClass(t, `[\dA-Z\sa-z]`, RegexFlags{})
 	wantKinds := []RegexCharElementKind{
-		RegexCharBreaker,            // \d
-		RegexCharRange,              // A-Z
-		RegexCharBreaker,            // \s
-		RegexCharRange,              // a-z
+		RegexCharBreaker, // \d
+		RegexCharRange,   // A-Z
+		RegexCharBreaker, // \s
+		RegexCharRange,   // a-z
 	}
 	if len(els) != len(wantKinds) {
 		t.Fatalf("len=%d, want %d (got %+v)", len(els), len(wantKinds), els)
@@ -479,6 +479,102 @@ func TestParseRegexCharacterClass_Position(t *testing.T) {
 	if els[1].Start != 5 || els[1].End != 6 {
 		t.Errorf("[1] span = %d..%d, want 5..6", els[1].Start, els[1].End)
 	}
+}
+
+func TestParseRegexCharacterClassWithEnd(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		pattern string
+		flags   RegexFlags
+	}{
+		{name: "prefixed class", pattern: "before[ab\\u0043]after"},
+		{name: "empty", pattern: "[]"},
+		{name: "negated empty", pattern: "[^]", flags: RegexFlags{Unicode: true}},
+		{name: "negated", pattern: "[^a-z\\d]"},
+		{name: "escaped bracket", pattern: `[a\]b]`},
+		{name: "raw astral", pattern: "[A👍B]"},
+		{name: "unicode code point", pattern: `[\u{1F44D}A]`, flags: RegexFlags{Unicode: true}},
+		{name: "unicode property", pattern: `[\p{Letter}A]`, flags: RegexFlags{Unicode: true}},
+		{name: "unicode sets nested", pattern: `[[a-z]--[\q{x|y}]]`, flags: RegexFlags{UnicodeSets: true}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			assertKnownEndParserParity(t, testCase.pattern, testCase.flags)
+		})
+	}
+
+	pattern := "[a]x]"
+	if _, _, ok := ParseRegexCharacterClassWithEnd(pattern, -1, 3, RegexFlags{}); ok {
+		t.Fatal("negative start unexpectedly succeeded")
+	}
+	if _, _, ok := ParseRegexCharacterClassWithEnd(pattern, 0, len(pattern)+1, RegexFlags{}); ok {
+		t.Fatal("out-of-range end unexpectedly succeeded")
+	}
+	if _, _, ok := ParseRegexCharacterClassWithEnd(pattern, 0, 2, RegexFlags{}); ok {
+		t.Fatal("end before closing bracket unexpectedly succeeded")
+	}
+	if _, _, ok := ParseRegexCharacterClassWithEnd(pattern, 0, len(pattern), RegexFlags{}); ok {
+		t.Fatal("a later unrelated closing bracket unexpectedly matched")
+	}
+}
+
+func FuzzParseRegexCharacterClassWithEndParity(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"[]",
+		"[^]",
+		"before[abc]after",
+		`[\]\-\u0041]`,
+		`[\uD83D\uDC4D]`,
+		`[[a-z]--[\q{x|y}]]`,
+		`[0-[]]`,
+		`[unterminated`,
+		string([]byte{'[', 0xff, ']'}),
+	} {
+		for mode := range uint8(3) {
+			f.Add(seed, mode)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, pattern string, mode uint8) {
+		if len(pattern) > 4<<10 {
+			t.Skip()
+		}
+		var flags RegexFlags
+		switch mode % 3 {
+		case 1:
+			flags.Unicode = true
+		case 2:
+			flags.UnicodeSets = true
+		}
+		assertKnownEndParserParity(t, pattern, flags)
+	})
+}
+
+func assertKnownEndParserParity(t *testing.T, pattern string, flags RegexFlags) {
+	t.Helper()
+	IterateRegexCharacterClasses(pattern, flags, func(start, end int) {
+		got, gotEnd, gotOK := ParseRegexCharacterClassWithEnd(pattern, start, end, flags)
+		want, wantEnd, wantOK := ParseRegexCharacterClass(pattern, start, flags)
+		// The old entry point can accept a prefix ending at an inner `]`
+		// even though the boundary scanner correctly found a later matching
+		// bracket (for example `[0-[]]` in v mode). The known-end entry point
+		// intentionally rejects that inconsistent parse.
+		if wantOK && wantEnd != end {
+			if gotOK {
+				t.Fatalf(
+					"known-end parse accepted mismatched end for pattern %q, flags %+v, range [%d,%d): got (%+v, %d)",
+					pattern, flags, start, end, got, gotEnd,
+				)
+			}
+			return
+		}
+		if gotOK != wantOK || gotEnd != wantEnd || !reflect.DeepEqual(got, want) {
+			t.Fatalf(
+				"known-end parse mismatch for pattern %q, flags %+v, range [%d,%d): got (%+v, %d, %v), want (%+v, %d, %v)",
+				pattern, flags, start, end, got, gotEnd, gotOK, want, wantEnd, wantOK,
+			)
+		}
+	})
 }
 
 func TestParseRegexCharacterClass_RangeWithDashChain(t *testing.T) {


### PR DESCRIPTION
## Summary

- Cache per-file RegExp callee classification, keep canonical constructors off the TypeChecker hot path, and retain the conservative global-object gate.
- Reuse character-class boundaries for bounded parser preallocation, process detector sequences as flat slices, and collapse surrogate pairs in place.
- Preserve rule behavior with a frozen pre-optimization oracle, exhaustive detector coverage, parser/detector fuzzing, and mixed true/false callee-cache regression cases.

### Performance data

Apple M1 Max, Go 1.26.1, `-benchmem`, 5 runs per case:

| Case | Before | After |
| --- | ---: | ---: |
| 10k calls, `RegExp` marker | 1.78–2.62 ms; ~404 KB, 20,011 allocs | 1.04–1.35 ms; ~1.6 KB, 16 allocs |
| 10k calls, `global` marker | 1.63–1.84 ms; ~404 KB, 20,011 allocs | 1.05–1.09 ms; ~1.6 KB, 16 allocs |
| 2k small character classes | 0.89–0.93 ms; 1.60 MB, 22,000 allocs | 0.38–0.58 ms; 544 KB, 4,000 allocs |
| One 10k-character class | 1.08–1.16 ms; 3.59 MB, 10,039 allocs | 0.49–0.57 ms; 885 KB, 2 allocs |
| 250-level nested `v` class | 0.14–0.20 ms; 36 KB, 503 allocs | 0.14–0.23 ms; 24 KB, 500 allocs |

Repository run with the JS config (`rslint.config.ts`, `--singleThreaded --timing all`): the rule handled 164 files in 0.2 ms; total wall time was 3.79 s.

### Correctness and verification

- 11,690 generated valid character-class combinations across plain/`u`/`v`, with `allowEscape` both off and on: diagnostic counts and message IDs matched ESLint 10.7.0 exactly.
- Exhaustive length-0–4 detector parity against the frozen old implementation; targeted race checks passed.
- Parser and detector fuzz targets passed (191,937 and 86,836 executions in the final 10-second runs).
- `go test ./internal/rules/no_misleading_character_class -count=1`
- Targeted `internal/utils` regex character-class tests
- Rule JS suite: 2/2 passed
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint` on the two changed Go packages only: 0 issues

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; no user-facing behavior change).