### PR TITLE
perf: port no-class-assign to RefStore

### DIFF
--- a/internal/rules/no_class_assign/no_class_assign.go
+++ b/internal/rules/no_class_assign/no_class_assign.go
@@ -14,317 +14,19 @@ func buildClassReassignmentMessage(className string) rule.RuleMessage {
 	}
 }
 
-// getIdentifierName extracts the name from an identifier node
-func getIdentifierName(node *ast.Node) string {
-	if node == nil || node.Kind != ast.KindIdentifier {
-		return ""
-	}
-	return node.Text()
-}
-
-// isWriteReference checks if a node is a write reference (assignment target)
-func isWriteReference(node *ast.Node) bool {
-	if node == nil || node.Parent == nil {
-		return false
-	}
-
-	parent := node.Parent
-
-	switch parent.Kind {
-	case ast.KindBinaryExpression:
-		binary := parent.AsBinaryExpression()
-		if binary == nil || binary.OperatorToken == nil {
-			return false
-		}
-
-		// Check if it's an assignment operator and node is on the left side
-		switch binary.OperatorToken.Kind {
-		case ast.KindEqualsToken,
-			ast.KindPlusEqualsToken,
-			ast.KindMinusEqualsToken,
-			ast.KindAsteriskAsteriskEqualsToken,
-			ast.KindAsteriskEqualsToken,
-			ast.KindSlashEqualsToken,
-			ast.KindPercentEqualsToken,
-			ast.KindLessThanLessThanEqualsToken,
-			ast.KindGreaterThanGreaterThanEqualsToken,
-			ast.KindGreaterThanGreaterThanGreaterThanEqualsToken,
-			ast.KindAmpersandEqualsToken,
-			ast.KindBarEqualsToken,
-			ast.KindCaretEqualsToken,
-			ast.KindBarBarEqualsToken,
-			ast.KindAmpersandAmpersandEqualsToken,
-			ast.KindQuestionQuestionEqualsToken:
-			return binary.Left == node
-		}
-
-	case ast.KindPostfixUnaryExpression:
-		postfix := parent.AsPostfixUnaryExpression()
-		if postfix == nil {
-			return false
-		}
-		// ++ and -- are write operations
-		switch postfix.Operator {
-		case ast.KindPlusPlusToken, ast.KindMinusMinusToken:
-			return postfix.Operand == node
-		}
-
-	case ast.KindPrefixUnaryExpression:
-		prefix := parent.AsPrefixUnaryExpression()
-		if prefix == nil {
-			return false
-		}
-		// ++ and -- are write operations
-		switch prefix.Operator {
-		case ast.KindPlusPlusToken, ast.KindMinusMinusToken:
-			return prefix.Operand == node
-		}
-
-	case ast.KindObjectBindingPattern:
-		// In destructuring like {A} = obj, A is a write reference
-		// ObjectBindingPattern is used in destructuring assignments
-		// Check if this pattern is on the left side of an assignment
-		return isBindingPatternInAssignment(parent)
-
-	case ast.KindArrayBindingPattern:
-		// In array destructuring like [A] = arr, A is a write reference
-		return isBindingPatternInAssignment(parent)
-
-	case ast.KindBindingElement:
-		// Check if the binding element is part of a write context
-		return isWriteReference(parent)
-
-	case ast.KindShorthandPropertyAssignment:
-		// In destructuring like {A} = obj or ({A} = obj), A is a write reference
-		shorthand := parent.AsShorthandPropertyAssignment()
-		if shorthand != nil && shorthand.Name() == node {
-			return isInDestructuringAssignment(parent)
-		}
-
-	case ast.KindPropertyAssignment:
-		// In destructuring like {b: A} = obj, A is a write reference
-		propAssignment := parent.AsPropertyAssignment()
-		if propAssignment != nil && propAssignment.Initializer == node {
-			return isInDestructuringAssignment(parent)
-		}
-
-	case ast.KindArrayLiteralExpression:
-		// In array destructuring like [A] = arr, A is a write reference
-		return isInDestructuringAssignment(parent)
-
-	case ast.KindObjectLiteralExpression:
-		// In object destructuring like {A} = obj, A is a write reference
-		return isInDestructuringAssignment(parent)
-
-	case ast.KindParenthesizedExpression:
-		// Unwrap parentheses and check the parent context
-		return isWriteReference(parent)
-
-	case ast.KindAsExpression, ast.KindTypeAssertionExpression:
-		// Type assertions like (A as any) = 0
-		// The type assertion wraps the identifier, check if the assertion is a write target
-		return isWriteReference(parent)
-	}
-
-	return false
-}
-
-// isBindingPatternInAssignment checks if a binding pattern is the left side of an assignment
-func isBindingPatternInAssignment(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-
-	// The binding pattern's parent might be wrapped in parentheses
-	parent := node.Parent
-
-	// Unwrap parentheses
-	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-		parent = parent.Parent
-	}
-
-	// Check if the parent is a binary expression with = operator
-	if parent != nil && parent.Kind == ast.KindBinaryExpression {
-		binary := parent.AsBinaryExpression()
-		if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
-			// Check if the binding pattern is on the left side
-			leftNode := binary.Left
-			// Unwrap parentheses on the left side
-			for leftNode != nil && leftNode.Kind == ast.KindParenthesizedExpression {
-				parenExpr := leftNode.AsParenthesizedExpression()
-				if parenExpr != nil {
-					leftNode = parenExpr.Expression
-				} else {
-					break
-				}
-			}
-			return leftNode == node
-		}
-	}
-
-	return false
-}
-
-// isInDestructuringAssignment checks if a node is part of a destructuring assignment pattern
-func isInDestructuringAssignment(node *ast.Node) bool {
-	current := node
-	for current != nil {
-		if current.Kind == ast.KindObjectLiteralExpression || current.Kind == ast.KindArrayLiteralExpression {
-			// Check if this literal is the left side of an assignment
-			// May be wrapped in parentheses
-			parent := current.Parent
-
-			// Unwrap parentheses
-			for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-				parent = parent.Parent
-			}
-
-			if parent != nil && parent.Kind == ast.KindBinaryExpression {
-				binary := parent.AsBinaryExpression()
-				if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
-					// Check if the literal (or its parent parenthesized expression) is on the left
-					leftNode := binary.Left
-					// Unwrap parentheses on left side
-					for leftNode != nil && leftNode.Kind == ast.KindParenthesizedExpression {
-						parenExpr := leftNode.AsParenthesizedExpression()
-						if parenExpr != nil {
-							leftNode = parenExpr.Expression
-						} else {
-							break
-						}
-					}
-					if leftNode == current {
-						return true
-					}
-				}
-			}
-			return false
-		}
-		current = current.Parent
-	}
-	return false
-}
-
-// getClassSymbol gets the symbol for a class node
-func getClassSymbol(classNode *ast.Node, ctx *rule.RuleContext) *ast.Symbol {
-	if ctx.TypeChecker == nil {
-		return nil
-	}
-
-	switch classNode.Kind {
-	case ast.KindClassDeclaration:
-		classDecl := classNode.AsClassDeclaration()
-		if classDecl != nil && classDecl.Name() != nil {
-			return ctx.TypeChecker.GetSymbolAtLocation(classDecl.Name())
-		}
-	case ast.KindClassExpression:
-		classExpr := classNode.AsClassExpression()
-		if classExpr != nil && classExpr.Name() != nil {
-			return ctx.TypeChecker.GetSymbolAtLocation(classExpr.Name())
-		}
-	}
-
-	return nil
-}
-
-// isNameShadowed checks if an identifier references a different variable due to shadowing
-func isNameShadowed(node *ast.Node, className string, classNode *ast.Node, ctx *rule.RuleContext) bool {
-	if node == nil || ctx.TypeChecker == nil {
-		return false
-	}
-
-	// Get the symbol at the identifier location
-	symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
-	if symbol == nil {
-		return false
-	}
-
-	// Get the symbol of the class declaration
-	var classSymbol = getClassSymbol(classNode, ctx)
-
-	// If symbols are different, the name is shadowed
-	if classSymbol != nil {
-		return symbol != classSymbol
-	}
-
-	// Fallback: check if the identifier is within a scope that shadows the
-	// class name. Walks only up to classNode (not to SourceFile).
-	return utils.IsNameShadowedBetween(node, classNode, className)
-}
-
-// checkClassReassignments finds all reassignments to the class name
-func checkClassReassignments(classNode *ast.Node, className string, ctx *rule.RuleContext) {
-	if className == "" {
+// checkClassReassignments reports every write-reference to classNode's own
+// symbol. RefStore resolution is scope-correct by construction, so a local
+// binding that shadows the class name is never returned as a reference here.
+func checkClassReassignments(classNode *ast.Node, ctx *rule.RuleContext) {
+	sym := classNode.Symbol()
+	if sym == nil {
 		return
 	}
-
-	// Find the scope to search - for class declarations, we need to search the parent scope
-	// For class expressions, we only search within the class itself
-	var searchRoot *ast.Node
-	if classNode.Kind == ast.KindClassDeclaration {
-		// For class declarations, search the enclosing block or source file
-		searchRoot = findEnclosingScope(classNode)
-	} else {
-		// For class expressions, search within the class only
-		searchRoot = classNode
-	}
-
-	if searchRoot == nil {
-		return
-	}
-
-	// Walk the tree to find all identifiers with the class name
-	var walk func(*ast.Node)
-	walk = func(node *ast.Node) {
-		if node == nil {
-			return
+	for _, ref := range ctx.Refs.References(sym) {
+		if utils.IsWriteReference(ref) {
+			ctx.ReportNode(ref, buildClassReassignmentMessage(sym.Name))
 		}
-
-		if node.Kind == ast.KindIdentifier && getIdentifierName(node) == className {
-			// Skip if this is the class name declaration itself
-			if node.Parent == classNode {
-				// Continue walking children
-				node.ForEachChild(func(child *ast.Node) bool {
-					walk(child)
-					return false
-				})
-				return
-			}
-
-			// Check if this is a write reference
-			if isWriteReference(node) {
-				// Check if the name is shadowed by a local variable
-				if !isNameShadowed(node, className, classNode, ctx) {
-					ctx.ReportNode(node, buildClassReassignmentMessage(className))
-				}
-			}
-		}
-
-		// Recursively check children
-		node.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
 	}
-
-	walk(searchRoot)
-}
-
-// findEnclosingScope finds the enclosing block or source file for a node
-func findEnclosingScope(node *ast.Node) *ast.Node {
-	current := node.Parent
-	for current != nil {
-		switch current.Kind {
-		case ast.KindSourceFile:
-			return current
-		case ast.KindBlock:
-			return current
-		case ast.KindModuleBlock:
-			return current
-		}
-		current = current.Parent
-	}
-	return nil
 }
 
 // NoClassAssignRule disallows reassigning class declarations
@@ -334,26 +36,20 @@ var NoClassAssignRule = rule.Rule{
 		return rule.RuleListeners{
 			// Check class declarations
 			ast.KindClassDeclaration: func(node *ast.Node) {
-				classDecl := node.AsClassDeclaration()
-				if classDecl == nil || classDecl.Name() == nil {
+				if node.AsClassDeclaration().Name() == nil {
 					return
 				}
-
-				className := getIdentifierName(classDecl.Name())
-				checkClassReassignments(node, className, &ctx)
+				checkClassReassignments(node, &ctx)
 			},
 
-			// Check named class expressions
+			// Check named class expressions. The name is only visible inside
+			// the class body, which RefStore's scope-aware resolution
+			// enforces on its own.
 			ast.KindClassExpression: func(node *ast.Node) {
-				classExpr := node.AsClassExpression()
-				if classExpr == nil || classExpr.Name() == nil {
+				if node.AsClassExpression().Name() == nil {
 					return
 				}
-
-				// Only check named class expressions
-				// For `let A = class A { ... }`, we need to check reassignments inside the class
-				className := getIdentifierName(classExpr.Name())
-				checkClassReassignments(node, className, &ctx)
+				checkClassReassignments(node, &ctx)
 			},
 		}
 	},

--- a/internal/rules/no_class_assign/no_class_assign.go
+++ b/internal/rules/no_class_assign/no_class_assign.go
@@ -17,14 +17,18 @@ func buildClassReassignmentMessage(className string) rule.RuleMessage {
 // checkClassReassignments reports every write-reference to classNode's own
 // symbol. RefStore resolution is scope-correct by construction, so a local
 // binding that shadows the class name is never returned as a reference here.
-func checkClassReassignments(classNode *ast.Node, ctx *rule.RuleContext) {
+//
+// name comes from the declaration's name node rather than the symbol: a
+// default-exported class is bound to an export symbol named "default",
+// while the reported name must be the one written in the source.
+func checkClassReassignments(classNode *ast.Node, name string, ctx *rule.RuleContext) {
 	sym := classNode.Symbol()
 	if sym == nil {
 		return
 	}
 	for _, ref := range ctx.Refs.References(sym) {
 		if utils.IsWriteReference(ref) {
-			ctx.ReportNode(ref, buildClassReassignmentMessage(sym.Name))
+			ctx.ReportNode(ref, buildClassReassignmentMessage(name))
 		}
 	}
 }
@@ -36,20 +40,22 @@ var NoClassAssignRule = rule.Rule{
 		return rule.RuleListeners{
 			// Check class declarations
 			ast.KindClassDeclaration: func(node *ast.Node) {
-				if node.AsClassDeclaration().Name() == nil {
+				nameNode := node.AsClassDeclaration().Name()
+				if nameNode == nil {
 					return
 				}
-				checkClassReassignments(node, &ctx)
+				checkClassReassignments(node, nameNode.Text(), &ctx)
 			},
 
 			// Check named class expressions. The name is only visible inside
 			// the class body, which RefStore's scope-aware resolution
 			// enforces on its own.
 			ast.KindClassExpression: func(node *ast.Node) {
-				if node.AsClassExpression().Name() == nil {
+				nameNode := node.AsClassExpression().Name()
+				if nameNode == nil {
 					return
 				}
-				checkClassReassignments(node, &ctx)
+				checkClassReassignments(node, nameNode.Text(), &ctx)
 			},
 		}
 	},

--- a/internal/rules/no_class_assign/no_class_assign_test.go
+++ b/internal/rules/no_class_assign/no_class_assign_test.go
@@ -60,13 +60,12 @@ func TestNoClassAssignRule(t *testing.T) {
 			},
 
 			// Destructuring assignment with class name
-			// TODO: This test case is not working yet - needs investigation of AST structure
-			// {
-			// 	Code: `class A { } ({A} = 0);`,
-			// 	Errors: []rule_tester.InvalidTestCaseError{
-			// 		{MessageId: "classReassignment", Line: 1, Column: 15},
-			// 	},
-			// },
+			{
+				Code: `class A { } ({A} = 0);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "classReassignment", Line: 1, Column: 15},
+				},
+			},
 
 			// Destructuring assignment with default value
 			{

--- a/internal/rules/no_class_assign/no_class_assign_test.go
+++ b/internal/rules/no_class_assign/no_class_assign_test.go
@@ -259,6 +259,17 @@ func TestNoClassAssignRule(t *testing.T) {
 					{MessageId: "classReassignment", Line: 1, Column: 14},
 				},
 			},
+
+			// Default-exported class reassigned at module level: the export
+			// symbol is named "default", but the reported name must be the
+			// source declaration name.
+			{
+				Code: `export default class A {}
+A = 0;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "classReassignment", Message: "'A' is a class.", Line: 2, Column: 1},
+				},
+			},
 		},
 	)
 }


### PR DESCRIPTION
## Summary

- Port `no-class-assign` to `ctx.Refs.References(sym)`, replacing the manual whole-scope AST walk, name-string matching, and TypeChecker-based shadow detection. The old implementation re-walked the class's enclosing block-scope container (for a top-level class: the whole `SourceFile`) once per class, so cost grew as classes-per-file × file size.
- Shadowing no longer needs an explicit check — RefStore resolution is scope-correct by construction, so a local binding that shadows the class name is never returned as a reference.
- Re-enables the previously-disabled test case for shorthand destructuring assignment (`({A} = 0)`), which now passes.

## Benchmark

Synthetic corpus: 1200 `.ts` files / 25 MiB, 20 top-level classes per file plus named class expressions and plenty of non-write references.

Per-rule time from `--timing all` (summed across workers), 5 runs after a warmup:

| | 1 | 2 | 3 | 4 | 5 | mean | median |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `main` | 883.8 | 938.9 | 883.4 | 845.8 | 1025.3 | **915.4 ms** | 883.8 ms |
| this PR | 129.6 | 143.1 | 122.2 | 176.2 | 124.7 | **139.2 ms** | 129.6 ms |

Rule time: **−84.8%** (~6.6×).

End-to-end wall clock on the same corpus (hyperfine, 10 runs + 2 warmup): 902.6 ms ± 31.5 → 710.9 ms ± 16.4, **−21.2%**.

## Validation

- `go test ./internal/rules/no_class_assign/...`
- `go vet ./internal/rules/no_class_assign/...`
- Both binaries produce byte-identical diagnostics (679) on the benchmark corpus.

## Related Links

Follow-up to #1335, which added `ctx.Refs` and listed further reference-collecting rules as candidates for migration.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
