### PR TITLE
perf: port no-func-assign to RefStore

### DIFF
--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -63,16 +63,34 @@ func (s *RefStore) References(sym *ast.Symbol) []*ast.Node {
 		s.walked = true
 		s.collectCandidates()
 	}
-	if pending, ok := s.candidates[sym.Name]; ok {
-		delete(s.candidates, sym.Name)
-		for _, id := range pending {
-			target := s.resolver.Resolve(id, id.Text(), referenceMeaning(id), nil, true /*isUse*/, false /*excludeGlobals*/)
-			if target != nil {
-				s.refs[target] = append(s.refs[target], id)
-			}
+	s.resolvePending(sym.Name)
+	// A symbol's name is not always the name its references are written with:
+	// `export default function foo() {}` binds the declaration to an export
+	// symbol named "default", while every reference still spells `foo`. Drain
+	// the bucket of each declared name too, or those references stay pending
+	// forever.
+	for _, decl := range sym.Declarations {
+		if name := decl.Name(); name != nil && name.Kind == ast.KindIdentifier && name.Text() != sym.Name {
+			s.resolvePending(name.Text())
 		}
 	}
 	return s.refs[sym]
+}
+
+// resolvePending resolves every not-yet-resolved candidate identifier spelled
+// name and files each one under the symbol it references.
+func (s *RefStore) resolvePending(name string) {
+	pending, ok := s.candidates[name]
+	if !ok {
+		return
+	}
+	delete(s.candidates, name)
+	for _, id := range pending {
+		target := s.resolver.Resolve(id, name, referenceMeaning(id), nil, true /*isUse*/, false /*excludeGlobals*/)
+		if target != nil {
+			s.refs[target] = append(s.refs[target], id)
+		}
+	}
 }
 
 // collectCandidates walks the file once and buckets by name every identifier

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -205,3 +205,52 @@ func TestRefStoreExportAssignmentResolvesTypeOnlySymbol(t *testing.T) {
 		t.Fatalf("References = %v, want [%v] (the `export = Foo` reference)", got, exportIdent)
 	}
 }
+
+func TestRefStoreExportDefaultNamedFunction(t *testing.T) {
+	// A named default export is bound to an export symbol named "default", so
+	// looking its candidates up by symbol name finds nothing: the references
+	// are bucketed under the name they are written with.
+	sourceFile, refs := newBoundRefStore(t, "/export-default.ts", core.ScriptKindTS,
+		"export default function foo() { foo = 1; }\nfoo = 2;\n")
+
+	occurrences := identifiers(sourceFile.AsNode(), "foo")
+	if len(occurrences) != 3 {
+		t.Fatalf("expected 3 occurrences of foo, got %d", len(occurrences))
+	}
+	declIdent, innerIdent, outerIdent := occurrences[0], occurrences[1], occurrences[2]
+	sym := declIdent.Parent.Symbol()
+	if sym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+	if sym.Name != ast.InternalSymbolNameDefault {
+		t.Fatalf("declaration symbol name = %q, want %q", sym.Name, ast.InternalSymbolNameDefault)
+	}
+
+	got := refs.References(sym)
+	if len(got) != 2 || got[0] != innerIdent || got[1] != outerIdent {
+		t.Fatalf("References = %v, want [%v %v] (both assignments to foo)", got, innerIdent, outerIdent)
+	}
+}
+
+func TestRefStoreExportedFunctionDeclaration(t *testing.T) {
+	// A non-default export is bound to an export symbol too; the local symbol
+	// left in the file's locals carries only the ExportValue marker, so
+	// references must still resolve to the queried export symbol.
+	sourceFile, refs := newBoundRefStore(t, "/export-named.ts", core.ScriptKindTS,
+		"export function foo() {}\nfoo = 1;\n")
+
+	occurrences := identifiers(sourceFile.AsNode(), "foo")
+	if len(occurrences) != 2 {
+		t.Fatalf("expected 2 occurrences of foo, got %d", len(occurrences))
+	}
+	declIdent, useIdent := occurrences[0], occurrences[1]
+	sym := declIdent.Parent.Symbol()
+	if sym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	got := refs.References(sym)
+	if len(got) != 1 || got[0] != useIdent {
+		t.Fatalf("References = %v, want [%v] (the `foo = 1` assignment)", got, useIdent)
+	}
+}

--- a/internal/rules/no_func_assign/no_func_assign.go
+++ b/internal/rules/no_func_assign/no_func_assign.go
@@ -13,86 +13,19 @@ func buildMessage(name string) rule.RuleMessage {
 	}
 }
 
-// isNameShadowed checks whether the identifier at `node` refers to a different
-// binding than `declNode`'s name, i.e. a local variable/parameter/catch binding
-// that shadows the function name.
-//
-// When a TypeChecker is available, symbol identity is checked first (fast path).
-// Because the TypeChecker sometimes resolves shorthand-property identifiers in
-// destructuring assignments to a *property* symbol rather than the variable
-// symbol, a positive result is confirmed by a scope-based walk before we
-// declare the name shadowed.
-func isNameShadowed(node *ast.Node, name string, declNode *ast.Node, ctx *rule.RuleContext) bool {
-	if node == nil || ctx.TypeChecker == nil {
-		return false
-	}
-
-	identSymbol := ctx.TypeChecker.GetSymbolAtLocation(node)
-	if identSymbol == nil {
-		return false
-	}
-
-	// Get the symbol at the declaration's name.
-	declName := declNode.Name()
-	if declName == nil {
-		return false
-	}
-	declSymbol := ctx.TypeChecker.GetSymbolAtLocation(declName)
-
-	if declSymbol != nil {
-		if identSymbol == declSymbol {
-			return false // same binding — not shadowed
-		}
-		// Different symbol — confirm with scope analysis before concluding,
-		// because some AST positions (e.g. shorthand destructuring) resolve
-		// to a property symbol rather than the variable symbol.
-		return isInShadowingScope(node, name, declNode)
-	}
-
-	return isInShadowingScope(node, name, declNode)
-}
-
-// isInShadowingScope walks from `node` up to (but not including) `declNode`,
-// returning true if any intermediate scope introduces a binding with the given
-// name. Also treats `declNode`'s own parameters as shadowing
-// (e.g. `function foo(foo) { foo = bar; }`).
-func isInShadowingScope(node *ast.Node, name string, declNode *ast.Node) bool {
-	if utils.IsNameShadowedBetween(node, declNode, name) {
-		return true
-	}
-	return declNode != nil && utils.HasShadowingParameter(declNode, name)
-}
-
-// checkReassignments walks `searchRoot` and reports every write-reference to `name`
-// that targets the same binding as `declNode`.
-func checkReassignments(searchRoot *ast.Node, name string, declNode *ast.Node, ctx *rule.RuleContext) {
-	if name == "" {
+// checkReassignments reports every write-reference to declNode's own symbol.
+// RefStore resolution is scope-correct by construction, so a local binding
+// that shadows the function name is never returned as a reference here.
+func checkReassignments(declNode *ast.Node, ctx *rule.RuleContext) {
+	sym := declNode.Symbol()
+	if sym == nil {
 		return
 	}
-
-	var walk func(*ast.Node)
-	walk = func(node *ast.Node) {
-		if node == nil {
-			return
+	for _, ref := range ctx.Refs.References(sym) {
+		if utils.IsWriteReference(ref) {
+			ctx.ReportNode(ref, buildMessage(sym.Name))
 		}
-
-		if node.Kind == ast.KindIdentifier && node.Text() == name {
-			// Skip the declaration's own name node.
-			if node.Parent == declNode {
-				return
-			}
-			if utils.IsWriteReference(node) && !isNameShadowed(node, name, declNode, ctx) {
-				ctx.ReportNode(node, buildMessage(name))
-			}
-		}
-
-		node.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
 	}
-
-	walk(searchRoot)
 }
 
 // NoFuncAssignRule disallows reassigning function declarations.
@@ -105,31 +38,18 @@ var NoFuncAssignRule = rule.Rule{
 				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
 					return
 				}
-				funcName := nameNode.Text()
-				if funcName == "" {
-					return
-				}
-
-				searchRoot := ast.GetEnclosingBlockScopeContainer(node)
-				if searchRoot == nil {
-					return
-				}
-
-				checkReassignments(searchRoot, funcName, node, &ctx)
+				checkReassignments(node, &ctx)
 			},
 
-			// Named function expressions: the name is only visible inside the body.
+			// Named function expressions: the name is only visible inside the
+			// body, which RefStore's scope-aware resolution enforces on its
+			// own.
 			ast.KindFunctionExpression: func(node *ast.Node) {
 				nameNode := node.Name()
 				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
 					return
 				}
-				funcName := nameNode.Text()
-				if funcName == "" {
-					return
-				}
-
-				checkReassignments(node, funcName, node, &ctx)
+				checkReassignments(node, &ctx)
 			},
 		}
 	},

--- a/internal/rules/no_func_assign/no_func_assign.go
+++ b/internal/rules/no_func_assign/no_func_assign.go
@@ -16,14 +16,18 @@ func buildMessage(name string) rule.RuleMessage {
 // checkReassignments reports every write-reference to declNode's own symbol.
 // RefStore resolution is scope-correct by construction, so a local binding
 // that shadows the function name is never returned as a reference here.
-func checkReassignments(declNode *ast.Node, ctx *rule.RuleContext) {
+//
+// name comes from the declaration's name node rather than the symbol: a
+// default-exported function is bound to an export symbol named "default",
+// while the reported name must be the one written in the source.
+func checkReassignments(declNode *ast.Node, name string, ctx *rule.RuleContext) {
 	sym := declNode.Symbol()
 	if sym == nil {
 		return
 	}
 	for _, ref := range ctx.Refs.References(sym) {
 		if utils.IsWriteReference(ref) {
-			ctx.ReportNode(ref, buildMessage(sym.Name))
+			ctx.ReportNode(ref, buildMessage(name))
 		}
 	}
 }
@@ -38,7 +42,7 @@ var NoFuncAssignRule = rule.Rule{
 				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
 					return
 				}
-				checkReassignments(node, &ctx)
+				checkReassignments(node, nameNode.Text(), &ctx)
 			},
 
 			// Named function expressions: the name is only visible inside the
@@ -49,7 +53,7 @@ var NoFuncAssignRule = rule.Rule{
 				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
 					return
 				}
-				checkReassignments(node, &ctx)
+				checkReassignments(node, nameNode.Text(), &ctx)
 			},
 		}
 	},

--- a/internal/rules/no_func_assign/no_func_assign_test.go
+++ b/internal/rules/no_func_assign/no_func_assign_test.go
@@ -59,6 +59,14 @@ func TestNoFuncAssignRule(t *testing.T) {
 
 			// Catch clause parameter shadows function name
 			{Code: `function foo() {} try {} catch(foo) { foo = 1; }`},
+
+			// Local var shadows a default-exported function's name
+			{Code: `export default function foo() {}
+function bar() { var foo; foo = 1; }`},
+
+			// Re-exporting a function is not a reassignment
+			{Code: `export default function foo() {}
+export { foo as bar };`},
 		},
 		// Invalid cases - ported from ESLint
 		[]rule_tester.InvalidTestCase{
@@ -252,6 +260,43 @@ func TestNoFuncAssignRule(t *testing.T) {
 				Code: `function foo() {} try { foo = 1; } catch(foo) { foo = 2; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "isAFunction", Line: 1, Column: 25},
+				},
+			},
+
+			// Default-exported function reassigned at module level: the
+			// declaration is bound to an export symbol named "default", but the
+			// reference — and the reported name — use the local name.
+			{
+				Code: `export default function foo() {}
+foo = bar;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "isAFunction", Message: "'foo' is a function.", Line: 2, Column: 1},
+				},
+			},
+
+			// Default-exported function reassigned inside its own body
+			{
+				Code: `export default function foo() { foo = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "isAFunction", Line: 1, Column: 33},
+				},
+			},
+
+			// Destructuring assignment to a default-exported function
+			{
+				Code: `export default function foo() {}
+[foo] = [1];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "isAFunction", Line: 2, Column: 2},
+				},
+			},
+
+			// Named export reassigned at module level
+			{
+				Code: `export function foo() {}
+foo = bar;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "isAFunction", Line: 2, Column: 1},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- Port `no-func-assign` to `ctx.Refs.References(sym)`, replacing the manual whole-scope AST walk, name-string matching, and TypeChecker-based shadow detection. The old implementation re-walked the function's enclosing block-scope container (for a top-level function: the whole `SourceFile`) once per function declaration, and confirmed every write reference with a `GetSymbolAtLocation` call plus a scope walk.
- Shadowing no longer needs an explicit check — RefStore resolution is scope-correct by construction, so a local binding that shadows the function name is never returned as a reference.

## Benchmark

Synthetic corpus: 1200 `.ts` files / 19 MiB, 20 top-level function declarations per file plus named function expressions, many non-write references, and shadowing locals.

Per-rule time from `--timing all` (summed across workers), 5 runs after a warmup:

| | 1 | 2 | 3 | 4 | 5 | mean | median |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `main` | 2224.1 | 2145.9 | 2208.2 | 2147.8 | 2299.3 | **2205.1 ms** | 2208.2 ms |
| this PR | 130.3 | 132.8 | 143.4 | 140.3 | 132.8 | **135.9 ms** | 132.8 ms |

Rule time: **−93.8%** (~16.2×).

End-to-end wall clock on the same corpus (hyperfine, 10 runs + 2 warmup): 1.195 s ± 0.023 → 634.7 ms ± 28.2, **−46.9%**.

## Validation

- `go test ./internal/rules/no_func_assign/...`
- `go vet ./internal/rules/no_func_assign/...`
- Both binaries produce byte-identical diagnostics (679) on the benchmark corpus.

## Related Links

Follow-up to #1335, which added `ctx.Refs` and listed further reference-collecting rules as candidates for migration.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
