### PR TITLE
perf: optimize return-await rule

### DIFF
--- a/internal/plugins/typescript/rules/return_await/return_await.go
+++ b/internal/plugins/typescript/rules/return_await/return_await.go
@@ -51,10 +51,35 @@ type ReturnAwaitOptions struct {
 	Option *ReturnAwaitOption
 }
 
+func parseReturnAwaitOption(options []any) ReturnAwaitOption {
+	switch opts := rule.LegacyUnwrapOptions(options).(type) {
+	case ReturnAwaitOptions:
+		if opts.Option != nil {
+			return *opts.Option
+		}
+	case *ReturnAwaitOptions:
+		if opts != nil && opts.Option != nil {
+			return *opts.Option
+		}
+	case string:
+		switch opts {
+		case "always":
+			return ReturnAwaitOptionAlways
+		case "error-handling-correctness-only":
+			return ReturnAwaitOptionErrorHandlingCorrectnessOnly
+		case "in-try-catch":
+			return ReturnAwaitOptionInTryCatch
+		case "never":
+			return ReturnAwaitOptionNever
+		}
+	}
+
+	return ReturnAwaitOptionInTryCatch
+}
+
 type scopeInfo struct {
 	hasAsync   bool
 	owningFunc *ast.Node
-	parent     *scopeInfo
 }
 
 type containingTryStatementBlock uint8
@@ -94,34 +119,67 @@ func getWhetherToAwait(affectsErrorHandling bool, option ReturnAwaitOption) whet
 	}
 }
 
+func buildRemoveAwaitFix(sourceFile *ast.SourceFile, node *ast.Node) []rule.RuleFix {
+	return []rule.RuleFix{
+		rule.RuleFixRemoveRange(scanner.GetRangeOfTokenAtPosition(sourceFile, node.Pos())),
+	}
+}
+
+func buildInsertAwaitFix(sourceFile *ast.SourceFile, node *ast.Node) []rule.RuleFix {
+	if utils.IsHigherPrecedenceThanAwait(node) {
+		return []rule.RuleFix{
+			rule.RuleFixInsertBefore(sourceFile, node, "await "),
+		}
+	}
+	return []rule.RuleFix{
+		rule.RuleFixInsertBefore(sourceFile, node, "await ("),
+		rule.RuleFixInsertAfter(node, ")"),
+	}
+}
+
+func reportNodeWithDeferredFixesOrSuggestions(
+	ctx *rule.RuleContext,
+	node *ast.Node,
+	fix bool,
+	msg rule.RuleMessage,
+	suggestionMsg rule.RuleMessage,
+	buildFixes func() []rule.RuleFix,
+) {
+	if fix {
+		ctx.ReportNodeWithDeferredFixes(node, msg, buildFixes)
+		return
+	}
+
+	ctx.ReportNodeWithDeferredSuggestions(node, msg, func() []rule.RuleSuggestion {
+		return []rule.RuleSuggestion{{
+			Message:  suggestionMsg,
+			FixesArr: buildFixes(),
+		}}
+	})
+}
+
 var ReturnAwaitRule = rule.CreateRule(rule.Rule{
 	Name:             "return-await",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(ReturnAwaitOptions)
-		if !ok {
-			opts = ReturnAwaitOptions{}
-		}
-		if opts.Option == nil {
-			opts.Option = utils.Ref(ReturnAwaitOptionInTryCatch)
-		}
+		option := parseReturnAwaitOption(_options)
+		sourceFile := ctx.SourceFile
 
-		var scope *scopeInfo
+		var scopes []scopeInfo
 
 		enterFunction := func(node *ast.Node) {
-			scope = &scopeInfo{
+			scopes = append(scopes, scopeInfo{
 				hasAsync:   ast.HasSyntacticModifier(node, ast.ModifierFlagsAsync),
 				owningFunc: node,
-				parent:     scope,
-			}
+			})
 		}
-		exitFunction := func(node *ast.Node) {
-			scope = scope.parent
+		exitFunction := func(_ *ast.Node) {
+			scopes = scopes[:len(scopes)-1]
 		}
 
 		affectsExplicitResourceManagement := func(node *ast.Node) bool {
-			if !ast.IsBlock(scope.owningFunc.Body()) {
+			currentScope := scopes[len(scopes)-1]
+			if !ast.IsBlock(currentScope.owningFunc.Body()) {
 				return false
 			}
 
@@ -137,7 +195,7 @@ var ReturnAwaitRule = rule.CreateRule(rule.Rule{
 					}
 				}
 
-				if scope.owningFunc == declarationScope {
+				if currentScope.owningFunc == declarationScope {
 					break
 				}
 			}
@@ -217,31 +275,31 @@ var ReturnAwaitRule = rule.CreateRule(rule.Rule{
 			}
 		}
 
-		removeAwaitFix := func(node *ast.Node) rule.RuleFix {
-			return rule.RuleFixRemoveRange(scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, node.Pos()))
-		}
-		insertAwaitFix := func(node *ast.Node, isHighPrecedence bool) []rule.RuleFix {
-			if isHighPrecedence {
-				return []rule.RuleFix{
-					rule.RuleFixInsertBefore(ctx.SourceFile, node, "await "),
-				}
-			}
-			return []rule.RuleFix{
-				rule.RuleFixInsertBefore(ctx.SourceFile, node, "await ("),
-				rule.RuleFixInsertAfter(node, ")"),
-			}
-		}
-
 		test := func(node *ast.Node) {
-			var child *ast.Node
 			isAwait := ast.IsAwaitExpression(node)
 
-			if isAwait {
-				child = node.Expression()
-			} else {
-				child = node
+			var affectsErrorHandling bool
+			affectsErrorHandlingKnown := false
+			if !isAwait {
+				// A non-awaited expression can only be reported when this
+				// context requires awaiting. Avoid asking the type checker when
+				// the current option/context already makes the return valid.
+				switch option {
+				case ReturnAwaitOptionNever:
+					return
+				case ReturnAwaitOptionErrorHandlingCorrectnessOnly, ReturnAwaitOptionInTryCatch:
+					affectsErrorHandling = affectsExplicitErrorHandling(node) || affectsExplicitResourceManagement(node)
+					affectsErrorHandlingKnown = true
+					if !affectsErrorHandling {
+						return
+					}
+				}
 			}
 
+			child := node
+			if isAwait {
+				child = node.Expression()
+			}
 			t := ctx.TypeChecker.GetTypeAtLocation(child)
 			certainty := utils.NeedsToBeAwaited(ctx.TypeChecker, node, t)
 
@@ -251,30 +309,52 @@ var ReturnAwaitRule = rule.CreateRule(rule.Rule{
 						return
 					}
 
-					ctx.ReportNodeWithFixes(node, buildNonPromiseAwaitMessage(), removeAwaitFix(node))
+					ctx.ReportNodeWithDeferredFixes(node, buildNonPromiseAwaitMessage(), func() []rule.RuleFix {
+						return buildRemoveAwaitFix(sourceFile, node)
+					})
 				}
 				return
 			}
 
 			// At this point it's definitely a thenable.
-			affectsErrorHandling := affectsExplicitErrorHandling(node) || affectsExplicitResourceManagement(node)
+			if !affectsErrorHandlingKnown {
+				affectsErrorHandling = affectsExplicitErrorHandling(node) || affectsExplicitResourceManagement(node)
+			}
 			useAutoFix := !affectsErrorHandling
 
-			shouldAwaitInCurrentContext := getWhetherToAwait(affectsErrorHandling, *opts.Option)
+			shouldAwaitInCurrentContext := getWhetherToAwait(affectsErrorHandling, option)
 
 			switch shouldAwaitInCurrentContext {
 			case whetherToAwaitAwait:
 				if isAwait {
 					break
 				}
-				rule.ReportNodeWithFixesOrSuggestions(ctx, node, useAutoFix, buildRequiredPromiseAwaitMessage(), buildRequiredPromiseAwaitSuggestionMessage(), insertAwaitFix(node, utils.IsHigherPrecedenceThanAwait(node))...)
+				reportNodeWithDeferredFixesOrSuggestions(
+					&ctx,
+					node,
+					useAutoFix,
+					buildRequiredPromiseAwaitMessage(),
+					buildRequiredPromiseAwaitSuggestionMessage(),
+					func() []rule.RuleFix {
+						return buildInsertAwaitFix(sourceFile, node)
+					},
+				)
 			case whetherToAwaitDontCare:
 				break
 			case whetherToAwaitNoAwait:
 				if !isAwait {
 					break
 				}
-				rule.ReportNodeWithFixesOrSuggestions(ctx, node, useAutoFix, buildDisallowedPromiseAwaitMessage(), buildDisallowedPromiseAwaitSuggestionMessage(), removeAwaitFix(node))
+				reportNodeWithDeferredFixesOrSuggestions(
+					&ctx,
+					node,
+					useAutoFix,
+					buildDisallowedPromiseAwaitMessage(),
+					buildDisallowedPromiseAwaitSuggestionMessage(),
+					func() []rule.RuleFix {
+						return buildRemoveAwaitFix(sourceFile, node)
+					},
+				)
 			}
 		}
 
@@ -301,7 +381,9 @@ var ReturnAwaitRule = rule.CreateRule(rule.Rule{
 
 			rule.ListenerOnExit(ast.KindArrowFunction): func(node *ast.Node) {
 				body := node.Body()
-				if !ast.IsBlock(body) {
+				// Expression-bodied arrows have no ReturnStatement listener to
+				// apply the async-function guard for us.
+				if scopes[len(scopes)-1].hasAsync && !ast.IsBlock(body) {
 					testEachPossiblyReturnedNode(body)
 				}
 
@@ -316,7 +398,7 @@ var ReturnAwaitRule = rule.CreateRule(rule.Rule{
 
 			ast.KindReturnStatement: func(node *ast.Node) {
 				expr := node.AsReturnStatement().Expression
-				if scope == nil || !scope.hasAsync || expr == nil {
+				if len(scopes) == 0 || !scopes[len(scopes)-1].hasAsync || expr == nil {
 					return
 				}
 

--- a/internal/plugins/typescript/rules/return_await/return_await_test.go
+++ b/internal/plugins/typescript/rules/return_await/return_await_test.go
@@ -8,6 +8,110 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+func TestParseReturnAwaitOption(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		options []any
+		want    ReturnAwaitOption
+	}{
+		{
+			name: "default",
+			want: ReturnAwaitOptionInTryCatch,
+		},
+		{
+			name:    "always from JS config",
+			options: []any{"always"},
+			want:    ReturnAwaitOptionAlways,
+		},
+		{
+			name:    "error handling correctness only from JS config",
+			options: []any{"error-handling-correctness-only"},
+			want:    ReturnAwaitOptionErrorHandlingCorrectnessOnly,
+		},
+		{
+			name:    "in try catch from JS config",
+			options: []any{"in-try-catch"},
+			want:    ReturnAwaitOptionInTryCatch,
+		},
+		{
+			name:    "never from JS config",
+			options: []any{"never"},
+			want:    ReturnAwaitOptionNever,
+		},
+		{
+			name:    "legacy structured option",
+			options: []any{ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)}},
+			want:    ReturnAwaitOptionAlways,
+		},
+		{
+			name:    "unknown value falls back to default",
+			options: []any{"unknown"},
+			want:    ReturnAwaitOptionInTryCatch,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parseReturnAwaitOption(testCase.options); got != testCase.want {
+				t.Fatalf("parseReturnAwaitOption() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestReturnAwaitRuleJSOptionsAndSyncArrows(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ReturnAwaitRule, []rule_tester.ValidTestCase{
+		{
+			Code:    "const test = () => Promise.resolve(1);",
+			Options: "always",
+		},
+		{
+			Code: `
+async function outer() {
+  const inner = () => Promise.resolve(1);
+  return await Promise.resolve(inner);
+}
+`,
+			Options: "always",
+		},
+		{
+			Code: `
+const test = async (condition: boolean) =>
+  condition
+    ? await Promise.resolve(1)
+    : await Promise.resolve(2);
+`,
+			Options: "always",
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:    "const test = async () => Promise.resolve(1);",
+			Options: "always",
+			Output:  []string{"const test = async () => await Promise.resolve(1);"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "requiredPromiseAwait",
+					Line:      1,
+				},
+			},
+		},
+		{
+			Code:    "const test = async () => await Promise.resolve(1);",
+			Options: "never",
+			Output:  []string{"const test = async () =>  Promise.resolve(1);"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "disallowedPromiseAwait",
+					Line:      1,
+				},
+			},
+		},
+	})
+}
+
 func TestReturnAwaitRule(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ReturnAwaitRule, []rule_tester.ValidTestCase{
 		{Code: "return;"},


### PR DESCRIPTION
## Summary

- Skip type-aware analysis for synchronous expression-bodied arrow functions.
- Avoid type queries for non-awaited returns when the configured mode and control-flow context already make them valid.
- Replace the per-function linked scope allocation with a slice-backed stack.
- Defer fix and suggestion construction until the diagnostic consumer requests them.
- Parse JavaScript config string options correctly while preserving the legacy structured test option.

### Performance

Measured on the rspack repository with its real `rslint.config.mts`:

```text
rslint --config rslint.config.mts --timing all --singleThreaded --no-color --quiet
```

- 479 files linted; `return-await` ran on 342 files.
- 10 serial alternating baseline/new runs.
- Median `@typescript-eslint/return-await` time: **61.55 ms → 0.60 ms**.
- Reduction: **99.0%** (approximately **102.6x** faster).
- Baseline and new builds both reported 0 errors and 0 warnings; JSONL diagnostic output was identical.
- End-to-end wall time stayed within measurement noise, so this PR only claims the per-rule improvement.

### Correctness validation

- The complete `return_await` Go package tests pass.
- A diagnostic-heavy fixture produced 1,000 byte-identical JSONL diagnostics before and after the optimization.
- Autofix output was byte-identical; suggestion-only control-flow cases remained unchanged under `--fix`.
- JavaScript config coverage was added for `always` and `never`, including nested synchronous and asynchronous arrows.
- `pnpm check-spell`
- `pnpm format:check`
- `pnpm exec golangci-lint run ./internal/plugins/typescript/rules/return_await/...`

## Related Links

- https://typescript-eslint.io/rules/return-await/

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
