### PR TITLE
perf: optimize require-await rule

### DIFF
--- a/internal/plugins/typescript/rules/require_await/require_await.go
+++ b/internal/plugins/typescript/rules/require_await/require_await.go
@@ -26,30 +26,110 @@ type scopeInfo struct {
 	hasAwait      bool
 	isAsyncYield  bool
 	functionFlags ast.FunctionFlags
-	upper         *scopeInfo
+}
+
+func hasCallSignature(typeChecker *checker.Checker, t *checker.Type) bool {
+	if utils.IsUnionType(t) {
+		for _, typePart := range t.Types() {
+			if len(utils.GetCallSignatures(typeChecker, typePart)) != 0 {
+				return true
+			}
+		}
+		return false
+	}
+	return len(utils.GetCallSignatures(typeChecker, t)) != 0
+}
+
+func isCallbackParameter(typeChecker *checker.Checker, param *ast.Symbol, node *ast.Node) bool {
+	t := checker.Checker_getApparentType(typeChecker, typeChecker.GetTypeOfSymbolAtLocation(param, node))
+	if param.ValueDeclaration != nil &&
+		ast.IsParameterDeclaration(param.ValueDeclaration) &&
+		param.ValueDeclaration.AsParameterDeclaration().DotDotDotToken != nil {
+		t = checker.Checker_getIndexTypeOfType(typeChecker, t, checker.Checker_numberType(typeChecker))
+		if t == nil {
+			return false
+		}
+	}
+	return hasCallSignature(typeChecker, t)
+}
+
+func hasThenCallbackSignature(typeChecker *checker.Checker, node *ast.Node, t *checker.Type) bool {
+	if utils.IsUnionType(t) {
+		for _, typePart := range t.Types() {
+			if hasThenCallbackSignature(typeChecker, node, typePart) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, signature := range utils.GetCallSignatures(typeChecker, t) {
+		parameters := checker.Signature_parameters(signature)
+		if len(parameters) != 0 && isCallbackParameter(typeChecker, parameters[0], node) {
+			return true
+		}
+	}
+	return false
+}
+
+func isThenableTypePart(typeChecker *checker.Checker, node *ast.Node, t *checker.Type) bool {
+	then := checker.Checker_getPropertyOfType(typeChecker, t, "then")
+	if then == nil {
+		return false
+	}
+	return hasThenCallbackSignature(typeChecker, node, typeChecker.GetTypeOfSymbolAtLocation(then, node))
+}
+
+// isThenableType mirrors utils.IsThenableType without materializing singleton
+// slices for the overwhelmingly common non-union path.
+func isThenableType(typeChecker *checker.Checker, node *ast.Node, t *checker.Type) bool {
+	if t == nil {
+		t = typeChecker.GetTypeAtLocation(node)
+	}
+	t = checker.Checker_getApparentType(typeChecker, t)
+	if utils.IsUnionType(t) {
+		for _, typePart := range t.Types() {
+			if isThenableTypePart(typeChecker, node, typePart) {
+				return true
+			}
+		}
+		return false
+	}
+	return isThenableTypePart(typeChecker, node, t)
+}
+
+func hasAsyncIterator(typeChecker *checker.Checker, t *checker.Type) bool {
+	if utils.IsTypeFlagSet(t, checker.TypeFlagsUnionOrIntersection) {
+		for _, typePart := range t.Types() {
+			if hasAsyncIterator(typeChecker, typePart) {
+				return true
+			}
+		}
+		return false
+	}
+	return utils.GetWellKnownSymbolPropertyOfType(t, "asyncIterator", typeChecker) != nil
 }
 
 var RequireAwaitRule = rule.CreateRule(rule.Rule{
 	Name:             "require-await",
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		var currentScope *scopeInfo
+		var scopes []scopeInfo
 
 		enterFunction := func(node *ast.Node) {
-			currentScope = &scopeInfo{
+			scope := scopeInfo{
 				hasAwait:      false,
 				isAsyncYield:  false,
 				functionFlags: ast.FunctionFlagsNormal,
-				upper:         currentScope,
 			}
-
 			if utils.HasNonEmptyFunctionBody(node) {
-				currentScope.functionFlags = ast.GetFunctionFlags(node)
+				scope.functionFlags = ast.GetFunctionFlags(node)
 			}
+			scopes = append(scopes, scope)
 		}
 
 		exitFunction := func(node *ast.Node) {
-			if currentScope.functionFlags&ast.FunctionFlagsAsync != 0 && !currentScope.hasAwait && (currentScope.functionFlags&ast.FunctionFlagsGenerator == 0 || !currentScope.isAsyncYield) {
+			scope := &scopes[len(scopes)-1]
+			if scope.functionFlags&ast.FunctionFlagsAsync != 0 && !scope.hasAwait && (scope.functionFlags&ast.FunctionFlagsGenerator == 0 || !scope.isAsyncYield) {
 				// TODO(port): implement suggestions
 				// // If the function belongs to a method definition or
 				// // property, then the function's range may not include the
@@ -178,13 +258,26 @@ var RequireAwaitRule = rule.CreateRule(rule.Rule{
 				ctx.ReportNode(node, buildMissingAwaitMessage())
 			}
 
-			currentScope = currentScope.upper
+			scopes = scopes[:len(scopes)-1]
 		}
 
 		markAsHasAwait := func() {
-			if currentScope != nil {
-				currentScope.hasAwait = true
+			if len(scopes) != 0 {
+				scopes[len(scopes)-1].hasAwait = true
 			}
+		}
+
+		exitArrowFunction := func(node *ast.Node) {
+			scope := &scopes[len(scopes)-1]
+			if scope.functionFlags&ast.FunctionFlagsAsync != 0 && !scope.hasAwait {
+				body := ast.SkipParentheses(node.Body())
+				if !ast.IsBlock(body) &&
+					!ast.IsAwaitExpression(body) &&
+					isThenableType(ctx.TypeChecker, body, ctx.TypeChecker.GetTypeAtLocation(body)) {
+					scope.hasAwait = true
+				}
+			}
+			exitFunction(node)
 		}
 
 		return rule.RuleListeners{
@@ -201,24 +294,8 @@ var RequireAwaitRule = rule.CreateRule(rule.Rule{
 			rule.ListenerOnExit(ast.KindSetAccessor):         exitFunction,
 			ast.KindFunctionExpression:                       enterFunction,
 			rule.ListenerOnExit(ast.KindFunctionExpression):  exitFunction,
-			ast.KindArrowFunction: func(node *ast.Node) {
-				enterFunction(node)
-				// check body-less async arrow function.
-				// ignore `async () => await foo` because it's obviously correct
-				if currentScope.functionFlags&ast.FunctionFlagsAsync == 0 {
-					return
-				}
-
-				body := ast.SkipParentheses(node.Body())
-				if ast.IsBlock(body) || ast.IsAwaitExpression(body) {
-					return
-				}
-
-				if utils.IsThenableType(ctx.TypeChecker, body, ctx.TypeChecker.GetTypeAtLocation(body)) {
-					markAsHasAwait()
-				}
-			},
-			rule.ListenerOnExit(ast.KindArrowFunction): exitFunction,
+			ast.KindArrowFunction:                            enterFunction,
+			rule.ListenerOnExit(ast.KindArrowFunction):       exitArrowFunction,
 
 			ast.KindAwaitExpression: func(node *ast.Node) { markAsHasAwait() },
 			ast.KindForOfStatement: func(node *ast.Node) {
@@ -237,12 +314,16 @@ var RequireAwaitRule = rule.CreateRule(rule.Rule{
 			 *    or
 			 *  2) yields thenable type
 			 */
-			ast.KindYieldExpression: func(node *ast.Node) {
-				if currentScope == nil || currentScope.isAsyncYield {
+			rule.ListenerOnExit(ast.KindYieldExpression): func(node *ast.Node) {
+				if len(scopes) == 0 {
 					return
 				}
+				scope := &scopes[len(scopes)-1]
 				argument := node.Expression()
-				if currentScope.functionFlags&ast.FunctionFlagsGenerator == 0 || argument == nil {
+				if scope.hasAwait ||
+					scope.isAsyncYield ||
+					scope.functionFlags&ast.FunctionFlagsAsyncGenerator != ast.FunctionFlagsAsyncGenerator ||
+					argument == nil {
 					return
 				}
 
@@ -253,28 +334,29 @@ var RequireAwaitRule = rule.CreateRule(rule.Rule{
 				}
 
 				if node.AsYieldExpression().AsteriskToken == nil {
-					if utils.IsThenableType(ctx.TypeChecker, argument, ctx.TypeChecker.GetTypeAtLocation(argument)) {
-						currentScope.isAsyncYield = true
+					if isThenableType(ctx.TypeChecker, argument, ctx.TypeChecker.GetTypeAtLocation(argument)) {
+						scope.isAsyncYield = true
 					}
 					return
 				}
 
 				t := ctx.TypeChecker.GetTypeAtLocation(argument)
-				hasAsyncYield := utils.TypeRecurser(t, func(t *checker.Type) bool {
-					return utils.GetWellKnownSymbolPropertyOfType(t, "asyncIterator", ctx.TypeChecker) != nil
-				})
-				if hasAsyncYield {
-					currentScope.isAsyncYield = true
+				if hasAsyncIterator(ctx.TypeChecker, t) {
+					scope.isAsyncYield = true
 				}
 			},
-			ast.KindReturnStatement: func(node *ast.Node) {
-				if currentScope == nil || currentScope.hasAwait || currentScope.functionFlags&ast.FunctionFlagsAsync == 0 {
+			rule.ListenerOnExit(ast.KindReturnStatement): func(node *ast.Node) {
+				if len(scopes) == 0 {
+					return
+				}
+				scope := &scopes[len(scopes)-1]
+				if scope.hasAwait || scope.functionFlags&ast.FunctionFlagsAsync == 0 {
 					return
 				}
 
 				expr := node.Expression()
-				if expr != nil && utils.IsThenableType(ctx.TypeChecker, expr, ctx.TypeChecker.GetTypeAtLocation(expr)) {
-					markAsHasAwait()
+				if expr != nil && isThenableType(ctx.TypeChecker, expr, ctx.TypeChecker.GetTypeAtLocation(expr)) {
+					scope.hasAwait = true
 				}
 			},
 		}

--- a/internal/plugins/typescript/rules/require_await/require_await_test.go
+++ b/internal/plugins/typescript/rules/require_await/require_await_test.go
@@ -1,10 +1,18 @@
 package require_await
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestRequireAwaitRule(t *testing.T) {
@@ -1092,4 +1100,293 @@ for await (let num of asyncIterable) {
 			},
 		},
 	})
+}
+
+func TestRequireAwaitDeferredTypeChecks(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RequireAwaitRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `
+declare function consume(value: number): number;
+async function returnsAwait() {
+  return consume(await Promise.resolve(1));
+}
+      `},
+			{Code: `
+declare function consume(value: number): number;
+const arrow = async () => consume(await Promise.resolve(1));
+      `},
+			{Code: `
+declare function consume(value: number): number;
+async function* yieldsAwait() {
+  yield consume(await Promise.resolve(1));
+}
+      `},
+			{Code: `
+async function* awaitsBeforeYield() {
+  await Promise.resolve();
+  yield Promise.resolve(1);
+}
+      `},
+			{Code: `
+interface StructuralThenable {
+  then(onfulfilled: (value: number) => unknown): unknown;
+}
+declare const value: StructuralThenable;
+async function returnsThenable() {
+  return value;
+}
+      `},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `
+interface FakeThenable {
+  then(value: number): unknown;
+}
+declare const value: FakeThenable;
+async function returnsFakeThenable() {
+  return value;
+}
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+			{
+				Code: `
+interface FakeThenable {
+  then(value: number): unknown;
+}
+declare const value: FakeThenable;
+const returnsFakeThenable = async () => value;
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+			{
+				Code: `
+interface FakeThenable {
+  then(value: number): unknown;
+}
+declare const value: FakeThenable;
+async function* yieldsFakeThenable() {
+  yield value;
+}
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+			{
+				Code: `
+async function outer() {
+  function* syncGenerator() {
+    yield Promise.resolve(1);
+  }
+}
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+			{
+				Code: `
+async function outer() {
+  return async () => await Promise.resolve(1);
+}
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+			{
+				Code: `
+async function* outer() {
+  yield async () => await Promise.resolve(1);
+}
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingAwait"}},
+			},
+		},
+	)
+}
+
+func TestRequireAwaitDeepScopeStack(t *testing.T) {
+	const depth = 40
+	var source strings.Builder
+	for i := range depth {
+		source.WriteString("async function f")
+		source.WriteString(strconv.Itoa(i))
+		source.WriteString("() {\n")
+	}
+	source.WriteString("await Promise.resolve();\n")
+	for range depth {
+		source.WriteString("}\n")
+	}
+
+	errors := make([]rule_tester.InvalidTestCaseError, depth-1)
+	for i := range errors {
+		errors[i].MessageId = "missingAwait"
+	}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RequireAwaitRule,
+		nil,
+		[]rule_tester.InvalidTestCase{{
+			Code:   source.String(),
+			Errors: errors,
+		}},
+	)
+}
+
+func TestRequireAwaitThenableFastPathParity(t *testing.T) {
+	const source = `
+interface GoodThenable {
+  then(onfulfilled: (value: number) => unknown): unknown;
+}
+interface RestThenable {
+  then(...callbacks: Array<(value: number) => unknown>): unknown;
+}
+interface UnionCallbackThenable {
+  then(onfulfilled: ((value: number) => unknown) | { tag: string }): unknown;
+}
+interface BadThenable {
+  then(value: number): unknown;
+}
+interface NoArgThenable {
+  then(): unknown;
+}
+declare const good: GoodThenable;
+declare const rest: RestThenable;
+declare const unionCallback: UnionCallbackThenable;
+declare const bad: BadThenable;
+declare const noArg: NoArgThenable;
+
+const caseNumber = 1;
+const casePromise = Promise.resolve(1);
+const caseGood = good;
+const caseRest = rest;
+const caseUnionCallback = unionCallback;
+const caseBad = bad;
+const caseNoArg = noArg;
+const caseGoodUnion = null as number | GoodThenable;
+const caseBadUnion = null as number | BadThenable;
+const caseIntersection = null as GoodThenable & { tag: string };
+`
+	expected := map[string]bool{
+		"caseNumber":        false,
+		"casePromise":       true,
+		"caseGood":          true,
+		"caseRest":          true,
+		"caseUnionCallback": true,
+		"caseBad":           false,
+		"caseNoArg":         false,
+		"caseGoodUnion":     true,
+		"caseBadUnion":      false,
+		"caseIntersection":  true,
+	}
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(source, "require-await-thenable-parity.ts", "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	typeChecker, done := program.GetTypeChecker(t.Context())
+	defer done()
+
+	seen := make(map[string]bool, len(expected))
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if ast.IsExpressionNode(node) {
+			typ := typeChecker.GetTypeAtLocation(node)
+			got := isThenableType(typeChecker, node, typ)
+			shared := utils.IsThenableType(typeChecker, node, typ)
+			if got != shared {
+				t.Errorf(
+					"expression kind %v at [%d,%d): fast path = %t, shared helper = %t",
+					node.Kind,
+					node.Pos(),
+					node.End(),
+					got,
+					shared,
+				)
+			}
+		}
+		if node.Kind == ast.KindVariableDeclaration {
+			name := node.Name()
+			initializer := node.Initializer()
+			if name != nil && initializer != nil {
+				if want, ok := expected[name.Text()]; ok {
+					typ := typeChecker.GetTypeAtLocation(initializer)
+					got := isThenableType(typeChecker, initializer, typ)
+					shared := utils.IsThenableType(typeChecker, initializer, typ)
+					if got != shared {
+						t.Errorf("%s: fast path = %t, shared helper = %t", name.Text(), got, shared)
+					}
+					if got != want {
+						t.Errorf("%s: isThenableType = %t, want %t", name.Text(), got, want)
+					}
+					seen[name.Text()] = true
+				}
+			}
+		}
+		node.ForEachChild(visit)
+		return false
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+
+	for name := range expected {
+		if !seen[name] {
+			t.Errorf("test case %s was not visited", name)
+		}
+	}
+}
+
+func TestRequireAwaitRecoveryAST(t *testing.T) {
+	for index, source := range []string{
+		`async function value() {`,
+		`const value = async () => {`,
+		`async function* value() {`,
+		`async function outer() { function inner() {`,
+		`class Value { async method() {`,
+		`async function outer() { const inner = async () => {`,
+	} {
+		t.Run(strconv.Itoa(index), func(t *testing.T) {
+			fileName := "/require-await-recovery-" + strconv.Itoa(index) + ".ts"
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: fileName,
+				Path:     tspath.Path(fileName),
+			}, source, core.ScriptKindTS)
+			ctx := rule.RuleContext{
+				SourceFile:     sourceFile,
+				DisableManager: rule.NewDisableManager(sourceFile, rule.NewCommentStore(sourceFile)),
+			}.WithReporter(
+				RequireAwaitRule.Name,
+				rule.SeverityError,
+				func(diagnostic rule.RuleDiagnostic) {
+					if diagnostic.Range.Pos() < 0 ||
+						diagnostic.Range.End() < diagnostic.Range.Pos() ||
+						diagnostic.Range.End() > len(source) {
+						t.Errorf(
+							"out-of-bounds diagnostic range [%d,%d) for source length %d",
+							diagnostic.Range.Pos(),
+							diagnostic.Range.End(),
+							len(source),
+						)
+					}
+				},
+			)
+			listeners := RequireAwaitRule.Run(ctx, nil)
+
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if listener := listeners[node.Kind]; listener != nil {
+					listener(node)
+				}
+				node.ForEachChild(visit)
+				if listener := listeners[rule.ListenerOnExit(node.Kind)]; listener != nil {
+					listener(node)
+				}
+				return false
+			}
+			sourceFile.AsNode().ForEachChild(visit)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Optimize `@typescript-eslint/require-await` without changing the rule's behavior.
- Reuse a value-based function scope stack instead of allocating one linked scope per function.
- Defer return, yield, and expression-bodied arrow type checks until their expressions have been visited, then skip checks when an `await` has already satisfied the rule.
- Skip yield type analysis for sync generators and async generators that are already known to be valid.
- Add rule-local allocation-free fast paths for common non-union thenable checks and async-iterator recursion.
- Keep the optimization entirely within the rule layer. `ctx.Refs` cannot replace syntax/type analysis here, and report deferral does not help because this rule currently emits plain diagnostics without fixes or suggestions.

### Performance

The comparison is the pre-optimization `main` implementation versus this PR, using the same temporary Go benchmark harness on an Apple M1 Max. Each side was run with `-benchtime=500ms -count=5 -benchmem`; the table reports medians.

| Scenario | Before ns/op | After ns/op | Time | Before allocs/op | After allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| Sync functions | 569,766 | 535,964 | -5.9% | 2,109 | 62 |
| Async arrows | 270,655 | 252,400 | -6.7% | 1,597 | 574 |
| Returns before a later await | 401,309 | 374,735 | -6.6% | 1,340 | 61 |
| Sync generators | 208,147 | 117,452 | -43.6% | 1,340 | 61 |
| Async generators after await | 246,621 | 152,320 | -38.2% | 1,340 | 61 |

Real-repository validation used rspack's `rslint.config.mts`, `--singleThreaded`, and `--timing all`, alternating the before/after binaries for 10 rounds:

- `@typescript-eslint/require-await`: median **16.75 ms -> 1.00 ms (-94.0%)** across 342 type-aware files.
- All 20 runs exited successfully and produced identical empty diagnostic output.
- End-to-end wall-clock medians were 1.797 s and 1.946 s. The run-to-run noise is much larger than the roughly 16 ms rule saving, so no end-to-end improvement or regression is claimed.

### Validation

- `pnpm check-spell`
- `pnpm format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/require_await/...`
- `go test ./internal/plugins/typescript/rules/require_await -count=1`
- Adversarial coverage includes thenable parity, unions/intersections/rest callbacks, fake thenables, nested scope isolation, deep scope stacks, sync/async generators, and parser recovery ASTs.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
