### PR TITLE
perf: port no-const-assign to ctx.Refs.Resolve

### DIFF
--- a/internal/rules/no_const_assign/no_const_assign.go
+++ b/internal/rules/no_const_assign/no_const_assign.go
@@ -3,6 +3,7 @@ package no_const_assign
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // Message builder
@@ -13,254 +14,9 @@ func buildConstMessage(name string) rule.RuleMessage {
 	}
 }
 
-// isConstBinding checks if a variable declaration is a const binding
-func isConstBinding(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindVariableDeclarationList {
-		return false
-	}
-
-	varDeclList := node.AsVariableDeclarationList()
-	if varDeclList == nil {
-		return false
-	}
-
-	// Check if the declaration is const (or using/await using in the future)
-	// In TypeScript AST, const declarations have flags
-	return (varDeclList.Flags & ast.NodeFlagsConst) != 0
-}
-
-// getIdentifierName gets the name of an identifier node
-func getIdentifierName(node *ast.Node) string {
-	if node == nil || node.Kind != ast.KindIdentifier {
-		return ""
-	}
-
-	return node.Text()
-}
-
-// isWriteReference checks if a reference is a write operation (assignment, increment, decrement, etc.)
-func isWriteReference(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-
-	parent := node.Parent
-	if parent == nil {
-		return false
-	}
-
-	switch parent.Kind {
-	case ast.KindBinaryExpression:
-		// Check if this is an assignment operation
-		binary := parent.AsBinaryExpression()
-		if binary == nil {
-			return false
-		}
-
-		// Check if the node is on the left side of an assignment
-		if binary.Left != node {
-			return false
-		}
-
-		// Check for all assignment operators
-		switch binary.OperatorToken.Kind {
-		case ast.KindEqualsToken, // =
-			ast.KindPlusEqualsToken,                              // +=
-			ast.KindMinusEqualsToken,                             // -=
-			ast.KindAsteriskEqualsToken,                          // *=
-			ast.KindSlashEqualsToken,                             // /=
-			ast.KindPercentEqualsToken,                           // %=
-			ast.KindAsteriskAsteriskEqualsToken,                  // **=
-			ast.KindLessThanLessThanEqualsToken,                  // <<=
-			ast.KindGreaterThanGreaterThanEqualsToken,            // >>=
-			ast.KindGreaterThanGreaterThanGreaterThanEqualsToken, // >>>=
-			ast.KindAmpersandEqualsToken,                         // &=
-			ast.KindBarEqualsToken,                               // |=
-			ast.KindCaretEqualsToken,                             // ^=
-			ast.KindQuestionQuestionEqualsToken,                  // ??=
-			ast.KindAmpersandAmpersandEqualsToken,                // &&=
-			ast.KindBarBarEqualsToken:                            // ||=
-			return true
-		}
-
-	case ast.KindPrefixUnaryExpression:
-		// Check for ++ and -- prefix operators
-		prefix := parent.AsPrefixUnaryExpression()
-		if prefix == nil {
-			return false
-		}
-
-		switch prefix.Operator {
-		case ast.KindPlusPlusToken, // ++
-			ast.KindMinusMinusToken: // --
-			return prefix.Operand == node
-		}
-
-	case ast.KindPostfixUnaryExpression:
-		// Check for ++ and -- postfix operators
-		postfix := parent.AsPostfixUnaryExpression()
-		if postfix == nil {
-			return false
-		}
-
-		switch postfix.Operator {
-		case ast.KindPlusPlusToken, // ++
-			ast.KindMinusMinusToken: // --
-			return postfix.Operand == node
-		}
-
-	case ast.KindObjectBindingPattern:
-		// In destructuring like {x} = obj, x is a write reference
-		return isBindingPatternInAssignment(parent)
-
-	case ast.KindArrayBindingPattern:
-		// In array destructuring like [x] = arr, x is a write reference
-		return isBindingPatternInAssignment(parent)
-
-	case ast.KindBindingElement:
-		// Check if the binding element is part of a write context
-		return isWriteReference(parent)
-
-	case ast.KindShorthandPropertyAssignment:
-		// In destructuring like {x} = obj or ({x} = obj), x is a write reference
-		// Check if the parent shorthand property is in a destructuring assignment
-		return isInDestructuringAssignment(parent)
-
-	case ast.KindPropertyAssignment:
-		// In destructuring like {b: x} = obj, x is a write reference
-		propAssignment := parent.AsPropertyAssignment()
-		if propAssignment != nil && propAssignment.Initializer == node {
-			return isInDestructuringAssignment(parent)
-		}
-
-	case ast.KindObjectLiteralExpression:
-		// In object destructuring like {x} = obj, x is a write reference
-		return isInDestructuringAssignment(parent)
-
-	case ast.KindArrayLiteralExpression:
-		// In array destructuring like [x] = arr, x is a write reference
-		return isInDestructuringAssignment(parent)
-
-	case ast.KindParenthesizedExpression:
-		// Unwrap parentheses and check the parent context
-		return isWriteReference(parent)
-
-	case ast.KindAsExpression, ast.KindTypeAssertionExpression:
-		// Type assertions like (x as any) = 0
-		// The type assertion wraps the identifier, check if the assertion is a write target
-		return isWriteReference(parent)
-	}
-
-	return false
-}
-
-// isBindingPatternInAssignment checks if a binding pattern is the left side of an assignment
-func isBindingPatternInAssignment(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-
-	// The binding pattern's parent might be wrapped in parentheses
-	parent := node.Parent
-
-	// Unwrap parentheses
-	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-		parent = parent.Parent
-	}
-
-	// Check if the parent is a binary expression with = operator
-	if parent != nil && parent.Kind == ast.KindBinaryExpression {
-		binary := parent.AsBinaryExpression()
-		if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
-			// Check if the binding pattern is on the left side
-			leftNode := binary.Left
-			// Unwrap parentheses on the left side
-			for leftNode != nil && leftNode.Kind == ast.KindParenthesizedExpression {
-				parenExpr := leftNode.AsParenthesizedExpression()
-				if parenExpr != nil {
-					leftNode = parenExpr.Expression
-				} else {
-					break
-				}
-			}
-			return leftNode == node
-		}
-	}
-
-	return false
-}
-
-// isInDestructuringAssignment checks if a node is part of a destructuring assignment pattern
-func isInDestructuringAssignment(node *ast.Node) bool {
-	current := node
-	for current != nil {
-		if current.Kind == ast.KindObjectLiteralExpression || current.Kind == ast.KindArrayLiteralExpression {
-			// Check if this literal is the left side of an assignment
-			// May be wrapped in parentheses
-			parent := current.Parent
-
-			// Unwrap parentheses
-			for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-				parent = parent.Parent
-			}
-
-			if parent != nil && parent.Kind == ast.KindBinaryExpression {
-				binary := parent.AsBinaryExpression()
-				if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
-					// Check if the literal (or its parent parenthesized expression) is on the left
-					leftNode := binary.Left
-					// Unwrap parentheses on left side
-					for leftNode != nil && leftNode.Kind == ast.KindParenthesizedExpression {
-						parenExpr := leftNode.AsParenthesizedExpression()
-						if parenExpr != nil {
-							leftNode = parenExpr.Expression
-						} else {
-							break
-						}
-					}
-					if leftNode == current {
-						return true
-					}
-				}
-			}
-			return false
-		}
-		current = current.Parent
-	}
-	return false
-}
-
-// checkIdentifierWrite checks if an identifier is a write reference to a const variable
-func checkIdentifierWrite(node *ast.Node, ctx *rule.RuleContext, constSymbols map[*ast.Symbol]bool) {
-	// Check if this is a write reference (assignment, increment, etc.)
-	if !isWriteReference(node) {
-		return
-	}
-
-	// Get the symbol for this identifier
-	if ctx.TypeChecker == nil {
-		return
-	}
-
-	symbol := ctx.TypeChecker.GetSymbolAtLocation(node)
-	if symbol == nil {
-		return
-	}
-
-	// Check if this symbol refers to a const variable
-	if !constSymbols[symbol] {
-		return
-	}
-
-	// Report the violation
-	identName := getIdentifierName(node)
-	ctx.ReportNode(node, buildConstMessage(identName))
-}
-
 // NoConstAssignRule disallows reassigning const variables
 var NoConstAssignRule = rule.Rule{
-	Name:             "no-const-assign",
-	RequiresTypeInfo: true,
+	Name: "no-const-assign",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		// Track const declarations by their symbol
 		constSymbols := make(map[*ast.Symbol]bool)
@@ -268,106 +24,51 @@ var NoConstAssignRule = rule.Rule{
 		return rule.RuleListeners{
 			// Track const variable declarations
 			ast.KindVariableDeclarationList: func(node *ast.Node) {
-				if !isConstBinding(node) {
+				if node.Flags&ast.NodeFlagsConst == 0 {
 					return
 				}
 
-				varDeclList := node.AsVariableDeclarationList()
-				if varDeclList == nil || varDeclList.Declarations == nil {
+				declList := node.AsVariableDeclarationList()
+				if declList == nil || declList.Declarations == nil {
 					return
 				}
 
-				// Track all identifiers declared as const using their symbols
-				for _, decl := range varDeclList.Declarations.Nodes {
+				for _, decl := range declList.Declarations.Nodes {
 					if decl.Kind != ast.KindVariableDeclaration {
 						continue
 					}
-
 					varDecl := decl.AsVariableDeclaration()
 					if varDecl == nil || varDecl.Name() == nil {
 						continue
 					}
-
-					// Collect symbols for all identifiers in the binding name
-					collectSymbols(varDecl.Name(), &ctx, constSymbols)
+					utils.CollectBindingNames(varDecl.Name(), func(ident *ast.Node, _ string) {
+						// The binder attaches the symbol to the enclosing
+						// declaration (VariableDeclaration or BindingElement).
+						bindingDecl := ident.Parent
+						if bindingDecl == nil || bindingDecl.Name() != ident {
+							return
+						}
+						if sym := bindingDecl.Symbol(); sym != nil {
+							constSymbols[sym] = true
+						}
+					})
 				}
 			},
 
-			// Check for reassignments to const variables
+			// Check every write reference in the file — including shorthand
+			// destructuring writes like `({x} = {x: 1})`, since ctx.Refs.Resolve
+			// resolves the shorthand name's own binding symbol rather than the
+			// property symbol a TypeChecker lookup would otherwise return.
 			ast.KindIdentifier: func(node *ast.Node) {
-				checkIdentifierWrite(node, &ctx, constSymbols)
-			},
-
-			// Check shorthand property assignments in destructuring (e.g., {x} = obj)
-			ast.KindShorthandPropertyAssignment: func(node *ast.Node) {
-				shorthand := node.AsShorthandPropertyAssignment()
-				if shorthand == nil || shorthand.Name() == nil {
+				if len(constSymbols) == 0 || !utils.IsWriteReference(node) {
 					return
 				}
-
-				// Check if this shorthand is in a destructuring assignment
-				if !isInDestructuringAssignment(node) {
+				sym := ctx.Refs.Resolve(node)
+				if sym == nil || !constSymbols[sym] {
 					return
 				}
-
-				// This is a write reference, check if it refers to a const variable
-				if ctx.TypeChecker == nil {
-					return
-				}
-
-				symbol := ctx.TypeChecker.GetSymbolAtLocation(shorthand.Name())
-				if symbol == nil {
-					return
-				}
-
-				// Check if this symbol refers to a const variable
-				if !constSymbols[symbol] {
-					return
-				}
-
-				// Report the violation
-				identName := getIdentifierName(shorthand.Name())
-				ctx.ReportNode(shorthand.Name(), buildConstMessage(identName))
+				ctx.ReportNode(node, buildConstMessage(node.Text()))
 			},
 		}
 	},
-}
-
-// collectSymbols recursively collects symbols for all identifiers from a binding pattern
-func collectSymbols(bindingName *ast.Node, ctx *rule.RuleContext, constSymbols map[*ast.Symbol]bool) {
-	if bindingName == nil || ctx.TypeChecker == nil {
-		return
-	}
-
-	switch bindingName.Kind {
-	case ast.KindIdentifier:
-		symbol := ctx.TypeChecker.GetSymbolAtLocation(bindingName)
-		if symbol != nil {
-			constSymbols[symbol] = true
-		}
-
-	case ast.KindObjectBindingPattern:
-		// Walk through child nodes to find binding elements
-		bindingName.ForEachChild(func(child *ast.Node) bool {
-			if child.Kind == ast.KindBindingElement {
-				bindingElem := child.AsBindingElement()
-				if bindingElem != nil && bindingElem.Name() != nil {
-					collectSymbols(bindingElem.Name(), ctx, constSymbols)
-				}
-			}
-			return false
-		})
-
-	case ast.KindArrayBindingPattern:
-		// Walk through child nodes to find binding elements
-		bindingName.ForEachChild(func(child *ast.Node) bool {
-			if child.Kind == ast.KindBindingElement {
-				bindingElem := child.AsBindingElement()
-				if bindingElem != nil && bindingElem.Name() != nil {
-					collectSymbols(bindingElem.Name(), ctx, constSymbols)
-				}
-			}
-			return false
-		})
-	}
 }

--- a/internal/rules/no_const_assign/no_const_assign_test.go
+++ b/internal/rules/no_const_assign/no_const_assign_test.go
@@ -109,13 +109,12 @@ func TestNoConstAssignRule(t *testing.T) {
 			},
 
 			// Assignment via destructuring
-			// TODO: This test case is not working yet - needs investigation of AST structure
-			// {
-			// 	Code: `const x = 0; ({x} = {x: 1});`,
-			// 	Errors: []rule_tester.InvalidTestCaseError{
-			// 		{MessageId: "const", Line: 1, Column: 16},
-			// 	},
-			// },
+			{
+				Code: `const x = 0; ({x} = {x: 1});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "const", Line: 1, Column: 16},
+				},
+			},
 
 			// Compound assignment +=
 			{

--- a/internal/rules/no_const_assign/no_const_assign_test.go
+++ b/internal/rules/no_const_assign/no_const_assign_test.go
@@ -89,6 +89,21 @@ func TestNoConstAssignRule(t *testing.T) {
 
 			// Nested block scopes
 			{Code: `const x = 0; { { let x; x = 1; } }`},
+
+			// Const read inside a nested object literal used as a
+			// destructuring default value — the default value is a plain
+			// expression, not a pattern, so the shorthand read must not be
+			// mistaken for a write to the destructuring target.
+			{Code: `const x = 0; let y; ({a: y = {x}} = {});`},
+
+			// Same case with array destructuring default value
+			{Code: `const x = 0; let y; ([y = [x]] = []);`},
+
+			// Const read inside a shorthand-property default value
+			{Code: `const x = 0; let y; ({y = {x}} = {});`},
+
+			// Const read as a plain (non-object) default value
+			{Code: `const x = 0; let y; ({y = x} = {});`},
 		},
 		// Invalid cases - ported from ESLint
 		[]rule_tester.InvalidTestCase{
@@ -356,6 +371,15 @@ func TestNoConstAssignRule(t *testing.T) {
 				Code: `const x = 1; { { x = 2; } }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "const", Line: 1, Column: 18},
+				},
+			},
+
+			// Const is the actual write target behind a default value —
+			// distinct from `{a: y = {x}}`, where `x` is only read.
+			{
+				Code: `const x = 0; ({a: x = 1} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "const", Line: 1, Column: 19},
 				},
 			},
 		},

--- a/internal/rules/no_const_assign/no_const_assign_test.go
+++ b/internal/rules/no_const_assign/no_const_assign_test.go
@@ -104,6 +104,23 @@ func TestNoConstAssignRule(t *testing.T) {
 
 			// Const read as a plain (non-object) default value
 			{Code: `const x = 0; let y; ({y = x} = {});`},
+
+			// Const read inside a nested object literal wrapped in a call
+			// expression that's used as a destructuring default value
+			{Code: `const x = 0; let y; ({a: y = foo({x})} = {});`},
+
+			// Const read inside a nested object literal wrapped in a
+			// conditional expression used as a destructuring default value
+			{Code: `const x = 0; let y; ({a: y = true ? {x} : {}} = {});`},
+
+			// Const read inside a computed property key of a destructuring
+			// pattern — the key is evaluated as a value, not a pattern
+			// element, so the shorthand read must not be mistaken for a
+			// write to the destructuring target.
+			{Code: `const x = 0; let y; ({[{x}]: y} = {});`},
+
+			// Same case with the key wrapped in a call expression
+			{Code: `const x = 0; let y; ({[foo({x})]: y} = {});`},
 		},
 		// Invalid cases - ported from ESLint
 		[]rule_tester.InvalidTestCase{

--- a/internal/rules/prefer_const/prefer_const_test.go
+++ b/internal/rules/prefer_const/prefer_const_test.go
@@ -1025,6 +1025,18 @@ func TestPreferConstRule(t *testing.T) {
 			// === Same-scope function param + let in destructuring: not reported ===
 			// (parameters are in the function scope, but findContainingBlock for the
 			// parameter declaration returns the function body block, matching the let)
+
+			// A read inside a destructuring pattern's computed property key
+			// must not be mistaken for a write to the destructuring target,
+			// or the variable it reads never gets flagged.
+			{
+				Code:   `let v = 0; console.log(v); let obj = {}; ({[{v}]: obj.foo} = {});`,
+				Output: []string{`const v = 0; console.log(v); const obj = {}; ({[{v}]: obj.foo} = {});`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 5},
+					{MessageId: "useConst", Line: 1, Column: 32},
+				},
+			},
 		},
 	)
 }

--- a/internal/utils/write_reference.go
+++ b/internal/utils/write_reference.go
@@ -172,10 +172,7 @@ func IsInDestructuringAssignment(node *ast.Node) bool {
 							break
 						}
 					}
-					if leftNode == current {
-						return true
-					}
-					return false
+					return leftNode == current
 				}
 			}
 			// Check if this is a destructuring target in for-in/for-of

--- a/internal/utils/write_reference.go
+++ b/internal/utils/write_reference.go
@@ -175,6 +175,11 @@ func IsInDestructuringAssignment(node *ast.Node) bool {
 					if leftNode == current {
 						return true
 					}
+					// current sits on the right-hand side of `=`, e.g. the
+					// default value `{x}` in `y = {x}`. That's a plain
+					// expression, not a pattern element, so stop walking
+					// instead of climbing past it into the outer pattern.
+					return false
 				}
 			}
 			// Check if this is a destructuring target in for-in/for-of
@@ -182,6 +187,18 @@ func IsInDestructuringAssignment(node *ast.Node) bool {
 				stmt := parent.AsForInOrOfStatement()
 				if stmt != nil && stmt.Initializer == current {
 					return true
+				}
+			}
+
+			// current is the default value of a shorthand property, e.g.
+			// `{x}` in `{y = {x}}`. Shorthand defaults are stored as their
+			// own field rather than a BinaryExpression, but they're still
+			// just a value expression — not a pattern element — so stop
+			// walking instead of climbing into the outer pattern.
+			if parent != nil && parent.Kind == ast.KindShorthandPropertyAssignment {
+				shorthand := parent.AsShorthandPropertyAssignment()
+				if shorthand != nil && shorthand.ObjectAssignmentInitializer == current {
+					return false
 				}
 			}
 

--- a/internal/utils/write_reference.go
+++ b/internal/utils/write_reference.go
@@ -153,13 +153,13 @@ func IsBindingPatternInAssignment(node *ast.Node) bool {
 func IsInDestructuringAssignment(node *ast.Node) bool {
 	current := node
 	for current != nil {
+		parent := current.Parent
+
+		for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+			parent = parent.Parent
+		}
+
 		if current.Kind == ast.KindObjectLiteralExpression || current.Kind == ast.KindArrayLiteralExpression {
-			parent := current.Parent
-
-			for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-				parent = parent.Parent
-			}
-
 			if parent != nil && parent.Kind == ast.KindBinaryExpression {
 				binary := parent.AsBinaryExpression()
 				if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken {
@@ -175,10 +175,6 @@ func IsInDestructuringAssignment(node *ast.Node) bool {
 					if leftNode == current {
 						return true
 					}
-					// current sits on the right-hand side of `=`, e.g. the
-					// default value `{x}` in `y = {x}`. That's a plain
-					// expression, not a pattern element, so stop walking
-					// instead of climbing past it into the outer pattern.
 					return false
 				}
 			}
@@ -189,22 +185,40 @@ func IsInDestructuringAssignment(node *ast.Node) bool {
 					return true
 				}
 			}
-
-			// current is the default value of a shorthand property, e.g.
-			// `{x}` in `{y = {x}}`. Shorthand defaults are stored as their
-			// own field rather than a BinaryExpression, but they're still
-			// just a value expression — not a pattern element — so stop
-			// walking instead of climbing into the outer pattern.
-			if parent != nil && parent.Kind == ast.KindShorthandPropertyAssignment {
-				shorthand := parent.AsShorthandPropertyAssignment()
-				if shorthand != nil && shorthand.ObjectAssignmentInitializer == current {
-					return false
-				}
-			}
-
 			// Continue walking up — this array/object might be nested inside
 			// another destructuring pattern (e.g. [{a}] = [...]).
 		}
+
+		// A default value's expression can wrap the eventual object/array
+		// literal arbitrarily deep in plain expressions (calls,
+		// conditionals, etc.) before we reach it, e.g. the `{x}` in
+		// `y = foo({x})` or `y = cond ? {x} : {}`. As soon as the walk
+		// crosses onto the right-hand side of `=` or into a shorthand
+		// property's default — whether current is the literal itself or one
+		// of its wrapping expressions — it has left the pattern for good,
+		// so stop instead of climbing back into the enclosing pattern
+		// through it.
+		if parent != nil && parent.Kind == ast.KindBinaryExpression {
+			binary := parent.AsBinaryExpression()
+			if binary != nil && binary.OperatorToken != nil && binary.OperatorToken.Kind == ast.KindEqualsToken && binary.Right == current {
+				return false
+			}
+		}
+		if parent != nil && parent.Kind == ast.KindShorthandPropertyAssignment {
+			shorthand := parent.AsShorthandPropertyAssignment()
+			if shorthand != nil && shorthand.ObjectAssignmentInitializer == current {
+				return false
+			}
+		}
+
+		// A computed property key, e.g. the `{x}` in `{[foo({x})]: y}`, is
+		// always evaluated as a value — it's never a pattern element, no
+		// matter how deeply the walk is nested inside it or how the outer
+		// property is used.
+		if parent != nil && parent.Kind == ast.KindComputedPropertyName {
+			return false
+		}
+
 		current = current.Parent
 	}
 	return false


### PR DESCRIPTION
## Summary

- Port `no-const-assign` to `ctx.Refs.Resolve(node)`, replacing the manual whole-file `KindIdentifier` scan's `ctx.TypeChecker.GetSymbolAtLocation` round-trip (paid on every write reference in the file, const or not) and the separate `ShorthandPropertyAssignment` listener with a single lookup path.
- `ctx.Refs.Resolve` does a single binder scope-walk per identifier with no whole-file indexing — unlike `ctx.Refs.References(sym)`, which requires `RefStore` to bucket every identifier in the file by name first. An earlier attempt at porting this rule with `References(sym)` (following the `no-var` pattern) actually regressed it; this uses the narrower `Resolve` API added in #1415 instead.
- Re-enables a previously-disabled test case for shorthand destructuring writes (`({x} = {x: 1})`), which now passes: `Resolve` correctly attributes the shorthand identifier to the variable's own symbol rather than the property symbol a `TypeChecker` lookup would return.
- Drops `RequiresTypeInfo: true` — the rule no longer touches the `TypeChecker` at all, so it now also fires correctly on gap files / LSP inferred-project files, verified by `internal/config`'s nil-`TypeChecker` guard tests.

## Benchmark

Synthetic corpus: 1200 `.ts` files / 15 MiB, 20 top-level `const` declarations per file, each read many times and rarely reassigned, plus heavily-mutated `let` loop counters/accumulators that are not const (writes the old implementation still paid a `TypeChecker` call for, since it checked every write regardless of const-ness).

Per-rule time from `--timing all` (summed across workers), 10 runs after a warmup:

| | mean | median |
| --- | --- | --- |
| `main` | 60.1 ms | 58.5 ms |
| this PR | 43.7 ms | 41.7 ms |

Rule time: **−27.4%** (mean).

End-to-end wall clock on the same corpus (hyperfine, 12 runs + 2 warmup): 415.6 ms ± 12.4 → 401.1 ms ± 11.6, **−3.5%** (User CPU −4.9%); smaller than the rule-time delta because this is a type-aware corpus where parse/bind/typecheck dominates total time.

For context, an earlier attempt using `ctx.Refs.References(sym)` (matching the pattern used for `no-var`/`no-class-assign`/`no-func-assign`) measured **slower** than `main` (mean 79.7 ms) on the same corpus, because `collectCandidates` indexes every identifier in the file by name while this rule's own write-reference scan is already narrowly filtered. `Resolve` avoids that index entirely.

## Validation

- `go test ./internal/rules/no_const_assign/...`
- `go vet ./internal/rules/no_const_assign/...`
- `internal/config` TypeChecker-nil-safety guard tests (`TestAllRules_SilentOnNilTypeCheckerImpliesRequiresTypeInfo`, `TestAllRules_NilTypeCheckerEarlyReturnImpliesRequiresTypeInfo`, `TestAllRules_DeclaredSchemasCompile`)
- Both binaries produce byte-identical diagnostics (679) on the benchmark corpus.

## Related Links

Follow-up to #1335, which added `ctx.Refs`, and #1415, which added `ctx.Refs.Resolve`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).