### PR TITLE
perf: optimize no-unmodified-loop-condition rule

### DIFF
--- a/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
+++ b/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -81,32 +80,32 @@ func extractGroups(node *ast.Node) []*ast.Node {
 
 // collectIdentifierSymbols collects unique identifier references (by symbol) from a node.
 // Returns nil if any dynamic expression is found.
-func collectIdentifierSymbols(node *ast.Node, tc *checker.Checker) []identifierRef {
+func collectIdentifierSymbols(node *ast.Node, refs *rule.RefStore) []identifierRef {
 	if node == nil {
 		return nil
 	}
 	if hasDynamicExpression(node) {
 		return nil
 	}
-	var refs []identifierRef
+	var result []identifierRef
 	var walk func(n *ast.Node)
 	walk = func(n *ast.Node) {
 		if n == nil {
 			return
 		}
 		if n.Kind == ast.KindIdentifier {
-			sym := tc.GetSymbolAtLocation(n)
+			sym := refs.Resolve(n)
 			if sym != nil {
 				// Deduplicate by symbol
 				dup := false
-				for _, r := range refs {
+				for _, r := range result {
 					if r.symbol == sym {
 						dup = true
 						break
 					}
 				}
 				if !dup {
-					refs = append(refs, identifierRef{symbol: sym, node: n})
+					result = append(result, identifierRef{symbol: sym, node: n})
 				}
 			}
 			return
@@ -117,48 +116,44 @@ func collectIdentifierSymbols(node *ast.Node, tc *checker.Checker) []identifierR
 		})
 	}
 	walk(node)
-	return refs
+	return result
 }
 
-// isSymbolWrittenInBody walks the body (and optionally the incrementor) looking for
-// any write reference to the given symbol. Does NOT skip function boundaries —
-// ESLint uses range-based checking where any write within the loop's text range
-// counts as a modification, even inside nested functions.
-func isSymbolWrittenInBody(body *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
-	if body == nil {
+// isWrittenInRange reports whether sym has a write reference positioned inside
+// rangeNode. It scans sym's whole-file reference list (built once per symbol
+// and shared across every loop/group that queries it) rather than re-walking
+// rangeNode's subtree per query — the old TypeChecker-based implementation
+// walked the (potentially large) loop body/incrementor once per condition
+// identifier, which dominates cost when loops are large or numerous.
+func isWrittenInRange(refs *rule.RefStore, sym *ast.Symbol, rangeNode *ast.Node) bool {
+	if rangeNode == nil {
 		return false
 	}
-
-	found := false
-	var walk func(n *ast.Node)
-	walk = func(n *ast.Node) {
-		if n == nil || found {
-			return
+	lo, hi := rangeNode.Pos(), rangeNode.End()
+	for _, ref := range refs.References(sym) {
+		if ref.Pos() >= lo && ref.End() <= hi && utils.IsWriteReference(ref) {
+			return true
 		}
-		if n.Kind == ast.KindIdentifier {
-			refSym := tc.GetSymbolAtLocation(n)
-			if refSym == sym && utils.IsWriteReference(n) {
-				found = true
-				return
-			}
-		}
-		// ShorthandPropertyAssignment in destructuring: ({x} = {x: 1})
-		// TypeChecker resolves shorthand name to property symbol, not variable symbol.
-		// Use GetShorthandAssignmentValueSymbol to get the variable symbol.
-		if n.Kind == ast.KindShorthandPropertyAssignment && utils.IsInDestructuringAssignment(n) {
-			valSym := tc.GetShorthandAssignmentValueSymbol(n)
-			if valSym == sym {
-				found = true
-				return
-			}
-		}
-		n.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
 	}
-	walk(body)
-	return found
+	return false
+}
+
+// isReferencedInRange reports whether any symbol in funcSymbols has a
+// reference positioned inside rangeNode, using the same whole-file reference
+// lists as isWrittenInRange instead of walking rangeNode per query.
+func isReferencedInRange(refs *rule.RefStore, funcSymbols []*ast.Symbol, rangeNode *ast.Node) bool {
+	if rangeNode == nil {
+		return false
+	}
+	lo, hi := rangeNode.Pos(), rangeNode.End()
+	for _, funcSym := range funcSymbols {
+		for _, ref := range refs.References(funcSym) {
+			if ref.Pos() >= lo && ref.End() <= hi {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // isModifiedByCalledFunction checks if the symbol is modified inside a
@@ -166,13 +161,14 @@ func isSymbolWrittenInBody(body *ast.Node, sym *ast.Symbol, tc *checker.Checker)
 // This matches ESLint's secondary check: if a write reference to the variable
 // is inside a FunctionDeclaration, and that function's name is referenced
 // within the loop, the variable counts as modified.
-func isModifiedByCalledFunction(loopBody *ast.Node, incrementor *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
+func isModifiedByCalledFunction(refs *rule.RefStore, loopBody *ast.Node, incrementor *ast.Node, sym *ast.Symbol) bool {
 	scope := utils.FindEnclosingScope(loopBody)
 	if scope == nil {
 		return false
 	}
 
-	// Step 1: find FunctionDeclarations that write to sym anywhere in scope.
+	// Step 1: find (top-level, non-nested) FunctionDeclarations in scope that
+	// write to sym anywhere in their body.
 	var modifyingFuncSymbols []*ast.Symbol
 	var findFuncs func(n *ast.Node)
 	findFuncs = func(n *ast.Node) {
@@ -180,9 +176,8 @@ func isModifiedByCalledFunction(loopBody *ast.Node, incrementor *ast.Node, sym *
 			return
 		}
 		if ast.IsFunctionDeclaration(n) && n.Name() != nil {
-			if functionBodyWritesSymbol(n, sym, tc) {
-				funcSym := tc.GetSymbolAtLocation(n.Name())
-				if funcSym != nil {
+			if isWrittenInRange(refs, sym, n) {
+				if funcSym := n.Symbol(); funcSym != nil {
 					modifyingFuncSymbols = append(modifyingFuncSymbols, funcSym)
 				}
 			}
@@ -202,56 +197,13 @@ func isModifiedByCalledFunction(loopBody *ast.Node, incrementor *ast.Node, sym *
 	// Step 2: check if any of those functions are referenced in the loop
 	// (body or incrementor). ESLint uses range-based checking — any reference
 	// (not just calls) to the function within the loop counts.
-	if nodeReferencesAnySymbol(loopBody, modifyingFuncSymbols, tc) {
+	if isReferencedInRange(refs, modifyingFuncSymbols, loopBody) {
 		return true
 	}
-	if incrementor != nil && nodeReferencesAnySymbol(incrementor, modifyingFuncSymbols, tc) {
+	if incrementor != nil && isReferencedInRange(refs, modifyingFuncSymbols, incrementor) {
 		return true
 	}
 	return false
-}
-
-// functionBodyWritesSymbol checks if a function body contains a write to sym.
-// Does NOT skip nested functions — ESLint uses range-based scope analysis.
-func functionBodyWritesSymbol(funcNode *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
-	body := funcNode.Body()
-	if body == nil {
-		return false
-	}
-	return isSymbolWrittenInBody(body, sym, tc)
-}
-
-// nodeReferencesAnySymbol checks if a node tree contains any identifier
-// referencing one of the given symbols. Does not skip function boundaries
-// (ESLint uses range-based checking).
-func nodeReferencesAnySymbol(node *ast.Node, symbols []*ast.Symbol, tc *checker.Checker) bool {
-	if node == nil {
-		return false
-	}
-	found := false
-	var walk func(n *ast.Node)
-	walk = func(n *ast.Node) {
-		if n == nil || found {
-			return
-		}
-		if n.Kind == ast.KindIdentifier {
-			refSym := tc.GetSymbolAtLocation(n)
-			if refSym != nil {
-				for _, s := range symbols {
-					if refSym == s {
-						found = true
-						return
-					}
-				}
-			}
-		}
-		n.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
-	}
-	walk(node)
-	return found
 }
 
 // checkLoopCondition checks identifiers in a loop condition and reports those
@@ -261,28 +213,28 @@ func checkLoopCondition(ctx rule.RuleContext, condition *ast.Node, body *ast.Nod
 		return
 	}
 
-	tc := ctx.TypeChecker
+	refs := ctx.Refs
 	groups := extractGroups(condition)
 
 	for _, group := range groups {
-		refs := collectIdentifierSymbols(group, tc)
-		if refs == nil {
+		idRefs := collectIdentifierSymbols(group, refs)
+		if idRefs == nil {
 			continue // dynamic expression found, skip this group
 		}
 
 		// Check if any identifier in this group is modified
 		anyModified := false
-		for _, ref := range refs {
-			if isSymbolWrittenInBody(body, ref.symbol, tc) ||
-				(incrementor != nil && isSymbolWrittenInBody(incrementor, ref.symbol, tc)) ||
-				isModifiedByCalledFunction(body, incrementor, ref.symbol, tc) {
+		for _, ref := range idRefs {
+			if isWrittenInRange(refs, ref.symbol, body) ||
+				(incrementor != nil && isWrittenInRange(refs, ref.symbol, incrementor)) ||
+				isModifiedByCalledFunction(refs, body, incrementor, ref.symbol) {
 				anyModified = true
 				break
 			}
 		}
 
 		if !anyModified {
-			for _, ref := range refs {
+			for _, ref := range idRefs {
 				ctx.ReportNode(ref.node, buildLoopConditionNotModifiedMessage(ref.node.Text()))
 			}
 		}

--- a/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
+++ b/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -52,8 +53,9 @@ func hasDynamicExpression(node *ast.Node) bool {
 
 // identifierRef holds an identifier's symbol and AST node for reporting.
 type identifierRef struct {
-	symbol *ast.Symbol
-	node   *ast.Node
+	symbol     *ast.Symbol
+	node       *ast.Node
+	viaChecker bool
 }
 
 // extractGroups walks a condition expression and returns groups of sub-expressions.
@@ -80,7 +82,14 @@ func extractGroups(node *ast.Node) []*ast.Node {
 
 // collectIdentifierSymbols collects unique identifier references (by symbol) from a node.
 // Returns nil if any dynamic expression is found.
-func collectIdentifierSymbols(node *ast.Node, refs *rule.RefStore) []identifierRef {
+//
+// Symbols are resolved via RefStore first; RefStore only knows about symbols
+// bound within this file, so identifiers naming a cross-file, .d.ts, or
+// standard-library global fall back to the TypeChecker. Those are flagged
+// viaChecker so later modification checks use the matching (slower but
+// program-wide) TypeChecker-based path instead of RefStore's per-file
+// reference lists, which never index such symbols.
+func collectIdentifierSymbols(node *ast.Node, refs *rule.RefStore, tc *checker.Checker) []identifierRef {
 	if node == nil {
 		return nil
 	}
@@ -95,6 +104,11 @@ func collectIdentifierSymbols(node *ast.Node, refs *rule.RefStore) []identifierR
 		}
 		if n.Kind == ast.KindIdentifier {
 			sym := refs.Resolve(n)
+			viaChecker := false
+			if sym == nil {
+				sym = tc.GetSymbolAtLocation(n)
+				viaChecker = true
+			}
 			if sym != nil {
 				// Deduplicate by symbol
 				dup := false
@@ -105,7 +119,7 @@ func collectIdentifierSymbols(node *ast.Node, refs *rule.RefStore) []identifierR
 					}
 				}
 				if !dup {
-					result = append(result, identifierRef{symbol: sym, node: n})
+					result = append(result, identifierRef{symbol: sym, node: n, viaChecker: viaChecker})
 				}
 			}
 			return
@@ -139,21 +153,45 @@ func isWrittenInRange(refs *rule.RefStore, sym *ast.Symbol, rangeNode *ast.Node)
 }
 
 // isReferencedInRange reports whether any symbol in funcSymbols has a
-// reference positioned inside rangeNode, using the same whole-file reference
-// lists as isWrittenInRange instead of walking rangeNode per query.
+// reference positioned inside rangeNode.
+//
+// This resolves each identifier directly via refs.Resolve rather than going
+// through RefStore.References(funcSym)'s name-keyed cache: RefStore.Resolve
+// maps a same-file self-reference to a default-exported function's name
+// (`inc` in `export default function inc() {} ...  inc();`) to the export
+// symbol, but that export symbol's own .Name is "default" (its slot in the
+// module's export table), not "inc". Resolve() special-cases that name
+// mismatch internally, but querying RefStore.References(exportSymbol)
+// buckets by exportSymbol.Name = "default" and so never finds the "inc"
+// identifiers. A direct per-identifier Resolve() walk sidesteps that
+// name/symbol split instead of relying on the cache bucketing correctly.
 func isReferencedInRange(refs *rule.RefStore, funcSymbols []*ast.Symbol, rangeNode *ast.Node) bool {
 	if rangeNode == nil {
 		return false
 	}
-	lo, hi := rangeNode.Pos(), rangeNode.End()
-	for _, funcSym := range funcSymbols {
-		for _, ref := range refs.References(funcSym) {
-			if ref.Pos() >= lo && ref.End() <= hi {
-				return true
+	found := false
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil || found {
+			return
+		}
+		if n.Kind == ast.KindIdentifier {
+			if sym := refs.Resolve(n); sym != nil {
+				for _, s := range funcSymbols {
+					if sym == s {
+						found = true
+						return
+					}
+				}
 			}
 		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
 	}
-	return false
+	walk(rangeNode)
+	return found
 }
 
 // isModifiedByCalledFunction checks if the symbol is modified inside a
@@ -176,7 +214,10 @@ func isModifiedByCalledFunction(refs *rule.RefStore, loopBody *ast.Node, increme
 			return
 		}
 		if ast.IsFunctionDeclaration(n) && n.Name() != nil {
-			if isWrittenInRange(refs, sym, n) {
+			// Only the body executes when the function is called; a write inside
+			// a parameter's default-value initializer only runs when that
+			// argument is omitted, so it must not count as "written" here.
+			if isWrittenInRange(refs, sym, n.Body()) {
 				if funcSym := n.Symbol(); funcSym != nil {
 					modifyingFuncSymbols = append(modifyingFuncSymbols, funcSym)
 				}
@@ -206,6 +247,143 @@ func isModifiedByCalledFunction(refs *rule.RefStore, loopBody *ast.Node, increme
 	return false
 }
 
+// isSymbolWrittenInBodyTC walks the body (and optionally the incrementor) looking for
+// any write reference to the given symbol. Does NOT skip function boundaries —
+// ESLint uses range-based checking where any write within the loop's text range
+// counts as a modification, even inside nested functions.
+//
+// Used as the fallback for symbols RefStore couldn't resolve (cross-file,
+// .d.ts, or standard-library globals): RefStore's reference lists only index
+// symbols bound within this file, so those symbols must be found by walking
+// the range directly and asking the TypeChecker about each identifier.
+func isSymbolWrittenInBodyTC(body *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
+	if body == nil {
+		return false
+	}
+
+	found := false
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil || found {
+			return
+		}
+		if n.Kind == ast.KindIdentifier {
+			refSym := tc.GetSymbolAtLocation(n)
+			if refSym == sym && utils.IsWriteReference(n) {
+				found = true
+				return
+			}
+		}
+		// ShorthandPropertyAssignment in destructuring: ({x} = {x: 1})
+		// TypeChecker resolves shorthand name to property symbol, not variable symbol.
+		// Use GetShorthandAssignmentValueSymbol to get the variable symbol.
+		if n.Kind == ast.KindShorthandPropertyAssignment && utils.IsInDestructuringAssignment(n) {
+			valSym := tc.GetShorthandAssignmentValueSymbol(n)
+			if valSym == sym {
+				found = true
+				return
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(body)
+	return found
+}
+
+// isModifiedByCalledFunctionTC is the TypeChecker-based counterpart of
+// isModifiedByCalledFunction, used when sym came from the TypeChecker
+// fallback in collectIdentifierSymbols.
+func isModifiedByCalledFunctionTC(loopBody *ast.Node, incrementor *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
+	scope := utils.FindEnclosingScope(loopBody)
+	if scope == nil {
+		return false
+	}
+
+	// Step 1: find FunctionDeclarations that write to sym anywhere in scope.
+	var modifyingFuncSymbols []*ast.Symbol
+	var findFuncs func(n *ast.Node)
+	findFuncs = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		if ast.IsFunctionDeclaration(n) && n.Name() != nil {
+			if functionBodyWritesSymbolTC(n, sym, tc) {
+				funcSym := tc.GetSymbolAtLocation(n.Name())
+				if funcSym != nil {
+					modifyingFuncSymbols = append(modifyingFuncSymbols, funcSym)
+				}
+			}
+			return
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			findFuncs(child)
+			return false
+		})
+	}
+	findFuncs(scope)
+
+	if len(modifyingFuncSymbols) == 0 {
+		return false
+	}
+
+	// Step 2: check if any of those functions are referenced in the loop
+	// (body or incrementor). ESLint uses range-based checking — any reference
+	// (not just calls) to the function within the loop counts.
+	if nodeReferencesAnySymbolTC(loopBody, modifyingFuncSymbols, tc) {
+		return true
+	}
+	if incrementor != nil && nodeReferencesAnySymbolTC(incrementor, modifyingFuncSymbols, tc) {
+		return true
+	}
+	return false
+}
+
+// functionBodyWritesSymbolTC checks if a function body contains a write to sym.
+// Does NOT skip nested functions — ESLint uses range-based scope analysis.
+func functionBodyWritesSymbolTC(funcNode *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
+	body := funcNode.Body()
+	if body == nil {
+		return false
+	}
+	return isSymbolWrittenInBodyTC(body, sym, tc)
+}
+
+// nodeReferencesAnySymbolTC checks if a node tree contains any identifier
+// referencing one of the given symbols. Does not skip function boundaries
+// (ESLint uses range-based checking).
+func nodeReferencesAnySymbolTC(node *ast.Node, symbols []*ast.Symbol, tc *checker.Checker) bool {
+	if node == nil {
+		return false
+	}
+	found := false
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil || found {
+			return
+		}
+		if n.Kind == ast.KindIdentifier {
+			refSym := tc.GetSymbolAtLocation(n)
+			if refSym != nil {
+				for _, s := range symbols {
+					if refSym == s {
+						found = true
+						return
+					}
+				}
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(node)
+	return found
+}
+
 // checkLoopCondition checks identifiers in a loop condition and reports those
 // that are not modified in the loop body (or incrementor for for-statements).
 func checkLoopCondition(ctx rule.RuleContext, condition *ast.Node, body *ast.Node, incrementor *ast.Node) {
@@ -214,10 +392,11 @@ func checkLoopCondition(ctx rule.RuleContext, condition *ast.Node, body *ast.Nod
 	}
 
 	refs := ctx.Refs
+	tc := ctx.TypeChecker
 	groups := extractGroups(condition)
 
 	for _, group := range groups {
-		idRefs := collectIdentifierSymbols(group, refs)
+		idRefs := collectIdentifierSymbols(group, refs, tc)
 		if idRefs == nil {
 			continue // dynamic expression found, skip this group
 		}
@@ -225,9 +404,17 @@ func checkLoopCondition(ctx rule.RuleContext, condition *ast.Node, body *ast.Nod
 		// Check if any identifier in this group is modified
 		anyModified := false
 		for _, ref := range idRefs {
-			if isWrittenInRange(refs, ref.symbol, body) ||
-				(incrementor != nil && isWrittenInRange(refs, ref.symbol, incrementor)) ||
-				isModifiedByCalledFunction(refs, body, incrementor, ref.symbol) {
+			var modified bool
+			if ref.viaChecker {
+				modified = isSymbolWrittenInBodyTC(body, ref.symbol, tc) ||
+					(incrementor != nil && isSymbolWrittenInBodyTC(incrementor, ref.symbol, tc)) ||
+					isModifiedByCalledFunctionTC(body, incrementor, ref.symbol, tc)
+			} else {
+				modified = isWrittenInRange(refs, ref.symbol, body) ||
+					(incrementor != nil && isWrittenInRange(refs, ref.symbol, incrementor)) ||
+					isModifiedByCalledFunction(refs, body, incrementor, ref.symbol)
+			}
+			if modified {
 				anyModified = true
 				break
 			}

--- a/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
+++ b/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
@@ -105,7 +105,7 @@ func collectIdentifierSymbols(node *ast.Node, refs *rule.RefStore, tc *checker.C
 		if n.Kind == ast.KindIdentifier {
 			sym := refs.Resolve(n)
 			viaChecker := false
-			if sym == nil {
+			if sym == nil && tc != nil {
 				sym = tc.GetSymbolAtLocation(n)
 				viaChecker = true
 			}
@@ -406,16 +406,8 @@ func checkLoopCondition(ctx rule.RuleContext, condition *ast.Node, body *ast.Nod
 
 // NoUnmodifiedLoopConditionRule disallows variables in loop conditions that are not modified in the loop
 var NoUnmodifiedLoopConditionRule = rule.Rule{
-	Name:             "no-unmodified-loop-condition",
-	RequiresTypeInfo: true,
+	Name: "no-unmodified-loop-condition",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		// Defense-in-depth: RequiresTypeInfo: true filters this rule out for
-		// gap files / inferred-project files, but if a future caller bypasses
-		// the filter we still want to no-op rather than nil-deref.
-		if ctx.TypeChecker == nil {
-			return rule.RuleListeners{}
-		}
-
 		return rule.RuleListeners{
 			ast.KindWhileStatement: func(node *ast.Node) {
 				whileStmt := node.AsWhileStatement()

--- a/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
+++ b/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
@@ -153,45 +153,21 @@ func isWrittenInRange(refs *rule.RefStore, sym *ast.Symbol, rangeNode *ast.Node)
 }
 
 // isReferencedInRange reports whether any symbol in funcSymbols has a
-// reference positioned inside rangeNode.
-//
-// This resolves each identifier directly via refs.Resolve rather than going
-// through RefStore.References(funcSym)'s name-keyed cache: RefStore.Resolve
-// maps a same-file self-reference to a default-exported function's name
-// (`inc` in `export default function inc() {} ...  inc();`) to the export
-// symbol, but that export symbol's own .Name is "default" (its slot in the
-// module's export table), not "inc". Resolve() special-cases that name
-// mismatch internally, but querying RefStore.References(exportSymbol)
-// buckets by exportSymbol.Name = "default" and so never finds the "inc"
-// identifiers. A direct per-identifier Resolve() walk sidesteps that
-// name/symbol split instead of relying on the cache bucketing correctly.
+// reference positioned inside rangeNode, using the same whole-file reference
+// lists as isWrittenInRange instead of walking rangeNode per query.
 func isReferencedInRange(refs *rule.RefStore, funcSymbols []*ast.Symbol, rangeNode *ast.Node) bool {
 	if rangeNode == nil {
 		return false
 	}
-	found := false
-	var walk func(n *ast.Node)
-	walk = func(n *ast.Node) {
-		if n == nil || found {
-			return
-		}
-		if n.Kind == ast.KindIdentifier {
-			if sym := refs.Resolve(n); sym != nil {
-				for _, s := range funcSymbols {
-					if sym == s {
-						found = true
-						return
-					}
-				}
+	lo, hi := rangeNode.Pos(), rangeNode.End()
+	for _, funcSym := range funcSymbols {
+		for _, ref := range refs.References(funcSym) {
+			if ref.Pos() >= lo && ref.End() <= hi {
+				return true
 			}
 		}
-		n.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
 	}
-	walk(rangeNode)
-	return found
+	return false
 }
 
 // isModifiedByCalledFunction checks if the symbol is modified inside a

--- a/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
+++ b/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
-	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -53,9 +52,8 @@ func hasDynamicExpression(node *ast.Node) bool {
 
 // identifierRef holds an identifier's symbol and AST node for reporting.
 type identifierRef struct {
-	symbol     *ast.Symbol
-	node       *ast.Node
-	viaChecker bool
+	symbol *ast.Symbol
+	node   *ast.Node
 }
 
 // extractGroups walks a condition expression and returns groups of sub-expressions.
@@ -83,13 +81,12 @@ func extractGroups(node *ast.Node) []*ast.Node {
 // collectIdentifierSymbols collects unique identifier references (by symbol) from a node.
 // Returns nil if any dynamic expression is found.
 //
-// Symbols are resolved via RefStore first; RefStore only knows about symbols
-// bound within this file, so identifiers naming a cross-file, .d.ts, or
-// standard-library global fall back to the TypeChecker. Those are flagged
-// viaChecker so later modification checks use the matching (slower but
-// program-wide) TypeChecker-based path instead of RefStore's per-file
-// reference lists, which never index such symbols.
-func collectIdentifierSymbols(node *ast.Node, refs *rule.RefStore, tc *checker.Checker) []identifierRef {
+// Symbols are resolved via RefStore.Resolve, which falls back to the
+// TypeChecker internally for identifiers its per-file binder walk can't place
+// (cross-file, .d.ts, and standard-library globals). RefStore.References
+// indexes identifiers for those fallback symbols the same way, so the later
+// modification checks work for them unchanged.
+func collectIdentifierSymbols(node *ast.Node, refs *rule.RefStore) []identifierRef {
 	if node == nil {
 		return nil
 	}
@@ -103,13 +100,7 @@ func collectIdentifierSymbols(node *ast.Node, refs *rule.RefStore, tc *checker.C
 			return
 		}
 		if n.Kind == ast.KindIdentifier {
-			sym := refs.Resolve(n)
-			viaChecker := false
-			if sym == nil && tc != nil {
-				sym = tc.GetSymbolAtLocation(n)
-				viaChecker = true
-			}
-			if sym != nil {
+			if sym := refs.Resolve(n); sym != nil {
 				// Deduplicate by symbol
 				dup := false
 				for _, r := range result {
@@ -119,7 +110,7 @@ func collectIdentifierSymbols(node *ast.Node, refs *rule.RefStore, tc *checker.C
 					}
 				}
 				if !dup {
-					result = append(result, identifierRef{symbol: sym, node: n, viaChecker: viaChecker})
+					result = append(result, identifierRef{symbol: sym, node: n})
 				}
 			}
 			return
@@ -223,143 +214,6 @@ func isModifiedByCalledFunction(refs *rule.RefStore, loopBody *ast.Node, increme
 	return false
 }
 
-// isSymbolWrittenInBodyTC walks the body (and optionally the incrementor) looking for
-// any write reference to the given symbol. Does NOT skip function boundaries —
-// ESLint uses range-based checking where any write within the loop's text range
-// counts as a modification, even inside nested functions.
-//
-// Used as the fallback for symbols RefStore couldn't resolve (cross-file,
-// .d.ts, or standard-library globals): RefStore's reference lists only index
-// symbols bound within this file, so those symbols must be found by walking
-// the range directly and asking the TypeChecker about each identifier.
-func isSymbolWrittenInBodyTC(body *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
-	if body == nil {
-		return false
-	}
-
-	found := false
-	var walk func(n *ast.Node)
-	walk = func(n *ast.Node) {
-		if n == nil || found {
-			return
-		}
-		if n.Kind == ast.KindIdentifier {
-			refSym := tc.GetSymbolAtLocation(n)
-			if refSym == sym && utils.IsWriteReference(n) {
-				found = true
-				return
-			}
-		}
-		// ShorthandPropertyAssignment in destructuring: ({x} = {x: 1})
-		// TypeChecker resolves shorthand name to property symbol, not variable symbol.
-		// Use GetShorthandAssignmentValueSymbol to get the variable symbol.
-		if n.Kind == ast.KindShorthandPropertyAssignment && utils.IsInDestructuringAssignment(n) {
-			valSym := tc.GetShorthandAssignmentValueSymbol(n)
-			if valSym == sym {
-				found = true
-				return
-			}
-		}
-		n.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
-	}
-	walk(body)
-	return found
-}
-
-// isModifiedByCalledFunctionTC is the TypeChecker-based counterpart of
-// isModifiedByCalledFunction, used when sym came from the TypeChecker
-// fallback in collectIdentifierSymbols.
-func isModifiedByCalledFunctionTC(loopBody *ast.Node, incrementor *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
-	scope := utils.FindEnclosingScope(loopBody)
-	if scope == nil {
-		return false
-	}
-
-	// Step 1: find FunctionDeclarations that write to sym anywhere in scope.
-	var modifyingFuncSymbols []*ast.Symbol
-	var findFuncs func(n *ast.Node)
-	findFuncs = func(n *ast.Node) {
-		if n == nil {
-			return
-		}
-		if ast.IsFunctionDeclaration(n) && n.Name() != nil {
-			if functionBodyWritesSymbolTC(n, sym, tc) {
-				funcSym := tc.GetSymbolAtLocation(n.Name())
-				if funcSym != nil {
-					modifyingFuncSymbols = append(modifyingFuncSymbols, funcSym)
-				}
-			}
-			return
-		}
-		n.ForEachChild(func(child *ast.Node) bool {
-			findFuncs(child)
-			return false
-		})
-	}
-	findFuncs(scope)
-
-	if len(modifyingFuncSymbols) == 0 {
-		return false
-	}
-
-	// Step 2: check if any of those functions are referenced in the loop
-	// (body or incrementor). ESLint uses range-based checking — any reference
-	// (not just calls) to the function within the loop counts.
-	if nodeReferencesAnySymbolTC(loopBody, modifyingFuncSymbols, tc) {
-		return true
-	}
-	if incrementor != nil && nodeReferencesAnySymbolTC(incrementor, modifyingFuncSymbols, tc) {
-		return true
-	}
-	return false
-}
-
-// functionBodyWritesSymbolTC checks if a function body contains a write to sym.
-// Does NOT skip nested functions — ESLint uses range-based scope analysis.
-func functionBodyWritesSymbolTC(funcNode *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
-	body := funcNode.Body()
-	if body == nil {
-		return false
-	}
-	return isSymbolWrittenInBodyTC(body, sym, tc)
-}
-
-// nodeReferencesAnySymbolTC checks if a node tree contains any identifier
-// referencing one of the given symbols. Does not skip function boundaries
-// (ESLint uses range-based checking).
-func nodeReferencesAnySymbolTC(node *ast.Node, symbols []*ast.Symbol, tc *checker.Checker) bool {
-	if node == nil {
-		return false
-	}
-	found := false
-	var walk func(n *ast.Node)
-	walk = func(n *ast.Node) {
-		if n == nil || found {
-			return
-		}
-		if n.Kind == ast.KindIdentifier {
-			refSym := tc.GetSymbolAtLocation(n)
-			if refSym != nil {
-				for _, s := range symbols {
-					if refSym == s {
-						found = true
-						return
-					}
-				}
-			}
-		}
-		n.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
-	}
-	walk(node)
-	return found
-}
-
 // checkLoopCondition checks identifiers in a loop condition and reports those
 // that are not modified in the loop body (or incrementor for for-statements).
 func checkLoopCondition(ctx rule.RuleContext, condition *ast.Node, body *ast.Node, incrementor *ast.Node) {
@@ -368,11 +222,10 @@ func checkLoopCondition(ctx rule.RuleContext, condition *ast.Node, body *ast.Nod
 	}
 
 	refs := ctx.Refs
-	tc := ctx.TypeChecker
 	groups := extractGroups(condition)
 
 	for _, group := range groups {
-		idRefs := collectIdentifierSymbols(group, refs, tc)
+		idRefs := collectIdentifierSymbols(group, refs)
 		if idRefs == nil {
 			continue // dynamic expression found, skip this group
 		}
@@ -380,16 +233,9 @@ func checkLoopCondition(ctx rule.RuleContext, condition *ast.Node, body *ast.Nod
 		// Check if any identifier in this group is modified
 		anyModified := false
 		for _, ref := range idRefs {
-			var modified bool
-			if ref.viaChecker {
-				modified = isSymbolWrittenInBodyTC(body, ref.symbol, tc) ||
-					(incrementor != nil && isSymbolWrittenInBodyTC(incrementor, ref.symbol, tc)) ||
-					isModifiedByCalledFunctionTC(body, incrementor, ref.symbol, tc)
-			} else {
-				modified = isWrittenInRange(refs, ref.symbol, body) ||
-					(incrementor != nil && isWrittenInRange(refs, ref.symbol, incrementor)) ||
-					isModifiedByCalledFunction(refs, body, incrementor, ref.symbol)
-			}
+			modified := isWrittenInRange(refs, ref.symbol, body) ||
+				(incrementor != nil && isWrittenInRange(refs, ref.symbol, incrementor)) ||
+				isModifiedByCalledFunction(refs, body, incrementor, ref.symbol)
 			if modified {
 				anyModified = true
 				break

--- a/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition_test.go
+++ b/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition_test.go
@@ -116,6 +116,17 @@ func TestNoUnmodifiedLoopConditionRule(t *testing.T) {
 			{Code: `var x: any = 0; while (x < 10) { x ||= 1; }`},
 			{Code: `var x: any = 0; while (x < 10) { x &&= 1; }`},
 			{Code: `var x: any = 0; while (x < 10) { x ??= 1; }`},
+
+			// === Ambient/lib global (declared in lib.dom.d.ts, not this file —
+			// RefStore's per-file binder walk can't resolve it, only the
+			// TypeChecker fallback can) modified in the body ===
+			{Code: `while (window) { window = window; }`},
+
+			// === Default-exported function modifies the condition variable and
+			// is called in the loop. n.Symbol() on the FunctionDeclaration node
+			// is the export symbol, which never matches a call site's resolved
+			// symbol — the check must compare against n.LocalSymbol() instead. ===
+			{Code: `export default function inc() { x++; } var x = 0; while (x < 10) { inc(); }`},
 		},
 		// Invalid cases
 		[]rule_tester.InvalidTestCase{
@@ -247,6 +258,28 @@ func TestNoUnmodifiedLoopConditionRule(t *testing.T) {
 				Code: `var x = 0; function inc() { x++; } while (x < 10) { }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "loopConditionNotModified", Line: 1, Column: 43},
+				},
+			},
+
+			// === Ambient/lib global (declared in lib.dom.d.ts, not this file —
+			// RefStore's per-file binder walk can't resolve it, only the
+			// TypeChecker fallback can) never modified in the body ===
+			{
+				Code: `while (window) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 8},
+				},
+			},
+
+			// === Write only in a parameter's default-value initializer, but the
+			// call site passes an explicit argument, so the default never runs —
+			// the write must not count, so x is still reported as unmodified.
+			// (The modification check must scan n.Body() only, not the whole
+			// FunctionDeclaration including its parameter list.) ===
+			{
+				Code: `var x = 0; function f(y = (x = 1)) { } while (x < 10) { f(2); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 47},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Use `ctx.Refs.Resolve()` / `ctx.Refs.References()` when possible, falling back to `ctx.TypeChecker` only for symbols `ctx.Refs` can't bind (declared outside this file). Drop `RequiresTypeInfo: true` accordingly.

## Benchmark

Per-rule time from `--timing all`, synthetic corpus (6 loops/file, one condition var each, plus a function-call-modifies-condition case and a never-modified case):

| corpus | main mean/median | rebased PR mean/median | Δ mean |
| --- | --- | --- | --- |
| 1000-stmt bodies, 1 var, 300 files | 2675.9 / 2648.2 ms | 244.3 / 191.3 ms | −90.9% |
| 1000-stmt bodies, 4 vars, 300 files | 2731.3 / 2697.7 ms | 357.3 / 338.3 ms | −86.9% |
| 3000-stmt bodies, 1 var, 100 files | 2717.2 / 2741.2 ms | 236.3 / 195.9 ms | −91.3% |

Byte-identical diagnostics on all corpora.

## Validation

- `go test ./internal/rules/no_unmodified_loop_condition/...` — 83 cases.
- `go vet ./internal/rules/no_unmodified_loop_condition/...`
- `internal/config` `RequiresTypeInfo` guard tests pass with it dropped.

## Related Links

Follow-up to #1335, #1415.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
