### PR TITLE
perf: optimize no-useless-backreference call filtering

### DIFF
--- a/internal/rules/no_useless_backreference/no_useless_backreference.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference.go
@@ -93,11 +93,6 @@ func handleRegExpConstructor(
 	if args == nil || len(args.Nodes) == 0 {
 		return
 	}
-	callee = ast.SkipParentheses(callee)
-	if !isBuiltinRegExpCallee(ctx, callee, calleeCache) {
-		return
-	}
-
 	patternNode := ast.SkipParentheses(args.Nodes[0])
 	if patternNode == nil {
 		return
@@ -105,6 +100,7 @@ func handleRegExpConstructor(
 
 	flags := ""
 	var pattern string
+	patternReady := true
 	switch patternNode.Kind {
 	case ast.KindRegularExpressionLiteral:
 		pattern, flags = utils.ExtractRegexPatternAndFlags(patternNode.Text())
@@ -113,6 +109,24 @@ func handleRegExpConstructor(
 	case ast.KindNoSubstitutionTemplateLiteral:
 		pattern = patternNode.AsNoSubstitutionTemplateLiteral().Text
 	default:
+		if !mayEvaluateToRegexPattern(patternNode) {
+			return
+		}
+		patternReady = false
+	}
+
+	// Most calls with literal arguments are unrelated to RegExp. Reject them
+	// before asking the checker for the callee's flow-sensitive type.
+	if patternReady && !mayContainBackreference(pattern) {
+		return
+	}
+
+	callee = ast.SkipParentheses(callee)
+	if !isBuiltinRegExpCallee(ctx, callee, calleeCache) {
+		return
+	}
+
+	if !patternReady {
 		var patternOk bool
 		pattern, patternOk = getEval().Eval(patternNode)
 		if !patternOk {
@@ -135,6 +149,37 @@ func handleRegExpConstructor(
 
 	rxFlags := utils.ParseRegexFlags(flags)
 	checkRegex(ctx, callNode, pattern, rxFlags)
+}
+
+// mayEvaluateToRegexPattern is a conservative negative syntactic filter for
+// StaticStringEvaluator.Eval. Only expression forms whose values are
+// intrinsically non-string are rejected. Unknown and future syntax stays on the
+// normal checker/evaluator path so extending StaticStringEvaluator cannot turn
+// this optimization into a false negative.
+func mayEvaluateToRegexPattern(node *ast.Node) bool {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword,
+		ast.KindObjectLiteralExpression,
+		ast.KindArrayLiteralExpression,
+		ast.KindArrowFunction,
+		ast.KindFunctionExpression,
+		ast.KindClassExpression,
+		ast.KindPrefixUnaryExpression,
+		ast.KindPostfixUnaryExpression,
+		ast.KindDeleteExpression,
+		ast.KindVoidExpression:
+		return false
+	default:
+		return true
+	}
 }
 
 func literalStringValue(node *ast.Node) (string, bool) {

--- a/internal/rules/no_useless_backreference/no_useless_backreference_test.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference_test.go
@@ -1,6 +1,8 @@
 package no_useless_backreference
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -34,6 +36,16 @@ func TestNoUselessBackreferenceRule(t *testing.T) {
 			{Code: `RegExp('\\1(a)' + suffix)`},
 			{Code: "new RegExp(`${prefix}\\\\1(a)`)"},
 			{Code: "{ const String = { raw: () => '\\\\1(a)' }; new RegExp(String.raw`\\1(a)`); }"},
+			{Code: `RegExp(1); RegExp(1n); RegExp(true); RegExp(false); RegExp(null);`},
+			{Code: `
+declare function unknownPattern(): unknown;
+RegExp({});
+RegExp([]);
+RegExp(() => '\\1(a)');
+RegExp(function () { return '\\1(a)'; });
+RegExp(class {});
+RegExp(unknownPattern());
+RegExp(new String('\\1(a)'));`},
 
 			// ---- not the global RegExp ----
 			{Code: `let RegExp; new RegExp('\\1(a)');`},
@@ -329,6 +341,18 @@ func TestNoUselessBackreferenceRule(t *testing.T) {
 				},
 			},
 			{
+				Code: `const pattern = '\\1(a)'; RegExp((((pattern as string) satisfies unknown)!));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward"},
+				},
+			},
+			{
+				Code: "new RegExp(String.raw`\\1${\"(a)\"}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "forward"},
+				},
+			},
+			{
 				Code: `const r = RegExp; r('\\1(a)'); { const r = (value: string) => value; r('\\1(a)'); } r('\\1(a)');`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "forward"},
@@ -574,6 +598,169 @@ func TestImportedRegExpConstructorAlias(t *testing.T) {
 	)
 	if len(diagnostics) != 1 || diagnostics[0].Message.Id != "forward" {
 		t.Fatalf("diagnostics = %#v; want one forward report", diagnostics)
+	}
+}
+
+func TestMayEvaluateToRegexPatternAdversarial(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir, "file.ts")
+
+	var code strings.Builder
+	code.WriteString(`
+declare function makePattern(): unknown;
+const stablePattern = "\\1(a)";
+let counter = 0;
+enum Pattern {
+	Value = "\\1(a)",
+}
+`)
+
+	baseExpressions := []string{
+		`"\\1(a)"`,
+		"`\\\\1(a)`",
+		"`\\\\1${\"(a)\"}`",
+		"String.raw`\\1(a)`",
+		`stablePattern`,
+		`Pattern.Value`,
+		`Pattern["Value"]`,
+		`"\\1" + "(a)"`,
+		`true ? "\\1(a)" : "(a)"`,
+		`String("\\1(a)")`,
+		`String()`,
+		`"" || "\\1(a)"`,
+		`null ?? "\\1(a)"`,
+		`makePattern()`,
+		`new String("\\1(a)")`,
+		`typeof stablePattern`,
+	}
+	wrappers := []string{
+		`%s`,
+		`(%s)`,
+		`(%s as string)`,
+		`(%s satisfies unknown)`,
+		`(%s)!`,
+		`true ? %s : "(a)"`,
+		`String(%s)`,
+	}
+	candidateCount := 0
+	frontier := baseExpressions
+	for depth := range 2 {
+		next := make([]string, 0, len(frontier)*len(wrappers))
+		for expressionIndex, expression := range frontier {
+			for wrapperIndex, wrapper := range wrappers {
+				wrapped := fmt.Sprintf(wrapper, expression)
+				fmt.Fprintf(
+					&code,
+					"const candidate_%d_%d_%d = %s;\n",
+					depth,
+					expressionIndex,
+					wrapperIndex,
+					wrapped,
+				)
+				next = append(next, wrapped)
+				candidateCount++
+			}
+		}
+		frontier = next
+	}
+
+	rejectedExpressions := []string{
+		`1`,
+		`1n`,
+		`true`,
+		`false`,
+		`null`,
+		`{ value: "\\1(a)" }`,
+		`["\\1(a)"]`,
+		`() => "\\1(a)"`,
+		`function () { return "\\1(a)"; }`,
+		`class {}`,
+		`-1`,
+		`counter++`,
+		`delete ({ value: 1 }).value`,
+		`void stablePattern`,
+	}
+	for index, expression := range rejectedExpressions {
+		fmt.Fprintf(&code, "const rejected_%d = %s;\n", index, expression)
+	}
+
+	fs := utils.NewOverlayVFS(bundled.WrapFS(osvfs.FS()), map[string]string{
+		filePath: code.String(),
+	})
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceFile := program.GetSourceFile(filePath)
+	if sourceFile == nil {
+		t.Fatalf("%s was not loaded", filePath)
+	}
+	typeChecker, done := program.GetTypeChecker(t.Context())
+	defer done()
+	evaluator := utils.NewStaticStringEvaluatorWithSourceFile(typeChecker, sourceFile)
+
+	seenCandidates := 0
+	seenRejected := 0
+	evaluatedStrings := 0
+	evaluatedCandidateStrings := 0
+	var nonEvaluatedCandidates []string
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindVariableDeclaration {
+			declaration := node.AsVariableDeclaration()
+			if declaration != nil &&
+				declaration.Name() != nil &&
+				declaration.Name().Kind == ast.KindIdentifier &&
+				declaration.Initializer != nil {
+				name := declaration.Name().AsIdentifier().Text
+				mayEvaluate := mayEvaluateToRegexPattern(declaration.Initializer)
+				if strings.HasPrefix(name, "candidate_") {
+					seenCandidates++
+					if !mayEvaluate {
+						t.Errorf("%s: candidate expression was rejected", name)
+					}
+				}
+				if strings.HasPrefix(name, "rejected_") {
+					seenRejected++
+					if mayEvaluate {
+						t.Errorf("%s: known non-string expression passed the filter", name)
+					}
+				}
+				if _, ok := evaluator.Eval(declaration.Initializer); ok {
+					evaluatedStrings++
+					if strings.HasPrefix(name, "candidate_") {
+						evaluatedCandidateStrings++
+					}
+					if !mayEvaluate {
+						t.Errorf("%s: StaticStringEvaluator produced a string rejected by the filter", name)
+					}
+				} else if strings.HasPrefix(name, "candidate_") {
+					nonEvaluatedCandidates = append(nonEvaluatedCandidates, name)
+				}
+			}
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+
+	if seenCandidates != candidateCount {
+		t.Fatalf("visited %d candidate expressions, want %d", seenCandidates, candidateCount)
+	}
+	if seenRejected != len(rejectedExpressions) {
+		t.Fatalf("visited %d rejected expressions, want %d", seenRejected, len(rejectedExpressions))
+	}
+	const evaluableBaseExpressionCount = 11
+	minimumEvaluatedCandidates := evaluableBaseExpressionCount *
+		(len(wrappers) + len(wrappers)*len(wrappers))
+	if evaluatedCandidateStrings < minimumEvaluatedCandidates {
+		t.Fatalf(
+			"only evaluated %d of %d adversarial candidates to strings; all strings=%d, misses: %v",
+			evaluatedCandidateStrings,
+			candidateCount,
+			evaluatedStrings,
+			nonEvaluatedCandidates,
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reject literal patterns without backreference syntax before querying the callee's flow-sensitive type.
- Skip checker work for first-argument expression forms whose static value is intrinsically non-string, while conservatively keeping unknown and future syntax on the original checker/evaluator path.
- Add adversarial coverage for nested assertions, templates, `String.raw`, aliases, non-string expressions, and 896 generated wrapper combinations. The test fails if `StaticStringEvaluator` can produce a string that the fast filter rejects.

### Performance

Baseline: `b16346f6` (`origin/main`). Candidate: `1411d5ae`. Measurements were taken on an Apple M1 Max.

Temporary Go microbenchmark, `GOMAXPROCS=1`, `-count=5`, `-benchtime=1s`, median of five runs over 4,000 calls:

| Scenario | main | PR | Delta |
| --- | ---: | ---: | ---: |
| Calls without `RegExp` | 1.122 ms/op | 0.712 ms/op | -36.5% |
| Calls plus one `RegExp` | 1.392 ms/op | 0.994 ms/op | -28.6% |

Real repositories used their explicit JS configs, default workers, `--timing all`, and three alternating main/PR runs. Values are median summed rule time across workers:

| Repository / config | Files | main | PR | Delta |
| --- | ---: | ---: | ---: | ---: |
| rsbuild / `rslint.config.ts` | 2,196 | 171.2 ms | 140.2 ms | -18.1% |
| rspack / `rslint.config.mts` | 479 | 50.7 ms | 52.1 ms | +2.8% |

The rspack corpus is small and its +2.8% result is within observed run-to-run noise. The shared machine was under variable load, so medians and alternating order were used.

Sorted `jsonline` diagnostics were byte-identical between main and this PR:

| Repository | main | PR |
| --- | ---: | ---: |
| rsbuild | 0 | 0 |
| rspack | 0 | 0 |

Validation:

- `go test ./internal/rules/no_useless_backreference -count=1`
- `pnpm --filter @rslint/test-tools exec rstest run tests/eslint/rules/no-useless-backreference.test.ts`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/no_useless_backreference/...`

## Related Links

- #1411

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
