### PR TITLE
ci: update Darwin CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         runner:
           - rspack-ubuntu-22.04-large
-          - rspack-darwin-14-medium
+          - rspack-darwin-15.6.1-medium
           - rspack-windows-2022-large
         go-version: ['1.26.0']
     steps:


### PR DESCRIPTION
## Summary

- update the macOS CI runner from `rspack-darwin-14-medium` to `rspack-darwin-15.6.1-medium`

## Testing

- `git diff --check`
- pre-commit Prettier hook