### PR TITLE
perf: optimize no-loop-func rule

### DIFF
--- a/internal/rules/no_loop_func/no_loop_func.go
+++ b/internal/rules/no_loop_func/no_loop_func.go
@@ -170,6 +170,29 @@ func (r ReferenceEntry) Node() *ast.Node { return r.node }
 // Symbol returns the resolved symbol for the reference, or nil if unresolved.
 func (r ReferenceEntry) Symbol() *ast.Symbol { return r.symbol }
 
+// resolveReference resolves an identifier to its referenced symbol, trying
+// ctx.Refs first: it answers from a per-node binder scope-walk with no
+// TypeChecker round-trip, and correctly resolves same-file locals — the
+// overwhelming majority of through-references a loop-closure can actually
+// capture (loop counters, outer function locals, imported bindings, which are
+// all declared, and therefore locally bound, in this file). It returns nil
+// for identifiers naming a symbol declared outside this file — ambient/lib
+// globals (`console`, `Array`, ...) and checker-merged declarations (a
+// namespace merged with a value, for instance) — which only the TypeChecker
+// can see, so it's used as a fallback there when available. Falling all the
+// way through to nil (no TypeChecker either) simply excludes the reference
+// from the through-reference set — the same outcome as if it had resolved
+// but turned out to be declared outside `funcNode` and never written to.
+func (s *RunState) resolveReference(n *ast.Node) *ast.Symbol {
+	if sym := s.Ctx.Refs.Resolve(n); sym != nil {
+		return sym
+	}
+	if s.Ctx.TypeChecker != nil {
+		return utils.GetReferenceSymbol(n, s.Ctx.TypeChecker)
+	}
+	return nil
+}
+
 // collectThroughReferences walks the function-like node's parameters and body
 // and returns all identifier references whose resolved symbol has at least one
 // declaration outside the function subtree. The function's own name node is
@@ -199,7 +222,7 @@ func (s *RunState) CollectThroughReferences(funcNode *ast.Node) []ReferenceEntry
 		}
 
 		if n.Kind == ast.KindIdentifier && !utils.IsNonReferenceIdentifier(n) {
-			sym := utils.GetReferenceSymbol(n, s.Ctx.TypeChecker)
+			sym := s.resolveReference(n)
 			if sym != nil && (sym.Flags&ast.SymbolFlagsValue) != 0 {
 				if !isSymbolDeclaredInside(sym, funcNode) {
 					refs = append(refs, ReferenceEntry{
@@ -366,14 +389,16 @@ func (s *RunState) references(sym *ast.Symbol) []*ast.Node {
 // binderReferences returns sym's references via ctx.Refs, reporting false
 // when the binder-based index can't be trusted to answer for this symbol.
 //
-// ctx.Refs keys on raw binder symbols, while sym here comes from the checker
-// (utils.GetReferenceSymbol in CollectThroughReferences), which hands out
-// merged symbols that can compare unequal to the ones the binder's scope walk
-// returns — for example a namespace merged with a value, or a symbol declared
-// in lib/ambient code. A declaration keeps its own unmerged symbol, so
-// requiring decl.Symbol() == sym on every declaration (and that it lives in
-// this file, since ctx.Refs is per-file) is an exact identity test; failing
-// it falls back to the checker instead of risking a wrong answer.
+// ctx.Refs keys on raw binder symbols. resolveReference hands out exactly
+// that kind of symbol on its common path (ctx.Refs.Resolve), but falls back
+// to the checker for symbols the binder can't see from this file (ambient
+// globals, cross-file/merged declarations) — those checker symbols can
+// compare unequal to what the binder's own scope walk would return for the
+// same declaration (for example a namespace merged with a value). A
+// declaration keeps its own unmerged symbol, so requiring decl.Symbol() ==
+// sym on every declaration (and that it lives in this file, since ctx.Refs is
+// per-file) is an exact identity test; failing it falls back to the checker
+// instead of risking a wrong answer.
 //
 // ctx.Refs also excludes declaration-name identifiers (they declare the
 // symbol rather than reference it), but ESLint's scope manager — and
@@ -382,7 +407,7 @@ func (s *RunState) references(sym *ast.Symbol) []*ast.Node {
 // catch parameters. Those names are merged back into the result in source
 // order so isSafeCore keeps seeing them.
 func (s *RunState) binderReferences(sym *ast.Symbol) ([]*ast.Node, bool) {
-	if s.Ctx.Refs == nil || sym == nil || len(sym.Declarations) == 0 {
+	if sym == nil || len(sym.Declarations) == 0 {
 		return nil, false
 	}
 	declNames := make([]*ast.Node, 0, len(sym.Declarations))
@@ -491,15 +516,8 @@ func (s *RunState) checkForLoopsCore(node *ast.Node) {
 // NoLoopFuncRule disallows function declarations that contain unsafe
 // references to variable(s) inside loop statements.
 var NoLoopFuncRule = rule.Rule{
-	Name:             "no-loop-func",
-	RequiresTypeInfo: true,
+	Name: "no-loop-func",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		// Defense-in-depth: RequiresTypeInfo: true filters this rule out for
-		// gap files / inferred-project files, but if a future caller bypasses
-		// the filter we still want to no-op rather than nil-deref.
-		if ctx.TypeChecker == nil {
-			return rule.RuleListeners{}
-		}
 		s := &RunState{
 			Ctx:          ctx,
 			SkippedIIFEs: map[*ast.Node]bool{},

--- a/internal/rules/no_loop_func/no_loop_func.go
+++ b/internal/rules/no_loop_func/no_loop_func.go
@@ -20,11 +20,6 @@ func BuildUnsafeRefsMessage(varNames string) rule.RuleMessage {
 type RunState struct {
 	Ctx          rule.RuleContext
 	SkippedIIFEs map[*ast.Node]bool
-	refIndex     *utils.ReferenceIndex
-	// checkerRefs memoizes the checker-based fallback reference list per
-	// symbol, since isSafeCore may query the same outer symbol once for every
-	// function-in-loop that closes over it.
-	checkerRefs map[*ast.Symbol][]*ast.Node
 }
 
 // NewRunState constructs a RunState ready for one source-file pass.
@@ -170,29 +165,6 @@ func (r ReferenceEntry) Node() *ast.Node { return r.node }
 // Symbol returns the resolved symbol for the reference, or nil if unresolved.
 func (r ReferenceEntry) Symbol() *ast.Symbol { return r.symbol }
 
-// resolveReference resolves an identifier to its referenced symbol, trying
-// ctx.Refs first: it answers from a per-node binder scope-walk with no
-// TypeChecker round-trip, and correctly resolves same-file locals — the
-// overwhelming majority of through-references a loop-closure can actually
-// capture (loop counters, outer function locals, imported bindings, which are
-// all declared, and therefore locally bound, in this file). It returns nil
-// for identifiers naming a symbol declared outside this file — ambient/lib
-// globals (`console`, `Array`, ...) and checker-merged declarations (a
-// namespace merged with a value, for instance) — which only the TypeChecker
-// can see, so it's used as a fallback there when available. Falling all the
-// way through to nil (no TypeChecker either) simply excludes the reference
-// from the through-reference set — the same outcome as if it had resolved
-// but turned out to be declared outside `funcNode` and never written to.
-func (s *RunState) resolveReference(n *ast.Node) *ast.Symbol {
-	if sym := s.Ctx.Refs.Resolve(n); sym != nil {
-		return sym
-	}
-	if s.Ctx.TypeChecker != nil {
-		return utils.GetReferenceSymbol(n, s.Ctx.TypeChecker)
-	}
-	return nil
-}
-
 // collectThroughReferences walks the function-like node's parameters and body
 // and returns all identifier references whose resolved symbol has at least one
 // declaration outside the function subtree. The function's own name node is
@@ -222,7 +194,18 @@ func (s *RunState) CollectThroughReferences(funcNode *ast.Node) []ReferenceEntry
 		}
 
 		if n.Kind == ast.KindIdentifier && !utils.IsNonReferenceIdentifier(n) {
-			sym := s.resolveReference(n)
+			// ctx.Refs resolves same-file locals from the binder scope walk —
+			// the overwhelming majority of through-references a loop-closure
+			// can capture (loop counters, outer function locals, imported
+			// bindings) — and falls back to the checker internally for
+			// symbols only it can see (ambient/lib globals like `console`,
+			// cross-file and checker-merged declarations). nil — a position
+			// ctx.Refs doesn't treat as a variable reference (a lowercase
+			// JSX intrinsic tag name), an unresolvable name, or no checker
+			// available — excludes the identifier from the through-reference
+			// set, the same outcome as one that resolved but was declared
+			// outside `funcNode` and never written to.
+			sym := s.Ctx.Refs.Resolve(n)
 			if sym != nil && (sym.Flags&ast.SymbolFlagsValue) != 0 {
 				if !isSymbolDeclaredInside(sym, funcNode) {
 					refs = append(refs, ReferenceEntry{
@@ -355,13 +338,6 @@ func GetDeclListForSymbolDecl(decl *ast.Node) *ast.Node {
 	return utils.GetDeclListForSymbolDecl(decl)
 }
 
-func (s *RunState) buildRefIndex() {
-	if s.refIndex != nil {
-		return
-	}
-	s.refIndex = utils.NewReferenceIndex(s.Ctx.SourceFile, s.Ctx.TypeChecker)
-}
-
 // forEachReference invokes `cb` for every identifier node resolving to `sym`,
 // in source order. Returns early when `cb` returns true.
 func (s *RunState) ForEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
@@ -373,55 +349,35 @@ func (s *RunState) ForEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
 }
 
 // references returns every identifier resolving to `sym`, in source order,
-// preferring `ctx.Refs` — a per-file reference index built once and shared by
-// every query — over the checker's GetReferencesToSymbolInFile, which
-// recomputes references for the whole file from scratch on every call.
-// isSafeCore queries this once per (loop-function, through-reference) pair,
-// so a symbol closed over by many functions in a file pays the checker's
-// whole-file cost once per closure under the old path.
+// from ctx.Refs.References — a per-file index built once and shared by every
+// query. The index answers for checker-fallback symbols too, and files
+// references to a merged symbol under one identity regardless of which raw
+// declaration symbol the caller resolved, so no separate checker scan is
+// needed. isSafeCore queries this once per (loop-function, through-reference)
+// pair.
+//
+// ctx.Refs excludes declaration-name identifiers (they declare the symbol
+// rather than reference it), but ESLint's scope manager — and IsWriteRef,
+// which mirrors it — treats several of them as write references: var/let/
+// const bindings with initializers, for-in/of loop bindings, and catch
+// parameters. This file's declaration names are merged back into the result
+// in source order so isSafeCore keeps seeing them.
 func (s *RunState) references(sym *ast.Symbol) []*ast.Node {
-	if refs, ok := s.binderReferences(sym); ok {
-		return refs
+	if sym == nil {
+		return nil
 	}
-	return s.checkerReferences(sym)
-}
-
-// binderReferences returns sym's references via ctx.Refs, reporting false
-// when the binder-based index can't be trusted to answer for this symbol.
-//
-// ctx.Refs keys on raw binder symbols. resolveReference hands out exactly
-// that kind of symbol on its common path (ctx.Refs.Resolve), but falls back
-// to the checker for symbols the binder can't see from this file (ambient
-// globals, cross-file/merged declarations) — those checker symbols can
-// compare unequal to what the binder's own scope walk would return for the
-// same declaration (for example a namespace merged with a value). A
-// declaration keeps its own unmerged symbol, so requiring decl.Symbol() ==
-// sym on every declaration (and that it lives in this file, since ctx.Refs is
-// per-file) is an exact identity test; failing it falls back to the checker
-// instead of risking a wrong answer.
-//
-// ctx.Refs also excludes declaration-name identifiers (they declare the
-// symbol rather than reference it), but ESLint's scope manager — and
-// IsWriteRef, which mirrors it — treats several of them as write references:
-// var/let/const bindings with initializers, for-in/of loop bindings, and
-// catch parameters. Those names are merged back into the result in source
-// order so isSafeCore keeps seeing them.
-func (s *RunState) binderReferences(sym *ast.Symbol) ([]*ast.Node, bool) {
-	if sym == nil || len(sym.Declarations) == 0 {
-		return nil, false
-	}
-	declNames := make([]*ast.Node, 0, len(sym.Declarations))
+	refs := s.Ctx.Refs.References(sym)
+	var declNames []*ast.Node
 	for _, decl := range sym.Declarations {
-		if decl.Symbol() != sym || ast.GetSourceFileOfNode(decl) != s.Ctx.SourceFile {
-			return nil, false
+		if ast.GetSourceFileOfNode(decl) != s.Ctx.SourceFile {
+			continue
 		}
 		if name := decl.Name(); name != nil && name.Kind == ast.KindIdentifier {
 			declNames = append(declNames, name)
 		}
 	}
-	refs := s.Ctx.Refs.References(sym)
 	if len(declNames) == 0 {
-		return refs, true
+		return refs
 	}
 	sort.Slice(declNames, func(i, j int) bool { return declNames[i].Pos() < declNames[j].Pos() })
 	merged := make([]*ast.Node, 0, len(refs)+len(declNames))
@@ -433,27 +389,7 @@ func (s *RunState) binderReferences(sym *ast.Symbol) ([]*ast.Node, bool) {
 		}
 		merged = append(merged, name)
 	}
-	return append(merged, refs[next:]...), true
-}
-
-// checkerReferences returns sym's references via the TypeChecker, memoized
-// per symbol since the same fallback symbol may be queried by more than one
-// loop-function closure in the file.
-func (s *RunState) checkerReferences(sym *ast.Symbol) []*ast.Node {
-	if refs, ok := s.checkerRefs[sym]; ok {
-		return refs
-	}
-	s.buildRefIndex()
-	var refs []*ast.Node
-	s.refIndex.ForEachReference(sym, func(refNode *ast.Node) bool {
-		refs = append(refs, refNode)
-		return false
-	})
-	if s.checkerRefs == nil {
-		s.checkerRefs = map[*ast.Symbol][]*ast.Node{}
-	}
-	s.checkerRefs[sym] = refs
-	return refs
+	return append(merged, refs[next:]...)
 }
 
 // checkForLoops processes a function-like node: if it is inside a loop and

--- a/internal/rules/no_loop_func/no_loop_func.go
+++ b/internal/rules/no_loop_func/no_loop_func.go
@@ -2,6 +2,7 @@ package no_loop_func
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -20,6 +21,10 @@ type RunState struct {
 	Ctx          rule.RuleContext
 	SkippedIIFEs map[*ast.Node]bool
 	refIndex     *utils.ReferenceIndex
+	// checkerRefs memoizes the checker-based fallback reference list per
+	// symbol, since isSafeCore may query the same outer symbol once for every
+	// function-in-loop that closes over it.
+	checkerRefs map[*ast.Symbol][]*ast.Node
 }
 
 // NewRunState constructs a RunState ready for one source-file pass.
@@ -335,11 +340,95 @@ func (s *RunState) buildRefIndex() {
 }
 
 // forEachReference invokes `cb` for every identifier node resolving to `sym`,
-// in source order. Returns early when `cb` returns true. The underlying index
-// is built on first use via buildRefIndex so subsequent calls are O(refs).
+// in source order. Returns early when `cb` returns true.
 func (s *RunState) ForEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
+	for _, refNode := range s.references(sym) {
+		if cb(refNode) {
+			return
+		}
+	}
+}
+
+// references returns every identifier resolving to `sym`, in source order,
+// preferring `ctx.Refs` — a per-file reference index built once and shared by
+// every query — over the checker's GetReferencesToSymbolInFile, which
+// recomputes references for the whole file from scratch on every call.
+// isSafeCore queries this once per (loop-function, through-reference) pair,
+// so a symbol closed over by many functions in a file pays the checker's
+// whole-file cost once per closure under the old path.
+func (s *RunState) references(sym *ast.Symbol) []*ast.Node {
+	if refs, ok := s.binderReferences(sym); ok {
+		return refs
+	}
+	return s.checkerReferences(sym)
+}
+
+// binderReferences returns sym's references via ctx.Refs, reporting false
+// when the binder-based index can't be trusted to answer for this symbol.
+//
+// ctx.Refs keys on raw binder symbols, while sym here comes from the checker
+// (utils.GetReferenceSymbol in CollectThroughReferences), which hands out
+// merged symbols that can compare unequal to the ones the binder's scope walk
+// returns — for example a namespace merged with a value, or a symbol declared
+// in lib/ambient code. A declaration keeps its own unmerged symbol, so
+// requiring decl.Symbol() == sym on every declaration (and that it lives in
+// this file, since ctx.Refs is per-file) is an exact identity test; failing
+// it falls back to the checker instead of risking a wrong answer.
+//
+// ctx.Refs also excludes declaration-name identifiers (they declare the
+// symbol rather than reference it), but ESLint's scope manager — and
+// IsWriteRef, which mirrors it — treats several of them as write references:
+// var/let/const bindings with initializers, for-in/of loop bindings, and
+// catch parameters. Those names are merged back into the result in source
+// order so isSafeCore keeps seeing them.
+func (s *RunState) binderReferences(sym *ast.Symbol) ([]*ast.Node, bool) {
+	if s.Ctx.Refs == nil || sym == nil || len(sym.Declarations) == 0 {
+		return nil, false
+	}
+	declNames := make([]*ast.Node, 0, len(sym.Declarations))
+	for _, decl := range sym.Declarations {
+		if decl.Symbol() != sym || ast.GetSourceFileOfNode(decl) != s.Ctx.SourceFile {
+			return nil, false
+		}
+		if name := decl.Name(); name != nil && name.Kind == ast.KindIdentifier {
+			declNames = append(declNames, name)
+		}
+	}
+	refs := s.Ctx.Refs.References(sym)
+	if len(declNames) == 0 {
+		return refs, true
+	}
+	sort.Slice(declNames, func(i, j int) bool { return declNames[i].Pos() < declNames[j].Pos() })
+	merged := make([]*ast.Node, 0, len(refs)+len(declNames))
+	next := 0
+	for _, name := range declNames {
+		for next < len(refs) && refs[next].Pos() < name.Pos() {
+			merged = append(merged, refs[next])
+			next++
+		}
+		merged = append(merged, name)
+	}
+	return append(merged, refs[next:]...), true
+}
+
+// checkerReferences returns sym's references via the TypeChecker, memoized
+// per symbol since the same fallback symbol may be queried by more than one
+// loop-function closure in the file.
+func (s *RunState) checkerReferences(sym *ast.Symbol) []*ast.Node {
+	if refs, ok := s.checkerRefs[sym]; ok {
+		return refs
+	}
 	s.buildRefIndex()
-	s.refIndex.ForEachReference(sym, cb)
+	var refs []*ast.Node
+	s.refIndex.ForEachReference(sym, func(refNode *ast.Node) bool {
+		refs = append(refs, refNode)
+		return false
+	})
+	if s.checkerRefs == nil {
+		s.checkerRefs = map[*ast.Symbol][]*ast.Node{}
+	}
+	s.checkerRefs[sym] = refs
+	return refs
 }
 
 // checkForLoops processes a function-like node: if it is inside a loop and

--- a/internal/rules/no_loop_func/no_loop_func_test.go
+++ b/internal/rules/no_loop_func/no_loop_func_test.go
@@ -230,6 +230,11 @@ for (var i = 0; i < 10; i++) {
 			// ---- Enum reference (TS value+type) is a const-like binding ----
 			{Code: `enum Color { Red } for (var i = 0; i < l; i++) { (function() { Color.Red; }) }`},
 
+			// ---- Ambient/lib global (declared in lib.dom.d.ts, not this file —
+			// ctx.Refs' per-file binder walk can't resolve it, only the
+			// TypeChecker fallback can) is read-only — safe through ref ----
+			{Code: `for (var i = 0; i < l; i++) { (function() { window.location; }); }`},
+
 			// ---- Through refs collected from nested functions inside a non-loop
 			// outer function (the inner function itself IS the closure at risk) ----
 			{Code: `function outer() { for (var i = 0; i < l; i++) { let j = i; (function() { j; }); } }`},
@@ -993,6 +998,27 @@ for (var i = 0; i < 3; i++) {
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "unsafeRefs",
 					Message:   "Function declared in a loop contains unsafe references to variable(s) 'e'.",
+				}},
+			},
+
+			// ---- Ambient/lib global reassigned inside the loop and captured by an
+			// escaping closure. `window` is declared in lib.dom.d.ts, not this
+			// file, so resolving it — both the through-reference in
+			// CollectThroughReferences and the write-reference scan in
+			// isSafeCore — requires the TypeChecker fallback; ctx.Refs' per-file
+			// binder walk returns nil for it. Proves the fallback actually
+			// detects a real violation, not just that it avoids false positives
+			// on read-only globals (covered by the "window.location" valid case). ----
+			{
+				Code: `
+const funcs: unknown[] = [];
+for (var i = 0; i < 10; i++) {
+  window = i as any;
+  funcs.push(function () { return window; });
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'window'.",
 				}},
 			},
 		},

--- a/internal/rules/no_loop_func/no_loop_func_test.go
+++ b/internal/rules/no_loop_func/no_loop_func_test.go
@@ -231,8 +231,8 @@ for (var i = 0; i < 10; i++) {
 			{Code: `enum Color { Red } for (var i = 0; i < l; i++) { (function() { Color.Red; }) }`},
 
 			// ---- Ambient/lib global (declared in lib.dom.d.ts, not this file —
-			// ctx.Refs' per-file binder walk can't resolve it, only the
-			// TypeChecker fallback can) is read-only — safe through ref ----
+			// only ctx.Refs' TypeChecker fallback can resolve it, not the
+			// binder scope walk) is read-only — safe through ref ----
 			{Code: `for (var i = 0; i < l; i++) { (function() { window.location; }); }`},
 
 			// ---- Through refs collected from nested functions inside a non-loop
@@ -1005,10 +1005,11 @@ for (var i = 0; i < 3; i++) {
 			// escaping closure. `window` is declared in lib.dom.d.ts, not this
 			// file, so resolving it — both the through-reference in
 			// CollectThroughReferences and the write-reference scan in
-			// isSafeCore — requires the TypeChecker fallback; ctx.Refs' per-file
-			// binder walk returns nil for it. Proves the fallback actually
-			// detects a real violation, not just that it avoids false positives
-			// on read-only globals (covered by the "window.location" valid case). ----
+			// isSafeCore — requires ctx.Refs' internal TypeChecker fallback;
+			// the binder scope walk alone can't place it. Proves the fallback
+			// actually detects a real violation, not just that it avoids
+			// false positives on read-only globals (covered by the
+			// "window.location" valid case). ----
 			{
 				Code: `
 const funcs: unknown[] = [];


### PR DESCRIPTION
## Summary

- Resolve through-reference identifiers with `ctx.Refs.Resolve` and look up a symbol's references with `ctx.Refs.References`, replacing the rule's direct `TypeChecker` usage (`utils.GetReferenceSymbol` per identifier and `checker.GetReferencesToSymbolInFile` — an uncached whole-file text scan — per (loop-function, through-reference) pair).
- `ctx.Refs` covers every case the rule needs: it falls back to the checker internally for symbols the binder scope walk can't see (ambient/lib globals, cross-file and merged declarations) and files merged-symbol references under one identity, so the rule keeps no `TypeChecker` fallback of its own. Declaration names that ESLint's scope manager counts as write references (`var`/`let`/`const` initializers, `for-in`/`for-of` bindings, catch parameters) are merged back in.
- Drop `RequiresTypeInfo: true` and the nil-`TypeChecker` early return — the rule now also runs on files without type info.

## Benchmark

Synthetic corpus: 1200 `.ts` files × 16 functions, each function placing closures inside `for-of`/`while` loops that capture outer locals, the loop counter, and an ambient global; weighted toward safe closures (19,200 diagnostics over 230k closures).

Per-rule time from `--timing all` (summed across workers), 5 runs after a warmup:

| | mean | median |
| --- | --- | --- |
| `main` | 185,505.3 ms | 185,825.9 ms |
| this PR | 825.6 ms | 879.0 ms |

Rule time: **−99.5%**.

## Validation

- `go test ./internal/rules/no_loop_func/...`, including `TypeChecker`-fallback coverage for ambient globals (a read-only global is safe; a reassigned global captured by an escaping closure is flagged), verified against real ESLint 10.7.0 behavior.
- Both binaries produce identical diagnostics (19,200 lines, compared line by line) on the benchmark corpus.
- `pnpx cspell lint` and `golangci-lint run --new-from-rev=origin/main` on the changed files.

## Related Links

Follow-up to #1335 (`ctx.Refs`), #1415 (`ctx.Refs.Resolve`), and #1450 (checker fallback inside `ctx.Refs`).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
