### PR TITLE
perf: optimize no-case-declarations traversal

### DIFF
--- a/internal/rules/no_case_declarations/no_case_declarations.go
+++ b/internal/rules/no_case_declarations/no_case_declarations.go
@@ -5,29 +5,36 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
+var unexpectedMessage = rule.RuleMessage{
+	Id:          "unexpected",
+	Description: "Unexpected lexical declaration in case clause.",
+}
+
 // https://eslint.org/docs/latest/rules/no-case-declarations
 var NoCaseDeclarationsRule = rule.Rule{
 	Name: "no-case-declarations",
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		checkClause := func(node *ast.Node) {
-			clause := node.AsCaseOrDefaultClause()
-			if clause == nil || clause.Statements == nil {
-				return
-			}
-
-			for _, stmt := range clause.Statements.Nodes {
-				if isLexicalDeclaration(stmt) {
-					ctx.ReportNode(stmt, rule.RuleMessage{
-						Id:          "unexpected",
-						Description: "Unexpected lexical declaration in case clause.",
-					})
-				}
-			}
-		}
-
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 		return rule.RuleListeners{
-			ast.KindCaseClause:    checkClause,
-			ast.KindDefaultClause: checkClause,
+			ast.KindCaseBlock: func(node *ast.Node) {
+				caseBlock := node.AsCaseBlock()
+				if caseBlock == nil || caseBlock.Clauses == nil {
+					return
+				}
+
+				// Scan a switch in one callback instead of dispatching one listener
+				// for every case/default clause.
+				for _, clauseNode := range caseBlock.Clauses.Nodes {
+					clause := clauseNode.AsCaseOrDefaultClause()
+					if clause == nil || clause.Statements == nil {
+						continue
+					}
+					for _, statement := range clause.Statements.Nodes {
+						if isLexicalDeclaration(statement) {
+							ctx.ReportNode(statement, unexpectedMessage)
+						}
+					}
+				}
+			},
 		}
 	},
 }
@@ -41,12 +48,9 @@ func isLexicalDeclaration(node *ast.Node) bool {
 	case ast.KindVariableStatement:
 		varStmt := node.AsVariableStatement()
 		if varStmt != nil && varStmt.DeclarationList != nil {
-			flags := varStmt.DeclarationList.Flags
 			// NOTE: We also check `using` (TC39 Stage 3) since it has the same block-scoping
 			// semantics as let/const. ESLint does not check `using` yet.
-			if flags&ast.NodeFlagsLet != 0 || flags&ast.NodeFlagsConst != 0 || flags&ast.NodeFlagsUsing != 0 {
-				return true
-			}
+			return varStmt.DeclarationList.Flags&ast.NodeFlagsBlockScoped != 0
 		}
 	}
 	return false

--- a/internal/rules/no_case_declarations/no_case_declarations_test.go
+++ b/internal/rules/no_case_declarations/no_case_declarations_test.go
@@ -21,6 +21,9 @@ func TestNoCaseDeclarationsRule(t *testing.T) {
 			{Code: `switch (a) { case 1: var x = 1; break; }`},
 			{Code: `switch (a) { default: var x = 1; break; }`},
 			{Code: `switch (a) { case 1: break; }`},
+			{Code: `switch (a) {}`},
+			{Code: `switch (a) { case 1: if (a) { const x = 1; } break; }`},
+			{Code: `switch (a) { case 1: type T = string; interface I { value: T } break; }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
@@ -51,6 +54,34 @@ func TestNoCaseDeclarationsRule(t *testing.T) {
 				Code: `switch (a) { default: let x = 1; break; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `switch (a) {
+  case 1:
+    let x = 1;
+    const y = 2;
+    break;
+  case 2:
+  default:
+    class C {}
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 3, Column: 5},
+					{MessageId: "unexpected", Line: 4, Column: 5},
+					{MessageId: "unexpected", Line: 8, Column: 5},
+				},
+			},
+			{
+				Code: `switch (a) { case 1: using resource = acquire(); break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected"},
+				},
+			},
+			{
+				Code: `async function f() { switch (a) { case 1: await using resource = acquire(); break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected"},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- scan all clauses through one `CaseBlock` listener per switch instead of dispatching a listener for every case/default clause
- reuse the diagnostic message and use `NodeFlagsBlockScoped` for `let`, `const`, `using`, and `await using`
- keep the rule structural: `ctx.Refs` would build an unnecessary symbol index, while deferred reporting does not apply because the rule has no fixes or suggestions
- extend the existing rule test file with empty-switch, nested-block, TypeScript declaration, multi-clause, `using`, and `await using` coverage

### Performance

Measured on Apple M1 Max. The synthetic result is the median of 10 same-process samples with `0 allocs/op`; repository timings are medians of 5 interleaved before/after runs using a JS rslint config that enables only `no-case-declarations`.

| Dataset | Before | After | Change |
| --- | ---: | ---: | ---: |
| Synthetic switch-heavy benchmark | 547.5 µs/op | 509.8 µs/op | -6.9% |
| rspack (15,090 files) | 3.3 ms | 2.9 ms | -12.1% |
| rsbuild (2,178 files) | 0.5 ms | 0.5 ms | Within 0.1 ms timing resolution |

### Correctness

- exact diagnostic parity on rspack: 6 before / 6 after, with identical rule, message, file, range, and severity
- exact diagnostic parity on rsbuild: 0 before / 0 after
- adversarial nested-switch/directive corpus: 9 before / 9 after with identical ordered JSON-line output
- `go test -buildvcs=false ./internal/rules/no_case_declarations -run '^TestNoCaseDeclarationsRule$' -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run ./internal/rules/no_case_declarations`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
