### PR TITLE
perf: optimize no-compare-neg-zero traversal

### DIFF
--- a/internal/rules/no_compare_neg_zero/no_compare_neg_zero.go
+++ b/internal/rules/no_compare_neg_zero/no_compare_neg_zero.go
@@ -3,6 +3,7 @@ package no_compare_neg_zero
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // Message builder
@@ -37,69 +38,73 @@ func getOperatorText(kind ast.Kind) string {
 	}
 }
 
-// isNegativeZero checks if a node represents -0
-// This matches: UnaryExpression with operator "-" and argument being Literal with value 0
+func isZeroNumericLiteral(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipParentheses(node)
+	if node.Kind != ast.KindNumericLiteral {
+		return false
+	}
+	numeric := node.AsNumericLiteral()
+	return numeric != nil && numeric.Text == "0"
+}
+
+// isNegativeZero checks whether node represents the ESTree shape `-0`.
+// Parentheses are transparent around both the unary expression and its
+// numeric operand.
 func isNegativeZero(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindPrefixUnaryExpression {
+	if node == nil {
 		return false
 	}
-
+	node = ast.SkipParentheses(node)
+	if node.Kind != ast.KindPrefixUnaryExpression {
+		return false
+	}
 	prefix := node.AsPrefixUnaryExpression()
-	if prefix == nil || prefix.Operator != ast.KindMinusToken {
-		return false
-	}
-
-	operand := prefix.Operand
-	if operand == nil {
-		return false
-	}
-
-	// Check if the operand is a numeric literal with value 0
-	switch operand.Kind {
-	case ast.KindNumericLiteral:
-		numLiteral := operand.AsNumericLiteral()
-		if numLiteral != nil && numLiteral.Text == "0" {
-			return true
-		}
-	}
-
-	return false
+	return prefix != nil &&
+		prefix.Operator == ast.KindMinusToken &&
+		isZeroNumericLiteral(prefix.Operand)
 }
 
 // NoCompareNegZeroRule disallows comparisons to negative zero
 var NoCompareNegZeroRule = rule.Rule{
 	Name: "no-compare-neg-zero",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		// Define the operators we want to check
-		operatorsToCheck := map[ast.Kind]bool{
-			ast.KindGreaterThanToken:             true, // >
-			ast.KindGreaterThanEqualsToken:       true, // >=
-			ast.KindLessThanToken:                true, // <
-			ast.KindLessThanEqualsToken:          true, // <=
-			ast.KindEqualsEqualsToken:            true, // ==
-			ast.KindEqualsEqualsEqualsToken:      true, // ===
-			ast.KindExclamationEqualsToken:       true, // !=
-			ast.KindExclamationEqualsEqualsToken: true, // !==
-		}
-
 		return rule.RuleListeners{
-			ast.KindBinaryExpression: func(node *ast.Node) {
-				binary := node.AsBinaryExpression()
-				if binary == nil || binary.OperatorToken == nil {
+			ast.KindPrefixUnaryExpression: func(node *ast.Node) {
+				prefix := node.AsPrefixUnaryExpression()
+				if prefix == nil || prefix.Operator != ast.KindMinusToken {
 					return
 				}
 
-				// Check if this is one of the operators we care about
-				if !operatorsToCheck[binary.OperatorToken.Kind] {
+				operand := utils.OutermostParenthesizedExpression(node)
+				comparisonNode := operand.Parent
+				if comparisonNode == nil || comparisonNode.Kind != ast.KindBinaryExpression {
 					return
 				}
 
-				// Check if either side is -0
-				if isNegativeZero(binary.Left) || isNegativeZero(binary.Right) {
-					// Get the operator text for the error message
-					operatorText := getOperatorText(binary.OperatorToken.Kind)
-					ctx.ReportNode(node, buildCompareNegZeroMessage(operatorText))
+				comparison := comparisonNode.AsBinaryExpression()
+				if comparison == nil || comparison.OperatorToken == nil ||
+					comparison.Left != operand && comparison.Right != operand {
+					return
 				}
+
+				operatorText := getOperatorText(comparison.OperatorToken.Kind)
+				if operatorText == "" {
+					return
+				}
+				if !isZeroNumericLiteral(prefix.Operand) {
+					return
+				}
+
+				// When both operands are -0, the left listener reports the
+				// comparison and the right listener skips the duplicate.
+				if comparison.Right == operand && isNegativeZero(comparison.Left) {
+					return
+				}
+
+				ctx.ReportNode(comparisonNode, buildCompareNegZeroMessage(operatorText))
 			},
 		}
 	},

--- a/internal/rules/no_compare_neg_zero/no_compare_neg_zero_test.go
+++ b/internal/rules/no_compare_neg_zero/no_compare_neg_zero_test.go
@@ -42,6 +42,15 @@ func TestNoCompareNegZeroRule(t *testing.T) {
 
 			// Object.is() is the correct way to check for -0
 			{Code: `Object.is(x, -0)`},
+
+			// Only a direct numeric negative zero operand is compared
+			{Code: `x === -0n`},
+			{Code: `x === (-0 as number)`},
+			{Code: `x === (-0 satisfies number)`},
+			{Code: `x === -(-0)`},
+			{Code: `x === +(-0)`},
+			{Code: `x === (-0, y)`},
+			{Code: `x ** -0`},
 		},
 		// Invalid cases - ported from ESLint
 		[]rule_tester.InvalidTestCase{
@@ -128,6 +137,61 @@ func TestNoCompareNegZeroRule(t *testing.T) {
 					{MessageId: "unexpected", Line: 1, Column: 1},
 				},
 			},
+
+			// Inequality operators
+			noCompareNegZeroInvalid(`x != -0`, "!="),
+			noCompareNegZeroInvalid(`-0 != x`, "!="),
+			noCompareNegZeroInvalid(`x !== -0`, "!=="),
+			noCompareNegZeroInvalid(`-0 !== x`, "!=="),
+
+			// Parentheses are transparent in ESTree
+			noCompareNegZeroInvalid(`x === (-0)`, "==="),
+			noCompareNegZeroInvalid(`((-0)) === x`, "==="),
+			noCompareNegZeroInvalid(`x === -(0)`, "==="),
+			noCompareNegZeroInvalid(`x !== (((-(((0))))))`, "!=="),
+			noCompareNegZeroInvalid(`x === (/* before */ - /* after */ (0))`, "==="),
+
+			// All numeric literal spellings whose value is zero are negative zero
+			noCompareNegZeroInvalid(`x === -0.0`, "==="),
+			noCompareNegZeroInvalid(`x === -0e10`, "==="),
+			noCompareNegZeroInvalid(`x === -0x0`, "==="),
+
+			// A comparison with negative zero on both sides reports once
+			noCompareNegZeroInvalid(`-0 === -0`, "==="),
+			noCompareNegZeroInvalid(`((-0)) !== -(((0)))`, "!=="),
+
+			// Each nested comparison is a separate violation
+			{
+				Code: `x === -0 === -0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// The complete comparison, not only the -0 operand, is reported
+			{
+				Code: `if (x !== (-0)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unexpected",
+					Line:      1,
+					Column:    5,
+					EndLine:   1,
+					EndColumn: 15,
+				}},
+			},
 		},
 	)
+}
+
+func noCompareNegZeroInvalid(code string, operator string) rule_tester.InvalidTestCase {
+	return rule_tester.InvalidTestCase{
+		Code: code,
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "unexpected",
+			Message:   "Do not use the '" + operator + "' operator to compare against -0.",
+			Line:      1,
+			Column:    1,
+		}},
+	}
 }


### PR DESCRIPTION
## Summary

- Listen on `PrefixUnaryExpression` candidates instead of every `BinaryExpression`, and remove the per-file eight-entry operator map.
- Walk through parenthesized `-0` operands to match ESTree semantics while preserving one diagnostic when both operands are negative zero.
- `ctx.Refs` is not applicable because the rule inspects literals and operators rather than identifier bindings. Deferred reporting is also not applicable because the diagnostic has no fixes or suggestions to materialize lazily.

### Performance

Apple M1 Max, Go 1.26.1. Values are 5-run medians for real repositories and 8-run medians for the temporary Go benchmark. Real repositories used a JS config enabling only `no-compare-neg-zero` with `--timing all`.

| Corpus | Size | Before | After | Change |
| --- | ---: | ---: | ---: | ---: |
| Go binary-heavy listener benchmark | 12,288 binary expressions | 0.813 ms/op | 0.518 ms/op | -36.3% |
| rsbuild | 2,193 files | 0.9 ms | 0.5 ms | -44.4% |
| rspack | 14,997 files | 7.0 ms | 3.2 ms | -54.3% |

The temporary benchmark harness was removed before commit. As an adversarial bound, a synthetic file with 4,096 non-comparison `-0` literals adds about 37 microseconds total, or about 9 ns per literal, with zero allocations; the normal binary-heavy and real-repository distributions improve substantially.

### Validation

- `GOMAXPROCS=2 go test -p=1 ./internal/rules/no_compare_neg_zero -run ^TestNoCompareNegZeroRule$ -count=3`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/no_compare_neg_zero/...`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).