### PR TITLE
perf: speed up no-import-assign

### DIFF
--- a/internal/rules/no_import_assign/no_import_assign.go
+++ b/internal/rules/no_import_assign/no_import_assign.go
@@ -13,6 +13,7 @@ import (
 type importedBinding struct {
 	name        string
 	isNamespace bool
+	nameNode    *ast.Node
 	symbol      *ast.Symbol
 }
 
@@ -30,6 +31,16 @@ type importedBindingViolation struct {
 	kind    importedBindingViolationKind
 }
 
+type importedBindingGroup struct {
+	bindings   []importedBinding
+	violations []importedBindingViolation
+}
+
+type importedBindingTarget struct {
+	groupIndex   int
+	bindingIndex int
+}
+
 type noImportAssignRefStoreMode uint8
 
 const (
@@ -42,6 +53,7 @@ func makeImportedBinding(nameNode *ast.Node, isNamespace bool, symbol *ast.Symbo
 	return importedBinding{
 		name:        nameNode.Text(),
 		isNamespace: isNamespace,
+		nameNode:    nameNode,
 		symbol:      symbol,
 	}
 }
@@ -431,10 +443,94 @@ func reportImportedBindingGroup(ctx *rule.RuleContext, bindings []importedBindin
 	}
 }
 
-// walkImportedBindingReferences preserves the pre-RefStore implementation for
-// single-binding files, direct RuleContext callers without a Program/Refs, and
-// imports without binder symbols.
-func walkImportedBindingReferences(ctx *rule.RuleContext, bindings []importedBinding) {
+// walkImportedBindingGroups scans the source once against all imported bindings
+// collected by the normal listener traversal. It indexes only import names, so
+// unrelated identifiers never enter a per-file reference map. Violations are
+// bucketed by declaration to retain the rule's historical declaration-grouped
+// diagnostic order.
+func walkImportedBindingGroups(
+	ctx *rule.RuleContext,
+	groups []importedBindingGroup,
+	resolveReferenceSymbol func(*ast.Node) *ast.Symbol,
+) {
+	if ctx.SourceFile == nil {
+		return
+	}
+
+	bindingCount := 0
+	for _, group := range groups {
+		bindingCount += len(group.bindings)
+	}
+
+	targetsByName := make(map[string][]importedBindingTarget, bindingCount)
+	for groupIndex := range groups {
+		for bindingIndex, binding := range groups[groupIndex].bindings {
+			targetsByName[binding.name] = append(
+				targetsByName[binding.name],
+				importedBindingTarget{
+					groupIndex:   groupIndex,
+					bindingIndex: bindingIndex,
+				},
+			)
+		}
+	}
+
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+
+		if node.Kind == ast.KindIdentifier {
+			targets := targetsByName[node.Text()]
+			if len(targets) != 0 && !isImportBindingName(node) {
+				var referenceSymbol *ast.Symbol
+				if resolveReferenceSymbol != nil {
+					referenceSymbol = resolveReferenceSymbol(node)
+				}
+				for _, target := range targets {
+					binding := groups[target.groupIndex].bindings[target.bindingIndex]
+					if binding.symbol != nil && resolveReferenceSymbol != nil &&
+						referenceSymbol != binding.symbol {
+						continue
+					}
+
+					kind := classifyImportedBindingViolation(node, binding, ctx)
+					if kind != importedBindingViolationNone {
+						groups[target.groupIndex].violations = append(
+							groups[target.groupIndex].violations,
+							importedBindingViolation{
+								node:    node,
+								binding: binding,
+								kind:    kind,
+							},
+						)
+					}
+				}
+			}
+		}
+
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(ctx.SourceFile.AsNode())
+
+	for _, group := range groups {
+		for _, violation := range group.violations {
+			reportImportedBindingViolation(ctx, violation)
+		}
+	}
+}
+
+// walkImportedBindingReferences preserves the single-declaration compatibility
+// path used by forced strategy tests and avoids a name index for one binding.
+func walkImportedBindingReferences(
+	ctx *rule.RuleContext,
+	bindings []importedBinding,
+	resolveReferenceSymbol func(*ast.Node) *ast.Symbol,
+) {
 	if ctx.SourceFile == nil {
 		return
 	}
@@ -451,9 +547,8 @@ func walkImportedBindingReferences(ctx *rule.RuleContext, bindings []importedBin
 					continue
 				}
 
-				// Verify symbol identity when the type checker is available.
-				if binding.symbol != nil && ctx.TypeChecker != nil &&
-					utils.GetReferenceSymbol(node, ctx.TypeChecker) != binding.symbol {
+				if binding.symbol != nil && resolveReferenceSymbol != nil &&
+					resolveReferenceSymbol(node) != binding.symbol {
 					continue
 				}
 
@@ -485,44 +580,125 @@ func allBindingsHaveSymbols(bindings []importedBinding) bool {
 	return true
 }
 
+func allBindingGroupsHaveSymbols(groups []importedBindingGroup) bool {
+	for _, group := range groups {
+		if !allBindingsHaveSymbols(group.bindings) {
+			return false
+		}
+	}
+	return true
+}
+
 func noImportAssignListeners(
 	ctx rule.RuleContext,
 	refStoreMode noImportAssignRefStoreMode,
 ) rule.RuleListeners {
-	refStoreModeResolved := refStoreMode != noImportAssignRefStoreAuto
-	useRefStore := refStoreMode == noImportAssignRefStoreEnabled && ctx.Refs != nil
+	var checkerReferenceSymbol func(*ast.Node) *ast.Symbol
+	if ctx.TypeChecker != nil {
+		checkerReferenceSymbol = func(node *ast.Node) *ast.Symbol {
+			return utils.GetReferenceSymbol(node, ctx.TypeChecker)
+		}
+	}
 
+	// Keep the original one-listener compatibility path for the common
+	// single-binding case. It avoids every aggregation closure/allocation and
+	// is already optimal for one source walk.
+	if refStoreMode == noImportAssignRefStoreAuto &&
+		ctx.TypeChecker != nil &&
+		!hasMultipleTopLevelImportedBindings(ctx.SourceFile) {
+		refStoreMode = noImportAssignRefStoreDisabled
+	}
+
+	if refStoreMode != noImportAssignRefStoreAuto {
+		useRefStore := refStoreMode == noImportAssignRefStoreEnabled && ctx.Refs != nil
+		return rule.RuleListeners{
+			ast.KindImportDeclaration: func(node *ast.Node) {
+				if useRefStore {
+					bindings := collectImportedBindings(node, importBindingSymbol)
+					if len(bindings) == 0 {
+						return
+					}
+					if allBindingsHaveSymbols(bindings) {
+						reportImportedBindingGroup(&ctx, bindings)
+						return
+					}
+				}
+
+				bindings := collectImportedBindings(node, func(nameNode *ast.Node) *ast.Symbol {
+					return checkerImportBindingSymbol(nameNode, &ctx)
+				})
+				if len(bindings) != 0 {
+					walkImportedBindingReferences(&ctx, bindings, checkerReferenceSymbol)
+				}
+			},
+		}
+	}
+
+	resolveBindingSymbol := func(*ast.Node) *ast.Symbol { return nil }
+	resolveReferenceSymbol := checkerReferenceSymbol
+	if ctx.Refs != nil {
+		resolveBindingSymbol = importBindingSymbol
+		resolveReferenceSymbol = ctx.Refs.Resolve
+	} else if ctx.TypeChecker != nil {
+		resolveBindingSymbol = func(nameNode *ast.Node) *ast.Symbol {
+			return checkerImportBindingSymbol(nameNode, &ctx)
+		}
+	}
+
+	var firstGroup importedBindingGroup
+	var remainingGroups []importedBindingGroup
+	bindingCount := 0
 	return rule.RuleListeners{
 		ast.KindImportDeclaration: func(node *ast.Node) {
-			if !refStoreModeResolved {
-				// One imported binding needs only one compatibility walk, which
-				// avoids materializing RefStore buckets for every unrelated
-				// identifier. At two bindings the shared index already wins,
-				// and its advantage grows with the number of imports. Without a
-				// checker, RefStore is also required for exact shadow resolution.
-				useRefStore = ctx.Refs != nil &&
-					(ctx.TypeChecker == nil ||
-						hasMultipleTopLevelImportedBindings(ctx.SourceFile))
-				refStoreModeResolved = true
-			}
-
-			if useRefStore {
-				bindings := collectImportedBindings(node, importBindingSymbol)
-				if len(bindings) == 0 {
-					return
-				}
-				if allBindingsHaveSymbols(bindings) {
-					reportImportedBindingGroup(&ctx, bindings)
-					return
-				}
-			}
-
-			bindings := collectImportedBindings(node, func(nameNode *ast.Node) *ast.Symbol {
-				return checkerImportBindingSymbol(nameNode, &ctx)
-			})
+			bindings := collectImportedBindings(node, resolveBindingSymbol)
 			if len(bindings) != 0 {
-				walkImportedBindingReferences(&ctx, bindings)
+				group := importedBindingGroup{bindings: bindings}
+				if firstGroup.bindings == nil {
+					firstGroup = group
+				} else {
+					remainingGroups = append(remainingGroups, group)
+				}
+				bindingCount += len(bindings)
 			}
+		},
+		ast.KindEndOfFile: func(*ast.Node) {
+			if bindingCount == 0 {
+				return
+			}
+
+			// Without a checker, RefStore.Resolve keeps the one-binding path
+			// exact without materializing the reverse-reference index.
+			if bindingCount == 1 {
+				walkImportedBindingReferences(
+					&ctx,
+					firstGroup.bindings,
+					resolveReferenceSymbol,
+				)
+				return
+			}
+
+			groups := make([]importedBindingGroup, 1, 1+len(remainingGroups))
+			groups[0] = firstGroup
+			groups = append(groups, remainingGroups...)
+
+			// Recovered syntax can leave an import name without a binder symbol.
+			// In that case, keep the old checker fallback rather than mixing
+			// symbol domains or degrading that binding to text-only matching.
+			if ctx.Refs != nil && ctx.TypeChecker != nil &&
+				!allBindingGroupsHaveSymbols(groups) {
+				for groupIndex := range groups {
+					for bindingIndex := range groups[groupIndex].bindings {
+						binding := &groups[groupIndex].bindings[bindingIndex]
+						binding.symbol = checkerImportBindingSymbol(binding.nameNode, &ctx)
+					}
+				}
+				resolveReferenceSymbol = checkerReferenceSymbol
+			}
+
+			// A single selective scan avoids both repeated walks and RefStore's
+			// unrelated-name buckets. RefStore.Resolve provides binder identity
+			// without materializing the full reverse-reference index.
+			walkImportedBindingGroups(&ctx, groups, resolveReferenceSymbol)
 		},
 	}
 }

--- a/internal/rules/no_import_assign/no_import_assign_test.go
+++ b/internal/rules/no_import_assign/no_import_assign_test.go
@@ -493,6 +493,11 @@ func TestNoImportAssignRuleWithoutRefStore(t *testing.T) {
 		&fallbackRule,
 		[]rule_tester.ValidTestCase{
 			{Code: `import { value } from "mod"; { let value = 0; value = 1; }`},
+			{
+				Code: `import { first, second } from "mod";
+					{ let first = 0; first = 1; }
+					{ let second = {}; second.member = 1; }`,
+			},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
@@ -513,6 +518,15 @@ func TestNoImportAssignRuleWithoutRefStore(t *testing.T) {
 					{MessageId: "readonly", Message: "'value' is read-only.", Line: 1, Column: 33},
 				},
 			},
+			{
+				Code: `import { first, second } from "mod";
+					second = 1;
+					first = 2;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "readonly", Message: "'second' is read-only.", Line: 2},
+					{MessageId: "readonly", Message: "'first' is read-only.", Line: 3},
+				},
+			},
 		},
 	)
 }
@@ -531,6 +545,11 @@ func TestNoImportAssignRuleWithRefStoreWithoutTypeChecker(t *testing.T) {
 		&noCheckerRule,
 		[]rule_tester.ValidTestCase{
 			{Code: `import { value } from "mod"; { let value = 0; value = 1; }`},
+			{
+				Code: `import { first, second } from "mod";
+					{ let first = 0; first = 1; }
+					{ let second = {}; second.member = 1; }`,
+			},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
@@ -539,6 +558,24 @@ func TestNoImportAssignRuleWithRefStoreWithoutTypeChecker(t *testing.T) {
 					value = 2;`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "readonly", Message: "'value' is read-only.", Line: 3},
+				},
+			},
+			{
+				Code: `import * as namespace from "namespace";
+					import { value } from "value";
+					namespace.member = 1;
+					value = 2;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "readonlyMember",
+						Message:   "The members of 'namespace' are read-only.",
+						Line:      3,
+					},
+					{
+						MessageId: "readonly",
+						Message:   "'value' is read-only.",
+						Line:      4,
+					},
 				},
 			},
 		},
@@ -555,7 +592,7 @@ type noImportAssignDiagnosticFingerprint struct {
 func lintNoImportAssignForComparison(
 	t *testing.T,
 	code string,
-	useRefStore bool,
+	mode noImportAssignRefStoreMode,
 ) []noImportAssignDiagnosticFingerprint {
 	t.Helper()
 
@@ -583,11 +620,10 @@ func lintNoImportAssignForComparison(
 				Name:     NoImportAssignRule.Name,
 				Severity: rule.SeverityError,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {
-					if !useRefStore {
+					if mode == noImportAssignRefStoreDisabled {
 						ctx.Refs = nil
-						return noImportAssignListeners(ctx, noImportAssignRefStoreDisabled)
 					}
-					return noImportAssignListeners(ctx, noImportAssignRefStoreEnabled)
+					return noImportAssignListeners(ctx, mode)
 				},
 			}}
 		},
@@ -606,7 +642,7 @@ func lintNoImportAssignForComparison(
 	return diagnostics
 }
 
-func TestNoImportAssignRefStoreMatchesFallback(t *testing.T) {
+func TestNoImportAssignStrategiesMatch(t *testing.T) {
 	testCases := []struct {
 		name string
 		code string
@@ -696,29 +732,63 @@ func TestNoImportAssignRefStoreMatchesFallback(t *testing.T) {
 					nested = 1;
 				}`,
 		},
+		{
+			name: "mixed top-level and nested recovered imports",
+			code: `import { first } from "first";
+				if (condition) {
+					import { nested } from "nested";
+					nested = 1;
+				}
+				import { last } from "last";
+				last = 2;
+				first = 3;`,
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			fast := lintNoImportAssignForComparison(t, testCase.code, true)
-			fallback := lintNoImportAssignForComparison(t, testCase.code, false)
-			if len(fast) != len(fallback) {
-				t.Fatalf("diagnostic count differs: RefStore=%+v fallback=%+v", fast, fallback)
-			}
-			for i := range fast {
-				if fast[i] != fallback[i] {
-					t.Fatalf("diagnostic %d differs: RefStore=%+v fallback=%+v", i, fast[i], fallback[i])
+			auto := lintNoImportAssignForComparison(
+				t,
+				testCase.code,
+				noImportAssignRefStoreAuto,
+			)
+			for _, strategy := range []struct {
+				name string
+				mode noImportAssignRefStoreMode
+			}{
+				{name: "RefStore", mode: noImportAssignRefStoreEnabled},
+				{name: "fallback", mode: noImportAssignRefStoreDisabled},
+			} {
+				got := lintNoImportAssignForComparison(t, testCase.code, strategy.mode)
+				if len(got) != len(auto) {
+					t.Fatalf(
+						"diagnostic count differs: auto=%+v %s=%+v",
+						auto,
+						strategy.name,
+						got,
+					)
+				}
+				for i := range auto {
+					if got[i] != auto[i] {
+						t.Fatalf(
+							"diagnostic %d differs: auto=%+v %s=%+v",
+							i,
+							auto,
+							strategy.name,
+							got,
+						)
+					}
 				}
 			}
 		})
 	}
 }
 
-func TestNoImportAssignRefStoreHonorsDisableDirectives(t *testing.T) {
+func TestNoImportAssignAutoHonorsDisableDirectives(t *testing.T) {
 	diagnostics := lintNoImportAssignForComparison(t, `import { a, b } from "mod";
 		// eslint-disable-next-line no-import-assign
 		a = 1;
-		b = 2;`, true)
+		b = 2;`, noImportAssignRefStoreAuto)
 
 	if len(diagnostics) != 1 {
 		t.Fatalf("got diagnostics %+v, want one unsuppressed diagnostic", diagnostics)


### PR DESCRIPTION
## Summary

- replace the multi-binding `no-import-assign` reverse-reference index with one selective source scan
- use `ctx.Refs.Resolve` to preserve binder-level symbol identity without indexing unrelated identifiers
- preserve the existing single-binding path, diagnostic grouping/order, checker fallback for recovered syntax, and no-checker behavior
- keep reporting eager because report deferral only applies to fixes and suggestions, which this rule does not produce

### Performance

Apple M1 Max, Go 1.26.1, 5,000 unrelated statements, `-benchtime=500ms -count=7`; values are medians. Parsing/program creation is outside the timed section. The baseline is the current `main` RefStore strategy used for files with at least two imported bindings.

| Imported bindings | Baseline | Optimized | Time | Baseline B/op | Optimized B/op | Memory |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 2 | 1.166 ms | 0.746 ms | -36.0% | ~825 KB | ~3.9 KB | -99.5% |
| 20 | 1.135 ms | 0.772 ms | -32.0% | ~829 KB | ~10.8 KB | -98.7% |
| 100 | 1.202 ms | 0.888 ms | -26.1% | ~843 KB | ~36.1 KB | -95.7% |

With rsbuild's existing `rslint.config.ts`, five paired single-threaded runs stayed flat at a 0.9 ms median for this rule, and baseline/optimized diagnostic output was byte-identical.

### Validation

- `go test ./internal/rules/no_import_assign`
- `go test -race ./internal/rules/no_import_assign`
- strategy differential coverage for ordering, shadowing, recovered syntax, namespace writes, disable directives, checker fallback, and no-checker RefStore resolution
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=HEAD ./internal/rules/no_import_assign`

## Related Links

N/A

## Checklist

- [x] Tests updated (in the existing rule test file).
- [x] Documentation updated (not required; behavior and configuration are unchanged).
