### PR TITLE
fix: address staticcheck warning in backreference test

### DIFF
--- a/internal/rules/no_useless_backreference/no_useless_backreference_test.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference_test.go
@@ -701,6 +701,7 @@ enum Pattern {
 	sourceFile := program.GetSourceFile(filePath)
 	if sourceFile == nil {
 		t.Fatalf("%s was not loaded", filePath)
+		return
 	}
 	typeChecker, done := program.GetTypeChecker(t.Context())
 	defer done()


### PR DESCRIPTION
## Summary

- make the nil branch explicitly return after `t.Fatalf`
- avoid the `SA5011` false positive reported by golangci-lint v2.12.2

## Testing

- `go test ./internal/rules/no_useless_backreference`
- `golangci-lint run --timeout=15m ./internal/rules/no_useless_backreference/...`
- `git diff --check`