### PR TITLE
perf: optimize no-this-alias listener

### DIFF
--- a/internal/plugins/typescript/rules/no_this_alias/no_this_alias.go
+++ b/internal/plugins/typescript/rules/no_this_alias/no_this_alias.go
@@ -10,6 +10,39 @@ type NoThisAliasOptions struct {
 	AllowedNames       []string `json:"allowedNames"`
 }
 
+// aliasTarget returns the ESTree-equivalent VariableDeclarator id or
+// AssignmentExpression left-hand side for a `this` value. ESTree elides
+// parentheses, while the TypeScript AST preserves them.
+func aliasTarget(node *ast.Node) *ast.Node {
+	value := node
+	for value.Parent != nil && value.Parent.Kind == ast.KindParenthesizedExpression {
+		value = value.Parent
+	}
+
+	parent := value.Parent
+	if parent == nil {
+		return nil
+	}
+
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		declaration := parent.AsVariableDeclaration()
+		if declaration != nil && declaration.Initializer == value {
+			return declaration.Name()
+		}
+	case ast.KindBinaryExpression:
+		if !ast.IsAssignmentExpression(parent, false) {
+			return nil
+		}
+		expression := parent.AsBinaryExpression()
+		if expression != nil && expression.Right == value {
+			return ast.SkipParentheses(expression.Left)
+		}
+	}
+
+	return nil
+}
+
 var NoThisAliasRule = rule.CreateRule(rule.Rule{
 	Name: "no-this-alias",
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
@@ -46,108 +79,35 @@ var NoThisAliasRule = rule.CreateRule(rule.Rule{
 			}
 		}
 
-		// Helper to check if initializer is `this`
-		isThisKeyword := func(node *ast.Node) bool {
-			return node != nil && node.Kind == ast.KindThisKeyword
-		}
-
 		return rule.RuleListeners{
-			ast.KindVariableDeclaration: func(node *ast.Node) {
-				varDecl := node.AsVariableDeclaration()
-				if varDecl == nil || varDecl.Initializer == nil {
+			ast.KindThisKeyword: func(node *ast.Node) {
+				target := aliasTarget(node)
+				if target == nil {
 					return
 				}
 
-				// Check if initializer is `this`
-				if !isThisKeyword(varDecl.Initializer) {
+				if opts.AllowDestructuring && target.Kind != ast.KindIdentifier {
 					return
 				}
 
-				// Get the name node
-				nameNode := varDecl.Name()
-				if nameNode == nil {
-					return
-				}
-
-				// Check if it's destructuring
-				switch nameNode.Kind {
-				case ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
-					// Destructuring pattern
-					if !opts.AllowDestructuring {
-						ctx.ReportNode(nameNode, rule.RuleMessage{
-							Id:          "thisDestructure",
-							Description: "Destructuring `this` is not allowed.",
-						})
-					}
-					return
-				case ast.KindIdentifier:
-					// Check if the identifier name is in allowedNames
-					id := nameNode.AsIdentifier()
-					if id != nil {
-						idName := id.Text
-						for _, allowedName := range opts.AllowedNames {
-							if idName == allowedName {
-								// Name is allowed, don't report
-								return
-							}
+				if target.Kind == ast.KindIdentifier {
+					name := target.AsIdentifier().Text
+					for _, allowedName := range opts.AllowedNames {
+						if name == allowedName {
+							return
 						}
 					}
-					// Regular identifier assignment - report it
-					ctx.ReportNode(nameNode, rule.RuleMessage{
+					ctx.ReportNode(target, rule.RuleMessage{
 						Id:          "thisAssignment",
 						Description: "Unexpected aliasing of `this` to local variable.",
 					})
 					return
 				}
-			},
-			ast.KindBinaryExpression: func(node *ast.Node) {
-				binExpr := node.AsBinaryExpression()
-				if binExpr == nil {
-					return
-				}
 
-				// Check for assignment (=) operator
-				if binExpr.OperatorToken == nil || binExpr.OperatorToken.Kind != ast.KindEqualsToken {
-					return
-				}
-
-				// Check if right side is `this`
-				if !isThisKeyword(binExpr.Right) {
-					return
-				}
-
-				// Check left side
-				if binExpr.Left != nil {
-					switch binExpr.Left.Kind {
-					case ast.KindObjectLiteralExpression, ast.KindArrayLiteralExpression:
-						// Destructuring pattern
-						if !opts.AllowDestructuring {
-							ctx.ReportNode(binExpr.Left, rule.RuleMessage{
-								Id:          "thisDestructure",
-								Description: "Destructuring `this` is not allowed.",
-							})
-						}
-						return
-					case ast.KindIdentifier:
-						// Check if the identifier name is in allowedNames
-						id := binExpr.Left.AsIdentifier()
-						if id != nil {
-							idName := id.Text
-							for _, allowedName := range opts.AllowedNames {
-								if idName == allowedName {
-									// Name is allowed, don't report
-									return
-								}
-							}
-						}
-						// Regular identifier assignment
-						ctx.ReportNode(binExpr.Left, rule.RuleMessage{
-							Id:          "thisAssignment",
-							Description: "Unexpected aliasing of `this` to local variable.",
-						})
-						return
-					}
-				}
+				ctx.ReportNode(target, rule.RuleMessage{
+					Id:          "thisDestructure",
+					Description: "Destructuring `this` is not allowed.",
+				})
 			},
 		}
 	},

--- a/internal/plugins/typescript/rules/no_this_alias/no_this_alias_test.go
+++ b/internal/plugins/typescript/rules/no_this_alias/no_this_alias_test.go
@@ -16,12 +16,23 @@ func TestNoThisAliasRule(t *testing.T) {
 		// Valid cases
 		[]rule_tester.ValidTestCase{
 			{Code: `const self = foo(this);`},
+			{Code: `const value = this as unknown;`},
+			{Code: `const value = this!;`},
+			{Code: `const value = this satisfies unknown;`},
+			{Code: `const value = <unknown>this;`},
+			{Code: `function fn(value = this) {}`},
+			{Code: `class Example { value = this; }`},
+			{Code: `object.value = this;`},
+			{Code: `let value; value = foo(this); value = this as unknown; value = this!;`},
+			{Code: `let value; ({ value } = this); [value] = this;`},
+			{Code: `let value; (value as unknown) = this;`},
 			{Code: `const { props, state } = this;`},
 			{Code: `const { length } = this;`},
 			{Code: `const { length, toString } = this;`},
 			{Code: `const [foo] = this;`},
 			{Code: `const [foo, bar] = this;`},
 			{Code: `const self = this;`, Options: map[string]interface{}{"allowedNames": []interface{}{"self"}}},
+			{Code: `let self = 1; self ||= this;`, Options: map[string]interface{}{"allowedNames": []interface{}{"self"}}},
 			{Code: `setTimeout(() => { this.doWork(); });`},
 		},
 		// Invalid cases
@@ -33,8 +44,37 @@ func TestNoThisAliasRule(t *testing.T) {
 				},
 			},
 			{
+				Code: `const self = (((this)));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisAssignment", Line: 1, Column: 7, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
 				Code: `let that; that = this;`,
 				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisAssignment"},
+				},
+			},
+			{
+				Code: `let that; ((that)) = this;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisAssignment", Line: 1, Column: 13, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code: `let that = 1; that += this;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisAssignment"},
+				},
+			},
+			{
+				Code: `let value: unknown;
+value &&= this;
+value ||= (this);
+value ??= this;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisAssignment"},
+					{MessageId: "thisAssignment"},
 					{MessageId: "thisAssignment"},
 				},
 			},
@@ -71,6 +111,27 @@ const testLambda = () => {
 			},
 			{
 				Code:    `const [foo] = this;`,
+				Options: map[string]interface{}{"allowDestructuring": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisDestructure"},
+				},
+			},
+			{
+				Code:    `object.value = this;`,
+				Options: map[string]interface{}{"allowDestructuring": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisDestructure"},
+				},
+			},
+			{
+				Code:    `let value; (value as unknown) = this;`,
+				Options: map[string]interface{}{"allowDestructuring": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisDestructure"},
+				},
+			},
+			{
+				Code:    `({ value } = (this));`,
 				Options: map[string]interface{}{"allowDestructuring": false},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "thisDestructure"},


### PR DESCRIPTION
## Summary

- Replace the broad `VariableDeclaration` and `BinaryExpression` listeners with one `ThisKeyword` listener, then resolve only direct variable-declarator and assignment-expression parents.
- Preserve ESTree parenthesis behavior and align assignment handling with the upstream selector, including compound/logical assignments and non-Identifier left-hand sides.
- Add focused coverage for parentheses, TypeScript expression wrappers, assignment operators, `allowedNames`, destructuring, member targets, and exact report ranges.
- Keep the rule syntax-only: `ctx.Refs` indexes Identifier references rather than `this`, while deferred reporting only avoids fix/suggestion construction and this rule emits neither.

### Performance

Go benchmark (`128` generated TypeScript files, `-count=10 -benchtime=500ms`, compared with `benchstat`):

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Time | 655.3 µs/op | 601.2 µs/op | -8.26% |
| Memory | 109.60 KiB/op | 99.57 KiB/op | -9.15% |
| Allocations | 1.316k/op | 1.187k/op | -9.80% |

Real repositories were run single-threaded with their JavaScript/TypeScript rslint config and `--timing all`:

| Repository | Rule files | Before | After | Diagnostics |
| --- | ---: | ---: | ---: | ---: |
| rsbuild | 1,401 | 0.5 ms median (0.5/0.5/0.6) | 0.3 ms median (0.3/0.3/0.3) | 0 → 0 |
| rspack | 400 | 0.9 ms median (3 runs) | 0.8 ms median (5 runs) | 4 → 4 |

### Verification

- `go test ./internal/plugins/typescript/rules/no_this_alias -run '^TestNoThisAliasRule$' -count=1`
- `pnpm exec rstest run no-this-alias.test.ts --pool.maxWorkers 1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=HEAD` from the changed rule package

## Related Links

- [Upstream no-this-alias implementation](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-this-alias.ts)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
