### PR TITLE
perf: optimize no-inferrable-types rule

### DIFF
--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go
@@ -12,6 +12,55 @@ type Options struct {
 	IgnoreProperties bool
 }
 
+type inferrableType uint8
+
+const (
+	inferrableTypeNone inferrableType = iota
+	inferrableTypeBigInt
+	inferrableTypeBoolean
+	inferrableTypeNumber
+	inferrableTypeString
+	inferrableTypeNull
+	inferrableTypeRegExp
+	inferrableTypeUndefined
+	inferrableTypeSymbol
+)
+
+var noInferrableTypesMessages = [...]rule.RuleMessage{
+	inferrableTypeBigInt: {
+		Id:          "noInferrableType",
+		Description: "Type bigint trivially inferred from a bigint literal, remove type annotation.",
+	},
+	inferrableTypeBoolean: {
+		Id:          "noInferrableType",
+		Description: "Type boolean trivially inferred from a boolean literal, remove type annotation.",
+	},
+	inferrableTypeNumber: {
+		Id:          "noInferrableType",
+		Description: "Type number trivially inferred from a number literal, remove type annotation.",
+	},
+	inferrableTypeString: {
+		Id:          "noInferrableType",
+		Description: "Type string trivially inferred from a string literal, remove type annotation.",
+	},
+	inferrableTypeNull: {
+		Id:          "noInferrableType",
+		Description: "Type null trivially inferred from a null literal, remove type annotation.",
+	},
+	inferrableTypeRegExp: {
+		Id:          "noInferrableType",
+		Description: "Type RegExp trivially inferred from a RegExp literal, remove type annotation.",
+	},
+	inferrableTypeUndefined: {
+		Id:          "noInferrableType",
+		Description: "Type undefined trivially inferred from a undefined literal, remove type annotation.",
+	},
+	inferrableTypeSymbol: {
+		Id:          "noInferrableType",
+		Description: "Type symbol trivially inferred from a symbol literal, remove type annotation.",
+	},
+}
+
 func parseOptions(options any) Options {
 	// Default values match typescript-eslint defaults
 	opts := Options{
@@ -44,170 +93,176 @@ func parseOptions(options any) Options {
 	return opts
 }
 
-func buildNoInferrableTypesMessage(typeName string) rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "noInferrableType",
-		Description: "Type " + typeName + " trivially inferred from a " + typeName + " literal, remove type annotation.",
+func getInferrableTypeAnnotation(typeNode *ast.Node) inferrableType {
+	if typeNode == nil {
+		return inferrableTypeNone
 	}
+
+	switch typeNode.Kind {
+	case ast.KindBigIntKeyword:
+		return inferrableTypeBigInt
+	case ast.KindBooleanKeyword:
+		return inferrableTypeBoolean
+	case ast.KindNumberKeyword:
+		return inferrableTypeNumber
+	case ast.KindStringKeyword:
+		return inferrableTypeString
+	case ast.KindNullKeyword:
+		return inferrableTypeNull
+	case ast.KindLiteralType:
+		// Depending on the parser path, `null` can be represented directly or
+		// wrapped in a LiteralType node.
+		litType := typeNode.AsLiteralTypeNode()
+		if litType != nil && litType.Literal != nil && litType.Literal.Kind == ast.KindNullKeyword {
+			return inferrableTypeNull
+		}
+	case ast.KindUndefinedKeyword:
+		return inferrableTypeUndefined
+	case ast.KindSymbolKeyword:
+		return inferrableTypeSymbol
+	case ast.KindTypeReference:
+		typeRef := typeNode.AsTypeReferenceNode()
+		if typeRef != nil && isIdentifierNamed(typeRef.TypeName, "RegExp") {
+			return inferrableTypeRegExp
+		}
+	}
+	return inferrableTypeNone
 }
 
-// getInferrableType checks if the initializer is an inferrable type
-// Returns the type name if inferrable, empty string otherwise
-func getInferrableType(init *ast.Node) string {
-	if init == nil {
+func identifierName(node *ast.Node) string {
+	if node == nil || node.Kind != ast.KindIdentifier {
 		return ""
 	}
-
-	switch init.Kind {
-	case ast.KindBigIntLiteral:
-		return "bigint"
-
-	case ast.KindTrueKeyword, ast.KindFalseKeyword:
-		return "boolean"
-
-	case ast.KindNumericLiteral:
-		return "number"
-
-	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral:
-		return "string"
-
-	case ast.KindNullKeyword:
-		return "null"
-
-	case ast.KindRegularExpressionLiteral:
-		return "RegExp"
-
-	case ast.KindIdentifier:
-		id := init.AsIdentifier()
-		if id != nil {
-			switch id.Text {
-			case "undefined":
-				return "undefined"
-			case "Infinity", "NaN":
-				return "number"
-			}
-		}
-
-	case ast.KindPrefixUnaryExpression:
-		unary := init.AsPrefixUnaryExpression()
-		if unary != nil {
-			switch unary.Operator {
-			case ast.KindExclamationToken:
-				// !x is boolean
-				return "boolean"
-			case ast.KindPlusToken, ast.KindMinusToken:
-				// +x, -x with number/bigint literals or function calls
-				if unary.Operand != nil {
-					if unary.Operand.Kind == ast.KindNumericLiteral {
-						return "number"
-					}
-					if unary.Operand.Kind == ast.KindBigIntLiteral {
-						return "bigint"
-					}
-					// Check for Infinity, NaN identifiers
-					if unary.Operand.Kind == ast.KindIdentifier {
-						id := unary.Operand.AsIdentifier()
-						if id != nil && (id.Text == "Infinity" || id.Text == "NaN") {
-							return "number"
-						}
-					}
-					// Check for function calls like -BigInt(10), -Number('1')
-					if unary.Operand.Kind == ast.KindCallExpression {
-						call := unary.Operand.AsCallExpression()
-						if call != nil && call.Expression != nil && call.Expression.Kind == ast.KindIdentifier {
-							funcName := call.Expression.AsIdentifier()
-							if funcName != nil {
-								switch funcName.Text {
-								case "BigInt":
-									return "bigint"
-								case "Number":
-									return "number"
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-	case ast.KindVoidExpression:
-		return "undefined"
-
-	case ast.KindCallExpression:
-		call := init.AsCallExpression()
-		if call != nil && call.Expression != nil && call.Expression.Kind == ast.KindIdentifier {
-			funcName := call.Expression.AsIdentifier()
-			if funcName != nil {
-				switch funcName.Text {
-				case "BigInt":
-					return "bigint"
-				case "Boolean":
-					return "boolean"
-				case "Number":
-					return "number"
-				case "String":
-					return "string"
-				case "Symbol":
-					return "symbol"
-				case "RegExp":
-					return "RegExp"
-				}
-			}
-		}
-
-	case ast.KindNewExpression:
-		newExpr := init.AsNewExpression()
-		if newExpr != nil && newExpr.Expression != nil && newExpr.Expression.Kind == ast.KindIdentifier {
-			className := newExpr.Expression.AsIdentifier()
-			if className != nil && className.Text == "RegExp" {
-				return "RegExp"
-			}
-		}
+	identifier := node.AsIdentifier()
+	if identifier == nil {
+		return ""
 	}
-
-	return ""
+	return identifier.Text
 }
 
-// matchesTypeAnnotation checks if the type annotation matches the expected type
-func matchesTypeAnnotation(typeNode *ast.Node, expectedType string) bool {
-	if typeNode == nil {
+func isIdentifierNamed(node *ast.Node, name string) bool {
+	return identifierName(node) == name
+}
+
+func isNumberConstant(node *ast.Node) bool {
+	name := identifierName(node)
+	return name == "Infinity" || name == "NaN"
+}
+
+func isCallTo(node *ast.Node, name string) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := node.AsCallExpression()
+	return call != nil && isIdentifierNamed(call.Expression, name)
+}
+
+func isNewRegExp(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindNewExpression {
+		return false
+	}
+	newExpression := node.AsNewExpression()
+	return newExpression != nil && isIdentifierNamed(newExpression.Expression, "RegExp")
+}
+
+// isInferrableInitializer is deliberately keyed by the annotation first. Most
+// declarations use user-defined types, so they are rejected before inspecting
+// the initializer at all.
+func isInferrableInitializer(init *ast.Node, expectedType inferrableType) bool {
+	if init == nil {
 		return false
 	}
 
 	switch expectedType {
-	case "bigint":
-		return typeNode.Kind == ast.KindBigIntKeyword
-	case "boolean":
-		return typeNode.Kind == ast.KindBooleanKeyword
-	case "number":
-		return typeNode.Kind == ast.KindNumberKeyword
-	case "string":
-		return typeNode.Kind == ast.KindStringKeyword
-	case "null":
-		// null type can be KindNullKeyword directly or wrapped in LiteralType
-		if typeNode.Kind == ast.KindNullKeyword {
+	case inferrableTypeBigInt:
+		if init.Kind == ast.KindBigIntLiteral || isCallTo(init, "BigInt") {
 			return true
 		}
-		if typeNode.Kind == ast.KindLiteralType {
-			litType := typeNode.AsLiteralTypeNode()
-			if litType != nil && litType.Literal != nil {
-				return litType.Literal.Kind == ast.KindNullKeyword
-			}
+		if init.Kind == ast.KindPrefixUnaryExpression {
+			unary := init.AsPrefixUnaryExpression()
+			return unary != nil &&
+				unary.Operand != nil &&
+				(unary.Operator == ast.KindPlusToken || unary.Operator == ast.KindMinusToken) &&
+				(unary.Operand.Kind == ast.KindBigIntLiteral || isCallTo(unary.Operand, "BigInt"))
 		}
-		return false
-	case "undefined":
-		return typeNode.Kind == ast.KindUndefinedKeyword
-	case "symbol":
-		return typeNode.Kind == ast.KindSymbolKeyword
-	case "RegExp":
-		if typeNode.Kind == ast.KindTypeReference {
-			typeRef := typeNode.AsTypeReferenceNode()
-			if typeRef != nil && typeRef.TypeName != nil && typeRef.TypeName.Kind == ast.KindIdentifier {
-				return typeRef.TypeName.AsIdentifier().Text == "RegExp"
-			}
+
+	case inferrableTypeBoolean:
+		if init.Kind == ast.KindTrueKeyword || init.Kind == ast.KindFalseKeyword || isCallTo(init, "Boolean") {
+			return true
 		}
+		if init.Kind == ast.KindPrefixUnaryExpression {
+			unary := init.AsPrefixUnaryExpression()
+			return unary != nil && unary.Operator == ast.KindExclamationToken
+		}
+
+	case inferrableTypeNumber:
+		if init.Kind == ast.KindNumericLiteral ||
+			isNumberConstant(init) ||
+			isCallTo(init, "Number") {
+			return true
+		}
+		if init.Kind == ast.KindPrefixUnaryExpression {
+			unary := init.AsPrefixUnaryExpression()
+			return unary != nil &&
+				unary.Operand != nil &&
+				(unary.Operator == ast.KindPlusToken || unary.Operator == ast.KindMinusToken) &&
+				(unary.Operand.Kind == ast.KindNumericLiteral ||
+					isNumberConstant(unary.Operand) ||
+					isCallTo(unary.Operand, "Number"))
+		}
+
+	case inferrableTypeString:
+		return init.Kind == ast.KindStringLiteral ||
+			init.Kind == ast.KindNoSubstitutionTemplateLiteral ||
+			isCallTo(init, "String")
+
+	case inferrableTypeNull:
+		return init.Kind == ast.KindNullKeyword
+
+	case inferrableTypeRegExp:
+		return init.Kind == ast.KindRegularExpressionLiteral ||
+			isCallTo(init, "RegExp") ||
+			isNewRegExp(init)
+
+	case inferrableTypeUndefined:
+		return init.Kind == ast.KindVoidExpression || isIdentifierNamed(init, "undefined")
+
+	case inferrableTypeSymbol:
+		return isCallTo(init, "Symbol")
 	}
+
 	return false
+}
+
+func buildNoInferrableTypesFixes(sourceText string, typeAnnotation *ast.Node, postfixToken *ast.Node) []rule.RuleFix {
+	// parseTypeAnnotation records the type node's full start immediately after
+	// the colon token, even when comments or whitespace precede the type.
+	colonPos := typeAnnotation.Pos() - 1
+	if colonPos < 0 || colonPos >= len(sourceText) || sourceText[colonPos] != ':' {
+		// Recovery/synthesized ASTs should still get a diagnostic, but no
+		// potentially corrupting edit.
+		return nil
+	}
+
+	typeFix := rule.RuleFixRemoveRange(core.NewTextRange(colonPos, typeAnnotation.End()))
+	if postfixToken == nil {
+		return []rule.RuleFix{typeFix}
+	}
+
+	// Preserve comments around `?`/`!` exactly like the upstream two-edit fix:
+	// remove the token itself separately from the type annotation.
+	postfixPos := postfixToken.End() - 1
+	if postfixPos < 0 || postfixPos >= len(sourceText) {
+		return nil
+	}
+	postfix := sourceText[postfixPos]
+	if postfix != '?' && postfix != '!' {
+		return nil
+	}
+	return []rule.RuleFix{
+		rule.RuleFixRemoveRange(core.NewTextRange(postfixPos, postfixToken.End())),
+		typeFix,
+	}
 }
 
 var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
@@ -215,57 +270,32 @@ var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
 		opts := parseOptions(options)
+		sourceText := ctx.SourceFile.Text()
 
-		checkDeclaration := func(reportNode *ast.Node, typeAnnotation *ast.Node, initializer *ast.Node, hasQuestionToken bool, hasExclamationToken bool) {
+		checkDeclaration := func(reportNode *ast.Node, typeAnnotation *ast.Node, initializer *ast.Node, postfixToken *ast.Node) {
 			if typeAnnotation == nil || initializer == nil {
 				return
 			}
 
-			inferrableType := getInferrableType(initializer)
-			if inferrableType == "" {
+			inferrableType := getInferrableTypeAnnotation(typeAnnotation)
+			if inferrableType == inferrableTypeNone || !isInferrableInitializer(initializer, inferrableType) {
 				return
 			}
 
-			if matchesTypeAnnotation(typeAnnotation, inferrableType) {
-				// Report with fix to remove type annotation
-				// Find the colon position by scanning backwards from typeAnnotation
-				colonPos := typeAnnotation.Pos()
-				sourceText := ctx.SourceFile.Text()
-				for i := colonPos - 1; i >= 0; i-- {
-					if sourceText[i] == ':' {
-						colonPos = i
-						break
-					}
-				}
-
-				// If there's a question token (optional) or exclamation token (definite assignment),
-				// we need to remove it too and adjust the position
-				if hasQuestionToken || hasExclamationToken {
-					for i := colonPos - 1; i >= 0; i-- {
-						ch := sourceText[i]
-						if ch == '?' || ch == '!' {
-							colonPos = i
-							break
-						} else if ch != ' ' && ch != '\t' {
-							break
-						}
-					}
-				}
-
-				fixRange := core.NewTextRange(colonPos, typeAnnotation.End())
-				// Report range spans from the name node (trimmed) to the end of the initializer
-				// This matches typescript-eslint's behavior of reporting on the full declaration
-				trimmedStartPos := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, reportNode.Pos()).Pos()
-				reportRange := core.NewTextRange(trimmedStartPos, initializer.End())
-				ctx.ReportRangeWithFixes(
-					reportRange,
-					buildNoInferrableTypesMessage(inferrableType),
-					rule.RuleFixRemoveRange(fixRange),
-				)
-			}
+			// Report range spans from the first declaration token to the end of
+			// the initializer, matching typescript-eslint without allocating a
+			// scanner for every diagnostic.
+			reportRange := core.NewTextRange(scanner.SkipTrivia(sourceText, reportNode.Pos()), initializer.End())
+			ctx.ReportRangeWithDeferredFixes(
+				reportRange,
+				noInferrableTypesMessages[inferrableType],
+				func() []rule.RuleFix {
+					return buildNoInferrableTypesFixes(sourceText, typeAnnotation, postfixToken)
+				},
+			)
 		}
 
-		return rule.RuleListeners{
+		listeners := rule.RuleListeners{
 			ast.KindVariableDeclaration: func(node *ast.Node) {
 				varDecl := node.AsVariableDeclaration()
 				if varDecl == nil {
@@ -276,59 +306,46 @@ var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
 				if reportNode == nil {
 					reportNode = node
 				}
-				checkDeclaration(reportNode, varDecl.Type, varDecl.Initializer, false, false)
+				checkDeclaration(reportNode, varDecl.Type, varDecl.Initializer, nil)
 			},
+		}
 
-			ast.KindParameter: func(node *ast.Node) {
-				if opts.IgnoreParameters {
-					return
-				}
+		if !opts.IgnoreParameters {
+			listeners[ast.KindParameter] = func(node *ast.Node) {
 				param := node.AsParameterDeclaration()
 				if param == nil {
 					return
 				}
-				// Check for optional parameter with question token
-				hasQuestionToken := param.QuestionToken != nil
 				// Report on the name node for correct column position
 				reportNode := param.Name()
 				if reportNode == nil {
 					reportNode = node
 				}
-				checkDeclaration(reportNode, param.Type, param.Initializer, hasQuestionToken, false)
-			},
+				checkDeclaration(reportNode, param.Type, param.Initializer, param.QuestionToken)
+			}
+		}
 
-			ast.KindPropertyDeclaration: func(node *ast.Node) {
-				if opts.IgnoreProperties {
-					return
-				}
+		if !opts.IgnoreProperties {
+			listeners[ast.KindPropertyDeclaration] = func(node *ast.Node) {
 				prop := node.AsPropertyDeclaration()
-				if prop == nil {
+				if prop == nil || prop.Type == nil || prop.Initializer == nil {
 					return
 				}
-				// Check if this is an auto-accessor property
-				isAutoAccessor := false
-				if prop.Modifiers() != nil {
-					for _, mod := range prop.Modifiers().Nodes {
-						// Skip readonly properties
-						if mod.Kind == ast.KindReadonlyKeyword {
-							return
-						}
-						// Check for accessor modifier
-						if mod.Kind == ast.KindAccessorKeyword {
-							isAutoAccessor = true
-						}
-					}
-				}
-				// Check for optional property with question token - skip these
+
+				// Optional properties and readonly properties must keep their
+				// annotations because removing them can change their type.
 				if prop.PostfixToken != nil && prop.PostfixToken.Kind == ast.KindQuestionToken {
 					return
 				}
-				// Check for definite assignment assertion (!) - these should be reported with fix
-				hasExclamationToken := prop.PostfixToken != nil && prop.PostfixToken.Kind == ast.KindExclamationToken
+				modifierFlags := node.ModifierFlags()
+				if modifierFlags&ast.ModifierFlagsReadonly != 0 {
+					return
+				}
+
 				// For auto-accessor properties, report from the accessor keyword (full node)
 				// For regular properties, report from the name node
 				var reportNode *ast.Node
-				if isAutoAccessor {
+				if modifierFlags&ast.ModifierFlagsAccessor != 0 {
 					// Use the full property declaration node for auto-accessors
 					reportNode = node
 				} else {
@@ -337,8 +354,10 @@ var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
 						reportNode = node
 					}
 				}
-				checkDeclaration(reportNode, prop.Type, prop.Initializer, false, hasExclamationToken)
-			},
+				checkDeclaration(reportNode, prop.Type, prop.Initializer, prop.PostfixToken)
+			}
 		}
+
+		return listeners
 	},
 })

--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types_test.go
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types_test.go
@@ -1,9 +1,13 @@
 package no_inferrable_types
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -384,5 +388,169 @@ func TestNoInferrableTypesRule(t *testing.T) {
 				},
 			},
 		},
+
+		// Fixes use AST token boundaries rather than searching through comments
+		// that may themselves contain colons.
+		{
+			Code:   `const value /* name: keep */ : /* type: remove */ number = 1;`,
+			Output: []string{`const value /* name: keep */  = 1;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `function fn(value /* name: keep */ ? /* optional: keep */ : /* type: remove */ number = 1) {}`,
+			Output: []string{`function fn(value /* name: keep */  /* optional: keep */  = 1) {}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    13,
+				},
+			},
+		},
+		{
+			Code: `class Foo {
+  value /* name: keep */ ! /* definite: keep */ : /* type: remove */ string = 'value';
+}`,
+			Output: []string{`class Foo {
+  value /* name: keep */  /* definite: keep */  = 'value';
+}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      2,
+					Column:    3,
+				},
+			},
+		},
 	})
+}
+
+func TestNoInferrableTypesEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const source = `const value: number = 1;
+function fn(optional?: boolean = true) {}
+class Example {
+  property!: string = 'value';
+}`
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		source,
+		"no-inferrable-types-edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:      program,
+			File:         sourceFile.FileName(),
+			HasTypeInfo:  true,
+			ExcludePaths: []string{},
+			GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+				return []linter.ConfiguredRule{{
+					Name:     NoInferrableTypesRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return NoInferrableTypesRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		})
+		if len(diagnostics) != 3 {
+			t.Fatalf("demand %d: diagnostics = %d, want 3", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for index := range allEdits {
+		wantIdentity := withoutEdits(allEdits[index])
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandNone:       diagnosticsOnly,
+			rule.EditDemandAutofix:    autofixOnly,
+			rule.EditDemandSuggestion: suggestionOnly,
+		} {
+			if got := withoutEdits(diagnostics[index]); !reflect.DeepEqual(got, wantIdentity) {
+				t.Errorf(
+					"demand %d changed diagnostic %d:\ngot  %#v\nwant %#v",
+					demand,
+					index,
+					got,
+					wantIdentity,
+				)
+			}
+		}
+
+		if diagnosticsOnly[index].FixesPtr != nil || suggestionOnly[index].FixesPtr != nil {
+			t.Fatalf("diagnostic %d: non-autofix demand materialized fixes", index)
+		}
+		for _, diagnostics := range [][]rule.RuleDiagnostic{
+			diagnosticsOnly,
+			autofixOnly,
+			suggestionOnly,
+			allEdits,
+		} {
+			if diagnostics[index].Suggestions != nil {
+				t.Fatalf("diagnostic %d: autofix-only rule materialized suggestions", index)
+			}
+		}
+
+		for demand, diagnostics := range map[rule.EditDemand][]rule.RuleDiagnostic{
+			rule.EditDemandAutofix: autofixOnly,
+			rule.EditDemandAll:     allEdits,
+		} {
+			fixes := diagnostics[index].FixesPtr
+			wantFixes := 1
+			if index > 0 {
+				wantFixes = 2
+			}
+			if fixes == nil || len(*fixes) != wantFixes {
+				t.Fatalf(
+					"demand %d diagnostic %d: fixes = %#v, want %d",
+					demand,
+					index,
+					fixes,
+					wantFixes,
+				)
+			}
+		}
+	}
+
+	fixedSource, _, fixed := linter.ApplyRuleFixes(source, allEdits)
+	const wantFixed = `const value = 1;
+function fn(optional = true) {}
+class Example {
+  property = 'value';
+}`
+	if !fixed || fixedSource != wantFixed {
+		t.Fatalf("fixed source:\n%s\nwant:\n%s", fixedSource, wantFixed)
+	}
 }


### PR DESCRIPTION
## Summary

- Classify supported type annotations before inspecting initializers, reuse static diagnostics, and avoid creating a scanner for every report.
- Defer autofix construction until edits are requested, and remove `?`/`!` separately from the type annotation using AST token boundaries so intervening comments are preserved.
- Keep the optimization entirely inside the rule. Reference tracking is not used because this rule is syntactic and does not need symbol or reference information.

### Performance

Synthetic benchmark: 512 mixed declaration groups, `GOMAXPROCS=1`, five independent runs at three seconds each; values below are medians.

| Mode | Metric | Before | After | Change |
| --- | ---: | ---: | ---: | ---: |
| Diagnostics only | Time | 1,389,651 ns/op | 851,581 ns/op | -38.7% |
| Diagnostics only | Bytes | 592,840 B/op | 3,016 B/op | -99.5% |
| Diagnostics only | Allocations | 8,229 allocs/op | 37 allocs/op | -99.6% |
| Autofix requested | Time | 1,383,599 ns/op | 993,470 ns/op | -28.2% |
| Autofix requested | Bytes | 592,840 B/op | 101,320 B/op | -82.9% |
| Autofix requested | Allocations | 8,229 allocs/op | 4,133 allocs/op | -49.8% |

Real repositories were checked with minimal rslint JavaScript configs containing only this rule, using `--singleThreaded --timing all --format jsonline`.

| Repository | Files | Diagnostics | Before | After | Output comparison |
| --- | ---: | ---: | ---: | ---: | --- |
| rsbuild | 2,194 | 14 | 1.0 ms | 1.1 ms | Exact JSONLine match |
| rspack | 15,055 | 803 | 5.0 ms | 5.0 ms | Exact JSONLine match |

The real-repository timing is reported at 0.1 ms resolution and shows no measurable regression; the exact diagnostic output was unchanged.

### Validation

- `go test ./internal/plugins/typescript/rules/no_inferrable_types -run '^TestNoInferrableTypes(Rule|EditDemand)$' -count=1`
- `go test -race ./internal/plugins/typescript/rules/no_inferrable_types -run '^TestNoInferrableTypes(Rule|EditDemand)$' -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types_test.go`

## Related Links

- [Upstream typescript-eslint implementation](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-inferrable-types.ts)

## Checklist

- [x] Tests updated.
- [x] Documentation not required; there is no user-facing behavior or architecture change.
