### PR TITLE
perf: optimize default-case-last traversal

### DIFF
--- a/internal/rules/default_case_last/default_case_last.go
+++ b/internal/rules/default_case_last/default_case_last.go
@@ -10,39 +10,34 @@ var DefaultCaseLastRule = rule.Rule{
 	Name: "default-case-last",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
-			ast.KindSwitchStatement: func(node *ast.Node) {
-				switchStmt := node.AsSwitchStatement()
-				if switchStmt == nil {
+			ast.KindDefaultClause: func(node *ast.Node) {
+				parent := node.Parent
+				if parent == nil || parent.Kind != ast.KindCaseBlock {
 					return
 				}
 
-				caseBlockNode := switchStmt.CaseBlock
-				if caseBlockNode == nil {
-					return
-				}
-
-				caseBlock := caseBlockNode.AsCaseBlock()
+				caseBlock := parent.AsCaseBlock()
 				if caseBlock == nil || caseBlock.Clauses == nil {
 					return
 				}
 
-				clauseNodes := caseBlock.Clauses.Nodes
-				if len(clauseNodes) == 0 {
+				clauses := caseBlock.Clauses.Nodes
+				if len(clauses) == 0 || clauses[len(clauses)-1] == node {
 					return
 				}
 
-				// Find the default clause
-				for i, clause := range clauseNodes {
-					if clause.Kind == ast.KindDefaultClause {
-						// If it's not the last clause, report
-						if i != len(clauseNodes)-1 {
-							ctx.ReportNode(clause, rule.RuleMessage{
-								Id:          "notLast",
-								Description: "Default clause should be the last clause.",
-							})
-						}
+				for _, clause := range clauses {
+					if clause.Kind != ast.KindDefaultClause {
+						continue
+					}
+					if clause != node {
 						return
 					}
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "notLast",
+						Description: "Default clause should be the last clause.",
+					})
+					return
 				}
 			},
 		}

--- a/internal/rules/default_case_last/default_case_last_test.go
+++ b/internal/rules/default_case_last/default_case_last_test.go
@@ -140,6 +140,12 @@ func TestDefaultCaseLastRule(t *testing.T) {
 					{MessageId: "notLast", Line: 1, Column: 16},
 				},
 			},
+			{
+				Code: `switch (foo) { default: break; default: break; case 1: break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "notLast", Line: 1, Column: 16},
+				},
+			},
 
 			// nested switch — outer default not last, inner valid (only outer reports)
 			{


### PR DESCRIPTION
## Summary

- Listen on `DefaultClause` nodes and check the parent `CaseBlock` tail directly, avoiding clause scans for switches without a default and switches whose default is already last.
- Preserve the existing first-default-only behavior for duplicate default clauses and add regression coverage in the existing test file.
- Keep `ReportNode` semantics unchanged. `ctx.Refs` and deferred edit reporting were evaluated but are not applicable because this syntax-only rule uses neither symbols nor optional edit artifacts.

### Performance data

Apple M1 Max, Go 1.26.1, 256 clauses, median of 10 runs at 500 ms/run (temporary benchmark file not committed):

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| No default clause | 113.2 ns/op | 7.07 ns/op | -93.8% (16.0x faster) |
| Default clause last | 134.9 ns/op | 17.52 ns/op | -87.0% (7.7x faster) |

Both paths remain at 0 B/op and 0 allocs/op. Reporting paths retain the existing 1 allocation / 160 B diagnostic cost.

Real repositories were run single-threaded with a JavaScript config enabling only `default-case-last` and `--timing all`:

| Repository | Files | Before | After |
| --- | ---: | ---: | ---: |
| rsbuild | ~2.2k | 0.4 ms | 0.4-0.5 ms |
| rspack | ~15.1k | 2.7-3.2 ms | 3.2 ms |

The real-repository rule time is already sub-millisecond to low-single-digit milliseconds and remains within timing noise; the microbenchmark isolates the common-path listener improvement.

### Validation

- `go test ./internal/rules/default_case_last`
- before/after JSONL differential checks for nested switches, fallthrough, disable directives, diagnostic ranges, and duplicate defaults
- `golangci-lint run --timeout=15m ./internal/rules/default_case_last/...`
- `pnpm run check-spell`
- `pnpm run format:check`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; no user-facing behavior or configuration change).