### PR TITLE
perf: optimize no-namespace rule

### DIFF
--- a/internal/plugins/typescript/rules/no_namespace/no_namespace.go
+++ b/internal/plugins/typescript/rules/no_namespace/no_namespace.go
@@ -1,88 +1,99 @@
 package no_namespace
 
 import (
-	"strings"
-
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// build the message for no-namespace rule
-func buildNoNamespaceMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "moduleSyntaxIsPreferred",
-		Description: "Namespace is not allowed.",
-	}
+var noNamespaceMessage = rule.RuleMessage{
+	Id:          "moduleSyntaxIsPreferred",
+	Description: "ES2015 module syntax is preferred over namespaces.",
 }
 
-// rule options
 type NoNamespaceOptions struct {
-	AllowDeclarations    *bool `json:"allowDeclarations"`
-	AllowDefinitionFiles *bool `json:"allowDefinitionFiles"`
+	AllowDeclarations    bool `json:"allowDeclarations"`
+	AllowDefinitionFiles bool `json:"allowDefinitionFiles"`
 }
 
-// default options
 var defaultNoNamespaceOptions = NoNamespaceOptions{
-	AllowDeclarations:    utils.Ref(false),
-	AllowDefinitionFiles: utils.Ref(true),
+	AllowDeclarations:    false,
+	AllowDefinitionFiles: true,
 }
 
-// rule instance
-// check if the namespace is used
+func parseNoNamespaceOptions(options []any) NoNamespaceOptions {
+	opts := defaultNoNamespaceOptions
+	if len(options) == 0 {
+		return opts
+	}
+
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if allowDeclarations, ok := optsMap["allowDeclarations"].(bool); ok {
+		opts.AllowDeclarations = allowDeclarations
+	}
+	if allowDefinitionFiles, ok := optsMap["allowDefinitionFiles"].(bool); ok {
+		opts.AllowDefinitionFiles = allowDefinitionFiles
+	}
+	return opts
+}
+
+// isDeclaredNamespace mirrors typescript-eslint's recursive `declare` check.
+// In ordinary source files the parser propagates the ambient context flag to
+// every descendant, which makes the common path constant-time. Declaration
+// files are implicitly ambient, so when allowDefinitionFiles is disabled we
+// must instead look for an explicit `declare` modifier on the namespace or one
+// of its containing module declarations.
+func isDeclaredNamespace(node *ast.Node, isDefinitionFile bool) bool {
+	if !isDefinitionFile && node.Flags&ast.NodeFlagsAmbient != 0 {
+		return true
+	}
+	for current := node; current != nil; current = current.Parent {
+		if current.Kind == ast.KindModuleDeclaration &&
+			ast.HasSyntacticModifier(current, ast.ModifierFlagsAmbient) {
+			return true
+		}
+	}
+	return false
+}
+
 var NoNamespaceRule = rule.CreateRule(rule.Rule{
 	Name: "no-namespace",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts := defaultNoNamespaceOptions
-
-		// Parse options with dual-format support (handles both array and object formats)
-		if options != nil {
-			var optsMap map[string]interface{}
-			var ok bool
-
-			// Handle array format: [{ option: value }]
-			if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-				optsMap, ok = optArray[0].(map[string]interface{})
-			} else {
-				// Handle direct object format: { option: value }
-				optsMap, ok = options.(map[string]interface{})
-			}
-
-			if ok {
-				if allowDeclarations, ok := optsMap["allowDeclarations"].(bool); ok {
-					opts.AllowDeclarations = utils.Ref(allowDeclarations)
-				}
-				if allowDefinitionFiles, ok := optsMap["allowDefinitionFiles"].(bool); ok {
-					opts.AllowDefinitionFiles = utils.Ref(allowDefinitionFiles)
-				}
-			}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseNoNamespaceOptions(options)
+		if opts.AllowDefinitionFiles && ctx.SourceFile.IsDeclarationFile {
+			return nil
 		}
 
 		return rule.RuleListeners{
 			ast.KindModuleDeclaration: func(node *ast.Node) {
 				moduleDecl := node.AsModuleDeclaration()
-				if moduleDecl == nil {
+				name := moduleDecl.Name()
+				if name == nil ||
+					name.Kind == ast.KindStringLiteral ||
+					ast.IsGlobalScopeAugmentation(node) {
 					return
 				}
 
-				// Check if this is a namespace declaration (keyword is KindNamespaceKeyword)
-				if moduleDecl.Keyword != ast.KindNamespaceKeyword {
+				// TypeScript represents `namespace A.B {}` as nested module
+				// declarations. TSESTree exposes it as one declaration, so only
+				// the outer node corresponds to an upstream listener event.
+				if node.Parent != nil && node.Parent.Kind == ast.KindModuleDeclaration {
 					return
 				}
 
-				// Check if we're in a .d.ts file and allowDefinitionFiles is true
-				if opts.AllowDefinitionFiles != nil && *opts.AllowDefinitionFiles && strings.HasSuffix(ctx.SourceFile.FileName(), ".d.ts") {
+				if opts.AllowDeclarations && isDeclaredNamespace(node, ctx.SourceFile.IsDeclarationFile) {
 					return
 				}
 
-				// Check if this is a declare namespace and allowDeclarations is true
-				if opts.AllowDeclarations != nil && *opts.AllowDeclarations && utils.IncludesModifier(node, ast.KindDeclareKeyword) {
-					return
-				}
-
-				// Report the namespace usage
-				ctx.ReportNode(moduleDecl.Name(), buildNoNamespaceMessage())
+				// ReportRange avoids ReportNode's scanner allocation while
+				// preserving its trivia-trimmed, whole-declaration range.
+				ctx.ReportRange(
+					node.Loc.WithPos(scanner.SkipTrivia(ctx.SourceFile.Text(), node.Pos())),
+					noNamespaceMessage,
+				)
 			},
 		}
 	},

--- a/internal/plugins/typescript/rules/no_namespace/no_namespace_test.go
+++ b/internal/plugins/typescript/rules/no_namespace/no_namespace_test.go
@@ -3,8 +3,13 @@ package no_namespace
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoNamespaceRule(t *testing.T) {
@@ -29,6 +34,7 @@ declare module "bar" {
   export const baz: number;
 }
     `},
+		{Code: `module "foo" {}`},
 		{
 			Code: `
 // Declare namespace (allowed when allowDeclarations is true)
@@ -71,6 +77,36 @@ declare namespace Test {
 				},
 			},
 		},
+		{
+			Code: `
+declare namespace Outer {
+  namespace Inner {}
+}
+      `,
+			Options: map[string]interface{}{
+				"allowDeclarations": true,
+			},
+		},
+		{
+			Code: `
+declare global {
+  namespace Test {}
+}
+      `,
+			Options: map[string]interface{}{
+				"allowDeclarations": true,
+			},
+		},
+		{
+			Code: `
+declare module Test {
+  namespace Inner {}
+}
+      `,
+			Options: map[string]interface{}{
+				"allowDeclarations": true,
+			},
+		},
 		// Test empty options object
 		{
 			Code: `
@@ -96,6 +132,61 @@ namespace Test {
 }
       `,
 			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "moduleSyntaxIsPreferred",
+				},
+			},
+		},
+		{
+			Code: `namespace Test {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "moduleSyntaxIsPreferred",
+					Message:   "ES2015 module syntax is preferred over namespaces.",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 18,
+				},
+			},
+		},
+		{
+			Code: `module Test {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "moduleSyntaxIsPreferred",
+				},
+			},
+		},
+		{
+			Code: `module Test {}`,
+			Options: map[string]interface{}{
+				"allowDeclarations": true,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "moduleSyntaxIsPreferred",
+				},
+			},
+		},
+		{
+			Code: `namespace Foo.Bar {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "moduleSyntaxIsPreferred",
+				},
+			},
+		},
+		{
+			Code: `
+namespace Foo.Bar {
+  namespace Baz.Bas {}
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "moduleSyntaxIsPreferred",
+				},
 				{
 					MessageId: "moduleSyntaxIsPreferred",
 				},
@@ -297,6 +388,23 @@ declare global {
 				},
 			},
 		},
+		{
+			Code: `
+namespace Outer {
+  declare namespace Inner {
+    namespace Nested {}
+  }
+}
+      `,
+			Options: map[string]interface{}{
+				"allowDeclarations": true,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "moduleSyntaxIsPreferred",
+				},
+			},
+		},
 		// Test deeply nested namespaces
 		{
 			Code: `
@@ -373,25 +481,155 @@ namespace Test {
 	})
 }
 
+func TestNoNamespaceDefinitionFileOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		source   string
+		options  []any
+		want     int
+	}{
+		{name: "d.ts default", fileName: "/file.d.ts", source: `namespace Test {}`},
+		{name: "d.mts default", fileName: "/file.d.mts", source: `namespace Test {}`},
+		{name: "d.cts default", fileName: "/file.d.cts", source: `namespace Test {}`},
+		{
+			name:     "definition files disabled",
+			fileName: "/file.d.ts",
+			source:   `namespace Test {}`,
+			options:  []any{map[string]interface{}{"allowDefinitionFiles": false}},
+			want:     1,
+		},
+		{
+			name:     "implicit ambient is not explicit declare",
+			fileName: "/file.d.ts",
+			source:   `namespace Test {}`,
+			options: []any{map[string]interface{}{
+				"allowDeclarations":    true,
+				"allowDefinitionFiles": false,
+			}},
+			want: 1,
+		},
+		{
+			name:     "explicit declare remains allowed",
+			fileName: "/file.d.ts",
+			source:   `declare namespace Test {}`,
+			options: []any{map[string]interface{}{
+				"allowDeclarations":    true,
+				"allowDefinitionFiles": false,
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := len(runNoNamespaceRule(test.fileName, test.source, test.options)); got != test.want {
+				t.Fatalf("got %d diagnostics, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNoNamespaceReportRangeMatchesTrimmedNode(t *testing.T) {
+	sources := []string{
+		`namespace Test {}`,
+		"\n// leading comment\nexport namespace Test {}\n",
+		"\ufeff/* leading block */\nmodule Test {}",
+		"/** namespace docs */\nnamespace Outer.Inner {}",
+	}
+
+	for _, source := range sources {
+		diagnostics := runNoNamespaceRule("/file.ts", source, nil)
+		if len(diagnostics) != 1 {
+			t.Fatalf("source %q: got %d diagnostics, want 1", source, len(diagnostics))
+		}
+
+		sourceFile, ok := diagnostics[0].SourceFile.(*ast.SourceFile)
+		if !ok {
+			t.Fatalf("source %q: unexpected source file type %T", source, diagnostics[0].SourceFile)
+		}
+		var declaration *ast.Node
+		sourceFile.AsNode().ForEachChild(func(node *ast.Node) bool {
+			if node.Kind == ast.KindModuleDeclaration {
+				declaration = node
+				return true
+			}
+			return false
+		})
+		if declaration == nil {
+			t.Fatalf("source %q: module declaration not found", source)
+		}
+
+		got := diagnostics[0].Range
+		want := utils.TrimNodeTextRange(sourceFile, declaration)
+		if got.Pos() != want.Pos() || got.End() != want.End() {
+			t.Fatalf(
+				"source %q: report range [%d,%d), want trimmed node range [%d,%d)",
+				source,
+				got.Pos(),
+				got.End(),
+				want.Pos(),
+				want.End(),
+			)
+		}
+	}
+}
+
+func TestNoNamespaceDisableDirective(t *testing.T) {
+	source := "// rslint-disable-next-line test\nnamespace Test {}"
+	if diagnostics := runNoNamespaceRule("/file.ts", source, nil); len(diagnostics) != 0 {
+		t.Fatalf("disabled namespace produced %d diagnostics", len(diagnostics))
+	}
+}
+
+func runNoNamespaceRule(fileName string, source string, options []any) []rule.RuleDiagnostic {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: fileName,
+	}, source, core.ScriptKindTS)
+	comments := rule.NewCommentStore(sourceFile)
+	var diagnostics []rule.RuleDiagnostic
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithReporter("test", rule.SeverityError, func(diagnostic rule.RuleDiagnostic) {
+		diagnostics = append(diagnostics, diagnostic)
+	})
+
+	listener := NoNamespaceRule.Run(ctx, options)[ast.KindModuleDeclaration]
+	if listener == nil {
+		return diagnostics
+	}
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindModuleDeclaration {
+			listener(node)
+		}
+		node.ForEachChild(visit)
+		return false
+	}
+	visit(sourceFile.AsNode())
+	return diagnostics
+}
+
 // Test options parsing logic
 func TestNoNamespaceOptionsParsing(t *testing.T) {
 	// Test default options
 	opts := defaultNoNamespaceOptions
-	if *opts.AllowDeclarations != false {
-		t.Errorf("Expected default AllowDeclarations to be false, got %v", *opts.AllowDeclarations)
+	if opts.AllowDeclarations {
+		t.Errorf("Expected default AllowDeclarations to be false, got %v", opts.AllowDeclarations)
 	}
-	if *opts.AllowDefinitionFiles != true {
-		t.Errorf("Expected default AllowDefinitionFiles to be true, got %v", *opts.AllowDefinitionFiles)
+	if !opts.AllowDefinitionFiles {
+		t.Errorf("Expected default AllowDefinitionFiles to be true, got %v", opts.AllowDefinitionFiles)
 	}
 }
 
 // Test message building
 func TestNoNamespaceMessage(t *testing.T) {
-	message := buildNoNamespaceMessage()
+	message := noNamespaceMessage
 	if message.Id != "moduleSyntaxIsPreferred" {
 		t.Errorf("Expected message ID to be 'moduleSyntaxIsPreferred', got %s", message.Id)
 	}
-	if message.Description != "Namespace is not allowed." {
-		t.Errorf("Expected message description to be 'Namespace is not allowed.', got %s", message.Description)
+	if message.Description != "ES2015 module syntax is preferred over namespaces." {
+		t.Errorf("Expected upstream message, got %s", message.Description)
 	}
 }


### PR DESCRIPTION
## Summary

- Optimize @typescript-eslint/no-namespace reporting by avoiding a scanner allocation for every diagnostic and by skipping listener registration when definition files are allowed.
- Align module declarations, dotted namespaces, ambient ancestors, definition-file variants, diagnostic ranges, and the message with upstream behavior.
- Keep the optimization entirely in the rule. ctx.Refs would add an unnecessary reference-index build for this syntax-only rule, and deferred reports do not help because the rule has no fix or suggestion payload.

### Performance

Temporary Go benchmarks on Apple M1 Max, darwin/arm64, using the median of 6 runs. Stress cases contain 1,000 declarations per operation; benchmark files are not included in this PR.

| Case | Before | After | Result |
| --- | ---: | ---: | ---: |
| Ordinary file | 172.0 ns, 368 B, 4 allocs | 169.8 ns, 360 B, 4 allocs | No regression |
| 1,000 reported namespaces | 79.0 µs, 160,368 B, 1,004 allocs | 20.5 µs, 360 B, 4 allocs | 74.1% faster, 99.8% fewer bytes |
| 1,000 default-allowed definition-file namespaces | 4.31 µs, 368 B, 4 allocs | 52.3 ns, 144 B, 1 alloc | 98.8% faster |
| 1,000 allowed declarations | 7.07 µs, 369 B, 5 allocs | 5.77 µs, 360 B, 4 allocs | 18.5% faster |

Real-repository runs used each repository JS rslint configuration with only this rule enabled. Per-rule timings are rounded to 0.1 ms by the CLI.

| Repository | Files | Before median | After median | JSONL diagnostics |
| --- | ---: | ---: | ---: | --- |
| rsbuild | 1,402 | 0.3 ms | 0.3 ms | Unchanged |
| rspack | 401 | 0.5 ms | 0.5 ms | Unchanged |

Validation:

- Targeted package tests passed, including 20 repeated adversarial runs.
- Range parity, disable directives, module syntax, dotted namespaces, ambient ancestry, and d.ts/d.mts/d.cts behavior are covered in the existing test file.
- check-spell and format:check passed.
- golangci-lint passed for the changed Go package only.

## Related Links

- https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-namespace.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).