### PR TITLE
test: make nil guard control flow explicit

### DIFF
--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -1105,6 +1105,7 @@ func TestHandleLint_RejectsEmptyFilesArrayConfig(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected an error for empty files array")
+		return
 	}
 	if !strings.Contains(err.Error(), `key "files": expected value to be a non-empty array`) {
 		t.Fatalf("unexpected error: %v", err)

--- a/cmd/rslint/cmd_test.go
+++ b/cmd/rslint/cmd_test.go
@@ -139,6 +139,7 @@ func TestPrintDiagnosticUTF8(t *testing.T) {
 			}
 			if sourceFile == nil {
 				t.Fatal("Source file not found")
+				return
 			}
 
 			// Create diagnostic at position of variable name
@@ -219,6 +220,7 @@ func createTestDiagnostic(t *testing.T, source string, startOffset, endOffset in
 	}
 	if sourceFile == nil {
 		t.Fatal("Source file not found")
+		return rule.RuleDiagnostic{}, tspath.ComparePathsOptions{}
 	}
 
 	diagnostic := rule.RuleDiagnostic{
@@ -525,6 +527,7 @@ func TestSyntaxErrorFormat(t *testing.T) {
 	_, err := utils.CreateProgram(true, fs, tmpDir, "tsconfig.json", host)
 	if err == nil {
 		t.Fatal("Expected error for file with syntax errors")
+		return
 	}
 
 	errMsg := err.Error()
@@ -563,6 +566,7 @@ func TestSyntaxErrorFormatMultiple(t *testing.T) {
 	_, err := utils.CreateProgram(true, fs, tmpDir, "tsconfig.json", host)
 	if err == nil {
 		t.Fatal("Expected error for file with syntax errors")
+		return
 	}
 
 	errMsg := err.Error()
@@ -1644,6 +1648,7 @@ func TestApplyFixPassReturnsWriteError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected a write error")
+		return
 	}
 	if fixed != 0 {
 		t.Fatalf("failed write must not count as a fix, got %d", fixed)

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -838,6 +838,7 @@ func TestCreateProgramSetForConfigs_PreservesSymlinkedTsconfigBase(t *testing.T)
 	realProgram := programByConfigPath[exactFilesystemPathID(realConfigPath)]
 	if aliasProgram == nil || realProgram == nil {
 		t.Fatalf("missing lexical tsconfig Programs: %v", programByConfigPath)
+		return
 	}
 	aliasSource := tspath.ResolvePath(aliasDir, "src/alias.ts")
 	realSource := tspath.ResolvePath(realDir, "src/real.ts")
@@ -1009,6 +1010,7 @@ func TestResolveLintTargetPlan_RejectsCanonicalTargetWithDifferentOwners(t *test
 	)
 	if err == nil {
 		t.Fatal("expected aliases governed by different configs to be rejected")
+		return
 	}
 	if !strings.Contains(err.Error(), "resolve to the same file") || !strings.Contains(err.Error(), ownerA) || !strings.Contains(err.Error(), ownerB) {
 		t.Fatalf("unexpected ownership conflict error: %v", err)

--- a/internal/config/config_init_test.go
+++ b/internal/config/config_init_test.go
@@ -72,6 +72,7 @@ func TestInitDefaultConfig_AlreadyExists(t *testing.T) {
 			err := InitDefaultConfig(dir)
 			if err == nil {
 				t.Fatal("expected error when a JS/TS config already exists")
+				return
 			}
 			assertContains(t, err.Error(), "config file already exists")
 		})

--- a/internal/config/config_merge_test.go
+++ b/internal/config/config_merge_test.go
@@ -194,6 +194,7 @@ func TestGetConfigForFile_SeverityOnlyRuleOverridePreservesOptions(t *testing.T)
 			merged := config.GetConfigForFile("src/app.ts", "")
 			if merged == nil || merged.Rules["example"] == nil {
 				t.Fatal("expected merged example rule")
+				return
 			}
 			ruleConfig := merged.Rules["example"]
 			if ruleConfig.Level != "warn" {
@@ -216,6 +217,7 @@ func TestGetConfigForFile_NumericRuleSeverities(t *testing.T) {
 	merged := config.GetConfigForFile("src/app.ts", "")
 	if merged == nil {
 		t.Fatal("expected merged config")
+		return
 	}
 	for name, want := range map[string]string{"off": "off", "warn": "warn", "error": "error"} {
 		if got := merged.Rules[name]; got == nil || got.Level != want {
@@ -530,6 +532,7 @@ func TestGetConfigForFile_MultipleEntries_LanguageOptionsMerge(t *testing.T) {
 
 	if merged.LanguageOptions == nil || merged.LanguageOptions.ParserOptions == nil {
 		t.Fatal("Expected languageOptions with parserOptions")
+		return
 	}
 	if merged.LanguageOptions.ParserOptions.ProjectService == nil || *merged.LanguageOptions.ParserOptions.ProjectService != false {
 		t.Error("Expected projectService to be overridden to false")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -142,6 +142,7 @@ func TestParserOptionsProjectServicePtr(t *testing.T) {
 			} else {
 				if opts.ProjectService == nil {
 					t.Fatalf("Expected ProjectService to be non-nil")
+					return
 				}
 				if *opts.ProjectService != tt.expectedValue {
 					t.Errorf("Expected ProjectService to be %v, got %v", tt.expectedValue, *opts.ProjectService)

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -32,6 +32,7 @@ func TestValidateConfig_RejectsEmptyFilesArray(t *testing.T) {
 	err := ValidateConfig(cfg)
 	if err == nil {
 		t.Fatal("expected empty files array to be rejected")
+		return
 	}
 	if got := err.Error(); got != `config entry at index 0: key "files": expected value to be a non-empty array` {
 		t.Fatalf("unexpected error: %q", got)
@@ -52,6 +53,7 @@ func TestValidateConfig_RejectsNullFilesFromJSON(t *testing.T) {
 	err := json.Unmarshal([]byte(`[{"files": null, "rules": {}}]`), &cfg)
 	if err == nil {
 		t.Fatal("expected null files field to be rejected while unmarshaling")
+		return
 	}
 	if got := err.Error(); got != `config entry at index 0: key "files": expected value to be a non-empty array` {
 		t.Fatalf("unexpected error: %q", got)
@@ -63,6 +65,7 @@ func TestValidateConfig_RejectsEmptyFilesArrayFromJSON(t *testing.T) {
 	err := json.Unmarshal([]byte(`[{"files": [], "rules": {}}]`), &cfg)
 	if err == nil {
 		t.Fatal("expected empty files array to be rejected while unmarshaling")
+		return
 	}
 	if got := err.Error(); got != `config entry at index 0: key "files": expected value to be a non-empty array` {
 		t.Fatalf("unexpected error: %q", got)
@@ -202,6 +205,7 @@ func TestValidateConfig_RuleSeverities(t *testing.T) {
 		merged := cfg.GetConfigForFile("src/app.ts", "")
 		if merged == nil {
 			t.Fatal("expected JSON config to merge")
+			return
 		}
 		for name, want := range map[string]string{
 			"numeric-off": "off", "numeric-warn": "warn", "numeric-error": "error",
@@ -249,6 +253,7 @@ func TestValidateConfig_RejectsInvalidRuleValues(t *testing.T) {
 			err := json.Unmarshal([]byte(input), &cfg)
 			if err == nil {
 				t.Fatal("expected invalid rule value to be rejected during JSON ingress")
+				return
 			}
 			if message := err.Error(); !strings.Contains(message, `key "rules": rule "example"`) {
 				t.Fatalf("error does not identify the invalid rule: %q", message)
@@ -262,6 +267,7 @@ func TestValidateConfig_RejectsInvalidRuleValues(t *testing.T) {
 			err := ValidateConfig(RslintConfig{{Rules: Rules{"example": value}}})
 			if err == nil {
 				t.Fatal("expected invalid Go-constructed rule value to be rejected")
+				return
 			}
 			if message := err.Error(); !strings.Contains(message, `key "rules": rule "example"`) {
 				t.Fatalf("error does not identify the invalid rule: %q", message)

--- a/internal/config/discovery/discovery_test.go
+++ b/internal/config/discovery/discovery_test.go
@@ -2317,6 +2317,7 @@ func TestConfigDiscoveryReusesNativeCaseAliasAcrossLoadFrontiers(t *testing.T) {
 	}
 	if builder.loadStates[upperConfig] == nil || builder.loadStates[upperConfig] != builder.loadStates[lowerConfig] {
 		t.Fatal("case aliases did not resolve to the same representative load state")
+		return
 	}
 	if got := builder.loadStates[lowerConfig].candidate.path; got != upperConfig {
 		t.Fatalf("representative config path = %q, want %q", got, upperConfig)

--- a/internal/config/eslint_plugin_test.go
+++ b/internal/config/eslint_plugin_test.go
@@ -245,6 +245,7 @@ func TestGetConfigForFile_SplitEntry_ProjectFromNativeEntrySurvives(t *testing.T
 	}
 	if merged.LanguageOptions == nil || merged.LanguageOptions.ParserOptions == nil {
 		t.Fatal("merged languageOptions/parserOptions must survive from the native entry")
+		return
 	}
 	if len(merged.LanguageOptions.ParserOptions.Project) != 1 ||
 		merged.LanguageOptions.ParserOptions.Project[0] != "./tsconfig.json" {

--- a/internal/ipc/channel_test.go
+++ b/internal/ipc/channel_test.go
@@ -86,6 +86,7 @@ func TestChannel_InboundError(t *testing.T) {
 	_, err := a.SendRequest(ctx, "boom", nil)
 	if err == nil {
 		t.Fatal("expected error from peer handler")
+		return
 	}
 	if got := err.Error(); got == "" || !strings.Contains(got, "peer error") {
 		t.Fatalf("expected peer error, got %q", got)
@@ -283,6 +284,7 @@ func TestReadFrame_CapExceeded(t *testing.T) {
 	_, err := ReadFrame(bufio.NewReader(&buf))
 	if err == nil {
 		t.Fatal("expected frame-cap error")
+		return
 	}
 	if !strings.Contains(err.Error(), "exceeds cap") {
 		t.Fatalf("expected cap error, got %v", err)
@@ -671,6 +673,7 @@ func TestChannel_HandlerErrorPanicRecovered(t *testing.T) {
 		_, err := a.SendRequest(ctx, "x", nil)
 		if err == nil {
 			t.Fatal("expected peer error")
+			return
 		}
 		if !strings.Contains(err.Error(), "inbound handler error panicked: error boom") {
 			t.Fatalf("unexpected peer error: %v", err)
@@ -716,6 +719,7 @@ func TestChannel_HandlerPanicRecovered(t *testing.T) {
 	_, err := a.SendRequest(ctx, "x", nil)
 	if err == nil {
 		t.Fatal("expected error from panicking handler")
+		return
 	}
 	if !strings.Contains(err.Error(), "peer error") {
 		t.Fatalf("expected peer error frame, got %v", err)

--- a/internal/linter/eslint_plugin_test.go
+++ b/internal/linter/eslint_plugin_test.go
@@ -757,6 +757,7 @@ func TestDispatchEslintPlugin_FixAndSuggestionsRebuilt(t *testing.T) {
 	}
 	if got.Suggestions == nil || len(*got.Suggestions) != 1 {
 		t.Fatalf("expected exactly 1 rebuilt suggestion, got %v", got.Suggestions)
+		return
 	}
 	sg := (*got.Suggestions)[0]
 	if sg.Message.Id != "sid" || sg.Message.Description != "use z" {

--- a/internal/linter/linter_edits_test.go
+++ b/internal/linter/linter_edits_test.go
@@ -16,6 +16,7 @@ func TestRunLinterDiagnosticConsumerEditDemand(t *testing.T) {
 	sourceFile := program.GetSourceFile(paths["edits.ts"])
 	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) != 1 {
 		t.Fatal("edit-demand fixture did not parse into one statement")
+		return
 	}
 
 	reportNode := sourceFile.Statements.Nodes[0]
@@ -163,6 +164,7 @@ func TestRunLinterDeferredFixesSkipSuppressedDiagnostic(t *testing.T) {
 	sourceFile := program.GetSourceFile(paths["suppressed.ts"])
 	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) != 2 {
 		t.Fatal("suppression fixture did not parse into two statements")
+		return
 	}
 
 	builderCalls := 0
@@ -263,6 +265,7 @@ func TestRunLinterLegacyReportsRespectEditDemand(t *testing.T) {
 	sourceFile := program.GetSourceFile(paths["legacy.ts"])
 	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) != 1 {
 		t.Fatal("legacy fixture did not parse into one statement")
+		return
 	}
 	node := sourceFile.Statements.Nodes[0]
 	textRange := utils.TrimNodeTextRange(sourceFile, node)

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -171,6 +171,7 @@ func TestRunLinter_GlobalDeclarationMetadata(t *testing.T) {
 	}
 	if result.LintedFileCount != 1 || captured == nil {
 		t.Fatalf("captured context = %v, linted files = %d; want one", captured != nil, result.LintedFileCount)
+		return
 	}
 
 	if !reflect.DeepEqual(captured.ConfigGlobals, configGlobals) {
@@ -430,6 +431,7 @@ func TestRuleContextReporterPreservesDiagnosticSemantics(t *testing.T) {
 	sourceFile := program.GetSourceFile(paths["reporter.ts"])
 	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) != 2 {
 		t.Fatal("reporter fixture did not parse into two statements")
+		return
 	}
 
 	blockedNode := sourceFile.Statements.Nodes[0]

--- a/internal/lsp/lint_program_store_test.go
+++ b/internal/lsp/lint_program_store_test.go
@@ -110,6 +110,7 @@ func TestLintProgramStoreReusesAndUpdatesSource(t *testing.T) {
 	sourceFile := updated.GetSourceFile(fixture.sourcePath)
 	if sourceFile == nil {
 		t.Fatal("updated Program does not contain the lint target")
+		return
 	}
 	if sourceFile.Text() != changed {
 		t.Fatalf("updated source text = %q, want %q", sourceFile.Text(), changed)

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -416,6 +416,7 @@ func createOutputTestDiagnostic(t *testing.T, severity rule.DiagnosticSeverity) 
 	}
 	if sourceFile == nil {
 		t.Fatal("source file not found")
+		return rule.RuleDiagnostic{}, tspath.ComparePathsOptions{}
 	}
 	start := strings.Index(source, "value")
 	return rule.RuleDiagnostic{

--- a/internal/plugins/import/rules/first/first_ref_test.go
+++ b/internal/plugins/import/rules/first/first_ref_test.go
@@ -23,6 +23,7 @@ func parseStatements(t *testing.T, code string) []*ast.Node {
 	sf := program.GetSourceFile(fileName)
 	if sf == nil || sf.Statements == nil {
 		t.Fatal("source file has no statements")
+		return nil
 	}
 	return sf.Statements.Nodes
 }

--- a/internal/plugins/import/utils/export_map_test.go
+++ b/internal/plugins/import/utils/export_map_test.go
@@ -172,6 +172,7 @@ func TestGetExportMap(t *testing.T) {
 		deep := exportMap.Get("deep")
 		if deep == nil {
 			t.Fatal("expected export-all namespace alias to expose deep")
+			return
 		}
 		if deep.Namespace != nil {
 			t.Fatal("expected export-all namespace alias not to carry namespace metadata")
@@ -205,6 +206,7 @@ func TestGetExportMap(t *testing.T) {
 		b := exportMap.Get("b")
 		if b == nil {
 			t.Fatal("expected b namespace export alias")
+			return
 		}
 		if b.Namespace != nil {
 			t.Fatal("expected export-all namespace alias not to carry namespace metadata")
@@ -238,6 +240,7 @@ func TestGetExportMap(t *testing.T) {
 		ambient := exportMap.Get("ambient")
 		if ambient == nil {
 			t.Fatal("expected ambient namespace export")
+			return
 		}
 		if ambient.Namespace != nil {
 			t.Fatal("expected ambient namespace declaration not to carry namespace metadata")
@@ -268,6 +271,7 @@ func TestGetExportMap(t *testing.T) {
 		def := exportMap.Get("default")
 		if def == nil {
 			t.Fatal("expected string-literal namespace default to be visible")
+			return
 		}
 		if def.Namespace != nil {
 			t.Fatal("expected string-literal namespace default not to carry namespace metadata")
@@ -313,6 +317,7 @@ func TestGetExportMap(t *testing.T) {
 		def := exportMap.Get("default")
 		if def == nil {
 			t.Fatal("expected default export to be visible")
+			return
 		}
 		if def.Namespace != nil {
 			t.Fatal("expected default-import re-export not to carry namespace metadata")
@@ -358,6 +363,7 @@ func TestGetExportMap(t *testing.T) {
 		forwarded := exportMap.Get("forwardedLocal")
 		if forwarded == nil {
 			t.Fatal("expected local re-export to be visible")
+			return
 		}
 		if forwarded.Namespace != nil {
 			t.Fatal("expected named-import re-export not to carry namespace metadata")
@@ -604,10 +610,12 @@ func contextForImport(t *testing.T, source string) (rule.RuleContext, *ast.Node)
 	sourceFile := program.GetSourceFile(fileName)
 	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) == 0 {
 		t.Fatal("test source file was not parsed")
+		return rule.RuleContext{}, nil
 	}
 	importDecl := sourceFile.Statements.Nodes[0].AsImportDeclaration()
 	if importDecl == nil || importDecl.ModuleSpecifier == nil {
 		t.Fatal("test import declaration was not parsed")
+		return rule.RuleContext{}, nil
 	}
 
 	return rule.RuleContext{
@@ -631,10 +639,12 @@ func contextForImportWithFS(t *testing.T, fs vfs.FS, filePath string) (rule.Rule
 	sourceFile := program.GetSourceFile(filePath)
 	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) == 0 {
 		t.Fatal("test source file was not parsed")
+		return rule.RuleContext{}, nil
 	}
 	importDecl := sourceFile.Statements.Nodes[0].AsImportDeclaration()
 	if importDecl == nil || importDecl.ModuleSpecifier == nil {
 		t.Fatal("test import declaration was not parsed")
+		return rule.RuleContext{}, nil
 	}
 
 	return rule.RuleContext{
@@ -660,10 +670,12 @@ func contextForImportWithCompilerOptions(t *testing.T, source string, options *c
 	sourceFile := program.GetSourceFile(filePath)
 	if sourceFile == nil || sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) == 0 {
 		t.Fatal("test source file was not parsed")
+		return rule.RuleContext{}, nil
 	}
 	importDecl := sourceFile.Statements.Nodes[0].AsImportDeclaration()
 	if importDecl == nil || importDecl.ModuleSpecifier == nil {
 		t.Fatal("test import declaration was not parsed")
+		return rule.RuleContext{}, nil
 	}
 
 	return rule.RuleContext{

--- a/internal/plugins/import/utils/resolve_test.go
+++ b/internal/plugins/import/utils/resolve_test.go
@@ -19,6 +19,7 @@ func TestResolveSourceFileFromSourceFile(t *testing.T) {
 	}
 	if target == nil {
 		t.Fatal("ResolveSourceFileFromSourceFile() returned nil target")
+		return
 	}
 	if got := tspath.NormalizeSlashes(resolvedPath); !strings.HasSuffix(got, "/bar.ts") {
 		t.Fatalf("resolvedPath = %q, want suffix /bar.ts", resolvedPath)

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_cross_file_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_cross_file_test.go
@@ -66,6 +66,7 @@ func TestContainsNodeRejectsCrossFileNodes(t *testing.T) {
 	fileB := program.GetSourceFile(pathB)
 	if fileA == nil || fileB == nil {
 		t.Fatalf("missing source files: a=%v b=%v", fileA, fileB)
+		return
 	}
 
 	var outerInA, fooInB *ast.Node
@@ -89,6 +90,7 @@ func TestContainsNodeRejectsCrossFileNodes(t *testing.T) {
 	walk(fileB, "foo", &fooInB)
 	if outerInA == nil || fooInB == nil {
 		t.Fatalf("missing test nodes: outer=%v foo=%v", outerInA, fooInB)
+		return
 	}
 
 	// Sanity: by construction the byte ranges must overlap so that the
@@ -201,6 +203,7 @@ declare function setTimeout(handler: () => void, timeout: number): number;
 	tsxFile := program.GetSourceFile(tsxPath)
 	if tsxFile == nil {
 		t.Fatalf("missing user.tsx source file")
+		return
 	}
 
 	var mu sync.Mutex

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_test.go
@@ -567,6 +567,7 @@ func TestExhaustiveDepsEditDemand(t *testing.T) {
 					allSuggestions := diagnostics[rule.EditDemandAll].Suggestions
 					if suggestionOnly == nil || allSuggestions == nil || !reflect.DeepEqual(*suggestionOnly, *allSuggestions) {
 						t.Fatalf("suggestion artifacts differ between suggestion-only and all demand")
+						return
 					}
 					if len(*suggestionOnly) != 1 {
 						t.Fatalf("suggestions = %#v, want one suggestion", *suggestionOnly)
@@ -596,6 +597,7 @@ func TestExhaustiveDepsEditDemand(t *testing.T) {
 					allFixes := diagnostics[rule.EditDemandAll].FixesPtr
 					if autofixOnly == nil || allFixes == nil || !reflect.DeepEqual(*autofixOnly, *allFixes) {
 						t.Fatalf("autofix artifacts differ between autofix-only and all demand")
+						return
 					}
 					if len(*autofixOnly) != 1 || !reflect.DeepEqual((*autofixOnly)[0], suggestion.FixesArr[0]) {
 						t.Fatalf("dangerous autofix = %#v, want the first suggestion fix %#v", *autofixOnly, suggestion.FixesArr[0])

--- a/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor_test.go
+++ b/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor_test.go
@@ -446,6 +446,7 @@ func TestBuildArrayConstructorFixesRecoveryAST(t *testing.T) {
 	sourceFile.AsNode().ForEachChild(visit)
 	if call == nil {
 		t.Fatal("recovery fixture has no call expression")
+		return
 	}
 
 	reportRange := core.NewTextRange(0, call.End())

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
@@ -183,6 +183,7 @@ func runNoDeprecatedDiagnosticsForFiles(t *testing.T, files map[string]string, e
 	sourceFile := program.GetSourceFile(entryFile)
 	if sourceFile == nil {
 		t.Fatalf("failed to resolve entry file: %s", entryFile)
+		return nil
 	}
 	diagnostics := []rule.RuleDiagnostic{}
 	var diagnosticsMu sync.Mutex

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
@@ -1030,6 +1030,7 @@ func TestNoRestrictedTypesEditDemand(t *testing.T) {
 			} else {
 				if autofixOnly == nil || allFixes == nil || !reflect.DeepEqual(*autofixOnly, *allFixes) {
 					t.Fatalf("autofix artifacts differ between autofix-only and all demand")
+					return
 				}
 				if len(*autofixOnly) != 1 || (*autofixOnly)[0].Text != config.fixText {
 					t.Fatalf("autofixes = %#v, want replacement %q", *autofixOnly, config.fixText)
@@ -1046,6 +1047,7 @@ func TestNoRestrictedTypesEditDemand(t *testing.T) {
 			}
 			if suggestionOnly == nil || allSuggestions == nil || !reflect.DeepEqual(*suggestionOnly, *allSuggestions) {
 				t.Fatalf("suggestion artifacts differ between suggestion-only and all demand")
+				return
 			}
 			if len(*suggestionOnly) != len(config.suggestionTexts) {
 				t.Fatalf("suggestions = %#v, want %d", *suggestionOnly, len(config.suggestionTexts))

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint_test.go
@@ -1529,6 +1529,7 @@ func TestNoUnnecessaryTypeConstraintSuggestionEdges(t *testing.T) {
 			}
 			if diagnostic.Suggestions == nil || len(*diagnostic.Suggestions) != 1 {
 				t.Fatalf("suggestions = %#v, want exactly one", diagnostic.Suggestions)
+				return
 			}
 
 			suggestion := (*diagnostic.Suggestions)[0]
@@ -1602,6 +1603,7 @@ func TestNoUnnecessaryTypeConstraintEditDemand(t *testing.T) {
 	all := diagnostics[rule.EditDemandAll].Suggestions
 	if suggestionOnly == nil || all == nil || !reflect.DeepEqual(*suggestionOnly, *all) {
 		t.Fatalf("suggestion artifacts differ between suggestion-only and all demand")
+		return
 	}
 	if len(*suggestionOnly) != 1 {
 		t.Fatalf("suggestions = %#v, want exactly one", *suggestionOnly)
@@ -1665,6 +1667,7 @@ func TestNoUnnecessaryTypeConstraintMalformedASTWithholdsSuggestion(t *testing.T
 	sourceFile.AsNode().ForEachChild(visit)
 	if typeParameter == nil {
 		t.Fatal("test setup did not find a type parameter")
+		return
 	}
 
 	declaration := typeParameter.AsTypeParameterDeclaration()

--- a/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion_extras_test.go
@@ -1235,6 +1235,7 @@ func TestNoUnnecessaryTypeConversionEditDemand(t *testing.T) {
 		allEdits := diagnostics[rule.EditDemandAll][index].Suggestions
 		if suggestionOnly == nil || !reflect.DeepEqual(suggestionOnly, allEdits) {
 			t.Fatalf("diagnostic %d suggestions differ between suggestion and all-edits demand", index)
+			return
 		}
 		if len(*suggestionOnly) != 2 {
 			t.Fatalf("diagnostic %d suggestions = %#v, want 2", index, *suggestionOnly)

--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor_test.go
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor_test.go
@@ -1373,6 +1373,7 @@ class C {
 		allEdits := diagnostics[rule.EditDemandAll][index].Suggestions
 		if suggestionOnly == nil || !reflect.DeepEqual(suggestionOnly, allEdits) {
 			t.Fatalf("diagnostic %d: suggestion and all-edits demands produced different suggestions", index)
+			return
 		}
 		if len(*suggestionOnly) != 1 || len((*suggestionOnly)[0].Fixes()) != 1 {
 			t.Fatalf("diagnostic %d suggestions = %#v, want one suggestion with one fix", index, *suggestionOnly)

--- a/internal/rule/context_test.go
+++ b/internal/rule/context_test.go
@@ -333,6 +333,7 @@ func TestNodeDeferredFixesAndSuggestionsSkipsSuppressedBuilders(t *testing.T) {
 	}, "const visible = 1;\n// rslint-disable-next-line test\nconst blocked = 2;\n", core.ScriptKindTS)
 	if sourceFile.Statements == nil || len(sourceFile.Statements.Nodes) != 2 {
 		t.Fatal("suppression fixture did not parse into two statements")
+		return
 	}
 
 	fixBuilderCalls := 0

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -290,6 +290,7 @@ func TestRefStoreExportDefaultNamedFunction(t *testing.T) {
 	sym := declIdent.Parent.Symbol()
 	if sym == nil {
 		t.Fatal("declaration identifier has no bound symbol")
+		return
 	}
 	if sym.Name != ast.InternalSymbolNameDefault {
 		t.Fatalf("declaration symbol name = %q, want %q", sym.Name, ast.InternalSymbolNameDefault)

--- a/internal/rules/no_import_assign/no_import_assign_test.go
+++ b/internal/rules/no_import_assign/no_import_assign_test.go
@@ -607,6 +607,7 @@ func lintNoImportAssignForComparison(
 	sourceFile := program.GetSourceFile(fileName)
 	if sourceFile == nil {
 		t.Fatal("comparison source file was not loaded")
+		return nil
 	}
 
 	var diagnostics []noImportAssignDiagnosticFingerprint

--- a/internal/rules/no_useless_backreference/no_useless_backreference_test.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference_test.go
@@ -578,6 +578,7 @@ func TestImportedRegExpConstructorAlias(t *testing.T) {
 	sourceFile := program.GetSourceFile("file.ts")
 	if sourceFile == nil {
 		t.Fatal("file.ts was not loaded")
+		return
 	}
 
 	var diagnostics []rule.RuleDiagnostic

--- a/internal/utils/binding_names_test.go
+++ b/internal/utils/binding_names_test.go
@@ -18,6 +18,7 @@ func TestForEachVariableDeclarationBinding(t *testing.T) {
 	statement := sourceFile.Statements.Nodes[0].AsVariableStatement()
 	if statement == nil || statement.DeclarationList == nil {
 		t.Fatal("test source did not produce a variable declaration list")
+		return
 	}
 
 	type binding struct {

--- a/internal/utils/for_each_comment_test.go
+++ b/internal/utils/for_each_comment_test.go
@@ -50,6 +50,7 @@ func TestForEachComment_ReuseFactoryReportsAllCommentsPerToken(t *testing.T) {
 	}
 	if sf == nil {
 		t.Fatal("source file not found")
+		return
 	}
 
 	type cmt struct {
@@ -142,6 +143,7 @@ func TestHasCommentInSpan(t *testing.T) {
 	sf := prog.GetSourceFile(file)
 	if sf == nil {
 		t.Fatal("source file not found")
+		return
 	}
 
 	// HasCommentInSpan takes the file's pre-collected, sorted comment list

--- a/internal/utils/has_same_tokens_test.go
+++ b/internal/utils/has_same_tokens_test.go
@@ -40,6 +40,7 @@ func parseBinaryOperands(t *testing.T, code string) (*ast.SourceFile, *ast.Node,
 	}
 	if bin == nil {
 		t.Fatalf("no BinaryExpression found in code: %s", code)
+		return nil, nil, nil
 	}
 	b := bin.AsBinaryExpression()
 	return sourceFile, b.Left, b.Right

--- a/internal/utils/parse_cache_test.go
+++ b/internal/utils/parse_cache_test.go
@@ -363,6 +363,7 @@ func TestCachingHost_ExactAliasesAreNotMerged(t *testing.T) {
 	canonical := host.GetSourceFile(testParseOpts(canonicalPath, ast.ExternalModuleIndicatorOptions{}))
 	if alias == nil || canonical == nil {
 		t.Fatal("both aliases must produce a SourceFile")
+		return
 	}
 	if alias.Text() == canonical.Text() || alias == canonical {
 		t.Fatal("paths with the same realpath but distinct overlay text must not be merged")
@@ -409,6 +410,7 @@ func TestCachingHost_OverlaySymlinkAliasesWithSharedPathAreNotMerged(t *testing.
 	alias := host.GetSourceFile(aliasOpts)
 	if canonical == nil || alias == nil {
 		t.Fatal("both overlay aliases must produce a SourceFile")
+		return
 	}
 	if canonical == alias || canonical.Text() == alias.Text() {
 		t.Fatal("exact FileName overlays must remain distinct even when Path and realpath match")
@@ -671,6 +673,7 @@ func TestCachingHost_ConcurrentMissesUseOneWinningSnapshot(t *testing.T) {
 	winner := results[0]
 	if winner == nil {
 		t.Fatal("concurrent source lookup returned nil")
+		return
 	}
 	for i, result := range results[1:] {
 		if result != winner {
@@ -874,6 +877,7 @@ func TestNewParseCache_EnabledInitializesSourceGeneration(t *testing.T) {
 	cache := NewParseCache()
 	if cache == nil {
 		t.Fatal("enabled parse cache must be constructed")
+		return
 	}
 	initial := cache.sourceGeneration.Load()
 	if initial == nil {


### PR DESCRIPTION
## Summary

- add explicit returns after fatal nil assertions so static analysis can see that test control flow terminates
- fix the SA5011 sites from the [failing lint job](https://github.com/web-infra-dev/rslint/actions/runs/30331613221/job/90187826219?pr=1425) and the same pattern found across tracked test files
- keep production code unchanged, including `internal/utils/write_reference.go`

This is a mechanical test-only change covering 73 guards in 34 files.

## Validation

- ran `gofmt` on all changed Go test files
- ran golangci-lint v2.12.2 against the 20 exact changed packages with `--new-from-rev=main`: 0 issues
- rebased onto the latest `origin/main` and re-ran golangci-lint v2.12.2 for the overlapping `./internal/rules/no_import_assign` package: 0 issues
- ran `git diff --check`
