### PR TITLE
chore: upgrade monaco-editor to 0.56.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,8 +199,8 @@ catalogs:
       specifier: ^10.8.2
       version: 10.8.2
     monaco-editor:
-      specifier: 0.55.1
-      version: 0.55.1
+      specifier: ^0.56.0
+      version: 0.56.0
     ovsx:
       specifier: ^0.10.12
       version: 0.10.12
@@ -705,7 +705,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       monaco-editor:
         specifier: 'catalog:'
-        version: 0.55.1
+        version: 0.56.0
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -3705,8 +3705,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -5058,8 +5058,8 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
-  monaco-editor@0.55.1:
-    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
+  monaco-editor@0.56.0:
+    resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -9339,7 +9339,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.2.7:
+  dompurify@3.4.8:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -11122,9 +11122,9 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
-  monaco-editor@0.55.1:
+  monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.8
       marked: 14.0.0
 
   ms@2.1.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,7 +90,7 @@ catalog:
   dagre: ^0.8.5
   input-otp: ^1.4.2
   lucide-react: ^0.577.0
-  monaco-editor: 0.55.1
+  monaco-editor: ^0.56.0
   react: ^19.2.8
   react-dom: ^19.2.8
   rsbuild-plugin-google-analytics: ^1.0.6

--- a/website/theme/components/Playground/Editor.tsx
+++ b/website/theme/components/Playground/Editor.tsx
@@ -7,14 +7,11 @@ window.MonacoEnvironment = {
   getWorker: function (moduleId, label) {
     if (label === 'typescript' || label === 'javascript') {
       return new Worker(
-        new URL(
-          'monaco-editor/esm/vs/language/typescript/ts.worker',
-          import.meta.url,
-        ),
+        new URL('monaco-editor/language/typescript/ts.worker', import.meta.url),
       );
     }
     return new Worker(
-      new URL('monaco-editor/esm/vs/editor/editor.worker', import.meta.url),
+      new URL('monaco-editor/editor/editor.worker', import.meta.url),
     );
   },
 };

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useImperativeHandle, Ref } from 'react';
 import * as monaco from 'monaco-editor';
+import { jsonDefaults } from 'monaco-editor/languages/features/json/register';
 import { type Diagnostic } from '@rslint/wasm';
 import { Button } from '@components/ui/button';
 // Monaco-specific styles only (ast-node-highlight)
@@ -9,22 +10,16 @@ window.MonacoEnvironment = {
   getWorker: function (_moduleId, label) {
     if (label === 'typescript' || label === 'javascript') {
       return new Worker(
-        new URL(
-          'monaco-editor/esm/vs/language/typescript/ts.worker',
-          import.meta.url,
-        ),
+        new URL('monaco-editor/language/typescript/ts.worker', import.meta.url),
       );
     }
     if (label === 'json') {
       return new Worker(
-        new URL(
-          'monaco-editor/esm/vs/language/json/json.worker',
-          import.meta.url,
-        ),
+        new URL('monaco-editor/language/json/json.worker', import.meta.url),
       );
     }
     return new Worker(
-      new URL('monaco-editor/esm/vs/editor/editor.worker', import.meta.url),
+      new URL('monaco-editor/editor/editor.worker', import.meta.url),
     );
   },
 };
@@ -369,16 +364,12 @@ export const EditorTabs = ({
 
   // Configure Monaco JSON to allow comments and trailing commas (JSONC)
   useEffect(() => {
-    // Use type assertion to access jsonDefaults which may be typed as deprecated
-    const jsonLang = monaco.languages.json as any;
-    if (jsonLang.jsonDefaults?.setDiagnosticsOptions) {
-      jsonLang.jsonDefaults.setDiagnosticsOptions({
-        validate: true,
-        allowComments: true,
-        trailingCommas: 'ignore',
-        schemaValidation: 'ignore',
-      });
-    }
+    jsonDefaults.setDiagnosticsOptions({
+      validate: true,
+      allowComments: true,
+      trailingCommas: 'ignore',
+      schemaValidation: 'ignore',
+    });
   }, []);
 
   // Create rslint.json editor


### PR DESCRIPTION
## Summary

Upgrade `monaco-editor` to `0.56.0` and update Playground worker imports for the new package exports layout.

Also switch JSON diagnostics setup to Monaco's typed JSON register entry.

## Related Links

Following https://github.com/web-infra-dev/rslint/pull/1358