### PR TITLE
fix(eslint-plugin): restore cross-file context.options identity

### DIFF
--- a/packages/rslint/src/eslint-plugin/linter/context.ts
+++ b/packages/rslint/src/eslint-plugin/linter/context.ts
@@ -30,6 +30,7 @@
 
 import { makeFixer } from './fixer.js';
 import { applyOptionDefaults, type RuleSchema } from './options-defaults.js';
+import { resolveOptionsCached } from './resolved-options-cache.js';
 import {
   type ESTreeNode,
   type SourceCode,
@@ -113,6 +114,15 @@ export interface CreateContextOptions {
    * ESLint's diagnostic set.
    */
   defaultOptions?: readonly unknown[];
+  /**
+   * Identity of the rslint config that owns this file (`req.configKey`
+   * in `ecma-language-plugin.ts`). Scopes `resolveOptionsCached` so the
+   * resolved options are memoized/reused across every file this worker
+   * processes under the same config — see
+   * `resolved-options-cache.ts`. Omit (or pass `''`) to opt out of
+   * caching, e.g. from tests that construct a context directly.
+   */
+  configKey?: string;
   /** Merged flat-config settings. */
   settings: Record<string, unknown>;
   /**
@@ -244,10 +254,12 @@ export function createRuleContext(opts: CreateContextOptions): RuleContext {
   const { ruleName, filePath, settings, text, collectFixes, suggestionsMode } =
     opts;
   const messages = opts.messages ?? {};
-  const finalOptions = applyOptionDefaults(
+  const finalOptions = resolveOptionsCached(
+    opts.configKey ?? '',
+    ruleName,
     opts.userOptions,
-    opts.schema,
-    opts.defaultOptions,
+    () =>
+      applyOptionDefaults(opts.userOptions, opts.schema, opts.defaultOptions),
   );
 
   // lintFile builds one SourceCode per file (carrying the native parser's token/comment

--- a/packages/rslint/src/eslint-plugin/linter/ecma-language-plugin.ts
+++ b/packages/rslint/src/eslint-plugin/linter/ecma-language-plugin.ts
@@ -423,6 +423,7 @@ export function lintFile(
     const ctx = createRuleContext({
       ruleName,
       filePath: req.filePath,
+      configKey: req.configKey,
       userOptions: cfg.options ?? [],
       schema: ruleAny.meta?.schema as never,
       defaultOptions: ruleAny.meta?.defaultOptions,

--- a/packages/rslint/src/eslint-plugin/linter/resolved-options-cache.ts
+++ b/packages/rslint/src/eslint-plugin/linter/resolved-options-cache.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-worker cache for a rule's resolved `context.options`, keyed by
+ * `(configKey, ruleName, options content)`.
+ *
+ * Real ESLint runs a whole lint pass in one process and never re-clones
+ * `context.options` per file (`deepMergeArrays` returns the user's
+ * option objects by reference when no default merge is needed), so
+ * `context.options[i]` stays the SAME object across every file for a
+ * static rule config. Plugin rules rely on that — e.g. caching derived
+ * state in a `WeakMap` keyed by `context.options` itself.
+ *
+ * rslint dispatches each file to a worker thread via
+ * `worker.postMessage`, which structured-clones the message payload —
+ * so `req.rules[rule].options` is already a fresh object on arrival at
+ * `lintFile`, independent of anything `applyOptionDefaults` does. This
+ * cache restores the identity stability plugins expect by memoizing
+ * the resolved options per rule for the lifetime of the worker: the
+ * first file that hits a given (configKey, ruleName, content) triple
+ * computes it, every later file with the same triple reuses the same
+ * object.
+ *
+ * Cached results are deep-frozen. ESLint tolerates a rule mutating its
+ * own options only because nothing else reads the corrupted state
+ * before the process exits for that file; here the same object is
+ * reused by later files, so a mutating rule now throws immediately
+ * (caught by the per-rule try/catch in `ecma-language-plugin.ts`)
+ * instead of silently leaking state into unrelated files.
+ */
+
+const cache = new Map<string, unknown[]>();
+
+/**
+ * Return the cached resolved options for `(configKey, ruleName,
+ * userOptions)`, computing and freezing them via `compute()` on a
+ * cache miss. Falls back to always calling `compute()` uncached when
+ * `configKey` is empty (ad-hoc / test callers that don't scope a
+ * config) or when `userOptions` isn't safely key-able (contains a
+ * function, a Proxy, or another value `structuredClone` rejects).
+ */
+export function resolveOptionsCached(
+  configKey: string,
+  ruleName: string,
+  userOptions: readonly unknown[],
+  compute: () => unknown[],
+): unknown[] {
+  if (configKey === '') return compute();
+
+  const contentKey = stableKey(userOptions);
+  if (contentKey === undefined) return compute();
+
+  const cacheKey = `${configKey} ${ruleName} ${contentKey}`;
+  const hit = cache.get(cacheKey);
+  if (hit !== undefined) return hit;
+
+  const computed = compute();
+  deepFreeze(computed);
+  cache.set(cacheKey, computed);
+  return computed;
+}
+
+/**
+ * A stable, sorted-key JSON string for `value`, or `undefined` if
+ * `value` contains something that can't be told apart through JSON
+ * (functions collapse to `null` in arrays / are dropped from objects,
+ * which would make two DIFFERENT function-valued options key-collide).
+ * Gated on `structuredClone` succeeding first — the same non-cloneable
+ * values (functions, Proxies, ...) that `options-defaults.ts`'s
+ * `cloneDefault` guards against are exactly the ones JSON can't tell
+ * apart, so reuse that check rather than walking the value twice.
+ */
+function stableKey(value: readonly unknown[]): string | undefined {
+  try {
+    structuredClone(value);
+  } catch {
+    return undefined;
+  }
+  return JSON.stringify(value, sortKeysReplacer);
+}
+
+function sortKeysReplacer(_key: string, value: unknown): unknown {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  const sorted: Record<string, unknown> = {};
+  for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+    sorted[k] = (value as Record<string, unknown>)[k];
+  }
+  return sorted;
+}
+
+function deepFreeze(value: unknown): void {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) {
+    return;
+  }
+  Object.freeze(value);
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    deepFreeze((value as Record<string, unknown>)[key]);
+  }
+}

--- a/packages/rslint/tests/eslint-plugin/linter/resolved-options-cache.test.ts
+++ b/packages/rslint/tests/eslint-plugin/linter/resolved-options-cache.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Regression coverage for `resolved-options-cache.ts` — restoring
+ * cross-file `context.options` identity stability for a static rule
+ * config, scoped per `configKey`/rule/options-content. See the
+ * module doc for the ESLint-parity rationale.
+ */
+import { describe, test, expect } from '@rstest/core';
+
+import { lintFile } from '../../../src/eslint-plugin/linter/ecma-language-plugin.js';
+import type { LoadedPlugins } from '../../../src/eslint-plugin/plugin/plugin-loader.js';
+import type { RuleContext } from '../../../src/eslint-plugin/linter/context.js';
+
+function loadWithRule(create: (ctx: RuleContext) => unknown): LoadedPlugins {
+  return {
+    plugins: [],
+    rules: new Map<string, unknown>([
+      ['stub/probe', { meta: { name: 'probe' }, create }],
+    ]),
+  };
+}
+
+describe('resolveOptionsCached: cross-file context.options identity', () => {
+  test('same configKey + rule + options content → same context.options reference across files', () => {
+    const seen: unknown[] = [];
+    const loaded = loadWithRule((ctx) => {
+      seen.push(ctx.options[0]);
+      return {};
+    });
+
+    for (const filePath of ['a.js', 'b.js']) {
+      lintFile(
+        {
+          filePath,
+          text: 'const x = 1;',
+          configKey: 'cfg-dir-1',
+          rules: { 'stub/probe': { options: [{ allow: ['Array'] }] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+        },
+        loaded,
+      );
+    }
+
+    expect(seen.length).toBe(2);
+    expect(seen[0]).toBe(seen[1]);
+  });
+
+  test('different configKey → distinct context.options reference', () => {
+    const seen: unknown[] = [];
+    const loaded = loadWithRule((ctx) => {
+      seen.push(ctx.options[0]);
+      return {};
+    });
+
+    for (const configKey of ['cfg-dir-a', 'cfg-dir-b']) {
+      lintFile(
+        {
+          filePath: 'x.js',
+          text: 'const x = 1;',
+          configKey,
+          rules: { 'stub/probe': { options: [{ allow: ['Array'] }] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+        },
+        loaded,
+      );
+    }
+
+    expect(seen[0]).not.toBe(seen[1]);
+  });
+
+  test('different options content under the same configKey → distinct reference', () => {
+    const seen: unknown[] = [];
+    const loaded = loadWithRule((ctx) => {
+      seen.push(ctx.options[0]);
+      return {};
+    });
+
+    for (const allow of [['Array'], ['Object']]) {
+      lintFile(
+        {
+          filePath: 'y.js',
+          text: 'const x = 1;',
+          configKey: 'cfg-dir-2',
+          rules: { 'stub/probe': { options: [{ allow }] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+        },
+        loaded,
+      );
+    }
+
+    expect(seen[0]).not.toBe(seen[1]);
+  });
+
+  test('no configKey (ad-hoc caller) → caching opts out, no crash', () => {
+    const seen: unknown[] = [];
+    const loaded = loadWithRule((ctx) => {
+      seen.push(ctx.options[0]);
+      return {};
+    });
+
+    for (let i = 0; i < 2; i++) {
+      lintFile(
+        {
+          filePath: 'z.js',
+          text: 'const x = 1;',
+          rules: { 'stub/probe': { options: [{ allow: ['Array'] }] } },
+          collectFixes: false,
+          suggestionsMode: 'off',
+        },
+        loaded,
+      );
+    }
+
+    expect(seen.length).toBe(2);
+    // Content is still equal — just not memoized/shared by reference.
+    expect(seen[0]).toEqual(seen[1]);
+    expect(seen[0]).not.toBe(seen[1]);
+  });
+
+  test('mutating a cached options object throws instead of leaking to the next file', () => {
+    const loaded = loadWithRule((ctx) => ({
+      Program() {
+        const opt = ctx.options[0] as { allow: string[] };
+        // A rule pushing into its own options array — tolerated by
+        // real ESLint only because nothing re-reads the shared
+        // default afterward; here the object is reused by the next
+        // file hitting the same cache entry, so the frozen array
+        // must reject the mutation instead of silently corrupting
+        // state for that next file.
+        opt.allow.push('Object');
+      },
+    }));
+
+    const result = lintFile(
+      {
+        filePath: 'mutate.js',
+        text: 'const x = 1;',
+        configKey: 'cfg-dir-3',
+        rules: { 'stub/probe': { options: [{ allow: ['Array'] }] } },
+        collectFixes: false,
+        suggestionsMode: 'off',
+      },
+      loaded,
+    );
+
+    const errs = result.ruleErrors ?? [];
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs[0]?.rule).toBe('stub/probe');
+  });
+});


### PR DESCRIPTION
## Summary

- Worker threads structured-clone each file's task on `postMessage`, so `context.options` was a fresh object per file even for a static rule config — breaking plugin rules that memoize per option-object identity (e.g. a `WeakMap` keyed on `context.options`), a pattern real ESLint supports because it never re-clones options across files.
- Adds `resolved-options-cache.ts`: a per-worker cache keyed by `(configKey, ruleName, options content)` that memoizes and deep-freezes the resolved options, so repeated content reuses the same object reference across files.
- `createRuleContext` now routes through this cache via a new optional `configKey` on `CreateContextOptions`; `lintFile` forwards `req.configKey` (already present on the wire, previously unused there).
- Caching opts out (always computes fresh, matching prior behavior) when `configKey` is empty or the options aren't safely key-able (contain a function/Proxy).

## Related Links

Fixes #1452

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).