### PR TITLE
feat(rule): resolve local named export specifiers in RefStore

### DIFF
--- a/internal/plugins/typescript/rules/no_use_before_define/edge_cases_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/edge_cases_test.go
@@ -128,6 +128,14 @@ func TestEdgeCases(t *testing.T) {
 				Options: map[string]interface{}{"allowNamedExports": true},
 			},
 
+			// ----- Type-only named exports -----
+			{Code: `let x = 1; export type { x };`},
+			{Code: `type T = number; export type { T };`},
+			{
+				Code:    `export type { x }; let x = 1;`,
+				Options: map[string]interface{}{"allowNamedExports": true},
+			},
+
 			// ----- Decorators with classes:false -----
 			{
 				Code: `
@@ -386,6 +394,33 @@ declare global {
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "noUseBeforeDefine"},
 					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// ----- Type-only named exports before define (typescript-eslint -----
+			// ----- reports these even with the default ignoreTypeReferences) -----
+			{
+				Code: `export type { x }; let x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `export { type x }; let x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `export type { x as y }; let x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `export type { T }; type T = number;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
 				},
 			},
 

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
@@ -445,9 +445,10 @@ func checkIdentifier(ctx rule.RuleContext, opts options, node *ast.Node, refScop
 		return
 	}
 
-	// Export specifiers are deliberately excluded from RefStore because most
-	// rules treat them as binding syntax rather than references. This rule is
-	// the exception: named exports have their own option and must be checked.
+	// Named exports have their own `allowNamedExports` option and a simpler
+	// "declared before this line" check (no TDZ/scope-boundary nuance,
+	// matching typescript-eslint's own handling), so they're dispatched to
+	// their own path rather than falling into the general logic below.
 	if isNamedExport(node) {
 		checkNamedExport(ctx, opts, node)
 		return
@@ -589,67 +590,25 @@ func checkNamedExport(ctx rule.RuleContext, opts options, node *ast.Node) {
 		return
 	}
 
-	sym := ctx.TypeChecker.GetSymbolAtLocation(node)
+	// ctx.Refs.Resolve walks the binder's own scope chain, so it lands on
+	// the LOCAL symbol directly — for `export { foo }` where foo is an
+	// import, that's the import specifier's own symbol, not the remote
+	// module's. getDefinitionInfo below then finds that local declaration
+	// without any alias-chain walking through the checker.
+	sym := ctx.Refs.Resolve(node)
 	if sym == nil {
 		return
 	}
 
-	// Checker symbols for imported exports may point at the remote target.
-	// Keep the local alias declarations as candidates so the import remains
-	// the definition point.
-	declarations := sym.Declarations
-	if sym.Flags&ast.SymbolFlagsAlias != 0 {
-		if resolved := ctx.TypeChecker.SkipAlias(sym); resolved != nil && len(resolved.Declarations) > 0 {
-			declarations = append(append([]*ast.Node(nil), resolved.Declarations...), sym.Declarations...)
-		}
-	}
-	info := getDefinitionInfo(ctx.SourceFile, declarations)
+	info := getDefinitionInfo(ctx.SourceFile, sym.Declarations)
 	if info.declaration == nil {
 		return
 	}
 
-	localDeclName := findLocalBindingName(ctx, sym)
-	if localDeclName != nil && isDefinedBeforeUse(localDeclName, node) {
-		return
-	}
-	if localDeclName == nil && isDefinedBeforeUse(info.name, node) {
+	if isDefinedBeforeUse(info.name, node) {
 		return
 	}
 	reportNode(ctx, node)
-}
-
-// findLocalBindingName walks the alias chain from sym back through imports
-// to find the earliest local binding (import specifier / namespace import)
-// name node in the current file. Returns nil if no local binding is found.
-func findLocalBindingName(ctx rule.RuleContext, sym *ast.Symbol) *ast.Node {
-	// Walk through the alias chain to find import-site declarations.
-	current := sym
-	for current != nil && current.Flags&ast.SymbolFlagsAlias != 0 {
-		for _, d := range current.Declarations {
-			if ast.GetSourceFileOfNode(d) != ctx.SourceFile {
-				continue
-			}
-			switch d.Kind {
-			case ast.KindImportSpecifier, ast.KindNamespaceImport, ast.KindImportClause, ast.KindImportEqualsDeclaration:
-				return utils.GetDeclarationIdentifier(d)
-			}
-		}
-		resolved := ctx.TypeChecker.SkipAlias(current)
-		if resolved == current || resolved == nil {
-			break
-		}
-		current = resolved
-	}
-	// Fallback: find any local non-augmentation declaration.
-	for _, d := range sym.Declarations {
-		if d.Kind == ast.KindExportSpecifier {
-			continue
-		}
-		if ast.GetSourceFileOfNode(d) == ctx.SourceFile {
-			return utils.GetDeclarationIdentifier(d)
-		}
-	}
-	return nil
 }
 
 // isDefinedBeforeUse compares end positions (matching ESLint behavior).

--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -188,8 +188,9 @@ func sharesDeclaration(a, b *ast.Symbol) bool {
 // real TypeChecker round-trip, unlike the binder-only common path.
 //
 // Returns nil for identifiers that aren't reference positions (declaration
-// names, property keys, import/export bindings, labels, intrinsic JSX tags —
-// see isReferencePosition) and for names that don't resolve to any symbol.
+// names, property keys, import bindings, re-export/alias-label names, labels,
+// intrinsic JSX tags — see isReferencePosition) and for names that don't
+// resolve to any symbol.
 func (s *RefStore) Resolve(node *ast.Node) *ast.Symbol {
 	if s == nil || node == nil || node.Kind != ast.KindIdentifier || !isReferencePosition(node) {
 		return nil
@@ -222,8 +223,9 @@ func (s *RefStore) collectCandidates() {
 
 // isReferencePosition reports whether an identifier can reference a symbol
 // declared elsewhere: not a declaration name, and not a position that names
-// something non-local (property names, import/export bindings, labels,
-// intrinsic JSX tags).
+// something non-local (property names, import bindings, labels, intrinsic JSX
+// tags). The one exception is a local named export's real target — see the
+// ExportSpecifier case below.
 func isReferencePosition(n *ast.Node) bool {
 	p := n.Parent
 	if p != nil && p.Kind == ast.KindShorthandPropertyAssignment && p.AsShorthandPropertyAssignment().Name() == n {
@@ -232,6 +234,26 @@ func isReferencePosition(n *ast.Node) bool {
 		// IsDeclarationName treats this name as a declaration (it also
 		// declares the object's property), which would otherwise discard
 		// both real uses.
+		return true
+	}
+	if p != nil && p.Kind == ast.KindExportSpecifier {
+		// `export { foo }` / `export { foo as bar }` reads its local binding
+		// through PropertyName when present (the rename target, `foo`) or
+		// Name when it isn't (no rename) — ESLint's scope-manager marks this
+		// as a read of that binding. IsDeclarationName treats this node as a
+		// declaration either way (Name() equals the node itself when there's
+		// no PropertyName, and equals the alias label `bar` when there is),
+		// which would otherwise discard the real local reference the same
+		// way it would for a shorthand property name above. A re-export
+		// (`export { foo } from 'mod'`, aliased or not) references the
+		// other module's binding instead, so neither part is a reference
+		// there.
+		if utils.IsReExportSpecifier(p) {
+			return false
+		}
+		if propertyName := p.PropertyName(); propertyName != nil {
+			return propertyName == n
+		}
 		return true
 	}
 	if ast.IsDeclarationName(n) {
@@ -253,10 +275,11 @@ func isReferencePosition(n *ast.Node) bool {
 		// Import attribute keys (`type` in `with { type: "json" }`) are
 		// syntactic names, not references to same-named variables.
 		return p.AsImportAttribute().Name() != n
-	case ast.KindImportSpecifier, ast.KindExportSpecifier, ast.KindNamespaceImport,
+	case ast.KindImportSpecifier, ast.KindNamespaceImport,
 		ast.KindImportClause, ast.KindNamespaceExport:
-		// Import/export bindings resolve through module/alias machinery the
-		// checker owns; the current consumers never treat them as references.
+		// Import bindings and the export half of `export * as NS` resolve
+		// through module/alias machinery the checker owns; the current
+		// consumers never treat them as references.
 		return false
 	case ast.KindLabeledStatement, ast.KindBreakStatement, ast.KindContinueStatement:
 		// Labels live in their own namespace and never reference variables.
@@ -299,6 +322,11 @@ func referenceMeaning(n *ast.Node) ast.SymbolFlags {
 		// declarations such as an interface to be consumed by `export =`.
 		// Mirror the checker's getSymbolOfNameOrPropertyAccessExpression path
 		// instead of treating the identifier as an ordinary value expression.
+		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+	}
+	if p != nil && p.Kind == ast.KindExportSpecifier {
+		// `export { X }` can re-export a value, a type, or a namespace —
+		// same declaration-space breadth as `export =` above.
 		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
 	}
 	// `import a = b.c` — the right-hand side may name a value, type, or

--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -326,7 +326,12 @@ func referenceMeaning(n *ast.Node) ast.SymbolFlags {
 	}
 	if p != nil && p.Kind == ast.KindExportSpecifier {
 		// `export { X }` can re-export a value, a type, or a namespace —
-		// same declaration-space breadth as `export =` above.
+		// same declaration-space breadth as `export =` above. Type-only
+		// specifiers (`export type { X }` / `export { type X }`) resolve the
+		// same way, mirroring the type-flagged reference ESLint's
+		// scope-manager records for them; rules that only follow runtime
+		// reads classify the reference site instead (see
+		// utils.IsReadReference / utils.IsNonReferenceIdentifier).
 		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
 	}
 	// `import a = b.c` — the right-hand side may name a value, type, or

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -329,6 +329,141 @@ func TestRefStoreExportDefaultNamedFunction(t *testing.T) {
 	}
 }
 
+func TestRefStoreLocalExportSpecifierRead(t *testing.T) {
+	// `export { foo }` (no rename) reads the local `foo` — ESLint's
+	// scope-manager marks this as a reference, unlike import/export bindings
+	// in general.
+	sourceFile, refs := newBoundRefStore(t, "/export-specifier-read.ts", core.ScriptKindTS,
+		"var foo = 1;\nexport { foo };\n")
+
+	occurrences := identifiers(sourceFile.AsNode(), "foo")
+	if len(occurrences) != 2 {
+		t.Fatalf("expected 2 occurrences of foo, got %d", len(occurrences))
+	}
+	declIdent, specifierIdent := occurrences[0], occurrences[1]
+	if specifierIdent.Parent == nil || specifierIdent.Parent.Kind != ast.KindExportSpecifier {
+		t.Fatalf("expected the second foo to be the ExportSpecifier name, got parent kind %v", specifierIdent.Parent.Kind)
+	}
+	sym := declIdent.Parent.Symbol()
+	if sym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	if got := refs.Resolve(specifierIdent); got != sym {
+		t.Fatalf("Resolve(export specifier name) = %v, want %v", got, sym)
+	}
+	got := refs.References(sym)
+	if len(got) != 1 || got[0] != specifierIdent {
+		t.Fatalf("References = %v, want [%v] (the `export { foo }` read)", got, specifierIdent)
+	}
+}
+
+func TestRefStoreLocalExportSpecifierAliasReadsPropertyName(t *testing.T) {
+	// `export { foo as bar }` reads the local `foo` through PropertyName;
+	// `bar` is only the external export label and never a reference to
+	// anything in this file.
+	sourceFile, refs := newBoundRefStore(t, "/export-specifier-alias.ts", core.ScriptKindTS,
+		"var foo = 1;\nexport { foo as bar };\n")
+
+	fooOccurrences := identifiers(sourceFile.AsNode(), "foo")
+	if len(fooOccurrences) != 2 {
+		t.Fatalf("expected 2 occurrences of foo, got %d", len(fooOccurrences))
+	}
+	declIdent, propertyNameIdent := fooOccurrences[0], fooOccurrences[1]
+	sym := declIdent.Parent.Symbol()
+	if sym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	if got := refs.Resolve(propertyNameIdent); got != sym {
+		t.Fatalf("Resolve(PropertyName foo) = %v, want %v", got, sym)
+	}
+
+	barOccurrences := identifiers(sourceFile.AsNode(), "bar")
+	if len(barOccurrences) != 1 {
+		t.Fatalf("expected 1 occurrence of bar, got %d", len(barOccurrences))
+	}
+	if got := refs.Resolve(barOccurrences[0]); got != nil {
+		t.Fatalf("Resolve(export label bar) = %v, want nil (it's not a reference to anything)", got)
+	}
+}
+
+func TestRefStoreReExportSpecifierExcluded(t *testing.T) {
+	// `export { foo } from 'mod'` references the other module's binding, not
+	// anything in this file, even though a same-named local exists here.
+	sourceFile, refs := newBoundRefStore(t, "/re-export.ts", core.ScriptKindTS,
+		`var foo = 1;
+export { foo } from "./mod";
+foo;
+`)
+
+	occurrences := identifiers(sourceFile.AsNode(), "foo")
+	if len(occurrences) != 3 {
+		t.Fatalf("expected 3 occurrences of foo, got %d", len(occurrences))
+	}
+	declIdent, specifierIdent, useIdent := occurrences[0], occurrences[1], occurrences[2]
+	if specifierIdent.Parent == nil || specifierIdent.Parent.Kind != ast.KindExportSpecifier {
+		t.Fatalf("expected the second foo to be the ExportSpecifier name, got parent kind %v", specifierIdent.Parent.Kind)
+	}
+	sym := declIdent.Parent.Symbol()
+	if sym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	if got := refs.Resolve(specifierIdent); got != nil {
+		t.Fatalf("Resolve(re-export specifier name) = %v, want nil", got)
+	}
+	got := refs.References(sym)
+	if len(got) != 1 || got[0] != useIdent {
+		t.Fatalf("References = %v, want [%v] (the re-export specifier must be excluded)", got, useIdent)
+	}
+}
+
+func TestRefStoreReExportSpecifierAliasExcluded(t *testing.T) {
+	// `export { foo as bar } from 'mod'` — neither the source name nor the
+	// alias label references anything in this file.
+	sourceFile, refs := newBoundRefStore(t, "/re-export-alias.ts", core.ScriptKindTS,
+		`export { foo as bar } from "./mod";`)
+
+	fooOccurrences := identifiers(sourceFile.AsNode(), "foo")
+	if len(fooOccurrences) != 1 {
+		t.Fatalf("expected 1 occurrence of foo, got %d", len(fooOccurrences))
+	}
+	if got := refs.Resolve(fooOccurrences[0]); got != nil {
+		t.Fatalf("Resolve(re-export PropertyName foo) = %v, want nil", got)
+	}
+
+	barOccurrences := identifiers(sourceFile.AsNode(), "bar")
+	if len(barOccurrences) != 1 {
+		t.Fatalf("expected 1 occurrence of bar, got %d", len(barOccurrences))
+	}
+	if got := refs.Resolve(barOccurrences[0]); got != nil {
+		t.Fatalf("Resolve(re-export label bar) = %v, want nil", got)
+	}
+}
+
+func TestRefStoreExportSpecifierResolvesTypeOnlySymbol(t *testing.T) {
+	// `export { Foo }` can re-export a type-only local; referenceMeaning must
+	// include SymbolFlagsType or this never resolves.
+	sourceFile, refs := newBoundRefStore(t, "/export-specifier-type.ts", core.ScriptKindTS,
+		"type Foo = {};\nexport { Foo };\n")
+
+	occurrences := identifiers(sourceFile.AsNode(), "Foo")
+	if len(occurrences) != 2 {
+		t.Fatalf("expected 2 occurrences of Foo, got %d", len(occurrences))
+	}
+	declIdent, specifierIdent := occurrences[0], occurrences[1]
+	sym := declIdent.Parent.Symbol()
+	if sym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	got := refs.References(sym)
+	if len(got) != 1 || got[0] != specifierIdent {
+		t.Fatalf("References = %v, want [%v] (the `export { Foo }` reference to the type alias)", got, specifierIdent)
+	}
+}
+
 func TestRefStoreExportedFunctionDeclaration(t *testing.T) {
 	// A non-default export is bound to an export symbol too; the local symbol
 	// left in the file's locals carries only the ExportValue marker, so

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -464,6 +464,95 @@ func TestRefStoreExportSpecifierResolvesTypeOnlySymbol(t *testing.T) {
 	}
 }
 
+func TestRefStoreTypeOnlyExportSpecifierIndexed(t *testing.T) {
+	// `export type { x }` / `export { type x }` resolves to the binding like
+	// any other local export — ESLint's scope-manager records a type-flagged
+	// reference for it. Consumers that only follow runtime reads classify the
+	// reference site (utils.IsNonReferenceIdentifier reports these as
+	// non-reads); the index itself keeps them.
+	for name, source := range map[string]string{
+		"export type clause":  "let x;\nexport type { x };\nx = 1;\n",
+		"type specifier":      "let x;\nexport { type x };\nx = 1;\n",
+		"export type aliased": "let x;\nexport type { x as y };\nx = 1;\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			sourceFile, refs := newBoundRefStore(t, "/type-only-export.ts", core.ScriptKindTS, source)
+
+			occurrences := identifiers(sourceFile.AsNode(), "x")
+			if len(occurrences) != 3 {
+				t.Fatalf("expected 3 occurrences of x, got %d", len(occurrences))
+			}
+			declIdent, specifierIdent, writeIdent := occurrences[0], occurrences[1], occurrences[2]
+			sym := declIdent.Parent.Symbol()
+			if sym == nil {
+				t.Fatal("declaration identifier has no bound symbol")
+			}
+
+			if got := refs.Resolve(specifierIdent); got != sym {
+				t.Fatalf("Resolve(type-only export specifier x) = %v, want %v", got, sym)
+			}
+			got := refs.References(sym)
+			if len(got) != 2 || got[0] != specifierIdent || got[1] != writeIdent {
+				t.Fatalf("References = %v, want [%v %v] (the specifier and the `x = 1` write)", got, specifierIdent, writeIdent)
+			}
+		})
+	}
+}
+
+func TestRefStoreTypeOnlyExportSpecifierResolvesTypeSymbol(t *testing.T) {
+	// The type-space half of the meaning must stay: `export type { Foo }` of
+	// an actual type still references it.
+	sourceFile, refs := newBoundRefStore(t, "/type-only-export-type.ts", core.ScriptKindTS,
+		"type Foo = {};\nexport type { Foo };\n")
+
+	occurrences := identifiers(sourceFile.AsNode(), "Foo")
+	if len(occurrences) != 2 {
+		t.Fatalf("expected 2 occurrences of Foo, got %d", len(occurrences))
+	}
+	declIdent, specifierIdent := occurrences[0], occurrences[1]
+	sym := declIdent.Parent.Symbol()
+	if sym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	if got := refs.Resolve(specifierIdent); got != sym {
+		t.Fatalf("Resolve(type-only export specifier Foo) = %v, want %v", got, sym)
+	}
+	got := refs.References(sym)
+	if len(got) != 1 || got[0] != specifierIdent {
+		t.Fatalf("References = %v, want [%v] (the `export type { Foo }` reference)", got, specifierIdent)
+	}
+}
+
+func TestRefStoreTypeOnlyExportSpecifierWithChecker(t *testing.T) {
+	// With a TypeChecker present, the aliased type-only specifier's
+	// PropertyName must still resolve through the binder onto the same raw
+	// symbol the write does — not detour through the checker fallback, which
+	// would file it under a different (checker-merged alias) identity and
+	// split the index.
+	sourceFile, refs, done := newCheckedRefStore(t,
+		"let x;\nexport type { x as y };\nx = 1;\n")
+	defer done()
+
+	occurrences := identifiers(sourceFile.AsNode(), "x")
+	if len(occurrences) != 3 {
+		t.Fatalf("expected 3 occurrences of x, got %d", len(occurrences))
+	}
+	declIdent, specifierIdent, writeIdent := occurrences[0], occurrences[1], occurrences[2]
+	sym := declIdent.Parent.Symbol()
+	if sym == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	if got := refs.Resolve(specifierIdent); got != sym {
+		t.Fatalf("Resolve(type-only export PropertyName x) = %v, want %v", got, sym)
+	}
+	got := refs.References(sym)
+	if len(got) != 2 || got[0] != specifierIdent || got[1] != writeIdent {
+		t.Fatalf("References = %v, want [%v %v] (the specifier and the `x = 1` write)", got, specifierIdent, writeIdent)
+	}
+}
+
 func TestRefStoreExportedFunctionDeclaration(t *testing.T) {
 	// A non-default export is bound to an export symbol too; the local symbol
 	// left in the file's locals carries only the ExportValue marker, so

--- a/internal/rules/no_unassigned_vars/no_unassigned_vars.go
+++ b/internal/rules/no_unassigned_vars/no_unassigned_vars.go
@@ -1,8 +1,6 @@
 package no_unassigned_vars
 
 import (
-	"strings"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -23,8 +21,6 @@ func messageUnassigned(name string) rule.RuleMessage {
 type runState struct {
 	ctx                      rule.RuleContext
 	declarationWriteBySymbol map[*ast.Symbol]bool
-	localExportsScanned      bool
-	localExportReadBySym     map[*ast.Symbol]bool
 }
 
 type variableSymbols struct {
@@ -75,9 +71,6 @@ func (s *runState) checkVariableDeclarator(node *ast.Node) {
 		if hasWrite {
 			break
 		}
-	}
-	if !hasRead && !hasWrite {
-		hasRead = s.isLocalExportRead(symbols)
 	}
 	if hasWrite || !hasRead {
 		return
@@ -177,77 +170,6 @@ func (s *runState) symbolHasDeclarationWrite(sym *ast.Symbol) bool {
 	return hasWrite
 }
 
-// isLocalExportRead supplements ctx.Refs for local named export specifiers.
-// RefStore deliberately excludes import/export bindings because its other
-// consumers do not treat them as references, while ESLint scope-manager marks
-// `export { value }` as a read of value for this rule. The exact binder symbol
-// map preserves shadowing and ignores type-only/source-bearing re-exports.
-func (s *runState) isLocalExportRead(symbols variableSymbols) bool {
-	if !s.localExportsScanned {
-		s.localExportsScanned = true
-		if strings.Contains(s.ctx.SourceFile.Text(), "export") {
-			s.localExportReadBySym = collectLocalExportReads(s.ctx.SourceFile)
-		}
-	}
-	for _, sym := range symbols.values[:symbols.count] {
-		if s.localExportReadBySym[sym] {
-			return true
-		}
-	}
-	return false
-}
-
-func collectLocalExportReads(sourceFile *ast.SourceFile) map[*ast.Symbol]bool {
-	if sourceFile == nil {
-		return nil
-	}
-	var result map[*ast.Symbol]bool
-	var walk func(*ast.Node)
-	walk = func(node *ast.Node) {
-		if node == nil {
-			return
-		}
-		if node.Kind == ast.KindExportSpecifier &&
-			!ast.IsTypeOnlyImportOrExportDeclaration(node) &&
-			!utils.IsReExportSpecifier(node) {
-			specifier := node.AsExportSpecifier()
-			if specifier != nil {
-				localName := specifier.Name()
-				if specifier.PropertyName != nil {
-					localName = specifier.PropertyName
-				}
-				if target := binderLocalExportTarget(localName); target != nil {
-					if result == nil {
-						result = make(map[*ast.Symbol]bool)
-					}
-					result[target] = true
-				}
-			}
-		}
-		node.ForEachChild(func(child *ast.Node) bool {
-			walk(child)
-			return false
-		})
-	}
-	walk(sourceFile.AsNode())
-	return result
-}
-
-func binderLocalExportTarget(localName *ast.Node) *ast.Symbol {
-	if localName == nil || localName.Kind != ast.KindIdentifier {
-		return nil
-	}
-	name := localName.Text()
-	for current := localName.Parent; current != nil; current = current.Parent {
-		if ast.IsLocalsContainer(current) {
-			if sym := ast.GetLocals(current)[name]; sym != nil {
-				return sym
-			}
-		}
-	}
-	return nil
-}
-
 func (s *runState) shouldSkipDeclarator(node *ast.Node) bool {
 	if node == nil || node.Kind != ast.KindVariableDeclaration {
 		return true
@@ -286,13 +208,8 @@ func isReadReference(node *ast.Node) bool {
 }
 
 var NoUnassignedVarsRule = rule.Rule{
-	Name:             "no-unassigned-vars",
-	RequiresTypeInfo: true,
+	Name: "no-unassigned-vars",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		if ctx.TypeChecker == nil || ctx.Refs == nil {
-			return rule.RuleListeners{}
-		}
-
 		s := &runState{ctx: ctx}
 
 		return rule.RuleListeners{ast.KindVariableDeclaration: s.checkVariableDeclarator}

--- a/internal/rules/no_unassigned_vars/no_unassigned_vars.go
+++ b/internal/rules/no_unassigned_vars/no_unassigned_vars.go
@@ -64,7 +64,7 @@ func (s *runState) checkVariableDeclarator(node *ast.Node) {
 				hasWrite = true
 				break
 			}
-			if isReadReference(refNode) {
+			if utils.IsReadReference(refNode) {
 				hasRead = true
 			}
 		}
@@ -195,16 +195,6 @@ func (s *runState) shouldSkipDeclarator(node *ast.Node) bool {
 	}
 
 	return false
-}
-
-func isReadReference(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	if ast.IsPartOfTypeNode(node) || ast.IsPartOfTypeQuery(node) {
-		return false
-	}
-	return !utils.IsNonReferenceIdentifier(node)
 }
 
 var NoUnassignedVarsRule = rule.Rule{

--- a/internal/rules/prefer_const/prefer_const.go
+++ b/internal/rules/prefer_const/prefer_const.go
@@ -278,6 +278,13 @@ func isReadBeforeFirstAssign(refs []*ast.Node, declPos int) bool {
 			// Found the first write at or after the declaration - stop looking.
 			return foundRead
 		}
+		if utils.IsNonReferenceIdentifier(ref) {
+			// A type-only export (`export type { x }` / `export { type x }`)
+			// is the one reference position ctx.Refs indexes that ESLint's
+			// scope-manager flags as type-only rather than as a read — unlike
+			// `typeof x`, which does count as one.
+			continue
+		}
 		foundRead = true
 	}
 	return foundRead

--- a/internal/rules/prefer_const/prefer_const_test.go
+++ b/internal/rules/prefer_const/prefer_const_test.go
@@ -114,6 +114,13 @@ func TestPreferConstRule(t *testing.T) {
 				Options: map[string]interface{}{"ignoreReadBeforeAssign": true},
 			},
 
+			// ignoreReadBeforeAssign: true - a local named export before the
+			// first assignment is a read of the binding
+			{
+				Code:    `let x; export { x }; x = 1;`,
+				Options: map[string]interface{}{"ignoreReadBeforeAssign": true},
+			},
+
 			// Uninitialized, assigned inside if block - can't be safely converted to const
 			{Code: `let x: number; if (true) { x = 1; }`},
 
@@ -538,6 +545,37 @@ func TestPreferConstRule(t *testing.T) {
 				Options: map[string]interface{}{"ignoreReadBeforeAssign": false},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "useConst", Line: 1, Column: 8},
+				},
+			},
+
+			// A local named export before the first assignment is a read of the
+			// binding, so the report moves to the declaration
+			{
+				Code: `let x; export { x }; x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 5},
+				},
+			},
+
+			// A type-only export is not a read of the value binding: the report
+			// stays at the write, and ignoreReadBeforeAssign must not swallow it
+			{
+				Code: `let x; export type { x }; x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `let x; export { type x }; x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code:    `let x; export type { x }; x = 1;`,
+				Options: map[string]interface{}{"ignoreReadBeforeAssign": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 1, Column: 27},
 				},
 			},
 

--- a/internal/utils/write_reference.go
+++ b/internal/utils/write_reference.go
@@ -116,6 +116,24 @@ func IsWriteReference(node *ast.Node) bool {
 	return false
 }
 
+// IsReadReference reports whether a reference-position identifier represents
+// a genuine runtime read of the value it resolves to. It excludes:
+//   - non-reference positions (property keys, declaration names, labels,
+//     etc. — see IsNonReferenceIdentifier);
+//   - type-only positions (`typeof x` in a type query, or any other spot
+//     inside a type node), which never touch the value at runtime even
+//     though a symbol-based reference index (e.g. ctx.Refs) still resolves
+//     them to the same value symbol.
+func IsReadReference(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if ast.IsPartOfTypeNode(node) || ast.IsPartOfTypeQuery(node) {
+		return false
+	}
+	return !IsNonReferenceIdentifier(node)
+}
+
 // IsBindingPatternInAssignment checks if a binding pattern is the left side of an assignment.
 func IsBindingPatternInAssignment(node *ast.Node) bool {
 	if node == nil {


### PR DESCRIPTION
## Summary

- `ctx.Refs.Resolve`/`References` now resolve a local named export's real target (`export { foo }` / `export { foo as bar }`) through the ordinary binder scope walk, matching ESLint scope-manager semantics that treat it as a read. Re-exports (`export { foo } from 'mod'`) stay fully excluded either way, since neither side references anything in this file. `referenceMeaning` widens to `Value|Type|Namespace|Alias` for export specifiers. Type-only specifiers (`export type { foo }` / `export { type foo }`) resolve the same way, mirroring the type-flagged reference ESLint's scope-manager records for them; consumers that only follow runtime reads classify the reference site (`utils.IsReadReference` / `utils.IsNonReferenceIdentifier`) — `prefer-const`'s `isReadBeforeFirstAssign` now does exactly that, so a type-only export is not a read before assignment while `typeof x` still is.

- Drops two hand-rolled workarounds that existed only because of this gap:
  - `no_unassigned_vars`'s `collectLocalExportReads`/`binderLocalExportTarget`/`isLocalExportRead` — a standalone binder walk duplicating what `ctx.Refs.References` now does directly.
  - `no_use_before_define`'s `findLocalBindingName` and the `SkipAlias`/declarations-concat step in `checkNamedExport` — `ctx.Refs.Resolve` now lands directly on the local symbol (e.g. an import specifier's own symbol for a re-exported import), so there's no alias chain left to walk by hand.

- `no_unassigned_vars` also drops its now-dead `RequiresTypeInfo`/`ctx.TypeChecker`/`ctx.Refs` nil guards — it never calls `ctx.TypeChecker`, and `ctx.Refs` is non-nil whenever a `Program` exists, same reasoning as #1454.

- Extracts `IsReadReference` into `internal/utils/write_reference.go`, next to `IsWriteReference`, out of `no_unassigned_vars`'s private copy — a symmetric primitive other `ctx.Refs` consumers can reuse.

## Related Links

- #1454

## Validation

- `go test ./internal/rule/...` — 8 new tests covering local export reads, alias-only labels, re-exports with/without alias, and type-only local exports (indexed like scope-manager type references, still resolving actual type symbols, checker-identity stability).
- `go test ./internal/rules/prefer_const/...` — new cases locking the read classification: `export { x }` counts as a read before assignment, `export type { x }` / `export { type x }` does not, and `ignoreReadBeforeAssign` no longer swallows the type-only case.
- `go test ./internal/plugins/typescript/rules/no_use_before_define/...` — new valid/invalid cases for type-only named exports.
- `go test ./internal/rules/no_unassigned_vars/...`, `./internal/utils/...`.
- Report positions and type-only semantics verified against ESLint / typescript-eslint (`prefer-const`, `no-use-before-define`).
- Spot-checked every other `ctx.Refs.References`/`Resolve` consumer for regressions (`no_unused_vars` TS plugin, `new_for_builtins`, `no_class_assign`, `no_const_assign`, `no_func_assign`, `no_import_assign`, `no_misleading_character_class`, `no_obj_calls`, `no_shadow_restricted_names`, `no_var`, `prefer_const`) — all pass unmodified.
- `pnpx cspell lint` + `golangci-lint run --new-from-rev=origin/main` on changed files — clean.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
