### PR TITLE
refactor(jest,rstest): share test framework utilities between Jest and Rstest

### DIFF
--- a/internal/plugins/jest/utils/jest.go
+++ b/internal/plugins/jest/utils/jest.go
@@ -11,24 +11,25 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
-type JestFnType string
+type JestFnType = testFramework.FnKind
 
-type JestImportMode string
+type JestImportMode = testFramework.ReferenceMode
 
 const (
-	JEST_GLOBAL_MODE JestImportMode = "global"
-	JEST_IMPORT_MODE JestImportMode = "import"
+	JEST_GLOBAL_MODE = testFramework.ReferenceModeGlobal
+	JEST_IMPORT_MODE = testFramework.ReferenceModeImport
 )
 
 const (
 	JestFnTypeExpect   JestFnType = "expect"
-	JestFnTypeDescribe JestFnType = "describe"
-	JestFnTypeHook     JestFnType = "hook"
+	JestFnTypeDescribe            = testFramework.FnKindDescribe
+	JestFnTypeHook                = testFramework.FnKindHook
 	JestFnTypeJest     JestFnType = "jest"
-	JestFnTypeTest     JestFnType = "test"
-	JestFnTypeUnknown  JestFnType = "unknown"
+	JestFnTypeTest                = testFramework.FnKindTest
+	JestFnTypeUnknown             = testFramework.FnKindUnknown
 )
 
 var JEST_HOOKS_ORDER = []string{"beforeAll", "beforeEach", "afterEach", "afterAll"}
@@ -131,33 +132,18 @@ var VALID_JEST_FN_CALL_CHAINS = map[string]bool{
 	"xtest.fails":               true,
 }
 
-type ParsedJestFnMemberEntry struct {
-	Name string
-	Node *ast.Node
-	Call *ast.Node
-}
+// ParsedJestFnMemberEntry is the Jest-facing name for a shared member-chain
+// entry.
+type ParsedJestFnMemberEntry = testFramework.MemberEntry
 
 func JoinJestFnMemberEntries(entries []ParsedJestFnMemberEntry) string {
-	if len(entries) == 0 {
-		return ""
-	}
-
-	parts := make([]string, len(entries))
-	for i, e := range entries {
-		parts[i] = e.Name
-	}
-
-	return strings.Join(parts, ".")
+	return testFramework.JoinMemberEntries(entries)
 }
 
 // JestFnMemberEntriesRange returns the source range spanning the first through
 // last member entry nodes in a parsed jest/expect call chain.
 func JestFnMemberEntriesRange(entries []ParsedJestFnMemberEntry) (core.TextRange, bool) {
-	if len(entries) == 0 || entries[0].Node == nil || entries[len(entries)-1].Node == nil {
-		return core.TextRange{}, false
-	}
-
-	return core.NewTextRange(entries[0].Node.Pos(), entries[len(entries)-1].Node.End()), true
+	return testFramework.MemberEntriesRange(entries)
 }
 
 func getPropertyName(node *ast.Node) string {
@@ -194,82 +180,14 @@ func JestHookOrderIndex(name string) int {
 }
 
 func GetJestFnMemberEntries(node *ast.Node) []ParsedJestFnMemberEntry {
-	if node == nil {
-		return nil
-	}
-	node = ast.SkipParentheses(node)
-	if node == nil {
-		return nil
-	}
-
-	switch node.Kind {
-	case ast.KindIdentifier:
-		return []ParsedJestFnMemberEntry{{
-			Name: node.AsIdentifier().Text,
-			Node: node,
-		}}
-	case ast.KindPropertyAccessExpression:
-		property := node.AsPropertyAccessExpression()
-		left := GetJestFnMemberEntries(property.Expression)
-		nameNode := property.Name()
-		if name := getPropertyName(nameNode); name != "" {
-			return append(left, ParsedJestFnMemberEntry{
-				Name: name,
-				Node: nameNode,
-			})
-		}
-		return left
-	case ast.KindElementAccessExpression:
-		element := node.AsElementAccessExpression()
-		left := GetJestFnMemberEntries(element.Expression)
-		nameNode := ast.SkipParentheses(element.ArgumentExpression)
-		if name := getElementAccessName(nameNode); name != "" {
-			return append(left, ParsedJestFnMemberEntry{
-				Name: name,
-				Node: nameNode,
-			})
-		}
-		return nil
-	case ast.KindCallExpression:
-		entries := GetJestFnMemberEntries(node.AsCallExpression().Expression)
-		if len(entries) > 0 {
-			entries[len(entries)-1].Call = node
-		}
-		return entries
-	case ast.KindTaggedTemplateExpression:
-		return GetJestFnMemberEntries(node.AsTaggedTemplateExpression().Tag)
-	default:
-		return nil
-	}
-}
-
-func getElementAccessName(node *ast.Node) string {
-	if node == nil {
-		return ""
-	}
-
-	node = ast.SkipParentheses(node)
-	if node == nil {
-		return ""
-	}
-
-	switch node.Kind {
-	case ast.KindIdentifier:
-		return node.AsIdentifier().Text
-	case ast.KindStringLiteral:
-		return node.AsStringLiteral().Text
-	case ast.KindNoSubstitutionTemplateLiteral:
-		return node.AsNoSubstitutionTemplateLiteral().Text
-	default:
-		return ""
-	}
+	return testFramework.GetMemberEntries(node)
 }
 
 // CalleeChainName returns a dotted name for a call callee expression, mirroring
 // eslint-plugin-jest getNodeName for CallExpression callees (used by expect-expect
 // assertFunctionNames matching).
 //
-// It differs from GetJestFnMemberEntries / getElementAccessName: bracket notation
+// It differs from GetJestFnMemberEntries: bracket notation
 // contributes a segment only when the index matches eslint-plugin-jest's
 // supported accessor names (identifier, string literal, or no-substitution
 // template). Unsupported keys break the chain entirely. NewExpression is peeled

--- a/internal/plugins/jest/utils/parse_jest_fn.go
+++ b/internal/plugins/jest/utils/parse_jest_fn.go
@@ -7,31 +7,20 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
 type ParsedJestFnCall struct {
-	Name            string
-	LocalName       string
-	Kind            JestFnType
-	Members         []string
-	MemberEntries   []ParsedJestFnMemberEntry
+	testFramework.ParsedCall
 	Modifiers       []string
 	ModifierEntries []ParsedJestFnMemberEntry
 	Matcher         string
 	MatcherEntry    *ParsedJestFnMemberEntry
-	Head            ParsedJestFnCallHead
 }
 
-type ParsedJestFnCallHead struct {
-	Type     JestImportMode
-	Local    ParsedJestFnCallHeadEntry
-	Original ParsedJestFnCallHeadEntry
-}
+type ParsedJestFnCallHead = testFramework.ParsedCallHead
 
-type ParsedJestFnCallHeadEntry struct {
-	Value string
-	Node  *ast.Node
-}
+type ParsedJestFnCallHeadEntry = testFramework.ParsedCallHeadEntry
 
 const (
 	ExpectParseReasonNone            = ""
@@ -89,20 +78,22 @@ func ParseJestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedJestFnCall {
 	}
 
 	parsed := &ParsedJestFnCall{
-		Name:          name,
-		LocalName:     localName,
-		Kind:          kind,
-		Members:       members,
-		MemberEntries: memberEntries[1:],
-		Head: ParsedJestFnCallHead{
-			Type: headType,
-			Local: ParsedJestFnCallHeadEntry{
-				Value: localName,
-				Node:  localNode,
-			},
-			Original: ParsedJestFnCallHeadEntry{
-				Value: name,
-				Node:  originalNode,
+		ParsedCall: testFramework.ParsedCall{
+			Name:          name,
+			LocalName:     localName,
+			Kind:          kind,
+			Members:       members,
+			MemberEntries: memberEntries[1:],
+			Head: ParsedJestFnCallHead{
+				Type: headType,
+				Local: ParsedJestFnCallHeadEntry{
+					Value: localName,
+					Node:  localNode,
+				},
+				Original: ParsedJestFnCallHeadEntry{
+					Value: name,
+					Node:  originalNode,
+				},
 			},
 		},
 	}
@@ -142,15 +133,7 @@ func FindTopMostCallExpression(node *ast.Node) *ast.Node {
 }
 
 func FindImportDeclaration(node *ast.Node) *ast.ImportDeclaration {
-	current := node
-	for current != nil {
-		switch current.Kind {
-		case ast.KindImportDeclaration, ast.KindJSImportDeclaration:
-			return current.AsImportDeclaration()
-		}
-		current = current.Parent
-	}
-	return nil
+	return testFramework.FindImportDeclaration(node)
 }
 
 func applyParsedExpectCall(parsed *ParsedJestFnCall) bool {
@@ -229,134 +212,26 @@ func FindExpectModifiersAndMatcher(entries []ParsedJestFnMemberEntry) (
 }
 
 func ResolveJestFunctionReference(node *ast.Node, localName string, localNode *ast.Node, ctx rule.RuleContext) (string, *ast.Node, JestImportMode) {
-	if ctx.TypeChecker == nil {
-		return localName, localNode, JEST_GLOBAL_MODE
-	}
-
-	typeChecker := ctx.TypeChecker
-	callExpr := node.AsCallExpression()
-	if callExpr == nil {
-		return localName, localNode, JEST_GLOBAL_MODE
-	}
-
-	ident := ResolveFirstIdentifier(callExpr.Expression)
-	if ident == nil || ident.Kind != ast.KindIdentifier {
-		return localName, localNode, JEST_GLOBAL_MODE
-	}
-
-	symbol := typeChecker.GetSymbolAtLocation(ident)
-	if symbol == nil {
-		return localName, localNode, JEST_GLOBAL_MODE
-	}
-
-	hasLocalNonJestDeclaration := false
-	for _, decl := range symbol.Declarations {
-		if decl == nil {
-			continue
-		}
-
-		if name, originalNode, ok := resolveJestGlobalsImportSpecifier(decl); ok {
-			return name, originalNode, JEST_IMPORT_MODE
-		}
-
-		if name, originalNode, ok := resolveJestGlobalsRequireBinding(decl); ok {
-			return name, originalNode, JEST_IMPORT_MODE
-		}
-
-		if ctx.SourceFile != nil && ast.GetSourceFileOfNode(decl) == ctx.SourceFile {
-			hasLocalNonJestDeclaration = true
-		}
-	}
-
-	if hasLocalNonJestDeclaration {
-		return "", nil, JEST_GLOBAL_MODE
-	}
-
-	return localName, localNode, JEST_GLOBAL_MODE
+	return ResolveFunctionReferenceForModule(node, localName, localNode, ctx, jestGlobalsModule)
 }
 
-func resolveJestGlobalsImportSpecifier(decl *ast.Node) (string, *ast.Node, bool) {
-	if decl == nil || decl.Kind != ast.KindImportSpecifier {
-		return "", nil, false
-	}
-
-	importDecl := FindImportDeclaration(decl)
-	if importDecl == nil || importDecl.ModuleSpecifier == nil || importDecl.ModuleSpecifier.Text() != jestGlobalsModule {
-		return "", nil, false
-	}
-
-	spec := decl.AsImportSpecifier()
-	if spec == nil || spec.IsTypeOnly {
-		return "", nil, false
-	}
-
-	if spec.PropertyName != nil {
-		return spec.PropertyName.Text(), spec.PropertyName, true
-	}
-
-	name := spec.Name()
-	if name == nil {
-		return "", nil, false
-	}
-
-	return name.Text(), name, true
-}
-
-func resolveJestGlobalsRequireBinding(decl *ast.Node) (string, *ast.Node, bool) {
-	if decl == nil || decl.Kind != ast.KindBindingElement {
-		return "", nil, false
-	}
-
-	varDecl := internalUtils.EnclosingVariableDeclarationOfBindingElement(decl)
-	if varDecl == nil || !isJestGlobalsRequireCall(varDecl.AsVariableDeclaration().Initializer) {
-		return "", nil, false
-	}
-
-	binding := decl.AsBindingElement()
-	if binding == nil {
-		return "", nil, false
-	}
-
-	nameNode := binding.Name()
-	if binding.PropertyName != nil {
-		if name := getPropertyName(binding.PropertyName); name != "" {
-			return name, binding.PropertyName, true
-		}
-	}
-
-	if nameNode != nil {
-		if name := getPropertyName(nameNode); name != "" {
-			return name, nameNode, true
-		}
-	}
-
-	return "", nil, false
-}
-
-func isJestGlobalsRequireCall(node *ast.Node) bool {
-	node = ast.SkipParentheses(node)
-	if node == nil || !ast.IsRequireCall(node, true /*requireStringLiteralLikeArgument*/) {
-		return false
-	}
-
-	args := node.Arguments()
-	if len(args) == 0 || args[0] == nil {
-		return false
-	}
-
-	specifier := ast.SkipParentheses(args[0])
-	if specifier == nil {
-		return false
-	}
-
-	switch specifier.Kind {
-	case ast.KindStringLiteral:
-		return specifier.AsStringLiteral().Text == jestGlobalsModule
-	case ast.KindNoSubstitutionTemplateLiteral:
-		return specifier.AsNoSubstitutionTemplateLiteral().Text == jestGlobalsModule
-	default:
-		return false
-	}
+// ResolveFunctionReferenceForModule is the Jest-facing adapter for shared
+// module reference resolution.
+func ResolveFunctionReferenceForModule(
+	node *ast.Node,
+	localName string,
+	localNode *ast.Node,
+	ctx rule.RuleContext,
+	importModule string,
+) (string, *ast.Node, JestImportMode) {
+	return testFramework.ResolveFunctionReferenceForModule(
+		node,
+		localName,
+		localNode,
+		ctx.TypeChecker,
+		ctx.SourceFile,
+		importModule,
+	)
 }
 
 func resolveHeadLocalNode(callExpr *ast.CallExpression) *ast.Node {
@@ -369,29 +244,7 @@ func resolveHeadLocalNode(callExpr *ast.CallExpression) *ast.Node {
 // ResolveFirstIdentifier walks the left side of a call/member chain and returns
 // the first identifier it finds, if any.
 func ResolveFirstIdentifier(node *ast.Node) *ast.Node {
-	if node == nil {
-		return nil
-	}
-
-	node = ast.SkipParentheses(node)
-	if node == nil {
-		return nil
-	}
-
-	switch node.Kind {
-	case ast.KindIdentifier:
-		return node
-	case ast.KindCallExpression:
-		return ResolveFirstIdentifier(node.AsCallExpression().Expression)
-	case ast.KindPropertyAccessExpression:
-		return ResolveFirstIdentifier(node.AsPropertyAccessExpression().Expression)
-	case ast.KindElementAccessExpression:
-		return ResolveFirstIdentifier(node.AsElementAccessExpression().Expression)
-	case ast.KindTaggedTemplateExpression:
-		return ResolveFirstIdentifier(node.AsTaggedTemplateExpression().Tag)
-	}
-
-	return nil
+	return testFramework.ResolveFirstIdentifier(node)
 }
 
 func isEachFactoryCall(callExpr *ast.CallExpression, members []string) bool {

--- a/internal/plugins/rstest/utils/rstest.go
+++ b/internal/plugins/rstest/utils/rstest.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+const RstestImportModule = "@rstest/core"
+
+type RstestFnType = testFramework.FnKind
+
+type RstestImportMode = testFramework.ReferenceMode
+
+type ParsedRstestFnCall = testFramework.ParsedCall
+
+type ParsedRstestFnCallHead = testFramework.ParsedCallHead
+
+type ParsedRstestFnCallHeadEntry = testFramework.ParsedCallHeadEntry
+
+type ParsedRstestFnMemberEntry = testFramework.MemberEntry
+
+const (
+	RstestFnTypeDescribe = testFramework.FnKindDescribe
+	RstestFnTypeTest     = testFramework.FnKindTest
+)
+
+const (
+	RSTEST_GLOBAL_MODE = testFramework.ReferenceModeGlobal
+	RSTEST_IMPORT_MODE = testFramework.ReferenceModeImport
+)
+
+func GetRstestFnMemberEntries(node *ast.Node) []ParsedRstestFnMemberEntry {
+	return testFramework.GetMemberEntries(node)
+}
+
+func JoinRstestFnMemberEntries(entries []ParsedRstestFnMemberEntry) string {
+	return testFramework.JoinMemberEntries(entries)
+}
+
+func RstestFnMemberEntriesRange(entries []ParsedRstestFnMemberEntry) (core.TextRange, bool) {
+	return testFramework.MemberEntriesRange(entries)
+}
+
+func ResolveFirstIdentifier(node *ast.Node) *ast.Node {
+	return testFramework.ResolveFirstIdentifier(node)
+}
+
+func ResolveFunctionReferenceForModule(
+	node *ast.Node,
+	localName string,
+	localNode *ast.Node,
+	ctx rule.RuleContext,
+	importModule string,
+) (string, *ast.Node, RstestImportMode) {
+	return testFramework.ResolveFunctionReferenceForModule(
+		node,
+		localName,
+		localNode,
+		ctx.TypeChecker,
+		ctx.SourceFile,
+		importModule,
+	)
+}
+
+func ResolveRstestFunctionReference(
+	node *ast.Node,
+	localName string,
+	localNode *ast.Node,
+	ctx rule.RuleContext,
+) (string, *ast.Node, RstestImportMode) {
+	return ResolveFunctionReferenceForModule(node, localName, localNode, ctx, RstestImportModule)
+}

--- a/internal/utils/test_framework/member_chain.go
+++ b/internal/utils/test_framework/member_chain.go
@@ -1,0 +1,142 @@
+package test_framework
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+)
+
+// GetMemberEntries extracts identifiers and static property names from a
+// call/member chain. It is syntax-only; framework parsers decide which roots
+// and member sequences are legal.
+func GetMemberEntries(node *ast.Node) []MemberEntry {
+	if node == nil {
+		return nil
+	}
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return nil
+	}
+
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return []MemberEntry{{
+			Name: node.AsIdentifier().Text,
+			Node: node,
+		}}
+	case ast.KindPropertyAccessExpression:
+		property := node.AsPropertyAccessExpression()
+		left := GetMemberEntries(property.Expression)
+		nameNode := property.Name()
+		if name := propertyName(nameNode); name != "" {
+			return append(left, MemberEntry{
+				Name: name,
+				Node: nameNode,
+			})
+		}
+		return left
+	case ast.KindElementAccessExpression:
+		element := node.AsElementAccessExpression()
+		left := GetMemberEntries(element.Expression)
+		nameNode := ast.SkipParentheses(element.ArgumentExpression)
+		if name := elementAccessName(nameNode); name != "" {
+			return append(left, MemberEntry{
+				Name: name,
+				Node: nameNode,
+			})
+		}
+		return nil
+	case ast.KindCallExpression:
+		entries := GetMemberEntries(node.AsCallExpression().Expression)
+		if len(entries) > 0 {
+			entries[len(entries)-1].Call = node
+		}
+		return entries
+	case ast.KindTaggedTemplateExpression:
+		return GetMemberEntries(node.AsTaggedTemplateExpression().Tag)
+	default:
+		return nil
+	}
+}
+
+func propertyName(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text
+	case ast.KindPrivateIdentifier:
+		return node.AsPrivateIdentifier().Text
+	default:
+		return ""
+	}
+}
+
+func elementAccessName(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return ""
+	}
+
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text
+	default:
+		return ""
+	}
+}
+
+func JoinMemberEntries(entries []MemberEntry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+
+	parts := make([]string, len(entries))
+	for i, entry := range entries {
+		parts[i] = entry.Name
+	}
+	return strings.Join(parts, ".")
+}
+
+func MemberEntriesRange(entries []MemberEntry) (core.TextRange, bool) {
+	if len(entries) == 0 || entries[0].Node == nil || entries[len(entries)-1].Node == nil {
+		return core.TextRange{}, false
+	}
+	return core.NewTextRange(entries[0].Node.Pos(), entries[len(entries)-1].Node.End()), true
+}
+
+// ResolveFirstIdentifier walks the left side of a call/member chain and
+// returns its first identifier, if any.
+func ResolveFirstIdentifier(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return nil
+	}
+
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node
+	case ast.KindCallExpression:
+		return ResolveFirstIdentifier(node.AsCallExpression().Expression)
+	case ast.KindPropertyAccessExpression:
+		return ResolveFirstIdentifier(node.AsPropertyAccessExpression().Expression)
+	case ast.KindElementAccessExpression:
+		return ResolveFirstIdentifier(node.AsElementAccessExpression().Expression)
+	case ast.KindTaggedTemplateExpression:
+		return ResolveFirstIdentifier(node.AsTaggedTemplateExpression().Tag)
+	default:
+		return nil
+	}
+}

--- a/internal/utils/test_framework/member_chain_test.go
+++ b/internal/utils/test_framework/member_chain_test.go
@@ -1,0 +1,86 @@
+package test_framework
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+)
+
+func parseFirstCall(t *testing.T, code string) (*ast.SourceFile, *ast.Node) {
+	t.Helper()
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, code, core.ScriptKindTS)
+
+	var call *ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindCallExpression {
+			call = node
+			return true
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if call == nil {
+		t.Fatalf("no call expression in %q", code)
+	}
+	return sourceFile, call
+}
+
+func TestGetMemberEntries(t *testing.T) {
+	tests := []struct {
+		code      string
+		wantNames []string
+	}{
+		{
+			code:      "describe.only()",
+			wantNames: []string{"describe", "only"},
+		},
+		{
+			code:      `describe[ "only" ]("math", () => {})`,
+			wantNames: []string{"describe", "only"},
+		},
+		{
+			code:      "describe[\n  \"only\"\n](\"math\", () => {})",
+			wantNames: []string{"describe", "only"},
+		},
+		{
+			code:      "test.concurrent.only()",
+			wantNames: []string{"test", "concurrent", "only"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.code, func(t *testing.T) {
+			_, call := parseFirstCall(t, test.code)
+			entries := GetMemberEntries(call)
+			names := make([]string, len(entries))
+			for i, entry := range entries {
+				names[i] = entry.Name
+			}
+			if !slices.Equal(names, test.wantNames) {
+				t.Fatalf("member names = %v, want %v", names, test.wantNames)
+			}
+		})
+	}
+}
+
+func TestGetMemberEntriesRejectsDynamicElementAccess(t *testing.T) {
+	_, call := parseFirstCall(t, "describe[getMode()]()")
+	if entries := GetMemberEntries(call); entries != nil {
+		t.Fatalf("dynamic element access entries = %#v, want nil", entries)
+	}
+}
+
+func TestResolveFirstIdentifier(t *testing.T) {
+	_, call := parseFirstCall(t, "((test).each)`table`('name', () => {})")
+	identifier := ResolveFirstIdentifier(call.AsCallExpression().Expression)
+	if identifier == nil || identifier.Kind != ast.KindIdentifier || identifier.AsIdentifier().Text != "test" {
+		t.Fatalf("first identifier = %#v, want test", identifier)
+	}
+}

--- a/internal/utils/test_framework/module_reference.go
+++ b/internal/utils/test_framework/module_reference.go
@@ -1,0 +1,148 @@
+package test_framework
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// ResolveFunctionReferenceForModule resolves an imported/required test API
+// back to its exported name. Local declarations shadow framework globals.
+func ResolveFunctionReferenceForModule(
+	node *ast.Node,
+	localName string,
+	localNode *ast.Node,
+	typeChecker *checker.Checker,
+	sourceFile *ast.SourceFile,
+	importModule string,
+) (string, *ast.Node, ReferenceMode) {
+	if typeChecker == nil {
+		return localName, localNode, ReferenceModeGlobal
+	}
+
+	callExpr := node.AsCallExpression()
+	if callExpr == nil {
+		return localName, localNode, ReferenceModeGlobal
+	}
+
+	identifier := ResolveFirstIdentifier(callExpr.Expression)
+	if identifier == nil || identifier.Kind != ast.KindIdentifier {
+		return localName, localNode, ReferenceModeGlobal
+	}
+
+	symbol := typeChecker.GetSymbolAtLocation(identifier)
+	if symbol == nil {
+		return localName, localNode, ReferenceModeGlobal
+	}
+
+	hasLocalDeclaration := false
+	for _, declaration := range symbol.Declarations {
+		if declaration == nil {
+			continue
+		}
+
+		if name, originalNode, ok := resolveModuleImportSpecifier(declaration, importModule); ok {
+			return name, originalNode, ReferenceModeImport
+		}
+		if name, originalNode, ok := resolveModuleRequireBinding(declaration, importModule); ok {
+			return name, originalNode, ReferenceModeImport
+		}
+		if sourceFile != nil && ast.GetSourceFileOfNode(declaration) == sourceFile {
+			hasLocalDeclaration = true
+		}
+	}
+
+	if hasLocalDeclaration {
+		return "", nil, ReferenceModeGlobal
+	}
+	return localName, localNode, ReferenceModeGlobal
+}
+
+// FindImportDeclaration returns the import declaration enclosing node.
+func FindImportDeclaration(node *ast.Node) *ast.ImportDeclaration {
+	for current := node; current != nil; current = current.Parent {
+		switch current.Kind {
+		case ast.KindImportDeclaration, ast.KindJSImportDeclaration:
+			return current.AsImportDeclaration()
+		}
+	}
+	return nil
+}
+
+func resolveModuleImportSpecifier(declaration *ast.Node, importModule string) (string, *ast.Node, bool) {
+	if declaration == nil || declaration.Kind != ast.KindImportSpecifier {
+		return "", nil, false
+	}
+
+	importDeclaration := FindImportDeclaration(declaration)
+	if importDeclaration == nil ||
+		importDeclaration.ModuleSpecifier == nil ||
+		importDeclaration.ModuleSpecifier.Text() != importModule {
+		return "", nil, false
+	}
+
+	specifier := declaration.AsImportSpecifier()
+	if specifier == nil || specifier.IsTypeOnly {
+		return "", nil, false
+	}
+	if specifier.PropertyName != nil {
+		return specifier.PropertyName.Text(), specifier.PropertyName, true
+	}
+	name := specifier.Name()
+	if name == nil {
+		return "", nil, false
+	}
+	return name.Text(), name, true
+}
+
+func resolveModuleRequireBinding(declaration *ast.Node, importModule string) (string, *ast.Node, bool) {
+	if declaration == nil || declaration.Kind != ast.KindBindingElement {
+		return "", nil, false
+	}
+
+	varDeclaration := internalUtils.EnclosingVariableDeclarationOfBindingElement(declaration)
+	if varDeclaration == nil ||
+		!isModuleRequireCall(varDeclaration.AsVariableDeclaration().Initializer, importModule) {
+		return "", nil, false
+	}
+
+	binding := declaration.AsBindingElement()
+	if binding == nil {
+		return "", nil, false
+	}
+	if binding.PropertyName != nil {
+		if name := propertyName(binding.PropertyName); name != "" {
+			return name, binding.PropertyName, true
+		}
+	}
+	nameNode := binding.Name()
+	if name := propertyName(nameNode); name != "" {
+		return name, nameNode, true
+	}
+	return "", nil, false
+}
+
+func isModuleRequireCall(node *ast.Node, importModule string) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil || !ast.IsRequireCall(node, true /* requireStringLiteralLikeArgument */) {
+		return false
+	}
+
+	arguments := node.Arguments()
+	if len(arguments) == 0 || arguments[0] == nil {
+		return false
+	}
+	specifier := ast.SkipParentheses(arguments[0])
+	if specifier == nil {
+		return false
+	}
+
+	switch specifier.Kind {
+	case ast.KindStringLiteral:
+		return specifier.AsStringLiteral().Text == importModule
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return specifier.AsNoSubstitutionTemplateLiteral().Text == importModule
+	default:
+		return false
+	}
+}

--- a/internal/utils/test_framework/types.go
+++ b/internal/utils/test_framework/types.go
@@ -1,0 +1,54 @@
+package test_framework
+
+import "github.com/microsoft/typescript-go/shim/ast"
+
+// FnKind classifies a parsed test-framework call without encoding one
+// framework's root names or aliases. Framework parsers may define additional
+// values for assertion and namespace APIs.
+type FnKind string
+
+const (
+	FnKindDescribe FnKind = "describe"
+	FnKindHook     FnKind = "hook"
+	FnKindTest     FnKind = "test"
+	FnKindUnknown  FnKind = "unknown"
+)
+
+// ReferenceMode records whether a test API was resolved as a global or as an
+// import/require binding from a framework module.
+type ReferenceMode string
+
+const (
+	ReferenceModeGlobal ReferenceMode = "global"
+	ReferenceModeImport ReferenceMode = "import"
+)
+
+// MemberEntry describes one segment in a test API member chain.
+type MemberEntry struct {
+	Name string
+	Node *ast.Node
+	Call *ast.Node
+}
+
+// ParsedCall is the framework-neutral portion of a parsed test API call.
+// Framework parsers own root/member validation and may embed this type to add
+// matcher or framework-specific metadata.
+type ParsedCall struct {
+	Name          string
+	LocalName     string
+	Kind          FnKind
+	Members       []string
+	MemberEntries []MemberEntry
+	Head          ParsedCallHead
+}
+
+type ParsedCallHead struct {
+	Type     ReferenceMode
+	Local    ParsedCallHeadEntry
+	Original ParsedCallHeadEntry
+}
+
+type ParsedCallHeadEntry struct {
+	Value string
+	Node  *ast.Node
+}


### PR DESCRIPTION
## Summary

Extract framework-neutral test utilities from the Jest plugin into `internal/utils/test_framework`, providing shared infrastructure for future Jest and Rstest rules. The shared layer contains common call-chain parsing, types, and module reference resolution. Framework-specific behavior remains in each plugin.

Existing Jest wrappers are intentionally preserved so contributors currently porting Jest rules can continue using the established APIs without unrelated churn. They also maintain a clear framework boundary. Rstest provides the same wrapper structure.

The intended dependency direction is:

```text
Jest rules   -> Jest utils   \
                              -> internal/utils/test_framework
Rstest rules -> Rstest utils /
```

This PR only refactors shared utilities and does not change any rule behavior.

