### PR TITLE
refactor(jest,rstest): share no-mocks-import rule

### DIFF
--- a/internal/plugins/jest/rules/no_mocks_import/no_mocks_import.go
+++ b/internal/plugins/jest/rules/no_mocks_import/no_mocks_import.go
@@ -1,69 +1,13 @@
 package no_mocks_import
 
 import (
-	"fmt"
-	"slices"
-	"strings"
-
-	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	sharedNoMocksImport "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_mocks_import"
 )
-
-var mocksDirName = "__mocks__"
-
-// Message Builder
-
-func buildNoManualImportErrorMessage(mockFunction string) rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "noManualImport",
-		Description: fmt.Sprintf("Mocks should not be manually imported from a %s directory. Instead use `%s` and import from the original module path", mocksDirName, mockFunction),
-	}
-}
-
-func isMocksImportPath(path string) bool {
-	return slices.Contains(strings.Split(path, "/"), mocksDirName)
-}
-
-func isStringNode(node *ast.Node) bool {
-	return node.Kind == ast.KindStringLiteral || node.Kind == ast.KindNoSubstitutionTemplateLiteral
-}
 
 // NewRule creates a no-mocks-import rule for a test framework.
 func NewRule(name string, mockFunction string) rule.Rule {
-	return rule.Rule{
-		Name:   name,
-		Schema: rule.EmptyArraySchema,
-		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-			return rule.RuleListeners{
-				ast.KindImportDeclaration: func(node *ast.Node) {
-					if isMocksImportPath(node.AsImportDeclaration().ModuleSpecifier.Text()) {
-						ctx.ReportNode(node, buildNoManualImportErrorMessage(mockFunction))
-					}
-				},
-				ast.KindCallExpression: func(node *ast.Node) {
-					callExpr := node.AsCallExpression().Expression
-					if callExpr.Kind != ast.KindIdentifier {
-						return
-					}
-
-					callee := callExpr.AsIdentifier()
-					if callee == nil || callee.Text != "require" {
-						return
-					}
-
-					arguments := node.Arguments()
-					if len(arguments) == 0 {
-						return
-					}
-
-					firstArg := arguments[0]
-					if firstArg != nil && isStringNode(firstArg) && isMocksImportPath(firstArg.Text()) {
-						ctx.ReportNode(firstArg, buildNoManualImportErrorMessage(mockFunction))
-					}
-				},
-			}
-		},
-	}
+	return sharedNoMocksImport.NewRule(name, mockFunction)
 }
 
 var NoMocksImportRule = NewRule("jest/no-mocks-import", "jest.mock")

--- a/internal/plugins/rstest/rules/no_mocks_import/no_mocks_import.go
+++ b/internal/plugins/rstest/rules/no_mocks_import/no_mocks_import.go
@@ -1,5 +1,13 @@
 package no_mocks_import
 
-import jestNoMocksImport "github.com/web-infra-dev/rslint/internal/plugins/jest/rules/no_mocks_import"
+import (
+	"github.com/web-infra-dev/rslint/internal/rule"
+	sharedNoMocksImport "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_mocks_import"
+)
 
-var NoMocksImportRule = jestNoMocksImport.NewRule("rstest/no-mocks-import", "rs.mock")
+// NewRule creates a no-mocks-import rule for a test framework.
+func NewRule(name string, mockFunction string) rule.Rule {
+	return sharedNoMocksImport.NewRule(name, mockFunction)
+}
+
+var NoMocksImportRule = NewRule("rstest/no-mocks-import", "rs.mock")

--- a/internal/utils/test_framework/rules/no_mocks_import/no_mocks_import.go
+++ b/internal/utils/test_framework/rules/no_mocks_import/no_mocks_import.go
@@ -1,0 +1,66 @@
+package no_mocks_import
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const mocksDirName = "__mocks__"
+
+// NewRule creates a no-mocks-import rule for a test framework.
+func NewRule(name string, mockFunction string) rule.Rule {
+	return rule.Rule{
+		Name:   name,
+		Schema: rule.EmptyArraySchema,
+		Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+			return rule.RuleListeners{
+				ast.KindImportDeclaration: func(node *ast.Node) {
+					if isMocksImportPath(node.AsImportDeclaration().ModuleSpecifier.Text()) {
+						ctx.ReportNode(node, buildNoManualImportErrorMessage(mockFunction))
+					}
+				},
+				ast.KindCallExpression: func(node *ast.Node) {
+					callExpr := node.AsCallExpression().Expression
+					if callExpr.Kind != ast.KindIdentifier {
+						return
+					}
+
+					callee := callExpr.AsIdentifier()
+					if callee == nil || callee.Text != "require" {
+						return
+					}
+
+					arguments := node.Arguments()
+					if len(arguments) == 0 {
+						return
+					}
+
+					firstArg := arguments[0]
+					if firstArg != nil && isStringNode(firstArg) && isMocksImportPath(firstArg.Text()) {
+						ctx.ReportNode(firstArg, buildNoManualImportErrorMessage(mockFunction))
+					}
+				},
+			}
+		},
+	}
+}
+
+func buildNoManualImportErrorMessage(mockFunction string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noManualImport",
+		Description: fmt.Sprintf("Mocks should not be manually imported from a %s directory. Instead use `%s` and import from the original module path", mocksDirName, mockFunction),
+	}
+}
+
+func isMocksImportPath(path string) bool {
+	return slices.Contains(strings.Split(path, "/"), mocksDirName)
+}
+
+func isStringNode(node *ast.Node) bool {
+	return node.Kind == ast.KindStringLiteral ||
+		node.Kind == ast.KindNoSubstitutionTemplateLiteral
+}


### PR DESCRIPTION
## Summary

Move the framework-neutral `no-mocks-import` implementation to `internal/utils/test_framework/rules/no_mocks_import`.

Jest and Rstest keep their own rule wrappers, while both delegate to the shared implementation. This removes the direct Rstest dependency on the Jest rule.

The intended dependency direction is:

```text
Jest rules   -> Jest utils   \
                              -> internal/utils/test_framework
Rstest rules -> Rstest utils /
```