### PR TITLE
test(rule-tester): validate test case options against the rule's schema

### DIFF
--- a/internal/plugins/import/rules/namespace/namespace_extras_test.go
+++ b/internal/plugins/import/rules/namespace/namespace_extras_test.go
@@ -123,14 +123,6 @@ func TestNamespaceExtras(t *testing.T) {
 					{MessageId: "computed", Message: computedNames, Line: 1, Column: 61, EndLine: 1, EndColumn: 64},
 				},
 			},
-			// ---- Dimension 4: options, unrelated option object keeps computed reporting enabled ----
-			{
-				Code:    `import * as names from "./named-exports"; console.log(names["a"]);`,
-				Options: map[string]interface{}{"unknown": true},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "computed", Message: computedNames, Line: 1, Column: 61, EndLine: 1, EndColumn: 64},
-				},
-			},
 			// ---- Dimension 4: access/key forms, non-Identifier destructuring key is rejected ----
 			{
 				Code: `import * as names from "./named-exports"; const { "a": a } = names`,

--- a/internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go
@@ -126,20 +126,6 @@ func TestNoCycleExtras(t *testing.T) {
 					cycleError(messageViaTwoOne),
 				},
 			},
-			{
-				Code:    `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`,
-				Options: map[string]interface{}{"maxDepth": "2"},
-				Errors: []rule_tester.InvalidTestCaseError{
-					cycleError(messageViaTwoOne),
-				},
-			},
-			{
-				Code:    `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`,
-				Options: map[string]interface{}{"maxDepth": 2.5},
-				Errors: []rule_tester.InvalidTestCaseError{
-					cycleError(messageViaTwoOne),
-				},
-			},
 
 			// Locks in upstream detectCycle() dynamic arm: allowUnsafeDynamicCyclicDependency only skips the dynamic path, not unrelated static cycles.
 			{

--- a/internal/plugins/import/rules/no_cycle/no_cycle_upstream_test.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle_upstream_test.go
@@ -1,7 +1,6 @@
 package no_cycle_test
 
 import (
-	"math"
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
@@ -210,13 +209,6 @@ func noCycleUpstreamInvalidCases() []rule_tester.InvalidTestCase {
 			Code: `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`,
 			Errors: []rule_tester.InvalidTestCaseError{
 				cycleError(messageViaTwoOne),
-			},
-		},
-		{
-			Code:    `import { depthTwo } from "./no-cycle/depth-two"; export const rootValue = depthTwo; export type RootType = string;`,
-			Options: []interface{}{map[string]interface{}{"maxDepth": math.Inf(1)}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				cycleError(messageViaDepthOne),
 			},
 		},
 		{

--- a/internal/plugins/jest/rules/expect_expect/expect_expect_test.go
+++ b/internal/plugins/jest/rules/expect_expect/expect_expect_test.go
@@ -81,15 +81,6 @@ func TestExpectExpectRule(t *testing.T) {
 				Options: []interface{}{map[string]interface{}{"assertFunctionNames": []interface{}{"td.verify"}}},
 			},
 			{
-				Code: `it("should pass", () => expect(true).toBeDefined())`,
-				Options: []interface{}{
-					map[string]interface{}{
-						"assertFunctionNames":          nil,
-						"additionalTestBlockFunctions": nil,
-					},
-				},
-			},
-			{
 				Code: `
         theoretically('the number {input} is correctly translated to string', theories, theory => {
           const output = NumberToLongString(theory.input);

--- a/internal/plugins/jest/rules/max_expects/max_expects_test.go
+++ b/internal/plugins/jest/rules/max_expects/max_expects_test.go
@@ -300,42 +300,6 @@ func TestMaxExpectsRule(t *testing.T) {
       `,
 				Options: []interface{}{map[string]interface{}{"max": 5}},
 			},
-			{
-				Code: `
-        test('schema-invalid max zero falls back to default', () => {
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-        });
-      `,
-				Options: []interface{}{map[string]interface{}{"max": 0}},
-			},
-			{
-				Code: `
-        test('schema-invalid negative max falls back to default', () => {
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-        });
-      `,
-				Options: []interface{}{map[string]interface{}{"max": -1}},
-			},
-			{
-				Code: `
-        test('schema-invalid fractional max falls back to default', () => {
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-          expect(true).toBeDefined();
-        });
-      `,
-				Options: []interface{}{map[string]interface{}{"max": 1.5}},
-			},
 		},
 		[]rule_tester.InvalidTestCase{
 			{

--- a/internal/plugins/jest/rules/max_nested_describe/max_nested_describe_test.go
+++ b/internal/plugins/jest/rules/max_nested_describe/max_nested_describe_test.go
@@ -77,46 +77,6 @@ func TestMaxNestedDescribeRule(t *testing.T) {
 					map[string]interface{}{"max": 0},
 				},
 			},
-			{
-				Code: `
-        describe('foo', () => {
-          describe('bar', () => {
-            describe('baz', () => {
-              describe('qux', () => {
-                describe('quux', () => {
-                  it('something', async () => {
-                    expect('something').toBe('something');
-                  });
-                });
-              });
-            });
-          });
-        });
-    `,
-				Options: []interface{}{
-					map[string]interface{}{"max": -1},
-				},
-			},
-			{
-				Code: `
-        describe('foo', () => {
-          describe('bar', () => {
-            describe('baz', () => {
-              describe('qux', () => {
-                describe('quux', () => {
-                  it('something', async () => {
-                    expect('something').toBe('something');
-                  });
-                });
-              });
-            });
-          });
-        });
-    `,
-				Options: []interface{}{
-					map[string]interface{}{"max": 1.5},
-				},
-			},
 			{Code: `
       describe('foo', () => {
         describe.each(['hello', 'world'])("%s", (a) => {});

--- a/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect_test.go
+++ b/internal/plugins/jest/rules/no_standalone_expect/no_standalone_expect_test.go
@@ -100,20 +100,6 @@ func TestNoStandaloneExpectRule(t *testing.T) {
 			},
 			{
 				Code: `
-        describe('scenario', () => {
-          const t = Math.random() ? it.only : it;
-          t('testing', () => expect(true).toBe(false));
-        });
-      `,
-				Options: []interface{}{
-					map[string]interface{}{"additionalTestBlockFunctions": nil},
-				},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "unexpectedExpect", Line: 4, Column: 30, EndColumn: 54},
-				},
-			},
-			{
-				Code: `
         each([
           [1, 1, 2],
           [1, 2, 3],

--- a/internal/plugins/jest/rules/valid_title/valid_title_test.go
+++ b/internal/plugins/jest/rules/valid_title/valid_title_test.go
@@ -31,12 +31,6 @@ func TestValidTitleRule(t *testing.T) {
 		{
 			Code: `it("correctly sets the value", () => {});`,
 			Options: []interface{}{
-				map[string]interface{}{"disallowedWords": nil},
-			},
-		},
-		{
-			Code: `it("correctly sets the value", () => {});`,
-			Options: []interface{}{
 				map[string]interface{}{
 					"mustMatch": map[string]interface{}{},
 				},

--- a/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_has_content/anchor_has_content_extras_test.go
@@ -613,13 +613,6 @@ func TestAnchorHasContentOptionParsing(t *testing.T) {
 		{Code: `<Custom />`, Tsx: true, Options: map[string]interface{}{}},
 		// Empty components array — same as defaults.
 		{Code: `<Custom />`, Tsx: true, Options: map[string]interface{}{"components": []interface{}{}}},
-		// Components with non-string entries are silently skipped — locks in
-		// the type-guard inside parseOptions.
-		{Code: `<Anchor>x</Anchor>`, Tsx: true, Options: map[string]interface{}{"components": []interface{}{"Anchor", 42, true}}},
-		// Malformed components (string instead of array) — must not crash;
-		// falls back to defaults. Schema validation would reject this in
-		// real ESLint usage, but the rule must still be defensive.
-		{Code: `<Anchor />`, Tsx: true, Options: map[string]interface{}{"components": "Anchor"}},
 		// Unknown options keys are ignored.
 		{Code: `<Anchor />`, Tsx: true, Options: map[string]interface{}{"unknown": true, "components": []interface{}{}}},
 		// Components includes "a" (duplicate) — typeCheck has duplicates but

--- a/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/anchor_is_valid/anchor_is_valid_extras_test.go
@@ -123,13 +123,6 @@ func TestAnchorIsValidExtras(t *testing.T) {
 		//      across propsToValidate. ----
 		{Code: `<a href="foo" hrefLeft={null} />`, Tsx: true, Options: specialLinkOption},
 
-		// ---- Empty aspects array: upstream's runtime treats this as "no
-		//      aspects active", so even no-href elements pass. Locks in
-		//      our explicit-aspects-array deactivation logic. ----
-		{Code: `<a />`, Tsx: true, Options: []interface{}{
-			map[string]interface{}{"aspects": []interface{}{}},
-		}},
-
 		// ---- staticEval `||` short-circuit: falsy left → take right ----
 		// Upstream's jsx-ast-utils LogicalExpression extractor evaluates
 		// `getValue(left) || getValue(right)`. Empty string is falsy → use
@@ -230,13 +223,6 @@ func TestAnchorIsValidExtras(t *testing.T) {
 		//      iteration when a configured prop is absent. ----
 		{Code: `<a href="/foo" />`, Tsx: true, Options: []interface{}{
 			map[string]interface{}{"specialLink": []interface{}{"hrefBottom"}},
-		}},
-
-		// ---- aspects array with an unknown name — silently ignored,
-		//      matching upstream's `aspects.indexOf(aspect) !== -1`
-		//      mechanism. All three known aspects stay false → no report. ----
-		{Code: `<a />`, Tsx: true, Options: []interface{}{
-			map[string]interface{}{"aspects": []interface{}{"madeUpAspect"}},
 		}},
 
 		// ---- aspects with all three names = same as default (all active) ----
@@ -518,12 +504,6 @@ func TestAnchorIsValidExtras(t *testing.T) {
 		//      Below is a different shape that IS invalid:
 		//      `<a hrefLeft="" />` — explicit empty string, length 0,
 		//      invalid. Already covered in upstream tests.
-
-		// ---- aspects array with both ON and unknown — unknown silently
-		//      ignored, "noHref" still triggers reports. ----
-		{Code: `<a />`, Tsx: true, Options: []interface{}{
-			map[string]interface{}{"aspects": []interface{}{"noHref", "madeUpAspect"}},
-		}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noHref", Message: noHrefErrorMessage, Line: 1, Column: 1}}},
 
 		// ---- Bare-object options shape (single-option CLI / lint() API
 		//      shape) for the invalid path. Without an array wrap, the

--- a/internal/plugins/jsx_a11y/rules/aria_role/aria_role_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/aria_role/aria_role_extras_test.go
@@ -142,17 +142,6 @@ func TestAriaRoleExtras(t *testing.T) {
 			{Code: `<div role="button" />`, Tsx: true, Options: map[string]interface{}{}},
 
 			// ============================================================
-			// Non-string entries in allowedInvalidRoles are silently
-			// skipped — defensive but mirrors upstream's `new Set(opts...)`
-			// which would include the raw value but `validRoles.has(val)`
-			// type-mismatches on a string-vs-number compare.
-			// ============================================================
-			{
-				Code: `<div role="button" />`, Tsx: true,
-				Options: map[string]interface{}{"allowedInvalidRoles": []interface{}{42, "foo"}},
-			},
-
-			// ============================================================
 			// polymorphicAllowList: only `<Box>` consults polymorphic
 			// prop; `<Foo>` does not. Both with ignoreNonDOM and a custom
 			// role: Foo is not DOM and not on the allow-list, so polymorphic
@@ -231,20 +220,7 @@ func TestAriaRoleExtras(t *testing.T) {
 			// Whole options is nil / wrong type → defaults apply (no
 			// allowed list, ignoreNonDOM = false).
 			{Code: `<div role="button" />`, Tsx: true, Options: nil},
-			{Code: `<div role="button" />`, Tsx: true, Options: "not-a-map"},
-			{Code: `<div role="button" />`, Tsx: true, Options: 42},
 			{Code: `<div role="button" />`, Tsx: true, Options: []interface{}{}},
-
-			// ============================================================
-			// ignoreNonDOM option — non-boolean values.
-			// rslint's `parseOptions` does a type-asserted bool read;
-			// non-bool values (string "true", numeric 1, nil) silently fall
-			// back to the default `false`, so the rule continues to validate
-			// custom components. ESLint would reject these at schema-load
-			// time; we match the runtime behavior on rslint-side.
-			// ============================================================
-			{Code: `<div role="button" />`, Tsx: true, Options: map[string]interface{}{"ignoreNonDOM": "true"}},
-			{Code: `<div role="button" />`, Tsx: true, Options: map[string]interface{}{"ignoreNonDOM": 1}},
 
 			// ============================================================
 			// Settings — missing / malformed.
@@ -580,17 +556,6 @@ func TestAriaRoleExtras(t *testing.T) {
 			// custom component therefore still validates and the invalid
 			// role reports.
 			// ============================================================
-			{
-				Code: `<Foo role="datepicker" />`, Tsx: true,
-				Options: map[string]interface{}{"ignoreNonDOM": "true"},
-				Errors:  []rule_tester.InvalidTestCaseError{invalidRoleError()},
-			},
-			{
-				Code: `<Foo role="datepicker" />`, Tsx: true,
-				Options: map[string]interface{}{"ignoreNonDOM": 1},
-				Errors:  []rule_tester.InvalidTestCaseError{invalidRoleError()},
-			},
-
 			// ============================================================
 			// components map redirects a custom name to a DOM element →
 			// rule runs against the resolved type (no ignoreNonDOM bypass).

--- a/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/autocomplete_valid/autocomplete_valid_extras_test.go
@@ -157,13 +157,6 @@ func TestAutocompleteValidExtras(t *testing.T) {
 		},
 		// Nil options — defaults to just ["input"].
 		{Code: `<Foo autocomplete="foo" />;`, Tsx: true},
-		// Malformed option (non-array inputComponents) — tolerated by
-		// GetOptionsMap path, falls through to defaults.
-		{
-			Code:    `<Foo autocomplete="foo" />;`,
-			Tsx:     true,
-			Options: map[string]interface{}{"inputComponents": "MyInput"},
-		},
 		// `<input autocomplete={undefined} />` — getLiteralPropValue returns
 		// undefined; typeof !== string → return early.
 		{Code: `<input autocomplete={undefined} />;`, Tsx: true},

--- a/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/control_has_associated_label/control_has_associated_label_extras_test.go
@@ -359,9 +359,6 @@ func TestControlHasAssociatedLabelExtras(t *testing.T) {
 			// labelAttributes with hyphenated prop name.
 			{Code: `<button data-label="Save" />`, Tsx: true,
 				Options: map[string]interface{}{"labelAttributes": []interface{}{"data-label"}}},
-			// labelAttributes with duplicate entries — defensive.
-			{Code: `<button title="Save" />`, Tsx: true,
-				Options: map[string]interface{}{"labelAttributes": []interface{}{"title", "title"}}},
 			// labelAttributes containing a builtin name (alt) — redundant
 			// but harmless.
 			{Code: `<button><img alt="Save" /></button>`, Tsx: true,

--- a/internal/plugins/jsx_a11y/rules/heading_has_content/heading_has_content_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/heading_has_content/heading_has_content_extras_test.go
@@ -821,11 +821,6 @@ func TestHeadingHasContentOptionParsing(t *testing.T) {
 		{Code: `<Custom />`, Tsx: true, Options: map[string]interface{}{}},
 		// Empty components array — same as defaults.
 		{Code: `<Custom />`, Tsx: true, Options: map[string]interface{}{"components": []interface{}{}}},
-		// Components with non-string entries are silently skipped.
-		{Code: `<Heading>x</Heading>`, Tsx: true, Options: map[string]interface{}{"components": []interface{}{"Heading", 42, true}}},
-		// Malformed components (string instead of array) — must not crash;
-		// falls back to defaults.
-		{Code: `<Heading />`, Tsx: true, Options: map[string]interface{}{"components": "Heading"}},
 		// Unknown options keys are ignored.
 		{Code: `<Heading />`, Tsx: true, Options: map[string]interface{}{"unknown": true, "components": []interface{}{}}},
 		// Components includes "h1" (duplicate) — typeCheck has duplicates but

--- a/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/interactive_supports_focus/interactive_supports_focus_extras_test.go
@@ -345,16 +345,6 @@ func TestInteractiveSupportsFocusExtras(t *testing.T) {
 				Tsx:     true,
 				Options: map[string]interface{}{},
 			},
-			{
-				Code:    `<div role="button" onClick={() => {}} tabIndex="0" />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"tabbable": nil},
-			},
-			{
-				Code:    `<div role="button" onClick={() => {}} tabIndex="0" />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"tabbable": "not-an-array"},
-			},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Plain failure — fixed columns + suggestion output assertion.

--- a/internal/plugins/jsx_a11y/rules/label_has_associated_control/label_has_associated_control_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/label_has_associated_control/label_has_associated_control_extras_test.go
@@ -103,9 +103,6 @@ func TestLabelHasAssociatedControl_LockInExtras(t *testing.T) {
 			// under either mode (htmlFor present), so the unknown-assert
 			// behavior matches.
 			// ============================================================
-			{Code: `<label htmlFor="x">Save</label>`, Tsx: true, Options: []interface{}{map[string]interface{}{"assert": "garbage"}}},
-			// Empty assert string also normalizes to 'either'.
-			{Code: `<label htmlFor="x">Save</label>`, Tsx: true, Options: []interface{}{map[string]interface{}{"assert": ""}}},
 
 			// ============================================================
 			// Spread-attribute opacity: `<label {...props}>Save<input/></label>`
@@ -201,10 +198,6 @@ func TestLabelHasAssociatedControl_LockInExtras(t *testing.T) {
 			// behavior is `either` mode). `<label>Save</label>` has neither
 			// htmlFor nor nested control → reports `either`.
 			// ============================================================
-			{Code: `<label>Save</label>`, Tsx: true, Options: []interface{}{map[string]interface{}{"assert": "garbage"}},
-				Errors: []rule_tester.InvalidTestCaseError{expectedEither}},
-			{Code: `<label>Save</label>`, Tsx: true, Options: []interface{}{map[string]interface{}{"assert": ""}},
-				Errors: []rule_tester.InvalidTestCaseError{expectedEither}},
 
 			// ============================================================
 			// validateHtmlFor: `htmlFor={undefined}` resolves to undefined,
@@ -833,22 +826,6 @@ func TestLabelHasAssociatedControl_DepthBoundaries(t *testing.T) {
 				Options: []interface{}{map[string]interface{}{"depth": float64(0), "assert": "both"}},
 				Errors:  []rule_tester.InvalidTestCaseError{expectedBoth}},
 
-			// --------- Negative depth: mayHaveAccessibleLabel's `depth > maxDepth`
-			// bail fires at the ROOT (depth=0 > maxDepth=-1 is true), so even the
-			// root labelling-prop check is skipped → hasAccessibleLabel=false →
-			// accessibleLabel reports BEFORE the assert switch.
-			{Code: `<label htmlFor="x" aria-label="y"><input /></label>`, Tsx: true,
-				Options: []interface{}{map[string]interface{}{"depth": float64(-1), "assert": "both"}},
-				Errors:  []rule_tester.InvalidTestCaseError{expectedAccessibleLabel}},
-
-			// --------- Same root-bail for depth=-5: aria-label on root is NOT
-			// inspected — `0 > -5` is true, so mayHaveAccessibleLabel returns
-			// false immediately. Mirrors upstream's `Math.min(depth, 25)` (no
-			// lower-bound clamp) + `depth > maxDepth` bail.
-			{Code: `<label htmlFor="x" aria-label="y" />`, Tsx: true,
-				Options: []interface{}{map[string]interface{}{"depth": float64(-5), "assert": "htmlFor"}},
-				Errors:  []rule_tester.InvalidTestCaseError{expectedAccessibleLabel}},
-
 			// --------- depth=2 (default): input at depth 3 not found
 			{Code: `<label htmlFor="x">Save<span><span><input /></span></span></label>`, Tsx: true,
 				Options: []interface{}{map[string]interface{}{"assert": "both"}},
@@ -952,26 +929,6 @@ func TestLabelHasAssociatedControl_RealWorldPatterns(t *testing.T) {
 func TestLabelHasAssociatedControl_DefensiveOptions(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &LabelHasAssociatedControlRule,
 		[]rule_tester.ValidTestCase{
-			// --------- assert: non-string falls back to default 'either'
-			{Code: `<label>Save<input /></label>`, Tsx: true,
-				Options: []interface{}{map[string]interface{}{"assert": float64(42)}}},
-
-			// --------- depth: string instead of number → ignored → default 2
-			{Code: `<label>Save<input /></label>`, Tsx: true,
-				Options: []interface{}{map[string]interface{}{"depth": "not-a-number", "assert": "nesting"}}},
-
-			// --------- depth: nil → use default
-			{Code: `<label>Save<input /></label>`, Tsx: true,
-				Options: []interface{}{map[string]interface{}{"depth": nil, "assert": "nesting"}}},
-
-			// --------- labelComponents: array with mixed types → string entries kept
-			{Code: `<MyLabel htmlFor="x" aria-label="y" />`, Tsx: true,
-				Options: []interface{}{map[string]interface{}{"labelComponents": []interface{}{"MyLabel", float64(123), nil, true}, "assert": "htmlFor"}}},
-
-			// --------- labelComponents: not an array → ignored → only builtin 'label'
-			{Code: `<label htmlFor="x" aria-label="y" />`, Tsx: true,
-				Options: []interface{}{map[string]interface{}{"labelComponents": "not-array", "assert": "htmlFor"}}},
-
 			// --------- empty labelComponents array — builtin 'label' still applies
 			{Code: `<label htmlFor="x" aria-label="y" />`, Tsx: true,
 				Options: []interface{}{map[string]interface{}{"labelComponents": []interface{}{}, "assert": "htmlFor"}}},
@@ -1007,11 +964,5 @@ func TestLabelHasAssociatedControl_DefensiveOptions(t *testing.T) {
 				Settings: map[string]interface{}{"jsx-a11y": map[string]interface{}{"attributes": map[string]interface{}{"for": []interface{}{}}}},
 				Options:  []interface{}{map[string]interface{}{"assert": "htmlFor"}},
 				Errors:   []rule_tester.InvalidTestCaseError{expectedHtmlFor}},
-
-			// --------- depth: nil with deeply nested input → falls back to
-			// default 2 → input at depth 3 not found → both mode fails.
-			{Code: `<label htmlFor="x">label<span><span><input /></span></span></label>`, Tsx: true,
-				Options: []interface{}{map[string]interface{}{"depth": nil, "assert": "both"}},
-				Errors:  []rule_tester.InvalidTestCaseError{expectedBoth}},
 		})
 }

--- a/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/media_has_caption/media_has_caption_extras_test.go
@@ -124,18 +124,6 @@ func TestMediaHasCaptionExtras(t *testing.T) {
 		// Empty options object — equivalent to default; non-media tag still passes.
 		{Code: `<div />`, Tsx: true, Options: map[string]interface{}{}},
 
-		// nil-valued audio/video/track — falls back to defaults (no extra
-		// component names). Default audio/video/track still match.
-		{Code: `<audio muted />`, Tsx: true, Options: map[string]interface{}{"audio": nil, "video": nil, "track": nil}},
-		{Code: `<audio><track kind="captions" /></audio>`, Tsx: true, Options: map[string]interface{}{"track": nil}},
-
-		// rslint-extension: non-string entries silently dropped by
-		// StringSliceOption — `<MyAudio>` doesn't match the (empty post-filter)
-		// audio list, so it's NOT considered a media element and the rule
-		// short-circuits. (ESLint's JSON schema would reject this at config
-		// load, so upstream never sees it.)
-		{Code: `<MyAudio />`, Tsx: true, Options: map[string]interface{}{"audio": []interface{}{123, true}}},
-
 		// ============================================================
 		// Settings: components map without a matching entry — `<Audio>`
 		// stays as "Audio", which is not in the default media list.
@@ -463,15 +451,6 @@ func TestMediaHasCaptionExtras(t *testing.T) {
 			Options: map[string]interface{}{"video": []interface{}{"MyVideo"}},
 			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
 		},
-		// rslint extension: mixed-type array — non-string entries silently
-		// dropped, "MyAudio" still honored. Reports.
-		{
-			Code:    `<MyAudio />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"audio": []interface{}{"MyAudio", 123}},
-			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
-		},
-
 		// ============================================================
 		// Settings: components map maps `<MyAudio>` to "audio"
 		// ============================================================

--- a/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/mouse_events_have_key_events/mouse_events_have_key_events_extras_test.go
@@ -335,23 +335,6 @@ func TestMouseEventsHaveKeyEventsExtras(t *testing.T) {
 				Tsx:     true,
 				Options: []interface{}{},
 			},
-			// ---- Malformed options: non-string entries are filtered by
-			//      StringSliceOption. Remaining ["onMouseOver"] becomes
-			//      the effective hoverIn list. ----
-			{
-				Code:    `<div onMouseOver={fn} onFocus={fn} />`,
-				Tsx:     true,
-				Options: []interface{}{map[string]interface{}{"hoverInHandlers": []interface{}{1, true, "onMouseOver"}}},
-			},
-			// ---- Malformed hoverInHandlers — not an array → StringSliceOption
-			//      returns nil → defaults apply → `<div onMouseOver={fn}
-			//      onFocus={fn} />` paired. ----
-			{
-				Code:    `<div onMouseOver={fn} onFocus={fn} />`,
-				Tsx:     true,
-				Options: []interface{}{map[string]interface{}{"hoverInHandlers": "onMouseOver"}},
-			},
-
 			// ============================================================
 			// ShorthandPropertyAssignment in literal spread — `getProp`
 			// walks literal spreads (default spreadStrict: false). The

--- a/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_autofocus/no_autofocus_extras_test.go
@@ -552,15 +552,6 @@ func TestNoAutofocusExtras(t *testing.T) {
 			Options: []interface{}{map[string]interface{}{"ignoreNonDOM": false}},
 			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
 		},
-		// Malformed option (wrong type) is silently ignored → defaults to
-		// ignoreNonDOM=false → custom component still reports.
-		{
-			Code:    `<Foo autoFocus />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"ignoreNonDOM": "yes"},
-			Errors:  []rule_tester.InvalidTestCaseError{expectedError},
-		},
-
 		// ============================================================
 		// Group 16: Real-world component patterns
 		// ============================================================

--- a/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_distracting_elements/no_distracting_elements_extras_test.go
@@ -122,31 +122,6 @@ func TestNoDistractingElementsExtras(t *testing.T) {
 		// `options.elements` is NOT a list — fallback to defaults; `<div />`
 		// still passes.
 		// ============================================================
-		{
-			Code:    `<div />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"elements": "marquee"}, // wrong type, ignored
-		},
-
-		// `options.elements` is null — StringSliceOption returns nil →
-		// fallback to default. `<div />` is still valid.
-		{
-			Code:    `<div />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"elements": nil},
-		},
-
-		// rslint extension: an `elements` array containing only non-string
-		// entries — StringSliceOption filters them all out, leaving an empty
-		// `[]string`, which silences the rule. ESLint's JSON schema rejects
-		// this at config-load time so it never reaches rule logic upstream;
-		// rslint accepts the input and we lock the silenced behavior.
-		{
-			Code:    `<marquee />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"elements": []interface{}{123, true}},
-		},
-
 		// ============================================================
 		// Components map: map-to-non-distracting / non-string value
 		// ============================================================
@@ -410,15 +385,6 @@ func TestNoDistractingElementsExtras(t *testing.T) {
 		// Options: custom `elements` list — `<custom />` reports when
 		// "custom" is in the list.
 		// ============================================================
-		{
-			Code:    `<custom />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"elements": []interface{}{"custom"}},
-			Errors: []rule_tester.InvalidTestCaseError{{
-				MessageId: "distractingElement",
-				Message:   "Do not use <custom> elements as they can create visual accessibility issues and are deprecated.",
-			}},
-		},
 		// Custom list with only one of the defaults — only that one fires.
 		{
 			Code:    `<blink />`,
@@ -756,32 +722,5 @@ func TestNoDistractingElementsExtras(t *testing.T) {
 		// reach the rule's `find` and we lock in the literal-comparison
 		// behavior.
 		// ============================================================
-		// Mixed-type array — non-strings are dropped by StringSliceOption,
-		// "marquee" still matches.
-		{
-			Code:    `<marquee />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"elements": []interface{}{"marquee", 123}},
-			Errors:  []rule_tester.InvalidTestCaseError{expectedMarqueeError},
-		},
-		// (Note: "all non-strings → silenced" is a Valid case, see the
-		// valid block above for `[123, true]` coverage location.)
-		// Empty-string entry alongside marquee — empty never matches a
-		// real tag name, marquee still does.
-		{
-			Code:    `<marquee />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"elements": []interface{}{"", "marquee"}},
-			Errors:  []rule_tester.InvalidTestCaseError{expectedMarqueeError},
-		},
-		// Duplicate entry — `find` short-circuits on the first hit, only
-		// one report emitted. (Schema rejects upstream as
-		// uniqueItems-violation.)
-		{
-			Code:    `<marquee />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"elements": []interface{}{"marquee", "marquee"}},
-			Errors:  []rule_tester.InvalidTestCaseError{expectedMarqueeError},
-		},
 	})
 }

--- a/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_interactive_element_to_noninteractive_role/no_interactive_element_to_noninteractive_role_extras_test.go
@@ -357,37 +357,13 @@ func TestNoInteractiveElementToNoninteractiveRoleRoleStringBoundaries(t *testing
 //   - option role-value case mismatch (`{tr: ["Presentation"]}` vs `role="presentation"`)
 func TestNoInteractiveElementToNoninteractiveRoleOptionRobustness(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInteractiveElementToNoninteractiveRoleRule,
-		[]rule_tester.ValidTestCase{
-			// Mixed-type array — only "presentation" survives, exempting
-			// the case.
-			{
-				Code:    `<tr role="presentation" />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"tr": []interface{}{"none", 123, nil, "presentation"}},
-			},
-		},
+		[]rule_tester.ValidTestCase{},
 		[]rule_tester.InvalidTestCase{
 			// Empty array — no role exempted under that key.
 			{
 				Code:    `<tr role="presentation" />`,
 				Tsx:     true,
 				Options: map[string]interface{}{"tr": []interface{}{}},
-				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
-			},
-			// Non-array value — `StringSliceOption` returns nil, key is
-			// silently dropped from `allowedRoles`.
-			{
-				Code:    `<tr role="presentation" />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"tr": "presentation"},
-				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
-			},
-			// Mixed-type array containing only the WRONG roles — still
-			// reports.
-			{
-				Code:    `<tr role="presentation" />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"tr": []interface{}{"none", 123, nil}},
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noInteractiveElementToNoninteractiveRole", Message: errorMessage}},
 			},
 			// Option key case mismatch — `getElementType` returns "tr"

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_interactions/no_noninteractive_element_interactions_extras_test.go
@@ -367,15 +367,6 @@ func TestNoNoninteractiveElementInteractionsExtras(t *testing.T) {
 				Tsx:     true,
 				Options: map[string]interface{}{"handlers": []interface{}{"onMouseDown"}},
 			},
-			// ---- Mixed-type handlers array: non-strings silently dropped
-			//      (StringSliceOption defensive filter). Effective list
-			//      is just ['onMouseDown'], so onClick doesn't trigger. ----
-			{
-				Code:    `<article onClick={fn} />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"handlers": []interface{}{42, "onMouseDown", nil}},
-			},
-
 			// ============================================================
 			// Options — per-element allow-list filters event handlers.
 			// ============================================================

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_element_to_interactive_role/no_noninteractive_element_to_interactive_role_extras_test.go
@@ -343,12 +343,6 @@ func TestNoNoninteractiveElementToInteractiveRoleRoleStringBoundaries(t *testing
 func TestNoNoninteractiveElementToInteractiveRoleOptionRobustness(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoNoninteractiveElementToInteractiveRoleRule,
 		[]rule_tester.ValidTestCase{
-			// Mixed-type array — only "menu" survives, exempting the case.
-			{
-				Code:    `<ul role="menu" />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"ul": []interface{}{"menu", 123, nil, "menubar"}},
-			},
 			// Case-mismatched ROLE-attribute value vs lowercase allow-list
 			// — upstream lowercases the role via `getExplicitRole`, so
 			// `role="Menu"` matches allow-list entry "menu". Locks in the
@@ -366,22 +360,6 @@ func TestNoNoninteractiveElementToInteractiveRoleOptionRobustness(t *testing.T) 
 				Code:    `<ul role="menu" />`,
 				Tsx:     true,
 				Options: map[string]interface{}{"ul": []interface{}{}},
-				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveElementToInteractiveRole", Message: errorMessage}},
-			},
-			// Non-array value — `StringSliceOption` returns nil, key is
-			// silently dropped from `allowedRoles`.
-			{
-				Code:    `<ul role="menu" />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"ul": "menu"},
-				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveElementToInteractiveRole", Message: errorMessage}},
-			},
-			// Mixed-type array containing only the WRONG roles — still
-			// reports.
-			{
-				Code:    `<ul role="menu" />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"ul": []interface{}{"menubar", 123, nil}},
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noNoninteractiveElementToInteractiveRole", Message: errorMessage}},
 			},
 			// Option key case mismatch — `getElementType` returns "ul"

--- a/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_noninteractive_tabindex/no_noninteractive_tabindex_extras_test.go
@@ -521,8 +521,6 @@ func TestNoNoninteractiveTabindexExtras(t *testing.T) {
 		// Empty array — defaults to all-falsy (no escape hatches).
 		{Code: `<div tabIndex={-1} />`, Tsx: true, Options: []interface{}{}},
 		// Malformed option types are silently dropped → defaults apply.
-		{Code: `<div tabIndex={-1} />`, Tsx: true, Options: []interface{}{map[string]interface{}{"tags": "not-an-array"}}},
-		{Code: `<div tabIndex={-1} />`, Tsx: true, Options: []interface{}{map[string]interface{}{"roles": 123}}},
 		{Code: `<div tabIndex={-1} />`, Tsx: true, Options: []interface{}{map[string]interface{}{"allowExpressionValues": "yes"}}},
 		// Combined options on top of recommendedOptions shape.
 		{Code: `<div tabIndex={0} />`, Tsx: true, Options: allOptionsCombo},

--- a/internal/plugins/jsx_a11y/rules/no_redundant_roles/no_redundant_roles_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_redundant_roles/no_redundant_roles_extras_test.go
@@ -1047,13 +1047,6 @@ func TestNoRedundantRolesRobust(t *testing.T) {
 				Tsx:     true,
 				Options: map[string]interface{}{"ul": []interface{}{"list"}, "ol": []interface{}{"list"}, "nav": []interface{}{"navigation"}},
 			},
-			// ---- Allow-list with non-string entries — StringSliceOption
-			//      drops them silently, leaving the valid strings. ----
-			{
-				Code:    `<button role="button" />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"button": []interface{}{"button", 42, nil, true}},
-			},
 			// ---- Malformed value type (not an array) — StringSliceOption
 			//      returns nil; hasOwn still true → allow-list is the nil
 			//      slice → no entries match → REPORT (in invalid block). ----
@@ -1411,15 +1404,6 @@ function B() { return <h1 role="heading">x</h1>; }`,
 				Code:    `<nav role="navigation" />`,
 				Tsx:     true,
 				Options: map[string]interface{}{"nav": []interface{}{"main"}},
-				Errors:  []rule_tester.InvalidTestCaseError{invalidErr("nav", "navigation")},
-			},
-			// ---- Allow-list value is non-array (malformed) — StringSliceOption
-			//      drops it to nil. hasOwn=true → allowed=nil → no matches →
-			//      REPORT. Locks the defensive coercion. ----
-			{
-				Code:    `<nav role="navigation" />`,
-				Tsx:     true,
-				Options: map[string]interface{}{"nav": "not-an-array"},
 				Errors:  []rule_tester.InvalidTestCaseError{invalidErr("nav", "navigation")},
 			},
 			// ---- Allow-list keyed differently — `{ button: [...] }` covers

--- a/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions_extras_test.go
+++ b/internal/plugins/jsx_a11y/rules/no_static_element_interactions/no_static_element_interactions_extras_test.go
@@ -329,11 +329,6 @@ func TestNoStaticElementInteractionsOptionParsing(t *testing.T) {
 			// stays false; handlers stays as default.
 			{Code: `<TestComponent onClick={() => {}} />`, Tsx: true, Options: map[string]interface{}{}},
 			{Code: `<TestComponent onClick={() => {}} />`, Tsx: true, Options: []interface{}{}},
-			// Malformed handlers value — non-array shape should be treated
-			// as "user provided something" but produce an empty list →
-			// never reports.
-			{Code: `<div onClick={() => {}} />`, Tsx: true, Options: map[string]interface{}{"handlers": "not-an-array"}},
-			{Code: `<div onClick={() => {}} />`, Tsx: true, Options: map[string]interface{}{"handlers": 0}},
 			// Malformed allowExpressionValues value — non-bool ignored →
 			// stays falsy. Rule path falls through (no skip), but onClick on
 			// <button> is exempt via IsInteractiveElement → valid.

--- a/internal/plugins/promise/rules/valid_params/valid_params_extras_test.go
+++ b/internal/plugins/promise/rules/valid_params/valid_params_extras_test.go
@@ -64,7 +64,7 @@ func TestValidParamsExtras(t *testing.T) {
 			// This rule does not provide fixes.
 
 			// ---- Branch lock-in: exclude parses []string in Go tests as well as JSON []interface{} ----
-			{Code: `somePromise().catch(TypeError, handler)`, Options: map[string]interface{}{"exclude": []string{"catch"}}},
+			{Code: `somePromise().catch(TypeError, handler)`, Options: map[string]interface{}{"exclude": []interface{}{"catch"}}},
 
 			// ---- Branch lock-in: unknown methods are ignored even when nested after a promise call ----
 			{Code: `Promise.resolve(1).unknown(1, 2, 3)`},

--- a/internal/plugins/react/rules/boolean_prop_naming/boolean_prop_naming_test.go
+++ b/internal/plugins/react/rules/boolean_prop_naming/boolean_prop_naming_test.go
@@ -517,27 +517,6 @@ func TestBooleanPropNamingRule(t *testing.T) {
           }
         `, Tsx: true, Options: []interface{}{map[string]interface{}{"rule": "[unclosed"}}},
 
-		// ---- Locks in: empty `propTypeNames` array → falls back to default ['bool'] ----
-		// Upstream's schema requires `minItems: 1`; an empty array is
-		// malformed config. We coerce to the default rather than throw.
-		{Code: `
-          class Hello extends React.Component {
-            static propTypes = {isSomething: PropTypes.bool};
-            render () { return <div />; }
-          }
-        `, Tsx: true, Options: []interface{}{map[string]interface{}{
-			"rule":          patternIs,
-			"propTypeNames": []interface{}{},
-		}}},
-
-		// ---- Locks in: empty `rule` string → no-op ----
-		{Code: `
-          class Hello extends React.Component {
-            static propTypes = {something: PropTypes.bool};
-            render () { return <div />; }
-          }
-        `, Tsx: true, Options: []interface{}{map[string]interface{}{"rule": ""}}},
-
 		// ---- Bare-map Options shape (single-option CLI shape) ----
 		{
 			Code: `
@@ -559,18 +538,6 @@ func TestBooleanPropNamingRule(t *testing.T) {
               }
             `,
 			Tsx: true,
-		},
-
-		// ---- Options array with a non-map first element (malformed) → defaults ----
-		{
-			Code: `
-              class Hello extends React.Component {
-                static propTypes = {something: PropTypes.bool};
-                render () { return <div />; }
-              }
-            `,
-			Tsx:     true,
-			Options: []interface{}{"not-a-map"},
 		},
 
 		// ---- Interface heritage: `interface A extends B` ----
@@ -678,29 +645,6 @@ func TestBooleanPropNamingRule(t *testing.T) {
             render() { return <div/>; }
           }
         `, Tsx: true, Options: []interface{}{map[string]interface{}{"rule": "^[\\p{L}]+$"}}},
-
-		// ---- Empty propTypeNames → user-cleared list, no PropTypes match ----
-		{Code: `
-          class Hello extends React.Component {
-            static propTypes = { something: PropTypes.bool };
-            render () { return <div />; }
-          }
-        `, Tsx: true, Options: []interface{}{map[string]interface{}{
-			"rule":          patternIs,
-			"propTypeNames": []interface{}{},
-		}}},
-
-		// ---- Empty propTypeNames doesn't disable TS `: boolean` path ----
-		// (Documented difference from upstream; lock-in.)
-		// Although this is `valid` because the name matches the pattern,
-		// the test verifies that the TS path runs even without
-		// propTypeNames entries.
-		{Code: `
-          const Hello = (props: { isFoo: boolean }) => <div/>;
-        `, Tsx: true, Options: []interface{}{map[string]interface{}{
-			"rule":          patternIs,
-			"propTypeNames": []interface{}{},
-		}}},
 
 		// ---- 5-level validateNested (depth) ----
 		{Code: `

--- a/internal/plugins/react/rules/forbid_component_props/forbid_component_props_test.go
+++ b/internal/plugins/react/rules/forbid_component_props/forbid_component_props_test.go
@@ -366,13 +366,6 @@ func TestForbidComponentPropsRule(t *testing.T) {
 			Tsx:     true,
 			Options: map[string]interface{}{"forbid": []interface{}{"", "className"}},
 		},
-		// `forbid` not an array (schema-violating): falls back to defaults
-		// `['className', 'style']`. Here `other` isn't in defaults → valid.
-		{
-			Code:    `<Foo other="x" />;`,
-			Tsx:     true,
-			Options: map[string]interface{}{"forbid": "className"},
-		},
 		// Nested Components: outer/inner DOM and outer/inner Components mixed.
 		// `<a>` and `<span>` are DOM — their props aren't checked even if forbidden.
 		{
@@ -397,15 +390,6 @@ func TestForbidComponentPropsRule(t *testing.T) {
 				},
 			}},
 		},
-		// Non-string forbid entries (numbers, nulls, nested arrays) are ignored.
-		// Defaults are NOT re-applied because `forbid` is present (a non-nil
-		// array). Nothing is forbidden.
-		{
-			Code:    `<Foo className="x" style={{}} />;`,
-			Tsx:     true,
-			Options: map[string]interface{}{"forbid": []interface{}{42, nil, []interface{}{"className"}}},
-		},
-
 		// ---- TS-specific syntax & wrappers (Dimension 1) ----
 		// TS generic on a component tag: `<Foo<T>>` — tagName is still
 		// Identifier "Foo"; type arguments don't affect tag string.
@@ -469,17 +453,6 @@ func TestForbidComponentPropsRule(t *testing.T) {
 				map[string]interface{}{"allowedFor": []interface{}{"X"}},
 			}},
 		},
-		// `allowedFor` non-array (schema-violating) is silently ignored —
-		// fall back to "no allow list, no allow patterns" → defaults forbid
-		// applies. Here `bar` isn't forbidden so still valid.
-		{
-			Code: `<Foo bar="x" />;`,
-			Tsx:  true,
-			Options: map[string]interface{}{"forbid": []interface{}{
-				map[string]interface{}{"propName": "className", "allowedFor": "ReactModal"},
-			}},
-		},
-
 		// ---- Real-world allow patterns (designed for typical app configs) ----
 		// 1) Strict whitelist: only `Theme.*` may use `style`.
 		{

--- a/internal/plugins/react/rules/forbid_dom_props/forbid_dom_props_test.go
+++ b/internal/plugins/react/rules/forbid_dom_props/forbid_dom_props_test.go
@@ -255,20 +255,6 @@ func TestForbidDomPropsRule(t *testing.T) {
 			Tsx:     true,
 			Options: map[string]interface{}{"forbid": []interface{}{"className"}},
 		},
-		// Empty-string entries in the forbid list are skipped; a real entry
-		// alongside still applies — but `bar` is not the real entry.
-		{
-			Code:    `<div bar="x" />;`,
-			Tsx:     true,
-			Options: map[string]interface{}{"forbid": []interface{}{"", "id"}},
-		},
-		// `forbid` not an array (schema-violating): falls back to the empty
-		// default → nothing forbidden.
-		{
-			Code:    `<div id="x" />;`,
-			Tsx:     true,
-			Options: map[string]interface{}{"forbid": "id"},
-		},
 		// Object entry without `propName`/`propNamePattern` — silently
 		// skipped (upstream creates an entry keyed by `undefined`, which
 		// the listener never queries).
@@ -318,14 +304,6 @@ func TestForbidDomPropsRule(t *testing.T) {
 				},
 			}},
 		},
-		// Non-string entries (numbers, nulls, nested arrays) — silently
-		// skipped. The remaining entry restricts only `id`.
-		{
-			Code:    `<div className="x" />;`,
-			Tsx:     true,
-			Options: map[string]interface{}{"forbid": []interface{}{42, nil, []interface{}{"className"}, "id"}},
-		},
-
 		// ---- TS-specific syntax & wrappers (Dimension 1) ----
 		// TS generic on a Component tag — DOM check skips it.
 		{
@@ -632,24 +610,6 @@ func TestForbidDomPropsRule(t *testing.T) {
 			Options: map[string]interface{}{"forbid": []interface{}{
 				map[string]interface{}{"propName": "  "},
 			}},
-		},
-		// `disallowedValues` containing non-string elements (numbers, null) —
-		// upstream JS `[1, null].indexOf(propValue)` for string propValue
-		// returns -1; our `stringSlice` filters non-strings, equivalent
-		// outcome.
-		{
-			Code: `<div id="1" />;`,
-			Tsx:  true,
-			Options: map[string]interface{}{"forbid": []interface{}{
-				map[string]interface{}{"propName": "id", "disallowedValues": []interface{}{1, nil, true}},
-			}},
-		},
-		// `forbid` field literally `null` (vs absent) — JS `configuration.forbid || DEFAULTS`
-		// falls back to `[]` (empty default for forbid-dom-props). No diagnostic.
-		{
-			Code:    `<div id="x" />;`,
-			Tsx:     true,
-			Options: map[string]interface{}{"forbid": nil},
 		},
 		// Multiple forbid entries; only one matches the current attr —
 		// confirms unrelated entries don't cause false positives.
@@ -1216,21 +1176,6 @@ func TestForbidDomPropsRule(t *testing.T) {
 				},
 			},
 		},
-		// `disallowedFor` includes the same tag listed multiple times — no
-		// dedupe needed since `slices.Contains` short-circuits on first hit.
-		{
-			Code: `<div id="x" />;`,
-			Tsx:  true,
-			Options: map[string]interface{}{"forbid": []interface{}{
-				map[string]interface{}{
-					"propName":      "id",
-					"disallowedFor": []interface{}{"div", "div", "span"},
-				},
-			}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "propIsForbidden", Line: 1, Column: 6},
-			},
-		},
 		// String entry alongside object entry for the SAME propName —
 		// upstream Map's last-write-wins applies. Object entry with custom
 		// message comes second → its message wins.
@@ -1770,21 +1715,6 @@ func TestForbidDomPropsRule(t *testing.T) {
 				{MessageId: "propIsForbidden", Line: 1, Column: 27},
 			},
 		},
-		// `disallowedValues` with duplicate entries — schema-violation but
-		// `slices.Contains` short-circuits on first hit. Locks in tolerance.
-		{
-			Code: `<div id="x" />;`,
-			Tsx:  true,
-			Options: map[string]interface{}{"forbid": []interface{}{
-				map[string]interface{}{
-					"propName":         "id",
-					"disallowedValues": []interface{}{"x", "x", "x"},
-				},
-			}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "propIsForbiddenWithValue", Line: 1, Column: 6},
-			},
-		},
 		// Self-closing vs paired-element position equivalence: same
 		// attribute on `<div id="x" />` and `<div id="x"></div>` should
 		// report at the same column.
@@ -1870,8 +1800,6 @@ func TestForbidDomPropsOptionParsing(t *testing.T) {
 		{Code: `<div id="x" />;`, Tsx: true, Options: nil},
 		// Empty options array.
 		{Code: `<div id="x" />;`, Tsx: true, Options: []interface{}{}},
-		// Malformed `forbid` (string, not array) — silently ignored, defaults apply.
-		{Code: `<div id="x" />;`, Tsx: true, Options: map[string]interface{}{"forbid": "id"}},
 	}, []rule_tester.InvalidTestCase{
 		// Bare object with a real forbid list.
 		{

--- a/internal/plugins/react/rules/forbid_elements/forbid_elements_test.go
+++ b/internal/plugins/react/rules/forbid_elements/forbid_elements_test.go
@@ -1350,28 +1350,6 @@ class C {
 			},
 		},
 
-		// forbid object with extra unknown keys — silently ignored, the
-		// `element` and `message` fields still work. Lock-in: extra
-		// keys do not break parsing.
-		{
-			Code: `<button />`,
-			Tsx:  true,
-			Options: optsForbid(map[string]interface{}{
-				"element": "button",
-				"message": "use Button",
-				"extra":   "ignored",
-				"flag":    true,
-			}),
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "forbiddenElement_message",
-					Message:   "<button> is forbidden, use Button",
-					Line:      1,
-					Column:    2,
-				},
-			},
-		},
-
 		// Mixed forbid list — string, object-with-message, object-without
 		// — within one config; each entry tested in one expression.
 		{

--- a/internal/plugins/react/rules/forbid_prop_types/forbid_prop_types_test.go
+++ b/internal/plugins/react/rules/forbid_prop_types/forbid_prop_types_test.go
@@ -1114,18 +1114,6 @@ func TestForbidPropTypesRule(t *testing.T) {
 			Tsx: true,
 		},
 
-		// ---- Robustness: forbid list edge values ----
-		// Non-string entries in forbid array are silently dropped.
-		{
-			Code: `
-        class C extends React.Component {}
-        C.propTypes = { a: PropTypes.string };
-      `,
-			Tsx: true,
-			Options: map[string]interface{}{
-				"forbid": []interface{}{42, nil, []interface{}{"any"}},
-			},
-		},
 		// Empty string in forbid list — never matches a real type name.
 		{
 			Code: `
@@ -3336,21 +3324,6 @@ func TestForbidPropTypesRule(t *testing.T) {
 				{MessageId: "forbiddenPropType", Message: `Prop type "element" is forbidden`},
 			},
 		},
-		// Custom forbid alongside non-string entries (drop-and-keep semantics).
-		{
-			Code: `
-        class C extends React.Component {}
-        C.propTypes = { a: PropTypes.any };
-      `,
-			Tsx: true,
-			Options: map[string]interface{}{
-				"forbid": []interface{}{42, "any", nil},
-			},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "forbiddenPropType", Message: `Prop type "any" is forbidden`},
-			},
-		},
-
 		// ---- Robustness: combined options ----
 		// Both checkContextTypes AND checkChildContextTypes ON; both fire.
 		{

--- a/internal/plugins/react/rules/jsx_closing_bracket_location/jsx_closing_bracket_location_test.go
+++ b/internal/plugins/react/rules/jsx_closing_bracket_location/jsx_closing_bracket_location_test.go
@@ -646,36 +646,6 @@ func TestJsxClosingBracketLocationRule(t *testing.T) {
 			Tsx:     true,
 			Options: map[string]interface{}{"nonEmpty": false, "selfClosing": false},
 		},
-		// Unknown enum string — ESLint schema rejects, but rslint should
-		// degrade gracefully (default behavior; do not panic).
-		{
-			Code:    `<App />`,
-			Tsx:     true,
-			Options: "unknown-location-value",
-		},
-		// Numeric / boolean options — invalid per schema, must not crash.
-		{
-			Code:    `<App />`,
-			Tsx:     true,
-			Options: 42,
-		},
-		{
-			Code:    `<App />`,
-			Tsx:     true,
-			Options: true,
-		},
-		// Map with unknown key — ignored, defaults take effect.
-		{
-			Code:    `<App foo />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"unknownKey": "tag-aligned"},
-		},
-		// nonEmpty / selfClosing as non-string non-false (true) — ignored.
-		{
-			Code:    `<App foo />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"nonEmpty": true, "selfClosing": true},
-		},
 		// ---- CRLF line terminators (Windows) ----
 		// CRLF-terminated source, default tag-aligned — valid.
 		{
@@ -2241,45 +2211,6 @@ func TestJsxClosingBracketLocationRule(t *testing.T) {
 					Message:   "The closing bracket must be aligned with the line containing the opening tag (expected column 3 on the next line)",
 					Line:      3,
 					Column:    9,
-				},
-			},
-		},
-		// ---- Options-error fallback still triggers default behavior ----
-		// Even with non-string non-map options, default tag-aligned applies.
-		{
-			Code: `<App
-  foo
-  />`,
-			Tsx:     true,
-			Options: 42,
-			Output: []string{`<App
-  foo
-/>`},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "bracketLocation",
-					Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
-					Line:      3,
-					Column:    3,
-				},
-			},
-		},
-		// Map with unknown key — defaults still apply.
-		{
-			Code: `<App
-  foo
-  />`,
-			Tsx:     true,
-			Options: map[string]interface{}{"unknownKey": "props-aligned"},
-			Output: []string{`<App
-  foo
-/>`},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "bracketLocation",
-					Message:   "The closing bracket must be aligned with the opening tag (expected column 1)",
-					Line:      3,
-					Column:    3,
 				},
 			},
 		},

--- a/internal/plugins/react/rules/jsx_curly_spacing/jsx_curly_spacing_test.go
+++ b/internal/plugins/react/rules/jsx_curly_spacing/jsx_curly_spacing_test.go
@@ -464,16 +464,6 @@ func TestJsxCurlySpacingRule(t *testing.T) {
 			Tsx:     true,
 			Options: []interface{}{"always"},
 		},
-
-		// ---- JS-truthy semantics on schema-invalid `attributes` / `children` ----
-		// ESLint's JSON-schema validator rejects these before the rule runs;
-		// rslint does not validate schemas, so the rule must reproduce JS's
-		// `value ? cfg : null` semantics (0/null/"" → disabled).
-		{Code: `<App foo={ bar } />;`, Tsx: true, Options: []interface{}{opts{"attributes": nil}}},
-		{Code: `<App foo={ bar } />;`, Tsx: true, Options: []interface{}{opts{"attributes": 0}}},
-		{Code: `<App foo={ bar } />;`, Tsx: true, Options: []interface{}{opts{"attributes": ""}}},
-		{Code: `<App>{ bar }</App>;`, Tsx: true, Options: []interface{}{opts{"children": nil}}},
-		{Code: `<App>{ bar }</App>;`, Tsx: true, Options: []interface{}{opts{"children": 0}}},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Default config: attribute brace spacing reported, child untouched ----
 		{

--- a/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props_test.go
+++ b/internal/plugins/react/rules/jsx_indent_props/jsx_indent_props_test.go
@@ -398,15 +398,6 @@ func TestJsxIndentPropsRule(t *testing.T) {
 			Options: []interface{}{},
 		},
 
-		// Unrecognised string in object form (`indentMode: 'spaces'`)
-		// silently falls through to default 4-space — must not crash
-		// or produce false reports.
-		{
-			Code:    "\n        <App\n            foo\n        />\n      ",
-			Tsx:     true,
-			Options: []interface{}{map[string]interface{}{"indentMode": "spaces"}},
-		},
-
 		// First prop sharing the opening tag's `?`/`:` line: upstream's
 		// getNodeIndent gives useOperator (line starts with the operator)
 		// priority over useBracket (line contains `<`), so the operator state

--- a/internal/plugins/react/rules/jsx_max_depth/jsx_max_depth_test.go
+++ b/internal/plugins/react/rules/jsx_max_depth/jsx_max_depth_test.go
@@ -167,18 +167,6 @@ func TestJsxMaxDepthRule(t *testing.T) {
         <div>{x}</div>
       `, Tsx: true, Options: map[string]interface{}{"max": 0}},
 
-		// ---- Lock-in: option key with non-numeric value falls back to default ----
-		// Upstream's schema rejects `max: "two"` at config-load; rslint's
-		// option parsing tolerates it by defaulting to max=2 instead of
-		// crashing. Verify the default still applies (depth 2 fits max 2).
-		{Code: `
-        <App>
-          <foo>
-            <bar />
-          </foo>
-        </App>
-      `, Tsx: true, Options: map[string]interface{}{"max": "two"}},
-
 		// ---- Lock-in: reassignment to non-JSX after JSX init also bails ----
 		// Upstream picks the LAST write in source order; if it's neither JSX
 		// nor an Identifier the resolver returns null and no descendant walk
@@ -343,20 +331,6 @@ func TestJsxMaxDepthRule(t *testing.T) {
 		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: []interface{}{}},
 		// Empty object (`[{}]`) → defaults.
 		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{}},
-		// Numeric string `"2"` falls through to default rather than parsing
-		// (mirrors upstream's `has(option, 'max') ? option.max : 2` — when
-		// `max` IS present but isn't a number, ESLint also fails the schema
-		// at config-load and disables the rule). We default to be lenient.
-		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{"max": "2"}},
-		// `max: false` (boolean) → defaults.
-		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{"max": false}},
-		// `max: null` → defaults.
-		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{"max": nil}},
-		// Negative `max: -1` → defaults (upstream schema enforces minimum 0;
-		// we silently fall back to default rather than crashing).
-		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{"max": -1}},
-		// Unknown extra option keys are ignored.
-		{Code: `<App><foo><bar/></foo></App>`, Tsx: true, Options: map[string]interface{}{"max": 2, "unknown": true}},
 		// max=100 — anything fits.
 		{Code: `
         <a><b><c><d><e><f><g><h><i /></h></g></f></e></d></c></b></a>

--- a/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url_test.go
+++ b/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url_test.go
@@ -143,24 +143,6 @@ func TestJsxNoScriptUrl(t *testing.T) {
 			},
 			Tsx: true,
 		},
-		// Malformed legacy option: missing props
-		{
-			Code:    `<Foo href="javascript:"></Foo>`,
-			Options: []interface{}{[]interface{}{map[string]interface{}{"name": "Foo"}}},
-			Tsx:     true,
-		},
-		// Malformed legacy option: missing name
-		{
-			Code:    `<Foo href="javascript:"></Foo>`,
-			Options: []interface{}{[]interface{}{map[string]interface{}{"props": []interface{}{"href"}}}},
-			Tsx:     true,
-		},
-		// Malformed legacy option: props is string instead of array
-		{
-			Code:    `<Foo href="javascript:"></Foo>`,
-			Options: []interface{}{[]interface{}{map[string]interface{}{"name": "Foo", "props": "href"}}},
-			Tsx:     true,
-		},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream invalid cases ----
 		// Defaults — with full position assertion (EndLine/EndColumn)

--- a/internal/plugins/react/rules/no_array_index_key/no_array_index_key_test.go
+++ b/internal/plugins/react/rules/no_array_index_key/no_array_index_key_test.go
@@ -297,15 +297,6 @@ foo.map((baz, i) => cloneElement(someChild, { key: i }))
 		// AssignmentPattern has no plain `.name`, so the index is
 		// NOT pushed. Locked in for input/output parity.
 		{Code: `foo.map((bar, i = 0) => <Foo key={i} />)`, Tsx: true},
-		// Rule receives extra options — schema is `[]` upstream, but
-		// pass-through must not break. `GetOptionsMap` is not used by
-		// this rule; we still verify that arbitrary input doesn't
-		// disturb behavior.
-		{
-			Code:    `foo.map((bar, i) => <Foo key={bar.id} />)`,
-			Tsx:     true,
-			Options: map[string]interface{}{"unknown": true},
-		},
 		// `settings.react.pragma = "Act"` — `Act.createElement` becomes
 		// the recognized factory; `React.createElement` is no longer
 		// matched, so referencing the index in `React.createElement`

--- a/internal/plugins/react/rules/no_danger/no_danger_test.go
+++ b/internal/plugins/react/rules/no_danger/no_danger_test.go
@@ -105,22 +105,6 @@ func TestNoDangerRule(t *testing.T) {
 			`,
 			Tsx: true,
 		},
-		// Defensive: non-array `customComponentNames` is ignored silently.
-		{
-			Code: `<MyComponent dangerouslySetInnerHTML={{ __html: "" }} />;`,
-			Tsx:  true,
-			Options: map[string]interface{}{
-				"customComponentNames": "MyComponent",
-			},
-		},
-		// Defensive: non-string entries in the array are skipped.
-		{
-			Code: `<MyComponent dangerouslySetInnerHTML={{ __html: "" }} />;`,
-			Tsx:  true,
-			Options: map[string]interface{}{
-				"customComponentNames": []interface{}{42, nil, false},
-			},
-		},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream invalid cases ----
 		{

--- a/internal/plugins/react/rules/no_did_mount_set_state/no_did_mount_set_state_test.go
+++ b/internal/plugins/react/rules/no_did_mount_set_state/no_did_mount_set_state_test.go
@@ -421,19 +421,6 @@ func TestNoDidMountSetStateRule(t *testing.T) {
           }
         }
       `, Tsx: true},
-		// disallow-in-func option spelled in wrong case — upstream's enum is exact, so
-		// the value is treated as not-disallow-in-func and default mode applies. The
-		// nested-callback setState below should therefore stay valid.
-		{Code: `
-        class Hello extends React.Component {
-          componentDidMount() {
-            someClass.onSomeEvent(function(data) {
-              this.setState({ data: data });
-            });
-          }
-        }
-      `, Tsx: true, Options: []interface{}{"DISALLOW-IN-FUNC"}},
-
 		// Empirically-verified rslint divergence: pre-release React version
 		// "16.3.0-rc.1" is parsed by reactutil.ParseReactVersion as (16, 3, 0),
 		// which makes the noop gate fire (range is [16.3.0, 999.999.999)). Upstream

--- a/internal/plugins/react/rules/no_set_state/no_set_state_test.go
+++ b/internal/plugins/react/rules/no_set_state/no_set_state_test.go
@@ -1830,26 +1830,6 @@ class Hello {
 			},
 		},
 
-		// ---- Real-world: forward-compat — Options array with future option strings ----
-		// upstream `schema: []` accepts no options. We don't read
-		// `options` either, so passing a future-shape value must be a
-		// no-op (still report the call). Locks future-proofing.
-		{
-			Code: `
-        class Hello extends React.Component {
-          someMethod() {
-            this.setState({});
-          }
-          render() { return <div/>; }
-        }
-      `,
-			Tsx:     true,
-			Options: []interface{}{"some-future-option"},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "noSetState", Line: 4, Column: 13},
-			},
-		},
-
 		// ---- Real-world: empty Options array — same as default ----
 		{
 			Code: `

--- a/internal/plugins/react/rules/require_optimization/require_optimization_extra_test.go
+++ b/internal/plugins/react/rules/require_optimization/require_optimization_extra_test.go
@@ -1399,47 +1399,6 @@ class C extends Component {}`, Tsx: true},
 			},
 		},
 
-		// ---- Robustness: options malformed — `allowDecorators` is a string,
-		// not array → must fall back to default (empty) and report normally. ----
-		{
-			Code: `
-        @pure
-        class C extends Component {}
-      `,
-			Tsx:     true,
-			Options: map[string]interface{}{"allowDecorators": "pure"},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
-			},
-		},
-
-		// ---- Robustness: options has null/non-string entries in
-		// allowDecorators — non-string elements ignored, valid ones still apply. ----
-		{
-			Code: `
-        @observer
-        class C extends Component {}
-      `,
-			Tsx:     true,
-			Options: map[string]interface{}{"allowDecorators": []interface{}{nil, 42, "pure"}},
-			Errors: []rule_tester.InvalidTestCaseError{
-				// "observer" not in allow-list ("pure" is the only string), so reports.
-				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
-			},
-		},
-
-		// ---- Robustness: options is `[null]` — falls back to default. ----
-		{
-			Code: `
-        class C extends React.Component {}
-      `,
-			Tsx:     true,
-			Options: []interface{}{nil},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "noShouldComponentUpdate", Line: 2, Column: 9},
-			},
-		},
-
 		// ---- Robustness: options is `[{}]` empty object — defaults apply. ----
 		{
 			Code: `

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_edge_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_edge_test.go
@@ -110,19 +110,6 @@ var edgeValid = []rule_tester.ValidTestCase{
 		Options: map[string]interface{}{"additionalHooks": "^useV[0-9]+Effect$"},
 	},
 
-	// L9: invalid regex string — silently ignored (matches upstream's
-	// lenient `try { new RegExp(...) }` shape via our `regexp.Compile`
-	// returning err handled by skipping).
-	{
-		Code: `
-			function MyComponent() {
-				useEffect(() => {}, []);
-			}
-		`,
-		Tsx:     true,
-		Options: map[string]interface{}{"additionalHooks": "[invalid"},
-	},
-
 	// S4: hoisted function declaration in component scope, referenced
 	// in an effect callback. `f` captures no reactive values
 	// (only globals like `console`), so isFunctionWithoutCapturedValues

--- a/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_test.go
+++ b/internal/plugins/react_hooks/rules/exhaustive_deps/exhaustive_deps_test.go
@@ -516,10 +516,10 @@ func TestExhaustiveDepsEditDemand(t *testing.T) {
 		options   []any
 		dangerous bool
 	}{
-		{name: "suggestions", options: rule.NormalizeOptions(nil)},
+		{name: "suggestions", options: rule_tester.ResolveTestCaseOptions(t, &ExhaustiveDepsRule, nil)},
 		{
 			name: "dangerous autofix",
-			options: rule.NormalizeOptions(map[string]interface{}{
+			options: rule_tester.ResolveTestCaseOptions(t, &ExhaustiveDepsRule, map[string]interface{}{
 				"enableDangerousAutofixThisMayCauseInfiniteLoops": true,
 			}),
 			dangerous: true,

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated_test.go
@@ -199,7 +199,7 @@ func runNoDeprecatedDiagnosticsForFiles(t *testing.T, files map[string]string, e
 					Name:     "test",
 					Severity: rule.SeverityError,
 					Run: func(ctx rule.RuleContext) rule.RuleListeners {
-						return NoDeprecatedRule.Run(ctx, rule.NormalizeOptions(options))
+						return NoDeprecatedRule.Run(ctx, rule_tester.ResolveTestCaseOptions(t, &NoDeprecatedRule, options))
 					},
 				},
 			}

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
@@ -987,7 +987,7 @@ func TestNoRestrictedTypesEditDemand(t *testing.T) {
 				fmt.Sprintf("edit-demand-%d.ts", index),
 				source,
 			)
-			options := rule.NormalizeOptions(map[string]interface{}{
+			options := rule_tester.ResolveTestCaseOptions(t, &NoRestrictedTypesRule, map[string]interface{}{
 				"types": map[string]interface{}{
 					"Banned": config.bannedType,
 				},

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_imports_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_imports_test.go
@@ -299,13 +299,13 @@ console.log(usedValue);
 	}{
 		{
 			name:            "suggestions",
-			options:         rule.NormalizeOptions(nil),
+			options:         rule_tester.ResolveTestCaseOptions(t, &NoUnusedVarsRule, nil),
 			requestedDemand: rule.EditDemandSuggestion,
 			otherDemand:     rule.EditDemandAutofix,
 		},
 		{
 			name: "autofix",
-			options: rule.NormalizeOptions(map[string]interface{}{
+			options: rule_tester.ResolveTestCaseOptions(t, &NoUnusedVarsRule, map[string]interface{}{
 				"enableAutofixRemoval": map[string]interface{}{"imports": true},
 			}),
 			requestedDemand: rule.EditDemandAutofix,

--- a/internal/plugins/unicorn/rules/filename_case/filename_case_test.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case_test.go
@@ -418,26 +418,6 @@ func TestFilenameCase(t *testing.T) {
 			{Code: `// lock-in: all-ignored basename is valid`, FileName: "src/foo/$$$.js", Options: caseOpt("camelCase")},
 			{Code: `// lock-in: all-ignored basename + leading underscores is valid`, FileName: "src/foo/___$$.js", Options: caseOpt("camelCase")},
 
-			// Locks in: when `case` and `cases` are BOTH set, `case` wins
-			// (matches the if/else-if order in parseOptions). Upstream
-			// schema's `oneOf` would reject this config, but a JSON config
-			// can carry both — pinning the precedence keeps it deterministic.
-			{
-				Code: `// lock-in: case takes precedence over cases when both are set`,
-				FileName: "src/foo/fooBar.js",
-				Options: map[string]interface{}{
-					"case":  "camelCase",
-					"cases": map[string]interface{}{"snakeCase": true},
-				},
-			},
-
-			// Locks in: an unknown `case` value (e.g. `"camelcase"` lowercase
-			// typo, or any non-enum value) is silently ignored — the rule
-			// falls back to its default (kebab). The valid case below pins
-			// "fall through to kebab default", and the invalid case below
-			// proves the default fires when the basename violates kebab.
-			{Code: `// lock-in: unknown case value falls back to kebab default (valid)`, FileName: "src/foo/foo-bar.js", Options: caseOpt("camelcase" /* typo */)},
-
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Disable-comment INSIDE the file body — does NOT match a
@@ -1094,53 +1074,6 @@ func TestFilenameCase(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "filenameCase",
 					Message:   "Filename is not in pascal case. Rename it to `123Foo.js`.",
-				}},
-			},
-			// Locks in: an unknown / mistyped `case` value (e.g. lowercase
-			// `"camelcase"`, or any non-enum value) is silently ignored,
-			// the rule falls back to the default kebab case. Companion to
-			// the valid case above (where the basename is already kebab);
-			// here the basename violates kebab and we prove the default
-			// case actually fires.
-			{
-				Code: `// lock-in: unknown case value falls back to kebab default (invalid)`,
-				FileName: "src/foo/fooBar.js",
-				Options:  caseOpt("camelcase" /* typo */),
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
-					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
-				}},
-			},
-			// Locks in `case` + `cases` precedence end-to-end: when both
-			// are present and `case` is honoured, the basename validates
-			// against `case` only — even if it would have failed `cases`.
-			// `fooBar.js` is valid camel; `cases: { snakeCase: true }`
-			// alone would have flagged it. Here we confirm the rule
-			// honours `case` and reports nothing.
-			{
-				Code: `// lock-in: case+cases — case wins (filename violates cases-only set)`,
-				FileName: "src/foo/foo_bar.js",
-				Options: map[string]interface{}{
-					"case":  "snakeCase",
-					"cases": map[string]interface{}{"camelCase": true},
-				},
-				// Filename is valid snake → no diagnostic. We cover this
-				// in the valid block above; here the invalid mirror is:
-				// case=camel (basename `foo_bar.js`) wins, file violates
-				// camel → reports.
-				Skip: true, /* SKIP: redundant with the valid-block companion */
-				Errors: []rule_tester.InvalidTestCaseError{{}},
-			},
-			{
-				Code: `// lock-in: case+cases — case wins, basename violates the chosen case`,
-				FileName: "src/foo/foo_bar.js",
-				Options: map[string]interface{}{
-					"case":  "camelCase",
-					"cases": map[string]interface{}{"snakeCase": true},
-				},
-				Errors: []rule_tester.InvalidTestCaseError{{
-					MessageId: "filenameCase",
-					Message:   "Filename is not in camel case. Rename it to `fooBar.js`.",
 				}},
 			},
 			// Locks in `splitWords` Pass 2 multi-fire end-to-end: pascalCase

--- a/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_instanceof_builtins/no_instanceof_builtins_extras_test.go
@@ -35,8 +35,6 @@ func TestNoInstanceofBuiltinsExtras(t *testing.T) {
 		jsValidOptions("foo instanceof Array", map[string]interface{}{"exclude": []interface{}{"Array"}}),
 		// ---- Dimension 4: exclude still wins when strict strategy would otherwise report ----
 		jsValidOptions("foo instanceof Map", []interface{}{map[string]interface{}{"strategy": "strict", "exclude": []interface{}{"Map"}}}),
-		// ---- Dimension 4: malformed include option is ignored rather than widening matches ----
-		jsValidOptions("foo instanceof WebWorker", []interface{}{map[string]interface{}{"include": "WebWorker"}}),
 		// ---- Dimension 4: TS assertion on the right is not transparent to upstream's Identifier gate ----
 		tsValid("foo instanceof (Array as any)"),
 		// ---- Dimension 4: TS non-null on the right is not transparent to upstream's Identifier gate ----

--- a/internal/rule/schema.go
+++ b/internal/rule/schema.go
@@ -193,7 +193,7 @@ func compileSchemaJSON(rawJSON []byte) (*jsonschema.Schema, any, error) {
 // nested call's own useDefaults processing lands directly in the shared data
 // being validated here.
 //
-// A compound (map/slice) literalDefault is always run through [deepCopyJSON]
+// A compound (map/slice) literalDefault is always run through [DeepCopyJSON]
 // before it's inserted: the value literalDefault returns is owned by s — the
 // compiled *jsonschema.Schema, shared by every Validate call and every rule
 // that reuses the same Schema (e.g. [EmptyArraySchema]) — so inserting it
@@ -224,7 +224,7 @@ func applyDefaults(s *jsonschema.Schema, v any, doc any) any {
 					if !ok {
 						continue
 					}
-					val[key] = normalizeNumbers(deepCopyJSON(def))
+					val[key] = normalizeNumbers(DeepCopyJSON(def))
 				}
 				val[key] = applyDefaults(prop, val[key], doc)
 			}
@@ -258,7 +258,7 @@ func applyDefaults(s *jsonschema.Schema, v any, doc any) any {
 				for len(val) < i {
 					val = append(val, nil) // pad any not-yet-visited gap up to i
 				}
-				val = append(val, applyDefaults(item, normalizeNumbers(deepCopyJSON(def)), doc))
+				val = append(val, applyDefaults(item, normalizeNumbers(DeepCopyJSON(def)), doc))
 			}
 		case *jsonschema.Schema:
 			// List-style items: the same schema governs every element, so
@@ -465,7 +465,7 @@ func (r jsRegexp) MatchString(s string) bool {
 	return utils.Regexp2MatchString(r.re, s)
 }
 
-// deepCopyJSON returns a copy of v in which every nested map[string]any and
+// DeepCopyJSON returns a copy of v in which every nested map[string]any and
 // []any is freshly allocated, so mutating the result can never reach v
 // itself. v is always either decoded JSON (map[string]any/[]any/string/
 // bool/json.Number/nil) or, for *s.Default, a value produced by unmarshaling
@@ -481,18 +481,18 @@ func (r jsRegexp) MatchString(s string) bool {
 // the validated options) write into a map/slice another goroutine is
 // simultaneously reading or writing — a data race, and for a map a possible
 // fatal concurrent-map-write crash.
-func deepCopyJSON(v any) any {
+func DeepCopyJSON(v any) any {
 	switch val := v.(type) {
 	case map[string]any:
 		out := make(map[string]any, len(val))
 		for k, v2 := range val {
-			out[k] = deepCopyJSON(v2)
+			out[k] = DeepCopyJSON(v2)
 		}
 		return out
 	case []any:
 		out := make([]any, len(val))
 		for i, v2 := range val {
-			out[i] = deepCopyJSON(v2)
+			out[i] = DeepCopyJSON(v2)
 		}
 		return out
 	default:

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -120,7 +120,7 @@ type ESLintTestSuite struct {
 	Invalid []ESLintInvalidTestCase `json:"invalid"`
 }
 
-// resolveTestCaseOptions puts a test case's options through the same step a
+// ResolveTestCaseOptions puts a test case's options through the same step a
 // real config goes through before the rule ever runs: the normalized options
 // array is validated against the rule's declared schema, and schema-declared
 // `default`s are filled in. Options a real config would reject fail the test
@@ -131,42 +131,24 @@ type ESLintTestSuite struct {
 // Rules that declare no schema yet run whatever the test case passes,
 // preserving the pre-schema behavior.
 //
-// The options are deep-copied first because [rule.Schema.Validate] fills
-// defaults in place, the way ajv's `useDefaults` does. Test cases are package
-// level values shared by every case [RunRuleTester] runs, and those run in
-// parallel, so mutating the caller's own maps would be a data race.
-func resolveTestCaseOptions(t *testing.T, r *rule.Rule, rawOptions any) []any {
-	options := rule.NormalizeOptions(cloneOptionsValue(rawOptions))
+// It is exported so test harnesses that call a rule's Run directly instead of
+// going through [RunRuleTester] (e.g. to inspect diagnostics across multiple
+// files, or under different [rule.EditDemand]s) can still exercise the same
+// schema validation an ordinary config would apply.
+//
+// The options are deep-copied before validation because [rule.Schema.Validate]
+// fills defaults in place, the way ajv's `useDefaults` does. Test cases are
+// package level values shared by every case [RunRuleTester] runs, and those
+// run in parallel, so mutating the caller's own maps would be a data race.
+func ResolveTestCaseOptions(t *testing.T, r *rule.Rule, rawOptions any) []any {
 	if r.Schema == nil {
-		return options
+		return rule.NormalizeOptions(rawOptions)
 	}
+	options := rule.NormalizeOptions(rule.DeepCopyJSON(rawOptions))
 	if err := r.Schema.Validate(options); err != nil {
 		t.Fatalf("test case options %#v are rejected by %s's schema: %v", rawOptions, r.Name, err)
 	}
 	return options
-}
-
-// cloneOptionsValue deep-copies the JSON-shaped containers in a test case's
-// options. Leaves are returned as they are: they are immutable scalars, or —
-// for a test case written with a Go-native value such as []string — a value
-// the schema layer would reject anyway.
-func cloneOptionsValue(value any) any {
-	switch typed := value.(type) {
-	case map[string]any:
-		cloned := make(map[string]any, len(typed))
-		for key, item := range typed {
-			cloned[key] = cloneOptionsValue(item)
-		}
-		return cloned
-	case []any:
-		cloned := make([]any, len(typed))
-		for i, item := range typed {
-			cloned[i] = cloneOptionsValue(item)
-		}
-		return cloned
-	default:
-		return value
-	}
 }
 
 func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Rule, validTestCases []ValidTestCase, invalidTestCases []InvalidTestCase) {
@@ -176,7 +158,7 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 		slices.ContainsFunc(invalidTestCases, func(c InvalidTestCase) bool { return c.Only })
 
 	runLinter := func(t *testing.T, code string, rawOptions any, settings map[string]interface{}, globals map[string]bool, tsconfigPathOverride string, fileName string) []rule.RuleDiagnostic {
-		options := resolveTestCaseOptions(t, r, rawOptions)
+		options := ResolveTestCaseOptions(t, r, rawOptions)
 
 		var diagnosticsMu sync.Mutex
 		diagnostics := make([]rule.RuleDiagnostic, 0, 3)

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -120,13 +120,64 @@ type ESLintTestSuite struct {
 	Invalid []ESLintInvalidTestCase `json:"invalid"`
 }
 
+// resolveTestCaseOptions puts a test case's options through the same step a
+// real config goes through before the rule ever runs: the normalized options
+// array is validated against the rule's declared schema, and schema-declared
+// `default`s are filled in. Options a real config would reject fail the test
+// here, so a test case can't lock in a configuration no user can reach; and a
+// rule whose defaults live in its schema sees them in tests too, exactly as it
+// would at runtime.
+//
+// Rules that declare no schema yet run whatever the test case passes,
+// preserving the pre-schema behavior.
+//
+// The options are deep-copied first because [rule.Schema.Validate] fills
+// defaults in place, the way ajv's `useDefaults` does. Test cases are package
+// level values shared by every case [RunRuleTester] runs, and those run in
+// parallel, so mutating the caller's own maps would be a data race.
+func resolveTestCaseOptions(t *testing.T, r *rule.Rule, rawOptions any) []any {
+	options := rule.NormalizeOptions(cloneOptionsValue(rawOptions))
+	if r.Schema == nil {
+		return options
+	}
+	if err := r.Schema.Validate(options); err != nil {
+		t.Fatalf("test case options %#v are rejected by %s's schema: %v", rawOptions, r.Name, err)
+	}
+	return options
+}
+
+// cloneOptionsValue deep-copies the JSON-shaped containers in a test case's
+// options. Leaves are returned as they are: they are immutable scalars, or —
+// for a test case written with a Go-native value such as []string — a value
+// the schema layer would reject anyway.
+func cloneOptionsValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		cloned := make(map[string]any, len(typed))
+		for key, item := range typed {
+			cloned[key] = cloneOptionsValue(item)
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneOptionsValue(item)
+		}
+		return cloned
+	default:
+		return value
+	}
+}
+
 func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Rule, validTestCases []ValidTestCase, invalidTestCases []InvalidTestCase) {
 	t.Parallel()
 
 	onlyMode := slices.ContainsFunc(validTestCases, func(c ValidTestCase) bool { return c.Only }) ||
 		slices.ContainsFunc(invalidTestCases, func(c InvalidTestCase) bool { return c.Only })
 
-	runLinter := func(t *testing.T, code string, options any, settings map[string]interface{}, globals map[string]bool, tsconfigPathOverride string, fileName string) []rule.RuleDiagnostic {
+	runLinter := func(t *testing.T, code string, rawOptions any, settings map[string]interface{}, globals map[string]bool, tsconfigPathOverride string, fileName string) []rule.RuleDiagnostic {
+		options := resolveTestCaseOptions(t, r, rawOptions)
+
 		var diagnosticsMu sync.Mutex
 		diagnostics := make([]rule.RuleDiagnostic, 0, 3)
 
@@ -157,7 +208,7 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 						Globals:  globals,
 						Severity: rule.SeverityError,
 						Run: func(ctx rule.RuleContext) rule.RuleListeners {
-							return r.Run(ctx, rule.NormalizeOptions(options))
+							return r.Run(ctx, options)
 						},
 					},
 				}

--- a/internal/rules/prefer_destructuring/prefer_destructuring_extras_config_test.go
+++ b/internal/rules/prefer_destructuring/prefer_destructuring_extras_config_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
-	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -186,7 +185,7 @@ func preferDestructuringConfigMatrix() []preferDestructuringConfigCase {
 func TestPreferDestructuringParseOptionsMatrix(t *testing.T) {
 	for _, testCase := range preferDestructuringConfigMatrix() {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := parseOptions(rule.NormalizeOptions(testCase.options))
+			got := parseOptions(rule_tester.ResolveTestCaseOptions(t, &PreferDestructuringRule, testCase.options))
 			if got != testCase.want {
 				t.Fatalf("parseOptions() = %#v, want %#v", got, testCase.want)
 			}

--- a/internal/rules/prefer_destructuring/prefer_destructuring_extras_test.go
+++ b/internal/rules/prefer_destructuring/prefer_destructuring_extras_test.go
@@ -26,10 +26,6 @@ func TestPreferDestructuringExtras(t *testing.T) {
 		t,
 		&PreferDestructuringRule,
 		[]rule_tester.ValidTestCase{
-			// Direct Rule.Run/API fallback: public config validation rejects an
-			// empty first object because it matches both schema oneOf branches.
-			// If validation is bypassed, it safely disables both check kinds.
-			{Code: "const foo = object.foo;", Options: map[string]any{}},
 			// Locks in upstream shouldCheck() arm 2: a missing per-node-type
 			// assignment config disables the check.
 			{Code: "foo = object.foo;", Options: map[string]any{"AssignmentExpression": map[string]any{}}},


### PR DESCRIPTION
## Summary

`rule_tester` now puts a test case's options through the same step a real config
goes through before the rule runs: the normalized options array is validated
against the rule's declared schema, and schema-declared `default`s are filled
in. Rules that declare no schema yet run whatever the test case passes.

- Options are deep-copied before validation. `Schema.Validate` fills defaults in
  place, the way ajv's `useDefaults` does, and test cases are package-level
  values shared by cases that run in parallel.
- Validation sits in `runLinter`, so `RunRuleTesterFromJSON` and the
  ESLint-imported entry points go through it too.

## Removed cases

Validation rejects 125 existing cases. Each fed a rule's defensive option
parsing a value no config can carry, and that upstream's own schema rejects as
well. One commit per plugin.

| Plugin | Cases | What they passed |
| --- | --- | --- |
| promise | 1 | `[]string` where only `[]any` validates — reshaped, not removed |
| react-hooks | 1 | an unparsable `additionalHooks` regex |
| import | 4 | `maxDepth: "2"` / `2.5`, `math.Inf(1)`, an unknown option key |
| jest | 8 | `max: -1` / `0` / `1.5`, `nil` for a declared array |
| unicorn | 6 | `case: "camelcase"`, `case` alongside `cases`, string-valued `include` |
| jsx-a11y | 57 | a string where an array of names is declared, non-string entries in those arrays, `nil`, names outside a closed enum, duplicates under `uniqueItems`, a negative `depth`, a whole options value that is a string or a number |
| react | 49 | `max: "two"` / `-1` / `false`, `forbid` as a string, `Options: 42` / `true` / `"not-a-map"`, keys outside a closed object, values outside a closed enum, entries missing a required key, values below a declared minimum |

The rules keep their defensive parsing; what goes is the claim that a config can
reach it.

## One divergence left in place

`react/forbid-dom-props`: upstream leaves the `forbid` object branch open, so
`disallowedValues` is unconstrained there and ESLint accepts duplicate and
non-string entries. rslint declares that option with `uniqueItems` and a string
item type and refuses both. The schema is unchanged in this PR — the two cases
that covered the difference are removed with the rest, so this note is the
record of it.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
