### PR TITLE
perf: speed up Program target binding

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -936,10 +936,18 @@ collection, and plugin dispatch may still use infrastructure goroutines.
      otherwise introduce.
 
 5. **Program source identity index** (`bindLintTargetPlan`)
-   - Direct lexical Program lookups remain synchronous. If one misses, the
-     binder resolves each unique Program source path once and builds a
-     binding-pass canonical identity index. CLI fix passes rebuild it when they
-     rebind the target plan.
+   - Direct lexical Program lookups remain synchronous. The target identity
+     maps are not allocated until one misses. The binder then builds the
+     governing config's Program indexes in one canonicalization batch, reusing
+     target identities established by discovery before resolving unknown source
+     paths. Programs associated only with other configs remain untouched.
+   - Unknown source identities are cached once across the Programs actually
+     inspected during that binding pass. With complete VFS symlink metadata,
+     regular files in one lexical directory share its canonical directory
+     lookup; file symlinks, ambiguous casing, missing entries, and VFSes without
+     that metadata fall back to per-file realpath. Per-Program indexes retain
+     only canonical identities present in the target plan. CLI fix passes
+     create a fresh index when they rebind the target plan.
    - Independent realpath lookups use `core.NewWorkGroup`; `--singleThreaded`
      runs the same work serially.
 
@@ -950,6 +958,9 @@ Other invariants:
   canonical config root without a per-file realpath call. Explicit directory
   aliases are resolved once and their descendants inherit the corresponding
   physical path; explicit files and file symlinks are resolved individually.
+  A custom VFS whose `Entries.Symlinks` is nil has not established file
+  identity metadata, so the target walker conservatively resolves each selected
+  file instead of treating it as regular.
   Canonical identities use exact comparison, and aliases governed by different
   configs are rejected instead of choosing an owner by scan order.
 - Multi-config target discovery processes config roots in stable order. It uses

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -351,31 +351,81 @@ func exactProgramSourceFile(program *compiler.Program, targetPath string) *ast.S
 }
 
 // programFileIndex joins lint targets to Program sources by exact physical
-// path. It resolves each unique source path once and retains Program membership
-// so project declaration order remains authoritative during lookup.
+// path. It is scoped to one binding pass and builds the governing config's
+// Program indexes only after one of them misses an exact lexical lookup.
+// Canonical target identities established during discovery are reused before
+// consulting the filesystem, and unknown source paths are resolved at most once
+// across all Programs in the pass.
 type programFileIndex struct {
-	programs         []*compiler.Program
-	fsys             vfs.FS
-	singleThreaded   bool
-	built            bool
-	sourcesByProgram []map[string]*ast.SourceFile
+	programs              []*compiler.Program
+	targets               []resolvedLintTarget
+	fsys                  vfs.FS
+	singleThreaded        bool
+	initialized           bool
+	builtByProgram        []bool
+	sourcesByProgram      []map[string]*ast.SourceFile
+	targetCanonicalIDs    map[string]struct{}
+	canonicalBySourcePath map[string]string
+	directoryIdentities   map[string]programDirectoryIdentity
 }
 
-func newProgramFileIndex(programs []*compiler.Program, fsys vfs.FS, singleThreaded bool) *programFileIndex {
+func newProgramFileIndex(
+	programs []*compiler.Program,
+	targets []resolvedLintTarget,
+	fsys vfs.FS,
+	singleThreaded bool,
+) *programFileIndex {
 	return &programFileIndex{
 		programs:       programs,
+		targets:        targets,
 		fsys:           fsys,
 		singleThreaded: singleThreaded,
 	}
 }
 
-func (index *programFileIndex) sourceFile(programIndex int, canonicalTarget string) *ast.SourceFile {
+func (index *programFileIndex) initialize() {
+	if index.initialized {
+		return
+	}
+	index.initialized = true
+	index.builtByProgram = make([]bool, len(index.programs))
+	index.sourcesByProgram = make([]map[string]*ast.SourceFile, len(index.programs))
+	index.targetCanonicalIDs = make(map[string]struct{}, len(index.targets))
+	index.canonicalBySourcePath = make(map[string]string, len(index.targets)*2)
+	// Seed physical identities first so a lexical hint cannot overwrite a path
+	// that is itself the canonical identity of another target.
+	for _, target := range index.targets {
+		if target.CanonicalPath == "" {
+			continue
+		}
+		canonicalID := exactFilesystemPathID(target.CanonicalPath)
+		index.targetCanonicalIDs[canonicalID] = struct{}{}
+		index.canonicalBySourcePath[canonicalID] = canonicalID
+	}
+	for _, target := range index.targets {
+		if target.Path == "" || target.CanonicalPath == "" {
+			continue
+		}
+		sourcePathID := exactFilesystemPathID(target.Path)
+		if _, isCanonicalTarget := index.targetCanonicalIDs[sourcePathID]; !isCanonicalTarget {
+			index.canonicalBySourcePath[sourcePathID] = exactFilesystemPathID(target.CanonicalPath)
+		}
+	}
+	index.targets = nil
+}
+
+func (index *programFileIndex) sourceFile(
+	programIndexes []int,
+	programIndex int,
+	canonicalTarget string,
+) *ast.SourceFile {
 	if index == nil || index.fsys == nil || canonicalTarget == "" ||
 		programIndex < 0 || programIndex >= len(index.programs) {
 		return nil
 	}
-	if !index.built {
-		index.build()
+	index.initialize()
+	if !index.builtByProgram[programIndex] {
+		index.buildPrograms(programIndexes)
 	}
 	return index.sourcesByProgram[programIndex][exactFilesystemPathID(canonicalTarget)]
 }
@@ -383,53 +433,187 @@ func (index *programFileIndex) sourceFile(programIndex int, canonicalTarget stri
 type programSourceMembership struct {
 	programIndex int
 	sourceIndex  int
+	canonicalID  string
 	sourceFile   *ast.SourceFile
 }
 
-func (index *programFileIndex) build() {
-	index.built = true
-	index.sourcesByProgram = make([]map[string]*ast.SourceFile, len(index.programs))
+type programDirectoryIdentity struct {
+	canonicalPath string
+	entries       vfs.Entries
+}
 
+func regularFileNameFromEntries(entries vfs.Entries, fileName string, useCaseSensitive bool) (string, bool) {
+	if entries.Symlinks == nil {
+		return "", false
+	}
+	canonicalFileName := tspath.GetCanonicalFileName(fileName, useCaseSensitive)
+	match := ""
+	for _, entryName := range entries.Files {
+		if tspath.GetCanonicalFileName(entryName, useCaseSensitive) != canonicalFileName {
+			continue
+		}
+		if match != "" && match != entryName {
+			return "", false
+		}
+		match = entryName
+	}
+	if match == "" {
+		return "", false
+	}
+	if _, isSymlink := entries.Symlinks[match]; isSymlink {
+		return "", false
+	}
+	// GetAccessibleEntries supplies the filesystem's actual casing. Once its
+	// complete metadata proves this entry is regular, realpath(file) is exactly
+	// realpath(parent) joined with this name.
+	return match, true
+}
+
+func (index *programFileIndex) canonicalSourcePathIDs(sourcePaths []string) []string {
+	canonicalIDs := make([]string, len(sourcePaths))
+	if len(sourcePaths) == 0 {
+		return canonicalIDs
+	}
+	if index.directoryIdentities == nil {
+		index.directoryIdentities = make(map[string]programDirectoryIdentity)
+	}
+
+	sourceIndexesByDirectoryID := make(map[string][]int)
+	directoryPathByID := make(map[string]string)
+	for i, sourcePath := range sourcePaths {
+		directoryPath := tspath.GetDirectoryPath(sourcePath)
+		directoryID := exactFilesystemPathID(directoryPath)
+		directoryPathByID[directoryID] = directoryPath
+		sourceIndexesByDirectoryID[directoryID] = append(sourceIndexesByDirectoryID[directoryID], i)
+	}
+
+	directoryIDs := make([]string, 0, len(sourceIndexesByDirectoryID))
+	for directoryID := range sourceIndexesByDirectoryID {
+		directoryIDs = append(directoryIDs, directoryID)
+	}
+	sort.Strings(directoryIDs)
+	pendingIdentities := make([]programDirectoryIdentity, len(directoryIDs))
+	hasPendingIdentity := make([]bool, len(directoryIDs))
+	useCaseSensitive := index.fsys.UseCaseSensitiveFileNames()
+	work := core.NewWorkGroup(index.singleThreaded)
+	queueSource := func(sourceIndex int, directory programDirectoryIdentity) {
+		work.Queue(func() {
+			sourcePath := sourcePaths[sourceIndex]
+			fileName, regular := regularFileNameFromEntries(
+				directory.entries,
+				tspath.GetBaseFileName(sourcePath),
+				useCaseSensitive,
+			)
+			if regular {
+				canonicalIDs[sourceIndex] = exactFilesystemPathID(
+					tspath.CombinePaths(directory.canonicalPath, fileName),
+				)
+			} else {
+				canonicalIDs[sourceIndex] = canonicalFilesystemPathID(sourcePath, index.fsys)
+			}
+		})
+	}
+	for directoryIndex, directoryID := range directoryIDs {
+		sourceIndexes := sourceIndexesByDirectoryID[directoryID]
+		directory, cached := index.directoryIdentities[directoryID]
+		if len(sourceIndexes) == 1 && !cached {
+			sourceIndex := sourceIndexes[0]
+			work.Queue(func() {
+				canonicalIDs[sourceIndex] = canonicalFilesystemPathID(sourcePaths[sourceIndex], index.fsys)
+			})
+			continue
+		}
+		if cached {
+			for _, sourceIndex := range sourceIndexes {
+				queueSource(sourceIndex, directory)
+			}
+		} else {
+			work.Queue(func() {
+				directoryPath := directoryPathByID[directoryID]
+				directory = programDirectoryIdentity{
+					canonicalPath: authoritativeFilesystemPath(directoryPath, index.fsys),
+					entries:       index.fsys.GetAccessibleEntries(directoryPath),
+				}
+				pendingIdentities[directoryIndex] = directory
+				hasPendingIdentity[directoryIndex] = true
+				// Queue per-file work before the directory task returns. A
+				// WorkGroup permits nested Queue calls until RunAndWait has
+				// returned, retaining file-level parallelism without a second
+				// directory-to-file barrier.
+				for _, sourceIndex := range sourceIndexes {
+					queueSource(sourceIndex, directory)
+				}
+			})
+		}
+	}
+	work.RunAndWait()
+	for i, resolved := range hasPendingIdentity {
+		if resolved {
+			index.directoryIdentities[directoryIDs[i]] = pendingIdentities[i]
+		}
+	}
+	return canonicalIDs
+}
+
+func (index *programFileIndex) buildPrograms(programIndexes []int) {
 	sourceIndexByPath := make(map[string]int)
+	var sourcePathIDs []string
 	var sourcePaths []string
 	var memberships []programSourceMembership
-	for programIndex, program := range index.programs {
+
+	for _, programIndex := range programIndexes {
+		if programIndex < 0 || programIndex >= len(index.programs) ||
+			index.builtByProgram[programIndex] {
+			continue
+		}
+		index.builtByProgram[programIndex] = true
+
+		program := index.programs[programIndex]
 		if program == nil {
 			continue
 		}
 		for _, sourceFile := range program.GetSourceFiles() {
 			sourcePath := tspath.NormalizePath(sourceFile.FileName())
 			sourcePathID := exactFilesystemPathID(sourcePath)
-			sourceIndex, exists := sourceIndexByPath[sourcePathID]
-			if !exists {
-				sourceIndex = len(sourcePaths)
-				sourceIndexByPath[sourcePathID] = sourceIndex
-				sourcePaths = append(sourcePaths, sourcePath)
+			canonicalID, known := index.canonicalBySourcePath[sourcePathID]
+			sourceIndex := -1
+			if !known {
+				var pending bool
+				sourceIndex, pending = sourceIndexByPath[sourcePathID]
+				if !pending {
+					sourceIndex = len(sourcePaths)
+					sourceIndexByPath[sourcePathID] = sourceIndex
+					sourcePathIDs = append(sourcePathIDs, sourcePathID)
+					sourcePaths = append(sourcePaths, sourcePath)
+				}
 			}
 			memberships = append(memberships, programSourceMembership{
 				programIndex: programIndex,
 				sourceIndex:  sourceIndex,
+				canonicalID:  canonicalID,
 				sourceFile:   sourceFile,
 			})
 		}
 	}
 
-	canonicalIDs := make([]string, len(sourcePaths))
-	work := core.NewWorkGroup(index.singleThreaded)
-	for i := range sourcePaths {
-		work.Queue(func() {
-			canonicalIDs[i] = canonicalFilesystemPathID(sourcePaths[i], index.fsys)
-		})
+	canonicalIDs := index.canonicalSourcePathIDs(sourcePaths)
+	for i, sourcePathID := range sourcePathIDs {
+		index.canonicalBySourcePath[sourcePathID] = canonicalIDs[i]
 	}
-	work.RunAndWait()
 
 	for _, membership := range memberships {
+		canonicalID := membership.canonicalID
+		if membership.sourceIndex >= 0 {
+			canonicalID = canonicalIDs[membership.sourceIndex]
+		}
+		if _, isTarget := index.targetCanonicalIDs[canonicalID]; !isTarget {
+			continue
+		}
 		sources := index.sourcesByProgram[membership.programIndex]
 		if sources == nil {
 			sources = make(map[string]*ast.SourceFile)
 			index.sourcesByProgram[membership.programIndex] = sources
 		}
-		canonicalID := canonicalIDs[membership.sourceIndex]
 		existing := sources[canonicalID]
 		if existing == nil || membership.sourceFile.FileName() < existing.FileName() {
 			sources[canonicalID] = membership.sourceFile
@@ -511,7 +695,7 @@ func bindLintTargetPlan(
 
 	var gaps []resolvedLintTarget
 	programIndexesByConfig := make(map[string][]int)
-	programFiles := newProgramFileIndex(set.Programs, fsys, singleThreaded)
+	programFiles := newProgramFileIndex(set.Programs, plan.Targets, fsys, singleThreaded)
 	for _, target := range plan.Targets {
 		programIndexes, cached := programIndexesByConfig[target.OwnerConfigDir]
 		if !cached {
@@ -522,7 +706,7 @@ func bindLintTargetPlan(
 		for _, programIndex := range programIndexes {
 			sourceFile := exactProgramSourceFile(set.Programs[programIndex], target.Path)
 			if sourceFile == nil {
-				sourceFile = programFiles.sourceFile(programIndex, target.CanonicalPath)
+				sourceFile = programFiles.sourceFile(programIndexes, programIndex, target.CanonicalPath)
 			}
 			if sourceFile == nil {
 				continue

--- a/cmd/rslint/programs_test.go
+++ b/cmd/rslint/programs_test.go
@@ -4,11 +4,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/linter"
@@ -168,5 +171,558 @@ func TestBuildProgramFileSet_RealpathKeyForSymlinks(t *testing.T) {
 			}
 		}
 		t.Errorf("Expected fileSet to contain resolved path %s", resolvedFilePath)
+	}
+}
+
+type bindingIndexTestFS struct {
+	vfs.FS
+	mu            sync.Mutex
+	files         map[string]string
+	entries       map[string]vfs.Entries
+	realPaths     map[string]string
+	calls         map[string]int
+	caseSensitive bool
+}
+
+func (fsys *bindingIndexTestFS) UseCaseSensitiveFileNames() bool {
+	return fsys.caseSensitive
+}
+
+func (fsys *bindingIndexTestFS) FileExists(filePath string) bool {
+	_, ok := fsys.files[tspath.NormalizePath(filePath)]
+	return ok
+}
+
+func (fsys *bindingIndexTestFS) ReadFile(filePath string) (string, bool) {
+	content, ok := fsys.files[tspath.NormalizePath(filePath)]
+	return content, ok
+}
+
+func (fsys *bindingIndexTestFS) GetAccessibleEntries(directoryPath string) vfs.Entries {
+	if entries, ok := fsys.entries[tspath.NormalizePath(directoryPath)]; ok {
+		return entries
+	}
+	return fsys.FS.GetAccessibleEntries(directoryPath)
+}
+
+func (fsys *bindingIndexTestFS) Realpath(filePath string) string {
+	filePath = tspath.NormalizePath(filePath)
+	fsys.mu.Lock()
+	fsys.calls[filePath]++
+	fsys.mu.Unlock()
+	if realPath := fsys.realPaths[filePath]; realPath != "" {
+		return realPath
+	}
+	return filePath
+}
+
+func (fsys *bindingIndexTestFS) resetCalls() {
+	fsys.mu.Lock()
+	clear(fsys.calls)
+	fsys.mu.Unlock()
+}
+
+func (fsys *bindingIndexTestFS) callCount(filePath string) int {
+	fsys.mu.Lock()
+	defer fsys.mu.Unlock()
+	return fsys.calls[tspath.NormalizePath(filePath)]
+}
+
+func newBindingIndexTestFS(files []string, realPaths map[string]string) *bindingIndexTestFS {
+	contents := make(map[string]string, len(files))
+	for _, filePath := range files {
+		contents[tspath.NormalizePath(filePath)] = "export {};\n"
+	}
+	return &bindingIndexTestFS{
+		FS:            osvfs.FS(),
+		files:         contents,
+		entries:       make(map[string]vfs.Entries),
+		realPaths:     realPaths,
+		calls:         make(map[string]int),
+		caseSensitive: true,
+	}
+}
+
+func createBindingIndexTestProgram(t *testing.T, fsys vfs.FS, rootFiles ...string) *compiler.Program {
+	t.Helper()
+	currentDirectory := "/"
+	if len(rootFiles) > 0 {
+		currentDirectory = tspath.GetDirectoryPath(rootFiles[0])
+	}
+	program, err := utils.CreateProgramFromOptionsLenient(
+		true,
+		&core.CompilerOptions{
+			NoLib:     core.TSTrue,
+			NoResolve: core.TSTrue,
+		},
+		rootFiles,
+		utils.CreateCompilerHost(currentDirectory, fsys),
+	)
+	if err != nil {
+		t.Fatalf("CreateProgramFromOptionsLenient: %v", err)
+	}
+	return program
+}
+
+func TestBindLintTargetPlan_PreservesExactAndProjectOrder(t *testing.T) {
+	const (
+		configDir  = "/repo"
+		targetPath = "/repo/target.ts"
+		aliasPath  = "/aliases/target.ts"
+	)
+	fsys := newBindingIndexTestFS(
+		[]string{targetPath, aliasPath},
+		map[string]string{aliasPath: targetPath},
+	)
+
+	t.Run("earlier alias beats later exact", func(t *testing.T) {
+		aliasProgram := createBindingIndexTestProgram(t, fsys, aliasPath)
+		exactProgram := createBindingIndexTestProgram(t, fsys, targetPath)
+		set := lintProgramSet{
+			Programs: []*compiler.Program{aliasProgram, exactProgram},
+			ConfigOrders: []programConfigOrders{
+				{configDir: 0},
+				{configDir: 1},
+			},
+		}
+		plan := lintTargetPlan{Targets: []resolvedLintTarget{{
+			Path:           targetPath,
+			CanonicalPath:  targetPath,
+			OwnerConfigDir: configDir,
+		}}}
+
+		binding, err := bindLintTargetPlan(set, plan, configDir, fsys, utils.NewParseCache(), true)
+		if err != nil {
+			t.Fatalf("bindLintTargetPlan: %v", err)
+		}
+		if len(binding.TargetsByProgram[0]) != 1 || binding.TargetsByProgram[0][0] != aliasPath {
+			t.Fatalf("earlier alias Program must win, got %v", binding.TargetsByProgram)
+		}
+		if len(binding.TargetsByProgram[1]) != 0 {
+			t.Fatalf("later exact Program must remain unused, got %v", binding.TargetsByProgram)
+		}
+	})
+
+	t.Run("exact beats alias within one Program", func(t *testing.T) {
+		program := createBindingIndexTestProgram(t, fsys, aliasPath, targetPath)
+		set := lintProgramSet{
+			Programs:     []*compiler.Program{program},
+			ConfigOrders: []programConfigOrders{{configDir: 0}},
+		}
+		plan := lintTargetPlan{Targets: []resolvedLintTarget{{
+			Path:           targetPath,
+			CanonicalPath:  targetPath,
+			OwnerConfigDir: configDir,
+		}}}
+		fsys.resetCalls()
+
+		binding, err := bindLintTargetPlan(set, plan, configDir, fsys, utils.NewParseCache(), true)
+		if err != nil {
+			t.Fatalf("bindLintTargetPlan: %v", err)
+		}
+		if got := binding.TargetsByProgram[0]; len(got) != 1 || got[0] != targetPath {
+			t.Fatalf("exact source must beat its alias, got %v", got)
+		}
+		if calls := fsys.callCount(aliasPath); calls != 0 {
+			t.Fatalf("exact hit unexpectedly built the alias index: alias realpath calls=%d", calls)
+		}
+	})
+}
+
+func TestProgramFileIndex_IsTargetAwareAndLazyPerGoverningGroup(t *testing.T) {
+	const (
+		targetPath     = "/physical/target.ts"
+		targetAlias    = "/caller/target.ts"
+		sourceAlias    = "/sources/target.ts"
+		otherSource    = "/sources/dependency.ts"
+		otherCanonical = "/physical/dependency.ts"
+	)
+	fsys := newBindingIndexTestFS(
+		[]string{targetPath, sourceAlias, otherSource},
+		map[string]string{
+			sourceAlias: sourceAlias,
+			otherSource: otherCanonical,
+		},
+	)
+	targetProgram := createBindingIndexTestProgram(t, fsys, targetPath, otherSource)
+	aliasProgram := createBindingIndexTestProgram(t, fsys, sourceAlias)
+	fsys.resetCalls()
+
+	index := newProgramFileIndex(
+		[]*compiler.Program{targetProgram, aliasProgram},
+		[]resolvedLintTarget{{
+			Path:          targetAlias,
+			CanonicalPath: targetPath,
+		}},
+		fsys,
+		true,
+	)
+	sourceFile := index.sourceFile([]int{0}, 0, targetPath)
+	if sourceFile == nil || sourceFile.FileName() != targetPath {
+		t.Fatalf("target-backed source lookup returned %v", sourceFile)
+	}
+	if calls := fsys.callCount(targetPath); calls != 0 {
+		t.Fatalf("known target identity unexpectedly called Realpath %d time(s)", calls)
+	}
+	if !index.builtByProgram[0] || index.builtByProgram[1] {
+		t.Fatalf("only the requested Program may be built: %v", index.builtByProgram)
+	}
+	if sources := index.sourcesByProgram[0]; len(sources) != 1 {
+		t.Fatalf("per-Program index retained non-target identities: %v", sources)
+	}
+}
+
+func TestProgramFileIndex_BuildsGoverningGroupInOneBatch(t *testing.T) {
+	const (
+		firstAlias   = "/sources/first.ts"
+		firstTarget  = "/physical/first.ts"
+		secondAlias  = "/sources/second.ts"
+		secondTarget = "/physical/second.ts"
+	)
+	fsys := newBindingIndexTestFS(
+		[]string{firstAlias, secondAlias},
+		map[string]string{
+			firstAlias:  firstTarget,
+			secondAlias: secondTarget,
+		},
+	)
+	first := createBindingIndexTestProgram(t, fsys, firstAlias)
+	second := createBindingIndexTestProgram(t, fsys, secondAlias)
+	fsys.resetCalls()
+
+	index := newProgramFileIndex(
+		[]*compiler.Program{first, second},
+		[]resolvedLintTarget{
+			{Path: firstTarget, CanonicalPath: firstTarget},
+			{Path: secondTarget, CanonicalPath: secondTarget},
+		},
+		fsys,
+		false,
+	)
+	if sourceFile := index.sourceFile([]int{0, 1}, 0, firstTarget); sourceFile == nil ||
+		sourceFile.FileName() != firstAlias {
+		t.Fatalf("first Program lookup returned %v", sourceFile)
+	}
+	if !index.builtByProgram[0] || !index.builtByProgram[1] {
+		t.Fatalf("governing Program group was not built together: %v", index.builtByProgram)
+	}
+	if sourceFile := index.sourceFile([]int{0, 1}, 1, secondTarget); sourceFile == nil ||
+		sourceFile.FileName() != secondAlias {
+		t.Fatalf("second Program lookup returned %v", sourceFile)
+	}
+	if calls := fsys.callCount(firstAlias); calls != 1 {
+		t.Fatalf("first source resolved %d times, want 1", calls)
+	}
+	if calls := fsys.callCount(secondAlias); calls != 1 {
+		t.Fatalf("second source resolved %d times, want 1", calls)
+	}
+}
+
+func TestProgramFileIndex_CanonicalizesRegularFilesByDirectory(t *testing.T) {
+	const (
+		sourceDirectory = "/aliases"
+		firstSource     = "/aliases/first.ts"
+		firstTarget     = "/physical/first.ts"
+		secondSource    = "/aliases/second.ts"
+		secondTarget    = "/physical/second.ts"
+	)
+	fsys := newBindingIndexTestFS([]string{firstSource, secondSource}, map[string]string{
+		sourceDirectory: "/physical",
+		firstSource:     firstTarget,
+		secondSource:    secondTarget,
+	})
+	fsys.entries[sourceDirectory] = vfs.Entries{
+		Files:    []string{"first.ts", "second.ts"},
+		Symlinks: map[string]struct{}{},
+	}
+	program := createBindingIndexTestProgram(t, fsys, firstSource, secondSource)
+	fsys.resetCalls()
+
+	index := newProgramFileIndex(
+		[]*compiler.Program{program},
+		[]resolvedLintTarget{
+			{Path: firstTarget, CanonicalPath: firstTarget},
+			{Path: secondTarget, CanonicalPath: secondTarget},
+		},
+		fsys,
+		false,
+	)
+	for targetPath, sourcePath := range map[string]string{
+		firstTarget:  firstSource,
+		secondTarget: secondSource,
+	} {
+		sourceFile := index.sourceFile([]int{0}, 0, targetPath)
+		if sourceFile == nil || sourceFile.FileName() != sourcePath {
+			t.Fatalf("directory-derived canonical lookup for %q returned %v", targetPath, sourceFile)
+		}
+	}
+	if calls := fsys.callCount(sourceDirectory); calls != 1 {
+		t.Fatalf("source directory resolved %d times, want 1", calls)
+	}
+	for _, sourcePath := range []string{firstSource, secondSource} {
+		if calls := fsys.callCount(sourcePath); calls != 0 {
+			t.Fatalf("regular source %q unexpectedly resolved per file %d time(s)", sourcePath, calls)
+		}
+	}
+}
+
+func TestProgramFileIndex_FallsBackForUncertainFileIdentity(t *testing.T) {
+	const (
+		sourceDirectory = "/aliases"
+		sourcePath      = "/aliases/target.ts"
+		otherSource     = "/aliases/other.ts"
+		targetPath      = "/physical/target.ts"
+	)
+	tests := []struct {
+		name       string
+		ignoreCase bool
+		entries    vfs.Entries
+	}{
+		{
+			name: "file symlink",
+			entries: vfs.Entries{
+				Files:    []string{"other.ts", "target.ts"},
+				Symlinks: map[string]struct{}{"target.ts": {}},
+			},
+		},
+		{
+			name: "metadata unavailable",
+			entries: vfs.Entries{
+				Files: []string{"other.ts", "target.ts"},
+			},
+		},
+		{
+			name: "entry unavailable",
+			entries: vfs.Entries{
+				Files:    []string{"other.ts"},
+				Symlinks: map[string]struct{}{},
+			},
+		},
+		{
+			name:       "ambiguous case",
+			ignoreCase: true,
+			entries: vfs.Entries{
+				Files:    []string{"other.ts", "Target.ts", "target.ts"},
+				Symlinks: map[string]struct{}{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fsys := newBindingIndexTestFS([]string{sourcePath, otherSource}, map[string]string{
+				sourceDirectory: "/physical",
+				sourcePath:      targetPath,
+				otherSource:     "/physical/other.ts",
+			})
+			fsys.caseSensitive = !test.ignoreCase
+			fsys.entries[sourceDirectory] = test.entries
+			program := createBindingIndexTestProgram(t, fsys, sourcePath, otherSource)
+			fsys.resetCalls()
+
+			index := newProgramFileIndex(
+				[]*compiler.Program{program},
+				[]resolvedLintTarget{{Path: targetPath, CanonicalPath: targetPath}},
+				fsys,
+				true,
+			)
+			sourceFile := index.sourceFile([]int{0}, 0, targetPath)
+			if sourceFile == nil || sourceFile.FileName() != sourcePath {
+				t.Fatalf("fallback canonical lookup returned %v", sourceFile)
+			}
+			if calls := fsys.callCount(sourcePath); calls != 1 {
+				t.Fatalf("uncertain source identity resolved %d times, want 1", calls)
+			}
+		})
+	}
+}
+
+func TestProgramFileIndex_UsesPerFileIdentityForSingletonDirectory(t *testing.T) {
+	const (
+		sourceDirectory = "/aliases"
+		sourcePath      = "/aliases/target.ts"
+		targetPath      = "/physical/target.ts"
+	)
+	fsys := newBindingIndexTestFS([]string{sourcePath}, map[string]string{
+		sourceDirectory: "/physical",
+		sourcePath:      targetPath,
+	})
+	fsys.entries[sourceDirectory] = vfs.Entries{
+		Files:    []string{"target.ts"},
+		Symlinks: map[string]struct{}{},
+	}
+	program := createBindingIndexTestProgram(t, fsys, sourcePath)
+	fsys.resetCalls()
+
+	index := newProgramFileIndex(
+		[]*compiler.Program{program},
+		[]resolvedLintTarget{{Path: targetPath, CanonicalPath: targetPath}},
+		fsys,
+		false,
+	)
+	sourceFile := index.sourceFile([]int{0}, 0, targetPath)
+	if sourceFile == nil || sourceFile.FileName() != sourcePath {
+		t.Fatalf("singleton canonical lookup returned %v", sourceFile)
+	}
+	if calls := fsys.callCount(sourceDirectory); calls != 0 {
+		t.Fatalf("singleton source unexpectedly resolved its directory %d time(s)", calls)
+	}
+	if calls := fsys.callCount(sourcePath); calls != 1 {
+		t.Fatalf("singleton source resolved per file %d time(s), want 1", calls)
+	}
+}
+
+func TestProgramFileIndex_UsesFilesystemCasingForDirectoryIdentity(t *testing.T) {
+	const (
+		sourceDirectory = "C:/repo"
+		sourcePath      = "C:/repo/target.ts"
+		otherSource     = "C:/repo/other.ts"
+		targetPath      = "C:/Physical/Target.ts"
+		otherTarget     = "C:/Physical/Other.ts"
+	)
+	fsys := newBindingIndexTestFS([]string{sourcePath, otherSource}, map[string]string{
+		sourceDirectory: "C:/Physical",
+	})
+	fsys.caseSensitive = false
+	fsys.entries[sourceDirectory] = vfs.Entries{
+		Files:    []string{"Other.ts", "Target.ts"},
+		Symlinks: map[string]struct{}{},
+	}
+	program := createBindingIndexTestProgram(t, fsys, sourcePath, otherSource)
+	fsys.resetCalls()
+
+	index := newProgramFileIndex(
+		[]*compiler.Program{program},
+		[]resolvedLintTarget{
+			{Path: targetPath, CanonicalPath: targetPath},
+			{Path: otherTarget, CanonicalPath: otherTarget},
+		},
+		fsys,
+		true,
+	)
+	sourceFile := index.sourceFile([]int{0}, 0, targetPath)
+	if sourceFile == nil || sourceFile.FileName() != sourcePath {
+		t.Fatalf("case-corrected canonical lookup returned %v", sourceFile)
+	}
+	for _, path := range []string{sourcePath, otherSource} {
+		if calls := fsys.callCount(path); calls != 0 {
+			t.Fatalf("case-corrected regular source %q unexpectedly used per-file Realpath %d time(s)", path, calls)
+		}
+	}
+}
+
+func TestProgramFileIndex_ResolvesSharedUnknownSourceOnce(t *testing.T) {
+	const (
+		sourceAlias = "/sources/target.ts"
+		targetPath  = "/physical/target.ts"
+	)
+	fsys := newBindingIndexTestFS(
+		[]string{sourceAlias},
+		map[string]string{sourceAlias: targetPath},
+	)
+	first := createBindingIndexTestProgram(t, fsys, sourceAlias)
+	second := createBindingIndexTestProgram(t, fsys, sourceAlias)
+	fsys.resetCalls()
+
+	index := newProgramFileIndex(
+		[]*compiler.Program{first, second},
+		[]resolvedLintTarget{{Path: targetPath, CanonicalPath: targetPath}},
+		fsys,
+		true,
+	)
+	for programIndex := range index.programs {
+		sourceFile := index.sourceFile([]int{programIndex}, programIndex, targetPath)
+		if sourceFile == nil || sourceFile.FileName() != sourceAlias {
+			t.Fatalf("Program %d lookup returned %v", programIndex, sourceFile)
+		}
+	}
+	if calls := fsys.callCount(sourceAlias); calls != 1 {
+		t.Fatalf("shared source identity resolved %d times, want 1", calls)
+	}
+}
+
+func TestProgramFileIndex_PreservesLexicalAliasTieBreak(t *testing.T) {
+	const targetPath = "/physical/target.ts"
+	aliases := []string{"/aliases/z.ts", "/aliases/a.ts"}
+	fsys := newBindingIndexTestFS(
+		aliases,
+		map[string]string{
+			aliases[0]: targetPath,
+			aliases[1]: targetPath,
+		},
+	)
+	program := createBindingIndexTestProgram(t, fsys, aliases...)
+	fsys.resetCalls()
+
+	index := newProgramFileIndex(
+		[]*compiler.Program{program},
+		[]resolvedLintTarget{{Path: targetPath, CanonicalPath: targetPath}},
+		fsys,
+		false,
+	)
+	sourceFile := index.sourceFile([]int{0}, 0, targetPath)
+	if sourceFile == nil || sourceFile.FileName() != aliases[1] {
+		t.Fatalf("canonical alias tie-break returned %v, want %q", sourceFile, aliases[1])
+	}
+}
+
+func TestProgramFileIndex_UsesTspathIdentityAcrossFilesystemRoots(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourcePath string
+		targetPath string
+	}{
+		{
+			name:       "drive",
+			sourcePath: "C:/Repo/Alias.ts",
+			targetPath: "C:/Physical/Alias.ts",
+		},
+		{
+			name:       "unc",
+			sourcePath: "//server/share/repo/Alias.ts",
+			targetPath: "//server/share/physical/Alias.ts",
+		},
+		{
+			name:       "drive to unc reparse target",
+			sourcePath: "C:/Repo/Alias.ts",
+			targetPath: "//server/share/physical/Alias.ts",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceDirectory := tspath.GetDirectoryPath(test.sourcePath)
+			targetDirectory := tspath.GetDirectoryPath(test.targetPath)
+			otherSource := tspath.CombinePaths(sourceDirectory, "Other.ts")
+			fsys := newBindingIndexTestFS(
+				[]string{test.sourcePath, otherSource},
+				map[string]string{sourceDirectory: targetDirectory},
+			)
+			fsys.entries[sourceDirectory] = vfs.Entries{
+				Files:    []string{"Alias.ts", "Other.ts"},
+				Symlinks: map[string]struct{}{},
+			}
+			program := createBindingIndexTestProgram(t, fsys, test.sourcePath, otherSource)
+			fsys.resetCalls()
+
+			index := newProgramFileIndex(
+				[]*compiler.Program{program},
+				[]resolvedLintTarget{{Path: test.targetPath, CanonicalPath: test.targetPath}},
+				fsys,
+				true,
+			)
+			sourceFile := index.sourceFile([]int{0}, 0, test.targetPath)
+			if sourceFile == nil || sourceFile.FileName() != test.sourcePath {
+				t.Fatalf("lookup returned %v, want %q", sourceFile, test.sourcePath)
+			}
+			if calls := fsys.callCount(sourceDirectory); calls != 1 {
+				t.Fatalf("source directory resolved %d times, want 1", calls)
+			}
+			for _, sourcePath := range []string{test.sourcePath, otherSource} {
+				if calls := fsys.callCount(sourcePath); calls != 0 {
+					t.Fatalf("regular source %q unexpectedly used per-file Realpath %d time(s)", sourcePath, calls)
+				}
+			}
+		})
 	}
 }

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -273,7 +273,7 @@ func discoverLintTargetsWithStopDirs(
 		workers = 1
 	}
 
-	processFile := func(walkPath string, isSymlink bool) {
+	processFile := func(walkPath string, needsRealpath bool) {
 		fullPath := tspath.NormalizePath(tspath.CombinePaths(normalizedConfigDir, walkPath))
 		matchPath := configPathForMatching(fullPath)
 		targetPath := fullPath
@@ -303,7 +303,7 @@ func discoverLintTargetsWithStopDirs(
 		if !include {
 			return
 		}
-		if isSymlink && fsys != nil {
+		if needsRealpath && fsys != nil {
 			if realPath := fsys.Realpath(fullPath); realPath != "" {
 				canonicalPath = realPath
 			}
@@ -354,7 +354,11 @@ func discoverLintTargetsWithStopDirs(
 				}
 				childDirs = append(childDirs, childPath)
 			} else {
-				processFile(path.Join(walkPath, name), e.Type()&fs.ModeSymlink != 0)
+				needsRealpath := e.Type()&fs.ModeSymlink != 0
+				if entry, ok := e.(interface{ needsCanonicalRealpath() bool }); ok {
+					needsRealpath = needsRealpath || entry.needsCanonicalRealpath()
+				}
+				processFile(path.Join(walkPath, name), needsRealpath)
 			}
 		}
 		return childDirs

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -643,6 +643,38 @@ func TestDiscoverLintTargets_FileSymlinkResolvesPhysicalIdentity(t *testing.T) {
 	assert.Assert(t, fsys.callCount(linkPath) > 0)
 }
 
+func TestDiscoverLintTargets_MissingSymlinkMetadataResolvesFileIdentity(t *testing.T) {
+	const configDir = "/repo"
+	const filePath = "/repo/src/a.ts"
+	const physicalPath = "/physical/src/a.ts"
+	fsys := &discoveryMockFS{
+		FS: osvfs.FS(),
+		entries: map[string]vfs.Entries{
+			configDir: {
+				Directories: []string{"src"},
+				// A nil Symlinks map means identity metadata is unavailable.
+				Symlinks: nil,
+			},
+			"/repo/src": {
+				Files:    []string{"a.ts"},
+				Symlinks: nil,
+			},
+		},
+		resolvedPaths: map[string]string{
+			configDir:   configDir,
+			"/repo/src": "/repo/src",
+			filePath:    physicalPath,
+		},
+	}
+
+	targets := DiscoverLintTargets(nil, configDir, fsys, nil, nil, true)
+	assert.DeepEqual(t, targets, []DiscoveredLintTarget{{
+		Path:            filePath,
+		CanonicalPath:   physicalPath,
+		ConfigDirectory: configDir,
+	}})
+}
+
 func TestIsFileInAllowedDirsHonorsCaseSensitivity(t *testing.T) {
 	assert.Assert(t, isFileInAllowedDirs("/Repo/Src/a.ts", []string{"/repo/src"}, false))
 	assert.Assert(t, !isFileInAllowedDirs("/Repo/Src/a.ts", []string{"/repo/src"}, true))

--- a/internal/config/vfs_adapter.go
+++ b/internal/config/vfs_adapter.go
@@ -172,8 +172,16 @@ func (f *vfsDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 			f.entries = append(f.entries, &vfsDirEntry{name: dir, isDir: true})
 		}
 		for _, file := range accessible.Files {
-			_, isSymlink := accessible.Symlinks[file]
-			f.entries = append(f.entries, &vfsDirEntry{name: file, isSymlink: isSymlink})
+			isSymlink := false
+			needsRealpath := accessible.Symlinks == nil
+			if accessible.Symlinks != nil {
+				_, isSymlink = accessible.Symlinks[file]
+			}
+			f.entries = append(f.entries, &vfsDirEntry{
+				name:          file,
+				isSymlink:     isSymlink,
+				needsRealpath: needsRealpath,
+			})
 		}
 		sort.Slice(f.entries, func(i, j int) bool {
 			return f.entries[i].Name() < f.entries[j].Name()
@@ -207,13 +215,17 @@ func (f *vfsDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 
 // vfsDirEntry implements fs.DirEntry.
 type vfsDirEntry struct {
-	name      string
-	isDir     bool
-	isSymlink bool
+	name          string
+	isDir         bool
+	isSymlink     bool
+	needsRealpath bool
 }
 
 func (e *vfsDirEntry) Name() string { return e.name }
 func (e *vfsDirEntry) IsDir() bool  { return e.isDir }
+func (e *vfsDirEntry) needsCanonicalRealpath() bool {
+	return e.needsRealpath
+}
 func (e *vfsDirEntry) Type() fs.FileMode {
 	if e.isDir {
 		return fs.ModeDir

--- a/internal/config/vfs_adapter_test.go
+++ b/internal/config/vfs_adapter_test.go
@@ -364,6 +364,10 @@ func TestVfsDirEntry_TypeAndInfo(t *testing.T) {
 	symlinkEntry := &vfsDirEntry{name: "link.ts", isSymlink: true}
 	assert.Assert(t, !symlinkEntry.IsDir())
 	assert.Equal(t, symlinkEntry.Type(), fs.ModeSymlink)
+
+	unknownEntry := &vfsDirEntry{name: "unknown.ts", needsRealpath: true}
+	assert.Equal(t, unknownEntry.Type(), fs.FileMode(0), "unknown identity must not be exposed as a symlink")
+	assert.Assert(t, unknownEntry.needsCanonicalRealpath())
 }
 
 // spyVFS wraps a real VFS and counts DirectoryExists calls.


### PR DESCRIPTION
## Summary

- Build Program source identity indexes lazily after an exact lookup misses, and only for the Programs governed by the target's configuration.
- Reuse canonical target identities from discovery, retain only identities present in the lint target plan, and share directory realpath work for files proven to be regular.
- Preserve per-file realpath fallbacks for symlinks, ambiguous casing, incomplete VFS metadata, and singleton directories.
- Add focused coverage for project ordering, exact-match precedence, shared identities, VFS metadata fallbacks, Windows drive paths, and UNC paths; document the updated binding flow.

### Performance

Measured in an isolated Docker/Colima Linux arm64 environment (10 vCPUs, 8 GiB) with Node.js 22.23.1 and hyperfine 1.15.0. The workload used the tracked rsbuild source at `cba4a91d`, its normalized `rslint.config.ts`, and the current Node IPC CLI with `--format jsonline .`: 2,196 files, 83 rules, and zero diagnostics for both binaries.

Each order used 3 warmups and 15 measured runs. Combining the reversed-order rounds gives 30 samples per binary:

| Order | main median | this PR median | Change |
| --- | ---: | ---: | ---: |
| main → this PR | 658.8 ms | 604.2 ms | -8.3% |
| this PR → main | 552.9 ms | 488.7 ms | -11.6% |
| Combined | 646.5 ms | 594.7 ms | **-8.0%** |

The combined mean was 696.8 ± 302.0 ms on main and 617.5 ± 172.6 ms on this PR (-11.4%).

### Validation

- `pnpm check-spell`
- `pnpm format:check`
- `golangci-lint run --new-from-rev=HEAD ./cmd/rslint ./internal/config`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
