### PR TITLE
feat: port rule no-useless-assignment

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -118,6 +118,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unused_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unused_private_class_members"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unused_vars"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_assignment"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_backreference"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_call"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
@@ -289,6 +290,7 @@ func GetAllRules() []rule.Rule {
 		prefer_arrow_callback.PreferArrowCallbackRule,
 		no_dupe_else_if.NoDupeElseIfRule,
 		no_throw_literal.NoThrowLiteralRule,
+		no_useless_assignment.NoUselessAssignmentRule,
 		no_useless_backreference.NoUselessBackreferenceRule,
 		no_useless_call.NoUselessCallRule,
 		no_useless_catch.NoUselessCatchRule,

--- a/internal/rules/no_useless_assignment/cfg.go
+++ b/internal/rules/no_useless_assignment/cfg.go
@@ -1,0 +1,1404 @@
+package no_useless_assignment
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// This file builds a control-flow graph for one code path root (a source file,
+// a function, a class static block, or a class field initializer) and answers
+// "can the value written here still be read?" over it.
+//
+// The graph mirrors the shape ESLint's code path analysis produces, because the
+// rule's observable behaviour depends on it:
+//
+//   - the end of a `try` block flows into its `catch` block as well as past the
+//     statement;
+//   - the first node inside a `try` block (or inside the `catch` block of a
+//     `try` that has a `finally`) that could throw forks to the handler, so an
+//     assignment later in the block is bypassed on the throwing path;
+//   - a `finally` block is laid out twice, once for normal completion and once
+//     for the path that leaves the `try` statement through `return`, `throw`,
+//     or a suspended `yield`; `break` and `continue` do not take that path;
+//   - `&&`, `||`, `??`, `?:`, optional chains, and destructuring defaults fork
+//     around the operand they may skip.
+//
+// Reads and writes are recorded as events in evaluation order, so liveness is a
+// plain backward dataflow over the graph.
+
+type eventKind uint8
+
+const (
+	eventRead eventKind = iota
+	eventWrite
+)
+
+type event struct {
+	kind   eventKind
+	sym    *ast.Symbol
+	assign *assignment
+}
+
+type block struct {
+	events      []event
+	successors  []*block
+	hasIncoming bool
+
+	// Per-symbol dataflow scratch, reset by liveWrites for each symbol.
+	use     bool
+	def     bool
+	liveIn  bool
+	liveOut bool
+}
+
+// writeSite is one place in the graph where an assignment appears. An
+// assignment inside a `finally` block appears twice — once per copy of the
+// block — and only counts as unused when every site is dead.
+type writeSite struct {
+	blk   *block
+	index int
+}
+
+// assignment is one reportable write: the identifier ESLint reports on plus the
+// variable it targets.
+type assignment struct {
+	sym        *ast.Symbol
+	identifier *ast.Node
+	sites      []writeSite
+	// silent marks an assignment that still overwrites the variable but is
+	// never reported, because it sits in a `try` block.
+	silent bool
+}
+
+type tryPosition uint8
+
+const (
+	posTry tryPosition = iota
+	posCatch
+)
+
+// tryFrame tracks one enclosing `try` statement while its blocks are built.
+type tryFrame struct {
+	position     tryPosition
+	hasFinally   bool
+	catchEntry   *block
+	finallyEntry *block
+	thrownForked bool
+	thrownAny    bool
+	returnedAny  bool
+}
+
+// jumpTarget is one `break`/`continue` destination. continueTo is nil for
+// targets that only `break` can reach (switch statements, labelled blocks).
+type jumpTarget struct {
+	label      string
+	breakTo    *block
+	continueTo *block
+}
+
+type builder struct {
+	// assignByIdent maps a write target identifier to the assignment it
+	// belongs to; identifiers absent from the map target untracked variables.
+	assignByIdent map[*ast.Node]*assignment
+	// readNodes maps a reference identifier that reads a tracked variable to
+	// that variable's symbol.
+	readNodes map[*ast.Node]*ast.Symbol
+
+	blocks []*block
+	cur    *block
+
+	jumps      []jumpTarget
+	tryStack   []*tryFrame
+	chainJoins []*block
+}
+
+func (b *builder) newBlock() *block {
+	blk := &block{}
+	b.blocks = append(b.blocks, blk)
+	return blk
+}
+
+func (b *builder) link(from, to *block) {
+	if from == nil || to == nil {
+		return
+	}
+	from.successors = append(from.successors, to)
+	to.hasIncoming = true
+}
+
+// enter makes blk the current block when something can reach it, and marks the
+// path unreachable otherwise.
+func (b *builder) enter(blk *block) {
+	if blk.hasIncoming {
+		b.cur = blk
+	} else {
+		b.cur = nil
+	}
+}
+
+func (b *builder) emitRead(sym *ast.Symbol) {
+	if b.cur == nil {
+		return
+	}
+	b.cur.events = append(b.cur.events, event{kind: eventRead, sym: sym})
+}
+
+func (b *builder) emitWrite(a *assignment) {
+	if b.cur == nil {
+		return
+	}
+	a.sites = append(a.sites, writeSite{blk: b.cur, index: len(b.cur.events)})
+	b.cur.events = append(b.cur.events, event{kind: eventWrite, sym: a.sym, assign: a})
+}
+
+// ---------------------------------------------------------------------------
+// throw / return routing
+// ---------------------------------------------------------------------------
+
+// throwFrame returns the innermost `try` frame an exception raised at the
+// current position lands in, or -1 when it leaves the code path entirely.
+func (b *builder) throwFrame() int {
+	for i := len(b.tryStack) - 1; i >= 0; i-- {
+		f := b.tryStack[i]
+		if f.position == posTry || (f.hasFinally && f.position == posCatch) {
+			return i
+		}
+	}
+	return -1
+}
+
+func throwTarget(f *tryFrame) *block {
+	if f.position == posTry && f.catchEntry != nil {
+		return f.catchEntry
+	}
+	return f.finallyEntry
+}
+
+// returnFrame returns the innermost `try` frame whose `finally` block runs
+// before a `return` leaves the code path, or -1 when none does.
+func (b *builder) returnFrame() int {
+	for i := len(b.tryStack) - 1; i >= 0; i-- {
+		if b.tryStack[i].hasFinally {
+			return i
+		}
+	}
+	return -1
+}
+
+// firstThrowableFork forks to the enclosing handler the first time a node that
+// could throw is completed inside a `try` block (or inside the `catch` block of
+// a `try` that has a `finally`). Later throwable nodes in the same block reuse
+// that first fork, matching ESLint's approximation.
+func (b *builder) firstThrowableFork() {
+	if b.cur == nil {
+		return
+	}
+	i := b.throwFrame()
+	if i < 0 {
+		return
+	}
+	f := b.tryStack[i]
+	if f.thrownForked {
+		return
+	}
+	f.thrownForked = true
+	f.thrownAny = true
+	b.link(b.cur, throwTarget(f))
+	next := b.newBlock()
+	b.link(b.cur, next)
+	b.cur = next
+}
+
+// snapshotForks records the "already forked" state of every enclosing `try` so
+// the second copy of a `finally` block forks at the same place the first did.
+func (b *builder) snapshotForks() []bool {
+	snapshot := make([]bool, len(b.tryStack))
+	for i, f := range b.tryStack {
+		snapshot[i] = f.thrownForked
+	}
+	return snapshot
+}
+
+func (b *builder) restoreForks(snapshot []bool) {
+	for i, forked := range snapshot {
+		if i < len(b.tryStack) {
+			b.tryStack[i].thrownForked = forked
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// statements
+// ---------------------------------------------------------------------------
+
+func (b *builder) statements(list *ast.NodeList) {
+	if list == nil {
+		return
+	}
+	for _, stmt := range list.Nodes {
+		b.statement(stmt)
+	}
+}
+
+func (b *builder) statement(node *ast.Node) {
+	if node == nil || b.cur == nil {
+		return
+	}
+
+	switch node.Kind {
+	case ast.KindBlock:
+		b.statements(node.AsBlock().Statements)
+
+	case ast.KindVariableStatement:
+		b.variableDeclarationList(node.AsVariableStatement().DeclarationList)
+
+	case ast.KindExpressionStatement:
+		b.expr(node.AsExpressionStatement().Expression)
+
+	case ast.KindIfStatement:
+		b.ifStatement(node)
+
+	case ast.KindWhileStatement:
+		b.whileStatement(node)
+
+	case ast.KindDoStatement:
+		b.doStatement(node)
+
+	case ast.KindForStatement:
+		b.forStatement(node)
+
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		b.forInOfStatement(node)
+
+	case ast.KindSwitchStatement:
+		b.switchStatement(node)
+
+	case ast.KindTryStatement:
+		b.tryStatement(node)
+
+	case ast.KindLabeledStatement:
+		b.labeledStatement(node)
+
+	case ast.KindReturnStatement:
+		b.expr(node.AsReturnStatement().Expression)
+		b.makeReturn()
+
+	case ast.KindThrowStatement:
+		b.expr(node.AsThrowStatement().Expression)
+		b.makeThrow()
+
+	case ast.KindBreakStatement:
+		b.makeBreak(node.AsBreakStatement().Label)
+
+	case ast.KindContinueStatement:
+		b.makeContinue(node.AsContinueStatement().Label)
+
+	case ast.KindWithStatement:
+		with := node.AsWithStatement()
+		b.expr(with.Expression)
+		b.statement(with.Statement)
+
+	case ast.KindEmptyStatement, ast.KindDebuggerStatement,
+		ast.KindImportDeclaration, ast.KindImportEqualsDeclaration,
+		ast.KindFunctionDeclaration:
+		// Nothing executes here in the enclosing code path. A function
+		// declaration's parameters and body are its own code path root.
+
+	case ast.KindClassDeclaration:
+		b.classLike(node)
+
+	case ast.KindExportAssignment:
+		b.expr(node.AsExportAssignment().Expression)
+
+	case ast.KindExportDeclaration:
+		// Export bindings are resolved statically; nothing is evaluated.
+
+	default:
+		node.ForEachChild(func(child *ast.Node) bool {
+			b.visitUnknown(child)
+			return false
+		})
+	}
+}
+
+func (b *builder) variableDeclarationList(list *ast.Node) {
+	if list == nil {
+		return
+	}
+	declList := list.AsVariableDeclarationList()
+	if declList == nil || declList.Declarations == nil {
+		return
+	}
+	for _, decl := range declList.Declarations.Nodes {
+		b.variableDeclaration(decl)
+	}
+}
+
+func (b *builder) variableDeclaration(node *ast.Node) {
+	if node == nil {
+		return
+	}
+	decl := node.AsVariableDeclaration()
+	if decl == nil {
+		return
+	}
+	// A `typeof x` inside the annotation references the variable, so the
+	// annotation is walked even though nothing in it runs.
+	b.expr(decl.Type)
+	if decl.Initializer == nil {
+		// `let x;` writes nothing this rule can report on, but a binding
+		// pattern can still contain evaluated expressions.
+		b.patternReads(decl.Name())
+		return
+	}
+	b.patternReads(decl.Name())
+	b.expr(decl.Initializer)
+	b.patternWrites(decl.Name())
+}
+
+func (b *builder) ifStatement(node *ast.Node) {
+	stmt := node.AsIfStatement()
+	b.expr(stmt.Expression)
+	testEnd := b.cur
+	after := b.newBlock()
+
+	thenEntry := b.newBlock()
+	b.link(testEnd, thenEntry)
+	b.enter(thenEntry)
+	b.statement(stmt.ThenStatement)
+	b.link(b.cur, after)
+
+	if stmt.ElseStatement != nil {
+		elseEntry := b.newBlock()
+		b.link(testEnd, elseEntry)
+		b.enter(elseEntry)
+		b.statement(stmt.ElseStatement)
+		b.link(b.cur, after)
+	} else {
+		b.link(testEnd, after)
+	}
+
+	b.enter(after)
+}
+
+func (b *builder) whileStatement(node *ast.Node) {
+	stmt := node.AsWhileStatement()
+	test := b.newBlock()
+	b.link(b.cur, test)
+	b.enter(test)
+	b.expr(stmt.Expression)
+	testEnd := b.cur
+
+	after := b.newBlock()
+	if !isAlwaysTruthyTest(stmt.Expression) {
+		b.link(testEnd, after)
+	}
+	body := b.newBlock()
+	b.link(testEnd, body)
+
+	b.pushJump(node, after, test)
+	b.enter(body)
+	b.statement(stmt.Statement)
+	b.link(b.cur, test)
+	b.popJump()
+
+	b.enter(after)
+}
+
+func (b *builder) doStatement(node *ast.Node) {
+	stmt := node.AsDoStatement()
+	body := b.newBlock()
+	b.link(b.cur, body)
+	test := b.newBlock()
+	after := b.newBlock()
+
+	b.pushJump(node, after, test)
+	b.enter(body)
+	b.statement(stmt.Statement)
+	b.link(b.cur, test)
+	b.popJump()
+
+	b.enter(test)
+	b.expr(stmt.Expression)
+	if b.cur != nil {
+		b.link(b.cur, body)
+		if !isAlwaysTruthyTest(stmt.Expression) {
+			b.link(b.cur, after)
+		}
+	}
+
+	b.enter(after)
+}
+
+func (b *builder) forStatement(node *ast.Node) {
+	stmt := node.AsForStatement()
+	if stmt.Initializer != nil {
+		if stmt.Initializer.Kind == ast.KindVariableDeclarationList {
+			b.variableDeclarationList(stmt.Initializer)
+		} else {
+			b.expr(stmt.Initializer)
+		}
+	}
+
+	test := b.newBlock()
+	b.link(b.cur, test)
+	b.enter(test)
+	if stmt.Condition != nil {
+		b.expr(stmt.Condition)
+	}
+	testEnd := b.cur
+
+	after := b.newBlock()
+	if stmt.Condition != nil && !isAlwaysTruthyTest(stmt.Condition) {
+		b.link(testEnd, after)
+	}
+	body := b.newBlock()
+	b.link(testEnd, body)
+
+	update := test
+	if stmt.Incrementor != nil {
+		update = b.newBlock()
+	}
+
+	b.pushJump(node, after, update)
+	b.enter(body)
+	b.statement(stmt.Statement)
+	b.link(b.cur, update)
+	b.popJump()
+
+	if stmt.Incrementor != nil {
+		b.enter(update)
+		b.expr(stmt.Incrementor)
+		b.link(b.cur, test)
+	}
+
+	b.enter(after)
+}
+
+func (b *builder) forInOfStatement(node *ast.Node) {
+	stmt := node.AsForInOrOfStatement()
+	b.expr(stmt.Expression)
+
+	head := b.newBlock()
+	b.link(b.cur, head)
+	b.enter(head)
+
+	after := b.newBlock()
+	b.link(head, after)
+	body := b.newBlock()
+	b.link(head, body)
+
+	b.pushJump(node, after, head)
+	b.enter(body)
+	if stmt.Initializer != nil {
+		if stmt.Initializer.Kind == ast.KindVariableDeclarationList {
+			// The loop variable is bound, not assigned: ESLint only tracks
+			// declarators that carry an initializer.
+			declList := stmt.Initializer.AsVariableDeclarationList()
+			if declList != nil && declList.Declarations != nil {
+				for _, decl := range declList.Declarations.Nodes {
+					b.patternReads(decl.Name())
+				}
+			}
+		} else {
+			// `for (x of xs)` / `for ([a] of xs)` — a write reference, but not
+			// an assignment this rule reports on.
+			b.patternReads(stmt.Initializer)
+		}
+	}
+	b.statement(stmt.Statement)
+	b.link(b.cur, head)
+	b.popJump()
+
+	b.enter(after)
+}
+
+func (b *builder) switchStatement(node *ast.Node) {
+	stmt := node.AsSwitchStatement()
+	b.expr(stmt.Expression)
+
+	after := b.newBlock()
+	var clauses []*ast.Node
+	if stmt.CaseBlock != nil {
+		if caseBlock := stmt.CaseBlock.AsCaseBlock(); caseBlock != nil && caseBlock.Clauses != nil {
+			clauses = caseBlock.Clauses.Nodes
+		}
+	}
+	if len(clauses) == 0 {
+		b.link(b.cur, after)
+		b.enter(after)
+		return
+	}
+
+	bodies := make([]*block, len(clauses))
+	for i := range clauses {
+		bodies[i] = b.newBlock()
+	}
+
+	defaultIndex := -1
+	testCur := b.cur
+	for i, clause := range clauses {
+		if clause.Kind == ast.KindDefaultClause {
+			defaultIndex = i
+			continue
+		}
+		if testCur == nil {
+			break
+		}
+		b.cur = testCur
+		b.expr(clause.AsCaseOrDefaultClause().Expression)
+		b.link(b.cur, bodies[i])
+		if b.cur == nil {
+			testCur = nil
+			continue
+		}
+		nextTest := b.newBlock()
+		b.link(b.cur, nextTest)
+		testCur = nextTest
+	}
+	if testCur != nil {
+		if defaultIndex >= 0 {
+			b.link(testCur, bodies[defaultIndex])
+		} else {
+			b.link(testCur, after)
+		}
+	}
+
+	b.pushJump(node, after, nil)
+	var fallthroughFrom *block
+	for i, clause := range clauses {
+		b.link(fallthroughFrom, bodies[i])
+		b.enter(bodies[i])
+		b.statements(clause.AsCaseOrDefaultClause().Statements)
+		fallthroughFrom = b.cur
+	}
+	b.link(fallthroughFrom, after)
+	b.popJump()
+
+	b.enter(after)
+}
+
+func (b *builder) tryStatement(node *ast.Node) {
+	stmt := node.AsTryStatement()
+	hasCatch := stmt.CatchClause != nil
+	hasFinally := stmt.FinallyBlock != nil
+
+	frame := &tryFrame{position: posTry, hasFinally: hasFinally}
+	if hasCatch {
+		frame.catchEntry = b.newBlock()
+	}
+	if hasFinally {
+		frame.finallyEntry = b.newBlock()
+	}
+	b.tryStack = append(b.tryStack, frame)
+
+	b.statement(stmt.TryBlock)
+
+	var normalEnds []*block
+	if hasCatch {
+		if b.cur != nil {
+			// ESLint routes the end of a `try` block into the `catch` block as
+			// well as past the statement.
+			b.link(b.cur, frame.catchEntry)
+			normalEnds = append(normalEnds, b.cur)
+		}
+		frame.position = posCatch
+		frame.thrownForked = false
+		b.enter(frame.catchEntry)
+		catchClause := stmt.CatchClause.AsCatchClause()
+		if catchClause.VariableDeclaration != nil {
+			b.patternReads(catchClause.VariableDeclaration.Name())
+		}
+		b.statement(catchClause.Block)
+		if b.cur != nil {
+			normalEnds = append(normalEnds, b.cur)
+		}
+	} else if b.cur != nil {
+		normalEnds = append(normalEnds, b.cur)
+	}
+
+	b.tryStack = b.tryStack[:len(b.tryStack)-1]
+
+	after := b.newBlock()
+	if !hasFinally {
+		for _, end := range normalEnds {
+			b.link(end, after)
+		}
+		b.enter(after)
+		return
+	}
+
+	snapshot := b.snapshotForks()
+	if len(normalEnds) > 0 {
+		normalEntry := b.newBlock()
+		for _, end := range normalEnds {
+			b.link(end, normalEntry)
+		}
+		b.enter(normalEntry)
+		b.statement(stmt.FinallyBlock)
+		b.link(b.cur, after)
+	}
+
+	if frame.finallyEntry.hasIncoming {
+		// The `finally` block also runs on the path that leaves the statement
+		// abruptly, so it is laid out a second time. Rewinding the enclosing
+		// frames lets that copy fork at the same node the first copy did.
+		b.restoreForks(snapshot)
+		b.enter(frame.finallyEntry)
+		b.statement(stmt.FinallyBlock)
+		if b.cur != nil && frame.thrownAny {
+			if i := b.throwFrame(); i >= 0 {
+				outer := b.tryStack[i]
+				outer.thrownAny = true
+				b.link(b.cur, throwTarget(outer))
+			}
+		}
+	}
+
+	b.enter(after)
+}
+
+func (b *builder) labeledStatement(node *ast.Node) {
+	stmt := node.AsLabeledStatement()
+	if isBreakableStatement(stmt.Statement) {
+		// The label belongs to the loop or switch itself; pushJump reads it
+		// back off the parent chain.
+		b.statement(stmt.Statement)
+		return
+	}
+	after := b.newBlock()
+	b.jumps = append(b.jumps, jumpTarget{label: stmt.Label.Text(), breakTo: after})
+	b.statement(stmt.Statement)
+	b.popJump()
+	b.link(b.cur, after)
+	b.enter(after)
+}
+
+func (b *builder) pushJump(node *ast.Node, breakTo, continueTo *block) {
+	b.jumps = append(b.jumps, jumpTarget{label: labelOf(node), breakTo: breakTo, continueTo: continueTo})
+}
+
+func (b *builder) popJump() {
+	b.jumps = b.jumps[:len(b.jumps)-1]
+}
+
+func (b *builder) makeBreak(label *ast.Node) {
+	if b.cur == nil {
+		return
+	}
+	name := ""
+	if label != nil {
+		name = label.Text()
+	}
+	for i := len(b.jumps) - 1; i >= 0; i-- {
+		target := b.jumps[i]
+		if name == "" || target.label == name {
+			b.link(b.cur, target.breakTo)
+			break
+		}
+	}
+	b.cur = nil
+}
+
+func (b *builder) makeContinue(label *ast.Node) {
+	if b.cur == nil {
+		return
+	}
+	name := ""
+	if label != nil {
+		name = label.Text()
+	}
+	for i := len(b.jumps) - 1; i >= 0; i-- {
+		target := b.jumps[i]
+		if target.continueTo == nil {
+			continue
+		}
+		if name == "" || target.label == name {
+			b.link(b.cur, target.continueTo)
+			break
+		}
+	}
+	b.cur = nil
+}
+
+func (b *builder) makeReturn() {
+	if b.cur == nil {
+		return
+	}
+	if i := b.returnFrame(); i >= 0 {
+		frame := b.tryStack[i]
+		frame.returnedAny = true
+		b.link(b.cur, frame.finallyEntry)
+	}
+	b.cur = nil
+}
+
+func (b *builder) makeThrow() {
+	if b.cur == nil {
+		return
+	}
+	if i := b.throwFrame(); i >= 0 {
+		frame := b.tryStack[i]
+		frame.thrownAny = true
+		b.link(b.cur, throwTarget(frame))
+	}
+	b.cur = nil
+}
+
+// makeYield mirrors ESLint's handling of a suspended generator: the caller may
+// resume it with `.return()` or `.throw()`, so both leaving paths are recorded
+// before the normal continuation resumes in a fresh block.
+func (b *builder) makeYield() {
+	if b.cur == nil {
+		return
+	}
+	if i := b.returnFrame(); i >= 0 {
+		frame := b.tryStack[i]
+		frame.returnedAny = true
+		b.link(b.cur, frame.finallyEntry)
+	}
+	if i := b.throwFrame(); i >= 0 {
+		frame := b.tryStack[i]
+		frame.thrownAny = true
+		b.link(b.cur, throwTarget(frame))
+	}
+	next := b.newBlock()
+	b.link(b.cur, next)
+	b.cur = next
+}
+
+// ---------------------------------------------------------------------------
+// expressions
+// ---------------------------------------------------------------------------
+
+func (b *builder) expr(node *ast.Node) {
+	if node == nil || b.cur == nil {
+		return
+	}
+
+	switch node.Kind {
+	case ast.KindIdentifier:
+		if sym, ok := b.readNodes[node]; ok {
+			b.emitRead(sym)
+		}
+		if isThrowableIdentifier(node) {
+			b.firstThrowableFork()
+		}
+
+	case ast.KindParenthesizedExpression:
+		b.expr(node.AsParenthesizedExpression().Expression)
+
+	case ast.KindBinaryExpression:
+		b.binaryExpression(node)
+
+	case ast.KindConditionalExpression:
+		b.conditionalExpression(node)
+
+	case ast.KindPrefixUnaryExpression:
+		unary := node.AsPrefixUnaryExpression()
+		if unary.Operator == ast.KindPlusPlusToken || unary.Operator == ast.KindMinusMinusToken {
+			b.updateExpression(unary.Operand)
+			return
+		}
+		b.expr(unary.Operand)
+
+	case ast.KindPostfixUnaryExpression:
+		b.updateExpression(node.AsPostfixUnaryExpression().Operand)
+
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression,
+		ast.KindCallExpression, ast.KindNewExpression, ast.KindTaggedTemplateExpression:
+		b.accessOrCall(node)
+
+	case ast.KindYieldExpression:
+		b.expr(node.AsYieldExpression().Expression)
+		b.makeYield()
+
+	case ast.KindClassExpression:
+		b.classLike(node)
+
+	default:
+		if isCodePathRoot(node) {
+			b.nestedFunction(node)
+			return
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			b.visitUnknown(child)
+			return false
+		})
+	}
+}
+
+// visitUnknown routes a child of a node the builder has no dedicated handler
+// for. Statements and expressions are handled by their own walkers so control
+// flow inside them is still modelled.
+func (b *builder) visitUnknown(node *ast.Node) {
+	if node == nil || b.cur == nil {
+		return
+	}
+	if ast.IsStatement(node) {
+		b.statement(node)
+		return
+	}
+	b.expr(node)
+}
+
+func (b *builder) binaryExpression(node *ast.Node) {
+	binary := node.AsBinaryExpression()
+	operator := binary.OperatorToken.Kind
+
+	switch {
+	case operator == ast.KindAmpersandAmpersandToken ||
+		operator == ast.KindBarBarToken ||
+		operator == ast.KindQuestionQuestionToken:
+		b.expr(binary.Left)
+		join := b.newBlock()
+		b.link(b.cur, join)
+		right := b.newBlock()
+		b.link(b.cur, right)
+		b.enter(right)
+		b.expr(binary.Right)
+		b.link(b.cur, join)
+		b.enter(join)
+
+	case ast.IsLogicalOrCoalescingAssignmentOperator(operator):
+		// `a ||= b` reads a, then conditionally evaluates b and writes a.
+		b.patternReads(binary.Left)
+		b.expr(binary.Left)
+		join := b.newBlock()
+		b.link(b.cur, join)
+		right := b.newBlock()
+		b.link(b.cur, right)
+		b.enter(right)
+		b.expr(binary.Right)
+		b.patternWrites(binary.Left)
+		b.link(b.cur, join)
+		b.enter(join)
+
+	case operator == ast.KindEqualsToken:
+		b.patternReads(binary.Left)
+		b.expr(binary.Right)
+		b.patternWrites(binary.Left)
+
+	case ast.IsAssignmentOperator(operator):
+		// Compound assignment reads the target before writing it.
+		b.patternReads(binary.Left)
+		b.expr(binary.Left)
+		b.expr(binary.Right)
+		b.patternWrites(binary.Left)
+
+	default:
+		b.expr(binary.Left)
+		b.expr(binary.Right)
+	}
+}
+
+func (b *builder) conditionalExpression(node *ast.Node) {
+	cond := node.AsConditionalExpression()
+	b.expr(cond.Condition)
+	testEnd := b.cur
+	join := b.newBlock()
+
+	whenTrue := b.newBlock()
+	b.link(testEnd, whenTrue)
+	b.enter(whenTrue)
+	b.expr(cond.WhenTrue)
+	b.link(b.cur, join)
+
+	whenFalse := b.newBlock()
+	b.link(testEnd, whenFalse)
+	b.enter(whenFalse)
+	b.expr(cond.WhenFalse)
+	b.link(b.cur, join)
+
+	b.enter(join)
+}
+
+func (b *builder) updateExpression(operand *ast.Node) {
+	b.patternReads(operand)
+	b.expr(operand)
+	b.patternWrites(operand)
+}
+
+// accessOrCall walks a member access or call and forks around each `?.` link so
+// the rest of the chain can be skipped.
+func (b *builder) accessOrCall(node *ast.Node) {
+	outermost := ast.IsOptionalChain(node) && ast.IsOutermostOptionalChain(node)
+	if outermost {
+		b.chainJoins = append(b.chainJoins, b.newBlock())
+	}
+
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		b.expr(node.AsPropertyAccessExpression().Expression)
+		b.forkOptionalChain(node)
+	case ast.KindElementAccessExpression:
+		access := node.AsElementAccessExpression()
+		b.expr(access.Expression)
+		b.forkOptionalChain(node)
+		b.expr(access.ArgumentExpression)
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		b.expr(call.Expression)
+		b.forkOptionalChain(node)
+		if call.Arguments != nil {
+			for _, arg := range call.Arguments.Nodes {
+				b.expr(arg)
+			}
+		}
+	case ast.KindNewExpression:
+		newExpr := node.AsNewExpression()
+		b.expr(newExpr.Expression)
+		if newExpr.Arguments != nil {
+			for _, arg := range newExpr.Arguments.Nodes {
+				b.expr(arg)
+			}
+		}
+	case ast.KindTaggedTemplateExpression:
+		tagged := node.AsTaggedTemplateExpression()
+		b.expr(tagged.Tag)
+		b.expr(tagged.Template)
+	}
+
+	b.firstThrowableFork()
+
+	if outermost {
+		join := b.chainJoins[len(b.chainJoins)-1]
+		b.chainJoins = b.chainJoins[:len(b.chainJoins)-1]
+		b.link(b.cur, join)
+		b.enter(join)
+	}
+}
+
+func (b *builder) forkOptionalChain(node *ast.Node) {
+	if b.cur == nil || len(b.chainJoins) == 0 || !ast.IsOptionalChainRoot(node) {
+		return
+	}
+	b.link(b.cur, b.chainJoins[len(b.chainJoins)-1])
+	next := b.newBlock()
+	b.link(b.cur, next)
+	b.cur = next
+}
+
+// nestedFunction keeps evaluating the parts of a nested function that belong to
+// the enclosing code path — a computed member name and decorators — while its
+// parameters and body form their own code path root.
+func (b *builder) nestedFunction(node *ast.Node) {
+	b.memberHeader(node)
+}
+
+func (b *builder) classLike(node *ast.Node) {
+	class := node.ClassLikeData()
+	if class == nil {
+		return
+	}
+	b.decorators(node)
+	if class.HeritageClauses != nil {
+		for _, clause := range class.HeritageClauses.Nodes {
+			heritage := clause.AsHeritageClause()
+			if heritage == nil || heritage.Types == nil {
+				continue
+			}
+			for _, typeNode := range heritage.Types.Nodes {
+				b.expr(typeNode)
+			}
+		}
+	}
+	if class.Members != nil {
+		for _, member := range class.Members.Nodes {
+			b.memberHeader(member)
+		}
+	}
+}
+
+// memberHeader evaluates the parts of a class or object member that belong to
+// the enclosing code path: its decorators, its computed key, and its type
+// annotation. The member's parameters and body form their own code path.
+func (b *builder) memberHeader(node *ast.Node) {
+	b.decorators(node)
+	if ast.IsFunctionLikeDeclaration(node) {
+		for _, parameter := range node.Parameters() {
+			b.decorators(parameter)
+		}
+	}
+	name := node.Name()
+	if name != nil && name.Kind == ast.KindComputedPropertyName {
+		b.expr(name.AsComputedPropertyName().Expression)
+	}
+	if node.Kind == ast.KindPropertyDeclaration {
+		b.expr(node.AsPropertyDeclaration().Type)
+	}
+}
+
+func (b *builder) decorators(node *ast.Node) {
+	for _, decorator := range node.Decorators() {
+		b.expr(decorator.AsDecorator().Expression)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// assignment patterns
+// ---------------------------------------------------------------------------
+
+// patternReads emits the reads an assignment target performs before anything is
+// written: the object and computed key of a member target, and the key
+// expressions of a destructuring pattern.
+func (b *builder) patternReads(node *ast.Node) {
+	if node == nil || b.cur == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		// A pure target reads nothing, but ESLint still counts naming the
+		// variable as a point where the enclosing `try` block can throw — so
+		// the handler sees the value the target had before the assignment.
+		if isThrowableIdentifier(node) {
+			b.firstThrowableFork()
+		}
+
+	case ast.KindOmittedExpression:
+		// An array hole writes nothing.
+
+	case ast.KindParenthesizedExpression:
+		b.patternReads(node.AsParenthesizedExpression().Expression)
+
+	case ast.KindNonNullExpression:
+		b.patternReads(node.AsNonNullExpression().Expression)
+
+	case ast.KindAsExpression:
+		b.patternReads(node.AsAsExpression().Expression)
+
+	case ast.KindSatisfiesExpression:
+		b.patternReads(node.AsSatisfiesExpression().Expression)
+
+	case ast.KindTypeAssertionExpression:
+		b.patternReads(node.AsTypeAssertion().Expression)
+
+	case ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
+		pattern := node.AsBindingPattern()
+		if pattern.Elements == nil {
+			return
+		}
+		for _, element := range pattern.Elements.Nodes {
+			binding := element.AsBindingElement()
+			if binding == nil {
+				continue
+			}
+			if binding.PropertyName != nil && binding.PropertyName.Kind == ast.KindComputedPropertyName {
+				b.expr(binding.PropertyName.AsComputedPropertyName().Expression)
+			}
+			b.patternReads(binding.Name())
+		}
+
+	case ast.KindObjectLiteralExpression:
+		for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
+			switch property.Kind {
+			case ast.KindPropertyAssignment:
+				assignment := property.AsPropertyAssignment()
+				if name := assignment.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
+					b.expr(name.AsComputedPropertyName().Expression)
+				}
+				b.patternReads(assignment.Initializer)
+			case ast.KindShorthandPropertyAssignment:
+				// The name is the target; its default is evaluated later.
+			case ast.KindSpreadAssignment:
+				b.patternReads(property.AsSpreadAssignment().Expression)
+			}
+		}
+
+	case ast.KindArrayLiteralExpression:
+		for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
+			b.patternReads(element)
+		}
+
+	case ast.KindSpreadElement:
+		b.patternReads(node.AsSpreadElement().Expression)
+
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary.OperatorToken.Kind == ast.KindEqualsToken {
+			// A default inside a destructuring target; the default expression
+			// is evaluated during patternWrites.
+			b.patternReads(binary.Left)
+			return
+		}
+		b.expr(node)
+
+	default:
+		// A member target such as `obj.x` or `obj[k]` evaluates its receiver.
+		b.expr(node)
+	}
+}
+
+// patternWrites emits the writes an assignment target performs, in source
+// order, forking around each default value the target may skip.
+func (b *builder) patternWrites(node *ast.Node) {
+	if node == nil || b.cur == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		if a, ok := b.assignByIdent[node]; ok {
+			b.emitWrite(a)
+		}
+
+	case ast.KindOmittedExpression:
+
+	case ast.KindParenthesizedExpression:
+		b.patternWrites(node.AsParenthesizedExpression().Expression)
+
+	case ast.KindNonNullExpression:
+		b.patternWrites(node.AsNonNullExpression().Expression)
+
+	case ast.KindAsExpression:
+		b.patternWrites(node.AsAsExpression().Expression)
+
+	case ast.KindSatisfiesExpression:
+		b.patternWrites(node.AsSatisfiesExpression().Expression)
+
+	case ast.KindTypeAssertionExpression:
+		b.patternWrites(node.AsTypeAssertion().Expression)
+
+	case ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
+		pattern := node.AsBindingPattern()
+		if pattern.Elements == nil {
+			return
+		}
+		for _, element := range pattern.Elements.Nodes {
+			binding := element.AsBindingElement()
+			if binding == nil {
+				continue
+			}
+			b.withDefault(binding.Initializer, binding.Name())
+		}
+
+	case ast.KindObjectLiteralExpression:
+		for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
+			switch property.Kind {
+			case ast.KindPropertyAssignment:
+				b.patternWrites(property.AsPropertyAssignment().Initializer)
+			case ast.KindShorthandPropertyAssignment:
+				shorthand := property.AsShorthandPropertyAssignment()
+				b.withDefault(shorthand.ObjectAssignmentInitializer, shorthand.Name())
+			case ast.KindSpreadAssignment:
+				b.patternWrites(property.AsSpreadAssignment().Expression)
+			}
+		}
+
+	case ast.KindArrayLiteralExpression:
+		for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
+			b.patternWrites(element)
+		}
+
+	case ast.KindSpreadElement:
+		b.patternWrites(node.AsSpreadElement().Expression)
+
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary.OperatorToken.Kind == ast.KindEqualsToken {
+			b.withDefault(binary.Right, binary.Left)
+		}
+	}
+}
+
+// withDefault models `target = fallback` inside a destructuring pattern: the
+// fallback is only evaluated when the incoming value is undefined.
+func (b *builder) withDefault(fallback *ast.Node, target *ast.Node) {
+	if fallback == nil {
+		b.patternWrites(target)
+		return
+	}
+	if b.cur == nil {
+		return
+	}
+	join := b.newBlock()
+	bypass := b.newBlock()
+	b.link(b.cur, bypass)
+	withFallback := b.newBlock()
+	b.link(b.cur, withFallback)
+
+	b.enter(withFallback)
+	b.expr(fallback)
+	b.patternWrites(target)
+	b.link(b.cur, join)
+
+	b.enter(bypass)
+	b.patternWrites(target)
+	b.link(b.cur, join)
+
+	b.enter(join)
+}
+
+// ---------------------------------------------------------------------------
+// liveness
+// ---------------------------------------------------------------------------
+
+// deadWrites reports, per assignment, whether every site of that assignment is
+// dead — no read of the variable is reachable before the value is overwritten.
+func deadWrites(blocks []*block, assignments []*assignment) map[*assignment]bool {
+	bySymbol := make(map[*ast.Symbol][]*assignment)
+	for _, a := range assignments {
+		bySymbol[a.sym] = append(bySymbol[a.sym], a)
+	}
+
+	dead := make(map[*assignment]bool, len(assignments))
+	for sym, symAssignments := range bySymbol {
+		computeLiveness(blocks, sym)
+		for _, a := range symAssignments {
+			if len(a.sites) == 0 {
+				continue
+			}
+			isDead := true
+			for _, site := range a.sites {
+				if liveAfter(sym, site) {
+					isDead = false
+					break
+				}
+			}
+			dead[a] = isDead
+		}
+	}
+	return dead
+}
+
+// computeLiveness runs a backward liveness dataflow for one variable.
+func computeLiveness(blocks []*block, sym *ast.Symbol) {
+	for _, blk := range blocks {
+		blk.use = false
+		blk.def = false
+		blk.liveIn = false
+		blk.liveOut = false
+		for _, e := range blk.events {
+			if e.sym != sym {
+				continue
+			}
+			if e.kind == eventRead {
+				if !blk.def {
+					blk.use = true
+				}
+			} else if !blk.use {
+				blk.def = true
+			}
+			if blk.use || blk.def {
+				break
+			}
+		}
+		blk.liveIn = blk.use
+	}
+
+	for changed := true; changed; {
+		changed = false
+		for i := len(blocks) - 1; i >= 0; i-- {
+			blk := blocks[i]
+			liveOut := false
+			for _, successor := range blk.successors {
+				if successor.liveIn {
+					liveOut = true
+					break
+				}
+			}
+			liveIn := blk.use || (!blk.def && liveOut)
+			if liveOut != blk.liveOut || liveIn != blk.liveIn {
+				blk.liveOut = liveOut
+				blk.liveIn = liveIn
+				changed = true
+			}
+		}
+	}
+}
+
+// liveAfter reports whether the value written at site can still be read.
+func liveAfter(sym *ast.Symbol, site writeSite) bool {
+	for _, e := range site.blk.events[site.index+1:] {
+		if e.sym != sym {
+			continue
+		}
+		return e.kind == eventRead
+	}
+	return site.blk.liveOut
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func isBreakableStatement(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindSwitchStatement, ast.KindWhileStatement, ast.KindDoStatement,
+		ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement:
+		return true
+	}
+	return false
+}
+
+func labelOf(node *ast.Node) string {
+	parent := node.Parent
+	if parent == nil || parent.Kind != ast.KindLabeledStatement {
+		return ""
+	}
+	labeled := parent.AsLabeledStatement()
+	if labeled.Statement != node {
+		return ""
+	}
+	return labeled.Label.Text()
+}
+
+// isAlwaysTruthyTest mirrors ESLint's `getBooleanValueIfSimpleConstant`: only a
+// literal test can mark the loop infinite, so the code after it is unreachable.
+func isAlwaysTruthyTest(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindTrueKeyword, ast.KindRegularExpressionLiteral:
+		return true
+	case ast.KindNumericLiteral:
+		return utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text) != "0"
+	case ast.KindBigIntLiteral:
+		text := node.AsBigIntLiteral().Text
+		return text != "0n" && text != "0"
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text != ""
+	}
+	return false
+}
+
+// isThrowableIdentifier reports whether completing this identifier is one of
+// the points ESLint treats as able to throw inside a `try` block. Names that
+// only declare or label something are excluded, as are JSX names, which ESLint
+// sees as a separate node type.
+func isThrowableIdentifier(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	if ast.IsJsxTagName(node) {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindLabeledStatement, ast.KindBreakStatement, ast.KindContinueStatement,
+		ast.KindArrayBindingPattern, ast.KindImportSpecifier, ast.KindExportSpecifier,
+		ast.KindImportClause, ast.KindNamespaceImport, ast.KindNamespaceExport,
+		ast.KindJsxAttribute, ast.KindJsxNamespacedName:
+		return false
+	case ast.KindBindingElement:
+		binding := parent.AsBindingElement()
+		if binding.DotDotDotToken != nil || binding.PropertyName == node {
+			return false
+		}
+		return parent.Parent != nil && parent.Parent.Kind == ast.KindObjectBindingPattern
+	case ast.KindCatchClause:
+		return false
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
+		ast.KindClassDeclaration, ast.KindClassExpression, ast.KindVariableDeclaration,
+		ast.KindPropertyAssignment, ast.KindPropertyDeclaration, ast.KindMethodDeclaration,
+		ast.KindGetAccessor, ast.KindSetAccessor, ast.KindEnumDeclaration,
+		ast.KindModuleDeclaration, ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
+		return parent.Name() != node
+	}
+	return true
+}

--- a/internal/rules/no_useless_assignment/cfg.go
+++ b/internal/rules/no_useless_assignment/cfg.go
@@ -91,10 +91,14 @@ type tryFrame struct {
 
 // jumpTarget is one `break`/`continue` destination. continueTo is nil for
 // targets that only `break` can reach (switch statements, labelled blocks).
+// breakable mirrors ESLint's BreakContext#breakable: it is true for loops and
+// switch statements, and false for a labelled statement that wraps neither, so
+// an unlabelled `break` skips past it to the enclosing loop/switch.
 type jumpTarget struct {
 	label      string
 	breakTo    *block
 	continueTo *block
+	breakable  bool
 }
 
 type builder struct {
@@ -676,7 +680,7 @@ func (b *builder) labeledStatement(node *ast.Node) {
 }
 
 func (b *builder) pushJump(node *ast.Node, breakTo, continueTo *block) {
-	b.jumps = append(b.jumps, jumpTarget{label: labelOf(node), breakTo: breakTo, continueTo: continueTo})
+	b.jumps = append(b.jumps, jumpTarget{label: labelOf(node), breakTo: breakTo, continueTo: continueTo, breakable: true})
 }
 
 func (b *builder) popJump() {
@@ -693,10 +697,15 @@ func (b *builder) makeBreak(label *ast.Node) {
 	}
 	for i := len(b.jumps) - 1; i >= 0; i-- {
 		target := b.jumps[i]
-		if name == "" || target.label == name {
-			b.link(b.cur, target.breakTo)
-			break
+		if name == "" {
+			if !target.breakable {
+				continue
+			}
+		} else if target.label != name {
+			continue
 		}
+		b.link(b.cur, target.breakTo)
+		break
 	}
 	b.cur = nil
 }
@@ -864,7 +873,6 @@ func (b *builder) binaryExpression(node *ast.Node) {
 	case ast.IsLogicalOrCoalescingAssignmentOperator(operator):
 		// `a ||= b` reads a, then conditionally evaluates b and writes a.
 		b.patternReads(binary.Left)
-		b.expr(binary.Left)
 		join := b.newBlock()
 		b.link(b.cur, join)
 		right := b.newBlock()
@@ -883,7 +891,6 @@ func (b *builder) binaryExpression(node *ast.Node) {
 	case ast.IsAssignmentOperator(operator):
 		// Compound assignment reads the target before writing it.
 		b.patternReads(binary.Left)
-		b.expr(binary.Left)
 		b.expr(binary.Right)
 		b.patternWrites(binary.Left)
 
@@ -916,7 +923,6 @@ func (b *builder) conditionalExpression(node *ast.Node) {
 
 func (b *builder) updateExpression(operand *ast.Node) {
 	b.patternReads(operand)
-	b.expr(operand)
 	b.patternWrites(operand)
 }
 
@@ -941,6 +947,7 @@ func (b *builder) accessOrCall(node *ast.Node) {
 		call := node.AsCallExpression()
 		b.expr(call.Expression)
 		b.forkOptionalChain(node)
+		b.typeArguments(node)
 		if call.Arguments != nil {
 			for _, arg := range call.Arguments.Nodes {
 				b.expr(arg)
@@ -949,6 +956,7 @@ func (b *builder) accessOrCall(node *ast.Node) {
 	case ast.KindNewExpression:
 		newExpr := node.AsNewExpression()
 		b.expr(newExpr.Expression)
+		b.typeArguments(node)
 		if newExpr.Arguments != nil {
 			for _, arg := range newExpr.Arguments.Nodes {
 				b.expr(arg)
@@ -957,6 +965,7 @@ func (b *builder) accessOrCall(node *ast.Node) {
 	case ast.KindTaggedTemplateExpression:
 		tagged := node.AsTaggedTemplateExpression()
 		b.expr(tagged.Tag)
+		b.typeArguments(node)
 		b.expr(tagged.Template)
 	}
 
@@ -980,6 +989,28 @@ func (b *builder) forkOptionalChain(node *ast.Node) {
 	b.cur = next
 }
 
+// typeArguments walks an explicit `<T>` argument list, so a `typeof x` inside
+// it still counts as a read even though nothing in it runs.
+func (b *builder) typeArguments(node *ast.Node) {
+	for _, typeArg := range node.TypeArguments() {
+		b.expr(typeArg)
+	}
+}
+
+// typeParameters walks a `<T extends U = D>` declaration list, so a `typeof x`
+// inside a constraint or default still counts as a read even though nothing in
+// it runs.
+func (b *builder) typeParameters(node *ast.Node) {
+	for _, typeParam := range node.TypeParameters() {
+		param := typeParam.AsTypeParameterDeclaration()
+		if param == nil {
+			continue
+		}
+		b.expr(param.Constraint)
+		b.expr(param.DefaultType)
+	}
+}
+
 // nestedFunction keeps evaluating the parts of a nested function that belong to
 // the enclosing code path — a computed member name and decorators — while its
 // parameters and body form their own code path root.
@@ -993,6 +1024,7 @@ func (b *builder) classLike(node *ast.Node) {
 		return
 	}
 	b.decorators(node)
+	b.typeParameters(node)
 	if class.HeritageClauses != nil {
 		for _, clause := range class.HeritageClauses.Nodes {
 			heritage := clause.AsHeritageClause()
@@ -1013,7 +1045,10 @@ func (b *builder) classLike(node *ast.Node) {
 
 // memberHeader evaluates the parts of a class or object member that belong to
 // the enclosing code path: its decorators, its computed key, and its type
-// annotation. The member's parameters and body form their own code path.
+// annotation. A member with a body of its own — a method, accessor, or
+// property initializer — forms its own code path, so its parameters and
+// return type are walked there instead; an index signature has no body, so
+// its parameter and return types are walked here.
 func (b *builder) memberHeader(node *ast.Node) {
 	b.decorators(node)
 	if ast.IsFunctionLikeDeclaration(node) {
@@ -1025,8 +1060,14 @@ func (b *builder) memberHeader(node *ast.Node) {
 	if name != nil && name.Kind == ast.KindComputedPropertyName {
 		b.expr(name.AsComputedPropertyName().Expression)
 	}
-	if node.Kind == ast.KindPropertyDeclaration {
+	switch node.Kind {
+	case ast.KindPropertyDeclaration:
 		b.expr(node.AsPropertyDeclaration().Type)
+	case ast.KindIndexSignature:
+		for _, parameter := range node.Parameters() {
+			b.expr(parameter.Type())
+		}
+		b.expr(node.Type())
 	}
 }
 
@@ -1049,9 +1090,14 @@ func (b *builder) patternReads(node *ast.Node) {
 	}
 	switch node.Kind {
 	case ast.KindIdentifier:
-		// A pure target reads nothing, but ESLint still counts naming the
-		// variable as a point where the enclosing `try` block can throw — so
-		// the handler sees the value the target had before the assignment.
+		// A compound-assignment or update-expression target reads the
+		// variable before writing it; a plain assignment target does not,
+		// but ESLint still counts naming it as a point where the enclosing
+		// `try` block can throw — so the handler sees the value the target
+		// had before the assignment.
+		if sym, ok := b.readNodes[node]; ok {
+			b.emitRead(sym)
+		}
 		if isThrowableIdentifier(node) {
 			b.firstThrowableFork()
 		}

--- a/internal/rules/no_useless_assignment/cfg.go
+++ b/internal/rules/no_useless_assignment/cfg.go
@@ -1,6 +1,8 @@
 package no_useless_assignment
 
 import (
+	"slices"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -93,9 +95,11 @@ type tryFrame struct {
 // targets that only `break` can reach (switch statements, labelled blocks).
 // breakable mirrors ESLint's BreakContext#breakable: it is true for loops and
 // switch statements, and false for a labelled statement that wraps neither, so
-// an unlabelled `break` skips past it to the enclosing loop/switch.
+// an unlabelled `break` skips past it to the enclosing loop/switch. labels
+// holds every label the target answers to — a loop wrapped as
+// `outer: inner: while (…)` accepts both names.
 type jumpTarget struct {
-	label      string
+	labels     []string
 	breakTo    *block
 	continueTo *block
 	breakable  bool
@@ -350,15 +354,22 @@ func (b *builder) variableDeclaration(node *ast.Node) {
 	// A `typeof x` inside the annotation references the variable, so the
 	// annotation is walked even though nothing in it runs.
 	b.expr(decl.Type)
-	if decl.Initializer == nil {
-		// `let x;` writes nothing this rule can report on, but a binding
-		// pattern can still contain evaluated expressions.
-		b.patternReads(decl.Name())
+	name := decl.Name()
+	if name != nil && (name.Kind == ast.KindObjectBindingPattern || name.Kind == ast.KindArrayBindingPattern) {
+		// Run-time evaluation order: the initializer produces the value
+		// first, then the pattern binds element by element.
+		b.expr(decl.Initializer)
+		b.patternBind(name)
 		return
 	}
-	b.patternReads(decl.Name())
+	if decl.Initializer == nil {
+		// `let x;` writes nothing this rule can report on.
+		b.patternReads(name)
+		return
+	}
+	b.patternReads(name)
 	b.expr(decl.Initializer)
-	b.patternWrites(decl.Name())
+	b.patternWrites(name)
 }
 
 func (b *builder) ifStatement(node *ast.Node) {
@@ -498,17 +509,18 @@ func (b *builder) forInOfStatement(node *ast.Node) {
 	if stmt.Initializer != nil {
 		if stmt.Initializer.Kind == ast.KindVariableDeclarationList {
 			// The loop variable is bound, not assigned: ESLint only tracks
-			// declarators that carry an initializer.
+			// declarators that carry an initializer. Computed keys and
+			// destructuring defaults still evaluate every iteration.
 			declList := stmt.Initializer.AsVariableDeclarationList()
 			if declList != nil && declList.Declarations != nil {
 				for _, decl := range declList.Declarations.Nodes {
-					b.patternReads(decl.Name())
+					b.patternBind(decl.Name())
 				}
 			}
 		} else {
 			// `for (x of xs)` / `for ([a] of xs)` — a write reference, but not
 			// an assignment this rule reports on.
-			b.patternReads(stmt.Initializer)
+			b.patternBind(stmt.Initializer)
 		}
 	}
 	b.statement(stmt.Statement)
@@ -612,7 +624,7 @@ func (b *builder) tryStatement(node *ast.Node) {
 		b.enter(frame.catchEntry)
 		catchClause := stmt.CatchClause.AsCatchClause()
 		if catchClause.VariableDeclaration != nil {
-			b.patternReads(catchClause.VariableDeclaration.Name())
+			b.patternBind(catchClause.VariableDeclaration.Name())
 		}
 		b.statement(catchClause.Block)
 		if b.cur != nil {
@@ -684,7 +696,7 @@ func (b *builder) labeledStatement(node *ast.Node) {
 		return
 	}
 	after := b.newBlock()
-	b.jumps = append(b.jumps, jumpTarget{label: stmt.Label.Text(), breakTo: after})
+	b.jumps = append(b.jumps, jumpTarget{labels: []string{stmt.Label.Text()}, breakTo: after})
 	b.statement(stmt.Statement)
 	b.popJump()
 	b.link(b.cur, after)
@@ -692,7 +704,7 @@ func (b *builder) labeledStatement(node *ast.Node) {
 }
 
 func (b *builder) pushJump(node *ast.Node, breakTo, continueTo *block) {
-	b.jumps = append(b.jumps, jumpTarget{label: labelOf(node), breakTo: breakTo, continueTo: continueTo, breakable: true})
+	b.jumps = append(b.jumps, jumpTarget{labels: labelsOf(node), breakTo: breakTo, continueTo: continueTo, breakable: true})
 }
 
 func (b *builder) popJump() {
@@ -713,7 +725,7 @@ func (b *builder) makeBreak(label *ast.Node) {
 			if !target.breakable {
 				continue
 			}
-		} else if target.label != name {
+		} else if !slices.Contains(target.labels, name) {
 			continue
 		}
 		b.link(b.cur, target.breakTo)
@@ -735,7 +747,7 @@ func (b *builder) makeContinue(label *ast.Node) {
 		if target.continueTo == nil {
 			continue
 		}
-		if name == "" || target.label == name {
+		if name == "" || slices.Contains(target.labels, name) {
 			b.link(b.cur, target.continueTo)
 			break
 		}
@@ -896,6 +908,13 @@ func (b *builder) binaryExpression(node *ast.Node) {
 		b.enter(join)
 
 	case operator == ast.KindEqualsToken:
+		if isDestructuringTarget(binary.Left) {
+			// Run-time evaluation order: the right-hand side produces the
+			// value first, then the pattern binds element by element.
+			b.expr(binary.Right)
+			b.patternBind(binary.Left)
+			return
+		}
 		b.patternReads(binary.Left)
 		b.expr(binary.Right)
 		b.patternWrites(binary.Left)
@@ -1093,9 +1112,10 @@ func (b *builder) decorators(node *ast.Node) {
 // assignment patterns
 // ---------------------------------------------------------------------------
 
-// patternReads emits the reads an assignment target performs before anything is
-// written: the object and computed key of a member target, and the key
-// expressions of a destructuring pattern.
+// patternReads emits what an identifier or member assignment target evaluates
+// before the assigned expression: the receiver and computed key of a member
+// target, and the throwable fork ESLint records for naming the target inside a
+// `try` block. Destructuring targets are laid out by patternBind instead.
 func (b *builder) patternReads(node *ast.Node) {
 	if node == nil || b.cur == nil {
 		return
@@ -1114,9 +1134,6 @@ func (b *builder) patternReads(node *ast.Node) {
 			b.firstThrowableFork()
 		}
 
-	case ast.KindOmittedExpression:
-		// An array hole writes nothing.
-
 	case ast.KindParenthesizedExpression:
 		b.patternReads(node.AsParenthesizedExpression().Expression)
 
@@ -1132,64 +1149,14 @@ func (b *builder) patternReads(node *ast.Node) {
 	case ast.KindTypeAssertionExpression:
 		b.patternReads(node.AsTypeAssertion().Expression)
 
-	case ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
-		pattern := node.AsBindingPattern()
-		if pattern.Elements == nil {
-			return
-		}
-		for _, element := range pattern.Elements.Nodes {
-			binding := element.AsBindingElement()
-			if binding == nil {
-				continue
-			}
-			if binding.PropertyName != nil && binding.PropertyName.Kind == ast.KindComputedPropertyName {
-				b.expr(binding.PropertyName.AsComputedPropertyName().Expression)
-			}
-			b.patternReads(binding.Name())
-		}
-
-	case ast.KindObjectLiteralExpression:
-		for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
-			switch property.Kind {
-			case ast.KindPropertyAssignment:
-				assignment := property.AsPropertyAssignment()
-				if name := assignment.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
-					b.expr(name.AsComputedPropertyName().Expression)
-				}
-				b.patternReads(assignment.Initializer)
-			case ast.KindShorthandPropertyAssignment:
-				// The name is the target; its default is evaluated later.
-			case ast.KindSpreadAssignment:
-				b.patternReads(property.AsSpreadAssignment().Expression)
-			}
-		}
-
-	case ast.KindArrayLiteralExpression:
-		for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
-			b.patternReads(element)
-		}
-
-	case ast.KindSpreadElement:
-		b.patternReads(node.AsSpreadElement().Expression)
-
-	case ast.KindBinaryExpression:
-		binary := node.AsBinaryExpression()
-		if binary.OperatorToken.Kind == ast.KindEqualsToken {
-			// A default inside a destructuring target; the default expression
-			// is evaluated during patternWrites.
-			b.patternReads(binary.Left)
-			return
-		}
-		b.expr(node)
-
 	default:
 		// A member target such as `obj.x` or `obj[k]` evaluates its receiver.
 		b.expr(node)
 	}
 }
 
-// patternWrites emits the writes an assignment target performs, in source
-// order, forking around each default value the target may skip.
+// patternWrites emits the write of an identifier assignment target after its
+// assigned expression. Member targets write no variable.
 func (b *builder) patternWrites(node *ast.Node) {
 	if node == nil || b.cur == nil {
 		return
@@ -1199,8 +1166,6 @@ func (b *builder) patternWrites(node *ast.Node) {
 		if a, ok := b.assignByIdent[node]; ok {
 			b.emitWrite(a)
 		}
-
-	case ast.KindOmittedExpression:
 
 	case ast.KindParenthesizedExpression:
 		b.patternWrites(node.AsParenthesizedExpression().Expression)
@@ -1216,6 +1181,46 @@ func (b *builder) patternWrites(node *ast.Node) {
 
 	case ast.KindTypeAssertionExpression:
 		b.patternWrites(node.AsTypeAssertion().Expression)
+	}
+}
+
+// patternBind lays out a destructuring target the way it evaluates at run
+// time, after the assigned expression has produced its value: each element in
+// source order evaluates its computed key, forks around its default, and
+// writes its target.
+func (b *builder) patternBind(node *ast.Node) {
+	if node == nil || b.cur == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		if sym, ok := b.readNodes[node]; ok {
+			b.emitRead(sym)
+		}
+		if isThrowableIdentifier(node) {
+			b.firstThrowableFork()
+		}
+		if a, ok := b.assignByIdent[node]; ok {
+			b.emitWrite(a)
+		}
+
+	case ast.KindOmittedExpression:
+		// An array hole binds nothing.
+
+	case ast.KindParenthesizedExpression:
+		b.patternBind(node.AsParenthesizedExpression().Expression)
+
+	case ast.KindNonNullExpression:
+		b.patternBind(node.AsNonNullExpression().Expression)
+
+	case ast.KindAsExpression:
+		b.patternBind(node.AsAsExpression().Expression)
+
+	case ast.KindSatisfiesExpression:
+		b.patternBind(node.AsSatisfiesExpression().Expression)
+
+	case ast.KindTypeAssertionExpression:
+		b.patternBind(node.AsTypeAssertion().Expression)
 
 	case ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
 		pattern := node.AsBindingPattern()
@@ -1227,64 +1232,76 @@ func (b *builder) patternWrites(node *ast.Node) {
 			if binding == nil {
 				continue
 			}
-			b.withDefault(binding.Initializer, binding.Name())
+			if binding.PropertyName != nil && binding.PropertyName.Kind == ast.KindComputedPropertyName {
+				b.expr(binding.PropertyName.AsComputedPropertyName().Expression)
+			}
+			b.bindWithDefault(binding.Name(), binding.Initializer)
 		}
 
 	case ast.KindObjectLiteralExpression:
 		for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
 			switch property.Kind {
 			case ast.KindPropertyAssignment:
-				b.patternWrites(property.AsPropertyAssignment().Initializer)
+				assignment := property.AsPropertyAssignment()
+				if name := assignment.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
+					b.expr(name.AsComputedPropertyName().Expression)
+				}
+				b.patternBind(assignment.Initializer)
 			case ast.KindShorthandPropertyAssignment:
 				shorthand := property.AsShorthandPropertyAssignment()
-				b.withDefault(shorthand.ObjectAssignmentInitializer, shorthand.Name())
+				b.bindWithDefault(shorthand.Name(), shorthand.ObjectAssignmentInitializer)
 			case ast.KindSpreadAssignment:
-				b.patternWrites(property.AsSpreadAssignment().Expression)
+				b.patternBind(property.AsSpreadAssignment().Expression)
 			}
 		}
 
 	case ast.KindArrayLiteralExpression:
 		for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
-			b.patternWrites(element)
+			b.patternBind(element)
 		}
 
 	case ast.KindSpreadElement:
-		b.patternWrites(node.AsSpreadElement().Expression)
+		b.patternBind(node.AsSpreadElement().Expression)
 
 	case ast.KindBinaryExpression:
 		binary := node.AsBinaryExpression()
 		if binary.OperatorToken.Kind == ast.KindEqualsToken {
-			b.withDefault(binary.Right, binary.Left)
+			b.bindWithDefault(binary.Left, binary.Right)
+			return
 		}
+		b.expr(node)
+
+	default:
+		// A member target such as `obj.x` or `obj[k]` evaluates its receiver.
+		b.expr(node)
 	}
 }
 
-// withDefault models `target = fallback` inside a destructuring pattern: the
-// fallback is only evaluated when the incoming value is undefined.
-func (b *builder) withDefault(fallback *ast.Node, target *ast.Node) {
-	if fallback == nil {
-		b.patternWrites(target)
-		return
+// bindWithDefault lays out one pattern element: a fork around the default
+// value, which only runs when the incoming value is undefined, then the
+// target's own binding.
+func (b *builder) bindWithDefault(target *ast.Node, fallback *ast.Node) {
+	if fallback != nil && b.cur != nil {
+		join := b.newBlock()
+		b.link(b.cur, join)
+		withFallback := b.newBlock()
+		b.link(b.cur, withFallback)
+
+		b.enter(withFallback)
+		b.expr(fallback)
+		b.link(b.cur, join)
+
+		b.enter(join)
 	}
-	if b.cur == nil {
-		return
-	}
-	join := b.newBlock()
-	bypass := b.newBlock()
-	b.link(b.cur, bypass)
-	withFallback := b.newBlock()
-	b.link(b.cur, withFallback)
+	b.patternBind(target)
+}
 
-	b.enter(withFallback)
-	b.expr(fallback)
-	b.patternWrites(target)
-	b.link(b.cur, join)
-
-	b.enter(bypass)
-	b.patternWrites(target)
-	b.link(b.cur, join)
-
-	b.enter(join)
+// isDestructuringTarget reports whether an assignment's left-hand side is an
+// object or array pattern.
+func isDestructuringTarget(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	return node != nil &&
+		(node.Kind == ast.KindObjectLiteralExpression || node.Kind == ast.KindArrayLiteralExpression)
 }
 
 // ---------------------------------------------------------------------------
@@ -1392,16 +1409,23 @@ func isBreakableStatement(node *ast.Node) bool {
 	return false
 }
 
-func labelOf(node *ast.Node) string {
-	parent := node.Parent
-	if parent == nil || parent.Kind != ast.KindLabeledStatement {
-		return ""
+// labelsOf collects every label wrapped directly around a loop or switch, so
+// `outer: inner: while (…)` resolves `continue outer` and `break outer` as
+// well as `inner`. (ESLint's code path analysis attaches only the innermost
+// label and loses the back edge of a `continue` naming an outer one, falsely
+// reporting assignments the next iteration reads; this rule keeps the edge.)
+func labelsOf(node *ast.Node) []string {
+	var labels []string
+	current := node
+	for parent := current.Parent; parent != nil && parent.Kind == ast.KindLabeledStatement; parent = parent.Parent {
+		labeled := parent.AsLabeledStatement()
+		if labeled.Statement != current {
+			break
+		}
+		labels = append(labels, labeled.Label.Text())
+		current = parent
 	}
-	labeled := parent.AsLabeledStatement()
-	if labeled.Statement != node {
-		return ""
-	}
-	return labeled.Label.Text()
+	return labels
 }
 
 // isAlwaysTruthyTest mirrors ESLint's `getBooleanValueIfSimpleConstant`: only a

--- a/internal/rules/no_useless_assignment/cfg.go
+++ b/internal/rules/no_useless_assignment/cfg.go
@@ -651,11 +651,23 @@ func (b *builder) tryStatement(node *ast.Node) {
 		b.restoreForks(snapshot)
 		b.enter(frame.finallyEntry)
 		b.statement(stmt.FinallyBlock)
-		if b.cur != nil && frame.thrownAny {
-			if i := b.throwFrame(); i >= 0 {
-				outer := b.tryStack[i]
-				outer.thrownAny = true
-				b.link(b.cur, throwTarget(outer))
+		if b.cur != nil {
+			// A `return` inside this `try`/`catch` still needs to run every
+			// enclosing `finally` on its way out, not just this one — so this
+			// second copy's own abrupt exit must keep propagating outward.
+			if frame.returnedAny {
+				if i := b.returnFrame(); i >= 0 {
+					outer := b.tryStack[i]
+					outer.returnedAny = true
+					b.link(b.cur, outer.finallyEntry)
+				}
+			}
+			if frame.thrownAny {
+				if i := b.throwFrame(); i >= 0 {
+					outer := b.tryStack[i]
+					outer.thrownAny = true
+					b.link(b.cur, throwTarget(outer))
+				}
 			}
 		}
 	}

--- a/internal/rules/no_useless_assignment/no_useless_assignment.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.go
@@ -126,7 +126,10 @@ func collectAssignments(ctx *rule.RuleContext, sourceFile *ast.SourceFile, emit 
 }
 
 // forEachTargetIdentifier yields every identifier an assignment target writes
-// to, mirroring ESLint's `extractIdentifiersFromPattern`.
+// to, mirroring ESLint's `extractIdentifiersFromPattern`. A target wrapped in
+// a TS assertion — `x as T`, `x!`, `x satisfies T`, `<T>x` — yields nothing:
+// upstream does not treat those wrappers as patterns, so such a write is
+// invisible to the rule.
 func forEachTargetIdentifier(node *ast.Node, cb func(*ast.Node)) {
 	if node == nil {
 		return
@@ -137,14 +140,6 @@ func forEachTargetIdentifier(node *ast.Node, cb func(*ast.Node)) {
 
 	case ast.KindParenthesizedExpression:
 		forEachTargetIdentifier(node.AsParenthesizedExpression().Expression, cb)
-	case ast.KindNonNullExpression:
-		forEachTargetIdentifier(node.AsNonNullExpression().Expression, cb)
-	case ast.KindAsExpression:
-		forEachTargetIdentifier(node.AsAsExpression().Expression, cb)
-	case ast.KindSatisfiesExpression:
-		forEachTargetIdentifier(node.AsSatisfiesExpression().Expression, cb)
-	case ast.KindTypeAssertionExpression:
-		forEachTargetIdentifier(node.AsTypeAssertion().Expression, cb)
 
 	case ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
 		pattern := node.AsBindingPattern()
@@ -317,24 +312,7 @@ func (b *builder) parameter(node *ast.Node) {
 		return
 	}
 	b.expr(parameter.Type)
-	b.patternReads(parameter.Name())
-	if parameter.Initializer != nil {
-		join := b.newBlock()
-		bypass := b.newBlock()
-		b.link(b.cur, bypass)
-		withDefault := b.newBlock()
-		b.link(b.cur, withDefault)
-
-		b.enter(withDefault)
-		b.expr(parameter.Initializer)
-		b.link(b.cur, join)
-
-		b.enter(bypass)
-		b.link(bypass, join)
-
-		b.enter(join)
-	}
-	b.patternWrites(parameter.Name())
+	b.bindWithDefault(parameter.Name(), parameter.Initializer)
 }
 
 // isTrackable reports whether assignments to sym can be proven unused: the
@@ -377,14 +355,21 @@ func isTrackable(
 // variable that merely shares that name is a different binding.
 func isExported(sym *ast.Symbol, exportedNames map[string]bool, root *ast.Node) bool {
 	for _, decl := range sym.Declarations {
+		// `export let x = 1` and `export let { x } = obj` carry the modifier
+		// on the variable statement; climb to it from the declarator or the
+		// binding element.
 		target := decl
-		if decl.Kind == ast.KindVariableDeclaration {
-			// `export let x = 1` carries the modifier on the statement.
-			if list := decl.Parent; list != nil && list.Parent != nil {
-				target = list.Parent
+	climb:
+		for target != nil {
+			switch target.Kind {
+			case ast.KindBindingElement, ast.KindObjectBindingPattern, ast.KindArrayBindingPattern,
+				ast.KindVariableDeclaration, ast.KindVariableDeclarationList:
+				target = target.Parent
+			default:
+				break climb
 			}
 		}
-		if target.Parent != root {
+		if target == nil || target.Parent != root {
 			continue
 		}
 		if ast.HasSyntacticModifier(target, ast.ModifierFlagsExport) {

--- a/internal/rules/no_useless_assignment/no_useless_assignment.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.go
@@ -364,18 +364,18 @@ func isTrackable(
 	if !declaredHere {
 		return false
 	}
-	if isModule && root.Kind == ast.KindSourceFile && isExported(sym, exportedNames) {
+	if isModule && root.Kind == ast.KindSourceFile && isExported(sym, exportedNames, root) {
 		return false
 	}
 	return true
 }
 
 // isExported reports whether a module-level binding leaves the file, in which
-// case a later assignment to it can still be observed elsewhere.
-func isExported(sym *ast.Symbol, exportedNames map[string]bool) bool {
-	if exportedNames[sym.Name] {
-		return true
-	}
+// case a later assignment to it can still be observed elsewhere. Both an
+// `export` modifier and an `export { ... }` re-export only apply to the
+// declaration actually named at the top level of the file — a block-scoped
+// variable that merely shares that name is a different binding.
+func isExported(sym *ast.Symbol, exportedNames map[string]bool, root *ast.Node) bool {
 	for _, decl := range sym.Declarations {
 		target := decl
 		if decl.Kind == ast.KindVariableDeclaration {
@@ -384,7 +384,13 @@ func isExported(sym *ast.Symbol, exportedNames map[string]bool) bool {
 				target = list.Parent
 			}
 		}
+		if target.Parent != root {
+			continue
+		}
 		if ast.HasSyntacticModifier(target, ast.ModifierFlagsExport) {
+			return true
+		}
+		if exportedNames[sym.Name] {
 			return true
 		}
 	}

--- a/internal/rules/no_useless_assignment/no_useless_assignment.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.go
@@ -1,0 +1,535 @@
+package no_useless_assignment
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unnecessaryAssignment",
+		Description: "The value assigned to '" + name + "' is not used in subsequent statements.",
+	}
+}
+
+// https://eslint.org/docs/latest/rules/no-useless-assignment
+var NoUselessAssignmentRule = rule.Rule{
+	Name:   "no-useless-assignment",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		if ctx.Refs == nil {
+			return rule.RuleListeners{}
+		}
+
+		analyzed := false
+		analyze := func(*ast.Node) {
+			if analyzed {
+				return
+			}
+			analyzed = true
+			run(&ctx)
+		}
+
+		return rule.RuleListeners{
+			ast.KindVariableDeclaration:    analyze,
+			ast.KindBinaryExpression:       analyze,
+			ast.KindPrefixUnaryExpression:  analyze,
+			ast.KindPostfixUnaryExpression: analyze,
+		}
+	},
+}
+
+// rawAssignment is one syntactic write found in the file before it is known
+// whether the variable it targets can be tracked.
+type rawAssignment struct {
+	identifier *ast.Node
+	root       *ast.Node
+	sym        *ast.Symbol
+}
+
+func run(ctx *rule.RuleContext) {
+	sourceFile := ctx.SourceFile
+	isModule := ast.IsExternalModule(sourceFile)
+	var exportedNames map[string]bool
+	if isModule {
+		exportedNames = collectLocallyExportedNames(sourceFile)
+	}
+
+	byRoot := make(map[*ast.Node][]rawAssignment)
+	var rootOrder []*ast.Node
+	collectAssignments(ctx, sourceFile, func(raw rawAssignment) {
+		if _, seen := byRoot[raw.root]; !seen {
+			rootOrder = append(rootOrder, raw.root)
+		}
+		byRoot[raw.root] = append(byRoot[raw.root], raw)
+	})
+
+	var reports []*ast.Node
+	for _, root := range rootOrder {
+		reports = append(reports, analyzeRoot(ctx, root, byRoot[root], isModule, exportedNames)...)
+	}
+
+	// ESLint verifies one code path at a time and its reports are ordered by
+	// position afterwards; match that so nested functions don't reorder output.
+	slices.SortFunc(reports, func(a, b *ast.Node) int { return a.Pos() - b.Pos() })
+	for _, identifier := range reports {
+		ctx.ReportNode(identifier, buildMessage(identifier.Text()))
+	}
+}
+
+// collectAssignments walks the file once and reports every variable write the
+// rule considers: a declarator with an initializer, an assignment expression,
+// and an update expression.
+func collectAssignments(ctx *rule.RuleContext, sourceFile *ast.SourceFile, emit func(rawAssignment)) {
+	add := func(target *ast.Node) {
+		forEachTargetIdentifier(target, func(identifier *ast.Node) {
+			root := rootOf(identifier)
+			if root == nil {
+				return
+			}
+			sym := symbolOfTarget(ctx, identifier)
+			if sym == nil {
+				return
+			}
+			emit(rawAssignment{identifier: identifier, root: root, sym: sym})
+		})
+	}
+
+	var visit func(node *ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		switch node.Kind {
+		case ast.KindVariableDeclaration:
+			if decl := node.AsVariableDeclaration(); decl.Initializer != nil {
+				add(decl.Name())
+			}
+		case ast.KindBinaryExpression:
+			binary := node.AsBinaryExpression()
+			if ast.IsAssignmentOperator(binary.OperatorToken.Kind) {
+				add(binary.Left)
+			}
+		case ast.KindPrefixUnaryExpression:
+			unary := node.AsPrefixUnaryExpression()
+			if unary.Operator == ast.KindPlusPlusToken || unary.Operator == ast.KindMinusMinusToken {
+				add(unary.Operand)
+			}
+		case ast.KindPostfixUnaryExpression:
+			add(node.AsPostfixUnaryExpression().Operand)
+		}
+		node.ForEachChild(visit)
+		return false
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+}
+
+// forEachTargetIdentifier yields every identifier an assignment target writes
+// to, mirroring ESLint's `extractIdentifiersFromPattern`.
+func forEachTargetIdentifier(node *ast.Node, cb func(*ast.Node)) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		cb(node)
+
+	case ast.KindParenthesizedExpression:
+		forEachTargetIdentifier(node.AsParenthesizedExpression().Expression, cb)
+	case ast.KindNonNullExpression:
+		forEachTargetIdentifier(node.AsNonNullExpression().Expression, cb)
+	case ast.KindAsExpression:
+		forEachTargetIdentifier(node.AsAsExpression().Expression, cb)
+	case ast.KindSatisfiesExpression:
+		forEachTargetIdentifier(node.AsSatisfiesExpression().Expression, cb)
+	case ast.KindTypeAssertionExpression:
+		forEachTargetIdentifier(node.AsTypeAssertion().Expression, cb)
+
+	case ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
+		pattern := node.AsBindingPattern()
+		if pattern.Elements == nil {
+			return
+		}
+		for _, element := range pattern.Elements.Nodes {
+			if binding := element.AsBindingElement(); binding != nil {
+				forEachTargetIdentifier(binding.Name(), cb)
+			}
+		}
+
+	case ast.KindObjectLiteralExpression:
+		for _, property := range node.AsObjectLiteralExpression().Properties.Nodes {
+			switch property.Kind {
+			case ast.KindPropertyAssignment:
+				forEachTargetIdentifier(property.AsPropertyAssignment().Initializer, cb)
+			case ast.KindShorthandPropertyAssignment:
+				forEachTargetIdentifier(property.AsShorthandPropertyAssignment().Name(), cb)
+			case ast.KindSpreadAssignment:
+				forEachTargetIdentifier(property.AsSpreadAssignment().Expression, cb)
+			}
+		}
+
+	case ast.KindArrayLiteralExpression:
+		for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
+			forEachTargetIdentifier(element, cb)
+		}
+
+	case ast.KindSpreadElement:
+		forEachTargetIdentifier(node.AsSpreadElement().Expression, cb)
+
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary.OperatorToken.Kind == ast.KindEqualsToken {
+			forEachTargetIdentifier(binary.Left, cb)
+		}
+	}
+}
+
+// symbolOfTarget resolves the variable an assignment target names. Declaration
+// names carry their symbol directly; every other target is a reference the
+// binder-backed index can resolve.
+func symbolOfTarget(ctx *rule.RuleContext, identifier *ast.Node) *ast.Symbol {
+	parent := identifier.Parent
+	if parent != nil && parent.Name() == identifier {
+		switch parent.Kind {
+		case ast.KindVariableDeclaration, ast.KindBindingElement:
+			return parent.Symbol()
+		}
+	}
+	return ctx.Refs.Resolve(identifier)
+}
+
+func analyzeRoot(
+	ctx *rule.RuleContext,
+	root *ast.Node,
+	raws []rawAssignment,
+	isModule bool,
+	exportedNames map[string]bool,
+) []*ast.Node {
+	assignByIdent := make(map[*ast.Node]*assignment, len(raws))
+	readNodes := make(map[*ast.Node]*ast.Symbol)
+	trackedState := make(map[*ast.Symbol]bool)
+	var assignments []*assignment
+
+	for _, raw := range raws {
+		tracked, known := trackedState[raw.sym]
+		if !known {
+			tracked = isTrackable(ctx, raw.sym, root, isModule, exportedNames)
+			if tracked {
+				// The variable is only usable when every read of it happens in
+				// this same code path: a read from a nested function may run at
+				// any time, so no assignment to the variable can be proven
+				// unused.
+				reads := readReferences(ctx, raw.sym)
+				if len(reads) == 0 {
+					// An entirely unread variable is `no-unused-vars`' business.
+					tracked = false
+				} else {
+					for _, read := range reads {
+						if rootOf(read) != root {
+							tracked = false
+							break
+						}
+					}
+				}
+				if tracked {
+					for _, read := range reads {
+						readNodes[read] = raw.sym
+					}
+				}
+			}
+			trackedState[raw.sym] = tracked
+		}
+		if !tracked {
+			continue
+		}
+		// An assignment inside a `try` block is never reported — the block may
+		// be abandoned partway through, so the value can still matter — but it
+		// still overwrites the variable for every other assignment's sake.
+		a := &assignment{
+			sym:        raw.sym,
+			identifier: raw.identifier,
+			silent:     inTryBlockOfRoot(raw.identifier, root),
+		}
+		assignByIdent[raw.identifier] = a
+		assignments = append(assignments, a)
+	}
+
+	if len(assignments) == 0 {
+		return nil
+	}
+
+	b := &builder{assignByIdent: assignByIdent, readNodes: readNodes}
+	b.buildRoot(root)
+
+	dead := deadWrites(b.blocks, assignments)
+	var reports []*ast.Node
+	for _, a := range assignments {
+		if !a.silent && dead[a] {
+			reports = append(reports, a.identifier)
+		}
+	}
+	return reports
+}
+
+// buildRoot lays out the control-flow graph of one code path root.
+func (b *builder) buildRoot(root *ast.Node) {
+	b.cur = b.newBlock()
+	b.cur.hasIncoming = true
+
+	switch root.Kind {
+	case ast.KindSourceFile:
+		b.statements(root.AsSourceFile().Statements)
+
+	case ast.KindClassStaticBlockDeclaration:
+		b.statement(root.AsClassStaticBlockDeclaration().Body)
+
+	case ast.KindPropertyDeclaration:
+		b.expr(root.AsPropertyDeclaration().Initializer)
+
+	default:
+		for _, parameter := range root.Parameters() {
+			b.parameter(parameter)
+		}
+		// A `typeof x` inside the signature's type annotations references the
+		// variable even though nothing in them runs.
+		b.expr(root.Type())
+		body := root.Body()
+		if body == nil {
+			return
+		}
+		if body.Kind == ast.KindBlock {
+			b.statement(body)
+		} else {
+			b.expr(body)
+		}
+	}
+}
+
+// parameter models a parameter binding: its default value is skipped when an
+// argument was passed.
+func (b *builder) parameter(node *ast.Node) {
+	if b.cur == nil {
+		return
+	}
+	parameter := node.AsParameterDeclaration()
+	if parameter == nil {
+		return
+	}
+	b.expr(parameter.Type)
+	b.patternReads(parameter.Name())
+	if parameter.Initializer != nil {
+		join := b.newBlock()
+		bypass := b.newBlock()
+		b.link(b.cur, bypass)
+		withDefault := b.newBlock()
+		b.link(b.cur, withDefault)
+
+		b.enter(withDefault)
+		b.expr(parameter.Initializer)
+		b.link(b.cur, join)
+
+		b.enter(bypass)
+		b.link(bypass, join)
+
+		b.enter(join)
+	}
+	b.patternWrites(parameter.Name())
+}
+
+// isTrackable reports whether assignments to sym can be proven unused: the
+// variable must be declared in this very code path and must not be reachable
+// from outside the file through an export.
+func isTrackable(
+	ctx *rule.RuleContext,
+	sym *ast.Symbol,
+	root *ast.Node,
+	isModule bool,
+	exportedNames map[string]bool,
+) bool {
+	if len(sym.Declarations) == 0 {
+		return false
+	}
+	declaredHere := false
+	for _, decl := range sym.Declarations {
+		name := decl.Name()
+		if name == nil {
+			continue
+		}
+		if rootOf(name) == root {
+			declaredHere = true
+			break
+		}
+	}
+	if !declaredHere {
+		return false
+	}
+	if isModule && root.Kind == ast.KindSourceFile && isExported(sym, exportedNames) {
+		return false
+	}
+	return true
+}
+
+// isExported reports whether a module-level binding leaves the file, in which
+// case a later assignment to it can still be observed elsewhere.
+func isExported(sym *ast.Symbol, exportedNames map[string]bool) bool {
+	if exportedNames[sym.Name] {
+		return true
+	}
+	for _, decl := range sym.Declarations {
+		target := decl
+		if decl.Kind == ast.KindVariableDeclaration {
+			// `export let x = 1` carries the modifier on the statement.
+			if list := decl.Parent; list != nil && list.Parent != nil {
+				target = list.Parent
+			}
+		}
+		if ast.HasSyntacticModifier(target, ast.ModifierFlagsExport) {
+			return true
+		}
+	}
+	return false
+}
+
+// collectLocallyExportedNames gathers the local names of `export { ... }`
+// declarations, which re-export a binding without a modifier on it.
+func collectLocallyExportedNames(sourceFile *ast.SourceFile) map[string]bool {
+	var names map[string]bool
+	for _, statement := range sourceFile.Statements.Nodes {
+		if statement.Kind != ast.KindExportDeclaration {
+			continue
+		}
+		export := statement.AsExportDeclaration()
+		if export.ModuleSpecifier != nil || export.ExportClause == nil ||
+			export.ExportClause.Kind != ast.KindNamedExports {
+			continue
+		}
+		for _, element := range export.ExportClause.AsNamedExports().Elements.Nodes {
+			specifier := element.AsExportSpecifier()
+			local := specifier.PropertyName
+			if local == nil {
+				local = specifier.Name()
+			}
+			if local == nil || local.Kind != ast.KindIdentifier {
+				continue
+			}
+			if names == nil {
+				names = make(map[string]bool)
+			}
+			names[local.Text()] = true
+		}
+	}
+	return names
+}
+
+// readReferences returns the identifiers that read sym. A compound assignment
+// or an update expression reads its target before writing it, so those count
+// as reads too.
+func readReferences(ctx *rule.RuleContext, sym *ast.Symbol) []*ast.Node {
+	var reads []*ast.Node
+	for _, ref := range ctx.Refs.References(sym) {
+		if !utils.IsWriteReference(ref) || isReadWriteReference(ref) {
+			reads = append(reads, ref)
+		}
+	}
+	return reads
+}
+
+func isReadWriteReference(node *ast.Node) bool {
+	current := node
+	parent := node.Parent
+	for parent != nil {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression, ast.KindNonNullExpression,
+			ast.KindAsExpression, ast.KindTypeAssertionExpression, ast.KindSatisfiesExpression:
+			current = parent
+			parent = parent.Parent
+			continue
+		}
+		break
+	}
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindBinaryExpression:
+		binary := parent.AsBinaryExpression()
+		return binary.Left == current &&
+			binary.OperatorToken.Kind != ast.KindEqualsToken &&
+			ast.IsAssignmentOperator(binary.OperatorToken.Kind)
+	case ast.KindPrefixUnaryExpression:
+		unary := parent.AsPrefixUnaryExpression()
+		return unary.Operand == current &&
+			(unary.Operator == ast.KindPlusPlusToken || unary.Operator == ast.KindMinusMinusToken)
+	case ast.KindPostfixUnaryExpression:
+		return parent.AsPostfixUnaryExpression().Operand == current
+	}
+	return false
+}
+
+// inTryBlockOfRoot reports whether node sits in the `try` block of a statement
+// belonging to the same code path.
+func inTryBlockOfRoot(node *ast.Node, root *ast.Node) bool {
+	previous := node
+	for current := node.Parent; current != nil && current != root; current = current.Parent {
+		if current.Kind == ast.KindTryStatement && current.AsTryStatement().TryBlock == previous {
+			return true
+		}
+		previous = current
+	}
+	return false
+}
+
+// isCodePathRoot reports whether node owns a control-flow graph of its own.
+func isCodePathRoot(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindSourceFile,
+		ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
+		ast.KindMethodDeclaration, ast.KindConstructor,
+		ast.KindGetAccessor, ast.KindSetAccessor,
+		ast.KindClassStaticBlockDeclaration:
+		return true
+	case ast.KindPropertyDeclaration:
+		return node.AsPropertyDeclaration().Initializer != nil
+	}
+	return false
+}
+
+// rootOf returns the code path root node executes in.
+func rootOf(node *ast.Node) *ast.Node {
+	previous := node
+	var decorator *ast.Node
+	for current := node.Parent; current != nil; current = current.Parent {
+		if current.Kind == ast.KindDecorator {
+			decorator = current
+		}
+		if current.Kind == ast.KindSourceFile {
+			return current
+		}
+		if isCodePathRoot(current) && runsInsideRoot(current, previous, decorator) {
+			return current
+		}
+		previous = current
+	}
+	return nil
+}
+
+// runsInsideRoot reports whether a direct child of a code path root runs in
+// that root rather than in the surrounding one. A member's name runs where the
+// member is declared, and so do the decorators on the member and on each of its
+// parameters.
+func runsInsideRoot(root *ast.Node, child *ast.Node, decorator *ast.Node) bool {
+	switch root.Kind {
+	case ast.KindPropertyDeclaration:
+		return root.AsPropertyDeclaration().Initializer == child
+	case ast.KindClassStaticBlockDeclaration:
+		return root.AsClassStaticBlockDeclaration().Body == child
+	}
+	if root.Name() == child {
+		return false
+	}
+	if decorator != nil && (decorator.Parent == root || decorator.Parent == child) {
+		return false
+	}
+	return true
+}

--- a/internal/rules/no_useless_assignment/no_useless_assignment.md
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.md
@@ -77,9 +77,11 @@ function fn() {
 - For deeply nested `try`/`catch`/`switch` combinations, this rule's control
   flow modeling can occasionally diverge from ESLint's own, which has open,
   accepted-but-unfixed bugs in the same area
-  ([eslint/eslint#17579](https://github.com/eslint/eslint/issues/17579)).
-  These shapes are rare in practice; in the large majority of real code this
-  rule reports the same findings as ESLint.
+  ([eslint/eslint#17579](https://github.com/eslint/eslint/issues/17579)) and
+  its own false negatives on some such shapes. Matching it exactly there is
+  hard to pin down, so it is left as a known gap. These shapes are rare in
+  practice; in the large majority of real code this rule reports the same
+  findings as ESLint.
 
 ## Original Documentation
 

--- a/internal/rules/no_useless_assignment/no_useless_assignment.md
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.md
@@ -69,6 +69,20 @@ function fn() {
 
 ## Differences from ESLint
 
+- The `/* exported foo */` directive comment is not supported. In a script
+  file, ESLint treats a variable named by it as observable from outside and
+  reports no assignments to it; this rule still analyzes the variable.
+- Destructuring follows the run-time evaluation order: the initializer or
+  right-hand side produces its value first, then each element evaluates its
+  computed key and default. So `let { a = x } = (x = 1, obj)` is clean here —
+  the default may read `x = 1` — while ESLint reports it based on source
+  positions; and in `({ [a = 1]: x } = (a = 2, obj)); console.log(a)` this
+  rule reports the genuinely dead `a = 2` where ESLint reports the `a = 1`
+  the log actually observes.
+- Every label wrapped around a loop resolves its `break`/`continue`:
+  `outer: inner: while (cond) { … continue outer; }` keeps its back edge, so
+  values the next iteration reads are counted as used. ESLint attaches only
+  the innermost label and falsely reports such assignments.
 - A variable read from inside a parameter decorator's arguments is treated as
   used, so assignments to it are never reported:
   `const pipe = {}; class C { handler(@Body(pipe) body) {} }`. ESLint reports

--- a/internal/rules/no_useless_assignment/no_useless_assignment.md
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.md
@@ -72,29 +72,14 @@ function fn() {
 - A variable read from inside a parameter decorator's arguments is treated as
   used, so assignments to it are never reported:
   `const pipe = {}; class C { handler(@Body(pipe) body) {} }`. ESLint reports
-  `const pipe = {}` here — a false positive tracked at
-  [eslint/eslint#20947](https://github.com/eslint/eslint/issues/20947). Its
-  root cause turned out to be that `@typescript-eslint`'s scope manager does
-  not register reads inside legacy parameter decorators as a reference at
-  all, tracked separately at
-  [typescript-eslint/typescript-eslint#12407](https://github.com/typescript-eslint/typescript-eslint/issues/12407);
-  this rule's own reference tracking is not affected by that gap.
-- This rule models exceptions and control flow with its own approximation
-  rather than a literal port of ESLint's code-path analysis, so its findings
-  can diverge from ESLint's for deeply nested `try`/`catch`/`finally`
-  combinations — for instance a `switch` nested directly inside a `catch`
-  clause:
-  `function f() { let v = 0; try {} catch (e) { v = 1; switch (k) { case 1: use(v); v = 2; } } }`.
-  ESLint reports only `v = 2` there; this rule also reports the initial
-  `let v = 0`, which is unused on every path just as `v = 2` is. Other
-  diverging shapes involve a `try` without its own `catch` nested inside
-  another `try`. These shapes are uncommon in real-world code, and in the
-  large majority of cases this rule reports the same findings as ESLint.
-  ESLint's own code-path analysis has open, accepted-but-unfixed bugs in this
-  exact area — see
-  [eslint/eslint#17579](https://github.com/eslint/eslint/issues/17579), left
-  open specifically because fixing it would be a breaking change — so
-  matching it exactly for every nested shape isn't a well-defined target.
+  `const pipe = {}` here — a known false positive
+  ([eslint/eslint#20947](https://github.com/eslint/eslint/issues/20947)).
+- For deeply nested `try`/`catch`/`switch` combinations, this rule's control
+  flow modeling can occasionally diverge from ESLint's own, which has open,
+  accepted-but-unfixed bugs in the same area
+  ([eslint/eslint#17579](https://github.com/eslint/eslint/issues/17579)).
+  These shapes are rare in practice; in the large majority of real code this
+  rule reports the same findings as ESLint.
 
 ## Original Documentation
 

--- a/internal/rules/no_useless_assignment/no_useless_assignment.md
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.md
@@ -73,6 +73,13 @@ function fn() {
   used, so assignments to it are never reported:
   `const pipe = {}; class C { handler(@Body(pipe) body) {} }`. ESLint reports
   `const pipe = {}` here.
+- This rule models exceptions and control flow with its own approximation
+  rather than a literal port of ESLint's code-path analysis, so its findings
+  can diverge from ESLint's for deeply nested `try`/`catch`/`finally`
+  combinations — for instance a `switch` nested directly inside a `catch`
+  clause, or a `try` without its own `catch` nested inside another `try`.
+  These shapes are uncommon in real-world code, and in the large majority of
+  cases this rule reports the same findings as ESLint.
 
 ## Original Documentation
 

--- a/internal/rules/no_useless_assignment/no_useless_assignment.md
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.md
@@ -1,0 +1,79 @@
+# no-useless-assignment
+
+## Rule Details
+
+Disallows assignments whose value is never read. A variable that is written and
+then overwritten — or written on a path that ends without reading it again —
+carries a value nothing observes, which usually means a mistake: a typo in the
+variable name, a missing `return`, or leftover code from a refactor.
+
+The rule only looks at variables it can follow end to end. It stays silent when
+the variable is never read at all (that is `no-unused-vars`' job), when it is
+read from another function, when it is exported, and when the assignment sits
+inside a `try` block, where the block may be abandoned before the value is used.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function fn() {
+	let v = 'used';
+	console.log(v);
+	v = 'unused';
+}
+
+function fn() {
+	let v = 'unused';
+	if (condition) {
+		v = 'used';
+		console.log(v);
+		return;
+	}
+}
+
+function fn() {
+	let v = 'used';
+	console.log(v);
+	v = 'unused';
+	v = 'used';
+	console.log(v);
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function fn() {
+	let v = 'used';
+	console.log(v);
+	v = 'used-2';
+	console.log(v);
+}
+
+function fn() {
+	let v = 'used';
+	if (condition) {
+		v = 'used-2';
+		console.log(v);
+		return;
+	}
+	console.log(v);
+}
+
+function fn() {
+	let v = 'used';
+	console.log(v);
+	setTimeout(() => console.log(v), 1);
+	v = 'used in another scope';
+}
+```
+
+## Differences from ESLint
+
+- A variable read from inside a parameter decorator's arguments is treated as
+  used, so assignments to it are never reported:
+  `const pipe = {}; class C { handler(@Body(pipe) body) {} }`. ESLint reports
+  `const pipe = {}` here.
+
+## Original Documentation
+
+- [ESLint no-useless-assignment](https://eslint.org/docs/latest/rules/no-useless-assignment)

--- a/internal/rules/no_useless_assignment/no_useless_assignment.md
+++ b/internal/rules/no_useless_assignment/no_useless_assignment.md
@@ -72,14 +72,29 @@ function fn() {
 - A variable read from inside a parameter decorator's arguments is treated as
   used, so assignments to it are never reported:
   `const pipe = {}; class C { handler(@Body(pipe) body) {} }`. ESLint reports
-  `const pipe = {}` here.
+  `const pipe = {}` here — a false positive tracked at
+  [eslint/eslint#20947](https://github.com/eslint/eslint/issues/20947). Its
+  root cause turned out to be that `@typescript-eslint`'s scope manager does
+  not register reads inside legacy parameter decorators as a reference at
+  all, tracked separately at
+  [typescript-eslint/typescript-eslint#12407](https://github.com/typescript-eslint/typescript-eslint/issues/12407);
+  this rule's own reference tracking is not affected by that gap.
 - This rule models exceptions and control flow with its own approximation
   rather than a literal port of ESLint's code-path analysis, so its findings
   can diverge from ESLint's for deeply nested `try`/`catch`/`finally`
   combinations — for instance a `switch` nested directly inside a `catch`
-  clause, or a `try` without its own `catch` nested inside another `try`.
-  These shapes are uncommon in real-world code, and in the large majority of
-  cases this rule reports the same findings as ESLint.
+  clause:
+  `function f() { let v = 0; try {} catch (e) { v = 1; switch (k) { case 1: use(v); v = 2; } } }`.
+  ESLint reports only `v = 2` there; this rule also reports the initial
+  `let v = 0`, which is unused on every path just as `v = 2` is. Other
+  diverging shapes involve a `try` without its own `catch` nested inside
+  another `try`. These shapes are uncommon in real-world code, and in the
+  large majority of cases this rule reports the same findings as ESLint.
+  ESLint's own code-path analysis has open, accepted-but-unfixed bugs in this
+  exact area — see
+  [eslint/eslint#17579](https://github.com/eslint/eslint/issues/17579), left
+  open specifically because fixing it would be a breaking change — so
+  matching it exactly for every nested shape isn't a well-defined target.
 
 ## Original Documentation
 

--- a/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
@@ -100,6 +100,24 @@ export { foo as bar };`},
 			{Code: `declare function Body(p: unknown): any;
 const pipe = {};
 class C { handler(@Body(pipe) _b: unknown) {} }`},
+
+			// ---- Dimension 4: an unlabelled `break` inside a labelled non-loop
+			// block skips it and exits the enclosing loop instead ----
+			{Code: `function f() {
+  let v = 'used';
+  while (true) { lbl: { break; } v = 'x'; }
+  console.log(v);
+}`},
+
+			// ---- Dimension 4: `typeof` inside a call's type arguments reads the
+			// variable ----
+			{Code: `function f() { let v = 1; g(v); v = 2; h<typeof v>(); }`},
+			// ---- Dimension 4: `typeof` inside a class type parameter's
+			// constraint reads the variable ----
+			{Code: `let v = 1; g(v); v = 2; class C<T extends typeof v> {}`},
+			// ---- Dimension 4: `typeof` inside a class index signature's return
+			// type reads the variable ----
+			{Code: `let v = 1; g(v); v = 2; class C { [k: string]: typeof v; }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: parenthesized assignment target ----
@@ -369,6 +387,26 @@ function f(a: any): void { let v = 1; g(v); v = 2; }`,
 						Message:   "The value assigned to 'v' is not used in subsequent statements.",
 						Line:      1, Column: 33, EndLine: 1, EndColumn: 34,
 					},
+				},
+			},
+
+			// ---- Dimension 4: an update expression inside a member target's
+			// computed key is only read and written once ----
+			{
+				Code: `function f() { let i = 0; console.log(i); obj[i++] += 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 47, EndLine: 1, EndColumn: 48},
+				},
+			},
+
+			// ---- Dimension 4: `export { ... }` only silences the module-level
+			// binding it names, not a block-scoped shadow of the same name ----
+			{
+				Code: `let a = 1;
+export { a };
+{ let a = 2; a = 3; console.log(a); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 7, EndLine: 3, EndColumn: 8},
 				},
 			},
 		},

--- a/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
@@ -129,6 +129,53 @@ class C { handler(@Body(pipe) _b: unknown) {} }`},
     v = arr;
   } finally { console.log(v); }
 }`},
+
+			// ---- A TS assertion wrapper around an assignment target is not a
+			// pattern: the write is invisible to the rule, so it neither
+			// reports nor overwrites anything ----
+			{Code: `function f(g) { let x = 1; g(x); (x as any) = 2; }`},
+			{Code: `function f(g) { let x = 1; g(x); x! = 2; }`},
+			{Code: `function f(g) { let x = 1; g(x); (x satisfies any) = 2; }`},
+			{Code: `function f(g) { let x = 1; g(x); (<any>x) = 2; }`},
+			{Code: `function f(g, o) { let x = 1; g(x); ({ a: x as any } = o); }`},
+			{Code: `function f(g) { let x = 1; g(x); x = 2; (x as any) = 3; g(x); }`},
+
+			// ---- A computed key or default later in the pattern reads the
+			// value an earlier element just wrote ----
+			{Code: `function f(obj) { let { a: x, [x]: y } = obj; console.log(y); }`},
+			{Code: `function f(obj) { let x, y; ({ a: x, [x]: y } = obj); console.log(y); }`},
+			{Code: `function f(obj) { let { a, b = a } = obj; console.log(b); }`},
+
+			// ---- The initializer runs before the pattern binds, so a
+			// computed key or default can read a value the initializer wrote.
+			// (ESLint's position-based model reports both initializer writes;
+			// this rule follows the run-time order instead.) ----
+			{Code: `function f(obj) { let x = 0; console.log(x); let { a = x } = (x = 1, obj); console.log(a); }`},
+			{Code: `function f(obj) { let a = 0; console.log(a); let { [a]: q } = (a = 1, obj); console.log(q); }`},
+
+			// ---- Destructuring defaults in loop heads and catch bindings are
+			// read on every pass ----
+			{Code: `function f(xs) { let y = 1; console.log(y); y = 2; for (let [x = y] of xs) console.log(x); }`},
+			{Code: `function f(xs) { let y = 1; console.log(y); y = 2; for (let [x = y] in xs) console.log(x); }`},
+			{Code: `function f() { let y = 1; console.log(y); y = 2; try { throw {}; } catch ({ x = y }) { console.log(x); } }`},
+
+			// ---- A destructured top-level binding leaves the file like a
+			// plain one, whether by modifier or by `export { ... }` ----
+			{Code: `export let { a } = obj; console.log(a); a = 2; var obj;`},
+			{Code: `let { a } = obj; export { a }; console.log(a); a = 2; var obj;`},
+			{Code: `let { a } = obj; export { a as b }; console.log(a); a = 2; var obj;`},
+			{Code: `export let [c, d] = arr; console.log(c, d); c = 1; var arr;`},
+
+			// ---- Every label wrapped around a loop resolves its
+			// break/continue, so the next iteration's reads stay reachable.
+			// (ESLint attaches only the innermost label and falsely reports
+			// the `continue outer` cases; this rule keeps the back edge.) ----
+			{Code: `function f(c, v) { outer: inner: while (c()) { console.log(v); v = 1; continue inner; } }`},
+			{Code: `function f(c, v) { outer: inner: while (c()) { console.log(v); v = 1; continue outer; } }`},
+			{Code: `function f(c, v) { outer: inner: while (c()) { v = 1; continue outer; } console.log(v); }`},
+			{Code: `function f(c, v) { a: b: c2: while (c()) { console.log(v); v = 1; continue b; } }`},
+			{Code: `function f(c, v) { outer: inner: while (c()) { v = 1; break outer; } console.log(v); }`},
+			{Code: `function f(v) { outer: inner: { v = 1; break outer; } console.log(v); }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: parenthesized assignment target ----
@@ -419,6 +466,105 @@ export { a };
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unnecessaryAssignment", Line: 3, Column: 7, EndLine: 3, EndColumn: 8},
 				},
+			},
+			{
+				Code: `let { a } = obj;
+export { a };
+{ let a = 2; a = 3; console.log(a); }
+var obj;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 7, EndLine: 3, EndColumn: 8},
+				},
+			},
+
+			// ---- A TS-assertion-wrapped write is invisible: it does not count
+			// as a read of the overwritten store either ----
+			{
+				Code: `function f(g) { let x = 1; g(x); x = 2; (x as any) = 3; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 34, EndLine: 1, EndColumn: 35},
+				},
+			},
+
+			// ---- The right-hand side runs before the pattern binds, so a
+			// store the pattern immediately overwrites is dead. (ESLint's
+			// position-based model reports `a = 1` — which the final read
+			// actually observes — and misses `a = 2`; this rule follows the
+			// run-time order.) ----
+			{
+				Code: `function f(obj) { let a = 0, x; console.log(a); ({ [a = 1]: x } = (a = 2, obj)); console.log(a, x); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 68, EndLine: 1, EndColumn: 69},
+				},
+			},
+			// ---- A read inside the assignment's own right-hand side sees the
+			// value from before the write, so it cannot keep the write alive ----
+			{
+				Code: `function f(fn) { let x = 1; console.log(x); ({ a: x } = fn(x)); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 51, EndLine: 1, EndColumn: 52},
+				},
+			},
+
+			// ---- Known divergences on deeply nested try/catch/finally
+			// exception paths (found by differential fuzzing; the expectations
+			// below are ESLint 10.8 output). rslint routes the throw a
+			// destructuring or assignment target can raise before its write
+			// into the enclosing `finally`, and treats a store every reachable
+			// read path overwrites as dead — ESLint's segment approximation
+			// disagrees on the three shapes below. See "Differences from
+			// ESLint" in the rule docs. ----
+
+			// SKIP: rslint also reports `let v = 0` at 2:7 — every path to the
+			// `g(v)` read first runs the finally's `({ v } = o)` write, so the
+			// initial store is never read; ESLint misses it.
+			{
+				Code: `function f() {
+  let v = 0;
+  try { if (c) { for (;;) { h(); break; } } } catch (e) { while (c) { try { h(); } catch (e) { h(); } finally { ({ v } = o); } switch (k) { case 1: g(v); v = 3; break;  } } }
+  throw new Error();
+  do { try { v = 1; } finally { try { v++; } finally { g(v); } } } while (c);
+  try { v = 2; } finally { if (c) { try { v += 1; } catch (e) { v += 1; } finally { g(v); v = 3; } } else { ({ v } = o); } }
+  g(v);
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 155, EndLine: 3, EndColumn: 156},
+				},
+				Skip: true,
+			},
+			// SKIP: rslint reports nothing — `[v] = arr` can throw before
+			// writing `v`, so the preceding `v = 3` can still reach the
+			// enclosing finally's `g(v)` read.
+			{
+				Code: `function* f() {
+  let v = 0;
+  try { for (let i = 0; i < 3; i++) { yield 1; } } catch (e) { if (c) { try { [v] = arr; } finally { g(v); v = 3; } lbl: { [v] = arr; break lbl; } } else { throw new Error(); v += 1; } } finally { switch (k) { case 1: try { g(v); [v] = arr; } finally { g(v); v = 3; } break; default: switch (k) { case 1: ({ v } = o); break; default: h(); } } }
+  if (c) { for (;;) { do { v++; } while (c); continue; } }
+  g(v);
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 108, EndLine: 3, EndColumn: 109},
+				},
+				Skip: true,
+			},
+			// SKIP: rslint reports all but the `v += 1` at 3:223 — the `v = 1`
+			// that overwrites it can throw first, letting the value reach the
+			// outer finally's `v += 1` read.
+			{
+				Code: `function* f() {
+  let v = 0;
+  try { if (c) { if (c) { v++; c && (v = 4); } else { h(); } try { g(v); v = 1; } catch (e) { h(); } } } catch (e) { if (c) { for (let i = 0; i < 3; i++) { v++; ({ v } = o); } } else { try { c && (v = 4); h(); } finally { v += 1; } v = 1; } } finally { lbl: { v += 1;  } }
+  [v] = arr;
+  try { if (c) { for (;;) { g(v); v = 3; continue; } } else { try { g(v); v = 3; } finally { v = 2; } } } finally { for (let i = 0; i < 3; i++) { switch (k) { case 1: v = c ? 5 : 6; break;  } c && (v = 4); } }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 157, EndLine: 3, EndColumn: 158},
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 223, EndLine: 3, EndColumn: 224},
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 261, EndLine: 3, EndColumn: 262},
+					{MessageId: "unnecessaryAssignment", Line: 5, Column: 168, EndLine: 5, EndColumn: 169},
+					{MessageId: "unnecessaryAssignment", Line: 5, Column: 199, EndLine: 5, EndColumn: 200},
+				},
+				Skip: true,
 			},
 		},
 	)

--- a/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
@@ -118,6 +118,17 @@ class C { handler(@Body(pipe) _b: unknown) {} }`},
 			// ---- Dimension 4: `typeof` inside a class index signature's return
 			// type reads the variable ----
 			{Code: `let v = 1; g(v); v = 2; class C { [k: string]: typeof v; }`},
+
+			// ---- Dimension 4: a `return` inside a `try` block that lacks its
+			// own `catch` must still run every enclosing `finally` on its way
+			// out, not just the nearest one ----
+			{Code: `function f(){
+  let v = 1;
+  try { fails(); } catch (e) {
+    try { return; } finally { v = 2; }
+    v = arr;
+  } finally { console.log(v); }
+}`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Dimension 4: parenthesized assignment target ----

--- a/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment_extras_test.go
@@ -1,0 +1,376 @@
+package no_useless_assignment
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUselessAssignmentExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in. The upstream 1:1 migration lives in
+// no_useless_assignment_upstream_test.go.
+//
+// N/A: Dimension 3 (autofix boundaries) — the rule reports only, so there is no
+// fix or suggestion and therefore no TestNoUselessAssignmentEditDemand either.
+func TestNoUselessAssignmentExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessAssignmentRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: parenthesized read of the assigned value ----
+			{Code: `function f() { let v = 1; g((v)); v = 2; g(v); }`},
+			{Code: `function f() { let v = 1; g(((v))); v = 2; g(v); }`},
+
+			// ---- Dimension 4: TS type-expression wrappers around a read ----
+			{Code: `function f() { let v = 1; g(v as unknown); v = 2; g(v); }`},
+			{Code: `function f() { let v: number | null = 1; g(v!); v = 2; g(v); }`},
+			// ---- Real-user: eslint/eslint#19002 (`satisfies` hides the read) ----
+			{Code: `const foo = 'foo';
+if (true) {}
+([foo] satisfies Array<string>).forEach(str => { console.log(str); });`},
+
+			// ---- Dimension 4: optional chain skips the assignment ----
+			{Code: `function f() { let v = 1; a?.m(v = 2); g(v); }`},
+			{Code: `function f() { let v = 1; a?.b[v = 2]; g(v); }`},
+			{Code: `function f() { let v = 1; a?.b?.c(v = 2); g(v); }`},
+
+			// ---- Dimension 4: computed destructuring key is read before the write ----
+			{Code: `function f() { let v = 1, k = 'a'; g(v, k); ({ [v]: k } = o); g(k); }`},
+			// ---- Dimension 4: string-literal key in a declaration pattern ----
+			{Code: `function f() { let { 'k': v } = o; g(v); }`},
+
+			// ---- Dimension 4: class expression field initializer is its own code path ----
+			{Code: `let y = 1; const C = class { p = (y = 2); }; g(y);`},
+			// ---- Dimension 4: class-field arrow only writes from another code path ----
+			{Code: `let y = 1; g(y); class C { m = () => { y = 2; }; }`},
+
+			// ---- Dimension 4: graceful degradation on body-absent members ----
+			{Code: `abstract class A { abstract m(): void; }`},
+			{Code: `declare const x: number;`},
+			{Code: `function f(a: string): void;
+function f(a: number): void;
+function f(a: any): void { let v = 1; g(v); }`},
+			{Code: `function f() {}`},
+			{Code: `class A {}`},
+
+			// ---- Dimension 4: empty destructuring pattern writes nothing ----
+			{Code: `function f() { let v = 1; ({} = o); g(v); }`},
+			{Code: `function f() { let v = 1; [] = arr; g(v); }`},
+
+			// Locks in verifyAssignmentIsUsed() arm 3: a variable with no read
+			// reference belongs to no-unused-vars, not to this rule.
+			{Code: `function f() { let v = 1; v = 2; v = 3; }`},
+			// Locks in the collection listener arm that skips a variable whose
+			// declaration is outside the current code path.
+			{Code: `function f() { let v = 1; g(v); return function () { v = 2; }; }`},
+			// Locks in verifyAssignmentIsUsed() arm 5: a read from another code
+			// path can happen at any time, so nothing can be proven unused.
+			{Code: `function f() { let v = 1; v = 2; setTimeout(() => g(v)); }`},
+			// Locks in the collection listener arm that skips an unresolved
+			// global: nothing is known about where it is read.
+			{Code: `undeclaredGlobal = 1; g(undeclaredGlobal); undeclaredGlobal = 2;`},
+			// Locks in isIdentifierEvaluatedAfterAssignment() arm 2: an
+			// identifier inside the assigned expression is read before the write.
+			{Code: `function f() { let x = 1; x = x + 1; g(x); }`},
+			// Locks in the module-export arms: a binding that leaves the file
+			// can still be observed after the assignment.
+			{Code: `export class foo {}
+console.log(foo);
+foo = 1;`},
+			{Code: `export default function foo() {}
+console.log(foo);
+foo = 1;`},
+			{Code: `let foo = 1;
+console.log(foo);
+foo = 2;
+export { foo as bar };`},
+
+			// ---- Dimension 4: a `typeof` type query reads the variable ----
+			{Code: `function f() { let v = 1; g(v); v = 2; type T = typeof v; h<T>(); }`},
+
+			// ---- Real-user: eslint/eslint#20947 (parameter decorator argument) ----
+			// rslint treats the decorator's read as belonging to the method's own
+			// code path, so the variable is left alone; ESLint reports it.
+			{Code: `declare function Body(p: unknown): any;
+const pipe = {};
+class C { handler(@Body(pipe) _b: unknown) {} }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized assignment target ----
+			{
+				Code: `function f() { let v = 1; g(v); (v) = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 34, EndLine: 1, EndColumn: 35},
+				},
+			},
+			{
+				Code: `function f() { let v = 1; g(v); ((v)) = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 35, EndLine: 1, EndColumn: 36},
+				},
+			},
+			{
+				Code: `function f() { let v = 1; g(v); (v)++; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 34, EndLine: 1, EndColumn: 35},
+				},
+			},
+
+			// ---- Dimension 4: destructuring key forms ----
+			{
+				Code: `function f() { let v = 1; g(v); ({ v } = o); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 36, EndLine: 1, EndColumn: 37},
+				},
+			},
+			{
+				Code: `function f() { let v = 1; g(v); ({ 'k': v } = o); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 41, EndLine: 1, EndColumn: 42},
+				},
+			},
+			{
+				Code: `function f() { let v = 1; g(v); ({ 0: v } = o); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 39, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				Code: `function f() { let v = 1, k = 'a'; g(v, k); ({ [k]: v } = o); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 53, EndLine: 1, EndColumn: 54},
+				},
+			},
+
+			// ---- Dimension 4: async / generator / accessor / constructor roots ----
+			{
+				Code: `async function f() { let v = 1; g(v); v = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 39},
+				},
+			},
+			{
+				Code: `async function* f() { let v = 1; g(v); v = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 40},
+				},
+			},
+			{
+				Code: `const o = { *m() { let v = 1; g(v); v = 2; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 37},
+				},
+			},
+			{
+				Code: `const o = { set p(x) { let v = 1; g(v); v = 2; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 41},
+				},
+			},
+			{
+				Code: `class C { constructor() { let v = 1; g(v); v = 2; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 44},
+				},
+			},
+
+			// ---- Dimension 4: same-kind nesting must not bleed across roots ----
+			{
+				Code: `function f() { let v = 1; g(v); v = 2; function h() { let v = 1; g(v); v = 2; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 33},
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 72},
+				},
+			},
+			{
+				Code: `class A { static { let v = 1; g(v); v = 2; class B { static { let v = 1; g(v); v = 2; } } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 37},
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 80},
+				},
+			},
+			{
+				Code: `const o = { m() { let v = 1; g(v); v = 2; return () => { let v = 1; g(v); v = 2; }; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 36},
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 75},
+				},
+			},
+			// ---- Dimension 4: a shadowing block binding is a separate variable ----
+			{
+				Code: `function f() { let v = 1; { let v = 2; g(v); v = 3; } g(v); v = 4; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 46},
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 61},
+				},
+			},
+
+			// ---- Dimension 4: rest / spread targets in a pattern ----
+			{
+				Code: `function f() { let a = 1, r = 2; g(a, r); ({ a, ...r } = o); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 46},
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 52},
+				},
+			},
+			{
+				Code: `function f() { let a = 1, r = 2; g(a, r); [a, ...r] = arr; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 44},
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 50},
+				},
+			},
+			// Locks in extractIdentifiersFromPattern() arm 3: an array hole is
+			// skipped without shifting the elements after it.
+			{
+				Code: `function f() { let a = 1, b = 2; g(a, b); [a, , b] = arr; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 44},
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 49},
+				},
+			},
+			// Locks in extractIdentifiersFromPattern() arm 4: a rest element
+			// nested inside another pattern still yields its target.
+			{
+				Code: `function f() { let a = 1; g(a); ({ x: [ ...a ] } = o); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 44},
+				},
+			},
+
+			// Locks in isIdentifierUsedBetweenAssignedAndEqualSign() arm 1: an
+			// update expression has no assigned expression at all.
+			{
+				Code: `function f() { let v = 1; g(v); v--; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 33},
+				},
+			},
+			// Locks in the otherAssignmentAfterTargetAssignment arm that fires
+			// when the target sits inside the other assignment's expression.
+			{
+				Code: `function f() { let x = 1; g(x); x = (x = 2); h(x); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 38},
+				},
+			},
+			// Locks in the collection listener's unreachable-segment guard: the
+			// dead store before `return` is reported, the one after it is not.
+			{
+				Code: `function f() { let v = 1; g(v); v = 2; return; v = 3; g(v); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 33},
+				},
+			},
+			// Locks in verifyAssignmentIsUsed() arm 5 read-side detail: a write
+			// from another code path is not a read, so the last store is unused.
+			{
+				Code: `function f() { let v = 1; g(v); setTimeout(() => { v = 2; }); v = 3; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 63},
+				},
+			},
+			// Locks in the module-scope arms: an unexported binding in a module
+			// is still reported.
+			{
+				Code: `import 'x';
+let foo = 1;
+console.log(foo);
+foo = 2;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 1, EndLine: 4, EndColumn: 4},
+				},
+			},
+
+			// ---- Dimension 4: decorators run where the member is declared ----
+			{
+				Code: `declare function Dec(p: unknown): any;
+let v = 1;
+class C { @Dec(v) m() {} }
+v = 2;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 1, EndLine: 4, EndColumn: 2},
+				},
+			},
+			// ---- Dimension 4: an overload signature carries no body ----
+			{
+				Code: `function f(a: string): void;
+function f(a: number): void;
+function f(a: any): void { let v = 1; g(v); v = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 45},
+				},
+			},
+			// ---- Dimension 4: TS type-expression wrappers around a read ----
+			{
+				Code: `function f() { let v = 1; v = 2; g(v as any); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code: `function f() { let v: number | null = 1; v = 2; g(v!); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 20, EndLine: 1, EndColumn: 21},
+				},
+			},
+			// ---- Real-user: eslint/eslint#20491 (early return in the else arm) ----
+			{
+				Code: `function props(parameters) {
+	let content = '';
+
+	if (typeof parameters === 'string') {
+		content = parameters;
+	} else {
+		return {};
+	}
+
+	return { content };
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 6, EndLine: 2, EndColumn: 13},
+				},
+			},
+			// ---- Real-user: eslint/eslint#19818 (update on a parameter) ----
+			{
+				Code: `[1, 2, 3].map(i => ++i);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+				},
+			},
+
+			// ---- Message text and multi-line position ----
+			{
+				Code: `function f() {
+  let veryLongName = 1;
+  g(veryLongName);
+  veryLongName =
+    2;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryAssignment",
+						Message:   "The value assigned to 'veryLongName' is not used in subsequent statements.",
+						Line:      4, Column: 3, EndLine: 4, EndColumn: 15,
+					},
+				},
+			},
+			{
+				Code: `function f() { let v = 1; g(v); v = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unnecessaryAssignment",
+						Message:   "The value assigned to 'v' is not used in subsequent statements.",
+						Line:      1, Column: 33, EndLine: 1, EndColumn: 34,
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_useless_assignment/no_useless_assignment_upstream_test.go
+++ b/internal/rules/no_useless_assignment/no_useless_assignment_upstream_test.go
@@ -1,0 +1,1174 @@
+package no_useless_assignment
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoUselessAssignmentUpstream migrates the full valid/invalid suite from
+// upstream eslint/tests/lib/rules/no-useless-assignment.js 1:1. Position
+// assertions cover line/column for every invalid case. rslint-specific lock-in
+// cases live in the no_useless_assignment_extras_test.go file.
+func TestNoUselessAssignmentUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessAssignmentRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `let v = 'used';
+        console.log(v);
+        v = 'used-2'
+        console.log(v);`},
+			{Code: `function foo() {
+            let v = 'used';
+            console.log(v);
+            v = 'used-2';
+            console.log(v);
+        }`},
+			{Code: `function foo() {
+            let v = 'used';
+            if (condition) {
+                v = 'used-2';
+                console.log(v);
+                return
+            }
+            console.log(v);
+        }`},
+			{Code: `function foo() {
+            let v = 'used';
+            if (condition) {
+                console.log(v);
+            } else {
+                v = 'used-2';
+                console.log(v);
+            }
+        }`},
+			{Code: `function foo() {
+            let v = 'used';
+            if (condition) {
+                //
+            } else {
+                v = 'used-2';
+            }
+            console.log(v);
+        }`},
+			{Code: `var foo = function () {
+            let v = 'used';
+            console.log(v);
+            v = 'used-2'
+            console.log(v);
+        }`},
+			{Code: `var foo = () => {
+            let v = 'used';
+            console.log(v);
+            v = 'used-2'
+            console.log(v);
+        }`},
+			{Code: `class foo {
+            static {
+                let v = 'used';
+                console.log(v);
+                v = 'used-2'
+                console.log(v);
+            }
+        }`},
+			{Code: `function foo () {
+            let v = 'used';
+            for (let i = 0; i < 10; i++) {
+                console.log(v);
+                v = 'used in next iteration';
+            }
+        }`},
+			{Code: `function foo () {
+            let i = 0;
+            i++;
+            i++;
+            console.log(i);
+        }`},
+			{Code: `export let foo = 'used';
+        console.log(foo);
+        foo = 'unused like but exported';`},
+			{Code: `export function foo () {};
+        console.log(foo);
+        foo = 'unused like but exported';`},
+			{Code: `export class foo {};
+        console.log(foo);
+        foo = 'unused like but exported';`},
+			{Code: `export default function foo () {};
+        console.log(foo);
+        foo = 'unused like but exported';`},
+			{Code: `export default class foo {};
+        console.log(foo);
+        foo = 'unused like but exported';`},
+			{Code: `let foo = 'used';
+        export { foo };
+        console.log(foo);
+        foo = 'unused like but exported';`},
+			{Code: `function foo () {};
+        export { foo };
+        console.log(foo);
+        foo = 'unused like but exported';`},
+			{Code: `class foo {};
+        export { foo };
+        console.log(foo);
+        foo = 'unused like but exported';`},
+			{Code: `/* exported foo */
+            let foo = 'used';
+            console.log(foo);
+            foo = 'unused like but exported with directive';`,
+				// SKIP: rslint does not support ESLint's `/* exported */` directive comment.
+				Skip: true},
+			{Code: `/*eslint test/use-a:1*/
+        let a = 'used';
+        console.log(a);
+        a = 'unused like but marked by markVariableAsUsed()';
+        `,
+				// SKIP: rslint does not support ESLint plugins calling markVariableAsUsed().
+				Skip: true},
+			{Code: `v = 'used';
+        console.log(v);
+        v = 'unused'`},
+			{Code: `let v = 'used variable';`},
+			{Code: `function foo() {
+            return;
+
+            const x = 1;
+            if (y) {
+                bar(x);
+            }
+        }`},
+			{Code: `function foo() {
+            const x = 1;
+            console.log(x);
+            return;
+
+            x = 'Foo'
+        }`},
+			{Code: `function foo() {
+            let a = 42;
+            console.log(a);
+            a++;
+            console.log(a);
+        }`},
+			{Code: `function foo() {
+            let a = 42;
+            console.log(a);
+            a--;
+            console.log(a);
+        }`},
+			{Code: `function foo() {
+            let a = 42;
+            console.log(a);
+            a = 10;
+            a = a + 1;
+            console.log(a);
+        }`},
+			{Code: `function foo() {
+            let a = 42;
+            console.log(a);
+            a = 10;
+            if (cond) {
+                a = a + 1;
+            } else {
+                a = 2 + a;
+            }
+            console.log(a);
+        }`},
+			{Code: `function foo() {
+            let a = 'used', b = 'used', c = 'used', d = 'used';
+            console.log(a, b, c, d);
+            ({ a, arr: [b, c, ...d] } = fn());
+            console.log(a, b, c, d);
+        }`},
+			{Code: `function foo() {
+            let a = 'used', b = 'used', c = 'used';
+            console.log(a, b, c);
+            ({ a = 'unused', foo: b, ...c } = fn());
+            console.log(a, b, c);
+        }`},
+			{Code: `function foo() {
+            let a = {};
+            console.log(a);
+            a.b = 'unused like, but maybe used in setter';
+        }`},
+			{Code: `function foo() {
+            let a = { b: 42 };
+            console.log(a);
+            a.b++;
+        }`},
+			{Code: `function foo () {
+            let v = 'used';
+            console.log(v);
+            function bar() {
+                v = 'used in outer scope';
+            }
+            bar();
+            console.log(v);
+        }`},
+			{Code: `function foo () {
+            let v = 'used';
+            console.log(v);
+            setTimeout(() => console.log(v), 1);
+            v = 'used in other scope';
+        }`},
+			{Code: `function foo () {
+            let v = 'used';
+            console.log(v);
+            for (let i = 0; i < 10; i++) {
+                if (condition) {
+                    v = 'maybe used';
+                    continue;
+                }
+                console.log(v);
+            }
+        }`},
+			{Code: `/* globals foo */
+        const bk = foo;
+        foo = 42;
+        try {
+            // process
+        } finally {
+            foo = bk;
+        }`},
+			{Code: `
+            const bk = console;
+            console = { log () {} };
+            try {
+                // process
+            } finally {
+                console = bk;
+            }`, Globals: map[string]bool{"console": false}},
+			{Code: `let message = 'init';
+        try {
+            const result = call();
+            message = result.message;
+        } catch (e) {
+            // ignore
+        }
+        console.log(message)`},
+			{Code: `let message = 'init';
+        try {
+            message = call().message;
+        } catch (e) {
+            // ignore
+        }
+        console.log(message)`},
+			{Code: `let v = 'init';
+        try {
+            v = callA();
+            try {
+                v = callB();
+            } catch (e) {
+                // ignore
+            }
+        } catch (e) {
+            // ignore
+        }
+        console.log(v)`},
+			{Code: `let v = 'init';
+        try {
+            try {
+                v = callA();
+            } catch (e) {
+                // ignore
+            }
+        } catch (e) {
+            // ignore
+        }
+        console.log(v)`},
+			{Code: `let a;
+        try {
+            foo();
+        } finally {
+            a = 5;
+        }
+        console.log(a);`},
+			{Code: `function* generator() {
+            let done = false;
+            try {
+                yield 1;
+                done = true;
+            } catch {
+                done = true;
+            } finally {
+                if (!done) {
+                    console.log("done is false");
+                }
+            }
+        }`},
+			{Code: `function* generator() {
+            let done = false;
+            try {
+                yield 1;
+                done = true;
+                yield 2;
+            } finally {
+                if (done) {
+                    console.log("done is true");
+                }
+            }
+        }`},
+			{Code: `function* generator() {
+            let done = false;
+            try {
+                yield 1;
+            } catch {
+                console.log(done);
+            }
+        }`},
+			{Code: `function* generator() {
+            let done = false;
+            try {
+                foo();
+            } catch {
+                yield 1;
+                done = true;
+            } finally {
+                yield 2;
+                if (!done) {
+                    console.log(done);
+                }
+            }
+        }`},
+			{Code: `function foo() {
+			let outcome = 'unknown';
+
+			try {
+				helper1();
+				outcome = 'success';
+			} catch (err) {
+				helper2();
+				outcome = 'exception'; 
+			} finally {
+				console.log(outcome);
+			}
+		}`},
+			{Code: `function foo() {
+			let outcome = 'unknown';
+
+			try {
+				new Foo();
+				outcome = 'success';
+			} catch (err) {
+				new Bar();
+				outcome = 'exception'; 
+			} finally {
+				console.log(outcome);
+			}
+		}`},
+			{Code: `async function foo() {
+			let outcome = 'unknown';
+
+			try {
+				await import("./foo.js");
+				outcome = 'success';
+			} catch (err) {
+				await import("./bar.js");
+				outcome = 'exception';
+			} finally {
+				console.log(outcome);
+			}
+		}`},
+			{Code: `function foo() {
+			let outcome = 'unknown';
+
+			try {
+				obj.foo;
+				outcome = 'success';
+			} catch (err) {
+				obj.foo;
+				outcome = 'exception';
+			} finally {
+				console.log(outcome);
+			}
+		}`},
+			{Code: `function foo() {
+			let outcome = 'unknown';
+
+			try {
+				helper1();
+				outcome = 'success';
+			} catch (err) {
+			 	outcome = 'exception';
+				helper2(); 
+			} finally {
+				console.log(outcome);
+			}
+		}`},
+			{Code: `const obj = { a: 5 };
+        const { a, b = a } = obj;
+        console.log(b); // 5`},
+			{Code: `const arr = [6];
+        const [c, d = c] = arr;
+        console.log(d); // 6`},
+			{Code: `const obj = { a: 1 };
+        let {
+            a,
+            b = (a = 2)
+        } = obj;
+        console.log(a, b);`},
+			{Code: `let { a, b: {c = a} = {} } = obj;
+        console.log(c);`},
+			{Code: `function foo(){
+            let bar;
+            try {
+                bar = 2;
+                unsafeFn();
+                return { error: undefined };
+            } catch {
+                return { bar }; 
+            }
+        }   
+        function unsafeFn() {
+            throw new Error();
+        }`},
+			{Code: `function foo(){
+            let bar, baz;
+            try {
+                bar = 2;
+                unsafeFn();
+                return { error: undefined };
+            } catch {
+               baz = bar;
+            }
+            return baz;
+        }   
+        function unsafeFn() {
+            throw new Error();
+        }`},
+			{Code: `function foo(){
+            let bar;
+            try {
+                bar = 2;
+                unsafeFn();
+                bar = 4;
+            } catch {
+               // handle error
+            }
+            return bar;
+        }   
+        function unsafeFn() {
+            throw new Error();
+        }`},
+			{Code: `/*eslint test/unknown-ref:1*/
+        let a = "used";
+		console.log(a);
+		a = "unused";`,
+				// SKIP: rslint does not support ESLint plugins injecting scope references.
+				Skip: true},
+			{Code: `/*eslint test/unknown-ref:1*/
+		function foo() {
+			let a = "used";
+			console.log(a);
+			a = "unused";
+		}`,
+				// SKIP: rslint does not support ESLint plugins injecting scope references.
+				Skip: true},
+			{Code: `/*eslint test/unknown-ref:1*/
+		function foo() {
+			let a = "used";
+			if (condition) {
+				a = "unused";
+				return
+			}
+			console.log(a);
+        }`,
+				// SKIP: rslint does not support ESLint plugins injecting scope references.
+				Skip: true},
+			{Code: `
+                function App() {
+                    const A = "";
+                    return <A/>;
+                }
+            `, Tsx: true},
+			{Code: `
+                function App() {
+                    let A = "";
+                    foo(A);
+                    A = "A";
+                    return <A/>;
+                }
+            `, Tsx: true},
+			{Code: `
+                function App() {
+					let A = "a";
+                    foo(A);
+                    return <A/>;
+                }
+            `, Tsx: true},
+			{Code: `function App() {
+				let x = 0;
+				foo(x);
+				x = 1;
+				return <A prop={x} />;
+			}`, Tsx: true},
+			{Code: `function App() {
+				let x = "init";
+				foo(x);
+				x = "used";
+				return <A>{x}</A>;
+			}`, Tsx: true},
+			{Code: `function App() {
+				let props = { a: 1 };
+				foo(props);
+				props = { b: 2 };
+				return <A {...props} />;
+			}`, Tsx: true},
+			{Code: `function App() {
+				let NS = Lib;
+				return <NS.Cmp />;
+			}`, Tsx: true},
+			{Code: `function App() {
+				let a = 0;
+				a++;
+				return <A prop={a} />;
+			}`, Tsx: true},
+			{Code: `function App() {
+				const obj = { a: 1 };
+				const { a, b = a } = obj;
+				return <A prop={b} />;
+			}`, Tsx: true},
+			{Code: `function App() {
+				let { a, b: { c = a } = {} } = obj;
+				return <A prop={c} />;
+			}`, Tsx: true},
+			{Code: `function App() {
+				let x = "init";
+				if (cond) {
+					x = "used";
+					return <A prop={x} />;
+				}
+				return <A prop={x} />;
+			}`, Tsx: true},
+			{Code: `function App() {
+				let A;
+				if (cond) {
+				  A = Foo;
+				} else {
+				  A = Bar;
+				}
+				return <A />;
+			}`, Tsx: true},
+			{Code: `function App() {
+				let m;
+				try {
+				  m = 2;
+				  unsafeFn();
+				  m = 4;
+				} catch (e) {
+				  // ignore
+				}
+				return <A prop={m} />;
+			}`, Tsx: true},
+			{Code: `function App() {
+				const arr = [6];
+				const [c, d = c] = arr;
+				return <A prop={d} />;
+			}`, Tsx: true},
+			{Code: `function App() {
+				const obj = { a: 1 };
+				let {
+				  a,
+				  b = (a = 2)
+				} = obj;
+				return <A prop={a} />;
+			}`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `let v = 'used';
+            console.log(v);
+            v = 'unused'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 13},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'used';
+                if (condition) {
+                    v = 'unused';
+                    return
+                }
+                console.log(v);
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 21},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'used';
+                if (condition) {
+                    console.log(v);
+                } else {
+                    v = 'unused';
+                }
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 6, Column: 21},
+				},
+			},
+			{
+				Code: `var foo = function () {
+                let v = 'used';
+                console.log(v);
+                v = 'unused'
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+				},
+			},
+			{
+				Code: `var foo = () => {
+                let v = 'used';
+                console.log(v);
+                v = 'unused'
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+				},
+			},
+			{
+				Code: `class foo {
+                static {
+                    let v = 'used';
+                    console.log(v);
+                    v = 'unused'
+                }
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 5, Column: 21},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'unused';
+                if (condition) {
+                    v = 'used';
+                    console.log(v);
+                    return
+                }
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 21},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                v = 'unused';
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+					{MessageId: "unnecessaryAssignment", Line: 5, Column: 17},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                v = 'used';
+                console.log(v);
+                v = 'used';
+                console.log(v);
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+				},
+			},
+			{
+				Code: `
+            let v;
+            v = 'unused';
+            if (foo) {
+                v = 'used';
+            } else {
+                v = 'used';
+            }
+            console.log(v);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 13},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                v = 'unused';
+                v = 'used';
+                console.log(v);
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+					{MessageId: "unnecessaryAssignment", Line: 5, Column: 17},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'unused';
+                if (condition) {
+                    if (condition2) {
+                        v = 'used-2';
+                    } else {
+                        v = 'used-3';
+                    }
+                } else {
+                    v = 'used-4';
+                }
+                console.log(v);
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 21},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v;
+                if (condition) {
+                    v = 'unused';
+                } else {
+                    //
+                }
+                if (condition2) {
+                    v = 'used-1';
+                } else {
+                    v = 'used-2';
+                }
+                console.log(v);
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 21},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'used';
+                if (condition) {
+                    v = 'unused';
+                    v = 'unused';
+                    v = 'used';
+                }
+                console.log(v);
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 21},
+					{MessageId: "unnecessaryAssignment", Line: 5, Column: 21},
+				},
+			},
+			{
+				Code: `function foo() {
+                let a = 42;
+                console.log(a);
+                a++;
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+				},
+			},
+			{
+				Code: `function foo() {
+                let a = 42;
+                console.log(a);
+                a--;
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+				},
+			},
+			{
+				Code: `function foo() {
+                let a = 'used', b = 'used', c = 'used', d = 'used';
+                console.log(a, b, c, d);
+                ({ a, arr: [b, c,, ...d] } = fn());
+                console.log(c);
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 20},
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 29},
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 39},
+				},
+			},
+			{
+				Code: `function foo() {
+                let a = 'used', b = 'used', c = 'used';
+                console.log(a, b, c);
+                ({ a = 'unused', foo: b, ...c } = fn());
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 20},
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 39},
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 45},
+				},
+			},
+			{
+				Code: `function foo () {
+                let v = 'used';
+                console.log(v);
+                setTimeout(() => v = 42, 1);
+                v = 'unused and variable is only updated in other scopes';
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 5, Column: 17},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'used';
+                if (condition) {
+                    let v = 'used';
+                    console.log(v);
+                    v = 'unused';
+                }
+                console.log(v);
+                v = 'unused';
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 6, Column: 21},
+					{MessageId: "unnecessaryAssignment", Line: 9, Column: 17},
+				},
+			},
+			{
+				Code: `function foo() {
+                let v = 'used';
+                if (condition) {
+                    console.log(v);
+                    v = 'unused';
+                } else {
+                    v = 'unused';
+                }
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 5, Column: 21},
+					{MessageId: "unnecessaryAssignment", Line: 7, Column: 21},
+				},
+			},
+			{
+				Code: `function foo () {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                return;
+                console.log(v);
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+				},
+			},
+			{
+				Code: `function foo () {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                throw new Error();
+                console.log(v);
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+				},
+			},
+			{
+				Code: `function foo () {
+                let v = 'used';
+                console.log(v);
+                for (let i = 0; i < 10; i++) {
+                    v = 'unused';
+                    continue;
+                    console.log(v);
+                }
+            }
+            function bar () {
+                let v = 'used';
+                console.log(v);
+                for (let i = 0; i < 10; i++) {
+                    v = 'unused';
+                    break;
+                    console.log(v);
+                }
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 5, Column: 21},
+					{MessageId: "unnecessaryAssignment", Line: 14, Column: 21},
+				},
+			},
+			{
+				Code: `function foo () {
+                let v = 'used';
+                console.log(v);
+                for (let i = 0; i < 10; i++) {
+                    if (condition) {
+                        v = 'unused';
+                        break;
+                    }
+                    console.log(v);
+                }
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 6, Column: 25},
+				},
+			},
+			{
+				Code: `let message = 'unused';
+            try {
+                const result = call();
+                message = result.message;
+            } catch (e) {
+                message = 'used';
+            }
+            console.log(message)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `function* generator() {
+                let done = false;
+                yield 1;
+                done = true;
+                console.log(done);
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 21, EndLine: 2, EndColumn: 25},
+				},
+			},
+			{
+				Code: `function* generator() {
+                let done = false;
+                try {
+                    yield 1;
+                } finally {
+                    done = true;
+                    console.log(done);
+                }
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 21, EndLine: 2, EndColumn: 25},
+				},
+			},
+			{
+				Code: `let message = 'unused';
+            try {
+                message = 'used';
+                console.log(message)
+            } catch (e) {
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `let message = 'unused';
+            try {
+                message = call();
+            } catch (e) {
+                message = 'used';
+            }
+            console.log(message)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `let v = 'unused';
+            try {
+                v = callA();
+                try {
+                    v = callB();
+                } catch (e) {
+                    // ignore
+                }
+            } catch (e) {
+                v = 'used';
+            }
+            console.log(v)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `function foo() {
+				let outcome = 'unknown';
+
+				try {
+					bar();
+				} catch (err) {
+					new Baz();
+					outcome = 'exception'; 
+				} finally {
+					return;
+					console.log(outcome);
+				}
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 9},
+					{MessageId: "unnecessaryAssignment", Line: 8, Column: 6},
+				},
+			},
+			{
+				Code: `
+            var x = 1; // used
+            x = x + 1; // unused
+            x = 5; // used
+            f(x);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 13},
+				},
+			},
+			{
+				Code: `
+            var x = 1; // used
+            x = // used
+                x++; // unused
+            f(x);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 17},
+				},
+			},
+			{
+				Code: `const obj = { a: 1 };
+            let {
+                a,
+                b = (a = 2)
+            } = obj;
+            a = 3
+            console.log(a, b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 17},
+					{MessageId: "unnecessaryAssignment", Line: 4, Column: 22},
+				},
+			},
+			{
+				Code: `function App() {
+            let A = "unused";
+            A = "used";
+            return <A/>;
+            }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 17, EndLine: 2, EndColumn: 18},
+				},
+			},
+			{
+				Code: `function App() {
+            let A = "unused";
+            A = "used";
+            return <A></A>;
+            }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 17, EndLine: 2, EndColumn: 18},
+				},
+			},
+			{
+				Code: `function App() {
+            let A = "unused";
+            A = "used";
+            return <A.B />;
+            }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 17, EndLine: 2, EndColumn: 18},
+				},
+			},
+			{
+				Code: `function App() {
+            let x = "used";
+            if (cond) {
+              return <A prop={x} />;
+            } else {
+              x = "unused";
+            }
+            }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 6, Column: 15, EndLine: 6, EndColumn: 16},
+				},
+			},
+			{
+				Code: `function App() {
+            let A;
+            A = "unused";
+            if (cond) {
+              A = "used1";
+            } else {
+              A = "used2";
+            }
+            return <A/>;
+            }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 13, EndLine: 3, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function App() {
+            let message = 'unused';
+            try {
+              const result = call();
+              message = result.message;
+            } catch (e) {
+              message = 'used';
+            }
+            return <A prop={message} />;
+            }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 17, EndLine: 2, EndColumn: 24},
+				},
+			},
+			{
+				Code: `function App() {
+            let x = 1;
+            x = x + 1;
+            x = 5;
+            return <A prop={x} />;
+            }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 13, EndLine: 3, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function App() {
+            let x = 1;
+            x = 2;
+            return <A>{x}</A>;
+            }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 17, EndLine: 2, EndColumn: 18},
+				},
+			},
+			{
+				Code: `function App() {
+            let x = 0;
+            x = 1;
+            x = 2;
+            return <A prop={x} />;
+            }`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryAssignment", Line: 2, Column: 17, EndLine: 2, EndColumn: 18},
+					{MessageId: "unnecessaryAssignment", Line: 3, Column: 13, EndLine: 3, EndColumn: 14},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -128,6 +128,7 @@ export default defineConfig({
     './tests/eslint/rules/prefer-rest-params.test.ts',
     './tests/eslint/rules/prefer-spread.test.ts',
     './tests/eslint/rules/prefer-template.test.ts',
+    './tests/eslint/rules/no-useless-assignment.test.ts',
     './tests/eslint/rules/no-useless-computed-key.test.ts',
     './tests/eslint/rules/no-useless-concat.test.ts',
     // eslint-plugin-import

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-assignment.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-assignment.test.ts.snap
@@ -1,0 +1,1665 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-assignment > invalid 1`] = `
+{
+  "code": "let v = 'used';
+            console.log(v);
+            v = 'unused'",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 2`] = `
+{
+  "code": "function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 3`] = `
+{
+  "code": "function foo() {
+                let v = 'used';
+                if (condition) {
+                    v = 'unused';
+                    return
+                }
+                console.log(v);
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 4,
+        },
+        "start": {
+          "column": 21,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 4`] = `
+{
+  "code": "function foo() {
+                let v = 'used';
+                if (condition) {
+                    console.log(v);
+                } else {
+                    v = 'unused';
+                }
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 6,
+        },
+        "start": {
+          "column": 21,
+          "line": 6,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 5`] = `
+{
+  "code": "var foo = function () {
+                let v = 'used';
+                console.log(v);
+                v = 'unused'
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 6`] = `
+{
+  "code": "var foo = () => {
+                let v = 'used';
+                console.log(v);
+                v = 'unused'
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 7`] = `
+{
+  "code": "class foo {
+                static {
+                    let v = 'used';
+                    console.log(v);
+                    v = 'unused'
+                }
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 21,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 8`] = `
+{
+  "code": "function foo() {
+                let v = 'unused';
+                if (condition) {
+                    v = 'used';
+                    console.log(v);
+                    return
+                }
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 2,
+        },
+        "start": {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 9`] = `
+{
+  "code": "function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                v = 'unused';
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 17,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 10`] = `
+{
+  "code": "function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                v = 'used';
+                console.log(v);
+                v = 'used';
+                console.log(v);
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 11`] = `
+{
+  "code": "
+            let v;
+            v = 'unused';
+            if (foo) {
+                v = 'used';
+            } else {
+                v = 'used';
+            }
+            console.log(v);",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 12`] = `
+{
+  "code": "function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                v = 'unused';
+                v = 'used';
+                console.log(v);
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 17,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 13`] = `
+{
+  "code": "function foo() {
+                let v = 'unused';
+                if (condition) {
+                    if (condition2) {
+                        v = 'used-2';
+                    } else {
+                        v = 'used-3';
+                    }
+                } else {
+                    v = 'used-4';
+                }
+                console.log(v);
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 2,
+        },
+        "start": {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 14`] = `
+{
+  "code": "function foo() {
+                let v;
+                if (condition) {
+                    v = 'unused';
+                } else {
+                    //
+                }
+                if (condition2) {
+                    v = 'used-1';
+                } else {
+                    v = 'used-2';
+                }
+                console.log(v);
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 4,
+        },
+        "start": {
+          "column": 21,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 15`] = `
+{
+  "code": "function foo() {
+                let v = 'used';
+                if (condition) {
+                    v = 'unused';
+                    v = 'unused';
+                    v = 'used';
+                }
+                console.log(v);
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 4,
+        },
+        "start": {
+          "column": 21,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 21,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 16`] = `
+{
+  "code": "function foo() {
+                let a = 42;
+                console.log(a);
+                a++;
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'a' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 17`] = `
+{
+  "code": "function foo() {
+                let a = 42;
+                console.log(a);
+                a--;
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'a' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 18`] = `
+{
+  "code": "function foo() {
+                let a = 'used', b = 'used', c = 'used', d = 'used';
+                console.log(a, b, c, d);
+                ({ a, arr: [b, c,, ...d] } = fn());
+                console.log(c);
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'a' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 20,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'b' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 4,
+        },
+        "start": {
+          "column": 29,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'd' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 4,
+        },
+        "start": {
+          "column": 39,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 19`] = `
+{
+  "code": "function foo() {
+                let a = 'used', b = 'used', c = 'used';
+                console.log(a, b, c);
+                ({ a = 'unused', foo: b, ...c } = fn());
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'a' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 20,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'b' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 4,
+        },
+        "start": {
+          "column": 39,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'c' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 4,
+        },
+        "start": {
+          "column": 45,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 20`] = `
+{
+  "code": "function foo () {
+                let v = 'used';
+                console.log(v);
+                setTimeout(() => v = 42, 1);
+                v = 'unused and variable is only updated in other scopes';
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 17,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 21`] = `
+{
+  "code": "function foo() {
+                let v = 'used';
+                if (condition) {
+                    let v = 'used';
+                    console.log(v);
+                    v = 'unused';
+                }
+                console.log(v);
+                v = 'unused';
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 6,
+        },
+        "start": {
+          "column": 21,
+          "line": 6,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 9,
+        },
+        "start": {
+          "column": 17,
+          "line": 9,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 22`] = `
+{
+  "code": "function foo() {
+                let v = 'used';
+                if (condition) {
+                    console.log(v);
+                    v = 'unused';
+                } else {
+                    v = 'unused';
+                }
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 21,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 7,
+        },
+        "start": {
+          "column": 21,
+          "line": 7,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 23`] = `
+{
+  "code": "function foo () {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                return;
+                console.log(v);
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 24`] = `
+{
+  "code": "function foo () {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                throw new Error();
+                console.log(v);
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 25`] = `
+{
+  "code": "function foo () {
+                let v = 'used';
+                console.log(v);
+                for (let i = 0; i < 10; i++) {
+                    v = 'unused';
+                    continue;
+                    console.log(v);
+                }
+            }
+            function bar () {
+                let v = 'used';
+                console.log(v);
+                for (let i = 0; i < 10; i++) {
+                    v = 'unused';
+                    break;
+                    console.log(v);
+                }
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 21,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 14,
+        },
+        "start": {
+          "column": 21,
+          "line": 14,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 26`] = `
+{
+  "code": "function foo () {
+                let v = 'used';
+                console.log(v);
+                for (let i = 0; i < 10; i++) {
+                    if (condition) {
+                        v = 'unused';
+                        break;
+                    }
+                    console.log(v);
+                }
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 6,
+        },
+        "start": {
+          "column": 25,
+          "line": 6,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 27`] = `
+{
+  "code": "let message = 'unused';
+            try {
+                const result = call();
+                message = result.message;
+            } catch (e) {
+                message = 'used';
+            }
+            console.log(message)",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'message' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 28`] = `
+{
+  "code": "function* generator() {
+                let done = false;
+                yield 1;
+                done = true;
+                console.log(done);
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'done' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 2,
+        },
+        "start": {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 29`] = `
+{
+  "code": "function* generator() {
+                let done = false;
+                try {
+                    yield 1;
+                } finally {
+                    done = true;
+                    console.log(done);
+                }
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'done' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 2,
+        },
+        "start": {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 30`] = `
+{
+  "code": "let message = 'unused';
+            try {
+                message = 'used';
+                console.log(message)
+            } catch (e) {
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'message' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 31`] = `
+{
+  "code": "let message = 'unused';
+            try {
+                message = call();
+            } catch (e) {
+                message = 'used';
+            }
+            console.log(message)",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'message' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 32`] = `
+{
+  "code": "let v = 'unused';
+            try {
+                v = callA();
+                try {
+                    v = callB();
+                } catch (e) {
+                    // ignore
+                }
+            } catch (e) {
+                v = 'used';
+            }
+            console.log(v)",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'v' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 33`] = `
+{
+  "code": "function foo() {
+				let outcome = 'unknown';
+
+				try {
+					bar();
+				} catch (err) {
+					new Baz();
+					outcome = 'exception'; 
+				} finally {
+					return;
+					console.log(outcome);
+				}
+			}",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'outcome' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 9,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'outcome' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 8,
+        },
+        "start": {
+          "column": 6,
+          "line": 8,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 34`] = `
+{
+  "code": "
+            var x = 1; // used
+            x = x + 1; // unused
+            x = 5; // used
+            f(x);",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'x' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 35`] = `
+{
+  "code": "
+            var x = 1; // used
+            x = // used
+                x++; // unused
+            f(x);",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'x' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 36`] = `
+{
+  "code": "const obj = { a: 1 };
+            let {
+                a,
+                b = (a = 2)
+            } = obj;
+            a = 3
+            console.log(a, b);",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'a' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'a' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 4,
+        },
+        "start": {
+          "column": 22,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 37`] = `
+{
+  "code": "function App() {
+            let A = "unused";
+            A = "used";
+            return <A/>;
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'A' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 38`] = `
+{
+  "code": "function App() {
+            let A = "unused";
+            A = "used";
+            return <A></A>;
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'A' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 39`] = `
+{
+  "code": "function App() {
+            let A = "unused";
+            A = "used";
+            return <A.B />;
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'A' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 40`] = `
+{
+  "code": "function App() {
+            let x = "used";
+            if (cond) {
+              return <A prop={x} />;
+            } else {
+              x = "unused";
+            }
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'x' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 6,
+        },
+        "start": {
+          "column": 15,
+          "line": 6,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 41`] = `
+{
+  "code": "function App() {
+            let A;
+            A = "unused";
+            if (cond) {
+              A = "used1";
+            } else {
+              A = "used2";
+            }
+            return <A/>;
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'A' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 42`] = `
+{
+  "code": "function App() {
+            let message = 'unused';
+            try {
+              const result = call();
+              message = result.message;
+            } catch (e) {
+              message = 'used';
+            }
+            return <A prop={message} />;
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'message' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 43`] = `
+{
+  "code": "function App() {
+            let x = 1;
+            x = x + 1;
+            x = 5;
+            return <A prop={x} />;
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'x' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 44`] = `
+{
+  "code": "function App() {
+            let x = 1;
+            x = 2;
+            return <A>{x}</A>;
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'x' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-assignment > invalid 45`] = `
+{
+  "code": "function App() {
+            let x = 0;
+            x = 1;
+            x = 2;
+            return <A prop={x} />;
+            }",
+  "diagnostics": [
+    {
+      "message": "The value assigned to 'x' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+    {
+      "message": "The value assigned to 'x' is not used in subsequent statements.",
+      "messageId": "unnecessaryAssignment",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-useless-assignment",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-useless-assignment.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-useless-assignment.test.ts
@@ -1,0 +1,1190 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-assignment', {
+  valid: [
+    `let v = 'used';
+        console.log(v);
+        v = 'used-2'
+        console.log(v);`,
+    `function foo() {
+            let v = 'used';
+            console.log(v);
+            v = 'used-2';
+            console.log(v);
+        }`,
+    `function foo() {
+            let v = 'used';
+            if (condition) {
+                v = 'used-2';
+                console.log(v);
+                return
+            }
+            console.log(v);
+        }`,
+    `function foo() {
+            let v = 'used';
+            if (condition) {
+                console.log(v);
+            } else {
+                v = 'used-2';
+                console.log(v);
+            }
+        }`,
+    `function foo() {
+            let v = 'used';
+            if (condition) {
+                //
+            } else {
+                v = 'used-2';
+            }
+            console.log(v);
+        }`,
+    `var foo = function () {
+            let v = 'used';
+            console.log(v);
+            v = 'used-2'
+            console.log(v);
+        }`,
+    `var foo = () => {
+            let v = 'used';
+            console.log(v);
+            v = 'used-2'
+            console.log(v);
+        }`,
+    `class foo {
+            static {
+                let v = 'used';
+                console.log(v);
+                v = 'used-2'
+                console.log(v);
+            }
+        }`,
+    `function foo () {
+            let v = 'used';
+            for (let i = 0; i < 10; i++) {
+                console.log(v);
+                v = 'used in next iteration';
+            }
+        }`,
+    `function foo () {
+            let i = 0;
+            i++;
+            i++;
+            console.log(i);
+        }`,
+    `export let foo = 'used';
+        console.log(foo);
+        foo = 'unused like but exported';`,
+    `export function foo () {};
+        console.log(foo);
+        foo = 'unused like but exported';`,
+    `export class foo {};
+        console.log(foo);
+        foo = 'unused like but exported';`,
+    `export default function foo () {};
+        console.log(foo);
+        foo = 'unused like but exported';`,
+    `export default class foo {};
+        console.log(foo);
+        foo = 'unused like but exported';`,
+    `let foo = 'used';
+        export { foo };
+        console.log(foo);
+        foo = 'unused like but exported';`,
+    `function foo () {};
+        export { foo };
+        console.log(foo);
+        foo = 'unused like but exported';`,
+    `class foo {};
+        export { foo };
+        console.log(foo);
+        foo = 'unused like but exported';`,
+    `v = 'used';
+        console.log(v);
+        v = 'unused'`,
+    `let v = 'used variable';`,
+    `function foo() {
+            return;
+
+            const x = 1;
+            if (y) {
+                bar(x);
+            }
+        }`,
+    `function foo() {
+            const x = 1;
+            console.log(x);
+            return;
+
+            x = 'Foo'
+        }`,
+    `function foo() {
+            let a = 42;
+            console.log(a);
+            a++;
+            console.log(a);
+        }`,
+    `function foo() {
+            let a = 42;
+            console.log(a);
+            a--;
+            console.log(a);
+        }`,
+    `function foo() {
+            let a = 42;
+            console.log(a);
+            a = 10;
+            a = a + 1;
+            console.log(a);
+        }`,
+    `function foo() {
+            let a = 42;
+            console.log(a);
+            a = 10;
+            if (cond) {
+                a = a + 1;
+            } else {
+                a = 2 + a;
+            }
+            console.log(a);
+        }`,
+    `function foo() {
+            let a = 'used', b = 'used', c = 'used', d = 'used';
+            console.log(a, b, c, d);
+            ({ a, arr: [b, c, ...d] } = fn());
+            console.log(a, b, c, d);
+        }`,
+    `function foo() {
+            let a = 'used', b = 'used', c = 'used';
+            console.log(a, b, c);
+            ({ a = 'unused', foo: b, ...c } = fn());
+            console.log(a, b, c);
+        }`,
+    `function foo() {
+            let a = {};
+            console.log(a);
+            a.b = 'unused like, but maybe used in setter';
+        }`,
+    `function foo() {
+            let a = { b: 42 };
+            console.log(a);
+            a.b++;
+        }`,
+    `function foo () {
+            let v = 'used';
+            console.log(v);
+            function bar() {
+                v = 'used in outer scope';
+            }
+            bar();
+            console.log(v);
+        }`,
+    `function foo () {
+            let v = 'used';
+            console.log(v);
+            setTimeout(() => console.log(v), 1);
+            v = 'used in other scope';
+        }`,
+    `function foo () {
+            let v = 'used';
+            console.log(v);
+            for (let i = 0; i < 10; i++) {
+                if (condition) {
+                    v = 'maybe used';
+                    continue;
+                }
+                console.log(v);
+            }
+        }`,
+    `/* globals foo */
+        const bk = foo;
+        foo = 42;
+        try {
+            // process
+        } finally {
+            foo = bk;
+        }`,
+    `
+            const bk = console;
+            console = { log () {} };
+            try {
+                // process
+            } finally {
+                console = bk;
+            }`,
+    `let message = 'init';
+        try {
+            const result = call();
+            message = result.message;
+        } catch (e) {
+            // ignore
+        }
+        console.log(message)`,
+    `let message = 'init';
+        try {
+            message = call().message;
+        } catch (e) {
+            // ignore
+        }
+        console.log(message)`,
+    `let v = 'init';
+        try {
+            v = callA();
+            try {
+                v = callB();
+            } catch (e) {
+                // ignore
+            }
+        } catch (e) {
+            // ignore
+        }
+        console.log(v)`,
+    `let v = 'init';
+        try {
+            try {
+                v = callA();
+            } catch (e) {
+                // ignore
+            }
+        } catch (e) {
+            // ignore
+        }
+        console.log(v)`,
+    `let a;
+        try {
+            foo();
+        } finally {
+            a = 5;
+        }
+        console.log(a);`,
+    `function* generator() {
+            let done = false;
+            try {
+                yield 1;
+                done = true;
+            } catch {
+                done = true;
+            } finally {
+                if (!done) {
+                    console.log("done is false");
+                }
+            }
+        }`,
+    `function* generator() {
+            let done = false;
+            try {
+                yield 1;
+                done = true;
+                yield 2;
+            } finally {
+                if (done) {
+                    console.log("done is true");
+                }
+            }
+        }`,
+    `function* generator() {
+            let done = false;
+            try {
+                yield 1;
+            } catch {
+                console.log(done);
+            }
+        }`,
+    `function* generator() {
+            let done = false;
+            try {
+                foo();
+            } catch {
+                yield 1;
+                done = true;
+            } finally {
+                yield 2;
+                if (!done) {
+                    console.log(done);
+                }
+            }
+        }`,
+    `function foo() {
+			let outcome = 'unknown';
+
+			try {
+				helper1();
+				outcome = 'success';
+			} catch (err) {
+				helper2();
+				outcome = 'exception'; 
+			} finally {
+				console.log(outcome);
+			}
+		}`,
+    `function foo() {
+			let outcome = 'unknown';
+
+			try {
+				new Foo();
+				outcome = 'success';
+			} catch (err) {
+				new Bar();
+				outcome = 'exception'; 
+			} finally {
+				console.log(outcome);
+			}
+		}`,
+    `async function foo() {
+			let outcome = 'unknown';
+
+			try {
+				await import("./foo.js");
+				outcome = 'success';
+			} catch (err) {
+				await import("./bar.js");
+				outcome = 'exception';
+			} finally {
+				console.log(outcome);
+			}
+		}`,
+    `function foo() {
+			let outcome = 'unknown';
+
+			try {
+				obj.foo;
+				outcome = 'success';
+			} catch (err) {
+				obj.foo;
+				outcome = 'exception';
+			} finally {
+				console.log(outcome);
+			}
+		}`,
+    `function foo() {
+			let outcome = 'unknown';
+
+			try {
+				helper1();
+				outcome = 'success';
+			} catch (err) {
+			 	outcome = 'exception';
+				helper2(); 
+			} finally {
+				console.log(outcome);
+			}
+		}`,
+    `const obj = { a: 5 };
+        const { a, b = a } = obj;
+        console.log(b); // 5`,
+    `const arr = [6];
+        const [c, d = c] = arr;
+        console.log(d); // 6`,
+    `const obj = { a: 1 };
+        let {
+            a,
+            b = (a = 2)
+        } = obj;
+        console.log(a, b);`,
+    `let { a, b: {c = a} = {} } = obj;
+        console.log(c);`,
+    `function foo(){
+            let bar;
+            try {
+                bar = 2;
+                unsafeFn();
+                return { error: undefined };
+            } catch {
+                return { bar }; 
+            }
+        }   
+        function unsafeFn() {
+            throw new Error();
+        }`,
+    `function foo(){
+            let bar, baz;
+            try {
+                bar = 2;
+                unsafeFn();
+                return { error: undefined };
+            } catch {
+               baz = bar;
+            }
+            return baz;
+        }   
+        function unsafeFn() {
+            throw new Error();
+        }`,
+    `function foo(){
+            let bar;
+            try {
+                bar = 2;
+                unsafeFn();
+                bar = 4;
+            } catch {
+               // handle error
+            }
+            return bar;
+        }   
+        function unsafeFn() {
+            throw new Error();
+        }`,
+    {
+      code: `
+                function App() {
+                    const A = "";
+                    return <A/>;
+                }
+            `,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `
+                function App() {
+                    let A = "";
+                    foo(A);
+                    A = "A";
+                    return <A/>;
+                }
+            `,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `
+                function App() {
+					let A = "a";
+                    foo(A);
+                    return <A/>;
+                }
+            `,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				let x = 0;
+				foo(x);
+				x = 1;
+				return <A prop={x} />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				let x = "init";
+				foo(x);
+				x = "used";
+				return <A>{x}</A>;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				let props = { a: 1 };
+				foo(props);
+				props = { b: 2 };
+				return <A {...props} />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				let NS = Lib;
+				return <NS.Cmp />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				let a = 0;
+				a++;
+				return <A prop={a} />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				const obj = { a: 1 };
+				const { a, b = a } = obj;
+				return <A prop={b} />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				let { a, b: { c = a } = {} } = obj;
+				return <A prop={c} />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				let x = "init";
+				if (cond) {
+					x = "used";
+					return <A prop={x} />;
+				}
+				return <A prop={x} />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				let A;
+				if (cond) {
+				  A = Foo;
+				} else {
+				  A = Bar;
+				}
+				return <A />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				let m;
+				try {
+				  m = 2;
+				  unsafeFn();
+				  m = 4;
+				} catch (e) {
+				  // ignore
+				}
+				return <A prop={m} />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				const arr = [6];
+				const [c, d = c] = arr;
+				return <A prop={d} />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+    {
+      code: `function App() {
+				const obj = { a: 1 };
+				let {
+				  a,
+				  b = (a = 2)
+				} = obj;
+				return <A prop={a} />;
+			}`,
+      filename: 'src/virtual.tsx',
+    },
+  ],
+  invalid: [
+    {
+      code: `let v = 'used';
+            console.log(v);
+            v = 'unused'`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 3, column: 13 }],
+    },
+    {
+      code: `function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 17 }],
+    },
+    {
+      code: `function foo() {
+                let v = 'used';
+                if (condition) {
+                    v = 'unused';
+                    return
+                }
+                console.log(v);
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 21 }],
+    },
+    {
+      code: `function foo() {
+                let v = 'used';
+                if (condition) {
+                    console.log(v);
+                } else {
+                    v = 'unused';
+                }
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 6, column: 21 }],
+    },
+    {
+      code: `var foo = function () {
+                let v = 'used';
+                console.log(v);
+                v = 'unused'
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 17 }],
+    },
+    {
+      code: `var foo = () => {
+                let v = 'used';
+                console.log(v);
+                v = 'unused'
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 17 }],
+    },
+    {
+      code: `class foo {
+                static {
+                    let v = 'used';
+                    console.log(v);
+                    v = 'unused'
+                }
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 5, column: 21 }],
+    },
+    {
+      code: `function foo() {
+                let v = 'unused';
+                if (condition) {
+                    v = 'used';
+                    console.log(v);
+                    return
+                }
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 2, column: 21 }],
+    },
+    {
+      code: `function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                v = 'unused';
+            }`,
+      errors: [
+        { messageId: 'unnecessaryAssignment', line: 4, column: 17 },
+        { messageId: 'unnecessaryAssignment', line: 5, column: 17 },
+      ],
+    },
+    {
+      code: `function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                v = 'used';
+                console.log(v);
+                v = 'used';
+                console.log(v);
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 17 }],
+    },
+    {
+      code: `
+            let v;
+            v = 'unused';
+            if (foo) {
+                v = 'used';
+            } else {
+                v = 'used';
+            }
+            console.log(v);`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 3, column: 13 }],
+    },
+    {
+      code: `function foo() {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                v = 'unused';
+                v = 'used';
+                console.log(v);
+            }`,
+      errors: [
+        { messageId: 'unnecessaryAssignment', line: 4, column: 17 },
+        { messageId: 'unnecessaryAssignment', line: 5, column: 17 },
+      ],
+    },
+    {
+      code: `function foo() {
+                let v = 'unused';
+                if (condition) {
+                    if (condition2) {
+                        v = 'used-2';
+                    } else {
+                        v = 'used-3';
+                    }
+                } else {
+                    v = 'used-4';
+                }
+                console.log(v);
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 2, column: 21 }],
+    },
+    {
+      code: `function foo() {
+                let v;
+                if (condition) {
+                    v = 'unused';
+                } else {
+                    //
+                }
+                if (condition2) {
+                    v = 'used-1';
+                } else {
+                    v = 'used-2';
+                }
+                console.log(v);
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 21 }],
+    },
+    {
+      code: `function foo() {
+                let v = 'used';
+                if (condition) {
+                    v = 'unused';
+                    v = 'unused';
+                    v = 'used';
+                }
+                console.log(v);
+            }`,
+      errors: [
+        { messageId: 'unnecessaryAssignment', line: 4, column: 21 },
+        { messageId: 'unnecessaryAssignment', line: 5, column: 21 },
+      ],
+    },
+    {
+      code: `function foo() {
+                let a = 42;
+                console.log(a);
+                a++;
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 17 }],
+    },
+    {
+      code: `function foo() {
+                let a = 42;
+                console.log(a);
+                a--;
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 17 }],
+    },
+    {
+      code: `function foo() {
+                let a = 'used', b = 'used', c = 'used', d = 'used';
+                console.log(a, b, c, d);
+                ({ a, arr: [b, c,, ...d] } = fn());
+                console.log(c);
+            }`,
+      errors: [
+        { messageId: 'unnecessaryAssignment', line: 4, column: 20 },
+        { messageId: 'unnecessaryAssignment', line: 4, column: 29 },
+        { messageId: 'unnecessaryAssignment', line: 4, column: 39 },
+      ],
+    },
+    {
+      code: `function foo() {
+                let a = 'used', b = 'used', c = 'used';
+                console.log(a, b, c);
+                ({ a = 'unused', foo: b, ...c } = fn());
+            }`,
+      errors: [
+        { messageId: 'unnecessaryAssignment', line: 4, column: 20 },
+        { messageId: 'unnecessaryAssignment', line: 4, column: 39 },
+        { messageId: 'unnecessaryAssignment', line: 4, column: 45 },
+      ],
+    },
+    {
+      code: `function foo () {
+                let v = 'used';
+                console.log(v);
+                setTimeout(() => v = 42, 1);
+                v = 'unused and variable is only updated in other scopes';
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 5, column: 17 }],
+    },
+    {
+      code: `function foo() {
+                let v = 'used';
+                if (condition) {
+                    let v = 'used';
+                    console.log(v);
+                    v = 'unused';
+                }
+                console.log(v);
+                v = 'unused';
+            }`,
+      errors: [
+        { messageId: 'unnecessaryAssignment', line: 6, column: 21 },
+        { messageId: 'unnecessaryAssignment', line: 9, column: 17 },
+      ],
+    },
+    {
+      code: `function foo() {
+                let v = 'used';
+                if (condition) {
+                    console.log(v);
+                    v = 'unused';
+                } else {
+                    v = 'unused';
+                }
+            }`,
+      errors: [
+        { messageId: 'unnecessaryAssignment', line: 5, column: 21 },
+        { messageId: 'unnecessaryAssignment', line: 7, column: 21 },
+      ],
+    },
+    {
+      code: `function foo () {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                return;
+                console.log(v);
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 17 }],
+    },
+    {
+      code: `function foo () {
+                let v = 'used';
+                console.log(v);
+                v = 'unused';
+                throw new Error();
+                console.log(v);
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 17 }],
+    },
+    {
+      code: `function foo () {
+                let v = 'used';
+                console.log(v);
+                for (let i = 0; i < 10; i++) {
+                    v = 'unused';
+                    continue;
+                    console.log(v);
+                }
+            }
+            function bar () {
+                let v = 'used';
+                console.log(v);
+                for (let i = 0; i < 10; i++) {
+                    v = 'unused';
+                    break;
+                    console.log(v);
+                }
+            }`,
+      errors: [
+        { messageId: 'unnecessaryAssignment', line: 5, column: 21 },
+        { messageId: 'unnecessaryAssignment', line: 14, column: 21 },
+      ],
+    },
+    {
+      code: `function foo () {
+                let v = 'used';
+                console.log(v);
+                for (let i = 0; i < 10; i++) {
+                    if (condition) {
+                        v = 'unused';
+                        break;
+                    }
+                    console.log(v);
+                }
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 6, column: 25 }],
+    },
+    {
+      code: `let message = 'unused';
+            try {
+                const result = call();
+                message = result.message;
+            } catch (e) {
+                message = 'used';
+            }
+            console.log(message)`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 1, column: 5 }],
+    },
+    {
+      code: `function* generator() {
+                let done = false;
+                yield 1;
+                done = true;
+                console.log(done);
+            }`,
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 2,
+          column: 21,
+          endLine: 2,
+          endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: `function* generator() {
+                let done = false;
+                try {
+                    yield 1;
+                } finally {
+                    done = true;
+                    console.log(done);
+                }
+            }`,
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 2,
+          column: 21,
+          endLine: 2,
+          endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: `let message = 'unused';
+            try {
+                message = 'used';
+                console.log(message)
+            } catch (e) {
+            }`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 1, column: 5 }],
+    },
+    {
+      code: `let message = 'unused';
+            try {
+                message = call();
+            } catch (e) {
+                message = 'used';
+            }
+            console.log(message)`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 1, column: 5 }],
+    },
+    {
+      code: `let v = 'unused';
+            try {
+                v = callA();
+                try {
+                    v = callB();
+                } catch (e) {
+                    // ignore
+                }
+            } catch (e) {
+                v = 'used';
+            }
+            console.log(v)`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 1, column: 5 }],
+    },
+    {
+      code: `function foo() {
+				let outcome = 'unknown';
+
+				try {
+					bar();
+				} catch (err) {
+					new Baz();
+					outcome = 'exception'; 
+				} finally {
+					return;
+					console.log(outcome);
+				}
+			}`,
+      errors: [
+        { messageId: 'unnecessaryAssignment', line: 2, column: 9 },
+        { messageId: 'unnecessaryAssignment', line: 8, column: 6 },
+      ],
+    },
+    {
+      code: `
+            var x = 1; // used
+            x = x + 1; // unused
+            x = 5; // used
+            f(x);`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 3, column: 13 }],
+    },
+    {
+      code: `
+            var x = 1; // used
+            x = // used
+                x++; // unused
+            f(x);`,
+      errors: [{ messageId: 'unnecessaryAssignment', line: 4, column: 17 }],
+    },
+    {
+      code: `const obj = { a: 1 };
+            let {
+                a,
+                b = (a = 2)
+            } = obj;
+            a = 3
+            console.log(a, b);`,
+      errors: [
+        { messageId: 'unnecessaryAssignment', line: 3, column: 17 },
+        { messageId: 'unnecessaryAssignment', line: 4, column: 22 },
+      ],
+    },
+    {
+      code: `function App() {
+            let A = "unused";
+            A = "used";
+            return <A/>;
+            }`,
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 2,
+          column: 17,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: `function App() {
+            let A = "unused";
+            A = "used";
+            return <A></A>;
+            }`,
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 2,
+          column: 17,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: `function App() {
+            let A = "unused";
+            A = "used";
+            return <A.B />;
+            }`,
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 2,
+          column: 17,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: `function App() {
+            let x = "used";
+            if (cond) {
+              return <A prop={x} />;
+            } else {
+              x = "unused";
+            }
+            }`,
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 6,
+          column: 15,
+          endLine: 6,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `function App() {
+            let A;
+            A = "unused";
+            if (cond) {
+              A = "used1";
+            } else {
+              A = "used2";
+            }
+            return <A/>;
+            }`,
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 3,
+          column: 13,
+          endLine: 3,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function App() {
+            let message = 'unused';
+            try {
+              const result = call();
+              message = result.message;
+            } catch (e) {
+              message = 'used';
+            }
+            return <A prop={message} />;
+            }`,
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 2,
+          column: 17,
+          endLine: 2,
+          endColumn: 24,
+        },
+      ],
+    },
+    {
+      code: `function App() {
+            let x = 1;
+            x = x + 1;
+            x = 5;
+            return <A prop={x} />;
+            }`,
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 3,
+          column: 13,
+          endLine: 3,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function App() {
+            let x = 1;
+            x = 2;
+            return <A>{x}</A>;
+            }`,
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 2,
+          column: 17,
+          endLine: 2,
+          endColumn: 18,
+        },
+      ],
+    },
+    {
+      code: `function App() {
+            let x = 0;
+            x = 1;
+            x = 2;
+            return <A prop={x} />;
+            }`,
+      filename: 'src/virtual.tsx',
+      errors: [
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 2,
+          column: 17,
+          endLine: 2,
+          endColumn: 18,
+        },
+        {
+          messageId: 'unnecessaryAssignment',
+          line: 3,
+          column: 13,
+          endLine: 3,
+          endColumn: 14,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/rslint/src/config/presets/javascript.ts
+++ b/packages/rslint/src/config/presets/javascript.ts
@@ -42,7 +42,7 @@ const recommended: RslintConfigEntry = {
     'no-unused-private-class-members': 'error',
     // 'no-unused-vars': 'error', // not implemented
     'no-unassigned-vars': 'error',
-    // 'no-useless-assignment': 'error', // not implemented
+    'no-useless-assignment': 'error',
     'no-useless-backreference': 'error',
     'no-useless-catch': 'error',
     'no-useless-escape': 'error',

--- a/packages/rslint/src/config/presets/typescript.ts
+++ b/packages/rslint/src/config/presets/typescript.ts
@@ -71,7 +71,7 @@ const recommended: RslintConfigEntry = {
     'no-unused-labels': 'error',
     'no-unused-private-class-members': 'error',
     'no-unassigned-vars': 'error',
-    // 'no-useless-assignment': 'error', // not implemented
+    'no-useless-assignment': 'error',
     'no-useless-backreference': 'error',
     'no-useless-catch': 'error',
     'no-useless-escape': 'error',

--- a/packages/rslint/src/eslint-plugin/linter/ecma-language-plugin.ts
+++ b/packages/rslint/src/eslint-plugin/linter/ecma-language-plugin.ts
@@ -444,7 +444,7 @@ export function lintFile(
       suggestionsMode: req.suggestionsMode,
     });
 
-    let returnedListeners: Record<string, ListenerFn | ListenerFn[]> = {};
+    let returnedListeners: Record<string, ListenerFn | ListenerFn[]>;
     const createStart = ruleTimes ? performance.now() : 0;
     try {
       // ruleAny is `any` so the RHS is `any` and assigns to the typed


### PR DESCRIPTION
## Summary

Port the `no-useless-assignment` rule from ESLint to rslint.

### Differences from ESLint

- A variable read from inside a parameter decorator's arguments is treated as used, so assignments to it are never reported: `const pipe = {}; class C { handler(@Body(pipe) body) {} }`. ESLint reports `const pipe = {}` here — a known false positive ([eslint/eslint#20947](https://github.com/eslint/eslint/issues/20947)).
- For deeply nested `try`/`catch`/`switch` combinations, this rule's control flow modeling can occasionally diverge from ESLint's own, which has open, accepted-but-unfixed bugs in the same area ([eslint/eslint#17579](https://github.com/eslint/eslint/issues/17579)) and its own false negatives on some such shapes. Matching it exactly there is hard to pin down, so it is left as a known gap. These shapes are rare in practice; in the large majority of real code this rule reports the same findings as ESLint.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-useless-assignment
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-assignment.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
