### PR TITLE
feat(typescript-eslint): declare options JSON Schema for @typescript-eslint/ rules

### DIFF
--- a/internal/plugins/typescript/rules/adjacent_overload_signatures/adjacent_overload_signatures.go
+++ b/internal/plugins/typescript/rules/adjacent_overload_signatures/adjacent_overload_signatures.go
@@ -181,7 +181,8 @@ func checkBodyForOverloadMethods(ctx rule.RuleContext, node *ast.Node) {
 }
 
 var AdjacentOverloadSignaturesRule = rule.CreateRule(rule.Rule{
-	Name: "adjacent-overload-signatures",
+	Name:   "adjacent-overload-signatures",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		// Check the source file at the beginning
 		checkBodyForOverloadMethods(ctx, &ctx.SourceFile.Node)

--- a/internal/plugins/typescript/rules/array_type/array_type.go
+++ b/internal/plugins/typescript/rules/array_type/array_type.go
@@ -1,6 +1,7 @@
 package array_type
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -8,9 +9,27 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed array_type.schema.json
+var schemaJSON []byte
+
 type ArrayTypeOptions struct {
 	Default  string `json:"default"`
 	Readonly string `json:"readonly,omitempty"`
+}
+
+func parseOptions(options []any) ArrayTypeOptions {
+	opts := ArrayTypeOptions{Default: "array"}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]interface{})
+	if defaultVal, ok := optsMap["default"].(string); ok {
+		opts.Default = defaultVal
+	}
+	if readonlyVal, ok := optsMap["readonly"].(string); ok {
+		opts.Readonly = readonlyVal
+	}
+	return opts
 }
 
 // Check whatever node can be considered as simple
@@ -257,34 +276,10 @@ func buildArrayFixes(
 }
 
 var ArrayTypeRule = rule.CreateRule(rule.Rule{
-	Name: "array-type",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts := ArrayTypeOptions{
-			Default: "array",
-		}
-		// Parse options with dual-format support (handles both array and object formats)
-		if options != nil {
-			var optsMap map[string]interface{}
-			var ok bool
-
-			// Handle array format: [{ option: value }]
-			if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-				optsMap, ok = optArray[0].(map[string]interface{})
-			} else {
-				// Handle direct object format: { option: value }
-				optsMap, ok = options.(map[string]interface{})
-			}
-
-			if ok {
-				if defaultVal, ok := optsMap["default"].(string); ok {
-					opts.Default = defaultVal
-				}
-				if readonlyVal, ok := optsMap["readonly"].(string); ok {
-					opts.Readonly = readonlyVal
-				}
-			}
-		}
+	Name:   "array-type",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		defaultOption := opts.Default
 		readonlyOption := opts.Readonly

--- a/internal/plugins/typescript/rules/array_type/array_type.schema.json
+++ b/internal/plugins/typescript/rules/array_type/array_type.schema.json
@@ -1,0 +1,27 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "$defs": {
+        "arrayOption": {
+          "type": "string",
+          "enum": ["array", "generic", "array-simple"]
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "$ref": "#/items/0/$defs/arrayOption",
+          "description": "The array type expected for mutable cases."
+        },
+        "readonly": {
+          "$ref": "#/items/0/$defs/arrayOption",
+          "description": "The array type expected for readonly cases. If omitted, the value for `default` will be used."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/await_thenable/await_thenable.go
+++ b/internal/plugins/typescript/rules/await_thenable/await_thenable.go
@@ -44,6 +44,7 @@ func buildAwaitUsingOfNonAsyncDisposableMessage() rule.RuleMessage {
 
 var AwaitThenableRule = rule.CreateRule(rule.Rule{
 	Name:             "await-thenable",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.go
+++ b/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.go
@@ -1,6 +1,7 @@
 package ban_ts_comment
 
 import (
+	_ "embed"
 	"regexp"
 	"strconv"
 	"strings"
@@ -11,6 +12,9 @@ import (
 	"github.com/rivo/uniseg"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed ban_ts_comment.schema.json
+var schemaJSON []byte
 
 type DirectiveConfig struct {
 	Enabled              bool   // Whether the directive is enabled (true means banned)
@@ -53,8 +57,9 @@ var (
 // BanTsCommentRule implements the ban-ts-comment rule
 // Bans @ts-<directive> comments or requires descriptions after directive
 var BanTsCommentRule = rule.CreateRule(rule.Rule{
-	Name: "ban-ts-comment",
-	Run:  run,
+	Name:   "ban-ts-comment",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
 func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
@@ -100,18 +105,7 @@ func parseOptions(options []any) BanTsCommentOptions {
 		return opts
 	}
 
-	option := rule.LegacyUnwrapOptions(options)
-	// Preserve compatibility with callers that still pass the old nested
-	// array shape after the shared legacy-options shim has unwrapped Run's
-	// ESLint-style context.options.
-	if optionArray, ok := option.([]interface{}); ok && len(optionArray) > 0 {
-		option = optionArray[0]
-	}
-	optsMap, ok := option.(map[string]interface{})
-	if !ok {
-		return opts
-	}
-
+	optsMap, _ := options[0].(map[string]interface{})
 	if val, exists := optsMap["ts-expect-error"]; exists {
 		opts.TsExpectError = val
 	}

--- a/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.go
+++ b/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.go
@@ -2,15 +2,16 @@ package ban_ts_comment
 
 import (
 	_ "embed"
-	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/rivo/uniseg"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 //go:embed ban_ts_comment.schema.json
@@ -20,7 +21,7 @@ type DirectiveConfig struct {
 	Enabled              bool   // Whether the directive is enabled (true means banned)
 	AllowWithDescription bool   // Whether to allow with description
 	DescriptionFormat    string // Regex pattern for description format
-	descriptionRegex     *regexp.Regexp
+	descriptionRegex     *regexp2.Regexp
 }
 
 type BanTsCommentOptions struct {
@@ -148,7 +149,7 @@ func parseDirectiveConfig(value interface{}) DirectiveConfig {
 		}
 	}
 	if config.DescriptionFormat != "" {
-		config.descriptionRegex, _ = regexp.Compile(config.DescriptionFormat)
+		config.descriptionRegex, _ = utils.CompileRegexp2(config.DescriptionFormat, utils.JSRegexOptions)
 	}
 
 	return config
@@ -372,7 +373,7 @@ func reportDirective(ctx rule.RuleContext, commentText string, commentStart int,
 	}
 
 	// Check description format against raw (untrimmed) description
-	if config.descriptionRegex != nil && !config.descriptionRegex.MatchString(rawDescription) {
+	if config.descriptionRegex != nil && !utils.Regexp2MatchString(config.descriptionRegex, rawDescription) {
 		ctx.ReportRange(
 			commentRange,
 			rule.RuleMessage{

--- a/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.schema.json
+++ b/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.schema.json
@@ -1,0 +1,56 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "$defs": {
+        "directiveConfigSchema": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "type": "string",
+              "enum": ["allow-with-description"]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "descriptionFormat": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "minimumDescriptionLength": {
+          "type": "number",
+          "description": "A minimum character length for descriptions when `allow-with-description` is enabled."
+        },
+        "ts-check": {
+          "$ref": "#/items/0/$defs/directiveConfigSchema",
+          "description": "Whether to allow ts-check directives, and with which restrictions."
+        },
+        "ts-expect-error": {
+          "$ref": "#/items/0/$defs/directiveConfigSchema",
+          "description": "Whether to allow ts-expect-error directives, and with which restrictions."
+        },
+        "ts-ignore": {
+          "$ref": "#/items/0/$defs/directiveConfigSchema",
+          "description": "Whether to allow ts-ignore directives, and with which restrictions."
+        },
+        "ts-nocheck": {
+          "$ref": "#/items/0/$defs/directiveConfigSchema",
+          "description": "Whether to allow ts-nocheck directives, and with which restrictions."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.schema.json
+++ b/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.schema.json
@@ -19,7 +19,8 @@
               "additionalProperties": false,
               "properties": {
                 "descriptionFormat": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "regex"
                 }
               }
             }

--- a/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment_test.go
+++ b/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment_test.go
@@ -665,3 +665,22 @@ func TestBanTsCommentSuggestionDemand(t *testing.T) {
 		}
 	}
 }
+
+// TestBanTsCommentDescriptionFormatSchema locks in that `descriptionFormat`
+// is validated as a regex. The rule compiles it to check each directive's
+// description, so an unparsable pattern would otherwise be dropped and the
+// directive would go unchecked. Upstream's schema declares a bare string.
+func TestBanTsCommentDescriptionFormatSchema(t *testing.T) {
+	invalid := []any{map[string]any{
+		"ts-ignore": map[string]any{"descriptionFormat": "("},
+	}}
+	if err := BanTsCommentRule.Schema.Validate(invalid); err == nil {
+		t.Error("expected an invalid descriptionFormat regex to fail schema validation")
+	}
+	valid := []any{map[string]any{
+		"ts-ignore": map[string]any{"descriptionFormat": "^: TS\\d+ because .+$"},
+	}}
+	if err := BanTsCommentRule.Schema.Validate(valid); err != nil {
+		t.Errorf("expected a valid descriptionFormat regex to pass schema validation, got: %v", err)
+	}
+}

--- a/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment_test.go
+++ b/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment_test.go
@@ -684,3 +684,23 @@ func TestBanTsCommentDescriptionFormatSchema(t *testing.T) {
 		t.Errorf("expected a valid descriptionFormat regex to pass schema validation, got: %v", err)
 	}
 }
+
+// TestBanTsCommentDescriptionFormatLookahead locks in that `descriptionFormat`
+// is matched with the same ECMAScript regex engine the schema validates it
+// against (regexp2), not Go's RE2. RE2 cannot compile lookahead, so a
+// JS-only pattern that passes schema validation would otherwise silently
+// fail to compile and never flag a mismatched description.
+func TestBanTsCommentDescriptionFormatLookahead(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &BanTsCommentRule, []rule_tester.ValidTestCase{
+		{
+			Code:    "// @ts-expect-error: explanation",
+			Options: map[string]interface{}{"ts-expect-error": map[string]interface{}{"descriptionFormat": "^(?!: TODO).*$"}},
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:    "// @ts-expect-error: TODO fix me",
+			Options: map[string]interface{}{"ts-expect-error": map[string]interface{}{"descriptionFormat": "^(?!: TODO).*$"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "tsDirectiveCommentDescriptionNotMatchPattern"}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/ban_tslint_comment/ban_tslint_comment.go
+++ b/internal/plugins/typescript/rules/ban_tslint_comment/ban_tslint_comment.go
@@ -17,8 +17,9 @@ var enableDisableRegex = regexp.MustCompile(`^\s*tslint:(enable|disable)(?:-(lin
 // BanTslintCommentRule implements the ban-tslint-comment rule.
 // Disallows tslint directive comments like // tslint:disable
 var BanTslintCommentRule = rule.CreateRule(rule.Rule{
-	Name: "ban-tslint-comment",
-	Run:  run,
+	Name:   "ban-tslint-comment",
+	Schema: rule.EmptyArraySchema,
+	Run:    run,
 })
 
 func run(ctx rule.RuleContext, _ []any) rule.RuleListeners {

--- a/internal/plugins/typescript/rules/class_literal_property_style/class_literal_property_style.go
+++ b/internal/plugins/typescript/rules/class_literal_property_style/class_literal_property_style.go
@@ -1,12 +1,16 @@
 package class_literal_property_style
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed class_literal_property_style.schema.json
+var schemaJSON []byte
 
 type propertiesInfo struct {
 	excludeSet map[string]bool
@@ -187,22 +191,13 @@ func isFunction(node *ast.Node) bool {
 }
 
 var ClassLiteralPropertyStyleRule = rule.CreateRule(rule.Rule{
-	Name: "class-literal-property-style",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "class-literal-property-style",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		style := "fields" // default option
-
-		// Parse options - handle both string and array formats
-		if options != nil {
-			switch opts := options.(type) {
-			case string:
-				style = opts
-			case []interface{}:
-				if len(opts) > 0 {
-					if s, ok := opts[0].(string); ok {
-						style = s
-					}
-				}
+		if len(options) > 0 {
+			if s, ok := options[0].(string); ok {
+				style = s
 			}
 		}
 

--- a/internal/plugins/typescript/rules/class_literal_property_style/class_literal_property_style.schema.json
+++ b/internal/plugins/typescript/rules/class_literal_property_style/class_literal_property_style.schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "string",
+      "description": "Which literal class member syntax to prefer.",
+      "enum": ["fields", "getters"]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this.go
+++ b/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this.go
@@ -1,6 +1,7 @@
 package class_methods_use_this
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -11,14 +12,18 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed class_methods_use_this.schema.json
+var schemaJSON []byte
+
 // ClassMethodsUseThisRule mirrors @typescript-eslint/class-methods-use-this,
 // which extends ESLint core's class-methods-use-this with two TS-specific
 // options: `ignoreOverrideMethods` and `ignoreClassesThatImplementAnInterface`.
 //
 // https://typescript-eslint.io/rules/class-methods-use-this
 var ClassMethodsUseThisRule = rule.CreateRule(rule.Rule{
-	Name: "class-methods-use-this",
-	Run:  run,
+	Name:   "class-methods-use-this",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
 type ignoreClassesMode int
@@ -38,12 +43,13 @@ type ruleOptions struct {
 
 // parseOptions extracts the rule options. Defaults match the upstream
 // `defaultOptions`: `enforceForClassFields: true`, all other flags off.
-func parseOptions(raw any) ruleOptions {
+func parseOptions(raw []any) ruleOptions {
 	opts := ruleOptions{enforceForClassFields: true}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(raw) == 0 {
 		return opts
 	}
+	m, _ := raw[0].(map[string]interface{})
+
 	if v, ok := m["enforceForClassFields"]; ok {
 		if b, ok := v.(bool); ok {
 			opts.enforceForClassFields = b
@@ -86,8 +92,7 @@ type stackEntry struct {
 	usesThis  bool
 }
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	opts := parseOptions(options)
 	var stack *stackEntry
 

--- a/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this.schema.json
+++ b/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this.schema.json
@@ -1,0 +1,42 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enforceForClassFields": {
+          "type": "boolean",
+          "description": "Enforces that functions used as instance field initializers utilize `this`."
+        },
+        "exceptMethods": {
+          "type": "array",
+          "description": "Allows specified method names to be ignored with this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignoreClassesThatImplementAnInterface": {
+          "description": "Whether to ignore class members that are defined within a class that `implements` a type.",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Ignore all classes that implement an interface"
+            },
+            {
+              "type": "string",
+              "description": "Ignore only the public fields of classes that implement an interface",
+              "enum": ["public-fields"]
+            }
+          ]
+        },
+        "ignoreOverrideMethods": {
+          "type": "boolean",
+          "description": "Whether to ignore members marked with the `override` modifier."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this_extras_test.go
+++ b/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this_extras_test.go
@@ -460,8 +460,8 @@ class C implements I {
 			{Code: `class C { foo() { return this.x; } x = 0; }`, Options: objectOption(map[string]interface{}{})},
 
 			// ---- Locks in: passing a non-object options shape gracefully degrades ----
-			// rule_tester passes the value through GetOptionsMap which returns nil
-			// for non-object shapes; rule falls back to defaults.
+			// parseOptions gets a nil map for non-object shapes; the rule falls
+			// back to defaults.
 			{Code: `class C { foo() { return this.x; } x = 0; }`, Options: []interface{}{"not-an-object"}},
 
 			// ---- Locks in: exceptMethods with empty array is equivalent to no exceptions ----

--- a/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this_extras_test.go
+++ b/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this_extras_test.go
@@ -459,11 +459,6 @@ class C implements I {
 			// Counterpart already in upstream; locks in our parseOptions behavior for {}.
 			{Code: `class C { foo() { return this.x; } x = 0; }`, Options: objectOption(map[string]interface{}{})},
 
-			// ---- Locks in: passing a non-object options shape gracefully degrades ----
-			// parseOptions gets a nil map for non-object shapes; the rule falls
-			// back to defaults.
-			{Code: `class C { foo() { return this.x; } x = 0; }`, Options: []interface{}{"not-an-object"}},
-
 			// ---- Locks in: exceptMethods with empty array is equivalent to no exceptions ----
 			// (arm 5 of isIncludedInstanceMethod: `exceptMethods.size === 0 → true`)
 			// Method without this STILL reports under [] — locked in on the invalid side.

--- a/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this_upstream_test.go
+++ b/internal/plugins/typescript/rules/class_methods_use_this/class_methods_use_this_upstream_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 // objectOption is the array-wrapped single-option shape that matches
-// rule_tester's JSON path through utils.GetOptionsMap — the typed-struct
-// shortcut would silently bypass it. See PORT_RULE.md Phase 2 Step 4.
+// rule_tester's JSON path through parseOptions — the typed-struct shortcut
+// would silently bypass it. See PORT_RULE.md Phase 2 Step 4.
 func objectOption(opts map[string]interface{}) []interface{} {
 	return []interface{}{opts}
 }

--- a/internal/plugins/typescript/rules/consistent_generic_constructors/consistent_generic_constructors.go
+++ b/internal/plugins/typescript/rules/consistent_generic_constructors/consistent_generic_constructors.go
@@ -2,6 +2,7 @@ package consistent_generic_constructors
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )

--- a/internal/plugins/typescript/rules/consistent_generic_constructors/consistent_generic_constructors.go
+++ b/internal/plugins/typescript/rules/consistent_generic_constructors/consistent_generic_constructors.go
@@ -1,41 +1,40 @@
 package consistent_generic_constructors
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed consistent_generic_constructors.schema.json
+var schemaJSON []byte
 
 type ConsistentGenericConstructorsOptions struct {
 	Style string `json:"style"`
 }
 
+func parseOptions(options []any) ConsistentGenericConstructorsOptions {
+	opts := ConsistentGenericConstructorsOptions{
+		Style: "constructor",
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	if style, ok := options[0].(string); ok {
+		opts.Style = style
+	}
+	return opts
+}
+
 // ConsistentGenericConstructorsRule enforces consistent generic specifier style in constructor signatures
 var ConsistentGenericConstructorsRule = rule.CreateRule(rule.Rule{
-	Name: "consistent-generic-constructors",
-	Run:  run,
+	Name:   "consistent-generic-constructors",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
-	opts := ConsistentGenericConstructorsOptions{
-		Style: "constructor", // default
-	}
-
-	// Parse options
-	if options != nil {
-		// Handle array format: ["type-annotation"]
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			if style, ok := optArray[0].(string); ok {
-				opts.Style = style
-			}
-		} else if optsMap, ok := options.(map[string]interface{}); ok {
-			if style, exists := optsMap["style"].(string); exists {
-				opts.Style = style
-			}
-		} else if style, ok := options.(string); ok {
-			opts.Style = style
-		}
-	}
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
+	opts := parseOptions(options)
 
 	checkNode := func(node *ast.Node, typeAnnotation *ast.Node, initializer *ast.Node, isBindingElement bool) {
 		if initializer == nil {

--- a/internal/plugins/typescript/rules/consistent_generic_constructors/consistent_generic_constructors.schema.json
+++ b/internal/plugins/typescript/rules/consistent_generic_constructors/consistent_generic_constructors.schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "string",
+      "description": "Which constructor call syntax to prefer.",
+      "enum": ["type-annotation", "constructor"]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.go
+++ b/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.go
@@ -2,6 +2,7 @@ package consistent_indexed_object_style
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )

--- a/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.go
+++ b/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.go
@@ -1,9 +1,13 @@
 package consistent_indexed_object_style
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed consistent_indexed_object_style.schema.json
+var schemaJSON []byte
 
 type ConsistentIndexedObjectStyleOptions struct {
 	Style string `json:"style"`
@@ -11,31 +15,26 @@ type ConsistentIndexedObjectStyleOptions struct {
 
 // ConsistentIndexedObjectStyleRule enforces consistent usage of type imports
 var ConsistentIndexedObjectStyleRule = rule.CreateRule(rule.Rule{
-	Name: "consistent-indexed-object-style",
-	Run:  run,
+	Name:   "consistent-indexed-object-style",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
+func parseOptions(options []any) ConsistentIndexedObjectStyleOptions {
 	opts := ConsistentIndexedObjectStyleOptions{
 		Style: "record", // default
 	}
-
-	// Parse options
-	if options != nil {
-		// Handle array format: ["index-signature"]
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			if style, ok := optArray[0].(string); ok {
-				opts.Style = style
-			}
-		} else if optsMap, ok := options.(map[string]interface{}); ok {
-			if style, exists := optsMap["style"].(string); exists {
-				opts.Style = style
-			}
-		} else if style, ok := options.(string); ok {
-			opts.Style = style
-		}
+	if len(options) == 0 {
+		return opts
 	}
+	if style, ok := options[0].(string); ok {
+		opts.Style = style
+	}
+	return opts
+}
+
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
+	opts := parseOptions(options)
 
 	return rule.RuleListeners{
 		// Check interfaces with index signatures

--- a/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.schema.json
+++ b/internal/plugins/typescript/rules/consistent_indexed_object_style/consistent_indexed_object_style.schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "string",
+      "description": "Which indexed object syntax to prefer.",
+      "enum": ["record", "index-signature"]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/consistent_return/consistent_return.go
+++ b/internal/plugins/typescript/rules/consistent_return/consistent_return.go
@@ -1,11 +1,15 @@
 package consistent_return
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed consistent_return.schema.json
+var schemaJSON []byte
 
 type ConsistentReturnOptions struct {
 	TreatUndefinedAsUnspecified bool `json:"treatUndefinedAsUnspecified"`
@@ -14,6 +18,7 @@ type ConsistentReturnOptions struct {
 // ConsistentReturnRule enforces consistent return statements
 var ConsistentReturnRule = rule.CreateRule(rule.Rule{
 	Name:             "consistent-return",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run:              run,
 })
@@ -26,26 +31,22 @@ type functionInfo struct {
 	isVoidOrPromiseVoid   bool
 }
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
+func parseOptions(options []any) ConsistentReturnOptions {
 	opts := ConsistentReturnOptions{
 		TreatUndefinedAsUnspecified: false,
 	}
-
-	// Parse options
-	if options != nil {
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			if optsMap, ok := optArray[0].(map[string]interface{}); ok {
-				if v, exists := optsMap["treatUndefinedAsUnspecified"].(bool); exists {
-					opts.TreatUndefinedAsUnspecified = v
-				}
-			}
-		} else if optsMap, ok := options.(map[string]interface{}); ok {
-			if v, exists := optsMap["treatUndefinedAsUnspecified"].(bool); exists {
-				opts.TreatUndefinedAsUnspecified = v
-			}
-		}
+	if len(options) == 0 {
+		return opts
 	}
+	optsMap, _ := options[0].(map[string]interface{})
+	if v, ok := optsMap["treatUndefinedAsUnspecified"].(bool); ok {
+		opts.TreatUndefinedAsUnspecified = v
+	}
+	return opts
+}
+
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
+	opts := parseOptions(options)
 
 	// Stack to track nested functions
 	functionStack := make([]*functionInfo, 0)

--- a/internal/plugins/typescript/rules/consistent_return/consistent_return.go
+++ b/internal/plugins/typescript/rules/consistent_return/consistent_return.go
@@ -2,6 +2,7 @@ package consistent_return
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"

--- a/internal/plugins/typescript/rules/consistent_return/consistent_return.schema.json
+++ b/internal/plugins/typescript/rules/consistent_return/consistent_return.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "treatUndefinedAsUnspecified": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.go
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.go
@@ -1,12 +1,16 @@
 package consistent_type_assertions
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed consistent_type_assertions.schema.json
+var schemaJSON []byte
 
 type AssertionStyle string
 
@@ -223,26 +227,13 @@ func (e consistentTypeAssertionsEdits) angleToAsFix(
 // `({ ... }) as T` — the parenthesized object literal — get detected, matching
 // upstream.
 var ConsistentTypeAssertionsRule = rule.CreateRule(rule.Rule{
-	Name: "consistent-type-assertions",
-	Run:  run,
+	Name:   "consistent-type-assertions",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
-	opts := ConsistentTypeAssertionsOptions{
-		AssertionStyle:              AssertionStyleAs,
-		ObjectLiteralTypeAssertions: LiteralAssertionAllow,
-		ArrayLiteralTypeAssertions:  LiteralAssertionAllow,
-	}
-	if options != nil {
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			if optsMap, ok := optArray[0].(map[string]interface{}); ok {
-				parseOptionsMap(optsMap, &opts)
-			}
-		} else if optsMap, ok := options.(map[string]interface{}); ok {
-			parseOptionsMap(optsMap, &opts)
-		}
-	}
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
+	opts := parseOptions(options)
 
 	edits := consistentTypeAssertionsEdits{sourceFile: ctx.SourceFile}
 
@@ -405,7 +396,17 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 	}
 }
 
-func parseOptionsMap(optsMap map[string]interface{}, opts *ConsistentTypeAssertionsOptions) {
+func parseOptions(options []any) ConsistentTypeAssertionsOptions {
+	opts := ConsistentTypeAssertionsOptions{
+		AssertionStyle:              AssertionStyleAs,
+		ObjectLiteralTypeAssertions: LiteralAssertionAllow,
+		ArrayLiteralTypeAssertions:  LiteralAssertionAllow,
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]interface{})
+
 	if v, exists := optsMap["assertionStyle"]; exists {
 		if str, ok := v.(string); ok {
 			opts.AssertionStyle = AssertionStyle(str)
@@ -423,4 +424,6 @@ func parseOptionsMap(optsMap map[string]interface{}, opts *ConsistentTypeAsserti
 			opts.ArrayLiteralTypeAssertions = LiteralAssertion(str)
 		}
 	}
+
+	return opts
 }

--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.schema.json
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.schema.json
@@ -1,0 +1,44 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "assertionStyle": {
+              "type": "string",
+              "description": "The expected assertion style to enforce.",
+              "enum": ["never"]
+            }
+          },
+          "required": ["assertionStyle"]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "arrayLiteralTypeAssertions": {
+              "type": "string",
+              "description": "Whether to always prefer type declarations for array literals used as variable initializers, rather than type assertions.",
+              "enum": ["allow", "allow-as-parameter", "never"]
+            },
+            "assertionStyle": {
+              "type": "string",
+              "description": "The expected assertion style to enforce.",
+              "enum": ["as", "angle-bracket"]
+            },
+            "objectLiteralTypeAssertions": {
+              "type": "string",
+              "description": "Whether to always prefer type declarations for object literals used as variable initializers, rather than type assertions.",
+              "enum": ["allow", "allow-as-parameter", "never"]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.go
+++ b/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.go
@@ -1,6 +1,7 @@
 package consistent_type_definitions
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -8,6 +9,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed consistent_type_definitions.schema.json
+var schemaJSON []byte
 
 type DefinitionStyle string
 
@@ -18,6 +22,19 @@ const (
 
 type ConsistentTypeDefinitionsOptions struct {
 	Style DefinitionStyle `json:"style"`
+}
+
+func parseOptions(options []any) ConsistentTypeDefinitionsOptions {
+	opts := ConsistentTypeDefinitionsOptions{
+		Style: DefinitionStyleInterface,
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	if str, ok := options[0].(string); ok {
+		opts.Style = DefinitionStyle(str)
+	}
+	return opts
 }
 
 type consistentTypeDefinitionsFixer struct {
@@ -180,26 +197,13 @@ func (f consistentTypeDefinitionsFixer) interfaceFix(node *ast.Node, interfaceDe
 
 // ConsistentTypeDefinitionsRule enforces consistent type definitions
 var ConsistentTypeDefinitionsRule = rule.CreateRule(rule.Rule{
-	Name: "consistent-type-definitions",
-	Run:  run,
+	Name:   "consistent-type-definitions",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
-	opts := ConsistentTypeDefinitionsOptions{
-		Style: DefinitionStyleInterface,
-	}
-
-	// Parse options
-	if options != nil {
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			if str, ok := optArray[0].(string); ok {
-				opts.Style = DefinitionStyle(str)
-			}
-		} else if str, ok := options.(string); ok {
-			opts.Style = DefinitionStyle(str)
-		}
-	}
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
+	opts := parseOptions(options)
 
 	fixer := consistentTypeDefinitionsFixer{
 		sourceFile: ctx.SourceFile,

--- a/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.schema.json
+++ b/internal/plugins/typescript/rules/consistent_type_definitions/consistent_type_definitions.schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "string",
+      "description": "Which type definition syntax to prefer.",
+      "enum": ["interface", "type"]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/consistent_type_exports/consistent_type_exports.go
+++ b/internal/plugins/typescript/rules/consistent_type_exports/consistent_type_exports.go
@@ -1,9 +1,13 @@
 package consistent_type_exports
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed consistent_type_exports.schema.json
+var schemaJSON []byte
 
 type ConsistentTypeExportsOptions struct {
 	FixMixedExportsWithInlineTypeSpecifier bool `json:"fixMixedExportsWithInlineTypeSpecifier"`
@@ -12,30 +16,27 @@ type ConsistentTypeExportsOptions struct {
 // ConsistentTypeExportsRule enforces consistent type exports
 var ConsistentTypeExportsRule = rule.CreateRule(rule.Rule{
 	Name:             "consistent-type-exports",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run:              run,
 })
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
+func parseOptions(options []any) ConsistentTypeExportsOptions {
 	opts := ConsistentTypeExportsOptions{
 		FixMixedExportsWithInlineTypeSpecifier: false,
 	}
-
-	// Parse options
-	if options != nil {
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			if optMap, ok := optArray[0].(map[string]interface{}); ok {
-				if fixMixed, ok := optMap["fixMixedExportsWithInlineTypeSpecifier"].(bool); ok {
-					opts.FixMixedExportsWithInlineTypeSpecifier = fixMixed
-				}
-			}
-		} else if optMap, ok := options.(map[string]interface{}); ok {
-			if fixMixed, ok := optMap["fixMixedExportsWithInlineTypeSpecifier"].(bool); ok {
-				opts.FixMixedExportsWithInlineTypeSpecifier = fixMixed
-			}
-		}
+	if len(options) == 0 {
+		return opts
 	}
+	optMap, _ := options[0].(map[string]interface{})
+	if fixMixed, ok := optMap["fixMixedExportsWithInlineTypeSpecifier"].(bool); ok {
+		opts.FixMixedExportsWithInlineTypeSpecifier = fixMixed
+	}
+	return opts
+}
+
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
+	opts := parseOptions(options)
 
 	// Helper to check if a symbol is type-only
 	// Returns: true = type-only, false = value-based, nil = unknown/unresolved

--- a/internal/plugins/typescript/rules/consistent_type_exports/consistent_type_exports.go
+++ b/internal/plugins/typescript/rules/consistent_type_exports/consistent_type_exports.go
@@ -2,6 +2,7 @@ package consistent_type_exports
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )

--- a/internal/plugins/typescript/rules/consistent_type_exports/consistent_type_exports.schema.json
+++ b/internal/plugins/typescript/rules/consistent_type_exports/consistent_type_exports.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fixMixedExportsWithInlineTypeSpecifier": {
+          "type": "boolean",
+          "description": "Whether the rule will autofix \"mixed\" export cases using TS inline type specifiers."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/consistent_type_imports/consistent_type_imports.go
+++ b/internal/plugins/typescript/rules/consistent_type_imports/consistent_type_imports.go
@@ -1,9 +1,13 @@
 package consistent_type_imports
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed consistent_type_imports.schema.json
+var schemaJSON []byte
 
 type ConsistentTypeImportsOptions struct {
 	Prefer                  string `json:"prefer"`
@@ -13,44 +17,36 @@ type ConsistentTypeImportsOptions struct {
 
 // ConsistentTypeImportsRule enforces consistent type imports
 var ConsistentTypeImportsRule = rule.CreateRule(rule.Rule{
-	Name: "consistent-type-imports",
-	Run:  run,
+	Name:   "consistent-type-imports",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
+func parseOptions(options []any) ConsistentTypeImportsOptions {
 	opts := ConsistentTypeImportsOptions{
 		Prefer:                  "type-imports",
 		DisallowTypeAnnotations: true,
 		FixStyle:                "separate-type-imports",
 	}
-
-	// Parse options
-	if options != nil {
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			if optMap, ok := optArray[0].(map[string]interface{}); ok {
-				if prefer, ok := optMap["prefer"].(string); ok {
-					opts.Prefer = prefer
-				}
-				if disallow, ok := optMap["disallowTypeAnnotations"].(bool); ok {
-					opts.DisallowTypeAnnotations = disallow
-				}
-				if fixStyle, ok := optMap["fixStyle"].(string); ok {
-					opts.FixStyle = fixStyle
-				}
-			}
-		} else if optMap, ok := options.(map[string]interface{}); ok {
-			if prefer, ok := optMap["prefer"].(string); ok {
-				opts.Prefer = prefer
-			}
-			if disallow, ok := optMap["disallowTypeAnnotations"].(bool); ok {
-				opts.DisallowTypeAnnotations = disallow
-			}
-			if fixStyle, ok := optMap["fixStyle"].(string); ok {
-				opts.FixStyle = fixStyle
-			}
-		}
+	if len(options) == 0 {
+		return opts
 	}
+
+	optMap, _ := options[0].(map[string]interface{})
+	if prefer, ok := optMap["prefer"].(string); ok {
+		opts.Prefer = prefer
+	}
+	if disallow, ok := optMap["disallowTypeAnnotations"].(bool); ok {
+		opts.DisallowTypeAnnotations = disallow
+	}
+	if fixStyle, ok := optMap["fixStyle"].(string); ok {
+		opts.FixStyle = fixStyle
+	}
+	return opts
+}
+
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
+	opts := parseOptions(options)
 
 	checkImportDeclaration := func(node *ast.Node) {
 		importDecl := node.AsImportDeclaration()

--- a/internal/plugins/typescript/rules/consistent_type_imports/consistent_type_imports.go
+++ b/internal/plugins/typescript/rules/consistent_type_imports/consistent_type_imports.go
@@ -2,6 +2,7 @@ package consistent_type_imports
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )

--- a/internal/plugins/typescript/rules/consistent_type_imports/consistent_type_imports.schema.json
+++ b/internal/plugins/typescript/rules/consistent_type_imports/consistent_type_imports.schema.json
@@ -1,0 +1,27 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "disallowTypeAnnotations": {
+          "type": "boolean",
+          "description": "Whether to disallow type imports in type annotations (`import()`)."
+        },
+        "fixStyle": {
+          "type": "string",
+          "description": "The expected type modifier to be added when an import is detected as used only in the type position.",
+          "enum": ["separate-type-imports", "inline-type-imports"]
+        },
+        "prefer": {
+          "type": "string",
+          "description": "The expected import kind for type-only imports.",
+          "enum": ["type-imports", "no-type-imports"]
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/default_param_last/default_param_last.go
+++ b/internal/plugins/typescript/rules/default_param_last/default_param_last.go
@@ -7,8 +7,9 @@ import (
 
 // DefaultParamLastRule enforces default parameters to be last
 var DefaultParamLastRule = rule.CreateRule(rule.Rule{
-	Name: "default-param-last",
-	Run:  run,
+	Name:   "default-param-last",
+	Schema: rule.EmptyArraySchema,
+	Run:    run,
 })
 
 var shouldBeLastMessage = rule.RuleMessage{

--- a/internal/plugins/typescript/rules/dot_notation/dot_notation.go
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation.go
@@ -1,6 +1,7 @@
 package dot_notation
 
 import (
+	_ "embed"
 	"regexp"
 
 	"github.com/dlclark/regexp2"
@@ -12,6 +13,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed dot_notation.schema.json
+var schemaJSON []byte
+
 // Options mirrors @typescript-eslint/dot-notation options
 type Options struct {
 	AllowIndexSignaturePropertyAccess bool   `json:"allowIndexSignaturePropertyAccess"`
@@ -21,44 +25,31 @@ type Options struct {
 	AllowProtectedClassPropertyAccess bool   `json:"allowProtectedClassPropertyAccess"`
 }
 
-func parseOptions(options any) Options {
+func parseOptions(options []any) Options {
 	opts := Options{
 		AllowKeywords:                     true,
 		AllowIndexSignaturePropertyAccess: false,
 	}
 
-	if options == nil {
+	if len(options) == 0 {
 		return opts
 	}
+	optsMap, _ := options[0].(map[string]interface{})
 
-	// Parse options with dual-format support (handles both array and object formats)
-	var optsMap map[string]interface{}
-	var ok bool
-
-	// Handle array format: [{ option: value }]
-	if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-		optsMap, ok = optArray[0].(map[string]interface{})
-	} else {
-		// Handle direct object format: { option: value }
-		optsMap, ok = options.(map[string]interface{})
+	if v, ok := optsMap["allowIndexSignaturePropertyAccess"].(bool); ok {
+		opts.AllowIndexSignaturePropertyAccess = v
 	}
-
-	if ok {
-		if v, ok := optsMap["allowIndexSignaturePropertyAccess"].(bool); ok {
-			opts.AllowIndexSignaturePropertyAccess = v
-		}
-		if v, ok := optsMap["allowKeywords"].(bool); ok {
-			opts.AllowKeywords = v
-		}
-		if v, ok := optsMap["allowPattern"].(string); ok {
-			opts.AllowPattern = v
-		}
-		if v, ok := optsMap["allowPrivateClassPropertyAccess"].(bool); ok {
-			opts.AllowPrivateClassPropertyAccess = v
-		}
-		if v, ok := optsMap["allowProtectedClassPropertyAccess"].(bool); ok {
-			opts.AllowProtectedClassPropertyAccess = v
-		}
+	if v, ok := optsMap["allowKeywords"].(bool); ok {
+		opts.AllowKeywords = v
+	}
+	if v, ok := optsMap["allowPattern"].(string); ok {
+		opts.AllowPattern = v
+	}
+	if v, ok := optsMap["allowPrivateClassPropertyAccess"].(bool); ok {
+		opts.AllowPrivateClassPropertyAccess = v
+	}
+	if v, ok := optsMap["allowProtectedClassPropertyAccess"].(bool); ok {
+		opts.AllowProtectedClassPropertyAccess = v
 	}
 	return opts
 }
@@ -251,9 +242,9 @@ func (f *dotNotationFixer) buildUseBracketsFix(
 // See: /packages/rule-tester/src/index.ts line 273 - the lint() call doesn't use per-test config.
 var DotNotationRule = rule.CreateRule(rule.Rule{
 	Name:             "dot-notation",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 		// ECMAScript + Unicode flags mirror ESLint's `new RegExp(pattern, 'u')`
 		// so user patterns using lookaround, backreferences, or `\p{...}` work

--- a/internal/plugins/typescript/rules/dot_notation/dot_notation.schema.json
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation.schema.json
@@ -15,6 +15,7 @@
         },
         "allowPattern": {
           "type": "string",
+          "format": "regex",
           "description": "Regular expression of names to allow."
         },
         "allowPrivateClassPropertyAccess": {

--- a/internal/plugins/typescript/rules/dot_notation/dot_notation.schema.json
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation.schema.json
@@ -1,0 +1,33 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowIndexSignaturePropertyAccess": {
+          "type": "boolean",
+          "description": "Whether to allow accessing properties matching an index signature with array notation."
+        },
+        "allowKeywords": {
+          "type": "boolean",
+          "description": "Whether to allow keywords such as [\"class\"]`."
+        },
+        "allowPattern": {
+          "type": "string",
+          "description": "Regular expression of names to allow."
+        },
+        "allowPrivateClassPropertyAccess": {
+          "type": "boolean",
+          "description": "Whether to allow accessing class members marked as `private` with array notation."
+        },
+        "allowProtectedClassPropertyAccess": {
+          "type": "boolean",
+          "description": "Whether to allow accessing class members marked as `protected` with array notation."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/dot_notation/dot_notation_test.go
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation_test.go
@@ -420,3 +420,23 @@ func TestDotNotationEditDemand(t *testing.T) {
 		}
 	}
 }
+
+// TestDotNotationAllowPatternSchema locks in the fail-fast behavior for an
+// invalid allowPattern. The rule compiles `allowPattern` as an ECMAScript
+// regex, so an unparsable pattern would otherwise be dropped and the rule
+// would silently lint as if no pattern were configured. Marking it
+// `format: "regex"` moves the failure to config validation, matching what
+// ESLint core's dot-notation schema does — upstream's typescript-eslint
+// schema declares a bare string.
+func TestDotNotationAllowPatternSchema(t *testing.T) {
+	invalid := []any{map[string]any{"allowPattern": "("}}
+	if err := DotNotationRule.Schema.Validate(invalid); err == nil {
+		t.Error("expected an invalid allowPattern regex to fail schema validation")
+	}
+	// Lookbehind is JS-legal but RE2-illegal; it must still validate, proving
+	// the schema checks patterns with the ECMAScript engine, not Go's regexp.
+	valid := []any{map[string]any{"allowPattern": "(?<=a)b"}}
+	if err := DotNotationRule.Schema.Validate(valid); err != nil {
+		t.Errorf("expected a valid allowPattern regex to pass schema validation, got: %v", err)
+	}
+}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.go
@@ -2,6 +2,7 @@ package explicit_function_return_type
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/typescriptutil"
 	"github.com/web-infra-dev/rslint/internal/rule"

--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.go
@@ -1,11 +1,15 @@
 package explicit_function_return_type
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/typescriptutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed explicit_function_return_type.schema.json
+var schemaJSON []byte
 
 type options struct {
 	allowConciseArrowFunctionExpressionsStartingWithVoid bool
@@ -18,7 +22,7 @@ type options struct {
 	allowTypedFunctionExpressions                        bool
 }
 
-func parseOptions(rawOpts any) options {
+func parseOptions(rawOpts []any) options {
 	opts := options{
 		allowConciseArrowFunctionExpressionsStartingWithVoid: false,
 		allowDirectConstAssertionInArrowFunctions:            true,
@@ -30,10 +34,11 @@ func parseOptions(rawOpts any) options {
 		allowTypedFunctionExpressions:       true,
 	}
 
-	optsMap := utils.GetOptionsMap(rawOpts)
-	if optsMap == nil {
+	if len(rawOpts) == 0 {
 		return opts
 	}
+	optsMap, _ := rawOpts[0].(map[string]interface{})
+
 	if v, ok := optsMap["allowConciseArrowFunctionExpressionsStartingWithVoid"].(bool); ok {
 		opts.allowConciseArrowFunctionExpressionsStartingWithVoid = v
 	}
@@ -71,12 +76,12 @@ type functionInfo struct {
 }
 
 var ExplicitFunctionReturnTypeRule = rule.CreateRule(rule.Rule{
-	Name: "explicit-function-return-type",
-	Run:  run,
+	Name:   "explicit-function-return-type",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
-func run(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-	rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 	opts := parseOptions(rawOptions)
 	functionStack := make([]*functionInfo, 0)
 

--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.schema.json
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.schema.json
@@ -1,0 +1,48 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowConciseArrowFunctionExpressionsStartingWithVoid": {
+          "type": "boolean",
+          "description": "Whether to allow arrow functions that start with the `void` keyword."
+        },
+        "allowDirectConstAssertionInArrowFunctions": {
+          "type": "boolean",
+          "description": "Whether to ignore arrow functions immediately returning a `as const` value."
+        },
+        "allowedNames": {
+          "type": "array",
+          "description": "An array of function/method names that will not have their arguments or return values checked.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowExpressions": {
+          "type": "boolean",
+          "description": "Whether to ignore function expressions (functions which are not part of a declaration)."
+        },
+        "allowFunctionsWithoutTypeParameters": {
+          "type": "boolean",
+          "description": "Whether to ignore functions that don't have generic type parameters."
+        },
+        "allowHigherOrderFunctions": {
+          "type": "boolean",
+          "description": "Whether to ignore functions immediately returning another function expression."
+        },
+        "allowIIFEs": {
+          "type": "boolean",
+          "description": "Whether to ignore immediately invoked function expressions (IIFEs)."
+        },
+        "allowTypedFunctionExpressions": {
+          "type": "boolean",
+          "description": "Whether to ignore type annotations on the variable of function expressions."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/explicit_member_accessibility/explicit_member_accessibility.go
+++ b/internal/plugins/typescript/rules/explicit_member_accessibility/explicit_member_accessibility.go
@@ -1,6 +1,7 @@
 package explicit_member_accessibility
 
 import (
+	_ "embed"
 	"strings"
 	"unicode"
 
@@ -10,6 +11,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed explicit_member_accessibility.schema.json
+var schemaJSON []byte
 
 type accessibilityLevel string
 
@@ -33,15 +37,15 @@ type options struct {
 	overrides          overrides
 }
 
-func parseOptions(rawOpts any) options {
+func parseOptions(rawOpts []any) options {
 	opts := options{
 		accessibility:      levelExplicit,
 		ignoredMethodNames: map[string]bool{},
 	}
-	optsMap := utils.GetOptionsMap(rawOpts)
-	if optsMap == nil {
+	if len(rawOpts) == 0 {
 		return opts
 	}
+	optsMap, _ := rawOpts[0].(map[string]interface{})
 	if v, ok := optsMap["accessibility"].(string); ok {
 		opts.accessibility = accessibilityLevel(v)
 	}
@@ -318,9 +322,9 @@ func isClassMember(node *ast.Node) bool {
 }
 
 var ExplicitMemberAccessibilityRule = rule.CreateRule(rule.Rule{
-	Name: "explicit-member-accessibility",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "explicit-member-accessibility",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 		sf := ctx.SourceFile
 

--- a/internal/plugins/typescript/rules/explicit_member_accessibility/explicit_member_accessibility.schema.json
+++ b/internal/plugins/typescript/rules/explicit_member_accessibility/explicit_member_accessibility.schema.json
@@ -1,0 +1,72 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "$defs": {
+        "accessibilityLevel": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Always require an accessor.",
+              "enum": ["explicit"]
+            },
+            {
+              "type": "string",
+              "description": "Require an accessor except when public.",
+              "enum": ["no-public"]
+            },
+            {
+              "type": "string",
+              "description": "Never check whether there is an accessor.",
+              "enum": ["off"]
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "accessibility": {
+          "$ref": "#/items/0/$defs/accessibilityLevel",
+          "description": "Which accessibility modifier is required to exist or not exist."
+        },
+        "ignoredMethodNames": {
+          "type": "array",
+          "description": "Specific method names that may be ignored.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "overrides": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Changes to required accessibility modifiers for specific kinds of class members.",
+          "properties": {
+            "accessors": {
+              "$ref": "#/items/0/$defs/accessibilityLevel",
+              "description": "Which member accessibility modifier requirements to apply for accessors."
+            },
+            "constructors": {
+              "$ref": "#/items/0/$defs/accessibilityLevel",
+              "description": "Which member accessibility modifier requirements to apply for constructors."
+            },
+            "methods": {
+              "$ref": "#/items/0/$defs/accessibilityLevel",
+              "description": "Which member accessibility modifier requirements to apply for methods."
+            },
+            "parameterProperties": {
+              "$ref": "#/items/0/$defs/accessibilityLevel",
+              "description": "Which member accessibility modifier requirements to apply for parameterProperties."
+            },
+            "properties": {
+              "$ref": "#/items/0/$defs/accessibilityLevel",
+              "description": "Which member accessibility modifier requirements to apply for properties."
+            }
+          }
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types.go
+++ b/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types.go
@@ -1,6 +1,7 @@
 package explicit_module_boundary_types
 
 import (
+	_ "embed"
 	"sort"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -10,6 +11,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed explicit_module_boundary_types.schema.json
+var schemaJSON []byte
 
 // options mirrors upstream's schema.
 type options struct {
@@ -21,7 +25,7 @@ type options struct {
 	allowTypedFunctionExpressions             bool
 }
 
-func parseOptions(rawOpts any) options {
+func parseOptions(rawOpts []any) options {
 	opts := options{
 		allowArgumentsExplicitlyTypedAsAny:        false,
 		allowDirectConstAssertionInArrowFunctions: true,
@@ -30,10 +34,10 @@ func parseOptions(rawOpts any) options {
 		allowOverloadFunctions:        false,
 		allowTypedFunctionExpressions: true,
 	}
-	optsMap := utils.GetOptionsMap(rawOpts)
-	if optsMap == nil {
+	if len(rawOpts) == 0 {
 		return opts
 	}
+	optsMap, _ := rawOpts[0].(map[string]interface{})
 	if v, ok := optsMap["allowArgumentsExplicitlyTypedAsAny"].(bool); ok {
 		opts.allowArgumentsExplicitlyTypedAsAny = v
 	}
@@ -60,7 +64,8 @@ func parseOptions(rawOpts any) options {
 }
 
 var ExplicitModuleBoundaryTypesRule = rule.CreateRule(rule.Rule{
-	Name: "explicit-module-boundary-types",
+	Name:   "explicit-module-boundary-types",
+	Schema: rule.NewSchema(schemaJSON),
 	// Upstream rule isn't type-aware (uses ESLint's scope manager) but a
 	// TypeScript rule running on a TS project always has a TypeChecker
 	// available, and the symbol-based scope walk we use here is strictly
@@ -71,8 +76,7 @@ var ExplicitModuleBoundaryTypesRule = rule.CreateRule(rule.Rule{
 	Run:              run,
 })
 
-func run(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-	rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+func run(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 	opts := parseOptions(rawOptions)
 
 	// Per-file state. rslint constructs a new RuleListeners for each file, so

--- a/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types.schema.json
+++ b/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types.schema.json
@@ -1,0 +1,40 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowArgumentsExplicitlyTypedAsAny": {
+          "type": "boolean",
+          "description": "Whether to ignore arguments that are explicitly typed as `any`."
+        },
+        "allowDirectConstAssertionInArrowFunctions": {
+          "type": "boolean",
+          "description": "Whether to ignore return type annotations on body-less arrow functions that return an `as const` type assertion.\nYou must still type the parameters of the function."
+        },
+        "allowedNames": {
+          "type": "array",
+          "description": "An array of function/method names that will not have their arguments or return values checked.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowHigherOrderFunctions": {
+          "type": "boolean",
+          "description": "Whether to ignore return type annotations on functions immediately returning another function expression.\nYou must still type the parameters of the function."
+        },
+        "allowOverloadFunctions": {
+          "type": "boolean",
+          "description": "Whether to ignore return type annotations on functions with overload signatures."
+        },
+        "allowTypedFunctionExpressions": {
+          "type": "boolean",
+          "description": "Whether to ignore type annotations on the variable of a function expression."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types_extras_dim4_test.go
+++ b/internal/plugins/typescript/rules/explicit_module_boundary_types/explicit_module_boundary_types_extras_dim4_test.go
@@ -509,7 +509,7 @@ export class Test {
 		},
 
 		// ---- Locks in option-array form: single-element wrapper ----
-		// rslint's GetOptionsMap must handle `[{...}]` as well as `{...}`.
+		// Options in the canonical array form `[{...}]`.
 		// Already exercised in upstream cases — pin one explicitly.
 		{
 			Code: `
@@ -799,7 +799,6 @@ export const inc = (delta) => ({ type: 'inc', delta }) as const;
 				{MessageId: "missingArgType", Line: 2},
 			},
 		},
-
 
 		// ---- Locks in `export = expr` followReference path ----
 		{

--- a/internal/plugins/typescript/rules/init_declarations/init_declarations.go
+++ b/internal/plugins/typescript/rules/init_declarations/init_declarations.go
@@ -1,12 +1,16 @@
 package init_declarations
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed init_declarations.schema.json
+var schemaJSON []byte
 
 // InitDeclarationsRule mirrors @typescript-eslint/init-declarations, which wraps
 // the ESLint core init-declarations rule and additionally:
@@ -22,9 +26,9 @@ import (
 // Upstream wrapper: packages/eslint-plugin/src/rules/init-declarations.ts
 // Upstream base rule: eslint/lib/rules/init-declarations.js
 var InitDeclarationsRule = rule.CreateRule(rule.Rule{
-	Name: "init-declarations",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "init-declarations",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		return rule.RuleListeners{
@@ -44,43 +48,21 @@ type initDeclarationsOptions struct {
 	ignoreForLoopInit bool
 }
 
-// parseOptions accepts every shape config.go can hand a rule that uses ESLint's
-// `["mode", { ...sub-options }]` schema:
-//   - nil → defaults
-//   - "always" / "never" (string, from `['<level>', '<mode>']` — single-element
-//     option arrays are unwrapped by config.go)
-//   - []interface{}{"<mode>", map[string]interface{}{...}} (multi-element form,
-//     not unwrapped)
-//   - map[string]interface{}{...} (defensive — the CLI single-option fallback
-//     when only the sub-option object is supplied)
-func parseOptions(raw any) initDeclarationsOptions {
+// parseOptions reads ESLint's `["<mode>", { ...sub-options }]` options array:
+// the mode string in slot 0 (defaulting to "always"), and the sub-option
+// object — only meaningful for "never" — in slot 1.
+func parseOptions(options []any) initDeclarationsOptions {
 	opts := initDeclarationsOptions{mode: "always"}
 
-	if raw == nil {
+	if len(options) == 0 {
 		return opts
 	}
 
-	var modeStr string
-	var subOpts map[string]interface{}
-
-	switch v := raw.(type) {
-	case string:
-		modeStr = v
-	case []interface{}:
-		if len(v) > 0 {
-			modeStr, _ = v[0].(string)
-		}
-		if len(v) > 1 {
-			subOpts, _ = v[1].(map[string]interface{})
-		}
-	case map[string]interface{}:
-		subOpts = v
-	}
-
-	if modeStr == "always" || modeStr == "never" {
+	if modeStr, _ := options[0].(string); modeStr == "always" || modeStr == "never" {
 		opts.mode = modeStr
 	}
-	if subOpts != nil {
+	if len(options) > 1 {
+		subOpts, _ := options[1].(map[string]interface{})
 		if b, ok := subOpts["ignoreForLoopInit"].(bool); ok {
 			opts.ignoreForLoopInit = b
 		}

--- a/internal/plugins/typescript/rules/init_declarations/init_declarations.schema.json
+++ b/internal/plugins/typescript/rules/init_declarations/init_declarations.schema.json
@@ -1,0 +1,33 @@
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "items": [
+        {
+          "enum": ["always"]
+        }
+      ],
+      "minItems": 0,
+      "maxItems": 1
+    },
+    {
+      "type": "array",
+      "items": [
+        {
+          "enum": ["never"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ignoreForLoopInit": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "minItems": 0,
+      "maxItems": 2
+    }
+  ]
+}

--- a/internal/plugins/typescript/rules/init_declarations/init_declarations_extras_test.go
+++ b/internal/plugins/typescript/rules/init_declarations/init_declarations_extras_test.go
@@ -450,18 +450,6 @@ namespace Outer {
 				},
 			},
 
-			// Locks in option-shape coverage: bare-object option form (no mode
-			// string), exercising the `map[string]interface{}` arm of
-			// parseOptions. Defaults to mode="always" so an uninitialized binding
-			// reports.
-			{
-				Code:    `var foo;`,
-				Options: map[string]interface{}{"ignoreForLoopInit": true},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "initialized", Line: 1, Column: 5, EndLine: 1, EndColumn: 8},
-				},
-			},
-
 			// ---- Real-user: multi-declarator with mixed init under "never" ----
 			// Verifies per-declarator evaluation: only the initialized ones report.
 			{

--- a/internal/plugins/typescript/rules/init_declarations/init_declarations_upstream_test.go
+++ b/internal/plugins/typescript/rules/init_declarations/init_declarations_upstream_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-// arrayOption builds the array-wrapped option shape that exercises
-// utils.GetOptionsMap's JSON path — passing a Go struct directly would
-// short-circuit it and leave the CLI-facing wiring untested.
+// arrayOption builds the array-wrapped option shape that exercises the rule's
+// own options-array parsing — passing a Go struct directly would short-circuit
+// it and leave the CLI-facing wiring untested.
 func arrayOption(values ...interface{}) []interface{} {
 	return values
 }

--- a/internal/plugins/typescript/rules/max_params/max_params.go
+++ b/internal/plugins/typescript/rules/max_params/max_params.go
@@ -1,6 +1,7 @@
 package max_params
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -8,14 +9,18 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed max_params.schema.json
+var schemaJSON []byte
+
 // MaxParamsRule enforces a maximum number of parameters in function
 // definitions. Mirrors @typescript-eslint/max-params, which extends ESLint
 // core's max-params with the `countVoidThis` option.
 //
 // https://typescript-eslint.io/rules/max-params
 var MaxParamsRule = rule.CreateRule(rule.Rule{
-	Name: "max-params",
-	Run:  run,
+	Name:   "max-params",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
 const defaultMax = 3
@@ -25,8 +30,7 @@ type ruleOptions struct {
 	countVoidThis bool
 }
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	opts := parseOptions(options)
 
 	check := func(node *ast.Node) {
@@ -68,22 +72,19 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 }
 
 // parseOptions mirrors @typescript-eslint/max-params' schema: a single
-// optional object with `max`, `maximum`, and `countVoidThis`. Other shapes
-// (bare integer, integer-in-array) fall through to defaults — upstream
-// rejects them at schema validation, and rslint has no schema layer to
-// reproduce that, so we treat them as "no option" rather than guess.
+// optional object with `max`, `maximum`, and `countVoidThis`.
 //
 // `option.maximum || option.max` follows JS truthy coercion: a present-but-
 // zero `maximum` falls through to `max`; a present-but-falsy value with no
 // fallback leaves `numParams = undefined` upstream, which makes every
 // `count > undefined` comparison false. The shared legacy max helper models
 // that disabled state with MaxInt.
-func parseOptions(o any) ruleOptions {
+func parseOptions(options []any) ruleOptions {
 	out := ruleOptions{max: defaultMax}
-	m := utils.GetOptionsMap(o)
-	if m == nil {
+	if len(options) == 0 {
 		return out
 	}
+	m, _ := options[0].(map[string]interface{})
 	out.max = utils.ResolveLegacyMaxOption(m, defaultMax)
 	if v, ok := m["countVoidThis"]; ok {
 		if b, ok := v.(bool); ok {

--- a/internal/plugins/typescript/rules/max_params/max_params.schema.json
+++ b/internal/plugins/typescript/rules/max_params/max_params.schema.json
@@ -1,0 +1,27 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "countVoidThis": {
+          "type": "boolean",
+          "description": "Whether to count a `this` declaration when the type is `void`."
+        },
+        "max": {
+          "type": "integer",
+          "description": "A maximum number of parameters in function definitions.",
+          "minimum": 0
+        },
+        "maximum": {
+          "type": "integer",
+          "description": "(deprecated) A maximum number of parameters in function definitions.",
+          "minimum": 0
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/max_params/max_params_test.go
+++ b/internal/plugins/typescript/rules/max_params/max_params_test.go
@@ -204,12 +204,6 @@ class Foo {
 				Code:    "function foo(a, b, c, d) {}",
 				Options: objectOption(map[string]interface{}{"maximum": 4, "max": 2}),
 			},
-			// Bare integer / array-of-integer is rejected by the options schema;
-			// the rule tester does not validate, and such a shape falls back to
-			// defaults rather than guessing.
-			{Code: "function foo(a, b, c) {}", Options: 7},
-			{Code: "function foo(a, b, c) {}", Options: []interface{}{7}},
-
 			// --- this parameter handling ---
 			// `this` with no type annotation — never stripped (4 effective).
 			{

--- a/internal/plugins/typescript/rules/max_params/max_params_test.go
+++ b/internal/plugins/typescript/rules/max_params/max_params_test.go
@@ -7,9 +7,8 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-// objectOption returns the array-wrapped single-option shape that matches
-// rule_tester / multi-element CLI configs and exercises the JSON path through
-// utils.GetOptionsMap (the typed-struct shortcut would silently bypass it).
+// objectOption returns the array-wrapped single-option shape a config declares,
+// exercising the weakly-typed JSON path (a typed struct would bypass it).
 func objectOption(opts map[string]interface{}) []interface{} {
 	return []interface{}{opts}
 }
@@ -167,7 +166,7 @@ class Foo {
 			},
 
 			// --- Options shapes — exercise the JSON path ---
-			// Bare object (single-option CLI shape).
+			// Non-array `Options`, which the tester wraps into a one-element array.
 			{
 				Code:    "function foo(a, b, c, d) {}",
 				Options: map[string]interface{}{"max": 4},
@@ -205,9 +204,9 @@ class Foo {
 				Code:    "function foo(a, b, c, d) {}",
 				Options: objectOption(map[string]interface{}{"maximum": 4, "max": 2}),
 			},
-			// Bare integer / array-of-integer is REJECTED upstream by schema —
-			// rslint has no schema layer, so we treat as "no option" and fall
-			// back to defaults rather than guessing.
+			// Bare integer / array-of-integer is rejected by the options schema;
+			// the rule tester does not validate, and such a shape falls back to
+			// defaults rather than guessing.
 			{Code: "function foo(a, b, c) {}", Options: 7},
 			{Code: "function foo(a, b, c) {}", Options: []interface{}{7}},
 

--- a/internal/plugins/typescript/rules/member_ordering/member_ordering.go
+++ b/internal/plugins/typescript/rules/member_ordering/member_ordering.go
@@ -1,6 +1,7 @@
 package member_ordering
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -8,6 +9,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed member_ordering.schema.json
+var schemaJSON []byte
 
 // --- Message builders ---
 
@@ -307,16 +311,16 @@ func convertToMemberTypes(arr []interface{}) []interface{} {
 	return result
 }
 
-func parseOptions(options any) ruleOptions {
+func parseOptions(options []any) ruleOptions {
 	opts := ruleOptions{}
-	optsMap := utils.GetOptionsMap(options)
-	if optsMap == nil {
+	if len(options) == 0 {
 		opts.defaultConfig = &parsedConfig{
 			memberTypes: defaultOrder,
 			order:       orderAsWritten,
 		}
 		return opts
 	}
+	optsMap, _ := options[0].(map[string]interface{})
 
 	if def, ok := optsMap["default"]; ok {
 		opts.defaultConfig = parseConfig(def)
@@ -958,9 +962,9 @@ func getClassMembers(node *ast.Node) []*ast.Node {
 // --- Rule definition ---
 
 var MemberOrderingRule = rule.CreateRule(rule.Rule{
-	Name: "member-ordering",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "member-ordering",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		getConfig := func(nodeKind ast.Kind) *parsedConfig {

--- a/internal/plugins/typescript/rules/member_ordering/member_ordering.schema.json
+++ b/internal/plugins/typescript/rules/member_ordering/member_ordering.schema.json
@@ -1,0 +1,338 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "$defs": {
+        "allItems": {
+          "type": "string",
+          "enum": [
+            "readonly-signature",
+            "signature",
+            "readonly-field",
+            "public-readonly-field",
+            "public-decorated-readonly-field",
+            "decorated-readonly-field",
+            "static-readonly-field",
+            "public-static-readonly-field",
+            "instance-readonly-field",
+            "public-instance-readonly-field",
+            "abstract-readonly-field",
+            "public-abstract-readonly-field",
+            "protected-readonly-field",
+            "protected-decorated-readonly-field",
+            "protected-static-readonly-field",
+            "protected-instance-readonly-field",
+            "protected-abstract-readonly-field",
+            "private-readonly-field",
+            "private-decorated-readonly-field",
+            "private-static-readonly-field",
+            "private-instance-readonly-field",
+            "#private-readonly-field",
+            "#private-static-readonly-field",
+            "#private-instance-readonly-field",
+            "field",
+            "public-field",
+            "public-decorated-field",
+            "decorated-field",
+            "static-field",
+            "public-static-field",
+            "instance-field",
+            "public-instance-field",
+            "abstract-field",
+            "public-abstract-field",
+            "protected-field",
+            "protected-decorated-field",
+            "protected-static-field",
+            "protected-instance-field",
+            "protected-abstract-field",
+            "private-field",
+            "private-decorated-field",
+            "private-static-field",
+            "private-instance-field",
+            "#private-field",
+            "#private-static-field",
+            "#private-instance-field",
+            "method",
+            "public-method",
+            "public-decorated-method",
+            "decorated-method",
+            "static-method",
+            "public-static-method",
+            "instance-method",
+            "public-instance-method",
+            "abstract-method",
+            "public-abstract-method",
+            "protected-method",
+            "protected-decorated-method",
+            "protected-static-method",
+            "protected-instance-method",
+            "protected-abstract-method",
+            "private-method",
+            "private-decorated-method",
+            "private-static-method",
+            "private-instance-method",
+            "#private-method",
+            "#private-static-method",
+            "#private-instance-method",
+            "call-signature",
+            "constructor",
+            "public-constructor",
+            "protected-constructor",
+            "private-constructor",
+            "accessor",
+            "public-accessor",
+            "public-decorated-accessor",
+            "decorated-accessor",
+            "static-accessor",
+            "public-static-accessor",
+            "instance-accessor",
+            "public-instance-accessor",
+            "abstract-accessor",
+            "public-abstract-accessor",
+            "protected-accessor",
+            "protected-decorated-accessor",
+            "protected-static-accessor",
+            "protected-instance-accessor",
+            "protected-abstract-accessor",
+            "private-accessor",
+            "private-decorated-accessor",
+            "private-static-accessor",
+            "private-instance-accessor",
+            "#private-accessor",
+            "#private-static-accessor",
+            "#private-instance-accessor",
+            "get",
+            "public-get",
+            "public-decorated-get",
+            "decorated-get",
+            "static-get",
+            "public-static-get",
+            "instance-get",
+            "public-instance-get",
+            "abstract-get",
+            "public-abstract-get",
+            "protected-get",
+            "protected-decorated-get",
+            "protected-static-get",
+            "protected-instance-get",
+            "protected-abstract-get",
+            "private-get",
+            "private-decorated-get",
+            "private-static-get",
+            "private-instance-get",
+            "#private-get",
+            "#private-static-get",
+            "#private-instance-get",
+            "set",
+            "public-set",
+            "public-decorated-set",
+            "decorated-set",
+            "static-set",
+            "public-static-set",
+            "instance-set",
+            "public-instance-set",
+            "abstract-set",
+            "public-abstract-set",
+            "protected-set",
+            "protected-decorated-set",
+            "protected-static-set",
+            "protected-instance-set",
+            "protected-abstract-set",
+            "private-set",
+            "private-decorated-set",
+            "private-static-set",
+            "private-instance-set",
+            "#private-set",
+            "#private-static-set",
+            "#private-instance-set",
+            "static-initialization",
+            "static-static-initialization",
+            "public-static-static-initialization",
+            "instance-static-initialization",
+            "public-instance-static-initialization",
+            "abstract-static-initialization",
+            "public-abstract-static-initialization",
+            "protected-static-static-initialization",
+            "protected-instance-static-initialization",
+            "protected-abstract-static-initialization",
+            "private-static-static-initialization",
+            "private-instance-static-initialization",
+            "#private-static-static-initialization",
+            "#private-instance-static-initialization"
+          ]
+        },
+        "optionalityOrderOptions": {
+          "type": "string",
+          "enum": ["optional-first", "required-first"]
+        },
+        "orderOptions": {
+          "type": "string",
+          "enum": [
+            "alphabetically",
+            "alphabetically-case-insensitive",
+            "as-written",
+            "natural",
+            "natural-case-insensitive"
+          ]
+        },
+        "typeItems": {
+          "type": "string",
+          "enum": [
+            "readonly-signature",
+            "signature",
+            "readonly-field",
+            "field",
+            "method",
+            "constructor"
+          ]
+        },
+        "baseConfig": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["never"]
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/items/0/$defs/allItems"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/items/0/$defs/allItems"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "memberTypes": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/items/0/$defs/allItems"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/items/0/$defs/allItems"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "enum": ["never"]
+                    }
+                  ]
+                },
+                "optionalityOrder": {
+                  "$ref": "#/items/0/$defs/optionalityOrderOptions"
+                },
+                "order": {
+                  "$ref": "#/items/0/$defs/orderOptions"
+                }
+              }
+            }
+          ]
+        },
+        "typesConfig": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["never"]
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/items/0/$defs/typeItems"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/items/0/$defs/typeItems"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "memberTypes": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/items/0/$defs/typeItems"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/items/0/$defs/typeItems"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "enum": ["never"]
+                    }
+                  ]
+                },
+                "optionalityOrder": {
+                  "$ref": "#/items/0/$defs/optionalityOrderOptions"
+                },
+                "order": {
+                  "$ref": "#/items/0/$defs/orderOptions"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "classes": {
+          "$ref": "#/items/0/$defs/baseConfig",
+          "description": "Which ordering to enforce for classes."
+        },
+        "classExpressions": {
+          "$ref": "#/items/0/$defs/baseConfig",
+          "description": "Which ordering to enforce for classExpressions."
+        },
+        "default": {
+          "$ref": "#/items/0/$defs/baseConfig",
+          "description": "Which ordering to enforce for default."
+        },
+        "interfaces": {
+          "$ref": "#/items/0/$defs/typesConfig",
+          "description": "Which ordering to enforce for interfaces."
+        },
+        "typeLiterals": {
+          "$ref": "#/items/0/$defs/typesConfig",
+          "description": "Which ordering to enforce for typeLiterals."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style.go
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style.go
@@ -1,6 +1,7 @@
 package method_signature_style
 
 import (
+	_ "embed"
 	"sort"
 	"strings"
 
@@ -8,6 +9,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed method_signature_style.schema.json
+var schemaJSON []byte
 
 type mode string
 
@@ -31,8 +35,9 @@ func messageErrorProperty() rule.RuleMessage {
 }
 
 var MethodSignatureStyleRule = rule.CreateRule(rule.Rule{
-	Name: "method-signature-style",
-	Run:  run,
+	Name:   "method-signature-style",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
 // containsThisType recursively checks whether the given type node (or any of
@@ -241,11 +246,12 @@ func (f *methodSignatureFixer) buildPropertyFixes(
 	return []rule.RuleFix{rule.RuleFixReplace(f.sourceFile, node, replacement)}
 }
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
-	opt := mode(utils.GetOptionsString(options))
-	if opt == "" {
-		opt = modeProperty
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
+	opt := modeProperty
+	if len(options) > 0 {
+		if s, ok := options[0].(string); ok && s != "" {
+			opt = mode(s)
+		}
 	}
 
 	fixer := methodSignatureFixer{

--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style.schema.json
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style.schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "string",
+      "description": "The method signature style to enforce using.",
+      "enum": ["property", "method"]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.go
@@ -1,6 +1,7 @@
 package naming_convention
 
 import (
+	_ "embed"
 	"fmt"
 	"math/bits"
 	"regexp"
@@ -15,10 +16,14 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed naming_convention.schema.json
+var schemaJSON []byte
+
 // NamingConventionRule is the exported rule for registration.
 var NamingConventionRule = rule.CreateRule(rule.Rule{
-	Name: "naming-convention",
-	Run:  run,
+	Name:   "naming-convention",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
 // ---- Enums ----
@@ -443,29 +448,13 @@ func checkFormat(name string, format predefinedFormat) bool {
 
 // ---- Options parsing ----
 
-func parseOptions(rawOpts any) []normalizedSelector {
-	if rawOpts == nil {
-		return getDefaultConfig()
-	}
-
-	var optsList []interface{}
-	switch v := rawOpts.(type) {
-	case []interface{}:
-		optsList = v
-	case map[string]interface{}:
-		// Single selector object (e.g., when the config has one option element,
-		// LegacyUnwrapOptions collapses the single-element options array).
-		optsList = []interface{}{v}
-	default:
-		return getDefaultConfig()
-	}
-
-	if len(optsList) == 0 {
+func parseOptions(options []any) []normalizedSelector {
+	if len(options) == 0 {
 		return getDefaultConfig()
 	}
 
 	var selectors []normalizedSelector
-	for _, opt := range optsList {
+	for _, opt := range options {
 		optMap, ok := opt.(map[string]interface{})
 		if !ok {
 			continue
@@ -509,7 +498,7 @@ func parseOptions(rawOpts any) []normalizedSelector {
 }
 
 func getDefaultConfig() []normalizedSelector {
-	return parseOptions([]interface{}{
+	return parseOptions([]any{
 		map[string]interface{}{
 			"selector":           "default",
 			"format":             []interface{}{"camelCase"},
@@ -2146,8 +2135,7 @@ func collectReExportedNames(ctx rule.RuleContext) map[string]bool {
 
 // ---- Main run function ----
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	selectors := parseOptions(options)
 
 	if len(selectors) == 0 {

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.go
@@ -4,11 +4,11 @@ import (
 	_ "embed"
 	"fmt"
 	"math/bits"
-	"regexp"
 	"sort"
 	"strings"
 	"unicode"
 
+	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/scanner"
@@ -280,7 +280,7 @@ func parseTypeModifier(s string) (typeModifierKind, bool) {
 // ---- Normalized config types ----
 
 type matchRegex struct {
-	regex *regexp.Regexp
+	regex *regexp2.Regexp
 	match bool
 }
 
@@ -666,7 +666,7 @@ func parseMatchRegex(val interface{}) *matchRegex {
 	}
 	switch v := val.(type) {
 	case string:
-		re, err := regexp.Compile(v)
+		re, err := utils.CompileRegexp2(v, utils.JSUnicodeRegexOptions)
 		if err != nil {
 			return nil
 		}
@@ -677,7 +677,7 @@ func parseMatchRegex(val interface{}) *matchRegex {
 		if m, ok := v["match"].(bool); ok {
 			matchVal = m
 		}
-		re, err := regexp.Compile(regexStr)
+		re, err := utils.CompileRegexp2(regexStr, utils.JSUnicodeRegexOptions)
 		if err != nil {
 			return nil
 		}
@@ -879,7 +879,7 @@ func validate(name string, sel normalizedSelector, idMods modifierKind, idSelect
 
 	// 7. Validate custom regex (against processed name, after stripping underscores and affixes)
 	if sel.custom != nil {
-		matches := sel.custom.regex.MatchString(processedName)
+		matches := utils.Regexp2MatchString(sel.custom.regex, processedName)
 		if sel.custom.match != matches {
 			msg := satisfyCustomMessage(typeName, name, sel.custom.match, sel.custom.regex.String())
 			return validationResult{valid: false, message: &msg}
@@ -2206,7 +2206,7 @@ func validateIdentifier(ctx rule.RuleContext, id identifierInfo, selectors []nor
 		// Check filter match — if filter doesn't match the name, skip this
 		// selector entirely so the next one in specificity order can match.
 		if sel.filter != nil {
-			matches := sel.filter.regex.MatchString(id.name)
+			matches := utils.Regexp2MatchString(sel.filter.regex, id.name)
 			if sel.filter.match != matches {
 				continue
 			}

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.schema.json
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.schema.json
@@ -47,7 +47,8 @@
           "type": "boolean"
         },
         "regex": {
-          "type": "string"
+          "type": "string",
+          "format": "regex"
         }
       },
       "required": ["match", "regex"],
@@ -94,7 +95,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -202,7 +204,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -272,7 +275,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -324,7 +328,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -390,7 +395,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -442,7 +448,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -501,7 +508,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -564,7 +572,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -633,7 +642,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -692,7 +702,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -751,7 +762,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -810,7 +822,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -880,7 +893,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -942,7 +956,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -994,7 +1009,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1046,7 +1062,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1108,7 +1125,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1175,7 +1193,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1242,7 +1261,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1309,7 +1329,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1361,7 +1382,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1413,7 +1435,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1465,7 +1488,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1517,7 +1541,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1569,7 +1594,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1621,7 +1647,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"
@@ -1673,7 +1700,8 @@
             "oneOf": [
               {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "regex"
               },
               {
                 "$ref": "#/$defs/matchRegexConfig"

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.schema.json
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.schema.json
@@ -1,0 +1,1702 @@
+{
+  "$defs": {
+    "predefinedFormats": {
+      "enum": [
+        "camelCase",
+        "strictCamelCase",
+        "PascalCase",
+        "StrictPascalCase",
+        "snake_case",
+        "UPPER_CASE"
+      ],
+      "type": "string"
+    },
+    "typeModifiers": {
+      "enum": ["boolean", "string", "number", "function", "array"],
+      "type": "string"
+    },
+    "underscoreOptions": {
+      "enum": [
+        "forbid",
+        "allow",
+        "require",
+        "requireDouble",
+        "allowDouble",
+        "allowSingleOrDouble"
+      ],
+      "type": "string"
+    },
+    "formatOptionsConfig": {
+      "oneOf": [
+        {
+          "additionalItems": false,
+          "items": {
+            "$ref": "#/$defs/predefinedFormats"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "matchRegexConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "match": {
+          "type": "boolean"
+        },
+        "regex": {
+          "type": "string"
+        }
+      },
+      "required": ["match", "regex"],
+      "type": "object"
+    },
+    "prefixSuffixConfig": {
+      "additionalItems": false,
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "additionalItems": false,
+  "items": {
+    "oneOf": [
+      {
+        "additionalProperties": false,
+        "description": "Multiple selectors in one config",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "const",
+                "readonly",
+                "static",
+                "public",
+                "protected",
+                "private",
+                "#private",
+                "abstract",
+                "destructured",
+                "global",
+                "exported",
+                "unused",
+                "requiresQuotes",
+                "override",
+                "async",
+                "default",
+                "namespace"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "selector": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "default",
+                "variableLike",
+                "memberLike",
+                "typeLike",
+                "method",
+                "property",
+                "accessor",
+                "variable",
+                "function",
+                "parameter",
+                "parameterProperty",
+                "classicAccessor",
+                "enumMember",
+                "classMethod",
+                "objectLiteralMethod",
+                "typeMethod",
+                "classProperty",
+                "objectLiteralProperty",
+                "typeProperty",
+                "autoAccessor",
+                "class",
+                "interface",
+                "typeAlias",
+                "enum",
+                "typeParameter",
+                "import"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'default'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["default"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "const",
+                "readonly",
+                "static",
+                "public",
+                "protected",
+                "private",
+                "#private",
+                "abstract",
+                "destructured",
+                "global",
+                "exported",
+                "unused",
+                "requiresQuotes",
+                "override",
+                "async",
+                "default",
+                "namespace"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'variableLike'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["variableLike"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["unused", "async"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'variable'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["variable"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "const",
+                "destructured",
+                "exported",
+                "global",
+                "unused",
+                "async"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'function'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["function"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["exported", "global", "unused", "async"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'parameter'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["parameter"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["destructured", "unused"],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'memberLike'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["memberLike"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "abstract",
+                "private",
+                "#private",
+                "protected",
+                "public",
+                "readonly",
+                "requiresQuotes",
+                "static",
+                "override",
+                "async"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'classProperty'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["classProperty"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "abstract",
+                "private",
+                "#private",
+                "protected",
+                "public",
+                "readonly",
+                "requiresQuotes",
+                "static",
+                "override"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'objectLiteralProperty'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["objectLiteralProperty"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["public", "requiresQuotes"],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'typeProperty'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["typeProperty"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["public", "readonly", "requiresQuotes"],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'parameterProperty'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["parameterProperty"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["private", "protected", "public", "readonly"],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'property'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["property"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "abstract",
+                "private",
+                "#private",
+                "protected",
+                "public",
+                "readonly",
+                "requiresQuotes",
+                "static",
+                "override",
+                "async"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'classMethod'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["classMethod"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "abstract",
+                "private",
+                "#private",
+                "protected",
+                "public",
+                "requiresQuotes",
+                "static",
+                "override",
+                "async"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'objectLiteralMethod'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["objectLiteralMethod"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["public", "requiresQuotes", "async"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'typeMethod'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["typeMethod"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["public", "requiresQuotes"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'method'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["method"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "abstract",
+                "private",
+                "#private",
+                "protected",
+                "public",
+                "requiresQuotes",
+                "static",
+                "override",
+                "async"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'classicAccessor'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["classicAccessor"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "abstract",
+                "private",
+                "protected",
+                "public",
+                "requiresQuotes",
+                "static",
+                "override"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'autoAccessor'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["autoAccessor"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "abstract",
+                "private",
+                "protected",
+                "public",
+                "requiresQuotes",
+                "static",
+                "override"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'accessor'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["accessor"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": [
+                "abstract",
+                "private",
+                "protected",
+                "public",
+                "requiresQuotes",
+                "static",
+                "override"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "types": {
+            "additionalItems": false,
+            "items": {
+              "$ref": "#/$defs/typeModifiers"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'enumMember'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["enumMember"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["requiresQuotes"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'typeLike'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["typeLike"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["abstract", "exported", "unused"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'class'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["class"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["abstract", "exported", "unused"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'interface'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["interface"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["exported", "unused"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'typeAlias'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["typeAlias"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["exported", "unused"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'enum'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["enum"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["exported", "unused"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'typeParameter'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["typeParameter"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["unused"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
+        "description": "Selector 'import'",
+        "properties": {
+          "custom": {
+            "$ref": "#/$defs/matchRegexConfig"
+          },
+          "failureMessage": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/$defs/formatOptionsConfig"
+          },
+          "leadingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "prefix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "suffix": {
+            "$ref": "#/$defs/prefixSuffixConfig"
+          },
+          "trailingUnderscore": {
+            "$ref": "#/$defs/underscoreOptions"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/matchRegexConfig"
+              }
+            ]
+          },
+          "selector": {
+            "enum": ["import"],
+            "type": "string"
+          },
+          "modifiers": {
+            "additionalItems": false,
+            "items": {
+              "enum": ["default", "namespace"],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["selector", "format"],
+        "type": "object"
+      }
+    ]
+  },
+  "type": "array"
+}

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
@@ -584,3 +584,34 @@ func TestNamingConventionRule(t *testing.T) {
 		},
 	})
 }
+
+// TestNamingConventionRegexSchema locks in that both regex-valued options are
+// validated as regexes: `filter`'s bare-string form and the `regex` key of
+// its object form (shared by `custom`). The rule compiles each one, so an
+// unparsable pattern would otherwise be dropped and the selector would apply
+// to everything. Upstream's schema declares bare strings.
+func TestNamingConventionRegexSchema(t *testing.T) {
+	selector := func(filter any) []any {
+		return []any{map[string]any{
+			"selector": "variable",
+			"format":   []any{"camelCase"},
+			"filter":   filter,
+		}}
+	}
+	for name, filter := range map[string]any{
+		"bare string":  "(",
+		"regex object": map[string]any{"match": true, "regex": "("},
+	} {
+		if err := NamingConventionRule.Schema.Validate(selector(filter)); err == nil {
+			t.Errorf("expected an invalid filter %s to fail schema validation", name)
+		}
+	}
+	for name, filter := range map[string]any{
+		"bare string":  "^ignored",
+		"regex object": map[string]any{"match": true, "regex": "^ignored"},
+	} {
+		if err := NamingConventionRule.Schema.Validate(selector(filter)); err != nil {
+			t.Errorf("expected a valid filter %s to pass schema validation, got: %v", name, err)
+		}
+	}
+}

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
@@ -615,3 +615,44 @@ func TestNamingConventionRegexSchema(t *testing.T) {
 		}
 	}
 }
+
+// TestNamingConventionCustomLookahead locks in that `custom.regex` (and by
+// extension `filter`, which shares the same compile path) is matched with
+// the same ECMAScript regex engine the schema validates it against
+// (regexp2), not Go's RE2. RE2 cannot compile lookahead, so a JS-only
+// pattern that passes schema validation would otherwise silently fail to
+// compile and never flag a mismatched name.
+func TestNamingConventionCustomLookahead(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NamingConventionRule, []rule_tester.ValidTestCase{
+		{
+			Code: `const myVar = 1;`,
+			Options: []interface{}{
+				map[string]interface{}{
+					"selector": "variable",
+					"format":   []interface{}{"camelCase"},
+					"custom": map[string]interface{}{
+						"regex": "^(?!deprecated).*$",
+						"match": true,
+					},
+				},
+			},
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `const deprecatedVar = 1;`,
+			Options: []interface{}{
+				map[string]interface{}{
+					"selector": "variable",
+					"format":   []interface{}{"camelCase"},
+					"custom": map[string]interface{}{
+						"regex": "^(?!deprecated).*$",
+						"match": true,
+					},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "satisfyCustom", Line: 1, Column: 7},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor.go
+++ b/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor.go
@@ -119,7 +119,8 @@ func noArrayConstructorListeners(ctx rule.RuleContext) rule.RuleListeners {
 }
 
 var NoArrayConstructorRule = rule.CreateRule(rule.Rule{
-	Name: "no-array-constructor",
+	Name:   "no-array-constructor",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		if !sourceMayUseArrayConstructor(ctx.SourceFile) {
 			return nil

--- a/internal/plugins/typescript/rules/no_array_delete/no_array_delete.go
+++ b/internal/plugins/typescript/rules/no_array_delete/no_array_delete.go
@@ -23,6 +23,7 @@ func buildUseSpliceMessage() rule.RuleMessage {
 
 var NoArrayDeleteRule = rule.CreateRule(rule.Rule{
 	Name:             "no-array-delete",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		isUnderlyingTypeArray := func(t *checker.Type) bool {

--- a/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.go
+++ b/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.go
@@ -1,6 +1,7 @@
 package no_base_to_string
 
 import (
+	_ "embed"
 	"fmt"
 	"slices"
 
@@ -9,6 +10,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_base_to_string.schema.json
+var schemaJSON []byte
 
 func certaintyToString(certainty usefulness) string {
 	switch certainty {
@@ -50,13 +54,15 @@ const (
 
 var NoBaseToStringRule = rule.CreateRule(rule.Rule{
 	Name:             "no-base-to-string",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(NoBaseToStringOptions)
-		if !ok {
-			opts = NoBaseToStringOptions{
-				IgnoredTypeNames: []string{"Error", "RegExp", "URL", "URLSearchParams"},
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := NoBaseToStringOptions{
+			IgnoredTypeNames: []string{"Error", "RegExp", "URL", "URLSearchParams"},
+		}
+		if len(options) > 0 {
+			if typed, ok := options[0].(NoBaseToStringOptions); ok {
+				opts = typed
 			}
 		}
 

--- a/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.go
+++ b/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.go
@@ -2,6 +2,7 @@ package no_base_to_string
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"slices"
 
@@ -41,7 +42,22 @@ func buildBaseToStringMessage(name string, certainty usefulness) rule.RuleMessag
 }
 
 type NoBaseToStringOptions struct {
-	IgnoredTypeNames []string
+	IgnoredTypeNames []string `json:"ignoredTypeNames"`
+}
+
+func parseOptions(options []any) NoBaseToStringOptions {
+	opts := NoBaseToStringOptions{
+		IgnoredTypeNames: []string{"Error", "RegExp", "URL", "URLSearchParams"},
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	if optsMap, ok := options[0].(map[string]interface{}); ok {
+		if optsJSON, err := json.Marshal(optsMap); err == nil {
+			_ = json.Unmarshal(optsJSON, &opts)
+		}
+	}
+	return opts
 }
 
 type usefulness uint32
@@ -57,14 +73,7 @@ var NoBaseToStringRule = rule.CreateRule(rule.Rule{
 	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		opts := NoBaseToStringOptions{
-			IgnoredTypeNames: []string{"Error", "RegExp", "URL", "URLSearchParams"},
-		}
-		if len(options) > 0 {
-			if typed, ok := options[0].(NoBaseToStringOptions); ok {
-				opts = typed
-			}
-		}
+		opts := parseOptions(options)
 
 		var collectToStringCertainty func(
 			t *checker.Type,

--- a/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.schema.json
+++ b/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string.schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "checkUnknown": {
+          "type": "boolean",
+          "description": "Whether to also check values of type `unknown`"
+        },
+        "ignoredTypeNames": {
+          "type": "array",
+          "description": "Stringified type names to ignore.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string_test.go
+++ b/internal/plugins/typescript/rules/no_base_to_string/no_base_to_string_test.go
@@ -161,7 +161,7 @@ Number(1);
     `},
 			{
 				Code:    "String(/regex/);",
-				Options: NoBaseToStringOptions{IgnoredTypeNames: []string{"RegExp"}},
+				Options: map[string]interface{}{"ignoredTypeNames": []interface{}{"RegExp"}},
 			},
 			{
 				Code: `
@@ -169,7 +169,7 @@ type Foo = { a: string } | { b: string };
 declare const foo: Foo;
 String(foo);
       `,
-				Options: NoBaseToStringOptions{IgnoredTypeNames: []string{"Foo"}},
+				Options: map[string]interface{}{"ignoredTypeNames": []interface{}{"Foo"}},
 			},
 			// TODO(port): this is invalid ts file (with lib)
 			{Code: `

--- a/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion.go
+++ b/internal/plugins/typescript/rules/no_confusing_non_null_assertion/no_confusing_non_null_assertion.go
@@ -59,7 +59,8 @@ func buildWrapUpLeftMessage(op string) rule.RuleMessage {
 }
 
 var NoConfusingNonNullAssertionRule = rule.CreateRule(rule.Rule{
-	Name: "no-confusing-non-null-assertion",
+	Name:   "no-confusing-non-null-assertion",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindBinaryExpression: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.go
+++ b/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.go
@@ -73,9 +73,6 @@ func parseOptions(options []any) NoConfusingVoidExpressionOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	if typed, ok := options[0].(NoConfusingVoidExpressionOptions); ok {
-		return typed
-	}
 	// Convert the configured option object to JSON and back into the struct.
 	if optsJSON, err := json.Marshal(options[0]); err == nil {
 		_ = json.Unmarshal(optsJSON, &opts)

--- a/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.go
+++ b/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.go
@@ -1,6 +1,7 @@
 package no_confusing_void_expression
 
 import (
+	_ "embed"
 	"encoding/json"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -8,6 +9,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_confusing_void_expression.schema.json
+var schemaJSON []byte
 
 func buildInvalidVoidExprMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -64,28 +68,27 @@ type NoConfusingVoidExpressionOptions struct {
 	IgnoreVoidReturningFunctions bool `json:"ignoreVoidReturningFunctions,omitempty"`
 }
 
+func parseOptions(options []any) NoConfusingVoidExpressionOptions {
+	opts := NoConfusingVoidExpressionOptions{}
+	if len(options) == 0 {
+		return opts
+	}
+	if typed, ok := options[0].(NoConfusingVoidExpressionOptions); ok {
+		return typed
+	}
+	// Convert the configured option object to JSON and back into the struct.
+	if optsJSON, err := json.Marshal(options[0]); err == nil {
+		_ = json.Unmarshal(optsJSON, &opts)
+	}
+	return opts
+}
+
 var NoConfusingVoidExpressionRule = rule.CreateRule(rule.Rule{
 	Name:             "no-confusing-void-expression",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(NoConfusingVoidExpressionOptions)
-
-		if !ok {
-			// try convert options to JSON and back to struct
-			opts = NoConfusingVoidExpressionOptions{}
-			// get first element of options (re-wrapping config.rules' unwrapped
-			// single option into eslint-format []any)
-			options_array := rule.NormalizeOptions(options)
-			// if options_array has at least one element, try to unmarshal it
-			if len(options_array) > 0 {
-				optsJSON, err := json.Marshal(options_array[0])
-				if err == nil {
-					json.Unmarshal(optsJSON, &opts)
-				}
-
-			}
-		}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		canFix := func(node *ast.Node) bool {
 			t := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node)

--- a/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.schema.json
+++ b/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression.schema.json
@@ -1,0 +1,25 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ignoreArrowShorthand": {
+          "type": "boolean",
+          "description": "Whether to ignore \"shorthand\" `() =>` arrow functions: those without `{ ... }` braces."
+        },
+        "ignoreVoidOperator": {
+          "type": "boolean",
+          "description": "Whether to ignore returns that start with the `void` operator."
+        },
+        "ignoreVoidReturningFunctions": {
+          "type": "boolean",
+          "description": "Whether to ignore returns from functions with explicit `void` return types and functions with contextual `void` return types."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression_test.go
+++ b/internal/plugins/typescript/rules/no_confusing_void_expression/no_confusing_void_expression_test.go
@@ -19,85 +19,85 @@ func TestNoConfusingVoidExpressionRule(t *testing.T) {
 			Code: `
         () => console.log('foo');
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreArrowShorthand: true},
+			Options: map[string]interface{}{"ignoreArrowShorthand": true},
 		},
 		{
 			Code: `
         foo => foo && console.log(foo);
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreArrowShorthand: true},
+			Options: map[string]interface{}{"ignoreArrowShorthand": true},
 		},
 		{
 			Code: `
         foo => foo || console.log(foo);
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreArrowShorthand: true},
+			Options: map[string]interface{}{"ignoreArrowShorthand": true},
 		},
 		{
 			Code: `
         foo => (foo ? console.log(true) : console.log(false));
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreArrowShorthand: true},
+			Options: map[string]interface{}{"ignoreArrowShorthand": true},
 		},
 		{
 			Code: `
         !void console.log('foo');
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 		},
 		{
 			Code: `
         +void (foo && console.log(foo));
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 		},
 		{
 			Code: `
         -void (foo || console.log(foo));
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 		},
 		{
 			Code: `
         () => void ((foo && void console.log(true)) || console.log(false));
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 		},
 		{
 			Code: `
         const x = void (foo ? console.log(true) : console.log(false));
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 		},
 		{
 			Code: `
         !(foo && void console.log(foo));
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 		},
 		{
 			Code: `
         !!(foo || void console.log(foo));
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 		},
 		{
 			Code: `
         const x = (foo && void console.log(true)) || void console.log(false);
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 		},
 		{
 			Code: `
         () => (foo ? void console.log(true) : void console.log(false));
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 		},
 		{
 			Code: `
         return void console.log('foo');
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 		},
 		{Code: `
 function cool(input: string) {
@@ -119,7 +119,7 @@ function test(): void {
   return console.log('bar');
 }
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -127,13 +127,13 @@ const test = (): void => {
   return console.log('bar');
 };
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
 const test = (): void => console.log('bar');
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -143,7 +143,7 @@ function test(): void {
   }
 }
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -153,7 +153,7 @@ const obj = {
   },
 };
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -163,7 +163,7 @@ class Foo {
   }
 }
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -173,14 +173,14 @@ function test() {
   }
 }
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
 type Foo = () => void;
 const test = (() => console.log()) as Foo;
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -191,7 +191,7 @@ const test: Foo = {
   foo: () => console.log(),
 };
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -201,7 +201,7 @@ const test = {
   foo: () => void;
 };
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -211,7 +211,7 @@ const test: {
   foo: () => console.log(),
 };
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -223,7 +223,7 @@ const test = {
   foo: { bar: () => console.log() },
 } as Foo;
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -235,7 +235,7 @@ const test: Foo = {
   foo: { bar: () => console.log() },
 };
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -245,7 +245,7 @@ class App {
   private method: MethodType = () => console.log();
 }
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -259,14 +259,14 @@ function bar(): Foo {
   };
 }
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
 type Foo = () => () => () => void;
 const x: Foo = () => () => () => console.log();
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -278,14 +278,14 @@ const test = {
   foo: () => console.log(),
 } as Foo;
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
 type Foo = () => void;
 const test: Foo = () => console.log('foo');
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -297,7 +297,7 @@ declare function Component(props: Props): any;
 
 <Component onEvent={() => console.log()} />;
 			`,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Tsx:     true,
 		},
 		{
@@ -305,35 +305,35 @@ declare function Component(props: Props): any;
 declare function foo(arg: () => void): void;
 foo(() => console.log());
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
 declare function foo(arg: (() => void) | (() => string)): void;
 foo(() => console.log());
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
 declare function foo(arg: (() => void) | (() => string) | string): void;
 foo(() => console.log());
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
 declare function foo(arg: () => void | string): void;
 foo(() => console.log());
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
 declare function foo(options: { cb: () => void }): void;
 foo({ cb: () => console.log() });
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -343,7 +343,7 @@ const obj = {
   foo: { bar: () => void };
 };
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -351,7 +351,7 @@ function test(): void & void {
   return console.log('foo');
 }
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -363,20 +363,20 @@ function test(): Foo {
   return foo();
 }
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
 type Foo = void;
 const test = (): Foo => console.log('err');
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
 const test: () => any = (): void => console.log();
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -384,7 +384,7 @@ function test(): void | string {
   return console.log('bar');
 }
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		{
 			Code: `
@@ -403,19 +403,19 @@ test((() => {
   return console.log('123');
 }) as typeof makeDate | (() => string));
       `,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		// JSX: arrow function in onClick (void-returning) should be valid
 		{
 			Code:    `const foo = <button onClick={() => console.log()} />;`,
 			Tsx:     true,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		// JSX: arrow function with body in void-returning prop
 		{
 			Code:    `const foo = <button onClick={() => { console.log(); return console.log(); }} />;`,
 			Tsx:     true,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		// JSX: custom component with void-returning callback prop
 		{
@@ -424,7 +424,7 @@ declare function Comp(props: { handler: () => void }): any;
 const foo = <Comp handler={() => console.log()} />;
 `,
 			Tsx:     true,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 		// JSX: union type prop including void
 		{
@@ -433,7 +433,7 @@ declare function Comp(props: { handler: (() => void) | (() => number) }): any;
 const foo = <Comp handler={() => console.log()} />;
 `,
 			Tsx:     true,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 		},
 	}, []rule_tester.InvalidTestCase{
 		{
@@ -886,7 +886,7 @@ function notcool(input: string) {
 		{
 			Code:    "return console.log('foo');",
 			Output:  []string{"return void console.log('foo');"},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturnWrapVoid",
@@ -897,7 +897,7 @@ function notcool(input: string) {
 		},
 		{
 			Code:    "console.error(console.log('foo'));",
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprWrapVoid",
@@ -914,7 +914,7 @@ function notcool(input: string) {
 		},
 		{
 			Code:    "console.log('foo') ? true : false;",
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprWrapVoid",
@@ -931,7 +931,7 @@ function notcool(input: string) {
 		},
 		{
 			Code:    "const x = foo ?? console.log('foo');",
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprWrapVoid",
@@ -949,7 +949,7 @@ function notcool(input: string) {
 		{
 			Code:    "foo => foo || console.log(foo);",
 			Output:  []string{"foo => foo || void console.log(foo);"},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrowWrapVoid",
@@ -960,7 +960,7 @@ function notcool(input: string) {
 		},
 		{
 			Code:    "!!console.log('foo');",
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidOperator: true},
+			Options: map[string]interface{}{"ignoreVoidOperator": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprWrapVoid",
@@ -987,7 +987,7 @@ function test() {
 }
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturnLast",
@@ -999,7 +999,7 @@ function test() {
 		{
 			Code:    "const test = () => console.log('foo');",
 			Output:  []string{"const test = () =>{  console.log('foo'); };"},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1020,7 +1020,7 @@ const test = () => {
 };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturnLast",
@@ -1045,7 +1045,7 @@ function foo(): void {
 }
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturnLast",
@@ -1062,7 +1062,7 @@ function foo(): void {
         (): any =>{  console.log('foo'); };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1079,7 +1079,7 @@ function foo(): void {
         (): unknown =>{  console.log('foo'); };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1100,7 +1100,7 @@ function test(): void {
 }
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1119,7 +1119,7 @@ type Foo = any;
 (): Foo =>{  console.log(); };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1138,7 +1138,7 @@ type Foo = unknown;
 (): Foo =>{  console.log(); };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1159,7 +1159,7 @@ function test(): any {
 }
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1180,7 +1180,7 @@ function test(): unknown {
 }
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturnLast",
@@ -1201,7 +1201,7 @@ function test(): any {
 }
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturnLast",
@@ -1220,7 +1220,7 @@ type Foo = () => any;
 (): Foo => () =>{  console.log(); };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1239,7 +1239,7 @@ type Foo = () => unknown;
 (): Foo => () =>{  console.log(); };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1258,7 +1258,7 @@ type Foo = () => any;
 const test: Foo = () =>{  console.log(); };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1277,7 +1277,7 @@ type Foo = () => unknown;
 const test: Foo = () =>{  console.log(); };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprArrow",
@@ -1306,7 +1306,7 @@ const foo: Foo = function () {
 };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturnLast",
@@ -1331,7 +1331,7 @@ const foo = function () {
 };
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturnLast",
@@ -1348,7 +1348,7 @@ return console.log('foo');
 {  console.log('foo');; return; }
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturn",
@@ -1379,7 +1379,7 @@ function test(arg?: string): any | void {
 }
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturnLast",
@@ -1410,7 +1410,7 @@ function test(arg?: string): any | void {
 }
       `,
 			},
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalidVoidExprReturnLast",
@@ -1439,7 +1439,7 @@ declare function Comp(props: { getValue: () => string }): any;
 const foo = <Comp getValue={() =>{  console.log(); }} />;
 `},
 			Tsx:     true,
-			Options: NoConfusingVoidExpressionOptions{IgnoreVoidReturningFunctions: true},
+			Options: map[string]interface{}{"ignoreVoidReturningFunctions": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "invalidVoidExprArrow"},
 			},

--- a/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
+++ b/internal/plugins/typescript/rules/no_deprecated/no_deprecated.go
@@ -432,10 +432,10 @@ func deprecatedReasonFromDeclaration(declaration *ast.Node) string {
 // TypeOrValueSpecifier's own UnmarshalJSON rather than re-deriving both shapes
 // by hand.
 func parseAllowSpecifiers(options []any) []utils.TypeOrValueSpecifier {
-	optsMap := utils.GetOptionsMap(options)
-	if optsMap == nil {
+	if len(options) == 0 {
 		return nil
 	}
+	optsMap, _ := options[0].(map[string]interface{})
 	raw, ok := optsMap["allow"]
 	if !ok {
 		return nil

--- a/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.go
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.go
@@ -103,7 +103,8 @@ func (state *classState) register(name string, static bool, kind memberKind) boo
 }
 
 var NoDupeClassMembersRule = rule.CreateRule(rule.Rule{
-	Name: "no-dupe-class-members",
+	Name:   "no-dupe-class-members",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		checkClass := func(node *ast.Node) {
 			members := node.Members()

--- a/internal/plugins/typescript/rules/no_duplicate_enum_values/no_duplicate_enum_values.go
+++ b/internal/plugins/typescript/rules/no_duplicate_enum_values/no_duplicate_enum_values.go
@@ -99,7 +99,8 @@ func duplicateValueMessage(value enumValue) rule.RuleMessage {
 }
 
 var NoDuplicateEnumValuesRule = rule.CreateRule(rule.Rule{
-	Name: "no-duplicate-enum-values",
+	Name:   "no-duplicate-enum-values",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindEnumDeclaration: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.go
+++ b/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.go
@@ -2,6 +2,7 @@ package no_duplicate_type_constituents
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -42,8 +43,8 @@ const (
 )
 
 type NoDuplicateTypeConstituentsOptions struct {
-	IgnoreIntersections bool
-	IgnoreUnions        bool
+	IgnoreIntersections bool `json:"ignoreIntersections"`
+	IgnoreUnions        bool `json:"ignoreUnions"`
 }
 
 func parseOptions(options []any) NoDuplicateTypeConstituentsOptions {
@@ -54,8 +55,10 @@ func parseOptions(options []any) NoDuplicateTypeConstituentsOptions {
 	if len(options) == 0 {
 		return opts
 	}
-	if typed, ok := options[0].(NoDuplicateTypeConstituentsOptions); ok {
-		opts = typed
+	if optsMap, ok := options[0].(map[string]interface{}); ok {
+		if optsJSON, err := json.Marshal(optsMap); err == nil {
+			_ = json.Unmarshal(optsJSON, &opts)
+		}
 	}
 	return opts
 }

--- a/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.go
+++ b/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.go
@@ -1,6 +1,7 @@
 package no_duplicate_type_constituents
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -10,6 +11,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_duplicate_type_constituents.schema.json
+var schemaJSON []byte
 
 func buildDuplicateMessage(unionOrIntersection unionOrIntersection, previous string) rule.RuleMessage {
 	var msg string
@@ -42,18 +46,26 @@ type NoDuplicateTypeConstituentsOptions struct {
 	IgnoreUnions        bool
 }
 
+func parseOptions(options []any) NoDuplicateTypeConstituentsOptions {
+	opts := NoDuplicateTypeConstituentsOptions{
+		IgnoreIntersections: false,
+		IgnoreUnions:        false,
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	if typed, ok := options[0].(NoDuplicateTypeConstituentsOptions); ok {
+		opts = typed
+	}
+	return opts
+}
+
 var NoDuplicateTypeConstituentsRule = rule.CreateRule(rule.Rule{
 	Name:             "no-duplicate-type-constituents",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(NoDuplicateTypeConstituentsOptions)
-		if !ok {
-			opts = NoDuplicateTypeConstituentsOptions{
-				IgnoreIntersections: false,
-				IgnoreUnions:        false,
-			}
-		}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		unwindedParentType := func(node *ast.Node, kind ast.Kind) *ast.Node {
 			for {

--- a/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.schema.json
+++ b/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ignoreIntersections": {
+          "type": "boolean",
+          "description": "Whether to ignore `&` intersections."
+        },
+        "ignoreUnions": {
+          "type": "boolean",
+          "description": "Whether to ignore `|` unions."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents_test.go
+++ b/internal/plugins/typescript/rules/no_duplicate_type_constituents/no_duplicate_type_constituents_test.go
@@ -133,11 +133,11 @@ type T = Record<string, A | B>;
 		},
 		{
 			Code:    "type T = A | A;",
-			Options: NoDuplicateTypeConstituentsOptions{IgnoreUnions: true},
+			Options: map[string]interface{}{"ignoreUnions": true},
 		},
 		{
 			Code:    "type T = A & A;",
-			Options: NoDuplicateTypeConstituentsOptions{IgnoreIntersections: true},
+			Options: map[string]interface{}{"ignoreIntersections": true},
 		},
 		{
 			Code: "type T = Class<string> | Class<string>;",

--- a/internal/plugins/typescript/rules/no_dynamic_delete/no_dynamic_delete.go
+++ b/internal/plugins/typescript/rules/no_dynamic_delete/no_dynamic_delete.go
@@ -25,7 +25,8 @@ func isAllowedDeleteArgument(argument *ast.Node) bool {
 }
 
 var NoDynamicDeleteRule = rule.CreateRule(rule.Rule{
-	Name: "no-dynamic-delete",
+	Name:   "no-dynamic-delete",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindDeleteExpression: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_empty_function/no_empty_function.go
+++ b/internal/plugins/typescript/rules/no_empty_function/no_empty_function.go
@@ -1,6 +1,7 @@
 package no_empty_function
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -8,37 +9,38 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed no_empty_function.schema.json
+var schemaJSON []byte
+
 type NoEmptyFunctionOptions struct {
 	Allow []string `json:"allow"`
 }
 
-var NoEmptyFunctionRule = rule.CreateRule(rule.Rule{
-	Name: "no-empty-function",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts := NoEmptyFunctionOptions{
-			Allow: []string{},
-		}
-		if options != nil {
-			var optsMap map[string]interface{}
-			if optsArray, ok := options.([]interface{}); ok && len(optsArray) > 0 {
-				if opts, ok := optsArray[0].(map[string]interface{}); ok {
-					optsMap = opts
-				}
-			} else if opts, ok := options.(map[string]interface{}); ok {
-				optsMap = opts
-			}
+func parseOptions(options []any) NoEmptyFunctionOptions {
+	opts := NoEmptyFunctionOptions{
+		Allow: []string{},
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]interface{})
 
-			if optsMap != nil {
-				if allow, ok := optsMap["allow"].([]interface{}); ok {
-					for _, a := range allow {
-						if str, ok := a.(string); ok {
-							opts.Allow = append(opts.Allow, str)
-						}
-					}
-				}
+	if allow, ok := optsMap["allow"].([]interface{}); ok {
+		for _, a := range allow {
+			if str, ok := a.(string); ok {
+				opts.Allow = append(opts.Allow, str)
 			}
 		}
+	}
+
+	return opts
+}
+
+var NoEmptyFunctionRule = rule.CreateRule(rule.Rule{
+	Name:   "no-empty-function",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		// Helper to check if a type is allowed
 		isAllowed := func(allowType string) bool {

--- a/internal/plugins/typescript/rules/no_empty_function/no_empty_function.schema.json
+++ b/internal/plugins/typescript/rules/no_empty_function/no_empty_function.schema.json
@@ -1,0 +1,37 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allow": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "functions",
+              "arrowFunctions",
+              "generatorFunctions",
+              "methods",
+              "generatorMethods",
+              "getters",
+              "setters",
+              "constructors",
+              "private-constructors",
+              "protected-constructors",
+              "asyncFunctions",
+              "asyncMethods",
+              "decoratedFunctions",
+              "overrideMethods"
+            ],
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "Locations and kinds of functions that are allowed to be empty."
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_empty_interface/no_empty_interface.go
+++ b/internal/plugins/typescript/rules/no_empty_interface/no_empty_interface.go
@@ -1,6 +1,7 @@
 package no_empty_interface
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -9,37 +10,33 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed no_empty_interface.schema.json
+var schemaJSON []byte
+
 type NoEmptyInterfaceOptions struct {
 	AllowSingleExtends bool `json:"allowSingleExtends"`
 }
 
+func parseOptions(options []any) NoEmptyInterfaceOptions {
+	opts := NoEmptyInterfaceOptions{
+		AllowSingleExtends: false,
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]interface{})
+	if allowSingleExtends, ok := optsMap["allowSingleExtends"].(bool); ok {
+		opts.AllowSingleExtends = allowSingleExtends
+	}
+	return opts
+}
+
 var NoEmptyInterfaceRule = rule.CreateRule(rule.Rule{
 	Name:             "no-empty-interface",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts := NoEmptyInterfaceOptions{
-			AllowSingleExtends: false,
-		}
-		// Parse options with dual-format support (handles both array and object formats)
-		if options != nil {
-			var optsMap map[string]interface{}
-			var ok bool
-
-			// Handle array format: [{ option: value }]
-			if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-				optsMap, ok = optArray[0].(map[string]interface{})
-			} else {
-				// Handle direct object format: { option: value }
-				optsMap, ok = options.(map[string]interface{})
-			}
-
-			if ok {
-				if allowSingleExtends, ok := optsMap["allowSingleExtends"].(bool); ok {
-					opts.AllowSingleExtends = allowSingleExtends
-				}
-			}
-		}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		return rule.RuleListeners{
 			ast.KindInterfaceDeclaration: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_empty_interface/no_empty_interface.schema.json
+++ b/internal/plugins/typescript/rules/no_empty_interface/no_empty_interface.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowSingleExtends": {
+          "type": "boolean",
+          "description": "Whether to allow empty interfaces that extend a single other interface."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.go
@@ -3,8 +3,8 @@ package no_empty_object_type
 import (
 	_ "embed"
 	"fmt"
-	"regexp"
 
+	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
@@ -174,9 +174,9 @@ var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
-		var allowWithNameTester *regexp.Regexp
+		var allowWithNameTester *regexp2.Regexp
 		if opts.AllowWithName != "" {
-			allowWithNameTester, _ = regexp.Compile(opts.AllowWithName)
+			allowWithNameTester, _ = utils.CompileRegexp2(opts.AllowWithName, utils.JSUnicodeRegexOptions)
 		}
 
 		listeners := rule.RuleListeners{}
@@ -192,7 +192,7 @@ var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
 					return
 				}
 				if allowWithNameTester != nil {
-					if id := nameNode.AsIdentifier(); id != nil && allowWithNameTester.MatchString(id.Text) {
+					if id := nameNode.AsIdentifier(); id != nil && utils.Regexp2MatchString(allowWithNameTester, id.Text) {
 						return
 					}
 				}
@@ -272,7 +272,7 @@ var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
 					if typeAlias != nil {
 						aliasName := typeAlias.Name()
 						if aliasName != nil {
-							if id := aliasName.AsIdentifier(); id != nil && allowWithNameTester.MatchString(id.Text) {
+							if id := aliasName.AsIdentifier(); id != nil && utils.Regexp2MatchString(allowWithNameTester, id.Text) {
 								return
 							}
 						}

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.go
@@ -1,6 +1,7 @@
 package no_empty_object_type
 
 import (
+	_ "embed"
 	"fmt"
 	"regexp"
 
@@ -11,21 +12,24 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed no_empty_object_type.schema.json
+var schemaJSON []byte
+
 type NoEmptyObjectTypeOptions struct {
 	AllowInterfaces  string
 	AllowObjectTypes string
 	AllowWithName    string
 }
 
-func parseOptions(options any) NoEmptyObjectTypeOptions {
+func parseOptions(options []any) NoEmptyObjectTypeOptions {
 	opts := NoEmptyObjectTypeOptions{
 		AllowInterfaces:  "never",
 		AllowObjectTypes: "never",
 	}
-	optsMap := utils.GetOptionsMap(options)
-	if optsMap == nil {
+	if len(options) == 0 {
 		return opts
 	}
+	optsMap, _ := options[0].(map[string]interface{})
 	if v, ok := optsMap["allowInterfaces"].(string); ok {
 		opts.AllowInterfaces = v
 	}
@@ -165,9 +169,9 @@ func interfaceFixRange(ctx rule.RuleContext, interfaceDecl *ast.InterfaceDeclara
 }
 
 var NoEmptyObjectTypeRule = rule.CreateRule(rule.Rule{
-	Name: "no-empty-object-type",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "no-empty-object-type",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		var allowWithNameTester *regexp.Regexp

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.schema.json
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.schema.json
@@ -17,6 +17,7 @@
         },
         "allowWithName": {
           "type": "string",
+          "format": "regex",
           "description": "A stringified regular expression to allow interfaces and object type aliases with the configured name."
         }
       }

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.schema.json
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type.schema.json
@@ -1,0 +1,27 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowInterfaces": {
+          "type": "string",
+          "description": "Whether to allow empty interfaces.",
+          "enum": ["always", "never", "with-single-extends"]
+        },
+        "allowObjectTypes": {
+          "type": "string",
+          "description": "Whether to allow empty object type literals.",
+          "enum": ["always", "never"]
+        },
+        "allowWithName": {
+          "type": "string",
+          "description": "A stringified regular expression to allow interfaces and object type aliases with the configured name."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
@@ -130,8 +130,8 @@ interface Both extends A, B {}
 		// `map[string]interface{}{...}` shape (covered by all options tests
 		// above) AND the array-wrapped `[]interface{}{...}` shape (matches
 		// the multi-element rule_tester / CLI invocation). These mirror
-		// upstream-valid cases via the array shape so that the JSON path
-		// through `utils.GetOptionsMap` is exercised end-to-end.
+		// upstream-valid cases via the array shape so that the rule's own
+		// options-array parsing is exercised end-to-end.
 		{
 			Code:    `interface Base {}`,
 			Options: []interface{}{map[string]interface{}{"allowInterfaces": "always"}},
@@ -994,8 +994,8 @@ declare namespace N {
 
 		// ---- Option JSON-array shape coverage (invalid side) ----
 		// Mirrors an upstream-invalid case but passes options through the
-		// `[]interface{}{...}` shape to exercise `utils.GetOptionsMap`'s
-		// multi-element path end-to-end.
+		// `[]interface{}{...}` shape to exercise the rule's own
+		// options-array parsing end-to-end.
 		{
 			Code:    `type Base = {};`,
 			Options: []interface{}{map[string]interface{}{"allowObjectTypes": "never"}},

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
@@ -1030,3 +1030,35 @@ func TestNoEmptyObjectTypeAllowWithNameSchema(t *testing.T) {
 		t.Errorf("expected a valid allowWithName regex to pass schema validation, got: %v", err)
 	}
 }
+
+// TestNoEmptyObjectTypeAllowWithNameLookbehind locks in that `allowWithName`
+// is matched with the same ECMAScript regex engine the schema validates it
+// against (regexp2), not Go's RE2. RE2 cannot compile lookbehind, so a
+// JS-only pattern that passes schema validation would otherwise silently
+// fail to compile and never allow anything.
+func TestNoEmptyObjectTypeAllowWithNameLookbehind(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoEmptyObjectTypeRule, []rule_tester.ValidTestCase{
+		{
+			Code:    `interface Foo {}`,
+			Options: map[string]interface{}{"allowWithName": "(?<!I)Foo$"},
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:    `interface IFoo {}`,
+			Options: map[string]interface{}{"allowWithName": "(?<!I)Foo$"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noEmptyInterface",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 15,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceEmptyInterface", Output: `type IFoo = object`},
+						{MessageId: "replaceEmptyInterface", Output: `type IFoo = unknown`},
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
+++ b/internal/plugins/typescript/rules/no_empty_object_type/no_empty_object_type_extras_test.go
@@ -1015,3 +1015,18 @@ declare namespace N {
 		},
 	})
 }
+
+// TestNoEmptyObjectTypeAllowWithNameSchema locks in that `allowWithName` is
+// validated as a regex. The rule compiles it to decide which names to skip,
+// so an unparsable pattern would otherwise be dropped silently and every
+// name would report. Upstream's schema declares a bare string.
+func TestNoEmptyObjectTypeAllowWithNameSchema(t *testing.T) {
+	invalid := []any{map[string]any{"allowWithName": "("}}
+	if err := NoEmptyObjectTypeRule.Schema.Validate(invalid); err == nil {
+		t.Error("expected an invalid allowWithName regex to fail schema validation")
+	}
+	valid := []any{map[string]any{"allowWithName": "Props$"}}
+	if err := NoEmptyObjectTypeRule.Schema.Validate(valid); err != nil {
+		t.Errorf("expected a valid allowWithName regex to pass schema validation, got: %v", err)
+	}
+}

--- a/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go
+++ b/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go
@@ -1,9 +1,13 @@
 package no_explicit_any
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_explicit_any.schema.json
+var schemaJSON []byte
 
 type NoExplicitAnyOptions struct {
 	FixToUnknown   bool `json:"fixToUnknown"`
@@ -38,33 +42,17 @@ func buildSuggestPropertyKeyMessage() rule.RuleMessage {
 	}
 }
 
-func parseOptions(options any) NoExplicitAnyOptions {
+func parseOptions(options []any) NoExplicitAnyOptions {
 	opts := NoExplicitAnyOptions{}
-	if options == nil {
+	if len(options) == 0 {
 		return opts
 	}
-	// Handle array format: [{ option: value }]
-	if arr, ok := options.([]interface{}); ok {
-		if len(arr) > 0 {
-			if m, ok := arr[0].(map[string]interface{}); ok {
-				if v, ok := m["fixToUnknown"].(bool); ok {
-					opts.FixToUnknown = v
-				}
-				if v, ok := m["ignoreRestArgs"].(bool); ok {
-					opts.IgnoreRestArgs = v
-				}
-			}
-		}
-		return opts
+	m, _ := options[0].(map[string]interface{})
+	if v, ok := m["fixToUnknown"].(bool); ok {
+		opts.FixToUnknown = v
 	}
-	// Handle direct object format
-	if m, ok := options.(map[string]interface{}); ok {
-		if v, ok := m["fixToUnknown"].(bool); ok {
-			opts.FixToUnknown = v
-		}
-		if v, ok := m["ignoreRestArgs"].(bool); ok {
-			opts.IgnoreRestArgs = v
-		}
+	if v, ok := m["ignoreRestArgs"].(bool); ok {
+		opts.IgnoreRestArgs = v
 	}
 	return opts
 }
@@ -116,9 +104,9 @@ func isWithinKeyofAny(node *ast.Node) bool {
 }
 
 var NoExplicitAnyRule = rule.CreateRule(rule.Rule{
-	Name: "no-explicit-any",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "no-explicit-any",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go
+++ b/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go
@@ -2,6 +2,7 @@ package no_explicit_any
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )

--- a/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.schema.json
+++ b/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fixToUnknown": {
+          "type": "boolean",
+          "description": "Whether to enable auto-fixing in which the `any` type is converted to the `unknown` type."
+        },
+        "ignoreRestArgs": {
+          "type": "boolean",
+          "description": "Whether to ignore rest parameter arrays."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_extra_non_null_assertion/no_extra_non_null_assertion.go
+++ b/internal/plugins/typescript/rules/no_extra_non_null_assertion/no_extra_non_null_assertion.go
@@ -8,7 +8,8 @@ import (
 )
 
 var NoExtraNonNullAssertionRule = rule.CreateRule(rule.Rule{
-	Name: "no-extra-non-null-assertion",
+	Name:   "no-extra-non-null-assertion",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		msg := rule.RuleMessage{
 			Id:          "noExtraNonNullAssertion",

--- a/internal/plugins/typescript/rules/no_extraneous_class/no_extraneous_class.go
+++ b/internal/plugins/typescript/rules/no_extraneous_class/no_extraneous_class.go
@@ -1,9 +1,13 @@
 package no_extraneous_class
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_extraneous_class.schema.json
+var schemaJSON []byte
 
 type NoExtraneousClassOptions struct {
 	AllowConstructorOnly bool `json:"allowConstructorOnly"`
@@ -12,45 +16,37 @@ type NoExtraneousClassOptions struct {
 	AllowWithDecorator   bool `json:"allowWithDecorator"`
 }
 
+func parseOptions(options []any) NoExtraneousClassOptions {
+	opts := NoExtraneousClassOptions{
+		AllowConstructorOnly: false,
+		AllowEmpty:           false,
+		AllowStaticOnly:      false,
+		AllowWithDecorator:   false,
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]interface{})
+	if allowConstructorOnly, ok := optsMap["allowConstructorOnly"].(bool); ok {
+		opts.AllowConstructorOnly = allowConstructorOnly
+	}
+	if allowEmpty, ok := optsMap["allowEmpty"].(bool); ok {
+		opts.AllowEmpty = allowEmpty
+	}
+	if allowStaticOnly, ok := optsMap["allowStaticOnly"].(bool); ok {
+		opts.AllowStaticOnly = allowStaticOnly
+	}
+	if allowWithDecorator, ok := optsMap["allowWithDecorator"].(bool); ok {
+		opts.AllowWithDecorator = allowWithDecorator
+	}
+	return opts
+}
+
 var NoExtraneousClassRule = rule.CreateRule(rule.Rule{
-	Name: "no-extraneous-class",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts := NoExtraneousClassOptions{
-			AllowConstructorOnly: false,
-			AllowEmpty:           false,
-			AllowStaticOnly:      false,
-			AllowWithDecorator:   false,
-		}
-
-		// Parse options with dual-format support
-		if options != nil {
-			var optsMap map[string]interface{}
-			var ok bool
-
-			// Handle array format: [{ option: value }]
-			if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-				optsMap, ok = optArray[0].(map[string]interface{})
-			} else {
-				// Handle direct object format: { option: value }
-				optsMap, ok = options.(map[string]interface{})
-			}
-
-			if ok {
-				if allowConstructorOnly, ok := optsMap["allowConstructorOnly"].(bool); ok {
-					opts.AllowConstructorOnly = allowConstructorOnly
-				}
-				if allowEmpty, ok := optsMap["allowEmpty"].(bool); ok {
-					opts.AllowEmpty = allowEmpty
-				}
-				if allowStaticOnly, ok := optsMap["allowStaticOnly"].(bool); ok {
-					opts.AllowStaticOnly = allowStaticOnly
-				}
-				if allowWithDecorator, ok := optsMap["allowWithDecorator"].(bool); ok {
-					opts.AllowWithDecorator = allowWithDecorator
-				}
-			}
-		}
+	Name:   "no-extraneous-class",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		return rule.RuleListeners{
 			ast.KindClassDeclaration: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_extraneous_class/no_extraneous_class.go
+++ b/internal/plugins/typescript/rules/no_extraneous_class/no_extraneous_class.go
@@ -2,6 +2,7 @@ package no_extraneous_class
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )

--- a/internal/plugins/typescript/rules/no_extraneous_class/no_extraneous_class.schema.json
+++ b/internal/plugins/typescript/rules/no_extraneous_class/no_extraneous_class.schema.json
@@ -1,0 +1,29 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowConstructorOnly": {
+          "type": "boolean",
+          "description": "Whether to allow extraneous classes that contain only a constructor."
+        },
+        "allowEmpty": {
+          "type": "boolean",
+          "description": "Whether to allow extraneous classes that have no body (i.e. are empty)."
+        },
+        "allowStaticOnly": {
+          "type": "boolean",
+          "description": "Whether to allow extraneous classes that only contain static members."
+        },
+        "allowWithDecorator": {
+          "type": "boolean",
+          "description": "Whether to allow extraneous classes that include a decorator."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.go
+++ b/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.go
@@ -1,6 +1,7 @@
 package no_floating_promises
 
 import (
+	_ "embed"
 	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -10,6 +11,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed no_floating_promises.schema.json
+var schemaJSON []byte
+
 type NoFloatingPromisesOptions struct {
 	AllowForKnownSafeCalls          []utils.TypeOrValueSpecifier `json:"allowForKnownSafeCalls"`
 	AllowForKnownSafeCallsInline    []string                     `json:"allowForKnownSafeCallsInline"`
@@ -18,6 +22,34 @@ type NoFloatingPromisesOptions struct {
 	CheckThenables                  *bool                        `json:"checkThenables"`
 	IgnoreIIFE                      *bool                        `json:"ignoreIIFE"`
 	IgnoreVoid                      *bool                        `json:"ignoreVoid"`
+}
+
+func parseOptions(options []any) NoFloatingPromisesOptions {
+	opts := NoFloatingPromisesOptions{
+		AllowForKnownSafeCalls:          []utils.TypeOrValueSpecifier{},
+		AllowForKnownSafeCallsInline:    []string{},
+		AllowForKnownSafePromises:       []utils.TypeOrValueSpecifier{},
+		AllowForKnownSafePromisesInline: []string{},
+	}
+	if len(options) > 0 {
+		if typed, ok := options[0].(NoFloatingPromisesOptions); ok {
+			opts = typed
+		} else if optsMap, ok := options[0].(map[string]interface{}); ok {
+			if optsJSON, err := json.Marshal(optsMap); err == nil {
+				_ = json.Unmarshal(optsJSON, &opts)
+			}
+		}
+	}
+	if opts.CheckThenables == nil {
+		opts.CheckThenables = utils.Ref(false)
+	}
+	if opts.IgnoreIIFE == nil {
+		opts.IgnoreIIFE = utils.Ref(false)
+	}
+	if opts.IgnoreVoid == nil {
+		opts.IgnoreVoid = utils.Ref(true)
+	}
+	return opts
 }
 
 var messageBase = "Promises must be awaited, end with a call to .catch, or end with a call to .then with a rejection handler."
@@ -79,35 +111,10 @@ func buildFloatingVoidMessage() rule.RuleMessage {
 
 var NoFloatingPromisesRule = rule.CreateRule(rule.Rule{
 	Name:             "no-floating-promises",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(NoFloatingPromisesOptions)
-		if !ok {
-			opts = NoFloatingPromisesOptions{
-				AllowForKnownSafeCalls:          []utils.TypeOrValueSpecifier{},
-				AllowForKnownSafeCallsInline:    []string{},
-				AllowForKnownSafePromises:       []utils.TypeOrValueSpecifier{},
-				AllowForKnownSafePromisesInline: []string{},
-			}
-			// Options from JS configs may arrive as either an array
-			// (`[{ checkThenables: true }]`) or a bare object (`{ checkThenables: true }`).
-			// GetOptionsMap normalizes both shapes.
-			if optsMap := utils.GetOptionsMap(options); optsMap != nil {
-				if optsJSON, err := json.Marshal(optsMap); err == nil {
-					_ = json.Unmarshal(optsJSON, &opts)
-				}
-			}
-		}
-		if opts.CheckThenables == nil {
-			opts.CheckThenables = utils.Ref(false)
-		}
-		if opts.IgnoreIIFE == nil {
-			opts.IgnoreIIFE = utils.Ref(false)
-		}
-		if opts.IgnoreVoid == nil {
-			opts.IgnoreVoid = utils.Ref(true)
-		}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 		isHigherPrecedenceThanUnary := func(node *ast.Node) bool {
 			operator := ast.KindUnknown
 			if ast.IsBinaryExpression(node) {

--- a/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.go
+++ b/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.go
@@ -15,26 +15,20 @@ import (
 var schemaJSON []byte
 
 type NoFloatingPromisesOptions struct {
-	AllowForKnownSafeCalls          []utils.TypeOrValueSpecifier `json:"allowForKnownSafeCalls"`
-	AllowForKnownSafeCallsInline    []string                     `json:"allowForKnownSafeCallsInline"`
-	AllowForKnownSafePromises       []utils.TypeOrValueSpecifier `json:"allowForKnownSafePromises"`
-	AllowForKnownSafePromisesInline []string                     `json:"allowForKnownSafePromisesInline"`
-	CheckThenables                  *bool                        `json:"checkThenables"`
-	IgnoreIIFE                      *bool                        `json:"ignoreIIFE"`
-	IgnoreVoid                      *bool                        `json:"ignoreVoid"`
+	AllowForKnownSafeCalls    []utils.TypeOrValueSpecifier `json:"allowForKnownSafeCalls"`
+	AllowForKnownSafePromises []utils.TypeOrValueSpecifier `json:"allowForKnownSafePromises"`
+	CheckThenables            *bool                        `json:"checkThenables"`
+	IgnoreIIFE                *bool                        `json:"ignoreIIFE"`
+	IgnoreVoid                *bool                        `json:"ignoreVoid"`
 }
 
 func parseOptions(options []any) NoFloatingPromisesOptions {
 	opts := NoFloatingPromisesOptions{
-		AllowForKnownSafeCalls:          []utils.TypeOrValueSpecifier{},
-		AllowForKnownSafeCallsInline:    []string{},
-		AllowForKnownSafePromises:       []utils.TypeOrValueSpecifier{},
-		AllowForKnownSafePromisesInline: []string{},
+		AllowForKnownSafeCalls:    []utils.TypeOrValueSpecifier{},
+		AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{},
 	}
 	if len(options) > 0 {
-		if typed, ok := options[0].(NoFloatingPromisesOptions); ok {
-			opts = typed
-		} else if optsMap, ok := options[0].(map[string]interface{}); ok {
+		if optsMap, ok := options[0].(map[string]interface{}); ok {
 			if optsJSON, err := json.Marshal(optsMap); err == nil {
 				_ = json.Unmarshal(optsJSON, &opts)
 			}
@@ -175,7 +169,7 @@ var NoFloatingPromisesRule = rule.CreateRule(rule.Rule{
 			if utils.TypeMatchesSomeSpecifier(
 				t,
 				opts.AllowForKnownSafePromises,
-				opts.AllowForKnownSafePromisesInline,
+				nil,
 				ctx.Program,
 			) {
 				return false
@@ -260,7 +254,7 @@ var NoFloatingPromisesRule = rule.CreateRule(rule.Rule{
 			return utils.TypeMatchesSomeSpecifierWithCalleeNames(
 				t,
 				opts.AllowForKnownSafeCalls,
-				opts.AllowForKnownSafeCallsInline,
+				nil,
 				ctx.Program,
 				calleeNames,
 			)

--- a/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.schema.json
+++ b/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises.schema.json
@@ -1,0 +1,215 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowForKnownSafeCalls": {
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["file"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["lib"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["package"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "package": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name", "package"],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array",
+          "description": "Type specifiers of functions whose calls are safe to float."
+        },
+        "allowForKnownSafePromises": {
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["file"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["lib"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["package"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "package": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name", "package"],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array",
+          "description": "Type specifiers that are known to be safe to float."
+        },
+        "checkThenables": {
+          "type": "boolean",
+          "description": "Whether to check all \"Thenable\"s, not just the built-in Promise type."
+        },
+        "ignoreIIFE": {
+          "type": "boolean",
+          "description": "Whether to ignore async IIFEs (Immediately Invoked Function Expressions)."
+        },
+        "ignoreVoid": {
+          "type": "boolean",
+          "description": "Whether to ignore `void` expressions."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises_test.go
+++ b/internal/plugins/typescript/rules/no_floating_promises/no_floating_promises_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoFloatingPromisesRule(t *testing.T) {
@@ -34,7 +33,7 @@ async function test() {
   void Promise.resolve('value');
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreVoid": true},
 		},
 		{Code: `
 async function test() {
@@ -339,7 +338,7 @@ void doSomething();
           await something();
         })();
       `,
-			Options: NoFloatingPromisesOptions{IgnoreIIFE: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreIIFE": true},
 		},
 		{
 			Code: `
@@ -347,11 +346,11 @@ void doSomething();
           something();
         })();
       `,
-			Options: NoFloatingPromisesOptions{IgnoreIIFE: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreIIFE": true},
 		},
 		{
 			Code:    "(async function foo() {})();",
-			Options: NoFloatingPromisesOptions{IgnoreIIFE: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreIIFE": true},
 		},
 		{
 			Code: `
@@ -359,7 +358,7 @@ void doSomething();
           (async function bar() {})();
         }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreIIFE: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreIIFE": true},
 		},
 		{
 			Code: `
@@ -370,7 +369,7 @@ void doSomething();
             })();
           });
       `,
-			Options: NoFloatingPromisesOptions{IgnoreIIFE: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreIIFE": true},
 		},
 		{
 			Code: `
@@ -378,7 +377,7 @@ void doSomething();
           await res(1);
         })();
       `,
-			Options: NoFloatingPromisesOptions{IgnoreIIFE: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreIIFE": true},
 		},
 		{
 			Code: `
@@ -397,7 +396,7 @@ async function foo() {
   await (condition && myPromise());
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 		},
 		{
 			Code: `
@@ -416,7 +415,7 @@ async function foo() {
   condition && (await myPromise());
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 		},
 		{
 			Code: `
@@ -429,14 +428,14 @@ async function foo() {
   condition ?? myPromise();
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 		},
 		{
 			Code: `
 declare const definitelyCallable: () => void;
 Promise.reject().catch(definitelyCallable);
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 		},
 		{
 			Code: `
@@ -452,7 +451,7 @@ Promise.reject()
   .finally(() => {})
   .finally(() => {});
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 		},
 		{
 			Code: `
@@ -478,7 +477,7 @@ void promiseArray;
 			Code: `
 [1, 2, void Promise.reject(), 3];
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 		},
 		{
 			Code: `
@@ -502,9 +501,7 @@ interface SafeThenable<T> {
 let promise: SafeThenable<number> = Promise.resolve(5);
 0, promise;
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafeThenable"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafeThenable"}}}},
 		},
 		{
 			Code: `
@@ -523,9 +520,7 @@ interface SafeThenable<T> {
 let promise: SafeThenable<number> = Promise.resolve(5);
 0 ? promise : 3;
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafeThenable"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafeThenable"}}}},
 		},
 		{
 			Code: `
@@ -533,9 +528,7 @@ class SafePromise<T> extends Promise<T> {}
 let promise: { a: SafePromise<number> } = { a: Promise.resolve(5) };
 promise.a;
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}},
 		},
 		{
 			Code: `
@@ -543,9 +536,7 @@ class SafePromise<T> extends Promise<T> {}
 let promise: SafePromise<number> = Promise.resolve(5);
 promise;
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}},
 		},
 		{
 			Code: `
@@ -553,7 +544,7 @@ type Foo = Promise<number> & { hey?: string };
 let promise: Foo = Promise.resolve(5);
 0 || promise;
       `,
-			Options: NoFloatingPromisesOptions{AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"Foo"}}}},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"Foo"}}}},
 		},
 		{
 			Code: `
@@ -561,7 +552,7 @@ type Foo = Promise<number> & { hey?: string };
 let promise: Foo = Promise.resolve(5);
 promise.finally();
       `,
-			Options: NoFloatingPromisesOptions{AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"Foo"}}}},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"Foo"}}}},
 		},
 		{
 			Code: `
@@ -580,9 +571,7 @@ interface SafeThenable<T> {
 let promise: () => SafeThenable<number> = () => Promise.resolve(5);
 0, promise();
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafeThenable"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafeThenable"}}}},
 		},
 		{
 			Code: `
@@ -601,9 +590,7 @@ interface SafeThenable<T> {
 let promise: () => SafeThenable<number> = () => Promise.resolve(5);
 0 ? promise() : 3;
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafeThenable"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafeThenable"}}}},
 		},
 		{
 			Code: `
@@ -611,7 +598,7 @@ type Foo = Promise<number> & { hey?: string };
 let promise: () => Foo = () => Promise.resolve(5);
 promise();
       `,
-			Options: NoFloatingPromisesOptions{AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"Foo"}}}},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"Foo"}}}},
 		},
 		{
 			Code: `
@@ -619,7 +606,7 @@ type Foo = Promise<number> & { hey?: string };
 let promise: () => Foo = async () => 5;
 promise().finally();
       `,
-			Options: NoFloatingPromisesOptions{AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"Foo"}}}},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"Foo"}}}},
 		},
 		{
 			Code: `
@@ -627,9 +614,7 @@ class SafePromise<T> extends Promise<T> {}
 let promise: () => SafePromise<number> = async () => 5;
 0 || promise();
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}},
 		},
 		{
 			Code: `
@@ -637,16 +622,14 @@ class SafePromise<T> extends Promise<T> {}
 let promise: () => SafePromise<number> = async () => 5;
 null ?? promise();
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}},
 		},
 		{
 			Code: `
 let promise: () => PromiseLike<number> = () => Promise.resolve(5);
 promise();
       `,
-			Options: NoFloatingPromisesOptions{AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromLib, Name: []string{"PromiseLike"}}}},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "lib", "name": []interface{}{"PromiseLike"}}}},
 		},
 		{
 			Code: `
@@ -654,7 +637,7 @@ type Foo<T> = Promise<T> & { hey?: string };
 declare const arrayOrPromiseTuple: Foo<unknown>[];
 arrayOrPromiseTuple;
       `,
-			Options: NoFloatingPromisesOptions{AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"Foo"}}}},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"Foo"}}}},
 		},
 		{
 			Code: `
@@ -662,7 +645,7 @@ type Foo<T> = Promise<T> & { hey?: string };
 declare const arrayOrPromiseTuple: [Foo<unknown>, 5];
 arrayOrPromiseTuple;
       `,
-			Options: NoFloatingPromisesOptions{AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"Foo"}}}},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"Foo"}}}},
 		},
 		{
 			Code: `
@@ -670,9 +653,7 @@ type SafePromise = Promise<number> & { __linterBrands?: string };
 declare const myTag: (strings: TemplateStringsArray) => SafePromise;
 myTag` + "`" + `abc` + "`" + `;
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}},
 		},
 		{
 			Code: `
@@ -680,9 +661,7 @@ myTag` + "`" + `abc` + "`" + `;
 
         it('...', () => {});
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafeCalls: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"it"}, Path: "file.ts"}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafeCalls": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"it"}, "path": "file.ts"}}},
 		},
 		{
 			Code: `
@@ -749,9 +728,7 @@ interface SafeThenable<T> {
 let promise: () => SafeThenable<number> = () => Promise.resolve(5);
 promise().then(() => {});
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafeThenable"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafeThenable"}}}},
 		},
 		{
 			Code: `
@@ -760,9 +737,7 @@ promise().then(() => {});
         }
         it('...', () => {});
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafeCalls: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromPackage, Name: []string{"it"}, Package: "abc"}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafeCalls": []interface{}{map[string]interface{}{"from": "package", "name": []interface{}{"it"}, "package": "abc"}}},
 		},
 		{
 			Code: `
@@ -772,9 +747,7 @@ promise().then(() => {});
 
         it('...', () => {});
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafeCalls: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromPackage, Name: []string{"it"}, Package: "abc"}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafeCalls": []interface{}{map[string]interface{}{"from": "package", "name": []interface{}{"it"}, "package": "abc"}}},
 		},
 		{
 			Code: `
@@ -782,9 +755,7 @@ promise().then(() => {});
 
         it('...', () => {});
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafeCalls: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromPackage, Name: []string{"it"}, Package: "node:test"}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafeCalls": []interface{}{map[string]interface{}{"from": "package", "name": []interface{}{"it"}, "package": "node:test"}}},
 		},
 		{
 			Code: `
@@ -795,10 +766,7 @@ interface SafePromise<T> extends Promise<T> {
 declare const createSafePromise: () => SafePromise<string>;
 createSafePromise();
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-				CheckThenables:            utils.Ref(true),
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}, "checkThenables": true},
 		},
 		{Code: `
 declare const createPromiseLike: () => PromiseLike<number>;
@@ -1502,7 +1470,7 @@ async function test() {
   Promise.resolve('value');
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreVoid": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -2036,7 +2004,7 @@ async function test() {
   void Promise.resolve();
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -2061,7 +2029,7 @@ async function test() {
   promise;
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -2087,7 +2055,7 @@ async function returnsPromise() {
 }
 void returnsPromise();
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -2113,7 +2081,7 @@ async function returnsPromise() {
 }
 void /* ... */ returnsPromise();
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -2139,7 +2107,7 @@ async function returnsPromise() {
 }
 1, returnsPromise();
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -2165,7 +2133,7 @@ async function returnsPromise() {
 }
 bool ? returnsPromise() : null;
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -2696,7 +2664,7 @@ async function test() {
   thenable.then(() => {});
 }
       `,
-			Options: NoFloatingPromisesOptions{CheckThenables: utils.Ref(true)},
+			Options: map[string]interface{}{"checkThenables": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -3159,7 +3127,7 @@ async function test() {
           Promise.resolve();
         })();
       `,
-			Options: NoFloatingPromisesOptions{IgnoreIIFE: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreIIFE": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -3195,7 +3163,7 @@ declare const promiseIntersection: Promise<number> & number;
   promiseIntersection.finally();
 })();
       `,
-			Options: NoFloatingPromisesOptions{IgnoreIIFE: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreIIFE": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -3368,7 +3336,7 @@ async function foo() {
   (await condition) && myPromise();
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -3517,7 +3485,7 @@ async function foo() {
   condition && myPromise;
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -3545,7 +3513,7 @@ async function foo() {
   condition || myPromise;
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -3573,7 +3541,7 @@ async function foo() {
   condition ?? myPromise;
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -4017,7 +3985,7 @@ await (Promise.reject() || 3);
 			Code: `
 void Promise.resolve().then(() => {}, undefined);
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingUselessRejectionHandler",
@@ -4038,7 +4006,7 @@ await Promise.resolve().then(() => {}, undefined);
 declare const maybeCallable: string | (() => void);
 Promise.resolve().then(() => {}, maybeCallable);
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingUselessRejectionHandler",
@@ -4071,7 +4039,7 @@ Promise.resolve().catch(3);
 Promise.resolve().catch(maybeCallable);
 Promise.resolve().catch(definitelyCallable);
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingUselessRejectionHandler",
@@ -4271,7 +4239,7 @@ Promise.resolve().catch(definitelyCallable);
 			Code: `
 Promise.reject() || 3;
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -4318,7 +4286,7 @@ Promise.reject()
   .finally(() => {})
   .finally(() => {});
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floating",
@@ -4597,7 +4565,7 @@ array.map(() => Promise.reject());
 declare const promiseArray: Array<Promise<unknown>>;
 void promiseArray;
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingPromiseArray",
@@ -4612,7 +4580,7 @@ async function f() {
   await promiseArray;
 }
       `,
-			Options: NoFloatingPromisesOptions{IgnoreVoid: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreVoid": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingPromiseArray",
@@ -4792,10 +4760,7 @@ interface UnsafeThenable<T> {
 let promise: UnsafeThenable<number> = Promise.resolve(5);
 promise;
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafeThenable"}}},
-				CheckThenables:            utils.Ref(true),
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafeThenable"}}}, "checkThenables": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -4849,9 +4814,7 @@ class SafePromise<T> extends Promise<T> {}
 let promise: SafePromise<number> = Promise.resolve(5);
 promise.catch();
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -4883,9 +4846,7 @@ class UnsafePromise<T> extends Promise<T> {}
 let promise: () => UnsafePromise<number> = async () => 5;
 promise().finally();
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -4917,9 +4878,7 @@ type UnsafePromise = Promise<number> & { hey?: string };
 let promise: UnsafePromise = Promise.resolve(5);
 0 ? promise.catch() : 2;
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -4951,9 +4910,7 @@ type UnsafePromise = Promise<number> & { hey?: string };
 let promise: () => UnsafePromise = async () => 5;
 null ?? promise().catch();
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -4985,7 +4942,7 @@ type Foo<T> = Promise<T> & { hey?: string };
 declare const arrayOrPromiseTuple: Foo<unknown>[];
 arrayOrPromiseTuple;
       `,
-			Options: NoFloatingPromisesOptions{AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"Bar"}}}},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"Bar"}}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingPromiseArrayVoid",
@@ -5000,9 +4957,7 @@ let foo: SafePromise = Promise.resolve(1);
 let bar = [Promise.resolve(2), foo];
 bar;
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"SafePromise"}}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"SafePromise"}}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingPromiseArrayVoid",
@@ -5016,7 +4971,7 @@ type Foo<T> = Promise<T> & { hey?: string };
 declare const arrayOrPromiseTuple: [Foo<unknown>, 5];
 arrayOrPromiseTuple;
       `,
-			Options: NoFloatingPromisesOptions{AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"Bar"}}}},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"Bar"}}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingPromiseArrayVoid",
@@ -5030,7 +4985,7 @@ type SafePromise = Promise<number> & { __linterBrands?: string };
 declare const myTag: (strings: TemplateStringsArray) => SafePromise;
 myTag` + "`" + `abc` + "`" + `;
       `,
-			Options: NoFloatingPromisesOptions{AllowForKnownSafePromises: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"Foo"}}}},
+			Options: map[string]interface{}{"allowForKnownSafePromises": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"Foo"}}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -5062,9 +5017,7 @@ await myTag` + "`" + `abc` + "`" + `;
 
         unsafe('...', () => {});
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafeCalls: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"it"}, Path: "tests/fixtures/file.ts"}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafeCalls": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"it"}, "path": "tests/fixtures/file.ts"}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -5096,9 +5049,7 @@ await myTag` + "`" + `abc` + "`" + `;
 
         it('...', () => {}).then(() => {});
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafeCalls: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"it"}, Path: "tests/fixtures/file.ts"}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafeCalls": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"it"}, "path": "tests/fixtures/file.ts"}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -5130,9 +5081,7 @@ await myTag` + "`" + `abc` + "`" + `;
 
         it('...', () => {}).finally(() => {});
       `,
-			Options: NoFloatingPromisesOptions{
-				AllowForKnownSafeCalls: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"it"}, Path: "tests/fixtures/file.ts"}},
-			},
+			Options: map[string]interface{}{"allowForKnownSafeCalls": []interface{}{map[string]interface{}{"from": "file", "name": []interface{}{"it"}, "path": "tests/fixtures/file.ts"}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -5163,7 +5112,7 @@ await myTag` + "`" + `abc` + "`" + `;
 declare const createPromise: () => PromiseLike<number>;
 createPromise();
       `,
-			Options: NoFloatingPromisesOptions{CheckThenables: utils.Ref(true)},
+			Options: map[string]interface{}{"checkThenables": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -5197,7 +5146,7 @@ declare function createMyThenable(): MyThenable;
 
 createMyThenable();
       `,
-			Options: NoFloatingPromisesOptions{CheckThenables: utils.Ref(true)},
+			Options: map[string]interface{}{"checkThenables": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -5298,7 +5247,7 @@ class MyPromise<T> extends Promise<T> {
 declare const createMyPromise: () => MyPromise<number>;
 createMyPromise();
       `,
-			Options: NoFloatingPromisesOptions{CheckThenables: utils.Ref(true)},
+			Options: map[string]interface{}{"checkThenables": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "floatingVoid",
@@ -5500,17 +5449,12 @@ await (<Promise<number>>{});
 	})
 }
 
-// TestNoFloatingPromisesOptionParsing exercises the JSON options fallback path
-// that the CLI and JS configs actually hit. The main TestNoFloatingPromisesRule
-// passes NoFloatingPromisesOptions structs directly, which short-circuits the
-// type assertion and never exercises the JSON round-trip. This test covers the
-// shapes config.go and the JS rule tester produce:
+// TestNoFloatingPromisesOptionParsing exercises the option shapes config.go and
+// the JS rule tester produce:
 //   - nil (no options element)
 //   - bare map (single-option entry, unwrapped by config.go:414)
-//   - array-wrapped map (multi-element, or rule_tester with len>1)
+//   - array-wrapped map
 //   - empty array
-//   - multi-element array (only arr[0] is consumed)
-//   - malformed values (silently ignored, defaults retained)
 func TestNoFloatingPromisesOptionParsing(t *testing.T) {
 	// A thenable that matches the `.then(onFulfilled, onRejected)` shape.
 	// Triggers only when checkThenables=true; used to prove the option landed.
@@ -5551,20 +5495,6 @@ async function test() {
 			{Code: voidPromiseCode},
 			// Bare map with ignoreVoid=true (explicit default).
 			{Code: voidPromiseCode, Options: map[string]interface{}{"ignoreVoid": true}},
-			// Malformed: wrong type for checkThenables (string instead of bool).
-			// json.Unmarshal fails on the field; we keep the default (false).
-			{Code: thenableCode, Options: map[string]interface{}{"checkThenables": "yes"}},
-			// Completely unknown keys are ignored without tripping defaults.
-			{Code: thenableCode, Options: map[string]interface{}{"bogusKey": 42}},
-			// Multi-element array: only arr[0] is consumed. arr[0] turns checkThenables off,
-			// so thenable is NOT reported even though arr[1] would have turned it on.
-			{
-				Code: thenableCode,
-				Options: []interface{}{
-					map[string]interface{}{"checkThenables": false},
-					map[string]interface{}{"checkThenables": true},
-				},
-			},
 			// Nested allowForKnownSafePromises shape (array of TypeOrValueSpecifier maps)
 			// round-trips through JSON and suppresses the otherwise-floating thenable.
 			{
@@ -5582,7 +5512,7 @@ createSafePromise();
 					},
 				},
 			},
-			// Inline string-array option (allowForKnownSafePromisesInline) via JSON path.
+			// String shorthand specifiers (any origin) via the JSON path.
 			{
 				Code: `
 interface SafePromise<T> extends Promise<T> {
@@ -5592,7 +5522,7 @@ declare const createSafePromise: () => SafePromise<string>;
 createSafePromise();
 `,
 				Options: map[string]interface{}{
-					"allowForKnownSafePromisesInline": []interface{}{"SafePromise"},
+					"allowForKnownSafePromises": []interface{}{"SafePromise"},
 				},
 			},
 			// Combined options (multiple flags set at once) via JSON path.

--- a/internal/plugins/typescript/rules/no_for_in_array/no_for_in_array.go
+++ b/internal/plugins/typescript/rules/no_for_in_array/no_for_in_array.go
@@ -16,6 +16,7 @@ func buildForInViolationMessage() rule.RuleMessage {
 
 var NoForInArrayRule = rule.CreateRule(rule.Rule{
 	Name:             "no-for-in-array",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		hasArrayishLength := func(t *checker.Type) bool {

--- a/internal/plugins/typescript/rules/no_implied_eval/no_implied_eval.go
+++ b/internal/plugins/typescript/rules/no_implied_eval/no_implied_eval.go
@@ -27,6 +27,7 @@ var evalLikeFunctions = []string{"execScript", "setImmediate", "setInterval", "s
 
 var NoImpliedEvalRule = rule.CreateRule(rule.Rule{
 	Name:             "no-implied-eval",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		getCalleeName := func(node *ast.Expression) string {

--- a/internal/plugins/typescript/rules/no_import_type_side_effects/no_import_type_side_effects.go
+++ b/internal/plugins/typescript/rules/no_import_type_side_effects/no_import_type_side_effects.go
@@ -15,7 +15,8 @@ func buildUseTopLevelQualifierMessage() rule.RuleMessage {
 }
 
 var NoImportTypeSideEffectsRule = rule.CreateRule(rule.Rule{
-	Name: "no-import-type-side-effects",
+	Name:   "no-import-type-side-effects",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindImportDeclaration: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go
@@ -1,11 +1,15 @@
 package no_inferrable_types
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_inferrable_types.schema.json
+var schemaJSON []byte
 
 type Options struct {
 	IgnoreParameters bool
@@ -61,34 +65,21 @@ var noInferrableTypesMessages = [...]rule.RuleMessage{
 	},
 }
 
-func parseOptions(options any) Options {
+func parseOptions(options []any) Options {
 	// Default values match typescript-eslint defaults
 	opts := Options{
 		IgnoreParameters: false,
 		IgnoreProperties: false,
 	}
-	if options == nil {
+	if len(options) == 0 {
 		return opts
 	}
-
-	var optsMap map[string]interface{}
-	// Handle array format: [{ option: value }]
-	if arr, ok := options.([]interface{}); ok {
-		if len(arr) > 0 {
-			optsMap, _ = arr[0].(map[string]interface{})
-		}
-	} else {
-		// Handle direct object format
-		optsMap, _ = options.(map[string]interface{})
+	optsMap, _ := options[0].(map[string]interface{})
+	if v, ok := optsMap["ignoreParameters"].(bool); ok {
+		opts.IgnoreParameters = v
 	}
-
-	if optsMap != nil {
-		if v, ok := optsMap["ignoreParameters"].(bool); ok {
-			opts.IgnoreParameters = v
-		}
-		if v, ok := optsMap["ignoreProperties"].(bool); ok {
-			opts.IgnoreProperties = v
-		}
+	if v, ok := optsMap["ignoreProperties"].(bool); ok {
+		opts.IgnoreProperties = v
 	}
 	return opts
 }
@@ -266,9 +257,9 @@ func buildNoInferrableTypesFixes(sourceText string, typeAnnotation *ast.Node, po
 }
 
 var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
-	Name: "no-inferrable-types",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "no-inferrable-types",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 		sourceText := ctx.SourceFile.Text()
 

--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go
@@ -2,6 +2,7 @@ package no_inferrable_types
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"

--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.schema.json
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ignoreParameters": {
+          "type": "boolean",
+          "description": "Whether to ignore function parameters."
+        },
+        "ignoreProperties": {
+          "type": "boolean",
+          "description": "Whether to ignore class properties."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.go
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.go
@@ -1,6 +1,7 @@
 package no_invalid_this
 
 import (
+	_ "embed"
 	"regexp"
 	"slices"
 	"strings"
@@ -10,6 +11,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_invalid_this.schema.json
+var schemaJSON []byte
 
 // NoInvalidThisRule mirrors @typescript-eslint/no-invalid-this, which wraps
 // ESLint core's no-invalid-this with two TypeScript-specific recognitions:
@@ -28,8 +32,9 @@ import (
 //
 // https://typescript-eslint.io/rules/no-invalid-this
 var NoInvalidThisRule = rule.CreateRule(rule.Rule{
-	Name: "no-invalid-this",
-	Run:  run,
+	Name:   "no-invalid-this",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
 type ruleOptions struct {
@@ -38,12 +43,12 @@ type ruleOptions struct {
 	capIsConstructor bool
 }
 
-func parseOptions(raw any) ruleOptions {
+func parseOptions(options []any) ruleOptions {
 	opts := ruleOptions{capIsConstructor: true}
-	m := utils.GetOptionsMap(raw)
-	if m == nil {
+	if len(options) == 0 {
 		return opts
 	}
+	m, _ := options[0].(map[string]interface{})
 	if v, ok := m["capIsConstructor"]; ok {
 		if b, ok := v.(bool); ok {
 			opts.capIsConstructor = b
@@ -52,8 +57,7 @@ func parseOptions(raw any) ruleOptions {
 	return opts
 }
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	opts := parseOptions(options)
 	sf := ctx.SourceFile
 

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.schema.json
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "capIsConstructor": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_invalid_this/no_invalid_this_upstream_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-// objectOption produces the array-wrapped option shape that exercises
-// utils.GetOptionsMap's JSON path. Passing a typed struct directly would
+// objectOption produces the array-wrapped option shape that exercises the
+// rule's own options-array parsing. Passing a typed struct directly would
 // short-circuit the JSON round-trip and leave the CLI-facing wiring untested.
 func objectOption(opts map[string]interface{}) []interface{} {
 	return []interface{}{opts}

--- a/internal/plugins/typescript/rules/no_invalid_void_type/no_invalid_void_type.go
+++ b/internal/plugins/typescript/rules/no_invalid_void_type/no_invalid_void_type.go
@@ -1,6 +1,7 @@
 package no_invalid_void_type
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -8,9 +9,32 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed no_invalid_void_type.schema.json
+var schemaJSON []byte
+
 type NoInvalidVoidTypeOptions struct {
 	AllowInGenericTypeArguments interface{} `json:"allowInGenericTypeArguments"`
 	AllowAsThisParameter        bool        `json:"allowAsThisParameter"`
+}
+
+func parseOptions(options []any) NoInvalidVoidTypeOptions {
+	opts := NoInvalidVoidTypeOptions{
+		AllowInGenericTypeArguments: true,
+		AllowAsThisParameter:        false,
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]interface{})
+	if v, exists := optsMap["allowInGenericTypeArguments"]; exists {
+		opts.AllowInGenericTypeArguments = v
+	}
+	if v, exists := optsMap["allowAsThisParameter"]; exists {
+		if b, isBool := v.(bool); isBool {
+			opts.AllowAsThisParameter = b
+		}
+	}
+	return opts
 }
 
 // isAllowInGenericTruthy returns true when allowInGenericTypeArguments is not false
@@ -247,36 +271,10 @@ func hasOverloadSignatures(ctx rule.RuleContext, node *ast.Node) bool {
 }
 
 var NoInvalidVoidTypeRule = rule.CreateRule(rule.Rule{
-	Name: "no-invalid-void-type",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts := NoInvalidVoidTypeOptions{
-			AllowInGenericTypeArguments: true,
-			AllowAsThisParameter:        false,
-		}
-
-		// Parse options with dual-format support
-		if options != nil {
-			var optsMap map[string]interface{}
-			var ok bool
-
-			if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-				optsMap, ok = optArray[0].(map[string]interface{})
-			} else {
-				optsMap, ok = options.(map[string]interface{})
-			}
-
-			if ok {
-				if v, exists := optsMap["allowInGenericTypeArguments"]; exists {
-					opts.AllowInGenericTypeArguments = v
-				}
-				if v, exists := optsMap["allowAsThisParameter"]; exists {
-					if b, isBool := v.(bool); isBool {
-						opts.AllowAsThisParameter = b
-					}
-				}
-			}
-		}
+	Name:   "no-invalid-void-type",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		reportNotReturn := func(node *ast.Node) {
 			msgId := getNotReturnMessageId(opts)

--- a/internal/plugins/typescript/rules/no_invalid_void_type/no_invalid_void_type.schema.json
+++ b/internal/plugins/typescript/rules/no_invalid_void_type/no_invalid_void_type.schema.json
@@ -1,0 +1,34 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowAsThisParameter": {
+          "type": "boolean",
+          "description": "Whether a `this` parameter of a function may be `void`."
+        },
+        "allowInGenericTypeArguments": {
+          "description": "Whether `void` can be used as a valid value for generic type parameters.",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Whether `void` can be used as a valid value for all generic type parameters."
+            },
+            {
+              "type": "array",
+              "description": "Allowlist of types that may accept `void` as a generic type parameter.",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_loop_func/no_loop_func.go
+++ b/internal/plugins/typescript/rules/no_loop_func/no_loop_func.go
@@ -123,6 +123,7 @@ func checkForLoops(s *core.RunState, node *ast.Node) {
 //   - Repeated unsafe variable names are not deduplicated.
 var NoLoopFuncRule = rule.CreateRule(rule.Rule{
 	Name:             "no-loop-func",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		if ctx.TypeChecker == nil {

--- a/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers.go
+++ b/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers.go
@@ -1,6 +1,7 @@
 package no_magic_numbers
 
 import (
+	_ "embed"
 	"math"
 	"math/big"
 	"strconv"
@@ -10,6 +11,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_magic_numbers.schema.json
+var schemaJSON []byte
 
 // Maximum array length by the ECMAScript Specification.
 const maxArrayLength = 1<<32 - 1
@@ -27,14 +31,14 @@ type options struct {
 	ignoreTypeIndexes             bool
 }
 
-func parseOptions(rawOpts any) options {
+func parseOptions(rawOpts []any) options {
 	opts := options{
 		ignore: make(map[string]bool),
 	}
-	optsMap := utils.GetOptionsMap(rawOpts)
-	if optsMap == nil {
+	if len(rawOpts) == 0 {
 		return opts
 	}
+	optsMap, _ := rawOpts[0].(map[string]interface{})
 	if v, ok := optsMap["detectObjects"].(bool); ok {
 		opts.detectObjects = v
 	}
@@ -192,9 +196,9 @@ var useConstMessage = rule.RuleMessage{
 
 // NoMagicNumbersRule implements the @typescript-eslint/no-magic-numbers rule.
 var NoMagicNumbersRule = rule.CreateRule(rule.Rule{
-	Name: "no-magic-numbers",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "no-magic-numbers",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		handleNumericNode := func(node *ast.Node, isBigInt bool) {

--- a/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers.schema.json
+++ b/internal/plugins/typescript/rules/no_magic_numbers/no_magic_numbers.schema.json
@@ -1,0 +1,59 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "detectObjects": {
+          "type": "boolean"
+        },
+        "enforceConst": {
+          "type": "boolean"
+        },
+        "ignore": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^[+-]?(?:0|[1-9][0-9]*)n$"
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "ignoreArrayIndexes": {
+          "type": "boolean"
+        },
+        "ignoreDefaultValues": {
+          "type": "boolean"
+        },
+        "ignoreClassFieldInitialValues": {
+          "type": "boolean"
+        },
+        "ignoreEnums": {
+          "type": "boolean",
+          "description": "Whether enums used in TypeScript are considered okay."
+        },
+        "ignoreNumericLiteralTypes": {
+          "type": "boolean",
+          "description": "Whether numbers used in TypeScript numeric literal types are considered okay."
+        },
+        "ignoreReadonlyClassProperties": {
+          "type": "boolean",
+          "description": "Whether `readonly` class properties are considered okay."
+        },
+        "ignoreTypeIndexes": {
+          "type": "boolean",
+          "description": "Whether numbers used to index types are okay."
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.go
+++ b/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.go
@@ -1,6 +1,7 @@
 package no_meaningless_void_operator
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -8,6 +9,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_meaningless_void_operator.schema.json
+var schemaJSON []byte
 
 func buildMeaninglessVoidOperatorMessage(t string) rule.RuleMessage {
 	return rule.RuleMessage{
@@ -26,18 +30,25 @@ type NoMeaninglessVoidOperatorOptions struct {
 	CheckNever *bool
 }
 
+func parseOptions(options []any) NoMeaninglessVoidOperatorOptions {
+	opts := NoMeaninglessVoidOperatorOptions{}
+	if len(options) > 0 {
+		if typed, ok := options[0].(NoMeaninglessVoidOperatorOptions); ok {
+			opts = typed
+		}
+	}
+	if opts.CheckNever == nil {
+		opts.CheckNever = utils.Ref(false)
+	}
+	return opts
+}
+
 var NoMeaninglessVoidOperatorRule = rule.CreateRule(rule.Rule{
 	Name:             "no-meaningless-void-operator",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(NoMeaninglessVoidOperatorOptions)
-		if !ok {
-			opts = NoMeaninglessVoidOperatorOptions{}
-		}
-		if opts.CheckNever == nil {
-			opts.CheckNever = utils.Ref(false)
-		}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		return rule.RuleListeners{
 			ast.KindVoidExpression: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.go
+++ b/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.go
@@ -2,6 +2,7 @@ package no_meaningless_void_operator
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -27,14 +28,16 @@ func buildRemoveVoidMessage() rule.RuleMessage {
 }
 
 type NoMeaninglessVoidOperatorOptions struct {
-	CheckNever *bool
+	CheckNever *bool `json:"checkNever"`
 }
 
 func parseOptions(options []any) NoMeaninglessVoidOperatorOptions {
 	opts := NoMeaninglessVoidOperatorOptions{}
 	if len(options) > 0 {
-		if typed, ok := options[0].(NoMeaninglessVoidOperatorOptions); ok {
-			opts = typed
+		if optsMap, ok := options[0].(map[string]interface{}); ok {
+			if optsJSON, err := json.Marshal(optsMap); err == nil {
+				_ = json.Unmarshal(optsJSON, &opts)
+			}
 		}
 	}
 	if opts.CheckNever == nil {

--- a/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.schema.json
+++ b/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "checkNever": {
+          "type": "boolean",
+          "description": "Whether to suggest removing `void` when the argument has type `never`."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator_test.go
+++ b/internal/plugins/typescript/rules/no_meaningless_void_operator/no_meaningless_void_operator_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoMeaninglessVoidOperatorRule(t *testing.T) {
@@ -63,7 +62,7 @@ function bar(x: never) {
   void x;
 }
       `,
-			Options: NoMeaninglessVoidOperatorOptions{CheckNever: utils.Ref(true)},
+			Options: map[string]interface{}{"checkNever": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "meaninglessVoidOperator",

--- a/internal/plugins/typescript/rules/no_misused_new/no_misused_new.go
+++ b/internal/plugins/typescript/rules/no_misused_new/no_misused_new.go
@@ -38,7 +38,8 @@ func returnsParentType(typeNode *ast.Node, parent *ast.Node) bool {
 }
 
 var NoMisusedNewRule = rule.CreateRule(rule.Rule{
-	Name: "no-misused-new",
+	Name:   "no-misused-new",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindMethodDeclaration: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.go
@@ -1,6 +1,7 @@
 package no_misused_promises
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -10,6 +11,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_misused_promises.schema.json
+var schemaJSON []byte
 
 func buildConditionalMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -119,55 +123,59 @@ func (o *NoMisusedPromisesOptions) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-var NoMisusedPromisesRule = rule.CreateRule(rule.Rule{
-	Name:             "no-misused-promises",
-	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(NoMisusedPromisesOptions)
-		if !ok {
-			opts = NoMisusedPromisesOptions{}
-			// Options coming from JS configs / the test runner arrive as
-			// `[]interface{}` whose first element is the actual option object.
-			// Round-trip through JSON to populate the typed struct (matches the
-			// pattern used by other ported rules; malformed input falls back to
-			// defaults — global config-shape validation is a project-level concern).
-			if optsMap := utils.GetOptionsMap(options); optsMap != nil {
-				if optsJSON, err := json.Marshal(optsMap); err == nil {
-					_ = json.Unmarshal(optsJSON, &opts)
-				}
+func parseOptions(options []any) NoMisusedPromisesOptions {
+	opts := NoMisusedPromisesOptions{}
+	if len(options) > 0 {
+		if typed, ok := options[0].(NoMisusedPromisesOptions); ok {
+			opts = typed
+		} else if optsMap, ok := options[0].(map[string]interface{}); ok {
+			// Round-trip through JSON to populate the typed struct (malformed
+			// input falls back to defaults — config-shape validation is a
+			// project-level concern).
+			if optsJSON, err := json.Marshal(optsMap); err == nil {
+				_ = json.Unmarshal(optsJSON, &opts)
 			}
 		}
-		if opts.ChecksConditionals == nil {
-			opts.ChecksConditionals = utils.Ref(true)
-		}
-		if opts.ChecksSpreads == nil {
-			opts.ChecksSpreads = utils.Ref(true)
-		}
-		if opts.ChecksVoidReturn == nil {
-			opts.ChecksVoidReturn = utils.Ref(true)
-		}
-		if opts.ChecksVoidReturnOpts == nil {
-			opts.ChecksVoidReturnOpts = utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{})
-		}
-		if opts.ChecksVoidReturnOpts.Arguments == nil {
-			opts.ChecksVoidReturnOpts.Arguments = utils.Ref(true)
-		}
-		if opts.ChecksVoidReturnOpts.Attributes == nil {
-			opts.ChecksVoidReturnOpts.Attributes = utils.Ref(true)
-		}
-		if opts.ChecksVoidReturnOpts.InheritedMethods == nil {
-			opts.ChecksVoidReturnOpts.InheritedMethods = utils.Ref(true)
-		}
-		if opts.ChecksVoidReturnOpts.Properties == nil {
-			opts.ChecksVoidReturnOpts.Properties = utils.Ref(true)
-		}
-		if opts.ChecksVoidReturnOpts.Returns == nil {
-			opts.ChecksVoidReturnOpts.Returns = utils.Ref(true)
-		}
-		if opts.ChecksVoidReturnOpts.Variables == nil {
-			opts.ChecksVoidReturnOpts.Variables = utils.Ref(true)
-		}
+	}
+	if opts.ChecksConditionals == nil {
+		opts.ChecksConditionals = utils.Ref(true)
+	}
+	if opts.ChecksSpreads == nil {
+		opts.ChecksSpreads = utils.Ref(true)
+	}
+	if opts.ChecksVoidReturn == nil {
+		opts.ChecksVoidReturn = utils.Ref(true)
+	}
+	if opts.ChecksVoidReturnOpts == nil {
+		opts.ChecksVoidReturnOpts = utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{})
+	}
+	if opts.ChecksVoidReturnOpts.Arguments == nil {
+		opts.ChecksVoidReturnOpts.Arguments = utils.Ref(true)
+	}
+	if opts.ChecksVoidReturnOpts.Attributes == nil {
+		opts.ChecksVoidReturnOpts.Attributes = utils.Ref(true)
+	}
+	if opts.ChecksVoidReturnOpts.InheritedMethods == nil {
+		opts.ChecksVoidReturnOpts.InheritedMethods = utils.Ref(true)
+	}
+	if opts.ChecksVoidReturnOpts.Properties == nil {
+		opts.ChecksVoidReturnOpts.Properties = utils.Ref(true)
+	}
+	if opts.ChecksVoidReturnOpts.Returns == nil {
+		opts.ChecksVoidReturnOpts.Returns = utils.Ref(true)
+	}
+	if opts.ChecksVoidReturnOpts.Variables == nil {
+		opts.ChecksVoidReturnOpts.Variables = utils.Ref(true)
+	}
+	return opts
+}
+
+var NoMisusedPromisesRule = rule.CreateRule(rule.Rule{
+	Name:             "no-misused-promises",
+	Schema:           rule.NewSchema(schemaJSON),
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		anySignatureIsThenableType := func(
 			node *ast.Node,

--- a/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.go
+++ b/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.go
@@ -126,9 +126,7 @@ func (o *NoMisusedPromisesOptions) UnmarshalJSON(data []byte) error {
 func parseOptions(options []any) NoMisusedPromisesOptions {
 	opts := NoMisusedPromisesOptions{}
 	if len(options) > 0 {
-		if typed, ok := options[0].(NoMisusedPromisesOptions); ok {
-			opts = typed
-		} else if optsMap, ok := options[0].(map[string]interface{}); ok {
+		if optsMap, ok := options[0].(map[string]interface{}); ok {
 			// Round-trip through JSON to populate the typed struct (malformed
 			// input falls back to defaults — config-shape validation is a
 			// project-level concern).

--- a/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.schema.json
+++ b/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises.schema.json
@@ -1,0 +1,61 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "checksConditionals": {
+          "type": "boolean",
+          "description": "Whether to warn when a Promise is provided to conditional statements."
+        },
+        "checksSpreads": {
+          "type": "boolean",
+          "description": "Whether to warn when `...` spreading a `Promise`."
+        },
+        "checksVoidReturn": {
+          "description": "Whether to warn when a Promise is returned from a function typed as returning `void`.",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Whether to disable checking all asynchronous functions."
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Which forms of functions may have checking disabled.",
+              "properties": {
+                "arguments": {
+                  "type": "boolean",
+                  "description": "Disables checking an asynchronous function passed as argument where the parameter type expects a function that returns `void`."
+                },
+                "attributes": {
+                  "type": "boolean",
+                  "description": "Disables checking an asynchronous function passed as a JSX attribute expected to be a function that returns `void`."
+                },
+                "inheritedMethods": {
+                  "type": "boolean",
+                  "description": "Disables checking an asynchronous method in a type that extends or implements another type expecting that method to return `void`."
+                },
+                "properties": {
+                  "type": "boolean",
+                  "description": "Disables checking an asynchronous function passed as an object property expected to be a function that returns `void`."
+                },
+                "returns": {
+                  "type": "boolean",
+                  "description": "Disables checking an asynchronous function returned in a function whose return type is a function that returns `void`."
+                },
+                "variables": {
+                  "type": "boolean",
+                  "description": "Disables checking an asynchronous function used as a variable whose return type is a function that returns `void`."
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises_test.go
+++ b/internal/plugins/typescript/rules/no_misused_promises/no_misused_promises_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoMisusedPromisesRule(t *testing.T) {
@@ -19,7 +18,7 @@ if (true) {
 if (Promise.resolve()) {
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksConditionals: utils.Ref(false)},
+			Options: map[string]interface{}{"checksConditionals": false},
 		},
 		{Code: `
 if (true) {
@@ -34,28 +33,28 @@ if (Promise.resolve()) {
 } else {
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksConditionals: utils.Ref(false)},
+			Options: map[string]interface{}{"checksConditionals": false},
 		},
 		{Code: "for (;;) {}"},
 		{Code: "for (let i; i < 10; i++) {}"},
 		{
 			Code:    "for (let i; Promise.resolve(); i++) {}",
-			Options: NoMisusedPromisesOptions{ChecksConditionals: utils.Ref(false)},
+			Options: map[string]interface{}{"checksConditionals": false},
 		},
 		{Code: "do {} while (true);"},
 		{
 			Code:    "do {} while (Promise.resolve());",
-			Options: NoMisusedPromisesOptions{ChecksConditionals: utils.Ref(false)},
+			Options: map[string]interface{}{"checksConditionals": false},
 		},
 		{Code: "while (true) {}"},
 		{
 			Code:    "while (Promise.resolve()) {}",
-			Options: NoMisusedPromisesOptions{ChecksConditionals: utils.Ref(false)},
+			Options: map[string]interface{}{"checksConditionals": false},
 		},
 		{Code: "true ? 123 : 456;"},
 		{
 			Code:    "Promise.resolve() ? 123 : 456;",
-			Options: NoMisusedPromisesOptions{ChecksConditionals: utils.Ref(false)},
+			Options: map[string]interface{}{"checksConditionals": false},
 		},
 		{Code: `
 if (!true) {
@@ -66,17 +65,17 @@ if (!true) {
 if (!Promise.resolve()) {
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksConditionals: utils.Ref(false)},
+			Options: map[string]interface{}{"checksConditionals": false},
 		},
 		{Code: "(await Promise.resolve()) || false;"},
 		{
 			Code:    "Promise.resolve() || false;",
-			Options: NoMisusedPromisesOptions{ChecksConditionals: utils.Ref(false)},
+			Options: map[string]interface{}{"checksConditionals": false},
 		},
 		{Code: "(true && (await Promise.resolve())) || false;"},
 		{
 			Code:    "(true && Promise.resolve()) || false;",
-			Options: NoMisusedPromisesOptions{ChecksConditionals: utils.Ref(false)},
+			Options: map[string]interface{}{"checksConditionals": false},
 		},
 		{Code: "false || (true && Promise.resolve());"},
 		{Code: "(true && Promise.resolve()) || false;"},
@@ -110,12 +109,12 @@ if (value) {
 		{Code: "[1, 2, 3].forEach(val => {});"},
 		{
 			Code:    "[1, 2, 3].forEach(async val => {});",
-			Options: NoMisusedPromisesOptions{ChecksVoidReturn: utils.Ref(false)},
+			Options: map[string]interface{}{"checksVoidReturn": false},
 		},
 		{Code: "new Promise((resolve, reject) => resolve());"},
 		{
 			Code:    "new Promise(async (resolve, reject) => resolve());",
-			Options: NoMisusedPromisesOptions{ChecksVoidReturn: utils.Ref(false)},
+			Options: map[string]interface{}{"checksVoidReturn": false},
 		},
 		{Code: `
 Promise.all(
@@ -346,7 +345,7 @@ console.log([...(await Promise.resolve(42))]);
 			Code: `
 console.log({ ...Promise.resolve({ key: 42 }) });
       `,
-			Options: NoMisusedPromisesOptions{ChecksSpreads: utils.Ref(false)},
+			Options: map[string]interface{}{"checksSpreads": false},
 		},
 		{
 			Code: `
@@ -357,7 +356,7 @@ console.log({
   ...getData(),
 });
       `,
-			Options: NoMisusedPromisesOptions{ChecksSpreads: utils.Ref(false)},
+			Options: map[string]interface{}{"checksSpreads": false},
 		},
 		{
 			Code: `
@@ -368,14 +367,14 @@ console.log({ ...(condition || Promise.resolve({ key: 42 })) });
 console.log({ ...(condition ? {} : Promise.resolve({ key: 42 })) });
 console.log({ ...(condition ? Promise.resolve({ key: 42 }) : {}) });
       `,
-			Options: NoMisusedPromisesOptions{ChecksSpreads: utils.Ref(false)},
+			Options: map[string]interface{}{"checksSpreads": false},
 		},
 		{
 			Code: `
 // This is invalid Typescript, but it shouldn't trigger this linter specifically
 console.log([...Promise.resolve(42)]);
       `,
-			Options: NoMisusedPromisesOptions{ChecksSpreads: utils.Ref(false)},
+			Options: map[string]interface{}{"checksSpreads": false},
 		},
 		{Code: `
 function spreadAny(..._args: any): void {}
@@ -476,7 +475,7 @@ class Bar extends Foo {
   [key: string]: Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{Code: `
 function restTuple(...args: []): void;
@@ -538,7 +537,7 @@ foo(bar);
         <ASTViewer onSelectNode={onSelectFn} />;
       `,
 			Tsx:     true,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{Attributes: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"attributes": true}},
 		},
 		{
 			Code: `
@@ -554,7 +553,7 @@ class MySubclassExtendsMyClass extends MyClass {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -570,7 +569,7 @@ class MySubclassExtendsMyClass extends MyClass {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -586,7 +585,7 @@ class MySubclassExtendsMyClass extends MyClass {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -600,7 +599,7 @@ abstract class MyAbstractClassExtendsMyClass extends MyClass {
   abstract setThing(): void;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -614,7 +613,7 @@ abstract class MyAbstractClassExtendsMyClass extends MyClass {
   abstract setThing(): Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -628,7 +627,7 @@ interface MyInterfaceExtendsMyClass extends MyClass {
   setThing(): void;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -642,7 +641,7 @@ interface MyInterfaceExtendsMyClass extends MyClass {
   setThing(): Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -656,7 +655,7 @@ class MySubclassExtendsMyAbstractClass extends MyAbstractClass {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -670,7 +669,7 @@ class MySubclassExtendsMyAbstractClass extends MyAbstractClass {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -682,7 +681,7 @@ abstract class MyAbstractSubclassExtendsMyAbstractClass extends MyAbstractClass 
   abstract setThing(): void;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -694,7 +693,7 @@ abstract class MyAbstractSubclassExtendsMyAbstractClass extends MyAbstractClass 
   abstract setThing(): Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -706,7 +705,7 @@ interface MyInterfaceExtendsMyAbstractClass extends MyAbstractClass {
   setThing(): void;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -718,7 +717,7 @@ interface MyInterfaceExtendsMyAbstractClass extends MyAbstractClass {
   setThing(): Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -730,7 +729,7 @@ interface MySubInterfaceExtendsMyInterface extends MyInterface {
   setThing(): void;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -742,7 +741,7 @@ interface MySubInterfaceExtendsMyInterface extends MyInterface {
   setThing(): Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -756,7 +755,7 @@ class MyClassImplementsMyInterface implements MyInterface {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -770,7 +769,7 @@ class MyClassImplementsMyInterface implements MyInterface {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -782,7 +781,7 @@ abstract class MyAbstractClassImplementsMyInterface implements MyInterface {
   abstract setThing(): void;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -794,7 +793,7 @@ abstract class MyAbstractClassImplementsMyInterface implements MyInterface {
   abstract setThing(): Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -807,7 +806,7 @@ class MyClass implements MyTypeLiteralsIntersection {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -820,7 +819,7 @@ class MyClass implements MyTypeLiteralsIntersection {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -832,7 +831,7 @@ interface MyAsyncInterface extends MyGenericType {
   setThing(): Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -844,7 +843,7 @@ interface MyAsyncInterface extends MyGenericType<false> {
   setThing(): Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(false)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": false}},
 		},
 		{
 			Code: `
@@ -860,7 +859,7 @@ interface MyThirdInterface extends MyInterface, MyOtherInterface {
   setThing(): void;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -880,7 +879,7 @@ interface MyInterface extends MyClass, MyOtherClass {
   setThing(): void;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -904,7 +903,7 @@ class MySubclass extends MyClass implements MyInterface, MyOtherInterface {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -920,7 +919,7 @@ const MyClassExpressionExtendsMyClass = class extends MyClass {
   }
 };
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -936,7 +935,7 @@ class MyClassExtendsMyClassExpression extends MyClassExpression {
   }
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -951,7 +950,7 @@ interface MyInterfaceExtendsMyClassExpression extends MyClassExpressionType {
   setThing(): void;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -964,7 +963,7 @@ interface MyAsyncInterface extends MySyncCallSignatures {
   (arg: string): Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -977,7 +976,7 @@ interface ThisIsADifferentIssue extends MySyncConstructSignatures {
   new (arg: string): Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -990,7 +989,7 @@ interface ThisIsADifferentIssue extends MySyncIndexSignatures {
   [key: number]: Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -1009,7 +1008,7 @@ interface MyAsyncInterface extends MySyncInterfaceSignatures {
   [key: number]: () => Promise<void>;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{
 			Code: `
@@ -1045,7 +1044,7 @@ interface MyInterface extends MyCall, MyIndex, MyConstruct, MyMethods {
   syncMethodProperty: () => void;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{InheritedMethods: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"inheritedMethods": true}},
 		},
 		{Code: "const notAFn1: string = '';"},
 		{Code: "const notAFn2: number = 1;"},
@@ -1363,7 +1362,7 @@ f = async () => {
   return 3;
 };
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{Variables: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"variables": true}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "voidReturnVariable",
@@ -1431,7 +1430,7 @@ const obj: O = {
   f: async () => 'foo',
 };
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{Properties: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"properties": true}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "voidReturnProperty",
@@ -1537,7 +1536,7 @@ function f(): () => void {
   return async () => 0;
 }
       `,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{Returns: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"returns": true}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "voidReturnReturnValue",
@@ -1572,7 +1571,7 @@ const Component = (obj: O) => null;
 			Tsx: true,
 			// TODO(port) getContextualTypeForJsxExpression is not yet implemented
 			Skip:    true,
-			Options: NoMisusedPromisesOptions{ChecksVoidReturnOpts: utils.Ref(NoMisusedPromisesChecksVoidReturnOptions{Attributes: utils.Ref(true)})},
+			Options: map[string]interface{}{"checksVoidReturn": map[string]interface{}{"attributes": true}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "voidReturnAttribute",
@@ -2455,7 +2454,7 @@ array.every(() => Promise.resolve(true));
 const tuple: [number, number, number] = [1, 2, 3];
 tuple.find(() => Promise.resolve(false));
       `,
-			Options: NoMisusedPromisesOptions{ChecksConditionals: utils.Ref(true)},
+			Options: map[string]interface{}{"checksConditionals": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "predicate",

--- a/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.go
+++ b/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.go
@@ -2,6 +2,8 @@ package no_misused_spread
 
 import (
 	_ "embed"
+	"encoding/json"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/compiler"
@@ -79,8 +81,23 @@ func buildReplaceMapSpreadInObjectMessage() rule.RuleMessage {
 }
 
 type NoMisusedSpreadOptions struct {
-	Allow       []utils.TypeOrValueSpecifier
-	AllowInline []string
+	Allow []utils.TypeOrValueSpecifier `json:"allow"`
+}
+
+func parseOptions(options []any) NoMisusedSpreadOptions {
+	opts := NoMisusedSpreadOptions{}
+	if len(options) > 0 {
+		if optsMap, ok := options[0].(map[string]interface{}); ok {
+			// Convert the configured option object to JSON and back into the struct.
+			if optsJSON, err := json.Marshal(optsMap); err == nil {
+				_ = json.Unmarshal(optsJSON, &opts)
+			}
+		}
+	}
+	if opts.Allow == nil {
+		opts.Allow = []utils.TypeOrValueSpecifier{}
+	}
+	return opts
 }
 
 func isString(t *checker.Type) bool {
@@ -159,22 +176,11 @@ var NoMisusedSpreadRule = rule.CreateRule(rule.Rule{
 	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		var opts NoMisusedSpreadOptions
-		if len(options) > 0 {
-			if typed, ok := options[0].(NoMisusedSpreadOptions); ok {
-				opts = typed
-			}
-		}
-		if opts.Allow == nil {
-			opts.Allow = []utils.TypeOrValueSpecifier{}
-		}
-		if opts.AllowInline == nil {
-			opts.AllowInline = []string{}
-		}
+		opts := parseOptions(options)
 
 		checkArrayOrCallSpread := func(node *ast.Node) {
 			t := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node.AsSpreadElement().Expression)
-			if !utils.TypeMatchesSomeSpecifier(t, opts.Allow, opts.AllowInline, ctx.Program) && isString(t) {
+			if !utils.TypeMatchesSomeSpecifier(t, opts.Allow, nil, ctx.Program) && isString(t) {
 				ctx.ReportNode(node, buildNoStringSpreadMessage())
 			}
 		}
@@ -230,7 +236,7 @@ var NoMisusedSpreadRule = rule.CreateRule(rule.Rule{
 		checkObjectSpread := func(node *ast.Node, argument *ast.Node) {
 			t := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, argument)
 
-			if utils.TypeMatchesSomeSpecifier(t, opts.Allow, opts.AllowInline, ctx.Program) {
+			if utils.TypeMatchesSomeSpecifier(t, opts.Allow, nil, ctx.Program) {
 				return
 			}
 

--- a/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.go
+++ b/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.go
@@ -1,6 +1,7 @@
 package no_misused_spread
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/compiler"
@@ -8,6 +9,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_misused_spread.schema.json
+var schemaJSON []byte
 
 func buildAddAwaitMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -152,12 +156,14 @@ func isClassDeclaration(t *checker.Type) bool {
 
 var NoMisusedSpreadRule = rule.CreateRule(rule.Rule{
 	Name:             "no-misused-spread",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(NoMisusedSpreadOptions)
-		if !ok {
-			opts = NoMisusedSpreadOptions{}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		var opts NoMisusedSpreadOptions
+		if len(options) > 0 {
+			if typed, ok := options[0].(NoMisusedSpreadOptions); ok {
+				opts = typed
+			}
 		}
 		if opts.Allow == nil {
 			opts.Allow = []utils.TypeOrValueSpecifier{}

--- a/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.schema.json
+++ b/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread.schema.json
@@ -1,0 +1,108 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["file"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["lib"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["package"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "package": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name", "package"],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array",
+          "description": "An array of type specifiers that are known to be safe to spread."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread_test.go
+++ b/internal/plugins/typescript/rules/no_misused_spread/no_misused_spread_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoMisusedSpreadRule(t *testing.T) {
@@ -146,7 +145,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
         const promise = new Promise(() => {});
         const o = { ...promise };
       `,
-			Options: NoMisusedSpreadOptions{AllowInline: []string{"Promise"}},
+			Options: map[string]interface{}{"allow": []interface{}{"Promise"}},
 		},
 		{Code: `
       interface A {}
@@ -163,7 +162,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
         const str: string = 'test';
         const a = [...str];
       `,
-			Options: NoMisusedSpreadOptions{AllowInline: []string{"string"}},
+			Options: map[string]interface{}{"allow": []interface{}{"string"}},
 		},
 		{
 			Code: `
@@ -171,7 +170,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
 
         const a = { ...f };
       `,
-			Options: NoMisusedSpreadOptions{AllowInline: []string{"f"}},
+			Options: map[string]interface{}{"allow": []interface{}{"f"}},
 		},
 		{
 			Code: `
@@ -179,7 +178,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
 
         const a = { ...iterator };
       `,
-			Options: NoMisusedSpreadOptions{Allow: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromLib, Name: []string{"Iterable"}}}},
+			Options: map[string]interface{}{"allow": []interface{}{map[string]interface{}{"from": "lib", "name": "Iterable"}}},
 		},
 		{
 			Code: `
@@ -189,7 +188,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
 
         const spreadBrandedString = [...brandedString];
       `,
-			Options: NoMisusedSpreadOptions{Allow: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"BrandedString"}}}},
+			Options: map[string]interface{}{"allow": []interface{}{map[string]interface{}{"from": "file", "name": "BrandedString"}}},
 		},
 		{
 			Code: `
@@ -201,7 +200,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
 
         const a = { ...iterator };
       `,
-			Options: NoMisusedSpreadOptions{AllowInline: []string{"CustomIterable"}},
+			Options: map[string]interface{}{"allow": []interface{}{"CustomIterable"}},
 		},
 		{
 			Code: `
@@ -213,7 +212,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
 
         const a = { ...iterator };
       `,
-			Options: NoMisusedSpreadOptions{Allow: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"CustomIterable"}}}},
+			Options: map[string]interface{}{"allow": []interface{}{map[string]interface{}{"from": "file", "name": "CustomIterable"}}},
 		},
 		{
 			Code: `
@@ -229,8 +228,8 @@ func TestNoMisusedSpreadRule(t *testing.T) {
 
         const a = { ...iterator };
       `,
-			Options: NoMisusedSpreadOptions{
-				Allow: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromPackage, Name: []string{"CustomIterable"}, Package: "module"}},
+			Options: map[string]interface{}{
+				"allow": []interface{}{map[string]interface{}{"from": "package", "name": "CustomIterable", "package": "module"}},
 			},
 		},
 		{
@@ -243,7 +242,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
 
         const o = { ...a };
       `,
-			Options: NoMisusedSpreadOptions{AllowInline: []string{"A"}},
+			Options: map[string]interface{}{"allow": []interface{}{"A"}},
 		},
 		{
 			Code: `
@@ -253,7 +252,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
           },
         };
       `,
-			Options: NoMisusedSpreadOptions{AllowInline: []string{"A"}},
+			Options: map[string]interface{}{"allow": []interface{}{"A"}},
 		},
 	}, []rule_tester.InvalidTestCase{
 		{
@@ -1337,7 +1336,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
 
         const a = { ...iterator };
       `,
-			Options: NoMisusedSpreadOptions{AllowInline: []string{"AnotherIterable"}},
+			Options: map[string]interface{}{"allow": []interface{}{"AnotherIterable"}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "noIterableSpreadInObject",
@@ -1363,7 +1362,7 @@ func TestNoMisusedSpreadRule(t *testing.T) {
       `,
 			// TODO(port): for some reason tsgo returns `error` type for iterator
 			Skip:    true,
-			Options: NoMisusedSpreadOptions{Allow: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromPackage, Name: []string{"Nothing"}, Package: "module"}}},
+			Options: map[string]interface{}{"allow": []interface{}{map[string]interface{}{"from": "package", "name": "Nothing", "package": "module"}}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "noIterableSpreadInObject",

--- a/internal/plugins/typescript/rules/no_mixed_enums/no_mixed_enums.go
+++ b/internal/plugins/typescript/rules/no_mixed_enums/no_mixed_enums.go
@@ -24,6 +24,7 @@ const (
 
 var NoMixedEnumsRule = rule.CreateRule(rule.Rule{
 	Name:             "no-mixed-enums",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		getMemberType := func(node *ast.Node) allowedType {

--- a/internal/plugins/typescript/rules/no_namespace/no_namespace.go
+++ b/internal/plugins/typescript/rules/no_namespace/no_namespace.go
@@ -2,6 +2,7 @@ package no_namespace
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"

--- a/internal/plugins/typescript/rules/no_namespace/no_namespace.go
+++ b/internal/plugins/typescript/rules/no_namespace/no_namespace.go
@@ -1,10 +1,14 @@
 package no_namespace
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_namespace.schema.json
+var schemaJSON []byte
 
 var noNamespaceMessage = rule.RuleMessage{
 	Id:          "moduleSyntaxIsPreferred",
@@ -60,7 +64,8 @@ func isDeclaredNamespace(node *ast.Node, isDefinitionFile bool) bool {
 }
 
 var NoNamespaceRule = rule.CreateRule(rule.Rule{
-	Name: "no-namespace",
+	Name:   "no-namespace",
+	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseNoNamespaceOptions(options)
 		if opts.AllowDefinitionFiles && ctx.SourceFile.IsDeclarationFile {

--- a/internal/plugins/typescript/rules/no_namespace/no_namespace.schema.json
+++ b/internal/plugins/typescript/rules/no_namespace/no_namespace.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowDeclarations": {
+          "type": "boolean",
+          "description": "Whether to allow `declare` with custom TypeScript namespaces."
+        },
+        "allowDefinitionFiles": {
+          "type": "boolean",
+          "description": "Whether to allow `declare` with custom TypeScript namespaces inside definition files."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_non_null_asserted_nullish_coalescing/no_non_null_asserted_nullish_coalescing.go
+++ b/internal/plugins/typescript/rules/no_non_null_asserted_nullish_coalescing/no_non_null_asserted_nullish_coalescing.go
@@ -78,7 +78,8 @@ func checkAssignmentsBefore(identName string, node *ast.Node, scope *ast.Node) b
 }
 
 var NoNonNullAssertedNullishCoalescingRule = rule.CreateRule(rule.Rule{
-	Name: "no-non-null-asserted-nullish-coalescing",
+	Name:   "no-non-null-asserted-nullish-coalescing",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		msg := rule.RuleMessage{
 			Id:          "noNonNullAssertedNullishCoalescing",

--- a/internal/plugins/typescript/rules/no_non_null_asserted_optional_chain/no_non_null_asserted_optional_chain.go
+++ b/internal/plugins/typescript/rules/no_non_null_asserted_optional_chain/no_non_null_asserted_optional_chain.go
@@ -21,7 +21,8 @@ func isPartOfOptionalChain(node *ast.Node) bool {
 }
 
 var NoNonNullAssertedOptionalChainRule = rule.CreateRule(rule.Rule{
-	Name: "no-non-null-asserted-optional-chain",
+	Name:   "no-non-null-asserted-optional-chain",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		msg := rule.RuleMessage{
 			Id:          "noNonNullOptionalChain",

--- a/internal/plugins/typescript/rules/no_non_null_assertion/no_non_null_assertion.go
+++ b/internal/plugins/typescript/rules/no_non_null_assertion/no_non_null_assertion.go
@@ -22,7 +22,8 @@ func isAssignmentTarget(node *ast.Node) bool {
 }
 
 var NoNonNullAssertionRule = rule.CreateRule(rule.Rule{
-	Name: "no-non-null-assertion",
+	Name:   "no-non-null-assertion",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		msg := rule.RuleMessage{
 			Id:          "noNonNull",

--- a/internal/plugins/typescript/rules/no_redeclare/no_redeclare.go
+++ b/internal/plugins/typescript/rules/no_redeclare/no_redeclare.go
@@ -1,11 +1,16 @@
 package no_redeclare
 
 import (
+	_ "embed"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	coreNoRedeclare "github.com/web-infra-dev/rslint/internal/rules/no_redeclare"
 )
 
+//go:embed no_redeclare.schema.json
+var schemaJSON []byte
+
 var NoRedeclareRule = rule.CreateRule(rule.Rule{
-	Name: "no-redeclare",
-	Run:  coreNoRedeclare.RunTSESLint,
+	Name:   "no-redeclare",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    coreNoRedeclare.RunTSESLint,
 })

--- a/internal/plugins/typescript/rules/no_redeclare/no_redeclare.go
+++ b/internal/plugins/typescript/rules/no_redeclare/no_redeclare.go
@@ -2,6 +2,7 @@ package no_redeclare
 
 import (
 	_ "embed"
+
 	"github.com/web-infra-dev/rslint/internal/rule"
 	coreNoRedeclare "github.com/web-infra-dev/rslint/internal/rules/no_redeclare"
 )

--- a/internal/plugins/typescript/rules/no_redeclare/no_redeclare.schema.json
+++ b/internal/plugins/typescript/rules/no_redeclare/no_redeclare.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "builtinGlobals": {
+          "type": "boolean",
+          "description": "Whether to report shadowing of built-in global variables."
+        },
+        "ignoreDeclarationMerge": {
+          "type": "boolean",
+          "description": "Whether to ignore declaration merges between certain TypeScript declaration types."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/plugins/typescript/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -111,6 +111,7 @@ func (t *typeFlagsWithNodeOrType) ToString(typeChecker *checker.Checker) string 
 
 var NoRedundantTypeConstituentsRule = rule.CreateRule(rule.Rule{
 	Name:             "no-redundant-type-constituents",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		var getTypeNodeTypePartFlags func(node *ast.Node) []typeFlagsWithNodeOrType

--- a/internal/plugins/typescript/rules/no_require_imports/no_require_imports.go
+++ b/internal/plugins/typescript/rules/no_require_imports/no_require_imports.go
@@ -2,8 +2,8 @@ package no_require_imports
 
 import (
 	_ "embed"
-	"regexp"
 
+	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -47,14 +47,14 @@ var NoRequireImportsRule = rule.CreateRule(rule.Rule{
 			optsMap, _ = options[0].(map[string]interface{})
 		}
 		allowAsImport, _ := optsMap["allowAsImport"].(bool)
-		var allowPatterns []*regexp.Regexp
+		var allowPatterns []*regexp2.Regexp
 		if allow, ok := optsMap["allow"].([]interface{}); ok {
 			for _, rawPattern := range allow {
 				pattern, ok := rawPattern.(string)
 				if !ok {
 					continue
 				}
-				if compiled, err := regexp.Compile(pattern); err == nil {
+				if compiled, err := utils.CompileRegexp2(pattern, utils.JSUnicodeRegexOptions); err == nil {
 					allowPatterns = append(allowPatterns, compiled)
 				}
 			}
@@ -62,7 +62,7 @@ var NoRequireImportsRule = rule.CreateRule(rule.Rule{
 
 		isImportPathAllowed := func(importPath string) bool {
 			for _, pattern := range allowPatterns {
-				if pattern.MatchString(importPath) {
+				if utils.Regexp2MatchString(pattern, importPath) {
 					return true
 				}
 			}

--- a/internal/plugins/typescript/rules/no_require_imports/no_require_imports.go
+++ b/internal/plugins/typescript/rules/no_require_imports/no_require_imports.go
@@ -1,12 +1,16 @@
 package no_require_imports
 
 import (
+	_ "embed"
 	"regexp"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_require_imports.schema.json
+var schemaJSON []byte
 
 // getStaticStringValue extracts static string value from literal or template
 func getStaticStringValue(node *ast.Node) (string, bool) {
@@ -35,10 +39,13 @@ var noRequireImportsMessage = rule.RuleMessage{
 }
 
 var NoRequireImportsRule = rule.CreateRule(rule.Rule{
-	Name: "no-require-imports",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		optsMap := utils.GetOptionsMap(options)
+	Name:   "no-require-imports",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		var optsMap map[string]interface{}
+		if len(options) > 0 {
+			optsMap, _ = options[0].(map[string]interface{})
+		}
 		allowAsImport, _ := optsMap["allowAsImport"].(bool)
 		var allowPatterns []*regexp.Regexp
 		if allow, ok := optsMap["allow"].([]interface{}); ok {

--- a/internal/plugins/typescript/rules/no_require_imports/no_require_imports.schema.json
+++ b/internal/plugins/typescript/rules/no_require_imports/no_require_imports.schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "description": "Patterns of import paths to allow requiring from.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowAsImport": {
+          "type": "boolean",
+          "description": "Allows `require` statements in import declarations."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_require_imports/no_require_imports.schema.json
+++ b/internal/plugins/typescript/rules/no_require_imports/no_require_imports.schema.json
@@ -9,7 +9,8 @@
           "type": "array",
           "description": "Patterns of import paths to allow requiring from.",
           "items": {
-            "type": "string"
+            "type": "string",
+            "format": "regex"
           }
         },
         "allowAsImport": {

--- a/internal/plugins/typescript/rules/no_require_imports/no_require_imports_test.go
+++ b/internal/plugins/typescript/rules/no_require_imports/no_require_imports_test.go
@@ -515,3 +515,18 @@ configValidator.addSchema(require('./a.json'));
 		},
 	})
 }
+
+// TestNoRequireImportsAllowSchema locks in that each `allow` entry is
+// validated as a regex. The rule compiles every entry to match import paths,
+// so an unparsable one would otherwise be dropped and that path would keep
+// reporting. Upstream's schema declares a plain array of strings.
+func TestNoRequireImportsAllowSchema(t *testing.T) {
+	invalid := []any{map[string]any{"allow": []any{"("}}}
+	if err := NoRequireImportsRule.Schema.Validate(invalid); err == nil {
+		t.Error("expected an invalid allow pattern to fail schema validation")
+	}
+	valid := []any{map[string]any{"allow": []any{"/package\\.json$"}}}
+	if err := NoRequireImportsRule.Schema.Validate(valid); err != nil {
+		t.Errorf("expected a valid allow pattern to pass schema validation, got: %v", err)
+	}
+}

--- a/internal/plugins/typescript/rules/no_require_imports/no_require_imports_test.go
+++ b/internal/plugins/typescript/rules/no_require_imports/no_require_imports_test.go
@@ -530,3 +530,26 @@ func TestNoRequireImportsAllowSchema(t *testing.T) {
 		t.Errorf("expected a valid allow pattern to pass schema validation, got: %v", err)
 	}
 }
+
+// TestNoRequireImportsAllowLookahead locks in that `allow` patterns are
+// matched with the same ECMAScript regex engine the schema validates them
+// against (regexp2), not Go's RE2. RE2 cannot compile lookahead, so a
+// JS-only pattern that passes schema validation would otherwise silently
+// fail to compile and never allow anything.
+func TestNoRequireImportsAllowLookahead(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRequireImportsRule, []rule_tester.ValidTestCase{
+		{Code: "require('foo');", Options: map[string]interface{}{"allow": []interface{}{"^(?!bar)"}}},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:    "require('barbaz');",
+			Options: map[string]interface{}{"allow": []interface{}{"^(?!bar)"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noRequireImports",
+					Line:      1,
+					Column:    1,
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_restricted_imports/no_restricted_imports.go
+++ b/internal/plugins/typescript/rules/no_restricted_imports/no_restricted_imports.go
@@ -22,6 +22,7 @@
 package no_restricted_imports
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -30,10 +31,13 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed no_restricted_imports.schema.json
+var schemaJSON []byte
+
 var NoRestrictedImportsRule = rule.CreateRule(rule.Rule{
-	Name: "no-restricted-imports",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "no-restricted-imports",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		engine := core.NewEngine(options)
 		if !engine.IsActive() {
 			return rule.RuleListeners{}

--- a/internal/plugins/typescript/rules/no_restricted_imports/no_restricted_imports.schema.json
+++ b/internal/plugins/typescript/rules/no_restricted_imports/no_restricted_imports.schema.json
@@ -1,0 +1,163 @@
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string",
+                "minLength": 1
+              },
+              "importNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "allowImportNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "allowTypeImports": {
+                "type": "boolean",
+                "description": "Whether to allow type-only imports for a path."
+              }
+            },
+            "required": ["name"]
+          }
+        ]
+      },
+      "uniqueItems": true
+    },
+    {
+      "type": "array",
+      "additionalItems": false,
+      "items": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "paths": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "importNames": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "allowImportNames": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "allowTypeImports": {
+                        "type": "boolean",
+                        "description": "Whether to allow type-only imports for a path."
+                      }
+                    },
+                    "required": ["name"]
+                  }
+                ]
+              },
+              "uniqueItems": true
+            },
+            "patterns": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "importNames": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "uniqueItems": true
+                      },
+                      "allowImportNames": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "uniqueItems": true
+                      },
+                      "group": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "uniqueItems": true
+                      },
+                      "regex": {
+                        "type": "string"
+                      },
+                      "importNamePattern": {
+                        "type": "string"
+                      },
+                      "allowImportNamePattern": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "caseSensitive": {
+                        "type": "boolean"
+                      },
+                      "allowTypeImports": {
+                        "type": "boolean",
+                        "description": "Whether to allow type-only imports for a path."
+                      }
+                    }
+                  },
+                  "uniqueItems": true
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.go
@@ -1,6 +1,7 @@
 package no_restricted_types
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_restricted_types.schema.json
+var schemaJSON []byte
 
 // keywordTypeNames maps the tsgo keyword `ast.Kind` for a primitive type
 // annotation to the lower-case name upstream uses as the bannedTypes map key
@@ -149,11 +153,12 @@ func buildReplacementSuggestions(
 }
 
 var NoRestrictedTypesRule = rule.CreateRule(rule.Rule{
-	Name: "no-restricted-types",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "no-restricted-types",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		bannedTypes := map[string]bannedTypeConfig{}
-		if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+		if len(options) > 0 {
+			optsMap, _ := options[0].(map[string]interface{})
 			if types, ok := optsMap["types"].(map[string]interface{}); ok {
 				bannedTypes = parseBannedTypes(types)
 			}

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.schema.json
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types.schema.json
@@ -1,0 +1,57 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "$defs": {
+        "banConfig": {
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Bans the type with the default message.",
+              "enum": [true]
+            },
+            {
+              "type": "string",
+              "description": "Bans the type with a custom message."
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Bans a type.",
+              "properties": {
+                "fixWith": {
+                  "type": "string",
+                  "description": "Type to autofix replace with. Note that autofixers can be applied automatically - so you need to be careful with this option."
+                },
+                "message": {
+                  "type": "string",
+                  "description": "Custom error message."
+                },
+                "suggest": {
+                  "type": "array",
+                  "description": "Types to suggest replacing with.",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "types": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/items/0/$defs/banConfig"
+          },
+          "description": "An object whose keys are the types you want to ban, and the values are error messages."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
@@ -928,6 +928,29 @@ func TestNoRestrictedTypesNonFalsePositives(t *testing.T) {
 	}, []rule_tester.InvalidTestCase{})
 }
 
+// TestNoRestrictedTypesTypesSchema locks in that upstream's `$defs` container
+// still governs the `types` values under the draft-4 dialect rslint compiles
+// rule schemas with. `$defs` is a 2019-09 keyword, so draft-4 treats it as an
+// unknown keyword — but the JSON Pointer `#/items/0/$defs/banConfig` resolves
+// against the raw document regardless of which keywords the dialect knows, so
+// the ban-config `oneOf` is still enforced rather than silently dropped.
+func TestNoRestrictedTypesTypesSchema(t *testing.T) {
+	valid := []any{map[string]any{"types": map[string]any{
+		"Banned":  true,
+		"Banned2": "Use Ok instead.",
+		"Banned3": map[string]any{"fixWith": "Ok", "suggest": []any{"Ok"}},
+	}}}
+	if err := NoRestrictedTypesRule.Schema.Validate(valid); err != nil {
+		t.Errorf("expected every ban-config shape to pass schema validation, got: %v", err)
+	}
+	// `false` is not one of the ban-config branches (only `true` is), so it
+	// must fail — which it can only do if the `$ref` into `$defs` resolved.
+	invalid := []any{map[string]any{"types": map[string]any{"Banned": false}}}
+	if err := NoRestrictedTypesRule.Schema.Validate(invalid); err == nil {
+		t.Error("expected a non-ban-config value to fail schema validation")
+	}
+}
+
 func TestNoRestrictedTypesEditDemand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_extras_test.go
@@ -22,16 +22,6 @@ import (
 
 func TestNoRestrictedTypesExtras(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRestrictedTypesRule, []rule_tester.ValidTestCase{
-		// ---- Branch lock-in checkBannedTypes() arm 1: bannedType === null disables the ban ----
-		{
-			Code:    `let value: Banned;`,
-			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": nil}}),
-		},
-		// ---- Branch lock-in checkBannedTypes() arm 1: bannedType === false disables the ban ----
-		{
-			Code:    `let value: Banned;`,
-			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{"Banned": false}}),
-		},
 		// ---- Branch lock-in: keyword listener is not wired when its name is absent ----
 		// bigint is NOT in the types map → the keyword listener is never
 		// registered, so an unconfigured primitive keyword stays valid.
@@ -721,21 +711,6 @@ func TestNoRestrictedTypesExtras(t *testing.T) {
 				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned<X>` as a type. Replace whole Banned<X>.", Line: 1, Column: 8},
 			},
 		},
-		// ---- Branch lock-in: unknown JSON value shape collapses to bare ban ----
-		// Upstream getCustomMessage treats any truthy non-string non-object
-		// (e.g. a stray number `1` slipped past schema validation) as a bare
-		// ban — customMessage = ''. parseBannedTypes' default arm mirrors
-		// this: a number value goes through Kind="true", reporting with no
-		// custom-message suffix.
-		{
-			Code: `let v: Banned;`,
-			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
-				"Banned": 1,
-			}}),
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "bannedTypeMessage", Message: "Don't use `Banned` as a type.", Line: 1, Column: 8},
-			},
-		},
 		// ---- Real-user: same name banned and not-banned in same file ----
 		// User configures `Banned` but a *different* identifier `Allowed`
 		// appears in the same scope — must not bleed into reports.
@@ -915,15 +890,6 @@ func TestNoRestrictedTypesNonFalsePositives(t *testing.T) {
 		// entirely missing options) doesn't break the listener wiring.
 		{
 			Code: `let v: bigint | string; let w: {}; let x: []; class C implements Whatever {}`,
-		},
-		// ---- Non-FP: explicit `null` value disables an otherwise-active key ----
-		// Already covered in the positive-suite valid cases; repeating in the
-		// FP suite locks the disable-via-null branch into the FP audit.
-		{
-			Code: `let v: bigint;`,
-			Options: optionsArr(map[string]interface{}{"types": map[string]interface{}{
-				"bigint": nil,
-			}}),
 		},
 	}, []rule_tester.InvalidTestCase{})
 }

--- a/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_upstream_test.go
+++ b/internal/plugins/typescript/rules/no_restricted_types/no_restricted_types_upstream_test.go
@@ -14,7 +14,7 @@ import (
 
 // optionsArr wraps a single options object the way upstream's
 // `options: [{...}]` ships it across the JS bridge — exercising the
-// `GetOptionsMap` JSON path rather than a typed-struct shortcut.
+// decoded-JSON map path rather than a typed-struct shortcut.
 func optionsArr(o map[string]interface{}) []interface{} {
 	return []interface{}{o}
 }

--- a/internal/plugins/typescript/rules/no_shadow/no_shadow.go
+++ b/internal/plugins/typescript/rules/no_shadow/no_shadow.go
@@ -2,6 +2,7 @@ package no_shadow
 
 import (
 	_ "embed"
+
 	"github.com/web-infra-dev/rslint/internal/rule"
 	core "github.com/web-infra-dev/rslint/internal/rules/no_shadow"
 )

--- a/internal/plugins/typescript/rules/no_shadow/no_shadow.go
+++ b/internal/plugins/typescript/rules/no_shadow/no_shadow.go
@@ -1,9 +1,13 @@
 package no_shadow
 
 import (
+	_ "embed"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	core "github.com/web-infra-dev/rslint/internal/rules/no_shadow"
 )
+
+//go:embed no_shadow.schema.json
+var schemaJSON []byte
 
 // NoShadowRule is the typescript-eslint wrapper around the core no-shadow
 // implementation. The rule shares the entire scope/shadow-detection pipeline
@@ -11,6 +15,7 @@ import (
 // difference is the default `hoist` option, which is `functions-and-types`
 // here versus `functions` in core ESLint.
 var NoShadowRule = rule.CreateRule(rule.Rule{
-	Name: "no-shadow",
-	Run:  core.RunTSESLint,
+	Name:   "no-shadow",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    core.RunTSESLint,
 })

--- a/internal/plugins/typescript/rules/no_shadow/no_shadow.schema.json
+++ b/internal/plugins/typescript/rules/no_shadow/no_shadow.schema.json
@@ -1,0 +1,41 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "description": "Identifier names for which shadowing is allowed.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "builtinGlobals": {
+          "type": "boolean",
+          "description": "Whether to report shadowing of built-in global variables."
+        },
+        "hoist": {
+          "type": "string",
+          "description": "Whether to report shadowing before outer functions or variables are defined.",
+          "enum": ["all", "functions", "functions-and-types", "never", "types"]
+        },
+        "ignoreFunctionTypeParameterNameValueShadow": {
+          "type": "boolean",
+          "description": "Whether to ignore function parameters named the same as a variable."
+        },
+        "ignoreOnInitialization": {
+          "type": "boolean",
+          "description": "Whether to ignore the variable initializers when the shadowed variable is presumably still uninitialized."
+        },
+        "ignoreTypeValueShadow": {
+          "type": "boolean",
+          "description": "Whether to ignore types named the same as a variable."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_this_alias/no_this_alias.go
+++ b/internal/plugins/typescript/rules/no_this_alias/no_this_alias.go
@@ -1,10 +1,15 @@
 package no_this_alias
 
 import (
+	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_this_alias.schema.json
+var schemaJSON []byte
 
 type NoThisAliasOptions struct {
 	AllowDestructuring bool     `json:"allowDestructuring"`
@@ -62,17 +67,7 @@ func parseOptions(options []any) NoThisAliasOptions {
 		return opts
 	}
 
-	// A real config supplies context.options directly. Retain the old nested
-	// array compatibility for direct callers that still pass [[{...}]].
-	option := options[0]
-	if nested, ok := option.([]interface{}); ok {
-		if len(nested) == 0 {
-			return opts
-		}
-		option = nested[0]
-	}
-
-	optsMap, ok := option.(map[string]interface{})
+	optsMap, ok := options[0].(map[string]interface{})
 	if !ok {
 		return opts
 	}
@@ -132,7 +127,8 @@ func configuredThisListener(ctx *rule.RuleContext, opts NoThisAliasOptions) func
 }
 
 var NoThisAliasRule = rule.CreateRule(rule.Rule{
-	Name: "no-this-alias",
+	Name:   "no-this-alias",
+	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		if len(options) == 0 {
 			return rule.RuleListeners{ast.KindThisKeyword: defaultThisListener(&ctx)}

--- a/internal/plugins/typescript/rules/no_this_alias/no_this_alias.schema.json
+++ b/internal/plugins/typescript/rules/no_this_alias/no_this_alias.schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowDestructuring": {
+          "type": "boolean",
+          "description": "Whether to ignore destructuring, such as `const { props, state } = this`."
+        },
+        "allowedNames": {
+          "type": "array",
+          "description": "Names to ignore, such as [\"self\"] for `const self = this;`.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_this_alias/no_this_alias_test.go
+++ b/internal/plugins/typescript/rules/no_this_alias/no_this_alias_test.go
@@ -33,10 +33,7 @@ func TestNoThisAliasRule(t *testing.T) {
 			{Code: `const [foo, bar] = this;`},
 			{Code: `const self = this;`, Options: map[string]interface{}{"allowedNames": []interface{}{"self"}}},
 			{Code: `const \u0073elf = this;`, Options: map[string]interface{}{"allowedNames": []interface{}{"self"}}},
-			{
-				Code:    `const nested = this;`,
-				Options: []interface{}{[]interface{}{map[string]interface{}{"allowedNames": []interface{}{"nested"}}}},
-			},
+			{Code: `const nested = this;`, Options: map[string]interface{}{"allowedNames": []interface{}{"nested"}}},
 			{Code: `let self = 1; self ||= this;`, Options: map[string]interface{}{"allowedNames": []interface{}{"self"}}},
 			{Code: `setTimeout(() => { this.doWork(); });`},
 		},

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias.go
@@ -1,11 +1,15 @@
 package no_type_alias
 
 import (
+	_ "embed"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed no_type_alias.schema.json
+var schemaJSON []byte
 
 type optionValue string
 
@@ -51,7 +55,7 @@ func parseCompositionOption(val string) optionValue {
 	return optionNever
 }
 
-func parseOptions(options any) NoTypeAliasOptions {
+func parseOptions(options []any) NoTypeAliasOptions {
 	opts := NoTypeAliasOptions{
 		AllowAliases:          optionNever,
 		AllowCallbacks:        optionNever,
@@ -62,18 +66,10 @@ func parseOptions(options any) NoTypeAliasOptions {
 		AllowMappedTypes:      optionNever,
 		AllowTupleTypes:       optionNever,
 	}
-	if options == nil {
+	if len(options) == 0 {
 		return opts
 	}
-	var optsMap map[string]interface{}
-	if arr, ok := options.([]interface{}); ok && len(arr) > 0 {
-		optsMap, _ = arr[0].(map[string]interface{})
-	} else {
-		optsMap, _ = options.(map[string]interface{})
-	}
-	if optsMap == nil {
-		return opts
-	}
+	optsMap, _ := options[0].(map[string]interface{})
 	if v, ok := optsMap["allowAliases"].(string); ok {
 		opts.AllowAliases = parseCompositionOption(v)
 	}
@@ -132,9 +128,9 @@ func unwrapParenthesized(node *ast.Node) *ast.Node {
 }
 
 var NoTypeAliasRule = rule.CreateRule(rule.Rule{
-	Name: "no-type-alias",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "no-type-alias",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		isSupportedComposition := func(isTopLevel bool, composition compositionType, allowed optionValue) bool {

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias.schema.json
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias.schema.json
@@ -1,0 +1,61 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "$defs": {
+        "expandedOptions": {
+          "type": "string",
+          "enum": [
+            "always",
+            "never",
+            "in-unions",
+            "in-intersections",
+            "in-unions-and-intersections"
+          ]
+        },
+        "simpleOptions": {
+          "type": "string",
+          "enum": ["always", "never"]
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "allowAliases": {
+          "$ref": "#/items/0/$defs/expandedOptions",
+          "description": "Whether to allow direct one-to-one type aliases."
+        },
+        "allowCallbacks": {
+          "$ref": "#/items/0/$defs/simpleOptions",
+          "description": "Whether to allow type aliases for callbacks."
+        },
+        "allowConditionalTypes": {
+          "$ref": "#/items/0/$defs/simpleOptions",
+          "description": "Whether to allow type aliases for conditional types."
+        },
+        "allowConstructors": {
+          "$ref": "#/items/0/$defs/simpleOptions",
+          "description": "Whether to allow type aliases with constructors."
+        },
+        "allowGenerics": {
+          "$ref": "#/items/0/$defs/simpleOptions",
+          "description": "Whether to allow type aliases with generic types."
+        },
+        "allowLiterals": {
+          "$ref": "#/items/0/$defs/expandedOptions",
+          "description": "Whether to allow type aliases with object literal types."
+        },
+        "allowMappedTypes": {
+          "$ref": "#/items/0/$defs/expandedOptions",
+          "description": "Whether to allow type aliases with mapped types."
+        },
+        "allowTupleTypes": {
+          "$ref": "#/items/0/$defs/expandedOptions",
+          "description": "Whether to allow type aliases with tuple types."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
+++ b/internal/plugins/typescript/rules/no_type_alias/no_type_alias_test.go
@@ -413,59 +413,5 @@ func TestNoTypeAliasRule(t *testing.T) {
 			Options: map[string]interface{}{"allowGenerics": "never"},
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
 		},
-
-		// Invalid option values: simple options should fall back to "never" when given composition-only values
-		{
-			Code:    `type Foo = () => void`,
-			Options: map[string]interface{}{"allowCallbacks": "in-unions"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
-		},
-		{
-			Code:    `type Foo = () => void`,
-			Options: map[string]interface{}{"allowCallbacks": "in-intersections"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
-		},
-		{
-			Code:    `type Foo = () => void`,
-			Options: map[string]interface{}{"allowCallbacks": "in-unions-and-intersections"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
-		},
-		{
-			Code:    `type Foo<T> = T extends number ? number : null`,
-			Options: map[string]interface{}{"allowConditionalTypes": "in-unions"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
-		},
-		{
-			Code:    `type Foo = new (bar: number) => string | null`,
-			Options: map[string]interface{}{"allowConstructors": "in-unions"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
-		},
-		{
-			Code:    `type Foo = Record<string, number>`,
-			Options: map[string]interface{}{"allowGenerics": "in-unions"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
-		},
-
-		// Invalid option values: composition options should fall back to "never" when given invalid values
-		{
-			Code:    `type Foo = string`,
-			Options: map[string]interface{}{"allowAliases": "invalid"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
-		},
-		{
-			Code:    `type Foo = {}`,
-			Options: map[string]interface{}{"allowLiterals": "invalid"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
-		},
-		{
-			Code:    `type Foo<T> = { readonly [P in keyof T]: T[P] }`,
-			Options: map[string]interface{}{"allowMappedTypes": "invalid"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 15}},
-		},
-		{
-			Code:    `type Foo = [string]`,
-			Options: map[string]interface{}{"allowTupleTypes": "invalid"},
-			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noTypeAlias", Line: 1, Column: 12}},
-		},
 	})
 }

--- a/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.go
@@ -1,6 +1,7 @@
 package no_unnecessary_boolean_literal_compare
 
 import (
+	_ "embed"
 	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -9,6 +10,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_unnecessary_boolean_literal_compare.schema.json
+var schemaJSON []byte
 
 func buildComparingNullableToFalseMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -53,6 +57,28 @@ type NoUnnecessaryBooleanLiteralCompareOptions struct {
 	AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing *bool `json:"allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing,omitempty"`
 }
 
+func parseOptions(options []any) NoUnnecessaryBooleanLiteralCompareOptions {
+	opts := NoUnnecessaryBooleanLiteralCompareOptions{}
+	if len(options) > 0 {
+		if typed, ok := options[0].(NoUnnecessaryBooleanLiteralCompareOptions); ok {
+			opts = typed
+		} else if optsJSON, err := json.Marshal(options[0]); err == nil {
+			// Convert the configured option object to JSON and back into the struct.
+			_ = json.Unmarshal(optsJSON, &opts)
+		}
+	}
+	if opts.AllowComparingNullableBooleansToFalse == nil {
+		opts.AllowComparingNullableBooleansToFalse = utils.Ref(true)
+	}
+	if opts.AllowComparingNullableBooleansToTrue == nil {
+		opts.AllowComparingNullableBooleansToTrue = utils.Ref(true)
+	}
+	if opts.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing == nil {
+		opts.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = utils.Ref(false)
+	}
+	return opts
+}
+
 type booleanComparison struct {
 	expression                  *ast.Expression
 	literalBooleanInComparison  bool
@@ -66,31 +92,10 @@ func isBooleanType(t *checker.Type) bool {
 
 var NoUnnecessaryBooleanLiteralCompareRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unnecessary-boolean-literal-compare",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(NoUnnecessaryBooleanLiteralCompareOptions)
-		if !ok {
-			opts = NoUnnecessaryBooleanLiteralCompareOptions{}
-			if optionsArray, ok := options.([]interface{}); ok && len(optionsArray) > 0 {
-				if optsJSON, err := json.Marshal(optionsArray[0]); err == nil {
-					json.Unmarshal(optsJSON, &opts)
-				}
-			} else if optsMap, ok := options.(map[string]interface{}); ok {
-				if optsJSON, err := json.Marshal(optsMap); err == nil {
-					json.Unmarshal(optsJSON, &opts)
-				}
-			}
-		}
-		if opts.AllowComparingNullableBooleansToFalse == nil {
-			opts.AllowComparingNullableBooleansToFalse = utils.Ref(true)
-		}
-		if opts.AllowComparingNullableBooleansToTrue == nil {
-			opts.AllowComparingNullableBooleansToTrue = utils.Ref(true)
-		}
-		if opts.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing == nil {
-			opts.AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = utils.Ref(false)
-		}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		compilerOptions := ctx.Program.Options()
 		isStrictNullChecks := utils.IsStrictCompilerOptionEnabled(

--- a/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.go
@@ -60,9 +60,7 @@ type NoUnnecessaryBooleanLiteralCompareOptions struct {
 func parseOptions(options []any) NoUnnecessaryBooleanLiteralCompareOptions {
 	opts := NoUnnecessaryBooleanLiteralCompareOptions{}
 	if len(options) > 0 {
-		if typed, ok := options[0].(NoUnnecessaryBooleanLiteralCompareOptions); ok {
-			opts = typed
-		} else if optsJSON, err := json.Marshal(options[0]); err == nil {
+		if optsJSON, err := json.Marshal(options[0]); err == nil {
 			// Convert the configured option object to JSON and back into the struct.
 			_ = json.Unmarshal(optsJSON, &opts)
 		}

--- a/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.schema.json
+++ b/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare.schema.json
@@ -1,0 +1,25 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowComparingNullableBooleansToFalse": {
+          "type": "boolean",
+          "description": "Whether to allow comparisons between nullable boolean variables and `false`."
+        },
+        "allowComparingNullableBooleansToTrue": {
+          "type": "boolean",
+          "description": "Whether to allow comparisons between nullable boolean variables and `true`."
+        },
+        "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
+          "type": "boolean",
+          "description": "Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare/no_unnecessary_boolean_literal_compare_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestNoUnnecessaryBooleanLiteralCompareRule(t *testing.T) {
@@ -71,14 +70,14 @@ func TestNoUnnecessaryBooleanLiteralCompareRule(t *testing.T) {
         declare const varBooleanOrUndefined: boolean | undefined;
         varBooleanOrUndefined === true;
       `,
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToFalse: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToFalse": false},
 		},
 		{
 			Code: `
         declare const varBooleanOrUndefined: boolean | undefined;
         varBooleanOrUndefined === false;
       `,
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToTrue: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToTrue": false},
 		},
 		{
 			Code: `
@@ -89,7 +88,7 @@ func TestNoUnnecessaryBooleanLiteralCompareRule(t *testing.T) {
           }
         };
       `,
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToFalse: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToFalse": false},
 		},
 		{
 			Code: `
@@ -100,7 +99,7 @@ func TestNoUnnecessaryBooleanLiteralCompareRule(t *testing.T) {
           }
         };
       `,
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToTrue: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToTrue": false},
 		},
 		{Code: "'false' === true;"},
 		{Code: "'true' === false;"},
@@ -125,7 +124,7 @@ function test(a?: boolean): boolean {
   return a !== false;
 }
       `,
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: utils.Ref(true)},
+			Options: map[string]interface{}{"allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": true},
 		},
 	}, []rule_tester.InvalidTestCase{
 		{
@@ -194,7 +193,7 @@ function test(a?: boolean): boolean {
         }
       `,
 			},
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToTrue: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToTrue": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "comparingNullableToTrueDirect",
@@ -213,7 +212,7 @@ function test(a?: boolean): boolean {
         }
       `,
 			},
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToTrue: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToTrue": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "comparingNullableToTrueNegated",
@@ -234,7 +233,7 @@ function test(a?: boolean): boolean {
         }
       `,
 			},
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToFalse: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToFalse": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "comparingNullableToFalse",
@@ -255,7 +254,7 @@ function test(a?: boolean): boolean {
         }
       `,
 			},
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToFalse: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToFalse": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "comparingNullableToFalse",
@@ -276,7 +275,7 @@ function test(a?: boolean): boolean {
         }
       `,
 			},
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToFalse: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToFalse": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "comparingNullableToFalse",
@@ -892,9 +891,9 @@ function test(a?: boolean): boolean {
         }
       `,
 			},
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{
-				AllowComparingNullableBooleansToTrue:  utils.Ref(false),
-				AllowComparingNullableBooleansToFalse: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowComparingNullableBooleansToTrue":  false,
+				"allowComparingNullableBooleansToFalse": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -915,9 +914,9 @@ function test(a?: boolean): boolean {
         }
       `,
 			},
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{
-				AllowComparingNullableBooleansToTrue:  utils.Ref(false),
-				AllowComparingNullableBooleansToFalse: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowComparingNullableBooleansToTrue":  false,
+				"allowComparingNullableBooleansToFalse": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -938,7 +937,7 @@ function test(a?: boolean): boolean {
         }
       `,
 			},
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToTrue: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToTrue": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "comparingNullableToTrueDirect",
@@ -958,7 +957,7 @@ function test(a?: boolean): boolean {
         }
       `,
 			},
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToFalse: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToFalse": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "comparingNullableToFalse",
@@ -978,7 +977,7 @@ function test(a?: boolean): boolean {
         }
       `,
 			},
-			Options: NoUnnecessaryBooleanLiteralCompareOptions{AllowComparingNullableBooleansToFalse: utils.Ref(false)},
+			Options: map[string]interface{}{"allowComparingNullableBooleansToFalse": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "comparingNullableToFalse",
@@ -989,7 +988,7 @@ function test(a?: boolean): boolean {
 			Code: `
 function foo(): boolean {}
       `,
-			Options:  NoUnnecessaryBooleanLiteralCompareOptions{AllowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: utils.Ref(false)},
+			Options:  map[string]interface{}{"allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": false},
 			TSConfig: "tsconfig.unstrict.json",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -1,6 +1,7 @@
 package no_unnecessary_condition
 
 import (
+	_ "embed"
 	"fmt"
 	"math"
 	"strconv"
@@ -14,6 +15,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_unnecessary_condition.schema.json
+var schemaJSON []byte
 
 // strictNullishFlag matches the original typescript-eslint behavior:
 // only null and undefined are considered "nullish" for isAlwaysNullish.
@@ -254,21 +258,22 @@ type ruleOptions struct {
 	checkTypePredicates                                    bool
 }
 
-func parseOptions(options any) ruleOptions {
+func parseOptions(options []any) ruleOptions {
 	opts := ruleOptions{
 		allowConstantLoopConditions: loopConditionNever,
 	}
-	optsMap := utils.GetOptionsMap(options)
-	if optsMap != nil {
-		if v, ok := optsMap["allowConstantLoopConditions"]; ok {
-			opts.allowConstantLoopConditions = normalizeAllowConstantLoopConditions(v)
-		}
-		if v, ok := optsMap["allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing"].(bool); ok {
-			opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = v
-		}
-		if v, ok := optsMap["checkTypePredicates"].(bool); ok {
-			opts.checkTypePredicates = v
-		}
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]interface{})
+	if v, ok := optsMap["allowConstantLoopConditions"]; ok {
+		opts.allowConstantLoopConditions = normalizeAllowConstantLoopConditions(v)
+	}
+	if v, ok := optsMap["allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing"].(bool); ok {
+		opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = v
+	}
+	if v, ok := optsMap["checkTypePredicates"].(bool); ok {
+		opts.checkTypePredicates = v
 	}
 	return opts
 }
@@ -323,9 +328,9 @@ func buildTypeGuardAlreadyIsTypeMessage(typeGuardOrAssertionFunction string) rul
 // Rule definition
 var NoUnnecessaryConditionRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unnecessary-condition",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 		tc := ctx.TypeChecker
 

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.schema.json
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.schema.json
@@ -1,0 +1,35 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowConstantLoopConditions": {
+          "description": "Whether to ignore constant loop conditions, such as `while (true)`.",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Always ignore or not ignore the loop conditions"
+            },
+            {
+              "type": "string",
+              "description": "Which situations to ignore constant conditions in.",
+              "enum": ["always", "never", "only-allowed-literals"]
+            }
+          ]
+        },
+        "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
+          "type": "boolean",
+          "description": "Whether to not error when running with a tsconfig that has strictNullChecks turned."
+        },
+        "checkTypePredicates": {
+          "type": "boolean",
+          "description": "Whether to check the asserted argument of a type predicate function for unnecessary conditions"
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_parameter_property_assignment/no_unnecessary_parameter_property_assignment.go
@@ -20,6 +20,7 @@ import (
 // Upstream source: packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts
 var NoUnnecessaryParameterPropertyAssignmentRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unnecessary-parameter-property-assignment",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run:              run,
 })

--- a/internal/plugins/typescript/rules/no_unnecessary_qualifier/no_unnecessary_qualifier.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_qualifier/no_unnecessary_qualifier.go
@@ -27,6 +27,7 @@ import (
 //   - Upstream:  https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unnecessary-qualifier.ts
 var NoUnnecessaryQualifierRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unnecessary-qualifier",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run:              run,
 })

--- a/internal/plugins/typescript/rules/no_unnecessary_qualifier/no_unnecessary_qualifier_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_qualifier/no_unnecessary_qualifier_extras_test.go
@@ -145,16 +145,10 @@ namespace Outer {
   }
 }
     `},
-		// ---- Config contract: upstream schema is [] — any options shape must be ignored ----
-		// rslint's CLI / JS config passes options through several shapes
-		// (bare object, [{...}], null, []); none of them should change
-		// behavior or crash. Locks in that the rule's `Run` truly ignores
-		// its `options any` parameter, matching upstream's empty `schema`
-		// and `defaultOptions: []` contract.
+		// ---- Config contract: upstream schema is [], so the only shapes a
+		// config can carry are "no options at all" ----
 		{Code: `const x: A.B = 3;`, Options: nil},
 		{Code: `const x: A.B = 3;`, Options: []interface{}{}},
-		{Code: `const x: A.B = 3;`, Options: map[string]interface{}{"someUnknownOption": true}},
-		{Code: `const x: A.B = 3;`, Options: []interface{}{map[string]interface{}{"checkX": false}}},
 		// ---- Real-user: ImportType qualifier (`import('./foo').T`) outside scope ----
 		// `import('./foo').T` is an ImportTypeNode whose Qualifier is an
 		// EntityName — for `import('./foo').N.T` the Qualifier is a
@@ -555,29 +549,6 @@ namespace N {
     A,
     B = A,
   }
-}
-      `},
-		},
-		// ---- Config contract: invalid case carries options too (CLI-shape) ----
-		// Same rule semantics regardless of options shape. CLI ships a bare
-		// map after config.go unwraps single-element arrays; pass that
-		// shape directly to confirm the unwrap path doesn't accidentally
-		// gate the listeners on an option that doesn't exist.
-		{
-			Code: `
-namespace A {
-  export type B = number;
-  const x: A.B = 3;
-}
-      `,
-			Options: map[string]interface{}{"anyKey": "anyValue"},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "unnecessaryQualifier", Line: 4, Column: 12},
-			},
-			Output: []string{`
-namespace A {
-  export type B = number;
-  const x: B = 3;
 }
       `},
 		},

--- a/internal/plugins/typescript/rules/no_unnecessary_template_expression/no_unnecessary_template_expression.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_template_expression/no_unnecessary_template_expression.go
@@ -60,6 +60,7 @@ func isWhitespace(str string) bool {
 
 var NoUnnecessaryTemplateExpressionRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unnecessary-template-expression",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		reportSingleInterpolation := func(spanExpr *ast.Node, spanLiteral *ast.Node) {

--- a/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_arguments/no_unnecessary_type_arguments.go
@@ -28,6 +28,7 @@ func isInTypeContext(node *ast.Node) bool {
 
 var NoUnnecessaryTypeArgumentsRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unnecessary-type-arguments",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		getTypeParametersFromType := func(node *ast.Node, nodeName *ast.Node) []*ast.Node {

--- a/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -1,6 +1,7 @@
 package no_unnecessary_type_assertion
 
 import (
+	_ "embed"
 	"encoding/json"
 	"slices"
 	"strings"
@@ -12,6 +13,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_unnecessary_type_assertion.schema.json
+var schemaJSON []byte
 
 const nullableTypeFlags = checker.TypeFlagsAny |
 	checker.TypeFlagsUnknown |
@@ -50,17 +54,17 @@ type NoUnnecessaryTypeAssertionOptions struct {
 
 var NoUnnecessaryTypeAssertionRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unnecessary-type-assertion",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := NoUnnecessaryTypeAssertionOptions{}
-		if options != nil {
+		if len(options) > 0 {
 			// Try direct type assertion first (for Go tests)
-			if directOpts, ok := options.(NoUnnecessaryTypeAssertionOptions); ok {
+			if directOpts, ok := options[0].(NoUnnecessaryTypeAssertionOptions); ok {
 				opts = directOpts
 			} else {
 				// For IPC mode, options come as map[string]interface{}, convert via JSON
-				if jsonBytes, err := json.Marshal(options); err == nil {
+				if jsonBytes, err := json.Marshal(options[0]); err == nil {
 					_ = json.Unmarshal(jsonBytes, &opts)
 				}
 			}

--- a/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.go
@@ -52,26 +52,27 @@ type NoUnnecessaryTypeAssertionOptions struct {
 	CheckLiteralConstAssertions bool `json:"checkLiteralConstAssertions"`
 }
 
+func parseOptions(options []any) NoUnnecessaryTypeAssertionOptions {
+	opts := NoUnnecessaryTypeAssertionOptions{
+		TypesToIgnore: []string{},
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	if optsMap, ok := options[0].(map[string]interface{}); ok {
+		if optsJSON, err := json.Marshal(optsMap); err == nil {
+			_ = json.Unmarshal(optsJSON, &opts)
+		}
+	}
+	return opts
+}
+
 var NoUnnecessaryTypeAssertionRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unnecessary-type-assertion",
 	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		opts := NoUnnecessaryTypeAssertionOptions{}
-		if len(options) > 0 {
-			// Try direct type assertion first (for Go tests)
-			if directOpts, ok := options[0].(NoUnnecessaryTypeAssertionOptions); ok {
-				opts = directOpts
-			} else {
-				// For IPC mode, options come as map[string]interface{}, convert via JSON
-				if jsonBytes, err := json.Marshal(options[0]); err == nil {
-					_ = json.Unmarshal(jsonBytes, &opts)
-				}
-			}
-		}
-		if opts.TypesToIgnore == nil {
-			opts.TypesToIgnore = []string{}
-		}
+		opts := parseOptions(options)
 
 		sourceText := ctx.SourceFile.Text()
 		var fixScanner *scanner.Scanner

--- a/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.schema.json
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion.schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "checkLiteralConstAssertions": {
+          "type": "boolean",
+          "description": "Whether to check literal const assertions."
+        },
+        "typesToIgnore": {
+          "type": "array",
+          "description": "A list of type names to ignore.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_assertion/no_unnecessary_type_assertion_test.go
@@ -81,26 +81,26 @@ const bar: number = foo()!;
 type Foo = number;
 const foo = (3 + 5) as Foo;
       `,
-			Options: NoUnnecessaryTypeAssertionOptions{TypesToIgnore: []string{"Foo"}},
+			Options: map[string]interface{}{"typesToIgnore": []interface{}{"Foo"}},
 		},
 		{
 			Code:    "const foo = (3 + 5) as any;",
-			Options: NoUnnecessaryTypeAssertionOptions{TypesToIgnore: []string{"any"}},
+			Options: map[string]interface{}{"typesToIgnore": []interface{}{"any"}},
 		},
 		{
 			Code:    "(Syntax as any).ArrayExpression = 'foo';",
-			Options: NoUnnecessaryTypeAssertionOptions{TypesToIgnore: []string{"any"}},
+			Options: map[string]interface{}{"typesToIgnore": []interface{}{"any"}},
 		},
 		{
 			Code:    "const foo = (3 + 5) as string;",
-			Options: NoUnnecessaryTypeAssertionOptions{TypesToIgnore: []string{"string"}},
+			Options: map[string]interface{}{"typesToIgnore": []interface{}{"string"}},
 		},
 		{
 			Code: `
 type Foo = number;
 const foo = <Foo>(3 + 5);
       `,
-			Options: NoUnnecessaryTypeAssertionOptions{TypesToIgnore: []string{"Foo"}},
+			Options: map[string]interface{}{"typesToIgnore": []interface{}{"Foo"}},
 		},
 		{Code: `
 let bar: number;
@@ -405,7 +405,7 @@ foo!;
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code:    "const a = `a` as const;",
-			Options: NoUnnecessaryTypeAssertionOptions{CheckLiteralConstAssertions: true},
+			Options: map[string]interface{}{"checkLiteralConstAssertions": true},
 			Output:  []string{"const a = `a`;"},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -416,7 +416,7 @@ foo!;
 		},
 		{
 			Code:    "const a = 'a' as const;",
-			Options: NoUnnecessaryTypeAssertionOptions{CheckLiteralConstAssertions: true},
+			Options: map[string]interface{}{"checkLiteralConstAssertions": true},
 			Output:  []string{"const a = 'a';"},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -427,7 +427,7 @@ foo!;
 		},
 		{
 			Code:    "const a = <const>'a';",
-			Options: NoUnnecessaryTypeAssertionOptions{CheckLiteralConstAssertions: true},
+			Options: map[string]interface{}{"checkLiteralConstAssertions": true},
 			Output:  []string{"const a = 'a';"},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1330,7 +1330,7 @@ class T {
   readonly a = 'a' as const;
 }
       `,
-			Options: NoUnnecessaryTypeAssertionOptions{CheckLiteralConstAssertions: true},
+			Options: map[string]interface{}{"checkLiteralConstAssertions": true},
 			Output: []string{`
 class T {
   readonly a = 'a';
@@ -1457,7 +1457,7 @@ enum T {
 declare const a: T.Value1;
 const b = a as const;
       `,
-			Options: NoUnnecessaryTypeAssertionOptions{CheckLiteralConstAssertions: true},
+			Options: map[string]interface{}{"checkLiteralConstAssertions": true},
 			Output: []string{`
 enum T {
   Value1,

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.go
@@ -34,7 +34,8 @@ func buildRemoveUnnecessaryConstraintMessage(constraint string) rule.RuleMessage
 var disambiguationExtensions = []string{tspath.ExtensionCts, tspath.ExtensionMts, tspath.ExtensionTsx}
 
 var NoUnnecessaryTypeConstraintRule = rule.CreateRule(rule.Rule{
-	Name: "no-unnecessary-type-constraint",
+	Name:   "no-unnecessary-type-constraint",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		needsDisambiguationResolved := false
 		needsDisambiguation := false

--- a/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_conversion/no_unnecessary_type_conversion.go
@@ -389,6 +389,7 @@ func allUnionPartsAreIntegerNumberLiteral(t *checker.Type) bool {
 
 var NoUnnecessaryTypeConversionRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unnecessary-type-conversion",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		sourceFile := ctx.SourceFile

--- a/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument.go
+++ b/internal/plugins/typescript/rules/no_unsafe_argument/no_unsafe_argument.go
@@ -152,6 +152,7 @@ func (s *functionSignature) getNextParameterType() *checker.Type {
 
 var NoUnsafeArgumentRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unsafe-argument",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		describeType := func(t *checker.Type) string {

--- a/internal/plugins/typescript/rules/no_unsafe_assignment/no_unsafe_assignment.go
+++ b/internal/plugins/typescript/rules/no_unsafe_assignment/no_unsafe_assignment.go
@@ -67,6 +67,7 @@ const (
 
 var NoUnsafeAssignmentRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unsafe-assignment",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		compilerOptions := ctx.Program.Options()

--- a/internal/plugins/typescript/rules/no_unsafe_call/no_unsafe_call.go
+++ b/internal/plugins/typescript/rules/no_unsafe_call/no_unsafe_call.go
@@ -37,6 +37,7 @@ func buildUnsafeTemplateTagMessage(t string) rule.RuleMessage {
 
 var NoUnsafeCallRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unsafe-call",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		compilerOptions := ctx.Program.Options()

--- a/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging.go
+++ b/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging.go
@@ -150,7 +150,8 @@ func (s *mergeRuleState) reportIfUnsafeMerge(declNode *ast.Node, name *ast.Node,
 }
 
 var NoUnsafeDeclarationMergingRule = rule.CreateRule(rule.Rule{
-	Name: "no-unsafe-declaration-merging",
+	Name:   "no-unsafe-declaration-merging",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		// Declaration merges are almost always pairs. Keep that common path as
 		// a tiny slice scan, and only build an index for unusually large merged

--- a/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison.go
+++ b/internal/plugins/typescript/rules/no_unsafe_enum_comparison/no_unsafe_enum_comparison.go
@@ -76,6 +76,7 @@ func typeViolates(leftTypeParts []*checker.Type, rightType *checker.Type) bool {
 
 var NoUnsafeEnumComparisonRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unsafe-enum-comparison",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		isMismatchedComparison := func(

--- a/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type.go
+++ b/internal/plugins/typescript/rules/no_unsafe_function_type/no_unsafe_function_type.go
@@ -15,6 +15,7 @@ func buildBannedFunctionTypeMessage() rule.RuleMessage {
 
 var NoUnsafeFunctionTypeRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unsafe-function-type",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		checkBannedType := func(ident *ast.Node) {

--- a/internal/plugins/typescript/rules/no_unsafe_member_access/no_unsafe_member_access.go
+++ b/internal/plugins/typescript/rules/no_unsafe_member_access/no_unsafe_member_access.go
@@ -1,6 +1,7 @@
 package no_unsafe_member_access
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -8,6 +9,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_unsafe_member_access.schema.json
+var schemaJSON []byte
 
 func buildUnsafeComputedMemberAccessMessage(property, t string) rule.RuleMessage {
 	return rule.RuleMessage{
@@ -45,6 +49,7 @@ func createDataType(t *checker.Type) string {
 
 var NoUnsafeMemberAccessRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unsafe-member-access",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		compilerOptions := ctx.Program.Options()

--- a/internal/plugins/typescript/rules/no_unsafe_member_access/no_unsafe_member_access.schema.json
+++ b/internal/plugins/typescript/rules/no_unsafe_member_access/no_unsafe_member_access.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowOptionalChaining": {
+          "type": "boolean",
+          "description": "Whether to allow `?.` optional chains on `any` values."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return.go
+++ b/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return.go
@@ -31,6 +31,7 @@ func buildUnsafeReturnThisMessage(t string) rule.RuleMessage {
 
 var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unsafe-return",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		compilerOptions := ctx.Program.Options()

--- a/internal/plugins/typescript/rules/no_unsafe_type_assertion/no_unsafe_type_assertion.go
+++ b/internal/plugins/typescript/rules/no_unsafe_type_assertion/no_unsafe_type_assertion.go
@@ -53,6 +53,7 @@ func isObjectLiteralType(t *checker.Type) bool {
 
 var NoUnsafeTypeAssertionRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unsafe-type-assertion",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		checkExpression := func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_unsafe_unary_minus/no_unsafe_unary_minus.go
+++ b/internal/plugins/typescript/rules/no_unsafe_unary_minus/no_unsafe_unary_minus.go
@@ -18,6 +18,7 @@ func buildUnaryMinusMessage(t string) rule.RuleMessage {
 
 var NoUnsafeUnaryMinusRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unsafe-unary-minus",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.go
+++ b/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.go
@@ -2,6 +2,7 @@ package no_unused_expressions
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"

--- a/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.go
+++ b/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.go
@@ -1,10 +1,14 @@
 package no_unused_expressions
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_unused_expressions.schema.json
+var schemaJSON []byte
 
 func unusedExpressionMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -15,9 +19,9 @@ func unusedExpressionMessage() rule.RuleMessage {
 
 // https://typescript-eslint.io/rules/no-unused-expressions
 var NoUnusedExpressionsRule = rule.CreateRule(rule.Rule{
-	Name: "no-unused-expressions",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "no-unused-expressions",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := utils.ParseNoUnusedExpressionOptions(rawOptions)
 
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.schema.json
+++ b/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.schema.json
@@ -1,0 +1,28 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allowShortCircuit": {
+          "type": "boolean"
+        },
+        "allowTernary": {
+          "type": "boolean"
+        },
+        "allowTaggedTemplates": {
+          "type": "boolean"
+        },
+        "enforceForJSX": {
+          "type": "boolean"
+        },
+        "ignoreDirectives": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.go
+++ b/internal/plugins/typescript/rules/no_unused_private_class_members/no_unused_private_class_members.go
@@ -70,7 +70,8 @@ type thisAlias struct {
 }
 
 var NoUnusedPrivateClassMembersRule = rule.CreateRule(rule.Rule{
-	Name: "no-unused-private-class-members",
+	Name:   "no-unused-private-class-members",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		// Root scope corresponds to upstream's IntermediateScope-for-Program:
 		// no `this` binding.

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -1,6 +1,7 @@
 package no_unused_vars
 
 import (
+	_ "embed"
 	"regexp"
 	"strings"
 	"sync"
@@ -10,6 +11,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_unused_vars.schema.json
+var schemaJSON []byte
 
 type EnableAutofixRemoval struct {
 	Imports bool `json:"imports"`
@@ -93,15 +97,24 @@ var patternCache = struct {
 	order:   make([]string, 0, maxCachedPatterns),
 }
 
-func parseOptions(options interface{}) Config {
+func parseOptions(options []any) Config {
 	config := Config{
 		Vars:         "all",
 		Args:         "after-used",
 		CaughtErrors: "all",
 	}
 
-	if optsMap := utils.GetOptionsMap(options); optsMap != nil {
-		parseOptionsFromMap(optsMap, &config)
+	if len(options) == 0 {
+		return compilePatterns(config)
+	}
+
+	// The first option is either the broad `vars` setting as a bare string or a
+	// full options object.
+	switch first := options[0].(type) {
+	case string:
+		config.Vars = first
+	case map[string]interface{}:
+		parseOptionsFromMap(first, &config)
 	}
 
 	return compilePatterns(config)
@@ -2075,9 +2088,9 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 
 var NoUnusedVarsRule = rule.CreateRule(rule.Rule{
 	Name:             "no-unused-vars",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		ac := &analysisContext{

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -2,10 +2,10 @@ package no_unused_vars
 
 import (
 	_ "embed"
-	"regexp"
 	"strings"
 	"sync"
 
+	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -33,10 +33,10 @@ type Config struct {
 	ReportUsedIgnorePattern        bool                 `json:"reportUsedIgnorePattern"`
 	EnableAutofixRemoval           EnableAutofixRemoval `json:"enableAutofixRemoval"`
 
-	varsIgnoreRe              *regexp.Regexp
-	argsIgnoreRe              *regexp.Regexp
-	caughtErrorsIgnoreRe      *regexp.Regexp
-	destructuredArrayIgnoreRe *regexp.Regexp
+	varsIgnoreRe              *regexp2.Regexp
+	argsIgnoreRe              *regexp2.Regexp
+	caughtErrorsIgnoreRe      *regexp2.Regexp
+	destructuredArrayIgnoreRe *regexp2.Regexp
 }
 
 type analysisContext struct {
@@ -90,10 +90,10 @@ const maxCachedPatterns = 64
 
 var patternCache = struct {
 	sync.RWMutex
-	entries map[string]*regexp.Regexp
+	entries map[string]*regexp2.Regexp
 	order   []string
 }{
-	entries: make(map[string]*regexp.Regexp),
+	entries: make(map[string]*regexp2.Regexp),
 	order:   make([]string, 0, maxCachedPatterns),
 }
 
@@ -169,7 +169,7 @@ func compilePatterns(config Config) Config {
 	return config
 }
 
-func cachedPattern(pattern string) *regexp.Regexp {
+func cachedPattern(pattern string) *regexp2.Regexp {
 	if pattern == "" {
 		return nil
 	}
@@ -179,7 +179,7 @@ func cachedPattern(pattern string) *regexp.Regexp {
 	if ok {
 		return cached
 	}
-	re, _ := regexp.Compile(pattern)
+	re, _ := utils.CompileRegexp2(pattern, utils.JSUnicodeRegexOptions)
 	patternCache.Lock()
 	if cached, ok := patternCache.entries[pattern]; ok {
 		patternCache.Unlock()
@@ -1007,7 +1007,7 @@ func isDestructuredArrayElement(node *ast.Node) bool {
 // reporting (when reportUsedIgnorePattern is true and the variable is used).
 // Returns: (shouldIgnore bool, matchesPattern bool)
 func matchesIgnorePattern(varName string, varInfo *VariableInfo, opts *Config, writeRefs []*ast.Node) (bool, bool) {
-	var re *regexp.Regexp
+	var re *regexp2.Regexp
 
 	if isParameterNode(varInfo.Definition) {
 		if opts.Args == "none" {
@@ -1023,13 +1023,13 @@ func matchesIgnorePattern(varName string, varInfo *VariableInfo, opts *Config, w
 		re = opts.varsIgnoreRe
 	}
 
-	matched := re != nil && re.MatchString(varName)
+	matched := utils.Regexp2MatchString(re, varName)
 
 	// destructuredArrayIgnorePattern applies to array-destructured elements,
 	// checking both the declaration site AND assignment sites (e.g., `let _x; [_x] = arr`).
 	if !matched && opts.destructuredArrayIgnoreRe != nil {
 		if isDestructuredArrayElement(varInfo.Definition) || hasArrayDestructuringWrite(writeRefs) {
-			matched = opts.destructuredArrayIgnoreRe.MatchString(varName)
+			matched = utils.Regexp2MatchString(opts.destructuredArrayIgnoreRe, varName)
 		}
 	}
 

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.schema.json
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.schema.json
@@ -19,6 +19,7 @@
             },
             "argsIgnorePattern": {
               "type": "string",
+              "format": "regex",
               "description": "Regular expressions of argument names to not check for usage."
             },
             "caughtErrors": {
@@ -28,10 +29,12 @@
             },
             "caughtErrorsIgnorePattern": {
               "type": "string",
+              "format": "regex",
               "description": "Regular expressions of catch block argument names to not check for usage."
             },
             "destructuredArrayIgnorePattern": {
               "type": "string",
+              "format": "regex",
               "description": "Regular expressions of destructured array variable names to not check for usage."
             },
             "enableAutofixRemoval": {
@@ -68,6 +71,7 @@
             },
             "varsIgnorePattern": {
               "type": "string",
+              "format": "regex",
               "description": "Regular expressions of variable names to not check for usage."
             }
           }

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.schema.json
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.schema.json
@@ -1,0 +1,80 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Broad setting for unused variables to target.",
+          "enum": ["all", "local"]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "args": {
+              "type": "string",
+              "description": "Whether to check all, some, or no arguments.",
+              "enum": ["all", "after-used", "none"]
+            },
+            "argsIgnorePattern": {
+              "type": "string",
+              "description": "Regular expressions of argument names to not check for usage."
+            },
+            "caughtErrors": {
+              "type": "string",
+              "description": "Whether to check catch block arguments.",
+              "enum": ["all", "none"]
+            },
+            "caughtErrorsIgnorePattern": {
+              "type": "string",
+              "description": "Regular expressions of catch block argument names to not check for usage."
+            },
+            "destructuredArrayIgnorePattern": {
+              "type": "string",
+              "description": "Regular expressions of destructured array variable names to not check for usage."
+            },
+            "enableAutofixRemoval": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Configurable automatic fixes for different types of unused variables.",
+              "properties": {
+                "imports": {
+                  "type": "boolean",
+                  "description": "Whether to enable automatic removal of unused imports."
+                }
+              }
+            },
+            "ignoreClassWithStaticInitBlock": {
+              "type": "boolean",
+              "description": "Whether to ignore classes with at least one static initialization block."
+            },
+            "ignoreRestSiblings": {
+              "type": "boolean",
+              "description": "Whether to ignore sibling properties in `...` destructuring."
+            },
+            "ignoreUsingDeclarations": {
+              "type": "boolean",
+              "description": "Whether to ignore using or await using declarations."
+            },
+            "reportUsedIgnorePattern": {
+              "type": "boolean",
+              "description": "Whether to report variables that match any of the valid ignore pattern options if they have been used."
+            },
+            "vars": {
+              "type": "string",
+              "description": "Whether to check all variables or only locally-declared variables.",
+              "enum": ["all", "local"]
+            },
+            "varsIgnorePattern": {
+              "type": "string",
+              "description": "Regular expressions of variable names to not check for usage."
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_patterns_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_patterns_test.go
@@ -865,3 +865,20 @@ console.log(obj?.x?.y);`,
 
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, validTestCases, invalidTestCases)
 }
+
+// TestNoUnusedVarsPatternsLookahead locks in that the ignore patterns are
+// matched with the same ECMAScript regex engine the schema validates them
+// against (regexp2), not Go's RE2. RE2 cannot compile lookahead, so a
+// JS-only pattern that passes schema validation would otherwise silently
+// fail to compile and never ignore anything.
+func TestNoUnusedVarsPatternsLookahead(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, []rule_tester.ValidTestCase{
+		{Code: `const _foo = 1;`, Options: map[string]interface{}{"varsIgnorePattern": "^_(?!ignore)"}},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:    `const _ignoreMe = 1;`,
+			Options: map[string]interface{}{"varsIgnorePattern": "^_(?!ignore)"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 7}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_test.go
@@ -258,3 +258,26 @@ function foox() {
 
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, validTestCases, invalidTestCases)
 }
+
+// TestNoUnusedVarsIgnorePatternSchema locks in that every `*IgnorePattern`
+// option is validated as a regex. The rule compiles each one to decide what
+// to skip, so an unparsable pattern would otherwise be dropped and the names
+// it was meant to exempt would keep reporting. Upstream's schema declares
+// bare strings.
+func TestNoUnusedVarsIgnorePatternSchema(t *testing.T) {
+	for _, option := range []string{
+		"varsIgnorePattern",
+		"argsIgnorePattern",
+		"caughtErrorsIgnorePattern",
+		"destructuredArrayIgnorePattern",
+	} {
+		invalid := []any{map[string]any{option: "("}}
+		if err := NoUnusedVarsRule.Schema.Validate(invalid); err == nil {
+			t.Errorf("expected an invalid %s regex to fail schema validation", option)
+		}
+		valid := []any{map[string]any{option: "^_"}}
+		if err := NoUnusedVarsRule.Schema.Validate(valid); err != nil {
+			t.Errorf("expected a valid %s regex to pass schema validation, got: %v", option, err)
+		}
+	}
+}

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
@@ -2,6 +2,7 @@ package no_use_before_define
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
@@ -1,10 +1,14 @@
 package no_use_before_define
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_use_before_define.schema.json
+var schemaJSON []byte
 
 // options mirrors the typescript-eslint rule schema.
 // See https://typescript-eslint.io/rules/no-use-before-define/#options
@@ -18,7 +22,7 @@ type options struct {
 	allowNamedExports    bool
 }
 
-func parseOptions(rawOptions any) options {
+func parseOptions(rawOptions []any) options {
 	opts := options{
 		functions:            true,
 		classes:              true,
@@ -28,29 +32,19 @@ func parseOptions(rawOptions any) options {
 		ignoreTypeReferences: true,
 		allowNamedExports:    false,
 	}
+	if len(rawOptions) == 0 {
+		return opts
+	}
 
 	// Handle "nofunc" string option.
-	if str, ok := rawOptions.(string); ok {
+	if str, ok := rawOptions[0].(string); ok {
 		if str == "nofunc" {
 			opts.functions = false
 		}
 		return opts
 	}
 
-	// Handle array format from JS tests: ["nofunc"] or [{...}]
-	if arr, ok := rawOptions.([]interface{}); ok && len(arr) > 0 {
-		if str, ok := arr[0].(string); ok {
-			if str == "nofunc" {
-				opts.functions = false
-			}
-			return opts
-		}
-	}
-
-	optsMap := utils.GetOptionsMap(rawOptions)
-	if optsMap == nil {
-		return opts
-	}
+	optsMap, _ := rawOptions[0].(map[string]interface{})
 
 	if v, ok := optsMap["functions"].(bool); ok {
 		opts.functions = v
@@ -383,13 +377,13 @@ type definitionInfo struct {
 
 var NoUseBeforeDefineRule = rule.CreateRule(rule.Rule{
 	Name:             "no-use-before-define",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		if ctx.TypeChecker == nil || ctx.Refs == nil {
 			return rule.RuleListeners{}
 		}
 
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
 		opts := parseOptions(rawOptions)
 		var executionScopes []*ast.Node
 		currentExecutionScope := func() *ast.Node {

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.schema.json
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.schema.json
@@ -1,0 +1,50 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Broadly set functions and allowNamedExports to false.",
+          "enum": ["nofunc"]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allowNamedExports": {
+              "type": "boolean",
+              "description": "Whether to ignore named exports."
+            },
+            "classes": {
+              "type": "boolean",
+              "description": "Whether to ignore references to class declarations."
+            },
+            "enums": {
+              "type": "boolean",
+              "description": "Whether to check references to enums."
+            },
+            "functions": {
+              "type": "boolean",
+              "description": "Whether to ignore references to function declarations."
+            },
+            "ignoreTypeReferences": {
+              "type": "boolean",
+              "description": "Whether to ignore type references, such as in type annotations and assertions."
+            },
+            "typedefs": {
+              "type": "boolean",
+              "description": "Whether to check references to types."
+            },
+            "variables": {
+              "type": "boolean",
+              "description": "Whether to ignore references to variables."
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.go
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.go
@@ -296,7 +296,8 @@ func needsLeadingSemicolon(sourceFile *ast.SourceFile, classNode *ast.Node, node
 }
 
 var NoUselessConstructorRule = rule.CreateRule(rule.Rule{
-	Name: "no-useless-constructor",
+	Name:   "no-useless-constructor",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindConstructor: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.go
+++ b/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.go
@@ -1,12 +1,16 @@
 package no_useless_default_assignment
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed no_useless_default_assignment.schema.json
+var schemaJSON []byte
 
 // NoUselessDefaultAssignmentRule mirrors
 // @typescript-eslint/no-useless-default-assignment.
@@ -21,6 +25,7 @@ import (
 // Upstream source: packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
 var NoUselessDefaultAssignmentRule = rule.CreateRule(rule.Rule{
 	Name:             "no-useless-default-assignment",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run:              run,
 })
@@ -29,12 +34,12 @@ type Options struct {
 	allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing bool
 }
 
-func parseOptions(options any) Options {
+func parseOptions(options []any) Options {
 	opts := Options{}
-	optsMap := utils.GetOptionsMap(options)
-	if optsMap == nil {
+	if len(options) == 0 {
 		return opts
 	}
+	optsMap, _ := options[0].(map[string]interface{})
 	if v, ok := optsMap["allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing"].(bool); ok {
 		opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = v
 	}
@@ -71,8 +76,7 @@ func buildUselessUndefinedMessage(kind string) rule.RuleMessage {
 	}
 }
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	if ctx.TypeChecker == nil {
 		return rule.RuleListeners{}
 	}

--- a/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.go
+++ b/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.go
@@ -2,6 +2,7 @@ package no_useless_default_assignment
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"

--- a/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.schema.json
+++ b/internal/plugins/typescript/rules/no_useless_default_assignment/no_useless_default_assignment.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
+          "type": "boolean",
+          "description": "Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_useless_empty_export/no_useless_empty_export.go
+++ b/internal/plugins/typescript/rules/no_useless_empty_export/no_useless_empty_export.go
@@ -283,7 +283,8 @@ func isDefinitionFile(fileName string) bool {
 }
 
 var NoUselessEmptyExportRule = rule.CreateRule(rule.Rule{
-	Name: "no-useless-empty-export",
+	Name:   "no-useless-empty-export",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		// In a definition file, export {} is necessary to make the module properly
 		// encapsulated, even when there are other exports

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires.go
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires.go
@@ -1,38 +1,48 @@
 package no_var_requires
 
 import (
+	_ "embed"
 	"regexp"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
+//go:embed no_var_requires.schema.json
+var schemaJSON []byte
+
 type Options struct {
 	Allow []string `json:"allow"`
 }
 
-var NoVarRequiresRule = rule.CreateRule(rule.Rule{
-	Name: "no-var-requires",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts := &Options{}
-		if options != nil {
-			if optMap, ok := options.(map[string]interface{}); ok {
-				if allowList, exists := optMap["allow"]; exists {
-					if allowSlice, ok := allowList.([]interface{}); ok {
-						for _, item := range allowSlice {
-							if str, ok := item.(string); ok {
-								opts.Allow = append(opts.Allow, str)
-							}
-						}
-					} else if allowStrSlice, ok := allowList.([]string); ok {
-						opts.Allow = allowStrSlice
-					}
+func parseOptions(options []any) *Options {
+	opts := &Options{}
+	if len(options) == 0 {
+		return opts
+	}
+	if typed, ok := options[0].(*Options); ok {
+		return typed
+	}
+	optMap, _ := options[0].(map[string]interface{})
+	if allowList, exists := optMap["allow"]; exists {
+		if allowSlice, ok := allowList.([]interface{}); ok {
+			for _, item := range allowSlice {
+				if str, ok := item.(string); ok {
+					opts.Allow = append(opts.Allow, str)
 				}
-			} else if o, ok := options.(*Options); ok {
-				opts = o
 			}
+		} else if allowStrSlice, ok := allowList.([]string); ok {
+			opts.Allow = allowStrSlice
 		}
+	}
+	return opts
+}
+
+var NoVarRequiresRule = rule.CreateRule(rule.Rule{
+	Name:   "no-var-requires",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		// Compile allow patterns into regexes
 		var allowPatterns []*regexp.Regexp

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires.go
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires.go
@@ -20,9 +20,6 @@ func parseOptions(options []any) *Options {
 	if len(options) == 0 {
 		return opts
 	}
-	if typed, ok := options[0].(*Options); ok {
-		return typed
-	}
 	optMap, _ := options[0].(map[string]interface{})
 	if allowList, exists := optMap["allow"]; exists {
 		if allowSlice, ok := allowList.([]interface{}); ok {

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires.go
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires.go
@@ -2,10 +2,11 @@ package no_var_requires
 
 import (
 	_ "embed"
-	"regexp"
 
+	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 //go:embed no_var_requires.schema.json
@@ -38,16 +39,16 @@ var NoVarRequiresRule = rule.CreateRule(rule.Rule{
 		opts := parseOptions(options)
 
 		// Compile allow patterns into regexes
-		var allowPatterns []*regexp.Regexp
+		var allowPatterns []*regexp2.Regexp
 		for _, pattern := range opts.Allow {
-			if re, err := regexp.Compile(pattern); err == nil {
+			if re, err := utils.CompileRegexp2(pattern, utils.JSUnicodeRegexOptions); err == nil {
 				allowPatterns = append(allowPatterns, re)
 			}
 		}
 
 		isImportPathAllowed := func(importPath string) bool {
 			for _, pattern := range allowPatterns {
-				if pattern.MatchString(importPath) {
+				if utils.Regexp2MatchString(pattern, importPath) {
 					return true
 				}
 			}

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires.go
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires.go
@@ -21,15 +21,11 @@ func parseOptions(options []any) *Options {
 		return opts
 	}
 	optMap, _ := options[0].(map[string]interface{})
-	if allowList, exists := optMap["allow"]; exists {
-		if allowSlice, ok := allowList.([]interface{}); ok {
-			for _, item := range allowSlice {
-				if str, ok := item.(string); ok {
-					opts.Allow = append(opts.Allow, str)
-				}
+	if allowSlice, ok := optMap["allow"].([]interface{}); ok {
+		for _, item := range allowSlice {
+			if str, ok := item.(string); ok {
+				opts.Allow = append(opts.Allow, str)
 			}
-		} else if allowStrSlice, ok := allowList.([]string); ok {
-			opts.Allow = allowStrSlice
 		}
 	}
 	return opts

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires.schema.json
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires.schema.json
@@ -9,7 +9,8 @@
           "type": "array",
           "description": "Patterns of import paths to allow requiring from.",
           "items": {
-            "type": "string"
+            "type": "string",
+            "format": "regex"
           }
         }
       }

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires.schema.json
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires.schema.json
@@ -1,0 +1,20 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "description": "Patterns of import paths to allow requiring from.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires_test.go
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires_test.go
@@ -15,10 +15,10 @@ func TestNoVarRequiresRule(t *testing.T) {
 		{Code: "import { bar } from 'foo';"},
 		{Code: "require('foo');"},
 		{Code: "require?.('foo');"},
-		{Code: "const foo = require('foo');", Options: &Options{Allow: []string{"foo"}}},
-		{Code: "const foo = require('./foo');", Options: &Options{Allow: []string{"foo"}}},
-		{Code: "const foo = require('../foo');", Options: &Options{Allow: []string{"foo"}}},
-		{Code: "const foo = require('foo/bar');", Options: &Options{Allow: []string{"bar"}}},
+		{Code: "const foo = require('foo');", Options: map[string]interface{}{"allow": []interface{}{"foo"}}},
+		{Code: "const foo = require('./foo');", Options: map[string]interface{}{"allow": []interface{}{"foo"}}},
+		{Code: "const foo = require('../foo');", Options: map[string]interface{}{"allow": []interface{}{"foo"}}},
+		{Code: "const foo = require('foo/bar');", Options: map[string]interface{}{"allow": []interface{}{"bar"}}},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: "var foo = require('foo');",
@@ -97,7 +97,7 @@ func TestNoVarRequiresRule(t *testing.T) {
 		},
 		{
 			Code:    "const foo = require('foo'), bar = require('bar');",
-			Options: &Options{Allow: []string{"bar"}},
+			Options: map[string]interface{}{"allow": []interface{}{"bar"}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "noVarReqs",
@@ -108,7 +108,7 @@ func TestNoVarRequiresRule(t *testing.T) {
 		},
 		{
 			Code:    "const foo = require('./foo');",
-			Options: &Options{Allow: []string{"bar"}},
+			Options: map[string]interface{}{"allow": []interface{}{"bar"}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "noVarReqs",

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires_test.go
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires_test.go
@@ -139,3 +139,18 @@ func TestNoVarRequiresRule(t *testing.T) {
 		},
 	})
 }
+
+// TestNoVarRequiresAllowSchema locks in that each `allow` entry is validated
+// as a regex. The rule compiles every entry to match require paths, so an
+// unparsable one would otherwise be dropped and that path would keep
+// reporting. Upstream's schema declares a plain array of strings.
+func TestNoVarRequiresAllowSchema(t *testing.T) {
+	invalid := []any{map[string]any{"allow": []any{"("}}}
+	if err := NoVarRequiresRule.Schema.Validate(invalid); err == nil {
+		t.Error("expected an invalid allow pattern to fail schema validation")
+	}
+	valid := []any{map[string]any{"allow": []any{"/package\\.json$"}}}
+	if err := NoVarRequiresRule.Schema.Validate(valid); err != nil {
+		t.Errorf("expected a valid allow pattern to pass schema validation, got: %v", err)
+	}
+}

--- a/internal/plugins/typescript/rules/no_var_requires/no_var_requires_test.go
+++ b/internal/plugins/typescript/rules/no_var_requires/no_var_requires_test.go
@@ -154,3 +154,26 @@ func TestNoVarRequiresAllowSchema(t *testing.T) {
 		t.Errorf("expected a valid allow pattern to pass schema validation, got: %v", err)
 	}
 }
+
+// TestNoVarRequiresAllowLookahead locks in that `allow` patterns are matched
+// with the same ECMAScript regex engine the schema validates them against
+// (regexp2), not Go's RE2. RE2 cannot compile lookahead, so a JS-only
+// pattern that passes schema validation would otherwise silently fail to
+// compile and never allow anything.
+func TestNoVarRequiresAllowLookahead(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoVarRequiresRule, []rule_tester.ValidTestCase{
+		{Code: "const foo = require('foo');", Options: map[string]interface{}{"allow": []interface{}{"^(?!bar)"}}},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:    "const foo = require('barbaz');",
+			Options: map[string]interface{}{"allow": []interface{}{"^(?!bar)"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noVarReqs",
+					Line:      1,
+					Column:    13,
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types.go
+++ b/internal/plugins/typescript/rules/no_wrapper_object_types/no_wrapper_object_types.go
@@ -33,6 +33,7 @@ func buildBannedClassTypeMessage(typeName, preferred string) rule.RuleMessage {
 
 var NoWrapperObjectTypesRule = rule.CreateRule(rule.Rule{
 	Name:             "no-wrapper-object-types",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		// checkBannedTypes mirrors upstream's local `checkBannedTypes` —

--- a/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style.go
+++ b/internal/plugins/typescript/rules/non_nullable_type_assertion_style/non_nullable_type_assertion_style.go
@@ -17,6 +17,7 @@ func buildPreferNonNullAssertionMessage() rule.RuleMessage {
 
 var NonNullableTypeAssertionStyleRule = rule.CreateRule(rule.Rule{
 	Name:             "non-nullable-type-assertion-style",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		getTypesIfNotLoose := func(node *ast.Node) []*checker.Type {

--- a/internal/plugins/typescript/rules/only_throw_error/only_throw_error.go
+++ b/internal/plugins/typescript/rules/only_throw_error/only_throw_error.go
@@ -1,6 +1,7 @@
 package only_throw_error
 
 import (
+	_ "embed"
 	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -9,11 +10,40 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
+//go:embed only_throw_error.schema.json
+var schemaJSON []byte
+
 type OnlyThrowErrorOptions struct {
 	Allow                []utils.TypeOrValueSpecifier `json:"allow"`
 	AllowRethrowing      *bool                        `json:"allowRethrowing"`
 	AllowThrowingAny     *bool                        `json:"allowThrowingAny"`
 	AllowThrowingUnknown *bool                        `json:"allowThrowingUnknown"`
+}
+
+func parseOptions(options []any) OnlyThrowErrorOptions {
+	opts := OnlyThrowErrorOptions{}
+	if len(options) > 0 {
+		if typed, ok := options[0].(OnlyThrowErrorOptions); ok {
+			opts = typed
+		} else if optsMap, ok := options[0].(map[string]interface{}); ok {
+			if optsJSON, err := json.Marshal(optsMap); err == nil {
+				_ = json.Unmarshal(optsJSON, &opts)
+			}
+		}
+	}
+	if opts.Allow == nil {
+		opts.Allow = []utils.TypeOrValueSpecifier{}
+	}
+	if opts.AllowRethrowing == nil {
+		opts.AllowRethrowing = utils.Ref(true)
+	}
+	if opts.AllowThrowingAny == nil {
+		opts.AllowThrowingAny = utils.Ref(true)
+	}
+	if opts.AllowThrowingUnknown == nil {
+		opts.AllowThrowingUnknown = utils.Ref(true)
+	}
+	return opts
 }
 
 func buildObjectMessage() rule.RuleMessage {
@@ -133,32 +163,10 @@ func isRethrownError(ctx rule.RuleContext, expr *ast.Node) bool {
 
 var OnlyThrowErrorRule = rule.CreateRule(rule.Rule{
 	Name:             "only-throw-error",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(OnlyThrowErrorOptions)
-		if !ok {
-			opts = OnlyThrowErrorOptions{}
-			// When options come from JSON (API/TS tests), they arrive as []interface{};
-			// NormalizeOptions also re-wraps config.rules' unwrapped single option.
-			if optionsArray := rule.NormalizeOptions(options); len(optionsArray) > 0 {
-				if optsJSON, err := json.Marshal(optionsArray[0]); err == nil {
-					json.Unmarshal(optsJSON, &opts)
-				}
-			}
-		}
-		if opts.Allow == nil {
-			opts.Allow = []utils.TypeOrValueSpecifier{}
-		}
-		if opts.AllowRethrowing == nil {
-			opts.AllowRethrowing = utils.Ref(true)
-		}
-		if opts.AllowThrowingAny == nil {
-			opts.AllowThrowingAny = utils.Ref(true)
-		}
-		if opts.AllowThrowingUnknown == nil {
-			opts.AllowThrowingUnknown = utils.Ref(true)
-		}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		return rule.RuleListeners{
 			ast.KindThrowStatement: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/only_throw_error/only_throw_error.go
+++ b/internal/plugins/typescript/rules/only_throw_error/only_throw_error.go
@@ -23,9 +23,7 @@ type OnlyThrowErrorOptions struct {
 func parseOptions(options []any) OnlyThrowErrorOptions {
 	opts := OnlyThrowErrorOptions{}
 	if len(options) > 0 {
-		if typed, ok := options[0].(OnlyThrowErrorOptions); ok {
-			opts = typed
-		} else if optsMap, ok := options[0].(map[string]interface{}); ok {
+		if optsMap, ok := options[0].(map[string]interface{}); ok {
 			if optsJSON, err := json.Marshal(optsMap); err == nil {
 				_ = json.Unmarshal(optsJSON, &opts)
 			}

--- a/internal/plugins/typescript/rules/only_throw_error/only_throw_error.schema.json
+++ b/internal/plugins/typescript/rules/only_throw_error/only_throw_error.schema.json
@@ -1,0 +1,120 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["file"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["lib"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["package"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "package": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name", "package"],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array",
+          "description": "Type specifiers that can be thrown."
+        },
+        "allowRethrowing": {
+          "type": "boolean",
+          "description": "Whether to allow rethrowing caught values that are not `Error` objects."
+        },
+        "allowThrowingAny": {
+          "type": "boolean",
+          "description": "Whether to always allow throwing values typed as `any`."
+        },
+        "allowThrowingUnknown": {
+          "type": "boolean",
+          "description": "Whether to always allow throwing values typed as `unknown`."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/only_throw_error/only_throw_error_test.go
+++ b/internal/plugins/typescript/rules/only_throw_error/only_throw_error_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestOnlyThrowErrorRule(t *testing.T) {
@@ -139,10 +138,10 @@ function fun<T extends Error>(t: T): void {
 			Code: `
 throw undefined;
       `,
-			Options: OnlyThrowErrorOptions{
-				Allow:                []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromLib, Name: []string{"undefined"}}},
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allow":                []interface{}{map[string]interface{}{"from": "lib", "name": "undefined"}},
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 		},
 		{
@@ -150,20 +149,20 @@ throw undefined;
 class CustomError implements Error {}
 throw new CustomError();
       `,
-			Options: OnlyThrowErrorOptions{
-				Allow:                []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"CustomError"}}},
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allow":                []interface{}{map[string]interface{}{"from": "file", "name": "CustomError"}},
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 		},
 		{
 			Code: `
 throw new Map();
       `,
-			Options: OnlyThrowErrorOptions{
-				Allow:                []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromLib, Name: []string{"Map"}}},
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allow":                []interface{}{map[string]interface{}{"from": "lib", "name": "Map"}},
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 		},
 		{
@@ -174,10 +173,10 @@ throw new Map();
 			// Skip: 'errors' module doesn't exist in test fixtures, so createError()
 			// resolves to 'any' and can't match the package specifier.
 			Skip: true,
-			Options: OnlyThrowErrorOptions{
-				Allow:                []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromPackage, Name: []string{"ErrorLike"}, Package: "errors"}},
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allow":                []interface{}{map[string]interface{}{"from": "package", "name": "ErrorLike", "package": "errors"}},
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 		},
 		// allowRethrowing: valid cases
@@ -188,10 +187,10 @@ try {
   throw e;
 }
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowRethrowing:      utils.Ref(true),
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowRethrowing":      true,
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 		},
 		{
@@ -211,10 +210,10 @@ try {
   }
 }
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowRethrowing:      utils.Ref(true),
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowRethrowing":      true,
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 		},
 		{
@@ -223,10 +222,10 @@ Promise.reject('foo').catch(e => {
   throw e;
 });
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowRethrowing:      utils.Ref(true),
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowRethrowing":      true,
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 		},
 		// allow string shorthand with generic union
@@ -237,9 +236,7 @@ function func<T1, T2>() {
   throw err;
 }
       `,
-			Options: OnlyThrowErrorOptions{
-				Allow: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromString, Name: []string{"Promise"}}},
-			},
+			Options: map[string]interface{}{"allow": []interface{}{"Promise"}},
 		},
 		// throw await resolving to Error with allowThrowingAny: false
 		{
@@ -248,9 +245,7 @@ async function foo() {
   throw await Promise.resolve(new Error('error'));
 }
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowThrowingAny: utils.Ref(false),
-			},
+			Options: map[string]interface{}{"allowThrowingAny": false},
 		},
 		// generator with typed return
 		{
@@ -259,9 +254,7 @@ function* foo(): Generator<number, void, Error> {
   throw yield 303;
 }
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowThrowingAny: utils.Ref(false),
-			},
+			Options: map[string]interface{}{"allowThrowingAny": false},
 		},
 	}, []rule_tester.InvalidTestCase{
 		{
@@ -600,7 +593,7 @@ function fun(value: any) {
   throw value;
 }
       `,
-			Options: OnlyThrowErrorOptions{AllowThrowingAny: utils.Ref(false)},
+			Options: map[string]interface{}{"allowThrowingAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "object",
@@ -613,7 +606,7 @@ function fun(value: unknown) {
   throw value;
 }
       `,
-			Options: OnlyThrowErrorOptions{AllowThrowingUnknown: utils.Ref(false)},
+			Options: map[string]interface{}{"allowThrowingUnknown": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "object",
@@ -637,10 +630,10 @@ function fun<T extends number>(t: T): void {
 class UnknownError implements Error {}
 throw new UnknownError();
       `,
-			Options: OnlyThrowErrorOptions{
-				Allow:                []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromFile, Name: []string{"CustomError"}}},
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allow":                []interface{}{map[string]interface{}{"from": "file", "name": "CustomError"}},
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -656,10 +649,10 @@ Promise.reject('foo').catch(e => {
   throw x;
 });
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowRethrowing:      utils.Ref(true),
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowRethrowing":      true,
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -673,10 +666,10 @@ Promise.reject('foo').catch((...e) => {
   throw e;
 });
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowRethrowing:      utils.Ref(true),
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowRethrowing":      true,
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -691,10 +684,10 @@ Promise.reject('foo').catch(...x, e => {
   throw e;
 });
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowRethrowing:      utils.Ref(true),
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowRethrowing":      true,
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -709,10 +702,10 @@ Promise.reject('foo').then(...x, e => {
   throw e;
 });
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowRethrowing:      utils.Ref(true),
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowRethrowing":      true,
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -728,10 +721,10 @@ Promise.reject('foo').then(onFulfilled, ...x, e => {
   throw e;
 });
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowRethrowing:      utils.Ref(true),
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowRethrowing":      true,
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -745,10 +738,10 @@ Promise.reject('foo').then((...e) => {
   throw e;
 });
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowRethrowing:      utils.Ref(true),
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowRethrowing":      true,
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -762,10 +755,10 @@ Promise.reject('foo').then(e => {
   throw globalThis;
 });
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowRethrowing:      utils.Ref(true),
-				AllowThrowingAny:     utils.Ref(false),
-				AllowThrowingUnknown: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowRethrowing":      true,
+				"allowThrowingAny":     false,
+				"allowThrowingUnknown": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -781,9 +774,7 @@ function func<T1, T2>() {
   throw err;
 }
       `,
-			Options: OnlyThrowErrorOptions{
-				Allow: []utils.TypeOrValueSpecifier{{From: utils.TypeOrValueSpecifierFromString, Name: []string{"Promise"}}},
-			},
+			Options: map[string]interface{}{"allow": []interface{}{"Promise"}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "object",
@@ -797,9 +788,7 @@ async function foo() {
   throw await bar;
 }
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowThrowingAny: utils.Ref(false),
-			},
+			Options: map[string]interface{}{"allowThrowingAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "object",
@@ -813,9 +802,7 @@ async function foo() {
   throw await Promise.resolve<number>(303);
 }
       `,
-			Options: OnlyThrowErrorOptions{
-				AllowThrowingAny: utils.Ref(false),
-			},
+			Options: map[string]interface{}{"allowThrowingAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "object",

--- a/internal/plugins/typescript/rules/parameter_properties/parameter_properties.go
+++ b/internal/plugins/typescript/rules/parameter_properties/parameter_properties.go
@@ -1,6 +1,7 @@
 package parameter_properties
 
 import (
+	_ "embed"
 	"fmt"
 	"sort"
 	"strings"
@@ -8,8 +9,10 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed parameter_properties.schema.json
+var schemaJSON []byte
 
 // Modifier values that match the ESLint option schema:
 // "readonly", "private", "protected", "public",
@@ -20,15 +23,15 @@ type options struct {
 	prefer string
 }
 
-func parseOptions(rawOpts any) options {
+func parseOptions(rawOpts []any) options {
 	o := options{
 		allow:  make(map[string]bool),
 		prefer: "class-property",
 	}
-	optsMap := utils.GetOptionsMap(rawOpts)
-	if optsMap == nil {
+	if len(rawOpts) == 0 {
 		return o
 	}
+	optsMap, _ := rawOpts[0].(map[string]interface{})
 	if allow, ok := optsMap["allow"].([]interface{}); ok {
 		for _, a := range allow {
 			if s, ok := a.(string); ok {
@@ -86,9 +89,9 @@ type propertyNodes struct {
 }
 
 var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
-	Name: "parameter-properties",
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Name:   "parameter-properties",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		if opts.prefer == "class-property" {

--- a/internal/plugins/typescript/rules/parameter_properties/parameter_properties.schema.json
+++ b/internal/plugins/typescript/rules/parameter_properties/parameter_properties.schema.json
@@ -1,0 +1,39 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "$defs": {
+        "modifier": {
+          "type": "string",
+          "enum": [
+            "readonly",
+            "private",
+            "protected",
+            "public",
+            "private readonly",
+            "protected readonly",
+            "public readonly"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "description": "Whether to allow certain kinds of properties to be ignored.",
+          "items": {
+            "$ref": "#/items/0/$defs/modifier"
+          }
+        },
+        "prefer": {
+          "type": "string",
+          "description": "Whether to prefer class properties or parameter properties.",
+          "enum": ["class-property", "parameter-property"]
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/prefer_as_const/prefer_as_const.go
+++ b/internal/plugins/typescript/rules/prefer_as_const/prefer_as_const.go
@@ -105,7 +105,8 @@ func compareLiteralTypes(ctx *rule.RuleContext, sourceText string, valueNode *as
 }
 
 var PreferAsConstRule = rule.CreateRule(rule.Rule{
-	Name: "prefer-as-const",
+	Name:   "prefer-as-const",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		compareTypes := func(valueNode *ast.Node, typeNode *ast.Node, canFix bool) {
 			if valueNode == nil || typeNode == nil ||

--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.go
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.go
@@ -2,6 +2,7 @@ package prefer_destructuring
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"

--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.go
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.go
@@ -1,6 +1,7 @@
 package prefer_destructuring
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
@@ -8,6 +9,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed prefer_destructuring.schema.json
+var schemaJSON []byte
 
 // destructuringConfig holds the array/object enforcement flags for a given context.
 type destructuringConfig struct {
@@ -26,34 +30,26 @@ type options struct {
 	EnforceForDeclarationWithTypeAnnotation bool
 }
 
-func parseOptions(raw any) options {
+// parseOptions reads the two-element option tuple
+// [enabledTypes, enforcementOptions].
+func parseOptions(raw []any) options {
 	opts := options{
 		VariableDeclarator:   destructuringConfig{Array: true, Object: true},
 		AssignmentExpression: destructuringConfig{Array: true, Object: true},
 	}
 
-	if raw == nil {
+	if len(raw) == 0 {
 		return opts
 	}
 
-	// Options come as an array [enabledTypes, enforcementOptions]
-	optArray, isArray := raw.([]interface{})
-	if !isArray || len(optArray) == 0 {
-		// Try bare object format (from CLI single-option unwrap)
-		if m, ok := raw.(map[string]interface{}); ok {
-			parseFirstOption(m, &opts)
-		}
-		return opts
-	}
-
-	// Parse first element: enabled types
-	if first, ok := optArray[0].(map[string]interface{}); ok {
+	// First element: enabled types
+	if first, ok := raw[0].(map[string]interface{}); ok {
 		parseFirstOption(first, &opts)
 	}
 
-	// Parse second element: enforcement options
-	if len(optArray) > 1 {
-		if second, ok := optArray[1].(map[string]interface{}); ok {
+	// Second element: enforcement options
+	if len(raw) > 1 {
+		if second, ok := raw[1].(map[string]interface{}); ok {
 			if v, ok := second["enforceForRenamedProperties"].(bool); ok {
 				opts.EnforceForRenamedProperties = v
 			}
@@ -123,9 +119,9 @@ const precedenceOfAssignmentExpr = 1
 // PreferDestructuringRule implements @typescript-eslint/prefer-destructuring.
 var PreferDestructuringRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-destructuring",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _rawOptions []any) rule.RuleListeners {
-		rawOptions := rule.LegacyUnwrapOptions(_rawOptions)
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
 
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.schema.json
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.schema.json
@@ -1,0 +1,67 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "AssignmentExpression": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "array": {
+                  "type": "boolean"
+                },
+                "object": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "VariableDeclarator": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "array": {
+                  "type": "boolean"
+                },
+                "object": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "array": {
+              "type": "boolean"
+            },
+            "object": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enforceForDeclarationWithTypeAnnotation": {
+          "type": "boolean",
+          "description": "Whether to enforce destructuring on variable declarations with type annotations."
+        },
+        "enforceForRenamedProperties": {
+          "type": "boolean",
+          "description": "Whether to enforce destructuring that use a different variable name than the property name."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 2
+}

--- a/internal/plugins/typescript/rules/prefer_enum_initializers/prefer_enum_initializers.go
+++ b/internal/plugins/typescript/rules/prefer_enum_initializers/prefer_enum_initializers.go
@@ -25,7 +25,8 @@ func buildDefineInitializerSuggestionMessage(name, suggested string) rule.RuleMe
 }
 
 var PreferEnumInitializersRule = rule.CreateRule(rule.Rule{
-	Name: "prefer-enum-initializers",
+	Name:   "prefer-enum-initializers",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		sourceText := ctx.SourceFile.Text()
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/prefer_find/prefer_find.go
+++ b/internal/plugins/typescript/rules/prefer_find/prefer_find.go
@@ -46,6 +46,7 @@ type filterExpressionData struct {
 // that should be `arr.find(...)`. Mirrors typescript-eslint's prefer-find rule.
 var PreferFindRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-find",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		if ctx.TypeChecker == nil {

--- a/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of.go
+++ b/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of.go
@@ -7,7 +7,8 @@ import (
 )
 
 var PreferForOfRule = rule.CreateRule(rule.Rule{
-	Name: "prefer-for-of",
+	Name:   "prefer-for-of",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindForStatement: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.go
+++ b/internal/plugins/typescript/rules/prefer_function_type/prefer_function_type.go
@@ -42,8 +42,9 @@ func unexpectedThisMessage(interfaceName string) rule.RuleMessage {
 }
 
 var PreferFunctionTypeRule = rule.CreateRule(rule.Rule{
-	Name: "prefer-function-type",
-	Run:  run,
+	Name:   "prefer-function-type",
+	Schema: rule.EmptyArraySchema,
+	Run:    run,
 })
 
 // collectCommentsForward walks `text` starting at `start`, skipping whitespace

--- a/internal/plugins/typescript/rules/prefer_includes/prefer_includes.go
+++ b/internal/plugins/typescript/rules/prefer_includes/prefer_includes.go
@@ -220,6 +220,7 @@ func isConstVariableDeclaration(node *ast.Node) bool {
 // PreferIncludesRule checks for indexOf comparisons that can use includes instead.
 var PreferIncludesRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-includes",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		getNodeText := func(n *ast.Node) string {

--- a/internal/plugins/typescript/rules/prefer_literal_enum_member/prefer_literal_enum_member.go
+++ b/internal/plugins/typescript/rules/prefer_literal_enum_member/prefer_literal_enum_member.go
@@ -1,9 +1,14 @@
 package prefer_literal_enum_member
 
 import (
+	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed prefer_literal_enum_member.schema.json
+var schemaJSON []byte
 
 func buildNotLiteralMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -20,22 +25,12 @@ func buildNotLiteralOrBitwiseExpressionMessage() rule.RuleMessage {
 }
 
 var PreferLiteralEnumMemberRule = rule.CreateRule(rule.Rule{
-	Name: "prefer-literal-enum-member",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "prefer-literal-enum-member",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		allowBitwise := false
-
-		if options != nil {
-			var optsMap map[string]interface{}
-			var ok bool
-
-			if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-				optsMap, ok = optArray[0].(map[string]interface{})
-			} else {
-				optsMap, ok = options.(map[string]interface{})
-			}
-
-			if ok {
+		if len(options) > 0 {
+			if optsMap, ok := options[0].(map[string]interface{}); ok {
 				if allowBitwiseExpressions, ok := optsMap["allowBitwiseExpressions"].(bool); ok {
 					allowBitwise = allowBitwiseExpressions
 				}

--- a/internal/plugins/typescript/rules/prefer_literal_enum_member/prefer_literal_enum_member.schema.json
+++ b/internal/plugins/typescript/rules/prefer_literal_enum_member/prefer_literal_enum_member.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowBitwiseExpressions": {
+          "type": "boolean",
+          "description": "Whether to allow using bitwise expressions in enum initializers."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/prefer_namespace_keyword/prefer_namespace_keyword.go
+++ b/internal/plugins/typescript/rules/prefer_namespace_keyword/prefer_namespace_keyword.go
@@ -37,7 +37,8 @@ func moduleDeclarationRanges(sourceFile *ast.SourceFile, node *ast.Node) (core.T
 }
 
 var PreferNamespaceKeywordRule = rule.CreateRule(rule.Rule{
-	Name: "prefer-namespace-keyword",
+	Name:   "prefer-namespace-keyword",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindModuleDeclaration: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.go
+++ b/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.go
@@ -1,6 +1,7 @@
 package prefer_nullish_coalescing
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -11,6 +12,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed prefer_nullish_coalescing.schema.json
+var schemaJSON []byte
 
 func buildNoStrictNullCheckMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -71,12 +75,12 @@ func defaultOptions() Options {
 	}
 }
 
-func parseOptions(options any) Options {
+func parseOptions(options []any) Options {
 	opts := defaultOptions()
-	optsMap := utils.GetOptionsMap(options)
-	if optsMap == nil {
+	if len(options) == 0 {
 		return opts
 	}
+	optsMap, _ := options[0].(map[string]interface{})
 	if v, ok := optsMap["allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing"].(bool); ok {
 		opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = v
 	}
@@ -1034,9 +1038,9 @@ func getTypeFlags(t *checker.Type) checker.TypeFlags {
 
 var PreferNullishCoalescingRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-nullish-coalescing",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 		compilerOptions := ctx.Program.Options()
 		isStrictNullChecks := utils.IsStrictCompilerOptionEnabled(compilerOptions, compilerOptions.StrictNullChecks)

--- a/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.schema.json
+++ b/internal/plugins/typescript/rules/prefer_nullish_coalescing/prefer_nullish_coalescing.schema.json
@@ -1,0 +1,70 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
+          "type": "boolean",
+          "description": "Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`."
+        },
+        "ignoreBooleanCoercion": {
+          "type": "boolean",
+          "description": "Whether to ignore arguments to the `Boolean` constructor"
+        },
+        "ignoreConditionalTests": {
+          "type": "boolean",
+          "description": "Whether to ignore cases that are located within a conditional test."
+        },
+        "ignoreIfStatements": {
+          "type": "boolean",
+          "description": "Whether to ignore any if statements that could be simplified by using the nullish coalescing operator."
+        },
+        "ignoreMixedLogicalExpressions": {
+          "type": "boolean",
+          "description": "Whether to ignore any logical or expressions that are part of a mixed logical expression (with `&&`)."
+        },
+        "ignorePrimitives": {
+          "description": "Whether to ignore all (`true`) or some (an object with properties) primitive types.",
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Which primitives types may be ignored.",
+              "properties": {
+                "bigint": {
+                  "type": "boolean",
+                  "description": "Ignore bigint primitive types."
+                },
+                "boolean": {
+                  "type": "boolean",
+                  "description": "Ignore boolean primitive types."
+                },
+                "number": {
+                  "type": "boolean",
+                  "description": "Ignore number primitive types."
+                },
+                "string": {
+                  "type": "boolean",
+                  "description": "Ignore string primitive types."
+                }
+              }
+            },
+            {
+              "type": "boolean",
+              "description": "Ignore all primitive types.",
+              "enum": [true]
+            }
+          ]
+        },
+        "ignoreTernaryTests": {
+          "type": "boolean",
+          "description": "Whether to ignore any ternary expressions that could be simplified by using the nullish coalescing operator."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -1,12 +1,16 @@
 package prefer_optional_chain
 
 import (
+	_ "embed"
 	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed prefer_optional_chain.schema.json
+var schemaJSON []byte
 
 type PreferOptionalChainOptions struct {
 	AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing *bool `json:"allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing"`
@@ -34,21 +38,16 @@ func buildOptionalChainSuggestMessage() rule.RuleMessage {
 }
 
 var PreferOptionalChainRule = rule.CreateRule(rule.Rule{
-	Name: "prefer-optional-chain",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(PreferOptionalChainOptions)
-		if !ok {
-			opts = PreferOptionalChainOptions{}
-			if options != nil {
-				// For IPC mode, options come as []interface{} or map[string]interface{}
-				raw := options
-				if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-					raw = optArray[0]
-				}
-				if jsonBytes, err := json.Marshal(raw); err == nil {
-					_ = json.Unmarshal(jsonBytes, &opts)
-				}
+	Name:   "prefer-optional-chain",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := PreferOptionalChainOptions{}
+		if len(options) > 0 {
+			if typed, ok := options[0].(PreferOptionalChainOptions); ok {
+				opts = typed
+			} else if jsonBytes, err := json.Marshal(options[0]); err == nil {
+				// In IPC mode the option object arrives as map[string]interface{}.
+				_ = json.Unmarshal(jsonBytes, &opts)
 			}
 		}
 

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -43,11 +43,10 @@ var PreferOptionalChainRule = rule.CreateRule(rule.Rule{
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := PreferOptionalChainOptions{}
 		if len(options) > 0 {
-			if typed, ok := options[0].(PreferOptionalChainOptions); ok {
-				opts = typed
-			} else if jsonBytes, err := json.Marshal(options[0]); err == nil {
-				// In IPC mode the option object arrives as map[string]interface{}.
-				_ = json.Unmarshal(jsonBytes, &opts)
+			if optsMap, ok := options[0].(map[string]interface{}); ok {
+				if optsJSON, err := json.Marshal(optsMap); err == nil {
+					_ = json.Unmarshal(optsJSON, &opts)
+				}
 			}
 		}
 

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.schema.json
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.schema.json
@@ -1,0 +1,45 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing": {
+          "type": "boolean",
+          "description": "Allow autofixers that will change the return type of the expression. This option is considered unsafe as it may break the build."
+        },
+        "checkAny": {
+          "type": "boolean",
+          "description": "Check operands that are typed as `any` when inspecting \"loose boolean\" operands."
+        },
+        "checkBigInt": {
+          "type": "boolean",
+          "description": "Check operands that are typed as `bigint` when inspecting \"loose boolean\" operands."
+        },
+        "checkBoolean": {
+          "type": "boolean",
+          "description": "Check operands that are typed as `boolean` when inspecting \"loose boolean\" operands."
+        },
+        "checkNumber": {
+          "type": "boolean",
+          "description": "Check operands that are typed as `number` when inspecting \"loose boolean\" operands."
+        },
+        "checkString": {
+          "type": "boolean",
+          "description": "Check operands that are typed as `string` when inspecting \"loose boolean\" operands."
+        },
+        "checkUnknown": {
+          "type": "boolean",
+          "description": "Check operands that are typed as `unknown` when inspecting \"loose boolean\" operands."
+        },
+        "requireNullish": {
+          "type": "boolean",
+          "description": "Skip operands that are not typed with `null` and/or `undefined` when inspecting \"loose boolean\" operands."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain_test.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestPreferOptionalChainRule(t *testing.T) {
@@ -339,50 +338,50 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		// --- Options: checkAny=false ---
 		{
 			Code:    "declare const x: any;\nx && x.length;",
-			Options: PreferOptionalChainOptions{CheckAny: utils.Ref(false)},
+			Options: map[string]interface{}{"checkAny": false},
 		},
 		// --- Options: checkString=false ---
 		{
 			Code:    "declare const x: string;\nx && x.length;",
-			Options: PreferOptionalChainOptions{CheckString: utils.Ref(false)},
+			Options: map[string]interface{}{"checkString": false},
 		},
 		// --- Options: checkNumber=false ---
 		{
 			Code:    "declare const x: number;\nx && x.length;",
-			Options: PreferOptionalChainOptions{CheckNumber: utils.Ref(false)},
+			Options: map[string]interface{}{"checkNumber": false},
 		},
 		// --- Options: checkBoolean=false ---
 		{
 			Code:    "declare const x: boolean;\nx && x.length;",
-			Options: PreferOptionalChainOptions{CheckBoolean: utils.Ref(false)},
+			Options: map[string]interface{}{"checkBoolean": false},
 		},
 		// --- Options: checkBigInt=false ---
 		{
 			Code:    "declare const x: bigint;\nx && x.length;",
-			Options: PreferOptionalChainOptions{CheckBigInt: utils.Ref(false)},
+			Options: map[string]interface{}{"checkBigInt": false},
 		},
 		// --- Options: checkUnknown=false ---
 		{
 			Code:    "declare const x: unknown;\nx && x.length;",
-			Options: PreferOptionalChainOptions{CheckUnknown: utils.Ref(false)},
+			Options: map[string]interface{}{"checkUnknown": false},
 		},
 
 		// --- requireNullish valid cases ---
 		{
 			Code:    "declare const x: string;\nx && x.length;",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 		},
 		{
 			Code:    "declare const foo: string;\nfoo && foo.toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 		},
 		{
 			Code:    "declare const foo: { bar: string };\nfoo && foo.bar && foo.bar.toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 		},
 		{
 			Code:    "declare const foo: string;\n(foo || {}).toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 		},
 		// --- Additional valid patterns (false positive prevention) ---
 		{Code: `foo || ({} as any);`},
@@ -440,23 +439,23 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		// requireNullish additional valid
 		{
 			Code:    "declare const x: string | number | boolean | object;\nx && x.toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 		},
 		{
 			Code:    "declare const foo: string;\nfoo && foo.toString() && foo.toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 		},
 		{
 			Code:    "declare const foo: { bar: string };\nfoo && foo.bar && foo.bar.toString() && foo.bar.toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 		},
 		{
 			Code:    "declare const foo1: { bar: string | null };\nfoo1 && foo1.bar;",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 		},
 		{
 			Code:    "declare const foo: string | null;\n(foo || 'a' || {}).toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 		},
 
 		// --- Diverging property access paths (same terminal name, different chains) ---
@@ -1146,7 +1145,7 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		// =================================================================
 		{
 			Code:    "declare const thing1: string | null;\nthing1 && thing1.toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "preferOptionalChain",
@@ -1158,7 +1157,7 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		},
 		{
 			Code:    "declare const foo: { bar: string | null | undefined } | null | undefined;\nfoo && foo.bar && foo.bar.toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 			Output:  []string{"declare const foo: { bar: string | null | undefined } | null | undefined;\nfoo?.bar?.toString();"},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "preferOptionalChain"},
@@ -1166,7 +1165,7 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		},
 		{
 			Code:    "declare const foo: string | null;\n(foo || {}).toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "preferOptionalChain",
@@ -1182,7 +1181,7 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		// =================================================================
 		{
 			Code:    "declare const foo: { bar: number } | null | undefined;\nfoo != undefined && foo.bar;",
-			Options: PreferOptionalChainOptions{AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing: utils.Ref(true)},
+			Options: map[string]interface{}{"allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing": true},
 			Output:  []string{"declare const foo: { bar: number } | null | undefined;\nfoo?.bar;"},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "preferOptionalChain"},
@@ -1190,7 +1189,7 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		},
 		{
 			Code:    "declare const foo: { bar: number } | null | undefined;\nfoo != undefined && foo.bar;",
-			Options: PreferOptionalChainOptions{AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing: utils.Ref(false)},
+			Options: map[string]interface{}{"allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "preferOptionalChain",
@@ -1678,7 +1677,7 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		// =================================================================
 		{
 			Code:    "declare const foo: { bar: boolean } | null | undefined;\ndeclare function acceptsBoolean(arg: boolean): void;\nacceptsBoolean(foo != null && foo.bar);",
-			Options: PreferOptionalChainOptions{AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing: utils.Ref(true)},
+			Options: map[string]interface{}{"allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing": true},
 			Output:  []string{"declare const foo: { bar: boolean } | null | undefined;\ndeclare function acceptsBoolean(arg: boolean): void;\nacceptsBoolean(foo?.bar);"},
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
 		},
@@ -1688,7 +1687,7 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		// =================================================================
 		{
 			Code:    "declare const thing1: string | null;\nthing1 && thing1.toString() && true;",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 				{MessageId: "optionalChainSuggest", Output: "declare const thing1: string | null;\nthing1?.toString() && true;"},
 			}}},
@@ -1696,14 +1695,14 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		// Chains with duplicate last operands stop before the duplicate
 		{
 			Code:    "declare const foo: string | null;\nfoo && foo.toString() && foo.toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 				{MessageId: "optionalChainSuggest", Output: "declare const foo: string | null;\nfoo?.toString() && foo.toString();"},
 			}}},
 		},
 		{
 			Code:    "declare const foo: { bar: string | null | undefined } | null | undefined;\nfoo && foo.bar && foo.bar.toString() && foo.bar.toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 			Output:  []string{"declare const foo: { bar: string | null | undefined } | null | undefined;\nfoo?.bar?.toString() && foo.bar.toString();"},
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
 		},
@@ -1831,14 +1830,14 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		// =================================================================
 		{
 			Code:    "declare const foo: string;\n(foo || undefined || {}).toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 				{MessageId: "optionalChainSuggest", Output: "declare const foo: string;\n(foo || undefined)?.toString();"},
 			}}},
 		},
 		{
 			Code:    "declare const foo: string | null;\n(foo || undefined || {}).toString();",
-			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"requireNullish": true},
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
 				{MessageId: "optionalChainSuggest", Output: "declare const foo: string | null;\n(foo || undefined)?.toString();"},
 			}}},

--- a/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
+++ b/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
@@ -2,6 +2,8 @@ package prefer_promise_reject_errors
 
 import (
 	_ "embed"
+	"encoding/json"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -19,9 +21,35 @@ func buildRejectAnErrorMessage() rule.RuleMessage {
 }
 
 type PreferPromiseRejectErrorsOptions struct {
-	AllowEmptyReject     *bool
-	AllowThrowingAny     *bool
-	AllowThrowingUnknown *bool
+	AllowEmptyReject     *bool `json:"allowEmptyReject"`
+	AllowThrowingAny     *bool `json:"allowThrowingAny"`
+	AllowThrowingUnknown *bool `json:"allowThrowingUnknown"`
+}
+
+func parseOptions(options []any) PreferPromiseRejectErrorsOptions {
+	opts := PreferPromiseRejectErrorsOptions{
+		AllowEmptyReject:     utils.Ref(false),
+		AllowThrowingAny:     utils.Ref(false),
+		AllowThrowingUnknown: utils.Ref(false),
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	if optsMap, ok := options[0].(map[string]interface{}); ok {
+		if optsJSON, err := json.Marshal(optsMap); err == nil {
+			_ = json.Unmarshal(optsJSON, &opts)
+		}
+	}
+	if opts.AllowEmptyReject == nil {
+		opts.AllowEmptyReject = utils.Ref(false)
+	}
+	if opts.AllowThrowingAny == nil {
+		opts.AllowThrowingAny = utils.Ref(false)
+	}
+	if opts.AllowThrowingUnknown == nil {
+		opts.AllowThrowingUnknown = utils.Ref(false)
+	}
+	return opts
 }
 
 var PreferPromiseRejectErrorsRule = rule.CreateRule(rule.Rule{
@@ -29,21 +57,7 @@ var PreferPromiseRejectErrorsRule = rule.CreateRule(rule.Rule{
 	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		opts := PreferPromiseRejectErrorsOptions{}
-		if len(options) > 0 {
-			if typed, ok := options[0].(PreferPromiseRejectErrorsOptions); ok {
-				opts = typed
-			}
-		}
-		if opts.AllowEmptyReject == nil {
-			opts.AllowEmptyReject = utils.Ref(false)
-		}
-		if opts.AllowThrowingAny == nil {
-			opts.AllowThrowingAny = utils.Ref(false)
-		}
-		if opts.AllowThrowingUnknown == nil {
-			opts.AllowThrowingUnknown = utils.Ref(false)
-		}
+		opts := parseOptions(options)
 
 		checkRejectCall := func(callExpression *ast.CallExpression) {
 			if len(callExpression.Arguments.Nodes) != 0 {

--- a/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
+++ b/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
@@ -1,11 +1,15 @@
 package prefer_promise_reject_errors
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed prefer_promise_reject_errors.schema.json
+var schemaJSON []byte
 
 func buildRejectAnErrorMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -22,12 +26,14 @@ type PreferPromiseRejectErrorsOptions struct {
 
 var PreferPromiseRejectErrorsRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-promise-reject-errors",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(PreferPromiseRejectErrorsOptions)
-		if !ok {
-			opts = PreferPromiseRejectErrorsOptions{}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := PreferPromiseRejectErrorsOptions{}
+		if len(options) > 0 {
+			if typed, ok := options[0].(PreferPromiseRejectErrorsOptions); ok {
+				opts = typed
+			}
 		}
 		if opts.AllowEmptyReject == nil {
 			opts.AllowEmptyReject = utils.Ref(false)

--- a/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.schema.json
+++ b/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.schema.json
@@ -1,0 +1,120 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["file"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["lib"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["package"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "package": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name", "package"],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array",
+          "description": "Type specifiers that can be used as Promise rejection reasons."
+        },
+        "allowEmptyReject": {
+          "type": "boolean",
+          "description": "Whether to allow calls to `Promise.reject()` with no arguments."
+        },
+        "allowThrowingAny": {
+          "type": "boolean",
+          "description": "Whether to always allow throwing values typed as `any`."
+        },
+        "allowThrowingUnknown": {
+          "type": "boolean",
+          "description": "Whether to always allow throwing values typed as `unknown`."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors_test.go
+++ b/internal/plugins/typescript/rules/prefer_promise_reject_errors/prefer_promise_reject_errors_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestPreferPromiseRejectErrorsRule(t *testing.T) {
@@ -13,21 +12,21 @@ func TestPreferPromiseRejectErrorsRule(t *testing.T) {
 		{Code: "Promise.resolve(5);"},
 		{
 			Code:    "Promise.reject();",
-			Options: PreferPromiseRejectErrorsOptions{AllowEmptyReject: utils.Ref(true)},
+			Options: map[string]interface{}{"allowEmptyReject": true},
 		},
 		{
 			Code: `
         declare const someAnyValue: any;
         Promise.reject(someAnyValue);
       `,
-			Options: PreferPromiseRejectErrorsOptions{AllowThrowingAny: utils.Ref(true), AllowThrowingUnknown: utils.Ref(false)},
+			Options: map[string]interface{}{"allowThrowingAny": true, "allowThrowingUnknown": false},
 		},
 		{
 			Code: `
         declare const someUnknownValue: unknown;
         Promise.reject(someUnknownValue);
       `,
-			Options: PreferPromiseRejectErrorsOptions{AllowThrowingAny: utils.Ref(false), AllowThrowingUnknown: utils.Ref(true)},
+			Options: map[string]interface{}{"allowThrowingAny": false, "allowThrowingUnknown": true},
 		},
 		{Code: "Promise.reject(new Error());"},
 		{Code: "Promise.reject(new TypeError());"},
@@ -136,7 +135,7 @@ func TestPreferPromiseRejectErrorsRule(t *testing.T) {
           reject();
         });
       `,
-			Options: PreferPromiseRejectErrorsOptions{AllowEmptyReject: utils.Ref(true)},
+			Options: map[string]interface{}{"allowEmptyReject": true},
 		},
 		{Code: "new Promise((yes, no) => no(new Error()));"},
 		{Code: "new Promise();"},
@@ -285,14 +284,14 @@ func TestPreferPromiseRejectErrorsRule(t *testing.T) {
         declare const someAnyValue: any;
         Promise.reject(someAnyValue);
       `,
-			Options: PreferPromiseRejectErrorsOptions{AllowThrowingAny: utils.Ref(true), AllowThrowingUnknown: utils.Ref(true)},
+			Options: map[string]interface{}{"allowThrowingAny": true, "allowThrowingUnknown": true},
 		},
 		{
 			Code: `
         declare const someUnknownValue: unknown;
         Promise.reject(someUnknownValue);
       `,
-			Options: PreferPromiseRejectErrorsOptions{AllowThrowingAny: utils.Ref(true), AllowThrowingUnknown: utils.Ref(true)},
+			Options: map[string]interface{}{"allowThrowingAny": true, "allowThrowingUnknown": true},
 		},
 	}, []rule_tester.InvalidTestCase{
 		{
@@ -393,7 +392,7 @@ func TestPreferPromiseRejectErrorsRule(t *testing.T) {
 		},
 		{
 			Code:    "Promise.reject(undefined);",
-			Options: PreferPromiseRejectErrorsOptions{AllowEmptyReject: utils.Ref(true)},
+			Options: map[string]interface{}{"allowEmptyReject": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "rejectAnError",
@@ -1404,7 +1403,7 @@ function fun<T extends number>(t: T): void {
         declare const someAnyValue: any;
         Promise.reject(someAnyValue);
       `,
-			Options: PreferPromiseRejectErrorsOptions{AllowThrowingAny: utils.Ref(false), AllowThrowingUnknown: utils.Ref(true)},
+			Options: map[string]interface{}{"allowThrowingAny": false, "allowThrowingUnknown": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "rejectAnError",
@@ -1416,7 +1415,7 @@ function fun<T extends number>(t: T): void {
         declare const someUnknownValue: unknown;
         Promise.reject(someUnknownValue);
       `,
-			Options: PreferPromiseRejectErrorsOptions{AllowThrowingAny: utils.Ref(true), AllowThrowingUnknown: utils.Ref(false)},
+			Options: map[string]interface{}{"allowThrowingAny": true, "allowThrowingUnknown": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "rejectAnError",

--- a/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly.go
+++ b/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly.go
@@ -1,6 +1,7 @@
 package prefer_readonly
 
 import (
+	_ "embed"
 	"fmt"
 	"sort"
 	"strings"
@@ -11,6 +12,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed prefer_readonly.schema.json
+var schemaJSON []byte
 
 func messagePreferReadonly(name string) rule.RuleMessage {
 	return rule.RuleMessage{
@@ -23,23 +27,15 @@ type options struct {
 	onlyInlineLambdas bool
 }
 
-func parseOptions(rawOpts any) options {
+func parseOptions(rawOpts []any) options {
 	opts := options{onlyInlineLambdas: false}
-	if rawOpts == nil {
+	if len(rawOpts) == 0 {
 		return opts
 	}
 
-	var optsMap map[string]interface{}
-	if arr, ok := rawOpts.([]interface{}); ok && len(arr) > 0 {
-		optsMap, _ = arr[0].(map[string]interface{})
-	} else {
-		optsMap, _ = rawOpts.(map[string]interface{})
-	}
-
-	if optsMap != nil {
-		if v, ok := optsMap["onlyInlineLambdas"].(bool); ok {
-			opts.onlyInlineLambdas = v
-		}
+	optsMap, _ := rawOpts[0].(map[string]interface{})
+	if v, ok := optsMap["onlyInlineLambdas"].(bool); ok {
+		opts.onlyInlineLambdas = v
 	}
 	return opts
 }
@@ -401,9 +397,9 @@ func isDestructuringAssignment(node *ast.Node) bool {
 
 var PreferReadonlyRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-readonly",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _rawOpts []any) rule.RuleListeners {
-		rawOpts := rule.LegacyUnwrapOptions(_rawOpts)
+	Run: func(ctx rule.RuleContext, rawOpts []any) rule.RuleListeners {
 		if ctx.TypeChecker == nil {
 			return rule.RuleListeners{}
 		}

--- a/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly.schema.json
+++ b/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "onlyInlineLambdas": {
+          "type": "boolean",
+          "description": "Whether to restrict checking only to members immediately assigned a lambda value."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/prefer_readonly_parameter_types/prefer_readonly_parameter_types.go
+++ b/internal/plugins/typescript/rules/prefer_readonly_parameter_types/prefer_readonly_parameter_types.go
@@ -2,6 +2,7 @@ package prefer_readonly_parameter_types
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"

--- a/internal/plugins/typescript/rules/prefer_readonly_parameter_types/prefer_readonly_parameter_types.go
+++ b/internal/plugins/typescript/rules/prefer_readonly_parameter_types/prefer_readonly_parameter_types.go
@@ -1,11 +1,15 @@
 package prefer_readonly_parameter_types
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed prefer_readonly_parameter_types.schema.json
+var schemaJSON []byte
 
 type PreferReadonlyParameterTypesOptions struct {
 	CheckParameterProperties bool     `json:"checkParameterProperties"`
@@ -21,57 +25,30 @@ func buildShouldBeReadonlyMessage() rule.RuleMessage {
 	}
 }
 
-func parseOptions(options any) PreferReadonlyParameterTypesOptions {
+func parseOptions(options []any) PreferReadonlyParameterTypesOptions {
 	opts := PreferReadonlyParameterTypesOptions{
 		CheckParameterProperties: true,
 		IgnoreInferredTypes:      false,
 		TreatMethodsAsReadonly:   false,
 	}
-	if options == nil {
+	if len(options) == 0 {
 		return opts
 	}
-	// Handle array format: [{ option: value }]
-	if arr, ok := options.([]interface{}); ok {
-		if len(arr) > 0 {
-			if m, ok := arr[0].(map[string]interface{}); ok {
-				if v, ok := m["checkParameterProperties"].(bool); ok {
-					opts.CheckParameterProperties = v
-				}
-				if v, ok := m["ignoreInferredTypes"].(bool); ok {
-					opts.IgnoreInferredTypes = v
-				}
-				if v, ok := m["treatMethodsAsReadonly"].(bool); ok {
-					opts.TreatMethodsAsReadonly = v
-				}
-				if v, ok := m["allow"].([]interface{}); ok {
-					opts.Allow = make([]string, 0, len(v))
-					for _, item := range v {
-						if s, ok := item.(string); ok {
-							opts.Allow = append(opts.Allow, s)
-						}
-					}
-				}
-			}
-		}
-		return opts
+	optsMap, _ := options[0].(map[string]interface{})
+	if v, ok := optsMap["checkParameterProperties"].(bool); ok {
+		opts.CheckParameterProperties = v
 	}
-	// Handle direct object format
-	if m, ok := options.(map[string]interface{}); ok {
-		if v, ok := m["checkParameterProperties"].(bool); ok {
-			opts.CheckParameterProperties = v
-		}
-		if v, ok := m["ignoreInferredTypes"].(bool); ok {
-			opts.IgnoreInferredTypes = v
-		}
-		if v, ok := m["treatMethodsAsReadonly"].(bool); ok {
-			opts.TreatMethodsAsReadonly = v
-		}
-		if v, ok := m["allow"].([]interface{}); ok {
-			opts.Allow = make([]string, 0, len(v))
-			for _, item := range v {
-				if s, ok := item.(string); ok {
-					opts.Allow = append(opts.Allow, s)
-				}
+	if v, ok := optsMap["ignoreInferredTypes"].(bool); ok {
+		opts.IgnoreInferredTypes = v
+	}
+	if v, ok := optsMap["treatMethodsAsReadonly"].(bool); ok {
+		opts.TreatMethodsAsReadonly = v
+	}
+	if v, ok := optsMap["allow"].([]interface{}); ok {
+		opts.Allow = make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				opts.Allow = append(opts.Allow, s)
 			}
 		}
 	}
@@ -154,9 +131,9 @@ func checkParameter(ctx rule.RuleContext, param *ast.Node, opts PreferReadonlyPa
 
 var PreferReadonlyParameterTypesRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-readonly-parameter-types",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
 
 		checkParameters := func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/prefer_readonly_parameter_types/prefer_readonly_parameter_types.schema.json
+++ b/internal/plugins/typescript/rules/prefer_readonly_parameter_types/prefer_readonly_parameter_types.schema.json
@@ -1,0 +1,120 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["file"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["lib"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  }
+                },
+                "required": ["from", "name"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "from": {
+                    "enum": ["package"],
+                    "type": "string"
+                  },
+                  "name": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                        "uniqueItems": true
+                      }
+                    ]
+                  },
+                  "package": {
+                    "type": "string"
+                  }
+                },
+                "required": ["from", "name", "package"],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array",
+          "description": "An array of type specifiers to ignore."
+        },
+        "checkParameterProperties": {
+          "type": "boolean",
+          "description": "Whether to check class parameter properties."
+        },
+        "ignoreInferredTypes": {
+          "type": "boolean",
+          "description": "Whether to ignore parameters which don't explicitly specify a type."
+        },
+        "treatMethodsAsReadonly": {
+          "type": "boolean",
+          "description": "Whether to treat all mutable methods as though they are readonly."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/prefer_reduce_type_parameter/prefer_reduce_type_parameter.go
+++ b/internal/plugins/typescript/rules/prefer_reduce_type_parameter/prefer_reduce_type_parameter.go
@@ -16,6 +16,7 @@ func buildPreferTypeParameterMessage() rule.RuleMessage {
 
 var PreferReduceTypeParameterRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-reduce-type-parameter",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/prefer_regexp_exec/prefer_regexp_exec.go
+++ b/internal/plugins/typescript/rules/prefer_regexp_exec/prefer_regexp_exec.go
@@ -355,6 +355,7 @@ func buildPreferRegExpExecReplacement(ctx rule.RuleContext, callNode *ast.Node, 
 
 var PreferRegExpExecRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-regexp-exec",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/prefer_return_this_type/prefer_return_this_type.go
+++ b/internal/plugins/typescript/rules/prefer_return_this_type/prefer_return_this_type.go
@@ -15,6 +15,7 @@ func buildUseThisTypeMessage() rule.RuleMessage {
 
 var PreferReturnThisTypeRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-return-this-type",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		var tryGetNameInTypeNode func(name string, node *ast.Node) *ast.Node

--- a/internal/plugins/typescript/rules/prefer_string_starts_ends_with/prefer_string_starts_ends_with.go
+++ b/internal/plugins/typescript/rules/prefer_string_starts_ends_with/prefer_string_starts_ends_with.go
@@ -1,6 +1,7 @@
 package prefer_string_starts_ends_with
 
 import (
+	_ "embed"
 	"fmt"
 	"strconv"
 	"strings"
@@ -9,6 +10,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed prefer_string_starts_ends_with.schema.json
+var schemaJSON []byte
 
 func buildPreferStartsWithMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -410,25 +414,15 @@ func needsParentheses(node *ast.Node) bool {
 
 var PreferStringStartsEndsWithRule = rule.CreateRule(rule.Rule{
 	Name:             "prefer-string-starts-ends-with",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := defaultOpts
 
-		if options != nil {
-			var optsMap map[string]interface{}
-			var ok bool
-
-			if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-				optsMap, ok = optArray[0].(map[string]interface{})
-			} else {
-				optsMap, ok = options.(map[string]interface{})
-			}
-
-			if ok {
-				if allowSingleElementEquality, ok := optsMap["allowSingleElementEquality"].(string); ok {
-					opts.AllowSingleElementEquality = utils.Ref(allowSingleElementEquality)
-				}
+		if len(options) > 0 {
+			optsMap, _ := options[0].(map[string]interface{})
+			if allowSingleElementEquality, ok := optsMap["allowSingleElementEquality"].(string); ok {
+				opts.AllowSingleElementEquality = utils.Ref(allowSingleElementEquality)
 			}
 		}
 

--- a/internal/plugins/typescript/rules/prefer_string_starts_ends_with/prefer_string_starts_ends_with.schema.json
+++ b/internal/plugins/typescript/rules/prefer_string_starts_ends_with/prefer_string_starts_ends_with.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowSingleElementEquality": {
+          "type": "string",
+          "description": "Whether to allow equality checks against the first or last element of a string.",
+          "enum": ["always", "never"]
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/prefer_ts_expect_error/prefer_ts_expect_error.go
+++ b/internal/plugins/typescript/rules/prefer_ts_expect_error/prefer_ts_expect_error.go
@@ -106,7 +106,8 @@ func findTsIgnoreDirective(commentText string, kind ast.Kind) (int, int, bool) {
 }
 
 var PreferTsExpectErrorRule = rule.CreateRule(rule.Rule{
-	Name: "prefer-ts-expect-error",
+	Name:   "prefer-ts-expect-error",
+	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		fullText := ctx.SourceFile.Text()
 		if !strings.Contains(fullText, tsIgnoreDirective) {

--- a/internal/plugins/typescript/rules/promise_function_async/promise_function_async.go
+++ b/internal/plugins/typescript/rules/promise_function_async/promise_function_async.go
@@ -2,6 +2,8 @@ package promise_function_async
 
 import (
 	_ "embed"
+	"encoding/json"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -19,20 +21,23 @@ func buildMissingAsyncMessage() rule.RuleMessage {
 }
 
 type PromiseFunctionAsyncOptions struct {
-	AllowAny *bool
+	AllowAny *bool `json:"allowAny,omitempty"`
 	// TODO(port): TypeOrValueSpecifier
-	AllowedPromiseNames       []string
-	CheckArrowFunctions       *bool
-	CheckFunctionDeclarations *bool
-	CheckFunctionExpressions  *bool
-	CheckMethodDeclarations   *bool
+	AllowedPromiseNames       []string `json:"allowedPromiseNames,omitempty"`
+	CheckArrowFunctions       *bool    `json:"checkArrowFunctions,omitempty"`
+	CheckFunctionDeclarations *bool    `json:"checkFunctionDeclarations,omitempty"`
+	CheckFunctionExpressions  *bool    `json:"checkFunctionExpressions,omitempty"`
+	CheckMethodDeclarations   *bool    `json:"checkMethodDeclarations,omitempty"`
 }
 
 func parseOptions(options []any) PromiseFunctionAsyncOptions {
 	opts := PromiseFunctionAsyncOptions{}
 	if len(options) > 0 {
-		if typed, ok := options[0].(PromiseFunctionAsyncOptions); ok {
-			opts = typed
+		if optsMap, ok := options[0].(map[string]interface{}); ok {
+			// Convert the configured option object to JSON and back into the struct.
+			if optsJSON, err := json.Marshal(optsMap); err == nil {
+				_ = json.Unmarshal(optsJSON, &opts)
+			}
 		}
 	}
 	if opts.AllowAny == nil {

--- a/internal/plugins/typescript/rules/promise_function_async/promise_function_async.go
+++ b/internal/plugins/typescript/rules/promise_function_async/promise_function_async.go
@@ -1,11 +1,15 @@
 package promise_function_async
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed promise_function_async.schema.json
+var schemaJSON []byte
 
 func buildMissingAsyncMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -24,33 +28,40 @@ type PromiseFunctionAsyncOptions struct {
 	CheckMethodDeclarations   *bool
 }
 
+func parseOptions(options []any) PromiseFunctionAsyncOptions {
+	opts := PromiseFunctionAsyncOptions{}
+	if len(options) > 0 {
+		if typed, ok := options[0].(PromiseFunctionAsyncOptions); ok {
+			opts = typed
+		}
+	}
+	if opts.AllowAny == nil {
+		opts.AllowAny = utils.Ref(true)
+	}
+	if opts.AllowedPromiseNames == nil {
+		opts.AllowedPromiseNames = []string{}
+	}
+	if opts.CheckArrowFunctions == nil {
+		opts.CheckArrowFunctions = utils.Ref(true)
+	}
+	if opts.CheckFunctionDeclarations == nil {
+		opts.CheckFunctionDeclarations = utils.Ref(true)
+	}
+	if opts.CheckFunctionExpressions == nil {
+		opts.CheckFunctionExpressions = utils.Ref(true)
+	}
+	if opts.CheckMethodDeclarations == nil {
+		opts.CheckMethodDeclarations = utils.Ref(true)
+	}
+	return opts
+}
+
 var PromiseFunctionAsyncRule = rule.CreateRule(rule.Rule{
 	Name:             "promise-function-async",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(PromiseFunctionAsyncOptions)
-		if !ok {
-			opts = PromiseFunctionAsyncOptions{}
-		}
-		if opts.AllowAny == nil {
-			opts.AllowAny = utils.Ref(true)
-		}
-		if opts.AllowedPromiseNames == nil {
-			opts.AllowedPromiseNames = []string{}
-		}
-		if opts.CheckArrowFunctions == nil {
-			opts.CheckArrowFunctions = utils.Ref(true)
-		}
-		if opts.CheckFunctionDeclarations == nil {
-			opts.CheckFunctionDeclarations = utils.Ref(true)
-		}
-		if opts.CheckFunctionExpressions == nil {
-			opts.CheckFunctionExpressions = utils.Ref(true)
-		}
-		if opts.CheckMethodDeclarations == nil {
-			opts.CheckMethodDeclarations = utils.Ref(true)
-		}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		allAllowedPromiseNames := utils.NewSetWithSizeHint[string](len(opts.AllowedPromiseNames))
 		allAllowedPromiseNames.Add("Promise")

--- a/internal/plugins/typescript/rules/promise_function_async/promise_function_async.schema.json
+++ b/internal/plugins/typescript/rules/promise_function_async/promise_function_async.schema.json
@@ -1,0 +1,40 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowAny": {
+          "type": "boolean",
+          "description": "Whether to consider `any` and `unknown` to be Promises."
+        },
+        "allowedPromiseNames": {
+          "type": "array",
+          "description": "Any extra names of classes or interfaces to be considered Promises.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "checkArrowFunctions": {
+          "type": "boolean",
+          "description": "Whether to check arrow functions."
+        },
+        "checkFunctionDeclarations": {
+          "type": "boolean",
+          "description": "Whether to check standalone function declarations."
+        },
+        "checkFunctionExpressions": {
+          "type": "boolean",
+          "description": "Whether to check inline function expressions"
+        },
+        "checkMethodDeclarations": {
+          "type": "boolean",
+          "description": "Whether to check methods on classes and object literals."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/promise_function_async/promise_function_async_test.go
+++ b/internal/plugins/typescript/rules/promise_function_async/promise_function_async_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestPromiseFunctionAsyncRule(t *testing.T) {
@@ -107,7 +106,7 @@ function returnsAny(): any {
   return 0;
 }
       `,
-			Options: PromiseFunctionAsyncOptions{AllowAny: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": true},
 		},
 		{
 			Code: `
@@ -115,7 +114,7 @@ function returnsUnknown(): unknown {
   return 0;
 }
       `,
-			Options: PromiseFunctionAsyncOptions{AllowAny: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": true},
 		},
 		{
 			Code: `
@@ -200,7 +199,7 @@ function overloadingThatIncludeUnknown(a?: boolean): unknown | number {
   return Promise.resolve(5);
 }
       `,
-			Options: PromiseFunctionAsyncOptions{AllowAny: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": true},
 		},
 		{
 			Code: `
@@ -210,7 +209,7 @@ function overloadingThatIncludeAny(a?: boolean): any | number {
   return Promise.resolve(5);
 }
       `,
-			Options: PromiseFunctionAsyncOptions{AllowAny: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": true},
 		},
 	}, []rule_tester.InvalidTestCase{
 		{
@@ -219,7 +218,7 @@ function returnsAny(): any {
   return 0;
 }
       `,
-			Options: PromiseFunctionAsyncOptions{AllowAny: utils.Ref(false)},
+			Options: map[string]interface{}{"allowAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "missingAsync",
@@ -232,7 +231,7 @@ function returnsUnknown(): unknown {
   return 0;
 }
       `,
-			Options: PromiseFunctionAsyncOptions{AllowAny: utils.Ref(false)},
+			Options: map[string]interface{}{"allowAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "missingAsync",
@@ -433,7 +432,7 @@ class Test {
 }
       `,
 			},
-			Options: PromiseFunctionAsyncOptions{CheckArrowFunctions: utils.Ref(false)},
+			Options: map[string]interface{}{"checkArrowFunctions": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "missingAsync",
@@ -485,7 +484,7 @@ class Test {
 }
       `,
 			},
-			Options: PromiseFunctionAsyncOptions{CheckFunctionDeclarations: utils.Ref(false)},
+			Options: map[string]interface{}{"checkFunctionDeclarations": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "missingAsync",
@@ -537,7 +536,7 @@ class Test {
 }
       `,
 			},
-			Options: PromiseFunctionAsyncOptions{CheckFunctionExpressions: utils.Ref(false)},
+			Options: map[string]interface{}{"checkFunctionExpressions": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "missingAsync",
@@ -589,7 +588,7 @@ class Test {
 }
       `,
 			},
-			Options: PromiseFunctionAsyncOptions{CheckMethodDeclarations: utils.Ref(false)},
+			Options: map[string]interface{}{"checkMethodDeclarations": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "missingAsync",
@@ -617,7 +616,7 @@ class PromiseType {}
 const returnAllowedType =  async () => new PromiseType();
       `,
 			},
-			Options: PromiseFunctionAsyncOptions{AllowedPromiseNames: []string{"PromiseType"}},
+			Options: map[string]interface{}{"allowedPromiseNames": []interface{}{"PromiseType"}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "missingAsync",
@@ -643,7 +642,7 @@ interface SPromise<T> extends Promise<T> {}
 }
       `,
 			},
-			Options: PromiseFunctionAsyncOptions{AllowedPromiseNames: []string{"SPromise"}},
+			Options: map[string]interface{}{"allowedPromiseNames": []interface{}{"SPromise"}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "missingAsync",
@@ -853,7 +852,7 @@ function overloadingThatIncludeAny(a?: boolean): any | number {
   return Promise.resolve(5);
 }
       `,
-			Options: PromiseFunctionAsyncOptions{AllowAny: utils.Ref(false)},
+			Options: map[string]interface{}{"allowAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "missingAsync",
@@ -868,7 +867,7 @@ function overloadingThatIncludeUnknown(a?: boolean): unknown | number {
   return Promise.resolve(5);
 }
       `,
-			Options: PromiseFunctionAsyncOptions{AllowAny: utils.Ref(false)},
+			Options: map[string]interface{}{"allowAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "missingAsync",

--- a/internal/plugins/typescript/rules/related_getter_setter_pairs/related_getter_setter_pairs.go
+++ b/internal/plugins/typescript/rules/related_getter_setter_pairs/related_getter_setter_pairs.go
@@ -16,6 +16,7 @@ func buildMismatchMessage() rule.RuleMessage {
 
 var RelatedGetterSetterPairsRule = rule.CreateRule(rule.Rule{
 	Name:             "related-getter-setter-pairs",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		checkAccessorsPair := func(getter *ast.GetAccessorDeclaration, setter *ast.SetAccessorDeclaration) {

--- a/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.go
+++ b/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.go
@@ -1,11 +1,15 @@
 package require_array_sort_compare
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed require_array_sort_compare.schema.json
+var schemaJSON []byte
 
 func buildRequireCompareMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -18,18 +22,25 @@ type RequireArraySortCompareOptions struct {
 	IgnoreStringArrays *bool
 }
 
+func parseOptions(options []any) RequireArraySortCompareOptions {
+	opts := RequireArraySortCompareOptions{}
+	if len(options) > 0 {
+		if typed, ok := options[0].(RequireArraySortCompareOptions); ok {
+			opts = typed
+		}
+	}
+	if opts.IgnoreStringArrays == nil {
+		opts.IgnoreStringArrays = utils.Ref(true)
+	}
+	return opts
+}
+
 var RequireArraySortCompareRule = rule.CreateRule(rule.Rule{
 	Name:             "require-array-sort-compare",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(RequireArraySortCompareOptions)
-		if !ok {
-			opts = RequireArraySortCompareOptions{}
-		}
-		if opts.IgnoreStringArrays == nil {
-			opts.IgnoreStringArrays = utils.Ref(true)
-		}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {

--- a/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.go
+++ b/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.go
@@ -2,6 +2,8 @@ package require_array_sort_compare
 
 import (
 	_ "embed"
+	"encoding/json"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -19,14 +21,19 @@ func buildRequireCompareMessage() rule.RuleMessage {
 }
 
 type RequireArraySortCompareOptions struct {
-	IgnoreStringArrays *bool
+	IgnoreStringArrays *bool `json:"ignoreStringArrays"`
 }
 
 func parseOptions(options []any) RequireArraySortCompareOptions {
-	opts := RequireArraySortCompareOptions{}
-	if len(options) > 0 {
-		if typed, ok := options[0].(RequireArraySortCompareOptions); ok {
-			opts = typed
+	opts := RequireArraySortCompareOptions{
+		IgnoreStringArrays: utils.Ref(true),
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	if optsMap, ok := options[0].(map[string]interface{}); ok {
+		if optsJSON, err := json.Marshal(optsMap); err == nil {
+			_ = json.Unmarshal(optsJSON, &opts)
 		}
 	}
 	if opts.IgnoreStringArrays == nil {

--- a/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.schema.json
+++ b/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ignoreStringArrays": {
+          "type": "boolean",
+          "description": "Whether to ignore arrays in which all elements are strings."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare_test.go
+++ b/internal/plugins/typescript/rules/require_array_sort_compare/require_array_sort_compare_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestRequireArraySortCompareRule(t *testing.T) {
@@ -93,7 +92,7 @@ func TestRequireArraySortCompareRule(t *testing.T) {
 			Code: `
         ['foo', 'bar', 'baz'].sort();
       `,
-			Options: RequireArraySortCompareOptions{IgnoreStringArrays: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreStringArrays": true},
 		},
 		{
 			Code: `
@@ -102,7 +101,7 @@ func TestRequireArraySortCompareRule(t *testing.T) {
         }
         [getString(), getString()].sort();
       `,
-			Options: RequireArraySortCompareOptions{IgnoreStringArrays: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreStringArrays": true},
 		},
 		{
 			Code: `
@@ -111,14 +110,14 @@ func TestRequireArraySortCompareRule(t *testing.T) {
         const baz = 'baz';
         [foo, bar, baz].sort();
       `,
-			Options: RequireArraySortCompareOptions{IgnoreStringArrays: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreStringArrays": true},
 		},
 		{
 			Code: `
         declare const x: string[];
         x.sort();
       `,
-			Options: RequireArraySortCompareOptions{IgnoreStringArrays: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreStringArrays": true},
 		},
 		{
 			Code: `
@@ -158,7 +157,7 @@ func TestRequireArraySortCompareRule(t *testing.T) {
           a.sort();
         }
       `,
-			Options: RequireArraySortCompareOptions{IgnoreStringArrays: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreStringArrays": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requireCompare",
@@ -183,7 +182,7 @@ func TestRequireArraySortCompareRule(t *testing.T) {
           if (Array.isArray(a)) a.sort();
         }
       `,
-			Options: RequireArraySortCompareOptions{IgnoreStringArrays: utils.Ref(false)},
+			Options: map[string]interface{}{"ignoreStringArrays": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requireCompare",
@@ -278,7 +277,7 @@ func TestRequireArraySortCompareRule(t *testing.T) {
 			Code: `
         [2, 'bar', 'baz'].sort();
       `,
-			Options: RequireArraySortCompareOptions{IgnoreStringArrays: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreStringArrays": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requireCompare",
@@ -292,7 +291,7 @@ func TestRequireArraySortCompareRule(t *testing.T) {
         }
         [2, 3].sort();
       `,
-			Options: RequireArraySortCompareOptions{IgnoreStringArrays: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreStringArrays": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requireCompare",
@@ -306,7 +305,7 @@ func TestRequireArraySortCompareRule(t *testing.T) {
         const three = 3;
         [one, two, three].sort();
       `,
-			Options: RequireArraySortCompareOptions{IgnoreStringArrays: utils.Ref(true)},
+			Options: map[string]interface{}{"ignoreStringArrays": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requireCompare",

--- a/internal/plugins/typescript/rules/require_await/require_await.go
+++ b/internal/plugins/typescript/rules/require_await/require_await.go
@@ -111,6 +111,7 @@ func hasAsyncIterator(typeChecker *checker.Checker, t *checker.Type) bool {
 
 var RequireAwaitRule = rule.CreateRule(rule.Rule{
 	Name:             "require-await",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		var scopes []scopeInfo

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
@@ -1,6 +1,7 @@
 package restrict_plus_operands
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed restrict_plus_operands.schema.json
+var schemaJSON []byte
 
 func buildBigintAndNumberMessage(left, right string) rule.RuleMessage {
 	return rule.RuleMessage{
@@ -40,12 +44,14 @@ type RestrictPlusOperandsOptions struct {
 
 var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 	Name:             "restrict-plus-operands",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(RestrictPlusOperandsOptions)
-		if !ok {
-			opts = RestrictPlusOperandsOptions{}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		var opts RestrictPlusOperandsOptions
+		if len(options) > 0 {
+			if typed, ok := options[0].(RestrictPlusOperandsOptions); ok {
+				opts = typed
+			}
 		}
 		if opts.AllowAny == nil {
 			opts.AllowAny = utils.Ref(true)

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.go
@@ -2,6 +2,7 @@ package restrict_plus_operands
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -34,12 +35,32 @@ func buildMismatchedMessage(stringLike, left, right string) rule.RuleMessage {
 }
 
 type RestrictPlusOperandsOptions struct {
-	AllowAny                *bool
-	AllowBoolean            *bool
-	AllowNullish            *bool
-	AllowNumberAndString    *bool
-	AllowRegExp             *bool
-	SkipCompoundAssignments *bool
+	AllowAny                *bool `json:"allowAny"`
+	AllowBoolean            *bool `json:"allowBoolean"`
+	AllowNullish            *bool `json:"allowNullish"`
+	AllowNumberAndString    *bool `json:"allowNumberAndString"`
+	AllowRegExp             *bool `json:"allowRegExp"`
+	SkipCompoundAssignments *bool `json:"skipCompoundAssignments"`
+}
+
+func parseOptions(options []any) RestrictPlusOperandsOptions {
+	opts := RestrictPlusOperandsOptions{
+		AllowAny:                utils.Ref(true),
+		AllowBoolean:            utils.Ref(true),
+		AllowNullish:            utils.Ref(true),
+		AllowNumberAndString:    utils.Ref(true),
+		AllowRegExp:             utils.Ref(true),
+		SkipCompoundAssignments: utils.Ref(false),
+	}
+	if len(options) == 0 {
+		return opts
+	}
+	if optsMap, ok := options[0].(map[string]interface{}); ok {
+		if optsJSON, err := json.Marshal(optsMap); err == nil {
+			_ = json.Unmarshal(optsJSON, &opts)
+		}
+	}
+	return opts
 }
 
 var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
@@ -47,30 +68,7 @@ var RestrictPlusOperandsRule = rule.CreateRule(rule.Rule{
 	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		var opts RestrictPlusOperandsOptions
-		if len(options) > 0 {
-			if typed, ok := options[0].(RestrictPlusOperandsOptions); ok {
-				opts = typed
-			}
-		}
-		if opts.AllowAny == nil {
-			opts.AllowAny = utils.Ref(true)
-		}
-		if opts.AllowBoolean == nil {
-			opts.AllowBoolean = utils.Ref(true)
-		}
-		if opts.AllowNullish == nil {
-			opts.AllowNullish = utils.Ref(true)
-		}
-		if opts.AllowNumberAndString == nil {
-			opts.AllowNumberAndString = utils.Ref(true)
-		}
-		if opts.AllowRegExp == nil {
-			opts.AllowRegExp = utils.Ref(true)
-		}
-		if opts.SkipCompoundAssignments == nil {
-			opts.SkipCompoundAssignments = utils.Ref(false)
-		}
+		opts := parseOptions(options)
 
 		stringLikes := make([]string, 0, 5)
 		if *opts.AllowAny {

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.schema.json
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands.schema.json
@@ -1,0 +1,37 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowAny": {
+          "type": "boolean",
+          "description": "Whether to allow `any` typed values."
+        },
+        "allowBoolean": {
+          "type": "boolean",
+          "description": "Whether to allow `boolean` typed values."
+        },
+        "allowNullish": {
+          "type": "boolean",
+          "description": "Whether to allow potentially `null` or `undefined` typed values."
+        },
+        "allowNumberAndString": {
+          "type": "boolean",
+          "description": "Whether to allow `bigint`/`number` typed values and `string` typed values to be added together."
+        },
+        "allowRegExp": {
+          "type": "boolean",
+          "description": "Whether to allow `regexp` typed values."
+        },
+        "skipCompoundAssignments": {
+          "type": "boolean",
+          "description": "Whether to skip compound assignments such as `+=`."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
+++ b/internal/plugins/typescript/rules/restrict_plus_operands/restrict_plus_operands_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestRestrictPlusOperandsRule(t *testing.T) {
@@ -169,12 +168,12 @@ const x = a + b;
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(true),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          true,
 			},
 		},
 		{
@@ -183,53 +182,53 @@ const x = a + b;
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(true),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          true,
 			},
 		},
 		{
 			Code: `
 const f = (a: RegExp, b: RegExp) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowRegExp: utils.Ref(true)},
+			Options: map[string]interface{}{"allowRegExp": true},
 		},
 		{
 			Code: `
 let foo: string | undefined;
 foo = foo + 'some data';
       `,
-			Options: RestrictPlusOperandsOptions{AllowNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"allowNullish": true},
 		},
 		{
 			Code: `
 let foo: string | null;
 foo = foo + 'some data';
       `,
-			Options: RestrictPlusOperandsOptions{AllowNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"allowNullish": true},
 		},
 		{
 			Code: `
 let foo: string | null | undefined;
 foo = foo + 'some data';
       `,
-			Options: RestrictPlusOperandsOptions{AllowNullish: utils.Ref(true)},
+			Options: map[string]interface{}{"allowNullish": true},
 		},
 		{
 			Code: `
 let foo = '';
 foo += 0;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:                utils.Ref(false),
-				AllowBoolean:            utils.Ref(false),
-				AllowNullish:            utils.Ref(false),
-				AllowNumberAndString:    utils.Ref(false),
-				AllowRegExp:             utils.Ref(false),
-				SkipCompoundAssignments: utils.Ref(true),
+			Options: map[string]interface{}{
+				"allowAny":                false,
+				"allowBoolean":            false,
+				"allowNullish":            false,
+				"allowNumberAndString":    false,
+				"allowRegExp":             false,
+				"skipCompoundAssignments": true,
 			},
 		},
 		{
@@ -237,89 +236,89 @@ foo += 0;
 let foo = 0;
 foo += '';
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:                utils.Ref(false),
-				AllowBoolean:            utils.Ref(false),
-				AllowNullish:            utils.Ref(false),
-				AllowNumberAndString:    utils.Ref(false),
-				AllowRegExp:             utils.Ref(false),
-				SkipCompoundAssignments: utils.Ref(true),
+			Options: map[string]interface{}{
+				"allowAny":                false,
+				"allowBoolean":            false,
+				"allowNullish":            false,
+				"allowNumberAndString":    false,
+				"allowRegExp":             false,
+				"skipCompoundAssignments": true,
 			},
 		},
 		{
 			Code: `
 const f = (a: any, b: any) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": true},
 		},
 		{
 			Code: `
 const f = (a: any, b: string) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": true},
 		},
 		{
 			Code: `
 const f = (a: any, b: bigint) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": true},
 		},
 		{
 			Code: `
 const f = (a: any, b: number) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": true},
 		},
 		{
 			Code: `
 const f = (a: any, b: boolean) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(true), AllowBoolean: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": true, "allowBoolean": true},
 		},
 		{
 			Code: `
 const f = (a: string, b: string | number) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(true),
-				AllowBoolean:         utils.Ref(true),
-				AllowNullish:         utils.Ref(true),
-				AllowNumberAndString: utils.Ref(true),
-				AllowRegExp:          utils.Ref(true),
+			Options: map[string]interface{}{
+				"allowAny":             true,
+				"allowBoolean":         true,
+				"allowNullish":         true,
+				"allowNumberAndString": true,
+				"allowRegExp":          true,
 			},
 		},
 		{
 			Code: `
 const f = (a: string | number, b: number) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(true),
-				AllowBoolean:         utils.Ref(true),
-				AllowNullish:         utils.Ref(true),
-				AllowNumberAndString: utils.Ref(true),
-				AllowRegExp:          utils.Ref(true),
+			Options: map[string]interface{}{
+				"allowAny":             true,
+				"allowBoolean":         true,
+				"allowNullish":         true,
+				"allowNumberAndString": true,
+				"allowRegExp":          true,
 			},
 		},
 		{
 			Code: `
 const f = (a: string | number, b: string | number) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(true),
-				AllowBoolean:         utils.Ref(true),
-				AllowNullish:         utils.Ref(true),
-				AllowNumberAndString: utils.Ref(true),
-				AllowRegExp:          utils.Ref(true),
+			Options: map[string]interface{}{
+				"allowAny":             true,
+				"allowBoolean":         true,
+				"allowNullish":         true,
+				"allowNumberAndString": true,
+				"allowRegExp":          true,
 			},
 		},
 		{
 			Code:    "let foo = '1' + 1n;",
-			Options: RestrictPlusOperandsOptions{AllowNumberAndString: utils.Ref(true)},
+			Options: map[string]interface{}{"allowNumberAndString": true},
 		},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code:    "let foo = '1' + 1;",
-			Options: RestrictPlusOperandsOptions{AllowNumberAndString: utils.Ref(false)},
+			Options: map[string]interface{}{"allowNumberAndString": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatched",
@@ -330,12 +329,12 @@ const f = (a: string | number, b: string | number) => a + b;
 		},
 		{
 			Code: "let foo = '1' + 1;",
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -364,12 +363,12 @@ const f = (a: string | number, b: string | number) => a + b;
 		},
 		{
 			Code: "let foo = 5 + '10';",
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -431,7 +430,7 @@ const f = (a: string | number, b: string | number) => a + b;
 		},
 		{
 			Code:    "let foo = 5.5 + '5';",
-			Options: RestrictPlusOperandsOptions{AllowNumberAndString: utils.Ref(false)},
+			Options: map[string]interface{}{"allowNumberAndString": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatched",
@@ -442,7 +441,7 @@ const f = (a: string | number, b: string | number) => a + b;
 		},
 		{
 			Code:    "let foo = '5.5' + 5;",
-			Options: RestrictPlusOperandsOptions{AllowNumberAndString: utils.Ref(false)},
+			Options: map[string]interface{}{"allowNumberAndString": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatched",
@@ -457,7 +456,7 @@ let x = 5;
 let y = '10';
 let foo = x + y;
       `,
-			Options: RestrictPlusOperandsOptions{AllowNumberAndString: utils.Ref(false)},
+			Options: map[string]interface{}{"allowNumberAndString": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatched",
@@ -472,7 +471,7 @@ let x = 5;
 let y = '10';
 let foo = y + x;
       `,
-			Options: RestrictPlusOperandsOptions{AllowNumberAndString: utils.Ref(false)},
+			Options: map[string]interface{}{"allowNumberAndString": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatched",
@@ -512,12 +511,12 @@ let foo = [] + y;
 let pair = { first: 5, second: '10' };
 let foo = pair + pair;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -540,12 +539,12 @@ type Valued = { value: number };
 let value: Valued = { value: 0 };
 let combined = value + 0;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -608,12 +607,12 @@ function foo<T extends string>(a: T) {
   return a + 1;
 }
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -629,12 +628,12 @@ function foo<T extends 'a' | 'b'>(a: T) {
   return a + 1;
 }
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -650,12 +649,12 @@ function foo<T extends number>(a: T) {
   return a + '';
 }
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -671,12 +670,12 @@ function foo<T extends 1>(a: T) {
   return a + '';
 }
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -692,12 +691,12 @@ function foo<T extends 1>(a: T) {
         declare const b: number;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -713,12 +712,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -734,12 +733,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -755,12 +754,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -776,12 +775,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -797,12 +796,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -821,12 +820,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -848,12 +847,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -870,12 +869,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -891,12 +890,12 @@ function foo<T extends 1>(a: T) {
         declare const b: number;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -912,12 +911,12 @@ function foo<T extends 1>(a: T) {
         declare const b: bigint;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -933,12 +932,12 @@ function foo<T extends 1>(a: T) {
         declare const b: bigint;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -954,12 +953,12 @@ function foo<T extends 1>(a: T) {
         declare const b: bigint;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -975,12 +974,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -996,12 +995,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1017,12 +1016,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1038,12 +1037,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1059,12 +1058,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1080,12 +1079,12 @@ function foo<T extends 1>(a: T) {
         declare const b: string;
         const x = a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1100,13 +1099,13 @@ function foo<T extends 1>(a: T) {
 let foo: string | undefined;
 foo += 'some data';
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:                utils.Ref(false),
-				AllowBoolean:            utils.Ref(false),
-				AllowNullish:            utils.Ref(false),
-				AllowNumberAndString:    utils.Ref(false),
-				AllowRegExp:             utils.Ref(false),
-				SkipCompoundAssignments: utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":                false,
+				"allowBoolean":            false,
+				"allowNullish":            false,
+				"allowNumberAndString":    false,
+				"allowRegExp":             false,
+				"skipCompoundAssignments": false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1121,12 +1120,12 @@ foo += 'some data';
 let foo: string | null;
 foo += 'some data';
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1141,12 +1140,12 @@ foo += 'some data';
 let foo: string = '';
 foo += 1;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1161,12 +1160,12 @@ foo += 1;
 let foo = 0;
 foo += '';
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:             utils.Ref(false),
-				AllowBoolean:         utils.Ref(false),
-				AllowNullish:         utils.Ref(false),
-				AllowNumberAndString: utils.Ref(false),
-				AllowRegExp:          utils.Ref(false),
+			Options: map[string]interface{}{
+				"allowAny":             false,
+				"allowBoolean":         false,
+				"allowNullish":         false,
+				"allowNumberAndString": false,
+				"allowRegExp":          false,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1180,7 +1179,7 @@ foo += '';
 			Code: `
 const f = (a: any, b: boolean) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(true), AllowBoolean: utils.Ref(false)},
+			Options: map[string]interface{}{"allowAny": true, "allowBoolean": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1193,7 +1192,7 @@ const f = (a: any, b: boolean) => a + b;
 			Code: `
 const f = (a: any, b: []) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1206,7 +1205,7 @@ const f = (a: any, b: []) => a + b;
 			Code: `
 const f = (a: any, b: boolean) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(false), AllowBoolean: utils.Ref(true)},
+			Options: map[string]interface{}{"allowAny": false, "allowBoolean": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1219,7 +1218,7 @@ const f = (a: any, b: boolean) => a + b;
 			Code: `
 const f = (a: any, b: any) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(false)},
+			Options: map[string]interface{}{"allowAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1237,7 +1236,7 @@ const f = (a: any, b: any) => a + b;
 			Code: `
 const f = (a: any, b: string) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(false)},
+			Options: map[string]interface{}{"allowAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1250,7 +1249,7 @@ const f = (a: any, b: string) => a + b;
 			Code: `
 const f = (a: any, b: bigint) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(false)},
+			Options: map[string]interface{}{"allowAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1263,7 +1262,7 @@ const f = (a: any, b: bigint) => a + b;
 			Code: `
 const f = (a: any, b: number) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(false)},
+			Options: map[string]interface{}{"allowAny": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1276,7 +1275,7 @@ const f = (a: any, b: number) => a + b;
 			Code: `
 const f = (a: any, b: boolean) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowAny: utils.Ref(false), AllowBoolean: utils.Ref(false)},
+			Options: map[string]interface{}{"allowAny": false, "allowBoolean": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1294,7 +1293,7 @@ const f = (a: any, b: boolean) => a + b;
 			Code: `
 const f = (a: number, b: RegExp) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{AllowRegExp: utils.Ref(true)},
+			Options: map[string]interface{}{"allowRegExp": true},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1308,7 +1307,7 @@ const f = (a: number, b: RegExp) => a + b;
 let foo: string | boolean;
 foo = foo + 'some data';
       `,
-			Options: RestrictPlusOperandsOptions{AllowBoolean: utils.Ref(false)},
+			Options: map[string]interface{}{"allowBoolean": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1322,7 +1321,7 @@ foo = foo + 'some data';
 let foo: boolean;
 foo = foo + 'some data';
       `,
-			Options: RestrictPlusOperandsOptions{AllowBoolean: utils.Ref(false)},
+			Options: map[string]interface{}{"allowBoolean": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "invalid",
@@ -1335,11 +1334,11 @@ foo = foo + 'some data';
 			Code: `
 const f = (a: any, b: unknown) => a + b;
       `,
-			Options: RestrictPlusOperandsOptions{
-				AllowAny:     utils.Ref(true),
-				AllowBoolean: utils.Ref(true),
-				AllowNullish: utils.Ref(true),
-				AllowRegExp:  utils.Ref(true),
+			Options: map[string]interface{}{
+				"allowAny":     true,
+				"allowBoolean": true,
+				"allowNullish": true,
+				"allowRegExp":  true,
 			},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
@@ -1351,7 +1350,7 @@ const f = (a: any, b: unknown) => a + b;
 		},
 		{
 			Code:    "let foo = '1' + 1n;",
-			Options: RestrictPlusOperandsOptions{AllowNumberAndString: utils.Ref(false)},
+			Options: map[string]interface{}{"allowNumberAndString": false},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "mismatched",

--- a/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
+++ b/internal/plugins/typescript/rules/restrict_template_expressions/restrict_template_expressions.go
@@ -52,8 +52,11 @@ func parseOptions(options []any) RestrictTemplateExpressionsOptions {
 		AllowNumber:  true,
 		AllowRegExp:  true,
 	}
-	optsMap := utils.GetOptionsMap(options)
-	if optsMap == nil {
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, ok := options[0].(map[string]interface{})
+	if !ok {
 		return opts
 	}
 	if raw, ok := optsMap["allow"]; ok {

--- a/internal/plugins/typescript/rules/return_await/return_await.go
+++ b/internal/plugins/typescript/rules/return_await/return_await.go
@@ -2,6 +2,7 @@ package return_await
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -51,25 +52,12 @@ const (
 	ReturnAwaitOptionNever
 )
 
-type ReturnAwaitOptions struct {
-	Option *ReturnAwaitOption
-}
-
 func parseReturnAwaitOption(options []any) ReturnAwaitOption {
 	if len(options) == 0 {
 		return ReturnAwaitOptionInTryCatch
 	}
-	switch opts := options[0].(type) {
-	case ReturnAwaitOptions:
-		if opts.Option != nil {
-			return *opts.Option
-		}
-	case *ReturnAwaitOptions:
-		if opts != nil && opts.Option != nil {
-			return *opts.Option
-		}
-	case string:
-		switch opts {
+	if opt, ok := options[0].(string); ok {
+		switch opt {
 		case "always":
 			return ReturnAwaitOptionAlways
 		case "error-handling-correctness-only":

--- a/internal/plugins/typescript/rules/return_await/return_await.go
+++ b/internal/plugins/typescript/rules/return_await/return_await.go
@@ -1,11 +1,15 @@
 package return_await
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed return_await.schema.json
+var schemaJSON []byte
 
 func buildDisallowedPromiseAwaitMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -52,7 +56,10 @@ type ReturnAwaitOptions struct {
 }
 
 func parseReturnAwaitOption(options []any) ReturnAwaitOption {
-	switch opts := rule.LegacyUnwrapOptions(options).(type) {
+	if len(options) == 0 {
+		return ReturnAwaitOptionInTryCatch
+	}
+	switch opts := options[0].(type) {
 	case ReturnAwaitOptions:
 		if opts.Option != nil {
 			return *opts.Option
@@ -160,9 +167,10 @@ func reportNodeWithDeferredFixesOrSuggestions(
 
 var ReturnAwaitRule = rule.CreateRule(rule.Rule{
 	Name:             "return-await",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		option := parseReturnAwaitOption(_options)
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		option := parseReturnAwaitOption(options)
 		sourceFile := ctx.SourceFile
 
 		var scopes []scopeInfo

--- a/internal/plugins/typescript/rules/return_await/return_await.schema.json
+++ b/internal/plugins/typescript/rules/return_await/return_await.schema.json
@@ -1,0 +1,32 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "string",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Requires that all returned promises be awaited.",
+          "enum": ["always"]
+        },
+        {
+          "type": "string",
+          "description": "In error-handling contexts, the rule enforces that returned promises must be awaited. In ordinary contexts, the rule does not enforce any particular behavior around whether returned promises are awaited.",
+          "enum": ["error-handling-correctness-only"]
+        },
+        {
+          "type": "string",
+          "description": "In error-handling contexts, the rule enforces that returned promises must be awaited. In ordinary contexts, the rule enforces that returned promises _must not_ be awaited.",
+          "enum": ["in-try-catch"]
+        },
+        {
+          "type": "string",
+          "description": "Disallows awaiting any returned promises.",
+          "enum": ["never"]
+        }
+      ]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/return_await/return_await_test.go
+++ b/internal/plugins/typescript/rules/return_await/return_await_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func TestParseReturnAwaitOption(t *testing.T) {
@@ -39,11 +38,6 @@ func TestParseReturnAwaitOption(t *testing.T) {
 			name:    "never from JS config",
 			options: []any{"never"},
 			want:    ReturnAwaitOptionNever,
-		},
-		{
-			name:    "legacy structured option",
-			options: []any{ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)}},
-			want:    ReturnAwaitOptionAlways,
 		},
 		{
 			name:    "unknown value falls back to default",
@@ -191,7 +185,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionErrorHandlingCorrectnessOnly)},
+			Options: "error-handling-correctness-only",
 		},
 		{Code: `
       async function test() {
@@ -212,7 +206,7 @@ async function test(unknownParam: unknown) {
           return 1;
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code: `
@@ -220,15 +214,15 @@ async function test(unknownParam: unknown) {
           return 1;
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code:    "const test = () => 1;",
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code:    "const test = async () => 1;",
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code: `
@@ -236,7 +230,7 @@ async function test(unknownParam: unknown) {
           return Promise.resolve(1);
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code: `
@@ -250,7 +244,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code: `
@@ -262,7 +256,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code: `
@@ -276,7 +270,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code: `
@@ -292,7 +286,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code: `
@@ -300,11 +294,11 @@ async function test(unknownParam: unknown) {
           return Promise.resolve(1);
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionNever)},
+			Options: "never",
 		},
 		{
 			Code:    "const test = async () => Promise.resolve(1);",
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionNever)},
+			Options: "never",
 		},
 		{
 			Code: `
@@ -318,7 +312,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionNever)},
+			Options: "never",
 		},
 		{
 			Code: `
@@ -326,11 +320,11 @@ async function test(unknownParam: unknown) {
           return await Promise.resolve(1);
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 		},
 		{
 			Code:    "const test = async () => await Promise.resolve(1);",
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 		},
 		{
 			Code: `
@@ -344,7 +338,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 		},
 		{
 			Code: `
@@ -358,7 +352,7 @@ async function test(unknownParam: unknown) {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 		},
 		{
 			Code: `
@@ -475,7 +469,7 @@ async function f() {
   using something = bleh;
 }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 		},
 		{
 			Code: `
@@ -490,7 +484,7 @@ async function returnAwait() {
   return await asyncFn();
 }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code: `
@@ -507,7 +501,7 @@ async function outerFunction() {
   }
 }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code: `
@@ -522,7 +516,7 @@ async function outerFunction() {
   const innerFunction = async () => asyncFn();
 }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 		},
 		{
 			Code: `
@@ -690,7 +684,7 @@ class C<R extends unknown> {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionErrorHandlingCorrectnessOnly)},
+			Options: "error-handling-correctness-only",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -746,7 +740,7 @@ class C<R extends unknown> {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -802,7 +796,7 @@ class C<R extends unknown> {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -877,7 +871,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "nonPromiseAwait",
@@ -888,7 +882,7 @@ class C<R extends unknown> {
 		{
 			Code:    "const test = async () => await 1;",
 			Output:  []string{"const test = async () =>  1;"},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "nonPromiseAwait",
@@ -899,7 +893,7 @@ class C<R extends unknown> {
 		{
 			Code:    "const test = async () => await Promise.resolve(1);",
 			Output:  []string{"const test = async () =>  Promise.resolve(1);"},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",
@@ -919,7 +913,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",
@@ -939,7 +933,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionNever)},
+			Options: "never",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "nonPromiseAwait",
@@ -959,7 +953,7 @@ class C<R extends unknown> {
           }
         }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionNever)},
+			Options: "never",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",
@@ -1015,7 +1009,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionNever)},
+			Options: "never",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",
@@ -1035,7 +1029,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "nonPromiseAwait",
@@ -1055,7 +1049,7 @@ class C<R extends unknown> {
         }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1066,7 +1060,7 @@ class C<R extends unknown> {
 		{
 			Code:    "const test = async () => Promise.resolve(1);",
 			Output:  []string{"const test = async () => await Promise.resolve(1);"},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1094,7 +1088,7 @@ async function buzz() {
 }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1132,7 +1126,7 @@ async function buzz() {
 }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1168,7 +1162,7 @@ async function buzz() {
 }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1194,7 +1188,7 @@ async function baz() {}
 const buzz = async () => ((await foo()) ? await bar() : await baz());
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1218,7 +1212,7 @@ async function bar() {}
 const buzz = async () => ((await foo()) ?  1 : await bar());
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1652,7 +1646,7 @@ async function f() {
   }
 }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1688,7 +1682,7 @@ async function f() {
   }
 }
       `,
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1734,7 +1728,7 @@ async function f() {
 }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionAlways)},
+			Options: "always",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "requiredPromiseAwait",
@@ -1772,7 +1766,7 @@ async function outerFunction() {
 }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",
@@ -1806,7 +1800,7 @@ async function outerFunction() {
 }
       `,
 			},
-			Options: ReturnAwaitOptions{Option: utils.Ref(ReturnAwaitOptionInTryCatch)},
+			Options: "in-try-catch",
 			Errors: []rule_tester.InvalidTestCaseError{
 				{
 					MessageId: "disallowedPromiseAwait",

--- a/internal/plugins/typescript/rules/strict_boolean_expressions/strict_boolean_expressions.go
+++ b/internal/plugins/typescript/rules/strict_boolean_expressions/strict_boolean_expressions.go
@@ -10,6 +10,7 @@
 package strict_boolean_expressions
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -21,6 +22,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed strict_boolean_expressions.schema.json
+var schemaJSON []byte
 
 // Options mirrors typescript-eslint's option shape. Pointer-typed booleans
 // distinguish "user explicitly set false" from "user did not set, fall back to
@@ -51,7 +55,7 @@ type resolvedOptions struct {
 	allowString                                            bool
 }
 
-func parseOptions(options any) resolvedOptions {
+func parseOptions(options []any) resolvedOptions {
 	// Defaults match upstream:
 	//   allowString=true, allowNumber=true, allowNullableObject=true,
 	//   all other booleans default to false.
@@ -61,14 +65,16 @@ func parseOptions(options any) resolvedOptions {
 		allowNullableObject: true,
 	}
 
-	optsMap := utils.GetOptionsMap(options)
+	if len(options) == 0 {
+		return opts
+	}
+	optsMap, _ := options[0].(map[string]interface{})
 	if optsMap == nil {
 		return opts
 	}
 
-	// Round-trip via JSON so the call accepts both the CLI shape (bare object)
-	// and the rule_tester shape (array-wrapped), matching every other
-	// typescript-eslint rule in this repo.
+	// Round-trip via JSON to fill the pointer-typed Options struct, which keeps
+	// "explicitly set to false" distinguishable from "not set at all".
 	jsonBytes, err := json.Marshal(optsMap)
 	if err != nil {
 		return opts
@@ -278,10 +284,10 @@ func sugDefaultZero() rule.RuleMessage {
 
 var StrictBooleanExpressionsRule = rule.CreateRule(rule.Rule{
 	Name:             "strict-boolean-expressions",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _optionsRaw []any) rule.RuleListeners {
-		optionsRaw := rule.LegacyUnwrapOptions(_optionsRaw)
-		opts := parseOptions(optionsRaw)
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
 		tc := ctx.TypeChecker
 		sf := ctx.SourceFile
 

--- a/internal/plugins/typescript/rules/strict_boolean_expressions/strict_boolean_expressions.schema.json
+++ b/internal/plugins/typescript/rules/strict_boolean_expressions/strict_boolean_expressions.schema.json
@@ -1,0 +1,49 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowAny": {
+          "type": "boolean",
+          "description": "Whether to allow `any`s in a boolean context."
+        },
+        "allowNullableBoolean": {
+          "type": "boolean",
+          "description": "Whether to allow nullable `boolean`s in a boolean context."
+        },
+        "allowNullableEnum": {
+          "type": "boolean",
+          "description": "Whether to allow nullable `enum`s in a boolean context."
+        },
+        "allowNullableNumber": {
+          "type": "boolean",
+          "description": "Whether to allow nullable `number`s in a boolean context."
+        },
+        "allowNullableObject": {
+          "type": "boolean",
+          "description": "Whether to allow nullable `object`s, `symbol`s, and functions in a boolean context."
+        },
+        "allowNullableString": {
+          "type": "boolean",
+          "description": "Whether to allow nullable `string`s in a boolean context."
+        },
+        "allowNumber": {
+          "type": "boolean",
+          "description": "Whether to allow `number`s in a boolean context."
+        },
+        "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
+          "type": "boolean",
+          "description": "Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`."
+        },
+        "allowString": {
+          "type": "boolean",
+          "description": "Whether to allow `string`s in a boolean context."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/strict_void_return/strict_void_return.go
+++ b/internal/plugins/typescript/rules/strict_void_return/strict_void_return.go
@@ -1,6 +1,7 @@
 package strict_void_return
 
 import (
+	_ "embed"
 	"encoding/json"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -9,6 +10,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed strict_void_return.schema.json
+var schemaJSON []byte
 
 func buildAsyncFuncMessage() rule.RuleMessage {
 	return rule.RuleMessage{
@@ -37,13 +41,14 @@ type StrictVoidReturnOptions struct {
 
 var StrictVoidReturnRule = rule.CreateRule(rule.Rule{
 	Name:             "strict-void-return",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(StrictVoidReturnOptions)
-		if !ok {
-			opts = StrictVoidReturnOptions{}
-			if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := StrictVoidReturnOptions{}
+		if len(options) > 0 {
+			if typed, ok := options[0].(StrictVoidReturnOptions); ok {
+				opts = typed
+			} else if optsMap, ok := options[0].(map[string]interface{}); ok {
 				if optsJSON, err := json.Marshal(optsMap); err == nil {
 					_ = json.Unmarshal(optsJSON, &opts)
 				}

--- a/internal/plugins/typescript/rules/strict_void_return/strict_void_return.go
+++ b/internal/plugins/typescript/rules/strict_void_return/strict_void_return.go
@@ -46,9 +46,7 @@ var StrictVoidReturnRule = rule.CreateRule(rule.Rule{
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := StrictVoidReturnOptions{}
 		if len(options) > 0 {
-			if typed, ok := options[0].(StrictVoidReturnOptions); ok {
-				opts = typed
-			} else if optsMap, ok := options[0].(map[string]interface{}); ok {
+			if optsMap, ok := options[0].(map[string]interface{}); ok {
 				if optsJSON, err := json.Marshal(optsMap); err == nil {
 					_ = json.Unmarshal(optsJSON, &opts)
 				}

--- a/internal/plugins/typescript/rules/strict_void_return/strict_void_return.schema.json
+++ b/internal/plugins/typescript/rules/strict_void_return/strict_void_return.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowReturnAny": {
+          "type": "boolean",
+          "description": "Whether to allow functions returning `any` to be used in place expecting a `void` function."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/switch_exhaustiveness_check/switch_exhaustiveness_check.go
+++ b/internal/plugins/typescript/rules/switch_exhaustiveness_check/switch_exhaustiveness_check.go
@@ -1,9 +1,14 @@
 package switch_exhaustiveness_check
 
 import (
+	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed switch_exhaustiveness_check.schema.json
+var schemaJSON []byte
 
 type SwitchExhaustivenessCheckOptions struct {
 	AllowDefaultCaseForExhaustiveSwitch bool   `json:"allowDefaultCaseForExhaustiveSwitch"`
@@ -16,12 +21,12 @@ type SwitchExhaustivenessCheckOptions struct {
 // Require exhaustive switch statements
 var SwitchExhaustivenessCheckRule = rule.CreateRule(rule.Rule{
 	Name:             "switch-exhaustiveness-check",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
 	Run:              run,
 })
 
-func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-	options := rule.LegacyUnwrapOptions(_options)
+func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 	opts := SwitchExhaustivenessCheckOptions{
 		AllowDefaultCaseForExhaustiveSwitch: false,
 		RequireDefaultForNonUnion:           false,
@@ -30,31 +35,19 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 	}
 
 	// Parse options
-	if options != nil {
-		var optsMap map[string]interface{}
-		var ok bool
-
-		// Handle array format: [{ option: value }]
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			optsMap, ok = optArray[0].(map[string]interface{})
-		} else {
-			// Handle direct object format: { option: value }
-			optsMap, ok = options.(map[string]interface{})
+	if len(options) > 0 {
+		optsMap, _ := options[0].(map[string]interface{})
+		if allowDefault, ok := optsMap["allowDefaultCaseForExhaustiveSwitch"].(bool); ok {
+			opts.AllowDefaultCaseForExhaustiveSwitch = allowDefault
 		}
-
-		if ok {
-			if allowDefault, ok := optsMap["allowDefaultCaseForExhaustiveSwitch"].(bool); ok {
-				opts.AllowDefaultCaseForExhaustiveSwitch = allowDefault
-			}
-			if requireDefault, ok := optsMap["requireDefaultForNonUnion"].(bool); ok {
-				opts.RequireDefaultForNonUnion = requireDefault
-			}
-			if considerDefault, ok := optsMap["considerDefaultExhaustiveForUnions"].(bool); ok {
-				opts.ConsiderDefaultExhaustiveForUnions = considerDefault
-			}
-			if pattern, ok := optsMap["defaultCaseCommentPattern"].(string); ok {
-				opts.DefaultCaseCommentPattern = pattern
-			}
+		if requireDefault, ok := optsMap["requireDefaultForNonUnion"].(bool); ok {
+			opts.RequireDefaultForNonUnion = requireDefault
+		}
+		if considerDefault, ok := optsMap["considerDefaultExhaustiveForUnions"].(bool); ok {
+			opts.ConsiderDefaultExhaustiveForUnions = considerDefault
+		}
+		if pattern, ok := optsMap["defaultCaseCommentPattern"].(string); ok {
+			opts.DefaultCaseCommentPattern = pattern
 		}
 	}
 

--- a/internal/plugins/typescript/rules/switch_exhaustiveness_check/switch_exhaustiveness_check.schema.json
+++ b/internal/plugins/typescript/rules/switch_exhaustiveness_check/switch_exhaustiveness_check.schema.json
@@ -1,0 +1,29 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowDefaultCaseForExhaustiveSwitch": {
+          "type": "boolean",
+          "description": "If 'true', allow 'default' cases on switch statements with exhaustive cases."
+        },
+        "considerDefaultExhaustiveForUnions": {
+          "type": "boolean",
+          "description": "If 'true', the 'default' clause is used to determine whether the switch statement is exhaustive for union type"
+        },
+        "defaultCaseCommentPattern": {
+          "type": "string",
+          "description": "Regular expression for a comment that can indicate an intentionally omitted default case."
+        },
+        "requireDefaultForNonUnion": {
+          "type": "boolean",
+          "description": "If 'true', require a 'default' clause for switches on non-union types."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.go
+++ b/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.go
@@ -1,6 +1,7 @@
 package triple_slash_reference
 
 import (
+	_ "embed"
 	"regexp"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -9,6 +10,9 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed triple_slash_reference.schema.json
+var schemaJSON []byte
 
 type TripleSlashReferenceOptions struct {
 	Lib   string `json:"lib"`   // "always" | "never"
@@ -46,8 +50,9 @@ var tripleSlashReferenceCommentFactory = ast.NewNodeFactory(ast.NodeFactoryHooks
 // TripleSlashReferenceRule implements the triple-slash-reference rule.
 // Disallow certain triple slash directives in favor of import declarations.
 var TripleSlashReferenceRule = rule.CreateRule(rule.Rule{
-	Name: "triple-slash-reference",
-	Run:  run,
+	Name:   "triple-slash-reference",
+	Schema: rule.NewSchema(schemaJSON),
+	Run:    run,
 })
 
 func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
@@ -145,16 +150,19 @@ func parseOptions(options []any) TripleSlashReferenceOptions {
 		Types: "prefer-import",
 	}
 
-	if optionsMap := utils.GetOptionsMap(options); optionsMap != nil {
-		if lib, ok := optionsMap["lib"].(string); ok {
-			opts.Lib = lib
-		}
-		if path, ok := optionsMap["path"].(string); ok {
-			opts.Path = path
-		}
-		if types, ok := optionsMap["types"].(string); ok {
-			opts.Types = types
-		}
+	if len(options) == 0 {
+		return opts
+	}
+	optionsMap, _ := options[0].(map[string]interface{})
+
+	if lib, ok := optionsMap["lib"].(string); ok {
+		opts.Lib = lib
+	}
+	if path, ok := optionsMap["path"].(string); ok {
+		opts.Path = path
+	}
+	if types, ok := optionsMap["types"].(string); ok {
+		opts.Types = types
 	}
 
 	return opts

--- a/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.schema.json
+++ b/internal/plugins/typescript/rules/triple_slash_reference/triple_slash_reference.schema.json
@@ -1,0 +1,28 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lib": {
+          "type": "string",
+          "description": "What to enforce for `/// <reference lib=\"...\" />` references.",
+          "enum": ["always", "never"]
+        },
+        "path": {
+          "type": "string",
+          "description": "What to enforce for `/// <reference path=\"...\" />` references.",
+          "enum": ["always", "never"]
+        },
+        "types": {
+          "type": "string",
+          "description": "What to enforce for `/// <reference types=\"...\" />` references.",
+          "enum": ["always", "never", "prefer-import"]
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/unbound_method/unbound_method.go
+++ b/internal/plugins/typescript/rules/unbound_method/unbound_method.go
@@ -201,13 +201,9 @@ var UnboundMethodRule = rule.CreateRule(rule.Rule{
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := UnboundMethodOptions{}
 		if len(options) > 0 {
-			if typed, ok := options[0].(UnboundMethodOptions); ok {
-				opts = typed
-			} else {
-				optsMap, _ := options[0].(map[string]interface{})
-				if ignoreStatic, ok := optsMap["ignoreStatic"].(bool); ok {
-					opts.IgnoreStatic = utils.Ref(ignoreStatic)
-				}
+			optsMap, _ := options[0].(map[string]interface{})
+			if ignoreStatic, ok := optsMap["ignoreStatic"].(bool); ok {
+				opts.IgnoreStatic = utils.Ref(ignoreStatic)
 			}
 		}
 		if opts.IgnoreStatic == nil {

--- a/internal/plugins/typescript/rules/unbound_method/unbound_method.go
+++ b/internal/plugins/typescript/rules/unbound_method/unbound_method.go
@@ -1,11 +1,16 @@
 package unbound_method
 
 import (
+	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+//go:embed unbound_method.schema.json
+var schemaJSON []byte
 
 //go:generate node ./generate-natively-bound-members.mjs
 
@@ -191,23 +196,17 @@ func checkIfMethod(symbol *ast.Symbol, ignoreStatic bool) ( /* dangerous */ bool
 
 var UnboundMethodRule = rule.CreateRule(rule.Rule{
 	Name:             "unbound-method",
+	Schema:           rule.NewSchema(schemaJSON),
 	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts, ok := options.(UnboundMethodOptions)
-		if !ok {
-			opts = UnboundMethodOptions{}
-			if options != nil {
-				var optsMap map[string]interface{}
-				if optsArray, ok := options.([]interface{}); ok && len(optsArray) > 0 {
-					optsMap, _ = optsArray[0].(map[string]interface{})
-				} else {
-					optsMap, _ = options.(map[string]interface{})
-				}
-				if optsMap != nil {
-					if ignoreStatic, ok := optsMap["ignoreStatic"].(bool); ok {
-						opts.IgnoreStatic = utils.Ref(ignoreStatic)
-					}
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := UnboundMethodOptions{}
+		if len(options) > 0 {
+			if typed, ok := options[0].(UnboundMethodOptions); ok {
+				opts = typed
+			} else {
+				optsMap, _ := options[0].(map[string]interface{})
+				if ignoreStatic, ok := optsMap["ignoreStatic"].(bool); ok {
+					opts.IgnoreStatic = utils.Ref(ignoreStatic)
 				}
 			}
 		}

--- a/internal/plugins/typescript/rules/unbound_method/unbound_method.schema.json
+++ b/internal/plugins/typescript/rules/unbound_method/unbound_method.schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ignoreStatic": {
+          "type": "boolean",
+          "description": "Whether to skip checking whether `static` methods are correctly bound."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/unbound_method/unbound_method_test.go
+++ b/internal/plugins/typescript/rules/unbound_method/unbound_method_test.go
@@ -589,7 +589,7 @@ new ContainsMethods().unbound;
 
 ContainsMethods.unboundStatic;
       `,
-				Options: UnboundMethodOptions{IgnoreStatic: utils.Ref(true)},
+				Options: map[string]interface{}{"ignoreStatic": true},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{
 						MessageId: "unboundWithoutThisAnnotation",

--- a/internal/plugins/typescript/rules/unified_signatures/unified_signatures.go
+++ b/internal/plugins/typescript/rules/unified_signatures/unified_signatures.go
@@ -2,6 +2,7 @@ package unified_signatures
 
 import (
 	_ "embed"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )

--- a/internal/plugins/typescript/rules/unified_signatures/unified_signatures.go
+++ b/internal/plugins/typescript/rules/unified_signatures/unified_signatures.go
@@ -1,9 +1,13 @@
 package unified_signatures
 
 import (
+	_ "embed"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+//go:embed unified_signatures.schema.json
+var schemaJSON []byte
 
 type UnifiedSignaturesOptions struct {
 	IgnoreDifferentlyNamedParameters  bool `json:"ignoreDifferentlyNamedParameters"`
@@ -11,32 +15,21 @@ type UnifiedSignaturesOptions struct {
 }
 
 var UnifiedSignaturesRule = rule.CreateRule(rule.Rule{
-	Name: "unified-signatures",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
+	Name:   "unified-signatures",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := UnifiedSignaturesOptions{
 			IgnoreDifferentlyNamedParameters:  false,
 			IgnoreOverloadsWithDifferentJSDoc: false,
 		}
 
-		// Parse options with dual-format support
-		if options != nil {
-			var optsMap map[string]interface{}
-			var ok bool
-
-			if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-				optsMap, ok = optArray[0].(map[string]interface{})
-			} else {
-				optsMap, ok = options.(map[string]interface{})
+		if len(options) > 0 {
+			optsMap, _ := options[0].(map[string]interface{})
+			if val, ok := optsMap["ignoreDifferentlyNamedParameters"].(bool); ok {
+				opts.IgnoreDifferentlyNamedParameters = val
 			}
-
-			if ok {
-				if val, ok := optsMap["ignoreDifferentlyNamedParameters"].(bool); ok {
-					opts.IgnoreDifferentlyNamedParameters = val
-				}
-				if val, ok := optsMap["ignoreOverloadsWithDifferentJSDoc"].(bool); ok {
-					opts.IgnoreOverloadsWithDifferentJSDoc = val
-				}
+			if val, ok := optsMap["ignoreOverloadsWithDifferentJSDoc"].(bool); ok {
+				opts.IgnoreOverloadsWithDifferentJSDoc = val
 			}
 		}
 

--- a/internal/plugins/typescript/rules/unified_signatures/unified_signatures.schema.json
+++ b/internal/plugins/typescript/rules/unified_signatures/unified_signatures.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ignoreDifferentlyNamedParameters": {
+          "type": "boolean",
+          "description": "Whether two parameters with different names at the same index should be considered different even if their types are the same."
+        },
+        "ignoreOverloadsWithDifferentJSDoc": {
+          "type": "boolean",
+          "description": "Whether two overloads with different JSDoc comments should be considered different even if their parameter and return types are the same."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/typescript/rules/use_unknown_in_catch_callback_variable/use_unknown_in_catch_callback_variable.go
+++ b/internal/plugins/typescript/rules/use_unknown_in_catch_callback_variable/use_unknown_in_catch_callback_variable.go
@@ -58,6 +58,7 @@ func buildWrongTypeAnnotationSuggestionMessage() rule.RuleMessage {
 
 var UseUnknownInCatchCallbackVariableRule = rule.CreateRule(rule.Rule{
 	Name:             "use-unknown-in-catch-callback-variable",
+	Schema:           rule.EmptyArraySchema,
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		var collectFlaggedNodes func(node *ast.Node) []*ast.Node


### PR DESCRIPTION
## Summary

Step 4 of #1216 for the `typescript-eslint` package: all 130 `@typescript-eslint/` rules declare their options JSON Schema, so configs are validated the way ESLint validates them. 55 rules that take no options share `rule.EmptyArraySchema`; 75 embed a `<rule>.schema.json` taken from upstream's `meta.schema`, wrapped the way ESLint's `getRuleOptionsSchema` wraps the tuple form. `rule.LegacyUnwrapOptions`, `utils.GetOptionsMap` and `utils.GetOptionsString` are gone from this package, so the removed bare-object config form is no longer accepted.

That part is mechanical. The rest is not:

**Eight rules could not read their options from a real config.** `no-base-to-string`, `no-duplicate-type-constituents`, `no-meaningless-void-operator`, `no-misused-spread`, `prefer-promise-reject-errors`, `promise-function-async`, `require-array-sort-compare` and `restrict-plus-operands` only accepted a Go options struct via a type assertion. A config's `[{ "ignoreStringArrays": false }]` failed that assertion and fell through to defaults, silently; their Go tests passed the struct, so nothing caught it. They parse decoded JSON now, and several structs gained the `json` tags they were missing.

**Regex-valued options are validated as regexes.** Nine options across seven rules are compiled as regular expressions by the rule, but upstream declares them as bare strings, so an unparsable pattern was dropped and the rule linted as if nothing were configured. They are marked `format: "regex"` (37 schema nodes), as ESLint core's own `dot-notation` schema already does:

| rule | options |
| --- | --- |
| `ban-ts-comment` | `descriptionFormat` |
| `dot-notation` | `allowPattern` |
| `naming-convention` | `filter`, in both its string and object form (the object form is shared with `custom`) |
| `no-empty-object-type` | `allowWithName` |
| `no-require-imports` | `allow` |
| `no-unused-vars` | `vars` / `args` / `caughtErrors` / `destructuredArray` ignore patterns |
| `no-var-requires` | `allow` |

Patterns are checked with the ECMAScript engine, so JS-only syntax such as lookbehind still validates. This diverges from upstream, so each rule has a test pinning it. `ban-ts-comment`, `naming-convention`, `no-empty-object-type`, `no-require-imports`, `no-unused-vars` and `no-var-requires` also compile and match the pattern at runtime with the same ECMAScript engine (regexp2), matching `dot-notation`'s existing approach — otherwise a pattern that passes schema validation could still fail to compile with Go's RE2 and silently do nothing.

**`no-unused-vars` ignored the bare `vars` string.** Upstream's schema allows `"all"` / `"local"` at slot 0 and the rule implements `vars == "local"`, but parsing only handled the object form, so `["local"]` did nothing. It is honored now.

**Two stale rslint-only options are removed.** `no-floating-promises`' `allowForKnownSafeCallsInline` / `allowForKnownSafePromisesInline` and `no-misused-spread`'s `allowInline` predate #502, which taught `utils.TypeOrValueSpecifier` to accept a bare string; post-#502 rules pass `nil` for that argument and put bare strings in `allow`. Upstream declares no such options and its schemas are `additionalProperties: false`, so they were unreachable from a config. The test cases using them moved to the upstream option names and still pass.

**`$defs` resolves under the draft-4 dialect.** Eight rules' schemas reach into upstream's `$defs` via pointers like `#/items/0/$defs/banConfig`. `$defs` is a 2019-09 keyword, so draft-4 treats it as unknown, but the pointer resolves against the raw document regardless and the constraints still apply. Had that been wrong, validation would have silently loosened for all eight; `TestNoRestrictedTypesTypesSchema` pins it.

**Dead branches from the removed bare-object config form are gone.** `consistent-indexed-object-style` and `consistent-generic-constructors` also read a `{ "style": ... }` object, but upstream's schema is a bare string enum at slot 0. Same for `return-await`'s options wrapper type and `class-literal-property-style`'s duplicate string arm.

**Test cases that pinned unreachable configs are deleted**, because config validation now rejects the shapes they described: a bare integer for `max-params`, a non-object for `class-methods-use-this`, `null` / `false` / numeric ban configs for `no-restricted-types`, out-of-enum values for `no-type-alias`, unknown keys for rules that take no options, and a two-element options array under a `maxItems: 1` schema.

**Deliberately unchanged.** Options the schema declares because upstream declares them, but this port does not implement: `no-unsafe-member-access.allowOptionalChaining`, `naming-convention.failureMessage`, `no-unused-expressions.ignoreDirectives`, `no-base-to-string.checkUnknown`, `prefer-promise-reject-errors.allow`, and `prefer-readonly-parameter-types.allow`. A config using them validates and is ignored, as before.

**Follow-up for step 5.** Four rules here delegate to shared implementations that also serve the un-migrated ESLint core rules, and those still call the legacy helpers: `internal/rules/no_shadow`, `internal/rules/no_redeclare`, `internal/rules/no_restricted_imports`, `internal/utils/no_unused_expressions.go`. Behavior is unchanged today, but deleting the helpers needs the `eslint` package migrated in the same step.

## Related Links

- Tracking issue: #1216
- Test-case options validation this builds on: #1464
- Bare-string `TypeOrValueSpecifier` support that made the `*Inline` options redundant: #502

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).


