### PR TITLE
feat: Add basePath support and improve linting for config entries

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -234,6 +234,11 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 		configDirectory = currentDirectory
 	}
 	configDirectory = tspath.NormalizePath(configDirectory)
+	// Low-level API configs may still carry basePath (e.g. raw JSON). Desugar
+	// against the request match root before matching/project resolution.
+	if len(rslintConfig) > 0 {
+		rslintConfig = rslintconfig.ResolveBasePaths(rslintConfig, configDirectory)
+	}
 	if len(fileContents) > 0 {
 		addEquivalentFileContentPaths(fileContents, configDirectory, currentDirectory, fs)
 		fs = utils.NewOverlayVFS(fs, fileContents)
@@ -264,6 +269,9 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 			if err := rslintconfig.ValidateConfig(overrideConfig); err != nil {
 				return nil, fmt.Errorf("invalid configDiscovery.overrideConfig: %w", err)
 			}
+			// overrideConfig is rooted at the invocation cwd (same as
+			// ESLint overrideConfig / --config match root).
+			overrideConfig = rslintconfig.ResolveBasePaths(overrideConfig, currentDirectory)
 		}
 		discoveryRequest := discovery.ConfigDiscoveryRequest{
 			CWD:                       currentDirectory,

--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -237,7 +237,11 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 	// Low-level API configs may still carry basePath (e.g. raw JSON). Desugar
 	// against the request match root before matching/project resolution.
 	if len(rslintConfig) > 0 {
-		rslintConfig = rslintconfig.ResolveBasePaths(rslintConfig, configDirectory)
+		var err error
+		rslintConfig, err = rslintconfig.ResolveBasePaths(rslintConfig, configDirectory, fs)
+		if err != nil {
+			return nil, fmt.Errorf("invalid config: %w", err)
+		}
 	}
 	if len(fileContents) > 0 {
 		addEquivalentFileContentPaths(fileContents, configDirectory, currentDirectory, fs)
@@ -271,7 +275,11 @@ func (h *IPCHandler) handleLint(ctx context.Context, req api.LintRequest, dispat
 			}
 			// overrideConfig is rooted at the invocation cwd (same as
 			// ESLint overrideConfig / --config match root).
-			overrideConfig = rslintconfig.ResolveBasePaths(overrideConfig, currentDirectory)
+			var err error
+			overrideConfig, err = rslintconfig.ResolveBasePaths(overrideConfig, currentDirectory, fs)
+			if err != nil {
+				return nil, fmt.Errorf("invalid configDiscovery.overrideConfig: %w", err)
+			}
 		}
 		discoveryRequest := discovery.ConfigDiscoveryRequest{
 			CWD:                       currentDirectory,

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -744,7 +744,11 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 		}
 		// Desugar basePath against the final match root (cwd for --config,
 		// config-file directory for auto-discovered JSON).
-		rslintConfig = rslintconfig.ResolveBasePaths(rslintConfig, currentDirectory)
+		rslintConfig, err = rslintconfig.ResolveBasePaths(rslintConfig, currentDirectory, fs)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
 
 		var exactTargetFiles []string
 		if len(allowFiles) > 0 && len(allowDirs) == 0 {

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -742,6 +742,9 @@ func executeLintPipeline(args lintArgs, ctx context.Context, dispatch linter.Esl
 			// the cwd where rslint was invoked, not the config file's directory.
 			currentDirectory = workingDirectory
 		}
+		// Desugar basePath against the final match root (cwd for --config,
+		// config-file directory for auto-discovered JSON).
+		rslintConfig = rslintconfig.ResolveBasePaths(rslintConfig, currentDirectory)
 
 		var exactTargetFiles []string
 		if len(allowFiles) > 0 && len(allowDirs) == 0 {

--- a/internal/config/base_path.go
+++ b/internal/config/base_path.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 )
 
 // ResolveBasePaths desugars per-entry BasePath into ordinary relative
@@ -13,27 +15,41 @@ import (
 // configDirectory is the match root the rest of the engine already uses:
 // config-file directory for auto-discovered configs, cwd for --config.
 // Relative BasePath values resolve against it. Absolute BasePath values are
-// rebased via ConvertToRelativePath.
+// rebased via ConvertToRelativePath. fsys supplies filesystem case sensitivity
+// (as the rest of config matching does) so an absolute basePath whose casing
+// differs from the match root still resolves on case-insensitive filesystems.
+//
+// A BasePath that resolves outside configDirectory is rejected: its desugared
+// patterns would be ../-prefixed and could never match under the engine's
+// single-match-root model, indistinguishable from a typo. ESLint reports such
+// files as "ignored because outside of base path"; rslint fails fast instead
+// so the misconfiguration is actionable.
 //
 // JS/TS configs normally desugar basePath in Node before the payload reaches
 // Go; this path covers JSON/JSONC configs and any raw ConfigEntry constructed
 // with BasePath still set.
-func ResolveBasePaths(config RslintConfig, configDirectory string) RslintConfig {
+func ResolveBasePaths(config RslintConfig, configDirectory string, fsys vfs.FS) (RslintConfig, error) {
 	if len(config) == 0 {
-		return config
+		return config, nil
 	}
+	useCaseSensitive := fsys == nil || fsys.UseCaseSensitiveFileNames()
 	for i := range config {
-		resolveBasePathForEntry(&config[i], configDirectory)
+		if err := resolveBasePathForEntry(&config[i], configDirectory, useCaseSensitive); err != nil {
+			return nil, fmt.Errorf("config entry at index %d: %w", i, err)
+		}
 	}
-	return config
+	return config, nil
 }
 
-func resolveBasePathForEntry(entry *ConfigEntry, configDirectory string) {
+func resolveBasePathForEntry(entry *ConfigEntry, configDirectory string, useCaseSensitive bool) error {
 	if entry.BasePath == "" {
-		return
+		return nil
 	}
 
-	relativeBase := resolveRelativeBasePath(entry.BasePath, configDirectory)
+	relativeBase, err := resolveRelativeBasePath(entry.BasePath, configDirectory, useCaseSensitive)
+	if err != nil {
+		return err
+	}
 	entry.BasePath = ""
 
 	if len(entry.Files) > 0 {
@@ -81,6 +97,7 @@ func resolveBasePathForEntry(entry *ConfigEntry, configDirectory string) {
 		}
 		entry.Files = []string{catchAll}
 	}
+	return nil
 }
 
 func entryScopesToSubtree(entry ConfigEntry) bool {
@@ -90,26 +107,64 @@ func entryScopesToSubtree(entry ConfigEntry) bool {
 		entry.LanguageOptions != nil
 }
 
-// resolveRelativeBasePath returns a POSIX-ish path relative to configDirectory.
-// Empty means the config root itself (no prefix).
-func resolveRelativeBasePath(basePath string, configDirectory string) string {
+// resolveRelativeBasePath returns a glob-escaped POSIX-ish path relative to
+// configDirectory. Empty means the config root itself (no prefix). It rejects
+// a basePath that resolves outside configDirectory, since the resulting
+// ../-prefixed patterns could never match under the engine's single-match-root
+// model.
+func resolveRelativeBasePath(basePath string, configDirectory string, useCaseSensitive bool) (string, error) {
 	if basePath == "" {
-		return ""
+		return "", nil
+	}
+	// tspath.ResolvePath normalizes to forward slashes, but callers (and test
+	// fixtures) may hand in a configDirectory with native separators. Normalize
+	// once so the containment check and relative rebase compare like for like.
+	if configDirectory != "" {
+		configDirectory = tspath.NormalizePath(configDirectory)
 	}
 	absolute := tspath.ResolvePath(configDirectory, basePath)
+	if _, ok := RelativePathWithinConfigRoot(absolute, configDirectory, useCaseSensitive); !ok {
+		return "", fmt.Errorf(
+			"key \"basePath\": value %q resolves outside the config match root %q; basePath must be a subdirectory of the config root",
+			basePath,
+			configDirectory,
+		)
+	}
 	relative := tspath.ConvertToRelativePath(absolute, tspath.ComparePathsOptions{
-		UseCaseSensitiveFileNames: true,
+		UseCaseSensitiveFileNames: useCaseSensitive,
 		CurrentDirectory:          configDirectory,
 	})
 	relative = strings.ReplaceAll(tspath.NormalizePath(relative), "\\", "/")
 	relative = strings.TrimPrefix(relative, "./")
 	if relative == "." || relative == "" {
-		return ""
+		return "", nil
 	}
-	return relative
+	return escapeGlobBasePath(relative), nil
 }
 
-// rebasePattern prefixes a relative glob/path with relativeBase.
+// escapeGlobBasePath escapes glob metacharacters in a resolved basePath so the
+// directory is treated literally when spliced into glob patterns. ESLint treats
+// basePath as a literal path; without escaping, a basePath such as
+// "packages/[locale]" would be interpreted as a character class and never match.
+//
+// Escaping uses character classes ([*], [?], [[] ...), which the doublestar and
+// picomatch matchers understand on every platform and which survive the
+// tspath.NormalizePath applied to patterns before matching. A bare ']' or '}'
+// outside a class/brace pair is already literal to the matchers, so only the
+// characters that open a class/brace or introduce a wildcard need escaping. A
+// leading '!' (basePath "!vendor") has no class form the matchers accept as
+// literal, so it remains a known limitation.
+func escapeGlobBasePath(s string) string {
+	return strings.NewReplacer(
+		"[", "[[]",
+		"*", "[*]",
+		"?", "[?]",
+		"{", "[{]",
+	).Replace(s)
+}
+
+// rebasePattern prefixes a relative glob/path with the glob-escaped
+// relativeBase produced by resolveRelativeBasePath.
 // Leading ! negation is preserved; absolute patterns are left unchanged;
 // empty relativeBase only strips a leading ./.
 func rebasePattern(pattern string, relativeBase string) string {

--- a/internal/config/base_path.go
+++ b/internal/config/base_path.go
@@ -142,21 +142,8 @@ func rebasePattern(pattern string, relativeBase string) string {
 	return joined
 }
 
+// isAbsolutePattern reports whether pattern is an absolute path in any form
+// tspath recognizes (POSIX, UNC, Windows drive-letter).
 func isAbsolutePattern(pattern string) bool {
-	if pattern == "" {
-		return false
-	}
-	// POSIX absolute, Windows drive, or UNC.
-	if strings.HasPrefix(pattern, "/") || strings.HasPrefix(pattern, "\\") {
-		return true
-	}
-	if len(pattern) >= 3 {
-		drive := pattern[0]
-		if (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z') {
-			if pattern[1] == ':' && (pattern[2] == '/' || pattern[2] == '\\') {
-				return true
-			}
-		}
-	}
 	return tspath.GetEncodedRootLength(pattern) > 0
 }

--- a/internal/config/base_path.go
+++ b/internal/config/base_path.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"path"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/tspath"
+)
+
+// ResolveBasePaths desugars per-entry BasePath into ordinary relative
+// files / ignores / parserOptions.project patterns, then clears BasePath.
+//
+// configDirectory is the match root the rest of the engine already uses:
+// config-file directory for auto-discovered configs, cwd for --config.
+// Relative BasePath values resolve against it. Absolute BasePath values are
+// rebased via ConvertToRelativePath.
+//
+// JS/TS configs normally desugar basePath in Node before the payload reaches
+// Go; this path covers JSON/JSONC configs and any raw ConfigEntry constructed
+// with BasePath still set.
+func ResolveBasePaths(config RslintConfig, configDirectory string) RslintConfig {
+	if len(config) == 0 {
+		return config
+	}
+	for i := range config {
+		resolveBasePathForEntry(&config[i], configDirectory)
+	}
+	return config
+}
+
+func resolveBasePathForEntry(entry *ConfigEntry, configDirectory string) {
+	if entry.BasePath == "" {
+		return
+	}
+
+	relativeBase := resolveRelativeBasePath(entry.BasePath, configDirectory)
+	entry.BasePath = ""
+
+	if len(entry.Files) > 0 {
+		rebases := make([]string, len(entry.Files))
+		for i, pattern := range entry.Files {
+			rebases[i] = rebasePattern(pattern, relativeBase)
+		}
+		entry.Files = rebases
+	}
+	if len(entry.FilePatternGroups) > 0 {
+		groups := make([][]string, len(entry.FilePatternGroups))
+		for i, group := range entry.FilePatternGroups {
+			rebases := make([]string, len(group))
+			for j, pattern := range group {
+				rebases[j] = rebasePattern(pattern, relativeBase)
+			}
+			groups[i] = rebases
+		}
+		entry.FilePatternGroups = groups
+	}
+	if len(entry.Ignores) > 0 {
+		rebases := make([]string, len(entry.Ignores))
+		for i, pattern := range entry.Ignores {
+			rebases[i] = rebasePattern(pattern, relativeBase)
+		}
+		entry.Ignores = rebases
+	}
+	if entry.LanguageOptions != nil && entry.LanguageOptions.ParserOptions != nil {
+		projects := entry.LanguageOptions.ParserOptions.Project
+		if len(projects) > 0 {
+			rebases := make([]string, len(projects))
+			for i, project := range projects {
+				rebases[i] = rebasePattern(project, relativeBase)
+			}
+			entry.LanguageOptions.ParserOptions.Project = rebases
+		}
+	}
+
+	// Scoped entry with basePath but no files → limit to the base subtree,
+	// matching ESLint's "bare basePath applies under that directory" intent.
+	if !hasFileSelectors(*entry) && entryScopesToSubtree(*entry) {
+		catchAll := "**"
+		if relativeBase != "" {
+			catchAll = path.Join(relativeBase, "**")
+		}
+		entry.Files = []string{catchAll}
+	}
+}
+
+func entryScopesToSubtree(entry ConfigEntry) bool {
+	return entry.Rules != nil ||
+		entry.Plugins != nil ||
+		entry.Settings != nil ||
+		entry.LanguageOptions != nil
+}
+
+// resolveRelativeBasePath returns a POSIX-ish path relative to configDirectory.
+// Empty means the config root itself (no prefix).
+func resolveRelativeBasePath(basePath string, configDirectory string) string {
+	if basePath == "" {
+		return ""
+	}
+	absolute := tspath.ResolvePath(configDirectory, basePath)
+	relative := tspath.ConvertToRelativePath(absolute, tspath.ComparePathsOptions{
+		UseCaseSensitiveFileNames: true,
+		CurrentDirectory:          configDirectory,
+	})
+	relative = strings.ReplaceAll(tspath.NormalizePath(relative), "\\", "/")
+	relative = strings.TrimPrefix(relative, "./")
+	if relative == "." || relative == "" {
+		return ""
+	}
+	return relative
+}
+
+// rebasePattern prefixes a relative glob/path with relativeBase.
+// Leading ! negation is preserved; absolute patterns are left unchanged;
+// empty relativeBase only strips a leading ./.
+func rebasePattern(pattern string, relativeBase string) string {
+	negated := false
+	body := pattern
+	for strings.HasPrefix(body, "!") {
+		negated = !negated
+		body = strings.TrimPrefix(body, "!")
+	}
+	body = strings.ReplaceAll(body, "\\", "/")
+	for strings.HasPrefix(body, "./") {
+		body = strings.TrimPrefix(body, "./")
+	}
+	if body == "" || isAbsolutePattern(body) {
+		if negated {
+			return "!" + body
+		}
+		return body
+	}
+	if relativeBase == "" {
+		if negated {
+			return "!" + body
+		}
+		return body
+	}
+	joined := path.Join(relativeBase, body)
+	if negated {
+		return "!" + joined
+	}
+	return joined
+}
+
+func isAbsolutePattern(pattern string) bool {
+	if pattern == "" {
+		return false
+	}
+	// POSIX absolute, Windows drive, or UNC.
+	if strings.HasPrefix(pattern, "/") || strings.HasPrefix(pattern, "\\") {
+		return true
+	}
+	if len(pattern) >= 3 {
+		drive := pattern[0]
+		if (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z') {
+			if pattern[1] == ':' && (pattern[2] == '/' || pattern[2] == '\\') {
+				return true
+			}
+		}
+	}
+	return tspath.GetEncodedRootLength(pattern) > 0
+}

--- a/internal/config/base_path_test.go
+++ b/internal/config/base_path_test.go
@@ -1,0 +1,201 @@
+package config
+
+import (
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestResolveRelativeBasePath(t *testing.T) {
+	root := filepath.FromSlash("/repo")
+	if runtime.GOOS == "windows" {
+		root = `C:\repo`
+	}
+
+	got := resolveRelativeBasePath("packages/foo", root)
+	if got != "packages/foo" {
+		t.Fatalf("relative basePath: got %q, want packages/foo", got)
+	}
+
+	got = resolveRelativeBasePath(".", root)
+	if got != "" {
+		t.Fatalf("dot basePath: got %q, want empty", got)
+	}
+
+	got = resolveRelativeBasePath("packages/foo/../bar", root)
+	if got != "packages/bar" {
+		t.Fatalf("normalized basePath: got %q, want packages/bar", got)
+	}
+}
+
+func TestRebasePattern(t *testing.T) {
+	tests := []struct {
+		pattern string
+		base    string
+		want    string
+	}{
+		{"src/**/*.ts", "packages/foo", "packages/foo/src/**/*.ts"},
+		{"!fixtures/**", "packages/foo", "!packages/foo/fixtures/**"},
+		{"./src/**", "packages/foo", "packages/foo/src/**"},
+		{"!!src/**", "packages/foo", "packages/foo/src/**"},
+		{"/abs/**", "packages/foo", "/abs/**"},
+		{"src/**", "", "src/**"},
+		{"**/*.ts", "packages/foo", "packages/foo/**/*.ts"},
+		{"tsconfig.json", "packages/foo", "packages/foo/tsconfig.json"},
+	}
+	for _, tt := range tests {
+		got := rebasePattern(tt.pattern, tt.base)
+		if got != tt.want {
+			t.Errorf("rebasePattern(%q, %q) = %q, want %q", tt.pattern, tt.base, got, tt.want)
+		}
+	}
+}
+
+func TestResolveBasePaths_FilesIgnoresProject(t *testing.T) {
+	config := RslintConfig{
+		{
+			BasePath: "packages/foo",
+			Files:    []string{"src/**/*.ts", "**/*.tsx"},
+			FilePatternGroups: [][]string{
+				{"**/*.js", "!**/*.test.js"},
+			},
+			Ignores: []string{"fixtures/**", "!fixtures/keep.ts"},
+			LanguageOptions: &LanguageOptions{
+				ParserOptions: &ParserOptions{
+					Project: []string{"./tsconfig.json"},
+				},
+			},
+			Rules: Rules{"no-console": "error"},
+		},
+	}
+
+	got := ResolveBasePaths(config, "/repo")
+	entry := got[0]
+	if entry.BasePath != "" {
+		t.Fatalf("BasePath should be cleared, got %q", entry.BasePath)
+	}
+	if !reflect.DeepEqual(entry.Files, []string{"packages/foo/src/**/*.ts", "packages/foo/**/*.tsx"}) {
+		t.Fatalf("Files = %#v", entry.Files)
+	}
+	if !reflect.DeepEqual(entry.FilePatternGroups, [][]string{{"packages/foo/**/*.js", "!packages/foo/**/*.test.js"}}) {
+		t.Fatalf("FilePatternGroups = %#v", entry.FilePatternGroups)
+	}
+	if !reflect.DeepEqual(entry.Ignores, []string{"packages/foo/fixtures/**", "!packages/foo/fixtures/keep.ts"}) {
+		t.Fatalf("Ignores = %#v", entry.Ignores)
+	}
+	if !reflect.DeepEqual([]string(entry.LanguageOptions.ParserOptions.Project), []string{"packages/foo/tsconfig.json"}) {
+		t.Fatalf("Project = %#v", entry.LanguageOptions.ParserOptions.Project)
+	}
+}
+
+func TestResolveBasePaths_GlobalIgnoreWithBasePath(t *testing.T) {
+	config := RslintConfig{
+		{
+			BasePath: "packages/foo",
+			Ignores:   []string{"fixtures/**"},
+		},
+	}
+	got := ResolveBasePaths(config, "/repo")
+	entry := got[0]
+	if entry.BasePath != "" {
+		t.Fatalf("BasePath should be cleared")
+	}
+	if !reflect.DeepEqual(entry.Ignores, []string{"packages/foo/fixtures/**"}) {
+		t.Fatalf("Ignores = %#v", entry.Ignores)
+	}
+	if !isGlobalIgnoreEntry(entry) {
+		t.Fatal("expected global ignore entry after desugar")
+	}
+}
+
+func TestResolveBasePaths_BareBasePathInjectsCatchAll(t *testing.T) {
+	config := RslintConfig{
+		{
+			BasePath: "packages/foo",
+			Rules:    Rules{"no-console": "error"},
+		},
+	}
+	got := ResolveBasePaths(config, "/repo")
+	entry := got[0]
+	if !reflect.DeepEqual(entry.Files, []string{"packages/foo/**"}) {
+		t.Fatalf("Files = %#v, want [packages/foo/**]", entry.Files)
+	}
+	if entry.BasePath != "" {
+		t.Fatalf("BasePath should be cleared")
+	}
+}
+
+func TestResolveBasePaths_NoBasePathUnchanged(t *testing.T) {
+	config := RslintConfig{
+		{
+			Files:  []string{"src/**/*.ts"},
+			Ignores: []string{"dist/**"},
+			Rules:  Rules{"no-console": "error"},
+		},
+	}
+	got := ResolveBasePaths(config, "/repo")
+	if !reflect.DeepEqual(got[0].Files, []string{"src/**/*.ts"}) {
+		t.Fatalf("Files mutated: %#v", got[0].Files)
+	}
+	if !reflect.DeepEqual(got[0].Ignores, []string{"dist/**"}) {
+		t.Fatalf("Ignores mutated: %#v", got[0].Ignores)
+	}
+}
+
+func TestIsGlobalIgnoreEntry_WithBasePathMeta(t *testing.T) {
+	// basePath is meta: basePath + ignores is still a global ignore entry.
+	entry := ConfigEntry{
+		BasePath: "packages/foo",
+		Ignores:   []string{"fixtures/**"},
+	}
+	if !isGlobalIgnoreEntry(entry) {
+		t.Fatal("basePath + ignores should still be a global ignore entry")
+	}
+}
+
+func TestGetConfigForFile_WithDesugaredBasePath(t *testing.T) {
+	config := ResolveBasePaths(RslintConfig{
+		{
+			BasePath: "packages/foo",
+			Files:    []string{"src/**/*.ts"},
+			Rules:    Rules{"no-console": "error"},
+		},
+	}, "/repo")
+
+	// Match using relative paths (cwd empty → raw path matching), same style as
+	// the rest of the config unit tests.
+	matched := config.GetConfigForFile("packages/foo/src/a.ts", "")
+	if matched == nil {
+		t.Fatal("expected match under basePath")
+	}
+	if matched.Rules["no-console"] == nil || matched.Rules["no-console"].Level != "error" {
+		t.Fatalf("rules = %#v", matched.Rules)
+	}
+
+	outside := config.GetConfigForFile("packages/bar/src/a.ts", "")
+	if outside != nil {
+		t.Fatal("expected no match outside basePath")
+	}
+}
+
+func TestUnmarshalJSON_BasePathIsMetaForGlobalIgnore(t *testing.T) {
+	var config RslintConfig
+	raw := []byte(`[{"basePath":"packages/foo","ignores":["fixtures/**"]}]`)
+	if err := config.UnmarshalJSON(raw); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	if len(config) != 1 {
+		t.Fatalf("len = %d", len(config))
+	}
+	if config[0].BasePath != "packages/foo" {
+		t.Fatalf("BasePath = %q", config[0].BasePath)
+	}
+	// Must remain global: no settings marker injected for basePath meta.
+	if config[0].Settings != nil {
+		t.Fatalf("Settings should be nil for basePath+ignores, got %#v", config[0].Settings)
+	}
+	if !isGlobalIgnoreEntry(config[0]) {
+		t.Fatal("expected global ignore before desugar")
+	}
+}

--- a/internal/config/base_path_test.go
+++ b/internal/config/base_path_test.go
@@ -179,6 +179,30 @@ func TestGetConfigForFile_WithDesugaredBasePath(t *testing.T) {
 	}
 }
 
+func TestUnmarshalJSON_RejectsEmptyBasePath(t *testing.T) {
+	var config RslintConfig
+	raw := []byte(`[{"basePath":"","rules":{"no-console":"error"}}]`)
+	err := config.UnmarshalJSON(raw)
+	if err == nil {
+		t.Fatal("expected empty basePath to be rejected")
+	}
+	if got := err.Error(); got != `config entry at index 0: key "basePath": expected value to be a non-empty string` {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
+func TestUnmarshalJSON_RejectsNullBasePath(t *testing.T) {
+	var config RslintConfig
+	raw := []byte(`[{"basePath":null,"rules":{"no-console":"error"}}]`)
+	err := config.UnmarshalJSON(raw)
+	if err == nil {
+		t.Fatal("expected null basePath to be rejected")
+	}
+	if got := err.Error(); got != `config entry at index 0: key "basePath": expected value to be a non-empty string` {
+		t.Fatalf("unexpected error: %q", got)
+	}
+}
+
 func TestUnmarshalJSON_BasePathIsMetaForGlobalIgnore(t *testing.T) {
 	var config RslintConfig
 	raw := []byte(`[{"basePath":"packages/foo","ignores":["fixtures/**"]}]`)

--- a/internal/config/base_path_test.go
+++ b/internal/config/base_path_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -13,19 +14,86 @@ func TestResolveRelativeBasePath(t *testing.T) {
 		root = `C:\repo`
 	}
 
-	got := resolveRelativeBasePath("packages/foo", root)
+	got, err := resolveRelativeBasePath("packages/foo", root, true)
+	if err != nil {
+		t.Fatalf("resolveRelativeBasePath: %v", err)
+	}
 	if got != "packages/foo" {
 		t.Fatalf("relative basePath: got %q, want packages/foo", got)
 	}
 
-	got = resolveRelativeBasePath(".", root)
+	got, err = resolveRelativeBasePath(".", root, true)
+	if err != nil {
+		t.Fatalf("resolveRelativeBasePath: %v", err)
+	}
 	if got != "" {
 		t.Fatalf("dot basePath: got %q, want empty", got)
 	}
 
-	got = resolveRelativeBasePath("packages/foo/../bar", root)
+	got, err = resolveRelativeBasePath("packages/foo/../bar", root, true)
+	if err != nil {
+		t.Fatalf("resolveRelativeBasePath: %v", err)
+	}
 	if got != "packages/bar" {
 		t.Fatalf("normalized basePath: got %q, want packages/bar", got)
+	}
+}
+
+func TestResolveRelativeBasePath_EscapesGlobMeta(t *testing.T) {
+	root := filepath.FromSlash("/repo")
+	if runtime.GOOS == "windows" {
+		root = `C:\repo`
+	}
+
+	got, err := resolveRelativeBasePath("packages/[locale]", root, true)
+	if err != nil {
+		t.Fatalf("resolveRelativeBasePath: %v", err)
+	}
+	// [locale] must be treated as a literal directory, not a character class.
+	// The leading '[' is escaped as a class ([[]); the trailing ']' is already
+	// literal outside a class and needs no escaping.
+	if got != "packages/[[]locale]" {
+		t.Fatalf("escaped basePath: got %q, want packages/[[]locale]", got)
+	}
+
+	got, err = resolveRelativeBasePath("packages/foo", root, true)
+	if err != nil {
+		t.Fatalf("resolveRelativeBasePath: %v", err)
+	}
+	if got != "packages/foo" {
+		t.Fatalf("plain basePath must be unchanged, got %q", got)
+	}
+}
+
+func TestResolveRelativeBasePath_RejectsOutsideRoot(t *testing.T) {
+	root := filepath.FromSlash("/repo")
+	if runtime.GOOS == "windows" {
+		root = `C:\repo`
+	}
+
+	for _, base := range []string{"../shared", "../../outside"} {
+		if _, err := resolveRelativeBasePath(base, root, true); err == nil {
+			t.Fatalf("expected %q to be rejected as outside the match root", base)
+		}
+	}
+}
+
+func TestResolveRelativeBasePath_CaseInsensitiveRebase(t *testing.T) {
+	root := filepath.FromSlash("/repo")
+	caseDiffers := "/Repo/packages/foo"
+	if runtime.GOOS == "windows" {
+		root = `C:\repo`
+		caseDiffers = `C:\Repo\packages\foo`
+	}
+	// An absolute basePath whose casing differs from the match root must still
+	// resolve on a case-insensitive filesystem (useCaseSensitive=false models a
+	// case-insensitive vfs), instead of manufacturing ../ patterns.
+	got, err := resolveRelativeBasePath(caseDiffers, root, false)
+	if err != nil {
+		t.Fatalf("case-insensitive resolveRelativeBasePath: %v", err)
+	}
+	if got == "" || strings.HasPrefix(got, "..") {
+		t.Fatalf("expected a match-root-relative path, got %q", got)
 	}
 }
 
@@ -70,7 +138,10 @@ func TestResolveBasePaths_FilesIgnoresProject(t *testing.T) {
 		},
 	}
 
-	got := ResolveBasePaths(config, "/repo")
+	got, err := ResolveBasePaths(config, "/repo", nil)
+	if err != nil {
+		t.Fatalf("ResolveBasePaths: %v", err)
+	}
 	entry := got[0]
 	if entry.BasePath != "" {
 		t.Fatalf("BasePath should be cleared, got %q", entry.BasePath)
@@ -96,7 +167,10 @@ func TestResolveBasePaths_GlobalIgnoreWithBasePath(t *testing.T) {
 			Ignores:   []string{"fixtures/**"},
 		},
 	}
-	got := ResolveBasePaths(config, "/repo")
+	got, err := ResolveBasePaths(config, "/repo", nil)
+	if err != nil {
+		t.Fatalf("ResolveBasePaths: %v", err)
+	}
 	entry := got[0]
 	if entry.BasePath != "" {
 		t.Fatalf("BasePath should be cleared")
@@ -116,7 +190,10 @@ func TestResolveBasePaths_BareBasePathInjectsCatchAll(t *testing.T) {
 			Rules:    Rules{"no-console": "error"},
 		},
 	}
-	got := ResolveBasePaths(config, "/repo")
+	got, err := ResolveBasePaths(config, "/repo", nil)
+	if err != nil {
+		t.Fatalf("ResolveBasePaths: %v", err)
+	}
 	entry := got[0]
 	if !reflect.DeepEqual(entry.Files, []string{"packages/foo/**"}) {
 		t.Fatalf("Files = %#v, want [packages/foo/**]", entry.Files)
@@ -134,7 +211,10 @@ func TestResolveBasePaths_NoBasePathUnchanged(t *testing.T) {
 			Rules:  Rules{"no-console": "error"},
 		},
 	}
-	got := ResolveBasePaths(config, "/repo")
+	got, err := ResolveBasePaths(config, "/repo", nil)
+	if err != nil {
+		t.Fatalf("ResolveBasePaths: %v", err)
+	}
 	if !reflect.DeepEqual(got[0].Files, []string{"src/**/*.ts"}) {
 		t.Fatalf("Files mutated: %#v", got[0].Files)
 	}
@@ -155,13 +235,16 @@ func TestIsGlobalIgnoreEntry_WithBasePathMeta(t *testing.T) {
 }
 
 func TestGetConfigForFile_WithDesugaredBasePath(t *testing.T) {
-	config := ResolveBasePaths(RslintConfig{
+	config, err := ResolveBasePaths(RslintConfig{
 		{
 			BasePath: "packages/foo",
 			Files:    []string{"src/**/*.ts"},
 			Rules:    Rules{"no-console": "error"},
 		},
-	}, "/repo")
+	}, "/repo", nil)
+	if err != nil {
+		t.Fatalf("ResolveBasePaths: %v", err)
+	}
 
 	// Match using relative paths (cwd empty → raw path matching), same style as
 	// the rest of the config unit tests.
@@ -221,5 +304,43 @@ func TestUnmarshalJSON_BasePathIsMetaForGlobalIgnore(t *testing.T) {
 	}
 	if !isGlobalIgnoreEntry(config[0]) {
 		t.Fatal("expected global ignore before desugar")
+	}
+}
+
+func TestResolveBasePaths_RejectsOutsideRoot(t *testing.T) {
+	config := RslintConfig{
+		{
+			BasePath: "../shared",
+			Files:    []string{"src/**"},
+			Rules:    Rules{"no-console": "error"},
+		},
+	}
+	_, err := ResolveBasePaths(config, "/repo", nil)
+	if err == nil {
+		t.Fatal("expected outside-root basePath to be rejected")
+	}
+	if !strings.Contains(err.Error(), "config entry at index 0") {
+		t.Fatalf("expected entry index in error, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "outside the config match root") {
+		t.Fatalf("expected outside-root message in error, got %q", err)
+	}
+}
+
+func TestResolveBasePaths_GlobEscapesBasePathPrefix(t *testing.T) {
+	config := RslintConfig{
+		{
+			BasePath: "packages/[locale]",
+			Files:    []string{"src/**/*.ts"},
+			Rules:    Rules{"no-console": "error"},
+		},
+	}
+	got, err := ResolveBasePaths(config, "/repo", nil)
+	if err != nil {
+		t.Fatalf("ResolveBasePaths: %v", err)
+	}
+	want := []string{"packages/[[]locale]/src/**/*.ts"}
+	if !reflect.DeepEqual(got[0].Files, want) {
+		t.Fatalf("Files = %#v, want %#v", got[0].Files, want)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,6 +184,15 @@ func (config *RslintConfig) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(entryForDecode, &decoded); err != nil {
 			return err
 		}
+		// A present-but-empty (or null) "basePath" decodes to the same Go
+		// zero value as an absent key, so it must be rejected here while raw
+		// still distinguishes "key absent" from "key present". Mirrors
+		// normalizeConfig's rejection of "basePath": "" on the JS/TS config
+		// path, and also covers callers (e.g. the low-level API's Config
+		// field) that hand Go raw JSON without going through normalizeConfig.
+		if _, ok := raw["basePath"]; ok && decoded.BasePath == "" {
+			return fmt.Errorf("config entry at index %d: key \"basePath\": expected value to be a non-empty string", index)
+		}
 		if err := validateConfigRules(decoded.Rules); err != nil {
 			return fmt.Errorf("config entry at index %d: %w", index, err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,10 +32,11 @@ type ConfigEntry struct {
 	// BasePath is the optional ESLint flat-config subdirectory root for this
 	// entry. Relative values resolve from the config match root (config-file
 	// directory for auto-discovered configs, cwd for --config). JS/TS configs
-	// desugar basePath in Node before the payload reaches Go; JSON/JSONC
-	// configs are desugared in LoadRslintConfig via ResolveBasePaths. The field
-	// is cleared after desugaring so matching always sees ordinary relative
-	// files/ignores/project patterns.
+	// desugar basePath in Node before the payload reaches Go; JSON/JSONC configs
+	// keep BasePath intact through the loader and are desugared by callers
+	// (CLI/LSP/API) via ResolveBasePaths with the appropriate match root. The
+	// field is cleared after desugaring so matching always sees ordinary
+	// relative files/ignores/project patterns.
 	BasePath string `json:"basePath,omitempty"`
 	// Files retains the established Go construction API for top-level OR
 	// patterns. FilePatternGroups stores nested arrays, each of which is an AND

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,14 @@ type RslintConfig []ConfigEntry
 // ConfigEntry represents a single configuration entry in the config array
 type ConfigEntry struct {
 	Name string `json:"name,omitempty"`
+	// BasePath is the optional ESLint flat-config subdirectory root for this
+	// entry. Relative values resolve from the config match root (config-file
+	// directory for auto-discovered configs, cwd for --config). JS/TS configs
+	// desugar basePath in Node before the payload reaches Go; JSON/JSONC
+	// configs are desugared in LoadRslintConfig via ResolveBasePaths. The field
+	// is cleared after desugaring so matching always sees ordinary relative
+	// files/ignores/project patterns.
+	BasePath string `json:"basePath,omitempty"`
 	// Files retains the established Go construction API for top-level OR
 	// patterns. FilePatternGroups stores nested arrays, each of which is an AND
 	// group. JSON encoding combines both fields back into one mixed `files`
@@ -186,7 +194,7 @@ func (config *RslintConfig) UnmarshalJSON(data []byte) error {
 		// neutral but remains non-nil for isGlobalIgnoreEntry.
 		hasNonGlobalKey := false
 		for key := range raw {
-			if key != "ignores" && key != "name" {
+			if key != "ignores" && key != "name" && key != "basePath" {
 				hasNonGlobalKey = true
 				break
 			}
@@ -875,9 +883,11 @@ func (config RslintConfig) getConfigForFileWithIgnores(filePath string, cwd stri
 	return merged
 }
 
-// isGlobalIgnoreEntry returns true if the entry has only ignores and an
-// optional name. Empty config objects are still present and make ignores local
-// to the entry, matching ESLint flat config semantics.
+// isGlobalIgnoreEntry returns true if the entry has only ignores and optional
+// meta fields (name, basePath). Empty config objects are still present and make
+// ignores local to the entry, matching ESLint flat config semantics. After
+// ResolveBasePaths desugars basePath, BasePath is cleared and only ignores
+// (+ optional name) remain for global-ignore entries.
 func isGlobalIgnoreEntry(entry ConfigEntry) bool {
 	return entry.Files == nil &&
 		entry.FilePatternGroups == nil &&

--- a/internal/config/config_init.go
+++ b/internal/config/config_init.go
@@ -327,8 +327,10 @@ func extractGlobalIgnores(entries RslintConfig) RslintConfig {
 		return entries
 	}
 
-	// Create a global ignore entry and remove ignores from the original
-	globalIgnore := ConfigEntry{Ignores: entries[targetIdx].Ignores}
+	// Create a global ignore entry and remove ignores from the original.
+	// basePath is meta for global-ignore entries and must carry over so the
+	// extracted ignores stay scoped to the original entry's subtree.
+	globalIgnore := ConfigEntry{BasePath: entries[targetIdx].BasePath, Ignores: entries[targetIdx].Ignores}
 	entries[targetIdx].Ignores = nil
 
 	// Prepend global ignore entry
@@ -370,9 +372,9 @@ func (ic *importCollector) buildImportLine() string {
 // generateEntryCode generates the JS/TS config code for a single JSON config entry.
 // It inserts recommended preset references and deduplicates rules.
 func generateEntryCode(entry ConfigEntry, imports *importCollector, hasTSConfig bool) string {
-	// Global ignore entry — output as-is
+	// Global ignore entry — output as-is (basePath scope included)
 	if isGlobalIgnoreEntry(entry) {
-		return formatIgnoreEntry(entry.Ignores)
+		return formatIgnoreEntry(entry)
 	}
 
 	// Determine which presets apply to this entry
@@ -522,6 +524,13 @@ func normalizeSeverity(s string) string {
 func buildOverrideFields(entry ConfigEntry, remainingRules Rules, hasTS bool) string {
 	var fields []string
 
+	// basePath (ESLint flat-config entry scope). Dropping it would silently
+	// widen a basePath-scoped entry to the repo root after migration deletes
+	// the source JSON.
+	if entry.BasePath != "" {
+		fields = append(fields, "    basePath: '"+escapeJSString(entry.BasePath)+"'")
+	}
+
 	// files (skip empty arrays)
 	if hasFileSelectors(entry) {
 		fields = append(fields, "    files: "+formatFilesSelectors(entry))
@@ -554,12 +563,17 @@ func buildOverrideFields(entry ConfigEntry, remainingRules Rules, hasTS bool) st
 	return "  {\n" + strings.Join(fields, ",\n") + ",\n  }"
 }
 
-// formatIgnoreEntry formats a global ignore entry.
-func formatIgnoreEntry(ignores []string) string {
-	if len(ignores) <= 3 {
-		return "  { ignores: " + formatStringArray(ignores) + " }"
+// formatIgnoreEntry formats a global ignore entry, preserving a basePath scope
+// when present. Dropping it would silently widen a basePath-scoped ignore to
+// the repo root after migration deletes the source JSON.
+func formatIgnoreEntry(entry ConfigEntry) string {
+	if entry.BasePath != "" {
+		return "  {\n    basePath: '" + escapeJSString(entry.BasePath) + "',\n    ignores: " + formatStringArray(entry.Ignores) + ",\n  }"
 	}
-	return "  {\n    ignores: " + formatStringArray(ignores) + ",\n  }"
+	if len(entry.Ignores) <= 3 {
+		return "  { ignores: " + formatStringArray(entry.Ignores) + " }"
+	}
+	return "  {\n    ignores: " + formatStringArray(entry.Ignores) + ",\n  }"
 }
 
 // formatStringArray formats a string slice as a JS array literal.

--- a/internal/config/config_init_test.go
+++ b/internal/config/config_init_test.go
@@ -330,6 +330,61 @@ func TestMigrate_GlobalIgnoreEntry(t *testing.T) {
 	assertContains(t, content, "no-console")
 }
 
+func TestMigrate_GlobalIgnoreEntry_WithBasePath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "rslint.json"), `[
+		{ "basePath": "packages/foo", "ignores": ["fixtures/**"] },
+		{ "rules": { "no-console": "warn" } }
+	]`)
+
+	if err := InitDefaultConfig(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	content := readFile(t, filepath.Join(dir, "rslint.config.mjs"))
+	// Without basePath, the ignore would silently widen to every fixtures/** in
+	// the repo after the source JSON is deleted.
+	assertContains(t, content, "basePath: 'packages/foo'")
+	assertContains(t, content, "fixtures/**")
+}
+
+func TestMigrate_EntryWithBasePath_PreservedInOverride(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "rslint.json"), `[{
+		"basePath": "packages/foo",
+		"files": ["src/**/*.ts"],
+		"rules": { "no-console": "warn" }
+	}]`)
+
+	if err := InitDefaultConfig(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	content := readFile(t, filepath.Join(dir, "rslint.config.mjs"))
+	assertContains(t, content, "basePath: 'packages/foo'")
+	assertContains(t, content, "src/**/*.ts")
+}
+
+func TestMigrate_IgnoresExtractedAsGlobal_PreservesBasePath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "rslint.json"), `[{
+		"basePath": "packages/foo",
+		"ignores": ["fixtures/**"],
+		"rules": { "no-console": "warn" }
+	}]`)
+
+	if err := InitDefaultConfig(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	content := readFile(t, filepath.Join(dir, "rslint.config.mjs"))
+	// The extracted global ignore entry must stay scoped to packages/foo, and
+	// the original override entry must keep its own basePath too.
+	assertContains(t, content, "basePath: 'packages/foo'")
+	assertContains(t, content, "fixtures/**")
+	assertContains(t, content, "no-console")
+}
+
 func TestMigrate_MultiEntry_DifferentPlugins(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "tsconfig.json"), "{}")

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -295,7 +295,10 @@ func (loader *ConfigLoader) LoadConfiguration(configPath string) (RslintConfig, 
 	}
 
 	// Convenience path assumes auto-discovery match root = config-file directory.
-	rslintConfig = ResolveBasePaths(rslintConfig, configDirectory)
+	rslintConfig, err = ResolveBasePaths(rslintConfig, configDirectory, loader.fs)
+	if err != nil {
+		return nil, nil, "", err
+	}
 
 	tsConfigs, err := loader.LoadTsConfigsFromRslintConfig(rslintConfig, configDirectory)
 	if err != nil {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -60,9 +60,13 @@ func (loader *ConfigLoader) LoadRslintConfig(configPath string) (RslintConfig, s
 
 	// Normalize JSON config: inject core rules and plugin rules into each entry's Rules map.
 	// User-specified rules take precedence (they are applied after the defaults).
+	// BasePath is left intact here: the caller must run ResolveBasePaths with the
+	// correct match root (config-file directory for auto-discovered configs, cwd
+	// for --config) before matching.
 	config = normalizeJSONConfig(config)
 
-	// Update current directory to the config file's directory
+	// Physical config-file directory. Callers that apply --config flat-config
+	// semantics replace the match root with cwd after loading.
 	configDirectory := tspath.GetDirectoryPath(configFileName)
 	return config, configDirectory, nil
 }
@@ -289,6 +293,9 @@ func (loader *ConfigLoader) LoadConfiguration(configPath string) (RslintConfig, 
 	if err != nil {
 		return nil, nil, "", err
 	}
+
+	// Convenience path assumes auto-discovery match root = config-file directory.
+	rslintConfig = ResolveBasePaths(rslintConfig, configDirectory)
 
 	tsConfigs, err := loader.LoadTsConfigsFromRslintConfig(rslintConfig, configDirectory)
 	if err != nil {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -82,6 +82,30 @@ func TestLoadRslintConfig_AllowsMissingFiles(t *testing.T) {
 	assert.Assert(t, cfg[0].Files == nil)
 }
 
+func TestLoadRslintConfig_PreservesBasePathUntilResolve(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "rslint.jsonc")
+	if err := os.WriteFile(configPath, []byte(`[
+		{
+			"basePath": "packages/foo",
+			"files": ["src/**/*.ts"],
+			"rules": { "no-console": "error" }
+		}
+	]`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	loader := NewConfigLoader(osvfs.FS(), tmpDir)
+	cfg, configDir, err := loader.LoadRslintConfig("rslint.jsonc")
+	assert.NilError(t, err)
+	assert.Equal(t, cfg[0].BasePath, "packages/foo")
+	assert.DeepEqual(t, cfg[0].Files, []string{"src/**/*.ts"})
+
+	cfg = ResolveBasePaths(cfg, configDir)
+	assert.Equal(t, cfg[0].BasePath, "")
+	assert.DeepEqual(t, cfg[0].Files, []string{"packages/foo/src/**/*.ts"})
+}
+
 func TestLoadTsConfigsFromRslintConfig_GlobExpansion(t *testing.T) {
 	tmpDir := t.TempDir()
 	createTestFile(t, filepath.Join(tmpDir, "packages/ui/tsconfig.json"))

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -101,7 +101,10 @@ func TestLoadRslintConfig_PreservesBasePathUntilResolve(t *testing.T) {
 	assert.Equal(t, cfg[0].BasePath, "packages/foo")
 	assert.DeepEqual(t, cfg[0].Files, []string{"src/**/*.ts"})
 
-	cfg = ResolveBasePaths(cfg, configDir)
+	cfg, err = ResolveBasePaths(cfg, configDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.Equal(t, cfg[0].BasePath, "")
 	assert.DeepEqual(t, cfg[0].Files, []string{"packages/foo/src/**/*.ts"})
 }

--- a/internal/lsp/config_discovery.go
+++ b/internal/lsp/config_discovery.go
@@ -665,7 +665,10 @@ func loadJSONConfigFallbackWithFS(
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("load JSON fallback %q: %w", configPath, err)
 	}
-	rslintConfig = config.ResolveBasePaths(rslintConfig, cwd)
+	rslintConfig, err = config.ResolveBasePaths(rslintConfig, cwd, fsys)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("resolve base paths in JSON fallback %q: %w", configPath, err)
+	}
 	paths, err := resolveTsConfigPathsWithFS(rslintConfig, cwd, fsys)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("resolve tsconfig paths for JSON fallback %q: %w", configPath, err)

--- a/internal/lsp/config_discovery.go
+++ b/internal/lsp/config_discovery.go
@@ -665,6 +665,7 @@ func loadJSONConfigFallbackWithFS(
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("load JSON fallback %q: %w", configPath, err)
 	}
+	rslintConfig = config.ResolveBasePaths(rslintConfig, cwd)
 	paths, err := resolveTsConfigPathsWithFS(rslintConfig, cwd, fsys)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("resolve tsconfig paths for JSON fallback %q: %w", configPath, err)

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -254,7 +254,10 @@ func (s *Server) reloadConfig() error {
 	}
 	// LSP JSON config matching and project resolution are rooted at the
 	// workspace cwd (same as resolveTsConfigPaths below).
-	rslintConfig = config.ResolveBasePaths(rslintConfig, s.cwd)
+	rslintConfig, err = config.ResolveBasePaths(rslintConfig, s.cwd, s.fs)
+	if err != nil {
+		return fmt.Errorf("could not resolve base paths in rslint config: %w", err)
+	}
 	paths, err := s.resolveTsConfigPaths(rslintConfig, s.cwd)
 	if err != nil {
 		return fmt.Errorf("could not resolve tsconfig paths for %q: %w", s.rslintConfigPath, err)

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -252,6 +252,9 @@ func (s *Server) reloadConfig() error {
 	if err != nil {
 		return fmt.Errorf("could not load rslint config: %w", err)
 	}
+	// LSP JSON config matching and project resolution are rooted at the
+	// workspace cwd (same as resolveTsConfigPaths below).
+	rslintConfig = config.ResolveBasePaths(rslintConfig, s.cwd)
 	paths, err := s.resolveTsConfigPaths(rslintConfig, s.cwd)
 	if err != nil {
 		return fmt.Errorf("could not resolve tsconfig paths for %q: %w", s.rslintConfigPath, err)

--- a/packages/rslint-test-tools/tests/src/util/load-test-config.ts
+++ b/packages/rslint-test-tools/tests/src/util/load-test-config.ts
@@ -20,7 +20,11 @@ async function getBaseConfig(
   const cached = baseConfigCache.get(baseConfigPath);
   if (cached) return cached;
   const raw = await loadConfigFile(baseConfigPath);
-  const normalized = normalizeConfig(raw);
+  // Desugar any basePath against the base config file's directory — the same
+  // match root later handed to lint() — not process.cwd().
+  const normalized = normalizeConfig(raw, {
+    configDirectory: path.dirname(baseConfigPath),
+  });
   baseConfigCache.set(baseConfigPath, normalized);
   return normalized;
 }

--- a/packages/rslint/src/api/rslint.ts
+++ b/packages/rslint/src/api/rslint.ts
@@ -622,7 +622,13 @@ export class Rslint {
         );
       }
     }
-    this.#normalizedOverrideConfig = normalizeConfig(override);
+    // overrideConfig is rooted at the instance cwd, and Go matches the
+    // desugared patterns relative to that same cwd. Passing it explicitly (not
+    // process.cwd()) keeps an overrideConfig basePath from desugaring against
+    // the wrong root when the instance cwd differs from the process cwd.
+    this.#normalizedOverrideConfig = normalizeConfig(override, {
+      configDirectory: this.#cwd,
+    });
     return this.#normalizedOverrideConfig;
   }
 

--- a/packages/rslint/src/config/base-path.ts
+++ b/packages/rslint/src/config/base-path.ts
@@ -80,32 +80,28 @@ export function rebasePattern(pattern: string, relativeBase: string): string {
   return (negated ? '!' : '') + joined;
 }
 
-function rebaseFilesSelector(
-  selector: unknown,
-  relativeBase: string,
-): string | string[] {
+function rebaseFilesSelector(selector: unknown, relativeBase: string): unknown {
   if (typeof selector === 'string') {
     return rebasePattern(selector, relativeBase);
   }
   if (Array.isArray(selector)) {
     return selector.map((pattern) =>
-      typeof pattern === 'string' ? rebasePattern(pattern, relativeBase) : pattern,
-    ) as string[];
+      typeof pattern === 'string'
+        ? rebasePattern(pattern, relativeBase)
+        : pattern,
+    );
   }
-  return selector as string | string[];
+  return selector;
 }
 
-function rebaseProjectValue(
-  project: unknown,
-  relativeBase: string,
-): string | string[] | undefined {
+function rebaseProjectValue(project: unknown, relativeBase: string): unknown {
   if (typeof project === 'string') {
     return rebasePattern(project, relativeBase);
   }
   if (Array.isArray(project)) {
     return project.map((item) =>
       typeof item === 'string' ? rebasePattern(item, relativeBase) : item,
-    ) as string[];
+    );
   }
   return undefined;
 }

--- a/packages/rslint/src/config/base-path.ts
+++ b/packages/rslint/src/config/base-path.ts
@@ -1,30 +1,39 @@
 import path from 'node:path';
 
-/**
- * Options for desugaring per-entry `basePath` into ordinary relative
- * `files` / `ignores` / `parserOptions.project` patterns.
- *
- * `configDirectory` is the match root the Go engine already uses:
- * config-file directory for auto-discovered configs, cwd for `--config`
- * / explicit override configs. Relative `basePath` values resolve against it.
- */
-export interface ApplyBasePathOptions {
-  configDirectory?: string;
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 /** True for absolute POSIX or Windows paths (including drive-letter forms). */
-export function isAbsolutePattern(pattern: string): boolean {
+function isAbsolutePattern(pattern: string): boolean {
   return path.posix.isAbsolute(pattern) || path.win32.isAbsolute(pattern);
 }
 
 /**
- * Resolve an entry `basePath` to a POSIX path relative to `configDirectory`.
- * Absolute base paths are rebased via `path.relative`. Empty / "." means the
- * config root itself (no prefix).
+ * Escape glob metacharacters in a resolved basePath so the directory is treated
+ * literally when spliced into glob patterns. ESLint treats basePath as a literal
+ * path; without escaping, basePath "packages/[locale]" would be interpreted as a
+ * character class and never match. Character-class escapes ([*], [?], [[] ...)
+ * are understood by both the Go (doublestar) and TS (picomatch) matchers on
+ * every platform.
+ */
+function escapeGlobBasePath(s: string): string {
+  return s
+    .replaceAll('[', '[[]')
+    .replaceAll('*', '[*]')
+    .replaceAll('?', '[?]')
+    .replaceAll('{', '[{]');
+}
+
+/**
+ * Resolve an entry `basePath` to a glob-escaped POSIX path relative to
+ * `configDirectory`. Absolute base paths are rebased via `path.relative`.
+ * Empty / "." means the config root itself (no prefix).
+ *
+ * A basePath resolving outside `configDirectory` is rejected: the resulting
+ * `../`-prefixed (or cross-root) patterns could never match under the Go
+ * engine's single-match-root model, so it fails fast instead of silently
+ * contributing nothing (mirrors the Go `ResolveBasePaths` rejection).
  */
 export function resolveRelativeBasePath(
   basePath: string,
@@ -32,17 +41,27 @@ export function resolveRelativeBasePath(
 ): string {
   const root = configDirectory || process.cwd();
   const absoluteBase = path.resolve(root, basePath);
-  let relative = path.relative(root, absoluteBase);
-  relative = relative.split(path.sep).join('/');
+  let relative = path.relative(root, absoluteBase).replace(/\\/g, '/');
+  if (
+    relative === '..' ||
+    relative.startsWith('../') ||
+    isAbsolutePattern(relative)
+  ) {
+    throw new Error(
+      `basePath "${basePath}" resolves outside the config match root "${root}"; ` +
+        'basePath must be a subdirectory of the config root',
+    );
+  }
   relative = path.posix.normalize(relative);
   if (relative === '.' || relative === '') {
     return '';
   }
-  return relative.replace(/^\.\//, '');
+  return escapeGlobBasePath(relative).replace(/^\.\//, '');
 }
 
 /**
- * Rebase one glob or path pattern under `relativeBase`.
+ * Rebase one glob or path pattern under the glob-escaped `relativeBase`
+ * produced by {@link resolveRelativeBasePath}.
  *
  * - Leading `!` negation is preserved (odd count → negated).
  * - Leading `./` is stripped before joining.
@@ -71,7 +90,9 @@ export function rebasePattern(pattern: string, relativeBase: string): string {
   }
 
   // path.posix.join collapses `a` + `../b` and keeps `**` segments intact.
-  const joined = path.posix.join(relativeBase, body);
+  // Strip trailing slashes so the result matches Go's path.Join, which drops
+  // them — trailing-slash patterns must not behave differently per side.
+  const joined = path.posix.join(relativeBase, body).replace(/\/+$/, '');
   return (negated ? '!' : '') + joined;
 }
 
@@ -174,14 +195,4 @@ export function applyBasePathToEntry(
   }
 
   return next;
-}
-
-/**
- * Apply {@link applyBasePathToEntry} across a whole flat-config array.
- */
-export function applyBasePathToConfig(
-  entries: Record<string, unknown>[],
-  configDirectory: string = process.cwd(),
-): Record<string, unknown>[] {
-  return entries.map((entry) => applyBasePathToEntry(entry, configDirectory));
 }

--- a/packages/rslint/src/config/base-path.ts
+++ b/packages/rslint/src/config/base-path.ts
@@ -1,0 +1,196 @@
+import path from 'node:path';
+
+/**
+ * Options for desugaring per-entry `basePath` into ordinary relative
+ * `files` / `ignores` / `parserOptions.project` patterns.
+ *
+ * `configDirectory` is the match root the Go engine already uses:
+ * config-file directory for auto-discovered configs, cwd for `--config`
+ * / explicit override configs. Relative `basePath` values resolve against it.
+ */
+export interface ApplyBasePathOptions {
+  configDirectory?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** True for absolute POSIX or Windows paths (including drive-letter forms). */
+export function isAbsolutePattern(pattern: string): boolean {
+  if (path.posix.isAbsolute(pattern) || path.win32.isAbsolute(pattern)) {
+    return true;
+  }
+  // path.win32.isAbsolute requires a platform-aware check; also catch
+  // forward-slash drive forms that appear in serialized configs.
+  return /^[a-zA-Z]:[\\/]/.test(pattern);
+}
+
+/**
+ * Resolve an entry `basePath` to a POSIX path relative to `configDirectory`.
+ * Absolute base paths are rebased via `path.relative`. Empty / "." means the
+ * config root itself (no prefix).
+ */
+export function resolveRelativeBasePath(
+  basePath: string,
+  configDirectory: string,
+): string {
+  const root = configDirectory || process.cwd();
+  const absoluteBase = path.resolve(root, basePath);
+  let relative = path.relative(root, absoluteBase);
+  relative = relative.split(path.sep).join('/');
+  relative = path.posix.normalize(relative);
+  if (relative === '.' || relative === '') {
+    return '';
+  }
+  return relative.replace(/^\.\//, '');
+}
+
+/**
+ * Rebase one glob or path pattern under `relativeBase`.
+ *
+ * - Leading `!` negation is preserved (odd count → negated).
+ * - Leading `./` is stripped before joining.
+ * - Absolute patterns are left unchanged (not prefixed).
+ * - Empty relativeBase is a no-op besides `./` cleanup.
+ */
+export function rebasePattern(pattern: string, relativeBase: string): string {
+  let negated = false;
+  let body = pattern;
+  while (body.startsWith('!')) {
+    negated = !negated;
+    body = body.slice(1);
+  }
+
+  body = body.replace(/\\/g, '/');
+  while (body.startsWith('./')) {
+    body = body.slice(2);
+  }
+
+  if (body === '' || isAbsolutePattern(body)) {
+    return (negated ? '!' : '') + body;
+  }
+
+  if (!relativeBase) {
+    return (negated ? '!' : '') + body;
+  }
+
+  // path.posix.join collapses `a` + `../b` and keeps `**` segments intact.
+  const joined = path.posix.join(relativeBase, body);
+  return (negated ? '!' : '') + joined;
+}
+
+function rebaseFilesSelector(
+  selector: unknown,
+  relativeBase: string,
+): string | string[] {
+  if (typeof selector === 'string') {
+    return rebasePattern(selector, relativeBase);
+  }
+  if (Array.isArray(selector)) {
+    return selector.map((pattern) =>
+      typeof pattern === 'string' ? rebasePattern(pattern, relativeBase) : pattern,
+    ) as string[];
+  }
+  return selector as string | string[];
+}
+
+function rebaseProjectValue(
+  project: unknown,
+  relativeBase: string,
+): string | string[] | undefined {
+  if (typeof project === 'string') {
+    return rebasePattern(project, relativeBase);
+  }
+  if (Array.isArray(project)) {
+    return project.map((item) =>
+      typeof item === 'string' ? rebasePattern(item, relativeBase) : item,
+    ) as string[];
+  }
+  return undefined;
+}
+
+/**
+ * Desugar one config entry's `basePath` into ordinary relative patterns and
+ * drop the `basePath` field. Entries without `basePath` are returned as-is
+ * (still without a residual `basePath` key).
+ *
+ * When `basePath` is set and `files` is omitted but the entry still carries
+ * rules / plugins / languageOptions / settings, a catch-all
+ * `files: ["<base>/**"]` is injected so the entry is scoped to that subtree —
+ * matching ESLint's "bare basePath applies under that directory" intent.
+ */
+export function applyBasePathToEntry(
+  entry: Record<string, unknown>,
+  configDirectory: string,
+): Record<string, unknown> {
+  const hasBasePath = Object.prototype.hasOwnProperty.call(entry, 'basePath');
+  if (!hasBasePath) {
+    return entry;
+  }
+
+  const rawBasePath = entry.basePath;
+  if (typeof rawBasePath !== 'string') {
+    // Caller validates; defensive no-op strip.
+    const { basePath: _dropped, ...rest } = entry;
+    return rest;
+  }
+
+  const relativeBase = resolveRelativeBasePath(rawBasePath, configDirectory);
+  const { basePath: _dropped, ...rest } = entry;
+  const next: Record<string, unknown> = { ...rest };
+
+  if (Array.isArray(next.files)) {
+    next.files = next.files.map((selector) =>
+      rebaseFilesSelector(selector, relativeBase),
+    );
+  }
+
+  if (Array.isArray(next.ignores)) {
+    next.ignores = next.ignores.map((pattern) =>
+      typeof pattern === 'string'
+        ? rebasePattern(pattern, relativeBase)
+        : pattern,
+    );
+  }
+
+  if (isRecord(next.languageOptions)) {
+    const languageOptions = { ...next.languageOptions };
+    if (isRecord(languageOptions.parserOptions)) {
+      const parserOptions = { ...languageOptions.parserOptions };
+      if (Object.prototype.hasOwnProperty.call(parserOptions, 'project')) {
+        const rebased = rebaseProjectValue(parserOptions.project, relativeBase);
+        if (rebased !== undefined) {
+          parserOptions.project = rebased;
+        }
+      }
+      languageOptions.parserOptions = parserOptions;
+    }
+    next.languageOptions = languageOptions;
+  }
+
+  const hasFiles = Object.prototype.hasOwnProperty.call(next, 'files');
+  const scopesToSubtree =
+    next.rules !== undefined ||
+    next.plugins !== undefined ||
+    next.languageOptions !== undefined ||
+    next.settings !== undefined;
+
+  // Scoped entry with basePath but no files → limit to the base subtree.
+  if (!hasFiles && scopesToSubtree) {
+    const catchAll = relativeBase ? path.posix.join(relativeBase, '**') : '**';
+    next.files = [catchAll];
+  }
+
+  return next;
+}
+
+/**
+ * Apply {@link applyBasePathToEntry} across a whole flat-config array.
+ */
+export function applyBasePathToConfig(
+  entries: Record<string, unknown>[],
+  configDirectory: string = process.cwd(),
+): Record<string, unknown>[] {
+  return entries.map((entry) => applyBasePathToEntry(entry, configDirectory));
+}

--- a/packages/rslint/src/config/base-path.ts
+++ b/packages/rslint/src/config/base-path.ts
@@ -18,12 +18,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 /** True for absolute POSIX or Windows paths (including drive-letter forms). */
 export function isAbsolutePattern(pattern: string): boolean {
-  if (path.posix.isAbsolute(pattern) || path.win32.isAbsolute(pattern)) {
-    return true;
-  }
-  // path.win32.isAbsolute requires a platform-aware check; also catch
-  // forward-slash drive forms that appear in serialized configs.
-  return /^[a-zA-Z]:[\\/]/.test(pattern);
+  return path.posix.isAbsolute(pattern) || path.win32.isAbsolute(pattern);
 }
 
 /**

--- a/packages/rslint/src/config/config-file-loader.ts
+++ b/packages/rslint/src/config/config-file-loader.ts
@@ -115,8 +115,10 @@ function extractDefault(mod: unknown): unknown {
  *
  * `configDirectory` is the match root used to resolve relative `basePath`
  * values: config-file directory for auto-discovered configs, cwd for
- * `--config` / explicit override configs. When omitted, `process.cwd()` is
- * used (correct for overrideConfig and other cwd-rooted paths).
+ * `--config` / explicit override configs. Production callers must pass it —
+ * the API's `overrideConfig` is rooted at the instance cwd, not
+ * `process.cwd()` — so the `process.cwd()` default below only serves
+ * basePath-free test configs.
  */
 export interface NormalizeConfigOptions {
   configDirectory?: string;

--- a/packages/rslint/src/config/config-file-loader.ts
+++ b/packages/rslint/src/config/config-file-loader.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
+import { applyBasePathToEntry } from './base-path.js';
 import { NATIVE_PLUGIN_RESERVED_NAMES } from './define-config.js';
 import { selectPluginSource, unwrapPluginModule } from './plugin-source.js';
 
@@ -110,9 +111,28 @@ function extractDefault(mod: unknown): unknown {
 }
 
 /**
- * Validate and strip non-serializable fields from the config.
+ * Options for {@link normalizeConfig}.
+ *
+ * `configDirectory` is the match root used to resolve relative `basePath`
+ * values: config-file directory for auto-discovered configs, cwd for
+ * `--config` / explicit override configs. When omitted, `process.cwd()` is
+ * used (correct for overrideConfig and other cwd-rooted paths).
  */
-export function normalizeConfig(config: unknown): Record<string, unknown>[] {
+export interface NormalizeConfigOptions {
+  configDirectory?: string;
+}
+
+/**
+ * Validate and strip non-serializable fields from the config.
+ *
+ * Per-entry `basePath` is desugared here into ordinary relative `files` /
+ * `ignores` / `parserOptions.project` patterns so the Go engine keeps its
+ * single match-root model.
+ */
+export function normalizeConfig(
+  config: unknown,
+  options: NormalizeConfigOptions = {},
+): Record<string, unknown>[] {
   if (!Array.isArray(config)) {
     throw new Error(
       `rslint config must export an array (flat config format), got ${typeof config}`,
@@ -126,6 +146,8 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
       );
     }
   }
+
+  const configDirectory = options.configDirectory ?? process.cwd();
 
   return config.map((rawEntry: unknown, index: number) => {
     if (rawEntry === null) {
@@ -145,6 +167,18 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
     }
 
     const entry = rawEntry;
+
+    const hasBasePath = Object.prototype.hasOwnProperty.call(entry, 'basePath');
+    if (hasBasePath && typeof entry.basePath !== 'string') {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "basePath" must be a string, got ${typeof entry.basePath}`,
+      );
+    }
+    if (hasBasePath && entry.basePath === '') {
+      throw new Error(
+        `[rslint] Config entry at index ${index}: "basePath" must be a non-empty string`,
+      );
+    }
 
     const hasFiles = Object.prototype.hasOwnProperty.call(entry, 'files');
     if (hasFiles && !Array.isArray(entry.files)) {
@@ -280,10 +314,12 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
       : [];
     const plugins = [...new Set([...stringPlugins, ...pluginPrefixes])];
     // ESLint decides whether an ignores-bearing object is global from its
-    // authored keys, including keys whose value is undefined. Preserve that
-    // distinction when normalization omits an undefined or unsupported field.
+    // authored keys, including keys whose value is undefined. `basePath` and
+    // `name` are meta fields and do not make an ignores-only entry non-global.
+    // Preserve that distinction when normalization omits an undefined or
+    // unsupported field.
     const authoredNonGlobalKey = Object.keys(entry).some(
-      (key) => key !== 'name' && key !== 'ignores',
+      (key) => key !== 'name' && key !== 'ignores' && key !== 'basePath',
     );
     const serializesNonGlobalKey =
       hasFiles ||
@@ -291,11 +327,15 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
       entry.rules !== undefined ||
       hasPlugins ||
       entry.settings !== undefined;
+    // basePath on a scoped (non-global-ignore) entry may inject a catch-all
+    // files selector during desugaring; that alone does not need a settings
+    // shape marker because files will be present after applyBasePathToEntry.
     const needsNonGlobalShapeMarker =
       authoredNonGlobalKey && !serializesNonGlobalKey;
 
-    return {
+    const serializable: Record<string, unknown> = {
       ...(entry.name !== undefined ? { name: entry.name } : {}),
+      ...(hasBasePath ? { basePath: entry.basePath } : {}),
       ...(hasFiles ? { files: entry.files } : {}),
       ...(entry.ignores !== undefined ? { ignores: entry.ignores } : {}),
       ...(entry.languageOptions !== undefined
@@ -310,6 +350,10 @@ export function normalizeConfig(config: unknown): Record<string, unknown>[] {
           : {}),
       ...(pluginPrefixes.length > 0 ? { eslintPlugins: eslintPluginMeta } : {}),
     };
+
+    // Desugar basePath into ordinary relative patterns before the payload
+    // crosses to Go. The Go engine keeps a single match root per config.
+    return applyBasePathToEntry(serializable, configDirectory);
   });
 }
 

--- a/packages/rslint/src/config/config-hierarchy.ts
+++ b/packages/rslint/src/config/config-hierarchy.ts
@@ -8,7 +8,9 @@ export interface ConfigEntry {
 
 /**
  * Check if a config entry is a "global ignore" entry: an entry with only
- * `ignores` and an optional `name`.
+ * `ignores` and optional meta fields (`name`, and pre-desugar `basePath`).
+ * After normalizeConfig desugars `basePath`, only `ignores` (+ optional
+ * `name`) remain, so the post-desugar shape still matches.
  */
 function isGlobalIgnoreEntry(
   entry: unknown,
@@ -26,7 +28,9 @@ function isGlobalIgnoreEntry(
     return false;
   }
 
-  return Object.keys(entry).every((key) => key === 'ignores' || key === 'name');
+  return Object.keys(entry).every(
+    (key) => key === 'ignores' || key === 'name' || key === 'basePath',
+  );
 }
 
 function getGlobalIgnores(entries: unknown[]): string[] {

--- a/packages/rslint/src/config/config-loader.ts
+++ b/packages/rslint/src/config/config-loader.ts
@@ -9,8 +9,15 @@ export {
   loadConfigFile,
   loadConfigFileFresh,
   normalizeConfig,
+  type NormalizeConfigOptions,
   type PluginConfigDescriptor,
 } from './config-file-loader.js';
+export {
+  applyBasePathToConfig,
+  applyBasePathToEntry,
+  rebasePattern,
+  resolveRelativeBasePath,
+} from './base-path.js';
 export { ConfigModuleHost } from './config-module-host.js';
 export type {
   ConfigModuleActivationPlan,

--- a/packages/rslint/src/config/config-loader.ts
+++ b/packages/rslint/src/config/config-loader.ts
@@ -13,7 +13,6 @@ export {
   type PluginConfigDescriptor,
 } from './config-file-loader.js';
 export {
-  applyBasePathToConfig,
   applyBasePathToEntry,
   rebasePattern,
   resolveRelativeBasePath,

--- a/packages/rslint/src/config/config-module-host.ts
+++ b/packages/rslint/src/config/config-module-host.ts
@@ -564,7 +564,12 @@ export class ConfigModuleHost {
         ? this.#loadFresh(candidate.configPath)
         : this.#loadCached(candidate.configPath));
       failureCode = 'invalid';
-      const normalized = normalizeConfig(rawConfig);
+      // Pass configDirectory so relative basePath values resolve against the
+      // same match root Go already uses for files/ignores/project (config-file
+      // directory for auto-discovered configs, cwd for --config).
+      const normalized = normalizeConfig(rawConfig, {
+        configDirectory: candidate.configDirectory,
+      });
       // This is the cross-process serialization boundary. Keeping the canonical
       // JSON also prevents a caller mutating a response from corrupting session
       // state used later by #summarizeEffectiveConfigs.

--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -163,16 +163,33 @@ export interface RslintConfigEntry {
   /** Optional human-readable name for this config entry. */
   name?: string;
   /**
+   * Subdirectory this entry is rooted at, matching ESLint flat-config
+   * `basePath`. Relative values resolve from the config match root (config
+   * file directory for auto-discovered configs, cwd for `--config` /
+   * explicit override configs). That entry's `files`, `ignores`, and
+   * `languageOptions.parserOptions.project` are then interpreted relative to
+   * the resolved base. `{ basePath, ignores }` remains a global-ignore entry
+   * scoped under the base. During config normalization `basePath` is desugared
+   * into ordinary relative patterns before the Go engine sees the config.
+   *
+   * @example
+   * { basePath: 'packages/foo', files: ['src/**/*.ts'] }
+   * // equivalent to { files: ['packages/foo/src/**/*.ts'] }
+   */
+  basePath?: string;
+  /**
    * Glob selectors for files this entry applies to. Top-level selectors are
    * ORed; strings inside one nested array are ANDed, matching ESLint flat
-   * config semantics.
+   * config semantics. When `basePath` is set, patterns are relative to that
+   * base rather than the config match root.
    *
    * @example
    * files: ['src/**', 'tests/**']
    */
   files?: Array<string | string[]>;
   /**
-   * Glob patterns excluded from this entry.
+   * Glob patterns excluded from this entry. When `basePath` is set, patterns
+   * are relative to that base.
    *
    * @example
    * ignores: ['node_modules/**', 'dist/**']

--- a/packages/rslint/src/config/define-config.ts
+++ b/packages/rslint/src/config/define-config.ts
@@ -173,8 +173,8 @@ export interface RslintConfigEntry {
    * into ordinary relative patterns before the Go engine sees the config.
    *
    * @example
-   * { basePath: 'packages/foo', files: ['src/**/*.ts'] }
-   * // equivalent to { files: ['packages/foo/src/**/*.ts'] }
+   * { basePath: 'packages/foo', files: ['src/**\/*.ts'] }
+   * // equivalent to { files: ['packages/foo/src/**\/*.ts'] }
    */
   basePath?: string;
   /**

--- a/packages/rslint/tests/config-loader.test.ts
+++ b/packages/rslint/tests/config-loader.test.ts
@@ -353,6 +353,76 @@ describe('normalizeConfig', () => {
       ).toThrow(/must be/);
     }
   });
+
+  test('desugars basePath into files/ignores/project and drops basePath', () => {
+    const [entry] = normalizeConfig(
+      [
+        {
+          basePath: 'packages/foo',
+          files: ['src/**/*.ts', ['**/*.js', '!**/*.test.js']],
+          ignores: ['fixtures/**', '!fixtures/keep.ts'],
+          languageOptions: {
+            parserOptions: { project: ['./tsconfig.json'] },
+          },
+          rules: { 'no-console': 'error' },
+        },
+      ],
+      { configDirectory: '/repo' },
+    );
+    expect(entry).not.toHaveProperty('basePath');
+    expect(entry.files).toEqual([
+      'packages/foo/src/**/*.ts',
+      ['packages/foo/**/*.js', '!packages/foo/**/*.test.js'],
+    ]);
+    expect(entry.ignores).toEqual([
+      'packages/foo/fixtures/**',
+      '!packages/foo/fixtures/keep.ts',
+    ]);
+    expect(
+      (entry.languageOptions as { parserOptions: { project: string[] } })
+        .parserOptions.project,
+    ).toEqual(['packages/foo/tsconfig.json']);
+  });
+
+  test('keeps basePath+ignores as a global ignore after desugar', () => {
+    const [entry] = normalizeConfig(
+      [{ basePath: 'packages/foo', ignores: ['fixtures/**'] }],
+      { configDirectory: '/repo' },
+    );
+    expect(entry).toEqual({ ignores: ['packages/foo/fixtures/**'] });
+    expect(Object.keys(entry).sort()).toEqual(['ignores']);
+  });
+
+  test('injects catch-all files for bare basePath + rules', () => {
+    const [entry] = normalizeConfig(
+      [{ basePath: 'packages/foo', rules: { 'no-console': 'error' } }],
+      { configDirectory: '/repo' },
+    );
+    expect(entry.files).toEqual(['packages/foo/**']);
+    expect(entry).not.toHaveProperty('basePath');
+  });
+
+  test('rejects non-string basePath', () => {
+    expect(() =>
+      normalizeConfig([{ basePath: 1 as unknown as string, rules: {} }]),
+    ).toThrow(/"basePath" must be a string/);
+  });
+
+  test('rejects empty basePath', () => {
+    expect(() => normalizeConfig([{ basePath: '', rules: {} }])).toThrow(
+      /"basePath" must be a non-empty string/,
+    );
+  });
+
+  test('basePath alone does not force a non-global shape marker', () => {
+    // basePath is meta; without other non-global keys this is still only
+    // desugared ignores (or empty). An ignores-less bare basePath is a no-op
+    // entry after desugar.
+    const [entry] = normalizeConfig([{ basePath: 'packages/foo' }], {
+      configDirectory: '/repo',
+    });
+    expect(entry).toEqual({});
+  });
 });
 
 describe('normalizeConfig — community plugins (object-form)', () => {

--- a/packages/rslint/tests/config-loader.test.ts
+++ b/packages/rslint/tests/config-loader.test.ts
@@ -423,6 +423,36 @@ describe('normalizeConfig', () => {
     });
     expect(entry).toEqual({});
   });
+
+  test('glob-escapes basePath so it is treated as a literal directory', () => {
+    // ESLint treats basePath as a literal path; without escaping,
+    // "packages/[locale]" would become a character class and never match. Only
+    // the leading '[' needs escaping ([[]); a bare ']' is literal outside a
+    // class.
+    const [entry] = normalizeConfig(
+      [{ basePath: 'packages/[locale]', files: ['src/**/*.ts'] }],
+      { configDirectory: '/repo' },
+    );
+    expect(entry.files).toEqual(['packages/[[]locale]/src/**/*.ts']);
+  });
+
+  test('rejects a basePath resolving outside the config match root', () => {
+    expect(() =>
+      normalizeConfig([{ basePath: '../shared', rules: {} }], {
+        configDirectory: '/repo',
+      }),
+    ).toThrow(/resolves outside the config match root/);
+  });
+
+  test('strips trailing slashes like the Go path.Join', () => {
+    // Go's path.Join drops trailing slashes while path.posix.join keeps them;
+    // both sides must agree so trailing-slash ignores behave identically.
+    const [entry] = normalizeConfig(
+      [{ basePath: 'packages/foo', ignores: ['src/**/'] }],
+      { configDirectory: '/repo' },
+    );
+    expect(entry.ignores).toEqual(['packages/foo/src/**']);
+  });
 });
 
 describe('normalizeConfig — community plugins (object-form)', () => {

--- a/packages/rule-tester/src/index.ts
+++ b/packages/rule-tester/src/index.ts
@@ -28,7 +28,11 @@ async function getBaseConfig(
   const cached = baseConfigCache.get(baseConfigPath);
   if (cached) return cached;
   const raw = await loadConfigFile(baseConfigPath);
-  const normalized = normalizeConfig(raw);
+  // Desugar any basePath against the base config file's directory — the same
+  // match root later handed to lint() — not process.cwd().
+  const normalized = normalizeConfig(raw, {
+    configDirectory: path.dirname(baseConfigPath),
+  });
   baseConfigCache.set(baseConfigPath, normalized);
   return normalized;
 }

--- a/rslint-schema.json
+++ b/rslint-schema.json
@@ -16,6 +16,11 @@
           "type": "string",
           "description": "Optional human-readable name for this configuration entry"
         },
+        "basePath": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional subdirectory root for this entry (ESLint flat-config basePath). Relative values resolve from the config match root (config-file directory for auto-discovered configs, cwd for --config). That entry's files, ignores, and languageOptions.parserOptions.project are then interpreted relative to the resolved base. { basePath, ignores } remains a global-ignore entry scoped under the base."
+        },
         "files": {
           "type": "array",
           "description": "Non-empty file selector list. Top-level selectors are ORed; patterns inside a nested array are ANDed. Rslint unions these selectors with its default JavaScript and TypeScript extension baseline.",

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -126,6 +126,7 @@ describedby
 destabilising
 destructures
 desugars
+desugared
 desync
 dirxml
 disqualifier

--- a/website/docs/en/config/ignoring-files.md
+++ b/website/docs/en/config/ignoring-files.md
@@ -4,12 +4,20 @@
 
 - **Type:** `string[]`
 
-Glob patterns for files to exclude. An entry containing **only** `ignores` and an optional `name` acts as a global ignore: matching files are removed from the lint target set. An entry-level ignore prevents that entry's `files` selector, rules, and options from contributing. It cannot remove a path selected by the default extension baseline or another entry, so such a path may still receive configuration or a zero-rule syntax pass.
+Glob patterns for files to exclude. An entry containing **only** `ignores` and optional meta fields (`name`, `basePath`) acts as a global ignore: matching files are removed from the lint target set. An entry-level ignore prevents that entry's `files` selector, rules, and options from contributing. It cannot remove a path selected by the default extension baseline or another entry, so such a path may still receive configuration or a zero-rule syntax pass.
+
+When `basePath` is set, ignore patterns are relative to that base (see [Configuration → basePath](/config/index#basepath)).
 
 ```ts
 // Global ignore entry
 {
   ignores: ['**/dist/**', '**/fixtures/**'],
+}
+
+// Global ignore scoped under a package
+{
+  basePath: 'packages/foo',
+  ignores: ['fixtures/**'], // ≈ packages/foo/fixtures/**
 }
 
 // Entry-level ignore (only applies to this entry)

--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -67,6 +67,58 @@ For automatically discovered configs, relative `files`, `ignores`, and `language
 
 For a config supplied with `--config`, those patterns are resolved from the current working directory.
 
+### basePath
+
+- **Type:** `string`
+
+Optional subdirectory root for one config entry, matching ESLint flat-config `basePath`. A relative value is resolved from the config match root (config-file directory for auto-discovered configs, cwd for `--config`). That entry's `files`, `ignores`, and `languageOptions.parserOptions.project` are then interpreted relative to the resolved base.
+
+```ts
+export default defineConfig([
+  {
+    basePath: 'packages/foo',
+    files: ['src/**/*.ts'],
+    ignores: ['fixtures/**'],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+      },
+    },
+    rules: {
+      'no-console': 'error',
+    },
+  },
+]);
+```
+
+This is equivalent to writing the paths relative to the config match root:
+
+```ts
+{
+  files: ['packages/foo/src/**/*.ts'],
+  ignores: ['packages/foo/fixtures/**'],
+  languageOptions: {
+    parserOptions: {
+      project: ['packages/foo/tsconfig.json'],
+    },
+  },
+  rules: {
+    'no-console': 'error',
+  },
+}
+```
+
+`{ basePath, ignores }` (plus optional `name`) remains a **global ignore** entry, scoped under that base:
+
+```ts
+{
+  basePath: 'packages/foo',
+  ignores: ['fixtures/**'], // ≈ packages/foo/fixtures/**
+}
+```
+
+When `basePath` is set on a scoped entry that omits `files`, the entry is limited to that subtree (as if `files: ['<base>/**']` were written).
+
 To generate a default config, run:
 
 ```bash


### PR DESCRIPTION
## Summary

Adding basePath support to flat config entries. Each entry can now specify an optional basePath that scopes its files / ignores / parserOptions.project patterns to a subdirectory, instead of always resolving relative to the config file's directory or cwd — matching ESLint's flat-config basePath semantics.

## Related Links
Fixes #1201 
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
