### PR TITLE
docs: show rule release versions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -26,6 +26,7 @@ internal/plugins/**/rules/**/*.md
 internal/rules/**/*.md
 website/docs/en/rules/_meta.json
 website/docs/en/rules/*/
+website/rule-releases.json
 packages/vscode-extension/__tests__/fixtures-monorepo/packages/broken/
 crates/rslint-native/index.js
 crates/rslint-native/index.d.ts

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "version": "zx scripts/version.mjs",
     "version:crates": "zx scripts/version-crates.mjs",
     "release": "pnpm publish -r --no-git-checks",
+    "sync:rule-releases": "node scripts/sync-rule-releases.js",
     "publish:vsce": "zx scripts/publish-marketplace.mjs",
     "publish:ovsx": "zx scripts/publish-marketplace.mjs --marketplace=ovsx",
     "format": "prettier --write .",

--- a/scripts/sync-rule-releases.js
+++ b/scripts/sync-rule-releases.js
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const RULE_RELEASES_PATH = path.join(REPO_ROOT, 'website/rule-releases.json');
+const CORE_RULES_DIR = path.join(REPO_ROOT, 'internal/rules');
+const PLUGINS_DIR = path.join(REPO_ROOT, 'internal/plugins');
+const STABLE_VERSION_RE = /^\d+\.\d+\.\d+$/;
+const PLUGIN_GROUP_FALLBACKS = new Map([
+  ['import', 'eslint-plugin-import'],
+  ['jest', 'eslint-plugin-jest'],
+  ['jsx_a11y', 'eslint-plugin-jsx-a11y'],
+  ['promise', 'eslint-plugin-promise'],
+  ['react', 'eslint-plugin-react'],
+  ['react_hooks', 'eslint-plugin-react-hooks'],
+  ['typescript', '@typescript-eslint'],
+  ['unicorn', 'eslint-plugin-unicorn'],
+]);
+const pluginGroupByBlob = new Map();
+
+function normalizeVersion(version) {
+  return String(version).replace(/^v/, '');
+}
+
+function compareVersions(a, b) {
+  const aParts = normalizeVersion(a).split('.').map(Number);
+  const bParts = normalizeVersion(b).split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (aParts[i] !== bParts[i]) return aParts[i] - bParts[i];
+  }
+  return 0;
+}
+
+function canonicalRuleId(group, rule) {
+  return `${group}:${rule.replace(/_/g, '-')}`;
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function getGitOutput(args) {
+  return execFileSync('git', args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function getStableTags() {
+  return getGitOutput(['tag', '--list', 'v*'])
+    .split('\n')
+    .filter(Boolean)
+    .map((tag) => ({ tag, version: normalizeVersion(tag) }))
+    .filter(({ version }) => STABLE_VERSION_RE.test(version))
+    .sort((a, b) => compareVersions(a.version, b.version));
+}
+
+function getPluginGroup(content, plugin) {
+  const match = content?.match(/PLUGIN_NAME\s*=\s*"([^"]+)"/);
+  return match?.[1] || PLUGIN_GROUP_FALLBACKS.get(plugin) || plugin;
+}
+
+function getPluginGroupAtBlob(blob, plugin) {
+  if (!blob) return getPluginGroup(undefined, plugin);
+  if (!pluginGroupByBlob.has(blob)) {
+    pluginGroupByBlob.set(
+      blob,
+      getPluginGroup(getGitOutput(['cat-file', 'blob', blob]), plugin),
+    );
+  }
+  return pluginGroupByBlob.get(blob);
+}
+
+function getRuleIdsAtRef(ref) {
+  const tree = getGitOutput([
+    'ls-tree',
+    '-r',
+    ref,
+    '--',
+    'internal/rules',
+    'internal/plugins',
+  ]);
+  if (!tree) return [];
+
+  const coreRules = new Set();
+  const pluginRules = new Map();
+  const pluginBlobs = new Map();
+
+  for (const line of tree.split('\n')) {
+    const entry = /^\d+\s+\w+\s+([0-9a-f]+)\t(.+)$/.exec(line);
+    if (!entry) continue;
+    const [, blob, file] = entry;
+
+    const pluginFile = /^internal\/plugins\/([^/]+)\/plugin\.go$/.exec(file);
+    if (pluginFile) pluginBlobs.set(pluginFile[1], blob);
+
+    const coreRule = /^internal\/rules\/([^/]+)\//.exec(file);
+    if (coreRule && coreRule[1] !== 'fixtures') {
+      coreRules.add(coreRule[1]);
+      continue;
+    }
+
+    const pluginRule = /^internal\/plugins\/([^/]+)\/rules\/([^/]+)\//.exec(
+      file,
+    );
+    if (!pluginRule || pluginRule[2] === 'fixtures') continue;
+    const [, plugin, rule] = pluginRule;
+    if (!pluginRules.has(plugin)) pluginRules.set(plugin, new Set());
+    pluginRules.get(plugin).add(rule);
+  }
+
+  // Before v0.1.11, TypeScript rules lived in internal/rules.
+  const coreGroup = pluginRules.has('typescript')
+    ? 'eslint'
+    : '@typescript-eslint';
+  const ruleIds = [...coreRules].map((rule) =>
+    canonicalRuleId(coreGroup, rule),
+  );
+
+  for (const [plugin, rules] of pluginRules) {
+    const group = getPluginGroupAtBlob(pluginBlobs.get(plugin), plugin);
+    for (const rule of rules) {
+      ruleIds.push(canonicalRuleId(group, rule));
+    }
+  }
+
+  return uniqueSorted(ruleIds);
+}
+
+function getRuleDirectories(directory) {
+  if (!fs.existsSync(directory)) return [];
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        entry.name !== 'fixtures' &&
+        !entry.name.startsWith('.'),
+    )
+    .map((entry) => entry.name);
+}
+
+function getCurrentRuleIds() {
+  const ruleIds = getRuleDirectories(CORE_RULES_DIR).map((rule) =>
+    canonicalRuleId('eslint', rule),
+  );
+
+  for (const plugin of getRuleDirectories(PLUGINS_DIR)) {
+    const rulesDirectory = path.join(PLUGINS_DIR, plugin, 'rules');
+    const rules = getRuleDirectories(rulesDirectory);
+    if (rules.length === 0) continue;
+
+    const pluginFile = path.join(PLUGINS_DIR, plugin, 'plugin.go');
+    const content = fs.existsSync(pluginFile)
+      ? fs.readFileSync(pluginFile, 'utf8')
+      : undefined;
+    const group = getPluginGroup(content, plugin);
+    for (const rule of rules) {
+      ruleIds.push(canonicalRuleId(group, rule));
+    }
+  }
+
+  return uniqueSorted(ruleIds);
+}
+
+function readRuleReleases() {
+  return JSON.parse(fs.readFileSync(RULE_RELEASES_PATH, 'utf8'));
+}
+
+function writeRuleReleases(data) {
+  fs.mkdirSync(path.dirname(RULE_RELEASES_PATH), { recursive: true });
+  fs.writeFileSync(RULE_RELEASES_PATH, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function syncFullHistory() {
+  const stableTags = getStableTags();
+  if (stableTags.length === 0) {
+    throw new Error('No stable release tags were found');
+  }
+
+  const assignedRules = new Set();
+  const releases = stableTags.map(({ tag, version }) => {
+    const rules = getRuleIdsAtRef(tag).filter(
+      (rule) => !assignedRules.has(rule),
+    );
+    for (const rule of rules) assignedRules.add(rule);
+    return { version, rules };
+  });
+
+  writeRuleReleases(releases);
+}
+
+function syncCurrentVersion() {
+  const version = normalizeVersion(
+    JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'))
+      .version,
+  );
+  if (!STABLE_VERSION_RE.test(version)) {
+    throw new Error(`Package version "${version}" is not a stable version`);
+  }
+
+  const stableTags = getStableTags();
+  const latestTag = stableTags.at(-1);
+  if (latestTag?.version === version) {
+    console.log(
+      `Skipped: package version v${version} matches the latest stable tag.`,
+    );
+    return false;
+  }
+
+  const previousTag = stableTags
+    .filter((entry) => compareVersions(entry.version, version) < 0)
+    .at(-1);
+  if (!previousTag) {
+    throw new Error(`No stable tag exists before v${version}`);
+  }
+
+  const releases = readRuleReleases();
+  const latestRelease = releases.at(-1);
+  const targetIndex = releases.findIndex(
+    (release) => release.version === version,
+  );
+  if (
+    !latestRelease ||
+    (latestRelease.version !== previousTag.version &&
+      latestRelease.version !== version)
+  ) {
+    throw new Error(
+      `Rule release JSON must end at v${previousTag.version} before syncing v${version}`,
+    );
+  }
+  if (targetIndex !== -1 && targetIndex !== releases.length - 1) {
+    throw new Error(`Refusing to rewrite historical version v${version}`);
+  }
+
+  const previousRules = new Set(getRuleIdsAtRef(previousTag.tag));
+  const assignedRules = new Set(
+    releases
+      .filter((release) => compareVersions(release.version, version) < 0)
+      .flatMap((release) => release.rules),
+  );
+  const rules = getCurrentRuleIds().filter(
+    (rule) => !previousRules.has(rule) && !assignedRules.has(rule),
+  );
+  const release = { version, rules };
+
+  if (targetIndex === -1) {
+    releases.push(release);
+  } else {
+    releases[targetIndex] = release;
+  }
+  writeRuleReleases(releases);
+  return true;
+}
+
+function printUsage() {
+  console.log('\nUsage:');
+  console.log('  pnpm sync:rule-releases       Incremental sync (default)');
+  console.log('  pnpm sync:rule-releases full  Full historical sync');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length > 1 || (args[0] && args[0] !== 'full')) {
+    throw new Error('The only supported argument is "full"');
+  }
+
+  if (args[0] === 'full') {
+    syncFullHistory();
+    console.log(`Generated ${path.relative(REPO_ROOT, RULE_RELEASES_PATH)}.`);
+  } else {
+    const generated = syncCurrentVersion();
+    if (generated) {
+      console.log(`Generated ${path.relative(REPO_ROOT, RULE_RELEASES_PATH)}.`);
+    }
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`Rule release sync failed: ${error.message}`);
+  process.exitCode = 1;
+} finally {
+  printUsage();
+}

--- a/website/plugin-rule-manifest.ts
+++ b/website/plugin-rule-manifest.ts
@@ -5,11 +5,17 @@ import path from 'node:path';
 import * as rslintCore from '@rslint/core';
 import type { RslintConfigEntry } from '@rslint/core';
 import { PLUGIN_REGISTRY, groupToRouteSlug } from './theme/plugin-registry';
+import ruleReleases from './rule-releases.json';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const MANIFEST_PATH = path.resolve(__dirname, 'generated/rule-manifest.json');
 const SCRIPT_PATH = path.resolve(REPO_ROOT, 'scripts/gen-rule-manifest.js');
 const RULES_DOCS_DIR = path.resolve(__dirname, 'docs/en/rules');
+const RULE_VERSION_BY_ID = new Map(
+  ruleReleases.flatMap(({ version, rules }) =>
+    rules.map((rule) => [rule, version] as const),
+  ),
+);
 
 /** Shape of each rule entry in rule-manifest.json. */
 interface RuleEntry {
@@ -134,8 +140,11 @@ function loadManifest(): RuleEntry[] {
  *
  * Output (.mdx):
  *   import RuleConfig from '@/theme/components/RuleConfig.tsx';
+ *   import RuleVersionBadge from '@/theme/components/RuleVersionBadge.tsx';
  *
  *   # no-console
+ *
+ *   <RuleVersionBadge introducedIn="0.1.4" />
  *
  *   ## Configuration
  *
@@ -154,7 +163,14 @@ function buildRuleDocContent(rule: RuleEntry): string {
     'utf-8',
   );
   const fullName = getFullRuleName(rule);
-  const importLine = `import RuleConfig from '@/theme/components/RuleConfig.tsx';`;
+  const importLines = [
+    `import RuleConfig from '@/theme/components/RuleConfig.tsx';`,
+    `import RuleVersionBadge from '@/theme/components/RuleVersionBadge.tsx';`,
+  ].join('\n');
+  const introducedIn = RULE_VERSION_BY_ID.get(`${rule.group}:${rule.name}`);
+  const versionBadge = introducedIn
+    ? `<RuleVersionBadge introducedIn="${introducedIn}" />`
+    : `<RuleVersionBadge />`;
 
   // Build preset table if the rule is in any preset
   let presetTable = '';
@@ -180,12 +196,14 @@ function buildRuleDocContent(rule: RuleEntry): string {
 
   const headingEnd = sourceContent.indexOf('\n');
   if (headingEnd === -1) {
-    return `${importLine}\n\n${sourceContent}\n\n${configSection}\n`;
+    return `${importLines}\n\n${sourceContent}\n\n${versionBadge}\n\n${configSection}\n`;
   }
   return [
-    importLine,
+    importLines,
     '',
     sourceContent.slice(0, headingEnd),
+    '',
+    versionBadge,
     '',
     configSection,
     '',

--- a/website/rule-releases.json
+++ b/website/rule-releases.json
@@ -1,0 +1,646 @@
+[
+  {
+    "version": "0.1.4",
+    "rules": [
+      "@typescript-eslint:adjacent-overload-signatures",
+      "@typescript-eslint:array-type",
+      "@typescript-eslint:await-thenable",
+      "@typescript-eslint:class-literal-property-style",
+      "@typescript-eslint:no-array-delete",
+      "@typescript-eslint:no-base-to-string",
+      "@typescript-eslint:no-confusing-void-expression",
+      "@typescript-eslint:no-duplicate-type-constituents",
+      "@typescript-eslint:no-floating-promises",
+      "@typescript-eslint:no-for-in-array",
+      "@typescript-eslint:no-implied-eval",
+      "@typescript-eslint:no-meaningless-void-operator",
+      "@typescript-eslint:no-misused-promises",
+      "@typescript-eslint:no-misused-spread",
+      "@typescript-eslint:no-mixed-enums",
+      "@typescript-eslint:no-redundant-type-constituents",
+      "@typescript-eslint:no-unnecessary-boolean-literal-compare",
+      "@typescript-eslint:no-unnecessary-template-expression",
+      "@typescript-eslint:no-unnecessary-type-arguments",
+      "@typescript-eslint:no-unnecessary-type-assertion",
+      "@typescript-eslint:no-unsafe-argument",
+      "@typescript-eslint:no-unsafe-assignment",
+      "@typescript-eslint:no-unsafe-call",
+      "@typescript-eslint:no-unsafe-enum-comparison",
+      "@typescript-eslint:no-unsafe-member-access",
+      "@typescript-eslint:no-unsafe-return",
+      "@typescript-eslint:no-unsafe-type-assertion",
+      "@typescript-eslint:no-unsafe-unary-minus",
+      "@typescript-eslint:no-unused-vars",
+      "@typescript-eslint:no-useless-empty-export",
+      "@typescript-eslint:no-var-requires",
+      "@typescript-eslint:non-nullable-type-assertion-style",
+      "@typescript-eslint:only-throw-error",
+      "@typescript-eslint:prefer-as-const",
+      "@typescript-eslint:prefer-promise-reject-errors",
+      "@typescript-eslint:prefer-reduce-type-parameter",
+      "@typescript-eslint:prefer-return-this-type",
+      "@typescript-eslint:promise-function-async",
+      "@typescript-eslint:related-getter-setter-pairs",
+      "@typescript-eslint:require-array-sort-compare",
+      "@typescript-eslint:require-await",
+      "@typescript-eslint:restrict-plus-operands",
+      "@typescript-eslint:restrict-template-expressions",
+      "@typescript-eslint:return-await",
+      "@typescript-eslint:switch-exhaustiveness-check",
+      "@typescript-eslint:unbound-method",
+      "@typescript-eslint:use-unknown-in-catch-callback-variable"
+    ]
+  },
+  {
+    "version": "0.1.5",
+    "rules": []
+  },
+  {
+    "version": "0.1.6",
+    "rules": [
+      "@typescript-eslint:no-empty-function",
+      "@typescript-eslint:no-empty-interface",
+      "@typescript-eslint:no-namespace",
+      "@typescript-eslint:no-require-imports"
+    ]
+  },
+  {
+    "version": "0.1.7",
+    "rules": []
+  },
+  {
+    "version": "0.1.8",
+    "rules": [
+      "eslint-plugin-import:no-self-import"
+    ]
+  },
+  {
+    "version": "0.1.9",
+    "rules": []
+  },
+  {
+    "version": "0.1.10",
+    "rules": []
+  },
+  {
+    "version": "0.1.11",
+    "rules": []
+  },
+  {
+    "version": "0.1.12",
+    "rules": []
+  },
+  {
+    "version": "0.1.13",
+    "rules": [
+      "@typescript-eslint:no-explicit-any",
+      "eslint:dot-notation"
+    ]
+  },
+  {
+    "version": "0.1.14",
+    "rules": [
+      "@typescript-eslint:ban-ts-comment",
+      "@typescript-eslint:ban-types",
+      "@typescript-eslint:consistent-generic-constructors",
+      "@typescript-eslint:consistent-indexed-object-style",
+      "@typescript-eslint:consistent-return",
+      "@typescript-eslint:consistent-type-assertions",
+      "@typescript-eslint:consistent-type-definitions",
+      "@typescript-eslint:consistent-type-exports",
+      "@typescript-eslint:consistent-type-imports",
+      "@typescript-eslint:default-param-last",
+      "@typescript-eslint:dot-notation",
+      "@typescript-eslint:no-duplicate-enum-values",
+      "@typescript-eslint:no-extraneous-class",
+      "@typescript-eslint:no-invalid-void-type",
+      "@typescript-eslint:no-misused-new",
+      "@typescript-eslint:no-this-alias",
+      "@typescript-eslint:prefer-readonly-parameter-types",
+      "@typescript-eslint:triple-slash-reference",
+      "@typescript-eslint:unified-signatures",
+      "eslint-plugin-import:no-webpack-loader-syntax",
+      "eslint:array-callback-return",
+      "eslint:constructor-super",
+      "eslint:for-direction",
+      "eslint:getter-return",
+      "eslint:no-async-promise-executor",
+      "eslint:no-await-in-loop",
+      "eslint:no-class-assign",
+      "eslint:no-compare-neg-zero",
+      "eslint:no-cond-assign",
+      "eslint:no-const-assign",
+      "eslint:no-constant-binary-expression",
+      "eslint:no-constant-condition",
+      "eslint:no-constructor-return",
+      "eslint:no-debugger",
+      "eslint:no-sparse-arrays",
+      "eslint:no-template-curly-in-string"
+    ]
+  },
+  {
+    "version": "0.2.0",
+    "rules": []
+  },
+  {
+    "version": "0.2.1",
+    "rules": [
+      "@typescript-eslint:no-array-constructor",
+      "@typescript-eslint:no-extra-non-null-assertion",
+      "@typescript-eslint:no-inferrable-types",
+      "@typescript-eslint:no-non-null-asserted-nullish-coalescing",
+      "@typescript-eslint:no-non-null-asserted-optional-chain",
+      "@typescript-eslint:no-non-null-assertion",
+      "@typescript-eslint:prefer-literal-enum-member",
+      "@typescript-eslint:prefer-namespace-keyword",
+      "@typescript-eslint:prefer-readonly",
+      "@typescript-eslint:prefer-string-starts-ends-with",
+      "eslint:no-loss-of-precision"
+    ]
+  },
+  {
+    "version": "0.2.2",
+    "rules": [
+      "eslint:default-case",
+      "eslint:no-case-declarations",
+      "eslint:no-console",
+      "eslint:no-dupe-args",
+      "eslint:no-dupe-keys",
+      "eslint:no-duplicate-case",
+      "eslint:no-empty",
+      "eslint:no-empty-pattern"
+    ]
+  },
+  {
+    "version": "0.2.3",
+    "rules": []
+  },
+  {
+    "version": "0.3.0",
+    "rules": [
+      "@typescript-eslint:ban-tslint-comment",
+      "@typescript-eslint:prefer-includes",
+      "@typescript-eslint:prefer-regexp-exec",
+      "@typescript-eslint:prefer-ts-expect-error",
+      "eslint-plugin-react:jsx-boolean-value",
+      "eslint-plugin-react:jsx-closing-tag-location",
+      "eslint-plugin-react:jsx-equals-spacing",
+      "eslint-plugin-react:jsx-filename-extension",
+      "eslint-plugin-react:jsx-first-prop-new-line",
+      "eslint-plugin-react:jsx-max-props-per-line",
+      "eslint-plugin-react:jsx-props-no-multi-spaces",
+      "eslint-plugin-react:jsx-uses-react",
+      "eslint-plugin-react:jsx-uses-vars",
+      "eslint-plugin-react:jsx-wrap-multilines",
+      "eslint-plugin-react:react-in-jsx-scope",
+      "eslint-plugin-react:self-closing-comp",
+      "eslint-plugin-react:style-prop-object",
+      "eslint-plugin-react:void-dom-elements-no-children",
+      "eslint:no-ex-assign"
+    ]
+  },
+  {
+    "version": "0.3.1",
+    "rules": []
+  },
+  {
+    "version": "0.3.2",
+    "rules": [
+      "@typescript-eslint:no-dynamic-delete"
+    ]
+  },
+  {
+    "version": "0.3.3",
+    "rules": [
+      "eslint:no-this-before-super",
+      "eslint:no-undef",
+      "eslint:prefer-const"
+    ]
+  },
+  {
+    "version": "0.3.4",
+    "rules": [
+      "eslint-plugin-jest:no-hooks",
+      "eslint-plugin-jest:valid-describe-callback",
+      "eslint:no-extra-bind",
+      "eslint:no-global-assign"
+    ]
+  },
+  {
+    "version": "0.4.0",
+    "rules": [
+      "eslint-plugin-jest:no-disabled-tests",
+      "eslint-plugin-jest:no-focused-tests",
+      "eslint:default-case-last",
+      "eslint:no-caller",
+      "eslint:no-empty-character-class",
+      "eslint:no-func-assign",
+      "eslint:no-import-assign",
+      "eslint:no-inner-declarations",
+      "eslint:no-invalid-regexp",
+      "eslint:no-new-symbol",
+      "eslint:no-new-wrappers",
+      "eslint:no-obj-calls",
+      "eslint:no-self-assign",
+      "eslint:no-setter-return",
+      "eslint:no-unsafe-negation",
+      "eslint:no-var",
+      "eslint:prefer-rest-params",
+      "eslint:use-isnan"
+    ]
+  },
+  {
+    "version": "0.4.1",
+    "rules": [
+      "eslint-plugin-jest:no-test-prefixes",
+      "eslint:eqeqeq"
+    ]
+  },
+  {
+    "version": "0.4.2",
+    "rules": [
+      "@typescript-eslint:explicit-function-return-type",
+      "@typescript-eslint:member-ordering",
+      "@typescript-eslint:naming-convention",
+      "@typescript-eslint:no-dupe-class-members",
+      "@typescript-eslint:no-unnecessary-condition",
+      "@typescript-eslint:no-unused-expressions",
+      "@typescript-eslint:no-use-before-define",
+      "@typescript-eslint:no-useless-constructor",
+      "@typescript-eslint:parameter-properties",
+      "eslint-plugin-import:first",
+      "eslint-plugin-import:newline-after-import",
+      "eslint-plugin-import:no-duplicates",
+      "eslint-plugin-import:no-mutable-exports",
+      "eslint-plugin-jest:no-alias-methods",
+      "eslint-plugin-jest:prefer-to-have-length",
+      "eslint-plugin-jest:prefer-todo",
+      "eslint:no-alert",
+      "eslint:no-delete-var",
+      "eslint:no-eval",
+      "eslint:no-fallthrough",
+      "eslint:no-iterator",
+      "eslint:no-labels",
+      "eslint:no-multi-str",
+      "eslint:no-new-func",
+      "eslint:no-new-object",
+      "eslint:no-octal-escape",
+      "eslint:no-proto",
+      "eslint:no-restricted-imports",
+      "eslint:no-script-url",
+      "eslint:no-undef-init",
+      "eslint:no-unmodified-loop-condition",
+      "eslint:no-unreachable",
+      "eslint:no-unsafe-finally",
+      "eslint:no-unsafe-optional-chaining",
+      "eslint:no-with",
+      "eslint:require-atomic-updates",
+      "eslint:valid-typeof"
+    ]
+  },
+  {
+    "version": "0.5.0",
+    "rules": [
+      "@typescript-eslint:method-signature-style",
+      "@typescript-eslint:no-redeclare",
+      "@typescript-eslint:no-unnecessary-type-constraint",
+      "@typescript-eslint:prefer-optional-chain",
+      "eslint-plugin-jest:prefer-strict-equal",
+      "eslint-plugin-promise:param-names",
+      "eslint-plugin-react:button-has-type",
+      "eslint-plugin-react:jsx-key",
+      "eslint-plugin-react:jsx-no-bind",
+      "eslint-plugin-react:jsx-no-comment-textnodes",
+      "eslint-plugin-react:jsx-no-duplicate-props",
+      "eslint-plugin-react:jsx-no-target-blank",
+      "eslint-plugin-react:jsx-no-undef",
+      "eslint-plugin-react:jsx-pascal-case",
+      "eslint-plugin-react:no-access-state-in-setstate",
+      "eslint-plugin-react:no-children-prop",
+      "eslint-plugin-react:no-danger",
+      "eslint-plugin-react:no-danger-with-children",
+      "eslint-plugin-react:no-deprecated",
+      "eslint-plugin-react:no-did-update-set-state",
+      "eslint-plugin-react:no-direct-mutation-state",
+      "eslint-plugin-react:no-find-dom-node",
+      "eslint-plugin-react:no-is-mounted",
+      "eslint-plugin-react:no-redundant-should-component-update",
+      "eslint-plugin-react:no-render-return-value",
+      "eslint-plugin-react:no-string-refs",
+      "eslint-plugin-react:no-this-in-sfc",
+      "eslint-plugin-react:no-typos",
+      "eslint-plugin-react:no-unescaped-entities",
+      "eslint-plugin-react:no-unknown-property",
+      "eslint-plugin-react:no-will-update-set-state",
+      "eslint-plugin-react:prefer-es6-class",
+      "eslint-plugin-react:require-render-return",
+      "eslint:accessor-pairs",
+      "eslint:guard-for-in",
+      "eslint:max-lines",
+      "eslint:no-bitwise",
+      "eslint:no-control-regex",
+      "eslint:no-dupe-class-members",
+      "eslint:no-dupe-else-if",
+      "eslint:no-extend-native",
+      "eslint:no-extra-boolean-cast",
+      "eslint:no-extra-label",
+      "eslint:no-implicit-coercion",
+      "eslint:no-implied-eval",
+      "eslint:no-label-var",
+      "eslint:no-lone-blocks",
+      "eslint:no-loop-func",
+      "eslint:no-misleading-character-class",
+      "eslint:no-nested-ternary",
+      "eslint:no-new",
+      "eslint:no-octal",
+      "eslint:no-param-reassign",
+      "eslint:no-prototype-builtins",
+      "eslint:no-regex-spaces",
+      "eslint:no-return-assign",
+      "eslint:no-self-compare",
+      "eslint:no-sequences",
+      "eslint:no-shadow",
+      "eslint:no-shadow-restricted-names",
+      "eslint:no-throw-literal",
+      "eslint:no-unneeded-ternary",
+      "eslint:no-useless-call",
+      "eslint:no-useless-catch",
+      "eslint:no-useless-computed-key",
+      "eslint:no-useless-concat",
+      "eslint:no-useless-constructor",
+      "eslint:no-useless-rename",
+      "eslint:object-shorthand",
+      "eslint:prefer-promise-reject-errors",
+      "eslint:prefer-spread",
+      "eslint:prefer-template",
+      "eslint:radix",
+      "eslint:require-yield",
+      "eslint:strict",
+      "eslint:symbol-description"
+    ]
+  },
+  {
+    "version": "0.5.1",
+    "rules": [
+      "@typescript-eslint:no-magic-numbers",
+      "@typescript-eslint:prefer-destructuring",
+      "@typescript-eslint:prefer-for-of",
+      "eslint-plugin-react-hooks:exhaustive-deps",
+      "eslint-plugin-react-hooks:rules-of-hooks",
+      "eslint-plugin-react:jsx-curly-brace-presence",
+      "eslint-plugin-react:jsx-no-leaked-render",
+      "eslint-plugin-react:jsx-no-script-url",
+      "eslint-plugin-react:no-unstable-nested-components",
+      "eslint-plugin-react:no-unused-class-component-methods",
+      "eslint-plugin-react:no-unused-state",
+      "eslint-plugin-react:prefer-stateless-function",
+      "eslint-plugin-unicorn:filename-case",
+      "eslint-plugin-unicorn:no-static-only-class",
+      "eslint:no-irregular-whitespace"
+    ]
+  },
+  {
+    "version": "0.5.2",
+    "rules": [
+      "@typescript-eslint:explicit-member-accessibility",
+      "@typescript-eslint:max-params",
+      "@typescript-eslint:no-loop-func",
+      "@typescript-eslint:no-restricted-imports",
+      "@typescript-eslint:no-shadow",
+      "@typescript-eslint:prefer-nullish-coalescing",
+      "eslint-plugin-jest:no-deprecated-functions",
+      "eslint-plugin-jest:no-done-callback",
+      "eslint-plugin-jest:no-mocks-import",
+      "eslint-plugin-jest:prefer-to-contain",
+      "eslint-plugin-react:boolean-prop-naming",
+      "eslint-plugin-react:forbid-component-props",
+      "eslint-plugin-react:forbid-dom-props",
+      "eslint-plugin-react:forbid-elements",
+      "eslint-plugin-react:forbid-prop-types",
+      "eslint-plugin-react:jsx-child-element-spacing",
+      "eslint-plugin-react:jsx-curly-spacing",
+      "eslint-plugin-react:jsx-handler-names",
+      "eslint-plugin-react:no-array-index-key",
+      "eslint-plugin-react:no-did-mount-set-state",
+      "eslint-plugin-react:no-multi-comp",
+      "eslint-plugin-react:no-set-state",
+      "eslint:complexity",
+      "eslint:max-depth",
+      "eslint:max-lines-per-function",
+      "eslint:max-nested-callbacks",
+      "eslint:no-duplicate-imports",
+      "eslint:no-multi-assign",
+      "eslint:no-nonoctal-decimal-escape",
+      "eslint:no-restricted-syntax",
+      "eslint:no-unexpected-multiline",
+      "eslint:no-useless-backreference",
+      "eslint:no-useless-escape",
+      "eslint:one-var"
+    ]
+  },
+  {
+    "version": "0.5.3",
+    "rules": [
+      "eslint-plugin-jest:no-commented-out-tests",
+      "eslint-plugin-jest:no-identical-title",
+      "eslint-plugin-jest:prefer-to-be",
+      "eslint-plugin-jsx-a11y:alt-text",
+      "eslint-plugin-jsx-a11y:anchor-has-content",
+      "eslint-plugin-jsx-a11y:anchor-is-valid",
+      "eslint-plugin-jsx-a11y:aria-activedescendant-has-tabindex",
+      "eslint-plugin-jsx-a11y:aria-props",
+      "eslint-plugin-jsx-a11y:aria-proptypes",
+      "eslint-plugin-jsx-a11y:aria-role",
+      "eslint-plugin-jsx-a11y:aria-unsupported-elements",
+      "eslint-plugin-jsx-a11y:autocomplete-valid",
+      "eslint-plugin-jsx-a11y:click-events-have-key-events",
+      "eslint-plugin-jsx-a11y:control-has-associated-label",
+      "eslint-plugin-jsx-a11y:heading-has-content",
+      "eslint-plugin-jsx-a11y:html-has-lang",
+      "eslint-plugin-jsx-a11y:iframe-has-title",
+      "eslint-plugin-jsx-a11y:img-redundant-alt",
+      "eslint-plugin-jsx-a11y:interactive-supports-focus",
+      "eslint-plugin-jsx-a11y:label-has-associated-control",
+      "eslint-plugin-jsx-a11y:media-has-caption",
+      "eslint-plugin-jsx-a11y:mouse-events-have-key-events",
+      "eslint-plugin-jsx-a11y:no-access-key",
+      "eslint-plugin-jsx-a11y:no-autofocus",
+      "eslint-plugin-jsx-a11y:no-distracting-elements",
+      "eslint-plugin-jsx-a11y:no-interactive-element-to-noninteractive-role",
+      "eslint-plugin-jsx-a11y:no-noninteractive-element-interactions",
+      "eslint-plugin-jsx-a11y:no-noninteractive-element-to-interactive-role",
+      "eslint-plugin-jsx-a11y:no-noninteractive-tabindex",
+      "eslint-plugin-jsx-a11y:no-redundant-roles",
+      "eslint-plugin-jsx-a11y:no-static-element-interactions",
+      "eslint-plugin-jsx-a11y:role-has-required-aria-props",
+      "eslint-plugin-jsx-a11y:role-supports-aria-props",
+      "eslint-plugin-jsx-a11y:scope",
+      "eslint-plugin-jsx-a11y:tabindex-no-positive",
+      "eslint-plugin-react:destructuring-assignment",
+      "eslint-plugin-react:display-name",
+      "eslint-plugin-react:forbid-foreign-prop-types",
+      "eslint-plugin-react:jsx-closing-bracket-location",
+      "eslint-plugin-react:jsx-indent",
+      "eslint-plugin-react:jsx-indent-props",
+      "eslint-plugin-react:jsx-max-depth",
+      "eslint-plugin-react:jsx-no-literals",
+      "eslint-plugin-react:no-unsafe",
+      "eslint-plugin-react:require-optimization"
+    ]
+  },
+  {
+    "version": "0.6.0",
+    "rules": [
+      "@typescript-eslint:class-methods-use-this",
+      "@typescript-eslint:explicit-module-boundary-types",
+      "@typescript-eslint:init-declarations",
+      "@typescript-eslint:no-confusing-non-null-assertion",
+      "@typescript-eslint:no-deprecated",
+      "@typescript-eslint:no-empty-object-type",
+      "@typescript-eslint:no-import-type-side-effects",
+      "@typescript-eslint:no-invalid-this",
+      "@typescript-eslint:no-restricted-types",
+      "@typescript-eslint:no-type-alias",
+      "@typescript-eslint:no-unnecessary-parameter-property-assignment",
+      "@typescript-eslint:no-unnecessary-qualifier",
+      "@typescript-eslint:no-unnecessary-type-conversion",
+      "@typescript-eslint:no-unsafe-declaration-merging",
+      "@typescript-eslint:no-unsafe-function-type",
+      "@typescript-eslint:no-unused-private-class-members",
+      "@typescript-eslint:no-useless-default-assignment",
+      "@typescript-eslint:no-wrapper-object-types",
+      "@typescript-eslint:prefer-enum-initializers",
+      "@typescript-eslint:prefer-find",
+      "@typescript-eslint:prefer-function-type",
+      "@typescript-eslint:strict-boolean-expressions",
+      "@typescript-eslint:strict-void-return",
+      "eslint-plugin-jest:expect-expect",
+      "eslint-plugin-jest:max-nested-describe",
+      "eslint-plugin-jest:no-duplicate-hooks",
+      "eslint-plugin-jest:no-jasmine-globals",
+      "eslint-plugin-jest:no-standalone-expect",
+      "eslint-plugin-jest:prefer-called-with",
+      "eslint-plugin-jest:prefer-each",
+      "eslint-plugin-jest:prefer-expect-resolves",
+      "eslint-plugin-jest:prefer-to-have-been-called",
+      "eslint-plugin-jest:prefer-to-have-been-called-times",
+      "eslint-plugin-jest:valid-expect",
+      "eslint-plugin-jest:valid-title",
+      "eslint-plugin-jsx-a11y:anchor-ambiguous-text",
+      "eslint-plugin-jsx-a11y:lang",
+      "eslint-plugin-jsx-a11y:no-aria-hidden-on-focusable",
+      "eslint-plugin-jsx-a11y:prefer-tag-over-role",
+      "eslint-plugin-promise:always-return",
+      "eslint-plugin-promise:avoid-new",
+      "eslint-plugin-promise:catch-or-return",
+      "eslint-plugin-promise:no-return-wrap",
+      "eslint-plugin-react:checked-requires-onchange-or-readonly"
+    ]
+  },
+  {
+    "version": "0.6.1",
+    "rules": [
+      "eslint-plugin-jest:max-expects"
+    ]
+  },
+  {
+    "version": "0.6.2",
+    "rules": [
+      "eslint-plugin-jest:prefer-equality-matcher",
+      "eslint-plugin-promise:no-multiple-resolved",
+      "eslint-plugin-promise:no-nesting"
+    ]
+  },
+  {
+    "version": "0.6.3",
+    "rules": [
+      "eslint-plugin-jest:no-confusing-set-timeout",
+      "eslint-plugin-jest:no-export",
+      "eslint-plugin-jest:prefer-hooks-in-order",
+      "eslint-plugin-jest:prefer-hooks-on-top",
+      "eslint-plugin-promise:no-new-statics",
+      "eslint-plugin-promise:valid-params",
+      "eslint:arrow-body-style",
+      "eslint:curly"
+    ]
+  },
+  {
+    "version": "0.6.4",
+    "rules": [
+      "eslint-plugin-jest:prefer-jest-mocked",
+      "eslint-plugin-jest:prefer-spy-on",
+      "eslint-plugin-promise:no-callback-in-promise",
+      "eslint-plugin-promise:no-return-in-finally",
+      "eslint-plugin-promise:prefer-catch"
+    ]
+  },
+  {
+    "version": "0.6.5",
+    "rules": [
+      "eslint-plugin-import:default",
+      "eslint-plugin-import:namespace",
+      "eslint-plugin-import:no-cycle",
+      "eslint-plugin-import:no-default-export",
+      "eslint-plugin-jest:no-conditional-expect",
+      "eslint-plugin-jest:no-restricted-matchers",
+      "eslint-plugin-jest:no-unneeded-async-expect-function",
+      "eslint-plugin-promise:no-promise-in-callback",
+      "eslint-plugin-promise:prefer-await-to-then",
+      "eslint-plugin-react-hooks:component-hook-factories",
+      "eslint-plugin-react-hooks:error-boundaries",
+      "eslint-plugin-react-hooks:globals",
+      "eslint-plugin-react:forward-ref-uses-ref",
+      "eslint-plugin-react:jsx-fragments",
+      "eslint-plugin-react:jsx-props-no-spread-multi",
+      "eslint-plugin-unicorn:new-for-builtins",
+      "eslint-plugin-unicorn:no-instanceof-builtins",
+      "eslint-plugin-unicorn:no-thenable",
+      "eslint-plugin-unicorn:no-useless-switch-case",
+      "eslint-plugin-unicorn:prefer-array-flat-map",
+      "eslint-plugin-unicorn:prefer-number-properties",
+      "eslint:max-params",
+      "eslint:no-else-return",
+      "eslint:no-empty-function",
+      "eslint:no-empty-static-block",
+      "eslint:no-new-native-nonconstructor",
+      "eslint:no-unassigned-vars",
+      "eslint:no-unused-expressions",
+      "eslint:no-unused-labels",
+      "eslint:no-unused-private-class-members",
+      "eslint:prefer-arrow-callback",
+      "eslint:prefer-exponentiation-operator",
+      "eslint:prefer-numeric-literals",
+      "eslint:prefer-regex-literals",
+      "eslint:require-await"
+    ]
+  },
+  {
+    "version": "0.7.0",
+    "rules": [
+      "eslint-plugin-jest:no-interpolation-in-snapshots",
+      "eslint-plugin-jest:no-restricted-jest-methods",
+      "eslint-plugin-jest:prefer-comparison-matcher",
+      "eslint-plugin-unicorn:require-array-join-separator",
+      "eslint-plugin-unicorn:require-number-to-fixed-digits-argument",
+      "eslint:no-redeclare",
+      "eslint:no-restricted-globals"
+    ]
+  },
+  {
+    "version": "0.7.1",
+    "rules": [
+      "eslint-plugin-jest:no-conditional-in-test",
+      "eslint-plugin-unicorn:prefer-array-flat",
+      "eslint:no-unused-vars",
+      "eslint:prefer-destructuring",
+      "eslint:prefer-object-spread"
+    ]
+  },
+  {
+    "version": "0.7.2",
+    "rules": [
+      "eslint-plugin-jest:require-hook",
+      "rstest:no-mocks-import"
+    ]
+  }
+]

--- a/website/theme/components/RuleStates/rule.tsx
+++ b/website/theme/components/RuleStates/rule.tsx
@@ -12,7 +12,9 @@ import { CancelSymbol, TableSelector } from './table-selector';
 import { Badge, Heading, PresetBadge, Text } from './ui-utils';
 import { Button } from '@components/ui/button';
 import manifest from '@/generated/rule-manifest.json';
+import ruleReleases from '@/rule-releases.json';
 import { groupToRouteSlug } from '@/theme/plugin-registry';
+import RuleVersionBadge from '@/theme/components/RuleVersionBadge';
 
 // Type definitions
 type FailingCase = {
@@ -28,6 +30,12 @@ type Rule = {
   docPath: string | null;
   presets: { name: string; value: unknown }[];
 };
+
+const introducedInByRule = new Map(
+  ruleReleases.flatMap(({ version, rules }) =>
+    rules.map((rule) => [rule, version] as const),
+  ),
+);
 
 type RuleStateDescribe = {
   name: string;
@@ -231,6 +239,7 @@ const RuleImplementationStatus: React.FC = () => {
                   <TableHead className="w-2/6">Rule Name</TableHead>
                   <TableHead className="w-1/6">Group</TableHead>
                   <TableHead className="w-1/6">Preset</TableHead>
+                  <TableHead className="w-1/12">Since</TableHead>
                   <TableHead className="w-1/12">Status</TableHead>
                   <TableHead className="w-1/6">Failing Cases</TableHead>
                 </TableRow>
@@ -270,6 +279,13 @@ const RuleImplementationStatus: React.FC = () => {
                           ))}
                         </div>
                       )}
+                    </TableCell>
+                    <TableCell>
+                      <RuleVersionBadge
+                        introducedIn={introducedInByRule.get(
+                          `${rule.group}:${rule.name}`,
+                        )}
+                      />
                     </TableCell>
                     <TableCell>
                       <Badge>{rule.status}</Badge>

--- a/website/theme/components/RuleVersionBadge.tsx
+++ b/website/theme/components/RuleVersionBadge.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Badge } from '@components/ui/badge';
+
+export interface RuleVersionBadgeProps {
+  introducedIn?: string | null;
+}
+
+export const RuleVersionBadge: React.FC<RuleVersionBadgeProps> = ({
+  introducedIn,
+}) => {
+  if (!introducedIn) {
+    return (
+      <Badge
+        variant="unreleased"
+        title="This rule has not been assigned to an rslint release yet"
+      >
+        Unreleased
+      </Badge>
+    );
+  }
+
+  return (
+    <a
+      href={`https://github.com/web-infra-dev/rslint/releases/tag/v${introducedIn}`}
+      target="_blank"
+      rel="noreferrer"
+      className="group"
+      title={`View the rslint v${introducedIn} release`}
+    >
+      <Badge
+        variant="version"
+        className="underline-offset-2 group-hover:underline"
+      >
+        Added in v{introducedIn}
+      </Badge>
+    </a>
+  );
+};
+
+export default RuleVersionBadge;

--- a/website/theme/components/ui/badge.tsx
+++ b/website/theme/components/ui/badge.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/theme/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex w-fit shrink-0 items-center justify-center rounded-xs px-2 py-1 text-xs font-medium whitespace-nowrap',
+  {
+    variants: {
+      variant: {
+        secondary:
+          'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+        version:
+          'bg-emerald-200/80 text-black dark:bg-emerald-700/80 dark:text-white',
+        unreleased: 'bg-amber-100 text-black dark:bg-zinc-700 dark:text-white',
+      },
+    },
+    defaultVariants: {
+      variant: 'secondary',
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants>) {
+  return (
+    <span
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };


### PR DESCRIPTION
## Summary

- Show each rule's rslint release version on the rule page and in the rules table, linking published versions to their GitHub releases.
- Show rules without a release assignment as `Unreleased`.
- Add full-history and incremental synchronization modes that generate the top-level `website/rule-releases.json` release array.

### Data

| Metric | Value |
| --- | ---: |
| Stable releases represented | 36 (`v0.1.4`–`v0.7.2`) |
| Unique historical rule assignments | 473 |
| Rules in the current manifest | 470 |
| Current rules with a release assignment | 469 |
| Current unreleased rules | 1 (`eslint-plugin-jest:require-top-level-describe`) |
| Historical assignments no longer in the current manifest | 4 |

### Validation

- `pnpm check-spell`
- `pnpm format:check`
- Go lint changed-code scope verified empty because this PR changes no Go files.
- `pnpm sync:rule-releases full`
- Default no-op and simulated next-version incremental synchronization verified.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
