### PR TITLE
feat(rstest): add no-identical-title rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -1,12 +1,14 @@
 package rstest
 
 import (
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_identical_title"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
+		no_identical_title.NoIdenticalTitleRule,
 		no_mocks_import.NoMocksImportRule,
 	}
 }

--- a/internal/plugins/rstest/rules/no_identical_title/no_identical_title.go
+++ b/internal/plugins/rstest/rules/no_identical_title/no_identical_title.go
@@ -1,26 +1,24 @@
 package no_identical_title
 
 import (
-	"slices"
-
 	"github.com/microsoft/typescript-go/shim/ast"
-	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_identical_title"
 )
 
-func parseJestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
-	parsed := jestUtils.ParseJestFnCall(node, ctx)
+func parseRstestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
+	parsed := rstestUtils.ParseRstestFnCall(node, ctx)
 	if parsed == nil {
 		return nil
 	}
 	return &shared.ParsedCall{
 		Call:          &parsed.ParsedCall,
-		Parameterized: slices.Contains(parsed.Members, "each"),
+		Parameterized: parsed.Parameterized,
 	}
 }
 
 var NoIdenticalTitleRule = shared.NewRule(shared.Config{
-	Name:  "jest/no-identical-title",
-	Parse: parseJestCall,
+	Name:  "rstest/no-identical-title",
+	Parse: parseRstestCall,
 })

--- a/internal/plugins/rstest/rules/no_identical_title/no_identical_title.md
+++ b/internal/plugins/rstest/rules/no_identical_title/no_identical_title.md
@@ -1,0 +1,32 @@
+# no-identical-title
+
+## Rule Details
+
+Disallow the same static title for two tests or two `describe` blocks in the
+same scope.
+
+Examples of incorrect code:
+
+```ts
+test("loads user", () => {});
+test.only("loads user", () => {});
+
+describe("api", () => {});
+describe.skip("api", () => {});
+```
+
+Examples of correct code:
+
+```ts
+describe("api", () => {
+  test("loads user", () => {});
+
+  describe("nested", () => {
+    test("loads user", () => {});
+  });
+});
+```
+
+Test titles and describe titles are tracked separately. Dynamic titles are
+ignored. Parameterized `.each` and `.for` registration titles are also ignored
+because Rstest expands them at runtime.

--- a/internal/plugins/rstest/rules/no_identical_title/no_identical_title_test.go
+++ b/internal/plugins/rstest/rules/no_identical_title/no_identical_title_test.go
@@ -1,0 +1,191 @@
+package no_identical_title_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_identical_title"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoIdenticalTitleRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_identical_title.NoIdenticalTitleRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `test("one", () => {}); test("two", () => {});`},
+			{Code: `describe("same", () => {}); test("same", () => {});`},
+			{Code: `describe("outer", () => {
+  test("same", () => {});
+  describe("inner", () => {
+    test("same", () => {});
+  });
+});`},
+			{Code: `test("case " + name, () => {}); test("case " + name, () => {});`},
+			{Code: "test(`case ${name}`, () => {}); test(`case ${name}`, () => {});"},
+			{Code: `test.each([1, 2])("case %i", () => {});
+test.each([3, 4])("case %i", () => {});
+test.for([1, 2])("case %i", () => {});
+test.for([3, 4])("case %i", () => {});`},
+			{Code: "describe.each`value\n${1}`(\"case $value\", () => {});\ndescribe.for`value\n${1}`(\"case $value\", () => {});"},
+			{Code: `test.for([1]).concurrent("same", () => {});
+test.for([2]).concurrent("same", () => {});`},
+			{Code: `describe.each([1]).only("same", () => {});
+describe.each([2]).only("same", () => {});`},
+			{Code: `fit("same", () => {}); fit("same", () => {});
+xit("same", () => {}); xtest("same", () => {});
+fdescribe("same", () => {}); xdescribe("same", () => {});`},
+			{Code: `import { test } from "node:test";
+test("same", () => {});
+test("same", () => {});`},
+			{Code: `import { test, describe } from "vitest";
+test("same", () => {});
+test("same", () => {});
+describe("suite", () => {});
+describe("suite", () => {});`},
+			{Code: `const test = createRunner();
+test("same", () => {});
+test("same", () => {});`},
+			{Code: `let customTest = test;
+customTest("same", () => {});
+customTest("same", () => {});`},
+			{Code: `describe.fails("same", () => {});
+describe.fails("same", () => {});`},
+			{Code: `test.only.extend({})("same", () => {});
+test.only.extend({})("same", () => {});`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `test("same", () => {});
+test("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 2, Column: 6},
+				},
+			},
+			{
+				Code: `test("same", () => {});
+it("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 2, Column: 4},
+				},
+			},
+			{
+				Code: `describe("same", () => {});
+describe.only("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleDescribeTitle", Line: 2, Column: 15},
+				},
+			},
+			{
+				Code: `test.only.concurrent("same", () => {});
+test.concurrent.only("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 2, Column: 22},
+				},
+			},
+			{
+				Code: `test.skip("same", () => {});
+test.todo("same");
+test.fails("same", () => {});
+test.sequential("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 2, Column: 11},
+					{MessageId: "multipleTestTitle", Line: 3, Column: 12},
+					{MessageId: "multipleTestTitle", Line: 4, Column: 17},
+				},
+			},
+			{
+				Code: `test.runIf(condition)("same", () => {});
+test.skipIf(condition).only("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 2, Column: 29},
+				},
+			},
+			{
+				Code: `describe.concurrent("same", () => {});
+describe.sequential.runIf(condition)("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleDescribeTitle", Line: 2, Column: 38},
+				},
+			},
+			{
+				Code: `import { test as rstestTest, describe as rstestDescribe } from "@rstest/core";
+rstestTest("same", () => {});
+rstestTest.only("same", () => {});
+rstestDescribe("suite", () => {});
+rstestDescribe.skip("suite", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 3, Column: 17},
+					{MessageId: "multipleDescribeTitle", Line: 5, Column: 21},
+				},
+			},
+			{
+				Code: `const { test: rstestTest, describe: rstestDescribe } = require("@rstest/core");
+rstestTest("same", () => {});
+rstestTest("same", () => {});
+rstestDescribe("suite", () => {});
+rstestDescribe("suite", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 3, Column: 12},
+					{MessageId: "multipleDescribeTitle", Line: 5, Column: 16},
+				},
+			},
+			{
+				Code: `import * as rstest from "@rstest/core";
+rstest.test("same", () => {});
+rstest.test.only("same", () => {});
+rstest.describe("suite", () => {});
+rstest.describe.only("suite", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 3, Column: 18},
+					{MessageId: "multipleDescribeTitle", Line: 5, Column: 22},
+				},
+			},
+			{
+				Code: `const rstest = require("@rstest/core");
+rstest.test("same", () => {});
+rstest.test("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 3, Column: 13},
+				},
+			},
+			{
+				Code: `import { test } from "@rstest/core";
+const alias = test;
+const appTest = alias.extend({});
+const adminTest = appTest.extend({});
+test("same", () => {});
+appTest.only("same", () => {});
+adminTest.skipIf(condition)("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 6, Column: 14},
+					{MessageId: "multipleTestTitle", Line: 7, Column: 29},
+				},
+			},
+			{
+				Code: `test.extend({})("same", () => {});
+test.extend({}).only("same", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 2, Column: 22},
+				},
+			},
+			{
+				Code: `describe.each([1, 2])("case %i", () => {
+  test("duplicate", () => {});
+  test("duplicate", () => {});
+});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 3, Column: 8},
+				},
+			},
+			{
+				Code: "test('same', () => {});\ntest(`same`, () => {});",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleTestTitle", Line: 2, Column: 6},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"slices"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
@@ -40,11 +38,6 @@ type rstestResolvedAPI struct {
 	state        rstestAPIState
 	originalNode *ast.Node
 	mode         RstestImportMode
-}
-
-func IsTypeOfRstestFnCall(node *ast.Node, ctx rule.RuleContext, kinds ...RstestFnType) bool {
-	parsed := ParseRstestFnCall(node, ctx)
-	return parsed != nil && len(kinds) > 0 && slices.Contains(kinds, parsed.Kind)
 }
 
 // ParseRstestFnCall parses a final Rstest test/describe registration call.

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
@@ -153,8 +154,8 @@ func parseRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, bool, bool)
 			return nil, nil, false, false
 		}
 		nameNode := ast.SkipParentheses(element.ArgumentExpression)
-		name := staticRstestMemberName(nameNode)
-		if name == "" {
+		name, ok := internalUtils.GetStaticStringLiteralValue(nameNode)
+		if !ok || name == "" {
 			return nil, nil, false, false
 		}
 		return root, append(parts, rstestChainPart{
@@ -188,20 +189,6 @@ func parseRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, bool, bool)
 		return root, parts, rootInvoked, true
 	default:
 		return nil, nil, false, false
-	}
-}
-
-func staticRstestMemberName(node *ast.Node) string {
-	if node == nil {
-		return ""
-	}
-	switch node.Kind {
-	case ast.KindStringLiteral:
-		return node.AsStringLiteral().Text
-	case ast.KindNoSubstitutionTemplateLiteral:
-		return node.AsNoSubstitutionTemplateLiteral().Text
-	default:
-		return ""
 	}
 }
 

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -1,0 +1,358 @@
+package utils
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+type rstestAPIState uint8
+
+const (
+	rstestAPIInvalid rstestAPIState = iota
+	rstestAPITest
+	rstestAPITestWithExtend
+	rstestAPIDescribe
+	rstestAPIParameterizedTest
+	rstestAPIParameterizedDescribe
+)
+
+type rstestInvocation uint8
+
+const (
+	rstestNotInvoked rstestInvocation = iota
+	rstestCallInvoked
+	rstestTagInvoked
+)
+
+type rstestChainPart struct {
+	name       string
+	node       *ast.Node
+	invocation rstestInvocation
+}
+
+type rstestResolvedAPI struct {
+	name         string
+	kind         RstestFnType
+	state        rstestAPIState
+	originalNode *ast.Node
+	mode         RstestImportMode
+	extended     bool
+}
+
+func IsTypeOfRstestFnCall(node *ast.Node, ctx rule.RuleContext, kinds ...RstestFnType) bool {
+	parsed := ParseRstestFnCall(node, ctx)
+	return parsed != nil && len(kinds) > 0 && slices.Contains(kinds, parsed.Kind)
+}
+
+// ParseRstestFnCall parses a final Rstest test/describe registration call.
+// Factory calls such as test.each(cases), test.runIf(condition), and
+// test.extend(fixtures) are intentionally not returned.
+func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return nil
+	}
+
+	call := node.AsCallExpression()
+	root, parts, rootInvoked, ok := parseRstestChain(call.Expression)
+	if !ok || rootInvoked || root == nil {
+		return nil
+	}
+
+	resolved, consumed, ok := resolveRstestRoot(root, parts, ctx, make(map[*ast.Symbol]bool), 0)
+	if !ok {
+		return nil
+	}
+
+	state := resolved.state
+	for _, part := range parts[consumed:] {
+		state = applyRstestChainPart(state, part)
+		if state == rstestAPIInvalid {
+			return nil
+		}
+		if part.name == "extend" {
+			resolved.extended = true
+		}
+	}
+
+	parameterized := false
+	switch state {
+	case rstestAPITest, rstestAPITestWithExtend:
+		resolved.kind = RstestFnTypeTest
+	case rstestAPIDescribe:
+		resolved.kind = RstestFnTypeDescribe
+	case rstestAPIParameterizedTest:
+		resolved.kind = RstestFnTypeTest
+		parameterized = true
+	case rstestAPIParameterizedDescribe:
+		resolved.kind = RstestFnTypeDescribe
+		parameterized = true
+	default:
+		return nil
+	}
+
+	memberEntries := make([]ParsedRstestFnMemberEntry, 0, len(parts)-consumed)
+	members := make([]string, 0, len(parts)-consumed)
+	for _, part := range parts[consumed:] {
+		members = append(members, part.name)
+		memberEntries = append(memberEntries, ParsedRstestFnMemberEntry{
+			Name: part.name,
+			Node: part.node,
+		})
+	}
+
+	localName := root.AsIdentifier().Text
+	return &ParsedRstestFnCall{
+		ParsedCall: testFramework.ParsedCall{
+			Name:          resolved.name,
+			LocalName:     localName,
+			Kind:          resolved.kind,
+			Members:       members,
+			MemberEntries: memberEntries,
+			Head: ParsedRstestFnCallHead{
+				Type: resolved.mode,
+				Local: ParsedRstestFnCallHeadEntry{
+					Value: localName,
+					Node:  root,
+				},
+				Original: ParsedRstestFnCallHeadEntry{
+					Value: resolved.name,
+					Node:  resolved.originalNode,
+				},
+			},
+		},
+		Parameterized: parameterized,
+		Extended:      resolved.extended,
+	}
+}
+
+func parseRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, bool, bool) {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return nil, nil, false, false
+	}
+
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node, nil, false, true
+	case ast.KindPropertyAccessExpression:
+		property := node.AsPropertyAccessExpression()
+		root, parts, rootInvoked, ok := parseRstestChain(property.Expression)
+		if !ok {
+			return nil, nil, false, false
+		}
+		nameNode := property.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			return nil, nil, false, false
+		}
+		return root, append(parts, rstestChainPart{
+			name: nameNode.AsIdentifier().Text,
+			node: nameNode,
+		}), rootInvoked, true
+	case ast.KindElementAccessExpression:
+		element := node.AsElementAccessExpression()
+		root, parts, rootInvoked, ok := parseRstestChain(element.Expression)
+		if !ok {
+			return nil, nil, false, false
+		}
+		nameNode := ast.SkipParentheses(element.ArgumentExpression)
+		name := staticRstestMemberName(nameNode)
+		if name == "" {
+			return nil, nil, false, false
+		}
+		return root, append(parts, rstestChainPart{
+			name: name,
+			node: nameNode,
+		}), rootInvoked, true
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		root, parts, rootInvoked, ok := parseRstestChain(call.Expression)
+		if !ok {
+			return nil, nil, false, false
+		}
+		if len(parts) == 0 {
+			if rootInvoked {
+				return nil, nil, false, false
+			}
+			return root, parts, true, true
+		}
+		if parts[len(parts)-1].invocation != rstestNotInvoked {
+			return nil, nil, false, false
+		}
+		parts[len(parts)-1].invocation = rstestCallInvoked
+		return root, parts, rootInvoked, true
+	case ast.KindTaggedTemplateExpression:
+		tagged := node.AsTaggedTemplateExpression()
+		root, parts, rootInvoked, ok := parseRstestChain(tagged.Tag)
+		if !ok || len(parts) == 0 || parts[len(parts)-1].invocation != rstestNotInvoked {
+			return nil, nil, false, false
+		}
+		parts[len(parts)-1].invocation = rstestTagInvoked
+		return root, parts, rootInvoked, true
+	default:
+		return nil, nil, false, false
+	}
+}
+
+func staticRstestMemberName(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text
+	default:
+		return ""
+	}
+}
+
+func resolveRstestRoot(
+	root *ast.Node,
+	parts []rstestChainPart,
+	ctx rule.RuleContext,
+	visited map[*ast.Symbol]bool,
+	depth int,
+) (rstestResolvedAPI, int, bool) {
+	if root == nil || root.Kind != ast.KindIdentifier || depth > 16 {
+		return rstestResolvedAPI{}, 0, false
+	}
+
+	localName := root.AsIdentifier().Text
+	name, originalNode, mode := testFramework.ResolveFunctionIdentifierReference(
+		localName,
+		root,
+		ctx.TypeChecker,
+		ctx.SourceFile,
+		RstestImportModule,
+	)
+	if state := directRstestAPIState(name); state != rstestAPIInvalid {
+		return rstestResolvedAPI{
+			name:         name,
+			state:        state,
+			originalNode: originalNode,
+			mode:         mode,
+		}, 0, true
+	}
+
+	if testFramework.IsModuleNamespaceReference(root, ctx.TypeChecker, RstestImportModule) {
+		if len(parts) == 0 || parts[0].invocation != rstestNotInvoked {
+			return rstestResolvedAPI{}, 0, false
+		}
+		state := directRstestAPIState(parts[0].name)
+		if state == rstestAPIInvalid {
+			return rstestResolvedAPI{}, 0, false
+		}
+		return rstestResolvedAPI{
+			name:         parts[0].name,
+			state:        state,
+			originalNode: parts[0].node,
+			mode:         RSTEST_IMPORT_MODE,
+		}, 1, true
+	}
+
+	if ctx.TypeChecker == nil {
+		return rstestResolvedAPI{}, 0, false
+	}
+	symbol := ctx.TypeChecker.GetSymbolAtLocation(root)
+	if symbol == nil || visited[symbol] {
+		return rstestResolvedAPI{}, 0, false
+	}
+	visited[symbol] = true
+	defer delete(visited, symbol)
+
+	for _, declaration := range symbol.Declarations {
+		if !isConstRstestVariableDeclaration(declaration) {
+			continue
+		}
+		initializer := declaration.AsVariableDeclaration().Initializer
+		aliasRoot, aliasParts, aliasRootInvoked, ok := parseRstestChain(initializer)
+		if !ok || aliasRootInvoked {
+			continue
+		}
+		resolved, consumed, ok := resolveRstestRoot(aliasRoot, aliasParts, ctx, visited, depth+1)
+		if !ok {
+			continue
+		}
+		state := resolved.state
+		for _, part := range aliasParts[consumed:] {
+			state = applyRstestChainPart(state, part)
+			if state == rstestAPIInvalid {
+				break
+			}
+			if part.name == "extend" {
+				resolved.extended = true
+			}
+		}
+		if state == rstestAPIInvalid {
+			continue
+		}
+		resolved.state = state
+		return resolved, 0, true
+	}
+
+	return rstestResolvedAPI{}, 0, false
+}
+
+func isConstRstestVariableDeclaration(declaration *ast.Node) bool {
+	return declaration != nil &&
+		declaration.Kind == ast.KindVariableDeclaration &&
+		declaration.Parent != nil &&
+		declaration.Parent.Kind == ast.KindVariableDeclarationList &&
+		declaration.Parent.Flags&ast.NodeFlagsConst != 0 &&
+		declaration.AsVariableDeclaration().Initializer != nil
+}
+
+func directRstestAPIState(name string) rstestAPIState {
+	switch name {
+	case "test", "it":
+		return rstestAPITestWithExtend
+	case "describe":
+		return rstestAPIDescribe
+	default:
+		return rstestAPIInvalid
+	}
+}
+
+func applyRstestChainPart(state rstestAPIState, part rstestChainPart) rstestAPIState {
+	switch state {
+	case rstestAPITest, rstestAPITestWithExtend:
+		switch part.name {
+		case "only", "skip", "todo", "fails", "concurrent", "sequential":
+			if part.invocation == rstestNotInvoked {
+				return rstestAPITest
+			}
+		case "runIf", "skipIf":
+			if part.invocation == rstestCallInvoked {
+				return rstestAPITest
+			}
+		case "each", "for":
+			if part.invocation == rstestCallInvoked || part.invocation == rstestTagInvoked {
+				return rstestAPIParameterizedTest
+			}
+		case "extend":
+			if state == rstestAPITestWithExtend && part.invocation == rstestCallInvoked {
+				return rstestAPITestWithExtend
+			}
+		}
+	case rstestAPIDescribe:
+		switch part.name {
+		case "only", "skip", "todo", "concurrent", "sequential":
+			if part.invocation == rstestNotInvoked {
+				return rstestAPIDescribe
+			}
+		case "runIf", "skipIf":
+			if part.invocation == rstestCallInvoked {
+				return rstestAPIDescribe
+			}
+		case "each", "for":
+			if part.invocation == rstestCallInvoked || part.invocation == rstestTagInvoked {
+				return rstestAPIParameterizedDescribe
+			}
+		}
+	}
+	return rstestAPIInvalid
+}

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -54,7 +54,7 @@ func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall
 		return nil
 	}
 
-	resolved, consumed, ok := resolveRstestRoot(root, parts, ctx, make(map[*ast.Symbol]bool), 0)
+	resolved, consumed, ok := resolveRstestRoot(root, parts, ctx, nil, 0)
 	if !ok {
 		return nil
 	}
@@ -197,10 +197,14 @@ func resolveRstestRoot(
 	}
 
 	localName := root.AsIdentifier().Text
-	name, originalNode, mode := testFramework.ResolveFunctionIdentifierReference(
+	var symbol *ast.Symbol
+	if ctx.TypeChecker != nil {
+		symbol = ctx.TypeChecker.GetSymbolAtLocation(root)
+	}
+	name, originalNode, mode := testFramework.ResolveFunctionIdentifierReferenceFromSymbol(
 		localName,
 		root,
-		ctx.TypeChecker,
+		symbol,
 		ctx.SourceFile,
 		RstestImportModule,
 	)
@@ -213,7 +217,7 @@ func resolveRstestRoot(
 		}, 0, true
 	}
 
-	if testFramework.IsModuleNamespaceReference(root, ctx.TypeChecker, RstestImportModule) {
+	if testFramework.IsModuleNamespaceSymbol(symbol, RstestImportModule) {
 		if len(parts) == 0 || parts[0].invocation != rstestNotInvoked {
 			return rstestResolvedAPI{}, 0, false
 		}
@@ -229,16 +233,11 @@ func resolveRstestRoot(
 		}, 1, true
 	}
 
-	if ctx.TypeChecker == nil {
+	if symbol == nil || (visited != nil && visited[symbol]) {
 		return rstestResolvedAPI{}, 0, false
 	}
-	symbol := ctx.TypeChecker.GetSymbolAtLocation(root)
-	if symbol == nil || visited[symbol] {
-		return rstestResolvedAPI{}, 0, false
-	}
-	visited[symbol] = true
-	defer delete(visited, symbol)
 
+	tracking := false
 	for _, declaration := range symbol.Declarations {
 		if !isConstRstestVariableDeclaration(declaration) {
 			continue
@@ -247,6 +246,14 @@ func resolveRstestRoot(
 		aliasRoot, aliasParts, aliasRootInvoked, ok := parseRstestChain(initializer)
 		if !ok || aliasRootInvoked {
 			continue
+		}
+		if !tracking {
+			if visited == nil {
+				visited = make(map[*ast.Symbol]bool)
+			}
+			visited[symbol] = true
+			defer delete(visited, symbol)
+			tracking = true
 		}
 		resolved, consumed, ok := resolveRstestRoot(aliasRoot, aliasParts, ctx, visited, depth+1)
 		if !ok {

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -39,7 +39,6 @@ type rstestResolvedAPI struct {
 	state        rstestAPIState
 	originalNode *ast.Node
 	mode         RstestImportMode
-	extended     bool
 }
 
 func IsTypeOfRstestFnCall(node *ast.Node, ctx rule.RuleContext, kinds ...RstestFnType) bool {
@@ -71,9 +70,6 @@ func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall
 		state = applyRstestChainPart(state, part)
 		if state == rstestAPIInvalid {
 			return nil
-		}
-		if part.name == "extend" {
-			resolved.extended = true
 		}
 	}
 
@@ -124,7 +120,6 @@ func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall
 			},
 		},
 		Parameterized: parameterized,
-		Extended:      resolved.extended,
 	}
 }
 
@@ -282,9 +277,6 @@ func resolveRstestRoot(
 			state = applyRstestChainPart(state, part)
 			if state == rstestAPIInvalid {
 				break
-			}
-			if part.name == "extend" {
-				resolved.extended = true
 			}
 		}
 		if state == rstestAPIInvalid {

--- a/internal/plugins/rstest/utils/rstest.go
+++ b/internal/plugins/rstest/utils/rstest.go
@@ -13,7 +13,11 @@ type RstestFnType = testFramework.FnKind
 
 type RstestImportMode = testFramework.ReferenceMode
 
-type ParsedRstestFnCall = testFramework.ParsedCall
+type ParsedRstestFnCall struct {
+	testFramework.ParsedCall
+	Parameterized bool
+	Extended      bool
+}
 
 type ParsedRstestFnCallHead = testFramework.ParsedCallHead
 

--- a/internal/plugins/rstest/utils/rstest.go
+++ b/internal/plugins/rstest/utils/rstest.go
@@ -16,7 +16,6 @@ type RstestImportMode = testFramework.ReferenceMode
 type ParsedRstestFnCall struct {
 	testFramework.ParsedCall
 	Parameterized bool
-	Extended      bool
 }
 
 type ParsedRstestFnCallHead = testFramework.ParsedCallHead

--- a/internal/utils/test_framework/module_reference.go
+++ b/internal/utils/test_framework/module_reference.go
@@ -30,9 +30,31 @@ func ResolveFunctionReferenceForModule(
 		return localName, localNode, ReferenceModeGlobal
 	}
 
+	return ResolveFunctionIdentifierReference(
+		localName,
+		identifier,
+		typeChecker,
+		sourceFile,
+		importModule,
+	)
+}
+
+// ResolveFunctionIdentifierReference resolves one identifier as a framework
+// global or a named import/require binding from importModule.
+func ResolveFunctionIdentifierReference(
+	localName string,
+	identifier *ast.Node,
+	typeChecker *checker.Checker,
+	sourceFile *ast.SourceFile,
+	importModule string,
+) (string, *ast.Node, ReferenceMode) {
+	if identifier == nil || identifier.Kind != ast.KindIdentifier || typeChecker == nil {
+		return localName, identifier, ReferenceModeGlobal
+	}
+
 	symbol := typeChecker.GetSymbolAtLocation(identifier)
 	if symbol == nil {
-		return localName, localNode, ReferenceModeGlobal
+		return localName, identifier, ReferenceModeGlobal
 	}
 
 	hasLocalDeclaration := false
@@ -55,7 +77,7 @@ func ResolveFunctionReferenceForModule(
 	if hasLocalDeclaration {
 		return "", nil, ReferenceModeGlobal
 	}
-	return localName, localNode, ReferenceModeGlobal
+	return localName, identifier, ReferenceModeGlobal
 }
 
 // FindImportDeclaration returns the import declaration enclosing node.
@@ -67,6 +89,47 @@ func FindImportDeclaration(node *ast.Node) *ast.ImportDeclaration {
 		}
 	}
 	return nil
+}
+
+// IsModuleNamespaceReference reports whether identifier is bound to a namespace
+// import or a whole-module require for importModule.
+func IsModuleNamespaceReference(
+	identifier *ast.Node,
+	typeChecker *checker.Checker,
+	importModule string,
+) bool {
+	if identifier == nil || identifier.Kind != ast.KindIdentifier || typeChecker == nil {
+		return false
+	}
+
+	symbol := typeChecker.GetSymbolAtLocation(identifier)
+	if symbol == nil {
+		return false
+	}
+
+	for _, declaration := range symbol.Declarations {
+		if declaration == nil {
+			continue
+		}
+
+		if declaration.Kind == ast.KindNamespaceImport {
+			importDeclaration := FindImportDeclaration(declaration)
+			if importDeclaration != nil &&
+				importDeclaration.ModuleSpecifier != nil &&
+				importDeclaration.ModuleSpecifier.Text() == importModule {
+				return true
+			}
+		}
+
+		if declaration.Kind == ast.KindVariableDeclaration {
+			variable := declaration.AsVariableDeclaration()
+			if variable != nil && IsModuleRequireCall(variable.Initializer, importModule) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func resolveModuleImportSpecifier(declaration *ast.Node, importModule string) (string, *ast.Node, bool) {
@@ -102,7 +165,7 @@ func resolveModuleRequireBinding(declaration *ast.Node, importModule string) (st
 
 	varDeclaration := internalUtils.EnclosingVariableDeclarationOfBindingElement(declaration)
 	if varDeclaration == nil ||
-		!isModuleRequireCall(varDeclaration.AsVariableDeclaration().Initializer, importModule) {
+		!IsModuleRequireCall(varDeclaration.AsVariableDeclaration().Initializer, importModule) {
 		return "", nil, false
 	}
 
@@ -122,7 +185,8 @@ func resolveModuleRequireBinding(declaration *ast.Node, importModule string) (st
 	return "", nil, false
 }
 
-func isModuleRequireCall(node *ast.Node, importModule string) bool {
+// IsModuleRequireCall reports whether node is require(importModule).
+func IsModuleRequireCall(node *ast.Node, importModule string) bool {
 	node = ast.SkipParentheses(node)
 	if node == nil || !ast.IsRequireCall(node, true /* requireStringLiteralLikeArgument */) {
 		return false

--- a/internal/utils/test_framework/module_reference.go
+++ b/internal/utils/test_framework/module_reference.go
@@ -53,6 +53,28 @@ func ResolveFunctionIdentifierReference(
 	}
 
 	symbol := typeChecker.GetSymbolAtLocation(identifier)
+	return ResolveFunctionIdentifierReferenceFromSymbol(
+		localName,
+		identifier,
+		symbol,
+		sourceFile,
+		importModule,
+	)
+}
+
+// ResolveFunctionIdentifierReferenceFromSymbol resolves an identifier using
+// its already-looked-up symbol. Callers that perform additional symbol-based
+// checks can use this helper to avoid repeating TypeChecker lookups.
+func ResolveFunctionIdentifierReferenceFromSymbol(
+	localName string,
+	identifier *ast.Node,
+	symbol *ast.Symbol,
+	sourceFile *ast.SourceFile,
+	importModule string,
+) (string, *ast.Node, ReferenceMode) {
+	if identifier == nil || identifier.Kind != ast.KindIdentifier {
+		return localName, identifier, ReferenceModeGlobal
+	}
 	if symbol == nil {
 		return localName, identifier, ReferenceModeGlobal
 	}
@@ -91,18 +113,9 @@ func FindImportDeclaration(node *ast.Node) *ast.ImportDeclaration {
 	return nil
 }
 
-// IsModuleNamespaceReference reports whether identifier is bound to a namespace
-// import or a whole-module require for importModule.
-func IsModuleNamespaceReference(
-	identifier *ast.Node,
-	typeChecker *checker.Checker,
-	importModule string,
-) bool {
-	if identifier == nil || identifier.Kind != ast.KindIdentifier || typeChecker == nil {
-		return false
-	}
-
-	symbol := typeChecker.GetSymbolAtLocation(identifier)
+// IsModuleNamespaceSymbol reports whether symbol is a namespace import or a
+// whole-module require for importModule.
+func IsModuleNamespaceSymbol(symbol *ast.Symbol, importModule string) bool {
 	if symbol == nil {
 		return false
 	}

--- a/internal/utils/test_framework/rules/no_identical_title/no_identical_title.go
+++ b/internal/utils/test_framework/rules/no_identical_title/no_identical_title.go
@@ -1,0 +1,122 @@
+package no_identical_title
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+type ParsedCall struct {
+	Call          *testFramework.ParsedCall
+	Parameterized bool
+}
+
+type Config struct {
+	Name  string
+	Parse func(*ast.Node, rule.RuleContext) *ParsedCall
+}
+
+func buildMultipleTestTitleMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "multipleTestTitle",
+		Description: "Test title is used multiple times in the same describe block",
+	}
+}
+
+func buildMultipleDescribeTitleMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "multipleDescribeTitle",
+		Description: "Describe block title is used multiple times in the same describe block",
+	}
+}
+
+type titleLayer struct {
+	describeTitles map[string]struct{}
+	testTitles     map[string]struct{}
+}
+
+func newTitleLayer() *titleLayer {
+	return &titleLayer{
+		describeTitles: make(map[string]struct{}),
+		testTitles:     make(map[string]struct{}),
+	}
+}
+
+func staticTitleValue(arg *ast.Node) (string, bool) {
+	if arg == nil {
+		return "", false
+	}
+	switch arg.Kind {
+	case ast.KindStringLiteral:
+		return arg.AsStringLiteral().Text, true
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return arg.AsNoSubstitutionTemplateLiteral().Text, true
+	default:
+		return "", false
+	}
+}
+
+// NewRule creates a no-identical-title rule for a test framework.
+func NewRule(config Config) rule.Rule {
+	return rule.Rule{
+		Name:   config.Name,
+		Schema: rule.EmptyArraySchema,
+		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+			contexts := []*titleLayer{newTitleLayer()}
+
+			return rule.RuleListeners{
+				ast.KindCallExpression: func(node *ast.Node) {
+					parsed := config.Parse(node, ctx)
+					if parsed == nil || parsed.Call == nil {
+						return
+					}
+
+					current := contexts[len(contexts)-1]
+					if parsed.Call.Kind == testFramework.FnKindDescribe {
+						contexts = append(contexts, newTitleLayer())
+					}
+
+					if parsed.Parameterized {
+						return
+					}
+
+					call := node.AsCallExpression()
+					if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+						return
+					}
+					arg0 := call.Arguments.Nodes[0]
+					title, ok := staticTitleValue(arg0)
+					if !ok {
+						return
+					}
+
+					if parsed.Call.Kind == testFramework.FnKindTest {
+						if _, exists := current.testTitles[title]; exists {
+							ctx.ReportNode(arg0, buildMultipleTestTitleMessage())
+						}
+						current.testTitles[title] = struct{}{}
+						return
+					}
+
+					if parsed.Call.Kind != testFramework.FnKindDescribe {
+						return
+					}
+					if _, exists := current.describeTitles[title]; exists {
+						ctx.ReportNode(arg0, buildMultipleDescribeTitleMessage())
+					}
+					current.describeTitles[title] = struct{}{}
+				},
+				rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
+					parsed := config.Parse(node, ctx)
+					if parsed == nil || parsed.Call == nil ||
+						parsed.Call.Kind != testFramework.FnKindDescribe {
+						return
+					}
+					if len(contexts) > 1 {
+						contexts = contexts[:len(contexts)-1]
+					}
+				},
+			}
+		},
+	}
+}

--- a/internal/utils/test_framework/rules/no_identical_title/no_identical_title.go
+++ b/internal/utils/test_framework/rules/no_identical_title/no_identical_title.go
@@ -3,6 +3,7 @@ package no_identical_title
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
@@ -42,20 +43,6 @@ func newTitleLayer() *titleLayer {
 	}
 }
 
-func staticTitleValue(arg *ast.Node) (string, bool) {
-	if arg == nil {
-		return "", false
-	}
-	switch arg.Kind {
-	case ast.KindStringLiteral:
-		return arg.AsStringLiteral().Text, true
-	case ast.KindNoSubstitutionTemplateLiteral:
-		return arg.AsNoSubstitutionTemplateLiteral().Text, true
-	default:
-		return "", false
-	}
-}
-
 // NewRule creates a no-identical-title rule for a test framework.
 func NewRule(config Config) rule.Rule {
 	return rule.Rule{
@@ -85,7 +72,7 @@ func NewRule(config Config) rule.Rule {
 						return
 					}
 					arg0 := call.Arguments.Nodes[0]
-					title, ok := staticTitleValue(arg0)
+					title, ok := internalUtils.GetStaticStringLiteralValue(arg0)
 					if !ok {
 						return
 					}

--- a/internal/utils/test_framework/rules/no_identical_title/no_identical_title.go
+++ b/internal/utils/test_framework/rules/no_identical_title/no_identical_title.go
@@ -50,6 +50,7 @@ func NewRule(config Config) rule.Rule {
 		Schema: rule.EmptyArraySchema,
 		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 			contexts := []*titleLayer{newTitleLayer()}
+			var describeCalls []*ast.Node
 
 			return rule.RuleListeners{
 				ast.KindCallExpression: func(node *ast.Node) {
@@ -61,6 +62,7 @@ func NewRule(config Config) rule.Rule {
 					current := contexts[len(contexts)-1]
 					if parsed.Call.Kind == testFramework.FnKindDescribe {
 						contexts = append(contexts, newTitleLayer())
+						describeCalls = append(describeCalls, node)
 					}
 
 					if parsed.Parameterized {
@@ -94,14 +96,12 @@ func NewRule(config Config) rule.Rule {
 					current.describeTitles[title] = struct{}{}
 				},
 				rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
-					parsed := config.Parse(node, ctx)
-					if parsed == nil || parsed.Call == nil ||
-						parsed.Call.Kind != testFramework.FnKindDescribe {
+					last := len(describeCalls) - 1
+					if last < 0 || describeCalls[last] != node {
 						return
 					}
-					if len(contexts) > 1 {
-						contexts = contexts[:len(contexts)-1]
-					}
+					describeCalls = describeCalls[:last]
+					contexts = contexts[:len(contexts)-1]
 				},
 			}
 		},

--- a/internal/utils/test_framework/rules/no_identical_title/no_identical_title_test.go
+++ b/internal/utils/test_framework/rules/no_identical_title/no_identical_title_test.go
@@ -1,0 +1,52 @@
+package no_identical_title
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+func TestNewRuleParsesEachCallOnce(t *testing.T) {
+	parseCount := 0
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, "describe(); nested();", core.ScriptKindTS)
+	calls := make([]*ast.Node, 0, 2)
+	var collectCalls func(*ast.Node) bool
+	collectCalls = func(node *ast.Node) bool {
+		if node.Kind == ast.KindCallExpression {
+			calls = append(calls, node)
+		}
+		return node.ForEachChild(collectCalls)
+	}
+	sourceFile.AsNode().ForEachChild(collectCalls)
+	if len(calls) != 2 {
+		t.Fatalf("parsed %d CallExpressions, want 2", len(calls))
+	}
+	describeCall, nestedCall := calls[0], calls[1]
+	r := NewRule(Config{
+		Name: "test/no-identical-title",
+		Parse: func(node *ast.Node, ctx rule.RuleContext) *ParsedCall {
+			parseCount++
+			if node != describeCall {
+				return nil
+			}
+			return &ParsedCall{Call: &testFramework.ParsedCall{Kind: testFramework.FnKindDescribe}}
+		},
+	})
+
+	listeners := r.Run(rule.RuleContext{}, nil)
+	listeners[ast.KindCallExpression](describeCall)
+	listeners[ast.KindCallExpression](nestedCall)
+	listeners[rule.ListenerOnExit(ast.KindCallExpression)](nestedCall)
+	listeners[rule.ListenerOnExit(ast.KindCallExpression)](describeCall)
+
+	if parseCount != 2 {
+		t.Fatalf("Parse called %d times, want once for each CallExpression", parseCount)
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -541,6 +541,7 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/valid-title.test.ts',
 
     // rstest
+    './tests/rstest/rules/no-identical-title.test.ts',
     './tests/rstest/rules/no-mocks-import.test.ts',
 
     // eslint-plugin-promise

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -75,6 +75,7 @@ describe('defineConfig and config presets', () => {
     expect(rec.plugins).toBeDefined();
     expect(rec.plugins).toContain('rstest');
     expect(rec.rules).toEqual({
+      'rstest/no-identical-title': 'error',
       'rstest/no-mocks-import': 'error',
     });
   });

--- a/packages/rslint-test-tools/tests/rstest/rules/no-identical-title.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-identical-title.test.ts
@@ -1,0 +1,55 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-identical-title', {} as never, {
+  valid: [
+    {
+      code: 'test("one", () => {}); test("two", () => {});',
+    },
+    {
+      code: 'describe("same", () => {}); test("same", () => {});',
+    },
+    {
+      code: `
+        describe("outer", () => {
+          test("same", () => {});
+          describe("inner", () => {
+            test("same", () => {});
+          });
+        });
+      `,
+    },
+    {
+      code: `
+        test.each([1, 2])("case %i", () => {});
+        test.each([3, 4])("case %i", () => {});
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        test("same", () => {});
+        test("same", () => {});
+      `,
+      errors: [{ messageId: 'multipleTestTitle', line: 3, column: 14 }],
+    },
+    {
+      code: `
+        describe("same", () => {});
+        describe.only("same", () => {});
+      `,
+      errors: [{ messageId: 'multipleDescribeTitle', line: 3, column: 23 }],
+    },
+    {
+      code: `
+        describe("suite", () => {
+          test("same", () => {});
+          test.only("same", () => {});
+        });
+      `,
+      errors: [{ messageId: 'multipleTestTitle', line: 4, column: 21 }],
+    },
+  ],
+});

--- a/packages/rslint/src/config/presets/rstest.ts
+++ b/packages/rslint/src/config/presets/rstest.ts
@@ -3,6 +3,7 @@ import type { RslintConfigEntry } from '../define-config.js';
 const recommended: RslintConfigEntry = {
   plugins: ['rstest'],
   rules: {
+    'rstest/no-identical-title': 'error',
     'rstest/no-mocks-import': 'error',
   },
 };


### PR DESCRIPTION
## Summary

Add `rstest/no-identical-title` with support for Rstest modifiers, parameterized APIs, imports, and same-file `test.extend()` aliases.

Share the title-tracking implementation with Jest while preserving existing Jest behavior. Register the rule in `rstest.configs.recommended`.

## Related Links

Related https://github.com/web-infra-dev/rslint/issues/935

## Validation

- `go test ./internal/plugins/rstest/... ./internal/plugins/jest/rules/no-identical_title ./internal/utils/test_framework/...`
- `go test ./internal/plugins/jest/...`
- `go test ./internal/config/...`
- `go vet ./internal/plugins/rstest/... ./internal/utils/test_framework/... ./internal/plugins/jest/rules/no_identical_title`
- `pnpm --filter @rslint/test-tools exec rstest run tests/cli/js-config/presets.test.ts`
- `pnpm exec prettier --check packages/rslint/src/config/presets/rstest.ts packages/rslint-test-tools/tests/cli/js-config/presets.test.ts internal/plugins/rstest/rules/no_identical_title/no_identical_title.md`
- `git diff --check`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).