### PR TITLE
docs: normalize rule documentation titles

### DIFF
--- a/internal/plugins/import/rules/namespace/namespace.md
+++ b/internal/plugins/import/rules/namespace/namespace.md
@@ -1,4 +1,4 @@
-# import/namespace
+# namespace
 
 ## Rule Details
 

--- a/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.md
+++ b/internal/plugins/promise/rules/no_callback_in_promise/no_callback_in_promise.md
@@ -1,4 +1,4 @@
-# promise/no-callback-in-promise
+# no-callback-in-promise
 
 Disallow calling `cb()` inside of a `then()` (use `util.callbackify` instead).
 

--- a/internal/plugins/promise/rules/no_nesting/no_nesting.md
+++ b/internal/plugins/promise/rules/no_nesting/no_nesting.md
@@ -1,4 +1,4 @@
-# promise/no-nesting
+# no-nesting
 
 ## Rule Details
 

--- a/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.md
+++ b/internal/plugins/promise/rules/no_return_in_finally/no_return_in_finally.md
@@ -1,4 +1,4 @@
-# promise/no-return-in-finally
+# no-return-in-finally
 
 Disallow return statements inside a callback passed to `.finally()`, since nothing would consume what's returned.
 


### PR DESCRIPTION
Normalize four rule documentation headings to match the repository-wide unprefixed naming style.