### PR TITLE
feat(rstest): add no-disabled-tests rule

### DIFF
--- a/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/plugins/jest/rules/no_disabled_tests/no_disabled_tests.go
@@ -7,23 +7,8 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_disabled_tests"
 )
-
-// Message Builder
-
-func buildErrorMissingFunctionMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "missingFunction",
-		Description: "Test is missing function argument",
-	}
-}
-
-func buildErrorSkippedTestMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "skippedTest",
-		Description: "Tests should not be skipped",
-	}
-}
 
 func isPendingCall(node *ast.Node, ctx rule.RuleContext) bool {
 	if node == nil || node.Kind != ast.KindCallExpression {
@@ -68,35 +53,21 @@ func isPendingCall(node *ast.Node, ctx rule.RuleContext) bool {
 	return true
 }
 
-var NoDisabledTestsRule = rule.Rule{
-	Name:   "jest/no-disabled-tests",
-	Schema: rule.EmptyArraySchema,
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		return rule.RuleListeners{
-			ast.KindCallExpression: func(node *ast.Node) {
-				if isPendingCall(node, ctx) {
-					ctx.ReportNode(node, buildErrorSkippedTestMessage())
-					return
-				}
-
-				jestFnCall := utils.ParseJestFnCall(node, ctx)
-				if jestFnCall == nil ||
-					jestFnCall.Kind != utils.JestFnTypeDescribe &&
-						jestFnCall.Kind != utils.JestFnTypeTest {
-					return
-				}
-
-				if strings.HasPrefix(jestFnCall.Name, "x") ||
-					slices.Contains(jestFnCall.Members, "skip") {
-					ctx.ReportNode(node, buildErrorSkippedTestMessage())
-				}
-
-				if jestFnCall.Kind == utils.JestFnTypeTest {
-					if len(node.Arguments()) < 2 && !slices.Contains(jestFnCall.Members, "todo") {
-						ctx.ReportNode(node, buildErrorMissingFunctionMessage())
-					}
-				}
-			},
-		}
-	},
+func parseJestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
+	parsed := utils.ParseJestFnCall(node, ctx)
+	if parsed == nil {
+		return nil
+	}
+	return &shared.ParsedCall{
+		Call: &parsed.ParsedCall,
+		HasSkip: strings.HasPrefix(parsed.Name, "x") ||
+			slices.Contains(parsed.Members, "skip"),
+		HasTodo: slices.Contains(parsed.Members, "todo"),
+	}
 }
+
+var NoDisabledTestsRule = shared.NewRule(shared.Config{
+	Name:                    "jest/no-disabled-tests",
+	Parse:                   parseJestCall,
+	IsStandaloneSkippedCall: isPendingCall,
+})

--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -2,6 +2,7 @@ package rstest
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_commented_out_tests"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_disabled_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_identical_title"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_mocks_import"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -10,6 +11,7 @@ import (
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		no_commented_out_tests.NoCommentedOutTestsRule,
+		no_disabled_tests.NoDisabledTestsRule,
 		no_identical_title.NoIdenticalTitleRule,
 		no_mocks_import.NoMocksImportRule,
 	}

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.go
@@ -22,4 +22,6 @@ func parseRstestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
 var NoDisabledTestsRule = shared.NewRule(shared.Config{
 	Name:  "rstest/no-disabled-tests",
 	Parse: parseRstestCall,
+	// `TestCall` accepts `(description, options, fn?)`.
+	HasOptionsOverload: true,
 })

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.go
@@ -1,6 +1,8 @@
 package no_disabled_tests
 
 import (
+	"slices"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -14,8 +16,8 @@ func parseRstestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
 	}
 	return &shared.ParsedCall{
 		Call:    &parsed.ParsedCall,
-		HasSkip: parsed.HasSkip,
-		HasTodo: parsed.HasTodo,
+		HasSkip: slices.Contains(parsed.Members, "skip"),
+		HasTodo: slices.Contains(parsed.Members, "todo"),
 	}
 }
 

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.go
@@ -1,0 +1,25 @@
+package no_disabled_tests
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/no_disabled_tests"
+)
+
+func parseRstestCall(node *ast.Node, ctx rule.RuleContext) *shared.ParsedCall {
+	parsed := rstestUtils.ParseRstestFnCall(node, ctx)
+	if parsed == nil {
+		return nil
+	}
+	return &shared.ParsedCall{
+		Call:    &parsed.ParsedCall,
+		HasSkip: parsed.HasSkip,
+		HasTodo: parsed.HasTodo,
+	}
+}
+
+var NoDisabledTestsRule = shared.NewRule(shared.Config{
+	Name:  "rstest/no-disabled-tests",
+	Parse: parseRstestCall,
+})

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.md
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.md
@@ -14,6 +14,7 @@ describe.skip('suite', () => {});
 it.skip('case', () => {});
 test.skip.each(rows)('case $value', (value) => {});
 test('missing callback');
+test('options without a callback', { timeout: 100 });
 ```
 
 Examples of **correct** code for this rule:
@@ -40,9 +41,10 @@ The rule follows Rstest APIs imported from `@rstest/core`, globals, namespace
 imports, CommonJS requires, and same-file `const` aliases. It does not trace
 custom test APIs through arbitrary cross-file re-exports.
 
-The missing-callback check uses the same conservative argument-count check as
-`jest/no-disabled-tests`. An options-only call such as
-`test('case', options)` is therefore not reported.
+The missing-callback check covers Rstest's `(description, options, fn?)`
+overload only when the options argument is written as an object literal. An
+indirect options call such as `test('case', options)` is not reported, because
+the identifier may resolve to the callback itself.
 
 This rule does not provide an autofix because removing `skip` or inventing a
 callback would change test behavior.

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.md
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests.md
@@ -1,0 +1,48 @@
+# no-disabled-tests
+
+## Rule Details
+
+Disallow explicitly skipped or incomplete Rstest tests. This rule reports
+`test.skip`, `it.skip`, and `describe.skip`, including valid modifier,
+parameterized, and `test.extend()` chains. It also reports `test` and `it`
+registrations that omit the callback.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+describe.skip('suite', () => {});
+it.skip('case', () => {});
+test.skip.each(rows)('case $value', (value) => {});
+test('missing callback');
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+describe('suite', () => {});
+test('case', () => {});
+test.todo('future case');
+
+test('runtime condition', (context) => {
+  if (!available()) {
+    context.skip();
+  }
+});
+```
+
+`test.todo` is an explicit, visible todo state and is not reported.
+`context.skip()` is Rstest's runtime control-flow API and is also not reported.
+Conditional `skipIf` and `runIf` expressions are not evaluated by this rule.
+
+## Limitations
+
+The rule follows Rstest APIs imported from `@rstest/core`, globals, namespace
+imports, CommonJS requires, and same-file `const` aliases. It does not trace
+custom test APIs through arbitrary cross-file re-exports.
+
+The missing-callback check uses the same conservative argument-count check as
+`jest/no-disabled-tests`. An options-only call such as
+`test('case', options)` is therefore not reported.
+
+This rule does not provide an autofix because removing `skip` or inventing a
+callback would change test behavior.

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests_test.go
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests_test.go
@@ -27,7 +27,10 @@ func TestNoDisabledTestsRule(t *testing.T) {
 			{Code: `test("case", context => { context.skip(); });`},
 			{Code: `test("case", ctx => { ctx.skip(); }); request.skip();`},
 			{Code: `describe("empty suite"); describe.concurrent("empty suite");`},
+			// an identifier is not necessarily an options object
 			{Code: `test("case", options);`},
+			{Code: `test("case", { timeout: 100 }, () => {});`},
+			{Code: `test.todo("case", { timeout: 100 });`},
 			{Code: `fit("case", () => {}); xit("case", () => {}); xtest("case", () => {}); fdescribe("suite", () => {}); xdescribe("suite", () => {});`},
 			{Code: `pending();`},
 			{Code: `import { pending } from "actions"; pending();`},
@@ -191,6 +194,27 @@ adminTest.concurrent.skip("case", () => {});`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "missingFunction", Line: 1, Column: 1},
 					{MessageId: "missingFunction", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `test("case", { timeout: 100 }); it("case", {}); test.concurrent("case", { retry: 2 });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingFunction", Line: 1, Column: 1},
+					{MessageId: "missingFunction", Line: 1, Column: 33},
+					{MessageId: "missingFunction", Line: 1, Column: 49},
+				},
+			},
+			{
+				Code: `test.each([1])("case", { timeout: 100 });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingFunction", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `test.skip("case", { timeout: 100 });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+					{MessageId: "missingFunction", Line: 1, Column: 1},
 				},
 			},
 			{

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests_test.go
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests_test.go
@@ -36,6 +36,9 @@ func TestNoDisabledTestsRule(t *testing.T) {
 			{Code: `import { test, describe } from "vitest"; test.skip("case", () => {}); describe.skip("suite", () => {});`},
 			{Code: `const test = createRunner(); test.skip("case", () => {});`},
 			{Code: `let skipped = test.skip; skipped("case", () => {});`},
+			// a variable declaration without an initializer must not be treated as a require
+			{Code: `declare const skipped: any; skipped("case", () => {});`},
+			{Code: `declare const pending: any; pending();`},
 			{Code: `import { customTest } from "./test-utils"; customTest.skip("case", () => {});`},
 			{Code: `test.for([1]).skip("case", () => {}); describe.each([1]).skip("suite", () => {});`},
 		},

--- a/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests_test.go
+++ b/internal/plugins/rstest/rules/no_disabled_tests/no_disabled_tests_test.go
@@ -1,0 +1,215 @@
+package no_disabled_tests_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_disabled_tests"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDisabledTestsRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_disabled_tests.NoDisabledTestsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `test("case", () => {}); it("case", () => {}); describe("suite", () => {});`},
+			{Code: `test.only("case", () => {}); test.fails("case", () => {}); test.concurrent.sequential("case", () => {});`},
+			{Code: `describe.only("suite", () => {}); describe.concurrent.sequential("suite", () => {});`},
+			{Code: `test.todo("case"); it.todo("case"); describe.todo("suite");`},
+			{Code: `test.todo.each([1])("case"); test.todo.for([1])("case");`},
+			{Code: `const todoTest = test.todo; todoTest("case");`},
+			{Code: `test.skipIf(condition)("case", () => {}); test.runIf(condition)("case", () => {});`},
+			{Code: `describe.skipIf(condition)("suite", () => {}); describe.runIf(condition)("suite", () => {});`},
+			{Code: `test.skipIf(true)("case", () => {}); test.runIf(false)("case", () => {});`},
+			{Code: `test("case", context => { context.skip(); });`},
+			{Code: `test("case", ctx => { ctx.skip(); }); request.skip();`},
+			{Code: `describe("empty suite"); describe.concurrent("empty suite");`},
+			{Code: `test("case", options);`},
+			{Code: `fit("case", () => {}); xit("case", () => {}); xtest("case", () => {}); fdescribe("suite", () => {}); xdescribe("suite", () => {});`},
+			{Code: `pending();`},
+			{Code: `import { pending } from "actions"; pending();`},
+			{Code: `test[` + "`sk${suffix}`" + `]("case", () => {});`},
+			{Code: `import { test } from "node:test"; test.skip("case", () => {});`},
+			{Code: `import { test, describe } from "vitest"; test.skip("case", () => {}); describe.skip("suite", () => {});`},
+			{Code: `const test = createRunner(); test.skip("case", () => {});`},
+			{Code: `let skipped = test.skip; skipped("case", () => {});`},
+			{Code: `import { customTest } from "./test-utils"; customTest.skip("case", () => {});`},
+			{Code: `test.for([1]).skip("case", () => {}); describe.each([1]).skip("suite", () => {});`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `test.skip("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `it.skip("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `describe.skip("suite", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `test["skip"]("case", () => {}); it[` + "`skip`" + `]("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+					{MessageId: "skippedTest", Line: 1, Column: 33},
+				},
+			},
+			{
+				Code: `test.concurrent.skip("case", () => {}); test.skip.sequential("case", () => {}); test.fails.skip("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+					{MessageId: "skippedTest", Line: 1, Column: 41},
+					{MessageId: "skippedTest", Line: 1, Column: 81},
+				},
+			},
+			{
+				Code: `test.skip.only("case", () => {}); test.only.skip("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+					{MessageId: "skippedTest", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `describe.concurrent.skip("suite", () => {}); describe.skip.sequential("suite", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+					{MessageId: "skippedTest", Line: 1, Column: 46},
+				},
+			},
+			{
+				Code: `test.skip.each([1])("case", () => {}); test.skip.for([1])("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+					{MessageId: "skippedTest", Line: 1, Column: 40},
+				},
+			},
+			{
+				Code: `describe.skip.each([1])("suite", () => {}); describe.skip.for([1])("suite", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+					{MessageId: "skippedTest", Line: 1, Column: 45},
+				},
+			},
+			{
+				Code: "test.skip.each`value\n${1}`(\"case\", () => {});",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `import { test as rstestTest } from "@rstest/core";
+rstestTest.skip("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: `const { test: rstestTest } = require("@rstest/core");
+rstestTest.skip("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: `import * as rstest from "@rstest/core";
+rstest.test.skip("case", () => {});
+rstest.describe.skip("suite", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 2, Column: 1},
+					{MessageId: "skippedTest", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code: `const rstest = require("@rstest/core");
+rstest.test.skip("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: `const skipped = test.skip;
+skipped("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: `const base = test;
+const skipped = base.skip;
+skipped.each([1])("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code: `import * as rstest from "@rstest/core";
+const skippedSuite = rstest.describe.skip;
+skippedSuite("suite", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code: `test.extend({}).skip("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `const appTest = test.extend({});
+const adminTest = appTest.extend({});
+adminTest.concurrent.skip("case", () => {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 3, Column: 1},
+				},
+			},
+			{
+				Code: `test("case"); it("case"); test.concurrent("case"); test.fails("case");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingFunction", Line: 1, Column: 1},
+					{MessageId: "missingFunction", Line: 1, Column: 15},
+					{MessageId: "missingFunction", Line: 1, Column: 27},
+					{MessageId: "missingFunction", Line: 1, Column: 52},
+				},
+			},
+			{
+				Code: `test.each([1])("case"); test.for([1])("case");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingFunction", Line: 1, Column: 1},
+					{MessageId: "missingFunction", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `const customTest = test.extend({});
+customTest("case");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingFunction", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: `test.skip("case");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+					{MessageId: "missingFunction", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `test.todo.skip("case");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "skippedTest", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -38,8 +38,9 @@ type rstestResolvedAPI struct {
 	state        rstestAPIState
 	originalNode *ast.Node
 	mode         RstestImportMode
-	hasSkip      bool
-	hasTodo      bool
+	// members collects every chain member applied to the resolved API,
+	// including members consumed while following same-file const aliases.
+	members []string
 }
 
 // ParseRstestFnCall parses a final Rstest test/describe registration call.
@@ -83,10 +84,10 @@ func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall
 		return nil
 	}
 
+	// MemberEntries only covers members written at the call site, because
+	// members resolved through an alias have no node in this expression.
 	memberEntries := make([]ParsedRstestFnMemberEntry, 0, len(parts)-consumed)
-	members := make([]string, 0, len(parts)-consumed)
 	for _, part := range parts[consumed:] {
-		members = append(members, part.name)
 		memberEntries = append(memberEntries, ParsedRstestFnMemberEntry{
 			Name: part.name,
 			Node: part.node,
@@ -99,7 +100,7 @@ func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall
 			Name:          resolved.name,
 			LocalName:     localName,
 			Kind:          resolved.kind,
-			Members:       members,
+			Members:       resolved.members,
 			MemberEntries: memberEntries,
 			Head: ParsedRstestFnCallHead{
 				Type: resolved.mode,
@@ -114,8 +115,6 @@ func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall
 			},
 		},
 		Parameterized: parameterized,
-		HasSkip:       resolved.hasSkip,
-		HasTodo:       resolved.hasTodo,
 	}
 }
 
@@ -344,14 +343,6 @@ func applyResolvedRstestChainPart(resolved *rstestResolvedAPI, part rstestChainP
 	}
 
 	resolved.state = state
-	if part.invocation != rstestNotInvoked {
-		return true
-	}
-	switch part.name {
-	case "skip":
-		resolved.hasSkip = true
-	case "todo":
-		resolved.hasTodo = true
-	}
+	resolved.members = append(resolved.members, part.name)
 	return true
 }

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -38,6 +38,8 @@ type rstestResolvedAPI struct {
 	state        rstestAPIState
 	originalNode *ast.Node
 	mode         RstestImportMode
+	hasSkip      bool
+	hasTodo      bool
 }
 
 // ParseRstestFnCall parses a final Rstest test/describe registration call.
@@ -59,16 +61,14 @@ func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall
 		return nil
 	}
 
-	state := resolved.state
 	for _, part := range parts[consumed:] {
-		state = applyRstestChainPart(state, part)
-		if state == rstestAPIInvalid {
+		if !applyResolvedRstestChainPart(&resolved, part) {
 			return nil
 		}
 	}
 
 	parameterized := false
-	switch state {
+	switch resolved.state {
 	case rstestAPITest, rstestAPITestWithExtend:
 		resolved.kind = RstestFnTypeTest
 	case rstestAPIDescribe:
@@ -114,6 +114,8 @@ func ParseRstestFnCall(node *ast.Node, ctx rule.RuleContext) *ParsedRstestFnCall
 			},
 		},
 		Parameterized: parameterized,
+		HasSkip:       resolved.hasSkip,
+		HasTodo:       resolved.hasTodo,
 	}
 }
 
@@ -259,17 +261,16 @@ func resolveRstestRoot(
 		if !ok {
 			continue
 		}
-		state := resolved.state
+		valid := true
 		for _, part := range aliasParts[consumed:] {
-			state = applyRstestChainPart(state, part)
-			if state == rstestAPIInvalid {
+			if !applyResolvedRstestChainPart(&resolved, part) {
+				valid = false
 				break
 			}
 		}
-		if state == rstestAPIInvalid {
+		if !valid {
 			continue
 		}
-		resolved.state = state
 		return resolved, 0, true
 	}
 
@@ -334,4 +335,23 @@ func applyRstestChainPart(state rstestAPIState, part rstestChainPart) rstestAPIS
 		}
 	}
 	return rstestAPIInvalid
+}
+
+func applyResolvedRstestChainPart(resolved *rstestResolvedAPI, part rstestChainPart) bool {
+	state := applyRstestChainPart(resolved.state, part)
+	if state == rstestAPIInvalid {
+		return false
+	}
+
+	resolved.state = state
+	if part.invocation != rstestNotInvoked {
+		return true
+	}
+	switch part.name {
+	case "skip":
+		resolved.hasSkip = true
+	case "todo":
+		resolved.hasTodo = true
+	}
+	return true
 }

--- a/internal/plugins/rstest/utils/rstest.go
+++ b/internal/plugins/rstest/utils/rstest.go
@@ -16,6 +16,8 @@ type RstestImportMode = testFramework.ReferenceMode
 type ParsedRstestFnCall struct {
 	testFramework.ParsedCall
 	Parameterized bool
+	HasSkip       bool
+	HasTodo       bool
 }
 
 type ParsedRstestFnCallHead = testFramework.ParsedCallHead

--- a/internal/plugins/rstest/utils/rstest.go
+++ b/internal/plugins/rstest/utils/rstest.go
@@ -16,8 +16,6 @@ type RstestImportMode = testFramework.ReferenceMode
 type ParsedRstestFnCall struct {
 	testFramework.ParsedCall
 	Parameterized bool
-	HasSkip       bool
-	HasTodo       bool
 }
 
 type ParsedRstestFnCallHead = testFramework.ParsedCallHead

--- a/internal/utils/test_framework/module_reference.go
+++ b/internal/utils/test_framework/module_reference.go
@@ -200,6 +200,10 @@ func resolveModuleRequireBinding(declaration *ast.Node, importModule string) (st
 
 // IsModuleRequireCall reports whether node is require(importModule).
 func IsModuleRequireCall(node *ast.Node, importModule string) bool {
+	if node == nil {
+		return false
+	}
+
 	node = ast.SkipParentheses(node)
 	if node == nil || !ast.IsRequireCall(node, true /* requireStringLiteralLikeArgument */) {
 		return false

--- a/internal/utils/test_framework/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/utils/test_framework/rules/no_disabled_tests/no_disabled_tests.go
@@ -16,6 +16,24 @@ type Config struct {
 	Name                    string
 	Parse                   func(*ast.Node, rule.RuleContext) *ParsedCall
 	IsStandaloneSkippedCall func(*ast.Node, rule.RuleContext) bool
+	// HasOptionsOverload marks frameworks whose test API accepts a
+	// `(description, options, fn?)` overload. For those, a two-argument call
+	// passing an options object registers a test without a body.
+	HasOptionsOverload bool
+}
+
+// isMissingFunctionArgument reports whether a test registration omits its
+// callback.
+func isMissingFunctionArgument(node *ast.Node, hasOptionsOverload bool) bool {
+	arguments := node.Arguments()
+	if len(arguments) < 2 {
+		return true
+	}
+	if !hasOptionsOverload || len(arguments) > 2 {
+		return false
+	}
+	options := ast.SkipParentheses(arguments[1])
+	return options != nil && options.Kind == ast.KindObjectLiteralExpression
 }
 
 func buildErrorMissingFunctionMessage() rule.RuleMessage {
@@ -58,8 +76,8 @@ func NewRule(config Config) rule.Rule {
 					}
 
 					if parsed.Call.Kind == testFramework.FnKindTest &&
-						len(node.Arguments()) < 2 &&
-						!parsed.HasTodo {
+						!parsed.HasTodo &&
+						isMissingFunctionArgument(node, config.HasOptionsOverload) {
 						ctx.ReportNode(node, buildErrorMissingFunctionMessage())
 					}
 				},

--- a/internal/utils/test_framework/rules/no_disabled_tests/no_disabled_tests.go
+++ b/internal/utils/test_framework/rules/no_disabled_tests/no_disabled_tests.go
@@ -1,0 +1,69 @@
+package no_disabled_tests
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+type ParsedCall struct {
+	Call    *testFramework.ParsedCall
+	HasSkip bool
+	HasTodo bool
+}
+
+type Config struct {
+	Name                    string
+	Parse                   func(*ast.Node, rule.RuleContext) *ParsedCall
+	IsStandaloneSkippedCall func(*ast.Node, rule.RuleContext) bool
+}
+
+func buildErrorMissingFunctionMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "missingFunction",
+		Description: "Test is missing function argument",
+	}
+}
+
+func buildErrorSkippedTestMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "skippedTest",
+		Description: "Tests should not be skipped",
+	}
+}
+
+// NewRule creates a no-disabled-tests rule for a test framework.
+func NewRule(config Config) rule.Rule {
+	return rule.Rule{
+		Name:   config.Name,
+		Schema: rule.EmptyArraySchema,
+		Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+			return rule.RuleListeners{
+				ast.KindCallExpression: func(node *ast.Node) {
+					if config.IsStandaloneSkippedCall != nil &&
+						config.IsStandaloneSkippedCall(node, ctx) {
+						ctx.ReportNode(node, buildErrorSkippedTestMessage())
+						return
+					}
+
+					parsed := config.Parse(node, ctx)
+					if parsed == nil || parsed.Call == nil ||
+						parsed.Call.Kind != testFramework.FnKindDescribe &&
+							parsed.Call.Kind != testFramework.FnKindTest {
+						return
+					}
+
+					if parsed.HasSkip {
+						ctx.ReportNode(node, buildErrorSkippedTestMessage())
+					}
+
+					if parsed.Call.Kind == testFramework.FnKindTest &&
+						len(node.Arguments()) < 2 &&
+						!parsed.HasTodo {
+						ctx.ReportNode(node, buildErrorMissingFunctionMessage())
+					}
+				},
+			}
+		},
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -544,6 +544,7 @@ export default defineConfig({
 
     // rstest
     './tests/rstest/rules/no-commented-out-tests.test.ts',
+    './tests/rstest/rules/no-disabled-tests.test.ts',
     './tests/rstest/rules/no-identical-title.test.ts',
     './tests/rstest/rules/no-mocks-import.test.ts',
 

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -76,6 +76,7 @@ describe('defineConfig and config presets', () => {
     expect(rec.plugins).toContain('rstest');
     expect(rec.rules).toEqual({
       'rstest/no-commented-out-tests': 'warn',
+      'rstest/no-disabled-tests': 'warn',
       'rstest/no-identical-title': 'error',
       'rstest/no-mocks-import': 'error',
     });

--- a/packages/rslint-test-tools/tests/rstest/rules/no-disabled-tests.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-disabled-tests.test.ts
@@ -23,6 +23,9 @@ ruleTester.run('no-disabled-tests', {} as never, {
     // `skip` on the test context is a runtime decision, not a disabled test.
     { code: 'test("case", context => { context.skip(); });' },
     { code: 'describe("empty suite"); describe.concurrent("empty suite");' },
+    { code: 'test("case", { timeout: 100 }, () => {});' },
+    // an identifier is not necessarily an options object
+    { code: 'declare const options: any; test("case", options);' },
     // jest-only aliases are not rstest APIs
     {
       code: 'declare const fit: any, xit: any, xtest: any, fdescribe: any, xdescribe: any; fit("case", () => {}); xit("case", () => {}); xtest("case", () => {}); fdescribe("suite", () => {}); xdescribe("suite", () => {});',
@@ -136,6 +139,14 @@ ruleTester.run('no-disabled-tests', {} as never, {
       errors: [
         { line: 1, column: 1, messageId: 'missingFunction' },
         { line: 1, column: 25, messageId: 'missingFunction' },
+      ],
+    },
+    // `(description, options)` registers a test without a body
+    {
+      code: 'test("case", { timeout: 100 }); it("case", {});',
+      errors: [
+        { line: 1, column: 1, messageId: 'missingFunction' },
+        { line: 1, column: 33, messageId: 'missingFunction' },
       ],
     },
     // both a skipped test and a missing implementation

--- a/packages/rslint-test-tools/tests/rstest/rules/no-disabled-tests.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-disabled-tests.test.ts
@@ -1,0 +1,155 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-disabled-tests', {} as never, {
+  valid: [
+    {
+      code: 'test("case", () => {}); it("case", () => {}); describe("suite", () => {});',
+    },
+    { code: 'test.only("case", () => {}); test.fails("case", () => {});' },
+    {
+      code: 'describe.only("suite", () => {}); describe.concurrent.sequential("suite", () => {});',
+    },
+    { code: 'test.todo("case"); it.todo("case"); describe.todo("suite");' },
+    { code: 'test.todo.each([1])("case"); test.todo.for([1])("case");' },
+    { code: 'const todoTest = test.todo; todoTest("case");' },
+    {
+      code: 'const condition = true; test.skipIf(condition)("case", () => {}); test.runIf(condition)("case", () => {});',
+    },
+    {
+      code: 'const condition = true; describe.skipIf(condition)("suite", () => {}); describe.runIf(condition)("suite", () => {});',
+    },
+    // `skip` on the test context is a runtime decision, not a disabled test.
+    { code: 'test("case", context => { context.skip(); });' },
+    { code: 'describe("empty suite"); describe.concurrent("empty suite");' },
+    // jest-only aliases are not rstest APIs
+    {
+      code: 'declare const fit: any, xit: any, xtest: any, fdescribe: any, xdescribe: any; fit("case", () => {}); xit("case", () => {}); xtest("case", () => {}); fdescribe("suite", () => {}); xdescribe("suite", () => {});',
+    },
+    { code: 'declare const pending: any; pending();' },
+    // dynamic member access cannot be resolved to `skip`
+    {
+      code: 'declare const suffix: string; test[`sk${suffix}`]("case", () => {});',
+    },
+    // not the rstest `test`
+    { code: 'import { test } from "node:test"; test.skip("case", () => {});' },
+    {
+      code: 'import { test, describe } from "vitest"; test.skip("case", () => {}); describe.skip("suite", () => {});',
+    },
+    {
+      code: 'declare function createRunner(): any; const test = createRunner(); test.skip("case", () => {});',
+    },
+    // `.skip` after `.each`/`.for` is not a valid rstest chain
+    {
+      code: 'test.for([1]).skip("case", () => {}); describe.each([1]).skip("suite", () => {});',
+    },
+  ],
+  invalid: [
+    {
+      code: 'test.skip("case", () => {});',
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'skippedTest',
+          message: 'Tests should not be skipped',
+        },
+      ],
+    },
+    {
+      code: 'it.skip("case", () => {});',
+      errors: [{ line: 1, column: 1, messageId: 'skippedTest' }],
+    },
+    {
+      code: 'describe.skip("suite", () => {});',
+      errors: [{ line: 1, column: 1, messageId: 'skippedTest' }],
+    },
+    {
+      code: 'test["skip"]("case", () => {}); it[`skip`]("case", () => {});',
+      errors: [
+        { line: 1, column: 1, messageId: 'skippedTest' },
+        { line: 1, column: 33, messageId: 'skippedTest' },
+      ],
+    },
+    {
+      code: 'test.concurrent.skip("case", () => {}); test.skip.sequential("case", () => {});',
+      errors: [
+        { line: 1, column: 1, messageId: 'skippedTest' },
+        { line: 1, column: 41, messageId: 'skippedTest' },
+      ],
+    },
+    {
+      code: 'test.skip.each([1])("case", () => {}); test.skip.for([1])("case", () => {});',
+      errors: [
+        { line: 1, column: 1, messageId: 'skippedTest' },
+        { line: 1, column: 40, messageId: 'skippedTest' },
+      ],
+    },
+    {
+      code: 'describe.skip.each([1])("suite", () => {});',
+      errors: [{ line: 1, column: 1, messageId: 'skippedTest' }],
+    },
+    {
+      code: [
+        'import { test as rstestTest } from "@rstest/core";',
+        'rstestTest.skip("case", () => {});',
+      ].join('\n'),
+      errors: [{ line: 2, column: 1, messageId: 'skippedTest' }],
+    },
+    {
+      code: [
+        'import * as rstest from "@rstest/core";',
+        'rstest.test.skip("case", () => {});',
+        'rstest.describe.skip("suite", () => {});',
+      ].join('\n'),
+      errors: [
+        { line: 2, column: 1, messageId: 'skippedTest' },
+        { line: 3, column: 1, messageId: 'skippedTest' },
+      ],
+    },
+    {
+      code: ['const skipped = test.skip;', 'skipped("case", () => {});'].join(
+        '\n',
+      ),
+      errors: [{ line: 2, column: 1, messageId: 'skippedTest' }],
+    },
+    {
+      code: 'test.extend({}).skip("case", () => {});',
+      errors: [{ line: 1, column: 1, messageId: 'skippedTest' }],
+    },
+    {
+      code: 'test("case"); it("case"); test.concurrent("case");',
+      errors: [
+        {
+          line: 1,
+          column: 1,
+          messageId: 'missingFunction',
+          message: 'Test is missing function argument',
+        },
+        { line: 1, column: 15, messageId: 'missingFunction' },
+        { line: 1, column: 27, messageId: 'missingFunction' },
+      ],
+    },
+    {
+      code: 'test.each([1])("case"); test.for([1])("case");',
+      errors: [
+        { line: 1, column: 1, messageId: 'missingFunction' },
+        { line: 1, column: 25, messageId: 'missingFunction' },
+      ],
+    },
+    // both a skipped test and a missing implementation
+    {
+      code: 'test.skip("case");',
+      errors: [
+        { line: 1, column: 1, messageId: 'skippedTest' },
+        { line: 1, column: 1, messageId: 'missingFunction' },
+      ],
+    },
+    // `.todo` suppresses only the missing-function report
+    {
+      code: 'test.todo.skip("case");',
+      errors: [{ line: 1, column: 1, messageId: 'skippedTest' }],
+    },
+  ],
+});

--- a/packages/rslint/src/config/presets/rstest.ts
+++ b/packages/rslint/src/config/presets/rstest.ts
@@ -4,6 +4,7 @@ const recommended: RslintConfigEntry = {
   plugins: ['rstest'],
   rules: {
     'rstest/no-commented-out-tests': 'warn',
+    'rstest/no-disabled-tests': 'warn',
     'rstest/no-identical-title': 'error',
     'rstest/no-mocks-import': 'error',
   },


### PR DESCRIPTION
## Summary

Add `rstest/no-disabled-tests` with support for skipped, incomplete, parameterized, imported, and same-file custom test APIs.

Share the framework-neutral checks with Jest while preserving existing Jest behavior. Register the rule as a warning in `rstest.configs.recommended`.

## Related Links

Related https://github.com/web-infra-dev/rslint/issues/935

## Validation

- `go test ./internal/plugins/rstest/... ./internal/utils/test_framework/... ./internal/plugins/jest/rules/no_disabled_tests ./internal/config`
- `go test ./internal/plugins/jest/...`
- `go vet ./internal/plugins/rstest/... ./internal/utils/test_framework/... ./internal/plugins/jest/rules/no_disabled_tests`
- `pnpm -C packages/rslint build:js`
- `pnpm --filter @rslint/test-tools exec rstest run tests/cli/js-config/presets.test.ts`
- `git diff --check`

## Checklist

- [x] Tests updated.
- [x] Documentation updated.