### PR TITLE
fix: resolve type-only exports in the correct symbol space

### DIFF
--- a/internal/plugins/typescript/rules/no_use_before_define/edge_cases_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/edge_cases_test.go
@@ -130,7 +130,10 @@ func TestEdgeCases(t *testing.T) {
 
 			// ----- Type-only named exports -----
 			{Code: `let x = 1; export type { x };`},
+			{Code: `function f() {} export type { f };`},
 			{Code: `type T = number; export type { T };`},
+			// The local value does not shadow the real global type target.
+			{Code: `export type { HTMLElement }; let HTMLElement = 1;`},
 			{
 				Code:    `export type { x }; let x = 1;`,
 				Options: map[string]interface{}{"allowNamedExports": true},
@@ -413,6 +416,12 @@ declare global {
 			},
 			{
 				Code: `export type { x as y }; let x = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `export type { f }; function f() {}`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
 				},

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
@@ -596,6 +596,17 @@ func checkNamedExport(ctx rule.RuleContext, opts options, node *ast.Node) {
 	// module's. getDefinitionInfo below then finds that local declaration
 	// without any alias-chain walking through the checker.
 	sym := ctx.Refs.Resolve(node)
+	if sym == nil &&
+		ctx.TypeChecker != nil &&
+		ast.IsTypeOnlyImportOrExportDeclaration(node.Parent) &&
+		!utils.IsReExportSpecifier(node.Parent) {
+		// RefStore deliberately leaves a type-only reference unresolved when
+		// only a value binding exists. no-use-before-define is the exception:
+		// its named-export branch still compares that local value declaration
+		// with the export site. Keep this rule-specific lookup here instead of
+		// polluting RefStore's declaration-space semantics.
+		sym = ctx.TypeChecker.GetExportSpecifierLocalTargetSymbol(node.Parent)
+	}
 	if sym == nil {
 		return
 	}

--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -14,11 +14,13 @@ import (
 //
 // References are resolved with the binder's NameResolver — the same scope walk
 // the checker performs for identifiers. Resolve tries this scope walk first;
-// when it can't place an identifier (a symbol declared outside this file —
-// cross-file, .d.ts, and standard-library globals) and a TypeChecker was
-// supplied to NewRefStore, it falls back to the checker for that identifier.
-// Without a checker, that fallback is a no-op and Resolve returns nil for
-// those identifiers, the same as if they didn't resolve at all.
+// when it can't place an identifier and a TypeChecker was supplied to
+// NewRefStore, it falls back to the checker. This is usually needed for
+// cross-file, .d.ts, and standard-library globals; export specifiers also need
+// it when a declaration-space-specific lookup continues past a same-named
+// local binding. Without a checker, that fallback is a no-op and Resolve
+// returns nil for those identifiers, the same as if they didn't resolve at
+// all.
 //
 // References resolves symbols the same way internally, so it can return
 // identifiers referencing a symbol obtained from the checker fallback too; for
@@ -108,8 +110,8 @@ func (s *RefStore) References(sym *ast.Symbol) []*ast.Node {
 
 // resolvePending resolves every not-yet-resolved candidate identifier spelled
 // name and files each one under the symbol it references. Candidates the
-// binder scope walk can't place (declared outside this file) fall back to
-// the TypeChecker when one is available.
+// binder scope walk can't place fall back to the TypeChecker when one is
+// available.
 func (s *RefStore) resolvePending(name string) {
 	pending, ok := s.candidates[name]
 	if !ok {
@@ -117,11 +119,10 @@ func (s *RefStore) resolvePending(name string) {
 	}
 	delete(s.candidates, name)
 	for _, id := range pending {
-		target := s.resolver.Resolve(id, name, referenceMeaning(id), nil, true /*isUse*/, false /*excludeGlobals*/)
+		meaning := referenceMeaning(id)
+		target := s.resolver.Resolve(id, name, meaning, nil, true /*isUse*/, false /*excludeGlobals*/)
 		if target == nil {
-			if s.tc != nil {
-				target = utils.GetReferenceSymbol(id, s.tc)
-			}
+			target = s.checkerReferenceSymbol(id, meaning)
 		} else {
 			target = s.mergedSymbol(target, id)
 		}
@@ -182,10 +183,9 @@ func sharesDeclaration(a, b *ast.Symbol) bool {
 // to — the forward counterpart to References, for rules that need "what
 // declaration does this identifier refer to" rather than "what identifiers
 // refer to this declaration." It uses the binder's scope walk first; when
-// that can't place the identifier — a symbol declared outside this file
-// (cross-file, .d.ts, and standard-library globals) — and a TypeChecker was
-// supplied to NewRefStore, it falls back to the checker. That fallback is a
-// real TypeChecker round-trip, unlike the binder-only common path.
+// that can't place the identifier and a TypeChecker was supplied to
+// NewRefStore, it falls back to the checker. That fallback is a real
+// TypeChecker round-trip, unlike the binder-only common path.
 //
 // Returns nil for identifiers that aren't reference positions (declaration
 // names, property keys, import bindings, re-export/alias-label names, labels,
@@ -195,11 +195,30 @@ func (s *RefStore) Resolve(node *ast.Node) *ast.Symbol {
 	if s == nil || node == nil || node.Kind != ast.KindIdentifier || !isReferencePosition(node) {
 		return nil
 	}
-	if sym := s.resolver.Resolve(node, node.Text(), referenceMeaning(node), nil, true /*isUse*/, false /*excludeGlobals*/); sym != nil {
+	meaning := referenceMeaning(node)
+	if sym := s.resolver.Resolve(node, node.Text(), meaning, nil, true /*isUse*/, false /*excludeGlobals*/); sym != nil {
 		return sym
 	}
+	return s.checkerReferenceSymbol(node, meaning)
+}
+
+// checkerReferenceSymbol resolves a reference the binder-only scope walk
+// could not place. Most identifiers can use GetReferenceSymbol, whose
+// GetSymbolAtLocation fallback understands their syntactic context.
+//
+// Export specifiers are different: GetSymbolAtLocation returns the export
+// alias symbol rather than the local binding, and
+// GetExportSpecifierLocalTargetSymbol searches all declaration spaces at
+// once. The latter is also insufficient for a type-only export: a local
+// value-only binding could win that broad lookup even when an outer/global
+// type binding is the actual target. ResolveName applies meaning during the
+// scope walk, preserving both declaration-space selection and shadowing.
+func (s *RefStore) checkerReferenceSymbol(node *ast.Node, meaning ast.SymbolFlags) *ast.Symbol {
 	if s.tc == nil {
 		return nil
+	}
+	if node.Parent != nil && node.Parent.Kind == ast.KindExportSpecifier {
+		return s.tc.ResolveName(node.Text(), node, meaning, false /*excludeGlobals*/)
 	}
 	return utils.GetReferenceSymbol(node, s.tc)
 }
@@ -325,13 +344,16 @@ func referenceMeaning(n *ast.Node) ast.SymbolFlags {
 		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
 	}
 	if p != nil && p.Kind == ast.KindExportSpecifier {
-		// `export { X }` can re-export a value, a type, or a namespace —
-		// same declaration-space breadth as `export =` above. Type-only
-		// specifiers (`export type { X }` / `export { type X }`) resolve the
-		// same way, mirroring the type-flagged reference ESLint's
-		// scope-manager records for them; rules that only follow runtime
-		// reads classify the reference site instead (see
-		// utils.IsReadReference / utils.IsNonReferenceIdentifier).
+		// A type-only export creates a type reference. It may bind to a type,
+		// namespace, or import alias, but never to a value-only declaration.
+		// Namespace is separate from Type in the TypeScript binder even though
+		// typescript-eslint scope-manager treats namespace definitions as
+		// type-capable variables.
+		if ast.IsTypeOnlyImportOrExportDeclaration(p) {
+			return ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+		}
+		// A regular local export creates a dual value/type reference, so it
+		// can bind in any declaration space.
 		return ast.SymbolFlagsValue | ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
 	}
 	// `import a = b.c` — the right-hand side may name a value, type, or

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -464,16 +464,16 @@ func TestRefStoreExportSpecifierResolvesTypeOnlySymbol(t *testing.T) {
 	}
 }
 
-func TestRefStoreTypeOnlyExportSpecifierIndexed(t *testing.T) {
-	// `export type { x }` / `export { type x }` resolves to the binding like
-	// any other local export — ESLint's scope-manager records a type-flagged
-	// reference for it. Consumers that only follow runtime reads classify the
-	// reference site (utils.IsNonReferenceIdentifier reports these as
-	// non-reads); the index itself keeps them.
+func TestRefStoreTypeOnlyExportSpecifierExcludesValueOnlySymbol(t *testing.T) {
+	// A type-only export cannot resolve to a value-only declaration. This is
+	// declaration-space filtering, not merely read classification: the
+	// specifier must be absent from the value symbol's reference list.
 	for name, source := range map[string]string{
-		"export type clause":  "let x;\nexport type { x };\nx = 1;\n",
-		"type specifier":      "let x;\nexport { type x };\nx = 1;\n",
-		"export type aliased": "let x;\nexport type { x as y };\nx = 1;\n",
+		"export type clause":   "let x;\nexport type { x };\nx = 1;\n",
+		"inline type":          "let x;\nexport { type x };\nx = 1;\n",
+		"aliased":              "let x;\nexport type { x as y };\nx = 1;\n",
+		"value-only function":  "function x() {}\nexport type { x };\nx();\n",
+		"inline function type": "function x() {}\nexport { type x };\nx();\n",
 	} {
 		t.Run(name, func(t *testing.T) {
 			sourceFile, refs := newBoundRefStore(t, "/type-only-export.ts", core.ScriptKindTS, source)
@@ -482,54 +482,64 @@ func TestRefStoreTypeOnlyExportSpecifierIndexed(t *testing.T) {
 			if len(occurrences) != 3 {
 				t.Fatalf("expected 3 occurrences of x, got %d", len(occurrences))
 			}
-			declIdent, specifierIdent, writeIdent := occurrences[0], occurrences[1], occurrences[2]
+			declIdent, specifierIdent, valueUseIdent := occurrences[0], occurrences[1], occurrences[2]
+			sym := declIdent.Parent.Symbol()
+			if sym == nil {
+				t.Fatal("declaration identifier has no bound symbol")
+			}
+
+			if got := refs.Resolve(specifierIdent); got != nil {
+				t.Fatalf("Resolve(type-only export specifier x) = %v, want nil for a value-only declaration", got)
+			}
+			got := refs.References(sym)
+			if len(got) != 1 || got[0] != valueUseIdent {
+				t.Fatalf("References = %v, want [%v] (only the value-space use)", got, valueUseIdent)
+			}
+		})
+	}
+}
+
+func TestRefStoreTypeOnlyExportSpecifierResolvesTypeCapableSymbol(t *testing.T) {
+	// Type aliases/interfaces, dual-space declarations, namespaces, merged
+	// symbols, and import aliases are all type-capable in scope-manager's
+	// model and must keep their type-only export reference.
+	for name, source := range map[string]string{
+		"type alias":          "type X = {};\nexport type { X };\n",
+		"interface":           "interface X {}\nexport type { X };\n",
+		"class":               "class X {}\nexport type { X };\n",
+		"enum":                "enum X { A }\nexport type { X };\n",
+		"namespace":           "namespace X {}\nexport type { X };\n",
+		"function namespace":  "function X() {}\nnamespace X {}\nexport type { X };\n",
+		"interface and value": "interface X {}\nlet X;\nexport type { X };\n",
+		"import alias":        "import { Foo as X } from './missing';\nexport type { X };\n",
+		"type import alias":   "import type { Foo as X } from './missing';\nexport type { X };\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			sourceFile, refs := newBoundRefStore(t, "/type-only-export-type.ts", core.ScriptKindTS, source)
+			occurrences := identifiers(sourceFile.AsNode(), "X")
+			if len(occurrences) < 2 {
+				t.Fatalf("expected at least 2 occurrences of X, got %d", len(occurrences))
+			}
+			declIdent, specifierIdent := occurrences[0], occurrences[len(occurrences)-1]
 			sym := declIdent.Parent.Symbol()
 			if sym == nil {
 				t.Fatal("declaration identifier has no bound symbol")
 			}
 
 			if got := refs.Resolve(specifierIdent); got != sym {
-				t.Fatalf("Resolve(type-only export specifier x) = %v, want %v", got, sym)
+				t.Fatalf("Resolve(type-only export specifier X) = %v, want %v", got, sym)
 			}
 			got := refs.References(sym)
-			if len(got) != 2 || got[0] != specifierIdent || got[1] != writeIdent {
-				t.Fatalf("References = %v, want [%v %v] (the specifier and the `x = 1` write)", got, specifierIdent, writeIdent)
+			if len(got) != 1 || got[0] != specifierIdent {
+				t.Fatalf("References = %v, want [%v] (the type-only export reference)", got, specifierIdent)
 			}
 		})
 	}
 }
 
-func TestRefStoreTypeOnlyExportSpecifierResolvesTypeSymbol(t *testing.T) {
-	// The type-space half of the meaning must stay: `export type { Foo }` of
-	// an actual type still references it.
-	sourceFile, refs := newBoundRefStore(t, "/type-only-export-type.ts", core.ScriptKindTS,
-		"type Foo = {};\nexport type { Foo };\n")
-
-	occurrences := identifiers(sourceFile.AsNode(), "Foo")
-	if len(occurrences) != 2 {
-		t.Fatalf("expected 2 occurrences of Foo, got %d", len(occurrences))
-	}
-	declIdent, specifierIdent := occurrences[0], occurrences[1]
-	sym := declIdent.Parent.Symbol()
-	if sym == nil {
-		t.Fatal("declaration identifier has no bound symbol")
-	}
-
-	if got := refs.Resolve(specifierIdent); got != sym {
-		t.Fatalf("Resolve(type-only export specifier Foo) = %v, want %v", got, sym)
-	}
-	got := refs.References(sym)
-	if len(got) != 1 || got[0] != specifierIdent {
-		t.Fatalf("References = %v, want [%v] (the `export type { Foo }` reference)", got, specifierIdent)
-	}
-}
-
-func TestRefStoreTypeOnlyExportSpecifierWithChecker(t *testing.T) {
-	// With a TypeChecker present, the aliased type-only specifier's
-	// PropertyName must still resolve through the binder onto the same raw
-	// symbol the write does — not detour through the checker fallback, which
-	// would file it under a different (checker-merged alias) identity and
-	// split the index.
+func TestRefStoreTypeOnlyExportSpecifierWithCheckerExcludesValueOnlySymbol(t *testing.T) {
+	// The checker fallback must not reintroduce the value binding after the
+	// binder correctly rejects it.
 	sourceFile, refs, done := newCheckedRefStore(t,
 		"let x;\nexport type { x as y };\nx = 1;\n")
 	defer done()
@@ -544,12 +554,76 @@ func TestRefStoreTypeOnlyExportSpecifierWithChecker(t *testing.T) {
 		t.Fatal("declaration identifier has no bound symbol")
 	}
 
-	if got := refs.Resolve(specifierIdent); got != sym {
-		t.Fatalf("Resolve(type-only export PropertyName x) = %v, want %v", got, sym)
+	if got := refs.Resolve(specifierIdent); got != nil {
+		t.Fatalf("Resolve(type-only export PropertyName x) = %v, want nil", got)
 	}
 	got := refs.References(sym)
-	if len(got) != 2 || got[0] != specifierIdent || got[1] != writeIdent {
-		t.Fatalf("References = %v, want [%v %v] (the specifier and the `x = 1` write)", got, specifierIdent, writeIdent)
+	if len(got) != 1 || got[0] != writeIdent {
+		t.Fatalf("References = %v, want [%v] (only the `x = 1` write)", got, writeIdent)
+	}
+}
+
+func TestRefStoreTypeOnlyExportCheckerFallbackRespectsMeaningAndShadowing(t *testing.T) {
+	// A local value-only HTMLElement does not shadow the outer/global
+	// HTMLElement type. A broad checker lookup would pick the local value and
+	// either misfile the reference or lose the real type target; the requested
+	// declaration-space meaning must participate in the checker scope walk.
+	sourceFile, refs, done := newCheckedRefStore(t,
+		"let HTMLElement;\nexport type { HTMLElement as LocalHTMLElement };\n")
+	defer done()
+
+	occurrences := identifiers(sourceFile.AsNode(), "HTMLElement")
+	if len(occurrences) != 2 {
+		t.Fatalf("expected 2 occurrences of HTMLElement, got %d", len(occurrences))
+	}
+	declIdent, specifierIdent := occurrences[0], occurrences[1]
+	localValue := declIdent.Parent.Symbol()
+	if localValue == nil {
+		t.Fatal("declaration identifier has no bound symbol")
+	}
+
+	target := refs.Resolve(specifierIdent)
+	if target == nil {
+		t.Fatal("Resolve(type-only export HTMLElement) = nil, want the global type symbol")
+	}
+	if target == localValue {
+		t.Fatal("type-only export resolved to the shadowing local value symbol")
+	}
+	if target.Flags&(ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias) == 0 {
+		t.Fatalf("resolved checker symbol flags = %v, want a type-capable symbol", target.Flags)
+	}
+	if got := refs.References(localValue); len(got) != 0 {
+		t.Fatalf("References(local value) = %v, want none", got)
+	}
+	got := refs.References(target)
+	if len(got) != 1 || got[0] != specifierIdent {
+		t.Fatalf("References(global type) = %v, want [%v]", got, specifierIdent)
+	}
+}
+
+func TestRefStoreLocalExportCheckerFallbackResolvesGlobalValue(t *testing.T) {
+	// The meaning-aware ExportSpecifier fallback also preserves ordinary
+	// dual-space exports of globals; it must not be limited to type-only
+	// syntax.
+	sourceFile, refs, done := newCheckedRefStore(t,
+		"export { window as browserWindow };\n")
+	defer done()
+
+	occurrences := identifiers(sourceFile.AsNode(), "window")
+	if len(occurrences) != 1 {
+		t.Fatalf("expected 1 occurrence of window, got %d", len(occurrences))
+	}
+	specifierIdent := occurrences[0]
+	target := refs.Resolve(specifierIdent)
+	if target == nil {
+		t.Fatal("Resolve(local export window) = nil, want the global value symbol")
+	}
+	if target.Flags&ast.SymbolFlagsValue == 0 {
+		t.Fatalf("resolved checker symbol flags = %v, want a value-capable symbol", target.Flags)
+	}
+	got := refs.References(target)
+	if len(got) != 1 || got[0] != specifierIdent {
+		t.Fatalf("References(global value) = %v, want [%v]", got, specifierIdent)
 	}
 }
 

--- a/internal/rules/no_var/no_var_test.go
+++ b/internal/rules/no_var/no_var_test.go
@@ -87,6 +87,36 @@ func TestNoVarRule(t *testing.T) {
 					{MessageId: "unexpectedVar"},
 				},
 			},
+			// Type-only exports do not reference a value-only var, so they do
+			// not create a false "used before declaration" blocker for the fix.
+			{
+				Code:   `export type { x }; var x = 1;`,
+				Output: []string{`export type { x }; let x = 1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedVar"},
+				},
+			},
+			{
+				Code:   `export { type x }; var x = 1;`,
+				Output: []string{`export { type x }; let x = 1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedVar"},
+				},
+			},
+			{
+				Code:   `export type { x as y }; var x = 1;`,
+				Output: []string{`export type { x as y }; let x = 1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedVar"},
+				},
+			},
+			{
+				Code:   `export type { HTMLElement }; var HTMLElement = 1;`,
+				Output: []string{`export type { HTMLElement }; let HTMLElement = 1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedVar"},
+				},
+			},
 			// Import attribute keys are syntax names, not variable references.
 			{
 				Code:   `import data from "pkg" with { type: "json" }; var type = 1;`,

--- a/internal/rules/prefer_const/prefer_const.go
+++ b/internal/rules/prefer_const/prefer_const.go
@@ -278,13 +278,6 @@ func isReadBeforeFirstAssign(refs []*ast.Node, declPos int) bool {
 			// Found the first write at or after the declaration - stop looking.
 			return foundRead
 		}
-		if utils.IsNonReferenceIdentifier(ref) {
-			// A type-only export (`export type { x }` / `export { type x }`)
-			// is the one reference position ctx.Refs indexes that ESLint's
-			// scope-manager flags as type-only rather than as a read — unlike
-			// `typeof x`, which does count as one.
-			continue
-		}
 		foundRead = true
 	}
 	return foundRead

--- a/internal/rules/prefer_const/prefer_const_test.go
+++ b/internal/rules/prefer_const/prefer_const_test.go
@@ -121,6 +121,15 @@ func TestPreferConstRule(t *testing.T) {
 				Options: map[string]interface{}{"ignoreReadBeforeAssign": true},
 			},
 
+			// A type-only export does resolve to a merged type/value symbol.
+			// scope-manager records that reference on the variable, so
+			// ignoreReadBeforeAssign suppresses the report just like a regular
+			// read before assignment.
+			{
+				Code:    "interface X {}\nlet X; export type { X }; X = 1;",
+				Options: map[string]interface{}{"ignoreReadBeforeAssign": true},
+			},
+
 			// Uninitialized, assigned inside if block - can't be safely converted to const
 			{Code: `let x: number; if (true) { x = 1; }`},
 
@@ -576,6 +585,15 @@ func TestPreferConstRule(t *testing.T) {
 				Options: map[string]interface{}{"ignoreReadBeforeAssign": true},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "useConst", Line: 1, Column: 27},
+				},
+			},
+			// Unlike the value-only cases above, a merged interface/variable is
+			// type-capable, so the type-only export is attached to that symbol
+			// and moves the report to the declaration.
+			{
+				Code: "interface X {}\nlet X; export type { X }; X = 1;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useConst", Line: 2, Column: 5},
 				},
 			},
 


### PR DESCRIPTION
## Summary

- Resolve type-only local export specifiers only against type, namespace, and alias spaces instead of value-only bindings.
- Use a meaning-aware TypeChecker fallback so local value bindings do not hide valid outer or global type targets.
- Remove the prefer-const workaround and preserve the named-export behavior required by no-use-before-define.
- Add regression coverage for value-only and merged symbols, namespaces, import aliases, checker fallback, no-var fixes, and rule option behavior.
- Validate with check-spell, format:check, targeted Go lint, and the five affected Go packages.

## Related Links

- Follow-up to #1459

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).