### PR TITLE
fix: resolve type-only exports for unused variables

### DIFF
--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -1451,18 +1451,33 @@ func collectLocalExportTargets(ctx rule.RuleContext, node *ast.Node, ac *analysi
 		return
 	}
 	for _, spec := range namedExports.Elements.Nodes {
-		if spec.AsExportSpecifier() == nil {
+		exportSpecifier := spec.AsExportSpecifier()
+		if exportSpecifier == nil {
 			continue
 		}
-		target := ctx.TypeChecker.GetExportSpecifierLocalTargetSymbol(spec)
+		localName := exportSpecifier.Name()
+		if exportSpecifier.PropertyName != nil {
+			localName = exportSpecifier.PropertyName
+		}
+		// RefStore applies the specifier's declaration-space meaning. In
+		// particular, a type-only export remains unresolved when only a
+		// value binding exists.
+		target := ctx.Refs.Resolve(localName)
 		if target == nil {
 			continue
 		}
 		if ac.localExportTargets == nil {
 			ac.localExportTargets = make(map[*ast.Symbol]bool)
 		}
+		// RefStore returns binder symbols on its fast path, while
+		// processVariable starts from the checker symbol at the declaration.
+		// Retain both identities plus the alias target.
 		ac.localExportTargets[target] = true
-		if resolved := ctx.TypeChecker.SkipAlias(target); resolved != target {
+		if merged := ctx.TypeChecker.GetMergedSymbol(target); merged != nil {
+			target = merged
+			ac.localExportTargets[target] = true
+		}
+		if resolved := ctx.TypeChecker.SkipAlias(target); resolved != nil && resolved != target {
 			ac.localExportTargets[resolved] = true
 		}
 	}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_ref_store_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_ref_store_test.go
@@ -172,6 +172,41 @@ export { publicValue };`,
 	)
 }
 
+func TestNoUnusedVarsTypeOnlyLocalExports(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `type T = {}; export type { T };`},
+			{Code: `interface M {} const M = 1; export type { M };`},
+			{Code: `import { V } from "./foo"; export type { V };`},
+			{Code: `const value = 1; export namespace N { export { value }; } consume(N);`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `const value = 1; export type { value };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 7}},
+			},
+			{
+				Code:   "function f() {}\nexport { type f as F };",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 10}},
+			},
+			{
+				Code: "type Token = {};\nnamespace Box {\n  const Token = 1;\n  export type { Token };\n}\nconsume(Box);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unusedVar", Line: 3, Column: 9},
+				},
+			},
+			{
+				Code:   "let assigned;\nexport type { assigned };\nassigned = 1;",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 3, Column: 1}},
+			},
+		},
+	)
+}
+
 func TestNoUnusedVarsPatternCacheBounded(t *testing.T) {
 	for i := range maxCachedPatterns + 32 {
 		cachedPattern(fmt.Sprintf("^cache-attack-%d$", i))

--- a/internal/rule/ref_store.go
+++ b/internal/rule/ref_store.go
@@ -120,7 +120,7 @@ func (s *RefStore) resolvePending(name string) {
 	delete(s.candidates, name)
 	for _, id := range pending {
 		meaning := referenceMeaning(id)
-		target := s.resolver.Resolve(id, name, meaning, nil, true /*isUse*/, false /*excludeGlobals*/)
+		target := s.binderReferenceSymbol(id, meaning)
 		if target == nil {
 			target = s.checkerReferenceSymbol(id, meaning)
 		} else {
@@ -196,10 +196,27 @@ func (s *RefStore) Resolve(node *ast.Node) *ast.Symbol {
 		return nil
 	}
 	meaning := referenceMeaning(node)
-	if sym := s.resolver.Resolve(node, node.Text(), meaning, nil, true /*isUse*/, false /*excludeGlobals*/); sym != nil {
+	if sym := s.binderReferenceSymbol(node, meaning); sym != nil {
 		return sym
 	}
 	return s.checkerReferenceSymbol(node, meaning)
+}
+
+// binderReferenceSymbol resolves one reference without checker work. A named
+// export nested in a namespace needs one extra guard: the binder exposes that
+// export's own alias in the namespace's Exports table. If no local declaration
+// matches the requested meaning, NameResolver can otherwise return the alias
+// being declared instead of continuing to an outer lexical declaration.
+func (s *RefStore) binderReferenceSymbol(node *ast.Node, meaning ast.SymbolFlags) *ast.Symbol {
+	target := s.resolver.Resolve(node, node.Text(), meaning, nil, true /*isUse*/, false /*excludeGlobals*/)
+	if !isOwnExportAlias(node, target) {
+		return target
+	}
+	outer := outerExportScopeLocation(node)
+	if outer == nil {
+		return nil
+	}
+	return s.resolver.Resolve(outer, node.Text(), meaning, nil, true /*isUse*/, false /*excludeGlobals*/)
 }
 
 // checkerReferenceSymbol resolves a reference the binder-only scope walk
@@ -218,9 +235,47 @@ func (s *RefStore) checkerReferenceSymbol(node *ast.Node, meaning ast.SymbolFlag
 		return nil
 	}
 	if node.Parent != nil && node.Parent.Kind == ast.KindExportSpecifier {
-		return s.tc.ResolveName(node.Text(), node, meaning, false /*excludeGlobals*/)
+		target := s.tc.ResolveName(node.Text(), node, meaning, false /*excludeGlobals*/)
+		if !isOwnExportAlias(node, target) {
+			return target
+		}
+		outer := outerExportScopeLocation(node)
+		if outer == nil {
+			return nil
+		}
+		return s.tc.ResolveName(node.Text(), outer, meaning, false /*excludeGlobals*/)
 	}
 	return utils.GetReferenceSymbol(node, s.tc)
+}
+
+// isOwnExportAlias identifies the alias symbol declared by node's own export
+// specifier. It is a declaration result, not the local target that the
+// specifier references.
+func isOwnExportAlias(node *ast.Node, symbol *ast.Symbol) bool {
+	if node == nil || node.Parent == nil || node.Parent.Kind != ast.KindExportSpecifier || symbol == nil {
+		return false
+	}
+	for _, declaration := range symbol.Declarations {
+		if declaration == node.Parent {
+			return true
+		}
+	}
+	return false
+}
+
+// outerExportScopeLocation returns the first location outside the namespace
+// containing a local export specifier. Top-level module exports have no outer
+// lexical scope to retry.
+func outerExportScopeLocation(node *ast.Node) *ast.Node {
+	for current := node.Parent; current != nil; current = current.Parent {
+		if current.Kind == ast.KindModuleDeclaration {
+			return current.Parent
+		}
+		if current.Kind == ast.KindSourceFile {
+			return nil
+		}
+	}
+	return nil
 }
 
 // collectCandidates walks the file once and buckets by name every identifier

--- a/internal/rule/ref_store_test.go
+++ b/internal/rule/ref_store_test.go
@@ -601,6 +601,196 @@ func TestRefStoreTypeOnlyExportCheckerFallbackRespectsMeaningAndShadowing(t *tes
 	}
 }
 
+func TestRefStoreNestedLocalExports(t *testing.T) {
+	tests := []struct {
+		name            string
+		source          string
+		identifier      string
+		occurrenceCount int
+		targetIndex     int
+		localValueIndex int
+	}{
+		{
+			name: "type export skips a value shadow",
+			source: `
+type X = {};
+namespace N {
+	let X;
+	export type { X };
+}`,
+			identifier:      "X",
+			occurrenceCount: 3,
+			targetIndex:     0,
+			localValueIndex: 1,
+		},
+		{
+			name: "type export keeps its local type",
+			source: `
+namespace N {
+	type X = {};
+	export type { X };
+}`,
+			identifier:      "X",
+			occurrenceCount: 2,
+			targetIndex:     0,
+			localValueIndex: -1,
+		},
+		{
+			name: "deeply nested type export finds its lexical type",
+			source: `
+namespace Outer {
+	type X = {};
+	export namespace Inner {
+		let X;
+		export type { X };
+	}
+}`,
+			identifier:      "X",
+			occurrenceCount: 3,
+			targetIndex:     0,
+			localValueIndex: 1,
+		},
+		{
+			name: "type export rejects its own value-only alias",
+			source: `
+namespace N {
+	let x;
+	export type { x };
+}`,
+			identifier:      "x",
+			occurrenceCount: 2,
+			targetIndex:     -1,
+			localValueIndex: 0,
+		},
+		{
+			name: "ordinary export keeps its local value",
+			source: `
+namespace N {
+	const x = 1;
+	export { x };
+}`,
+			identifier:      "x",
+			occurrenceCount: 2,
+			targetIndex:     0,
+			localValueIndex: -1,
+		},
+		{
+			name: "ordinary export finds its outer value",
+			source: `
+const x = 1;
+namespace N {
+	export { x };
+}`,
+			identifier:      "x",
+			occurrenceCount: 2,
+			targetIndex:     0,
+			localValueIndex: -1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile, refs := newBoundRefStore(t, "/nested-local-export.ts", core.ScriptKindTS, test.source)
+			occurrences := identifiers(sourceFile.AsNode(), test.identifier)
+			if len(occurrences) != test.occurrenceCount {
+				t.Fatalf("identifier occurrences = %d, want %d", len(occurrences), test.occurrenceCount)
+			}
+			specifier := occurrences[len(occurrences)-1]
+
+			if test.targetIndex < 0 {
+				if got := refs.Resolve(specifier); got != nil {
+					t.Fatalf("Resolve(export specifier) = %v, want nil", got)
+				}
+			} else {
+				target := occurrences[test.targetIndex].Parent.Symbol()
+				if target == nil {
+					t.Fatal("target declaration identifier has no bound symbol")
+				}
+				if got := refs.Resolve(specifier); got != target {
+					t.Fatalf("Resolve(export specifier) = %v, want %v", got, target)
+				}
+				if got := refs.References(target); len(got) != 1 || got[0] != specifier {
+					t.Fatalf("References(target) = %v, want [%v]", got, specifier)
+				}
+			}
+
+			if test.localValueIndex >= 0 {
+				localValue := occurrences[test.localValueIndex].Parent.Symbol()
+				if localValue == nil {
+					t.Fatal("local value declaration identifier has no bound symbol")
+				}
+				if got := refs.References(localValue); len(got) != 0 {
+					t.Fatalf("References(local value) = %v, want none", got)
+				}
+			}
+		})
+	}
+}
+
+func TestRefStoreNestedTypeOnlyExportsWithChecker(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		identifier string
+		source     string
+		wantOuter  bool
+	}{
+		{
+			name:       "skips own alias and resolves global type",
+			identifier: "HTMLElement",
+			source: `
+namespace N {
+	let HTMLElement;
+	export type { HTMLElement };
+}`,
+			wantOuter: true,
+		},
+		{
+			name:       "does not return own alias without outer type",
+			identifier: "localValue",
+			source: `
+namespace N {
+	let localValue;
+	export type { localValue };
+}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile, refs, done := newCheckedRefStore(t, test.source)
+			defer done()
+
+			occurrences := identifiers(sourceFile.AsNode(), test.identifier)
+			if len(occurrences) != 2 {
+				t.Fatalf("identifier occurrences = %d, want 2", len(occurrences))
+			}
+			localValue := occurrences[0].Parent.Symbol()
+			specifier := occurrences[1]
+			if localValue == nil {
+				t.Fatal("local value declaration identifier has no bound symbol")
+			}
+
+			target := refs.Resolve(specifier)
+			if !test.wantOuter {
+				if target != nil {
+					t.Fatalf("Resolve(type-only export) = %v, want nil", target)
+				}
+			} else {
+				if target == nil || target == localValue || isOwnExportAlias(specifier, target) {
+					t.Fatalf("Resolve(type-only export) = %v, want the outer type", target)
+				}
+				if target.Flags&(ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias) == 0 {
+					t.Fatalf("resolved checker symbol flags = %v, want a type-capable symbol", target.Flags)
+				}
+				if got := refs.References(target); len(got) != 1 || got[0] != specifier {
+					t.Fatalf("References(outer type) = %v, want [%v]", got, specifier)
+				}
+			}
+			if got := refs.References(localValue); len(got) != 0 {
+				t.Fatalf("References(local value) = %v, want none", got)
+			}
+		})
+	}
+}
+
 func TestRefStoreLocalExportCheckerFallbackResolvesGlobalValue(t *testing.T) {
 	// The meaning-aware ExportSpecifier fallback also preserves ordinary
 	// dual-space exports of globals; it must not be limited to type-only

--- a/internal/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/rules/no_unused_vars/no_unused_vars.go
@@ -1733,10 +1733,51 @@ func binderReferenceSymbol(node *ast.Node) *ast.Symbol {
 	return nil
 }
 
+// binderReferenceSymbolWithMeaning is the declaration-space-aware fallback
+// used only when a RuleContext has no RefStore. Unlike the hot-path
+// binderReferenceSymbol above, it keeps walking when a same-named symbol
+// exists only in another declaration space.
+func binderReferenceSymbolWithMeaning(node *ast.Node, meaning ast.SymbolFlags) *ast.Symbol {
+	if meaning == ast.SymbolFlagsNone {
+		return binderReferenceSymbol(node)
+	}
+	if node == nil || !ast.IsIdentifier(node) {
+		return nil
+	}
+	name := node.Text()
+	matchesMeaning := func(symbol *ast.Symbol) bool {
+		return symbol != nil && symbol.Flags&meaning != 0
+	}
+	for current := node.Parent; current != nil; current = current.Parent {
+		if symbol := enumMemberSymbol(current, name); matchesMeaning(symbol) {
+			return symbol
+		}
+		if symbol := typeParameterSymbol(current, name); matchesMeaning(symbol) {
+			return symbol
+		}
+		if ast.IsLocalsContainer(current) {
+			symbol := ast.GetLocals(current)[name]
+			if matchesMeaning(symbol) {
+				if ast.IsFunctionLike(current) && referenceIsInFunctionSignature(node, current) &&
+					!symbolIsVisibleInFunctionSignature(symbol, current) {
+					// Body declarations are outside the function signature's
+					// parameter/type environment. Keep searching outward.
+				} else {
+					return symbol
+				}
+			}
+		}
+		if symbol := namedExpressionSymbol(current, name); matchesMeaning(symbol) {
+			return symbol
+		}
+	}
+	return nil
+}
+
 // collectLocalExportTargets adds the exact local symbols consumed by one named
 // export declaration. It deliberately ignores source-bearing re-exports: in
 // `export { A } from "mod"`, A does not refer to an in-scope declaration.
-func collectLocalExportTargets(node *ast.Node, targets map[*ast.Symbol]bool) {
+func collectLocalExportTargets(refs *rule.RefStore, node *ast.Node, targets map[*ast.Symbol]bool) {
 	if node == nil || node.Kind != ast.KindExportDeclaration {
 		return
 	}
@@ -1757,7 +1798,22 @@ func collectLocalExportTargets(node *ast.Node, targets map[*ast.Symbol]bool) {
 		if exportSpecifier.PropertyName != nil {
 			localName = exportSpecifier.PropertyName
 		}
-		target := binderReferenceSymbol(localName)
+		var target *ast.Symbol
+		if refs != nil {
+			// RefStore applies the export specifier's declaration-space
+			// meaning, so a type-only export cannot consume a value-only
+			// binding with the same name.
+			target = refs.Resolve(localName)
+		} else {
+			// RuleContext normally provides RefStore whenever a source file is
+			// linted. Preserve direct-use robustness without falling back to
+			// the old all-space behavior.
+			meaning := ast.SymbolFlagsNone
+			if ast.IsTypeOnlyImportOrExportDeclaration(spec) {
+				meaning = ast.SymbolFlagsType | ast.SymbolFlagsNamespace | ast.SymbolFlagsAlias
+			}
+			target = binderReferenceSymbolWithMeaning(localName, meaning)
+		}
 		if target != nil {
 			targets[target] = true
 		}
@@ -1769,7 +1825,7 @@ func collectLocalExportTargets(node *ast.Node, targets map[*ast.Symbol]bool) {
 //   - writeRefs: maps each symbol to its write-only reference nodes (assignments)
 //   - localExportTargets: local symbols consumed by named export declarations
 //   - globalRefsByName: references that are not shadowed by a local declaration
-func collectSymbolUsages(sourceFile *ast.Node, usages map[*ast.Symbol][]*ast.Node, writeRefs map[*ast.Symbol][]*ast.Node, localExportTargets map[*ast.Symbol]bool, globalRefsByName map[string][]*ast.Node) {
+func collectSymbolUsages(refs *rule.RefStore, sourceFile *ast.Node, usages map[*ast.Symbol][]*ast.Node, writeRefs map[*ast.Symbol][]*ast.Node, localExportTargets map[*ast.Symbol]bool, globalRefsByName map[string][]*ast.Node) {
 	sf := sourceFile.AsSourceFile()
 	addUsage := func(sym *ast.Symbol, node *ast.Node) {
 		if sym == nil {
@@ -1783,7 +1839,7 @@ func collectSymbolUsages(sourceFile *ast.Node, usages map[*ast.Symbol][]*ast.Nod
 		if node == nil {
 			return
 		}
-		collectLocalExportTargets(node, localExportTargets)
+		collectLocalExportTargets(refs, node, localExportTargets)
 
 		if ast.IsIdentifier(node) && !isNonReferenceIdentifier(node) {
 			sym := binderReferenceSymbol(node)
@@ -2106,7 +2162,7 @@ func newRule() rule.Rule {
 			ensureCollected := func(node *ast.Node) {
 				if !collected {
 					sourceFile := ast.GetSourceFileOfNode(node)
-					collectSymbolUsages(sourceFile.AsNode(), ac.allUsages, ac.writeRefs, ac.localExportTargets, ac.globalRefsByName)
+					collectSymbolUsages(ctx.Refs, sourceFile.AsNode(), ac.allUsages, ac.writeRefs, ac.localExportTargets, ac.globalRefsByName)
 					collected = true
 				}
 			}

--- a/internal/rules/no_unused_vars/no_unused_vars_extras_scopes_test.go
+++ b/internal/rules/no_unused_vars/no_unused_vars_extras_scopes_test.go
@@ -577,6 +577,22 @@ overloaded("x");`,
 			wantNames: []string{"A", "overloadArg", "implementationArg"},
 		},
 		{
+			name:      "type-only exports preserve declaration spaces",
+			extension: ".ts",
+			code: `type Outer = {};
+namespace N {
+  const Outer = 1;
+  const local = 1;
+  export type { Outer, local };
+}
+const top = 1;
+export type { top };
+const HTMLElement = 1;
+export type { HTMLElement };
+consume(N);`,
+			wantNames: []string{"Outer", "local", "top", "HTMLElement"},
+		},
+		{
 			name:      "typescript class type parameters",
 			extension: ".ts",
 			code: `class Box<T, U> { value!: T; method(arg: T) { return arg; } }

--- a/internal/rules/no_unused_vars/no_unused_vars_extras_test.go
+++ b/internal/rules/no_unused_vars/no_unused_vars_extras_test.go
@@ -375,6 +375,54 @@ func TestNoUnusedVarsExtras(t *testing.T) {
 	)
 }
 
+func TestNoUnusedVarsTypeOnlyLocalExports(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnusedVarsRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `type T = {}; export type { T };`},
+			{Code: `interface M {} const M = 1; export type { M };`},
+			{Code: `import { V } from "./foo"; export type { V };`},
+			{Code: `const value = 1; export namespace N { export { value }; } consume(N);`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `const value = 1; export type { value };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedErrorWithSuggestion("value", true, 1, 7, 12, ` export type { value };`),
+				},
+			},
+			{
+				Code: "function f() {}\nexport { type f as F };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedErrorWithSuggestion("f", false, 1, 10, 11, "\nexport { type f as F };"),
+				},
+			},
+			{
+				Code: "type Token = {};\nnamespace Box {\n  const Token = 1;\n  export type { Token };\n}\nconsume(Box);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedErrorWithSuggestion(
+						"Token",
+						true,
+						3,
+						9,
+						14,
+						"type Token = {};\nnamespace Box {\n  \n  export type { Token };\n}\nconsume(Box);",
+					),
+				},
+			},
+			{
+				Code: "let assigned;\nexport type { assigned };\nassigned = 1;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					extraUnusedError("assigned", true, 3, 1, 9, ""),
+				},
+			},
+		},
+	)
+}
+
 func TestNoUnusedVarsWithoutSourceFile(t *testing.T) {
 	t.Parallel()
 	listeners := NoUnusedVarsRule.Run(rule.RuleContext{}, nil)


### PR DESCRIPTION
## Summary

- Resolve named local exports in both `no-unused-vars` implementations through declaration-space-aware RefStore lookup.
- Keep value-only bindings unused when referenced only by `export type { value }` or `export { type value }`, while preserving type, namespace, merged, and import-alias exports.
- Prevent nested namespace exports from resolving to their own export alias, and continue lookup into outer type scopes and globals.
- Add focused regressions for direct and inline type-only exports, declaration merging, import aliases, nested shadows, checker-less gap files, ordinary exports, and diagnostic position.

Reproduction fixed:

```ts
const value = 1;
export type { value };
```

Both rules now report `value` as unused because the type-only export does not resolve to its value-only binding.

## Related Links

- Follow-up to https://github.com/web-infra-dev/rslint/pull/1476

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).