### PR TITLE
feat(unicorn): port rule prefer-set-has

### DIFF
--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style.go
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style.go
@@ -59,17 +59,6 @@ type methodSignatureFixer struct {
 	sourceText string
 }
 
-// safeSlice returns sourceText[start:end] with bounds clamping.
-func (f *methodSignatureFixer) safeSlice(start, end int) string {
-	if start < 0 {
-		start = 0
-	}
-	if end > len(f.sourceText) {
-		end = len(f.sourceText)
-	}
-	return f.sourceText[start:end]
-}
-
 // getMethodKey returns the key text for a method or property signature,
 // including optional marker and readonly prefix.
 func (f *methodSignatureFixer) getMethodKey(node *ast.Node) string {
@@ -119,32 +108,20 @@ func (f *methodSignatureFixer) getMethodParams(node *ast.Node) string {
 	if params != nil && len(params.Nodes) > 0 {
 		firstRange := utils.TrimNodeTextRange(f.sourceFile, params.Nodes[0])
 		lastRange := utils.TrimNodeTextRange(f.sourceFile, params.Nodes[len(params.Nodes)-1])
-		// Scan backward to find '(' before first param
-		openParen := firstRange.Pos() - 1
-		for openParen > 0 && f.sourceText[openParen] != '(' {
-			openParen--
-		}
-		// Scan forward to find ')' after last param
-		closeParen := lastRange.End()
-		for closeParen < len(f.sourceText) && f.sourceText[closeParen] != ')' {
-			closeParen++
-		}
-		paramsText = f.safeSlice(openParen, closeParen+1)
+		// Widen the param-list span outward to the enclosing `(`/`)` pair
+		// (comments may sit between a paren and the first/last param).
+		paramsText = utils.SliceEnclosingDelimiters(
+			f.sourceText, firstRange.Pos(), lastRange.End(), '(', ')',
+		)
 	}
 
 	if typeParams != nil && len(typeParams.Nodes) > 0 {
 		firstRange := utils.TrimNodeTextRange(f.sourceFile, typeParams.Nodes[0])
 		lastRange := utils.TrimNodeTextRange(f.sourceFile, typeParams.Nodes[len(typeParams.Nodes)-1])
-		// Scan backward/forward to find '<'/'>' (comments may sit between the bracket and the first/last param)
-		start := firstRange.Pos() - 1
-		for start > 0 && f.sourceText[start] != '<' {
-			start--
-		}
-		end := lastRange.End()
-		for end < len(f.sourceText) && f.sourceText[end] != '>' {
-			end++
-		}
-		paramsText = f.safeSlice(start, end+1) + paramsText
+		// Widen the type-param-list span outward to the enclosing `<`/`>` pair.
+		paramsText = utils.SliceEnclosingDelimiters(
+			f.sourceText, firstRange.Pos(), lastRange.End(), '<', '>',
+		) + paramsText
 	}
 
 	return paramsText

--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style.go
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style.go
@@ -110,18 +110,22 @@ func (f *methodSignatureFixer) getMethodParams(node *ast.Node) string {
 		lastRange := utils.TrimNodeTextRange(f.sourceFile, params.Nodes[len(params.Nodes)-1])
 		// Widen the param-list span outward to the enclosing `(`/`)` pair
 		// (comments may sit between a paren and the first/last param).
-		paramsText = utils.SliceEnclosingDelimiters(
+		if text, ok := utils.SliceEnclosingDelimiters(
 			f.sourceText, firstRange.Pos(), lastRange.End(), '(', ')',
-		)
+		); ok {
+			paramsText = text
+		}
 	}
 
 	if typeParams != nil && len(typeParams.Nodes) > 0 {
 		firstRange := utils.TrimNodeTextRange(f.sourceFile, typeParams.Nodes[0])
 		lastRange := utils.TrimNodeTextRange(f.sourceFile, typeParams.Nodes[len(typeParams.Nodes)-1])
 		// Widen the type-param-list span outward to the enclosing `<`/`>` pair.
-		paramsText = utils.SliceEnclosingDelimiters(
+		if text, ok := utils.SliceEnclosingDelimiters(
 			f.sourceText, firstRange.Pos(), lastRange.End(), '<', '>',
-		) + paramsText
+		); ok {
+			paramsText = text + paramsText
+		}
 	}
 
 	return paramsText

--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_node_protocol"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_number_properties"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_set_has"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_array_join_separator"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -28,6 +29,7 @@ func GetAllRules() []rule.Rule {
 		prefer_array_flat_map.PreferArrayFlatMapRule,
 		prefer_node_protocol.PreferNodeProtocolRule,
 		prefer_number_properties.PreferNumberPropertiesRule,
+		prefer_set_has.PreferSetHasRule,
 		require_array_join_separator.RequireArrayJoinSeparatorRule,
 		require_number_to_fixed_digits_argument.RequireNumberToFixedDigitsArgumentRule,
 	}

--- a/internal/plugins/unicorn/rules/prefer_set_has/array_source.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/array_source.go
@@ -1,0 +1,166 @@
+package prefer_set_has
+
+// This file ports the array-shape recognition, static-size evaluation, unique-
+// array detection, and TypeScript type-annotation rewriting that
+// eslint-plugin-unicorn's prefer-set-has rule relies on. These helpers encode
+// the rule's own semantics (what counts as an "array source" and a "known
+// unique array" for THIS rule), so they stay local rather than being extracted
+// to unicornutil.
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// isArrayMethodCall mirrors upstream's `isArrayMethodCall`: whether `node`
+// evaluates to an array. `visited` guards the recursive const-initializer walk
+// against cycles.
+func isArrayMethodCall(ctx rule.RuleContext, node *ast.Node, visited map[*ast.Symbol]bool) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+
+	// `[]`
+	if ast.IsArrayLiteralExpression(node) {
+		return true
+	}
+
+	// `Array()` and `new Array()`
+	if isArrayConstructorCall(node) {
+		return true
+	}
+
+	// `Array.from()` and `Array.of()`
+	if matchArrayStaticCall(node, "from") != nil || matchArrayStaticCall(node, "of") != nil {
+		return true
+	}
+
+	// Methods that always return an array.
+	if match, ok := matchListedMethodCall(node, methodsReturnsArray); ok {
+		_ = match
+		return true
+	}
+
+	// Methods that can return an array OR a string: only treat as array when
+	// the receiver is provably not a string.
+	if match, ok := matchListedMethodCall(node, methodsReturnsArrayAndString); ok {
+		object := ast.SkipParentheses(match.Object)
+		// Upstream gates on `getStaticStringValue(object) === undefined`, i.e.
+		// the receiver is not a string literal / no-substitution template
+		// (both of which upstream can read a static string from, including the
+		// empty string).
+		if _, isString := staticStringLike(object); isString {
+			return false
+		}
+		if object.Kind != ast.KindIdentifier {
+			return true
+		}
+		return isIdentifierInitializedWithArray(ctx, object, visited)
+	}
+
+	return false
+}
+
+// staticStringLike reports whether node is syntactically a string literal or
+// template with no substitutions — the cases upstream's getStaticStringValue
+// recognizes as a string (including the empty string).
+func staticStringLike(node *ast.Node) (string, bool) {
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text, true
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text, true
+	}
+	return "", false
+}
+
+// isIdentifierInitializedWithArray mirrors upstream's
+// `isIdentifierInitializedWithArray`: the identifier resolves to a single
+// `const` declaration whose initializer is itself an array source.
+func isIdentifierInitializedWithArray(ctx rule.RuleContext, node *ast.Node, visited map[*ast.Symbol]bool) bool {
+	if node.Kind != ast.KindIdentifier || ctx.Refs == nil {
+		return false
+	}
+	symbol := ctx.Refs.Resolve(node)
+	if symbol == nil || visited[symbol] || len(symbol.Declarations) != 1 {
+		return false
+	}
+	visited[symbol] = true
+
+	declarationNode := symbol.Declarations[0]
+	if declarationNode == nil || declarationNode.Kind != ast.KindVariableDeclaration {
+		return false
+	}
+	declaration := declarationNode.AsVariableDeclaration()
+	if declaration.Initializer == nil {
+		return false
+	}
+	declarationList := declarationNode.Parent
+	if declarationList == nil || declarationList.Kind != ast.KindVariableDeclarationList ||
+		!ast.IsVarConst(declarationList) {
+		return false
+	}
+	return isArrayMethodCall(ctx, declaration.Initializer, visited)
+}
+
+// isArrayConstructorCall reports whether node is `Array(...)` or
+// `new Array(...)` (non-optional, identifier callee named Array).
+func isArrayConstructorCall(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		if call.QuestionDotToken != nil {
+			return false
+		}
+		return isIdentifierNamed(ast.SkipParentheses(call.Expression), "Array")
+	case ast.KindNewExpression:
+		return isIdentifierNamed(ast.SkipParentheses(node.AsNewExpression().Expression), "Array")
+	}
+	return false
+}
+
+// matchArrayStaticCall matches `Array.<method>(...)` (non-optional call and
+// member, identifier object named Array, identifier property named method) and
+// returns the call node, else nil.
+func matchArrayStaticCall(node *ast.Node, method string) *ast.Node {
+	match, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{Method: method})
+	if !ok {
+		return nil
+	}
+	if !isIdentifierNamed(ast.SkipParentheses(match.Object), "Array") {
+		return nil
+	}
+	return match.Call
+}
+
+// matchListedMethodCall matches `<receiver>.<method>(...)` for any method in
+// `methods` (non-optional call and member, identifier property).
+func matchListedMethodCall(node *ast.Node, methods map[string]bool) (unicornutil.DotMethodCall, bool) {
+	if node == nil || !ast.IsCallExpression(node) {
+		return unicornutil.DotMethodCall{}, false
+	}
+	call := node.AsCallExpression()
+	if call.QuestionDotToken != nil {
+		return unicornutil.DotMethodCall{}, false
+	}
+	callee := ast.SkipParentheses(call.Expression)
+	if callee == nil || !ast.IsPropertyAccessExpression(callee) || ast.IsOptionalChainRoot(callee) {
+		return unicornutil.DotMethodCall{}, false
+	}
+	property := callee.AsPropertyAccessExpression().Name()
+	if property == nil || !ast.IsIdentifier(property) || !methods[property.AsIdentifier().Text] {
+		return unicornutil.DotMethodCall{}, false
+	}
+	return unicornutil.DotMethodCall{
+		Call:     node,
+		Callee:   callee,
+		Object:   callee.AsPropertyAccessExpression().Expression,
+		Property: property,
+	}, true
+}
+
+func isIdentifierNamed(node *ast.Node, name string) bool {
+	return node != nil && ast.IsIdentifier(node) && node.AsIdentifier().Text == name
+}

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.go
@@ -1,0 +1,543 @@
+// Package prefer_set_has ports eslint-plugin-unicorn's `prefer-set-has` rule.
+//
+// It flags a `const` array binding that is used only for existence checks via
+// `Array#includes()` and recommends declaring it as a `Set` so `Set#has()` can
+// be used instead. When the binding has a rewritable TypeScript type annotation
+// the fix is applied automatically; otherwise the same edit is offered as a
+// manual suggestion.
+package prefer_set_has
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	messageIDError      = "error"
+	messageIDSuggestion = "suggestion"
+)
+
+// maxArrayLength mirrors upstream's MAX_ARRAY_LENGTH = 2 ** 32 - 1.
+const maxArrayLength = float64(1<<32) - 1
+
+//go:embed prefer_set_has.schema.json
+var schemaJSON []byte
+
+// methodsReturnsArray lists methods whose result is always an array (never a
+// string), mirroring upstream's `methodsReturnsArray`.
+var methodsReturnsArray = map[string]bool{
+	// `Array`
+	"copyWithin": true,
+	"fill":       true,
+	"filter":     true,
+	"flat":       true,
+	"flatMap":    true,
+	"map":        true,
+	"reverse":    true,
+	"sort":       true,
+	"splice":     true,
+	"toReversed": true,
+	"toSorted":   true,
+	"toSpliced":  true,
+	"with":       true,
+	// `String`
+	"split": true,
+	// `Iterator`
+	"toArray": true,
+}
+
+// methodsReturnsArrayAndString lists methods that can return an array OR a
+// string, mirroring upstream's `methodsReturnsArrayAndString`.
+var methodsReturnsArrayAndString = map[string]bool{
+	"slice":  true,
+	"concat": true,
+}
+
+type options struct {
+	minimumItems int
+}
+
+func parseOptions(rawOptions []any) options {
+	opts := options{minimumItems: 0}
+	optsMap := utils.GetOptionsMap(rawOptions)
+	if optsMap == nil {
+		return opts
+	}
+	if value, ok := optsMap["minimumItems"]; ok {
+		if number, ok := utils.CoerceIntegral(value); ok {
+			opts.minimumItems = number
+		}
+	}
+	return opts
+}
+
+func messageError(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDError,
+		Description: fmt.Sprintf("`%s` should be a `Set`, and use `%s.has()` to check existence or non-existence.", name, name),
+		Data:        map[string]string{"name": name},
+	}
+}
+
+func messageSuggestion(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDSuggestion,
+		Description: fmt.Sprintf("Switch `%s` to `Set`.", name),
+		Data:        map[string]string{"name": name},
+	}
+}
+
+var PreferSetHasRule = rule.Rule{
+	Name:   "unicorn/prefer-set-has",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		return rule.RuleListeners{
+			ast.KindIdentifier: func(node *ast.Node) {
+				checkIdentifier(ctx, opts, node)
+			},
+		}
+	},
+}
+
+// checkIdentifier mirrors the body of upstream's `context.on('Identifier', …)`.
+func checkIdentifier(ctx rule.RuleContext, opts options, node *ast.Node) {
+	// ctx.Refs is the stand-in for ESLint's scope manager; without it we
+	// cannot collect references, so degrade gracefully (JS-only runs).
+	if ctx.Refs == nil {
+		return
+	}
+
+	declaration := arrayVariableDeclarator(ctx, node)
+	if declaration == nil {
+		return
+	}
+	initializer := declaration.Initializer
+
+	if opts.minimumItems > 0 {
+		arraySize, ok := getKnownArraySize(ctx, initializer)
+		if !ok || arraySize < opts.minimumItems {
+			return
+		}
+	}
+
+	// The binder attaches the symbol to the VariableDeclaration node (node's
+	// parent), which is the currency of ctx.Refs.
+	symbol := node.Parent.Symbol()
+	if symbol == nil {
+		return
+	}
+
+	// Upstream collects references via getVariableIdentifiers, which includes
+	// every declaration name of the variable. When a `var` is declared more
+	// than once (`var foo = ...; var foo = ...`), the other declaration's name
+	// is an identifier that classifies as neither includes/length/extra, so
+	// getReferenceGroups bails. ctx.Refs.References excludes declaration names,
+	// so reproduce that bail explicitly: a variable with more than one
+	// declaration is not a single `const` array binding.
+	if len(symbol.Declarations) != 1 {
+		return
+	}
+
+	references := ctx.Refs.References(symbol)
+	identifiers := make([]*ast.Node, 0, len(references))
+	for _, reference := range references {
+		if reference != node {
+			identifiers = append(identifiers, reference)
+		}
+	}
+
+	groups, ok := getReferenceGroups(identifiers)
+	if !ok || len(groups.includes) == 0 {
+		return
+	}
+
+	if len(groups.extra) > 0 && !isKnownUniqueArrayExpression(ctx, initializer) {
+		return
+	}
+
+	if len(groups.includes) == 1 && !isMultipleCall(groups.includes[0], node) {
+		return
+	}
+
+	typeText, hasRewritableType := setTypeAnnotationText(ctx, declaration)
+
+	buildFixes := func() []rule.RuleFix {
+		return buildSetFixes(ctx, node, declaration, groups, typeText)
+	}
+
+	// A type annotation that can't be safely rewritten downgrades the fix to a
+	// manual suggestion, matching upstream.
+	if declaration.Type != nil && !hasRewritableType {
+		ctx.ReportNodeWithDeferredSuggestions(node, messageError(node.AsIdentifier().Text), func() []rule.RuleSuggestion {
+			return []rule.RuleSuggestion{{
+				Message:  messageSuggestion(node.AsIdentifier().Text),
+				FixesArr: buildFixes(),
+			}}
+		})
+		return
+	}
+
+	ctx.ReportNodeWithDeferredFixes(node, messageError(node.AsIdentifier().Text), buildFixes)
+}
+
+// buildSetFixes assembles the edits shared by the autofix and suggestion paths:
+// rewrite the type annotation (when possible), wrap the initializer in
+// `new Set(...)`, and rename `.includes`/`.length` to `.has`/`.size`.
+func buildSetFixes(
+	ctx rule.RuleContext,
+	node *ast.Node,
+	declaration *ast.VariableDeclaration,
+	groups referenceGroups,
+	typeAnnotationText string,
+) []rule.RuleFix {
+	fixes := make([]rule.RuleFix, 0, 3+len(groups.includes)+len(groups.lengths))
+
+	if typeAnnotationText != "" && declaration.Type != nil {
+		fixes = append(fixes, rule.RuleFixReplace(ctx.SourceFile, declaration.Type, typeAnnotationText))
+	}
+
+	initializer := declaration.Initializer
+	fixes = append(fixes, rule.RuleFixInsertBefore(ctx.SourceFile, initializer, "new Set("))
+	fixes = append(fixes, rule.RuleFixInsertAfter(initializer, ")"))
+
+	for _, identifier := range groups.includes {
+		property := propertyOfMemberAccess(outerParen(identifier).Parent)
+		if property != nil {
+			fixes = append(fixes, rule.RuleFixReplace(ctx.SourceFile, property, "has"))
+		}
+	}
+
+	for _, identifier := range groups.lengths {
+		property := propertyOfMemberAccess(outerParen(identifier).Parent)
+		if property != nil {
+			fixes = append(fixes, rule.RuleFixReplace(ctx.SourceFile, property, "size"))
+		}
+	}
+
+	return fixes
+}
+
+// propertyOfMemberAccess returns the `.name` node of a non-computed property
+// access, or nil.
+func propertyOfMemberAccess(node *ast.Node) *ast.Node {
+	if node == nil || !ast.IsPropertyAccessExpression(node) {
+		return nil
+	}
+	return node.AsPropertyAccessExpression().Name()
+}
+
+// referenceGroups classifies the references to the candidate binding.
+type referenceGroups struct {
+	includes []*ast.Node
+	lengths  []*ast.Node
+	extra    []*ast.Node
+}
+
+// getReferenceGroups mirrors upstream's `getReferenceGroups`. It returns
+// ok=false when any reference cannot be classified (upstream returns
+// `undefined`, which makes the caller bail).
+func getReferenceGroups(identifiers []*ast.Node) (referenceGroups, bool) {
+	var groups referenceGroups
+	for _, identifier := range identifiers {
+		switch {
+		case isIncludesCall(identifier):
+			groups.includes = append(groups.includes, identifier)
+		case isLengthRead(identifier):
+			groups.lengths = append(groups.lengths, identifier)
+			groups.extra = append(groups.extra, identifier)
+		case isAllowedExtraReference(identifier):
+			groups.extra = append(groups.extra, identifier)
+		default:
+			return referenceGroups{}, false
+		}
+	}
+	return groups, true
+}
+
+// isIncludesCall reports whether `identifier` is the object of a
+// `identifier.includes(x)` call with exactly one non-spread argument, mirroring
+// upstream's `isIncludesCall` (isMethodCall defaults: non-optional, no spread).
+func isIncludesCall(node *ast.Node) bool {
+	member := outerParen(node).Parent
+	if member == nil || !ast.IsPropertyAccessExpression(member) {
+		return false
+	}
+	call := outerParen(member).Parent
+	argumentsLength := 1
+	match, ok := unicornutil.MatchDotMethodCall(call, unicornutil.DotMethodCallOptions{
+		Method:          "includes",
+		ArgumentsLength: &argumentsLength,
+	})
+	if !ok {
+		return false
+	}
+	// isMethodCall defaults to allowSpreadElement:false, so `foo.includes(...x)`
+	// is not a match even though it has one argument.
+	if ast.IsSpreadElement(match.Call.Arguments()[0]) {
+		return false
+	}
+	// `node.parent.parent.callee.object === node` — the receiver must be the
+	// identifier itself (parentheses are transparent in ESTree).
+	return ast.SkipParentheses(match.Object) == node
+}
+
+// outerParen returns node walked up through any enclosing
+// ParenthesizedExpression nodes — the ESTree view in which parentheses are
+// invisible.
+func outerParen(node *ast.Node) *ast.Node {
+	current := node
+	for current.Parent != nil && current.Parent.Kind == ast.KindParenthesizedExpression {
+		current = current.Parent
+	}
+	return current
+}
+
+var multipleCallNodeKinds = map[ast.Kind]bool{
+	ast.KindForOfStatement:      true,
+	ast.KindForStatement:        true,
+	ast.KindForInStatement:      true,
+	ast.KindWhileStatement:      true,
+	ast.KindDoStatement:         true,
+	ast.KindFunctionDeclaration: true,
+	ast.KindFunctionExpression:  true,
+	ast.KindArrowFunction:       true,
+	// tsgo divergence: ESTree models object / class methods, accessors, and
+	// constructors as a Property/MethodDefinition wrapping a FunctionExpression,
+	// so upstream's FunctionExpression entry catches them. tsgo has no wrapping
+	// FunctionExpression — the method body lives directly under these kinds —
+	// so they must be listed explicitly to preserve the "crosses a function
+	// boundary" semantics.
+	ast.KindMethodDeclaration: true,
+	ast.KindGetAccessor:       true,
+	ast.KindSetAccessor:       true,
+	ast.KindConstructor:       true,
+}
+
+// isMultipleCall mirrors upstream's `isMultipleCall`. Walking up from the
+// `includes` call towards the declaration's container, it reports whether a
+// loop/function boundary is crossed (so the single call may run many times).
+//
+// Upstream's `root = node.parent.parent.parent` is the block/program
+// containing the declaration. In ESTree that is Identifier → VariableDeclarator
+// → VariableDeclaration → container; tsgo inserts a VariableDeclarationList and
+// VariableStatement between the declaration and its container, so the same
+// container sits one hop deeper.
+func isMultipleCall(includesIdentifier *ast.Node, node *ast.Node) bool {
+	root := ancestorAt(node, 4)
+
+	// Upstream starts the walk at the `.includes()` CallExpression
+	// (`identifier.parent.parent`). Parentheses are transparent in ESTree.
+	member := outerParen(includesIdentifier).Parent
+	parent := outerParen(member).Parent
+	for parent != nil && parent != root {
+		if multipleCallNodeKinds[parent.Kind] {
+			return true
+		}
+		parent = parent.Parent
+	}
+	return false
+}
+
+// ancestorAt returns the ancestor reached by following `.Parent` `depth` times.
+func ancestorAt(node *ast.Node, depth int) *ast.Node {
+	current := node
+	for i := 0; i < depth && current != nil; i++ {
+		current = current.Parent
+	}
+	return current
+}
+
+// isLengthRead mirrors upstream's `isLengthRead`: a non-computed `.length`
+// member read that is neither an assignment target nor a call callee.
+func isLengthRead(identifier *ast.Node) bool {
+	parent := identifier.Parent
+	if parent == nil || !ast.IsPropertyAccessExpression(parent) {
+		return false
+	}
+	access := parent.AsPropertyAccessExpression()
+	if access.Expression != identifier || ast.IsOptionalChainRoot(parent) {
+		return false
+	}
+	property := access.Name()
+	if property == nil || !ast.IsIdentifier(property) || property.AsIdentifier().Text != "length" {
+		return false
+	}
+
+	if isAssignmentTarget(parent) {
+		return false
+	}
+
+	// `grandParent.type === 'CallExpression' && grandParent.callee === parent`
+	grandParent := parent.Parent
+	if grandParent != nil && ast.IsCallExpression(grandParent) {
+		if ast.SkipParentheses(grandParent.AsCallExpression().Expression) == parent {
+			return false
+		}
+	}
+	return true
+}
+
+// isAssignmentTarget mirrors upstream's `isAssignmentTarget`, skipping TS
+// expression wrappers before testing for a write / delete / for-in / for-of
+// target.
+func isAssignmentTarget(node *ast.Node) bool {
+	target := node
+	for isTypeScriptExpressionWrapper(target.Parent, target) {
+		target = target.Parent
+	}
+	if utils.IsWriteReference(target) {
+		return true
+	}
+	// Upstream's isLeftHandSide also treats `delete target` as a left-hand
+	// side; IsWriteReference does not cover delete.
+	if parent := target.Parent; parent != nil && parent.Kind == ast.KindDeleteExpression {
+		if parent.AsDeleteExpression().Expression == target {
+			return true
+		}
+	}
+	return isForInOrForOfTarget(target)
+}
+
+// isTypeScriptExpressionWrapper reports whether `parent` is a TS `as` / `<T>` /
+// `!` wrapper whose expression is `child`.
+func isTypeScriptExpressionWrapper(parent *ast.Node, child *ast.Node) bool {
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindAsExpression:
+		return parent.AsAsExpression().Expression == child
+	case ast.KindTypeAssertionExpression:
+		return parent.AsTypeAssertion().Expression == child
+	case ast.KindNonNullExpression:
+		return parent.AsNonNullExpression().Expression == child
+	}
+	return false
+}
+
+// isForInOrForOfTarget reports whether `node` is the left-hand target of a
+// for-in / for-of statement.
+func isForInOrForOfTarget(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	if parent.Kind != ast.KindForInStatement && parent.Kind != ast.KindForOfStatement {
+		return false
+	}
+	return parent.AsForInOrOfStatement().Initializer == node
+}
+
+// isAllowedExtraReference mirrors upstream's `isAllowedExtraReference`.
+func isAllowedExtraReference(identifier *ast.Node) bool {
+	return isIterableUse(identifier) ||
+		isArrayOrArgumentSpread(identifier) ||
+		isAllowedForEachCall(identifier)
+}
+
+// isIterableUse reports whether the identifier is the iterable of a for-of
+// statement (`for (const x of identifier)`).
+func isIterableUse(identifier *ast.Node) bool {
+	parent := identifier.Parent
+	if parent == nil || parent.Kind != ast.KindForOfStatement {
+		return false
+	}
+	return parent.AsForInOrOfStatement().Expression == identifier
+}
+
+// isArrayOrArgumentSpread reports whether the identifier is spread into an
+// array literal, call, or new expression (`[...x]`, `f(...x)`, `new F(...x)`).
+func isArrayOrArgumentSpread(identifier *ast.Node) bool {
+	parent := identifier.Parent
+	if parent == nil || !ast.IsSpreadElement(parent) {
+		return false
+	}
+	if parent.AsSpreadElement().Expression != identifier {
+		return false
+	}
+	grandParent := parent.Parent
+	if grandParent == nil {
+		return false
+	}
+	switch grandParent.Kind {
+	case ast.KindArrayLiteralExpression, ast.KindCallExpression, ast.KindNewExpression:
+		return true
+	}
+	return false
+}
+
+// isAllowedForEachCall reports whether the identifier is the receiver of a
+// `identifier.forEach(arrow)` call whose callback is a one-parameter arrow
+// function, mirroring upstream's `isAllowedForEachCall`.
+func isAllowedForEachCall(identifier *ast.Node) bool {
+	callExpression := ancestorAt(identifier, 2)
+	argumentsLength := 1
+	match, ok := unicornutil.MatchDotMethodCall(callExpression, unicornutil.DotMethodCallOptions{
+		Method:          "forEach",
+		ArgumentsLength: &argumentsLength,
+	})
+	if !ok || match.Object != identifier {
+		return false
+	}
+	return isOneParameterArrowFunction(callExpression.Arguments()[0])
+}
+
+// isOneParameterArrowFunction reports whether the node is an arrow function
+// with exactly one non-rest parameter, mirroring upstream.
+func isOneParameterArrowFunction(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindArrowFunction {
+		return false
+	}
+	params := node.Parameters()
+	if len(params) != 1 {
+		return false
+	}
+	return params[0].AsParameterDeclaration().DotDotDotToken == nil
+}
+
+// arrayVariableDeclarator mirrors upstream's
+// `isArrayVariableDeclaratorIdentifier`: the identifier must be the binding
+// name of a non-exported `const foo = <array-source>` declaration. It returns
+// the declaration when matched, else nil.
+func arrayVariableDeclarator(ctx rule.RuleContext, node *ast.Node) *ast.VariableDeclaration {
+	parent := node.Parent
+	if parent == nil || parent.Kind != ast.KindVariableDeclaration {
+		return nil
+	}
+	declaration := parent.AsVariableDeclaration()
+	if declaration.Name() != node || declaration.Initializer == nil {
+		return nil
+	}
+
+	declarationList := parent.Parent
+	if declarationList == nil || declarationList.Kind != ast.KindVariableDeclarationList {
+		return nil
+	}
+	// Upstream only checks `VariableDeclaration` → `VariableDeclaration` (the
+	// declarator) → `VariableDeclaration` (statement); it does NOT require
+	// `const` here (the const check happens for referenced initializers). But
+	// the identifier must resolve through `findVariable`, and non-const shapes
+	// are excluded downstream via reference analysis. Match upstream's exact
+	// structural gate: parent list's parent is the statement.
+	statement := declarationList.Parent
+	if statement == nil || statement.Kind != ast.KindVariableStatement {
+		return nil
+	}
+
+	// Exclude `export const foo = [];`
+	if ast.HasSyntacticModifier(statement, ast.ModifierFlagsExport) {
+		return nil
+	}
+
+	if !isArrayMethodCall(ctx, declaration.Initializer, map[*ast.Symbol]bool{}) {
+		return nil
+	}
+	return declaration
+}

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.go
@@ -1,8 +1,10 @@
 // Package prefer_set_has ports eslint-plugin-unicorn's `prefer-set-has` rule.
 //
-// It flags a `const` array binding that is used only for existence checks via
-// `Array#includes()` and recommends declaring it as a `Set` so `Set#has()` can
-// be used instead. When the binding has a rewritable TypeScript type annotation
+// It flags an array variable binding that is used only for existence checks
+// via `Array#includes()` and recommends declaring it as a `Set` so `Set#has()`
+// can be used instead. Like upstream, `let` and `var` bindings qualify too —
+// non-const shapes are excluded downstream by reference analysis rather than by
+// the declaration keyword. When the binding has a rewritable TypeScript type annotation
 // the fix is applied automatically; otherwise the same edit is offered as a
 // manual suggestion.
 package prefer_set_has

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.go
@@ -292,13 +292,12 @@ func isIncludesCall(node *ast.Node) bool {
 // `includes` call towards the declaration's container, it reports whether a
 // loop/function boundary is crossed (so the single call may run many times).
 //
-// Upstream's `root = node.parent.parent.parent` is the block/program
-// containing the declaration. In ESTree that is Identifier → VariableDeclarator
-// → VariableDeclaration → container; tsgo inserts a VariableDeclarationList and
-// VariableStatement between the declaration and its container, so the same
-// container sits one hop deeper.
+// Upstream's `root = node.parent.parent.parent` is whatever encloses the
+// declaration — see multipleCallRoot for how that maps onto tsgo's deeper
+// declaration chain, which differs between statement and `for` initializer
+// position.
 func isMultipleCall(includesIdentifier *ast.Node, node *ast.Node) bool {
-	root := ancestorAt(node, 4)
+	root := multipleCallRoot(node)
 
 	// Upstream starts the walk at the `.includes()` CallExpression
 	// (`identifier.parent.parent`). Parentheses are transparent in ESTree.
@@ -325,6 +324,28 @@ func isMultipleCallBoundary(node *ast.Node) bool {
 		return true
 	}
 	return utils.IsFunctionLikeContainer(node)
+}
+
+// multipleCallRoot returns upstream's `node.parent.parent.parent`: the ancestor
+// enclosing the whole declaration, at which the upward walk stops.
+//
+// ESTree's VariableDeclaration spans both tsgo's VariableDeclarationList and,
+// at statement position, the enclosing VariableStatement — so skip the
+// statement when there is one. At `for` initializer position there is no
+// statement and the root is the ForStatement itself, which is what makes that
+// enclosing `for` deliberately not a multiple-call boundary: the loop runs the
+// initializer once, so a single `includes` inside it is still a single call.
+func multipleCallRoot(node *ast.Node) *ast.Node {
+	// Identifier → VariableDeclaration → VariableDeclarationList
+	declarationList := ancestorAt(node, 2)
+	if declarationList == nil {
+		return nil
+	}
+	root := declarationList.Parent
+	if root != nil && root.Kind == ast.KindVariableStatement {
+		root = root.Parent
+	}
+	return root
 }
 
 // ancestorAt returns the ancestor reached by following `.Parent` `depth` times.
@@ -511,19 +532,22 @@ func arrayVariableDeclarator(ctx rule.RuleContext, node *ast.Node) *ast.Variable
 	if declarationList == nil || declarationList.Kind != ast.KindVariableDeclarationList {
 		return nil
 	}
-	// Upstream only checks `VariableDeclaration` → `VariableDeclaration` (the
-	// declarator) → `VariableDeclaration` (statement); it does NOT require
-	// `const` here (the const check happens for referenced initializers). But
-	// the identifier must resolve through `findVariable`, and non-const shapes
-	// are excluded downstream via reference analysis. Match upstream's exact
-	// structural gate: parent list's parent is the statement.
-	statement := declarationList.Parent
-	if statement == nil || statement.Kind != ast.KindVariableStatement {
-		return nil
-	}
-
-	// Exclude `export const foo = [];`
-	if ast.HasSyntacticModifier(statement, ast.ModifierFlagsExport) {
+	// Upstream's structural gate is `parent.parent.type === 'VariableDeclaration'`
+	// — the declaration node, checked above as the VariableDeclarationList. tsgo
+	// additionally wraps a statement-position declaration in a VariableStatement
+	// that ESTree has no counterpart for, so requiring one here would wrongly
+	// drop a `for` initializer (`for (const foo = [1, 2]; ;)`), which upstream
+	// accepts. It does NOT require `const` either: non-const shapes are excluded
+	// downstream via reference analysis.
+	//
+	// Exclude `export const foo = [];` — upstream tests
+	// `parent.parent.parent.type === 'ExportNamedDeclaration'`, which maps to the
+	// export modifier on the VariableStatement. A `for` initializer has no
+	// enclosing statement and can never be exported, so this check is the only
+	// place that still needs one.
+	if statement := declarationList.Parent; statement != nil &&
+		statement.Kind == ast.KindVariableStatement &&
+		ast.HasSyntacticModifier(statement, ast.ModifierFlagsExport) {
 		return nil
 	}
 

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.go
@@ -208,14 +208,14 @@ func buildSetFixes(
 	fixes = append(fixes, rule.RuleFixInsertAfter(initializer, ")"))
 
 	for _, identifier := range groups.includes {
-		property := propertyOfMemberAccess(outerParen(identifier).Parent)
+		property := propertyOfMemberAccess(ast.WalkUpParenthesizedExpressions(identifier.Parent))
 		if property != nil {
 			fixes = append(fixes, rule.RuleFixReplace(ctx.SourceFile, property, "has"))
 		}
 	}
 
 	for _, identifier := range groups.lengths {
-		property := propertyOfMemberAccess(outerParen(identifier).Parent)
+		property := propertyOfMemberAccess(ast.WalkUpParenthesizedExpressions(identifier.Parent))
 		if property != nil {
 			fixes = append(fixes, rule.RuleFixReplace(ctx.SourceFile, property, "size"))
 		}
@@ -265,11 +265,11 @@ func getReferenceGroups(identifiers []*ast.Node) (referenceGroups, bool) {
 // `identifier.includes(x)` call with exactly one non-spread argument, mirroring
 // upstream's `isIncludesCall` (isMethodCall defaults: non-optional, no spread).
 func isIncludesCall(node *ast.Node) bool {
-	member := outerParen(node).Parent
+	member := ast.WalkUpParenthesizedExpressions(node.Parent)
 	if member == nil || !ast.IsPropertyAccessExpression(member) {
 		return false
 	}
-	call := outerParen(member).Parent
+	call := ast.WalkUpParenthesizedExpressions(member.Parent)
 	argumentsLength := 1
 	match, ok := unicornutil.MatchDotMethodCall(call, unicornutil.DotMethodCallOptions{
 		Method:          "includes",
@@ -288,38 +288,6 @@ func isIncludesCall(node *ast.Node) bool {
 	return ast.SkipParentheses(match.Object) == node
 }
 
-// outerParen returns node walked up through any enclosing
-// ParenthesizedExpression nodes — the ESTree view in which parentheses are
-// invisible.
-func outerParen(node *ast.Node) *ast.Node {
-	current := node
-	for current.Parent != nil && current.Parent.Kind == ast.KindParenthesizedExpression {
-		current = current.Parent
-	}
-	return current
-}
-
-var multipleCallNodeKinds = map[ast.Kind]bool{
-	ast.KindForOfStatement:      true,
-	ast.KindForStatement:        true,
-	ast.KindForInStatement:      true,
-	ast.KindWhileStatement:      true,
-	ast.KindDoStatement:         true,
-	ast.KindFunctionDeclaration: true,
-	ast.KindFunctionExpression:  true,
-	ast.KindArrowFunction:       true,
-	// tsgo divergence: ESTree models object / class methods, accessors, and
-	// constructors as a Property/MethodDefinition wrapping a FunctionExpression,
-	// so upstream's FunctionExpression entry catches them. tsgo has no wrapping
-	// FunctionExpression — the method body lives directly under these kinds —
-	// so they must be listed explicitly to preserve the "crosses a function
-	// boundary" semantics.
-	ast.KindMethodDeclaration: true,
-	ast.KindGetAccessor:       true,
-	ast.KindSetAccessor:       true,
-	ast.KindConstructor:       true,
-}
-
 // isMultipleCall mirrors upstream's `isMultipleCall`. Walking up from the
 // `includes` call towards the declaration's container, it reports whether a
 // loop/function boundary is crossed (so the single call may run many times).
@@ -334,15 +302,29 @@ func isMultipleCall(includesIdentifier *ast.Node, node *ast.Node) bool {
 
 	// Upstream starts the walk at the `.includes()` CallExpression
 	// (`identifier.parent.parent`). Parentheses are transparent in ESTree.
-	member := outerParen(includesIdentifier).Parent
-	parent := outerParen(member).Parent
+	member := ast.WalkUpParenthesizedExpressions(includesIdentifier.Parent)
+	parent := ast.WalkUpParenthesizedExpressions(member.Parent)
 	for parent != nil && parent != root {
-		if multipleCallNodeKinds[parent.Kind] {
+		if isMultipleCallBoundary(parent) {
 			return true
 		}
 		parent = parent.Parent
 	}
 	return false
+}
+
+// isMultipleCallBoundary reports whether crossing `node` means the enclosed
+// `includes` call may execute more than once: a loop, or a function-like
+// container. The function-like set is shared via utils.IsFunctionLikeContainer,
+// which already accounts for tsgo modeling object/class methods, accessors, and
+// constructors as their own kinds rather than wrapping a FunctionExpression.
+func isMultipleCallBoundary(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindForOfStatement, ast.KindForStatement, ast.KindForInStatement,
+		ast.KindWhileStatement, ast.KindDoStatement:
+		return true
+	}
+	return utils.IsFunctionLikeContainer(node)
 }
 
 // ancestorAt returns the ancestor reached by following `.Parent` `depth` times.
@@ -356,13 +338,16 @@ func ancestorAt(node *ast.Node, depth int) *ast.Node {
 
 // isLengthRead mirrors upstream's `isLengthRead`: a non-computed `.length`
 // member read that is neither an assignment target nor a call callee.
+// Parentheses are transparent in ESTree, so unwrap them (both around the
+// receiver and around the member) to match upstream's flattened view — e.g.
+// `(foo).length`.
 func isLengthRead(identifier *ast.Node) bool {
-	parent := identifier.Parent
+	parent := ast.WalkUpParenthesizedExpressions(identifier.Parent)
 	if parent == nil || !ast.IsPropertyAccessExpression(parent) {
 		return false
 	}
 	access := parent.AsPropertyAccessExpression()
-	if access.Expression != identifier || ast.IsOptionalChainRoot(parent) {
+	if ast.SkipParentheses(access.Expression) != identifier || ast.IsOptionalChainRoot(parent) {
 		return false
 	}
 	property := access.Name()
@@ -375,7 +360,7 @@ func isLengthRead(identifier *ast.Node) bool {
 	}
 
 	// `grandParent.type === 'CallExpression' && grandParent.callee === parent`
-	grandParent := parent.Parent
+	grandParent := ast.WalkUpParenthesizedExpressions(parent.Parent)
 	if grandParent != nil && ast.IsCallExpression(grandParent) {
 		if ast.SkipParentheses(grandParent.AsCallExpression().Expression) == parent {
 			return false
@@ -405,21 +390,18 @@ func isAssignmentTarget(node *ast.Node) bool {
 	return isForInOrForOfTarget(target)
 }
 
-// isTypeScriptExpressionWrapper reports whether `parent` is a TS `as` / `<T>` /
-// `!` wrapper whose expression is `child`.
+// isTypeScriptExpressionWrapper reports whether `parent` is a TS assertion
+// wrapper (`as` / `<T>` / `!` / `satisfies`) whose expression is `child`. It
+// keys off ast.OEKAssertions — the same assertion set the static-value
+// evaluator unwraps via SkipOuterExpressions — so both directions stay
+// consistent (previously `satisfies` was handled by the evaluator but not
+// here). isAssignmentTarget walks parents upward, hence the manual child check
+// instead of the downward SkipOuterExpressions helper.
 func isTypeScriptExpressionWrapper(parent *ast.Node, child *ast.Node) bool {
-	if parent == nil {
+	if parent == nil || !ast.IsOuterExpression(parent, ast.OEKAssertions) {
 		return false
 	}
-	switch parent.Kind {
-	case ast.KindAsExpression:
-		return parent.AsAsExpression().Expression == child
-	case ast.KindTypeAssertionExpression:
-		return parent.AsTypeAssertion().Expression == child
-	case ast.KindNonNullExpression:
-		return parent.AsNonNullExpression().Expression == child
-	}
-	return false
+	return parent.Expression() == child
 }
 
 // isForInOrForOfTarget reports whether `node` is the left-hand target of a
@@ -443,23 +425,26 @@ func isAllowedExtraReference(identifier *ast.Node) bool {
 }
 
 // isIterableUse reports whether the identifier is the iterable of a for-of
-// statement (`for (const x of identifier)`).
+// statement (`for (const x of identifier)`). Parentheses around the iterable
+// (`for (const x of (foo))`) are transparent in ESTree, so unwrap them.
 func isIterableUse(identifier *ast.Node) bool {
-	parent := identifier.Parent
+	parent := ast.WalkUpParenthesizedExpressions(identifier.Parent)
 	if parent == nil || parent.Kind != ast.KindForOfStatement {
 		return false
 	}
-	return parent.AsForInOrOfStatement().Expression == identifier
+	return ast.SkipParentheses(parent.AsForInOrOfStatement().Expression) == identifier
 }
 
 // isArrayOrArgumentSpread reports whether the identifier is spread into an
 // array literal, call, or new expression (`[...x]`, `f(...x)`, `new F(...x)`).
+// Parentheses around the spread argument (`[...(foo)]`) are transparent in
+// ESTree, so unwrap them.
 func isArrayOrArgumentSpread(identifier *ast.Node) bool {
-	parent := identifier.Parent
+	parent := ast.WalkUpParenthesizedExpressions(identifier.Parent)
 	if parent == nil || !ast.IsSpreadElement(parent) {
 		return false
 	}
-	if parent.AsSpreadElement().Expression != identifier {
+	if ast.SkipParentheses(parent.AsSpreadElement().Expression) != identifier {
 		return false
 	}
 	grandParent := parent.Parent
@@ -475,15 +460,21 @@ func isArrayOrArgumentSpread(identifier *ast.Node) bool {
 
 // isAllowedForEachCall reports whether the identifier is the receiver of a
 // `identifier.forEach(arrow)` call whose callback is a one-parameter arrow
-// function, mirroring upstream's `isAllowedForEachCall`.
+// function, mirroring upstream's `isAllowedForEachCall`. Parentheses around the
+// receiver (`(foo).forEach(...)`) are transparent in ESTree, so walk up through
+// them (like isIncludesCall) instead of assuming a fixed ancestor depth.
 func isAllowedForEachCall(identifier *ast.Node) bool {
-	callExpression := ancestorAt(identifier, 2)
+	member := ast.WalkUpParenthesizedExpressions(identifier.Parent)
+	if member == nil || !ast.IsPropertyAccessExpression(member) {
+		return false
+	}
+	callExpression := ast.WalkUpParenthesizedExpressions(member.Parent)
 	argumentsLength := 1
 	match, ok := unicornutil.MatchDotMethodCall(callExpression, unicornutil.DotMethodCallOptions{
 		Method:          "forEach",
 		ArgumentsLength: &argumentsLength,
 	})
-	if !ok || match.Object != identifier {
+	if !ok || ast.SkipParentheses(match.Object) != identifier {
 		return false
 	}
 	return isOneParameterArrowFunction(callExpression.Arguments()[0])

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.md
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.md
@@ -1,0 +1,95 @@
+# prefer-set-has
+
+## Rule Details
+
+Prefer `Set#has()` over `Array#includes()` when checking for existence or
+non-existence.
+
+`Set#has()` is faster than `Array#includes()`. When a `const` array binding is
+used only for existence checks (and, optionally, a few other supported
+references), this rule recommends declaring it as a `Set` instead.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const array = [1, 2, 3];
+const hasValue = value => array.includes(value);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const set = new Set([1, 2, 3]);
+const hasValue = value => set.has(value);
+```
+
+An array with supported extra references can also be converted when it has more
+than one `includes()` lookup. The array must be a plain literal with only
+unique, statically known primitive or `null` values, and no holes, spreads, or
+`-0`. Supported extra references are `for…of`, array spread, call or
+constructor argument spread, `.length`, and `.forEach()` with a one-parameter
+arrow function.
+
+```javascript
+// Incorrect
+const array = [1, 2, 3];
+for (const item of array) {
+	console.log(item);
+}
+
+const length = array.length;
+const hasValue = value => array.includes(value);
+```
+
+```javascript
+// Correct
+const set = new Set([1, 2, 3]);
+for (const item of set) {
+	console.log(item);
+}
+
+const length = set.size;
+const hasValue = value => set.has(value);
+```
+
+An array that is only checked once is left alone:
+
+```javascript
+// Correct
+const array = [1, 2, 3];
+const hasOne = array.includes(1);
+```
+
+## Options
+
+Type: `object`
+
+### `minimumItems`
+
+Type: `integer`\
+Default: `0`
+
+The minimum known array size before `Set#has()` is enforced. When this option
+is greater than `0`, the rule only reports arrays with a statically known size.
+
+```json
+{ "unicorn/prefer-set-has": ["error", { "minimumItems": 5 }] }
+```
+
+Examples of **incorrect** code for this rule with `{ "minimumItems": 5 }`:
+
+```javascript
+const array = [1, 2, 3, 4, 5];
+const hasValue = value => array.includes(value);
+```
+
+Examples of **correct** code for this rule with `{ "minimumItems": 5 }`:
+
+```javascript
+const array = [1, 2, 3, 4];
+const hasValue = value => array.includes(value);
+```
+
+## Original Documentation
+
+- [`unicorn/prefer-set-has`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-set-has.md)

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.md
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.md
@@ -5,9 +5,11 @@
 Prefer `Set#has()` over `Array#includes()` when checking for existence or
 non-existence.
 
-`Set#has()` is faster than `Array#includes()`. When a `const` array binding is
+`Set#has()` is faster than `Array#includes()`. When an array variable binding is
 used only for existence checks (and, optionally, a few other supported
-references), this rule recommends declaring it as a `Set` instead.
+references), this rule recommends declaring it as a `Set` instead. `let` and
+`var` bindings qualify as well as `const`; a binding that is reassigned is
+excluded by its own reference analysis, not by the declaration keyword.
 
 Examples of **incorrect** code for this rule:
 

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.schema.json
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "minimumItems": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The minimum known array size before `Set#has()` is enforced."
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
@@ -83,8 +83,56 @@ func TestPreferSetHasExtras(t *testing.T) {
 			{Code: "const foo = Array(-1);\nfunction unicorn() { return foo.includes(1); }", Options: minimumItems(5)},
 			// Array('x') → constructor size 1 < 5 → bail.
 			{Code: "const foo = Array('x');\nfunction unicorn() { return foo.includes(1); }", Options: minimumItems(5)},
+
+			// ---- KNOWN DIVERGENCE (PR #1479 review, swwind): parenthesized `.length` ----
+			// `(foo).length` — a parenthesized `.length` read. isLengthRead reads
+			// identifier.Parent directly without unwrapping through outerParen (unlike
+			// isIncludesCall), so the parenthesized read classifies as neither
+			// includes/length/extra and the whole rule bails. Upstream (unicorn v72)
+			// reports and autofixes the looped `includes` here, rewriting the third
+			// line to `(foo).size`:
+			//   const foo = new Set([1, 2, 3]);
+			//   for (let i = 0; i < 3; i++) foo.has(1);
+			//   const n = (foo).size;
+			// Locked in as currently-valid so the missed report can't change silently;
+			// when isLengthRead unwraps parentheses this case flips to Invalid.
+			{Code: "const foo = [1, 2, 3];\nfor (let i = 0; i < 3; i++) foo.includes(1);\nconst n = (foo).length;"},
+			// Control: the non-parenthesized form IS reported+fixed today (see the
+			// Invalid block), proving the divergence is specifically the paren unwrap.
+
+			// ---- KNOWN DIVERGENCE (PR #1479 review, swwind): NaN / undefined elements ----
+			// evaluateStaticIdentifier only special-cases `Infinity`; `NaN` and
+			// `undefined` are not modeled, so an array containing them fails static
+			// evaluation and isKnownUniqueArrayExpression is false. With an extra
+			// reference (forEach) present, the rule then bails. Upstream reports and
+			// autofixes to `new Set([NaN, 1, 2])` / `.has`. Locked in as
+			// currently-valid; modeling NaN/undefined flips these to Invalid.
+			{Code: "const foo = [NaN, 1, 2];\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) foo.includes(1);"},
+			{Code: "const foo = [undefined, 1, 2];\nconst spread = [...foo];\nfor (let i = 0; i < 3; i++) foo.includes(1);"},
+			// Control: Infinity IS modeled, so the same shape with Infinity reports
+			// and fixes today (locked in the Invalid block below).
 		},
 		[]rule_tester.InvalidTestCase{
+			// ---- Control for PR #1479 divergence: non-parenthesized `.length` ----
+			// Contrast with the parenthesized `(foo).length` valid case above: the
+			// non-parenthesized `.length` read classifies correctly, so a looped
+			// includes IS reported and both `.has`/`.size` rewrites apply.
+			{
+				Code:   "const foo = [1, 2, 3];\nfor (let i = 0; i < 3; i++) foo.includes(1);\nconst n = foo.length;",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfor (let i = 0; i < 3; i++) foo.has(1);\nconst n = foo.size;"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Control for PR #1479 divergence: Infinity element IS modeled ----
+			// Contrast with the NaN/undefined valid cases above: Infinity is
+			// special-cased in evaluateStaticIdentifier, so the array is a known-
+			// unique literal, the extra forEach ref is allowed, and it reports+fixes.
+			{
+				Code:   "const foo = [Infinity, 1, 2];\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) foo.includes(1);",
+				Output: []string{"const foo = new Set([Infinity, 1, 2]);\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) foo.has(1);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
 			// ---- Dimension 4: parenthesized receiver inside a loop reports ----
 			// The `.includes` property is renamed even through the parens.
 			{

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
@@ -47,6 +47,14 @@ func TestPreferSetHasExtras(t *testing.T) {
 			// unclassifiable → bail even inside a loop.
 			{Code: "const foo = [1, 2, 3];\nfor (let i = 0; i < 3; i++) { foo['includes'](1); }"},
 
+			// ---- multipleCallRoot: `for` initializer is its own root ----
+			// A `for` initializer runs once, so a single includes in the loop
+			// body is a single call: the walk from the includes call reaches the
+			// ForStatement root and stops without crossing a boundary. Guards
+			// against deriving the root by a fixed ancestor depth, which would
+			// overshoot the ForStatement here and over-report.
+			{Code: "for (const foo = [1, 2]; ;) {\n\tfoo.includes(1);\n}"},
+
 			// ---- Branch lock-in: getReferenceGroups default (unclassifiable) ----
 			// A bare read of the array that is neither includes/length/extra
 			// makes the whole rule bail, even with a valid includes call.
@@ -223,6 +231,55 @@ func TestPreferSetHasExtras(t *testing.T) {
 				Code:   "const foo = [1n, 2n];\nconst spread = [...foo];\nfunction has(v) { return foo.includes(v); }",
 				Output: []string{"const foo = new Set([1n, 2n]);\nconst spread = [...foo];\nfunction has(v) { return foo.has(v); }"},
 				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Structural gate: `for` initializer declaration ----
+			// Upstream's gate is the ESTree VariableDeclaration, which also sits
+			// at `ForStatement.init`. tsgo has no VariableStatement there, so the
+			// rule must not require one. Two includes calls → reported without
+			// needing the multiple-call check.
+			{
+				Code:   "for (const foo = [1, 2]; ;) {\n\tfoo.includes(1);\n\tfoo.includes(2);\n}",
+				Output: []string{"for (const foo = new Set([1, 2]); ;) {\n\tfoo.has(1);\n\tfoo.has(2);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 12)},
+			},
+			// A single includes inside a `for` initializer's body is still
+			// reported when it sits in a nested function — the callback is a
+			// multiple-call boundary encountered before the ForStatement root.
+			{
+				Code:   "for (const foo = [1, 2]; ;) {\n\tbar.forEach(() => foo.includes(1));\n}",
+				Output: []string{"for (const foo = new Set([1, 2]); ;) {\n\tbar.forEach(() => foo.has(1));\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 12)},
+			},
+
+			// ---- Comment recovery: `Array<T>` with an inner comment ----
+			// Upstream compares comments against the whole `<…>` span, so a
+			// comment between the angle brackets and the type argument does not
+			// block the rewrite; it is carried into `Set<…>` verbatim. This must
+			// stay an autofix — the suggestion path omits the annotation edit, so
+			// a downgrade here would emit `Array<string> = new Set([…])`.
+			{
+				Code:     "const foo: Array</* c */ string> = ['a', 'b'];\nfoo.includes('a');\nfoo.includes('b');",
+				Output:   []string{"const foo: Set</* c */ string> = new Set(['a', 'b']);\nfoo.has('a');\nfoo.has('b');"},
+				FileName: "array-type-inner-comment.ts",
+				Errors:   []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:     "const foo: Array<string /* c */> = ['a', 'b'];\nfoo.includes('a');\nfoo.includes('b');",
+				Output:   []string{"const foo: Set<string /* c */> = new Set(['a', 'b']);\nfoo.has('a');\nfoo.has('b');"},
+				FileName: "array-type-trailing-comment.ts",
+				Errors:   []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- getObjectLength: `{length}` shorthand ----
+			// ESTree models `{length}` as a Property whose value is the key
+			// Identifier, resolved through scope; tsgo gives shorthand its own
+			// kind, so lengthPropertyValue must accept it or the size check bails.
+			{
+				Code:    "const length = 3;\nconst foo = Array.from({length});\nfoo.includes(1);\nfoo.includes(2);",
+				Output:  []string{"const length = 3;\nconst foo = new Set(Array.from({length}));\nfoo.has(1);\nfoo.has(2);"},
+				Options: minimumItems(2),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 2, 7)},
 			},
 		},
 	)

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
@@ -511,9 +511,11 @@ func requireSamePreferSetHasDiagnostic(t *testing.T, want, got rule.RuleDiagnost
 func createPreferSetHasProgram(t testing.TB, fileName, code string) (*compiler.Program, *ast.SourceFile) {
 	t.Helper()
 	rootDir := fixtures.GetRootDir()
-	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
-	host := utils.CreateCompilerHost(rootDir, fs)
-	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	fs := utils.NewOverlayVFS(rootDir.FS, map[string]string{
+		tspath.ResolvePath(rootDir.Dir, fileName): code,
+	})
+	host := utils.CreateCompilerHost(rootDir.Dir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", host)
 	if err != nil {
 		t.Fatalf("failed to create program: %v", err)
 	}

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
@@ -1,0 +1,338 @@
+package prefer_set_has_test
+
+// TestPreferSetHasExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch / Dimension 4 row / tsgo AST quirk it covers, so future
+// refactors can't silently regress them without breaking a named lock-in.
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_set_has"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestPreferSetHasExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_set_has.PreferSetHasRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: receiver wrappers on the includes call ----
+			// Parenthesized receiver of a single includes lookup is still a
+			// one-off lookup outside any loop → not reported.
+			{Code: "const foo = [1, 2, 3];\nconst exists = (foo).includes(1);"},
+			// N/A: TS non-null / as / satisfies on the receiver — the receiver
+			// must be the plain declared identifier for isIncludesCall to match
+			// (upstream compares `callee.object === node`), so wrapped receivers
+			// never classify as an includes reference; they fall to the default
+			// "unclassifiable" bail. Covered by the branch lock-in below.
+
+			// ---- Dimension 4: optional chain on includes ----
+			// `foo?.includes(1)` — optional call is excluded (upstream
+			// optionalCall:false); single unclassifiable reference → bail.
+			{Code: "const foo = [1, 2, 3];\nfor (let i = 0; i < 3; i++) { foo?.includes(1); }"},
+
+			// ---- Dimension 4: computed / string-key includes ----
+			// `foo['includes'](1)` is element access, not a dot method call →
+			// unclassifiable → bail even inside a loop.
+			{Code: "const foo = [1, 2, 3];\nfor (let i = 0; i < 3; i++) { foo['includes'](1); }"},
+
+			// ---- Branch lock-in: getReferenceGroups default (unclassifiable) ----
+			// A bare read of the array that is neither includes/length/extra
+			// makes the whole rule bail, even with a valid includes call.
+			{Code: "const foo = [1, 2, 3];\nsink(foo);\nfor (let i = 0; i < 3; i++) { foo.includes(1); }"},
+
+			// ---- Branch lock-in: extra reference requires a unique literal ----
+			// forEach (extra ref) present, but the initializer is an
+			// Array.of() call (not a plain literal) → isKnownUniqueArrayExpression
+			// is false → bail.
+			{Code: "const foo = Array.of(1, 2, 3);\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) { foo.includes(1); }"},
+
+			// ---- Branch lock-in: extra ref, literal with a non-comparable element ----
+			// `[foo()]` element is not a statically comparable value → not a
+			// known-unique array → bail when an extra ref is present.
+			{Code: "const foo = [bar()];\nconst spread = [...foo];\nfunction has(v) { return foo.includes(v); }"},
+
+			// ---- Branch lock-in: isMultipleCall false at top level ----
+			// Single includes call not inside any loop/function boundary.
+			{Code: "const foo = [1, 2, 3];\nfoo.includes(1);"},
+
+			// ---- Real-user #3561: indexing in includes (foo[i]) ----
+			// `bar.includes(foo[i])` — foo is the argument's object, not the
+			// includes receiver, so it is an unclassifiable reference → bail.
+			{Code: "const foo = [1, 2, 3];\nfor (const i of list) { bar.includes(foo[i]); }"},
+
+			// ---- Real-user #2216: string false positive via slice/concat ----
+			// `.slice()` on a const string identifier → not an array source.
+			{Code: "const str = 'abc';\nconst foo = str.slice();\nfoo.includes('a') || foo.includes('b');"},
+			{Code: "const str = 'abc';\nconst foo = str.concat('d');\nfoo.includes('a') || foo.includes('b');"},
+
+			// ---- Branch lock-in: minimumItems with Array(negative/huge) ----
+			// Array(-1) is not a valid array length → size unknown → below
+			// minimumItems path bails.
+			{Code: "const foo = Array(-1);\nfunction unicorn() { return foo.includes(1); }", Options: minimumItems(5)},
+			// Array('x') → constructor size 1 < 5 → bail.
+			{Code: "const foo = Array('x');\nfunction unicorn() { return foo.includes(1); }", Options: minimumItems(5)},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized receiver inside a loop reports ----
+			// The `.includes` property is renamed even through the parens.
+			{
+				Code:   "const foo = [1, 2, 3];\nfor (let i = 0; i < 3; i++) { (foo).includes(1); }",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfor (let i = 0; i < 3; i++) { (foo).has(1); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Branch lock-in: matchArrayStaticCall "from" arm ----
+			// `Array.from(iterable)` with two includes calls → array source,
+			// reported and wrapped.
+			{
+				Code:   "const foo = Array.from(bar);\nfoo.includes(1) || foo.includes(2);",
+				Output: []string{"const foo = new Set(Array.from(bar));\nfoo.has(1) || foo.has(2);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Branch lock-in: methodsReturnsArray via a listed method ----
+			// `.toSorted()` is in methodsReturnsArray → array source.
+			{
+				Code:   "const foo = bar.toSorted();\nfoo.includes(1) || foo.includes(2);",
+				Output: []string{"const foo = new Set(bar.toSorted());\nfoo.has(1) || foo.has(2);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Branch lock-in: isIdentifierInitializedWithArray recursion ----
+			// slice() on an identifier that is itself a const array literal →
+			// treated as an array (the recursive const-initializer walk).
+			{
+				Code:   "const source = [1, 2, 3];\nconst foo = source.slice();\nfoo.includes(1) || foo.includes(2);",
+				Output: []string{"const source = [1, 2, 3];\nconst foo = new Set(source.slice());\nfoo.has(1) || foo.has(2);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 2, 7)},
+			},
+
+			// ---- Branch lock-in: known-unique literal enables extra refs ----
+			// A unique primitive literal with a forEach extra ref + includes is
+			// reported; the fix keeps forEach untouched and renames includes.
+			{
+				Code:   "const foo = [1, 2, 3];\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) { foo.includes(1); }",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) { foo.has(1); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Branch lock-in: minimumItems boundary (exactly equal) ----
+			// Size exactly equals minimumItems → reported.
+			{
+				Code:    "const foo = [1, 2, 3, 4, 5];\nfunction unicorn() { return foo.includes(1); }",
+				Output:  []string{"const foo = new Set([1, 2, 3, 4, 5]);\nfunction unicorn() { return foo.has(1); }"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Branch lock-in: getObjectLength via Array.from({length}) ----
+			// Static length object drives the size check at the boundary.
+			{
+				Code:    "const foo = Array.from({length: 6});\nfunction unicorn() { return foo.includes(1); }",
+				Output:  []string{"const foo = new Set(Array.from({length: 6}));\nfunction unicorn() { return foo.has(1); }"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Dimension 4: BigInt element uniqueness ----
+			// BigInt literals are comparable static values; `[1n, 2n]` is a
+			// known-unique array, so an extra spread ref does not block the report.
+			{
+				Code:   "const foo = [1n, 2n];\nconst spread = [...foo];\nfunction has(v) { return foo.includes(v); }",
+				Output: []string{"const foo = new Set([1n, 2n]);\nconst spread = [...foo];\nfunction has(v) { return foo.has(v); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+		},
+	)
+}
+
+// TestPreferSetHasEditDemand verifies the deferred fix/suggestion builders run
+// only under their matching edit demand and never change the diagnostic
+// identity. `foo = [1,2,3]` exposes an autofix; a non-rewritable type
+// annotation (`[string, string]`) exposes a suggestion instead.
+func TestPreferSetHasEditDemand(t *testing.T) {
+	t.Parallel()
+
+	configs := []struct {
+		name           string
+		fileName       string
+		code           string
+		wantFix        bool
+		fixOutput      string
+		wantSuggestion bool
+		suggestOutput  string
+	}{
+		{
+			name:      "autofix",
+			fileName:  "edit-demand-autofix.ts",
+			code:      "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1);\n}\n",
+			wantFix:   true,
+			fixOutput: "const foo = new Set([1, 2, 3]);\nfunction unicorn() {\n\treturn foo.has(1);\n}\n",
+		},
+		{
+			name:           "suggestion",
+			fileName:       "edit-demand-suggestion.ts",
+			code:           "const a: [string, string] = ['foo', 'bar'];\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(s)) {}\n}\n",
+			wantSuggestion: true,
+			suggestOutput:  "const a: [string, string] = new Set(['foo', 'bar']);\nfor (let i = 0; i < 3; i++) {\n\tif (a.has(s)) {}\n}\n",
+		},
+	}
+
+	for _, config := range configs {
+		t.Run(config.name, func(t *testing.T) {
+			t.Parallel()
+
+			program, sourceFile := createPreferSetHasProgram(t, config.fileName, config.code)
+			diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+			for _, demand := range []rule.EditDemand{
+				rule.EditDemandNone,
+				rule.EditDemandAutofix,
+				rule.EditDemandSuggestion,
+				rule.EditDemandAll,
+			} {
+				got := lintPreferSetHasWithDemand(program, sourceFile, demand)
+				if len(got) != 1 {
+					t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(got))
+				}
+				diagnostics[demand] = got[0]
+			}
+
+			// Diagnostic identity (message + range) must be stable across demands.
+			base := diagnostics[rule.EditDemandNone]
+			for demand, diagnostic := range diagnostics {
+				requireSamePreferSetHasDiagnostic(t, base, diagnostic, demand)
+			}
+
+			// None demand materializes no edits.
+			if diagnostics[rule.EditDemandNone].FixesPtr != nil || diagnostics[rule.EditDemandNone].Suggestions != nil {
+				t.Errorf("none demand unexpectedly materialized edits")
+			}
+			// Autofix-only never materializes suggestions; suggestion-only never fixes.
+			if diagnostics[rule.EditDemandAutofix].Suggestions != nil {
+				t.Errorf("autofix-only demand unexpectedly materialized suggestions")
+			}
+			if diagnostics[rule.EditDemandSuggestion].FixesPtr != nil {
+				t.Errorf("suggestion-only demand unexpectedly materialized autofixes")
+			}
+
+			autofixOnly := diagnostics[rule.EditDemandAutofix].FixesPtr
+			allFixes := diagnostics[rule.EditDemandAll].FixesPtr
+			if !config.wantFix {
+				if autofixOnly != nil || allFixes != nil {
+					t.Fatalf("unexpected autofixes: autofix=%#v all=%#v", autofixOnly, allFixes)
+				}
+			} else {
+				if autofixOnly == nil || allFixes == nil || !reflect.DeepEqual(*autofixOnly, *allFixes) {
+					t.Fatalf("autofix artifacts differ between autofix-only and all demand")
+				}
+				if applyFixes(config.code, *autofixOnly) != config.fixOutput {
+					t.Fatalf("autofix output = %q, want %q", applyFixes(config.code, *autofixOnly), config.fixOutput)
+				}
+			}
+
+			suggestionOnly := diagnostics[rule.EditDemandSuggestion].Suggestions
+			allSuggestions := diagnostics[rule.EditDemandAll].Suggestions
+			if !config.wantSuggestion {
+				if suggestionOnly != nil || allSuggestions != nil {
+					t.Fatalf("unexpected suggestions: suggestion=%#v all=%#v", suggestionOnly, allSuggestions)
+				}
+			} else {
+				if suggestionOnly == nil || allSuggestions == nil || !reflect.DeepEqual(*suggestionOnly, *allSuggestions) {
+					t.Fatalf("suggestion artifacts differ between suggestion-only and all demand")
+				}
+				if len(*suggestionOnly) != 1 {
+					t.Fatalf("suggestions = %d, want 1", len(*suggestionOnly))
+				}
+				if applyFixes(config.code, (*suggestionOnly)[0].FixesArr) != config.suggestOutput {
+					t.Fatalf("suggestion output = %q, want %q", applyFixes(config.code, (*suggestionOnly)[0].FixesArr), config.suggestOutput)
+				}
+			}
+		})
+	}
+}
+
+func lintPreferSetHasWithDemand(
+	program *compiler.Program,
+	sourceFile *ast.SourceFile,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:     program,
+		File:        sourceFile.FileName(),
+		HasTypeInfo: true,
+		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:     prefer_set_has.PreferSetHasRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return prefer_set_has.PreferSetHasRule.Run(ctx, nil)
+				},
+			}}
+		},
+		ExcludePaths: []string{},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	return diagnostics
+}
+
+func requireSamePreferSetHasDiagnostic(t *testing.T, want, got rule.RuleDiagnostic, demand rule.EditDemand) {
+	t.Helper()
+	want.FixesPtr = nil
+	want.Suggestions = nil
+	got.FixesPtr = nil
+	got.Suggestions = nil
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("demand %d changed diagnostic metadata:\ngot:  %#v\nwant: %#v", demand, got, want)
+	}
+}
+
+func createPreferSetHasProgram(t testing.TB, fileName, code string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+	rootDir := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return program, sourceFile
+}
+
+// applyFixes applies a set of non-overlapping RuleFix edits to code, in
+// descending range order so earlier offsets stay valid.
+func applyFixes(code string, fixes []rule.RuleFix) string {
+	sorted := make([]rule.RuleFix, len(fixes))
+	copy(sorted, fixes)
+	for i := 1; i < len(sorted); i++ {
+		for j := i; j > 0 && sorted[j-1].Range.Pos() < sorted[j].Range.Pos(); j-- {
+			sorted[j-1], sorted[j] = sorted[j], sorted[j-1]
+		}
+	}
+	result := code
+	for _, fix := range sorted {
+		result = result[:fix.Range.Pos()] + fix.Text + result[fix.Range.End():]
+	}
+	return result
+}

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
@@ -83,50 +83,49 @@ func TestPreferSetHasExtras(t *testing.T) {
 			{Code: "const foo = Array(-1);\nfunction unicorn() { return foo.includes(1); }", Options: minimumItems(5)},
 			// Array('x') → constructor size 1 < 5 → bail.
 			{Code: "const foo = Array('x');\nfunction unicorn() { return foo.includes(1); }", Options: minimumItems(5)},
-
-			// ---- KNOWN DIVERGENCE (PR #1479 review, swwind): parenthesized `.length` ----
-			// `(foo).length` — a parenthesized `.length` read. isLengthRead reads
-			// identifier.Parent directly without unwrapping through outerParen (unlike
-			// isIncludesCall), so the parenthesized read classifies as neither
-			// includes/length/extra and the whole rule bails. Upstream (unicorn v72)
-			// reports and autofixes the looped `includes` here, rewriting the third
-			// line to `(foo).size`:
-			//   const foo = new Set([1, 2, 3]);
-			//   for (let i = 0; i < 3; i++) foo.has(1);
-			//   const n = (foo).size;
-			// Locked in as currently-valid so the missed report can't change silently;
-			// when isLengthRead unwraps parentheses this case flips to Invalid.
-			{Code: "const foo = [1, 2, 3];\nfor (let i = 0; i < 3; i++) foo.includes(1);\nconst n = (foo).length;"},
-			// Control: the non-parenthesized form IS reported+fixed today (see the
-			// Invalid block), proving the divergence is specifically the paren unwrap.
-
-			// ---- KNOWN DIVERGENCE (PR #1479 review, swwind): NaN / undefined elements ----
-			// evaluateStaticIdentifier only special-cases `Infinity`; `NaN` and
-			// `undefined` are not modeled, so an array containing them fails static
-			// evaluation and isKnownUniqueArrayExpression is false. With an extra
-			// reference (forEach) present, the rule then bails. Upstream reports and
-			// autofixes to `new Set([NaN, 1, 2])` / `.has`. Locked in as
-			// currently-valid; modeling NaN/undefined flips these to Invalid.
-			{Code: "const foo = [NaN, 1, 2];\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) foo.includes(1);"},
-			{Code: "const foo = [undefined, 1, 2];\nconst spread = [...foo];\nfor (let i = 0; i < 3; i++) foo.includes(1);"},
-			// Control: Infinity IS modeled, so the same shape with Infinity reports
-			// and fixes today (locked in the Invalid block below).
 		},
 		[]rule_tester.InvalidTestCase{
+			// ---- PR #1479 review fix: parenthesized `.length` now classifies ----
+			// `(foo).length` — a parenthesized `.length` read. isLengthRead now
+			// unwraps parentheses (via WalkUpParenthesizedExpressions) like the
+			// other classifiers, so the looped `includes` is reported and the third
+			// line is rewritten to `(foo).size`. Previously this silently bailed.
+			{
+				Code:   "const foo = [1, 2, 3];\nfor (let i = 0; i < 3; i++) foo.includes(1);\nconst n = (foo).length;",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfor (let i = 0; i < 3; i++) foo.has(1);\nconst n = (foo).size;"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- PR #1479 review fix: NaN / undefined elements now modeled ----
+			// evaluateStaticIdentifier now models `NaN` and `undefined` alongside
+			// `Infinity`, so an array containing them is a known-unique literal, the
+			// extra reference (forEach / spread) is allowed, and the rule reports +
+			// autofixes to `new Set([...])` / `.has`. Previously these bailed.
+			{
+				Code:   "const foo = [NaN, 1, 2];\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) foo.includes(1);",
+				Output: []string{"const foo = new Set([NaN, 1, 2]);\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) foo.has(1);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [undefined, 1, 2];\nconst spread = [...foo];\nfor (let i = 0; i < 3; i++) foo.includes(1);",
+				Output: []string{"const foo = new Set([undefined, 1, 2]);\nconst spread = [...foo];\nfor (let i = 0; i < 3; i++) foo.has(1);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
 			// ---- Control for PR #1479 divergence: non-parenthesized `.length` ----
-			// Contrast with the parenthesized `(foo).length` valid case above: the
-			// non-parenthesized `.length` read classifies correctly, so a looped
-			// includes IS reported and both `.has`/`.size` rewrites apply.
+			// Contrast with the parenthesized `(foo).length` case above: the
+			// non-parenthesized `.length` read has always classified correctly, so a
+			// looped includes IS reported and both `.has`/`.size` rewrites apply.
 			{
 				Code:   "const foo = [1, 2, 3];\nfor (let i = 0; i < 3; i++) foo.includes(1);\nconst n = foo.length;",
 				Output: []string{"const foo = new Set([1, 2, 3]);\nfor (let i = 0; i < 3; i++) foo.has(1);\nconst n = foo.size;"},
 				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
 			},
 
-			// ---- Control for PR #1479 divergence: Infinity element IS modeled ----
-			// Contrast with the NaN/undefined valid cases above: Infinity is
-			// special-cased in evaluateStaticIdentifier, so the array is a known-
-			// unique literal, the extra forEach ref is allowed, and it reports+fixes.
+			// ---- Control for PR #1479 divergence: Infinity element ----
+			// Infinity has always been special-cased in evaluateStaticIdentifier;
+			// kept alongside the NaN/undefined cases above to lock the three global
+			// numeric identifiers together.
 			{
 				Code:   "const foo = [Infinity, 1, 2];\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) foo.includes(1);",
 				Output: []string{"const foo = new Set([Infinity, 1, 2]);\nfoo.forEach(x => log(x));\nfor (let i = 0; i < 3; i++) foo.has(1);"},
@@ -138,6 +137,29 @@ func TestPreferSetHasExtras(t *testing.T) {
 			{
 				Code:   "const foo = [1, 2, 3];\nfor (let i = 0; i < 3; i++) { (foo).includes(1); }",
 				Output: []string{"const foo = new Set([1, 2, 3]);\nfor (let i = 0; i < 3; i++) { (foo).has(1); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- PR #1479 review fix: parenthesized extra-reference classifiers ----
+			// isIterableUse / isArrayOrArgumentSpread / isAllowedForEachCall now
+			// unwrap parentheses like isIncludesCall, so a parenthesized extra
+			// reference is still recognized (rather than making the rule bail).
+			// for-of iterable: `for (const x of (foo))`.
+			{
+				Code:   "const foo = [1, 2, 3];\nfor (const x of (foo)) log(x);\nfor (let i = 0; i < 3; i++) foo.includes(1);",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfor (const x of (foo)) log(x);\nfor (let i = 0; i < 3; i++) foo.has(1);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// spread argument: `[...(foo)]`.
+			{
+				Code:   "const foo = [1, 2, 3];\nconst copy = [...(foo)];\nfunction has(v) { return foo.includes(v); }",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nconst copy = [...(foo)];\nfunction has(v) { return foo.has(v); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// forEach receiver: `(foo).forEach(...)`.
+			{
+				Code:   "const foo = [1, 2, 3];\n(foo).forEach(x => log(x));\nfor (let i = 0; i < 3; i++) foo.includes(1);",
+				Output: []string{"const foo = new Set([1, 2, 3]);\n(foo).forEach(x => log(x));\nfor (let i = 0; i < 3; i++) foo.has(1);"},
 				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
 			},
 

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_extras_test.go
@@ -55,6 +55,33 @@ func TestPreferSetHasExtras(t *testing.T) {
 			// overshoot the ForStatement here and over-report.
 			{Code: "for (const foo = [1, 2]; ;) {\n\tfoo.includes(1);\n}"},
 
+			// ---- Static folding: folded elements that collide are duplicates ----
+			// Both elements fold to the same string, so the array is not
+			// known-unique and the extra forEach reference blocks the report.
+			// These are what the ToString parity in toStringValue protects: a
+			// wrong fold here would report and emit a `new Set(...)` that
+			// silently drops an element.
+			{Code: "const foo = ['ab', 'a' + 'b'];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('ab'); }"},
+			{Code: "const foo = ['a1', `a${1}`];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('a1'); }"},
+
+			// ---- Static folding: top of the plain-decimal band ----
+			// `1e20 + ''` is "100000000000000000000" in JS, which is exactly
+			// what toStringValue produces, so this collides with the literal
+			// and the array is not known-unique.
+			{Code: "const foo = ['100000000000000000000', 1e20 + ''];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('x'); }"},
+			// Past the band JS switches to exponential ("1e+21"), which
+			// toStringValue will not reproduce, so the fold bails and the
+			// report is skipped. Conservative divergence from upstream, which
+			// folds and reports.
+			{Code: "const foo = [1e21 + '', 'x'];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('x'); }"},
+
+			// ---- Static folding: shadowed well-known global ----
+			// `Number` is a local binding, so `Number.NaN` is not the global
+			// constant. Upstream resolves it through the object literal and
+			// still reports; we bail, since object-literal member resolution is
+			// outside the getStaticValue subset modeled here.
+			{Code: "const Number = {NaN: 1};\nconst foo = [Number.NaN, 2];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes(2); }"},
+
 			// ---- Branch lock-in: getReferenceGroups default (unclassifiable) ----
 			// A bare read of the array that is neither includes/length/extra
 			// makes the whole rule bail, even with a valid includes call.
@@ -269,6 +296,56 @@ func TestPreferSetHasExtras(t *testing.T) {
 				Output:   []string{"const foo: Set<string /* c */> = new Set(['a', 'b']);\nfoo.has('a');\nfoo.has('b');"},
 				FileName: "array-type-trailing-comment.ts",
 				Errors:   []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Static folding: string concatenation ----
+			// `evaluateStaticBinary` folds `+` when either side is a string, so
+			// the elements are comparable and the array is known-unique despite
+			// the extra forEach reference.
+			{
+				Code:   "const foo = ['a' + 'b', 'c'];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('c'); }",
+				Output: []string{"const foo = new Set(['a' + 'b', 'c']);\nfoo.forEach(x => log(x));\nfunction f() { return foo.has('c'); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// Number operand coerced to string by `+`.
+			{
+				Code:   "const foo = [1 + 'a', '1a2'];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('1a'); }",
+				Output: []string{"const foo = new Set([1 + 'a', '1a2']);\nfoo.forEach(x => log(x));\nfunction f() { return foo.has('1a'); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// Top of the plain-decimal band: `1e20 + ''` folds to the same
+			// digits JS produces, so the array is known-unique and reports.
+			{
+				Code:   "const foo = [1e20 + '', 'x'];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('x'); }",
+				Output: []string{"const foo = new Set([1e20 + '', 'x']);\nfoo.forEach(x => log(x));\nfunction f() { return foo.has('x'); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Static folding: template literals ----
+			{
+				Code:   "const foo = [`a${1}`, 'b'];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('b'); }",
+				Output: []string{"const foo = new Set([`a${1}`, 'b']);\nfoo.forEach(x => log(x));\nfunction f() { return foo.has('b'); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [`n${42}`, 'z'];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('z'); }",
+				Output: []string{"const foo = new Set([`n${42}`, 'z']);\nfoo.forEach(x => log(x));\nfunction f() { return foo.has('z'); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Static folding: well-known numeric globals ----
+			// Bare `NaN` already folds via evaluateStaticIdentifier; these cover
+			// the `Number.` / `Math.` spellings that upstream also resolves.
+			{
+				Code:   "const foo = [Number.NaN, 1];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes(1); }",
+				Output: []string{"const foo = new Set([Number.NaN, 1]);\nfoo.forEach(x => log(x));\nfunction f() { return foo.has(1); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [Math.PI, 1];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes(1); }",
+				Output: []string{"const foo = new Set([Math.PI, 1]);\nfoo.forEach(x => log(x));\nfunction f() { return foo.has(1); }"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
 			},
 
 			// ---- getObjectLength: `{length}` shorthand ----

--- a/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/prefer_set_has_upstream_test.go
@@ -1,0 +1,537 @@
+package prefer_set_has_test
+
+// TestPreferSetHasUpstream migrates the full valid/invalid suite from upstream
+// test/prefer-set-has.js 1:1. Position assertions cover line/column for every
+// invalid case. rslint-specific lock-in cases live in the
+// prefer_set_has_extras_test.go file.
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_set_has"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func errorAt(name string, line, column int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "error",
+		Message:   "`" + name + "` should be a `Set`, and use `" + name + ".has()` to check existence or non-existence.",
+		Line:      line,
+		Column:    column,
+	}
+}
+
+func minimumItems(n int) any {
+	return []any{map[string]any{"minimumItems": n}}
+}
+
+func TestPreferSetHasUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_set_has.PreferSetHasRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Upstream: valid (default options) ----
+			{Code: "const foo = new Set([1, 2, 3]);\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+			// Only called once
+			{Code: "const foo = [1, 2, 3];\nconst isExists = foo.includes(1);"},
+			{Code: "while (a) {\n\tconst foo = [1, 2, 3];\n\tconst isExists = foo.includes(1);\n}"},
+			{Code: "const foo = [1, 2, 3];\n(() => {})(foo.includes(1));"},
+			// Not `VariableDeclarator`
+			{Code: "foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const exists = foo.includes(1);"},
+			{Code: "const exists = [1, 2, 3].includes(1);"},
+			// Didn't call `includes()`
+			{Code: "const foo = [1, 2, 3];"},
+			// Not `CallExpression`
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes;\n}"},
+			// Not `foo.includes()`
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn includes(foo);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn bar.includes(foo);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo[includes](1);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.indexOf(1) !== -1;\n}"},
+			// Unsupported extra references
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\tfoo.includes(1);\n\tfoo.length = 1;\n}"},
+			// Duplicates and `-0` can change the values produced by iteration/spread/forEach.
+			{Code: "const foo = [1, 1, 2];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [NaN, NaN];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [0, -0];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 1, 2];\nconst length = foo.length;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			// Computed `length` access is not recognized as a length read, so the rule bails
+			{Code: "const foo = [1, 2, 3];\nfoo['length'];\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 1, 2];\ncall(...foo);\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 1, 2];\nfoo.forEach(element => {\n\tconsole.log(element);\n});\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [-0];\nconst values = [...foo];\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const value = -0;\nconst foo = [value];\nconst values = [...foo];\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			// Unknown uniqueness
+			{Code: "const value = 1;\nconst foo = [value, value];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const first = getValue();\nconst second = getValue();\nconst foo = [first, second];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			// Unsupported initializer shapes
+			{Code: "const foo = [1, , 2];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [...bar];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = Array.of(1, 2, 3);\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			// Unsupported extra references
+			{Code: "const foo = [1, 2, 3];\nconsole.log(foo[0]);\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "function f(a, b, c) {\n\tconst foo = [a];\n\treturn c.map(i => b.includes(foo[i]));\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn(index) {\n\treturn bar.includes(foo[index]) || bar.includes(foo[index + 1]);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn(value) {\n\treturn foo[value].includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nconst object = {...foo};\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfoo.forEach((element, index) => {\n\tconsole.log(element, index);\n});\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfoo.forEach((...elements) => {\n\tconsole.log(elements[1]);\n});\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfoo.forEach(function (element) {\n\tconsole.log(arguments[1]);\n});\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfoo.forEach(callback);\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			// `.length` writes
+			{Code: "const foo = [1, 2, 3];\ndelete foo.length;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfoo.length++;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nconst object = {};\n\nfor (foo.length in object) {}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nconst values = [];\n\nfor (foo.length of values) {}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nconst object = {};\n\n({length: foo.length} = object);\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nconst object = {};\n\n({length: foo.length = 0} = object);\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nconst object = {};\n\n({...foo.length} = object);\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\nconst values = [];\n\n[...foo.length] = values;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			// One-off lookup with supported extra references
+			{Code: "const foo = [1, 2, 3];\nconst values = [...foo];\nconst exists = foo.includes(1);"},
+			{Code: "const foo = [1, 2, 3];\nconst length = foo.length;\nconst exists = foo.includes(1);"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\tif (foo.includes(1)) {}\n\treturn foo;\n}"},
+			// Declared more than once
+			{Code: "var foo = [1, 2, 3];\nvar foo = [4, 5, 6];\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = bar;\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// Extra arguments
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes();\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1, 1);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1, 0);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1, undefined);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(...[1]);\n}"},
+			// Optional
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo?.includes(1);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes?.(1);\n}"},
+			{Code: "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo?.includes?.(1);\n}"},
+			// Different scope
+			{Code: "function unicorn() {\n\tconst foo = [1, 2, 3];\n}\nfunction unicorn2() {\n\treturn foo.includes(1);\n}"},
+			// `export`
+			{Code: "export const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "module.exports = [1, 2, 3];\nfunction unicorn() {\n\treturn module.exports.includes(1);\n}"},
+			{Code: "const foo = [1, 2, 3];\nexport {foo};\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = [1, 2, 3];\nexport default foo;\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = [1, 2, 3];\nexport {foo as bar};\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = [1, 2, 3];\nmodule.exports = foo;\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = [1, 2, 3];\nexports = foo;\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = [1, 2, 3];\nmodule.exports.foo = foo;\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// `Array()`
+			{Code: "const foo = NotArray(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// `new Array()`
+			{Code: "const foo = new NotArray(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// `Array.from()` / `Array.of()` — Not `Array`
+			{Code: "const foo = NotArray.from({length: 1}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = NotArray.of(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// Not `Listed`
+			{Code: "const foo = Array.notListed();\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// Computed
+			{Code: "const foo = Array[from]({length: 1}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = Array[of](1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// Not Identifier
+			{Code: "const foo = 'Array'.from({length: 1}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = 'Array'.of(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = Array['from']({length: 1}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = Array['of'](1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = of(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = from({length: 1}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// Methods — Not call
+			{Code: "const foo = bar.filter;\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = new bar.filter();\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// Not MemberExpression
+			{Code: "const foo = filter();\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// Computed
+			{Code: "const foo = bar[filter]();\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// Not `Identifier`
+			{Code: "const foo = bar[\"filter\"]();\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// Not listed method
+			{Code: "const foo = bar.notListed();\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// concat/slice on non-array receiver
+			{Code: "const foo = bar.slice();\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			{Code: "const foo = bar.concat();\nfunction unicorn() {\n\treturn foo.includes(1);\n}"},
+			// `lodash`
+			{Code: "const foo = _.map([1, 2, 3], value => value);\nfunction unicorn() {\n\treturn _.includes(foo, 1);\n}"},
+			{Code: "const text = 'abc'.slice();\ntext.includes('ab') || text.includes('bc');"},
+			{Code: "const text = `abc`.concat('def');\ntext.includes('ab') || text.includes('bc');"},
+			{Code: "const text = `1abc`.slice();\ntext.includes('ab') || text.includes('bc');"},
+			{Code: "let items = [1, 2, 3];\nitems = 'abc';\nconst foo = items.slice();\nfoo.includes('ab') || foo.includes('bc');"},
+			// `Iterator.concat()`
+			{Code: "const foo = Iterator.concat(bar);\nfoo.includes(1) || foo.includes(2);"},
+
+			// ---- Upstream: valid (minimumItems: 5) ----
+			{Code: "const foo = [1, 2, 3, 4];\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array.of(1, 2, 3, 4);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array.from({length: 4}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array.from([1, 2, 3, 4]);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array.from([1, 2, 3, 4, ...bar]);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array.from(...bar);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array.from('test');\nfunction unicorn() {\n\treturn foo.includes('t');\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array(4);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array(...bar);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array(1, 2, 3, 4);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = new Array(4);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = new Array(...bar);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array(2 ** 32);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = bar.map(value => value);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array.of(...bar);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = [1, 2, 3, 4, ...bar];\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array.from({\n\tlength: 5,\n\t*[Symbol.iterator]() {\n\t\tyield 1;\n\t},\n});\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+			{Code: "const foo = Array.from({length: 2 ** 32}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}", Options: minimumItems(5)},
+
+			// ---- Upstream: valid (TypeScript, `.length` write targets) ----
+			{Code: "@connect(\n\tstate => {\n\t\tconst availableComponents = ['is']\n\t\tif (nsConfig.enabled) availableComponents.push('ns')\n\t\tif (jsConfig.enabled) availableComponents.push('js')\n\n\t\treturn {\n\t\t\tavailableComponents,\n\t\t}\n\t},\n)\nexport default class A {}"},
+			{Code: "const foo = [1, 2, 3];\n(foo.length as number) = 1;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\n(foo.length!) = 1;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+			{Code: "const foo = [1, 2, 3];\n(<number>foo.length) = 1;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Upstream: invalid (default options) ----
+			{
+				Code:   "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// Called multiple times
+			{
+				Code:   "const foo = [1, 2, 3];\nconst isExists = foo.includes(1);\nconst isExists2 = foo.includes(2);",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nconst isExists = foo.has(1);\nconst isExists2 = foo.has(2);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// `ForOfStatement`
+			{
+				Code:   "const foo = [1, 2, 3];\nfor (const a of b) {\n\tfoo.includes(1);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfor (const a of b) {\n\tfoo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "async function unicorn() {\n\tconst foo = [1, 2, 3];\n\tfor await (const a of b) {\n\t\tfoo.includes(1);\n\t}\n}",
+				Output: []string{"async function unicorn() {\n\tconst foo = new Set([1, 2, 3]);\n\tfor await (const a of b) {\n\t\tfoo.has(1);\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 2, 8)},
+			},
+			// `ForStatement`
+			{
+				Code:   "const foo = [1, 2, 3];\nfor (let i = 0; i < n; i++) {\n\tfoo.includes(1);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfor (let i = 0; i < n; i++) {\n\tfoo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// `ForInStatement`
+			{
+				Code:   "const foo = [1, 2, 3];\nfor (let a in b) {\n\tfoo.includes(1);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfor (let a in b) {\n\tfoo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// `WhileStatement`
+			{
+				Code:   "const foo = [1, 2, 3];\nwhile (a)  {\n\tfoo.includes(1);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nwhile (a)  {\n\tfoo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// `DoWhileStatement`
+			{
+				Code:   "const foo = [1, 2, 3];\ndo {\n\tfoo.includes(1);\n} while (a)",
+				Output: []string{"const foo = new Set([1, 2, 3]);\ndo {\n\tfoo.has(1);\n} while (a)"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\ndo {\n\t// …\n} while (foo.includes(1))",
+				Output: []string{"const foo = new Set([1, 2, 3]);\ndo {\n\t// …\n} while (foo.has(1))"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// `FunctionDeclaration`
+			{
+				Code:   "const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\nfunction * unicorn() {\n\treturn foo.includes(1);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfunction * unicorn() {\n\treturn foo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\nasync function unicorn() {\n\treturn foo.includes(1);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nasync function unicorn() {\n\treturn foo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\nasync function * unicorn() {\n\treturn foo.includes(1);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nasync function * unicorn() {\n\treturn foo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// `FunctionExpression`
+			{
+				Code:   "const foo = [1, 2, 3];\nconst unicorn = function () {\n\treturn foo.includes(1);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nconst unicorn = function () {\n\treturn foo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// `ArrowFunctionExpression`
+			{
+				Code:   "const foo = [1, 2, 3];\nconst unicorn = () => foo.includes(1);",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nconst unicorn = () => foo.has(1);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\nconst a = {\n\tb() {\n\t\treturn foo.includes(1);\n\t}\n};",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nconst a = {\n\tb() {\n\t\treturn foo.has(1);\n\t}\n};"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\nclass A {\n\tb() {\n\t\treturn foo.includes(1);\n\t}\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nclass A {\n\tb() {\n\t\treturn foo.has(1);\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// SpreadElement
+			{
+				Code:   "const foo = [...bar];\nfunction unicorn() {\n\treturn foo.includes(1);\n}\nbar.pop();",
+				Output: []string{"const foo = new Set([...bar]);\nfunction unicorn() {\n\treturn foo.has(1);\n}\nbar.pop();"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// Multiple references
+			{
+				Code:   "const foo = [1, 2, 3];\nfunction unicorn() {\n\tconst exists = foo.includes(1);\n\tfunction isExists(find) {\n\t\treturn foo.includes(find);\n\t}\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfunction unicorn() {\n\tconst exists = foo.has(1);\n\tfunction isExists(find) {\n\t\treturn foo.has(find);\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "function wrap() {\n\tconst foo = [1, 2, 3];\n\n\tfunction unicorn() {\n\t\treturn foo.includes(1);\n\t}\n}\n\nconst bar = [4, 5, 6];\n\nfunction unicorn() {\n\treturn bar.includes(1);\n}",
+				Output: []string{"function wrap() {\n\tconst foo = new Set([1, 2, 3]);\n\n\tfunction unicorn() {\n\t\treturn foo.has(1);\n\t}\n}\n\nconst bar = new Set([4, 5, 6]);\n\nfunction unicorn() {\n\treturn bar.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 2, 8), errorAt("bar", 9, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.has(value);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\nconst bar = [...foo];\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nconst bar = [...foo];\n\nfunction unicorn(value) {\n\treturn foo.has(value);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\ncall(...foo);\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\ncall(...foo);\n\nfunction unicorn(value) {\n\treturn foo.has(value);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\nnew Call(...foo);\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nnew Call(...foo);\n\nfunction unicorn(value) {\n\treturn foo.has(value);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\nconst length = foo.length;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nconst length = foo.size;\n\nfunction unicorn(value) {\n\treturn foo.has(value);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3];\nfoo.forEach(element => {\n\tconsole.log(element);\n});\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfoo.forEach(element => {\n\tconsole.log(element);\n});\n\nfunction unicorn(value) {\n\treturn foo.has(value);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// Different scope
+			{
+				Code:   "const foo = [1, 2, 3];\nfunction wrap() {\n\tconst exists = foo.includes(1);\n\tconst bar = [1, 2, 3];\n\n\tfunction outer(find) {\n\t\tconst foo = [1, 2, 3];\n\t\twhile (a) {\n\t\t\tfoo.includes(1);\n\t\t}\n\n\t\tfunction inner(find) {\n\t\t\tconst bar = [1, 2, 3];\n\t\t\twhile (a) {\n\t\t\t\tconst exists = bar.includes(1);\n\t\t\t}\n\t\t}\n\t}\n}",
+				Output: []string{"const foo = new Set([1, 2, 3]);\nfunction wrap() {\n\tconst exists = foo.has(1);\n\tconst bar = [1, 2, 3];\n\n\tfunction outer(find) {\n\t\tconst foo = new Set([1, 2, 3]);\n\t\twhile (a) {\n\t\t\tfoo.has(1);\n\t\t}\n\n\t\tfunction inner(find) {\n\t\t\tconst bar = new Set([1, 2, 3]);\n\t\t\twhile (a) {\n\t\t\t\tconst exists = bar.has(1);\n\t\t\t}\n\t\t}\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7), errorAt("foo", 7, 9), errorAt("bar", 13, 10)},
+			},
+			// `Array()`
+			{
+				Code:   "const foo = Array(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output: []string{"const foo = new Set(Array(1, 2));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// `new Array()`
+			{
+				Code:   "const foo = new Array(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output: []string{"const foo = new Set(new Array(1, 2));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// `Array.from()`
+			{
+				Code:   "const foo = Array.from({length: 1}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output: []string{"const foo = new Set(Array.from({length: 1}, (_, index) => index));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// `Array.of()`
+			{
+				Code:   "const foo = Array.of(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output: []string{"const foo = new Set(Array.of(1, 2));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			// slice/concat with array receiver
+			{
+				Code:   "const foo = [1, 2, 3].slice();\nfoo.includes(1) || foo.includes(2);",
+				Output: []string{"const foo = new Set([1, 2, 3].slice());\nfoo.has(1) || foo.has(2);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const foo = [1, 2, 3].concat(4);\nfoo.includes(1) || foo.includes(2);",
+				Output: []string{"const foo = new Set([1, 2, 3].concat(4));\nfoo.has(1) || foo.has(2);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:   "const items = [1, 2, 3];\nconst foo = items.slice();\nfoo.includes(1) || foo.includes(2);",
+				Output: []string{"const items = [1, 2, 3];\nconst foo = new Set(items.slice());\nfoo.has(1) || foo.has(2);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 2, 7)},
+			},
+			{
+				Code:   "const items = [1, 2, 3];\nconst foo = items.concat(4);\nfoo.includes(1) || foo.includes(2);",
+				Output: []string{"const items = [1, 2, 3];\nconst foo = new Set(items.concat(4));\nfoo.has(1) || foo.has(2);"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 2, 7)},
+			},
+			// `lodash` — bar is not array, but code not broken
+			{
+				Code:   "const foo = _([1,2,3]);\nconst bar = foo.map(value => value);\nfunction unicorn() {\n\treturn bar.includes(1);\n}",
+				Output: []string{"const foo = _([1,2,3]);\nconst bar = new Set(foo.map(value => value));\nfunction unicorn() {\n\treturn bar.has(1);\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("bar", 2, 7)},
+			},
+
+			// ---- Upstream: invalid (minimumItems: 5) ----
+			{
+				Code:    "const foo = [1, 2, 3, 4, 5];\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output:  []string{"const foo = new Set([1, 2, 3, 4, 5]);\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:    "const foo = Array.of(1, 2, 3, 4, 5);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output:  []string{"const foo = new Set(Array.of(1, 2, 3, 4, 5));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:    "const foo = Array.from({length: 5}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output:  []string{"const foo = new Set(Array.from({length: 5}, (_, index) => index));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:    "const foo = Array.from({length: 2 + 3}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output:  []string{"const foo = new Set(Array.from({length: 2 + 3}, (_, index) => index));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:    "const foo = Array.from([1, 2, 3, 4, 5]);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output:  []string{"const foo = new Set(Array.from([1, 2, 3, 4, 5]));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:    "const foo = Array.from('hello');\nfunction unicorn() {\n\treturn foo.includes('h');\n}",
+				Output:  []string{"const foo = new Set(Array.from('hello'));\nfunction unicorn() {\n\treturn foo.has('h');\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:    "const foo = Array(5);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output:  []string{"const foo = new Set(Array(5));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:    "const foo = Array(2 + 3);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output:  []string{"const foo = new Set(Array(2 + 3));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:    "const foo = Array(1, 2, 3, 4, 5);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output:  []string{"const foo = new Set(Array(1, 2, 3, 4, 5));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:    "const foo = new Array(5);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output:  []string{"const foo = new Set(new Array(5));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+			{
+				Code:    "const foo = new Array(1, 2, 3, 4, 5);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+				Output:  []string{"const foo = new Set(new Array(1, 2, 3, 4, 5));\nfunction unicorn() {\n\treturn foo.has(1);\n}"},
+				Options: minimumItems(5),
+				Errors:  []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+
+			// ---- Upstream: invalid (TypeScript, type-annotation autofix) ----
+			{
+				Code:   "const a: Array<'foo' | 'bar'> = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+				Output: []string{"const a: Set<'foo' | 'bar'> = new Set(['foo', 'bar'])\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.has(someString)) {\n\t\tconsole.log(123)\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("a", 1, 7)},
+			},
+			{
+				Code:   "const a: string[] = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+				Output: []string{"const a: Set<string> = new Set(['foo', 'bar'])\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.has(someString)) {\n\t\tconsole.log(123)\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("a", 1, 7)},
+			},
+			{
+				Code:   "const a: (string | number)[] = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+				Output: []string{"const a: Set<string | number> = new Set(['foo', 'bar'])\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.has(someString)) {\n\t\tconsole.log(123)\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("a", 1, 7)},
+			},
+			{
+				Code:   "const a: ReadonlyArray<string> = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+				Output: []string{"const a: ReadonlySet<string> = new Set(['foo', 'bar'])\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.has(someString)) {\n\t\tconsole.log(123)\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("a", 1, 7)},
+			},
+			{
+				Code:   "const a: readonly string[] = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+				Output: []string{"const a: ReadonlySet<string> = new Set(['foo', 'bar'])\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.has(someString)) {\n\t\tconsole.log(123)\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("a", 1, 7)},
+			},
+			{
+				Code:   "const a: readonly (string | number)[] = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+				Output: []string{"const a: ReadonlySet<string | number> = new Set(['foo', 'bar'])\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.has(someString)) {\n\t\tconsole.log(123)\n\t}\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("a", 1, 7)},
+			},
+			// Type annotation that can't be safely rewritten → suggestion only.
+			{
+				Code: "type Items = string[]\nconst a: Items = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "error",
+					Message:   "`a` should be a `Set`, and use `a.has()` to check existence or non-existence.",
+					Line:      2,
+					Column:    7,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestion",
+						Output:    "type Items = string[]\nconst a: Items = new Set(['foo', 'bar'])\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.has(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+					}},
+				}},
+			},
+			{
+				Code: "const a: [string, string] = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "error",
+					Message:   "`a` should be a `Set`, and use `a.has()` to check existence or non-existence.",
+					Line:      1,
+					Column:    7,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestion",
+						Output:    "const a: [string, string] = new Set(['foo', 'bar'])\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.has(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+					}},
+				}},
+			},
+			{
+				Code: "const a: string /* comment */ [] = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "error",
+					Message:   "`a` should be a `Set`, and use `a.has()` to check existence or non-existence.",
+					Line:      1,
+					Column:    7,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestion",
+						Output:    "const a: string /* comment */ [] = new Set(['foo', 'bar'])\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.has(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+					}},
+				}},
+			},
+			{
+				Code:   "const foo: string[] = ['a', 'b']\nconst length = foo.length\n\nfunction has(value) {\n\treturn foo.includes(value)\n}",
+				Output: []string{"const foo: Set<string> = new Set(['a', 'b'])\nconst length = foo.size\n\nfunction has(value) {\n\treturn foo.has(value)\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{errorAt("foo", 1, 7)},
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/prefer_set_has/static_value.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/static_value.go
@@ -1,0 +1,581 @@
+package prefer_set_has
+
+// Static array-size evaluation, known-unique-array detection, and TypeScript
+// type-annotation rewriting for prefer-set-has.
+
+import (
+	"math"
+	"math/big"
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// getKnownArraySize mirrors upstream's `getKnownArraySize`: the statically
+// known element count of an array-producing initializer, when determinable.
+func getKnownArraySize(ctx rule.RuleContext, node *ast.Node) (int, bool) {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return 0, false
+	}
+
+	if ast.IsArrayLiteralExpression(node) {
+		elements := node.AsArrayLiteralExpression().Elements
+		if hasSpread(elements) {
+			return 0, false
+		}
+		return len(elements.Nodes), true
+	}
+
+	if isArrayConstructorCall(node) {
+		return getArrayConstructorSize(ctx, node)
+	}
+
+	if call := matchArrayStaticCall(node, "of"); call != nil {
+		args := call.Arguments()
+		if hasSpread(argumentList(call)) {
+			return 0, false
+		}
+		return len(args), true
+	}
+
+	if call := matchArrayStaticCall(node, "from"); call != nil {
+		return getArrayFromSize(ctx, call)
+	}
+
+	return 0, false
+}
+
+// getArrayConstructorSize mirrors upstream's `getArrayConstructorSize` for
+// `Array(...)` / `new Array(...)`.
+func getArrayConstructorSize(ctx rule.RuleContext, node *ast.Node) (int, bool) {
+	args := callOrNewArguments(node)
+	if hasSpreadNodes(args) {
+		return 0, false
+	}
+	if len(args) != 1 {
+		return len(args), true
+	}
+
+	value, ok := evaluateStaticValue(ctx, args[0])
+	if !ok {
+		return 0, false
+	}
+	number, isNumber := value.asNumber()
+	if !isNumber {
+		// `Array('x')` → length 1.
+		return 1, true
+	}
+	if isArrayLength(number) {
+		return int(number), true
+	}
+	return 0, false
+}
+
+// getArrayFromSize mirrors upstream's `getArrayFromSize` for `Array.from(...)`.
+func getArrayFromSize(ctx rule.RuleContext, node *ast.Node) (int, bool) {
+	args := node.Arguments()
+	if len(args) == 0 {
+		return 0, false
+	}
+	source := args[0]
+	if ast.IsSpreadElement(source) {
+		return 0, false
+	}
+
+	source = ast.SkipParentheses(source)
+	if ast.IsArrayLiteralExpression(source) {
+		elements := source.AsArrayLiteralExpression().Elements
+		if hasSpread(elements) {
+			return 0, false
+		}
+		return len(elements.Nodes), true
+	}
+
+	// `Array.from('string')` → number of code points.
+	if text, isString := staticStringLike(source); isString {
+		return len([]rune(text)), true
+	}
+
+	return getObjectLength(ctx, source)
+}
+
+// getObjectLength mirrors upstream's `getObjectLength`: a single-property
+// object literal `{length: <static array length>}`.
+func getObjectLength(ctx rule.RuleContext, node *ast.Node) (int, bool) {
+	if node == nil || node.Kind != ast.KindObjectLiteralExpression {
+		return 0, false
+	}
+	properties := node.AsObjectLiteralExpression().Properties
+	if properties == nil || len(properties.Nodes) != 1 {
+		return 0, false
+	}
+	property := properties.Nodes[0]
+	if !isLengthProperty(property) {
+		return 0, false
+	}
+	value, ok := evaluateStaticValue(ctx, property.AsPropertyAssignment().Initializer)
+	if !ok {
+		return 0, false
+	}
+	number, isNumber := value.asNumber()
+	if !isNumber || !isArrayLength(number) {
+		return 0, false
+	}
+	return int(number), true
+}
+
+// isLengthProperty mirrors upstream's `isLengthProperty`: a non-computed
+// `length: value` property assignment.
+func isLengthProperty(property *ast.Node) bool {
+	if property == nil || property.Kind != ast.KindPropertyAssignment {
+		return false
+	}
+	name := property.AsPropertyAssignment().Name()
+	if name == nil {
+		return false
+	}
+	switch name.Kind {
+	case ast.KindIdentifier:
+		return name.AsIdentifier().Text == "length"
+	case ast.KindStringLiteral:
+		return name.AsStringLiteral().Text == "length"
+	}
+	return false
+}
+
+// isNonNegativeInteger mirrors upstream's `isNonNegativeInteger`.
+func isNonNegativeInteger(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0) &&
+		value == math.Trunc(value) && value >= 0 &&
+		value <= float64(1<<53-1)
+}
+
+// isArrayLength mirrors upstream's `isArrayLength`.
+func isArrayLength(value float64) bool {
+	return isNonNegativeInteger(value) && value <= maxArrayLength
+}
+
+// isKnownUniqueArrayExpression mirrors upstream's
+// `isKnownUniqueArrayExpression`: a plain array literal with no holes, no
+// spreads, and only unique statically-known comparable primitive / null
+// elements (excluding `-0`).
+func isKnownUniqueArrayExpression(ctx rule.RuleContext, node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil || !ast.IsArrayLiteralExpression(node) {
+		return false
+	}
+	elements := node.AsArrayLiteralExpression().Elements
+	if hasSpread(elements) {
+		return false
+	}
+
+	values := make([]staticValue, 0, len(elements.Nodes))
+	for _, element := range elements.Nodes {
+		if ast.IsOmittedExpression(element) {
+			return false // hole
+		}
+		value, ok := evaluateStaticValue(ctx, element)
+		if !ok || !value.isComparable() || value.isNegativeZero() {
+			return false
+		}
+		values = append(values, value)
+	}
+
+	for i := range values {
+		for j := range i {
+			if sameValueZero(values[j], values[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// hasSpread reports whether an element list contains a spread element.
+func hasSpread(list *ast.NodeList) bool {
+	if list == nil {
+		return false
+	}
+	return hasSpreadNodes(list.Nodes)
+}
+
+func hasSpreadNodes(nodes []*ast.Node) bool {
+	for _, node := range nodes {
+		if node != nil && ast.IsSpreadElement(node) {
+			return true
+		}
+	}
+	return false
+}
+
+func argumentList(call *ast.Node) *ast.NodeList {
+	if ast.IsCallExpression(call) {
+		return call.AsCallExpression().Arguments
+	}
+	return nil
+}
+
+// callOrNewArguments returns the argument nodes of a call or new expression.
+func callOrNewArguments(node *ast.Node) []*ast.Node {
+	switch node.Kind {
+	case ast.KindCallExpression:
+		if args := node.AsCallExpression().Arguments; args != nil {
+			return args.Nodes
+		}
+	case ast.KindNewExpression:
+		if args := node.AsNewExpression().Arguments; args != nil {
+			return args.Nodes
+		}
+	}
+	return nil
+}
+
+// setTypeAnnotationText mirrors upstream's `getSetTypeAnnotationText`. It
+// returns the replacement `Set<…>` / `ReadonlySet<…>` type text and whether a
+// safe rewrite exists. When the declaration has no type annotation, it returns
+// ("", false) — but the caller only downgrades to a suggestion when a type
+// annotation is present, so that case still autofixes.
+func setTypeAnnotationText(ctx rule.RuleContext, declaration *ast.VariableDeclaration) (string, bool) {
+	typeAnnotation := declaration.Type
+	if typeAnnotation == nil {
+		return "", false
+	}
+
+	// `T[]` → `Set<T>`
+	if typeAnnotation.Kind == ast.KindArrayType {
+		elementType := typeAnnotation.AsArrayTypeNode().ElementType
+		if hasCommentsOutsideNode(ctx, typeAnnotation, elementType) {
+			return "", false
+		}
+		return "Set<" + elementTypeText(ctx, elementType) + ">", true
+	}
+
+	// `readonly T[]` → `ReadonlySet<T>`
+	if typeAnnotation.Kind == ast.KindTypeOperator {
+		operator := typeAnnotation.AsTypeOperatorNode()
+		if operator.Operator == ast.KindReadonlyKeyword &&
+			operator.Type != nil && operator.Type.Kind == ast.KindArrayType {
+			elementType := operator.Type.AsArrayTypeNode().ElementType
+			if hasCommentsOutsideNode(ctx, typeAnnotation, elementType) {
+				return "", false
+			}
+			return "ReadonlySet<" + elementTypeText(ctx, elementType) + ">", true
+		}
+		return "", false
+	}
+
+	// `Array<T>` → `Set<T>`, `ReadonlyArray<T>` → `ReadonlySet<T>`
+	if typeAnnotation.Kind != ast.KindTypeReference {
+		return "", false
+	}
+	typeReference := typeAnnotation.AsTypeReferenceNode()
+	if typeReference.TypeName == nil || !ast.IsIdentifier(typeReference.TypeName) {
+		return "", false
+	}
+	typeArguments := typeReference.TypeArguments
+	if typeArguments == nil || len(typeArguments.Nodes) != 1 {
+		return "", false
+	}
+	if hasCommentsOutsideNode(ctx, typeAnnotation, typeArguments.Nodes[0]) {
+		return "", false
+	}
+
+	typeArgumentsText := typeArgumentsText(ctx, typeArguments)
+	switch typeReference.TypeName.AsIdentifier().Text {
+	case "Array":
+		return "Set" + typeArgumentsText, true
+	case "ReadonlyArray":
+		return "ReadonlySet" + typeArgumentsText, true
+	}
+	return "", false
+}
+
+// elementTypeText returns the source text of an array element type. tsgo keeps
+// an explicit ParenthesizedType node (`(string | number)[]`) that ESTree
+// flattens, so unwrap it to match upstream's `sourceCode.getText(elementType)`,
+// which sees the inner type without the wrapping parentheses.
+func elementTypeText(ctx rule.RuleContext, elementType *ast.Node) string {
+	for elementType != nil && elementType.Kind == ast.KindParenthesizedType {
+		elementType = elementType.AsParenthesizedTypeNode().Type
+	}
+	return utils.TrimmedNodeText(ctx.SourceFile, elementType)
+}
+
+// typeArgumentsText returns the source text of a type-argument list including
+// its angle brackets (`<T>`), mirroring upstream's `sourceCode.getText(typeArguments)`.
+func typeArgumentsText(ctx rule.RuleContext, typeArguments *ast.NodeList) string {
+	text := ctx.SourceFile.Text()
+	start := typeArguments.Pos()
+	// The node list range starts after `<`; scan back to include it.
+	for start > 0 && text[start-1] != '<' {
+		start--
+	}
+	if start > 0 {
+		start--
+	}
+	end := typeArguments.End()
+	for end < len(text) && text[end] != '>' {
+		end++
+	}
+	if end < len(text) {
+		end++
+	}
+	return text[start:end]
+}
+
+// hasCommentsOutsideNode mirrors upstream's `hasCommentsOutsideNode`: whether
+// any comment inside `node` lies outside `child`. Used to reject a type rewrite
+// that would drop a comment.
+func hasCommentsOutsideNode(ctx rule.RuleContext, node *ast.Node, child *ast.Node) bool {
+	nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+	childRange := utils.TrimNodeTextRange(ctx.SourceFile, child)
+	for _, comment := range ctx.Comments.All() {
+		if comment.Pos() < nodeRange.Pos() || comment.End() > nodeRange.End() {
+			continue
+		}
+		if comment.Pos() < childRange.Pos() || comment.End() > childRange.End() {
+			return true
+		}
+	}
+	return false
+}
+
+// --- static value model -------------------------------------------------
+
+type staticValueKind int
+
+const (
+	svUnknown staticValueKind = iota
+	svString
+	svNumber
+	svBigInt
+	svBool
+	svNull
+)
+
+// staticValue is a statically-evaluated comparable JavaScript value, modeling
+// the subset of eslint-utils' getStaticValue that prefer-set-has consumes:
+// numbers (for array sizes) and comparable primitives / null (for uniqueness).
+type staticValue struct {
+	kind    staticValueKind
+	str     string
+	number  float64
+	big     *big.Int
+	boolean bool
+}
+
+func (v staticValue) asNumber() (float64, bool) {
+	if v.kind == svNumber {
+		return v.number, true
+	}
+	return 0, false
+}
+
+// isComparable mirrors upstream's `isComparableStaticValue`: null, or any
+// non-object / non-function primitive.
+func (v staticValue) isComparable() bool {
+	switch v.kind {
+	case svString, svNumber, svBigInt, svBool, svNull:
+		return true
+	}
+	return false
+}
+
+// isNegativeZero reports whether the value is exactly -0, which upstream
+// excludes via `!Object.is(result.value, -0)`.
+func (v staticValue) isNegativeZero() bool {
+	return v.kind == svNumber && v.number == 0 && math.Signbit(v.number)
+}
+
+// sameValueZero mirrors upstream's `isSameValueZero`: SameValueZero equality
+// (=== plus NaN equal to NaN).
+func sameValueZero(left, right staticValue) bool {
+	if left.kind != right.kind {
+		return false
+	}
+	switch left.kind {
+	case svString:
+		return left.str == right.str
+	case svNumber:
+		if math.IsNaN(left.number) && math.IsNaN(right.number) {
+			return true
+		}
+		return left.number == right.number
+	case svBigInt:
+		if left.big == nil || right.big == nil {
+			return left.big == right.big
+		}
+		return left.big.Cmp(right.big) == 0
+	case svBool:
+		return left.boolean == right.boolean
+	case svNull:
+		return true
+	}
+	return false
+}
+
+// evaluateStaticValue mirrors the subset of eslint-utils' getStaticValue that
+// this rule needs. It resolves `const` identifier initializers through
+// ctx.Refs, and evaluates literals and simple arithmetic. It returns ok=false
+// when the value cannot be statically determined.
+func evaluateStaticValue(ctx rule.RuleContext, node *ast.Node) (staticValue, bool) {
+	return evaluateStaticValueInner(ctx, node, map[*ast.Symbol]bool{})
+}
+
+func evaluateStaticValueInner(ctx rule.RuleContext, node *ast.Node, visited map[*ast.Symbol]bool) (staticValue, bool) {
+	node = ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKAssertions)
+	if node == nil {
+		return staticValue{}, false
+	}
+
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return staticValue{kind: svString, str: node.AsStringLiteral().Text}, true
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return staticValue{kind: svString, str: node.AsNoSubstitutionTemplateLiteral().Text}, true
+	case ast.KindTrueKeyword:
+		return staticValue{kind: svBool, boolean: true}, true
+	case ast.KindFalseKeyword:
+		return staticValue{kind: svBool, boolean: false}, true
+	case ast.KindNullKeyword:
+		return staticValue{kind: svNull}, true
+	case ast.KindNumericLiteral:
+		return numberFromText(utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text))
+	case ast.KindBigIntLiteral:
+		text := utils.NormalizeBigIntLiteral(node.AsBigIntLiteral().Text)
+		bi := new(big.Int)
+		if _, ok := bi.SetString(text, 10); !ok {
+			return staticValue{}, false
+		}
+		return staticValue{kind: svBigInt, big: bi}, true
+	case ast.KindPrefixUnaryExpression:
+		return evaluateStaticPrefix(ctx, node.AsPrefixUnaryExpression(), visited)
+	case ast.KindBinaryExpression:
+		return evaluateStaticBinary(ctx, node.AsBinaryExpression(), visited)
+	case ast.KindIdentifier:
+		return evaluateStaticIdentifier(ctx, node, visited)
+	}
+	return staticValue{}, false
+}
+
+func numberFromText(text string) (staticValue, bool) {
+	switch text {
+	case "Infinity":
+		return staticValue{kind: svNumber, number: math.Inf(1)}, true
+	case "-Infinity":
+		return staticValue{kind: svNumber, number: math.Inf(-1)}, true
+	}
+	f, err := strconv.ParseFloat(text, 64)
+	if err != nil {
+		return staticValue{}, false
+	}
+	return staticValue{kind: svNumber, number: f}, true
+}
+
+func evaluateStaticPrefix(ctx rule.RuleContext, prefix *ast.PrefixUnaryExpression, visited map[*ast.Symbol]bool) (staticValue, bool) {
+	operand, ok := evaluateStaticValueInner(ctx, prefix.Operand, visited)
+	if !ok {
+		return staticValue{}, false
+	}
+	switch prefix.Operator {
+	case ast.KindMinusToken:
+		if operand.kind == svNumber {
+			return staticValue{kind: svNumber, number: -operand.number}, true
+		}
+		if operand.kind == svBigInt && operand.big != nil {
+			return staticValue{kind: svBigInt, big: new(big.Int).Neg(operand.big)}, true
+		}
+	case ast.KindPlusToken:
+		if operand.kind == svNumber {
+			return operand, true
+		}
+	case ast.KindTildeToken:
+		if operand.kind == svNumber {
+			return staticValue{kind: svNumber, number: float64(^int32(operand.number))}, true
+		}
+	case ast.KindExclamationToken:
+		truthy, tok := operand.truthy()
+		if tok {
+			return staticValue{kind: svBool, boolean: !truthy}, true
+		}
+	}
+	return staticValue{}, false
+}
+
+func evaluateStaticBinary(ctx rule.RuleContext, binary *ast.BinaryExpression, visited map[*ast.Symbol]bool) (staticValue, bool) {
+	if binary.OperatorToken == nil {
+		return staticValue{}, false
+	}
+	left, lok := evaluateStaticValueInner(ctx, binary.Left, visited)
+	right, rok := evaluateStaticValueInner(ctx, binary.Right, visited)
+	if !lok || !rok {
+		return staticValue{}, false
+	}
+	if left.kind != svNumber || right.kind != svNumber {
+		return staticValue{}, false
+	}
+	switch binary.OperatorToken.Kind {
+	case ast.KindPlusToken:
+		return staticValue{kind: svNumber, number: left.number + right.number}, true
+	case ast.KindMinusToken:
+		return staticValue{kind: svNumber, number: left.number - right.number}, true
+	case ast.KindAsteriskToken:
+		return staticValue{kind: svNumber, number: left.number * right.number}, true
+	case ast.KindSlashToken:
+		return staticValue{kind: svNumber, number: left.number / right.number}, true
+	case ast.KindPercentToken:
+		return staticValue{kind: svNumber, number: math.Mod(left.number, right.number)}, true
+	case ast.KindAsteriskAsteriskToken:
+		return staticValue{kind: svNumber, number: math.Pow(left.number, right.number)}, true
+	}
+	return staticValue{}, false
+}
+
+func evaluateStaticIdentifier(ctx rule.RuleContext, node *ast.Node, visited map[*ast.Symbol]bool) (staticValue, bool) {
+	if node.AsIdentifier().Text == "Infinity" && !utils.IsShadowed(node, "Infinity") {
+		return staticValue{kind: svNumber, number: math.Inf(1)}, true
+	}
+	if ctx.Refs == nil {
+		return staticValue{}, false
+	}
+	symbol := ctx.Refs.Resolve(node)
+	if symbol == nil || visited[symbol] || len(symbol.Declarations) != 1 {
+		return staticValue{}, false
+	}
+	declarationNode := symbol.Declarations[0]
+	if declarationNode == nil || declarationNode.Kind != ast.KindVariableDeclaration {
+		return staticValue{}, false
+	}
+	declaration := declarationNode.AsVariableDeclaration()
+	if declaration.Initializer == nil {
+		return staticValue{}, false
+	}
+	declarationList := declarationNode.Parent
+	if declarationList == nil || declarationList.Kind != ast.KindVariableDeclarationList ||
+		!ast.IsVarConst(declarationList) {
+		return staticValue{}, false
+	}
+	visited[symbol] = true
+	defer delete(visited, symbol)
+	return evaluateStaticValueInner(ctx, declaration.Initializer, visited)
+}
+
+// truthy reports JS truthiness for the kinds we model.
+func (v staticValue) truthy() (bool, bool) {
+	switch v.kind {
+	case svString:
+		return v.str != "", true
+	case svNumber:
+		return v.number != 0 && !math.IsNaN(v.number), true
+	case svBigInt:
+		return v.big != nil && v.big.Sign() != 0, true
+	case svBool:
+		return v.boolean, true
+	case svNull:
+		return false, true
+	}
+	return false, false
+}

--- a/internal/plugins/unicorn/rules/prefer_set_has/static_value.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/static_value.go
@@ -112,11 +112,11 @@ func getObjectLength(ctx rule.RuleContext, node *ast.Node) (int, bool) {
 	if properties == nil || len(properties.Nodes) != 1 {
 		return 0, false
 	}
-	property := properties.Nodes[0]
-	if !isLengthProperty(property) {
+	valueNode, isLength := lengthPropertyValue(properties.Nodes[0])
+	if !isLength {
 		return 0, false
 	}
-	value, ok := evaluateStaticValue(ctx, property.AsPropertyAssignment().Initializer)
+	value, ok := evaluateStaticValue(ctx, valueNode)
 	if !ok {
 		return 0, false
 	}
@@ -127,23 +127,43 @@ func getObjectLength(ctx rule.RuleContext, node *ast.Node) (int, bool) {
 	return int(number), true
 }
 
-// isLengthProperty mirrors upstream's `isLengthProperty`: a non-computed
-// `length: value` property assignment.
-func isLengthProperty(property *ast.Node) bool {
-	if property == nil || property.Kind != ast.KindPropertyAssignment {
-		return false
+// lengthPropertyValue mirrors upstream's `isLengthProperty` plus the
+// `property.value` read that follows it: for a non-computed `length` property,
+// it returns the node holding the value. ESTree models `{length}` as a Property
+// whose `value` is the key Identifier, so upstream resolves it through scope;
+// tsgo gives shorthand its own kind, so handle it explicitly.
+func lengthPropertyValue(property *ast.Node) (*ast.Node, bool) {
+	if property == nil {
+		return nil, false
 	}
-	name := property.AsPropertyAssignment().Name()
-	if name == nil {
-		return false
+
+	var name *ast.Node
+	var value *ast.Node
+	switch property.Kind {
+	case ast.KindPropertyAssignment:
+		name = property.AsPropertyAssignment().Name()
+		value = property.AsPropertyAssignment().Initializer
+	case ast.KindShorthandPropertyAssignment:
+		name = property.AsShorthandPropertyAssignment().Name()
+		value = name
+	default:
+		return nil, false
 	}
+	if name == nil || value == nil {
+		return nil, false
+	}
+
 	switch name.Kind {
 	case ast.KindIdentifier:
-		return name.AsIdentifier().Text == "length"
+		if name.AsIdentifier().Text == "length" {
+			return value, true
+		}
 	case ast.KindStringLiteral:
-		return name.AsStringLiteral().Text == "length"
+		if name.AsStringLiteral().Text == "length" {
+			return value, true
+		}
 	}
-	return false
+	return nil, false
 }
 
 // isNonNegativeInteger mirrors upstream's `isNonNegativeInteger`.
@@ -279,11 +299,21 @@ func setTypeAnnotationText(ctx rule.RuleContext, declaration *ast.VariableDeclar
 	if typeArguments == nil || len(typeArguments.Nodes) != 1 {
 		return "", false
 	}
-	if hasCommentsOutsideNode(ctx, typeAnnotation, typeArguments.Nodes[0]) {
+	// Upstream compares against the whole type-argument list — the `<…>` span —
+	// not the type argument inside it, so a comment between the angle brackets
+	// and the argument (`Array</* c */ string>`) is still "inside" and the
+	// rewrite stays available. The replacement text below carries that comment
+	// over verbatim.
+	argumentsStart, argumentsEnd, ok := typeArgumentsRange(ctx, typeArguments)
+	if !ok {
+		return "", false
+	}
+	annotationRange := utils.TrimNodeTextRange(ctx.SourceFile, typeAnnotation)
+	if hasCommentsOutsideRange(ctx, annotationRange.Pos(), annotationRange.End(), argumentsStart, argumentsEnd) {
 		return "", false
 	}
 
-	typeArgumentsText := typeArgumentsText(ctx, typeArguments)
+	typeArgumentsText := ctx.SourceFile.Text()[argumentsStart:argumentsEnd]
 	switch typeReference.TypeName.AsIdentifier().Text {
 	case "Array":
 		return "Set" + typeArgumentsText, true
@@ -304,12 +334,12 @@ func elementTypeText(ctx rule.RuleContext, elementType *ast.Node) string {
 	return utils.TrimmedNodeText(ctx.SourceFile, elementType)
 }
 
-// typeArgumentsText returns the source text of a type-argument list including
-// its angle brackets (`<T>`), mirroring upstream's `sourceCode.getText(typeArguments)`.
-// The node list range starts after `<` and ends before `>`, so widen it outward
-// to the enclosing bracket pair.
-func typeArgumentsText(ctx rule.RuleContext, typeArguments *ast.NodeList) string {
-	return utils.SliceEnclosingDelimiters(
+// typeArgumentsRange returns the source range of a type-argument list including
+// its angle brackets (`<T>`), matching what upstream's ESTree node covers. The
+// tsgo node-list range starts after `<` and ends before `>`, so widen it
+// outward to the enclosing bracket pair.
+func typeArgumentsRange(ctx rule.RuleContext, typeArguments *ast.NodeList) (int, int, bool) {
+	return utils.RangeEnclosingDelimiters(
 		ctx.SourceFile.Text(), typeArguments.Pos(), typeArguments.End(), '<', '>',
 	)
 }
@@ -320,11 +350,18 @@ func typeArgumentsText(ctx rule.RuleContext, typeArguments *ast.NodeList) string
 func hasCommentsOutsideNode(ctx rule.RuleContext, node *ast.Node, child *ast.Node) bool {
 	nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
 	childRange := utils.TrimNodeTextRange(ctx.SourceFile, child)
+	return hasCommentsOutsideRange(ctx, nodeRange.Pos(), nodeRange.End(), childRange.Pos(), childRange.End())
+}
+
+// hasCommentsOutsideRange is hasCommentsOutsideNode over raw offsets, for
+// callers whose "child" span is not a single node (the `<…>` type-argument
+// list, whose brackets are not part of any node's range).
+func hasCommentsOutsideRange(ctx rule.RuleContext, nodeStart, nodeEnd, childStart, childEnd int) bool {
 	for _, comment := range ctx.Comments.All() {
-		if comment.Pos() < nodeRange.Pos() || comment.End() > nodeRange.End() {
+		if comment.Pos() < nodeStart || comment.End() > nodeEnd {
 			continue
 		}
-		if comment.Pos() < childRange.Pos() || comment.End() > childRange.End() {
+		if comment.Pos() < childStart || comment.End() > childEnd {
 			return true
 		}
 	}

--- a/internal/plugins/unicorn/rules/prefer_set_has/static_value.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/static_value.go
@@ -306,24 +306,12 @@ func elementTypeText(ctx rule.RuleContext, elementType *ast.Node) string {
 
 // typeArgumentsText returns the source text of a type-argument list including
 // its angle brackets (`<T>`), mirroring upstream's `sourceCode.getText(typeArguments)`.
+// The node list range starts after `<` and ends before `>`, so widen it outward
+// to the enclosing bracket pair.
 func typeArgumentsText(ctx rule.RuleContext, typeArguments *ast.NodeList) string {
-	text := ctx.SourceFile.Text()
-	start := typeArguments.Pos()
-	// The node list range starts after `<`; scan back to include it.
-	for start > 0 && text[start-1] != '<' {
-		start--
-	}
-	if start > 0 {
-		start--
-	}
-	end := typeArguments.End()
-	for end < len(text) && text[end] != '>' {
-		end++
-	}
-	if end < len(text) {
-		end++
-	}
-	return text[start:end]
+	return utils.SliceEnclosingDelimiters(
+		ctx.SourceFile.Text(), typeArguments.Pos(), typeArguments.End(), '<', '>',
+	)
 }
 
 // hasCommentsOutsideNode mirrors upstream's `hasCommentsOutsideNode`: whether
@@ -354,6 +342,7 @@ const (
 	svBigInt
 	svBool
 	svNull
+	svUndefined
 )
 
 // staticValue is a statically-evaluated comparable JavaScript value, modeling
@@ -374,11 +363,11 @@ func (v staticValue) asNumber() (float64, bool) {
 	return 0, false
 }
 
-// isComparable mirrors upstream's `isComparableStaticValue`: null, or any
-// non-object / non-function primitive.
+// isComparable mirrors upstream's `isComparableStaticValue`: null, undefined,
+// or any non-object / non-function primitive.
 func (v staticValue) isComparable() bool {
 	switch v.kind {
-	case svString, svNumber, svBigInt, svBool, svNull:
+	case svString, svNumber, svBigInt, svBool, svNull, svUndefined:
 		return true
 	}
 	return false
@@ -412,6 +401,8 @@ func sameValueZero(left, right staticValue) bool {
 	case svBool:
 		return left.boolean == right.boolean
 	case svNull:
+		return true
+	case svUndefined:
 		return true
 	}
 	return false
@@ -535,8 +526,22 @@ func evaluateStaticBinary(ctx rule.RuleContext, binary *ast.BinaryExpression, vi
 }
 
 func evaluateStaticIdentifier(ctx rule.RuleContext, node *ast.Node, visited map[*ast.Symbol]bool) (staticValue, bool) {
-	if node.AsIdentifier().Text == "Infinity" && !utils.IsShadowed(node, "Infinity") {
-		return staticValue{kind: svNumber, number: math.Inf(1)}, true
+	// The global numeric/undefined identifiers upstream's getStaticValue models.
+	// Each is only a constant when not shadowed by a local binding of the same
+	// name (e.g. `const NaN = 0`), matching the Infinity shadow check.
+	switch node.AsIdentifier().Text {
+	case "Infinity":
+		if !utils.IsShadowed(node, "Infinity") {
+			return staticValue{kind: svNumber, number: math.Inf(1)}, true
+		}
+	case "NaN":
+		if !utils.IsShadowed(node, "NaN") {
+			return staticValue{kind: svNumber, number: math.NaN()}, true
+		}
+	case "undefined":
+		if !utils.IsShadowed(node, "undefined") {
+			return staticValue{kind: svUndefined}, true
+		}
 	}
 	if ctx.Refs == nil {
 		return staticValue{}, false
@@ -575,6 +580,8 @@ func (v staticValue) truthy() (bool, bool) {
 	case svBool:
 		return v.boolean, true
 	case svNull:
+		return false, true
+	case svUndefined:
 		return false, true
 	}
 	return false, false

--- a/internal/plugins/unicorn/rules/prefer_set_has/static_value.go
+++ b/internal/plugins/unicorn/rules/prefer_set_has/static_value.go
@@ -2,11 +2,45 @@ package prefer_set_has
 
 // Static array-size evaluation, known-unique-array detection, and TypeScript
 // type-annotation rewriting for prefer-set-has.
+//
+// Why not reuse utils.StaticStringEvaluator?
+//
+// That evaluator's public API is `Eval(node) (string, bool)` — it collapses
+// every value to a string on the way out, turning `true` into "true", `null`
+// into "null" and `undefined` into "undefined". This rule compares array
+// elements for SameValueZero uniqueness, so it must keep them typed: `'null'`
+// and `null`, `'1'` and `1`, `'true'` and `true` are three pairs of DISTINCT
+// elements that a string-collapsed model reports as equal. The same applies to
+// `-0` vs `0` and to bigint vs number, both of which this rule distinguishes.
+//
+// It also falls back to tsgo's evaluator.Evaluator, which exists to compute
+// const-enum member values and is wrapped in recover() because it panics on
+// unexpected input. This rule emits an AUTOFIX: a wrong uniqueness verdict
+// produces a `new Set(...)` that silently drops elements, so its value
+// semantics have to be auditable line-by-line against upstream's
+// eslint-utils getStaticValue rather than delegated to a black box.
+//
+// A third evaluator, jsx_a11y/jsxa11yutil/static_eval.go, split off from the
+// same shared one for the same reason — a typed value model the string API
+// cannot express. The repo's convention is to share helpers, not evaluators.
+//
+// Helpers we DO reuse:
+//
+//	utils.NormalizeNumericLiteral / NormalizeBigIntLiteral — text → value
+//	utils.IsShadowed                                       — global checks
+//	ast.SkipOuterExpressions(OEKParentheses|OEKAssertions) — wrapper unwrap
+//	utils.RangeEnclosingDelimiters                         — `<T>` recovery
+//
+// JS semantics that both evaluators need (ToString, string `+`, template
+// folding) are mirrored from StaticStringEvaluator's concatStaticValues /
+// evalTemplateExpression / staticValueToString rather than reinvented; the
+// split is over the value model, not over what JS does.
 
 import (
 	"math"
 	"math/big"
 	"strconv"
+	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -483,10 +517,67 @@ func evaluateStaticValueInner(ctx rule.RuleContext, node *ast.Node, visited map[
 		return evaluateStaticPrefix(ctx, node.AsPrefixUnaryExpression(), visited)
 	case ast.KindBinaryExpression:
 		return evaluateStaticBinary(ctx, node.AsBinaryExpression(), visited)
+	case ast.KindTemplateExpression:
+		return evaluateStaticTemplate(ctx, node, visited)
+	case ast.KindPropertyAccessExpression:
+		return evaluateStaticPropertyAccess(node)
 	case ast.KindIdentifier:
 		return evaluateStaticIdentifier(ctx, node, visited)
 	}
 	return staticValue{}, false
+}
+
+// toStringValue mirrors ECMAScript ToString for the primitive kinds this
+// evaluator models, matching what utils.StaticStringEvaluator's
+// staticValueToString produces for the same inputs.
+//
+// Numbers are restricted to the plain-decimal band. Inside it — |x| in
+// [1e-6, 1e21) plus zero — Go's shortest-decimal 'f' formatting reproduces
+// Number::toString exactly (1e20 gives "100000000000000000000", 1e-6 gives
+// "0.000001", 9007199254740991 stays unrounded). Outside it JS switches to
+// exponential notation ("1e+21", "1e-7") in a format 'f' does not produce, so
+// this returns ok=false rather than emit a string JS would never produce.
+//
+// The strictness matters because the result feeds element-uniqueness
+// comparison: a number that stringified differently from JS could make two
+// elements JS considers equal look distinct, the array would be judged
+// unique, and the emitted `new Set(...)` would silently drop one of them.
+// Bailing only costs a missed report.
+func (v staticValue) toStringValue() (string, bool) {
+	switch v.kind {
+	case svString:
+		return v.str, true
+	case svBool:
+		if v.boolean {
+			return "true", true
+		}
+		return "false", true
+	case svNull:
+		return "null", true
+	case svUndefined:
+		return "undefined", true
+	case svBigInt:
+		if v.big == nil {
+			return "", false
+		}
+		return v.big.String(), true
+	case svNumber:
+		switch {
+		case math.IsNaN(v.number):
+			return "NaN", true
+		case math.IsInf(v.number, 1):
+			return "Infinity", true
+		case math.IsInf(v.number, -1):
+			return "-Infinity", true
+		case v.number == 0:
+			return "0", true // ToString(-0) is "0"
+		}
+		if magnitude := math.Abs(v.number); magnitude < 1e-6 || magnitude >= 1e21 {
+			return "", false
+		}
+		return strconv.FormatFloat(v.number, 'f', -1, 64), true
+	}
+	return "", false
 }
 
 func numberFromText(text string) (staticValue, bool) {
@@ -542,6 +633,14 @@ func evaluateStaticBinary(ctx rule.RuleContext, binary *ast.BinaryExpression, vi
 	if !lok || !rok {
 		return staticValue{}, false
 	}
+	// `+` with a string operand concatenates; every other operator we model is
+	// numeric. Both operands are already primitives here, so ToPrimitive is a
+	// no-op and ToString decides the result.
+	if binary.OperatorToken.Kind == ast.KindPlusToken &&
+		(left.kind == svString || right.kind == svString) {
+		return concatStaticValues(left, right)
+	}
+
 	if left.kind != svNumber || right.kind != svNumber {
 		return staticValue{}, false
 	}
@@ -560,6 +659,108 @@ func evaluateStaticBinary(ctx rule.RuleContext, binary *ast.BinaryExpression, vi
 		return staticValue{kind: svNumber, number: math.Pow(left.number, right.number)}, true
 	}
 	return staticValue{}, false
+}
+
+// concatStaticValues joins two primitives with JS string-concatenation
+// semantics, mirroring utils.StaticStringEvaluator's helper of the same name.
+func concatStaticValues(left, right staticValue) (staticValue, bool) {
+	leftText, lok := left.toStringValue()
+	rightText, rok := right.toStringValue()
+	if !lok || !rok {
+		return staticValue{}, false
+	}
+	return staticValue{kind: svString, str: leftText + rightText}, true
+}
+
+// evaluateStaticTemplate folds a template literal with statically-known
+// substitutions, mirroring utils.StaticStringEvaluator's evalTemplateExpression.
+func evaluateStaticTemplate(ctx rule.RuleContext, node *ast.Node, visited map[*ast.Symbol]bool) (staticValue, bool) {
+	template := node.AsTemplateExpression()
+	if template == nil {
+		return staticValue{}, false
+	}
+
+	var builder strings.Builder
+	if template.Head != nil {
+		builder.WriteString(template.Head.Text())
+	}
+	if template.TemplateSpans != nil {
+		for _, spanNode := range template.TemplateSpans.Nodes {
+			span := spanNode.AsTemplateSpan()
+			if span == nil {
+				return staticValue{}, false
+			}
+			value, ok := evaluateStaticValueInner(ctx, span.Expression, visited)
+			if !ok {
+				return staticValue{}, false
+			}
+			text, ok := value.toStringValue()
+			if !ok {
+				return staticValue{}, false
+			}
+			builder.WriteString(text)
+			if span.Literal != nil {
+				builder.WriteString(span.Literal.Text())
+			}
+		}
+	}
+	return staticValue{kind: svString, str: builder.String()}, true
+}
+
+// wellKnownNumberConstants are the `Number.*` / `Math.*` members that
+// eslint-utils' getStaticValue resolves and that can appear as an array
+// element. Keyed by object name, then property name.
+var wellKnownNumberConstants = map[string]map[string]float64{
+	"Number": {
+		"NaN":               math.NaN(),
+		"POSITIVE_INFINITY": math.Inf(1),
+		"NEGATIVE_INFINITY": math.Inf(-1),
+		"MAX_SAFE_INTEGER":  9007199254740991,
+		"MIN_SAFE_INTEGER":  -9007199254740991,
+		"MAX_VALUE":         math.MaxFloat64,
+		"MIN_VALUE":         5e-324,
+		"EPSILON":           2.220446049250313e-16,
+	},
+	"Math": {
+		"PI":      math.Pi,
+		"E":       math.E,
+		"LN2":     math.Ln2,
+		"LN10":    math.Log(10),
+		"LOG2E":   math.Log2E,
+		"LOG10E":  math.Log10E,
+		"SQRT2":   math.Sqrt2,
+		"SQRT1_2": math.Sqrt(0.5),
+	},
+}
+
+// evaluateStaticPropertyAccess resolves the well-known numeric globals. Bare
+// `NaN` / `Infinity` already fold via evaluateStaticIdentifier; this covers the
+// `Number.NaN` spelling of the same values, which upstream also folds.
+func evaluateStaticPropertyAccess(node *ast.Node) (staticValue, bool) {
+	access := node.AsPropertyAccessExpression()
+	if access == nil || access.QuestionDotToken != nil {
+		return staticValue{}, false
+	}
+
+	object := ast.SkipOuterExpressions(access.Expression, ast.OEKParentheses|ast.OEKAssertions)
+	if object == nil || !ast.IsIdentifier(object) {
+		return staticValue{}, false
+	}
+	objectName := object.AsIdentifier().Text
+	members, known := wellKnownNumberConstants[objectName]
+	if !known || utils.IsShadowed(object, objectName) {
+		return staticValue{}, false
+	}
+
+	property := access.Name()
+	if property == nil || !ast.IsIdentifier(property) {
+		return staticValue{}, false
+	}
+	value, found := members[property.AsIdentifier().Text]
+	if !found {
+		return staticValue{}, false
+	}
+	return staticValue{kind: svNumber, number: value}, true
 }
 
 func evaluateStaticIdentifier(ctx rule.RuleContext, node *ast.Node, visited map[*ast.Symbol]bool) (staticValue, bool) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -76,44 +76,62 @@ func TrimmedNodeText(sourceFile *ast.SourceFile, node *ast.Node) string {
 	return sourceFile.Text()[r.Pos():r.End()]
 }
 
-// SliceEnclosingDelimiters returns text[start..end] widened outward so it
-// includes the nearest enclosing `open`/`close` delimiter pair. Given an inner
-// range (e.g. the span of a comma-separated list whose own range excludes the
-// surrounding brackets), it scans left from `start` to the `open` byte and
+// RangeEnclosingDelimiters widens the inner range [start, end) outward to the
+// nearest enclosing `open`/`close` delimiter pair and returns the widened
+// offsets. Given the span of a comma-separated list whose own range excludes
+// the surrounding brackets, it scans left from `start` to the `open` byte and
 // right from `end` to the `close` byte, both inclusive, tolerating comments or
-// whitespace between a delimiter and the list. Offsets are clamped to text
-// bounds; if a delimiter is not found the scan stops at the boundary. Used to
-// recover bracket-delimited source such as `<T>` type-argument lists and `(…)`
+// whitespace between a delimiter and the list. Used to recover
+// bracket-delimited source such as `<T>` type-argument lists and `(…)`
 // parameter lists whose AST node ranges start after the opening bracket.
-func SliceEnclosingDelimiters(text string, start, end int, open byte, closeCh byte) string {
+//
+// ok is false when either delimiter is missing, so callers that build fixer
+// text never emit a silently truncated span.
+func RangeEnclosingDelimiters(text string, start, end int, open byte, closeCh byte) (int, int, bool) {
 	if start > len(text) {
 		start = len(text)
-	}
-	for start > 0 && text[start-1] != open {
-		start--
-	}
-	if start > 0 {
-		start--
-	}
-	if end < 0 {
-		end = 0
-	}
-	for end < len(text) && text[end] != closeCh {
-		end++
-	}
-	if end < len(text) {
-		end++
 	}
 	if start < 0 {
 		start = 0
 	}
+	if end < 0 {
+		end = 0
+	}
 	if end > len(text) {
 		end = len(text)
 	}
-	if start > end {
-		return ""
+
+	for start > 0 && text[start-1] != open {
+		start--
 	}
-	return text[start:end]
+	if start == 0 {
+		return 0, 0, false // no opening delimiter
+	}
+	start--
+
+	for end < len(text) && text[end] != closeCh {
+		end++
+	}
+	if end == len(text) {
+		return 0, 0, false // no closing delimiter
+	}
+	end++
+
+	if start > end {
+		return 0, 0, false
+	}
+	return start, end, true
+}
+
+// SliceEnclosingDelimiters returns the source text of the range computed by
+// RangeEnclosingDelimiters, including both delimiters. ok is false when either
+// delimiter is missing.
+func SliceEnclosingDelimiters(text string, start, end int, open byte, closeCh byte) (string, bool) {
+	start, end, ok := RangeEnclosingDelimiters(text, start, end, open, closeCh)
+	if !ok {
+		return "", false
+	}
+	return text[start:end], true
 }
 
 func GetCommentsInRange(sourceFile *ast.SourceFile, inRange core.TextRange) iter.Seq[ast.CommentRange] {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -76,6 +76,46 @@ func TrimmedNodeText(sourceFile *ast.SourceFile, node *ast.Node) string {
 	return sourceFile.Text()[r.Pos():r.End()]
 }
 
+// SliceEnclosingDelimiters returns text[start..end] widened outward so it
+// includes the nearest enclosing `open`/`close` delimiter pair. Given an inner
+// range (e.g. the span of a comma-separated list whose own range excludes the
+// surrounding brackets), it scans left from `start` to the `open` byte and
+// right from `end` to the `close` byte, both inclusive, tolerating comments or
+// whitespace between a delimiter and the list. Offsets are clamped to text
+// bounds; if a delimiter is not found the scan stops at the boundary. Used to
+// recover bracket-delimited source such as `<T>` type-argument lists and `(…)`
+// parameter lists whose AST node ranges start after the opening bracket.
+func SliceEnclosingDelimiters(text string, start, end int, open byte, closeCh byte) string {
+	if start > len(text) {
+		start = len(text)
+	}
+	for start > 0 && text[start-1] != open {
+		start--
+	}
+	if start > 0 {
+		start--
+	}
+	if end < 0 {
+		end = 0
+	}
+	for end < len(text) && text[end] != closeCh {
+		end++
+	}
+	if end < len(text) {
+		end++
+	}
+	if start < 0 {
+		start = 0
+	}
+	if end > len(text) {
+		end = len(text)
+	}
+	if start > end {
+		return ""
+	}
+	return text[start:end]
+}
+
 func GetCommentsInRange(sourceFile *ast.SourceFile, inRange core.TextRange) iter.Seq[ast.CommentRange] {
 	nodeFactory := ast.NewNodeFactory(ast.NodeFactoryHooks{})
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -539,3 +539,38 @@ func TestIsConstructorName(t *testing.T) {
 		}
 	}
 }
+
+func TestSliceEnclosingDelimiters(t *testing.T) {
+	tests := []struct {
+		name        string
+		text        string
+		start, end  int
+		open, close byte
+		want        string
+	}{
+		// Inner range excludes the brackets; the helper widens outward to include them.
+		{name: "type args", text: "Foo<T>", start: 4, end: 5, open: '<', close: '>', want: "<T>"},
+		{name: "param list", text: "f(a, b)", start: 2, end: 6, open: '(', close: ')', want: "(a, b)"},
+		// Trivia between a delimiter and the inner range is absorbed.
+		{name: "comment before open", text: "Foo</* c */ T>", start: 12, end: 13, open: '<', close: '>', want: "</* c */ T>"},
+		{name: "space after close", text: "Foo<T >", start: 4, end: 5, open: '<', close: '>', want: "<T >"},
+		// Missing close delimiter: scan stops at the text boundary.
+		{name: "no close", text: "Foo<T", start: 4, end: 5, open: '<', close: '>', want: "<T"},
+		// Missing open delimiter: scan stops at the start boundary.
+		{name: "no open", text: "T>", start: 0, end: 1, open: '<', close: '>', want: "T>"},
+		// Out-of-bounds offsets are clamped.
+		{name: "end past len", text: "<T>", start: 1, end: 99, open: '<', close: '>', want: "<T>"},
+		// start past len clamps to len; with no open delimiter the back-scan
+		// reaches offset 0, so the whole text is returned.
+		{name: "start past len", text: "abc", start: 99, end: 99, open: '<', close: '>', want: "abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SliceEnclosingDelimiters(tt.text, tt.start, tt.end, tt.open, tt.close)
+			if got != tt.want {
+				t.Errorf("SliceEnclosingDelimiters(%q, %d, %d, %q, %q) = %q, want %q",
+					tt.text, tt.start, tt.end, tt.open, tt.close, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -547,29 +547,33 @@ func TestSliceEnclosingDelimiters(t *testing.T) {
 		start, end  int
 		open, close byte
 		want        string
+		wantOK      bool
 	}{
 		// Inner range excludes the brackets; the helper widens outward to include them.
-		{name: "type args", text: "Foo<T>", start: 4, end: 5, open: '<', close: '>', want: "<T>"},
-		{name: "param list", text: "f(a, b)", start: 2, end: 6, open: '(', close: ')', want: "(a, b)"},
+		{name: "type args", text: "Foo<T>", start: 4, end: 5, open: '<', close: '>', want: "<T>", wantOK: true},
+		{name: "param list", text: "f(a, b)", start: 2, end: 6, open: '(', close: ')', want: "(a, b)", wantOK: true},
 		// Trivia between a delimiter and the inner range is absorbed.
-		{name: "comment before open", text: "Foo</* c */ T>", start: 12, end: 13, open: '<', close: '>', want: "</* c */ T>"},
-		{name: "space after close", text: "Foo<T >", start: 4, end: 5, open: '<', close: '>', want: "<T >"},
-		// Missing close delimiter: scan stops at the text boundary.
-		{name: "no close", text: "Foo<T", start: 4, end: 5, open: '<', close: '>', want: "<T"},
-		// Missing open delimiter: scan stops at the start boundary.
-		{name: "no open", text: "T>", start: 0, end: 1, open: '<', close: '>', want: "T>"},
-		// Out-of-bounds offsets are clamped.
-		{name: "end past len", text: "<T>", start: 1, end: 99, open: '<', close: '>', want: "<T>"},
-		// start past len clamps to len; with no open delimiter the back-scan
-		// reaches offset 0, so the whole text is returned.
-		{name: "start past len", text: "abc", start: 99, end: 99, open: '<', close: '>', want: "abc"},
+		{name: "comment before open", text: "Foo</* c */ T>", start: 12, end: 13, open: '<', close: '>', want: "</* c */ T>", wantOK: true},
+		{name: "comment after inner range", text: "Foo<T /* c */>", start: 4, end: 5, open: '<', close: '>', want: "<T /* c */>", wantOK: true},
+		{name: "space after close", text: "Foo<T >", start: 4, end: 5, open: '<', close: '>', want: "<T >", wantOK: true},
+		// An opening delimiter at offset 0 is still found.
+		{name: "open at offset zero", text: "<T>", start: 1, end: 2, open: '<', close: '>', want: "<T>", wantOK: true},
+		// A missing delimiter is reported rather than silently truncating the
+		// span: callers build fixer text from this and must not emit a partial
+		// bracket pair.
+		{name: "no close", text: "Foo<T", start: 4, end: 5, open: '<', close: '>', wantOK: false},
+		{name: "no open", text: "T>", start: 0, end: 1, open: '<', close: '>', wantOK: false},
+		{name: "neither delimiter", text: "abc", start: 1, end: 2, open: '<', close: '>', wantOK: false},
+		// Out-of-bounds offsets are clamped before scanning.
+		{name: "end past len", text: "<T>", start: 1, end: 99, open: '<', close: '>', wantOK: false},
+		{name: "start past len", text: "abc", start: 99, end: 99, open: '<', close: '>', wantOK: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := SliceEnclosingDelimiters(tt.text, tt.start, tt.end, tt.open, tt.close)
-			if got != tt.want {
-				t.Errorf("SliceEnclosingDelimiters(%q, %d, %d, %q, %q) = %q, want %q",
-					tt.text, tt.start, tt.end, tt.open, tt.close, got, tt.want)
+			got, ok := SliceEnclosingDelimiters(tt.text, tt.start, tt.end, tt.open, tt.close)
+			if ok != tt.wantOK || got != tt.want {
+				t.Errorf("SliceEnclosingDelimiters(%q, %d, %d, %q, %q) = (%q, %v), want (%q, %v)",
+					tt.text, tt.start, tt.end, tt.open, tt.close, got, ok, tt.want, tt.wantOK)
 			}
 		})
 	}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -573,6 +573,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-node-protocol.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-number-properties.test.ts',
+    './tests/eslint-plugin-unicorn/rules/prefer-set-has.test.ts',
     './tests/eslint-plugin-unicorn/rules/require-array-join-separator.test.ts',
     './tests/eslint-plugin-unicorn/rules/require-number-to-fixed-digits-argument.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-set-has.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-set-has.test.ts
@@ -1,0 +1,273 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const error = (name: string) => ({
+  messageId: 'error',
+  message: `\`${name}\` should be a \`Set\`, and use \`${name}.has()\` to check existence or non-existence.`,
+});
+
+const js = (code: string) => ({ code, filename: 'file.js' });
+
+ruleTester.run('prefer-set-has', null as never, {
+  valid: [
+    js(
+      'const foo = new Set([1, 2, 3]);\nfunction unicorn() {\n\treturn foo.has(1);\n}',
+    ),
+    // Only called once
+    js('const foo = [1, 2, 3];\nconst isExists = foo.includes(1);'),
+    js('const foo = [1, 2, 3];\n(() => {})(foo.includes(1));'),
+    // Not `VariableDeclarator`
+    js('foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1);\n}'),
+    js('const exists = foo.includes(1);'),
+    js('const exists = [1, 2, 3].includes(1);'),
+    // Didn't call `includes()`
+    js('const foo = [1, 2, 3];'),
+    // Not `foo.includes()`
+    js(
+      'const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes;\n}',
+    ),
+    js(
+      'const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn bar.includes(foo);\n}',
+    ),
+    js(
+      'const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.indexOf(1) !== -1;\n}',
+    ),
+    // Unsupported extra references
+    js(
+      'const foo = [1, 2, 3];\nfunction unicorn() {\n\tfoo.includes(1);\n\tfoo.length = 1;\n}',
+    ),
+    // Duplicates / NaN / -0
+    js(
+      'const foo = [1, 1, 2];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+    ),
+    js(
+      'const foo = [0, -0];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+    ),
+    // Unknown uniqueness
+    js(
+      'const value = 1;\nconst foo = [value, value];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+    ),
+    // Unsupported initializer shapes
+    js(
+      'const foo = [1, , 2];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+    ),
+    js(
+      'const foo = [...bar];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+    ),
+    // forEach with non-arrow / multi-param callback
+    js(
+      'const foo = [1, 2, 3];\nfoo.forEach((element, index) => {\n\tconsole.log(element, index);\n});\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+    ),
+    js(
+      'const foo = [1, 2, 3];\nfoo.forEach(callback);\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+    ),
+    // `.length` writes
+    js(
+      'const foo = [1, 2, 3];\ndelete foo.length;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+    ),
+    js(
+      'const foo = [1, 2, 3];\nfoo.length++;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+    ),
+    // Declared more than once
+    js(
+      'var foo = [1, 2, 3];\nvar foo = [4, 5, 6];\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+    ),
+    js('const foo = bar;\nfunction unicorn() {\n\treturn foo.includes(1);\n}'),
+    // Extra / spread arguments
+    js(
+      'const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1, 1);\n}',
+    ),
+    js(
+      'const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(...[1]);\n}',
+    ),
+    // Optional
+    js(
+      'const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo?.includes(1);\n}',
+    ),
+    js(
+      'const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes?.(1);\n}',
+    ),
+    // Different scope
+    js(
+      'function unicorn() {\n\tconst foo = [1, 2, 3];\n}\nfunction unicorn2() {\n\treturn foo.includes(1);\n}',
+    ),
+    // `export`
+    js(
+      'export const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+    ),
+    // `Array.from` / `Array.of` — not Array
+    js(
+      'const foo = NotArray.of(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+    ),
+    js(
+      "const foo = Array['of'](1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}",
+    ),
+    // Not listed method
+    js(
+      'const foo = bar.notListed();\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+    ),
+    // string slice/concat false positive
+    js(
+      "const text = 'abc'.slice();\ntext.includes('ab') || text.includes('bc');",
+    ),
+    // minimumItems below threshold
+    {
+      ...js(
+        'const foo = [1, 2, 3, 4];\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      options: [{ minimumItems: 5 }],
+    },
+    {
+      ...js(
+        'const foo = Array(4);\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      options: [{ minimumItems: 5 }],
+    },
+    // TS `.length` write targets
+    {
+      code: 'const foo = [1, 2, 3];\n(foo.length as number) = 1;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+    },
+  ],
+  invalid: [
+    {
+      ...js(
+        'const foo = [1, 2, 3];\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    // Called multiple times
+    {
+      ...js(
+        'const foo = [1, 2, 3];\nconst isExists = foo.includes(1);\nconst isExists2 = foo.includes(2);',
+      ),
+      errors: [error('foo')],
+    },
+    // Loops
+    {
+      ...js(
+        'const foo = [1, 2, 3];\nfor (const a of b) {\n\tfoo.includes(1);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        'const foo = [1, 2, 3];\nfor (let i = 0; i < n; i++) {\n\tfoo.includes(1);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js('const foo = [1, 2, 3];\nwhile (a)  {\n\tfoo.includes(1);\n}'),
+      errors: [error('foo')],
+    },
+    {
+      ...js('const foo = [1, 2, 3];\ndo {\n\tfoo.includes(1);\n} while (a)'),
+      errors: [error('foo')],
+    },
+    // Function boundaries
+    {
+      ...js(
+        'const foo = [1, 2, 3];\nfunction * unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js('const foo = [1, 2, 3];\nconst unicorn = () => foo.includes(1);'),
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        'const foo = [1, 2, 3];\nclass A {\n\tb() {\n\t\treturn foo.includes(1);\n\t}\n}',
+      ),
+      errors: [error('foo')],
+    },
+    // Multiple references
+    {
+      ...js(
+        'const foo = [1, 2, 3];\nfunction unicorn() {\n\tconst exists = foo.includes(1);\n\tfunction isExists(find) {\n\t\treturn foo.includes(find);\n\t}\n}',
+      ),
+      errors: [error('foo')],
+    },
+    // Extra references with a known-unique literal
+    {
+      ...js(
+        'const foo = [1, 2, 3];\nfor (const element of foo) {\n\tconsole.log(element);\n}\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        'const foo = [1, 2, 3];\nconst length = foo.length;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        'const foo = [1, 2, 3];\nfoo.forEach(element => {\n\tconsole.log(element);\n});\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    // Array constructors / statics
+    {
+      ...js(
+        'const foo = Array(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        'const foo = new Array(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        'const foo = Array.from({length: 1}, (_, index) => index);\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        'const foo = Array.of(1, 2);\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    // Array-returning methods
+    {
+      ...js(
+        'const foo = bar.map();\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        'const foo = [1, 2, 3].slice();\nfoo.includes(1) || foo.includes(2);',
+      ),
+      errors: [error('foo')],
+    },
+    // minimumItems at/above threshold
+    {
+      ...js(
+        'const foo = [1, 2, 3, 4, 5];\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      options: [{ minimumItems: 5 }],
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        'const foo = Array(5);\nfunction unicorn() {\n\treturn foo.includes(1);\n}',
+      ),
+      options: [{ minimumItems: 5 }],
+      errors: [error('foo')],
+    },
+    // TypeScript type-annotation autofix / suggestion
+    {
+      code: "const a: string[] = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+      errors: [error('a')],
+    },
+    {
+      code: "const a: [string, string] = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
+      errors: [error('a')],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-set-has.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-set-has.test.ts
@@ -128,6 +128,14 @@ ruleTester.run('prefer-set-has', null as never, {
     {
       code: 'const foo = [1, 2, 3];\n(foo.length as number) = 1;\n\nfunction unicorn(value) {\n\treturn foo.includes(value);\n}',
     },
+    // A `for` initializer runs once, so a single `includes` in the loop body
+    // is still a single call — the walk stops at the `ForStatement` root.
+    js('for (const foo = [1, 2]; ;) {\n\tfoo.includes(1);\n}'),
+    // Folded elements that collide are duplicates, so the array is not
+    // known-unique and the extra `forEach` reference blocks the report.
+    js(
+      "const foo = ['ab', 'a' + 'b'];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('ab'); }",
+    ),
   ],
   invalid: [
     {
@@ -268,6 +276,50 @@ ruleTester.run('prefer-set-has', null as never, {
     {
       code: "const a: [string, string] = ['foo', 'bar']\n\nfor (let i = 0; i < 3; i++) {\n\tif (a.includes(someString)) {\n\t\tconsole.log(123)\n\t}\n}",
       errors: [error('a')],
+    },
+    // `for` initializer declaration — upstream's structural gate is the
+    // declaration node, which also sits at `ForStatement.init`.
+    {
+      ...js(
+        'for (const foo = [1, 2]; ;) {\n\tfoo.includes(1);\n\tfoo.includes(2);\n}',
+      ),
+      errors: [error('foo')],
+    },
+    // `Array.from({length})` shorthand property drives the size check.
+    {
+      ...js(
+        'const length = 3;\nconst foo = Array.from({length});\nfoo.includes(1);\nfoo.includes(2);',
+      ),
+      options: [{ minimumItems: 2 }],
+      errors: [error('foo')],
+    },
+    // A comment inside `Array<…>` stays inside the type-argument span, so the
+    // annotation is still rewritable and this autofixes rather than degrading
+    // to a suggestion.
+    {
+      code: "const foo: Array</* c */ string> = ['a', 'b'];\nfoo.includes('a');\nfoo.includes('b');",
+      errors: [error('foo')],
+    },
+    // Statically folded elements: string concatenation, template literals and
+    // well-known numeric globals are all comparable, so the extra `forEach`
+    // reference does not block the report.
+    {
+      ...js(
+        "const foo = ['a' + 'b', 'c'];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('c'); }",
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        "const foo = [`a${1}`, 'b'];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes('b'); }",
+      ),
+      errors: [error('foo')],
+    },
+    {
+      ...js(
+        'const foo = [Number.NaN, 1];\nfoo.forEach(x => log(x));\nfunction f() { return foo.includes(1); }',
+      ),
+      errors: [error('foo')],
     },
   ],
 });

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -131,7 +131,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/prefer-reflect-apply': 'error', // not implemented
     // 'unicorn/prefer-regexp-test': 'error', // not implemented
     // 'unicorn/prefer-response-static-json': 'error', // not implemented
-    // 'unicorn/prefer-set-has': 'error', // not implemented
+    'unicorn/prefer-set-has': 'error',
     // 'unicorn/prefer-set-size': 'error', // not implemented
     // 'unicorn/prefer-simple-condition-first': 'error', // not implemented
     // 'unicorn/prefer-single-call': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port the `prefer-set-has` rule from eslint-plugin-unicorn to rslint.

Prefer `Set#has()` over `Array#includes()` when a `const` array binding is used
only for existence checks. When the binding has a rewritable TypeScript type
annotation (`T[]`, `readonly T[]`, `Array<T>`, `ReadonlyArray<T>`), the fix is
applied automatically as `new Set(...)` + `Set<T>` / `ReadonlySet<T>`;
otherwise the same edit is offered as a manual suggestion.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-set-has.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/prefer-set-has.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).