### PR TITLE
feat: port rule preserve-caught-error

### DIFF
--- a/internal/rules/all.go
+++ b/internal/rules/all.go
@@ -142,6 +142,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_spread"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_template"
+	"github.com/web-infra-dev/rslint/internal/rules/preserve_caught_error"
 	"github.com/web-infra-dev/rslint/internal/rules/radix"
 	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
 	"github.com/web-infra-dev/rslint/internal/rules/require_await"
@@ -257,6 +258,7 @@ func GetAllRules() []rule.Rule {
 		prefer_numeric_literals.PreferNumericLiteralsRule,
 		prefer_object_spread.PreferObjectSpreadRule,
 		prefer_promise_reject_errors.PreferPromiseRejectErrorsRule,
+		preserve_caught_error.PreserveCaughtErrorRule,
 		prefer_regex_literals.PreferRegexLiteralsRule,
 		prefer_template.PreferTemplateRule,
 		no_this_before_super.NoThisBeforeSuperRule,

--- a/internal/rules/max_lines_per_function/max_lines_per_function.go
+++ b/internal/rules/max_lines_per_function/max_lines_per_function.go
@@ -83,13 +83,13 @@ func parseOptions(opts any) maxLinesPerFunctionOptions {
 		}
 		opts = arr[0]
 	}
-	if n, ok := utils.ToInt(opts); ok {
+	if n, ok := utils.CoerceInt(opts); ok {
 		result.max = n
 		return result
 	}
 	if m, ok := opts.(map[string]interface{}); ok {
 		if v, ok := m["max"]; ok {
-			if n, ok := utils.ToInt(v); ok {
+			if n, ok := utils.CoerceInt(v); ok {
 				result.max = n
 			}
 		}

--- a/internal/rules/max_lines_per_function/max_lines_per_function.go
+++ b/internal/rules/max_lines_per_function/max_lines_per_function.go
@@ -83,13 +83,13 @@ func parseOptions(opts any) maxLinesPerFunctionOptions {
 		}
 		opts = arr[0]
 	}
-	if n, ok := toInt(opts); ok {
+	if n, ok := utils.ToInt(opts); ok {
 		result.max = n
 		return result
 	}
 	if m, ok := opts.(map[string]interface{}); ok {
 		if v, ok := m["max"]; ok {
-			if n, ok := toInt(v); ok {
+			if n, ok := utils.ToInt(v); ok {
 				result.max = n
 			}
 		}
@@ -104,22 +104,6 @@ func parseOptions(opts any) maxLinesPerFunctionOptions {
 		}
 	}
 	return result
-}
-
-func toInt(v any) (int, bool) {
-	switch n := v.(type) {
-	case int:
-		return n, true
-	case int32:
-		return int(n), true
-	case int64:
-		return int(n), true
-	case float64:
-		return int(n), true
-	case float32:
-		return int(n), true
-	}
-	return 0, false
 }
 
 // upperCaseFirst mirrors ESLint's shared/string-utils upperCaseFirst — used to

--- a/internal/rules/preserve_caught_error/preserve_caught_error.go
+++ b/internal/rules/preserve_caught_error/preserve_caught_error.go
@@ -53,7 +53,7 @@ func parseOptions(options []any) Options {
 			if !ok {
 				continue
 			}
-			position, ok := utils.ToInt(entry["argumentPosition"])
+			position, ok := utils.CoerceIntegral(entry["argumentPosition"])
 			if !ok {
 				continue
 			}
@@ -329,7 +329,7 @@ func insertAt(pos int, text string) rule.RuleFix {
 // insertion lands outside any parentheses wrapping that argument.
 func appendArguments(info thrownError, text string) []rule.RuleFix {
 	args := info.args()
-	return []rule.RuleFix{insertAt(args[len(args)-1].End(), text)}
+	return []rule.RuleFix{rule.RuleFixInsertAfter(args[len(args)-1], text)}
 }
 
 // addArgumentsToEmptyCall inserts text as the whole argument list, whether the
@@ -338,7 +338,7 @@ func addArgumentsToEmptyCall(info thrownError, text string) []rule.RuleFix {
 	if info.arguments != nil {
 		return []rule.RuleFix{insertAt(info.arguments.Pos(), text)}
 	}
-	return []rule.RuleFix{insertAt(info.expression.End(), "("+text+")")}
+	return []rule.RuleFix{rule.RuleFixInsertAfter(info.expression, "("+text+")")}
 }
 
 // insertCauseIntoOptions adds `cause` to an existing inline options object.
@@ -355,7 +355,7 @@ func insertCauseIntoOptions(optionsArg *ast.Node, caughtName string) []rule.Rule
 		return []rule.RuleFix{insertAt(properties.Pos(), "cause: "+caughtName)}
 	}
 	lastProperty := properties.Nodes[len(properties.Nodes)-1]
-	return []rule.RuleFix{insertAt(lastProperty.End(), ", cause: "+caughtName)}
+	return []rule.RuleFix{rule.RuleFixInsertAfter(lastProperty, ", cause: "+caughtName)}
 }
 
 // buildMissingCauseFixes attaches the caught error as the `cause` of an error

--- a/internal/rules/preserve_caught_error/preserve_caught_error.go
+++ b/internal/rules/preserve_caught_error/preserve_caught_error.go
@@ -189,6 +189,12 @@ func classifyThrownError(ctx rule.RuleContext, expression *ast.Node, opts Option
 	info.expression = expression
 
 	callee := ast.SkipParentheses(info.callee)
+	// Parentheses end an optional chain, so a chain used as the callee stays a
+	// `ChainExpression` in ESLint's AST — `(ns?.AppError)('m')` matches neither
+	// a global error name nor a configured class.
+	if ast.IsOptionalChain(callee) {
+		return info, false
+	}
 	if isBuiltInGlobalError(ctx, callee) {
 		info.builtIn = true
 		info.className = callee.AsIdentifier().Text
@@ -419,6 +425,19 @@ func buildIncorrectCauseFixes(ctx rule.RuleContext, cause causeInfo, caughtName 
 	return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, cause.value, caughtName)}
 }
 
+// isCaughtErrorShadowed reports whether the identifier attached as `cause`
+// resolves to a binding other than the catch parameter it is spelled like. A
+// `var` sharing the name is hoisted out of the catch clause and still resolves
+// to the parameter, so only a closer block-scoped binding shadows it.
+func isCaughtErrorShadowed(ctx rule.RuleContext, causeValue *ast.Node, param *ast.Node) bool {
+	caught := param.Symbol()
+	if caught == nil {
+		return false
+	}
+	target := ctx.Refs.Resolve(causeValue)
+	return target != nil && target != caught
+}
+
 func suggestIncludeCause(fixes []rule.RuleFix) []rule.RuleSuggestion {
 	if len(fixes) == 0 {
 		return nil
@@ -487,7 +506,7 @@ var PreserveCaughtErrorRule = rule.Rule{
 					return
 				}
 
-				if utils.IsNameShadowedBetween(cause.value, parentCatch, caughtName) {
+				if isCaughtErrorShadowed(ctx, cause.value, param) {
 					ctx.ReportNode(node, messageCaughtErrorShadowed())
 				}
 			},

--- a/internal/rules/preserve_caught_error/preserve_caught_error.go
+++ b/internal/rules/preserve_caught_error/preserve_caught_error.go
@@ -1,0 +1,496 @@
+package preserve_caught_error
+
+import (
+	_ "embed"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+//go:embed preserve_caught_error.schema.json
+var schemaJSON []byte
+
+// Global error constructors that accept an options bag with a `cause`.
+var builtInErrorTypes = map[string]bool{
+	"Error":          true,
+	"EvalError":      true,
+	"RangeError":     true,
+	"ReferenceError": true,
+	"SyntaxError":    true,
+	"TypeError":      true,
+	"URIError":       true,
+	"AggregateError": true,
+}
+
+// defaultArgumentPosition is the 1-based options position assumed for an
+// `errorClassNames` entry given as a bare string.
+const defaultArgumentPosition = 2
+
+type Options struct {
+	RequireCatchParameter bool
+	// ErrorClassNames maps a configured error class name to the 1-based
+	// position of its error-options argument.
+	ErrorClassNames map[string]int
+}
+
+func parseOptions(options []any) Options {
+	opts := Options{ErrorClassNames: map[string]int{}}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+	opts.RequireCatchParameter, _ = optsMap["requireCatchParameter"].(bool)
+	items, _ := optsMap["errorClassNames"].([]interface{})
+	for _, item := range items {
+		switch entry := item.(type) {
+		case string:
+			opts.ErrorClassNames[entry] = defaultArgumentPosition
+		case map[string]interface{}:
+			name, ok := entry["name"].(string)
+			if !ok {
+				continue
+			}
+			position, ok := utils.ToInt(entry["argumentPosition"])
+			if !ok {
+				continue
+			}
+			opts.ErrorClassNames[name] = position
+		}
+	}
+	return opts
+}
+
+func messageMissingCause() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "missingCause",
+		Description: "There is no `cause` attached to the symptom error being thrown.",
+	}
+}
+
+func messageIncorrectCause() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "incorrectCause",
+		Description: "The symptom error is being thrown with an incorrect `cause`.",
+	}
+}
+
+func messageIncludeCause() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "includeCause",
+		Description: "Include the original caught error as the `cause` of the symptom error.",
+	}
+}
+
+func messageMissingCatchErrorParam() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "missingCatchErrorParam",
+		Description: "The caught error is not accessible because the catch clause lacks the error parameter. Start referencing the caught error using the catch parameter.",
+	}
+}
+
+func messagePartiallyLostError() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "partiallyLostError",
+		Description: "Re-throws cannot preserve the caught error as a part of it is being lost due to destructuring.",
+	}
+}
+
+func messageCaughtErrorShadowed() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "caughtErrorShadowed",
+		Description: "The caught error is being attached as `cause`, but is shadowed by a closer scoped redeclaration.",
+	}
+}
+
+// findParentCatch returns the `catch` clause the node re-throws from, or nil
+// when the node is outside a catch clause or separated from it by a function
+// or class static block — the caught error is not directly related to a throw
+// nested in one of those.
+func findParentCatch(node *ast.Node) *ast.Node {
+	for current := node; current != nil; current = current.Parent {
+		if current.Kind == ast.KindCatchClause {
+			return current
+		}
+		switch current.Kind {
+		case ast.KindFunctionDeclaration,
+			ast.KindFunctionExpression,
+			ast.KindArrowFunction,
+			ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor,
+			ast.KindConstructor,
+			ast.KindClassStaticBlockDeclaration,
+			ast.KindSourceFile:
+			return nil
+		}
+	}
+	return nil
+}
+
+// isBuiltInGlobalError reports whether the callee refers to one of the global
+// error constructors. A local declaration or a disabled global un-declares the
+// name, so the built-in signature can no longer be assumed.
+func isBuiltInGlobalError(ctx rule.RuleContext, callee *ast.Node) bool {
+	if callee == nil || callee.Kind != ast.KindIdentifier {
+		return false
+	}
+	name := callee.AsIdentifier().Text
+	if !builtInErrorTypes[name] || utils.IsShadowed(callee, name) {
+		return false
+	}
+	declared, ok := ctx.Globals[name]
+	return !ok || declared
+}
+
+// thrownError describes a `throw` of a newly constructed error the rule checks.
+type thrownError struct {
+	// expression is the CallExpression / NewExpression being thrown, with any
+	// wrapping parentheses removed.
+	expression *ast.Node
+	// callee is the constructor expression as written, parentheses included.
+	callee    *ast.Node
+	arguments *ast.NodeList
+	className string
+	builtIn   bool
+	// optionsIndex is the 0-based argument position of the error options bag.
+	optionsIndex int
+}
+
+func (t thrownError) args() []*ast.Node {
+	if t.arguments == nil {
+		return nil
+	}
+	return t.arguments.Nodes
+}
+
+// classifyThrownError inspects the thrown expression and reports whether it
+// constructs an error whose `cause` this rule checks.
+func classifyThrownError(ctx rule.RuleContext, expression *ast.Node, opts Options) (thrownError, bool) {
+	var info thrownError
+
+	switch expression.Kind {
+	case ast.KindNewExpression:
+		newExpr := expression.AsNewExpression()
+		info.callee, info.arguments = newExpr.Expression, newExpr.Arguments
+	case ast.KindCallExpression:
+		callExpr := expression.AsCallExpression()
+		info.callee, info.arguments = callExpr.Expression, callExpr.Arguments
+	default:
+		return info, false
+	}
+	// ESLint sees an optional chain as a `ChainExpression`, which is neither a
+	// `CallExpression` nor a `NewExpression`, so those never reach the rule.
+	if info.callee == nil || ast.IsOptionalChain(expression) {
+		return info, false
+	}
+	info.expression = expression
+
+	callee := ast.SkipParentheses(info.callee)
+	if isBuiltInGlobalError(ctx, callee) {
+		info.builtIn = true
+		info.className = callee.AsIdentifier().Text
+		info.optionsIndex = 1
+		if info.className == "AggregateError" {
+			info.optionsIndex = 2
+		}
+		return info, true
+	}
+
+	target := callee
+	if callee.Kind == ast.KindPropertyAccessExpression {
+		target = callee.AsPropertyAccessExpression().Name()
+	}
+	if target == nil || target.Kind != ast.KindIdentifier {
+		return info, false
+	}
+	name := target.AsIdentifier().Text
+	position, ok := opts.ErrorClassNames[name]
+	if !ok {
+		return info, false
+	}
+	info.className = name
+	info.optionsIndex = position - 1
+	return info, true
+}
+
+type causeStatus int
+
+const (
+	// causeUnknown means the error options are too complicated to analyze.
+	causeUnknown causeStatus = iota
+	causeMissing
+	causeFound
+)
+
+type causeInfo struct {
+	status causeStatus
+	// member is the object-literal member declaring `cause`.
+	member *ast.Node
+	// value is the `cause` value, with wrapping parentheses removed. It is nil
+	// when `cause` is declared as a method or accessor.
+	value               *ast.Node
+	multipleDefinitions bool
+}
+
+// getErrorCause finds the `cause` declared in the thrown error's options bag.
+func getErrorCause(info thrownError) causeInfo {
+	args := info.args()
+
+	// A spread at or before the options position shifts the effective argument
+	// order, so where the error options actually land is no longer known.
+	for index, arg := range args {
+		if arg.Kind == ast.KindSpreadElement {
+			if index <= info.optionsIndex {
+				return causeInfo{status: causeUnknown}
+			}
+			break
+		}
+	}
+
+	if info.optionsIndex < 0 || info.optionsIndex >= len(args) {
+		return causeInfo{status: causeMissing}
+	}
+
+	errorOptions := ast.SkipParentheses(args[info.optionsIndex])
+	if errorOptions.Kind != ast.KindObjectLiteralExpression {
+		return causeInfo{status: causeUnknown}
+	}
+	properties := errorOptions.AsObjectLiteralExpression().Properties
+	if properties == nil {
+		return causeInfo{status: causeMissing}
+	}
+
+	var causeMember *ast.Node
+	causeCount := 0
+	for _, member := range properties.Nodes {
+		if member.Kind == ast.KindSpreadAssignment {
+			// A spread can contribute a `cause` that is impossible to verify.
+			return causeInfo{status: causeUnknown}
+		}
+		name := member.Name()
+		if name == nil {
+			continue
+		}
+		if propertyName, ok := utils.GetStaticPropertyName(name); ok && propertyName == "cause" {
+			causeMember = member
+			causeCount++
+		}
+	}
+	if causeMember == nil {
+		return causeInfo{status: causeMissing}
+	}
+	return causeInfo{
+		status:              causeFound,
+		member:              causeMember,
+		value:               causeValue(causeMember),
+		multipleDefinitions: causeCount > 1,
+	}
+}
+
+// causeValue returns the value node of an object-literal member, or nil for
+// methods and accessors, which hold their body instead of a value expression.
+func causeValue(member *ast.Node) *ast.Node {
+	switch member.Kind {
+	case ast.KindPropertyAssignment:
+		initializer := member.AsPropertyAssignment().Initializer
+		if initializer == nil {
+			return nil
+		}
+		return ast.SkipParentheses(initializer)
+	case ast.KindShorthandPropertyAssignment:
+		return member.Name()
+	default:
+		return nil
+	}
+}
+
+// causeReportRange is the range ESLint reports an incorrect `cause` on. For a
+// method or accessor that is the function ESLint stores as the member's value,
+// which starts at the parameter list and runs to the end of the body.
+func causeReportRange(ctx rule.RuleContext, cause causeInfo) core.TextRange {
+	if cause.value != nil {
+		return utils.TrimNodeTextRange(ctx.SourceFile, cause.value)
+	}
+	start := cause.member.End()
+	if name := cause.member.Name(); name != nil {
+		start = scanner.SkipTrivia(ctx.SourceFile.Text(), name.End())
+	}
+	return core.NewTextRange(start, cause.member.End())
+}
+
+func insertAt(pos int, text string) rule.RuleFix {
+	return rule.RuleFixReplaceRange(core.NewTextRange(pos, pos), text)
+}
+
+// appendArguments inserts text after the last argument as written, so the
+// insertion lands outside any parentheses wrapping that argument.
+func appendArguments(info thrownError, text string) []rule.RuleFix {
+	args := info.args()
+	return []rule.RuleFix{insertAt(args[len(args)-1].End(), text)}
+}
+
+// addArgumentsToEmptyCall inserts text as the whole argument list, whether the
+// call already has empty parentheses (`new Error()`) or none (`new Error`).
+func addArgumentsToEmptyCall(info thrownError, text string) []rule.RuleFix {
+	if info.arguments != nil {
+		return []rule.RuleFix{insertAt(info.arguments.Pos(), text)}
+	}
+	return []rule.RuleFix{insertAt(info.expression.End(), "("+text+")")}
+}
+
+// insertCauseIntoOptions adds `cause` to an existing inline options object.
+func insertCauseIntoOptions(optionsArg *ast.Node, caughtName string) []rule.RuleFix {
+	options := ast.SkipParentheses(optionsArg)
+	if options.Kind != ast.KindObjectLiteralExpression {
+		return nil
+	}
+	properties := options.AsObjectLiteralExpression().Properties
+	if properties == nil {
+		return nil
+	}
+	if len(properties.Nodes) == 0 {
+		return []rule.RuleFix{insertAt(properties.Pos(), "cause: "+caughtName)}
+	}
+	lastProperty := properties.Nodes[len(properties.Nodes)-1]
+	return []rule.RuleFix{insertAt(lastProperty.End(), ", cause: "+caughtName)}
+}
+
+// buildMissingCauseFixes attaches the caught error as the `cause` of an error
+// thrown without one, filling in any positional arguments it has to skip over.
+func buildMissingCauseFixes(info thrownError, caughtName string) []rule.RuleFix {
+	args := info.args()
+	options := "{ cause: " + caughtName + " }"
+
+	if info.builtIn && info.className == "AggregateError" {
+		switch len(args) {
+		case 0:
+			return addArgumentsToEmptyCall(info, `[], "", `+options)
+		case 1:
+			return appendArguments(info, `, "", `+options)
+		case 2:
+			return appendArguments(info, ", "+options)
+		default:
+			return insertCauseIntoOptions(args[2], caughtName)
+		}
+	}
+
+	if info.builtIn {
+		switch len(args) {
+		case 0:
+			return addArgumentsToEmptyCall(info, `"", `+options)
+		case 1:
+			return appendArguments(info, ", "+options)
+		default:
+			return insertCauseIntoOptions(args[1], caughtName)
+		}
+	}
+
+	// A custom error's signature is unknown, so skip the suggestion rather than
+	// synthesize placeholder values for missing positional arguments.
+	if len(args) < info.optionsIndex {
+		return nil
+	}
+	if info.optionsIndex >= len(args) {
+		if len(args) > 0 {
+			return appendArguments(info, ", "+options)
+		}
+		return addArgumentsToEmptyCall(info, options)
+	}
+	return insertCauseIntoOptions(args[info.optionsIndex], caughtName)
+}
+
+// buildIncorrectCauseFixes replaces the wrong `cause` with the caught error.
+// Shorthand, method, and accessor members carry no plain value to replace, so
+// the whole member becomes a `cause: <caught>` property.
+func buildIncorrectCauseFixes(ctx rule.RuleContext, cause causeInfo, caughtName string) []rule.RuleFix {
+	switch cause.member.Kind {
+	case ast.KindShorthandPropertyAssignment,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, cause.member, "cause: "+caughtName)}
+	}
+	if cause.value == nil {
+		return nil
+	}
+	return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, cause.value, caughtName)}
+}
+
+func suggestIncludeCause(fixes []rule.RuleFix) []rule.RuleSuggestion {
+	if len(fixes) == 0 {
+		return nil
+	}
+	return []rule.RuleSuggestion{{Message: messageIncludeCause(), FixesArr: fixes}}
+}
+
+// https://eslint.org/docs/latest/rules/preserve-caught-error
+var PreserveCaughtErrorRule = rule.Rule{
+	Name:   "preserve-caught-error",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		return rule.RuleListeners{
+			ast.KindThrowStatement: func(node *ast.Node) {
+				throwStatement := node.AsThrowStatement()
+				if throwStatement.Expression == nil {
+					return
+				}
+				parentCatch := findParentCatch(node)
+				if parentCatch == nil {
+					return
+				}
+				info, ok := classifyThrownError(ctx, ast.SkipParentheses(throwStatement.Expression), opts)
+				if !ok {
+					return
+				}
+
+				param := parentCatch.AsCatchClause().VariableDeclaration
+				if param != nil && param.Name().Kind != ast.KindIdentifier {
+					// Destructuring the caught error at the parameter level
+					// loses everything the pattern doesn't name.
+					ctx.ReportNode(parentCatch, messagePartiallyLostError())
+					return
+				}
+				if param == nil {
+					if opts.RequireCatchParameter {
+						ctx.ReportNode(node, messageMissingCatchErrorParam())
+					}
+					return
+				}
+				caughtName := param.Name().AsIdentifier().Text
+
+				cause := getErrorCause(info)
+				switch cause.status {
+				case causeUnknown:
+					return
+				case causeMissing:
+					ctx.ReportNodeWithDeferredSuggestions(node, messageMissingCause(), func() []rule.RuleSuggestion {
+						return suggestIncludeCause(buildMissingCauseFixes(info, caughtName))
+					})
+					return
+				}
+
+				if cause.value == nil || cause.value.Kind != ast.KindIdentifier ||
+					cause.value.AsIdentifier().Text != caughtName {
+					ctx.ReportRangeWithDeferredSuggestions(causeReportRange(ctx, cause), messageIncorrectCause(), func() []rule.RuleSuggestion {
+						if cause.multipleDefinitions {
+							// With several `cause` definitions a suggestion
+							// would be more confusing than helpful.
+							return nil
+						}
+						return suggestIncludeCause(buildIncorrectCauseFixes(ctx, cause, caughtName))
+					})
+					return
+				}
+
+				if utils.IsNameShadowedBetween(cause.value, parentCatch, caughtName) {
+					ctx.ReportNode(node, messageCaughtErrorShadowed())
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/preserve_caught_error/preserve_caught_error.md
+++ b/internal/rules/preserve_caught_error/preserve_caught_error.md
@@ -153,8 +153,7 @@ try {
 
 ## Differences from ESLint
 
-- A `cause` key written as a parenthesized computed key — `{ [('cause')]: error }` — is reported as a missing `cause`; ESLint accepts it. Every other spelling of the key (`cause`, `'cause'`, `["cause"]`, `` [`cause`] ``) is accepted by both.
-- For a constructor written with type arguments and no argument list — `throw new AppError<T>;` — the suggestion inserts the arguments after the type arguments (`new AppError<T>({ cause: error })`); ESLint inserts them before the type arguments.
+- For a constructor written without an argument list, the suggestion adds the arguments after the whole expression — `new AppError<T>` becomes `new AppError<T>({ cause: error })` and `new (AppError)` becomes `new (AppError)({ cause: error })`. ESLint puts them directly after the callee name, which lands inside the type arguments or the parentheses.
 
 ## Original Documentation
 

--- a/internal/rules/preserve_caught_error/preserve_caught_error.md
+++ b/internal/rules/preserve_caught_error/preserve_caught_error.md
@@ -1,0 +1,161 @@
+# preserve-caught-error
+
+## Rule Details
+
+When a `catch` block reacts to a failure by throwing a new, more descriptive error, the original error should travel along with it as the new error's `cause`. This rule requires every error constructed and thrown inside a `catch` block to receive the caught error as its `cause`, so the underlying failure stays visible in stack traces and error reports.
+
+The rule checks the global error constructors — `Error`, `EvalError`, `RangeError`, `ReferenceError`, `SyntaxError`, `TypeError`, `URIError`, and `AggregateError` — and reports both a missing `cause` and a `cause` set to anything other than the caught error. Each report comes with a suggestion that attaches the caught error.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+try {
+  doSomething();
+} catch (error) {
+  throw new Error('Failed to perform error prone operations');
+}
+
+try {
+  doSomething();
+} catch (error) {
+  throw new Error('Failed to perform error prone operations', {
+    cause: error.message,
+  });
+}
+
+try {
+  doSomething();
+} catch (error) {
+  if (whatever) {
+    const error = anotherError;
+    throw new Error('Something went wrong', { cause: error });
+  }
+}
+
+try {
+  doSomething();
+} catch ({ message }) {
+  throw new Error(message);
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+try {
+  doSomething();
+} catch (error) {
+  throw new Error('Failed to perform error prone operations', { cause: error });
+}
+
+try {
+  doSomething();
+} catch (error) {
+  throw new Error('Failed to perform error prone operations', {
+    cause: error,
+    retryable: true,
+  });
+}
+
+try {
+  doSomething();
+} catch (error) {
+  console.error(error);
+}
+
+try {
+  doSomething();
+} catch (error) {
+  foo = {
+    bar() {
+      throw new Error('Unrelated to the caught error');
+    },
+  };
+}
+```
+
+## Options
+
+### `requireCatchParameter`
+
+By default a `catch` block may omit the parameter entirely, which discards the caught error before the rule can ask for it. Set `requireCatchParameter` to `true` to require the parameter so the caught error stays available.
+
+Examples of **incorrect** code for this rule with `{ "requireCatchParameter": true }`:
+
+```json
+{ "preserve-caught-error": ["error", { "requireCatchParameter": true }] }
+```
+
+```javascript
+try {
+  doSomething();
+} catch {
+  throw new Error('Something went wrong');
+}
+```
+
+Examples of **correct** code for this rule with `{ "requireCatchParameter": true }`:
+
+```json
+{ "preserve-caught-error": ["error", { "requireCatchParameter": true }] }
+```
+
+```javascript
+try {
+  doSomething();
+} catch (error) {
+  throw new Error('Something went wrong', { cause: error });
+}
+```
+
+### `errorClassNames`
+
+Custom error classes are checked when their name is listed in `errorClassNames`. A bare string means the class takes its error options as the second argument, matching the built-in error signature. To describe a different signature, use an object with `name` and the 1-based `argumentPosition` of the options argument.
+
+The name is matched against the constructor identifier, including the property name of a namespaced constructor such as `new errors.AppError()`.
+
+Examples of **incorrect** code for this rule with `{ "errorClassNames": ["AppError"] }`:
+
+```json
+{ "preserve-caught-error": ["error", { "errorClassNames": ["AppError"] }] }
+```
+
+```javascript
+class AppError extends Error {}
+
+try {
+  doSomething();
+} catch (error) {
+  throw new AppError('Something went wrong');
+}
+```
+
+Examples of **correct** code for this rule with `{ "errorClassNames": [{ "name": "AppError", "argumentPosition": 3 }] }`:
+
+```json
+{
+  "preserve-caught-error": [
+    "error",
+    { "errorClassNames": [{ "name": "AppError", "argumentPosition": 3 }] }
+  ]
+}
+```
+
+```javascript
+class AppError extends Error {}
+
+try {
+  doSomething();
+} catch (error) {
+  throw new AppError('Something went wrong', context, { cause: error });
+}
+```
+
+## Differences from ESLint
+
+- A `cause` key written as a parenthesized computed key — `{ [('cause')]: error }` — is reported as a missing `cause`; ESLint accepts it. Every other spelling of the key (`cause`, `'cause'`, `["cause"]`, `` [`cause`] ``) is accepted by both.
+- For a constructor written with type arguments and no argument list — `throw new AppError<T>;` — the suggestion inserts the arguments after the type arguments (`new AppError<T>({ cause: error })`); ESLint inserts them before the type arguments.
+
+## Original Documentation
+
+[https://eslint.org/docs/latest/rules/preserve-caught-error](https://eslint.org/docs/latest/rules/preserve-caught-error)

--- a/internal/rules/preserve_caught_error/preserve_caught_error.schema.json
+++ b/internal/rules/preserve_caught_error/preserve_caught_error.schema.json
@@ -1,0 +1,43 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "requireCatchParameter": {
+          "type": "boolean",
+          "description": "Requires the catch blocks to always have the caught error parameter so it is not discarded."
+        },
+        "errorClassNames": {
+          "type": "array",
+          "description": "Additional error class names to check for cause preservation.",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "required": ["name", "argumentPosition"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "argumentPosition": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/rules/preserve_caught_error/preserve_caught_error_extras_test.go
+++ b/internal/rules/preserve_caught_error/preserve_caught_error_extras_test.go
@@ -56,6 +56,12 @@ func TestPreserveCaughtErrorExtras(t *testing.T) {
 			{Code: `try {} catch (err) { throw a?.b.AppError("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
 			// ---- Dimension 4: optional call of a configured error class ----
 			{Code: `try {} catch (err) { throw obj.AppError?.("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
+			// ---- Dimension 4: parenthesized optional chain as the call callee ----
+			{Code: `try {} catch (err) { throw (ns?.AppError)("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
+			// ---- Dimension 4: parenthesized optional chain as the new callee ----
+			{Code: `try {} catch (err) { throw new (ns?.AppError)("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
+			// ---- Dimension 4: the chain root itself is parenthesized, the property is not ----
+			{Code: `try {} catch (err) { throw (ns?.errors.AppError)("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
 			// ---- Dimension 4: element access callee is never a configured error class ----
 			{Code: `try {} catch (err) { throw new lib["AppError"]("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
 			// ---- Dimension 4: function declaration boundary ----
@@ -133,6 +139,18 @@ try {} catch (err) { throw new RangeError("m"); }`},
 			{Code: `try {} catch (cause) { throw new Error("m", { cause }); }`},
 			// Locks in upstream shadow arm 1: an unshadowed caught error passes.
 			{Code: `try {} catch (err) { if (x) { throw new Error("m", { cause: err }); } }`},
+			// ---- Dimension 4: a parenthesized computed key names the static `cause` ----
+			{Code: `try {} catch (err) { throw new Error("m", { [('cause')]: err }); }`},
+			// ---- Dimension 4: `var` hoists out of the catch clause, so it is not a closer binding ----
+			{Code: `try {} catch (err) { var err; throw new Error("m", { cause: err }); }`},
+			// ---- Dimension 4: `var` in a nested block still hoists past the catch clause ----
+			{Code: `try {} catch (err) { { var err; } throw new Error("m", { cause: err }); }`},
+			// ---- Dimension 4: a `var` for-of binding is not scoped to the loop ----
+			{Code: `try {} catch (err) { for (var err of list) {} throw new Error("m", { cause: err }); }`},
+			// ---- Dimension 4: a `var` for binding is not scoped to the loop ----
+			{Code: `try {} catch (err) { for (var err = 0; err < 1; err++) {} throw new Error("m", { cause: err }); }`},
+			// ---- Dimension 4: a `var` in another switch case is not a closer binding ----
+			{Code: `try {} catch (err) { switch (x) { case 1: var err = 1; break; case 2: throw new Error("m", { cause: err }); } }`},
 			// ---- Real-user: extra diagnostic data alongside the cause is accepted in any order ----
 			{Code: `try {} catch (error) { throw new Error("m", { retryable: true, cause: error }); }`},
 			// ---- Options: array-wrapped errorClassNames ----
@@ -143,13 +161,16 @@ try {} catch (err) { throw new RangeError("m"); }`},
 			{Code: `try {} catch (err) { throw new AppError("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"OtherError"}}},
 		},
 		[]rule_tester.InvalidTestCase{
-			// ---- Dimension 4: parenthesized computed key ----
-			// Parentheses around a computed key hide the static `cause` name, so
-			// the rule asks for a cause ESLint considers already present. See the
-			// rule doc's "Differences from ESLint".
+			// ---- Dimension 4: parenthesized computed key holding the wrong value ----
 			{
-				Code:   `try {} catch (err) { throw new Error("m", { [('cause')]: err }); }`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 65, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { [('cause')]: err, cause: err }); }`}}}},
+				Code:   `try {} catch (err) { throw new Error("m", { [('cause')]: other }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 58, EndLine: 1, EndColumn: 63, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { [('cause')]: err }); }`}}}},
+			},
+			// ---- Dimension 4: a chain broken by parentheses before the property ----
+			{
+				Code:    `try {} catch (err) { throw (ns?.errors).AppError("m"); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 55, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw (ns?.errors).AppError("m", { cause: err }); }`}}}},
 			},
 			// ---- Dimension 4: type arguments with no argument list ----
 			// The suggestion appends the argument list after the type arguments;
@@ -159,6 +180,15 @@ try {} catch (err) { throw new RangeError("m"); }`},
 				Code:    `try {} catch (err) { throw new AppError<string>; }`,
 				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AppError", "argumentPosition": 1}}},
 				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 49, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new AppError<string>({ cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: parenthesized callee with no argument list ----
+			// The suggestion appends the argument list after the parentheses;
+			// ESLint puts it inside them. See the rule doc's "Differences from
+			// ESLint".
+			{
+				Code:    `try {} catch (err) { throw new (AppError); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AppError", "argumentPosition": 1}}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 43, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new (AppError)({ cause: err }); }`}}}},
 			},
 			// ---- Dimension 4: parenthesized thrown expression ----
 			{

--- a/internal/rules/preserve_caught_error/preserve_caught_error_extras_test.go
+++ b/internal/rules/preserve_caught_error/preserve_caught_error_extras_test.go
@@ -611,10 +611,10 @@ func preserveCaughtErrorConfiguredRules(options []any) func(*ast.SourceFile) []l
 func createPreserveCaughtErrorProgram(t testing.TB, fileName string, code string) (*compiler.Program, *ast.SourceFile) {
 	t.Helper()
 
-	rootDir := fixtures.GetRootDir()
-	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
-	host := utils.CreateCompilerHost(rootDir, fs)
-	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	root := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFS(root.FS, map[string]string{tspath.ResolvePath(root.Dir, fileName): code})
+	host := utils.CreateCompilerHost(root.Dir, fs)
+	program, err := utils.CreateProgram(true, fs, root.Dir, "tsconfig.json", host)
 	if err != nil {
 		t.Fatalf("failed to create program: %v", err)
 	}

--- a/internal/rules/preserve_caught_error/preserve_caught_error_extras_test.go
+++ b/internal/rules/preserve_caught_error/preserve_caught_error_extras_test.go
@@ -1,0 +1,596 @@
+package preserve_caught_error
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// TestPreserveCaughtErrorExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+//
+// N/A Dimension 4 rows:
+//   - PrivateIdentifier keys: an object literal cannot declare `#cause`, and the
+//     rule only reads keys of the error-options object literal.
+//   - Class declaration vs class expression, function declaration vs expression
+//     vs arrow: the rule targets `throw` statements, so these shapes matter only
+//     as traversal boundaries — each is covered by a boundary case below.
+//   - Overload signatures / `abstract` / `declare` members: a body-less member
+//     holds no `throw` statement to report on.
+func TestPreserveCaughtErrorExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreserveCaughtErrorRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream isBuiltInGlobalError arm 2: a global turned off
+			// through the config un-declares the built-in error constructor.
+			{Code: `try {} catch (err) { throw new Error("m"); }`, Globals: map[string]bool{"Error": false}},
+			// ---- Dimension 4: parenthesized options argument already carrying the cause ----
+			{Code: `try {} catch (err) { throw new Error("m", ({ cause: err })); }`},
+			// ---- Dimension 4: parenthesized cause value matching the caught error ----
+			{Code: `try {} catch (err) { throw new Error("m", { cause: (err) }); }`},
+			// ---- Dimension 4: non-null assertion on the callee ----
+			{Code: `try {} catch (err) { throw new Error!("m"); }`},
+			// ---- Dimension 4: non-null assertion on the thrown expression ----
+			{Code: `try {} catch (err) { throw (new Error("m"))!; }`},
+			// ---- Dimension 4: type assertion on the thrown expression ----
+			{Code: `try {} catch (err) { throw (new Error("m") as Error); }`},
+			// ---- Dimension 4: satisfies wrapper on the options argument ----
+			{Code: `try {} catch (err) { throw new Error("m", {} satisfies object); }`},
+			// ---- Dimension 4: optional call of a global error constructor ----
+			{Code: `try {} catch (err) { throw Error?.("m"); }`},
+			// ---- Dimension 4: optional chain reaching a configured error class ----
+			{Code: `try {} catch (err) { throw a?.b.AppError("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
+			// ---- Dimension 4: optional call of a configured error class ----
+			{Code: `try {} catch (err) { throw obj.AppError?.("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
+			// ---- Dimension 4: element access callee is never a configured error class ----
+			{Code: `try {} catch (err) { throw new lib["AppError"]("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
+			// ---- Dimension 4: function declaration boundary ----
+			{Code: `try {} catch (err) { function f() { throw new Error("m"); } }`},
+			// ---- Dimension 4: function expression boundary ----
+			{Code: `try {} catch (err) { const f = function () { throw new Error("m"); }; }`},
+			// ---- Dimension 4: arrow function boundary ----
+			{Code: `try {} catch (err) { const f = () => { throw new Error("m"); }; }`},
+			// ---- Dimension 4: async generator boundary ----
+			{Code: `try {} catch (err) { async function* f() { throw new Error("m"); } }`},
+			// ---- Dimension 4: class method boundary ----
+			{Code: `try {} catch (err) { class A { m() { throw new Error("m"); } } }`},
+			// ---- Dimension 4: class constructor boundary ----
+			{Code: `try {} catch (err) { class A { constructor() { throw new Error("m"); } } }`},
+			// ---- Dimension 4: class getter boundary ----
+			{Code: `try {} catch (err) { class A { get p() { throw new Error("m"); } } }`},
+			// ---- Dimension 4: class setter boundary ----
+			{Code: `try {} catch (err) { class A { set p(v) { throw new Error("m"); } } }`},
+			// ---- Dimension 4: class static block boundary ----
+			{Code: `try {} catch (err) { class A { static { throw new Error("m"); } } }`},
+			// ---- Dimension 4: class field arrow boundary ----
+			{Code: `try {} catch (err) { class A { f = () => { throw new Error("m"); }; } }`},
+			// ---- Dimension 4: object accessor boundary ----
+			{Code: `try {} catch (err) { o = { get p() { throw new Error("m"); } }; }`},
+			// ---- Dimension 4: nesting boundary — the innermost catch owns the throw ----
+			{Code: `try {} catch (outer) { try {} catch (inner) { throw new Error("m", { cause: inner }); } }`},
+			// ---- Dimension 4: spread member in the options bag ----
+			{Code: `try {} catch (err) { throw new Error("m", { ...o, cause: err }); }`},
+			// ---- Dimension 4: spread member after the cause in the options bag ----
+			{Code: `try {} catch (err) { throw new Error("m", { cause: err, ...o }); }`},
+			// ---- Dimension 4: spread argument before the options position ----
+			{Code: `try {} catch (err) { throw new Error(...a); }`},
+			// ---- Dimension 4: throwing a value that is not a constructed error ----
+			{Code: `try {} catch (err) { throw err; }`},
+			// ---- Dimension 4: options argument that is not an object literal ----
+			{Code: `try {} catch (err) { throw new Error("m", opts); }`},
+			// Locks in upstream ThrowStatement listener arm 1: a throw outside any catch is never checked.
+			{Code: `throw new Error("m");`},
+			// Locks in upstream isBuiltInGlobalError arm 1: a name outside the built-in set is only checked when configured.
+			{Code: `try {} catch (err) { throw new Foo("m"); }`},
+			// Locks in upstream isBuiltInGlobalError arm 2: a local class declaration un-declares the global.
+			{Code: `class Error {}
+try {} catch (err) { throw new Error("m"); }`},
+			// Locks in upstream isBuiltInGlobalError arm 2: a local variable un-declares the global.
+			{Code: `let TypeError = Custom;
+try {} catch (err) { throw new TypeError("m"); }`},
+			// Locks in upstream isBuiltInGlobalError arm 2: a namespace declaration un-declares the global.
+			{Code: `namespace RangeError {}
+try {} catch (err) { throw new RangeError("m"); }`},
+			// Locks in upstream optionsIndex arm 1: AggregateError takes its options third.
+			{Code: `try {} catch (err) { throw new AggregateError([e], "m", { cause: err }); }`},
+			// Locks in upstream optionsIndex arm 2: other built-in errors take their options second.
+			{Code: `try {} catch (err) { throw new EvalError("m", { cause: err }); }`},
+			// Locks in upstream optionsIndex arm 3: a string entry means the options come second.
+			{Code: `try {} catch (err) { throw new AppError("m", { cause: err }); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
+			// Locks in upstream optionsIndex arm 3: argumentPosition 1 puts the options first.
+			{Code: `try {} catch (err) { throw new AppError({ cause: err }); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AppError", "argumentPosition": 1}}}},
+			// Locks in upstream getErrorCause arm 1: a spread before the options position blocks the check.
+			{Code: `try {} catch (err) { throw new AggregateError(...a, "m", {}); }`},
+			// Locks in upstream getErrorCause arm 1: a spread exactly at the options position blocks the check.
+			{Code: `try {} catch (err) { throw new Error("m", ...a); }`},
+			// Locks in upstream getErrorCause arm 2: a non-object options argument blocks the check.
+			{Code: `try {} catch (err) { throw new Error("m", cond ? {} : {}); }`},
+			// Locks in upstream getErrorCause arm 3: a spread member in the options bag blocks the check.
+			{Code: `try {} catch (err) { throw new Error("m", { ...defaults }); }`},
+			// Locks in upstream getErrorCause arm 4: the last of several cause definitions decides the verdict.
+			{Code: `try {} catch (err) { throw new Error("m", { cause: other, cause: err }); }`},
+			// Locks in upstream catch-parameter arm 2: a missing parameter is accepted by default.
+			{Code: `try {} catch { throw new Error("m"); }`},
+			// Locks in upstream catch-parameter arm 2: requireCatchParameter only fires on a checked error class.
+			{Code: `try {} catch { throw "m"; }`, Options: map[string]interface{}{"requireCatchParameter": true}},
+			// Locks in upstream catch-parameter arm 3: a type-annotated parameter is still an identifier.
+			{Code: `try {} catch (err: unknown) { throw new Error("m", { cause: err }); }`},
+			// Locks in upstream cause-value arm 2: a shorthand naming the caught error is accepted.
+			{Code: `try {} catch (cause) { throw new Error("m", { cause }); }`},
+			// Locks in upstream shadow arm 1: an unshadowed caught error passes.
+			{Code: `try {} catch (err) { if (x) { throw new Error("m", { cause: err }); } }`},
+			// ---- Real-user: extra diagnostic data alongside the cause is accepted in any order ----
+			{Code: `try {} catch (error) { throw new Error("m", { retryable: true, cause: error }); }`},
+			// ---- Options: array-wrapped errorClassNames ----
+			{Code: `try {} catch (err) { throw new AppError("m", { cause: err }); }`, Options: []interface{}{map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}}},
+			// ---- Options: an empty options object keeps every default ----
+			{Code: `try {} catch { throw new Error("m"); }`, Options: map[string]interface{}{}},
+			// ---- Options: an unlisted custom error class is never checked ----
+			{Code: `try {} catch (err) { throw new AppError("m"); }`, Options: map[string]interface{}{"errorClassNames": []interface{}{"OtherError"}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parenthesized computed key ----
+			// Parentheses around a computed key hide the static `cause` name, so
+			// the rule asks for a cause ESLint considers already present. See the
+			// rule doc's "Differences from ESLint".
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { [('cause')]: err }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 65, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { [('cause')]: err, cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: type arguments with no argument list ----
+			// The suggestion appends the argument list after the type arguments;
+			// ESLint puts it before them. See the rule doc's "Differences from
+			// ESLint".
+			{
+				Code:    `try {} catch (err) { throw new AppError<string>; }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AppError", "argumentPosition": 1}}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 49, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new AppError<string>({ cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: parenthesized thrown expression ----
+			{
+				Code:   `try {} catch (err) { throw (new Error("m")); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 45, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw (new Error("m", { cause: err })); }`}}}},
+			},
+			// ---- Dimension 4: multi-level parenthesized thrown expression ----
+			{
+				Code:   `try {} catch (err) { throw ((new Error("m"))); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 47, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw ((new Error("m", { cause: err }))); }`}}}},
+			},
+			// ---- Dimension 4: multi-level parenthesized callee ----
+			{
+				Code:   `try {} catch (err) { throw new ((Error))("m"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 47, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new ((Error))("m", { cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: parenthesized options argument ----
+			{
+				Code:   `try {} catch (err) { throw new Error("m", ({})); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 49, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", ({cause: err})); }`}}}},
+			},
+			// ---- Dimension 4: parenthesized cause value not matching the caught error ----
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { cause: (other) }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 53, EndLine: 1, EndColumn: 58, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { cause: (err) }); }`}}}},
+			},
+			// ---- Dimension 4: non-null assertion on the cause value ----
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { cause: err! }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 52, EndLine: 1, EndColumn: 56, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: type assertion on the cause value ----
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { cause: err as Error }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 52, EndLine: 1, EndColumn: 64, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: parentheses end the optional chain, so the call is checked ----
+			{
+				Code:    `try {} catch (err) { throw (a?.b).AppError("m"); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 49, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw (a?.b).AppError("m", { cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: single-quoted cause key with a wrong value ----
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { 'cause': other }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 54, EndLine: 1, EndColumn: 59, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { 'cause': err }); }`}}}},
+			},
+			// ---- Dimension 4: computed string cause key with a wrong value ----
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { ["cause"]: other }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 56, EndLine: 1, EndColumn: 61, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { ["cause"]: err }); }`}}}},
+			},
+			// ---- Dimension 4: computed template cause key with a wrong value ----
+			{
+				Code:   "try {} catch (err) { throw new Error(\"m\", { [`cause`]: other }); }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 56, EndLine: 1, EndColumn: 61, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: "try {} catch (err) { throw new Error(\"m\", { [`cause`]: err }); }"}}}},
+			},
+			// ---- Dimension 4: numeric key is not a cause key ----
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { 0: err }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 55, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { 0: err, cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: computed numeric key is not a cause key ----
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { [0]: err }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 57, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { [0]: err, cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: nested member callee matches on its property name ----
+			{
+				Code:    `try {} catch (err) { throw new a.b.AppError("m"); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 50, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new a.b.AppError("m", { cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: member callee behind an element access still matches ----
+			{
+				Code:    `try {} catch (err) { throw new a["b"].AppError("m"); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 53, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new a["b"].AppError("m", { cause: err }); }`}}}},
+			},
+			// ---- Dimension 4: nesting boundary — a nested try block is still inside the catch ----
+			{
+				Code:   `try {} catch (err) { try { throw new Error("m"); } catch {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 28, EndLine: 1, EndColumn: 49, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { try { throw new Error("m", { cause: err }); } catch {} }`}}}},
+			},
+			// ---- Dimension 4: nesting boundary — a nested finally block is still inside the catch ----
+			{
+				Code:   `try {} catch (err) { try {} finally { throw new Error("m"); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 39, EndLine: 1, EndColumn: 60, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { try {} finally { throw new Error("m", { cause: err }); } }`}}}},
+			},
+			// ---- Dimension 4: nesting boundary — a catch inside a nested function owns its own throw ----
+			{
+				Code:   `try {} catch (outer) { function g() { try {} catch (inner) { throw new Error("m"); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 62, EndLine: 1, EndColumn: 83, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (outer) { function g() { try {} catch (inner) { throw new Error("m", { cause: inner }); } } }`}}}},
+			},
+			// ---- Dimension 4: spread argument after the options position ----
+			{
+				Code:   `try {} catch (err) { throw new Error("m", {}, ...a); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 53, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", {cause: err}, ...a); }`}}}},
+			},
+			// ---- Dimension 4: empty argument list holding only a comment ----
+			{
+				Code:   `try {} catch (err) { throw new Error(/* why */); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 49, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("", { cause: err }/* why */); }`}}}},
+			},
+			// ---- Dimension 4: trailing comma in the options bag ----
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { a: 1, }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 54, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { a: 1, cause: err, }); }`}}}},
+			},
+			// ---- Dimension 4: multi-line options bag ----
+			{
+				Code: `try {} catch (err) {
+  throw new Error("m", {
+    a: 1
+  });
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 2, Column: 3, EndLine: 4, EndColumn: 6, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) {
+  throw new Error("m", {
+    a: 1, cause: err
+  });
+}`}}}},
+			},
+			// Locks in upstream isBuiltInGlobalError arm 3: a type-only declaration leaves the global value in place.
+			{
+				Code: `interface Error {}
+try {} catch (err) { throw new Error("m"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 2, Column: 22, EndLine: 2, EndColumn: 43, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `interface Error {}
+try {} catch (err) { throw new Error("m", { cause: err }); }`}}}},
+			},
+			// Locks in upstream isBuiltInGlobalError arm 3: a type alias leaves the global value in place.
+			{
+				Code: `type SyntaxError = never;
+try {} catch (err) { throw new SyntaxError("m"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 2, Column: 22, EndLine: 2, EndColumn: 49, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `type SyntaxError = never;
+try {} catch (err) { throw new SyntaxError("m", { cause: err }); }`}}}},
+			},
+			// Locks in upstream isThrowingNewError arm 1: every built-in error constructor is covered.
+			{
+				Code:   `try {} catch (err) { throw new URIError("m"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 46, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new URIError("m", { cause: err }); }`}}}},
+			},
+			// Locks in upstream isThrowingNewError arm 2: a shadowed built-in name still matches through errorClassNames.
+			{
+				Code: `class Error {}
+try {} catch (err) { throw new Error("m"); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"Error"}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 2, Column: 22, EndLine: 2, EndColumn: 43, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `class Error {}
+try {} catch (err) { throw new Error("m", { cause: err }); }`}}}},
+			},
+			// Locks in upstream optionsIndex arm 3: a global error name configured through errorClassNames keeps its built-in position.
+			{
+				Code:    `try {} catch (err) { throw new AggregateError([e], "m"); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AggregateError", "argumentPosition": 1}}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 57, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new AggregateError([e], "m", { cause: err }); }`}}}},
+			},
+			// Locks in upstream getErrorCause arm 4: several cause definitions suppress the suggestion.
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { cause: err, cause: other }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 64, EndLine: 1, EndColumn: 69}},
+			},
+			// Locks in upstream catch-parameter arm 1: an array pattern parameter loses part of the caught error.
+			{
+				Code:   `try {} catch ([first]) { throw new Error("m"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "partiallyLostError", Line: 1, Column: 8, EndLine: 1, EndColumn: 49}},
+			},
+			// Locks in upstream catch-parameter arm 1: the destructuring report wins over requireCatchParameter.
+			{
+				Code:    `try {} catch ({ message }) { throw new Error("m"); }`,
+				Options: map[string]interface{}{"requireCatchParameter": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "partiallyLostError", Line: 1, Column: 8, EndLine: 1, EndColumn: 53}},
+			},
+			// ---- Dimension 4: empty destructuring pattern parameter ----
+			{
+				Code:   `try {} catch ({}) { throw new Error("m"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "partiallyLostError", Line: 1, Column: 8, EndLine: 1, EndColumn: 44}},
+			},
+			// Locks in upstream cause-value arm 1: a setter cannot carry the caught error.
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { set cause(v) {} }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 54, EndLine: 1, EndColumn: 60, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { cause: err }); }`}}}},
+			},
+			// Locks in upstream cause-value arm 1: an async method cannot carry the caught error.
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { async cause() {} }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 56, EndLine: 1, EndColumn: 61, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { cause: err }); }`}}}},
+			},
+			// Locks in upstream cause-value arm 1: a generator method cannot carry the caught error.
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { *cause() {} }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 51, EndLine: 1, EndColumn: 56, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { cause: err }); }`}}}},
+			},
+			// Locks in upstream cause-value arm 1: a computed accessor key is still recognized as cause.
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { get ["cause"]() {} }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 58, EndLine: 1, EndColumn: 63, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { cause: err }); }`}}}},
+			},
+			// Locks in upstream cause-value arm 2: the caught error name is used verbatim in the suggestion.
+			{
+				Code:   `try {} catch (cause) { throw new Error("m", { cause: other }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 54, EndLine: 1, EndColumn: 59, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (cause) { throw new Error("m", { cause: cause }); }`}}}},
+			},
+			// Locks in upstream cause-value arm 3: null is not the caught error.
+			{
+				Code:   `try {} catch (err) { throw new Error("m", { cause: null }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 52, EndLine: 1, EndColumn: 56, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("m", { cause: err }); }`}}}},
+			},
+			// Locks in upstream shadow arm 2: a const in a nested block shadows the caught error.
+			{
+				Code:   `try {} catch (err) { { const err = other; throw new Error("m", { cause: err }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "caughtErrorShadowed", Line: 1, Column: 43, EndLine: 1, EndColumn: 80}},
+			},
+			// Locks in upstream shadow arm 2: a for-loop binding shadows the caught error.
+			{
+				Code:   `try {} catch (err) { for (let err of list) { throw new Error("m", { cause: err }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "caughtErrorShadowed", Line: 1, Column: 46, EndLine: 1, EndColumn: 83}},
+			},
+			// Locks in upstream shadow arm 2: a class declaration shadows the caught error.
+			{
+				Code:   `try {} catch (err) { { class err {} throw new Error("m", { cause: err }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "caughtErrorShadowed", Line: 1, Column: 37, EndLine: 1, EndColumn: 74}},
+			},
+			// Locks in upstream includeCause fix arm 1: AggregateError with only the errors argument.
+			{
+				Code:   `try {} catch (err) { throw new AggregateError([e]); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 52, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new AggregateError([e], "", { cause: err }); }`}}}},
+			},
+			// Locks in upstream includeCause fix arm 2: AggregateError with an existing options bag.
+			{
+				Code:   `try {} catch (err) { throw new AggregateError([e], "m", { a: 1 }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 67, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new AggregateError([e], "m", { a: 1, cause: err }); }`}}}},
+			},
+			// Locks in upstream includeCause fix arm 3: a custom class with fewer arguments than the options position gets no suggestion.
+			{
+				Code:    `try {} catch (err) { throw new AppError("m"); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AppError", "argumentPosition": 3}}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 46}},
+			},
+			// Locks in upstream includeCause fix arm 4: a custom class whose options slot is the next argument gets an appended options bag.
+			{
+				Code:    `try {} catch (err) { throw new AppError("m", ctx); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AppError", "argumentPosition": 3}}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 51, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new AppError("m", ctx, { cause: err }); }`}}}},
+			},
+			// Locks in upstream includeCause fix arm 5: a custom class taking options first and called without arguments.
+			{
+				Code:    `try {} catch (err) { throw new AppError(); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AppError", "argumentPosition": 1}}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 43, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new AppError({ cause: err }); }`}}}},
+			},
+			// Locks in upstream includeCause fix arm 6: a custom class with an existing options bag.
+			{
+				Code:    `try {} catch (err) { throw new AppError("m", { a: 1 }); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 56, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new AppError("m", { a: 1, cause: err }); }`}}}},
+			},
+			// ---- Real-user: an AggregateError built from the caught error still needs it as the cause ----
+			{
+				Code:   `try {} catch (error) { throw new AggregateError([error], "Multiple failures"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 24, EndLine: 1, EndColumn: 79, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (error) { throw new AggregateError([error], "Multiple failures", { cause: error }); }`}}}},
+			},
+			// ---- Real-user: a namespaced custom error class is matched by its property name ----
+			{
+				Code: `const errors = { AppError: class AppError extends Error {} };
+try {} catch (error) { throw new errors.AppError("m", { cause: error.message }); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 2, Column: 64, EndLine: 2, EndColumn: 77, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `const errors = { AppError: class AppError extends Error {} };
+try {} catch (error) { throw new errors.AppError("m", { cause: error }); }`}}}},
+			},
+			// ---- Real-user: a getter returning the caught error is still not the caught error ----
+			{
+				Code:   `try {} catch (error) { throw new Error("m", { get cause() { return error; } }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 1, Column: 56, EndLine: 1, EndColumn: 76, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (error) { throw new Error("m", { cause: error }); }`}}}},
+			},
+			// ---- Options: array-wrapped requireCatchParameter ----
+			{
+				Code:    `try {} catch { throw new Error("m"); }`,
+				Options: []interface{}{map[string]interface{}{"requireCatchParameter": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCatchErrorParam", Line: 1, Column: 16, EndLine: 1, EndColumn: 37}},
+			},
+			// ---- Message text: missingCause ----
+			{
+				Code:   `try {} catch (err) { throw new ReferenceError("m"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Message: "There is no `cause` attached to the symptom error being thrown.", Line: 1, Column: 22, EndLine: 1, EndColumn: 52, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new ReferenceError("m", { cause: err }); }`}}}},
+			},
+			// ---- Message text: incorrectCause ----
+			{
+				Code:   `try {} catch (err) { throw new ReferenceError("m", { cause: other }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Message: "The symptom error is being thrown with an incorrect `cause`.", Line: 1, Column: 61, EndLine: 1, EndColumn: 66, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new ReferenceError("m", { cause: err }); }`}}}},
+			},
+			// ---- Message text: missingCatchErrorParam ----
+			{
+				Code:    `try {} catch { throw new ReferenceError("m"); }`,
+				Options: map[string]interface{}{"requireCatchParameter": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCatchErrorParam", Message: "The caught error is not accessible because the catch clause lacks the error parameter. Start referencing the caught error using the catch parameter.", Line: 1, Column: 16, EndLine: 1, EndColumn: 46}},
+			},
+			// ---- Message text: partiallyLostError ----
+			{
+				Code:   `try {} catch ({ message }) { throw new ReferenceError(message); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "partiallyLostError", Message: "Re-throws cannot preserve the caught error as a part of it is being lost due to destructuring.", Line: 1, Column: 8, EndLine: 1, EndColumn: 66}},
+			},
+			// ---- Message text: caughtErrorShadowed ----
+			{
+				Code:   `try {} catch (err) { { const err = other; throw new ReferenceError("m", { cause: err }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "caughtErrorShadowed", Message: "The caught error is being attached as `cause`, but is shadowed by a closer scoped redeclaration.", Line: 1, Column: 43, EndLine: 1, EndColumn: 89}},
+			},
+		},
+	)
+}
+
+// TestPreserveCaughtErrorEditDemand verifies that the suggestion builder does
+// not change what the rule reports: diagnostic count, message, and range stay
+// identical across every edit demand, and the suggestion is materialized only
+// when it was requested.
+func TestPreserveCaughtErrorEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const source = "try {\n} catch (err) {\n  throw new Error(\"m\");\n}\n"
+
+	program, sourceFile := createPreserveCaughtErrorProgram(t, "edit-demand.ts", source)
+	options := rule_tester.ResolveTestCaseOptions(t, &PreserveCaughtErrorRule, nil)
+
+	diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		got := lintPreserveCaughtErrorWithDemand(program, sourceFile, options, demand)
+		if len(got) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(got))
+		}
+		if got[0].Message.Id != "missingCause" {
+			t.Errorf("demand %d: unexpected message id %q", demand, got[0].Message.Id)
+		}
+		if got[0].Message.Description != "There is no `cause` attached to the symptom error being thrown." {
+			t.Errorf("demand %d: unexpected message %q", demand, got[0].Message.Description)
+		}
+		diagnostics[demand] = got[0]
+	}
+
+	diagnosticsOnly := diagnostics[rule.EditDemandNone]
+	for demand, diagnostic := range diagnostics {
+		want, got := diagnosticsOnly, diagnostic
+		want.FixesPtr, want.Suggestions = nil, nil
+		got.FixesPtr, got.Suggestions = nil, nil
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic metadata:\ngot:  %#v\nwant: %#v", demand, got, want)
+		}
+	}
+
+	// The rule offers suggestions only, so neither the diagnostics-only nor the
+	// autofix demand may materialize anything.
+	for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix} {
+		diagnostic := diagnostics[demand]
+		if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+			t.Errorf(
+				"demand %d unexpectedly materialized edits: fixes=%#v suggestions=%#v",
+				demand,
+				diagnostic.FixesPtr,
+				diagnostic.Suggestions,
+			)
+		}
+	}
+
+	for _, demand := range []rule.EditDemand{rule.EditDemandSuggestion, rule.EditDemandAll} {
+		diagnostic := diagnostics[demand]
+		if diagnostic.FixesPtr != nil {
+			t.Errorf("demand %d unexpectedly materialized autofixes: %#v", demand, diagnostic.FixesPtr)
+		}
+		if diagnostic.Suggestions == nil || len(*diagnostic.Suggestions) != 1 {
+			t.Fatalf("demand %d: suggestions = %#v, want exactly one", demand, diagnostic.Suggestions)
+		}
+		suggestion := (*diagnostic.Suggestions)[0]
+		if suggestion.Message.Id != "includeCause" {
+			t.Errorf("demand %d: unexpected suggestion id %q", demand, suggestion.Message.Id)
+		}
+		fixes := suggestion.Fixes()
+		if len(fixes) != 1 || fixes[0].Text != ", { cause: err }" {
+			t.Errorf("demand %d: unexpected suggestion fixes %#v", demand, fixes)
+		}
+	}
+}
+
+func lintPreserveCaughtErrorWithDemand(
+	program *compiler.Program,
+	sourceFile *ast.SourceFile,
+	options []any,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:         program,
+		File:            sourceFile.FileName(),
+		HasTypeInfo:     true,
+		GetRulesForFile: preserveCaughtErrorConfiguredRules(options),
+		ExcludePaths:    []string{},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	return diagnostics
+}
+
+func preserveCaughtErrorConfiguredRules(options []any) func(*ast.SourceFile) []linter.ConfiguredRule {
+	return func(*ast.SourceFile) []linter.ConfiguredRule {
+		return []linter.ConfiguredRule{{
+			Name:     PreserveCaughtErrorRule.Name,
+			Severity: rule.SeverityError,
+			Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				return PreserveCaughtErrorRule.Run(ctx, options)
+			},
+		}}
+	}
+}
+
+func createPreserveCaughtErrorProgram(t testing.TB, fileName string, code string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+
+	rootDir := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return program, sourceFile
+}

--- a/internal/rules/preserve_caught_error/preserve_caught_error_upstream_test.go
+++ b/internal/rules/preserve_caught_error/preserve_caught_error_upstream_test.go
@@ -1,0 +1,818 @@
+package preserve_caught_error
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestPreserveCaughtErrorUpstream migrates the full valid/invalid suite from
+// upstream tests/lib/rules/preserve-caught-error.js 1:1. Position assertions
+// cover line/column for every invalid case. rslint-specific lock-in cases live
+// in the preserve_caught_error_extras_test.go file.
+func TestPreserveCaughtErrorUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreserveCaughtErrorRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `try {
+        throw new Error("Original error");
+    } catch (error) {
+        throw new Error("Failed to perform error prone operations", { cause: error });
+    }`},
+			{Code: `try {
+		doSomething();
+	} catch (error) {
+		throw new Error("Something failed", { 'cause': error });
+	}`},
+			{Code: `try {
+		doSomething();
+	} catch (error) {
+		throw new Error("Something failed", { "cause": error });
+	}`},
+			{Code: `try {
+		doSomething();
+	} catch (error) {
+		throw new Error("Something failed", { ['cause']: error });
+	}`},
+			{Code: `try {
+		doSomething();
+	} catch (error) {
+		throw new Error("Something failed", { ["cause"]: error });
+	}`},
+			{Code: "try {\n\t\tdoSomething();\n\t} catch (error) {\n\t\tthrow new Error(\"Something failed\", { [`cause`]: error });\n\t}"},
+			{Code: `try {
+        doSomething();
+    } catch (e) {
+        console.error(e);
+    }`},
+			{Code: `try {
+        doSomething();
+    } catch (err) {
+        throw new Error("Failed", { cause: err, extra: 42 });
+    }`},
+			{Code: `try {
+        doSomething();
+    } catch (error) {
+        switch (error.code) {
+            case "A":
+                throw new Error("Type A", { cause: error });
+            case "B":
+                throw new Error("Type B", { cause: error });
+            default:
+                throw new Error("Other", { cause: error });
+        }
+    }`},
+			{Code: `try {
+		// ...
+	} catch (err) {
+		const opts = { cause: err }
+		throw new Error("msg", { ...opts });
+	}
+	`},
+			{Code: `try {
+	} catch (error) {
+		foo = {
+			bar() {
+				throw new Error();
+			}
+		};
+	}`},
+			{Code: `try {
+				doSomething();
+			} catch (error) {
+				const args = [];
+				throw new Error(...args);
+		}`},
+			{Code: `import { Error } from "./my-custom-error.js";
+			try {
+				doSomething();
+			} catch (error) {
+				throw Error("Failed to perform error prone operations");
+			}`},
+			{Code: `try {
+		doSomething();
+	} catch {
+		throw new Error("Something went wrong");
+	}`, Options: map[string]interface{}{"requireCatchParameter": false}},
+			{Code: `try {
+			doSomething();
+		} catch (error) {
+			throw new Error("Something failed", { cause: anotherError, cause: error });
+		}`},
+			{Code: `try {
+			doSomething();
+		} catch (error) {
+			throw new Error("Something failed", { "cause": anotherError, "cause": error });
+		}`},
+			{Code: `try {
+			doSomething();
+		} catch (error) {
+			throw new Error("Something failed", { cause: anotherError, "cause": error });
+		}`},
+			{Code: `
+			const errors = { AppError: class AppError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new errors.AppError("Something failed", { cause: error });
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}}},
+			{Code: `
+			const lib = { APIError: class APIError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new lib.APIError("Something failed", { cause: error });
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{"APIError"}}},
+			{Code: `
+			class CustomApplicationError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomApplicationError("Cause not provided", { cause: err });
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{"CustomApplicationError"}}},
+			{Code: `
+			class APIError extends Error {}
+			try {
+				doSomething();
+			} catch (error) {
+				throw new APIError("API failed", { cause: error });
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{"APIError"}}},
+			{Code: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError("No cause");
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{}}},
+			{Code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData, { cause: err });
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "MyError", "argumentPosition": 3}}}},
+			{Code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new SimpleError({ cause: err });
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "SimpleError", "argumentPosition": 1}}}},
+			{Code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new AppError("Message", {}, { cause: err });
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AppError", "argumentPosition": 2}, map[string]interface{}{"name": "AppError", "argumentPosition": 3}}}},
+			{Code: `
+			try {
+			    doSomething();
+			} catch (err) {
+			    throw new context.Error("failed", someData, { cause: err });
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "Error", "argumentPosition": 3}}}},
+			{Code: `
+			try {
+			    doSomething();
+			} catch (err) {
+			    throw new Error("failed", { cause: err });
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "Error", "argumentPosition": 3}}}},
+			{Code: `import { AggregateError } from "some-module";
+			try {
+				doSomething();
+			} catch (err) {
+				throw new AggregateError({ cause: err });
+			}`, Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AggregateError", "argumentPosition": 1}}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `try {
+            doSomething();
+        } catch (err) {
+            throw new Error("Something failed");
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 13, EndLine: 4, EndColumn: 49, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (err) {
+            throw new Error("Something failed", { cause: err });
+        }`}}}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (err) {
+            const unrelated = new Error("other");
+            throw new Error("Something failed", { cause: unrelated });
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 5, Column: 58, EndLine: 5, EndColumn: 67, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (err) {
+            const unrelated = new Error("other");
+            throw new Error("Something failed", { cause: err });
+        }`}}}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (err) {
+            const unrelated = new Error("other");
+            throw new Error("Something failed", { "cause": unrelated });
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 5, Column: 60, EndLine: 5, EndColumn: 69, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (err) {
+            const unrelated = new Error("other");
+            throw new Error("Something failed", { "cause": err });
+        }`}}}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (err) {
+            const e = err;
+            throw new Error("Failed", { cause: e });
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 5, Column: 48, EndLine: 5, EndColumn: 49, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (err) {
+            const e = err;
+            throw new Error("Failed", { cause: err });
+        }`}}}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (error) {
+            throw new Error("Failed", { cause: error.message });
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 4, Column: 48, EndLine: 4, EndColumn: 61, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (error) {
+            throw new Error("Failed", { cause: error });
+        }`}}}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (error) {
+            if (shouldThrow) {
+                while (true) {
+                    if (Math.random() > 0.5) {
+                        throw new Error("Failed without cause");
+                    }
+                }
+            }
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 7, Column: 25, EndLine: 7, EndColumn: 65, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (error) {
+            if (shouldThrow) {
+                while (true) {
+                    if (Math.random() > 0.5) {
+                        throw new Error("Failed without cause", { cause: error });
+                    }
+                }
+            }
+        }`}}}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (error) {
+            switch (error.code) {
+                case "A":
+                    throw new Error("Type A");
+                case "B":
+                    throw new Error("Type B", { cause: error });
+                default:
+                    throw new Error("Other", { cause: error });
+            }
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 6, Column: 21, EndLine: 6, EndColumn: 47, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (error) {
+            switch (error.code) {
+                case "A":
+                    throw new Error("Type A", { cause: error });
+                case "B":
+                    throw new Error("Type B", { cause: error });
+                default:
+                    throw new Error("Other", { cause: error });
+            }
+        }`}}}},
+			},
+			{
+				Code:   "try {\n            doSomething();\n        } catch (error) {\n            throw new Error(`The certificate key \"${chalk.yellow(keyFile)}\" is invalid.\n${err.message}`);\n        }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 13, EndLine: 5, EndColumn: 18, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: "try {\n            doSomething();\n        } catch (error) {\n            throw new Error(`The certificate key \"${chalk.yellow(keyFile)}\" is invalid.\n${err.message}`, { cause: error });\n        }"}}}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (error) {
+            const errorMessage = "Operation failed";
+            throw new Error(errorMessage);
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 5, Column: 13, EndLine: 5, EndColumn: 43, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (error) {
+            const errorMessage = "Operation failed";
+            throw new Error(errorMessage, { cause: error });
+        }`}}}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (error) {
+            const errorMessage = "Operation failed";
+            throw new Error(errorMessage, { existingOption: true, complexOption: { moreOptions: {} } });
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 5, Column: 13, EndLine: 5, EndColumn: 105, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (error) {
+            const errorMessage = "Operation failed";
+            throw new Error(errorMessage, { existingOption: true, complexOption: { moreOptions: {} }, cause: error });
+        }`}}}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (err) {
+            if (err.code === "A") {
+                throw new Error("Type A");
+            }
+            throw new TypeError("Fallback error");
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 5, Column: 17, EndLine: 5, EndColumn: 43, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (err) {
+            if (err.code === "A") {
+                throw new Error("Type A", { cause: err });
+            }
+            throw new TypeError("Fallback error");
+        }`}}}, {MessageId: "missingCause", Line: 7, Column: 13, EndLine: 7, EndColumn: 51, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (err) {
+            if (err.code === "A") {
+                throw new Error("Type A");
+            }
+            throw new TypeError("Fallback error", { cause: err });
+        }`}}}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (err) {
+            throw Error("Something failed");
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 13, EndLine: 4, EndColumn: 45, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (err) {
+            throw Error("Something failed", { cause: err });
+        }`}}}},
+			},
+			{
+				Code: `try {
+        } catch (err) {
+            my_label:
+            throw new Error("Failed without cause");
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 13, EndLine: 4, EndColumn: 53, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+        } catch (err) {
+            my_label:
+            throw new Error("Failed without cause", { cause: err });
+        }`}}}},
+			},
+			{
+				Code: `try {
+        } catch (err) {
+            {
+                throw new Error("Something went wrong");
+            }
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 17, EndLine: 4, EndColumn: 57, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+        } catch (err) {
+            {
+                throw new Error("Something went wrong", { cause: err });
+            }
+        }`}}}},
+			},
+			{
+				Code: `try {
+        } catch (err) {
+            {
+                throw new Error();
+            }
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 17, EndLine: 4, EndColumn: 35, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+        } catch (err) {
+            {
+                throw new Error("", { cause: err });
+            }
+        }`}}}},
+			},
+			{
+				Code: `try {
+        } catch (err) {
+            {
+                throw new AggregateError([], "Lorem ipsum");
+            }
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 17, EndLine: 4, EndColumn: 61, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+        } catch (err) {
+            {
+                throw new AggregateError([], "Lorem ipsum", { cause: err });
+            }
+        }`}}}},
+			},
+			{
+				Code: `try {
+        } catch (err) {
+            {
+                throw new AggregateError();
+            }
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 17, EndLine: 4, EndColumn: 44, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+        } catch (err) {
+            {
+                throw new AggregateError([], "", { cause: err });
+            }
+        }`}}}},
+			},
+			{
+				Code: `try {
+        } catch (err) {
+            {
+                throw new AggregateError([]);
+            }
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 17, EndLine: 4, EndColumn: 46, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+        } catch (err) {
+            {
+                throw new AggregateError([], "", { cause: err });
+            }
+        }`}}}},
+			},
+			{
+				Code: `try {
+			doSomething();
+		} catch {
+			throw new Error("Something went wrong");
+		}`,
+				Options: map[string]interface{}{"requireCatchParameter": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCatchErrorParam", Line: 4, Column: 4, EndLine: 4, EndColumn: 44}},
+			},
+			{
+				Code: `try {
+            doSomething();
+        } catch (err) {
+            throw new Error("Something failed", { cause });
+        }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 4, Column: 51, EndLine: 4, EndColumn: 56, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+            doSomething();
+        } catch (err) {
+            throw new Error("Something failed", { cause: err });
+        }`}}}},
+			},
+			{
+				Code: `try {
+				doSomething();
+			} catch ({ message }) {
+				throw new Error(message);
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "partiallyLostError", Line: 3, Column: 6, EndLine: 5, EndColumn: 5}},
+			},
+			{
+				Code: `try {
+				doSomethingElse();
+			} catch ({ ...error }) {
+				throw new Error(error.message);
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "partiallyLostError", Line: 3, Column: 6, EndLine: 5, EndColumn: 5}},
+			},
+			{
+				Code: `try {
+				doSomething();
+			} catch (error) {
+				if (whatever) {
+					const error = anotherError;
+					throw new Error("Something went wrong", { cause: error });
+				}
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "caughtErrorShadowed", Line: 6, Column: 6, EndLine: 6, EndColumn: 64}},
+			},
+			{
+				Code: `try {
+				doSomething();
+			} catch (error) {
+				throw new Error(
+					"Something went wrong" // some comments
+				);
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 5, EndLine: 6, EndColumn: 7, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+				doSomething();
+			} catch (error) {
+				throw new Error(
+					"Something went wrong", { cause: error } // some comments
+				);
+			}`}}}},
+			},
+			{
+				Code: `try {
+				doSomething();
+			} catch (err) {
+				throw new Error("Something failed", {});
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 4, Column: 5, EndLine: 4, EndColumn: 45, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+				doSomething();
+			} catch (err) {
+				throw new Error("Something failed", {cause: err});
+			}`}}}},
+			},
+			{
+				Code: `try {
+			doSomething();
+		} catch (error) {
+			const cause = "desc";
+			throw new Error("Something failed", { [cause]: "Some error" });
+		}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 5, Column: 4, EndLine: 5, EndColumn: 67, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+			doSomething();
+		} catch (error) {
+			const cause = "desc";
+			throw new Error("Something failed", { [cause]: "Some error", cause: error });
+		}`}}}},
+			},
+			{
+				Code: `try {
+			doSomething();
+			} catch (error) {
+			throw new Error("Something failed", { cause() { /* do something */ }  });
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 4, Column: 47, EndLine: 4, EndColumn: 72, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {
+			doSomething();
+			} catch (error) {
+			throw new Error("Something failed", { cause: error  });
+			}`}}}},
+			},
+			{
+				Code: `try {} catch (error) {
+				throw new Error("Something failed", { cause: error, cause: anotherError });
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 2, Column: 64, EndLine: 2, EndColumn: 76}},
+			},
+			{
+				Code: `try {} catch (error) {
+				throw new Error("Something failed", { cause: error, "cause": anotherError });
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 2, Column: 66, EndLine: 2, EndColumn: 78}},
+			},
+			{
+				Code: `try {} catch (error) {
+				throw new Error("Something failed", { get cause() { } });
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 2, Column: 52, EndLine: 2, EndColumn: 58, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (error) {
+				throw new Error("Something failed", { cause: error });
+			}`}}}},
+			},
+			{
+				Code: `try {} catch (error) {
+				throw new Error("Something failed", { set cause(value) { } });
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 2, Column: 52, EndLine: 2, EndColumn: 63, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (error) {
+				throw new Error("Something failed", { cause: error });
+			}`}}}},
+			},
+			{
+				Code: `try {} catch (error) {
+				throw new Error("Something failed", {
+					get cause() { return error; },
+					set cause(value) { error = value; },
+				});
+			}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 4, Column: 15, EndLine: 4, EndColumn: 41}},
+			},
+			{
+				Code:   `try { doSomething(); } catch (err) { throw new Error(("Something failed")); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 38, EndLine: 1, EndColumn: 76, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try { doSomething(); } catch (err) { throw new Error(("Something failed"), { cause: err }); }`}}}},
+			},
+			{
+				Code:   `try { doSomething(); } catch (err) { throw new Error(("Something failed"),); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 38, EndLine: 1, EndColumn: 77, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try { doSomething(); } catch (err) { throw new Error(("Something failed"), { cause: err },); }`}}}},
+			},
+			{
+				Code:   `try { doSomething(); } catch (err) { throw new AggregateError((errors)); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 38, EndLine: 1, EndColumn: 73, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try { doSomething(); } catch (err) { throw new AggregateError((errors), "", { cause: err }); }`}}}},
+			},
+			{
+				Code:   `try { doSomething(); } catch (err) { throw new AggregateError(errors, ("message")); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 38, EndLine: 1, EndColumn: 84, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try { doSomething(); } catch (err) { throw new AggregateError(errors, ("message"), { cause: err }); }`}}}},
+			},
+			{
+				Code:    `try { doSomething(); } catch (err) { throw new CustomError((foo)); }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"CustomError"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 38, EndLine: 1, EndColumn: 67, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try { doSomething(); } catch (err) { throw new CustomError((foo), { cause: err }); }`}}}},
+			},
+			{
+				Code: `
+			class CustomApplicationError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomApplicationError("Cause not provided");
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"CustomApplicationError"}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 6, Column: 5, EndLine: 6, EndColumn: 60, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `
+			class CustomApplicationError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomApplicationError("Cause not provided", { cause: err });
+			}`}}}},
+			},
+			{
+				Code: `
+			class APIError extends Error {}
+			try {
+				doSomething();
+			} catch (error) {
+				throw new APIError("API failed", { cause: wrong });
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"APIError"}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 6, Column: 47, EndLine: 6, EndColumn: 52, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `
+			class APIError extends Error {}
+			try {
+				doSomething();
+			} catch (error) {
+				throw new APIError("API failed", { cause: error });
+			}`}}}},
+			},
+			{
+				Code: `
+			const errors = { AppError: class AppError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new errors.AppError("Something failed");
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"AppError"}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 6, Column: 5, EndLine: 6, EndColumn: 51, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `
+			const errors = { AppError: class AppError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new errors.AppError("Something failed", { cause: error });
+			}`}}}},
+			},
+			{
+				Code: `
+			const lib = { APIError: class APIError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new lib.APIError("Something failed", { cause: wrong });
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"APIError"}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 6, Column: 57, EndLine: 6, EndColumn: 62, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `
+			const lib = { APIError: class APIError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new lib.APIError("Something failed", { cause: error });
+			}`}}}},
+			},
+			{
+				Code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData);
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "MyError", "argumentPosition": 3}}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 5, Column: 5, EndLine: 5, EndColumn: 43, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData, { cause: err });
+			}`}}}},
+			},
+			{
+				Code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData, { cause: wrong });
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "MyError", "argumentPosition": 3}}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 5, Column: 52, EndLine: 5, EndColumn: 57, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData, { cause: err });
+			}`}}}},
+			},
+			{
+				Code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new SimpleError();
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "SimpleError", "argumentPosition": 1}}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 5, Column: 5, EndLine: 5, EndColumn: 29, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new SimpleError({ cause: err });
+			}`}}}},
+			},
+			{
+				Code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError();
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{"MyError"}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 5, Column: 5, EndLine: 5, EndColumn: 25}},
+			},
+			{
+				Code: `
+			try {
+			    doSomething();
+			} catch (err) {
+			    throw new context.Error("failed", someData);
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "Error", "argumentPosition": 3}}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 5, Column: 8, EndLine: 5, EndColumn: 52, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `
+			try {
+			    doSomething();
+			} catch (err) {
+			    throw new context.Error("failed", someData, { cause: err });
+			}`}}}},
+			},
+			{
+				Code: `
+			try {
+			    doSomething();
+			} catch (err) {
+			    throw new Error("failed");
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "Error", "argumentPosition": 3}}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 5, Column: 8, EndLine: 5, EndColumn: 34, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `
+			try {
+			    doSomething();
+			} catch (err) {
+			    throw new Error("failed", { cause: err });
+			}`}}}},
+			},
+			{
+				Code: `import { AggregateError } from "some-module";
+			try {
+				doSomething();
+			} catch (err) {
+				throw new AggregateError();
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AggregateError", "argumentPosition": 1}}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 5, Column: 5, EndLine: 5, EndColumn: 32, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `import { AggregateError } from "some-module";
+			try {
+				doSomething();
+			} catch (err) {
+				throw new AggregateError({ cause: err });
+			}`}}}},
+			},
+			{
+				Code: `import { AggregateError } from "some-module";
+			try {
+				doSomething();
+			} catch (err) {
+				throw new AggregateError({ cause: wrong });
+			}`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "AggregateError", "argumentPosition": 1}}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "incorrectCause", Line: 5, Column: 39, EndLine: 5, EndColumn: 44, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `import { AggregateError } from "some-module";
+			try {
+				doSomething();
+			} catch (err) {
+				throw new AggregateError({ cause: err });
+			}`}}}},
+			},
+			{
+				Code:   `try {} catch (err) { throw new Error; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 38, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new Error("", { cause: err }); }`}}}},
+			},
+			{
+				Code:   `try {} catch (err) { throw new AggregateError; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 47, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new AggregateError([], "", { cause: err }); }`}}}},
+			},
+			{
+				Code:    `try {} catch (err) { throw new CustomError; }`,
+				Options: map[string]interface{}{"errorClassNames": []interface{}{map[string]interface{}{"name": "CustomError", "argumentPosition": 1}}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 44, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new CustomError({ cause: err }); }`}}}},
+			},
+			{
+				Code:   `try {} catch (err) { throw new (Error); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingCause", Line: 1, Column: 22, EndLine: 1, EndColumn: 40, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "includeCause", Output: `try {} catch (err) { throw new (Error)("", { cause: err }); }`}}}},
+			},
+		},
+	)
+}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1410,7 +1410,9 @@ func GetStaticPropertyName(nameNode *ast.Node) (string, bool) {
 	case ast.KindNumericLiteral:
 		return NormalizeNumericLiteral(nameNode.AsNumericLiteral().Text), true
 	case ast.KindComputedPropertyName:
-		expr := nameNode.AsComputedPropertyName().Expression
+		// ESLint's AST has no parenthesized-expression node, so `[('a')]`
+		// names the same static property as `['a']`.
+		expr := ast.SkipParentheses(nameNode.AsComputedPropertyName().Expression)
 		switch expr.Kind {
 		case ast.KindStringLiteral:
 			return expr.AsStringLiteral().Text, true

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -610,6 +610,26 @@ func ToStringSlice(val interface{}) []string {
 	return result
 }
 
+// ToInt converts a weakly-typed JSON number to an int. Rule options reach a
+// rule as float64 when decoded from a JSON/JS config and as int when written
+// as a Go literal in a test, so both shapes have to be accepted. Returns false
+// when the value is not a number.
+func ToInt(val interface{}) (int, bool) {
+	switch n := val.(type) {
+	case int:
+		return n, true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case float32:
+		return int(n), true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}
+
 // NeedsLeadingSpaceForReplacement reports whether inserting `replacement`
 // at `insertPos` in `src` would merge with the preceding character into a
 // single identifier token. Callers use this when synthesizing a fix whose

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -610,26 +610,6 @@ func ToStringSlice(val interface{}) []string {
 	return result
 }
 
-// ToInt converts a weakly-typed JSON number to an int. Rule options reach a
-// rule as float64 when decoded from a JSON/JS config and as int when written
-// as a Go literal in a test, so both shapes have to be accepted. Returns false
-// when the value is not a number.
-func ToInt(val interface{}) (int, bool) {
-	switch n := val.(type) {
-	case int:
-		return n, true
-	case int32:
-		return int(n), true
-	case int64:
-		return int(n), true
-	case float32:
-		return int(n), true
-	case float64:
-		return int(n), true
-	}
-	return 0, false
-}
-
 // NeedsLeadingSpaceForReplacement reports whether inserting `replacement`
 // at `insertPos` in `src` would merge with the preceding character into a
 // single identifier token. Callers use this when synthesizing a fix whose

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -433,6 +433,7 @@ export default defineConfig({
     './tests/eslint/rules/no-regex-spaces.test.ts',
     './tests/eslint/rules/no-redeclare.test.ts',
     './tests/eslint/rules/prefer-regex-literals.test.ts',
+    './tests/eslint/rules/preserve-caught-error.test.ts',
     './tests/eslint/rules/no-new-symbol.test.ts',
     './tests/eslint/rules/no-restricted-globals.test.ts',
     './tests/eslint/rules/no-restricted-imports.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/preserve-caught-error.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/preserve-caught-error.test.ts.snap
@@ -1,0 +1,1612 @@
+// Rstest Snapshot v1
+
+exports[`preserve-caught-error > invalid 1`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (err) {
+            throw new Error("Something failed");
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 2`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (err) {
+            const unrelated = new Error("other");
+            throw new Error("Something failed", { cause: unrelated });
+        }",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 5,
+        },
+        "start": {
+          "column": 58,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 3`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (err) {
+            const unrelated = new Error("other");
+            throw new Error("Something failed", { "cause": unrelated });
+        }",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 5,
+        },
+        "start": {
+          "column": 60,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 4`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (err) {
+            const e = err;
+            throw new Error("Failed", { cause: e });
+        }",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 5,
+        },
+        "start": {
+          "column": 48,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 5`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (error) {
+            throw new Error("Failed", { cause: error.message });
+        }",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 4,
+        },
+        "start": {
+          "column": 48,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 6`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (error) {
+            if (shouldThrow) {
+                while (true) {
+                    if (Math.random() > 0.5) {
+                        throw new Error("Failed without cause");
+                    }
+                }
+            }
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 7,
+        },
+        "start": {
+          "column": 25,
+          "line": 7,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 7`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (error) {
+            switch (error.code) {
+                case "A":
+                    throw new Error("Type A");
+                case "B":
+                    throw new Error("Type B", { cause: error });
+                default:
+                    throw new Error("Other", { cause: error });
+            }
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 6,
+        },
+        "start": {
+          "column": 21,
+          "line": 6,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 8`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (error) {
+            throw new Error(\`The certificate key "\${chalk.yellow(keyFile)}" is invalid.
+\${err.message}\`);
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 9`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (error) {
+            const errorMessage = "Operation failed";
+            throw new Error(errorMessage);
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 5,
+        },
+        "start": {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 10`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (error) {
+            const errorMessage = "Operation failed";
+            throw new Error(errorMessage, { existingOption: true, complexOption: { moreOptions: {} } });
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 105,
+          "line": 5,
+        },
+        "start": {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 11`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (err) {
+            if (err.code === "A") {
+                throw new Error("Type A");
+            }
+            throw new TypeError("Fallback error");
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 5,
+        },
+        "start": {
+          "column": 17,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 7,
+        },
+        "start": {
+          "column": 13,
+          "line": 7,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 12`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (err) {
+            throw Error("Something failed");
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 13`] = `
+{
+  "code": "try {
+        } catch (err) {
+            my_label:
+            throw new Error("Failed without cause");
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 14`] = `
+{
+  "code": "try {
+        } catch (err) {
+            {
+                throw new Error("Something went wrong");
+            }
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 15`] = `
+{
+  "code": "try {
+        } catch (err) {
+            {
+                throw new Error();
+            }
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 16`] = `
+{
+  "code": "try {
+        } catch (err) {
+            {
+                throw new AggregateError([], "Lorem ipsum");
+            }
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 17`] = `
+{
+  "code": "try {
+        } catch (err) {
+            {
+                throw new AggregateError();
+            }
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 18`] = `
+{
+  "code": "try {
+        } catch (err) {
+            {
+                throw new AggregateError([]);
+            }
+        }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 19`] = `
+{
+  "code": "try {
+			doSomething();
+		} catch {
+			throw new Error("Something went wrong");
+		}",
+  "diagnostics": [
+    {
+      "message": "The caught error is not accessible because the catch clause lacks the error parameter. Start referencing the caught error using the catch parameter.",
+      "messageId": "missingCatchErrorParam",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 4,
+        },
+        "start": {
+          "column": 4,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 20`] = `
+{
+  "code": "try {
+            doSomething();
+        } catch (err) {
+            throw new Error("Something failed", { cause });
+        }",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 4,
+        },
+        "start": {
+          "column": 51,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 21`] = `
+{
+  "code": "try {
+				doSomething();
+			} catch ({ message }) {
+				throw new Error(message);
+			}",
+  "diagnostics": [
+    {
+      "message": "Re-throws cannot preserve the caught error as a part of it is being lost due to destructuring.",
+      "messageId": "partiallyLostError",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 22`] = `
+{
+  "code": "try {
+				doSomethingElse();
+			} catch ({ ...error }) {
+				throw new Error(error.message);
+			}",
+  "diagnostics": [
+    {
+      "message": "Re-throws cannot preserve the caught error as a part of it is being lost due to destructuring.",
+      "messageId": "partiallyLostError",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 23`] = `
+{
+  "code": "try {
+				doSomething();
+			} catch (error) {
+				if (whatever) {
+					const error = anotherError;
+					throw new Error("Something went wrong", { cause: error });
+				}
+			}",
+  "diagnostics": [
+    {
+      "message": "The caught error is being attached as \`cause\`, but is shadowed by a closer scoped redeclaration.",
+      "messageId": "caughtErrorShadowed",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 6,
+        },
+        "start": {
+          "column": 6,
+          "line": 6,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 24`] = `
+{
+  "code": "try {
+				doSomething();
+			} catch (error) {
+				throw new Error(
+					"Something went wrong" // some comments
+				);
+			}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 25`] = `
+{
+  "code": "try {
+				doSomething();
+			} catch (err) {
+				throw new Error("Something failed", {});
+			}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 26`] = `
+{
+  "code": "try {
+			doSomething();
+		} catch (error) {
+			const cause = "desc";
+			throw new Error("Something failed", { [cause]: "Some error" });
+		}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 5,
+        },
+        "start": {
+          "column": 4,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 27`] = `
+{
+  "code": "try {
+			doSomething();
+			} catch (error) {
+			throw new Error("Something failed", { cause() { /* do something */ }  });
+			}",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 4,
+        },
+        "start": {
+          "column": 47,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 28`] = `
+{
+  "code": "try {} catch (error) {
+				throw new Error("Something failed", { cause: error, cause: anotherError });
+			}",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 76,
+          "line": 2,
+        },
+        "start": {
+          "column": 64,
+          "line": 2,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 29`] = `
+{
+  "code": "try {} catch (error) {
+				throw new Error("Something failed", { cause: error, "cause": anotherError });
+			}",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 2,
+        },
+        "start": {
+          "column": 66,
+          "line": 2,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 30`] = `
+{
+  "code": "try {} catch (error) {
+				throw new Error("Something failed", { get cause() { } });
+			}",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 2,
+        },
+        "start": {
+          "column": 52,
+          "line": 2,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 31`] = `
+{
+  "code": "try {} catch (error) {
+				throw new Error("Something failed", { set cause(value) { } });
+			}",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 2,
+        },
+        "start": {
+          "column": 52,
+          "line": 2,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 32`] = `
+{
+  "code": "try {} catch (error) {
+				throw new Error("Something failed", {
+					get cause() { return error; },
+					set cause(value) { error = value; },
+				});
+			}",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 4,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 33`] = `
+{
+  "code": "try { doSomething(); } catch (err) { throw new Error(("Something failed")); }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 76,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 34`] = `
+{
+  "code": "try { doSomething(); } catch (err) { throw new Error(("Something failed"),); }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 35`] = `
+{
+  "code": "try { doSomething(); } catch (err) { throw new AggregateError((errors)); }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 36`] = `
+{
+  "code": "try { doSomething(); } catch (err) { throw new AggregateError(errors, ("message")); }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 37`] = `
+{
+  "code": "try { doSomething(); } catch (err) { throw new CustomError((foo)); }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 38`] = `
+{
+  "code": "
+			class CustomApplicationError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomApplicationError("Cause not provided");
+			}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 39`] = `
+{
+  "code": "
+			class APIError extends Error {}
+			try {
+				doSomething();
+			} catch (error) {
+				throw new APIError("API failed", { cause: wrong });
+			}",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 6,
+        },
+        "start": {
+          "column": 47,
+          "line": 6,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 40`] = `
+{
+  "code": "
+			const errors = { AppError: class AppError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new errors.AppError("Something failed");
+			}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 41`] = `
+{
+  "code": "
+			const lib = { APIError: class APIError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new lib.APIError("Something failed", { cause: wrong });
+			}",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 6,
+        },
+        "start": {
+          "column": 57,
+          "line": 6,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 42`] = `
+{
+  "code": "
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData);
+			}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 43`] = `
+{
+  "code": "
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData, { cause: wrong });
+			}",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 5,
+        },
+        "start": {
+          "column": 52,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 44`] = `
+{
+  "code": "
+			try {
+				doSomething();
+			} catch (err) {
+				throw new SimpleError();
+			}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 45`] = `
+{
+  "code": "
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError();
+			}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 46`] = `
+{
+  "code": "
+			try {
+			    doSomething();
+			} catch (err) {
+			    throw new context.Error("failed", someData);
+			}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 5,
+        },
+        "start": {
+          "column": 8,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 47`] = `
+{
+  "code": "
+			try {
+			    doSomething();
+			} catch (err) {
+			    throw new Error("failed");
+			}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 5,
+        },
+        "start": {
+          "column": 8,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 48`] = `
+{
+  "code": "import { AggregateError } from "some-module";
+			try {
+				doSomething();
+			} catch (err) {
+				throw new AggregateError();
+			}",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 49`] = `
+{
+  "code": "import { AggregateError } from "some-module";
+			try {
+				doSomething();
+			} catch (err) {
+				throw new AggregateError({ cause: wrong });
+			}",
+  "diagnostics": [
+    {
+      "message": "The symptom error is being thrown with an incorrect \`cause\`.",
+      "messageId": "incorrectCause",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 5,
+        },
+        "start": {
+          "column": 39,
+          "line": 5,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 50`] = `
+{
+  "code": "try {} catch (err) { throw new Error; }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 51`] = `
+{
+  "code": "try {} catch (err) { throw new AggregateError; }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 52`] = `
+{
+  "code": "try {} catch (err) { throw new CustomError; }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`preserve-caught-error > invalid 53`] = `
+{
+  "code": "try {} catch (err) { throw new (Error); }",
+  "diagnostics": [
+    {
+      "message": "There is no \`cause\` attached to the symptom error being thrown.",
+      "messageId": "missingCause",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "preserve-caught-error",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/preserve-caught-error.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/preserve-caught-error.test.ts
@@ -1,0 +1,350 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('preserve-caught-error', {
+  valid: [
+    {
+      code: 'try {\n        throw new Error("Original error");\n    } catch (error) {\n        throw new Error("Failed to perform error prone operations", { cause: error });\n    }',
+    },
+    {
+      code: 'try {\n\t\tdoSomething();\n\t} catch (error) {\n\t\tthrow new Error("Something failed", { \'cause\': error });\n\t}',
+    },
+    {
+      code: 'try {\n\t\tdoSomething();\n\t} catch (error) {\n\t\tthrow new Error("Something failed", { "cause": error });\n\t}',
+    },
+    {
+      code: 'try {\n\t\tdoSomething();\n\t} catch (error) {\n\t\tthrow new Error("Something failed", { [\'cause\']: error });\n\t}',
+    },
+    {
+      code: 'try {\n\t\tdoSomething();\n\t} catch (error) {\n\t\tthrow new Error("Something failed", { ["cause"]: error });\n\t}',
+    },
+    {
+      code: 'try {\n\t\tdoSomething();\n\t} catch (error) {\n\t\tthrow new Error("Something failed", { [`cause`]: error });\n\t}',
+    },
+    {
+      code: 'try {\n        doSomething();\n    } catch (e) {\n        console.error(e);\n    }',
+    },
+    {
+      code: 'try {\n        doSomething();\n    } catch (err) {\n        throw new Error("Failed", { cause: err, extra: 42 });\n    }',
+    },
+    {
+      code: 'try {\n        doSomething();\n    } catch (error) {\n        switch (error.code) {\n            case "A":\n                throw new Error("Type A", { cause: error });\n            case "B":\n                throw new Error("Type B", { cause: error });\n            default:\n                throw new Error("Other", { cause: error });\n        }\n    }',
+    },
+    {
+      code: 'try {\n\t\t// ...\n\t} catch (err) {\n\t\tconst opts = { cause: err }\n\t\tthrow new Error("msg", { ...opts });\n\t}\n\t',
+    },
+    {
+      code: 'try {\n\t} catch (error) {\n\t\tfoo = {\n\t\t\tbar() {\n\t\t\t\tthrow new Error();\n\t\t\t}\n\t\t};\n\t}',
+    },
+    {
+      code: 'try {\n\t\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\t\tconst args = [];\n\t\t\t\tthrow new Error(...args);\n\t\t}',
+    },
+    {
+      code: 'import { Error } from "./my-custom-error.js";\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\t\tthrow Error("Failed to perform error prone operations");\n\t\t\t}',
+    },
+    {
+      code: 'try {\n\t\tdoSomething();\n\t} catch {\n\t\tthrow new Error("Something went wrong");\n\t}',
+      options: { requireCatchParameter: false },
+    },
+    {
+      code: 'try {\n\t\t\tdoSomething();\n\t\t} catch (error) {\n\t\t\tthrow new Error("Something failed", { cause: anotherError, cause: error });\n\t\t}',
+    },
+    {
+      code: 'try {\n\t\t\tdoSomething();\n\t\t} catch (error) {\n\t\t\tthrow new Error("Something failed", { "cause": anotherError, "cause": error });\n\t\t}',
+    },
+    {
+      code: 'try {\n\t\t\tdoSomething();\n\t\t} catch (error) {\n\t\t\tthrow new Error("Something failed", { cause: anotherError, "cause": error });\n\t\t}',
+    },
+    {
+      code: '\n\t\t\tconst errors = { AppError: class AppError extends Error {} };\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\t\tthrow new errors.AppError("Something failed", { cause: error });\n\t\t\t}',
+      options: { errorClassNames: ['AppError'] },
+    },
+    {
+      code: '\n\t\t\tconst lib = { APIError: class APIError extends Error {} };\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\t\tthrow new lib.APIError("Something failed", { cause: error });\n\t\t\t}',
+      options: { errorClassNames: ['APIError'] },
+    },
+    {
+      code: '\n\t\t\tclass CustomApplicationError extends Error {}\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new CustomApplicationError("Cause not provided", { cause: err });\n\t\t\t}',
+      options: { errorClassNames: ['CustomApplicationError'] },
+    },
+    {
+      code: '\n\t\t\tclass APIError extends Error {}\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\t\tthrow new APIError("API failed", { cause: error });\n\t\t\t}',
+      options: { errorClassNames: ['APIError'] },
+    },
+    {
+      code: '\n\t\t\tclass CustomError extends Error {}\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new CustomError("No cause");\n\t\t\t}',
+      options: { errorClassNames: [] },
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new MyError("failed", someData, { cause: err });\n\t\t\t}',
+      options: { errorClassNames: [{ name: 'MyError', argumentPosition: 3 }] },
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new SimpleError({ cause: err });\n\t\t\t}',
+      options: {
+        errorClassNames: [{ name: 'SimpleError', argumentPosition: 1 }],
+      },
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new AppError("Message", {}, { cause: err });\n\t\t\t}',
+      options: {
+        errorClassNames: [
+          { name: 'AppError', argumentPosition: 2 },
+          { name: 'AppError', argumentPosition: 3 },
+        ],
+      },
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t    doSomething();\n\t\t\t} catch (err) {\n\t\t\t    throw new context.Error("failed", someData, { cause: err });\n\t\t\t}',
+      options: { errorClassNames: [{ name: 'Error', argumentPosition: 3 }] },
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t    doSomething();\n\t\t\t} catch (err) {\n\t\t\t    throw new Error("failed", { cause: err });\n\t\t\t}',
+      options: { errorClassNames: [{ name: 'Error', argumentPosition: 3 }] },
+    },
+    {
+      code: 'import { AggregateError } from "some-module";\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new AggregateError({ cause: err });\n\t\t\t}',
+      options: {
+        errorClassNames: [{ name: 'AggregateError', argumentPosition: 1 }],
+      },
+    },
+  ],
+  invalid: [
+    {
+      code: 'try {\n            doSomething();\n        } catch (err) {\n            throw new Error("Something failed");\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (err) {\n            const unrelated = new Error("other");\n            throw new Error("Something failed", { cause: unrelated });\n        }',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (err) {\n            const unrelated = new Error("other");\n            throw new Error("Something failed", { "cause": unrelated });\n        }',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (err) {\n            const e = err;\n            throw new Error("Failed", { cause: e });\n        }',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (error) {\n            throw new Error("Failed", { cause: error.message });\n        }',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (error) {\n            if (shouldThrow) {\n                while (true) {\n                    if (Math.random() > 0.5) {\n                        throw new Error("Failed without cause");\n                    }\n                }\n            }\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (error) {\n            switch (error.code) {\n                case "A":\n                    throw new Error("Type A");\n                case "B":\n                    throw new Error("Type B", { cause: error });\n                default:\n                    throw new Error("Other", { cause: error });\n            }\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (error) {\n            throw new Error(`The certificate key "${chalk.yellow(keyFile)}" is invalid.\n${err.message}`);\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (error) {\n            const errorMessage = "Operation failed";\n            throw new Error(errorMessage);\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (error) {\n            const errorMessage = "Operation failed";\n            throw new Error(errorMessage, { existingOption: true, complexOption: { moreOptions: {} } });\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (err) {\n            if (err.code === "A") {\n                throw new Error("Type A");\n            }\n            throw new TypeError("Fallback error");\n        }',
+      errors: [{ messageId: 'missingCause' }, { messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (err) {\n            throw Error("Something failed");\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n        } catch (err) {\n            my_label:\n            throw new Error("Failed without cause");\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n        } catch (err) {\n            {\n                throw new Error("Something went wrong");\n            }\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n        } catch (err) {\n            {\n                throw new Error();\n            }\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n        } catch (err) {\n            {\n                throw new AggregateError([], "Lorem ipsum");\n            }\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n        } catch (err) {\n            {\n                throw new AggregateError();\n            }\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n        } catch (err) {\n            {\n                throw new AggregateError([]);\n            }\n        }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n\t\t\tdoSomething();\n\t\t} catch {\n\t\t\tthrow new Error("Something went wrong");\n\t\t}',
+      options: { requireCatchParameter: true },
+      errors: [{ messageId: 'missingCatchErrorParam' }],
+    },
+    {
+      code: 'try {\n            doSomething();\n        } catch (err) {\n            throw new Error("Something failed", { cause });\n        }',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {\n\t\t\t\tdoSomething();\n\t\t\t} catch ({ message }) {\n\t\t\t\tthrow new Error(message);\n\t\t\t}',
+      errors: [{ messageId: 'partiallyLostError' }],
+    },
+    {
+      code: 'try {\n\t\t\t\tdoSomethingElse();\n\t\t\t} catch ({ ...error }) {\n\t\t\t\tthrow new Error(error.message);\n\t\t\t}',
+      errors: [{ messageId: 'partiallyLostError' }],
+    },
+    {
+      code: 'try {\n\t\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\t\tif (whatever) {\n\t\t\t\t\tconst error = anotherError;\n\t\t\t\t\tthrow new Error("Something went wrong", { cause: error });\n\t\t\t\t}\n\t\t\t}',
+      errors: [{ messageId: 'caughtErrorShadowed' }],
+    },
+    {
+      code: 'try {\n\t\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\t\tthrow new Error(\n\t\t\t\t\t"Something went wrong" // some comments\n\t\t\t\t);\n\t\t\t}',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new Error("Something failed", {});\n\t\t\t}',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n\t\t\tdoSomething();\n\t\t} catch (error) {\n\t\t\tconst cause = "desc";\n\t\t\tthrow new Error("Something failed", { [cause]: "Some error" });\n\t\t}',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {\n\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\tthrow new Error("Something failed", { cause() { /* do something */ }  });\n\t\t\t}',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {} catch (error) {\n\t\t\t\tthrow new Error("Something failed", { cause: error, cause: anotherError });\n\t\t\t}',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {} catch (error) {\n\t\t\t\tthrow new Error("Something failed", { cause: error, "cause": anotherError });\n\t\t\t}',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {} catch (error) {\n\t\t\t\tthrow new Error("Something failed", { get cause() { } });\n\t\t\t}',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {} catch (error) {\n\t\t\t\tthrow new Error("Something failed", { set cause(value) { } });\n\t\t\t}',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {} catch (error) {\n\t\t\t\tthrow new Error("Something failed", {\n\t\t\t\t\tget cause() { return error; },\n\t\t\t\t\tset cause(value) { error = value; },\n\t\t\t\t});\n\t\t\t}',
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try { doSomething(); } catch (err) { throw new Error(("Something failed")); }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try { doSomething(); } catch (err) { throw new Error(("Something failed"),); }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try { doSomething(); } catch (err) { throw new AggregateError((errors)); }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try { doSomething(); } catch (err) { throw new AggregateError(errors, ("message")); }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try { doSomething(); } catch (err) { throw new CustomError((foo)); }',
+      options: { errorClassNames: ['CustomError'] },
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: '\n\t\t\tclass CustomApplicationError extends Error {}\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new CustomApplicationError("Cause not provided");\n\t\t\t}',
+      options: { errorClassNames: ['CustomApplicationError'] },
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: '\n\t\t\tclass APIError extends Error {}\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\t\tthrow new APIError("API failed", { cause: wrong });\n\t\t\t}',
+      options: { errorClassNames: ['APIError'] },
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: '\n\t\t\tconst errors = { AppError: class AppError extends Error {} };\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\t\tthrow new errors.AppError("Something failed");\n\t\t\t}',
+      options: { errorClassNames: ['AppError'] },
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: '\n\t\t\tconst lib = { APIError: class APIError extends Error {} };\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (error) {\n\t\t\t\tthrow new lib.APIError("Something failed", { cause: wrong });\n\t\t\t}',
+      options: { errorClassNames: ['APIError'] },
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new MyError("failed", someData);\n\t\t\t}',
+      options: { errorClassNames: [{ name: 'MyError', argumentPosition: 3 }] },
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new MyError("failed", someData, { cause: wrong });\n\t\t\t}',
+      options: { errorClassNames: [{ name: 'MyError', argumentPosition: 3 }] },
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new SimpleError();\n\t\t\t}',
+      options: {
+        errorClassNames: [{ name: 'SimpleError', argumentPosition: 1 }],
+      },
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new MyError();\n\t\t\t}',
+      options: { errorClassNames: ['MyError'] },
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t    doSomething();\n\t\t\t} catch (err) {\n\t\t\t    throw new context.Error("failed", someData);\n\t\t\t}',
+      options: { errorClassNames: [{ name: 'Error', argumentPosition: 3 }] },
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: '\n\t\t\ttry {\n\t\t\t    doSomething();\n\t\t\t} catch (err) {\n\t\t\t    throw new Error("failed");\n\t\t\t}',
+      options: { errorClassNames: [{ name: 'Error', argumentPosition: 3 }] },
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'import { AggregateError } from "some-module";\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new AggregateError();\n\t\t\t}',
+      options: {
+        errorClassNames: [{ name: 'AggregateError', argumentPosition: 1 }],
+      },
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'import { AggregateError } from "some-module";\n\t\t\ttry {\n\t\t\t\tdoSomething();\n\t\t\t} catch (err) {\n\t\t\t\tthrow new AggregateError({ cause: wrong });\n\t\t\t}',
+      options: {
+        errorClassNames: [{ name: 'AggregateError', argumentPosition: 1 }],
+      },
+      errors: [{ messageId: 'incorrectCause' }],
+    },
+    {
+      code: 'try {} catch (err) { throw new Error; }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {} catch (err) { throw new AggregateError; }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {} catch (err) { throw new CustomError; }',
+      options: {
+        errorClassNames: [{ name: 'CustomError', argumentPosition: 1 }],
+      },
+      errors: [{ messageId: 'missingCause' }],
+    },
+    {
+      code: 'try {} catch (err) { throw new (Error); }',
+      errors: [{ messageId: 'missingCause' }],
+    },
+  ],
+});

--- a/packages/rslint/src/config/presets/javascript.ts
+++ b/packages/rslint/src/config/presets/javascript.ts
@@ -47,7 +47,7 @@ const recommended: RslintConfigEntry = {
     'no-useless-catch': 'error',
     'no-useless-escape': 'error',
     'no-with': 'error',
-    // 'preserve-caught-error': 'error', // not implemented
+    'preserve-caught-error': 'error',
     'require-yield': 'error',
     'use-isnan': 'error',
     'valid-typeof': 'error',

--- a/packages/rslint/src/config/presets/typescript.ts
+++ b/packages/rslint/src/config/presets/typescript.ts
@@ -75,7 +75,7 @@ const recommended: RslintConfigEntry = {
     'no-useless-backreference': 'error',
     'no-useless-catch': 'error',
     'no-useless-escape': 'error',
-    // 'preserve-caught-error': 'error', // not implemented
+    'preserve-caught-error': 'error',
     'require-yield': 'error',
     'use-isnan': 'error',
     'valid-typeof': 'error',

--- a/packages/vscode-extension/src/main.ts
+++ b/packages/vscode-extension/src/main.ts
@@ -20,6 +20,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
       throw new AggregateError(
         [activationError, closeError],
         'Rslint activation and partial-start cleanup both failed',
+        { cause: activationError },
       );
     }
     throw activationError;


### PR DESCRIPTION
## Summary

Port the `preserve-caught-error` rule from ESLint to rslint.

The rule requires errors constructed and thrown inside a `catch` block to carry the caught error as their `cause`, and reports a `cause` set to anything else. It covers the global error constructors, plus custom classes listed in `errorClassNames`, and offers a suggestion that attaches the caught error.

Enabled in the `javascript` and `typescript` recommended presets (upstream marks it `recommended`). Dogfooding surfaced one violation in `packages/vscode-extension/src/main.ts`, fixed in this PR.

`utils.ToInt` is extracted from `max_lines_per_function` so both rules share one JSON-number coercion helper.

### Differences from ESLint

- A parenthesized computed `cause` key — `{ [('cause')]: error }` — is reported as a missing `cause`; every other spelling of the key is accepted by both.
- For a constructor with type arguments and no argument list — `new AppError<T>;` — the suggestion inserts the arguments after the type arguments rather than before them.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/preserve-caught-error
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/preserve-caught-error.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
