### PR TITLE
feat(unicorn): port rule prefer-node-protocol

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_node_protocol"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_number_properties"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_array_join_separator"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument"
@@ -25,6 +26,7 @@ func GetAllRules() []rule.Rule {
 		no_useless_switch_case.NoUselessSwitchCaseRule,
 		prefer_array_flat.PreferArrayFlatRule,
 		prefer_array_flat_map.PreferArrayFlatMapRule,
+		prefer_node_protocol.PreferNodeProtocolRule,
 		prefer_number_properties.PreferNumberPropertiesRule,
 		require_array_join_separator.RequireArrayJoinSeparatorRule,
 		require_number_to_fixed_digits_argument.RequireNumberToFixedDigitsArgumentRule,

--- a/internal/plugins/unicorn/rules/prefer_node_protocol/builtin_modules.go
+++ b/internal/plugins/unicorn/rules/prefer_node_protocol/builtin_modules.go
@@ -1,0 +1,72 @@
+package prefer_node_protocol
+
+// builtinModuleNames is the set of Node.js builtin module names that have a
+// `node:`-prefixed form, mirroring the `is-builtin-module` package that
+// eslint-plugin-unicorn's prefer-node-protocol depends on. Upstream
+// deliberately uses this static list (from `builtin-modules`) instead of Node's
+// runtime `module.isBuiltin` so the result is stable across Node.js versions.
+//
+// Derived from builtin-modules@5.3.0 (builtin-modules.json), the version
+// resolved by is-builtin-module@5's `builtin-modules: "^5.0.0"` dependency
+// range. The rule only ever inspects specifiers WITHOUT the `node:` prefix and
+// rewrites them to `node:<name>`, so this set keeps only the bare names that
+// have a valid `node:` counterpart. Names that exist solely under the `node:`
+// prefix (e.g. `test`, `sqlite`, `sea`, `quic`, `ffi`, `vfs`) are intentionally
+// absent: bare `import "test"` must not be flagged because bare `test` is not a
+// builtin module.
+var builtinModuleNames = map[string]bool{
+	"assert":              true,
+	"assert/strict":       true,
+	"async_hooks":         true,
+	"buffer":              true,
+	"child_process":       true,
+	"cluster":             true,
+	"console":             true,
+	"constants":           true,
+	"crypto":              true,
+	"dgram":               true,
+	"diagnostics_channel": true,
+	"dns":                 true,
+	"dns/promises":        true,
+	"domain":              true,
+	"events":              true,
+	"fs":                  true,
+	"fs/promises":         true,
+	"http":                true,
+	"http2":               true,
+	"https":               true,
+	"inspector":           true,
+	"inspector/promises":  true,
+	"module":              true,
+	"net":                 true,
+	"os":                  true,
+	"path":                true,
+	"path/posix":          true,
+	"path/win32":          true,
+	"perf_hooks":          true,
+	"process":             true,
+	"querystring":         true,
+	"readline":            true,
+	"readline/promises":   true,
+	"repl":                true,
+	"stream":              true,
+	"stream/consumers":    true,
+	"stream/iter":         true,
+	"stream/promises":     true,
+	"stream/web":          true,
+	"string_decoder":      true,
+	"timers":              true,
+	"timers/promises":     true,
+	"tls":                 true,
+	"trace_events":        true,
+	"tty":                 true,
+	"url":                 true,
+	"util":                true,
+	"util/types":          true,
+	"v8":                  true,
+	"vm":                  true,
+	"wasi":                true,
+	"worker_threads":      true,
+	"zlib":                true,
+	"zlib/iter":           true,
+}

--- a/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol.go
+++ b/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol.go
@@ -1,0 +1,170 @@
+// Package prefer_node_protocol ports eslint-plugin-unicorn's
+// `prefer-node-protocol` rule.
+//
+// It flags a Node.js builtin-module specifier written without the `node:`
+// protocol prefix — in `import`/`export` sources, dynamic `import()`,
+// `require()`, `process.getBuiltinModule()`, and TypeScript `import(...)` type
+// nodes — and autofixes it by inserting `node:` after the opening quote.
+package prefer_node_protocol
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const messageID = "prefer-node-protocol"
+
+// nodeProtocol is the prefix upstream inserts and tests against.
+const nodeProtocol = "node:"
+
+func message(moduleName string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageID,
+		Description: "Prefer `" + nodeProtocol + moduleName + "` over `" + moduleName + "`.",
+		Data:        map[string]string{"moduleName": moduleName},
+	}
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-node-protocol.md
+var PreferNodeProtocolRule = rule.Rule{
+	Name:   "unicorn/prefer-node-protocol",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		// check inspects a string-literal module specifier and reports + fixes
+		// it when it names a Node.js builtin missing the `node:` prefix.
+		//
+		// tsgo divergence: ESTree flattens parentheses, so a parenthesized call
+		// argument (`require(("fs"))`, `import(("fs"))`) presents its inner string
+		// Literal directly to upstream's listener. tsgo keeps the
+		// ParenthesizedExpression, so skip it to match the ESTree view.
+		check := func(specifier *ast.Node) {
+			if specifier == nil {
+				return
+			}
+			specifier = ast.SkipParentheses(specifier)
+			if specifier == nil || !ast.IsStringLiteral(specifier) {
+				return
+			}
+			value := specifier.AsStringLiteral().Text
+			if !shouldPrefix(value) {
+				return
+			}
+
+			// Mirror upstream's `sourceCode.getRange(node)[0] + 1` (after the
+			// opening quote). TrimNodeTextRange skips leading trivia so a
+			// preceding comment (e.g. `import(/* c */"fs")`) doesn't shift the
+			// insert position onto the comment.
+			insertPosition := utils.TrimNodeTextRange(ctx.SourceFile, specifier).Pos() + 1
+			ctx.ReportNodeWithDeferredFixes(specifier, message(value), func() []rule.RuleFix {
+				return []rule.RuleFix{
+					rule.RuleFixReplaceRange(core.NewTextRange(insertPosition, insertPosition), nodeProtocol),
+				}
+			})
+		}
+
+		checkModuleSpecifier := func(node *ast.Node) {
+			check(node.ModuleSpecifier())
+		}
+
+		// tsgo divergence: ESTree fires the rule's single `Literal` listener and
+		// branches on `node.parent.type` (ImportDeclaration / ImportExpression /
+		// require call / getBuiltinModule call / TSImportType). tsgo has no
+		// `Literal` kind and represents each of these positions with a distinct
+		// node kind, so the ESTree branch table becomes one listener per kind.
+		// The CallExpression listener folds together dynamic `import()`,
+		// `require()`, and `process.getBuiltinModule()`.
+		checkCall := func(node *ast.Node) {
+			call := node.AsCallExpression()
+
+			// Dynamic `import("fs")` — tsgo models the ESTree ImportExpression as
+			// a CallExpression whose callee is the `import` keyword.
+			if call.Expression.Kind == ast.KindImportKeyword {
+				check(firstArgument(call))
+				return
+			}
+
+			// `require("fs")` — isStaticRequire: bare `require` identifier callee,
+			// exactly one string-literal argument, non-optional call.
+			if isStaticRequire(node) {
+				check(firstArgument(call))
+				return
+			}
+
+			// `process.getBuiltinModule("fs")` — non-optional dot call on the
+			// `process` identifier, exactly one argument. Parentheses around the
+			// object are transparent in ESTree, so skip them before the name check.
+			argumentsLength := 1
+			if match, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+				Method:          "getBuiltinModule",
+				ArgumentsLength: &argumentsLength,
+			}); ok {
+				object := ast.SkipParentheses(match.Object)
+				if object != nil && object.Kind == ast.KindIdentifier &&
+					object.AsIdentifier().Text == "process" {
+					check(firstArgument(call))
+				}
+			}
+		}
+
+		// TypeScript `import("fs")` type node. tsgo nests the specifier as a
+		// LiteralType (`ImportTypeNode.Argument` → `LiteralTypeNode.Literal`),
+		// unlike ESTree where the string Literal is a direct child of TSImportType.
+		checkImportType := func(node *ast.Node) {
+			argument := node.AsImportTypeNode().Argument
+			if argument == nil || argument.Kind != ast.KindLiteralType {
+				return
+			}
+			check(argument.AsLiteralTypeNode().Literal)
+		}
+
+		return rule.RuleListeners{
+			ast.KindImportDeclaration:   checkModuleSpecifier,
+			ast.KindJSImportDeclaration: checkModuleSpecifier,
+			ast.KindExportDeclaration:   checkModuleSpecifier,
+			ast.KindCallExpression:      checkCall,
+			ast.KindImportType:          checkImportType,
+		}
+	},
+}
+
+// shouldPrefix mirrors upstream's value gate: a string that lacks the `node:`
+// prefix and whose bare name is a Node.js builtin module with a valid `node:`
+// counterpart. builtinModuleNames already encodes "has a valid node: form", so
+// a single lookup suffices — e.g. bare `test` is absent (only `node:test`
+// exists) and is therefore left alone.
+func shouldPrefix(value string) bool {
+	return !strings.HasPrefix(value, nodeProtocol) && builtinModuleNames[value]
+}
+
+// isStaticRequire mirrors upstream's `isStaticRequire`: a non-optional call to a
+// bare `require` identifier with exactly one string-literal argument.
+func isStaticRequire(node *ast.Node) bool {
+	if !ast.IsCallExpression(node) || ast.IsOptionalChainRoot(node) {
+		return false
+	}
+	call := node.AsCallExpression()
+	if call.Expression.Kind != ast.KindIdentifier ||
+		call.Expression.AsIdentifier().Text != "require" {
+		return false
+	}
+	args := call.Arguments
+	if args == nil || len(args.Nodes) != 1 {
+		return false
+	}
+	// Parentheses are transparent in ESTree, so `require(("fs"))` still counts
+	// as a static string-literal argument.
+	return ast.IsStringLiteral(ast.SkipParentheses(args.Nodes[0]))
+}
+
+// firstArgument returns the sole/first call argument, or nil when absent.
+func firstArgument(call *ast.CallExpression) *ast.Node {
+	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+		return nil
+	}
+	return call.Arguments.Nodes[0]
+}

--- a/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol.go
+++ b/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol.go
@@ -148,8 +148,12 @@ func isStaticRequire(node *ast.Node) bool {
 		return false
 	}
 	call := node.AsCallExpression()
-	if call.Expression.Kind != ast.KindIdentifier ||
-		call.Expression.AsIdentifier().Text != "require" {
+	// Parentheses are transparent in ESTree, so `(require)("fs")` presents a
+	// bare `require` identifier callee to upstream. tsgo keeps the
+	// ParenthesizedExpression, so skip it before the name check.
+	callee := ast.SkipParentheses(call.Expression)
+	if callee == nil || callee.Kind != ast.KindIdentifier ||
+		callee.AsIdentifier().Text != "require" {
 		return false
 	}
 	args := call.Arguments

--- a/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol.md
+++ b/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol.md
@@ -1,0 +1,54 @@
+# prefer-node-protocol
+
+## Rule Details
+
+Enforces the use of the `node:` protocol when importing Node.js builtin modules.
+The `node:` protocol makes it explicit that a module is a Node.js builtin and
+disambiguates it from a same-named package on disk.
+
+The rule checks module specifiers in `import`/`export` statements, dynamic
+`import()`, `require()`, `process.getBuiltinModule()`, and TypeScript `import(...)`
+type nodes. It reports a builtin module referenced without the `node:` prefix and
+autofixes it by inserting `node:` before the module name.
+
+A specifier is only flagged when both its bare name and its `node:`-prefixed name
+are Node.js builtin modules. Names that exist only under one form are left alone
+(e.g. `test` is untouched because only `node:test` is a builtin, and `punycode`
+is untouched because it is no longer a builtin under either form).
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+import fs from 'fs';
+export { promises } from 'fs';
+const fs = require('fs/promises');
+const fs = process.getBuiltinModule('fs');
+```
+
+```typescript
+type fs = import('fs');
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+import fs from 'node:fs';
+const fs = require('node:fs/promises');
+
+// Not a Node.js builtin module.
+import fs from 'unknown-builtin-module';
+
+// Only `node:test` is a builtin, bare `test` is not.
+import 'test';
+
+// No longer a builtin under either form.
+import 'punycode';
+```
+
+```typescript
+type fs = import('node:fs');
+```
+
+## Original Documentation
+
+[eslint-plugin-unicorn/prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md)

--- a/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol_extras_test.go
@@ -87,6 +87,22 @@ func TestPreferNodeProtocolExtras(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 21}},
 			},
 
+			// ---- Branch lock-in: parenthesized require callee ----
+			// ESTree flattens parentheses, so `(require)("fs")` presents a bare
+			// `require` identifier callee to upstream. tsgo keeps the
+			// ParenthesizedExpression, so isStaticRequire applies SkipParentheses
+			// to the callee to stay 1:1.
+			{
+				Code:   `const fs = (require)("fs")`,
+				Output: []string{`const fs = (require)("node:fs")`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 22}},
+			},
+			{
+				Code:   `const fs = ((require))("fs")`,
+				Output: []string{`const fs = ((require))("node:fs")`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 24}},
+			},
+
 			// ---- Branch lock-in: direct (unparenthesized) process.getBuiltinModule ----
 			{
 				Code:   `const fs = process.getBuiltinModule("buffer")`,

--- a/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol_extras_test.go
@@ -1,0 +1,267 @@
+package prefer_node_protocol_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_node_protocol"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// TestPreferNodeProtocolExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+func TestPreferNodeProtocolExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_node_protocol.PreferNodeProtocolRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: template-literal specifiers are not string literals ----
+			// tsgo splits ESTree's `Literal` into StringLiteral vs
+			// NoSubstitutionTemplateLiteral; the rule matches only the former.
+			{Code: "const fs = require(`fs`);"},
+			{Code: "async function foo() {\n\treturn import(`fs`);\n}"},
+
+			// ---- Dimension 4: optional-chain require / getBuiltinModule are excluded ----
+			{Code: `const fs = require?.("fs");`},
+			{Code: `const fs = process.getBuiltinModule?.("fs");`},
+			{Code: `const fs = process?.getBuiltinModule("fs");`},
+
+			// ---- Dimension 4: computed / non-`process` receiver for getBuiltinModule ----
+			{Code: `const fs = process["getBuiltinModule"]("fs");`},
+			{Code: `const fs = notProcess.getBuiltinModule("fs");`},
+
+			// ---- Dimension 4: already-prefixed and non-builtin specifiers ----
+			{Code: `import fs from "node:fs/promises";`},
+			{Code: `const fs = require("node:fs");`},
+			{Code: `type fs = import("node:fs");`},
+			{Code: `type fs = import("./local");`},
+
+			// ---- Asymmetric builtin-modules list entries (node:-only, no bare form) ----
+			// These names exist only under the `node:` prefix in builtin-modules,
+			// so the dual membership check keeps the bare form unflagged.
+			{Code: `import "sea";`},
+			{Code: `import "sqlite";`},
+			{Code: `import "quic";`},
+			{Code: `import "test";`},
+
+			// ---- Dimension 4: dynamic import with non-literal / no argument ----
+			{Code: "async function foo() {\n\treturn import(name);\n}"},
+			{Code: "async function foo() {\n\treturn import();\n}"},
+
+			// ---- Real-user: type-position import in a generic argument stays untouched when non-builtin ----
+			{Code: `type T = import("./types").Foo<import("./other").Bar>;`},
+
+			// ---- Real-user: export * / export named from a non-builtin path ----
+			{Code: `export * from "./barrel";`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Branch lock-in: parenthesized `process` receiver for getBuiltinModule ----
+			// ESTree flattens parentheses, so `(process).getBuiltinModule("fs")`
+			// presents a bare `process` identifier object to upstream. tsgo keeps
+			// the ParenthesizedExpression, so the rule applies SkipParentheses to
+			// the object to stay 1:1.
+			{
+				Code:   `const fs = (process).getBuiltinModule("buffer")`,
+				Output: []string{`const fs = (process).getBuiltinModule("node:buffer")`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 39}},
+			},
+
+			// ---- Branch lock-in: parenthesized string argument to require ----
+			// ESTree flattens the paren, so `require(("fs"))` is still a static
+			// string-literal argument.
+			{
+				Code:   `const fs = require(("fs"))`,
+				Output: []string{`const fs = require(("node:fs"))`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 21}},
+			},
+
+			// ---- Branch lock-in: direct (unparenthesized) process.getBuiltinModule ----
+			{
+				Code:   `const fs = process.getBuiltinModule("buffer")`,
+				Output: []string{`const fs = process.getBuiltinModule("node:buffer")`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 37}},
+			},
+
+			// ---- Dimension 4: single-quote fix preserves the original quote ----
+			{
+				Code:   `import fs from 'fs';`,
+				Output: []string{`import fs from 'node:fs';`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 16}},
+			},
+
+			// ---- Locks in JSImportDeclaration (JS-flavored import) parity with ImportDeclaration ----
+			{
+				Code:     `import fs from "fs";`,
+				FileName: "js-import.js",
+				Output:   []string{`import fs from "node:fs";`},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 16}},
+			},
+
+			// ---- Real-user: subpath builtin (`fs/promises`) via require ----
+			{
+				Code:   `const {readFile} = require("fs/promises");`,
+				Output: []string{`const {readFile} = require("node:fs/promises");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 28}},
+			},
+
+			// ---- Real-user: multi-line import statement position ----
+			{
+				Code:   "import {\n\treadFile,\n} from \"fs/promises\";",
+				Output: []string{"import {\n\treadFile,\n} from \"node:fs/promises\";"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 3, Column: 8}},
+			},
+
+			// ---- Locks in the message text (data interpolation of moduleName) ----
+			{
+				Code:   `import "child_process";`,
+				Output: []string{`import "node:child_process";`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "prefer-node-protocol",
+					Message:   "Prefer `node:child_process` over `child_process`.",
+					Line:      1, Column: 8,
+				}},
+			},
+		},
+	)
+}
+
+// TestPreferNodeProtocolEditDemand verifies the deferred fix builder runs only
+// under a matching edit demand and never changes the diagnostic identity. The
+// rule emits an autofix and no suggestions.
+func TestPreferNodeProtocolEditDemand(t *testing.T) {
+	t.Parallel()
+
+	const fileName = "edit-demand.ts"
+	const code = `import fs from "fs";`
+	const fixOutput = `import fs from "node:fs";`
+
+	program, sourceFile := createPreferNodeProtocolProgram(t, fileName, code)
+	diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		got := lintPreferNodeProtocolWithDemand(program, sourceFile, demand)
+		if len(got) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(got))
+		}
+		diagnostics[demand] = got[0]
+	}
+
+	// Diagnostic identity (message + range) must be stable across demands.
+	base := diagnostics[rule.EditDemandNone]
+	for demand, diagnostic := range diagnostics {
+		requireSamePreferNodeProtocolDiagnostic(t, base, diagnostic, demand)
+	}
+
+	// None and suggestion-only demands materialize no autofixes.
+	if diagnostics[rule.EditDemandNone].FixesPtr != nil {
+		t.Errorf("none demand unexpectedly materialized fixes")
+	}
+	if diagnostics[rule.EditDemandSuggestion].FixesPtr != nil {
+		t.Errorf("suggestion-only demand unexpectedly materialized fixes")
+	}
+	// The rule never emits suggestions.
+	for demand, diagnostic := range diagnostics {
+		if diagnostic.Suggestions != nil {
+			t.Errorf("demand %d unexpectedly materialized suggestions", demand)
+		}
+	}
+
+	autofixOnly := diagnostics[rule.EditDemandAutofix].FixesPtr
+	allFixes := diagnostics[rule.EditDemandAll].FixesPtr
+	if autofixOnly == nil || allFixes == nil || !reflect.DeepEqual(*autofixOnly, *allFixes) {
+		t.Fatalf("autofix artifacts differ between autofix-only and all demand")
+	}
+	if applyPreferNodeProtocolFixes(code, *autofixOnly) != fixOutput {
+		t.Fatalf("autofix output = %q, want %q", applyPreferNodeProtocolFixes(code, *autofixOnly), fixOutput)
+	}
+}
+
+func lintPreferNodeProtocolWithDemand(
+	program *compiler.Program,
+	sourceFile *ast.SourceFile,
+	demand rule.EditDemand,
+) []rule.RuleDiagnostic {
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:     program,
+		File:        sourceFile.FileName(),
+		HasTypeInfo: true,
+		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:     prefer_node_protocol.PreferNodeProtocolRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return prefer_node_protocol.PreferNodeProtocolRule.Run(ctx, nil)
+				},
+			}}
+		},
+		ExcludePaths: []string{},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	return diagnostics
+}
+
+func requireSamePreferNodeProtocolDiagnostic(t *testing.T, want, got rule.RuleDiagnostic, demand rule.EditDemand) {
+	t.Helper()
+	want.FixesPtr = nil
+	want.Suggestions = nil
+	got.FixesPtr = nil
+	got.Suggestions = nil
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("demand %d changed diagnostic metadata:\ngot:  %#v\nwant: %#v", demand, got, want)
+	}
+}
+
+func createPreferNodeProtocolProgram(t testing.TB, fileName, code string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+	rootDir := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return program, sourceFile
+}
+
+// applyPreferNodeProtocolFixes applies non-overlapping RuleFix edits to code, in
+// descending range order so earlier offsets stay valid.
+func applyPreferNodeProtocolFixes(code string, fixes []rule.RuleFix) string {
+	sorted := make([]rule.RuleFix, len(fixes))
+	copy(sorted, fixes)
+	for i := 1; i < len(sorted); i++ {
+		for j := i; j > 0 && sorted[j-1].Range.Pos() < sorted[j].Range.Pos(); j-- {
+			sorted[j-1], sorted[j] = sorted[j], sorted[j-1]
+		}
+	}
+	result := code
+	for _, fix := range sorted {
+		result = result[:fix.Range.Pos()] + fix.Text + result[fix.Range.End():]
+	}
+	return result
+}

--- a/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_node_protocol/prefer_node_protocol_upstream_test.go
@@ -1,0 +1,203 @@
+package prefer_node_protocol_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_node_protocol"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestPreferNodeProtocolUpstream migrates the full valid/invalid suite from
+// upstream test/prefer-node-protocol.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in the
+// prefer_node_protocol_extras_test.go file.
+func TestPreferNodeProtocolUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_node_protocol.PreferNodeProtocolRule,
+		[]rule_tester.ValidTestCase{
+			// ---- import / export / dynamic import ----
+			{Code: `import unicorn from "unicorn";`},
+			{Code: `import fs from "./fs";`},
+			{Code: `import fs from "unknown-builtin-module";`},
+			{Code: `import fs from "node:fs";`},
+			{Code: "async function foo() {\n\tconst fs = await import(fs);\n}"},
+			{Code: "async function foo() {\n\tconst fs = await import(0);\n}"},
+			{Code: "async function foo() {\n\tconst fs = await import(`fs`);\n}"},
+			{Code: `import "punycode";`},      // Deprecated
+			{Code: `import "node:punycode";`}, // Deprecated
+			{Code: `import "punycode/";`},
+			{Code: `import "fs/";`},
+			// `test` is not a builtin module, `node:test` is
+			{Code: `import "test";`},
+			{Code: `import "node:test";`},
+			// https://bun.sh/docs/runtime/bun-apis
+			{Code: `import "bun";`},
+			{Code: `import "bun:jsc";`},
+			{Code: `import "bun:sqlite";`},
+
+			// ---- require ----
+			{Code: `const fs = require("node:fs");`},
+			{Code: `const fs = require("node:fs/promises");`},
+			{Code: `const fs = require(fs);`},
+			{Code: `const fs = notRequire("fs");`},
+			{Code: `const fs = foo.require("fs");`},
+			{Code: `const fs = require.resolve("fs");`},
+			{Code: "const fs = require(`fs`);"},
+			{Code: `const fs = require?.("fs");`},
+			{Code: `const fs = require("fs", extra);`},
+			{Code: `const fs = require();`},
+			{Code: `const fs = require(...["fs"]);`},
+			{Code: `const fs = require("unicorn");`},
+
+			// ---- process.getBuiltinModule ----
+			{Code: `const fs = process.getBuiltinModule("node:fs")`},
+			{Code: `const fs = process.getBuiltinModule?.("fs")`},
+			{Code: `const fs = process?.getBuiltinModule("fs")`},
+			{Code: `const fs = process.notGetBuiltinModule("fs")`},
+			{Code: `const fs = notProcess.getBuiltinModule("fs")`},
+			{Code: `const fs = process.getBuiltinModule("fs", extra)`},
+			{Code: `const fs = process.getBuiltinModule(...["fs"])`},
+			{Code: `const fs = process.getBuiltinModule()`},
+			{Code: `const fs = process.getBuiltinModule("unicorn")`},
+			// Not checking this to avoid false positive
+			{Code: "import {getBuiltinModule} from 'node:process';\nconst fs = getBuiltinModule(\"fs\");"},
+
+			// ---- TypeScript ----
+			{Code: `const fs = require("node:fs") as "fs";`},
+			{Code: `type fs = typeof import("node:fs");`},
+			{Code: `type fs = typeof SomeType<"fs">;`},
+			{Code: `type fs = typeof fs;`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- import / export / dynamic import ----
+			{
+				Code:   `import fs from "fs";`,
+				Output: []string{`import fs from "node:fs";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 16}},
+			},
+			{
+				Code:   `export {promises} from "fs";`,
+				Output: []string{`export {promises} from "node:fs";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 24}},
+			},
+			{
+				Code:   `export * from "fs";`,
+				Output: []string{`export * from "node:fs";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `export * as ns from "fs";`,
+				Output: []string{`export * as ns from "node:fs";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 21}},
+			},
+			{
+				Code:   "async function foo() {\n\tconst fs = await import('fs');\n}",
+				Output: []string{"async function foo() {\n\tconst fs = await import('node:fs');\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 2, Column: 26}},
+			},
+			{
+				Code:   `import fs from "fs/promises";`,
+				Output: []string{`import fs from "node:fs/promises";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 16}},
+			},
+			{
+				Code:   `export {default} from "fs/promises";`,
+				Output: []string{`export {default} from "node:fs/promises";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 23}},
+			},
+			{
+				Code:   "async function foo() {\n\tconst fs = await import('fs/promises');\n}",
+				Output: []string{"async function foo() {\n\tconst fs = await import('node:fs/promises');\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 2, Column: 26}},
+			},
+			{
+				Code:   `import {promises} from "fs";`,
+				Output: []string{`import {promises} from "node:fs";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 24}},
+			},
+			{
+				Code:   `export {default as promises} from "fs";`,
+				Output: []string{`export {default as promises} from "node:fs";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 35}},
+			},
+			{
+				Code:   `import {promises} from 'fs';`,
+				Output: []string{`import {promises} from 'node:fs';`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 24}},
+			},
+			{
+				Code:   "async function foo() {\n\tconst fs = await import(\"fs/promises\");\n}",
+				Output: []string{"async function foo() {\n\tconst fs = await import(\"node:fs/promises\");\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 2, Column: 26}},
+			},
+			{
+				Code:   "async function foo() {\n\tconst fs = await import(/* escaped */\"\\u{66}s/promises\");\n}",
+				Output: []string{"async function foo() {\n\tconst fs = await import(/* escaped */\"node:\\u{66}s/promises\");\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 2, Column: 39}},
+			},
+			{
+				Code:   `import "buffer";`,
+				Output: []string{`import "node:buffer";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 8}},
+			},
+			{
+				Code:   `import "child_process";`,
+				Output: []string{`import "node:child_process";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 8}},
+			},
+			{
+				Code:   `import "timers/promises";`,
+				Output: []string{`import "node:timers/promises";`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 8}},
+			},
+
+			// ---- require ----
+			{
+				Code:   `const {promises} = require("fs")`,
+				Output: []string{`const {promises} = require("node:fs")`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 28}},
+			},
+			{
+				Code:   `const fs = require('fs/promises')`,
+				Output: []string{`const fs = require('node:fs/promises')`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 20}},
+			},
+
+			// ---- process.getBuiltinModule ----
+			{
+				Code:   `const fs = process.getBuiltinModule("fs")`,
+				Output: []string{`const fs = process.getBuiltinModule("node:fs")`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 37}},
+			},
+
+			// ---- TypeScript ----
+			{
+				Code:   `const fs = require("fs") as typeof import("fs");`,
+				Output: []string{`const fs = require("node:fs") as typeof import("node:fs");`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "prefer-node-protocol", Line: 1, Column: 20},
+					{MessageId: "prefer-node-protocol", Line: 1, Column: 43},
+				},
+			},
+			{
+				Code:   `type fs = import("fs");`,
+				Output: []string{`type fs = import("node:fs");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 18}},
+			},
+			{
+				Code:   `type fs = import("fs").fs<"fs">`,
+				Output: []string{`type fs = import("node:fs").fs<"fs">`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 18}},
+			},
+			{
+				Code:   `const fs = someFunc() as SomeType<typeof import("fs")>;`,
+				Output: []string{`const fs = someFunc() as SomeType<typeof import("node:fs")>;`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "prefer-node-protocol", Line: 1, Column: 49}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -569,6 +569,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',
+    './tests/eslint-plugin-unicorn/rules/prefer-node-protocol.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-number-properties.test.ts',
     './tests/eslint-plugin-unicorn/rules/require-array-join-separator.test.ts',
     './tests/eslint-plugin-unicorn/rules/require-number-to-fixed-digits-argument.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-node-protocol.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-node-protocol.test.ts
@@ -1,0 +1,113 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// Mirrors upstream test/prefer-node-protocol.js (Layer 1). This suite verifies
+// registration + wire protocol + ESLint-compatible diagnostic shape end-to-end;
+// tsgo-specific edge shapes and branch lock-ins live in the Go extras suite.
+const js = (code: string) => ({ code, filename: 'file.js' });
+const jsInvalid = (code: string, errors = 1) => ({
+  code,
+  filename: 'file.js',
+  errors,
+});
+const ts = (code: string) => ({ code, filename: 'file.ts' });
+const tsInvalid = (code: string, errors = 1) => ({
+  code,
+  filename: 'file.ts',
+  errors,
+});
+
+ruleTester.run('prefer-node-protocol', null as never, {
+  valid: [
+    // import / export / dynamic import
+    js('import unicorn from "unicorn";'),
+    js('import fs from "./fs";'),
+    js('import fs from "unknown-builtin-module";'),
+    js('import fs from "node:fs";'),
+    js('async function foo() {\n\tconst fs = await import(fs);\n}'),
+    js('async function foo() {\n\tconst fs = await import(0);\n}'),
+    js('async function foo() {\n\tconst fs = await import(`fs`);\n}'),
+    js('import "punycode";'),
+    js('import "node:punycode";'),
+    js('import "punycode/";'),
+    js('import "fs/";'),
+    js('import "test";'),
+    js('import "node:test";'),
+    js('import "bun";'),
+    js('import "bun:jsc";'),
+    js('import "bun:sqlite";'),
+
+    // require
+    js('const fs = require("node:fs");'),
+    js('const fs = require("node:fs/promises");'),
+    js('const fs = require(fs);'),
+    js('const fs = notRequire("fs");'),
+    js('const fs = foo.require("fs");'),
+    js('const fs = require.resolve("fs");'),
+    js('const fs = require(`fs`);'),
+    js('const fs = require?.("fs");'),
+    js('const fs = require("fs", extra);'),
+    js('const fs = require();'),
+    js('const fs = require(...["fs"]);'),
+    js('const fs = require("unicorn");'),
+
+    // process.getBuiltinModule
+    js('const fs = process.getBuiltinModule("node:fs")'),
+    js('const fs = process.getBuiltinModule?.("fs")'),
+    js('const fs = process?.getBuiltinModule("fs")'),
+    js('const fs = process.notGetBuiltinModule("fs")'),
+    js('const fs = notProcess.getBuiltinModule("fs")'),
+    js('const fs = process.getBuiltinModule("fs", extra)'),
+    js('const fs = process.getBuiltinModule(...["fs"])'),
+    js('const fs = process.getBuiltinModule()'),
+    js('const fs = process.getBuiltinModule("unicorn")'),
+    js(
+      'import {getBuiltinModule} from \'node:process\';\nconst fs = getBuiltinModule("fs");',
+    ),
+
+    // TypeScript
+    ts('const fs = require("node:fs") as "fs";'),
+    ts('type fs = typeof import("node:fs");'),
+    ts('type fs = typeof SomeType<"fs">;'),
+    ts('type fs = typeof fs;'),
+  ],
+  invalid: [
+    // import / export / dynamic import
+    jsInvalid('import fs from "fs";'),
+    jsInvalid('export {promises} from "fs";'),
+    jsInvalid('export * from "fs";'),
+    jsInvalid('export * as ns from "fs";'),
+    jsInvalid("async function foo() {\n\tconst fs = await import('fs');\n}"),
+    jsInvalid('import fs from "fs/promises";'),
+    jsInvalid('export {default} from "fs/promises";'),
+    jsInvalid(
+      "async function foo() {\n\tconst fs = await import('fs/promises');\n}",
+    ),
+    jsInvalid('import {promises} from "fs";'),
+    jsInvalid('export {default as promises} from "fs";'),
+    jsInvalid("import {promises} from 'fs';"),
+    jsInvalid(
+      'async function foo() {\n\tconst fs = await import("fs/promises");\n}',
+    ),
+    jsInvalid(
+      'async function foo() {\n\tconst fs = await import(/* escaped */"\\u{66}s/promises");\n}',
+    ),
+    jsInvalid('import "buffer";'),
+    jsInvalid('import "child_process";'),
+    jsInvalid('import "timers/promises";'),
+
+    // require
+    jsInvalid('const {promises} = require("fs")'),
+    jsInvalid("const fs = require('fs/promises')"),
+
+    // process.getBuiltinModule
+    jsInvalid('const fs = process.getBuiltinModule("fs")'),
+
+    // TypeScript
+    tsInvalid('const fs = require("fs") as typeof import("fs");', 2),
+    tsInvalid('type fs = import("fs");'),
+    tsInvalid('type fs = import("fs").fs<"fs">'),
+    tsInvalid('const fs = someFunc() as SomeType<typeof import("fs")>;'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -122,7 +122,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/prefer-module': 'error', // not implemented
     // 'unicorn/prefer-native-coercion-functions': 'error', // not implemented
     // 'unicorn/prefer-negative-index': 'error', // not implemented
-    // 'unicorn/prefer-node-protocol': 'error', // not implemented
+    'unicorn/prefer-node-protocol': 'error',
     'unicorn/prefer-number-properties': 'error',
     // 'unicorn/prefer-object-from-entries': 'error', // not implemented
     // 'unicorn/prefer-optional-catch-binding': 'error', // not implemented

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -610,6 +610,7 @@ vitest
 vname
 Värde
 walltime
+wasi
 wasmer
 wasmfs
 WCAG


### PR DESCRIPTION
## Summary

Port the `prefer-node-protocol` rule from ESLint to rslint.

Enforces the `node:` protocol when importing Node.js builtin modules, across `import`/`export` sources, dynamic `import()`, `require()`, `process.getBuiltinModule()`, and TypeScript `import(...)` type nodes. A specifier is flagged only when its bare name is a Node.js builtin with a valid `node:` counterpart, and is autofixed by inserting `node:` before the module name.

## Related Links

- ESLint rule: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/prefer-node-protocol.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).