### PR TITLE
feat(unicorn): port rule prefer-array-some

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_some"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_node_protocol"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_number_properties"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_array_join_separator"
@@ -26,6 +27,7 @@ func GetAllRules() []rule.Rule {
 		no_useless_switch_case.NoUselessSwitchCaseRule,
 		prefer_array_flat.PreferArrayFlatRule,
 		prefer_array_flat_map.PreferArrayFlatMapRule,
+		prefer_array_some.PreferArraySomeRule,
 		prefer_node_protocol.PreferNodeProtocolRule,
 		prefer_number_properties.PreferNumberPropertiesRule,
 		require_array_join_separator.RequireArrayJoinSeparatorRule,

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
@@ -375,7 +375,7 @@ func checkFilterLength(ctx rule.RuleContext, node *ast.Node) {
 
 	filterProperty := filterCall.Property
 	ctx.ReportNodeWithDeferredFixes(filterProperty, messageArrayFilter(), func() []rule.RuleFix {
-		lengthObjectEnd := parenthesizedEndOf(ctx, filterCall.Call)
+		lengthObjectEnd := parenthesizedEnd(ctx, filterCall.Call)
 		end := node.End()
 		// Removing `.length > 0` would drop comments in the removed range.
 		if utils.HasCommentInSpan(ctx.Comments.All(), lengthObjectEnd, end) {
@@ -391,7 +391,7 @@ func checkFilterLength(ctx rule.RuleContext, node *ast.Node) {
 			// parentheses wrapping the member survive the removal.
 			rule.RuleFixRemoveRange(core.NewTextRange(lengthObjectEnd, utils.TrimNodeTextRange(ctx.SourceFile, lengthMember).End())),
 			// Remove `> 0`, starting after any parentheses around the member.
-			rule.RuleFixRemoveRange(core.NewTextRange(parenthesizedEndOf(ctx, lengthMember), end)),
+			rule.RuleFixRemoveRange(core.NewTextRange(parenthesizedEnd(ctx, lengthMember), end)),
 		}
 	})
 }
@@ -604,10 +604,6 @@ func parenthesizedEnd(ctx rule.RuleContext, node *ast.Node) int {
 	return parenthesizedRange(ctx, node).End()
 }
 
-func parenthesizedEndOf(ctx rule.RuleContext, node *ast.Node) int {
-	return parenthesizedEnd(ctx, node)
-}
-
 // insertBeforeRange returns a zero-width fix that inserts text at the start of
 // the given range.
 func insertBeforeRange(textRange core.TextRange, text string) rule.RuleFix {
@@ -728,10 +724,7 @@ func classifyReceiver(ctx rule.RuleContext, node *ast.Node, targetNames, nonTarg
 // a plain identifier name are resolved (matching upstream's getTypeFromVariable
 // preconditions).
 func constInitializer(ctx rule.RuleContext, idNode *ast.Node) *ast.Node {
-	if ctx.TypeChecker == nil {
-		return nil
-	}
-	sym := ctx.TypeChecker.GetSymbolAtLocation(idNode)
+	sym := ctx.Refs.Resolve(idNode)
 	if sym == nil || len(sym.Declarations) != 1 {
 		return nil
 	}

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
@@ -384,9 +384,11 @@ func checkFilterLength(ctx rule.RuleContext, node *ast.Node) {
 		return []rule.RuleFix{
 			rule.RuleFixReplace(ctx.SourceFile, filterProperty, "some"),
 			// Remove `.length`: from the end of the filter call up to the end
-			// of the `.length` member expression.
-			rule.RuleFixRemoveRange(core.NewTextRange(lengthObjectEnd, parenthesizedEndOf(ctx, lengthMember))),
-			// Remove `> 0`.
+			// of the member expression itself. Upstream's
+			// removeMemberExpressionProperty stops at the member's own end, so
+			// parentheses wrapping the member survive the removal.
+			rule.RuleFixRemoveRange(core.NewTextRange(lengthObjectEnd, utils.TrimNodeTextRange(ctx.SourceFile, lengthMember).End())),
+			// Remove `> 0`, starting after any parentheses around the member.
 			rule.RuleFixRemoveRange(core.NewTextRange(parenthesizedEndOf(ctx, lengthMember), end)),
 		}
 	})

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
@@ -862,22 +862,24 @@ func classifyType(ctx rule.RuleContext, t *checker.Type, targetNames, nonTargetN
 	if targetNames.Has(name) {
 		return classTarget
 	}
-	// Interface / class heritage: `interface Items extends Array<string>` (and
-	// `class X extends Array`) resolve to the array target through their base
-	// types. Upstream reaches the same conclusion via its interface-heritage
-	// walk. Only consult heritage when the receiver could be an array target;
-	// keyed-collection classification does not widen through heritage.
+	// Interface heritage: `interface Items extends Array<string>` resolves to
+	// the array target through its base types. Upstream reaches the same
+	// conclusion via its interface-heritage walk, which runs with
+	// `checkClassHeritage: false` — `class MyArray extends Array {}` therefore
+	// stays a non-target. Only consult heritage when the receiver could be an
+	// array target; keyed-collection classification does not widen through it.
 	if targetNames.Has("Array") && classifyHeritage(ctx, t, targetNames, nonTargetNames) == classTarget {
 		return classTarget
 	}
 	return classNonTarget
 }
 
-// classifyHeritage inspects the base types of a class / interface symbol,
-// returning classTarget when any base resolves to the target classification.
+// classifyHeritage inspects the base types of an interface symbol, returning
+// classTarget when any base resolves to the target classification. Classes are
+// excluded to match upstream's `checkClassHeritage: false`.
 func classifyHeritage(ctx rule.RuleContext, t *checker.Type, targetNames, nonTargetNames *utils.Set[string]) typeClass {
 	symbol := checker.Type_symbol(t)
-	if symbol == nil || symbol.Flags&(ast.SymbolFlagsClass|ast.SymbolFlagsInterface) == 0 {
+	if symbol == nil || symbol.Flags&ast.SymbolFlagsInterface == 0 {
 		return classUnknown
 	}
 	declared := checker.Checker_getDeclaredTypeOfSymbol(ctx.TypeChecker, symbol)

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
@@ -1,0 +1,948 @@
+package prefer_array_some
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	messageIDArraySome           = "some"
+	messageIDArraySomeSuggestion = "some-suggestion"
+	messageIDArrayFilter         = "filter"
+)
+
+func messageArraySome(method string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDArraySome,
+		Description: "Prefer `.some(…)` over `." + method + "(…)`.",
+		Data:        map[string]string{"method": method},
+	}
+}
+
+func messageArraySomeSuggestion(method string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDArraySomeSuggestion,
+		Description: "Replace `." + method + "(…)` with `.some(…)`.",
+		Data:        map[string]string{"method": method},
+	}
+}
+
+func messageArrayFilter() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          messageIDArrayFilter,
+		Description: "Prefer `.some(…)` over non-zero length check from `.filter(…)`.",
+	}
+}
+
+// PreferArraySomeRule mirrors eslint-plugin-unicorn's prefer-array-some. It is
+// syntactic-first: the type checker is only consulted (when available) to skip
+// receivers that are known non-indexed collections (`Map`/`Set`/typed arrays'
+// keyed cousins) and, for the `.find()` variable-usage branch, to confirm the
+// receiver is an array. On JS / gap files (`ctx.TypeChecker == nil`) those
+// checks degrade to "unknown", exactly like upstream when no parser services
+// are present — so the rule stays useful and MUST NOT declare RequiresTypeInfo.
+var PreferArraySomeRule = rule.Rule{
+	Name:   "unicorn/prefer-array-some",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			// `.find(…)` / `.findLast(…)` used in a boolean position.
+			ast.KindCallExpression: func(node *ast.Node) {
+				checkFindCall(ctx, node)
+			},
+			// `.{findIndex,findLastIndex}(…)` compared against -1 / 0, and
+			// `.filter(…).length` compared against 0. Both collapse onto
+			// tsgo's single BinaryExpression kind.
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				if checkFindIndexComparison(ctx, node) {
+					return
+				}
+				checkFilterLength(ctx, node)
+			},
+		}
+	},
+}
+
+// ---- `.find()` / `.findLast()` ----
+
+func checkFindCall(ctx rule.RuleContext, node *ast.Node) {
+	minArgs := 1
+	maxArgs := 2
+	call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+		Methods:             []string{"find", "findLast"},
+		MinimumArguments:    &minArgs,
+		MaximumArguments:    &maxArgs,
+		RejectSpreadElement: true,
+	})
+	if !ok {
+		return
+	}
+	// `foo.find<Item>(fn)` — explicit type arguments mean the result is used
+	// for its value, not as a boolean. tsgo exposes them on the call node.
+	if node.AsCallExpression().TypeArguments != nil {
+		return
+	}
+
+	if isKnownNonIndexedCollection(ctx, call.Object) {
+		return
+	}
+
+	isCompare := isCheckingUndefined(node)
+	if !isCompare &&
+		!isBooleanExpression(ctx, node) &&
+		!isControlFlowTest(node) &&
+		!isFindResultVariableUsedOnlyAsBoolean(ctx, node, call) {
+		return
+	}
+
+	methodNode := call.Property
+	method := methodNode.AsIdentifier().Text
+
+	comparison := comparisonParent(node) // non-nil only when isCompare
+
+	// Removing the comparison would drop comments between the call and the end
+	// of the comparison; upstream withholds the suggestion in that case.
+	wouldDropComments := isCompare && utils.HasCommentInSpan(
+		ctx.Comments.All(),
+		parenthesizedEnd(ctx, node),
+		comparison.End(),
+	)
+
+	if wouldDropComments {
+		ctx.ReportNode(methodNode, messageArraySome(method))
+		return
+	}
+
+	ctx.ReportNodeWithDeferredSuggestions(methodNode, messageArraySome(method), func() []rule.RuleSuggestion {
+		fixes := []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, methodNode, "some")}
+		if isCompare {
+			// Remove the `== undefined` / `!== null` tail.
+			parenEnd := parenthesizedEnd(ctx, node)
+			fixes = append(fixes, rule.RuleFixRemoveRange(core.NewTextRange(parenEnd, comparison.End())))
+
+			// `!=` / `!==` already mean "found"; other operators (`==` / `===`)
+			// mean "not found", so negate.
+			operator := comparison.AsBinaryExpression().OperatorToken.Kind
+			if operator != ast.KindExclamationEqualsToken && operator != ast.KindExclamationEqualsEqualsToken {
+				fixes = append(fixes, insertBeforeRange(parenthesizedRange(ctx, node), "!"))
+			}
+		}
+		return []rule.RuleSuggestion{{
+			Message:  messageArraySomeSuggestion(method),
+			FixesArr: fixes,
+		}}
+	})
+}
+
+// comparisonParent returns the BinaryExpression comparing `node` against
+// undefined / null (per isCheckingUndefined), skipping parentheses around the
+// call. Returns nil when node is not the left operand of such a comparison.
+func comparisonParent(node *ast.Node) *ast.Node {
+	parent := effectiveParent(node)
+	if parent == nil || !ast.IsBinaryExpression(parent) {
+		return nil
+	}
+	bin := parent.AsBinaryExpression()
+	if ast.SkipParentheses(bin.Left) != node {
+		return nil
+	}
+	right := bin.Right
+	switch bin.OperatorToken.Kind {
+	case ast.KindEqualsEqualsToken, ast.KindExclamationEqualsToken:
+		if utils.IsUndefinedIdentifier(right) || isNullLiteral(right) {
+			return parent
+		}
+	case ast.KindEqualsEqualsEqualsToken, ast.KindExclamationEqualsEqualsToken:
+		if utils.IsUndefinedIdentifier(right) {
+			return parent
+		}
+	}
+	return nil
+}
+
+// isCheckingUndefined mirrors upstream: the call is the left operand of a
+// comparison against `undefined` (`==`/`!=`/`===`/`!==`) or `null` (`==`/`!=`).
+// Yoda comparisons (`undefined !== foo.find()`) are intentionally not matched.
+func isCheckingUndefined(node *ast.Node) bool {
+	return comparisonParent(node) != nil
+}
+
+// isFindResultVariableUsedOnlyAsBoolean mirrors upstream's helper: a
+// `const x = arr.find(fn)` whose every read is used as a boolean. Requires the
+// receiver to be a known array (upstream `isArray`), a plain single-name
+// `const` binding that isn't exported, and ≥1 reference — all of which must be
+// boolean-position reads.
+func isFindResultVariableUsedOnlyAsBoolean(ctx rule.RuleContext, callExpression *ast.Node, call unicornutil.DotMethodCall) bool {
+	if !isArray(ctx, call.Object) {
+		return false
+	}
+	if ctx.Refs == nil {
+		return false
+	}
+
+	// callExpression.Parent must be `VariableDeclaration` whose Initializer is
+	// the call, with a plain Identifier name and no type annotation.
+	declarator := callExpression.Parent
+	if declarator == nil || !ast.IsVariableDeclaration(declarator) {
+		return false
+	}
+	varDecl := declarator.AsVariableDeclaration()
+	if varDecl.Initializer != callExpression {
+		return false
+	}
+	name := varDecl.Name()
+	if name == nil || !ast.IsIdentifier(name) || varDecl.Type != nil {
+		return false
+	}
+
+	// The declaration list must be `const` and not part of an `export`.
+	declList := declarator.Parent
+	if declList == nil || !ast.IsVariableDeclarationList(declList) ||
+		declList.Flags&ast.NodeFlagsConst == 0 {
+		return false
+	}
+	statement := declList.Parent
+	if statement == nil || !ast.IsVariableStatement(statement) {
+		return false
+	}
+	if statement.Parent != nil && ast.IsExportDeclaration(statement.Parent) {
+		return false
+	}
+	if statement.ModifierFlags()&ast.ModifierFlagsExport != 0 {
+		return false
+	}
+
+	sym := declarator.Symbol()
+	if sym == nil {
+		return false
+	}
+	references := ctx.Refs.References(sym)
+	if len(references) == 0 {
+		return false
+	}
+
+	for _, reference := range references {
+		if !isBooleanExpression(ctx, reference) && !isControlFlowTest(reference) {
+			return false
+		}
+	}
+	return true
+}
+
+// ---- `.{findIndex,findLastIndex}(…)` compared against -1 / 0 ----
+
+func checkFindIndexComparison(ctx rule.RuleContext, node *ast.Node) bool {
+	bin := node.AsBinaryExpression()
+	if bin.OperatorToken == nil {
+		return false
+	}
+
+	argsLen := 1
+	call, ok := unicornutil.MatchDotMethodCall(bin.Left, unicornutil.DotMethodCallOptions{
+		Methods:             []string{"findIndex", "findLastIndex"},
+		ArgumentsLength:     &argsLen,
+		RejectSpreadElement: true,
+	})
+	if !ok {
+		return false
+	}
+
+	operator := bin.OperatorToken.Kind
+	rhsMatches := false
+	switch operator {
+	case ast.KindExclamationEqualsEqualsToken, ast.KindExclamationEqualsToken,
+		ast.KindGreaterThanToken, ast.KindEqualsEqualsEqualsToken, ast.KindEqualsEqualsToken:
+		rhsMatches = isNegativeOne(bin.Right)
+	case ast.KindGreaterThanEqualsToken, ast.KindLessThanToken:
+		rhsMatches = isLiteralZero(bin.Right)
+	}
+	if !rhsMatches {
+		return false
+	}
+
+	if isKnownNonIndexedCollection(ctx, call.Object) {
+		return false
+	}
+
+	methodNode := call.Property
+	ctx.ReportNodeWithDeferredFixes(methodNode, messageArraySome(methodNode.AsIdentifier().Text), func() []rule.RuleFix {
+		// The operator token starts the `!== -1` / `>= 0` tail to remove. Use
+		// its trimmed source range directly (robust across `>=` / `!==` forms
+		// that a kind-matching token scan handles inconsistently).
+		operatorStart := utils.TrimNodeTextRange(ctx.SourceFile, bin.OperatorToken).Pos()
+		end := node.End()
+		// Removing the comparison would drop comments in the removed range.
+		if utils.HasCommentInSpan(ctx.Comments.All(), operatorStart, end) {
+			return nil
+		}
+
+		fixes := make([]rule.RuleFix, 0, 3)
+		// `=== -1` / `== -1` / `< 0` mean "not found", so negate.
+		if operator == ast.KindEqualsEqualsEqualsToken || operator == ast.KindEqualsEqualsToken ||
+			operator == ast.KindLessThanToken {
+			fixes = append(fixes, insertBeforeRange(utils.TrimNodeTextRange(ctx.SourceFile, node), "!"))
+		}
+		fixes = append(fixes, rule.RuleFixReplace(ctx.SourceFile, methodNode, "some"))
+		fixes = append(fixes, rule.RuleFixRemoveRange(core.NewTextRange(operatorStart, end)))
+		return fixes
+	})
+	return true
+}
+
+// isNegativeOne matches `-1` (with any parenthesized / spaced form of the `1`).
+// tsgo models `-1` as PrefixUnaryExpression(minus, NumericLiteral "1").
+func isNegativeOne(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil || node.Kind != ast.KindPrefixUnaryExpression {
+		return false
+	}
+	unary := node.AsPrefixUnaryExpression()
+	if unary.Operator != ast.KindMinusToken {
+		return false
+	}
+	operand := ast.SkipParentheses(unary.Operand)
+	return operand != nil && operand.Kind == ast.KindNumericLiteral &&
+		utils.NormalizeNumericLiteral(operand.AsNumericLiteral().Text) == "1"
+}
+
+func isLiteralZero(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	return node != nil && node.Kind == ast.KindNumericLiteral &&
+		utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text) == "0"
+}
+
+// ---- `.filter(…).length > 0` / `!== 0` ----
+
+func checkFilterLength(ctx rule.RuleContext, node *ast.Node) {
+	bin := node.AsBinaryExpression()
+	if bin.OperatorToken == nil {
+		return
+	}
+	// We assume the user already follows `unicorn/explicit-length-check`; only
+	// `> 0` and `!== 0` are allowed there.
+	if bin.OperatorToken.Kind != ast.KindGreaterThanToken &&
+		bin.OperatorToken.Kind != ast.KindExclamationEqualsEqualsToken {
+		return
+	}
+	// The right side must be the RAW literal `0` — `0.` / `0x00` / `.0` are
+	// distinct source forms upstream deliberately does not match.
+	if !isRawZeroLiteral(ctx.SourceFile, bin.Right) {
+		return
+	}
+
+	// The left side must be `<filterCall>.length` (non-optional dot access).
+	lengthMember := ast.SkipParentheses(bin.Left)
+	if lengthMember == nil || !ast.IsPropertyAccessExpression(lengthMember) ||
+		ast.IsOptionalChain(lengthMember) {
+		return
+	}
+	lengthAccess := lengthMember.AsPropertyAccessExpression()
+	lengthName := lengthAccess.Name()
+	if lengthName == nil || !ast.IsIdentifier(lengthName) || lengthName.AsIdentifier().Text != "length" {
+		return
+	}
+
+	filterCall, ok := unicornutil.MatchDotMethodCall(
+		ast.SkipParentheses(lengthAccess.Expression),
+		unicornutil.DotMethodCallOptions{Method: "filter"},
+	)
+	if !ok {
+		return
+	}
+
+	filterObject := filterCall.Object
+	// `$`-prefixed receivers are treated as jQuery-like (`$element.filter(...)`).
+	skippedObject := ast.SkipParentheses(filterObject)
+	if skippedObject != nil && ast.IsIdentifier(skippedObject) &&
+		len(skippedObject.AsIdentifier().Text) > 0 && skippedObject.AsIdentifier().Text[0] == '$' {
+		return
+	}
+	if isKnownNonIndexedCollection(ctx, filterObject) {
+		return
+	}
+
+	filterArgs := filterCall.Call.Arguments()
+	if len(filterArgs) == 0 || isNodeValueNotFunction(filterArgs[0]) {
+		return
+	}
+
+	filterProperty := filterCall.Property
+	ctx.ReportNodeWithDeferredFixes(filterProperty, messageArrayFilter(), func() []rule.RuleFix {
+		lengthObjectEnd := parenthesizedEndOf(ctx, filterCall.Call)
+		end := node.End()
+		// Removing `.length > 0` would drop comments in the removed range.
+		if utils.HasCommentInSpan(ctx.Comments.All(), lengthObjectEnd, end) {
+			return nil
+		}
+
+		// `.filter` → `.some`; remove `.length`; remove `> 0`.
+		return []rule.RuleFix{
+			rule.RuleFixReplace(ctx.SourceFile, filterProperty, "some"),
+			// Remove `.length`: from the end of the filter call up to the end
+			// of the `.length` member expression.
+			rule.RuleFixRemoveRange(core.NewTextRange(lengthObjectEnd, parenthesizedEndOf(ctx, lengthMember))),
+			// Remove `> 0`.
+			rule.RuleFixRemoveRange(core.NewTextRange(parenthesizedEndOf(ctx, lengthMember), end)),
+		}
+	})
+}
+
+// isRawZeroLiteral reports whether node is a numeric literal whose raw source
+// text is exactly "0" (matching upstream's `right.raw === '0'`). Uses raw
+// source text because NumericLiteral.Text is decimal-normalized at parse time,
+// which would incorrectly fold `0.` / `0x00` into "0".
+func isRawZeroLiteral(sourceFile *ast.SourceFile, node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindNumericLiteral {
+		return false
+	}
+	return scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, node, false) == "0"
+}
+
+// isNodeValueNotFunction mirrors upstream's is-node-value-not-function helper.
+// It rejects `.filter` arguments that cannot be a callback (literals, objects,
+// arrays, etc.), while treating `.bind()` calls as possible functions.
+func isNodeValueNotFunction(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindArrayLiteralExpression,
+		ast.KindObjectLiteralExpression,
+		ast.KindClassExpression,
+		ast.KindTemplateExpression,
+		ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindPrefixUnaryExpression,
+		ast.KindPostfixUnaryExpression,
+		// Literals (ESTree collapses these into one `Literal` node type).
+		ast.KindStringLiteral,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword,
+		// mostLikelyNotNodeTypes
+		ast.KindAwaitExpression,
+		ast.KindNewExpression,
+		ast.KindTaggedTemplateExpression,
+		ast.KindThisKeyword:
+		return true
+	case ast.KindBinaryExpression:
+		// ESTree splits BinaryExpression / LogicalExpression / AssignmentExpression;
+		// upstream lists BinaryExpression and AssignmentExpression as impossible,
+		// LogicalExpression is not. Match by operator.
+		operator := node.AsBinaryExpression().OperatorToken.Kind
+		return isImpossibleBinaryOperator(operator)
+	case ast.KindCallExpression:
+		// A call could return a function only via `.bind()`.
+		_, isBind := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{Method: "bind"})
+		return !isBind
+	}
+	return utils.IsUndefinedIdentifier(node)
+}
+
+// isImpossibleBinaryOperator returns true for arithmetic / comparison / bitwise
+// operators (ESTree BinaryExpression) and assignment operators (ESTree
+// AssignmentExpression), but false for `&&` / `||` / `??` (ESTree
+// LogicalExpression), matching upstream's impossible / most-likely-not sets.
+func isImpossibleBinaryOperator(operator ast.Kind) bool {
+	switch operator {
+	case ast.KindAmpersandAmpersandToken, ast.KindBarBarToken, ast.KindQuestionQuestionToken,
+		ast.KindCommaToken:
+		return false
+	}
+	return true
+}
+
+// ---- boolean / control-flow position (upstream utils/boolean.js) ----
+
+func isLogicalExpression(node *ast.Node) bool {
+	if node == nil || !ast.IsBinaryExpression(node) {
+		return false
+	}
+	operator := node.AsBinaryExpression().OperatorToken.Kind
+	return operator == ast.KindAmpersandAmpersandToken || operator == ast.KindBarBarToken
+}
+
+func isLogicNot(node *ast.Node) bool {
+	return node != nil && node.Kind == ast.KindPrefixUnaryExpression &&
+		node.AsPrefixUnaryExpression().Operator == ast.KindExclamationToken
+}
+
+func isLogicNotArgument(node *ast.Node) bool {
+	parent := effectiveParent(node)
+	return isLogicNot(parent) &&
+		ast.SkipParentheses(parent.AsPrefixUnaryExpression().Operand) == node
+}
+
+// isGlobalBooleanCall reports whether node is a `Boolean(...)` call to the
+// global Boolean (single non-spread argument, not optional, not shadowed).
+func isGlobalBooleanCall(ctx rule.RuleContext, node *ast.Node) bool {
+	if node == nil || !ast.IsCallExpression(node) {
+		return false
+	}
+	call := node.AsCallExpression()
+	if call.QuestionDotToken != nil {
+		return false
+	}
+	callee := ast.SkipParentheses(call.Expression)
+	if callee == nil || !ast.IsIdentifier(callee) || callee.AsIdentifier().Text != "Boolean" {
+		return false
+	}
+	args := node.Arguments()
+	if len(args) != 1 || args[0].Kind == ast.KindSpreadElement {
+		return false
+	}
+	return !utils.IsShadowed(callee, "Boolean")
+}
+
+func isBooleanCallArgument(ctx rule.RuleContext, node *ast.Node) bool {
+	parent := effectiveParent(node)
+	if !isGlobalBooleanCall(ctx, parent) {
+		return false
+	}
+	args := parent.Arguments()
+	return len(args) == 1 && ast.SkipParentheses(args[0]) == node
+}
+
+func isDirectBooleanExpression(ctx rule.RuleContext, node *ast.Node) bool {
+	return isLogicNot(node) ||
+		isLogicNotArgument(node) ||
+		isGlobalBooleanCall(ctx, node) ||
+		isBooleanCallArgument(ctx, node)
+}
+
+func isBooleanExpression(ctx rule.RuleContext, node *ast.Node) bool {
+	if isDirectBooleanExpression(ctx, node) {
+		return true
+	}
+	parent := effectiveParent(node)
+	if isLogicalExpression(parent) {
+		return isBooleanExpression(ctx, parent)
+	}
+	return false
+}
+
+func isDirectControlFlowTest(node *ast.Node) bool {
+	parent := effectiveParent(node)
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindIfStatement:
+		return ast.SkipParentheses(parent.AsIfStatement().Expression) == node
+	case ast.KindConditionalExpression:
+		return ast.SkipParentheses(parent.AsConditionalExpression().Condition) == node
+	case ast.KindWhileStatement:
+		return ast.SkipParentheses(parent.AsWhileStatement().Expression) == node
+	case ast.KindDoStatement:
+		return ast.SkipParentheses(parent.AsDoStatement().Expression) == node
+	case ast.KindForStatement:
+		return ast.SkipParentheses(parent.AsForStatement().Condition) == node
+	}
+	return false
+}
+
+func isControlFlowTest(node *ast.Node) bool {
+	if isDirectControlFlowTest(node) {
+		return true
+	}
+	parent := effectiveParent(node)
+	if isLogicalExpression(parent) {
+		return isControlFlowTest(parent)
+	}
+	return false
+}
+
+// ---- misc AST helpers ----
+
+// effectiveParent returns node's nearest ancestor that is not a
+// ParenthesizedExpression, mirroring how ESTree "flattens" parentheses so that
+// a node's parent is the semantic construct wrapping it.
+func effectiveParent(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	return ast.WalkUpParenthesizedExpressions(node.Parent)
+}
+
+func isNullLiteral(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	return node != nil && node.Kind == ast.KindNullKeyword
+}
+
+// parenthesizedRange returns the outermost parenthesized range of node (its own
+// range when unparenthesized), mirroring upstream's getParenthesizedRange.
+func parenthesizedRange(ctx rule.RuleContext, node *ast.Node) core.TextRange {
+	return utils.TrimNodeTextRange(ctx.SourceFile, outermostParenthesized(node))
+}
+
+// outermostParenthesized climbs from node through any enclosing
+// ParenthesizedExpression parents and returns the outermost one (node itself
+// when it isn't parenthesized).
+func outermostParenthesized(node *ast.Node) *ast.Node {
+	result := node
+	for result.Parent != nil && result.Parent.Kind == ast.KindParenthesizedExpression {
+		result = result.Parent
+	}
+	return result
+}
+
+func parenthesizedEnd(ctx rule.RuleContext, node *ast.Node) int {
+	return parenthesizedRange(ctx, node).End()
+}
+
+func parenthesizedEndOf(ctx rule.RuleContext, node *ast.Node) int {
+	return parenthesizedEnd(ctx, node)
+}
+
+// insertBeforeRange returns a zero-width fix that inserts text at the start of
+// the given range.
+func insertBeforeRange(textRange core.TextRange, text string) rule.RuleFix {
+	return rule.RuleFixReplaceRange(textRange.WithEnd(textRange.Pos()), text)
+}
+
+// ---- type classification (upstream utils/is-array.js) ----
+
+// isKnownNonIndexedCollection reports whether the receiver is definitely a
+// keyed collection (`Map`/`Set`/`WeakMap`/`WeakSet`/`ReadonlyMap`/`ReadonlySet`)
+// — types that carry a `.find` / `.filter` / `.findIndex` surface but are not
+// arrays, so the rewrite would be wrong. Returns false when the type is unknown
+// (including when no TypeChecker is available), matching upstream.
+func isKnownNonIndexedCollection(ctx rule.RuleContext, node *ast.Node) bool {
+	return classifyReceiver(ctx, node, indexedCollectionTargets, keyedCollectionNames) == classNonTarget
+}
+
+// isArray reports whether the receiver is definitely an Array / ReadonlyArray /
+// tuple, using syntactic shape first and the type checker as a fallback.
+func isArray(ctx rule.RuleContext, node *ast.Node) bool {
+	return classifyReceiver(ctx, node, arrayTargets, knownNonArrayNames) == classTarget
+}
+
+type typeClass int
+
+const (
+	classUnknown typeClass = iota
+	classTarget
+	classNonTarget
+)
+
+var arrayTargets = utils.NewSetFromItems("Array", "ReadonlyArray")
+
+var indexedCollectionTargets = func() *utils.Set[string] {
+	s := utils.NewSetFromItems("Array", "ReadonlyArray")
+	for _, name := range typedArrayNames {
+		s.Add(name)
+	}
+	return s
+}()
+
+var keyedCollectionNames = utils.NewSetFromItems(
+	"Map", "ReadonlyMap", "WeakMap", "Set", "ReadonlySet", "WeakSet",
+)
+
+var knownNonArrayNames = func() *utils.Set[string] {
+	s := utils.NewSetFromItems(
+		"Map", "ReadonlyMap", "WeakMap", "Set", "ReadonlySet", "WeakSet",
+	)
+	for _, name := range typedArrayNames {
+		s.Add(name)
+	}
+	return s
+}()
+
+var typedArrayNames = []string{
+	"Int8Array", "Uint8Array", "Uint8ClampedArray", "Int16Array", "Uint16Array",
+	"Int32Array", "Uint32Array", "Float16Array", "Float32Array", "Float64Array",
+	"BigInt64Array", "BigUint64Array",
+}
+
+// classifyReceiver mirrors the syntactic short-circuits of unicorn's `getType`
+// (array literals, `Array()` / `new Array()` / `Array.from` / `Array.of`
+// constructors) and then falls back to a type-checker classification analogous
+// to `getTypeScriptType`. `targetNames` and `nonTargetNames` are the type-name
+// sets that resolve to target / non-target respectively.
+func classifyReceiver(ctx rule.RuleContext, node *ast.Node, targetNames, nonTargetNames *utils.Set[string]) typeClass {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return classUnknown
+	}
+
+	// Syntactic target shapes shared by both classifications: an array literal
+	// or an `Array` constructor / factory call is always an array (target for
+	// arrays; not a keyed collection either, so also non-target there).
+	if isSyntacticArrayNode(node) {
+		if targetNames.Has("Array") {
+			return classTarget
+		}
+		return classNonTarget
+	}
+
+	// Syntactic non-array shapes (upstream isNonArrayNode): `new X()` and
+	// object / function / arrow / class / template literals are never arrays,
+	// so they resolve to non-target for both classifications without needing
+	// the type system.
+	if isSyntacticNonArrayNode(node) {
+		return classNonTarget
+	}
+
+	// A plain `const x = <initializer>` reference resolves to the syntactic
+	// class of its initializer (upstream getTypeFromVariable). This catches
+	// shapes the checker alone can miss on error types, e.g.
+	// `const store = new Store()` where `Store` is undeclared.
+	if ast.IsIdentifier(node) {
+		if init := constInitializer(ctx, node); init != nil {
+			switch {
+			case isSyntacticArrayNode(init):
+				if targetNames.Has("Array") {
+					return classTarget
+				}
+				return classNonTarget
+			case isSyntacticNonArrayNode(init):
+				return classNonTarget
+			}
+		}
+	}
+
+	if ctx.TypeChecker == nil {
+		return classUnknown
+	}
+	t := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, node)
+	return classifyType(ctx, t, targetNames, nonTargetNames)
+}
+
+// constInitializer returns the initializer expression of a `const` variable
+// that idNode references, or nil. Only single-declaration `const` bindings with
+// a plain identifier name are resolved (matching upstream's getTypeFromVariable
+// preconditions).
+func constInitializer(ctx rule.RuleContext, idNode *ast.Node) *ast.Node {
+	if ctx.TypeChecker == nil {
+		return nil
+	}
+	sym := ctx.TypeChecker.GetSymbolAtLocation(idNode)
+	if sym == nil || len(sym.Declarations) != 1 {
+		return nil
+	}
+	decl := sym.Declarations[0]
+	if decl == nil || !ast.IsVariableDeclaration(decl) {
+		return nil
+	}
+	parent := decl.Parent
+	if parent == nil || !ast.IsVariableDeclarationList(parent) || parent.Flags&ast.NodeFlagsConst == 0 {
+		return nil
+	}
+	varDecl := decl.AsVariableDeclaration()
+	if varDecl.Name() == nil || !ast.IsIdentifier(varDecl.Name()) || varDecl.Type != nil {
+		return nil
+	}
+	return ast.SkipParentheses(varDecl.Initializer)
+}
+
+// isSyntacticArrayNode matches `[]`, `Array(...)`, `new Array(...)`,
+// `Array.from(...)`, and `Array.of(...)` — the shapes upstream's isArrayNode
+// treats as a definite array without consulting the type system.
+func isSyntacticArrayNode(node *ast.Node) bool {
+	if node.Kind == ast.KindArrayLiteralExpression {
+		return true
+	}
+	if ast.IsCallExpression(node) {
+		callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+		if callee == nil {
+			return false
+		}
+		// `Array.from(...)` / `Array.of(...)`
+		if ast.IsPropertyAccessExpression(callee) && !ast.IsOptionalChain(callee) {
+			pae := callee.AsPropertyAccessExpression()
+			obj := ast.SkipParentheses(pae.Expression)
+			name := pae.Name()
+			if obj != nil && ast.IsIdentifier(obj) && obj.AsIdentifier().Text == "Array" &&
+				name != nil && ast.IsIdentifier(name) {
+				m := name.AsIdentifier().Text
+				return m == "from" || m == "of"
+			}
+			return false
+		}
+		// `Array(...)`
+		if ast.IsIdentifier(callee) {
+			return callee.AsIdentifier().Text == "Array"
+		}
+		return false
+	}
+	// `new Array(...)`
+	if ast.IsNewExpression(node) {
+		callee := ast.SkipParentheses(node.AsNewExpression().Expression)
+		return callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == "Array"
+	}
+	return false
+}
+
+// isSyntacticNonArrayNode mirrors upstream's isNonArrayNode: `new X()` and
+// object / function / arrow / class / template literals are definitely not
+// arrays. (An `Array` constructor / factory is handled by isSyntacticArrayNode
+// before this is consulted, so `new Array()` never reaches here as non-array.)
+func isSyntacticNonArrayNode(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindNewExpression,
+		ast.KindObjectLiteralExpression,
+		ast.KindFunctionExpression,
+		ast.KindArrowFunction,
+		ast.KindClassExpression,
+		ast.KindTemplateExpression,
+		ast.KindNoSubstitutionTemplateLiteral:
+		return true
+	}
+	return false
+}
+
+// classifyType mirrors unicorn's getTypeScriptType: recurse through
+// unions/intersections/type-parameter constraints, then decide by the resolved
+// symbol name.
+func classifyType(ctx rule.RuleContext, t *checker.Type, targetNames, nonTargetNames *utils.Set[string]) typeClass {
+	if t == nil {
+		return classUnknown
+	}
+	if utils.IsTypeAnyType(t) || utils.IsTypeUnknownType(t) || utils.IsIntrinsicErrorType(t) {
+		return classUnknown
+	}
+	// null / undefined are nullish → treated as non-target by both callers.
+	if utils.IsTypeFlagSet(t, checker.TypeFlagsNull|checker.TypeFlagsUndefined) {
+		return classNonTarget
+	}
+
+	if utils.IsTypeParameter(t) {
+		constraint := checker.Checker_getBaseConstraintOfType(ctx.TypeChecker, t)
+		if constraint == nil {
+			return classUnknown
+		}
+		return classifyType(ctx, constraint, targetNames, nonTargetNames)
+	}
+
+	if utils.IsUnionType(t) {
+		return combineUnion(ctx, utils.UnionTypeParts(t), targetNames, nonTargetNames)
+	}
+	if utils.IsIntersectionType(t) {
+		return combineIntersection(ctx, utils.IntersectionTypeParts(t), targetNames, nonTargetNames)
+	}
+
+	// Array / tuple structural check (mirrors upstream isTargetType).
+	if targetNames.Has("Array") && checker.Checker_isArrayOrTupleType(ctx.TypeChecker, t) {
+		return classTarget
+	}
+
+	// Base constraint fallback (e.g. `T extends string[]` reached via apparent
+	// constraint rather than the type-parameter branch above).
+	constraint := checker.Checker_getBaseConstraintOfType(ctx.TypeChecker, t)
+	if constraint != nil && constraint != t {
+		return classifyType(ctx, constraint, targetNames, nonTargetNames)
+	}
+
+	name, ok := typeSymbolName(t)
+	if !ok {
+		// A primitive (string / number / boolean / bigint / symbol, literal or
+		// not) or any other intrinsic is never an Array or keyed collection →
+		// non-target. Mirrors upstream, where such a value resolves to
+		// non-target via its intrinsicName or static value.
+		if utils.IsTypeFlagSet(t, checker.TypeFlagsPrimitive|checker.TypeFlagsIntrinsic) {
+			return classNonTarget
+		}
+		return classUnknown
+	}
+	if targetNames.Has(name) {
+		return classTarget
+	}
+	// Interface / class heritage: `interface Items extends Array<string>` (and
+	// `class X extends Array`) resolve to the array target through their base
+	// types. Upstream reaches the same conclusion via its interface-heritage
+	// walk. Only consult heritage when the receiver could be an array target;
+	// keyed-collection classification does not widen through heritage.
+	if targetNames.Has("Array") && classifyHeritage(ctx, t, targetNames, nonTargetNames) == classTarget {
+		return classTarget
+	}
+	return classNonTarget
+}
+
+// classifyHeritage inspects the base types of a class / interface symbol,
+// returning classTarget when any base resolves to the target classification.
+func classifyHeritage(ctx rule.RuleContext, t *checker.Type, targetNames, nonTargetNames *utils.Set[string]) typeClass {
+	symbol := checker.Type_symbol(t)
+	if symbol == nil || symbol.Flags&(ast.SymbolFlagsClass|ast.SymbolFlagsInterface) == 0 {
+		return classUnknown
+	}
+	declared := checker.Checker_getDeclaredTypeOfSymbol(ctx.TypeChecker, symbol)
+	if declared == nil {
+		return classUnknown
+	}
+	for _, base := range checker.Checker_getBaseTypes(ctx.TypeChecker, declared) {
+		if classifyType(ctx, base, targetNames, nonTargetNames) == classTarget {
+			return classTarget
+		}
+	}
+	return classUnknown
+}
+
+func combineUnion(ctx rule.RuleContext, parts []*checker.Type, targetNames, nonTargetNames *utils.Set[string]) typeClass {
+	// Filter nullish parts (normalizeType folds nullish → nonTarget, and a
+	// union is target only when every non-nullish part is target).
+	filtered := make([]typeClass, 0, len(parts))
+	for _, part := range parts {
+		if utils.IsTypeFlagSet(part, checker.TypeFlagsNull|checker.TypeFlagsUndefined) {
+			continue
+		}
+		filtered = append(filtered, classifyType(ctx, part, targetNames, nonTargetNames))
+	}
+	if len(filtered) == 0 {
+		return classNonTarget
+	}
+	allTarget := true
+	allNonTarget := true
+	for _, c := range filtered {
+		if c != classTarget {
+			allTarget = false
+		}
+		if c != classNonTarget {
+			allNonTarget = false
+		}
+	}
+	if allTarget {
+		return classTarget
+	}
+	if allNonTarget {
+		return classNonTarget
+	}
+	return classUnknown
+}
+
+func combineIntersection(ctx rule.RuleContext, parts []*checker.Type, targetNames, nonTargetNames *utils.Set[string]) typeClass {
+	classes := make([]typeClass, 0, len(parts))
+	for _, part := range parts {
+		classes = append(classes, classifyType(ctx, part, targetNames, nonTargetNames))
+	}
+	for _, c := range classes {
+		if c == classTarget {
+			return classTarget
+		}
+	}
+	for _, c := range classes {
+		if c != classNonTarget {
+			return classUnknown
+		}
+	}
+	return classNonTarget
+}
+
+// typeSymbolName returns the symbol name of a type (its own symbol, falling
+// back to the alias symbol), mirroring upstream's `type.getSymbol() ??
+// type.aliasSymbol` + `symbol.getName()`.
+func typeSymbolName(t *checker.Type) (string, bool) {
+	if sym := checker.Type_symbol(t); sym != nil && sym.Name != "" {
+		return sym.Name, true
+	}
+	if alias := checker.Type_alias(t); alias != nil {
+		if sym := alias.Symbol(); sym != nil && sym.Name != "" {
+			return sym.Name, true
+		}
+	}
+	return "", false
+}

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
@@ -330,8 +330,10 @@ func checkFilterLength(ctx rule.RuleContext, node *ast.Node) {
 		return
 	}
 	// The right side must be the RAW literal `0` — `0.` / `0x00` / `.0` are
-	// distinct source forms upstream deliberately does not match.
-	if !isRawZeroLiteral(ctx.SourceFile, bin.Right) {
+	// distinct source forms upstream deliberately does not match. ESTree drops
+	// parentheses, so upstream sees the literal through `(( 0 ))`; skip them
+	// here to match, the inner literal's source text is still `0`.
+	if !isRawZeroLiteral(ctx.SourceFile, ast.SkipParentheses(bin.Right)) {
 		return
 	}
 

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
@@ -417,8 +417,14 @@ func isNodeValueNotFunction(node *ast.Node) bool {
 		ast.KindClassExpression,
 		ast.KindTemplateExpression,
 		ast.KindNoSubstitutionTemplateLiteral,
+		// ESTree's UnaryExpression covers `!x` / `-x` as well as `typeof x`,
+		// `void x` and `delete x`; tsgo splits the last three into their own
+		// kinds, so all five have to be listed here.
 		ast.KindPrefixUnaryExpression,
 		ast.KindPostfixUnaryExpression,
+		ast.KindTypeOfExpression,
+		ast.KindVoidExpression,
+		ast.KindDeleteExpression,
 		// Literals (ESTree collapses these into one `Literal` node type).
 		ast.KindStringLiteral,
 		ast.KindNumericLiteral,

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.go
@@ -105,20 +105,20 @@ func checkFindCall(ctx rule.RuleContext, node *ast.Node) {
 
 	comparison := comparisonParent(node) // non-nil only when isCompare
 
-	// Removing the comparison would drop comments between the call and the end
-	// of the comparison; upstream withholds the suggestion in that case.
-	wouldDropComments := isCompare && utils.HasCommentInSpan(
-		ctx.Comments.All(),
-		parenthesizedEnd(ctx, node),
-		comparison.End(),
-	)
-
-	if wouldDropComments {
-		ctx.ReportNode(methodNode, messageArraySome(method))
-		return
-	}
-
 	ctx.ReportNodeWithDeferredSuggestions(methodNode, messageArraySome(method), func() []rule.RuleSuggestion {
+		// Removing the comparison would drop comments between the call and the
+		// end of the comparison; upstream withholds the suggestion in that
+		// case. Checked inside the builder so lint-only runs never materialize
+		// the comment list — returning no suggestions reports exactly what
+		// ReportNode would.
+		if isCompare && utils.HasCommentInSpan(
+			ctx.Comments.All(),
+			parenthesizedEnd(ctx, node),
+			comparison.End(),
+		) {
+			return nil
+		}
+
 		fixes := []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, methodNode, "some")}
 		if isCompare {
 			// Remove the `== undefined` / `!== null` tail.

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.md
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.md
@@ -1,0 +1,45 @@
+# prefer-array-some
+
+## Rule Details
+
+Prefer using [`Array#some(…)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) over:
+
+- [`Array#find(…)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) / [`Array#findLast(…)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast) when the result is only used as a boolean.
+- [`Array#findIndex(…)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex) / [`Array#findLastIndex(…)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex) compared against `-1` / `0`.
+- A non-zero length check on [`Array#filter(…)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter).
+
+`.some(…)` communicates the intent — "is there a match?" — more directly and can stop iterating at the first match.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+if (array.find(element => element === "🦄")) {
+	// …
+}
+
+const hasUnicorn = array.findIndex(element => element === "🦄") !== -1;
+
+const hasUnicorn = array.filter(element => element === "🦄").length > 0;
+
+const foo = array.find(element => element === "🦄") ? bar : baz;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+if (array.some(element => element === "🦄")) {
+	// …
+}
+
+const hasUnicorn = array.some(element => element === "🦄");
+
+// The result is used, not just as a boolean.
+const unicorn = array.find(element => element === "🦄");
+
+// The index is used.
+const index = array.findIndex(element => element === "🦄");
+```
+
+## Original Documentation
+
+- [eslint-plugin-unicorn / prefer-array-some](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-some.md)

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.md
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some.md
@@ -10,6 +10,10 @@ Prefer using [`Array#some(…)`](https://developer.mozilla.org/en-US/docs/Web/Ja
 
 `.some(…)` communicates the intent — "is there a match?" — more directly and can stop iterating at the first match.
 
+Typed arrays carry the same methods and are checked too. Keyed collections
+(`Map`, `Set`, `WeakMap`, `WeakSet`) are not: their `.find(…)` / `.filter(…)`
+are unrelated APIs where the rewrite would not hold.
+
 Examples of **incorrect** code for this rule:
 
 ```javascript

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_extras_test.go
@@ -1,0 +1,271 @@
+// TestPreferArraySomeExtras locks in branches and edge shapes that the
+// upstream test suite doesn't exercise. Each case carries an inline comment
+// pointing at the specific branch / Dimension 4 row / tsgo AST quirk it covers,
+// so future refactors can't silently regress them without breaking a named
+// lock-in.
+package prefer_array_some_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_some"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestPreferArraySomeExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &prefer_array_some.PreferArraySomeRule, []rule_tester.ValidTestCase{
+		// ---- Dimension 4: Receiver wrappers ----
+
+		// Optional-chain member access `foo?.find(fn)` — MatchDotMethodCall
+		// rejects an optional member for the find branch (optionalMember:false).
+		{Code: `if (foo?.find(fn)) {}`},
+		// Optional call `foo.find?.(fn)` — optionalCall:false rejects it.
+		{Code: `if (foo.find?.(fn)) {}`},
+		// `.filter?.(fn).length > 0` — optional filter call, not matched.
+		{Code: `array.filter?.(fn).length > 0`},
+		// `array?.filter(fn).length > 0` — optional member on filter, not matched.
+		{Code: `array?.filter(fn).length > 0`},
+
+		// ---- Dimension 4: Access / key forms ----
+
+		// Computed string key `foo["find"]` is not a dot call.
+		{Code: `if (foo["find"](fn)) {}`},
+		// Numeric-literal-keyed length access is not `.length`.
+		{Code: `array.filter(fn)[0] > 0`},
+
+		// ---- Dimension 4: findIndex arg-count boundary ----
+
+		// findIndex with 0 args — ArgumentsLength:1 rejects it.
+		{Code: `foo.findIndex() !== -1`},
+		// findIndex with 2 args — rejected.
+		{Code: `foo.findIndex(fn, extra) !== -1`},
+
+		// ---- Dimension 4: RHS literal forms for findIndex ----
+
+		// `!== 1` (not -1) must not match.
+		{Code: `foo.findIndex(fn) !== 1`},
+		// `> 0` (not -1, and `>` pairs with -1 only) must not match.
+		{Code: `foo.findIndex(fn) > 0`},
+		// `>= 1` (not 0) must not match.
+		{Code: `foo.findIndex(fn) >= 1`},
+		// `< 1` (not 0) must not match.
+		{Code: `foo.findIndex(fn) < 1`},
+
+		// N/A: autofix-comment interplay covered in invalid cases below.
+
+		// ---- Locks in filter().length arm: `$`-prefixed receiver skipped ----
+		{Code: `$foo.filter(fn).length > 0`},
+		// Parenthesized `$`-prefixed receiver is still skipped.
+		{Code: `($foo).filter(fn).length > 0`},
+
+		// ---- Locks in filter().length arm: non-function first arg skipped ----
+		{Code: `array.filter(1).length > 0`},
+		{Code: `array.filter("x").length > 0`},
+		{Code: `array.filter({}).length > 0`},
+		{Code: `array.filter([]).length > 0`},
+		{Code: `array.filter(new Foo()).length > 0`},
+		// No first argument at all.
+		{Code: `array.filter().length > 0`},
+
+		// ---- Real-user: #1305 — `.filter(fn).length` with `.bind()` arg is a function ----
+		// A `.bind()` call IS possibly a function, so it should still report
+		// (covered in invalid). Here the negative: a non-bind call is skipped.
+		{Code: `array.filter(getPredicate()).length > 0`},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Dimension 4: parenthesized receiver in boolean position ----
+		{
+			Code:   `if ((foo).find(fn)) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{findErrorExtras(`if ((foo).some(fn)) {}`)},
+		},
+		// Double-parenthesized call in a control-flow test.
+		{
+			Code:   `if (((foo.find(fn)))) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{findErrorExtras(`if (((foo.some(fn)))) {}`)},
+		},
+
+		// ---- Locks in isCheckingUndefined arm: `!=` keeps positive ----
+		{Code: `foo.find(fn) != undefined`, Errors: []rule_tester.InvalidTestCaseError{findErrorExtras(`foo.some(fn)`)}},
+
+		// ---- Locks in findIndex arm: `>= 0` positive, `< 0` negated ----
+		{Code: `foo.findIndex(fn) >= 0`, Output: []string{`foo.some(fn) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findIndex(fn) < 0`, Output: []string{`!foo.some(fn) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+
+		// ---- Locks in filter().length arm: `.bind()` arg is a possible function ----
+		// #1305-style: `array.filter(cb.bind(thisArg)).length > 0` reports.
+		{Code: `array.filter(cb.bind(thisArg)).length > 0`, Output: []string{`array.some(cb.bind(thisArg))`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+
+		// ---- Locks in filter().length arm: `!== 0` operator ----
+		{Code: `array.filter(fn).length !== 0`, Output: []string{`array.some(fn)`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+
+		// ---- Real-user: logical-expression boolean context (&& / ||) ----
+		// `x && foo.find(fn)` where the whole thing is a control-flow test.
+		{Code: `if (x && foo.find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findErrorExtras(`if (x && foo.some(fn)) {}`)}},
+	})
+}
+
+// findErrorExtras mirrors findError from the upstream test file (same package,
+// but that helper lives in the other _test.go; redeclare a local one to keep
+// the files independent).
+func findErrorExtras(output string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageSome,
+		Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+			{MessageId: messageSuggest, Output: output},
+		},
+	}
+}
+
+// TestPreferArraySomeEditDemand verifies the deferred fix / suggestion builders
+// only materialize when their artifact category is demanded, and that the
+// diagnostic identity (message + range) is invariant across demands. The rule
+// emits a suggestion for `.find()` and an autofix for `.findIndex(...) !== -1`.
+func TestPreferArraySomeEditDemand(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		source         string
+		wantFix        bool
+		wantSuggestion bool
+	}{
+		{
+			name:           "find suggestion",
+			source:         "if (foo.find(fn)) {}\n",
+			wantSuggestion: true,
+		},
+		{
+			name:    "findIndex autofix",
+			source:  "foo.findIndex(fn) !== -1;\n",
+			wantFix: true,
+		},
+		{
+			name:    "filter length autofix",
+			source:  "array.filter(fn).length > 0;\n",
+			wantFix: true,
+		},
+	}
+
+	for index, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			program, sourceFile := createPreferArraySomeProgram(
+				t,
+				preferArraySomeFileName(index),
+				tc.source,
+			)
+			diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+			for _, demand := range []rule.EditDemand{
+				rule.EditDemandNone,
+				rule.EditDemandAutofix,
+				rule.EditDemandSuggestion,
+				rule.EditDemandAll,
+			} {
+				got := lintPreferArraySomeWithDemand(program, sourceFile, demand)
+				if len(got) != 1 {
+					t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(got))
+				}
+				diagnostics[demand] = got[0]
+			}
+
+			// Diagnostic identity (range + message) is invariant across demands.
+			base := diagnostics[rule.EditDemandNone]
+			if base.FixesPtr != nil || base.Suggestions != nil {
+				t.Errorf("EditDemandNone unexpectedly materialized edits")
+			}
+			for demand, diagnostic := range diagnostics {
+				if diagnostic.Range != base.Range {
+					t.Errorf("demand %d changed diagnostic range", demand)
+				}
+				if diagnostic.Message.Id != base.Message.Id ||
+					diagnostic.Message.Description != base.Message.Description {
+					t.Errorf("demand %d changed diagnostic message", demand)
+				}
+			}
+
+			// Autofix appears only under Autofix / All.
+			if diagnostics[rule.EditDemandSuggestion].FixesPtr != nil {
+				t.Errorf("suggestion-only demand materialized autofixes")
+			}
+			autofixOnly := diagnostics[rule.EditDemandAutofix].FixesPtr
+			allFixes := diagnostics[rule.EditDemandAll].FixesPtr
+			if tc.wantFix {
+				if autofixOnly == nil || allFixes == nil || !reflect.DeepEqual(*autofixOnly, *allFixes) {
+					t.Fatalf("autofix artifacts differ between autofix-only and all demand")
+				}
+			} else if autofixOnly != nil {
+				t.Errorf("unexpected autofix: %#v", *autofixOnly)
+			}
+
+			// Suggestions appear only under Suggestion / All.
+			if diagnostics[rule.EditDemandAutofix].Suggestions != nil {
+				t.Errorf("autofix-only demand materialized suggestions")
+			}
+			suggestionOnly := diagnostics[rule.EditDemandSuggestion].Suggestions
+			allSuggestions := diagnostics[rule.EditDemandAll].Suggestions
+			if tc.wantSuggestion {
+				if suggestionOnly == nil || allSuggestions == nil || !reflect.DeepEqual(*suggestionOnly, *allSuggestions) {
+					t.Fatalf("suggestion artifacts differ between suggestion-only and all demand")
+				}
+			} else if suggestionOnly != nil {
+				t.Errorf("unexpected suggestions: %#v", *suggestionOnly)
+			}
+		})
+	}
+}
+
+func preferArraySomeFileName(index int) string {
+	return "edit-demand-" + string(rune('a'+index)) + ".ts"
+}
+
+func createPreferArraySomeProgram(t testing.TB, fileName, code string) (*compiler.Program, *ast.SourceFile) {
+	t.Helper()
+	rootDir := fixtures.GetRootDir()
+	fs := utils.NewOverlayVFS(rootDir.FS, map[string]string{
+		tspath.ResolvePath(rootDir.Dir, fileName): code,
+	})
+	host := utils.CreateCompilerHost(rootDir.Dir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil {
+		t.Fatalf("source file %q not found", fileName)
+	}
+	return program, sourceFile
+}
+
+func lintPreferArraySomeWithDemand(program *compiler.Program, sourceFile *ast.SourceFile, demand rule.EditDemand) []rule.RuleDiagnostic {
+	var diagnostics []rule.RuleDiagnostic
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program:     program,
+		File:        sourceFile.FileName(),
+		HasTypeInfo: true,
+		GetRulesForFile: func(*ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:     prefer_array_some.PreferArraySomeRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return prefer_array_some.PreferArraySomeRule.Run(ctx, nil)
+				},
+			}}
+		},
+		ExcludePaths: []string{},
+		Consumer: rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		},
+	})
+	return diagnostics
+}

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_extras_test.go
@@ -72,6 +72,11 @@ func TestPreferArraySomeExtras(t *testing.T) {
 		{Code: `array.filter({}).length > 0`},
 		{Code: `array.filter([]).length > 0`},
 		{Code: `array.filter(new Foo()).length > 0`},
+		// ESTree folds these into UnaryExpression; tsgo gives each its own kind.
+		{Code: `array.filter(!foo).length > 0`},
+		{Code: `array.filter(typeof foo).length > 0`},
+		{Code: `array.filter(void 0).length > 0`},
+		{Code: `array.filter(delete a.b).length > 0`},
 		// No first argument at all.
 		{Code: `array.filter().length > 0`},
 

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_extras_test.go
@@ -61,6 +61,13 @@ func TestPreferArraySomeExtras(t *testing.T) {
 
 		// N/A: autofix-comment interplay covered in invalid cases below.
 
+		// ---- Class heritage does not widen to Array ----
+		// Upstream's is-array checker runs with `checkClassHeritage: false`, so
+		// only interface heritage reaches the array target (that case is in the
+		// upstream suite as invalid).
+		{Code: `class MyArray extends Array {} function foo(items: MyArray) { if (items.find(fn)) {} }`, Tsx: false},
+		{Code: `class MyArray extends Array {} function foo(items: MyArray) { items.filter(fn).length > 0; }`, Tsx: false},
+
 		// ---- Locks in filter().length arm: `$`-prefixed receiver skipped ----
 		{Code: `$foo.filter(fn).length > 0`},
 		// Parenthesized `$`-prefixed receiver is still skipped.

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_upstream_test.go
@@ -1,7 +1,8 @@
 // TestPreferArraySomeUpstream migrates the full valid/invalid suite from
-// upstream test/prefer-array-some.js 1:1. Position assertions cover
-// line/column for every invalid case. rslint-specific lock-in cases live in
-// the prefer_array_some_extras_test.go file.
+// upstream test/prefer-array-some.js 1:1, at eslint-plugin-unicorn 9c2b0bb1
+// ("Harden rules", #3585). Position assertions cover line/column for every
+// invalid case. rslint-specific lock-in cases live in the
+// prefer_array_some_extras_test.go file.
 //
 // Upstream's Vue test cases (test.vue) are omitted: rslint does not support
 // Vue single-file components.

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_upstream_test.go
@@ -1,0 +1,317 @@
+// TestPreferArraySomeUpstream migrates the full valid/invalid suite from
+// upstream test/prefer-array-some.js 1:1. Position assertions cover
+// line/column for every invalid case. rslint-specific lock-in cases live in
+// the prefer_array_some_extras_test.go file.
+//
+// Upstream's Vue test cases (test.vue) are omitted: rslint does not support
+// Vue single-file components.
+package prefer_array_some_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_some"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageSome    = "some"
+	messageFilter  = "filter"
+	messageSuggest = "some-suggestion"
+)
+
+// findError builds the expected `.some` error with its suggestion for a
+// `.find` / `.findLast` case.
+func findError(output string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: messageSome,
+		Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+			{MessageId: messageSuggest, Output: output},
+		},
+	}
+}
+
+func TestPreferArraySomeUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &prefer_array_some.PreferArraySomeRule, []rule_tester.ValidTestCase{
+		// ---- `.find()` result is not used as a boolean ----
+		{Code: `const bar = foo.find(fn)`},
+		{Code: `const bar = foo.find(fn) || baz`},
+		{Code: `if (foo.find(fn) ?? bar) {}`},
+		{Code: `let hasFoo = foo.find(fn); if (hasFoo) {}`},
+		{Code: `const hasFoo = foo.find(fn); hasFoo.value;`},
+		{Code: `const hasFoo = foo.find(fn); if (hasFoo) { const value = hasFoo; }`},
+		{Code: `const hasFoo = foo.find(fn); const value = other || hasFoo;`},
+		{Code: `const {hasFoo} = foo.find(fn); if (hasFoo) {}`},
+		{Code: `export const hasFoo = foo.find(fn);`},
+		{Code: `const hasFoo = foo.find(fn); export {hasFoo};`},
+		{Code: `const hasFoo = foo.find(fn);`},
+		{Code: `const hasFoo = foo.find(fn); if (hasFoo === undefined) {}`},
+		{Code: `const hasFoo = foo.find(fn); if (hasFoo || !hasFoo || Boolean(hasFoo)) {}`},
+		// `Boolean` is shadowed → not the global boolean cast.
+		{Code: `const Boolean = value => value; if (Boolean(foo.find(fn))) {}`},
+		{Code: `function unicorn(Boolean) { if (Boolean(foo.find(fn))) {} }`},
+		{Code: `const font = this.form[$globalData].fontFinder.find(typeface); if (!font) {}`},
+
+		// ---- receiver is definitely not an array (new X(), string) ----
+		{Code: `if (new Foo().find(fn)) {}`},
+		{Code: `if (new Foo().findLast(fn)) {}`},
+		{Code: `new Foo().findIndex(fn) !== -1`},
+		{Code: `new Foo().findLastIndex(fn) !== -1`},
+		{Code: `new Foo().filter(fn).length > 0`},
+		{Code: `if ("foo".find(fn)) {}`},
+		{Code: `const value = "foo"; if (value.find(fn)) {}`},
+		{Code: "if ((`foo${bar}`).find(fn)) {}"},
+		{Code: `if (({find() {}}).find(fn)) {}`},
+		{Code: `if ((function () {}).find(fn)) {}`},
+		{Code: `if ((() => {}).find(fn)) {}`},
+		{Code: `if ((class {}).find(fn)) {}`},
+		{Code: "(`foo${bar}`).findIndex(fn) !== -1"},
+		{Code: "(`foo${bar}`).filter(fn).length > 0"},
+		{Code: `({findIndex() {}}).findIndex(fn) !== -1`},
+		{Code: `({filter() {}}).filter(fn).length > 0`},
+
+		// ---- receiver is a non-indexed collection or unknown-with-shape ----
+		{Code: `const collection = {find() {}}; if (collection.find(fn)) {}`, Tsx: false},
+		{Code: `const store = new Store(); if (store.find(fn)) {}`},
+		{Code: `interface QueryCache {find(queryKey: string[]): unknown} declare const queryClient: {getQueryCache(): QueryCache}; queryClient.getQueryCache().find(["foo"]) ? "foo" : "bar";`, Tsx: false},
+		{Code: `interface QueryCache {findIndex(predicate: Function): number} declare const queryCache: QueryCache; queryCache.findIndex(fn) !== -1;`, Tsx: false},
+		{Code: `interface QueryCache {filter(predicate: Function): {length: number}} declare const queryCache: QueryCache; queryCache.filter(fn).length > 0;`, Tsx: false},
+		{Code: `interface QueryCache {findIndex(predicate: Function): number} declare function getQueryCache(): QueryCache; getQueryCache().findIndex(fn) !== -1;`, Tsx: false},
+		{Code: `interface QueryCache {filter(predicate: Function): {length: number}} declare function getQueryCache(): QueryCache; getQueryCache().filter(fn).length > 0;`, Tsx: false},
+		{Code: `class Store {find(key: string): boolean {return key.length > 0}} const store = new Store(); if (store.find("key")) {}`, Tsx: false},
+		{Code: `class Store extends HTMLElement {find(key: string): boolean {return key.length > 0}} const store = new Store(); if (store.find("key")) {}`, Tsx: false},
+		{Code: `function foo(collection: {find(predicate: Function): unknown}) { if (collection.find(fn)) {} }`, Tsx: false},
+		{Code: `function foo<T extends {find(predicate: Function): unknown}>(collection: T) { if (collection.find(fn)) {} }`, Tsx: false},
+		{Code: `function foo(collection: {findIndex(predicate: Function): number}) { collection.findIndex(fn) !== -1; }`, Tsx: false},
+		{Code: `function foo(collection: {filter(predicate: Function): {length: number}}) { collection.filter(fn).length > 0; }`, Tsx: false},
+		{Code: `type Collection = {find(predicate: Function): unknown}; const collection: Collection = [] as never; if (collection.find(fn)) {}`, Tsx: false},
+		{Code: `type Collection = {findIndex(predicate: Function): number}; ([] as Collection).findIndex(fn) !== -1`, Tsx: false},
+		{Code: `type Collection = {filter(predicate: Function): {length: number}}; ([] as Collection).filter(fn).length > 0`, Tsx: false},
+
+		// ---- explicit type arguments mean the value is used ----
+		{Code: `const hasFoo: Item | undefined = foo.find(fn); if (hasFoo) {}`, Tsx: false},
+		{Code: `const hasFoo = foo.find<Item>(fn); if (hasFoo) {}`, Tsx: false},
+		{Code: `const hasFoo = foo.findLast<Item>(fn); if (hasFoo) {}`, Tsx: false},
+		{Code: `if (foo.find<Item>(fn)) {}`, Tsx: false},
+		{Code: `if (foo.findLast<Item>(fn)) {}`, Tsx: false},
+		{Code: `foo.find<Item>(fn) !== undefined`, Tsx: false},
+		{Code: `foo.findLast<Item>(fn) !== undefined`, Tsx: false},
+
+		// ---- not a matched CallExpression ----
+		{Code: `if (new foo.find(fn)) {}`},
+		{Code: `if (new foo.findLast(fn)) {}`},
+		{Code: `if (find(fn)) {}`},
+		{Code: `if (findLast(fn)) {}`},
+		{Code: `if (foo["find"](fn)) {}`},
+		{Code: `if (foo["findLast"](fn)) {}`},
+		{Code: `if (foo["fi" + "nd"](fn)) {}`},
+		{Code: `if (foo["fi" + "ndLast"](fn)) {}`},
+		{Code: "if (foo[`find`](fn)) {}"},
+		{Code: "if (foo[`findLast`](fn)) {}"},
+		{Code: `if (foo[find](fn)) {}`},
+		{Code: `if (foo[findLast](fn)) {}`},
+		{Code: `if (foo.notFind(fn)) {}`},
+		{Code: `if (foo.notFindLast(fn)) {}`},
+		{Code: `if (foo.find()) {}`},
+		{Code: `if (foo.findLast()) {}`},
+		{Code: `if (foo.find(fn, thisArgument, extraArgument)) {}`},
+		{Code: `if (foo.findLast(fn, thisArgument, extraArgument)) {}`},
+		{Code: `if (foo.find(...argumentsArray)) {}`},
+		{Code: `if (foo.findLast(...argumentsArray)) {}`},
+
+		// ---- `.filter().length` valid comparisons (explicit-length-check) ----
+		{Code: `array.filter(fn).length > 0.`},
+		{Code: `array.filter(fn).length > .0`},
+		{Code: `array.filter(fn).length > 0.0`},
+		{Code: `array.filter(fn).length > 0x00`},
+		{Code: `array.filter(fn).length < 0`},
+		{Code: `array.filter(fn).length >= 0`},
+		{Code: `0 > array.filter(fn).length`},
+		{Code: `array.filter(fn).length !== 0.`},
+		{Code: `array.filter(fn).length !== .0`},
+		{Code: `array.filter(fn).length !== 0.0`},
+		{Code: `array.filter(fn).length !== 0x00`},
+		{Code: `array.filter(fn).length != 0`},
+		{Code: `array.filter(fn).length === 0`},
+		{Code: `array.filter(fn).length == 0`},
+		{Code: `array.filter(fn).length = 0`},
+		{Code: `0 !== array.filter(fn).length`},
+		{Code: `array.filter(fn).length >= 1`},
+		{Code: `array.filter(fn).length >= 1.`},
+		{Code: `array.filter(fn).length >= 1.0`},
+		{Code: `array.filter(fn).length >= 0x1`},
+		{Code: `array.filter(fn).length > 1`},
+		{Code: `array.filter(fn).length < 1`},
+		{Code: `array.filter(fn).length = 1`},
+		{Code: `array.filter(fn).length += 1`},
+		{Code: `1 >= array.filter(fn).length`},
+		{Code: `array.filter(fn)?.length > 0`},
+		{Code: `array.filter(fn)[length] > 0`},
+		{Code: `array.filter(fn).notLength > 0`},
+		{Code: `array.filter(fn).length() > 0`},
+		{Code: `+array.filter(fn).length >= 1`},
+		{Code: `array.filter?.(fn).length > 0`},
+		{Code: `array?.filter(fn).length > 0`},
+		{Code: `array.notFilter(fn).length > 0`},
+		{Code: `array.filter.length > 0`},
+		{Code: `$element.filter(":visible").length > 0`},
+		{Code: `var res = $module.filter(selector.disabled).length > 0;`},
+		{Code: `$module.filter(fn).length !== 0`},
+
+		// ---- `.findIndex()` valid comparisons ----
+		{Code: `foo.notMatchedMethod(bar) !== -1`},
+		{Code: `new foo.findIndex(bar) !== -1`},
+		{Code: `foo.findIndex(bar, extraArgument) !== -1`},
+		{Code: `foo.findIndex(bar) instanceof -1`},
+		{Code: `foo.findIndex(...bar) !== -1`},
+		{Code: `_.findIndex(bar)`},
+		{Code: `_.findIndex(foo, bar)`},
+
+		// ---- compare-with-undefined valid ----
+		{Code: `foo.find(fn) == 0`},
+		{Code: `foo.find(fn) != ""`},
+		{Code: `foo.find(fn) === null`},
+		{Code: `foo.find(fn) !== "null"`},
+		{Code: `foo.find(fn) >= undefined`},
+		{Code: `foo.find(fn) instanceof undefined`},
+		// We are not checking `typeof` right now.
+		{Code: `typeof foo.find(fn) === "undefined"`},
+	}, []rule_tester.InvalidTestCase{
+		// ---- boolean-position `.find()` / `.findLast()` ----
+		{Code: `const bar = !foo.find(fn)`, Errors: []rule_tester.InvalidTestCaseError{findError(`const bar = !foo.some(fn)`)}},
+		{Code: `const bar = !foo.findLast(fn)`, Errors: []rule_tester.InvalidTestCaseError{findError(`const bar = !foo.some(fn)`)}},
+		{Code: `const bar = Boolean(foo.find(fn))`, Errors: []rule_tester.InvalidTestCaseError{findError(`const bar = Boolean(foo.some(fn))`)}},
+		{Code: `const bar = Boolean(foo.findLast(fn))`, Errors: []rule_tester.InvalidTestCaseError{findError(`const bar = Boolean(foo.some(fn))`)}},
+		{Code: `const bar = !!Boolean(foo.find(fn))`, Errors: []rule_tester.InvalidTestCaseError{findError(`const bar = !!Boolean(foo.some(fn))`)}},
+		{Code: `const bar = !!Boolean(foo.findLast(fn))`, Errors: []rule_tester.InvalidTestCaseError{findError(`const bar = !!Boolean(foo.some(fn))`)}},
+		{Code: `if (foo.find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`if (foo.some(fn)) {}`)}},
+		{Code: `if (foo.findLast(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`if (foo.some(fn)) {}`)}},
+		{Code: `const bar = foo.find(fn) ? 1 : 2`, Errors: []rule_tester.InvalidTestCaseError{findError(`const bar = foo.some(fn) ? 1 : 2`)}},
+		{Code: `const bar = foo.findLast(fn) ? 1 : 2`, Errors: []rule_tester.InvalidTestCaseError{findError(`const bar = foo.some(fn) ? 1 : 2`)}},
+		{Code: `while (foo.find(fn)) foo.shift();`, Errors: []rule_tester.InvalidTestCaseError{findError(`while (foo.some(fn)) foo.shift();`)}},
+		{Code: `while (foo.findLast(fn)) foo.shift();`, Errors: []rule_tester.InvalidTestCaseError{findError(`while (foo.some(fn)) foo.shift();`)}},
+		{Code: `do {foo.shift();} while (foo.find(fn));`, Errors: []rule_tester.InvalidTestCaseError{findError(`do {foo.shift();} while (foo.some(fn));`)}},
+		{Code: `do {foo.shift();} while (foo.findLast(fn));`, Errors: []rule_tester.InvalidTestCaseError{findError(`do {foo.shift();} while (foo.some(fn));`)}},
+		{Code: `for (; foo.find(fn); ) foo.shift();`, Errors: []rule_tester.InvalidTestCaseError{findError(`for (; foo.some(fn); ) foo.shift();`)}},
+		{Code: `for (; foo.findLast(fn); ) foo.shift();`, Errors: []rule_tester.InvalidTestCaseError{findError(`for (; foo.some(fn); ) foo.shift();`)}},
+
+		// ---- variable used only as boolean (array receiver) ----
+		{Code: `const hasFoo = [].find(fn); if (hasFoo) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`const hasFoo = [].some(fn); if (hasFoo) {}`)}},
+		{Code: `const hasFoo = [].findLast(fn); if (hasFoo) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`const hasFoo = [].some(fn); if (hasFoo) {}`)}},
+		{Code: `const array = []; const hasFoo = array.find(fn); if (hasFoo) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`const array = []; const hasFoo = array.some(fn); if (hasFoo) {}`)}},
+		{Code: `const array = []; const hasFoo = array.findLast(fn); if (hasFoo) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`const array = []; const hasFoo = array.some(fn); if (hasFoo) {}`)}},
+
+		// ---- comments: suggestion keeps comments when only replacing method ----
+		{
+			Code:   `console.log(foo /* comment 1 */ . /* comment 2 */ find /* comment 3 */ (fn) ? a : b)`,
+			Errors: []rule_tester.InvalidTestCaseError{findError(`console.log(foo /* comment 1 */ . /* comment 2 */ some /* comment 3 */ (fn) ? a : b)`)},
+		},
+		// jQuery.find is always truthy but upstream still reports.
+		{Code: `if (jQuery.find(".outer > div")) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`if (jQuery.some(".outer > div")) {}`)}},
+
+		// ---- actual message text ----
+		{
+			Code: `if (bar.find(fn)) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: messageSome,
+				Message:   "Prefer `.some(…)` over `.find(…)`.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: messageSuggest, Output: `if (bar.some(fn)) {}`},
+				},
+			}},
+		},
+		{
+			Code: `if (bar.findLast(fn)) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: messageSome,
+				Message:   "Prefer `.some(…)` over `.findLast(…)`.",
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: messageSuggest, Output: `if (bar.some(fn)) {}`},
+				},
+			}},
+		},
+
+		// ---- array receiver forms (type-aware, .ts) ----
+		{Code: `if ([].find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`if ([].some(fn)) {}`)}},
+		{Code: `if (Array().find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`if (Array().some(fn)) {}`)}},
+		{Code: `if (new Array().find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`if (new Array().some(fn)) {}`)}},
+		{Code: `if (Array.from(iterable).find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`if (Array.from(iterable).some(fn)) {}`)}},
+		{Code: `if (Array.of(value).find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`if (Array.of(value).some(fn)) {}`)}},
+		{Code: `const array = []; if (array.find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`const array = []; if (array.some(fn)) {}`)}},
+		{Code: `const array = Array(); if (array.find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`const array = Array(); if (array.some(fn)) {}`)}},
+		{Code: `const array = new Array(); if (array.find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`const array = new Array(); if (array.some(fn)) {}`)}},
+		{Code: `const array = Array.from(iterable); if (array.find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`const array = Array.from(iterable); if (array.some(fn)) {}`)}},
+		{Code: `const array = Array.of(value); if (array.find(fn)) {}`, Errors: []rule_tester.InvalidTestCaseError{findError(`const array = Array.of(value); if (array.some(fn)) {}`)}},
+		{Code: `function foo(array: string[]) { if (array.find(fn)) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`function foo(array: string[]) { if (array.some(fn)) {} }`)}},
+		{Code: `function foo(array: readonly string[]) { if (array.find(fn)) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`function foo(array: readonly string[]) { if (array.some(fn)) {} }`)}},
+		{Code: `function foo(array: ReadonlyArray<string>) { if (array.find(fn)) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`function foo(array: ReadonlyArray<string>) { if (array.some(fn)) {} }`)}},
+		{Code: `function foo(array: [string, string]) { if (array.find(fn)) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`function foo(array: [string, string]) { if (array.some(fn)) {} }`)}},
+		{Code: `function foo<T extends string[]>(array: T) { if (array.find(fn)) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`function foo<T extends string[]>(array: T) { if (array.some(fn)) {} }`)}},
+		{Code: `type Items = string[]; function foo(items: Items) { if (items.find(fn)) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`type Items = string[]; function foo(items: Items) { if (items.some(fn)) {} }`)}},
+		{Code: `interface Items extends Array<string> {} function foo(items: Items) { if (items.find(fn)) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`interface Items extends Array<string> {} function foo(items: Items) { if (items.some(fn)) {} }`)}},
+		{Code: `function foo<T>(items: string[] | {find(predicate: Function): unknown} | T) { if (items.find(fn)) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`function foo<T>(items: string[] | {find(predicate: Function): unknown} | T) { if (items.some(fn)) {} }`)}},
+		{Code: `type Items = string[] | {find(predicate: Function): unknown}; function foo(items: Items) { if (items.find(fn)) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`type Items = string[] | {find(predicate: Function): unknown}; function foo(items: Items) { if (items.some(fn)) {} }`)}},
+		{Code: `type Collection = {find(predicate: Function): unknown}; if (([] satisfies Collection).find(fn)) {}`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`type Collection = {find(predicate: Function): unknown}; if (([] satisfies Collection).some(fn)) {}`)}},
+		{Code: `declare function getItems(): string[]; if (getItems().find(fn)) {}`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`declare function getItems(): string[]; if (getItems().some(fn)) {}`)}},
+		{Code: `function foo(array: string[]) { const hasFoo = array.find(fn); if (hasFoo) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`function foo(array: string[]) { const hasFoo = array.some(fn); if (hasFoo) {} }`)}},
+		{Code: `declare function getItems(): string[]; const hasFoo = getItems().find(fn); if (hasFoo) {}`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`declare function getItems(): string[]; const hasFoo = getItems().some(fn); if (hasFoo) {}`)}},
+		{Code: `function foo<T>(collection: T) { if (collection.find(fn)) {} }`, Tsx: false, Errors: []rule_tester.InvalidTestCaseError{findError(`function foo<T>(collection: T) { if (collection.some(fn)) {} }`)}},
+
+		// ---- snapshot group: find used as boolean ----
+		{
+			Code:   `if (array.find(element => element === "🦄")) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{findError(`if (array.some(element => element === "🦄")) {}`)},
+		},
+		{
+			Code:   `const foo = array.find(element => element === "🦄") ? bar : baz;`,
+			Errors: []rule_tester.InvalidTestCaseError{findError(`const foo = array.some(element => element === "🦄") ? bar : baz;`)},
+		},
+
+		// ---- `.filter().length` reported forms ----
+		{Code: `array.filter(fn).length > 0`, Output: []string{`array.some(fn)`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+		{Code: `array.filter(fn).length !== 0`, Output: []string{`array.some(fn)`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+		// Don't drop comments in the removed part → no fix.
+		{Code: `array.filter(fn).length /* keep */ > 0`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+		{Code: `module$.filter(fn).length > 0`, Output: []string{`module$.some(fn)`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+		{Code: `type Collection = {filter(predicate: Function): {length: number}}; ([] satisfies Collection).filter(fn).length > 0`, Tsx: false, Output: []string{`type Collection = {filter(predicate: Function): {length: number}}; ([] satisfies Collection).some(fn)`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+		{Code: `type Items = string[] | {filter(predicate: Function): {length: number}}; function foo(items: Items) { items.filter(fn).length > 0; }`, Tsx: false, Output: []string{`type Items = string[] | {filter(predicate: Function): {length: number}}; function foo(items: Items) { items.some(fn); }`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+		{Code: `declare function getItems(): string[]; getItems().filter(fn).length > 0;`, Tsx: false, Output: []string{`declare function getItems(): string[]; getItems().some(fn);`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+		// A typed array shares `Array#filter()` and `Array#some()`.
+		{Code: `function f(array: Int8Array) { return array.filter(fn).length > 0; }`, Tsx: false, Output: []string{`function f(array: Int8Array) { return array.some(fn); }`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+
+		// ---- `.findIndex()` / `.findLastIndex()` compared ----
+		{Code: `foo.findIndex(bar) !== -1`, Output: []string{`foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findLastIndex(bar) !== -1`, Output: []string{`foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findIndex(bar) != -1`, Output: []string{`foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findLastIndex(bar) != -1`, Output: []string{`foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findIndex(bar) > - 1`, Output: []string{`foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findLastIndex(bar) > - 1`, Output: []string{`foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findIndex(bar) === -1`, Output: []string{`!foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findLastIndex(bar) === -1`, Output: []string{`!foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findIndex(bar) == - 1`, Output: []string{`!foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findLastIndex(bar) == - 1`, Output: []string{`!foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findIndex(bar) >= 0`, Output: []string{`foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findLastIndex(bar) >= 0`, Output: []string{`foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findIndex(bar) < 0`, Output: []string{`!foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findLastIndex(bar) < 0`, Output: []string{`!foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findIndex(bar) !== (( - 1 ))`, Output: []string{`foo.some(bar) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `foo.findIndex(element => element.bar === 1) !== (( - 1 ))`, Output: []string{`foo.some(element => element.bar === 1) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		// Don't drop comments in the removed part → no fix.
+		{Code: `foo.findIndex(bar) !== /* keep */ -1`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `type Collection = {findIndex(predicate: Function): number}; ([] satisfies Collection).findIndex(fn) !== -1`, Tsx: false, Output: []string{`type Collection = {findIndex(predicate: Function): number}; ([] satisfies Collection).some(fn) `}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `type Items = string[] | {findIndex(predicate: Function): number}; function foo(items: Items) { items.findIndex(fn) !== -1; }`, Tsx: false, Output: []string{`type Items = string[] | {findIndex(predicate: Function): number}; function foo(items: Items) { items.some(fn) ; }`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+		{Code: `declare function getItems(): string[]; getItems().findIndex(fn) !== -1;`, Tsx: false, Output: []string{`declare function getItems(): string[]; getItems().some(fn) ;`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+
+		// ---- compare-with-undefined reported forms ----
+		{Code: `foo.find(fn) == null`, Errors: []rule_tester.InvalidTestCaseError{findError(`!foo.some(fn)`)}},
+		{Code: `foo.find(fn) == undefined`, Errors: []rule_tester.InvalidTestCaseError{findError(`!foo.some(fn)`)}},
+		{Code: `foo.find(fn) === undefined`, Errors: []rule_tester.InvalidTestCaseError{findError(`!foo.some(fn)`)}},
+		{Code: `foo.find(fn) != null`, Errors: []rule_tester.InvalidTestCaseError{findError(`foo.some(fn)`)}},
+		{Code: `foo.find(fn) != undefined`, Errors: []rule_tester.InvalidTestCaseError{findError(`foo.some(fn)`)}},
+		{Code: `foo.find(fn) !== undefined`, Errors: []rule_tester.InvalidTestCaseError{findError(`foo.some(fn)`)}},
+		{Code: `a = (( ((foo.find(fn))) == ((null)) )) ? "no" : "yes";`, Errors: []rule_tester.InvalidTestCaseError{findError(`a = (( !((foo.some(fn))) )) ? "no" : "yes";`)}},
+		// Don't drop comments in the removed comparison part → no suggestion.
+		{Code: `foo.find(fn) === /* keep */ undefined`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageSome}}},
+	})
+}

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_upstream_test.go
@@ -273,6 +273,9 @@ func TestPreferArraySomeUpstream(t *testing.T) {
 		{Code: `array.filter(fn).length !== 0`, Output: []string{`array.some(fn)`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
 		// Don't drop comments in the removed part → no fix.
 		{Code: `array.filter(fn).length /* keep */ > 0`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+		// Parentheses around `.length` survive the removal.
+		{Code: `((array.filter(fn).length)) > 0`, Output: []string{`((array.some(fn)))`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+		{Code: `(( array.filter(fn).length )) > 0`, Output: []string{`(( array.some(fn) ))`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
 		{Code: `module$.filter(fn).length > 0`, Output: []string{`module$.some(fn)`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
 		{Code: `type Collection = {filter(predicate: Function): {length: number}}; ([] satisfies Collection).filter(fn).length > 0`, Tsx: false, Output: []string{`type Collection = {filter(predicate: Function): {length: number}}; ([] satisfies Collection).some(fn)`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
 		{Code: `type Items = string[] | {filter(predicate: Function): {length: number}}; function foo(items: Items) { items.filter(fn).length > 0; }`, Tsx: false, Output: []string{`type Items = string[] | {filter(predicate: Function): {length: number}}; function foo(items: Items) { items.some(fn); }`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},

--- a/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_array_some/prefer_array_some_upstream_test.go
@@ -273,6 +273,8 @@ func TestPreferArraySomeUpstream(t *testing.T) {
 		{Code: `array.filter(fn).length !== 0`, Output: []string{`array.some(fn)`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
 		// Don't drop comments in the removed part → no fix.
 		{Code: `array.filter(fn).length /* keep */ > 0`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
+		// A parenthesized `0` still matches, like upstream's paren-free ESTree.
+		{Code: `(( (( array.filter(fn) )).length )) > (( 0 ))`, Output: []string{`(( (( array.some(fn) )) ))`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
 		// Parentheses around `.length` survive the removal.
 		{Code: `((array.filter(fn).length)) > 0`, Output: []string{`((array.some(fn)))`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},
 		{Code: `(( array.filter(fn).length )) > 0`, Output: []string{`(( array.some(fn) ))`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: messageFilter}}},

--- a/internal/plugins/unicorn/unicornutil/method_call.go
+++ b/internal/plugins/unicorn/unicornutil/method_call.go
@@ -12,11 +12,20 @@ type DotMethodCall struct {
 }
 
 // DotMethodCallOptions mirrors the subset of unicorn's isMethodCall options
-// used by native rslint rules. Nil argument limits disable that check.
+// used by native rslint rules. Nil argument limits disable that check. Method
+// matches a single name; Methods matches any name in the set. Supply at most
+// one of them.
 type DotMethodCallOptions struct {
-	Method              string
-	ArgumentsLength     *int
-	MinimumArguments    *int
+	Method           string
+	Methods          []string
+	ArgumentsLength  *int
+	MinimumArguments *int
+	MaximumArguments *int
+	// RejectSpreadElement opts into upstream isMethodCall's default
+	// `allowSpreadElement: false` behavior: a SpreadElement argument appearing
+	// below the effective argument bound disqualifies the match. It defaults to
+	// off so existing callers keep matching spread-argument calls.
+	RejectSpreadElement bool
 	AllowOptionalCall   bool
 	AllowOptionalMember bool
 }
@@ -42,6 +51,27 @@ func MatchDotMethodCall(node *ast.Node, options DotMethodCallOptions) (DotMethod
 	if options.MinimumArguments != nil && len(args) < *options.MinimumArguments {
 		return DotMethodCall{}, false
 	}
+	if options.MaximumArguments != nil && len(args) > *options.MaximumArguments {
+		return DotMethodCall{}, false
+	}
+	// Mirror upstream's spread rejection: when spread elements are not allowed,
+	// a SpreadElement appearing at an index below the effective maximum-args
+	// bound (maximumArguments, else argumentsLength) disqualifies the match.
+	if options.RejectSpreadElement {
+		bound := -1
+		if options.MaximumArguments != nil {
+			bound = *options.MaximumArguments
+		} else if options.ArgumentsLength != nil {
+			bound = *options.ArgumentsLength
+		}
+		if bound >= 0 {
+			for i, arg := range args {
+				if i < bound && arg.Kind == ast.KindSpreadElement {
+					return DotMethodCall{}, false
+				}
+			}
+		}
+	}
 
 	rawCallee := call.Expression
 	callee := ast.SkipParentheses(rawCallee)
@@ -58,7 +88,7 @@ func MatchDotMethodCall(node *ast.Node, options DotMethodCallOptions) (DotMethod
 
 	property := propertyAccess.Name()
 	if property == nil || !ast.IsIdentifier(property) ||
-		property.AsIdentifier().Text != options.Method {
+		!matchesMethodName(property.AsIdentifier().Text, options) {
 		return DotMethodCall{}, false
 	}
 
@@ -69,4 +99,22 @@ func MatchDotMethodCall(node *ast.Node, options DotMethodCallOptions) (DotMethod
 		Object:    propertyAccess.Expression,
 		Property:  property,
 	}, true
+}
+
+// matchesMethodName reports whether name satisfies the option's Method /
+// Methods constraint. Methods takes precedence when non-empty; otherwise Method
+// is matched. When neither is set, any name matches.
+func matchesMethodName(name string, options DotMethodCallOptions) bool {
+	if len(options.Methods) > 0 {
+		for _, m := range options.Methods {
+			if name == m {
+				return true
+			}
+		}
+		return false
+	}
+	if options.Method != "" {
+		return name == options.Method
+	}
+	return true
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -571,6 +571,7 @@ export default defineConfig({
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',
+    './tests/eslint-plugin-unicorn/rules/prefer-array-some.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-node-protocol.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-number-properties.test.ts',
     './tests/eslint-plugin-unicorn/rules/require-array-join-separator.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-array-some.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-array-some.test.ts
@@ -1,0 +1,196 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// The JS suite mirrors upstream Layer 1 only: it verifies rule registration,
+// the IPC wire protocol, and ESLint-compatible diagnostic shape. Edge-shape
+// (Dimension 4), branch lock-in, and type-aware cases live in the Go
+// prefer_array_some_extras_test.go / _upstream_test.go files.
+
+const suggestionFind = (output: string, method = 'find') => [
+  {
+    messageId: 'some-suggestion',
+    data: { method },
+    output,
+  },
+];
+
+const valid = (code: string) => ({ code });
+
+ruleTester.run('prefer-array-some', null as never, {
+  valid: [
+    // `.find()` result not used as a boolean
+    valid('const bar = foo.find(fn)'),
+    valid('const bar = foo.find(fn) || baz'),
+    valid('if (foo.find(fn) ?? bar) {}'),
+    valid('let hasFoo = foo.find(fn); if (hasFoo) {}'),
+    valid('const hasFoo = foo.find(fn); hasFoo.value;'),
+    valid('const {hasFoo} = foo.find(fn); if (hasFoo) {}'),
+    valid('export const hasFoo = foo.find(fn);'),
+    valid('const hasFoo = foo.find(fn); if (hasFoo === undefined) {}'),
+    valid('const Boolean = value => value; if (Boolean(foo.find(fn))) {}'),
+
+    // receiver definitely not an array
+    valid('if (new Foo().find(fn)) {}'),
+    valid('if (new Foo().findLast(fn)) {}'),
+    valid('new Foo().findIndex(fn) !== -1'),
+    valid('new Foo().filter(fn).length > 0'),
+    valid('if ("foo".find(fn)) {}'),
+
+    // not a matched CallExpression
+    valid('if (find(fn)) {}'),
+    valid('if (foo["find"](fn)) {}'),
+    valid('if (foo.notFind(fn)) {}'),
+    valid('if (foo.find()) {}'),
+    valid('if (foo.find(fn, thisArgument, extraArgument)) {}'),
+    valid('if (foo.find(...argumentsArray)) {}'),
+
+    // `.filter().length` valid comparisons
+    valid('array.filter(fn).length > 0.'),
+    valid('array.filter(fn).length < 0'),
+    valid('array.filter(fn).length >= 0'),
+    valid('array.filter(fn).length != 0'),
+    valid('array.filter(fn).length === 0'),
+    valid('array.filter(fn).length >= 1'),
+    valid('array.filter(fn)?.length > 0'),
+    valid('array.filter?.(fn).length > 0'),
+    valid('array?.filter(fn).length > 0'),
+    valid('$element.filter(":visible").length > 0'),
+
+    // `.findIndex()` valid comparisons
+    valid('foo.notMatchedMethod(bar) !== -1'),
+    valid('new foo.findIndex(bar) !== -1'),
+    valid('foo.findIndex(bar, extraArgument) !== -1'),
+    valid('foo.findIndex(...bar) !== -1'),
+
+    // compare-with-undefined valid
+    valid('foo.find(fn) == 0'),
+    valid('foo.find(fn) === null'),
+    valid('foo.find(fn) >= undefined'),
+    valid('typeof foo.find(fn) === "undefined"'),
+  ],
+  invalid: [
+    // boolean-position `.find()` / `.findLast()`
+    {
+      code: 'const bar = !foo.find(fn)',
+      errors: [
+        {
+          messageId: 'some',
+          suggestions: suggestionFind('const bar = !foo.some(fn)'),
+        },
+      ],
+    },
+    {
+      code: 'if (foo.find(fn)) {}',
+      errors: [
+        {
+          messageId: 'some',
+          suggestions: suggestionFind('if (foo.some(fn)) {}'),
+        },
+      ],
+    },
+    {
+      code: 'if (foo.findLast(fn)) {}',
+      errors: [
+        {
+          messageId: 'some',
+          suggestions: suggestionFind('if (foo.some(fn)) {}', 'findLast'),
+        },
+      ],
+    },
+    {
+      code: 'const bar = Boolean(foo.find(fn))',
+      errors: [
+        {
+          messageId: 'some',
+          suggestions: suggestionFind('const bar = Boolean(foo.some(fn))'),
+        },
+      ],
+    },
+    {
+      code: 'const bar = foo.find(fn) ? 1 : 2',
+      errors: [
+        {
+          messageId: 'some',
+          suggestions: suggestionFind('const bar = foo.some(fn) ? 1 : 2'),
+        },
+      ],
+    },
+    // variable used only as boolean (array receiver)
+    {
+      code: 'const hasFoo = [].find(fn); if (hasFoo) {}',
+      errors: [
+        {
+          messageId: 'some',
+          suggestions: suggestionFind(
+            'const hasFoo = [].some(fn); if (hasFoo) {}',
+          ),
+        },
+      ],
+    },
+    // actual message text
+    {
+      code: 'if (bar.find(fn)) {}',
+      errors: [
+        {
+          message: 'Prefer `.some(…)` over `.find(…)`.',
+          suggestions: [
+            {
+              messageId: 'some-suggestion',
+              data: { method: 'find' },
+              output: 'if (bar.some(fn)) {}',
+            },
+          ],
+        },
+      ],
+    },
+
+    // `.findIndex()` compared → autofix
+    {
+      code: 'foo.findIndex(bar) !== -1',
+      output: 'foo.some(bar) ',
+      errors: [{ messageId: 'some' }],
+    },
+    {
+      code: 'foo.findIndex(bar) === -1',
+      output: '!foo.some(bar) ',
+      errors: [{ messageId: 'some' }],
+    },
+    {
+      code: 'foo.findLastIndex(bar) >= 0',
+      output: 'foo.some(bar) ',
+      errors: [{ messageId: 'some' }],
+    },
+    {
+      code: 'foo.findIndex(bar) < 0',
+      output: '!foo.some(bar) ',
+      errors: [{ messageId: 'some' }],
+    },
+
+    // `.filter().length` → autofix
+    {
+      code: 'array.filter(fn).length > 0',
+      output: 'array.some(fn)',
+      errors: [{ messageId: 'filter' }],
+    },
+    {
+      code: 'array.filter(fn).length !== 0',
+      output: 'array.some(fn)',
+      errors: [{ messageId: 'filter' }],
+    },
+
+    // compare-with-undefined → suggestion
+    {
+      code: 'foo.find(fn) == null',
+      errors: [
+        { messageId: 'some', suggestions: suggestionFind('!foo.some(fn)') },
+      ],
+    },
+    {
+      code: 'foo.find(fn) !== undefined',
+      errors: [
+        { messageId: 'some', suggestions: suggestionFind('foo.some(fn)') },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `unicorn/prefer-array-some` rule from eslint-plugin-unicorn to rslint, at upstream `9c2b0bb1` ("Harden rules", #3585).

Suggests replacing `.find()`/`.findLast()` boolean checks, `.findIndex()`/`.findLastIndex()` comparisons against `-1`/`0`, and `.filter(…).length > 0` with `.some(…)`.

`RequiresTypeInfo: false` — syntactic-first, type info only refines (skips keyed-collection receivers, confirms array for the variable-usage branch).

### Differential validation

22 (rslint) vs 21 (ESLint) on a controlled fixture. rslint covers all 21 ESLint reports. The extra one is `Int8Array.filter(fn).length > 0`, which the ESLint side does not report because it runs the last published release; upstream's `isKnownNonIndexedCollection` change makes typed arrays targets, and its test suite has this case as invalid. Behavior here follows that.

## Related Links

- Rule doc: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-some.md
- Source: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/9c2b0bb1/rules/prefer-array-some.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
