### PR TITLE
perf: parallelize TypeScript program builds

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -920,7 +920,7 @@ collection, and plugin dispatch may still use infrastructure goroutines.
      lint-target walk.
    - Configured Program identities, config associations, and result slots are
      planned serially in stable config/project order. Construction then uses at
-     most `min(8, GOMAXPROCS, Program count)` workers and merges results and
+     most `min(GOMAXPROCS, Program count)` workers and merges results and
      errors by the planned order.
    - `--singleThreaded` executes the same state machine with one Go discovery
      worker and serializes module evaluation within each Node frontier batch.

--- a/architecture.md
+++ b/architecture.md
@@ -874,7 +874,7 @@ The CLI has a two-layer architecture: a Node.js wrapper (`packages/rslint/src/cl
    - `--api`: starts the IPC API server
    - default: runs direct CLI linting
 4. **Lint Target Plan**: Go resolves a stable target set from CLI/API scope, the implicit default baseline, explicit config `files`, global ignores, and `.gitignore`
-5. **Program Registry**: plain lint builds each normalized tsconfig path declared by an active governing config once; `--type-check` and `--type-check-only` instead retain every project declared by the effective loaded config catalog. Shared declared paths preserve each active config association and declaration order.
+5. **Program Registry**: plain lint builds each normalized tsconfig path declared by an active governing config once; `--type-check` and `--type-check-only` instead retain every project declared by the effective loaded config catalog. Shared declared paths preserve each active config association and declaration order. Planning fixes those identities and stable slots serially, then independent Programs fill the slots through a bounded worker pool.
 6. **Program Binding**: each target is bound by exact lexical or canonical filesystem identity to the first containing Program declared by its governing config; unbound targets, including projects with no tsconfig, are parsed through a non-project-backed fallback Program
 7. **Rule Resolution**: `getRulesForFile` resolves enabled rules from the stable lint-target path, never the Program source alias, and filters type-aware rules off no-type-info gap files
 8. **Rule Execution**: `RunLinter()` schedules per-Program work over the exact target plan; the unexported `runLintRulesInProgram()` does the actual per-file traversal. The CLI supplies a native edit demand independently of rule selection: diagnostics-only for plain lint, autofix-only for writable `--fix` passes, and diagnostics-only for the final verification pass. When `--type-check` is enabled, a separate program-wide pass over real tsconfig Programs aggregates `tsc --noEmit`-aligned diagnostics through `collectNoEmitDiagnostics()`
@@ -918,8 +918,10 @@ collection, and plugin dispatch may still use infrastructure goroutines.
      represented configs. `--type-check` and `--type-check-only` construct
      every Program in the effective reachable catalog; the latter skips the
      lint-target walk.
-   - Configured Programs remain serial in stable config/project order because
-     typescript-go's API is invoked one Program at a time.
+   - Configured Program identities, config associations, and result slots are
+     planned serially in stable config/project order. Construction then uses at
+     most `min(8, GOMAXPROCS, Program count)` workers and merges results and
+     errors by the planned order.
    - `--singleThreaded` executes the same state machine with one Go discovery
      worker and serializes module evaluation within each Node frontier batch.
      Coordinator batches and results remain ordered in either mode.
@@ -1004,6 +1006,7 @@ Other invariants:
 | Linter work group             | Collapsed to serial via `core.NewWorkGroup(true)`.                                                            |
 | Type-check work group         | Program diagnostics are computed serially via `core.NewWorkGroup(true)`.                                      |
 | Staged catalog discovery      | Sibling-frontier workers and Node module evaluation are serialized; batches and catalog merge remain ordered. |
+| Configured Program builds     | Planned and constructed serially in stable config/project order, retaining fail-fast error behavior.          |
 | Lint-target walker workers    | Forced to 1 (single goroutine, no concurrency).                                                               |
 | Program source identity index | Canonical source paths are resolved serially through `core.NewWorkGroup(true)`.                               |
 
@@ -1015,7 +1018,7 @@ goroutines remain outside that guarantee.
 ### Design Principles
 
 - **Direct ts-go Data Model**: rslint operates on ts-go `Program`, AST, and `TypeChecker` objects directly instead of converting through a second AST representation
-- **Program-Level Parallelism**: `RunLinter` queues work per `Program` through `core.NewWorkGroup`; `--singleThreaded` forces the same flow to run serially
+- **Program-Level Parallelism**: configured Program construction uses a bounded, stable-slot worker pool, and `RunLinter` queues subsequent lint work per Program through `core.NewWorkGroup`; `--singleThreaded` forces both flows to run serially
 - **Single-Walk Rule Dispatch**: each file is traversed once, with rules registering listeners up front and sharing the same AST walk
 - **Early Filtering**: exact lint target plans, skip paths, global-ignore filters, and gap-file type filtering reduce work before listeners run
 
@@ -1049,9 +1052,9 @@ goroutines remain outside that guarantee.
 - **Program Build Context Boundary**: one CLI invocation or API lint request owns one `ProgramBuildContext`, created only after the request's overlay/canonical VFS wrappers are complete. It is passed explicitly through real Program construction, gap fallback construction, and fix rebuilds. It is never global, never shared across API requests, and is not used by LSP, whose project session has a different invalidation model.
 - **Run/Request-Scoped Program Metadata**: successful `package.json` reads and explicitly registered root, project-reference, and extended tsconfig reads are snapshotted for the context lifetime. Keys remain exact caller paths—no cleaning, case folding, resolving real paths, or symlink merging—and failed reads are retried. Per-key read single-flight avoids duplicate concurrent I/O; generation swaps make future VFS writes safe without clearing a live map. Arbitrary JSON and non-metadata reads bypass this layer.
 - **Extended Config Parse Reuse**: the context implements ts-go's `ExtendedConfigCache` shim contract and shares common `extends` parse results across Programs. Parsing occurs outside map locks and publishes with `LoadOrStore`, avoiding recursive cross-cycle lock ordering; rare concurrent misses may duplicate parsing but share the winning immutable result and still single-flight raw bytes. Root `ParsedCommandLine` values and parsed `package.json` objects are not cached.
-- **Run/Request-Scoped Source Snapshots**: CLI runs and individual API requests share immutable source text/hash snapshots across their Programs. Keys are the exact compiler-host source names, never real paths, so lexical, overlay, and symlink aliases remain distinct. Failed reads are not cached. The source layer in one cache binds to one filesystem view across its generations; compiler hosts using another view bypass this layer while retaining content-keyed AST reuse.
+- **Run/Request-Scoped Source Snapshots**: CLI runs and individual API requests share immutable source text/hash snapshots across their Programs. Keys are the exact compiler-host source names, never real paths, so lexical, overlay, and symlink aliases remain distinct. Concurrent misses for one key share the successful read/hash operation; failed reads are shared only by the overlapping callers and are not retained. The source layer in one cache binds to one filesystem view across its generations; compiler hosts using another view bypass this layer while retaining content-keyed AST reuse.
 - **Generation-Based Fix Invalidation**: after every CLI fix write attempt, the compiler host atomically installs an empty source generation before any Program rebuild. Swapping generations rather than clearing a live map prevents an older in-flight read from repopulating the new generation. The API fix path only returns output and does not mutate or rebuild its overlay, while LSP remains version/didChange-driven.
-- **Run-Scoped Parse Reuse**: CLI Program rebuilds within one invocation and Programs within one API request share the existing content-keyed AST parse cache. Source-generation invalidation does not clear AST entries, so unchanged bytes can reuse their `SourceFile`. The cache is discarded with its run/request and is never repository-persistent or shared across lint requests.
+- **Run-Scoped Parse Reuse**: CLI Program rebuilds within one invocation and Programs within one API request share the existing content-keyed AST parse cache. Concurrent misses for the same full parse key are single-flight, so bounded Program construction does not duplicate parsing. Source-generation invalidation does not clear AST entries, so unchanged bytes can reuse their `SourceFile`. The cache is discarded with its run/request and is never repository-persistent or shared across lint requests.
 - **Bounded Multi-Pass Fixing**: `--fix` and LSP `fixAll` intentionally rerun lint after applying edits, but cap the cascade at `maxFixPasses = 10`
 
 ### Memory Management

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -30,8 +30,6 @@ type lintProgramSet struct {
 	ConfigOrders []programConfigOrders
 }
 
-const maxParallelProgramBuilds = 8
-
 // programBuildSpec is one stable slot in the Program registry. Planning and
 // construction are deliberately separate: config/project order and shared
 // tsconfig associations are resolved serially, while independent Program
@@ -168,7 +166,7 @@ func executeProgramBuildPlan(
 		)
 	}
 
-	workerCount := min(maxParallelProgramBuilds, runtime.GOMAXPROCS(0), len(plan.specs))
+	workerCount := min(runtime.GOMAXPROCS(0), len(plan.specs))
 	if singleThreaded || workerCount <= 1 {
 		for index := range plan.specs {
 			build(index)
@@ -216,8 +214,9 @@ func executeProgramBuildPlan(
 }
 
 // createProgramSetForConfigs builds each planned Program into its stable
-// registry slot. At most min(8, GOMAXPROCS) Programs are built concurrently;
-// --singleThreaded retains the original serial, fail-fast path exactly.
+// registry slot. At most min(GOMAXPROCS, Program count) Programs are built
+// concurrently; --singleThreaded retains the original serial, fail-fast path
+// exactly.
 func createProgramSetForConfigs(
 	configMap map[string]rslintconfig.RslintConfig,
 	singleThreaded bool,

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sort"
+	"sync"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/compiler"
@@ -26,6 +28,23 @@ type programConfigOrders map[string]int
 type lintProgramSet struct {
 	Programs     []*compiler.Program
 	ConfigOrders []programConfigOrders
+}
+
+const maxParallelProgramBuilds = 8
+
+// programBuildSpec is one stable slot in the Program registry. Planning and
+// construction are deliberately separate: config/project order and shared
+// tsconfig associations are resolved serially, while independent Program
+// construction may fill the already-ordered slots concurrently.
+type programBuildSpec struct {
+	tsconfigPath string
+	programCwd   string
+	configOrders programConfigOrders
+}
+
+type programBuildPlan struct {
+	specs       []programBuildSpec
+	terminalErr error
 }
 
 func exactFilesystemPathID(filePath string) string {
@@ -70,19 +89,18 @@ func storeSourcePathMapping(mapping map[string]string, sourcePath string, canoni
 	}
 }
 
-// createProgramSetForConfigs builds each normalized tsconfig path once while
-// retaining every config that declared it. Config roots are processed in a
-// stable order; target binding later uses the per-config project order rather
-// than map iteration or Program construction order.
-func createProgramSetForConfigs(
+// buildProgramPlan resolves each normalized tsconfig path once while retaining
+// every config that declared it. It stops at the first resolution failure but
+// retains earlier work: the serial implementation built those earlier Programs
+// before surfacing that failure, so executeProgramBuildPlan must preserve the
+// same error precedence.
+func buildProgramPlan(
 	configMap map[string]rslintconfig.RslintConfig,
-	singleThreaded bool,
-	buildContext *utils.ProgramBuildContext,
-) (lintProgramSet, error) {
+	fsys vfs.FS,
+) programBuildPlan {
 	if len(configMap) == 0 {
-		return lintProgramSet{}, nil
+		return programBuildPlan{}
 	}
-	fsys := buildContext.FS()
 
 	configDirs := make([]string, 0, len(configMap))
 	for configDir := range configMap {
@@ -90,7 +108,7 @@ func createProgramSetForConfigs(
 	}
 	sort.Strings(configDirs)
 
-	set := lintProgramSet{}
+	plan := programBuildPlan{}
 	programByTsconfig := make(map[string]int)
 	for _, configDir := range configDirs {
 		entries := configMap[configDir]
@@ -98,15 +116,16 @@ func createProgramSetForConfigs(
 		configDirID := exactFilesystemPathID(normalizedConfigDir)
 		tsConfigs, err := rslintconfig.ResolveTsConfigPaths(entries, normalizedConfigDir, fsys)
 		if err != nil {
-			return lintProgramSet{}, fmt.Errorf("resolve tsconfigs for %q: %w", configDir, err)
+			plan.terminalErr = fmt.Errorf("resolve tsconfigs for %q: %w", configDir, err)
+			return plan
 		}
 
 		for order, tsconfigPath := range tsConfigs {
 			tsconfigPath = tspath.NormalizePath(tsconfigPath)
 			tsconfigID := exactFilesystemPathID(tsconfigPath)
 			if programIndex, ok := programByTsconfig[tsconfigID]; ok {
-				if _, alreadyAssociated := set.ConfigOrders[programIndex][configDirID]; !alreadyAssociated {
-					set.ConfigOrders[programIndex][configDirID] = order
+				if _, alreadyAssociated := plan.specs[programIndex].configOrders[configDirID]; !alreadyAssociated {
+					plan.specs[programIndex].configOrders[configDirID] = order
 				}
 				continue
 			}
@@ -114,19 +133,98 @@ func createProgramSetForConfigs(
 			// Relative paths in a tsconfig are resolved from the declared path,
 			// including when that path is a file symlink. This matches tsc/tsgo;
 			// realpath is only a source-identity fallback during target binding.
-			programCwd := tspath.GetDirectoryPath(tsconfigPath)
-			program, err := buildContext.CreateProgramLenient(singleThreaded, programCwd, tsconfigPath)
-			if err != nil {
-				return lintProgramSet{}, fmt.Errorf("create TypeScript Program from %q: %w", tsconfigPath, err)
-			}
-
-			programByTsconfig[tsconfigID] = len(set.Programs)
-			set.Programs = append(set.Programs, program)
-			set.ConfigOrders = append(set.ConfigOrders, programConfigOrders{configDirID: order})
+			programByTsconfig[tsconfigID] = len(plan.specs)
+			plan.specs = append(plan.specs, programBuildSpec{
+				tsconfigPath: tsconfigPath,
+				programCwd:   tspath.GetDirectoryPath(tsconfigPath),
+				configOrders: programConfigOrders{configDirID: order},
+			})
 		}
 	}
 
-	return set, nil
+	return plan
+}
+
+func executeProgramBuildPlan(
+	plan programBuildPlan,
+	singleThreaded bool,
+	buildContext *utils.ProgramBuildContext,
+) (lintProgramSet, error) {
+	if len(plan.specs) == 0 {
+		if plan.terminalErr != nil {
+			return lintProgramSet{}, plan.terminalErr
+		}
+		return lintProgramSet{}, nil
+	}
+
+	programs := make([]*compiler.Program, len(plan.specs))
+	errs := make([]error, len(plan.specs))
+	build := func(index int) {
+		spec := plan.specs[index]
+		programs[index], errs[index] = buildContext.CreateProgramLenient(
+			singleThreaded,
+			spec.programCwd,
+			spec.tsconfigPath,
+		)
+	}
+
+	workerCount := min(maxParallelProgramBuilds, runtime.GOMAXPROCS(0), len(plan.specs))
+	if singleThreaded || workerCount <= 1 {
+		for index := range plan.specs {
+			build(index)
+			if errs[index] != nil {
+				break
+			}
+		}
+	} else {
+		jobs := make(chan int, workerCount)
+		var workers sync.WaitGroup
+		workers.Add(workerCount)
+		for range workerCount {
+			go func() {
+				defer workers.Done()
+				for index := range jobs {
+					build(index)
+				}
+			}()
+		}
+		for index := range plan.specs {
+			jobs <- index
+		}
+		close(jobs)
+		workers.Wait()
+	}
+
+	for index, err := range errs {
+		if err != nil {
+			return lintProgramSet{}, fmt.Errorf(
+				"create TypeScript Program from %q: %w",
+				plan.specs[index].tsconfigPath,
+				err,
+			)
+		}
+	}
+	if plan.terminalErr != nil {
+		return lintProgramSet{}, plan.terminalErr
+	}
+
+	configOrders := make([]programConfigOrders, len(plan.specs))
+	for index := range plan.specs {
+		configOrders[index] = plan.specs[index].configOrders
+	}
+	return lintProgramSet{Programs: programs, ConfigOrders: configOrders}, nil
+}
+
+// createProgramSetForConfigs builds each planned Program into its stable
+// registry slot. At most min(8, GOMAXPROCS) Programs are built concurrently;
+// --singleThreaded retains the original serial, fail-fast path exactly.
+func createProgramSetForConfigs(
+	configMap map[string]rslintconfig.RslintConfig,
+	singleThreaded bool,
+	buildContext *utils.ProgramBuildContext,
+) (lintProgramSet, error) {
+	plan := buildProgramPlan(configMap, buildContext.FS())
+	return executeProgramBuildPlan(plan, singleThreaded, buildContext)
 }
 
 func createProgramSetForConfig(

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -3,10 +3,13 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
@@ -25,6 +28,47 @@ type targetPlanRealpathCountingFS struct {
 	vfs.FS
 	mu    sync.Mutex
 	calls map[string]int
+}
+
+type blockingProgramConfigFS struct {
+	vfs.FS
+	paths      map[string]struct{}
+	waitFor    int
+	mu         sync.Mutex
+	active     int
+	peak       int
+	allStarted chan struct{}
+	release    chan struct{}
+	startOnce  sync.Once
+}
+
+func (f *blockingProgramConfigFS) ReadFile(filePath string) (string, bool) {
+	if _, blocks := f.paths[tspath.NormalizePath(filePath)]; !blocks {
+		return f.FS.ReadFile(filePath)
+	}
+
+	f.mu.Lock()
+	f.active++
+	if f.active > f.peak {
+		f.peak = f.active
+	}
+	if f.active == f.waitFor {
+		f.startOnce.Do(func() { close(f.allStarted) })
+	}
+	f.mu.Unlock()
+
+	<-f.release
+	content, ok := f.FS.ReadFile(filePath)
+	f.mu.Lock()
+	f.active--
+	f.mu.Unlock()
+	return content, ok
+}
+
+func (f *blockingProgramConfigFS) peakConcurrency() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.peak
 }
 
 func (f *targetPlanRealpathCountingFS) Realpath(filePath string) string {
@@ -796,6 +840,131 @@ func TestCreateProgramSetForConfigs_DeduplicatesSharedTsconfigAndRetainsOwners(t
 	}
 	if order, ok := set.ConfigOrders[0][childKey]; !ok || order != 0 {
 		t.Fatalf("missing child config association: %v", set.ConfigOrders[0])
+	}
+}
+
+func TestCreateProgramSetForConfigs_BoundsParallelBuildsAndPreservesOrder(t *testing.T) {
+	rootDir := t.TempDir()
+	const configCount = maxParallelProgramBuilds + 3
+	files := make(map[string]string, configCount)
+	projects := make([]string, 0, configCount)
+	configPaths := make(map[string]struct{}, configCount)
+	for index := range configCount {
+		name := "tsconfig-" + strconv.Itoa(index) + ".json"
+		files[name] = `{"compilerOptions":{"noLib":true},"files":["./shared.ts"]}`
+		projects = append(projects, "./"+name)
+		configPaths[tspath.NormalizePath(filepath.Join(rootDir, name))] = struct{}{}
+	}
+	files["shared.ts"] = "export const shared = true;\n"
+	writeProgramTestFiles(t, rootDir, files)
+
+	expectedConcurrency := min(maxParallelProgramBuilds, runtime.GOMAXPROCS(0), configCount)
+	fsys := &blockingProgramConfigFS{
+		FS:         bundled.WrapFS(osvfs.FS()),
+		paths:      configPaths,
+		waitFor:    expectedConcurrency,
+		allStarted: make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	type result struct {
+		set lintProgramSet
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		set, err := createProgramSetForConfig(
+			tspath.NormalizePath(rootDir),
+			projectConfig(projects...),
+			false,
+			utils.NewProgramBuildContext(fsys),
+		)
+		done <- result{set: set, err: err}
+	}()
+
+	select {
+	case <-fsys.allStarted:
+		close(fsys.release)
+	case <-time.After(5 * time.Second):
+		close(fsys.release)
+		t.Fatalf("Program builds did not reach expected concurrency %d", expectedConcurrency)
+	}
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("createProgramSetForConfig: %v", got.err)
+	}
+	if got := fsys.peakConcurrency(); got != expectedConcurrency {
+		t.Fatalf("peak Program build concurrency = %d, want %d", got, expectedConcurrency)
+	}
+	if len(got.set.Programs) != configCount {
+		t.Fatalf("Programs = %d, want %d", len(got.set.Programs), configCount)
+	}
+	for index, program := range got.set.Programs {
+		want := tspath.ResolvePath(rootDir, projects[index])
+		if got := tspath.NormalizePath(program.Options().ConfigFilePath); got != want {
+			t.Fatalf("Program %d config path = %q, want %q", index, got, want)
+		}
+	}
+}
+
+func TestCreateProgramSetForConfigs_SingleThreadedBuildsSerially(t *testing.T) {
+	rootDir := t.TempDir()
+	files := map[string]string{
+		"tsconfig-a.json": `{"compilerOptions":{"noLib":true},"files":[]}`,
+		"tsconfig-b.json": `{"compilerOptions":{"noLib":true},"files":[]}`,
+	}
+	writeProgramTestFiles(t, rootDir, files)
+	configPaths := make(map[string]struct{}, len(files))
+	for name := range files {
+		configPaths[tspath.NormalizePath(filepath.Join(rootDir, name))] = struct{}{}
+	}
+	fsys := &blockingProgramConfigFS{
+		FS:         bundled.WrapFS(osvfs.FS()),
+		paths:      configPaths,
+		waitFor:    1,
+		allStarted: make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := createProgramSetForConfig(
+			tspath.NormalizePath(rootDir),
+			projectConfig("./tsconfig-a.json", "./tsconfig-b.json"),
+			true,
+			utils.NewProgramBuildContext(fsys),
+		)
+		done <- err
+	}()
+	<-fsys.allStarted
+	close(fsys.release)
+	if err := <-done; err != nil {
+		t.Fatalf("createProgramSetForConfig: %v", err)
+	}
+	if got := fsys.peakConcurrency(); got != 1 {
+		t.Fatalf("--singleThreaded peak Program build concurrency = %d, want 1", got)
+	}
+}
+
+func TestExecuteProgramBuildPlan_PreservesFirstErrorPrecedence(t *testing.T) {
+	rootDir := tspath.NormalizePath(t.TempDir())
+	first := tspath.ResolvePath(rootDir, "missing-first.json")
+	second := tspath.ResolvePath(rootDir, "missing-second.json")
+	plan := programBuildPlan{
+		specs: []programBuildSpec{
+			{tsconfigPath: first, programCwd: rootDir},
+			{tsconfigPath: second, programCwd: rootDir},
+		},
+		terminalErr: os.ErrInvalid,
+	}
+	_, err := executeProgramBuildPlan(
+		plan,
+		false,
+		utils.NewProgramBuildContext(bundled.WrapFS(osvfs.FS())),
+	)
+	if err == nil || !strings.Contains(err.Error(), first) {
+		t.Fatalf("error = %v, want first Program path %q", err, first)
+	}
+	if strings.Contains(err.Error(), second) || strings.Contains(err.Error(), os.ErrInvalid.Error()) {
+		t.Fatalf("later error won over the first Program failure: %v", err)
 	}
 }
 

--- a/cmd/rslint/programs_typecheck_skip_test.go
+++ b/cmd/rslint/programs_typecheck_skip_test.go
@@ -845,7 +845,15 @@ func TestCreateProgramSetForConfigs_DeduplicatesSharedTsconfigAndRetainsOwners(t
 
 func TestCreateProgramSetForConfigs_BoundsParallelBuildsAndPreservesOrder(t *testing.T) {
 	rootDir := t.TempDir()
-	const configCount = maxParallelProgramBuilds + 3
+	const (
+		testGOMAXPROCS = 9 // Deliberately exceeds the former fixed worker limit.
+		configCount    = testGOMAXPROCS + 3
+	)
+	previousGOMAXPROCS := runtime.GOMAXPROCS(testGOMAXPROCS)
+	t.Cleanup(func() {
+		runtime.GOMAXPROCS(previousGOMAXPROCS)
+	})
+
 	files := make(map[string]string, configCount)
 	projects := make([]string, 0, configCount)
 	configPaths := make(map[string]struct{}, configCount)
@@ -858,7 +866,7 @@ func TestCreateProgramSetForConfigs_BoundsParallelBuildsAndPreservesOrder(t *tes
 	files["shared.ts"] = "export const shared = true;\n"
 	writeProgramTestFiles(t, rootDir, files)
 
-	expectedConcurrency := min(maxParallelProgramBuilds, runtime.GOMAXPROCS(0), configCount)
+	expectedConcurrency := testGOMAXPROCS
 	fsys := &blockingProgramConfigFS{
 		FS:         bundled.WrapFS(osvfs.FS()),
 		paths:      configPaths,

--- a/internal/utils/parse_cache.go
+++ b/internal/utils/parse_cache.go
@@ -42,9 +42,10 @@ import (
 //	I3: file.Hash is never written. The --api EncodeAST header encodes
 //	    sourceFile.Hash (bytes 4-19) and is all-zero today; writing it
 //	    would change encoded output bytes.
-//	I4: concurrent source and AST misses resolve via LoadOrStore. Every loser
-//	    uses the published winner; duplicate cold reads/parses may occur, but
-//	    callers within a generation observe one winning snapshot/AST per key.
+//	I4: concurrent source and AST misses are single-flight. Every caller within
+//	    a generation observes one winning snapshot/AST per key, without
+//	    duplicating successful cold reads, content hashes, or parses. Failed
+//	    reads are retried, and a panic never leaves waiters blocked.
 //	I5: the source layer owned by one cache binds to one exact pointer-identity
 //	    FS across its generations. Hosts backed by another or a non-pointer FS
 //	    bypass only the source layer and still use the content-keyed AST cache.
@@ -58,7 +59,8 @@ import (
 //	I9: cache ownership is explicit and bounded to one CLI run or API request;
 //	    no package-level singleton may extend source/AST lifetime implicitly.
 type ParseCache struct {
-	m sync.Map // project.ParseCacheKey -> *ast.SourceFile
+	m        sync.Map // project.ParseCacheKey -> *ast.SourceFile
+	inflight sync.Map // project.ParseCacheKey -> *parseCacheFlight
 
 	sourceGeneration atomic.Pointer[sourceSnapshotGeneration]
 	sourceFSMu       sync.Mutex
@@ -66,12 +68,26 @@ type ParseCache struct {
 }
 
 type sourceSnapshotGeneration struct {
-	entries sync.Map // exact opts.FileName -> sourceSnapshot
+	entries  sync.Map // exact opts.FileName -> sourceSnapshot
+	inflight sync.Map // exact opts.FileName -> *sourceSnapshotFlight
 }
 
 type sourceSnapshot struct {
 	text string
 	hash xxh3.Uint128
+}
+
+type sourceSnapshotFlight struct {
+	ready     chan struct{}
+	snapshot  sourceSnapshot
+	ok        bool
+	completed bool
+}
+
+type parseCacheFlight struct {
+	ready      chan struct{}
+	sourceFile *ast.SourceFile
+	completed  bool
 }
 
 // NewParseCache returns a fresh cache, or nil (disabling caching entirely via
@@ -104,24 +120,90 @@ func (c *ParseCache) acquireSnapshot(opts ast.SourceFileParseOptions, snapshot s
 	// what the parse below actually uses.
 	scriptKind := core.GetScriptKindFromFileName(opts.FileName)
 	key := project.NewParseCacheKey(opts, snapshot.hash, scriptKind)
-	if v, ok := c.m.Load(key); ok {
-		if cached, ok := v.(*ast.SourceFile); ok {
-			return cached
+	if value, ok := c.m.Load(key); ok {
+		if sourceFile, ok := value.(*ast.SourceFile); ok {
+			return sourceFile
 		}
 	}
-	sf := parser.ParseSourceFile(opts, snapshot.text, scriptKind) // I2/I3: same text, Hash left zero
-	actual, _ := c.m.LoadOrStore(key, sf)                         // I4: winner is the only object handed out
-	if winner, ok := actual.(*ast.SourceFile); ok {
-		return winner
+	return c.acquireParseMiss(key, func() *ast.SourceFile {
+		return parser.ParseSourceFile(opts, snapshot.text, scriptKind) // I2/I3: same text, Hash left zero
+	})
+}
+
+func (c *ParseCache) acquireParseMiss(
+	key project.ParseCacheKey,
+	parse func() *ast.SourceFile,
+) *ast.SourceFile {
+	for {
+		candidate := &parseCacheFlight{ready: make(chan struct{})}
+		actual, loaded := c.inflight.LoadOrStore(key, candidate)
+		if loaded {
+			flight := mustParseCacheFlight(actual)
+			<-flight.ready
+			if flight.completed {
+				return flight.sourceFile
+			}
+			continue
+		}
+
+		// A previous owner can publish the final entry and remove its flight
+		// between acquireSnapshot's fast-path miss and our LoadOrStore above.
+		if value, ok := c.m.Load(key); ok {
+			if sourceFile, ok := value.(*ast.SourceFile); ok {
+				candidate.sourceFile = sourceFile
+				candidate.completed = true
+				c.completeParseFlight(key, candidate)
+				return sourceFile
+			}
+		}
+		return c.parseAndPublish(key, candidate, parse)
 	}
-	return sf // unreachable: the map only ever holds *ast.SourceFile
+}
+
+func (c *ParseCache) parseAndPublish(
+	key project.ParseCacheKey,
+	flight *parseCacheFlight,
+	parse func() *ast.SourceFile,
+) *ast.SourceFile {
+	completed := false
+	defer func() {
+		if !completed {
+			// Preserve the panic while allowing a waiting caller to retry.
+			c.completeParseFlight(key, flight)
+		}
+	}()
+
+	sourceFile := parse()
+	if sourceFile != nil {
+		actual, _ := c.m.LoadOrStore(key, sourceFile)
+		if winner, ok := actual.(*ast.SourceFile); ok {
+			sourceFile = winner
+		}
+	}
+	flight.sourceFile = sourceFile
+	flight.completed = true
+	completed = true
+	c.completeParseFlight(key, flight)
+	return sourceFile
+}
+
+func (c *ParseCache) completeParseFlight(key project.ParseCacheKey, flight *parseCacheFlight) {
+	c.inflight.CompareAndDelete(key, flight)
+	close(flight.ready)
+}
+
+func mustParseCacheFlight(value any) *parseCacheFlight {
+	flight, ok := value.(*parseCacheFlight)
+	if !ok {
+		panic("parse cache in-flight map contains an unexpected value")
+	}
+	return flight
 }
 
 // RetainOnly evicts every entry whose SourceFile is not referenced by any of
 // the given programs (live set = union of all GetSourceFiles() pointers,
 // including gap-fallback programs). One sweep reclaims both --fix
-// intermediate versions (old-hash objects absent from rebuilt programs) and
-// build-time dedup losers (parsed but never included in a program).
+// intermediate versions (old-hash objects absent from rebuilt programs).
 // Deletion-only per I8: an evicted entry that is requested again is re-parsed
 // into a fresh object, which is the no-cache baseline behavior. Source
 // snapshots have a separate generation lifetime and are not pruned here.
@@ -139,8 +221,12 @@ func (c *ParseCache) RetainOnly(programs []*compiler.Program) {
 		}
 	}
 	c.m.Range(func(k, v any) bool {
-		if _, ok := live[v.(*ast.SourceFile)]; !ok {
-			c.m.Delete(k)
+		sourceFile, ok := v.(*ast.SourceFile)
+		if !ok {
+			return true
+		}
+		if _, ok := live[sourceFile]; !ok {
+			c.m.CompareAndDelete(k, v)
 		}
 		return true
 	})
@@ -217,26 +303,11 @@ func WithParseCache(host compiler.CompilerHost, cache *ParseCache) compiler.Comp
 func (h *cachingCompilerHost) GetSourceFile(opts ast.SourceFileParseOptions) *ast.SourceFile {
 	if h.useSourceSnapshots {
 		generation := h.cache.currentSourceGeneration() // I7: capture exactly one generation
-		if value, ok := generation.entries.Load(opts.FileName); ok {
-			if snapshot, ok := value.(sourceSnapshot); ok {
-				return h.cache.acquireSnapshot(opts, snapshot)
-			}
-		}
-
-		text, ok := h.FS().ReadFile(opts.FileName)
+		snapshot, ok := h.acquireSourceSnapshot(generation, opts.FileName)
 		if !ok {
 			return nil // I1: failed reads are never published
 		}
-		candidate := sourceSnapshot{
-			text: text,
-			hash: xxh3.HashString128(text),
-		}
-		actual, _ := generation.entries.LoadOrStore(opts.FileName, candidate)
-		snapshot, ok := actual.(sourceSnapshot)
-		if !ok {
-			snapshot = candidate // unreachable: entries only ever stores sourceSnapshot values
-		}
-		return h.cache.acquireSnapshot(opts, snapshot) // I4: always use the winner
+		return h.cache.acquireSnapshot(opts, snapshot)
 	}
 
 	text, ok := h.FS().ReadFile(opts.FileName)
@@ -244,4 +315,93 @@ func (h *cachingCompilerHost) GetSourceFile(opts ast.SourceFileParseOptions) *as
 		return nil // same as the default host, and never cached
 	}
 	return h.cache.acquire(opts, text)
+}
+
+func (h *cachingCompilerHost) acquireSourceSnapshot(
+	generation *sourceSnapshotGeneration,
+	fileName string,
+) (sourceSnapshot, bool) {
+	for {
+		if value, ok := generation.entries.Load(fileName); ok {
+			if snapshot, ok := value.(sourceSnapshot); ok {
+				return snapshot, true
+			}
+		}
+
+		candidate := &sourceSnapshotFlight{ready: make(chan struct{})}
+		actual, loaded := generation.inflight.LoadOrStore(fileName, candidate)
+		if loaded {
+			flight := mustSourceSnapshotFlight(actual)
+			<-flight.ready
+			if flight.completed {
+				return flight.snapshot, flight.ok
+			}
+			// The owner panicked. Retry rather than leaving this caller blocked.
+			continue
+		}
+
+		// As with the AST layer, close the small race between the initial
+		// cache lookup and becoming the single-flight owner.
+		if value, ok := generation.entries.Load(fileName); ok {
+			if snapshot, ok := value.(sourceSnapshot); ok {
+				candidate.snapshot = snapshot
+				candidate.ok = true
+				candidate.completed = true
+				h.completeSourceSnapshotFlight(generation, fileName, candidate)
+				return snapshot, true
+			}
+		}
+		return h.readAndPublishSourceSnapshot(generation, fileName, candidate)
+	}
+}
+
+func (h *cachingCompilerHost) readAndPublishSourceSnapshot(
+	generation *sourceSnapshotGeneration,
+	fileName string,
+	flight *sourceSnapshotFlight,
+) (sourceSnapshot, bool) {
+	completed := false
+	defer func() {
+		if !completed {
+			// A panicking VFS must not strand Programs waiting on the same file.
+			h.completeSourceSnapshotFlight(generation, fileName, flight)
+		}
+	}()
+
+	text, ok := h.FS().ReadFile(fileName)
+	if !ok {
+		flight.completed = true
+		completed = true
+		h.completeSourceSnapshotFlight(generation, fileName, flight)
+		return sourceSnapshot{}, false
+	}
+
+	snapshot := sourceSnapshot{text: text, hash: xxh3.HashString128(text)}
+	actual, _ := generation.entries.LoadOrStore(fileName, snapshot)
+	flight.snapshot = snapshot
+	if winner, ok := actual.(sourceSnapshot); ok {
+		flight.snapshot = winner
+	}
+	flight.ok = true
+	flight.completed = true
+	completed = true
+	h.completeSourceSnapshotFlight(generation, fileName, flight)
+	return flight.snapshot, true
+}
+
+func (h *cachingCompilerHost) completeSourceSnapshotFlight(
+	generation *sourceSnapshotGeneration,
+	fileName string,
+	flight *sourceSnapshotFlight,
+) {
+	generation.inflight.CompareAndDelete(fileName, flight)
+	close(flight.ready)
+}
+
+func mustSourceSnapshotFlight(value any) *sourceSnapshotFlight {
+	flight, ok := value.(*sourceSnapshotFlight)
+	if !ok {
+		panic("source snapshot in-flight map contains an unexpected value")
+	}
+	return flight
 }

--- a/internal/utils/parse_cache_test.go
+++ b/internal/utils/parse_cache_test.go
@@ -7,11 +7,13 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/project"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
@@ -126,6 +128,12 @@ func (f *divergentConcurrentFS) ReadFile(path string) (string, bool) {
 	return fmt.Sprintf("export const value = %d;\n", readNumber), true
 }
 
+func (f *divergentConcurrentFS) readCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reads
+}
+
 type blockingGenerationFS struct {
 	vfs.FS
 	path    string
@@ -134,6 +142,38 @@ type blockingGenerationFS struct {
 	reads   int
 	started chan struct{}
 	release chan struct{}
+}
+
+type panicOnceSourceFS struct {
+	vfs.FS
+	path    string
+	text    string
+	mu      sync.Mutex
+	reads   int
+	started chan struct{}
+	release chan struct{}
+}
+
+func (f *panicOnceSourceFS) ReadFile(path string) (string, bool) {
+	if path != f.path {
+		return f.FS.ReadFile(path)
+	}
+	f.mu.Lock()
+	f.reads++
+	first := f.reads == 1
+	f.mu.Unlock()
+	if first {
+		close(f.started)
+		<-f.release
+		panic("source read panic")
+	}
+	return f.text, true
+}
+
+func (f *panicOnceSourceFS) readCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reads
 }
 
 func (f *blockingGenerationFS) ReadFile(path string) (string, bool) {
@@ -649,7 +689,7 @@ func TestCachingHost_ConcurrentMissesUseOneWinningSnapshot(t *testing.T) {
 	fs := &divergentConcurrentFS{
 		FS:         bundled.WrapFS(osvfs.FS()),
 		path:       fileName,
-		wantReads:  callers,
+		wantReads:  1,
 		allStarted: make(chan struct{}),
 		release:    make(chan struct{}),
 	}
@@ -680,6 +720,9 @@ func TestCachingHost_ConcurrentMissesUseOneWinningSnapshot(t *testing.T) {
 			t.Fatalf("caller %d did not use the source/AST winner", i+1)
 		}
 	}
+	if got := fs.readCount(); got != 1 {
+		t.Fatalf("concurrent source lookup performed %d reads, want 1", got)
+	}
 	value, ok := cache.currentSourceGeneration().entries.Load(fileName)
 	if !ok {
 		t.Fatal("winning source snapshot was not stored")
@@ -687,6 +730,109 @@ func TestCachingHost_ConcurrentMissesUseOneWinningSnapshot(t *testing.T) {
 	snapshot := value.(sourceSnapshot)
 	if winner.Text() != snapshot.text || snapshot.hash != xxh3.HashString128(snapshot.text) {
 		t.Fatal("winner AST and immutable source text/hash pair diverged")
+	}
+}
+
+func TestParseCache_PanicReleasesConcurrentParseMiss(t *testing.T) {
+	fileName := "/virtual/parse-panic.ts"
+	text := "export const recovered = true;\n"
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+	key := project.NewParseCacheKey(
+		opts,
+		xxh3.HashString128(text),
+		core.GetScriptKindFromFileName(fileName),
+	)
+	reference := new(ParseCache).acquire(opts, text)
+	cache := &ParseCache{}
+	parseStarted := make(chan struct{})
+	releaseParse := make(chan struct{})
+	ownerPanic := make(chan any, 1)
+
+	go func() {
+		defer func() { ownerPanic <- recover() }()
+		cache.acquireParseMiss(key, func() *ast.SourceFile {
+			close(parseStarted)
+			<-releaseParse
+			panic("parse panic")
+		})
+	}()
+	<-parseStarted
+
+	waiterResult := make(chan *ast.SourceFile, 1)
+	go func() {
+		waiterResult <- cache.acquireParseMiss(key, func() *ast.SourceFile {
+			return reference
+		})
+	}()
+	close(releaseParse)
+
+	select {
+	case recovered := <-ownerPanic:
+		if recovered == nil {
+			t.Fatal("expected parse panic")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("parse owner did not propagate its panic")
+	}
+	select {
+	case sourceFile := <-waiterResult:
+		if sourceFile != reference {
+			t.Fatal("waiting parse caller did not retry after owner panic")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("parse panic stranded a concurrent waiter")
+	}
+	if _, loaded := cache.inflight.Load(key); loaded {
+		t.Fatal("panicking parse remained in the in-flight map")
+	}
+}
+
+func TestCachingHost_PanicReleasesConcurrentSourceMiss(t *testing.T) {
+	fileName := "/virtual/source-panic.ts"
+	text := "export const recovered = true;\n"
+	fs := &panicOnceSourceFS{
+		FS:      bundled.WrapFS(osvfs.FS()),
+		path:    fileName,
+		text:    text,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	cache := &ParseCache{}
+	host := WithParseCache(CreateCompilerHost("/virtual", fs), cache)
+	opts := testParseOpts(fileName, ast.ExternalModuleIndicatorOptions{})
+	ownerPanic := make(chan any, 1)
+
+	go func() {
+		defer func() { ownerPanic <- recover() }()
+		host.GetSourceFile(opts)
+	}()
+	<-fs.started
+
+	waiterResult := make(chan *ast.SourceFile, 1)
+	go func() { waiterResult <- host.GetSourceFile(opts) }()
+	close(fs.release)
+
+	select {
+	case recovered := <-ownerPanic:
+		if recovered == nil {
+			t.Fatal("expected source read panic")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("source owner did not propagate its panic")
+	}
+	select {
+	case sourceFile := <-waiterResult:
+		if sourceFile == nil || sourceFile.Text() != text {
+			t.Fatalf("waiting source caller did not retry successfully: %v", sourceFile)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("source read panic stranded a concurrent waiter")
+	}
+	if got := fs.readCount(); got != 2 {
+		t.Fatalf("source reads after one panic = %d, want 2", got)
+	}
+	if _, loaded := cache.currentSourceGeneration().inflight.Load(fileName); loaded {
+		t.Fatal("panicking source read remained in the in-flight map")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Plan configured TypeScript Program identities and stable result slots serially, then build independent Programs with at most `min(GOMAXPROCS, Program count)` workers.
- Single-flight request-scoped source snapshot/hash misses and content-keyed AST parse misses so parallel Program builds do not duplicate cold work.
- Preserve config/project ordering, first-error precedence, `--singleThreaded` serial fail-fast behavior, exact path identity, cache generations, and request boundaries.
- Document the Program construction and parse-cache concurrency model.

### Correctness

- Added focused tests for CPU-scaled concurrency above the former worker limit, stable Program order, shared SourceFile construction, serial behavior, first-error precedence, panic cleanup, and cache generation races.
- Targeted Go tests and race tests pass for the changed Program construction path.
- `check-spell`, `format:check`, and changed-package Go lint pass.
- rspack and rsbuild produced identical normalized stdout, stderr, diagnostics, and exit codes across plain, explicit config, type-check, and type-check-only coverage.
- No hangs or residual rslint processes were observed.

### Performance: main vs parallel Program construction

Baseline: `main@a5d85e4a`. Both environments used `GOMAXPROCS=8`, balanced A/B ordering, warm-up runs, and wall/internal timing agreement.

Docker/Linux, fixed 8 CPUs, 20 measured rounds per variant:

| Mode | rspack wall median | rsbuild wall median |
| --- | ---: | ---: |
| Plain | 313.7 → 307.9 ms (-1.9%) | 604.8 → 560.8 ms (-7.3%) |
| Explicit config | 309.8 → 303.9 ms (-1.9%) | 584.4 → 549.5 ms (-6.0%) |
| Type-check | 392.7 → 376.1 ms (-4.2%) | 977.6 → 945.1 ms (-3.3%) |
| Type-check-only | 313.3 → 301.2 ms (-3.9%) | 710.7 → 672.4 ms (-5.4%) |

macOS native, idle ≥80% before each pair, 10 measured rounds per variant:

| Mode | rspack wall median | rsbuild wall median |
| --- | ---: | ---: |
| Plain | 407.2 → 402.3 ms (-1.2%) | 841.4 → 763.4 ms (-9.3%) |
| Explicit config | 410.2 → 397.5 ms (-3.1%) | 839.7 → 752.9 ms (-10.3%) |
| Type-check | 552.6 → 534.5 ms (-3.3%) | 1477.5 → 1394.8 ms (-5.6%) |
| Type-check-only | 450.3 → 417.5 ms (-7.3%) | 1402.3 → 1262.0 ms (-10.0%) |

The rspack plain/config Docker deltas are small and their paired confidence intervals cross zero; the consistent material gain is on multi-Program workloads such as rsbuild. Internal timings move in the same direction as wall time in every row.

### Performance: fixed 8-worker cap vs CPU-scaled workers

Both variants were built with the release command (`GOOS/GOARCH go build -ldflags="-s -w" ./cmd/rslint`) and invoked through the published npm 0.7.2 CLI. Each cell is the wall-time median from 10 balanced A/B hyperfine rounds; every round contains one fixed/scaled pair, with odd/even rounds reversing their order. macOS waited for host idle ≥80% before every pair. Docker waited for 10 consecutive idle ≥80% samples before each batch and monitored competing processes throughout; none were observed. Negative percentages mean the CPU-scaled implementation is faster. Output and exit status were exact across every pair.

At `GOMAXPROCS=8`, both implementations use the same effective Program worker count. These runs are the measurement-noise control.

macOS native, 8-way execution:

| Mode | rspack: fixed → scaled | rsbuild: fixed → scaled |
| --- | ---: | ---: |
| Plain | 432.4 → 441.2 ms (+2.0%) | 796.0 → 805.0 ms (+1.1%) |
| Explicit config | 417.6 → 425.7 ms (+1.9%) | 781.4 → 772.3 ms (-1.2%) |
| Type-check | 568.3 → 553.9 ms (-2.5%) | 1444.2 → 1443.7 ms (-0.0%) |
| Type-check-only | 438.6 → 421.4 ms (-3.9%) | 1292.9 → 1293.3 ms (+0.0%) |

Docker/Linux, fixed 8 CPUs:

| Mode | rspack: fixed → scaled | rsbuild: fixed → scaled |
| --- | ---: | ---: |
| Plain | 317.3 → 312.5 ms (-1.5%) | 564.6 → 562.4 ms (-0.4%) |
| Explicit config | 320.8 → 314.1 ms (-2.1%) | 541.3 → 547.8 ms (+1.2%) |
| Type-check | 382.4 → 377.3 ms (-1.3%) | 943.0 → 938.1 ms (-0.5%) |
| Type-check-only | 305.1 → 295.2 ms (-3.2%) | 673.0 → 671.7 ms (-0.2%) |

At `GOMAXPROCS=10`, the fixed implementation still uses at most 8 Program workers, while the CPU-scaled implementation may use up to 10.

macOS native, 10-way execution:

| Mode | rspack: fixed → scaled | rsbuild: fixed → scaled |
| --- | ---: | ---: |
| Plain | 415.3 → 405.5 ms (-2.4%) | 804.9 → 797.1 ms (-1.0%) |
| Explicit config | 415.5 → 410.9 ms (-1.1%) | 816.5 → 802.5 ms (-1.7%) |
| Type-check | 553.3 → 555.9 ms (+0.5%) | 1417.1 → 1433.6 ms (+1.2%) |
| Type-check-only | 417.4 → 421.3 ms (+0.9%) | 1256.9 → 1259.3 ms (+0.2%) |

Docker/Linux, fixed 10 CPUs:

| Mode | rspack: fixed → scaled | rsbuild: fixed → scaled |
| --- | ---: | ---: |
| Plain | 312.6 → 310.0 ms (-0.8%) | 560.3 → 562.5 ms (+0.4%) |
| Explicit config | 307.1 → 300.7 ms (-2.1%) | 552.3 → 553.2 ms (+0.2%) |
| Type-check | 384.6 → 376.8 ms (-2.0%) | 903.4 → 909.3 ms (+0.7%) |
| Type-check-only | 298.4 → 310.2 ms (+3.9%) | 660.8 → 658.5 ms (-0.3%) |

The 10-way macOS ordinary lint paths consistently trend faster with CPU-scaled Program workers. Docker ordinary lint is approximately flat to slightly faster, while type-check results are mixed. The natural `GOMAXPROCS` and Program-count bounds avoid creating workers beyond the runtime CPU budget or available work.

## Related Links

- None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
