### PR TITLE
perf: reuse effective config plans by match shape

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -775,6 +775,16 @@ Config merging follows flat-config-style semantics in `GetConfigForFile()`:
 4. later rule values override earlier values; a severity-only override retains earlier rule options
 5. settings and language options recursively merge ordinary objects, while later arrays and scalar values replace earlier values
 
+`FileConfigResolver` applies that policy in two phases: it first matches a file
+to the exact ordered set of contributing entries, then compiles the set into an
+immutable effective config/rule plan. Files with the same set share one plan for
+that resolver's lifetime. Shape identity is collision-free (`uint64` for the
+first 64 entries plus the complete remaining bitset), resolver-local, and
+independent of path identity. File-cache keys remain the exact caller strings;
+the resolver does not clean, case-fold, canonicalize, or merge symlink aliases.
+The direct `GetConfigForFile()` compatibility path uses the same match/merge
+primitives without retaining a cache.
+
 The staged coordinator builds the effective catalog used by
 `ConfigOwnerResolver.Resolve()` before `GetConfigForFile()` merges the selected
 entries. Staged CLI, native API, and transactional LSP paths therefore reuse the
@@ -1041,6 +1051,12 @@ goroutines remain outside that guarantee.
   their matching kind is requested, so lint-only runs preserve diagnostics while
   avoiding edit-only analysis. Eager reporting methods remain compatible while
   rules migrate incrementally.
+- **Exact Config-Shape Interning**: a `FileConfigResolver` parses global and
+  entry-local ignores once, maps each exact file path to its complete matched
+  flat-config entry bitset, and merges/prepares enabled rules once per unique
+  bitset. CLI/API native and third-party plugin collection can share the fully
+  published immutable plan. LSP keeps its existing per-document resolver
+  lifetime; per-file rule runtime state stays outside every plan.
 
 ### Caching Strategy
 
@@ -1049,6 +1065,13 @@ goroutines remain outside that guarantee.
 - **Parse Cache in LSP**: the LSP server passes a shared ts-go `project.ParseCache` into the session to avoid re-parsing from scratch on every change.
 - **Debounced Re-linting**: `refreshCh` and `debounceCh` collapse bursts of file changes and session refreshes onto the main dispatch loop.
 - **CLI/API Are Mostly Fresh Runs**: CLI and one-shot API requests generally rebuild `Program` state per run; there is no repository-local rule-result cache or persistent incremental lint cache in the main CLI path today. JavaScript API path canonicalization is also scoped to one `lintFiles()` call.
+- **Resolver-Scoped Effective Config Plans**: each `FileConfigResolver` owns
+  exact-path file entries and exact matched-entry shape entries. Both caches use
+  publish-once values so concurrent readers of the same resolver wait for
+  complete initialization. They are discarded with the resolver; CLI fix
+  generations, API requests, LSP lint passes, and config reloads never share a
+  plan cache. Merged config maps and configured-rule slices returned by the
+  resolver are immutable shared state.
 - **Program Build Context Boundary**: one CLI invocation or API lint request owns one `ProgramBuildContext`, created only after the request's overlay/canonical VFS wrappers are complete. It is passed explicitly through real Program construction, gap fallback construction, and fix rebuilds. It is never global, never shared across API requests, and is not used by LSP, whose project session has a different invalidation model.
 - **Run/Request-Scoped Program Metadata**: successful `package.json` reads and explicitly registered root, project-reference, and extended tsconfig reads are snapshotted for the context lifetime. Keys remain exact caller paths—no cleaning, case folding, resolving real paths, or symlink merging—and failed reads are retried. Per-key read single-flight avoids duplicate concurrent I/O; generation swaps make future VFS writes safe without clearing a live map. Arbitrary JSON and non-metadata reads bypass this layer.
 - **Extended Config Parse Reuse**: the context implements ts-go's `ExtendedConfigCache` shim contract and shares common `extends` parse results across Programs. Parsing occurs outside map locks and publishes with `LoadOrStore`, avoiding recursive cross-cycle lock ordering; rare concurrent misses may duplicate parsing but share the winning immutable result and still single-flight raw bytes. Root `ParsedCommandLine` values and parsed `package.json` objects are not cached.
@@ -1226,7 +1249,7 @@ If the rule-porting workflow changes, update the material under `.agents/skills/
 │  Bind by Governing Config / Project Order ─────► Non-project Fallback        │
 │                           │                                                  │
 │                           ▼                                                  │
-│  Resolve / Merge Config and Enabled Rules Per File                           │
+│  Match Config Shape -> Reuse/Merge Immutable Config and Enabled Rules        │
 │            │                                                                 │
 │            ▼                                                                 │
 │  Run Rule Initializers -> Register Listeners                                 │

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -790,89 +790,11 @@ func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *Merged
 // patterns supplied by the caller, so repeated calls against the same config
 // (one per lint target) don't re-parse the same ignore pattern strings.
 func (config RslintConfig) getConfigForFileWithIgnores(filePath string, cwd string, globalIgnorePatterns []IgnorePattern) *MergedConfig {
-	merged := &MergedConfig{
-		Rules:   make(map[string]*RuleConfig),
-		Plugins: make(map[string]struct{}),
-	}
-
-	if len(globalIgnorePatterns) > 0 {
-		if isDirBlockedByIgnores(filePath, globalIgnorePatterns, cwd) {
-			return nil
-		}
-		if isFileIgnored(filePath, globalIgnorePatterns, cwd) {
-			return nil
-		}
-	}
-
-	// A CLI/API explicit target can bypass config `files` for parsing, but it
-	// must not make unscoped entries apply to a path the config itself never
-	// selected. Conversely, an explicit selector makes unscoped entries apply
-	// to that file, as in ESLint flat config cascading.
-	if !isFileSelectedByConfig(config, filePath, cwd) {
+	key, matched := config.matchConfigEntries(filePath, cwd, globalIgnorePatterns, nil)
+	if !matched {
 		return nil
 	}
-
-	// Track whether any non-global entry matched this file
-	entryMatched := false
-
-	for _, entry := range config {
-		if isGlobalIgnoreEntry(entry) {
-			continue
-		}
-
-		// 2. files matching
-		if hasFileSelectors(entry) && !isFileMatchedByConfigEntry(filePath, entry, cwd) {
-			continue
-		}
-
-		// 3. Entry-level ignores. Parsed per entry; entry.Ignores is usually
-		// empty (ESLint configs put ignores in a dedicated global-ignore entry),
-		// so ParseIgnorePatterns returns nil and this is free in the common case.
-		if isFileIgnored(filePath, ParseIgnorePatterns(entry.Ignores), cwd) {
-			continue
-		}
-
-		entryMatched = true
-
-		// 4. Rules: later entries override earlier ones. When the later value
-		// changes only severity, ESLint retains the earlier rule options.
-		for ruleName, ruleValue := range entry.Rules {
-			next, hasOptions, err := parseRuleConfigValue(ruleValue)
-			if err != nil {
-				// Config ingress validates rule values before merge. Keep this
-				// guard for callers that construct a config without validating it.
-				continue
-			}
-			if previous := merged.Rules[ruleName]; !hasOptions && previous != nil {
-				next.Options = append([]interface{}(nil), previous.Options...)
-			}
-			merged.Rules[ruleName] = next
-		}
-
-		// 5. Plugins: union from all matching entries (normalized to rule prefix form)
-		for _, plugin := range entry.Plugins {
-			merged.Plugins[NormalizePluginName(plugin)] = struct{}{}
-		}
-
-		// 6. Settings: recursively merge ordinary objects; arrays and scalar
-		// values are replaced by the later entry.
-		if entry.Settings != nil {
-			merged.Settings = Settings(deepMergeConfigObjects(
-				map[string]any(merged.Settings),
-				map[string]any(entry.Settings),
-			))
-		}
-
-		// 7. LanguageOptions: deep merge
-		merged.LanguageOptions = mergeLanguageOptions(merged.LanguageOptions, entry.LanguageOptions)
-	}
-
-	// No entry matched this file — do not lint it
-	if !entryMatched {
-		return nil
-	}
-
-	return merged
+	return config.mergeConfigEntries(key)
 }
 
 // isGlobalIgnoreEntry returns true if the entry has only ignores and an

--- a/internal/config/config_resolution.go
+++ b/internal/config/config_resolution.go
@@ -1,0 +1,141 @@
+package config
+
+// configMatchKey is the exact resolver-local identity of the ordered config
+// entries that apply to one file. The first 64 entries avoid allocation; the
+// complete tail bitset keeps configs with more entries collision-free.
+type configMatchKey struct {
+	first uint64
+	tail  string
+}
+
+func (key *configMatchKey) add(index int, tail []byte) {
+	if index < 64 {
+		key.first |= uint64(1) << index
+		return
+	}
+	tailIndex := index - 64
+	tail[tailIndex/8] |= byte(1 << (tailIndex % 8))
+}
+
+func (key configMatchKey) contains(index int) bool {
+	if index < 64 {
+		return key.first&(uint64(1)<<index) != 0
+	}
+	tailIndex := index - 64
+	return key.tail[tailIndex/8]&byte(1<<(tailIndex%8)) != 0
+}
+
+func parseEntryIgnorePatterns(config RslintConfig) [][]IgnorePattern {
+	patterns := make([][]IgnorePattern, len(config))
+	for index, entry := range config {
+		if !isGlobalIgnoreEntry(entry) {
+			patterns[index] = ParseIgnorePatterns(entry.Ignores)
+		}
+	}
+	return patterns
+}
+
+// matchConfigEntries applies the flat-config selection policy once and returns
+// the exact set of contributing entries. A nil entryIgnorePatterns asks the
+// direct compatibility path to parse entry ignores on demand; run-scoped
+// resolvers pass their precomputed immutable patterns.
+func (config RslintConfig) matchConfigEntries(
+	filePath string,
+	cwd string,
+	globalIgnorePatterns []IgnorePattern,
+	entryIgnorePatterns [][]IgnorePattern,
+) (configMatchKey, bool) {
+	if len(globalIgnorePatterns) > 0 &&
+		(isDirBlockedByIgnores(filePath, globalIgnorePatterns, cwd) ||
+			isFileIgnored(filePath, globalIgnorePatterns, cwd)) {
+		return configMatchKey{}, false
+	}
+
+	selected := isDefaultLintFile(filePath)
+	matched := false
+	var key configMatchKey
+	var tail []byte
+	if tailEntryCount := len(config) - 64; tailEntryCount > 0 {
+		tail = make([]byte, (tailEntryCount+7)/8)
+	}
+
+	for index, entry := range config {
+		if isGlobalIgnoreEntry(entry) {
+			continue
+		}
+		if hasFileSelectors(entry) && !isFileMatchedByConfigEntry(filePath, entry, cwd) {
+			continue
+		}
+
+		ignores := entryIgnorePatternsAt(entryIgnorePatterns, index, entry)
+		if isFileIgnored(filePath, ignores, cwd) {
+			continue
+		}
+
+		matched = true
+		if hasFileSelectors(entry) {
+			selected = true
+		}
+		key.add(index, tail)
+	}
+
+	if !selected || !matched {
+		return configMatchKey{}, false
+	}
+	if tail != nil {
+		key.tail = string(tail)
+	}
+	return key, true
+}
+
+func entryIgnorePatternsAt(patterns [][]IgnorePattern, index int, entry ConfigEntry) []IgnorePattern {
+	if patterns != nil {
+		return patterns[index]
+	}
+	return ParseIgnorePatterns(entry.Ignores)
+}
+
+// mergeConfigEntries performs only the path-independent half of flat-config
+// resolution. key must come from matchConfigEntries for this config.
+func (config RslintConfig) mergeConfigEntries(key configMatchKey) *MergedConfig {
+	merged := &MergedConfig{
+		Rules:   make(map[string]*RuleConfig),
+		Plugins: make(map[string]struct{}),
+	}
+
+	for index, entry := range config {
+		if !key.contains(index) {
+			continue
+		}
+
+		// Later entries override earlier rules. A severity-only override keeps
+		// the previous options, matching ESLint flat-config behavior.
+		for ruleName, ruleValue := range entry.Rules {
+			next, hasOptions, err := parseRuleConfigValue(ruleValue)
+			if err != nil {
+				// Config ingress validates rule values before merge. Keep this guard
+				// for callers that construct RslintConfig directly.
+				continue
+			}
+			if previous := merged.Rules[ruleName]; !hasOptions && previous != nil {
+				next.Options = append([]interface{}(nil), previous.Options...)
+			}
+			merged.Rules[ruleName] = next
+		}
+
+		for _, plugin := range entry.Plugins {
+			merged.Plugins[NormalizePluginName(plugin)] = struct{}{}
+		}
+
+		if entry.Settings != nil {
+			merged.Settings = Settings(deepMergeConfigObjects(
+				map[string]any(merged.Settings),
+				map[string]any(entry.Settings),
+			))
+		}
+
+		merged.LanguageOptions = mergeLanguageOptions(merged.LanguageOptions, entry.LanguageOptions)
+	}
+
+	return merged
+}

--- a/internal/config/file_resolver.go
+++ b/internal/config/file_resolver.go
@@ -1,21 +1,15 @@
 package config
 
-import (
-	"sync"
+import "github.com/web-infra-dev/rslint/internal/linter"
 
-	"github.com/web-infra-dev/rslint/internal/linter"
-)
-
-type cachedMergedConfig struct {
-	value *MergedConfig
+type effectiveConfigPlan struct {
+	mergedConfig *MergedConfig
+	enabledRules []linter.ConfiguredRule
 }
 
-type cachedEnabledRules struct {
-	value []linter.ConfiguredRule
-}
-
-// FileConfigResolver caches per-file config and rule resolution for one lint
-// run. It is safe for concurrent use by RunLinter workers.
+// FileConfigResolver resolves config and rules for one immutable config root.
+// It interns files with the same exact matched-entry shape for the resolver's
+// lifetime and is safe for concurrent use by native and plugin lint workers.
 type FileConfigResolver struct {
 	config         RslintConfig
 	cwd            string
@@ -25,10 +19,10 @@ type FileConfigResolver struct {
 	// re-deriving it (string parsing + allocation) on every ConfigForFile
 	// call is pure waste at thousands-of-files scale.
 	globalIgnorePatterns []IgnorePattern
+	entryIgnorePatterns  [][]IgnorePattern
 
-	mu          sync.RWMutex
-	configCache map[string]cachedMergedConfig
-	rulesCache  map[string]cachedEnabledRules
+	filePlans  publishOnceCache[string, *effectiveConfigPlan]
+	shapePlans publishOnceCache[configMatchKey, *effectiveConfigPlan]
 }
 
 // NewFileConfigResolver creates a per-run resolver for one config root.
@@ -38,55 +32,50 @@ func NewFileConfigResolver(config RslintConfig, cwd string, enforcePlugins bool)
 		cwd:                  cwd,
 		enforcePlugins:       enforcePlugins,
 		globalIgnorePatterns: extractConfigIgnores(config),
-		configCache:          make(map[string]cachedMergedConfig),
-		rulesCache:           make(map[string]cachedEnabledRules),
+		entryIgnorePatterns:  parseEntryIgnorePatterns(config),
 	}
 }
 
 // ConfigForFile returns the merged config for filePath, caching nil misses.
+// The returned value is shared immutable resolver state and must be read-only.
 func (r *FileConfigResolver) ConfigForFile(filePath string) *MergedConfig {
-	r.mu.RLock()
-	if cached, ok := r.configCache[filePath]; ok {
-		r.mu.RUnlock()
-		return cached.value
+	plan := r.planForFile(filePath)
+	if plan == nil {
+		return nil
 	}
-	r.mu.RUnlock()
-
-	merged := r.config.getConfigForFileWithIgnores(filePath, r.cwd, r.globalIgnorePatterns)
-
-	r.mu.Lock()
-	if cached, ok := r.configCache[filePath]; ok {
-		r.mu.Unlock()
-		return cached.value
-	}
-	r.configCache[filePath] = cachedMergedConfig{value: merged}
-	r.mu.Unlock()
-	return merged
+	return plan.mergedConfig
 }
 
 // EnabledRulesForFile returns cached enabled rules and their merged config.
-// The returned rule slice is shared cache state and must be treated read-only.
+// Both returned values are shared immutable resolver state and must be read-only.
 func (r *FileConfigResolver) EnabledRulesForFile(filePath string) ([]linter.ConfiguredRule, *MergedConfig) {
-	r.mu.RLock()
-	if cached, ok := r.rulesCache[filePath]; ok {
-		merged := r.configCache[filePath].value
-		r.mu.RUnlock()
-		return cached.value, merged
+	plan := r.planForFile(filePath)
+	if plan == nil {
+		return nil, nil
 	}
-	r.mu.RUnlock()
+	return plan.enabledRules, plan.mergedConfig
+}
 
-	merged := r.ConfigForFile(filePath)
-	enabledRules := GlobalRuleRegistry.GetEnabledRulesForMergedConfig(merged, r.enforcePlugins)
+func (r *FileConfigResolver) planForFile(filePath string) *effectiveConfigPlan {
+	return r.filePlans.getOrInit(filePath, func() *effectiveConfigPlan {
+		key, matched := r.config.matchConfigEntries(
+			filePath,
+			r.cwd,
+			r.globalIgnorePatterns,
+			r.entryIgnorePatterns,
+		)
+		if !matched {
+			return nil
+		}
 
-	r.mu.Lock()
-	if cached, ok := r.rulesCache[filePath]; ok {
-		merged = r.configCache[filePath].value
-		r.mu.Unlock()
-		return cached.value, merged
-	}
-	r.rulesCache[filePath] = cachedEnabledRules{value: enabledRules}
-	r.mu.Unlock()
-	return enabledRules, merged
+		return r.shapePlans.getOrInit(key, func() *effectiveConfigPlan {
+			mergedConfig := r.config.mergeConfigEntries(key)
+			return &effectiveConfigPlan{
+				mergedConfig: mergedConfig,
+				enabledRules: GlobalRuleRegistry.GetEnabledRulesForMergedConfig(mergedConfig, r.enforcePlugins),
+			}
+		})
+	})
 }
 
 // ActiveRulesForFile filters cached enabled rules by the optional type-info set.

--- a/internal/config/file_resolver_shape_test.go
+++ b/internal/config/file_resolver_shape_test.go
@@ -1,0 +1,376 @@
+package config
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/linter"
+)
+
+func TestConfigShapeResolutionMatchesLegacyAlgorithm(t *testing.T) {
+	RegisterAllRules()
+	random := rand.New(rand.NewSource(0x5a17_2026))
+	paths := []string{
+		"/repo/src/app.ts",
+		"/repo/src/app.test.ts",
+		"/repo/src/special.ts",
+		"/repo/src/generated/app.ts",
+		"/repo/test/app.js",
+		"/repo/component.vue",
+		"/repo/component.unsupported",
+	}
+
+	for sample := range 100 {
+		entryCount := 1 + random.Intn(80)
+		config := make(RslintConfig, entryCount)
+		for index := range config {
+			entry := ConfigEntry{Name: fmt.Sprintf("sample-%d-entry-%d", sample, index)}
+			switch random.Intn(6) {
+			case 1:
+				entry.Files = []string{"src/**/*.ts"}
+			case 2:
+				entry.Files = []string{"**/*.vue"}
+			case 3:
+				entry.Files = []string{"src/special.ts"}
+			case 4:
+				entry.FilePatternGroups = [][]string{{"src/**", "**/*.ts", "!**/*.test.ts"}}
+			case 5:
+				entry.FilePatternGroups = [][]string{{}}
+			}
+			if random.Intn(4) == 0 {
+				ignores := []string{"**/*.test.ts", "src/generated/**", "!src/generated/keep.ts"}
+				entry.Ignores = ignores[:1+random.Intn(len(ignores))]
+			}
+			if random.Intn(3) != 0 {
+				severities := []any{"off", "warn", "error", []any{"error", map[string]any{"allow": []any{"warn"}}}}
+				entry.Rules = Rules{"no-console": severities[random.Intn(len(severities))]}
+			}
+			if random.Intn(4) == 0 {
+				entry.Settings = Settings{
+					"shared": map[string]any{
+						"sample": sample,
+						"entry":  index,
+					},
+				}
+			}
+			if random.Intn(6) == 0 {
+				entry.LanguageOptions = &LanguageOptions{Raw: map[string]any{
+					"globals": map[string]any{"testGlobal": "readonly"},
+				}}
+			}
+			if random.Intn(8) == 0 {
+				entry.Plugins = []string{"@typescript-eslint"}
+			}
+			config[index] = entry
+		}
+
+		resolver := NewFileConfigResolver(config, "/repo", false)
+		for _, filePath := range paths {
+			want := legacyMergedConfigForTest(config, filePath, "/repo", extractConfigIgnores(config))
+			if got := config.GetConfigForFile(filePath, "/repo"); !reflect.DeepEqual(got, want) {
+				t.Fatalf("sample %d path %s direct mismatch:\nnew:    %#v\nlegacy: %#v", sample, filePath, got, want)
+			}
+			if got := resolver.ConfigForFile(filePath); !reflect.DeepEqual(got, want) {
+				t.Fatalf("sample %d path %s resolver mismatch:\nnew:    %#v\nlegacy: %#v", sample, filePath, got, want)
+			}
+		}
+	}
+}
+
+func TestFileConfigResolverMatchesDirectResolutionAcrossShapes(t *testing.T) {
+	RegisterAllRules()
+	config := RslintConfig{
+		{Ignores: []string{"generated/**"}},
+		{
+			Rules: Rules{
+				"no-console": []any{"warn", map[string]any{"allow": []any{"warn"}}},
+			},
+			Settings: Settings{"shared": map[string]any{"base": true}},
+		},
+		{
+			Files: []string{"src/**/*.ts"},
+			Rules: Rules{
+				"no-debugger": "error",
+			},
+			Settings: Settings{"shared": map[string]any{"typed": true}},
+			LanguageOptions: &LanguageOptions{Raw: map[string]any{
+				"globals": map[string]any{"typedGlobal": "readonly"},
+			}},
+		},
+		{
+			Files: []string{"src/special.ts"},
+			Rules: Rules{
+				"no-console": "error",
+			},
+		},
+		{
+			Files:   []string{"src/**/*.ts"},
+			Ignores: []string{"**/*.test.ts"},
+			Rules: Rules{
+				"eqeqeq": "warn",
+			},
+		},
+		{
+			FilePatternGroups: [][]string{{"src/**", "**/*.ts"}},
+			Rules: Rules{
+				"no-alert": "warn",
+			},
+		},
+		{
+			Files: []string{"**/*.vue"},
+			Rules: Rules{
+				"no-debugger": "warn",
+			},
+		},
+	}
+
+	resolver := NewFileConfigResolver(config, "/repo", false)
+	paths := []string{
+		"/repo/src/a.ts",
+		"/repo/src/b.ts",
+		"/repo/src/special.ts",
+		"/repo/src/a.test.ts",
+		"/repo/src/a.js",
+		"/repo/components/view.vue",
+		"/repo/generated/skip.ts",
+		"/repo/outside.unsupported",
+	}
+	for _, filePath := range paths {
+		directMerged := config.GetConfigForFile(filePath, "/repo")
+		directRules := GlobalRuleRegistry.GetEnabledRulesForMergedConfig(directMerged, false)
+		resolvedRules, resolvedMerged := resolver.EnabledRulesForFile(filePath)
+		if !reflect.DeepEqual(resolvedMerged, directMerged) {
+			t.Fatalf("%s merged config mismatch:\nresolver: %#v\ndirect:   %#v", filePath, resolvedMerged, directMerged)
+		}
+		if got, want := configuredRuleViews(resolvedRules), configuredRuleViews(directRules); !reflect.DeepEqual(got, want) {
+			t.Fatalf("%s enabled rules mismatch:\nresolver: %#v\ndirect:   %#v", filePath, got, want)
+		}
+	}
+
+	first := resolver.planForFile("/repo/src/a.ts")
+	if second := resolver.planForFile("/repo/src/b.ts"); first == nil || second != first {
+		t.Fatal("files with the same exact config shape did not share one effective plan")
+	}
+	if special := resolver.planForFile("/repo/src/special.ts"); special == nil || special == first {
+		t.Fatal("files with different config shapes shared an effective plan")
+	}
+}
+
+func TestFileConfigResolverDistinguishesMatchedZeroRulesAndMisses(t *testing.T) {
+	config := RslintConfig{{Settings: Settings{}}}
+	resolver := NewFileConfigResolver(config, "/repo", false)
+
+	rules, merged := resolver.EnabledRulesForFile("/repo/src/file.ts")
+	if merged == nil || len(rules) != 0 {
+		t.Fatalf("default-selected zero-rule file resolved to rules=%v merged=%#v", rules, merged)
+	}
+	if rules, merged = resolver.EnabledRulesForFile("/repo/src/file.vue"); rules != nil || merged != nil {
+		t.Fatalf("unsupported unselected file resolved to rules=%v merged=%#v", rules, merged)
+	}
+}
+
+func TestFileConfigResolverShapeKeyPreservesEntriesBeyond64(t *testing.T) {
+	RegisterAllRules()
+	config := make(RslintConfig, 72)
+	for index := range config {
+		config[index] = ConfigEntry{Name: fmt.Sprintf("base-%d", index)}
+	}
+	config[63] = ConfigEntry{
+		Name:  "low-special",
+		Files: []string{"src/low.ts"},
+		Rules: Rules{"no-alert": "warn"},
+	}
+	config[64] = ConfigEntry{
+		Name:  "tail-special",
+		Files: []string{"src/tail.ts"},
+		Rules: Rules{"no-debugger": "error"},
+	}
+	config[71] = ConfigEntry{
+		Name:  "tail-vue",
+		Files: []string{"**/*.vue"},
+		Rules: Rules{"no-console": "warn"},
+	}
+
+	resolver := NewFileConfigResolver(config, "/repo", false)
+	paths := []string{
+		"/repo/src/ordinary.ts",
+		"/repo/src/low.ts",
+		"/repo/src/tail.ts",
+		"/repo/component.vue",
+		"/repo/component.unsupported",
+	}
+	plans := make(map[string]*effectiveConfigPlan, len(paths))
+	for _, filePath := range paths {
+		resolvedRules, resolvedMerged := resolver.EnabledRulesForFile(filePath)
+		directMerged := config.GetConfigForFile(filePath, "/repo")
+		directRules := GlobalRuleRegistry.GetEnabledRulesForMergedConfig(directMerged, false)
+		if !reflect.DeepEqual(resolvedMerged, directMerged) ||
+			!reflect.DeepEqual(configuredRuleViews(resolvedRules), configuredRuleViews(directRules)) {
+			t.Fatalf("resolution mismatch for %s", filePath)
+		}
+		plans[filePath] = resolver.planForFile(filePath)
+	}
+	if plans["/repo/src/ordinary.ts"] == plans["/repo/src/low.ts"] ||
+		plans["/repo/src/ordinary.ts"] == plans["/repo/src/tail.ts"] ||
+		plans["/repo/src/ordinary.ts"] == plans["/repo/component.vue"] {
+		t.Fatal("entry bits at or beyond the 64-entry boundary collided")
+	}
+	if plans["/repo/component.unsupported"] != nil {
+		t.Fatal("unsupported file with only unscoped matches should remain unselected")
+	}
+}
+
+func TestFileConfigResolverPreservesWindowsPathMatching(t *testing.T) {
+	config := RslintConfig{{
+		Files:   []string{"src/**/*.ts"},
+		Ignores: []string{"src/generated/**"},
+		Rules:   Rules{"no-console": "error"},
+	}}
+	tests := []struct {
+		filePath string
+		cwd      string
+	}{
+		{"C:/Users/project/src/index.ts", "C:/Users/project"},
+		{"C:/Users/project/src/index.ts", `C:\Users\project`},
+		{"C:/Users/project/src/generated/index.ts", `C:\Users\project`},
+		{"C:/repo/packages/foo/src/index.ts", "C:/repo"},
+	}
+	for _, test := range tests {
+		resolver := NewFileConfigResolver(config, test.cwd, false)
+		got := resolver.ConfigForFile(test.filePath)
+		want := config.GetConfigForFile(test.filePath, test.cwd)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("filePath=%q cwd=%q: resolver=%#v direct=%#v", test.filePath, test.cwd, got, want)
+		}
+	}
+}
+
+func TestFileConfigResolverConcurrentShapePublication(t *testing.T) {
+	RegisterAllRules()
+	config := RslintConfig{{
+		Files: []string{"src/**/*.ts"},
+		Rules: Rules{
+			"no-console":  "warn",
+			"no-debugger": "error",
+		},
+	}}
+	resolver := NewFileConfigResolver(config, "/repo", false)
+	plans := make(chan *effectiveConfigPlan, 128)
+	var waitGroup sync.WaitGroup
+	for index := range 128 {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			plans <- resolver.planForFile(fmt.Sprintf("/repo/src/file-%d.ts", index))
+		}()
+	}
+	waitGroup.Wait()
+	close(plans)
+
+	var first *effectiveConfigPlan
+	for plan := range plans {
+		if plan == nil {
+			t.Fatal("matching file resolved to a nil plan")
+		}
+		if first == nil {
+			first = plan
+			continue
+		}
+		if plan != first {
+			t.Fatal("concurrent files with one shape published multiple effective plans")
+		}
+	}
+}
+
+type configuredRuleView struct {
+	name               string
+	settings           map[string]interface{}
+	globals            map[string]bool
+	severity           int
+	requiresTypeInfo   bool
+	isEslintPluginRule bool
+	options            []any
+	hasRun             bool
+}
+
+func configuredRuleViews(rules []linter.ConfiguredRule) []configuredRuleView {
+	views := make([]configuredRuleView, len(rules))
+	for index, configuredRule := range rules {
+		views[index] = configuredRuleView{
+			name:               configuredRule.Name,
+			settings:           configuredRule.Settings,
+			globals:            configuredRule.Globals,
+			severity:           int(configuredRule.Severity),
+			requiresTypeInfo:   configuredRule.RequiresTypeInfo,
+			isEslintPluginRule: configuredRule.IsEslintPluginRule,
+			options:            configuredRule.Options,
+			hasRun:             configuredRule.Run != nil,
+		}
+	}
+	return views
+}
+
+// legacyMergedConfigForTest is the pre-interning selection and merge algorithm.
+// Keeping this independent test-only oracle attacks semantic drift introduced
+// when the production path combines selection and entry matching into one pass.
+func legacyMergedConfigForTest(
+	config RslintConfig,
+	filePath string,
+	cwd string,
+	globalIgnorePatterns []IgnorePattern,
+) *MergedConfig {
+	merged := &MergedConfig{
+		Rules:   make(map[string]*RuleConfig),
+		Plugins: make(map[string]struct{}),
+	}
+	if len(globalIgnorePatterns) > 0 &&
+		(isDirBlockedByIgnores(filePath, globalIgnorePatterns, cwd) ||
+			isFileIgnored(filePath, globalIgnorePatterns, cwd)) {
+		return nil
+	}
+	if !isFileSelectedByConfig(config, filePath, cwd) {
+		return nil
+	}
+
+	entryMatched := false
+	for _, entry := range config {
+		if isGlobalIgnoreEntry(entry) {
+			continue
+		}
+		if hasFileSelectors(entry) && !isFileMatchedByConfigEntry(filePath, entry, cwd) {
+			continue
+		}
+		if isFileIgnored(filePath, ParseIgnorePatterns(entry.Ignores), cwd) {
+			continue
+		}
+		entryMatched = true
+
+		for ruleName, ruleValue := range entry.Rules {
+			next, hasOptions, err := parseRuleConfigValue(ruleValue)
+			if err != nil {
+				continue
+			}
+			if previous := merged.Rules[ruleName]; !hasOptions && previous != nil {
+				next.Options = append([]interface{}(nil), previous.Options...)
+			}
+			merged.Rules[ruleName] = next
+		}
+		for _, plugin := range entry.Plugins {
+			merged.Plugins[NormalizePluginName(plugin)] = struct{}{}
+		}
+		if entry.Settings != nil {
+			merged.Settings = Settings(deepMergeConfigObjects(
+				map[string]any(merged.Settings),
+				map[string]any(entry.Settings),
+			))
+		}
+		merged.LanguageOptions = mergeLanguageOptions(merged.LanguageOptions, entry.LanguageOptions)
+	}
+	if !entryMatched {
+		return nil
+	}
+	return merged
+}

--- a/internal/config/resolution_cache.go
+++ b/internal/config/resolution_cache.go
@@ -1,0 +1,21 @@
+package config
+
+import "sync"
+
+// publishOnceCache publishes only completely initialized values. Every lookup,
+// including a losing LoadOrStore path, invokes the stored sync.OnceValue and
+// therefore waits for the winning initializer instead of observing its slot.
+type publishOnceCache[K comparable, V any] struct {
+	entries sync.Map
+}
+
+type publishOnceEntry[V any] struct {
+	value func() V
+}
+
+func (cache *publishOnceCache[K, V]) getOrInit(key K, init func() V) V {
+	candidate := &publishOnceEntry[V]{value: sync.OnceValue(init)}
+	actual, _ := cache.entries.LoadOrStore(key, candidate)
+	// entries is private and every stored value is a publishOnceEntry[V].
+	return actual.(*publishOnceEntry[V]).value() //nolint:forcetypeassert
+}

--- a/internal/config/resolution_cache_test.go
+++ b/internal/config/resolution_cache_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPublishOnceCacheWaitsForPublishedInitializer(t *testing.T) {
+	var cache publishOnceCache[string, int]
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	firstResult := make(chan int, 1)
+	secondResult := make(chan int, 1)
+
+	go func() {
+		firstResult <- cache.getOrInit("same", func() int {
+			calls.Add(1)
+			close(started)
+			<-release
+			return 42
+		})
+	}()
+	<-started
+
+	go func() {
+		secondResult <- cache.getOrInit("same", func() int {
+			calls.Add(1)
+			return -1
+		})
+	}()
+
+	select {
+	case value := <-secondResult:
+		t.Fatalf("reader returned %d before the published initializer completed", value)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(release)
+	if got := <-firstResult; got != 42 {
+		t.Fatalf("first result = %d, want 42", got)
+	}
+	if got := <-secondResult; got != 42 {
+		t.Fatalf("second result = %d, want the published value 42", got)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("initializer calls = %d, want 1", got)
+	}
+}
+
+func TestPublishOnceCacheReplaysInitializerPanic(t *testing.T) {
+	var cache publishOnceCache[string, int]
+	var calls atomic.Int32
+	panicValue := &struct{}{}
+
+	for attempt := range 2 {
+		var recovered any
+		func() {
+			defer func() {
+				recovered = recover()
+			}()
+			cache.getOrInit("same", func() int {
+				calls.Add(1)
+				panic(panicValue)
+			})
+		}()
+		if recovered != panicValue {
+			t.Fatalf("attempt %d recovered %#v, want the original panic value", attempt, recovered)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("initializer calls = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Split flat-config resolution into path-dependent entry matching and path-independent config/rule-plan construction.
- Intern exact matched-entry shapes inside each `FileConfigResolver`, using a collision-free key and publish-once concurrent initialization. Files with the same shape reuse one immutable effective plan; per-file rule runtime state remains isolated.
- Parse global and entry-local ignore patterns once per resolver while preserving exact path, config-generation, plugin-gating, fix, API, and LSP semantics. The direct compatibility path uses the same matching/merging primitives without retaining cache state.
- Document the resolver-scoped lifecycle and cache boundary in `architecture.md`.

### Correctness and adversarial validation

- Differential oracle: 100 deterministic randomized configs, including selector/ignore interactions, zero-rule matches, unsupported extensions, settings/language options, and configs with more than 64 entries.
- Concurrency: focused publication and same-shape tests passed 50 repetitions; focused `-race` tests passed 20 repetitions with no race, panic, or deadlock.
- Product paths: relevant config, CLI/API, plugin, ignore, type-info, fix, config-discovery, and LSP tests passed.
- Real repositories: rspack and rsbuild matched the main baseline byte-for-byte for stdout/stderr and exactly for exit code in plain, explicit `--config`, `--type-check`, and `--type-check-only` modes. `--fix` final content and forced-color output also matched.
- Cross-platform release builds passed for macOS, Linux, and Windows on both amd64 and arm64.
- Changed-scope cspell, Prettier/gofmt, golangci-lint, and `git diff --check` passed. No unrelated full-repository test suite was run.

### Performance

The benchmark compared exact standalone package layouts for
`main@219101a` and `candidate@6d15baa`. Each variant used the original
`packages/rslint/bin/rslint.js`, its own `dist/`, and its own release-stripped
native binary (`go build -ldflags="-s -w"`). Docker disabled VCS stamping for
both binaries only to keep non-runtime build metadata symmetric. No custom JS
runner or injected native-binary argument was used.

All modes invoked the package bin directly with `--no-color --quiet`. Each
case warmed both variants, waited for three consecutive host samples at or
above 80% idle, then used `hyperfine` with counterbalanced main/candidate
order. `GOMAXPROCS` was unset. Raw stdout/stderr was captured per run so the
wall result and native summary time could be checked independently. Negative
percentages are faster; the 95% intervals are deterministic 100,000-resample
bootstrap intervals over paired wall-time deltas.

Docker/Linux arm64, 8 CPUs, 7 GiB, 12 AB/BA cycles:

| Repository | Mode | Wall median main → candidate | Wall Δ | Paired median | Paired-mean 95% CI | Internal median main → candidate |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| rspack | plain | 316.0 → 287.5 ms | -28.5 ms | -6.90% | [-9.01%, -3.14%] | 281.5 → 254.0 ms |
| rspack | explicit config | 315.0 → 283.0 ms | -32.0 ms | -8.98% | [-11.72%, -4.22%] | 277.5 → 248.0 ms |
| rspack | type-check | 384.3 → 381.6 ms | -2.7 ms | -2.67% | [-6.04%, +0.55%] | 347.0 → 342.0 ms |
| rspack | type-check-only | 326.8 → 331.8 ms | +5.0 ms | +1.57% | [-1.76%, +8.28%] | 288.0 → 294.0 ms |
| rsbuild | plain | 565.7 → 500.4 ms | -65.3 ms | -11.04% | [-12.53%, -8.52%] | 525.5 → 460.5 ms |
| rsbuild | explicit config | 547.7 → 478.6 ms | -69.1 ms | -12.64% | [-14.14%, -10.79%] | 506.5 → 440.0 ms |
| rsbuild | type-check | 960.1 → 905.1 ms | -55.0 ms | -6.25% | [-7.05%, -5.20%] | 910.5 → 852.0 ms |
| rsbuild | type-check-only | 700.8 → 698.8 ms | -2.0 ms | -0.65% | [-1.68%, +1.10%] | 649.5 → 649.0 ms |

Native macOS arm64, runtime default 10 threads, 10 AB/BA cycles:

| Repository | Mode | Wall median main → candidate | Wall Δ | Paired median | Paired-mean 95% CI | Internal median main → candidate |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| rspack | plain | 397.4 → 408.3 ms | +10.9 ms | +5.30% | [-2.50%, +6.46%] | 351.0 → 357.5 ms |
| rspack | explicit config | 396.6 → 388.5 ms | -8.1 ms | -3.22% | [-7.12%, +1.71%] | 354.0 → 347.5 ms |
| rspack | type-check | 532.3 → 527.5 ms | -4.8 ms | -2.08% | [-7.93%, +2.35%] | 482.0 → 468.5 ms |
| rspack | type-check-only | 450.2 → 459.9 ms | +9.7 ms | +1.39% | [-0.88%, +3.23%] | 397.5 → 402.5 ms |
| rsbuild | plain | 774.1 → 768.5 ms | -5.6 ms | -0.65% | [-4.46%, +1.26%] | 724.5 → 703.0 ms |
| rsbuild | explicit config | 765.4 → 747.2 ms | -18.2 ms | -1.94% | [-4.33%, +1.06%] | 720.0 → 696.0 ms |
| rsbuild | type-check | 1423.6 → 1406.7 ms | -16.9 ms | -0.38% | [-3.87%, +2.51%] | 1362.0 → 1339.0 ms |
| rsbuild | type-check-only | 1192.1 → 1203.2 ms | +11.1 ms | -0.91% | [-1.83%, +3.35%] | 1130.5 → 1135.0 ms |

Docker confirms wall and internal wins for rspack plain/config and rsbuild
plain/config/type-check. The remaining Docker cases are inconclusive. Every
native macOS wall interval crosses zero, so no native-host win or regression is
claimed. Across all measured runs, main and candidate had identical exit codes
and identical summary counts for diagnostics, files, rules, and type-checked
files; measured stderr was empty.
## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
