### PR TITLE
refactor(rule): port no-ex-assign to the Refs API

### DIFF
--- a/internal/config/all_rules_silent_on_nil_tc_test.go
+++ b/internal/config/all_rules_silent_on_nil_tc_test.go
@@ -23,7 +23,7 @@ import (
 // The static check matches `if ctx.TypeChecker == nil { return RuleListeners{} }`
 // at the top of Run. Some rules instead push the nil-TC gate into a helper
 // (e.g. no-obj-calls's checkCallee, no-const-assign's checkIdentifierWrite,
-// no-ex-assign's checkReassignments, no-use-before-define's checkIdentifier)
+// no-use-before-define's checkIdentifier)
 // — every listener funnels through that helper, so the rule emits zero
 // diagnostics without TC even though Run itself is unguarded.
 //

--- a/internal/rules/no_ex_assign/no_ex_assign.go
+++ b/internal/rules/no_ex_assign/no_ex_assign.go
@@ -8,7 +8,8 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// Message builder
+// https://eslint.org/docs/latest/rules/no-ex-assign
+
 func buildExAssignMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "unexpected",
@@ -16,274 +17,50 @@ func buildExAssignMessage() rule.RuleMessage {
 	}
 }
 
-func collectCatchBindingNamesAndSymbols(node *ast.Node, ctx rule.RuleContext) ([]string, []*ast.Symbol) {
-	if node == nil {
-		return nil, nil
-	}
-	if ast.IsIdentifier(node) {
-		var sym *ast.Symbol
-		if ctx.TypeChecker != nil {
-			sym = ctx.TypeChecker.GetSymbolAtLocation(node)
-		}
-		return []string{node.Text()}, []*ast.Symbol{sym}
-	}
-	if ast.IsBindingPattern(node) {
-		var names []string
-		var symbols []*ast.Symbol
-		for _, elem := range node.Elements() {
-			if elem == nil || !ast.IsBindingElement(elem) {
-				continue
-			}
-			be := elem.AsBindingElement()
-			if be == nil || be.Name() == nil {
-				continue
-			}
-			utils.CollectBindingNames(be.Name(), func(ident *ast.Node, name string) {
-				names = append(names, name)
-				var sym *ast.Symbol
-				if ctx.TypeChecker != nil {
-					sym = ctx.TypeChecker.GetSymbolAtLocation(ident)
-				}
-				symbols = append(symbols, sym)
-			})
-		}
-		return names, symbols
-	}
-	return nil, nil
-}
-
-func isBindingPatternInAssignment(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-
-	parent := node.Parent
-
-	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-		parent = parent.Parent
-	}
-
-	if parent == nil || parent.Kind != ast.KindBinaryExpression {
-		return false
-	}
-
-	binary := parent.AsBinaryExpression()
-	if binary == nil || binary.OperatorToken == nil {
-		return false
-	}
-
-	switch binary.OperatorToken.Kind {
-	case ast.KindEqualsToken:
-		return binary.Left == node
-	}
-
-	return false
-}
-
-func isInDestructuringAssignment(node *ast.Node) bool {
-	current := node
-	for current != nil {
-		parent := current.Parent
-		if parent == nil {
-			return false
-		}
-
-		switch parent.Kind {
-		case ast.KindBinaryExpression:
-			binary := parent.AsBinaryExpression()
-			if binary != nil && binary.OperatorToken != nil &&
-				binary.OperatorToken.Kind == ast.KindEqualsToken {
-				return binary.Left == current
-			}
-			return false
-		case ast.KindParenthesizedExpression,
-			ast.KindObjectLiteralExpression,
-			ast.KindArrayLiteralExpression,
-			ast.KindPropertyAssignment,
-			ast.KindShorthandPropertyAssignment,
-			ast.KindSpreadAssignment:
-			current = parent
-		default:
-			return false
-		}
-	}
-	return false
-}
-
-func isWriteReference(node *ast.Node) bool {
-	if node == nil || node.Parent == nil {
-		return false
-	}
-
-	parent := node.Parent
-
-	switch parent.Kind {
-	case ast.KindBinaryExpression:
-		binary := parent.AsBinaryExpression()
-		if binary == nil || binary.OperatorToken == nil {
-			return false
-		}
-
-		switch binary.OperatorToken.Kind {
-		case ast.KindEqualsToken,
-			ast.KindPlusEqualsToken,
-			ast.KindMinusEqualsToken,
-			ast.KindAsteriskAsteriskEqualsToken,
-			ast.KindAsteriskEqualsToken,
-			ast.KindSlashEqualsToken,
-			ast.KindPercentEqualsToken,
-			ast.KindLessThanLessThanEqualsToken,
-			ast.KindGreaterThanGreaterThanEqualsToken,
-			ast.KindGreaterThanGreaterThanGreaterThanEqualsToken,
-			ast.KindAmpersandEqualsToken,
-			ast.KindBarEqualsToken,
-			ast.KindCaretEqualsToken,
-			ast.KindBarBarEqualsToken,
-			ast.KindAmpersandAmpersandEqualsToken,
-			ast.KindQuestionQuestionEqualsToken:
-			return binary.Left == node
-		}
-	case ast.KindPostfixUnaryExpression:
-		postfix := parent.AsPostfixUnaryExpression()
-		if postfix == nil {
-			return false
-		}
-		switch postfix.Operator {
-		case ast.KindPlusPlusToken, ast.KindMinusMinusToken:
-			return postfix.Operand == node
-		}
-	case ast.KindPrefixUnaryExpression:
-		prefix := parent.AsPrefixUnaryExpression()
-		if prefix == nil {
-			return false
-		}
-		switch prefix.Operator {
-		case ast.KindPlusPlusToken, ast.KindMinusMinusToken:
-			return prefix.Operand == node
-		}
-	case ast.KindForInStatement:
-		forIn := parent.AsForInOrOfStatement()
-		if forIn == nil {
-			return false
-		}
-		return forIn.Initializer == node
-	case ast.KindForOfStatement:
-		forOf := parent.AsForInOrOfStatement()
-		if forOf == nil {
-			return false
-		}
-		return forOf.Initializer == node
-	case ast.KindObjectBindingPattern:
-		return isBindingPatternInAssignment(parent)
-	case ast.KindArrayBindingPattern:
-		return isBindingPatternInAssignment(parent)
-	case ast.KindBindingElement:
-		return isWriteReference(parent)
-	case ast.KindShorthandPropertyAssignment:
-		shorthand := parent.AsShorthandPropertyAssignment()
-		if shorthand != nil && shorthand.Name() == node {
-			return isInDestructuringAssignment(parent)
-		}
-	case ast.KindPropertyAssignment:
-		propAssignment := parent.AsPropertyAssignment()
-		if propAssignment != nil && propAssignment.Initializer == node {
-			return isInDestructuringAssignment(parent)
-		}
-	case ast.KindObjectLiteralExpression:
-		return isInDestructuringAssignment(parent)
-	case ast.KindArrayLiteralExpression:
-		return isInDestructuringAssignment(parent)
-	case ast.KindParenthesizedExpression:
-		return isWriteReference(parent)
-	case ast.KindAsExpression, ast.KindTypeAssertionExpression:
-		return isWriteReference(parent)
-	}
-
-	return false
-}
-
-func isNameShadowed(node *ast.Node, symbols []*ast.Symbol, ctx rule.RuleContext) bool {
-	if node == nil || ctx.TypeChecker == nil || len(symbols) == 0 {
-		return false
-	}
-
-	symbol := utils.GetReferenceSymbol(node, ctx.TypeChecker)
-	if symbol == nil {
-		return false
-	}
-
-	for _, s := range symbols {
-		if s == symbol {
-			return false
-		}
-	}
-	return true
-}
-
-func getIdentifierName(node *ast.Node) string {
-	if node == nil || node.Kind != ast.KindIdentifier {
-		return ""
-	}
-	return node.Text()
-}
-
-func checkReassignments(block *ast.Node, names []string, symbols []*ast.Symbol, ctx rule.RuleContext) {
-	if block == nil || ctx.TypeChecker == nil || len(names) == 0 || len(symbols) == 0 {
-		return
-	}
-
-	var walk func(*ast.Node)
-	walk = func(block *ast.Node) {
-		if block == nil {
+// catchBindingSymbols returns the binder symbol of every name bound by the
+// catch clause's variable declaration: the lone identifier of `catch (e)` or
+// each name nested in a destructuring pattern. The symbol is attached to the
+// declaration node owning the name — the VariableDeclaration itself for a
+// plain identifier, the enclosing BindingElement for pattern names.
+func catchBindingSymbols(name *ast.Node) []*ast.Symbol {
+	var symbols []*ast.Symbol
+	utils.CollectBindingNames(name, func(ident *ast.Node, _ string) {
+		if ident.Parent == nil {
 			return
 		}
-
-		block.ForEachChild(func(child *ast.Node) bool {
-			if child == nil {
-				return false
-			}
-
-			childName := getIdentifierName(child)
-			if child.Kind == ast.KindIdentifier && slices.Contains(names, childName) {
-				if isWriteReference(child) {
-					shadowed := isNameShadowed(child, symbols, ctx)
-					if !shadowed {
-						ctx.ReportNode(child, buildExAssignMessage())
-					}
-				}
-			} else {
-				walk(child)
-			}
-
-			return false
-		})
-	}
-
-	walk(block)
+		if sym := ident.Parent.Symbol(); sym != nil {
+			symbols = append(symbols, sym)
+		}
+	})
+	return symbols
 }
 
 var NoExAssignRule = rule.Rule{
-	Name:             "no-ex-assign",
-	RequiresTypeInfo: true,
+	Name: "no-ex-assign",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindCatchClause: func(node *ast.Node) {
-				if node.AsCatchClause().VariableDeclaration == nil {
-					return
-				}
-
-				varDecl := node.AsCatchClause().VariableDeclaration.AsVariableDeclaration()
+				varDecl := node.AsCatchClause().VariableDeclaration
 				if varDecl == nil || varDecl.Name() == nil {
 					return
 				}
 
-				block := node.AsCatchClause().Block
-				if block == nil {
-					return
+				var writes []*ast.Node
+				for _, sym := range catchBindingSymbols(varDecl.Name()) {
+					for _, ref := range ctx.Refs.References(sym) {
+						if utils.IsWriteReference(ref) {
+							writes = append(writes, ref)
+						}
+					}
 				}
 
-				names, symbols := collectCatchBindingNamesAndSymbols(varDecl.Name(), ctx)
-				checkReassignments(block, names, symbols, ctx)
+				// References is source-ordered per symbol; a destructuring
+				// pattern binds several symbols, so restore document order
+				// across them before reporting.
+				slices.SortFunc(writes, func(a, b *ast.Node) int { return a.Pos() - b.Pos() })
+				for _, ref := range writes {
+					ctx.ReportNode(ref, buildExAssignMessage())
+				}
 			},
 		}
 	},

--- a/internal/rules/no_ex_assign/no_ex_assign.go
+++ b/internal/rules/no_ex_assign/no_ex_assign.go
@@ -1,6 +1,7 @@
 package no_ex_assign
 
 import (
+	"cmp"
 	"slices"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -17,24 +18,6 @@ func buildExAssignMessage() rule.RuleMessage {
 	}
 }
 
-// catchBindingSymbols returns the binder symbol of every name bound by the
-// catch clause's variable declaration: the lone identifier of `catch (e)` or
-// each name nested in a destructuring pattern. The symbol is attached to the
-// declaration node owning the name — the VariableDeclaration itself for a
-// plain identifier, the enclosing BindingElement for pattern names.
-func catchBindingSymbols(name *ast.Node) []*ast.Symbol {
-	var symbols []*ast.Symbol
-	utils.CollectBindingNames(name, func(ident *ast.Node, _ string) {
-		if ident.Parent == nil {
-			return
-		}
-		if sym := ident.Parent.Symbol(); sym != nil {
-			symbols = append(symbols, sym)
-		}
-	})
-	return symbols
-}
-
 var NoExAssignRule = rule.Rule{
 	Name: "no-ex-assign",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
@@ -46,7 +29,7 @@ var NoExAssignRule = rule.Rule{
 				}
 
 				var writes []*ast.Node
-				for _, sym := range catchBindingSymbols(varDecl.Name()) {
+				for _, sym := range utils.BindingSymbols(varDecl.Name()) {
 					for _, ref := range ctx.Refs.References(sym) {
 						if utils.IsWriteReference(ref) {
 							writes = append(writes, ref)
@@ -57,7 +40,9 @@ var NoExAssignRule = rule.Rule{
 				// References is source-ordered per symbol; a destructuring
 				// pattern binds several symbols, so restore document order
 				// across them before reporting.
-				slices.SortFunc(writes, func(a, b *ast.Node) int { return a.Pos() - b.Pos() })
+				slices.SortStableFunc(writes, func(a *ast.Node, b *ast.Node) int {
+					return cmp.Compare(a.Pos(), b.Pos())
+				})
 				for _, ref := range writes {
 					ctx.ReportNode(ref, buildExAssignMessage())
 				}

--- a/internal/rules/no_ex_assign/no_ex_assign_extras_test.go
+++ b/internal/rules/no_ex_assign/no_ex_assign_extras_test.go
@@ -50,6 +50,15 @@ func TestNoExAssignExtras(t *testing.T) {
 					{MessageId: "unexpected", Line: 1, Column: 33},
 				},
 			},
+			// Branch lock-in: a write inside a sibling binding's default-value
+			// initializer targets the catch binding even though it sits in the
+			// pattern rather than the catch block (upstream reports this too).
+			{
+				Code: "try { } catch ({a, b = (a = 1)}) { }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
 			// Dimension: rest element symbol comes from its BindingElement.
 			{
 				Code: "try { } catch ({...rest}) { rest = {}; }",

--- a/internal/rules/no_ex_assign/no_ex_assign_extras_test.go
+++ b/internal/rules/no_ex_assign/no_ex_assign_extras_test.go
@@ -1,0 +1,76 @@
+package no_ex_assign
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNoExAssignExtras locks in the resolution-sensitive behaviors of the
+// Refs-API implementation that the upstream ESLint suite doesn't exercise.
+// Each case carries an inline comment pointing at the specific branch /
+// Dimension row / real-user shape it covers, so future refactors can't
+// silently regress them without breaking a named lock-in.
+func TestNoExAssignExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoExAssignRule,
+		[]rule_tester.ValidTestCase{
+			// Branch lock-in: optional catch binding — no VariableDeclaration, rule bails.
+			{Code: "try { } catch { e = 10; }"},
+			// Branch lock-in: a nested function parameter shadows the catch binding,
+			// so the scope walk resolves the write to the parameter symbol.
+			{Code: "try { } catch (e) { const f = (e: unknown) => { e = 10; }; }"},
+			// Branch lock-in: labels are not variable references (RefStore skips them).
+			{Code: "try { } catch (e) { e: for (;;) { break e; } }"},
+			// Branch lock-in: a type-query reference resolves to the catch binding
+			// but is not a write.
+			{Code: "try { } catch (e) { let x: typeof e; }"},
+			// Dimension: rest element in a destructured catch binding, read only.
+			{Code: "try { } catch ({...rest}) { log(rest); }"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Real-user shape: assignment from a nested function still targets the
+			// catch binding via the scope walk (upstream reports this too).
+			{
+				Code: "try { } catch (e) { function f() { e = 10; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+				},
+			},
+			// Branch lock-in: writes to a multi-name destructured binding are
+			// reported in document order, not per-symbol order.
+			{
+				Code: "try { } catch ({a, b}) { b = 1; a = 2; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 26},
+					{MessageId: "unexpected", Line: 1, Column: 33},
+				},
+			},
+			// Dimension: rest element symbol comes from its BindingElement.
+			{
+				Code: "try { } catch ({...rest}) { rest = {}; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 29},
+				},
+			},
+			// Dimension: name nested two pattern levels deep.
+			{
+				Code: "try { } catch ({a: {b}}) { b = 1; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 28},
+				},
+			},
+			// Branch lock-in: parenthesized assignment target.
+			{
+				Code: "try { } catch (e) { (e) = 10; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/binding_symbols.go
+++ b/internal/utils/binding_symbols.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// BindingNameSymbol returns the binder symbol of a declared binding name. The
+// binder attaches the symbol to the declaration node owning the name — the
+// declaration itself (VariableDeclaration, Parameter, ImportSpecifier, ...)
+// for a plain identifier, the enclosing BindingElement for names nested in a
+// destructuring pattern. Binder symbols are the currency of ctx.Refs, so use
+// them on the declaration side too. Returns nil when ident is not its
+// parent's declared name.
+func BindingNameSymbol(ident *ast.Node) *ast.Symbol {
+	if ident == nil || ident.Parent == nil || ident.Parent.Name() != ident {
+		return nil
+	}
+	return ident.Parent.Symbol()
+}
+
+// BindingSymbols returns the binder symbol of every name bound by a
+// declaration's name node: the lone symbol of a plain identifier, or one per
+// name nested in a destructuring pattern.
+func BindingSymbols(nameNode *ast.Node) []*ast.Symbol {
+	var symbols []*ast.Symbol
+	CollectBindingNames(nameNode, func(ident *ast.Node, _ string) {
+		if sym := BindingNameSymbol(ident); sym != nil {
+			symbols = append(symbols, sym)
+		}
+	})
+	return symbols
+}


### PR DESCRIPTION
## Summary

Ports `no-ex-assign` from per-identifier TypeChecker resolution to the shared `ctx.Refs` reference index, and drops `RequiresTypeInfo: true` — the rule now also runs on gap files and LSP inferred-project files.

- Catch-binding symbols come straight from the declaration nodes (`VariableDeclaration` / `BindingElement`); `ctx.Refs.References(sym)` returns every reference, filtered through the shared `utils.IsWriteReference`. Shadowing is handled by the binder scope walk itself, so the hand-rolled `GetSymbolAtLocation`/`GetReferenceSymbol` shadow check and the local write-reference machinery (~220 lines) are deleted.
- Writes are sorted by position before reporting, since `References` is source-ordered per symbol but a destructuring pattern binds several symbols.
- New `no_ex_assign_extras_test.go` locks in the resolution-sensitive behaviors: optional catch binding, shadowing by nested-function params, labels, type-query references, rest/nested patterns, parenthesized targets, document-order reporting, and writes from nested functions.

## Benchmarks

Measured on a synthetic 8000-file corpus (~63MB) via the Node CLI, 2 warmups + 7 timed runs, mean ± sd.

**Only `no-ex-assign` enabled:**

| | rule time | wall clock |
|---|---|---|
| main | 25.6 ± 3.5 ms | 1636 ± 82 ms |
| this PR | 332.5 ± 64.2 ms | 1715 ± 37 ms |

**Both Refs-using rules of `js.configs.recommended` enabled (`no-ex-assign` + `no-unassigned-vars`):**

| | no-ex-assign | no-unassigned-vars | sum | wall clock |
|---|---|---|---|---|
| main | 21.7 ± 0.9 ms | 276.6 ± 9.5 ms | 298.3 ms | 1566 ± 31 ms |
| this PR | 282.3 ± 5.3 ms | 24.4 ± 0.7 ms | 306.7 ms | 1575 ± 32 ms |

`RefStore`'s per-file candidate walk is lazy and paid once by whichever rule queries first. Alone, `no-ex-assign` pays it all, so its attributed time regresses. In the recommended preset the walk was already being paid by `no-unassigned-vars` — this PR only moves the attribution: the pair's combined time is +8.4ms across 8000 files (+2.8%) and wall clock is statistically unchanged.
