### PR TITLE
perf: port require-atomic-updates to the Refs API

### DIFF
--- a/internal/rules/require_atomic_updates/require_atomic_updates.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates.go
@@ -217,9 +217,6 @@ func (a *analyzer) collectDeclsIn(node *ast.Node) {
 		return
 	}
 	node.ForEachChild(func(child *ast.Node) bool {
-		if ast.IsFunctionLikeDeclaration(child) {
-			return false
-		}
 		switch child.Kind {
 		case ast.KindVariableDeclaration:
 			vd := child.AsVariableDeclaration()
@@ -240,6 +237,9 @@ func (a *analyzer) collectDeclsIn(node *ast.Node) {
 					a.collectBindingSymbols(vd.Name(), false)
 				}
 			}
+		}
+		if ast.IsFunctionLikeDeclaration(child) {
+			return false
 		}
 		a.collectDeclsIn(child)
 		return false

--- a/internal/rules/require_atomic_updates/require_atomic_updates.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates.go
@@ -129,29 +129,16 @@ func newAnalyzer(ctx rule.RuleContext, funcNode *ast.Node, allowProperties bool)
 	return a
 }
 
-// symbolOf returns the *ast.Symbol that `node` resolves to (or nil). The rule
-// is type-aware (RequiresTypeInfo is set), so TypeChecker is guaranteed non-nil
-// at runtime. Shorthand property identifiers resolve to their VALUE symbol
-// (the outer binding of the same name), and symbols augmented into the global
-// scope via `declare global { … }` are treated as unresolved — ESLint's
-// scope analyzer leaves those references unresolved too.
+// symbolOf returns the *ast.Symbol that the reference-position identifier
+// `node` resolves to (or nil), through the shared per-file reference index.
+// Shorthand property identifiers resolve to their VALUE symbol (the outer
+// binding of the same name — ctx.Refs treats them as reference positions),
+// and symbols augmented into the global scope via `declare global { … }` are
+// treated as unresolved — ESLint's scope analyzer leaves those references
+// unresolved too.
 func (a *analyzer) symbolOf(node *ast.Node) *ast.Symbol {
-	if node == nil || a.ctx.TypeChecker == nil {
-		return nil
-	}
-	var sym *ast.Symbol
-	if node.Kind == ast.KindIdentifier && node.Parent != nil &&
-		node.Parent.Kind == ast.KindShorthandPropertyAssignment &&
-		node.Parent.AsShorthandPropertyAssignment().Name() == node {
-		sym = a.ctx.TypeChecker.GetShorthandAssignmentValueSymbol(node.Parent)
-	}
-	if sym == nil {
-		sym = a.ctx.TypeChecker.GetSymbolAtLocation(node)
-	}
-	if sym == nil {
-		return nil
-	}
-	if symbolIsDeclareGlobal(sym) {
+	sym := a.ctx.Refs.Resolve(node)
+	if sym == nil || symbolIsDeclareGlobal(sym) {
 		return nil
 	}
 	return sym
@@ -206,7 +193,13 @@ func (a *analyzer) collectBindingSymbols(nameNode *ast.Node, isParam bool) {
 		return
 	}
 	utils.CollectBindingNames(nameNode, func(ident *ast.Node, _ string) {
-		if sym := a.symbolOf(ident); sym != nil {
+		// A declaration name is not a reference position; its binder symbol
+		// lives on the owning declaration node (ParameterDeclaration,
+		// VariableDeclaration, or BindingElement).
+		if ident.Parent == nil {
+			return
+		}
+		if sym := ident.Parent.Symbol(); sym != nil {
 			a.declaredInFunc[sym] = true
 			if isParam {
 				a.parameterSymbols[sym] = true
@@ -236,7 +229,7 @@ func (a *analyzer) collectDeclsIn(node *ast.Node) {
 		case ast.KindFunctionDeclaration, ast.KindClassDeclaration,
 			ast.KindEnumDeclaration, ast.KindModuleDeclaration:
 			if n := child.Name(); n != nil && n.Kind == ast.KindIdentifier {
-				if sym := a.symbolOf(n); sym != nil {
+				if sym := child.Symbol(); sym != nil {
 					a.declaredInFunc[sym] = true
 				}
 			}
@@ -1132,8 +1125,7 @@ func (a *analyzer) walkForStatement(node *ast.Node, state *analysisState) {
 // RequireAtomicUpdatesRule disallows assignments that can lead to race conditions
 // due to usage of `await` or `yield`.
 var RequireAtomicUpdatesRule = rule.Rule{
-	Name:             "require-atomic-updates",
-	RequiresTypeInfo: true,
+	Name: "require-atomic-updates",
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
 		allowProperties := false

--- a/internal/rules/require_atomic_updates/require_atomic_updates_extras_test.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates_extras_test.go
@@ -27,8 +27,10 @@ func TestRequireAtomicUpdatesExtras(t *testing.T) {
 			// Branch lock-in: destructured local declarations register the same way.
 			{Code: `async function x() { let { value } = obj; value; await p; value = value + 1; }`},
 			// Branch lock-in: a hoisted function declaration's name is collected
-			// from the declaration node's symbol; writes to it stay local.
-			{Code: `async function x() { function helper() {} helper; await p; helper = () => {}; }`},
+			// from the declaration node's symbol; writes to it stay local. The
+			// RHS must not be function-like, or isFunctionLikeRHS skips the
+			// check before the collected symbol matters.
+			{Code: `async function x() { function helper() {} helper; await p; helper = null; }`},
 			// Branch lock-in: a local shadowing an outer name binds its own
 			// symbol, so state on the outer variable never leaks onto it.
 			{Code: `let value: number; async function x() { let value = 0; value; await p; value = value + 1; }`},

--- a/internal/rules/require_atomic_updates/require_atomic_updates_extras_test.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates_extras_test.go
@@ -1,0 +1,70 @@
+package require_atomic_updates
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestRequireAtomicUpdatesExtras locks in the resolution-sensitive behaviors
+// of the Refs-API implementation that the upstream ESLint suite doesn't
+// exercise. The rule keys all of its state by symbol, so every case here pins
+// the identity contract between declaration-site symbols (taken from the
+// declaration nodes) and reference resolution through ctx.Refs — a mismatch
+// surfaces as a false positive (a local treated as outer-scope), which no
+// upstream case would catch as such.
+func TestRequireAtomicUpdatesExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RequireAtomicUpdatesRule,
+		[]rule_tester.ValidTestCase{
+			// Branch lock-in: destructured parameter names resolve to their
+			// BindingElement symbols, so they register as locals.
+			{Code: `async function x({ count }: { count: number }) { count; await p; count = count + 1; }`},
+			// Branch lock-in: destructured local declarations register the same way.
+			{Code: `async function x() { let { value } = obj; value; await p; value = value + 1; }`},
+			// Branch lock-in: a hoisted function declaration's name is collected
+			// from the declaration node's symbol; writes to it stay local.
+			{Code: `async function x() { function helper() {} helper; await p; helper = () => {}; }`},
+			// Branch lock-in: a local shadowing an outer name binds its own
+			// symbol, so state on the outer variable never leaks onto it.
+			{Code: `let value: number; async function x() { let value = 0; value; await p; value = value + 1; }`},
+			// Branch lock-in: `declare global` symbols resolve through the
+			// checker fallback but are filtered like unresolved references,
+			// matching ESLint's scope analyzer.
+			{Code: `declare global { var mutableFlag: number; }
+export async function x() { mutableFlag; await p; mutableFlag = mutableFlag + 1; }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Real-user shape: a destructured local that escapes into a nested
+			// arrow is race-prone again — escape marking and write resolution
+			// must agree on the BindingElement symbol.
+			{
+				Code: `async function x() { let { value } = obj; const f = () => value; value += await p; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			// Branch lock-in: shorthand destructuring assignment targets
+			// resolve to the outer binding (the value symbol, not the property).
+			{
+				Code: `let value: number; async function x() { value; await p; ({ value } = obj); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			// Branch lock-in: an ambient global resolved via the checker
+			// fallback is an outer-scope variable like any other.
+			{
+				Code: `declare var ambientCounter: number;
+async function x() { ambientCounter += await p; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+		},
+	)
+}


### PR DESCRIPTION
## Summary

Ports `require-atomic-updates` from per-identifier TypeChecker resolution to the shared `ctx.Refs` reference index, and drops `RequiresTypeInfo: true` — the rule now also runs on gap files and LSP inferred-project files.

- Reference positions resolve through `ctx.Refs.Resolve`; the shorthand-property special case (`GetShorthandAssignmentValueSymbol`) is gone because the RefStore already resolves shorthand names to their value binding. The `declare global` filter is unchanged.
- Declaration names are no longer resolved at all: their binder symbols come straight from the owning declaration nodes (`ParameterDeclaration`/`VariableDeclaration`/`BindingElement`, and `child.Symbol()` for named function/class/enum/module declarations), keeping all symbol-keyed state identity-consistent with what the binder scope walk returns.
- New `require_atomic_updates_extras_test.go` locks in the resolution-sensitive behaviors: declaration/reference symbol identity for destructured params, locals, and hoisted function names; shadowing; escape marking; shorthand destructuring assignment targets; the `declare global` filter; and ambient globals via the checker fallback.

## Benchmark

8000-file synthetic corpus (async-heavy: locals, destructuring, awaits, module-level state), only this rule enabled, via the Node CLI, 2 warmups + 7 timed runs, mean ± sd:

| | rule time | wall clock |
|---|---|---|
| main | 361.2 ± 15.6 ms | 1397 ± 22 ms |
| this PR | 298.0 ± 42.9 ms (−17%) | 1369 ± 19 ms |

The rule only uses forward resolution (`Refs.Resolve`), which never triggers the RefStore's per-file candidate walk — so it is faster even with no other Refs rule enabled.
