### PR TITLE
perf: optimize prefer-literal-enum-member

### DIFF
--- a/internal/plugins/typescript/rules/prefer_literal_enum_member/prefer_literal_enum_member.go
+++ b/internal/plugins/typescript/rules/prefer_literal_enum_member/prefer_literal_enum_member.go
@@ -3,7 +3,6 @@ package prefer_literal_enum_member
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 func buildNotLiteralMessage() rule.RuleMessage {
@@ -20,19 +19,11 @@ func buildNotLiteralOrBitwiseExpressionMessage() rule.RuleMessage {
 	}
 }
 
-type PreferLiteralEnumMemberOptions struct {
-	AllowBitwiseExpressions *bool `json:"allowBitwiseExpressions"`
-}
-
-var defaultOptions = PreferLiteralEnumMemberOptions{
-	AllowBitwiseExpressions: utils.Ref(false),
-}
-
 var PreferLiteralEnumMemberRule = rule.CreateRule(rule.Rule{
 	Name: "prefer-literal-enum-member",
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
-		opts := defaultOptions
+		allowBitwise := false
 
 		if options != nil {
 			var optsMap map[string]interface{}
@@ -46,12 +37,10 @@ var PreferLiteralEnumMemberRule = rule.CreateRule(rule.Rule{
 
 			if ok {
 				if allowBitwiseExpressions, ok := optsMap["allowBitwiseExpressions"].(bool); ok {
-					opts.AllowBitwiseExpressions = utils.Ref(allowBitwiseExpressions)
+					allowBitwise = allowBitwiseExpressions
 				}
 			}
 		}
-
-		allowBitwise := opts.AllowBitwiseExpressions != nil && *opts.AllowBitwiseExpressions
 
 		return rule.RuleListeners{
 			ast.KindEnumDeclaration: func(node *ast.Node) {
@@ -60,22 +49,18 @@ var PreferLiteralEnumMemberRule = rule.CreateRule(rule.Rule{
 					return
 				}
 
-				// Collect member names for self-referencing check
-				memberNames := make(map[string]bool)
-				for _, memberNode := range enumDecl.Members.Nodes {
-					member := memberNode.AsEnumMember()
-					if member == nil {
-						continue
+				// Most enums contain only literal expressions. Delay indexing member
+				// names until a bitwise expression actually references one.
+				var enumMembers *enumMemberNames
+				if allowBitwise {
+					enumName := ""
+					if name := enumDecl.Name(); name != nil {
+						enumName = name.Text()
 					}
-					name := getMemberName(member)
-					if name != "" {
-						memberNames[name] = true
+					enumMembers = &enumMemberNames{
+						enumName: enumName,
+						members:  enumDecl.Members.Nodes,
 					}
-				}
-
-				enumName := ""
-				if enumDecl.Name() != nil {
-					enumName = enumDecl.Name().Text()
 				}
 
 				for _, memberNode := range enumDecl.Members.Nodes {
@@ -84,18 +69,43 @@ var PreferLiteralEnumMemberRule = rule.CreateRule(rule.Rule{
 						continue
 					}
 
-					if !isAllowedInitializer(member.Initializer, allowBitwise, false, enumName, memberNames) {
-						msg := buildNotLiteralMessage()
+					if !isAllowedInitializer(member.Initializer, false, enumMembers) {
+						message := buildNotLiteralMessage()
 						if allowBitwise {
-							msg = buildNotLiteralOrBitwiseExpressionMessage()
+							message = buildNotLiteralOrBitwiseExpressionMessage()
 						}
-						ctx.ReportNode(member.Name(), msg)
+						ctx.ReportNode(member.Name(), message)
 					}
 				}
 			},
 		}
 	},
 })
+
+type enumMemberNames struct {
+	enumName    string
+	members     []*ast.Node
+	names       map[string]struct{}
+	initialized bool
+}
+
+func (e *enumMemberNames) contains(name string) bool {
+	if !e.initialized {
+		e.initialized = true
+		e.names = make(map[string]struct{}, len(e.members))
+		for _, memberNode := range e.members {
+			member := memberNode.AsEnumMember()
+			if member == nil {
+				continue
+			}
+			if memberName := getMemberName(member); memberName != "" {
+				e.names[memberName] = struct{}{}
+			}
+		}
+	}
+	_, ok := e.names[name]
+	return ok
+}
 
 func getMemberName(member *ast.EnumMember) string {
 	name := member.Name()
@@ -117,7 +127,7 @@ func getMemberName(member *ast.EnumMember) string {
 	return ""
 }
 
-func isAllowedInitializer(expr *ast.Node, allowBitwise bool, partOfBitwiseComputation bool, enumName string, memberNames map[string]bool) bool {
+func isAllowedInitializer(expr *ast.Node, partOfBitwiseComputation bool, enumMembers *enumMemberNames) bool {
 	if expr == nil {
 		return false
 	}
@@ -141,17 +151,17 @@ func isAllowedInitializer(expr *ast.Node, allowBitwise bool, partOfBitwiseComput
 		}
 		switch unary.Operator {
 		case ast.KindMinusToken, ast.KindPlusToken:
-			return isAllowedInitializer(unary.Operand, allowBitwise, partOfBitwiseComputation, enumName, memberNames)
+			return isAllowedInitializer(unary.Operand, partOfBitwiseComputation, enumMembers)
 		case ast.KindTildeToken:
-			if !allowBitwise {
+			if enumMembers == nil {
 				return false
 			}
-			return isAllowedInitializer(unary.Operand, allowBitwise, true, enumName, memberNames)
+			return isAllowedInitializer(unary.Operand, true, enumMembers)
 		}
 		return false
 
 	case ast.KindBinaryExpression:
-		if !allowBitwise {
+		if enumMembers == nil {
 			return false
 		}
 		binary := expr.AsBinaryExpression()
@@ -161,44 +171,44 @@ func isAllowedInitializer(expr *ast.Node, allowBitwise bool, partOfBitwiseComput
 		switch binary.OperatorToken.Kind {
 		case ast.KindAmpersandToken, ast.KindBarToken, ast.KindCaretToken,
 			ast.KindLessThanLessThanToken, ast.KindGreaterThanGreaterThanToken, ast.KindGreaterThanGreaterThanGreaterThanToken:
-			return isAllowedInitializer(binary.Left, allowBitwise, true, enumName, memberNames) &&
-				isAllowedInitializer(binary.Right, allowBitwise, true, enumName, memberNames)
+			return isAllowedInitializer(binary.Left, true, enumMembers) &&
+				isAllowedInitializer(binary.Right, true, enumMembers)
 		}
 		return false
 
 	case ast.KindIdentifier:
 		// Self-referencing enum member is only allowed in bitwise context
-		if partOfBitwiseComputation {
+		if partOfBitwiseComputation && enumMembers != nil {
 			name := expr.Text()
-			return memberNames[name]
+			return enumMembers.contains(name)
 		}
 		return false
 
 	case ast.KindPropertyAccessExpression:
 		// Foo.A or Foo['A'] style self-references, only in bitwise context
-		if partOfBitwiseComputation {
+		if partOfBitwiseComputation && enumMembers != nil {
 			propAccess := expr.AsPropertyAccessExpression()
 			if propAccess == nil {
 				return false
 			}
 			obj := propAccess.Expression
-			if obj == nil || obj.Kind != ast.KindIdentifier || obj.Text() != enumName {
+			if obj == nil || obj.Kind != ast.KindIdentifier || obj.Text() != enumMembers.enumName {
 				return false
 			}
 			memberName := propAccess.Name().Text()
-			return memberNames[memberName]
+			return enumMembers.contains(memberName)
 		}
 		return false
 
 	case ast.KindElementAccessExpression:
 		// Foo['A'] style self-references, only in bitwise context
-		if partOfBitwiseComputation {
+		if partOfBitwiseComputation && enumMembers != nil {
 			elemAccess := expr.AsElementAccessExpression()
 			if elemAccess == nil {
 				return false
 			}
 			obj := elemAccess.Expression
-			if obj == nil || obj.Kind != ast.KindIdentifier || obj.Text() != enumName {
+			if obj == nil || obj.Kind != ast.KindIdentifier || obj.Text() != enumMembers.enumName {
 				return false
 			}
 			arg := elemAccess.ArgumentExpression
@@ -206,7 +216,7 @@ func isAllowedInitializer(expr *ast.Node, allowBitwise bool, partOfBitwiseComput
 				return false
 			}
 			memberName := arg.AsStringLiteral().Text
-			return memberNames[memberName]
+			return enumMembers.contains(memberName)
 		}
 		return false
 
@@ -215,7 +225,7 @@ func isAllowedInitializer(expr *ast.Node, allowBitwise bool, partOfBitwiseComput
 		if paren == nil {
 			return false
 		}
-		return isAllowedInitializer(paren.Expression, allowBitwise, partOfBitwiseComputation, enumName, memberNames)
+		return isAllowedInitializer(paren.Expression, partOfBitwiseComputation, enumMembers)
 	}
 
 	return false


### PR DESCRIPTION
## Summary

- Avoid eagerly walking every enum twice and allocating a member-name map for literal-only initializers.
- Build the self-reference index lazily only when an allowed bitwise expression reaches an enum-member reference.
- Keep the optimization rule-local. `ctx.Refs` would initialize a file-wide reference index for a syntax-only rule, while deferred report APIs only help rules that construct fixes or suggestions.

### Performance

Temporary benchmark fixture: 128 enums with 32 members each, Apple M1 Max, Go 1.26.1, `-benchtime=500ms -count=6 -cpu=1`; values below are medians. The benchmark file is not committed.

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| Default literal members | 388.3 µs/op, 410,984 B/op, 900 allocs/op | 13.34 µs/op, 360 B/op, 4 allocs/op | 29.10x faster, -99.9% bytes |
| Bitwise literal expressions | 466.1 µs/op, 410,984 B/op, 900 allocs/op | 33.51 µs/op, 360 B/op, 4 allocs/op | 13.91x faster, -99.9% bytes |
| Bitwise self-references | 468.7 µs/op, 410,984 B/op, 900 allocs/op | 219.1 µs/op, 241,000 B/op, 516 allocs/op | 2.14x faster, -41.4% bytes |

Real-repository runs used a standalone JavaScript rslint config enabling only this rule, `--singleThreaded --timing all`, and tracked TypeScript files matching an enum declaration pattern. The timing table displays one decimal place, so `0.0 ms` means below 0.05 ms.

| Repository | Files | Before (5 runs) | After (5 runs) | Diagnostics |
| --- | ---: | ---: | ---: | --- |
| rsbuild | 6 | <0.05 ms in every run | <0.05 ms in every run | Exact JSON output match |
| rspack | 30 | 0.1 ms in every run | <0.05 ms in every run | Exact JSON output match (27 diagnostics) |

Validation:

- Targeted Go rule test passed.
- Default and bitwise adversarial corpora produced byte-identical JSON diagnostics before and after the change.
- `check-spell`, `format:check`, and changed-package `golangci-lint` passed.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
