### PR TITLE
perf: optimize no-dupe-class-members

### DIFF
--- a/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.go
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.go
@@ -27,6 +27,22 @@ type stateEntry struct {
 	static    memberState
 }
 
+// Keep common classes allocation-free while bounding the linear lookup cost.
+// Overflow starts at twice this size instead of using the raw member count,
+// which may be inflated by ignored overloads or dynamic computed members.
+const inlineClassStateCapacity = 32
+
+type namedStateEntry struct {
+	name  string
+	state stateEntry
+}
+
+type classState struct {
+	inline   [inlineClassStateCapacity]namedStateEntry
+	count    int
+	overflow map[string]stateEntry
+}
+
 func registerMember(state memberState, kind memberKind) (memberState, bool) {
 	var flag memberState
 	var conflicts memberState
@@ -44,44 +60,95 @@ func registerMember(state memberState, kind memberKind) (memberState, bool) {
 	return state | flag, state&conflicts != 0
 }
 
+func registerState(entry *stateEntry, static bool, kind memberKind) bool {
+	state := &entry.nonStatic
+	if static {
+		state = &entry.static
+	}
+	var isDuplicate bool
+	*state, isDuplicate = registerMember(*state, kind)
+	return isDuplicate
+}
+
+func (state *classState) register(name string, static bool, kind memberKind) bool {
+	if state.overflow != nil {
+		entry := state.overflow[name]
+		isDuplicate := registerState(&entry, static, kind)
+		state.overflow[name] = entry
+		return isDuplicate
+	}
+
+	for index := range state.count {
+		entry := &state.inline[index]
+		if entry.name == name {
+			return registerState(&entry.state, static, kind)
+		}
+	}
+	if state.count < len(state.inline) {
+		entry := &state.inline[state.count]
+		entry.name = name
+		state.count++
+		return registerState(&entry.state, static, kind)
+	}
+
+	state.overflow = make(map[string]stateEntry, inlineClassStateCapacity*2)
+	for index := range state.count {
+		entry := &state.inline[index]
+		state.overflow[entry.name] = entry.state
+	}
+	entry := stateEntry{}
+	isDuplicate := registerState(&entry, static, kind)
+	state.overflow[name] = entry
+	return isDuplicate
+}
+
 var NoDupeClassMembersRule = rule.CreateRule(rule.Rule{
 	Name: "no-dupe-class-members",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		checkClass := func(node *ast.Node) {
-			stateMap := make(map[string]stateEntry)
+			members := node.Members()
+			if len(members) < 2 {
+				return
+			}
+			state := classState{}
 
-			for _, member := range node.Members() {
-				// Skip the class constructor. In TypeScript-Go's AST, both keyword
-				// constructor() and string-literal 'constructor'() parse as
-				// KindConstructor. ESLint skips both (kind="constructor"), so we
-				// do the same — but only for non-static members. Static constructor()
-				// is a regular static method in ESLint (kind="method").
-				if ast.IsConstructorDeclaration(member) && !ast.IsStatic(member) {
+			for _, member := range members {
+				// Determine the duplicate-detection category.
+				// get + set for the same name is allowed; any other combination is a duplicate.
+				var kind memberKind
+				switch member.Kind {
+				case ast.KindGetAccessor:
+					kind = memberKindGet
+				case ast.KindSetAccessor:
+					kind = memberKindSet
+				case ast.KindMethodDeclaration, ast.KindPropertyDeclaration:
+					kind = memberKindInit
+				case ast.KindConstructor:
+					// Static constructor — treated as a static method named "constructor".
+					kind = memberKindInit
+				default:
 					continue
+				}
+				var isStatic bool
+				// In TypeScript-Go's AST, both keyword constructor() and string-literal
+				// 'constructor'() parse as KindConstructor. ESLint skips both
+				// (kind="constructor"), so we do the same — but only for non-static
+				// members. Static constructor() is a regular static method in ESLint.
+				if member.Kind == ast.KindConstructor {
+					isStatic = ast.IsStatic(member)
+					if !isStatic {
+						continue
+					}
 				}
 				// Overload signatures and abstract declarations (methods, getters,
 				// setters) have no body. Skip them so only concrete implementations
 				// participate in duplicate checking. PropertyDeclaration never has a
 				// body and must not be skipped.
-				if !ast.IsPropertyDeclaration(member) && member.Body() == nil {
+				if member.Kind != ast.KindPropertyDeclaration && member.Body() == nil {
 					continue
 				}
-
-				// Determine the duplicate-detection category.
-				// get + set for the same name is allowed; any other combination is a duplicate.
-				var kind memberKind
-				switch {
-				case ast.IsGetAccessorDeclaration(member):
-					kind = memberKindGet
-				case ast.IsSetAccessorDeclaration(member):
-					kind = memberKindSet
-				case ast.IsMethodDeclaration(member), ast.IsPropertyDeclaration(member):
-					kind = memberKindInit
-				case ast.IsConstructorDeclaration(member):
-					// Static constructor — treated as a static method named "constructor".
-					kind = memberKindInit
-				default:
-					continue
+				if member.Kind != ast.KindConstructor {
+					isStatic = ast.IsStatic(member)
 				}
 
 				// Get member name. Static constructors have name=nil in
@@ -89,27 +156,25 @@ var NoDupeClassMembersRule = rule.CreateRule(rule.Rule{
 				var name string
 				nameNode := ast.GetNameOfDeclaration(member)
 				if nameNode != nil {
-					var ok bool
-					name, ok = utils.GetStaticPropertyName(nameNode)
+					var ok = true
+					switch nameNode.Kind {
+					case ast.KindIdentifier:
+						name = nameNode.AsIdentifier().Text
+					case ast.KindStringLiteral:
+						name = nameNode.AsStringLiteral().Text
+					default:
+						name, ok = utils.GetStaticPropertyName(nameNode)
+					}
 					if !ok {
 						continue // computed property with non-static expression
 					}
-				} else if ast.IsConstructorDeclaration(member) {
+				} else if member.Kind == ast.KindConstructor {
 					name = "constructor"
 				} else {
 					continue
 				}
 
-				entry := stateMap[name]
-				var isDuplicate bool
-				if ast.IsStatic(member) {
-					entry.static, isDuplicate = registerMember(entry.static, kind)
-				} else {
-					entry.nonStatic, isDuplicate = registerMember(entry.nonStatic, kind)
-				}
-				stateMap[name] = entry
-
-				if isDuplicate {
+				if state.register(name, isStatic, kind) {
 					reportNode := nameNode
 					if reportNode == nil {
 						reportNode = member // static constructor (no name node)

--- a/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members_test.go
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members_test.go
@@ -1,6 +1,7 @@
 package no_dupe_class_members
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
@@ -619,4 +620,100 @@ func TestRegisterMemberExhaustive(t *testing.T) {
 		}
 	}
 	visit(0, referenceState{}, nil)
+}
+
+func TestClassStateInlineAndOverflow(t *testing.T) {
+	memberCount := inlineClassStateCapacity + 1
+	state := classState{}
+
+	for index := range inlineClassStateCapacity {
+		name := "member" + strconv.Itoa(index)
+		if state.register(name, false, memberKindInit) {
+			t.Fatalf("first registration of %q was reported as duplicate", name)
+		}
+	}
+	if state.overflow != nil {
+		t.Fatal("state promoted before inline capacity was exhausted")
+	}
+
+	lastName := "member" + strconv.Itoa(inlineClassStateCapacity)
+	if state.register(lastName, false, memberKindInit) {
+		t.Fatalf("first registration of %q was reported as duplicate", lastName)
+	}
+	if state.overflow == nil {
+		t.Fatal("state did not promote after inline capacity was exhausted")
+	}
+
+	for index := range memberCount {
+		name := "member" + strconv.Itoa(index)
+		if !state.register(name, false, memberKindInit) {
+			t.Fatalf("second non-static registration of %q was not reported as duplicate", name)
+		}
+		if state.register(name, true, memberKindInit) {
+			t.Fatalf("first static registration of %q conflicted with non-static state", name)
+		}
+		if !state.register(name, true, memberKindInit) {
+			t.Fatalf("second static registration of %q was not reported as duplicate", name)
+		}
+	}
+
+	if state.register("", false, memberKindGet) {
+		t.Fatal("first empty-name getter was reported as duplicate")
+	}
+	if state.register("", false, memberKindSet) {
+		t.Fatal("empty-name getter/setter pair was reported as duplicate")
+	}
+	if !state.register("", false, memberKindGet) {
+		t.Fatal("second empty-name getter was not reported as duplicate")
+	}
+}
+
+func TestClassStateMatchesMap(t *testing.T) {
+	const operationCount = 10_000
+	nameCount := inlineClassStateCapacity*2 + 3
+	state := classState{}
+	reference := make(map[string]stateEntry, nameCount)
+	seed := uint64(0x9e3779b97f4a7c15)
+
+	for operation := range operationCount {
+		seed = seed*6364136223846793005 + 1
+		nameIndex := operation
+		if nameIndex >= nameCount {
+			nameIndex = int(seed % uint64(nameCount))
+		}
+		var name string
+		switch nameIndex {
+		case 0:
+			name = ""
+		case 1:
+			name = "__proto__"
+		default:
+			name = "member" + strconv.Itoa(nameIndex)
+		}
+		static := seed&(1<<8) != 0
+		kind := memberKind(seed % 3)
+
+		expected := reference[name]
+		var wantDuplicate bool
+		if static {
+			expected.static, wantDuplicate = registerMember(expected.static, kind)
+		} else {
+			expected.nonStatic, wantDuplicate = registerMember(expected.nonStatic, kind)
+		}
+		reference[name] = expected
+
+		if gotDuplicate := state.register(name, static, kind); gotDuplicate != wantDuplicate {
+			t.Fatalf("operation %d (%q, static=%v, kind=%d): duplicate = %v, want %v",
+				operation, name, static, kind, gotDuplicate, wantDuplicate)
+		}
+	}
+
+	if state.overflow == nil {
+		t.Fatal("adversarial sequence did not exercise overflow storage")
+	}
+	for name, expected := range reference {
+		if actual := state.overflow[name]; actual != expected {
+			t.Fatalf("state for %q = %#v, want %#v", name, actual, expected)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Optimize `@typescript-eslint/no-dupe-class-members` entirely within the rule: keep up to 32 names in inline class state, promote larger classes to a bounded-capacity map, fast-path common member kinds/names, and skip classes that cannot contain duplicates.
- Preserve constructor, overload, accessor, static/instance, computed-name, and reporting semantics. Add boundary coverage plus a deterministic 10,000-operation comparison against the original map-based state machine.
- `ctx.Refs` is intentionally not used because this rule only compares declarations within one class and building a per-file reference index would add unrelated work. Report deferral is not applicable because these diagnostics have no fixes, suggestions, or deferred payload.
- Documentation is not required because rule behavior and public configuration are unchanged.

### Performance

Measured on Apple M1 Max with real repository corpora parsed once, then the rule listener run 1,000 times per sample with zero diagnostics. Values are the mean of repeated samples.

| Corpus | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| rsbuild | 65,555 → 30,786 (-53.0%) | 42,184 → 21,472 (-49.1%) | 331 → 244 (-26.3%) |
| rspack | 311,783 → 168,038 (-46.1%) | 259,288 → 190,320 (-26.6%) | 2,027 → 1,800 (-11.2%) |

Before/after CLI validation used a JavaScript rslint config and produced aligned diagnostics on both corpora.

### Validation

- `go test ./internal/plugins/typescript/rules/no_dupe_class_members`
- Temporary adversarial differential harness against the previous algorithm (`-count=10`)
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run ./internal/plugins/typescript/rules/no_dupe_class_members`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
