### PR TITLE
perf: optimize no-useless-switch-case reporting

### DIFF
--- a/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case.go
+++ b/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case.go
@@ -5,7 +5,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 const (
@@ -36,31 +35,38 @@ var NoUselessSwitchCaseRule = rule.Rule{
 
 				// Upstream walks backward from the final `default` and stops at
 				// the first non-empty case, but ESLint still emits diagnostics in
-				// source order. Collect first, then report in source order.
-				candidates := make([]*ast.Node, 0, len(clauses)-1)
+				// source order. Remember the boundary instead of allocating a
+				// temporary slice for every switch that ends in `default`.
+				firstCandidate := len(clauses) - 1
 				for index := len(clauses) - 2; index >= 0; index-- {
 					clause := clauses[index]
 					if !isEmptySwitchCase(clause) {
 						break
 					}
 
-					candidates = append(candidates, clause)
+					firstCandidate = index
 				}
 
-				for index := len(candidates) - 1; index >= 0; index-- {
-					clause := candidates[index]
-					ctx.ReportRangeWithSuggestions(
-						switchCaseHeadRange(clause, ctx.SourceFile),
+				for index := firstCandidate; index < len(clauses)-1; index++ {
+					clause := clauses[index]
+					headRange := switchCaseHeadRange(clause, ctx.SourceFile)
+					removalRange := headRange.WithEnd(clause.End())
+					ctx.ReportRangeWithDeferredSuggestions(
+						headRange,
 						rule.RuleMessage{
 							Id:          messageIDError,
 							Description: "Useless case in switch statement.",
 						},
-						rule.RuleSuggestion{
-							Message: rule.RuleMessage{
-								Id:          messageIDSuggestion,
-								Description: "Remove this case.",
-							},
-							FixesArr: []rule.RuleFix{rule.RuleFixRemove(ctx.SourceFile, clause)},
+						func() []rule.RuleSuggestion {
+							return []rule.RuleSuggestion{
+								{
+									Message: rule.RuleMessage{
+										Id:          messageIDSuggestion,
+										Description: "Remove this case.",
+									},
+									FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(removalRange)},
+								},
+							}
 						},
 					)
 				}
@@ -105,12 +111,20 @@ func isEmptyNode(node *ast.Node) bool {
 }
 
 func switchCaseHeadRange(node *ast.Node, sourceFile *ast.SourceFile) core.TextRange {
-	start := utils.TrimNodeTextRange(sourceFile, node).Pos()
+	start := scanner.GetTokenPosOfNode(node, sourceFile, false)
 	scanStart := start
 	if clause := node.AsCaseOrDefaultClause(); clause != nil && clause.Expression != nil {
 		scanStart = clause.Expression.End()
 	}
 
+	text := sourceFile.Text()
+	colonStart := scanner.SkipTrivia(text, scanStart)
+	if colonStart < node.End() && colonStart < len(text) && text[colonStart] == ':' {
+		return core.NewTextRange(start, colonStart+1)
+	}
+
+	// Preserve the recovery behavior for malformed clauses where the next
+	// non-trivia byte is not the separator the parser associated with the case.
 	s := scanner.GetScannerForSourceFile(sourceFile, scanStart)
 	for s.Token() != ast.KindEndOfFile && s.TokenStart() < node.End() {
 		if s.Token() == ast.KindColonToken {

--- a/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case_extras_test.go
+++ b/internal/plugins/unicorn/rules/no_useless_switch_case/no_useless_switch_case_extras_test.go
@@ -1,10 +1,15 @@
 package no_useless_switch_case_test
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -447,4 +452,78 @@ func TestNoUselessSwitchCaseExtras(t *testing.T) {
 			),
 		},
 	)
+}
+
+func TestNoUselessSwitchCaseEditDemand(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, "switch (value) { case value /* comment */: default: useDefault(); }", core.ScriptKindTS)
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+
+		comments := rule.NewCommentStore(sourceFile)
+		diagnostics := make([]rule.RuleDiagnostic, 0, 1)
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(
+			no_useless_switch_case.NoUselessSwitchCaseRule.Name,
+			rule.SeverityError,
+			rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		)
+
+		listeners := no_useless_switch_case.NoUselessSwitchCaseRule.Run(ctx, nil)
+		var visit ast.Visitor
+		visit = func(node *ast.Node) bool {
+			if listener := listeners[node.Kind]; listener != nil {
+				listener(node)
+			}
+			return node.ForEachChild(visit)
+		}
+		sourceFile.AsNode().ForEachChild(visit)
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       diagnosticsOnly,
+		rule.EditDemandAutofix:    autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got, want := withoutEdits(diagnostic), withoutEdits(allEdits); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.Suggestions != nil || autofixOnly.Suggestions != nil {
+		t.Fatal("a non-suggestion demand materialized suggestions")
+	}
+	if suggestionOnly.Suggestions == nil || !reflect.DeepEqual(suggestionOnly.Suggestions, allEdits.Suggestions) {
+		t.Fatal("suggestion and all-edits demands produced different suggestions")
+	}
+	if diagnosticsOnly.FixesPtr != nil || autofixOnly.FixesPtr != nil ||
+		suggestionOnly.FixesPtr != nil || allEdits.FixesPtr != nil {
+		t.Fatal("suggestion-only rule materialized autofixes")
+	}
 }


### PR DESCRIPTION
## Summary

- Avoid allocating a reversed candidate slice for every switch that ends in default; retain the first matching index and report forward in source order.
- Use an allocation-free token-position/trivia fast path for normal case separators while retaining the scanner fallback for malformed clauses.
- Defer removal suggestions until the consumer requests them, so normal CLI diagnostics and suppressed reports do not construct suggestion fixes.
- Keep the change rule-local. ctx.Refs is not applicable because this rule only inspects switch clause syntax and never resolves identifier references.

### Performance

Apple M1 Max, six-run median from a temporary Go benchmark:

| Scenario | Before | After | Change | B/op | Allocations/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| 400 switches with no candidates | 34.38 µs | 7.47 µs | -78.3% | 51,552 → 352 | 404 → 4 |
| 2,000 reports, diagnostics only | 542.43 µs | 68.43 µs | -87.4% | 1,200,357 → 352 | 12,254 → 4 |
| 2,000 reports with suggestions | 542.15 µs | 202.25 µs | -62.7% | 1,200,356 → 224,352 | 12,254 → 6,004 |
| 120 deeply nested empty cases | 147.71 µs | 117.93 µs | -20.2% | 71,392 → 352 | 724 → 4 |

Real repositories, three single-threaded runs using each repository's existing JavaScript rslint configuration plus a temporary Unicorn rule entry:

| Repository | Files | Before median | After median | Target diagnostics |
| --- | ---: | ---: | ---: | ---: |
| rsbuild | 2,196 | 0.4 ms | 0.4 ms | 0 → 0 |
| rspack | 479 | 0.1 ms | 0.1 ms | 0 → 0 |

These real-repository timings are already at the timing table's 0.1 ms display floor. Baseline and optimized JSONL output was byte-identical in every run.

An additional adversarial corpus covered source-order barriers, multi-line and commented separators, conditional and TypeScript expressions, regular expressions and template literals containing colons, nested empty blocks and switches, disable directives, and suggestion-demand modes. Its diagnostics were also byte-identical.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

### Validation

- go test ./internal/plugins/unicorn/rules/no_useless_switch_case
- pnpm run check-spell
- pnpm run format:check
- pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/unicorn/rules/no_useless_switch_case