### PR TITLE
perf: optimize no-class-assign

### DIFF
--- a/internal/rules/no_class_assign/no_class_assign.go
+++ b/internal/rules/no_class_assign/no_class_assign.go
@@ -21,15 +21,23 @@ func buildClassReassignmentMessage(className string) rule.RuleMessage {
 // name comes from the declaration's name node rather than the symbol: a
 // default-exported class is bound to an export symbol named "default",
 // while the reported name must be the one written in the source.
-func checkClassReassignments(classNode *ast.Node, name string, ctx *rule.RuleContext) {
-	sym := classNode.Symbol()
-	if sym == nil {
+func checkClassReassignments(classNode *ast.Node, nameNode *ast.Node, ctx *rule.RuleContext) {
+	symbol := classNode.Symbol()
+	if symbol == nil {
 		return
 	}
-	for _, ref := range ctx.Refs.References(sym) {
-		if utils.IsWriteReference(ref) {
-			ctx.ReportNode(ref, buildClassReassignmentMessage(name))
+
+	var message rule.RuleMessage
+	hasMessage := false
+	for _, reference := range ctx.Refs.References(symbol) {
+		if !utils.IsWriteReference(reference) {
+			continue
 		}
+		if !hasMessage {
+			message = buildClassReassignmentMessage(nameNode.Text())
+			hasMessage = true
+		}
+		ctx.ReportNode(reference, message)
 	}
 }
 
@@ -37,26 +45,16 @@ func checkClassReassignments(classNode *ast.Node, name string, ctx *rule.RuleCon
 var NoClassAssignRule = rule.Rule{
 	Name: "no-class-assign",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		checkClass := func(node *ast.Node) {
+			nameNode := node.Name()
+			if nameNode == nil {
+				return
+			}
+			checkClassReassignments(node, nameNode, &ctx)
+		}
 		return rule.RuleListeners{
-			// Check class declarations
-			ast.KindClassDeclaration: func(node *ast.Node) {
-				nameNode := node.AsClassDeclaration().Name()
-				if nameNode == nil {
-					return
-				}
-				checkClassReassignments(node, nameNode.Text(), &ctx)
-			},
-
-			// Check named class expressions. The name is only visible inside
-			// the class body, which RefStore's scope-aware resolution
-			// enforces on its own.
-			ast.KindClassExpression: func(node *ast.Node) {
-				nameNode := node.AsClassExpression().Name()
-				if nameNode == nil {
-					return
-				}
-				checkClassReassignments(node, nameNode.Text(), &ctx)
-			},
+			ast.KindClassDeclaration: checkClass,
+			ast.KindClassExpression:  checkClass,
 		}
 	},
 }

--- a/internal/rules/no_class_assign/no_class_assign_test.go
+++ b/internal/rules/no_class_assign/no_class_assign_test.go
@@ -116,6 +116,24 @@ func TestNoClassAssignRule(t *testing.T) {
 				},
 			},
 
+			// Multiple write references share one message, including
+			// destructuring and for-in/for-of assignment targets.
+			{
+				Code: `class A {}
+A = 0;
+A++;
+[A] = [];
+for (A in object) {}
+for (A of values) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "classReassignment", Message: "'A' is a class.", Line: 2, Column: 1},
+					{MessageId: "classReassignment", Line: 3, Column: 1},
+					{MessageId: "classReassignment", Line: 4, Column: 2},
+					{MessageId: "classReassignment", Line: 5, Column: 6},
+					{MessageId: "classReassignment", Message: "'A' is a class.", Line: 6, Column: 6},
+				},
+			},
+
 			// Compound assignment operators
 			{
 				Code: `class A { } A += 0;`,


### PR DESCRIPTION
## Summary

- Reuse one class listener for declarations and named expressions, avoiding one captured callback allocation for every linted file.
- Build the class reassignment message only for the first write and reuse it for subsequent diagnostics from the same class.
- Keep `ctx.Refs.References` as the scope-correct reference source. A rule-local `Resolve` plus AST-scan prototype improved isolated runs but duplicated the shared reference-index walk when other reference-aware rules were enabled, so it was rejected after adversarial benchmarking.
- Report deferral does not apply because this rule has no fixes or suggestions. Documentation is not required because behavior and configuration are unchanged.

### Performance

Measured on Apple M1 Max with Go 1.26.1. The corpus harness initializes the rule for every parsed file, executes it on bound class-containing files, and reports zero diagnostics. Temporary benchmark code is not included in this PR.

| Corpus | Iterations | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| rsbuild (2,217 files / 71 classes) | 1,000 | 1,894,079 → 1,862,104 (-1.7%) | 1,620,000 → 1,584,529 (-2.2%) | 19,326 → 17,109 (-11.5%) |
| rspack (15,191 files / 632 classes) | 100 | 11,203,062 → 10,851,520 (-3.1%) | 10,719,008 → 10,475,953 (-2.3%) | 133,704 → 118,513 (-11.4%) |

The corpora contain no violations for this rule, so the table measures the per-file listener improvement; reuse of the diagnostic message is covered by the multi-write test and the differential attack.

### Validation

- `go test ./internal/rules/no_class_assign`
- Temporary old-algorithm differential attack across modules, global scripts, shadowing, default exports, class expressions, destructuring, loops, and compound writes (`-count=100`)
- Shared-RefStore prewarm benchmark to reject duplicate-walk regressions
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run ./internal/rules/no_class_assign`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
