### PR TITLE
perf: optimize ban-ts-comment

### DIFF
--- a/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.go
+++ b/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment.go
@@ -2,6 +2,7 @@ package ban_ts_comment
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -15,6 +16,7 @@ type DirectiveConfig struct {
 	Enabled              bool   // Whether the directive is enabled (true means banned)
 	AllowWithDescription bool   // Whether to allow with description
 	DescriptionFormat    string // Regex pattern for description format
+	descriptionRegex     *regexp.Regexp
 }
 
 type BanTsCommentOptions struct {
@@ -25,19 +27,27 @@ type BanTsCommentOptions struct {
 	MinimumDescriptionLength int         `json:"minimumDescriptionLength"`
 }
 
-// Regexes for single-line comments.
-// ts-expect-error and ts-ignore: match any number of leading slashes (original: /^\/*\s*@ts-.../)
-// ts-check and ts-nocheck: only match 2 or 3 slashes (pragma comments: /^\/\/\/?\s*@ts-.../)
+type directiveKind uint8
+
+const (
+	directiveExpectError directiveKind = iota
+	directiveIgnore
+	directiveNocheck
+	directiveCheck
+	directiveCount
+)
+
+type directiveConfigs [directiveCount]DirectiveConfig
+
 var (
-	// For ts-expect-error / ts-ignore in single-line comments: any number of leading slashes
-	singleLineDirectiveRegex = regexp.MustCompile(`^/{2,}\s*@ts-(expect-error|ignore)\b`)
-
-	// For ts-check / ts-nocheck in single-line comments: exactly 2 or 3 slashes (pragma style)
-	singleLinePragmaRegex = regexp.MustCompile(`^///?\s*@ts-(check|nocheck)\b`)
-
-	// For ts-expect-error / ts-ignore on the last line of a block comment
-	// Matches optional whitespace, optional leading * or /, then the directive
-	multiLineLastLineRegex = regexp.MustCompile(`^\s*(?:[/*])*\s*@ts-(expect-error|ignore)\b`)
+	tsIgnoreInsteadOfExpectErrorMessage = rule.RuleMessage{
+		Id:          "tsIgnoreInsteadOfExpectError",
+		Description: "Prefer '@ts-expect-error' over '@ts-ignore' as it requires error to be present in next line.",
+	}
+	replaceTsIgnoreWithTsExpectErrorMessage = rule.RuleMessage{
+		Id:          "replaceTsIgnoreWithTsExpectError",
+		Description: "Replace '@ts-ignore' with '@ts-expect-error'.",
+	}
 )
 
 // BanTsCommentRule implements the ban-ts-comment rule
@@ -53,7 +63,31 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		return rule.RuleListeners{}
 	}
 
-	options := rule.LegacyUnwrapOptions(_options)
+	opts := parseOptions(_options)
+	configs := directiveConfigs{
+		directiveExpectError: parseDirectiveConfig(opts.TsExpectError),
+		directiveIgnore:      parseDirectiveConfig(opts.TsIgnore),
+		directiveNocheck:     parseDirectiveConfig(opts.TsNocheck),
+		directiveCheck:       parseDirectiveConfig(opts.TsCheck),
+	}
+	if !containsEnabledDirective(text, &configs) {
+		return rule.RuleListeners{}
+	}
+
+	// Determine token position of the first statement (excluding leading trivia)
+	// only when an enabled ts-nocheck pragma could need the position check.
+	firstStatementPos := -1
+	if configs[directiveNocheck].Enabled && strings.Contains(text, "@ts-nocheck") &&
+		ctx.SourceFile.Statements != nil && len(ctx.SourceFile.Statements.Nodes) > 0 {
+		firstStatementPos = scanner.GetTokenPosOfNode(ctx.SourceFile.Statements.Nodes[0], ctx.SourceFile, false)
+	}
+
+	processComments(ctx, text, &configs, opts.MinimumDescriptionLength, firstStatementPos)
+
+	return rule.RuleListeners{}
+}
+
+func parseOptions(options []any) BanTsCommentOptions {
 	opts := BanTsCommentOptions{
 		TsExpectError:            "allow-with-description",
 		TsIgnore:                 true,
@@ -62,63 +96,46 @@ func run(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		MinimumDescriptionLength: 3,
 	}
 
-	// Parse options
-	if options != nil {
-		var optsMap map[string]interface{}
-		var ok bool
-
-		// Handle array format: [{ option: value }]
-		if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-			optsMap, ok = optArray[0].(map[string]interface{})
-		} else {
-			// Handle direct object format: { option: value }
-			optsMap, ok = options.(map[string]interface{})
-		}
-
-		if ok {
-			if val, exists := optsMap["ts-expect-error"]; exists {
-				opts.TsExpectError = val
-			}
-			if val, exists := optsMap["ts-ignore"]; exists {
-				opts.TsIgnore = val
-			}
-			if val, exists := optsMap["ts-nocheck"]; exists {
-				opts.TsNocheck = val
-			}
-			if val, exists := optsMap["ts-check"]; exists {
-				opts.TsCheck = val
-			}
-			if val, ok := optsMap["minimumDescriptionLength"].(float64); ok {
-				opts.MinimumDescriptionLength = int(val)
-			} else if val, ok := optsMap["minimumDescriptionLength"].(int); ok {
-				opts.MinimumDescriptionLength = val
-			}
-		}
+	if len(options) == 0 {
+		return opts
 	}
 
-	// Parse directive configurations
-	configs := map[string]*DirectiveConfig{
-		"ts-expect-error": parseDirectiveConfig(opts.TsExpectError),
-		"ts-ignore":       parseDirectiveConfig(opts.TsIgnore),
-		"ts-nocheck":      parseDirectiveConfig(opts.TsNocheck),
-		"ts-check":        parseDirectiveConfig(opts.TsCheck),
+	option := rule.LegacyUnwrapOptions(options)
+	// Preserve compatibility with callers that still pass the old nested
+	// array shape after the shared legacy-options shim has unwrapped Run's
+	// ESLint-style context.options.
+	if optionArray, ok := option.([]interface{}); ok && len(optionArray) > 0 {
+		option = optionArray[0]
+	}
+	optsMap, ok := option.(map[string]interface{})
+	if !ok {
+		return opts
 	}
 
-	// Determine token position of the first statement (excluding leading trivia)
-	// for ts-nocheck pragma check: only report if comment is before first real code
-	firstStatementPos := -1
-	if ctx.SourceFile.Statements != nil && len(ctx.SourceFile.Statements.Nodes) > 0 {
-		firstStatementPos = scanner.GetTokenPosOfNode(ctx.SourceFile.Statements.Nodes[0], ctx.SourceFile, false)
+	if val, exists := optsMap["ts-expect-error"]; exists {
+		opts.TsExpectError = val
+	}
+	if val, exists := optsMap["ts-ignore"]; exists {
+		opts.TsIgnore = val
+	}
+	if val, exists := optsMap["ts-nocheck"]; exists {
+		opts.TsNocheck = val
+	}
+	if val, exists := optsMap["ts-check"]; exists {
+		opts.TsCheck = val
+	}
+	if val, ok := optsMap["minimumDescriptionLength"].(float64); ok {
+		opts.MinimumDescriptionLength = int(val)
+	} else if val, ok := optsMap["minimumDescriptionLength"].(int); ok {
+		opts.MinimumDescriptionLength = val
 	}
 
-	processComments(ctx, text, configs, opts.MinimumDescriptionLength, firstStatementPos)
-
-	return rule.RuleListeners{}
+	return opts
 }
 
 // parseDirectiveConfig converts the option value to DirectiveConfig
-func parseDirectiveConfig(value interface{}) *DirectiveConfig {
-	config := &DirectiveConfig{}
+func parseDirectiveConfig(value interface{}) DirectiveConfig {
+	config := DirectiveConfig{}
 
 	switch v := value.(type) {
 	case bool:
@@ -136,12 +153,34 @@ func parseDirectiveConfig(value interface{}) *DirectiveConfig {
 			config.DescriptionFormat = descFormat
 		}
 	}
+	if config.DescriptionFormat != "" {
+		config.descriptionRegex, _ = regexp.Compile(config.DescriptionFormat)
+	}
 
 	return config
 }
 
+// containsEnabledDirective is a source-text gate before the shared comment
+// store is materialized. It is deliberately conservative about lexical
+// context (a marker in a string may reach the comment scan), but exact about
+// directive spelling, word boundaries, and whether that directive is enabled.
+func containsEnabledDirective(text string, configs *directiveConfigs) bool {
+	for searchStart := 0; searchStart < len(text); {
+		offset := strings.Index(text[searchStart:], "@ts-")
+		if offset < 0 {
+			return false
+		}
+		markerStart := searchStart + offset
+		if directive, _, ok := matchDirectiveNameAt(text, markerStart); ok && configs[directive].Enabled {
+			return true
+		}
+		searchStart = markerStart + len("@ts-")
+	}
+	return false
+}
+
 // processComments scans real comment trivia and checks for banned directives.
-func processComments(ctx rule.RuleContext, text string, configs map[string]*DirectiveConfig, minDescLength int, firstStatementPos int) {
+func processComments(ctx rule.RuleContext, text string, configs *directiveConfigs, minDescLength int, firstStatementPos int) {
 	for _, comment := range ctx.Comments.All() {
 		if comment == nil {
 			continue
@@ -162,86 +201,131 @@ func processComments(ctx rule.RuleContext, text string, configs map[string]*Dire
 }
 
 // checkSingleLineComment handles single-line comments (// or /// style).
-func checkSingleLineComment(ctx rule.RuleContext, commentText string, commentStart int, configs map[string]*DirectiveConfig, minDescLength int, firstStatementPos int) {
-	// Try matching ts-expect-error / ts-ignore (any number of leading slashes)
-	if match := singleLineDirectiveRegex.FindStringSubmatch(commentText); match != nil {
-		directiveType := match[1] // "expect-error" or "ignore"
-		directiveName := "ts-" + directiveType
-		description := extractSingleLineDescription(commentText, "@ts-"+directiveType)
-		reportDirective(ctx, commentText, commentStart, configs, directiveName, directiveType, description, minDescLength)
+func checkSingleLineComment(ctx rule.RuleContext, commentText string, commentStart int, configs *directiveConfigs, minDescLength int, firstStatementPos int) {
+	directive, descriptionStart, ok := matchSingleLineDirective(commentText)
+	if !ok {
 		return
 	}
 
-	// Try matching ts-check / ts-nocheck (only 2 or 3 slashes, pragma style)
-	if match := singleLinePragmaRegex.FindStringSubmatch(commentText); match != nil {
-		directiveType := match[1] // "check" or "nocheck"
-		directiveName := "ts-" + directiveType
-
-		// ts-nocheck after the first statement is not effective and should not be reported
-		if directiveType == "nocheck" && firstStatementPos >= 0 && commentStart >= firstStatementPos {
-			return
-		}
-
-		description := extractSingleLineDescription(commentText, "@ts-"+directiveType)
-		reportDirective(ctx, commentText, commentStart, configs, directiveName, directiveType, description, minDescLength)
+	// ts-nocheck after the first statement is not effective and should not be reported.
+	if directive == directiveNocheck && firstStatementPos >= 0 && commentStart >= firstStatementPos {
+		return
 	}
+
+	reportDirective(ctx, commentText, commentStart, configs, directive, commentText[descriptionStart:], minDescLength)
 }
 
 // checkMultiLineComment handles block comments (/* */ style).
 // Only ts-expect-error and ts-ignore are checked in block comments.
 // ts-check and ts-nocheck are pragma-only (single-line).
 // The directive must appear on the LAST line of the comment to be recognized.
-func checkMultiLineComment(ctx rule.RuleContext, commentText string, commentStart int, configs map[string]*DirectiveConfig, minDescLength int) {
-	// Extract content between /* and */
-	if len(commentText) < 4 {
-		return
-	}
-	content := commentText[2 : len(commentText)-2]
-
-	// Get the last line of the comment content
-	lastLineStart := strings.LastIndexByte(content, '\n')
-	var lastLine string
-	if lastLineStart == -1 {
-		lastLine = content
-	} else {
-		lastLine = content[lastLineStart+1:]
-	}
-
-	// Check if the last line contains a directive (ts-expect-error or ts-ignore only)
-	match := multiLineLastLineRegex.FindStringSubmatch(lastLine)
-	if match == nil {
+func checkMultiLineComment(ctx rule.RuleContext, commentText string, commentStart int, configs *directiveConfigs, minDescLength int) {
+	directive, descriptionStart, contentEnd, ok := matchMultiLineDirective(commentText)
+	if !ok {
 		return
 	}
 
-	directiveType := match[1] // "expect-error" or "ignore"
-	directiveName := "ts-" + directiveType
-
-	// Extract raw description from the last line after the directive
-	directivePattern := "@ts-" + directiveType
-	idx := strings.Index(lastLine, directivePattern)
-	if idx == -1 {
-		return
-	}
-	rawDescription := lastLine[idx+len(directivePattern):]
-
-	reportDirective(ctx, commentText, commentStart, configs, directiveName, directiveType, rawDescription, minDescLength)
+	reportDirective(ctx, commentText, commentStart, configs, directive, commentText[descriptionStart:contentEnd], minDescLength)
 }
 
-// extractSingleLineDescription extracts the raw description from a single-line comment after the directive.
-// The returned string is NOT trimmed — callers decide how to use it (raw for format check, trimmed for length).
-func extractSingleLineDescription(commentText string, directive string) string {
-	idx := strings.Index(commentText, directive)
-	if idx == -1 {
-		return ""
+func matchSingleLineDirective(commentText string) (directiveKind, int, bool) {
+	slashCount := 0
+	for slashCount < len(commentText) && commentText[slashCount] == '/' {
+		slashCount++
 	}
-	return commentText[idx+len(directive):]
+	if slashCount < 2 {
+		return 0, 0, false
+	}
+
+	directiveStart := skipDirectiveWhitespace(commentText, slashCount)
+	directive, descriptionStart, ok := matchDirectiveNameAt(commentText, directiveStart)
+	if !ok {
+		return 0, 0, false
+	}
+	if directive == directiveExpectError || directive == directiveIgnore {
+		return directive, descriptionStart, true
+	}
+	if slashCount <= 3 && (directive == directiveCheck || directive == directiveNocheck) {
+		return directive, descriptionStart, true
+	}
+	return 0, 0, false
+}
+
+func matchMultiLineDirective(commentText string) (directiveKind, int, int, bool) {
+	if len(commentText) < 4 {
+		return 0, 0, 0, false
+	}
+
+	contentStart := 2
+	contentEnd := len(commentText) - 2
+	if lastLineBreak := strings.LastIndexByte(commentText[contentStart:contentEnd], '\n'); lastLineBreak >= 0 {
+		contentStart += lastLineBreak + 1
+	}
+
+	directiveStart := skipDirectiveWhitespace(commentText, contentStart)
+	for directiveStart < contentEnd && (commentText[directiveStart] == '/' || commentText[directiveStart] == '*') {
+		directiveStart++
+	}
+	directiveStart = skipDirectiveWhitespace(commentText[:contentEnd], directiveStart)
+
+	directive, descriptionStart, ok := matchDirectiveNameAt(commentText[:contentEnd], directiveStart)
+	if !ok || (directive != directiveExpectError && directive != directiveIgnore) {
+		return 0, 0, 0, false
+	}
+	return directive, descriptionStart, contentEnd, true
+}
+
+func matchDirectiveNameAt(text string, start int) (directiveKind, int, bool) {
+	if start < 0 || start+len("@ts-") > len(text) || text[start:start+len("@ts-")] != "@ts-" {
+		return 0, 0, false
+	}
+
+	nameStart := start + len("@ts-")
+	var directive directiveKind
+	var name string
+	if nameStart < len(text) {
+		switch text[nameStart] {
+		case 'e':
+			directive, name = directiveExpectError, "expect-error"
+		case 'i':
+			directive, name = directiveIgnore, "ignore"
+		case 'n':
+			directive, name = directiveNocheck, "nocheck"
+		case 'c':
+			directive, name = directiveCheck, "check"
+		}
+	}
+	nameEnd := nameStart + len(name)
+	if name == "" || nameEnd > len(text) || text[nameStart:nameEnd] != name {
+		return 0, 0, false
+	}
+	if nameEnd < len(text) && isASCIIWordByte(text[nameEnd]) {
+		return 0, 0, false
+	}
+	return directive, nameEnd, true
+}
+
+func skipDirectiveWhitespace(text string, start int) int {
+	for start < len(text) {
+		switch text[start] {
+		case ' ', '\t', '\n', '\f', '\r':
+			start++
+		default:
+			return start
+		}
+	}
+	return start
+}
+
+func isASCIIWordByte(value byte) bool {
+	return value == '_' || value >= '0' && value <= '9' || value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
 }
 
 // reportDirective reports a directive violation if applicable.
 // rawDescription is the text after the directive keyword (untrimmed), used for format matching.
-func reportDirective(ctx rule.RuleContext, commentText string, commentStart int, configs map[string]*DirectiveConfig, directiveName string, directiveType string, rawDescription string, minDescLength int) {
-	config := configs[directiveName]
-	if config == nil || !config.Enabled {
+func reportDirective(ctx rule.RuleContext, commentText string, commentStart int, configs *directiveConfigs, directive directiveKind, rawDescription string, minDescLength int) {
+	config := &configs[directive]
+	if !config.Enabled {
 		return
 	}
 
@@ -250,44 +334,32 @@ func reportDirective(ctx rule.RuleContext, commentText string, commentStart int,
 	// Special case: for ts-ignore with no description allowed, suggest ts-expect-error
 	// BUT only if ts-expect-error is not also completely banned — otherwise it's contradictory
 	// to suggest something that's also forbidden.
-	expectErrorConfig := configs["ts-expect-error"]
-	expectErrorAlsoBanned := expectErrorConfig != nil && expectErrorConfig.Enabled && !expectErrorConfig.AllowWithDescription
-	if directiveType == "ignore" && !config.AllowWithDescription && !expectErrorAlsoBanned {
-		msg := rule.RuleMessage{
-			Id:          "tsIgnoreInsteadOfExpectError",
-			Description: "Prefer '@ts-expect-error' over '@ts-ignore' as it requires error to be present in next line.",
-		}
+	expectErrorConfig := &configs[directiveExpectError]
+	expectErrorAlsoBanned := expectErrorConfig.Enabled && !expectErrorConfig.AllowWithDescription
+	if directive == directiveIgnore && !config.AllowWithDescription && !expectErrorAlsoBanned {
 		// Provide a suggestion (not autofix): replace @ts-ignore with @ts-expect-error.
 		// This is intentionally a suggestion rather than an autofix because @ts-expect-error
 		// requires the next line to actually have a type error — auto-replacing could break code.
-		idx := strings.LastIndex(commentText, "@ts-ignore")
-		if idx >= 0 {
+		ctx.ReportRangeWithDeferredSuggestions(commentRange, tsIgnoreInsteadOfExpectErrorMessage, func() []rule.RuleSuggestion {
+			idx := strings.LastIndex(commentText, "@ts-ignore")
+			if idx < 0 {
+				return nil
+			}
 			fixRange := core.NewTextRange(commentStart+idx, commentStart+idx+len("@ts-ignore"))
-			fix := rule.RuleFixReplaceRange(fixRange, "@ts-expect-error")
-			ctx.ReportRangeWithSuggestions(commentRange, msg, rule.RuleSuggestion{
-				Message: rule.RuleMessage{
-					Id:          "replaceTsIgnoreWithTsExpectError",
-					Description: "Replace '@ts-ignore' with '@ts-expect-error'.",
-				},
-				FixesArr: []rule.RuleFix{fix},
-			})
-		} else {
-			ctx.ReportRange(commentRange, msg)
-		}
+			return []rule.RuleSuggestion{{
+				Message:  replaceTsIgnoreWithTsExpectErrorMessage,
+				FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(fixRange, "@ts-expect-error")},
+			}}
+		})
 		return
 	}
 
 	// If the directive is completely banned (no description allowed)
 	if !config.AllowWithDescription {
-		ctx.ReportRange(
-			commentRange,
-			rule.RuleMessage{
-				Id:          "tsDirectiveComment",
-				Description: "Do not use '@" + directiveName + "' because it alters compilation errors.",
-			},
-		)
+		ctx.ReportRange(commentRange, directiveCommentMessage(directive))
 		return
 	}
+	fullDirectiveName := directiveName(directive)
 
 	// Trimmed description for length check; raw description for format check
 	trimmedDescription := strings.TrimSpace(rawDescription)
@@ -299,26 +371,51 @@ func reportDirective(ctx rule.RuleContext, commentText string, commentStart int,
 			commentRange,
 			rule.RuleMessage{
 				Id:          "tsDirectiveCommentRequiresDescription",
-				Description: "Include a description after the '@" + directiveName + "' directive to explain why the '@" + directiveName + "' is necessary. The description must be " + formatInt(minDescLength) + " characters or longer.",
+				Description: "Include a description after the '@" + fullDirectiveName + "' directive to explain why the '@" + fullDirectiveName + "' is necessary. The description must be " + strconv.Itoa(minDescLength) + " characters or longer.",
 			},
 		)
 		return
 	}
 
 	// Check description format against raw (untrimmed) description
-	if config.DescriptionFormat != "" {
-		formatRegex, err := regexp.Compile(config.DescriptionFormat)
-		if err == nil {
-			if !formatRegex.MatchString(rawDescription) {
-				ctx.ReportRange(
-					commentRange,
-					rule.RuleMessage{
-						Id:          "tsDirectiveCommentDescriptionNotMatchPattern",
-						Description: "The description for the '@" + directiveName + "' directive must match the format '" + config.DescriptionFormat + "'.",
-					},
-				)
-			}
-		}
+	if config.descriptionRegex != nil && !config.descriptionRegex.MatchString(rawDescription) {
+		ctx.ReportRange(
+			commentRange,
+			rule.RuleMessage{
+				Id:          "tsDirectiveCommentDescriptionNotMatchPattern",
+				Description: "The description for the '@" + fullDirectiveName + "' directive must match the format '" + config.DescriptionFormat + "'.",
+			},
+		)
+	}
+}
+
+func directiveName(directive directiveKind) string {
+	switch directive {
+	case directiveExpectError:
+		return "ts-expect-error"
+	case directiveIgnore:
+		return "ts-ignore"
+	case directiveNocheck:
+		return "ts-nocheck"
+	case directiveCheck:
+		return "ts-check"
+	default:
+		return ""
+	}
+}
+
+func directiveCommentMessage(directive directiveKind) rule.RuleMessage {
+	switch directive {
+	case directiveExpectError:
+		return rule.RuleMessage{Id: "tsDirectiveComment", Description: "Do not use '@ts-expect-error' because it alters compilation errors."}
+	case directiveIgnore:
+		return rule.RuleMessage{Id: "tsDirectiveComment", Description: "Do not use '@ts-ignore' because it alters compilation errors."}
+	case directiveNocheck:
+		return rule.RuleMessage{Id: "tsDirectiveComment", Description: "Do not use '@ts-nocheck' because it alters compilation errors."}
+	case directiveCheck:
+		return rule.RuleMessage{Id: "tsDirectiveComment", Description: "Do not use '@ts-check' because it alters compilation errors."}
+	default:
+		return rule.RuleMessage{Id: "tsDirectiveComment"}
 	}
 }
 
@@ -326,15 +423,4 @@ func reportDirective(ctx rule.RuleContext, commentText string, commentStart int,
 // Uses proper Unicode grapheme cluster segmentation (UAX#29) via rivo/uniseg.
 func graphemeLength(s string) int {
 	return uniseg.GraphemeClusterCount(s)
-}
-
-// formatInt converts an integer to a string
-func formatInt(n int) string {
-	if n < 0 {
-		return "-" + formatInt(-n)
-	}
-	if n < 10 {
-		return string(rune('0' + n))
-	}
-	return formatInt(n/10) + string(rune('0'+n%10))
 }

--- a/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment_test.go
+++ b/internal/plugins/typescript/rules/ban_ts_comment/ban_ts_comment_test.go
@@ -1,9 +1,15 @@
 package ban_ts_comment
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -480,4 +486,182 @@ func TestBanTsCommentRule(t *testing.T) {
 			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "tsDirectiveCommentRequiresDescription"}},
 		},
 	})
+}
+
+func TestDirectiveMatchersMatchRegexOracle(t *testing.T) {
+	singleLineDirectiveRegex := regexp.MustCompile(`^/{2,}\s*@ts-(expect-error|ignore)\b`)
+	singleLinePragmaRegex := regexp.MustCompile(`^///?\s*@ts-(check|nocheck)\b`)
+	multiLineLastLineRegex := regexp.MustCompile(`^\s*(?:[/*])*\s*@ts-(expect-error|ignore)\b`)
+
+	directiveFromSuffix := func(suffix string) (directiveKind, bool) {
+		switch suffix {
+		case "expect-error":
+			return directiveExpectError, true
+		case "ignore":
+			return directiveIgnore, true
+		case "nocheck":
+			return directiveNocheck, true
+		case "check":
+			return directiveCheck, true
+		default:
+			return 0, false
+		}
+	}
+	oracleSingleLine := func(commentText string) (directiveKind, int, bool) {
+		for _, expression := range []*regexp.Regexp{singleLineDirectiveRegex, singleLinePragmaRegex} {
+			match := expression.FindStringSubmatchIndex(commentText)
+			if match == nil {
+				continue
+			}
+			directive, ok := directiveFromSuffix(commentText[match[2]:match[3]])
+			return directive, match[1], ok
+		}
+		return 0, 0, false
+	}
+	oracleMultiLine := func(commentText string) (directiveKind, int, int, bool) {
+		contentStart := 2
+		contentEnd := len(commentText) - 2
+		lastLineStart := contentStart
+		if lineBreak := strings.LastIndexByte(commentText[contentStart:contentEnd], '\n'); lineBreak >= 0 {
+			lastLineStart += lineBreak + 1
+		}
+		match := multiLineLastLineRegex.FindStringSubmatchIndex(commentText[lastLineStart:contentEnd])
+		if match == nil {
+			return 0, 0, 0, false
+		}
+		directive, ok := directiveFromSuffix(commentText[lastLineStart+match[2] : lastLineStart+match[3]])
+		return directive, lastLineStart + match[1], contentEnd, ok
+	}
+
+	directives := []string{
+		"@ts-expect-error",
+		"@ts-ignore",
+		"@ts-nocheck",
+		"@ts-check",
+		"@ts-unknown",
+	}
+	whitespace := []string{"", " ", "\t", "\n", "\f", "\r", "\v", " \t\f\r"}
+	suffixes := []string{"", " ", ": why", "-why", "/", "_suffix", "0", "A", "é"}
+	configs := directiveConfigs{}
+	for directive := directiveKind(0); directive < directiveCount; directive++ {
+		configs[directive].Enabled = true
+	}
+
+	for _, slashes := range []string{"", "/", "//", "///", "////", "/////", "//x"} {
+		for _, space := range whitespace {
+			for _, directiveText := range directives {
+				for _, suffix := range suffixes {
+					commentText := slashes + space + directiveText + suffix
+					wantDirective, wantDescriptionStart, wantOK := oracleSingleLine(commentText)
+					gotDirective, gotDescriptionStart, gotOK := matchSingleLineDirective(commentText)
+					if gotOK != wantOK || gotDirective != wantDirective || gotDescriptionStart != wantDescriptionStart {
+						t.Fatalf(
+							"single-line match for %q = (%d, %d, %t), want (%d, %d, %t)",
+							commentText,
+							gotDirective,
+							gotDescriptionStart,
+							gotOK,
+							wantDirective,
+							wantDescriptionStart,
+							wantOK,
+						)
+					}
+					if wantOK && !containsEnabledDirective(commentText, &configs) {
+						t.Fatalf("source-text gate rejected matching single-line directive %q", commentText)
+					}
+				}
+			}
+		}
+	}
+
+	lastLinePrefixes := []string{"", " ", "\t", "\f", "\r", "\v", "*", "**", "/", "/*", " */ ", "\t/*\r"}
+	for _, previousLines := range []string{"", "header\n", "header\r\n", "\n"} {
+		for _, prefix := range lastLinePrefixes {
+			for _, directiveText := range directives {
+				for _, suffix := range suffixes {
+					commentText := "/*" + previousLines + prefix + directiveText + suffix + "*/"
+					wantDirective, wantDescriptionStart, wantContentEnd, wantOK := oracleMultiLine(commentText)
+					gotDirective, gotDescriptionStart, gotContentEnd, gotOK := matchMultiLineDirective(commentText)
+					if gotOK != wantOK || gotDirective != wantDirective || gotDescriptionStart != wantDescriptionStart || gotContentEnd != wantContentEnd {
+						t.Fatalf(
+							"multi-line match for %q = (%d, %d, %d, %t), want (%d, %d, %d, %t)",
+							commentText,
+							gotDirective,
+							gotDescriptionStart,
+							gotContentEnd,
+							gotOK,
+							wantDirective,
+							wantDescriptionStart,
+							wantContentEnd,
+							wantOK,
+						)
+					}
+					if wantOK && !containsEnabledDirective(commentText, &configs) {
+						t.Fatalf("source-text gate rejected matching multi-line directive %q", commentText)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestBanTsCommentSuggestionDemand(t *testing.T) {
+	const source = "// @ts-ignore"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/ban-ts-comment-suggestion.ts",
+		Path:     "/ban-ts-comment-suggestion.ts",
+	}, source, core.ScriptKindTS)
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(BanTsCommentRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		})
+		BanTsCommentRule.Run(ctx, nil)
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d produced %d diagnostics, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		diagnostic := run(demand)
+		if diagnostic.Message.Id != "tsIgnoreInsteadOfExpectError" || diagnostic.Range.Pos() != 0 || diagnostic.Range.End() != len(source) {
+			t.Fatalf("demand %d changed the diagnostic: %#v", demand, diagnostic)
+		}
+		if diagnostic.FixesPtr != nil {
+			t.Fatalf("demand %d unexpectedly materialized an autofix", demand)
+		}
+		if demand&rule.EditDemandSuggestion == 0 {
+			if diagnostic.Suggestions != nil {
+				t.Fatalf("demand %d materialized suggestions", demand)
+			}
+			continue
+		}
+		if diagnostic.Suggestions == nil || len(*diagnostic.Suggestions) != 1 {
+			t.Fatalf("demand %d suggestions = %#v, want one", demand, diagnostic.Suggestions)
+		}
+		suggestion := (*diagnostic.Suggestions)[0]
+		if suggestion.Message.Id != "replaceTsIgnoreWithTsExpectError" || len(suggestion.Fixes()) != 1 {
+			t.Fatalf("demand %d suggestion = %#v, want one replacement", demand, suggestion)
+		}
+		fix := suggestion.Fixes()[0]
+		if fix.Range.Pos() != 3 || fix.Range.End() != len(source) || fix.Text != "@ts-expect-error" {
+			t.Fatalf("demand %d fix = %#v, want @ts-ignore replacement", demand, fix)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- replace per-comment regular-expression submatches with a byte matcher that preserves the previous ASCII whitespace, word-boundary, slash-count, and block-comment-last-line semantics
- skip shared comment materialization when no enabled directive is present, compile `descriptionFormat` once per rule run, and only compute the first statement position when `ts-nocheck` can use it
- reuse `ctx.Comments`, `scanner.GetTokenPosOfNode`, and `LegacyUnwrapOptions`; `ctx.Refs` is intentionally not used because this rule performs no identifier or symbol lookup
- defer the `ts-ignore` replacement suggestion until the diagnostic consumer requests suggestions
- add adversarial matcher-oracle and edit-demand tests to the existing test file

### Performance

Apple M1 Max, Go 1.26.1, `-cpu=1`; medians of 3 runs from a temporary benchmark that is not included in the commit:

| Scenario | Before | After | Time |
| --- | ---: | ---: | ---: |
| no `@ts-` marker | 321.9 ns/op, 160 B/op, 3 allocs/op | 310.6 ns/op, 160 B/op, 3 allocs/op | -3.5% |
| marker only in a string, warm shared comments | 89.3 µs/op, 210 B/op, 6 allocs/op | 4.39 µs/op, 112 B/op, 2 allocs/op | -95.1% |
| 512 banned `ts-ignore` comments, no suggestion demand, warm shared comments | ~186 µs/op, 73,945 B/op, 2,054 allocs/op | 26.3 µs/op, 112 B/op, 2 allocs/op | -85.9% |
| 512 `descriptionFormat` checks, warm shared comments | ~2.93 ms/op, 3.69 MB/op, 40,971 allocs/op | 284 µs/op, 7.28 KB/op, 81 allocs/op | -90.3% |

Real-repository rule-pass results:

| Repository | Files / marker files | Diagnostics | Time median | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| rsbuild before | 2,198 / 12 | 0 | 1.466 ms | 1,514,632 | 36,390 |
| rsbuild after | 2,198 / 12 | 0 | 0.796 ms (-45.7%) | 675,317 (-55.4%) | 15,719 (-56.8%) |
| rspack before | 15,964 / 78 | 62 | noisy; omitted | 21,333,997 | 521,279 |
| rspack after | 15,964 / 78 | 62 | noisy; omitted | 21,106,816 (-1.1%) | 515,774 (-1.1%) |

The short rspack wall-time samples ranged too widely to support a reliable time claim, so only stable diagnostic and allocation results are reported.

## Related Links

- [Upstream typescript-eslint rule](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/ban-ts-comment.ts)

## Checklist

- [x] Tests updated (matcher equivalence and deferred-suggestion demand coverage).
- [x] Documentation updated (not required; no user-facing behavior change).

Validation:

- `go test -count=1 ./internal/plugins/typescript/rules/ban_ts_comment`
- adversarial matcher and suggestion-demand tests repeated 20 times
- `pnpm run check-spell`
- `pnpm run format:check`
- changed-package Go lint with `--new-from-rev=origin/main` (0 issues)
