### PR TITLE
perf: optimize no-misused-new

### DIFF
--- a/internal/plugins/typescript/rules/no_misused_new/no_misused_new.go
+++ b/internal/plugins/typescript/rules/no_misused_new/no_misused_new.go
@@ -3,26 +3,38 @@ package no_misused_new
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-/**
- * check whether the name of the return type of the node is the same as the name of the parent node.
- */
-func check(node *ast.Node) bool {
-	parentName := node.Parent.Name()
-	if parentName == nil {
+// Only identifiers and static computed string names can equal the valid
+// identifiers this rule checks. Keep the hot path on the AST and avoid the
+// generic source-text fallback, which creates a scanner for dynamic names.
+func isMemberNamed(name *ast.Node, expected string) bool {
+	if name == nil {
 		return false
 	}
 
-	nodeType := node.Type()
-	if nodeType != nil && ast.IsTypeReferenceNode(nodeType) {
-		typeName := nodeType.AsTypeReferenceNode().TypeName
-		if ast.IsIdentifier(typeName) {
-			return typeName.Text() == parentName.Text()
-		}
+	switch name.Kind {
+	case ast.KindIdentifier:
+		return name.AsIdentifier().Text == expected
+	case ast.KindComputedPropertyName:
+		expression := name.AsComputedPropertyName().Expression
+		return ast.IsStringLiteralLike(expression) && expression.Text() == expected
 	}
 	return false
+}
+
+func returnsParentType(typeNode *ast.Node, parent *ast.Node) bool {
+	if typeNode == nil || !ast.IsTypeReferenceNode(typeNode) {
+		return false
+	}
+
+	typeName := typeNode.AsTypeReferenceNode().TypeName
+	if !ast.IsIdentifier(typeName) {
+		return false
+	}
+
+	parentName := parent.Name()
+	return parentName != nil && typeName.Text() == parentName.Text()
 }
 
 var NoMisusedNewRule = rule.CreateRule(rule.Rule{
@@ -30,22 +42,22 @@ var NoMisusedNewRule = rule.CreateRule(rule.Rule{
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		return rule.RuleListeners{
 			ast.KindMethodDeclaration: func(node *ast.Node) {
+				method := node.AsMethodDeclaration()
+				// A method with an implementation is valid regardless of its name.
+				if method.Body != nil {
+					return
+				}
+
 				parentKind := node.Parent.Kind
 				if parentKind != ast.KindClassDeclaration && parentKind != ast.KindClassExpression {
 					return
 				}
 
-				nodeNameText, _ := utils.GetNameFromMember(ctx.SourceFile, node.Name())
-				if nodeNameText != "new" {
-					return
-				}
-				// If the function body exists, it's valid for this rule.
-				body := node.Body()
-				if body != nil {
+				if !isMemberNamed(method.Name(), "new") {
 					return
 				}
 
-				if check(node) {
+				if returnsParentType(method.Type, node.Parent) {
 					ctx.ReportNode(node, rule.RuleMessage{
 						Id:          "errorMessageClass",
 						Description: "Class cannot have method named `new`.",
@@ -56,7 +68,8 @@ var NoMisusedNewRule = rule.CreateRule(rule.Rule{
 				if node.Parent.Kind != ast.KindInterfaceDeclaration {
 					return
 				}
-				if check(node) {
+
+				if returnsParentType(node.AsConstructSignatureDeclaration().Type, node.Parent) {
 					ctx.ReportNode(node, rule.RuleMessage{
 						Id:          "errorMessageInterface",
 						Description: "interfaces cannot be constructed, only classes.",
@@ -64,8 +77,7 @@ var NoMisusedNewRule = rule.CreateRule(rule.Rule{
 				}
 			},
 			ast.KindMethodSignature: func(node *ast.Node) {
-				nodeNameText, _ := utils.GetNameFromMember(ctx.SourceFile, node.Name())
-				if nodeNameText == "constructor" {
+				if isMemberNamed(node.AsMethodSignatureDeclaration().Name(), "constructor") {
 					ctx.ReportNode(node, rule.RuleMessage{
 						Id:          "errorMessageInterface",
 						Description: "interfaces cannot be constructed, only classes.",

--- a/internal/plugins/typescript/rules/no_misused_new/no_misused_new_test.go
+++ b/internal/plugins/typescript/rules/no_misused_new/no_misused_new_test.go
@@ -91,6 +91,24 @@ func TestNoMisusedNewRule(t *testing.T) {
 				}
 			`,
 		},
+		{
+			Code: `
+				declare class C {
+				  [methodName](): C;
+				  new(): Namespace.C;
+				  new(): (C);
+				}
+				interface I {
+				  [methodName](): void;
+				}
+				type T = {
+				  [methodName](): void;
+				};
+			`,
+		},
+		{
+			Code: "class C { [`new`](): C {} }",
+		},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `
@@ -225,6 +243,37 @@ func TestNoMisusedNewRule(t *testing.T) {
 				{
 					MessageId: "errorMessageInterface",
 				},
+			},
+		},
+		{
+			Code: "declare class C { [`new`](): C; }",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "errorMessageClass",
+				},
+			},
+		},
+		{
+			Code: `
+				declare class C {
+				  ["\u006e\u0065\u0077"](): C;
+				  new<T>(): C<T>;
+				}
+				const Value = class Inner {
+				  new(): Inner;
+				};
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMessageClass"},
+				{MessageId: "errorMessageClass"},
+				{MessageId: "errorMessageClass"},
+			},
+		},
+		{
+			Code: "interface I { [`constructor`](): void; }\ntype T = { [`constructor`](): void; };",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMessageInterface"},
+				{MessageId: "errorMessageInterface"},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- avoid the generic source-text member-name fallback for `no-misused-new` by matching the relevant AST name forms directly
- skip member-name work for implemented methods, which are always valid for this rule
- preserve diagnostics for computed strings/templates, escaped names, generic self returns, and named class expressions

### Performance

Local temporary benchmark on Apple M1 Max with Go 1.26.1 and `GOMAXPROCS=1`. Each operation reuses parsed ASTs and runs all matching rule listeners; values are medians across repeated samples.

| Corpus | Before | After | Change | Allocations |
| --- | ---: | ---: | ---: | ---: |
| Mixed class/interface/type hot path | 130,064 ns/op | 54,240 ns/op | -58.3% | 600 allocs / 96,000 B → 0 |
| 10,000 dynamic computed names | 822,052 ns/op | 43,889 ns/op | -94.7% | 10,000 allocs / 1,600,000 B → 0 |
| rsbuild (1,568 TS files, 775 listener nodes) | 5,325 ns/op | 4,561 ns/op | -14.3% | 0 → 0 |
| rspack (416 TS files, 1,070 listener nodes) | 8,086 ns/op | 5,270 ns/op | -34.8% | 5 allocs / 800 B → 0 |

The real-repository harness also compared diagnostic ranges, message IDs, and ordering between the old and optimized implementations.

### Validation

- `go test ./internal/plugins/typescript/rules/no_misused_new -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_misused_new/...`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
