### PR TITLE
perf: optimize no-this-alias diagnostics

### DIFF
--- a/internal/plugins/typescript/rules/no_this_alias/no_this_alias.go
+++ b/internal/plugins/typescript/rules/no_this_alias/no_this_alias.go
@@ -2,6 +2,7 @@ package no_this_alias
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
@@ -10,16 +11,28 @@ type NoThisAliasOptions struct {
 	AllowedNames       []string `json:"allowedNames"`
 }
 
+var (
+	thisAssignmentMessage = rule.RuleMessage{
+		Id:          "thisAssignment",
+		Description: "Unexpected aliasing of `this` to local variable.",
+	}
+	thisDestructureMessage = rule.RuleMessage{
+		Id:          "thisDestructure",
+		Description: "Destructuring `this` is not allowed.",
+	}
+)
+
 // aliasTarget returns the ESTree-equivalent VariableDeclarator id or
 // AssignmentExpression left-hand side for a `this` value. ESTree elides
 // parentheses, while the TypeScript AST preserves them.
 func aliasTarget(node *ast.Node) *ast.Node {
 	value := node
-	for value.Parent != nil && value.Parent.Kind == ast.KindParenthesizedExpression {
-		value = value.Parent
+	parent := value.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		value = parent
+		parent = value.Parent
 	}
 
-	parent := value.Parent
 	if parent == nil {
 		return nil
 	}
@@ -27,7 +40,7 @@ func aliasTarget(node *ast.Node) *ast.Node {
 	switch parent.Kind {
 	case ast.KindVariableDeclaration:
 		declaration := parent.AsVariableDeclaration()
-		if declaration != nil && declaration.Initializer == value {
+		if declaration.Initializer == value {
 			return declaration.Name()
 		}
 	case ast.KindBinaryExpression:
@@ -35,7 +48,7 @@ func aliasTarget(node *ast.Node) *ast.Node {
 			return nil
 		}
 		expression := parent.AsBinaryExpression()
-		if expression != nil && expression.Right == value {
+		if expression.Right == value {
 			return ast.SkipParentheses(expression.Left)
 		}
 	}
@@ -43,72 +56,91 @@ func aliasTarget(node *ast.Node) *ast.Node {
 	return nil
 }
 
+func parseOptions(options []any) NoThisAliasOptions {
+	opts := NoThisAliasOptions{AllowDestructuring: true}
+	if len(options) == 0 {
+		return opts
+	}
+
+	// A real config supplies context.options directly. Retain the old nested
+	// array compatibility for direct callers that still pass [[{...}]].
+	option := options[0]
+	if nested, ok := option.([]interface{}); ok {
+		if len(nested) == 0 {
+			return opts
+		}
+		option = nested[0]
+	}
+
+	optsMap, ok := option.(map[string]interface{})
+	if !ok {
+		return opts
+	}
+	if allowDestructuring, ok := optsMap["allowDestructuring"].(bool); ok {
+		opts.AllowDestructuring = allowDestructuring
+	}
+	if allowedNames, ok := optsMap["allowedNames"].([]interface{}); ok {
+		opts.AllowedNames = make([]string, 0, len(allowedNames))
+		for _, name := range allowedNames {
+			if name, ok := name.(string); ok {
+				opts.AllowedNames = append(opts.AllowedNames, name)
+			}
+		}
+	}
+	return opts
+}
+
+func reportTarget(ctx *rule.RuleContext, target *ast.Node, message rule.RuleMessage) {
+	ctx.ReportRange(
+		target.Loc.WithPos(scanner.SkipTrivia(ctx.SourceFile.Text(), target.Pos())),
+		message,
+	)
+}
+
+func defaultThisListener(ctx *rule.RuleContext) func(node *ast.Node) {
+	return func(node *ast.Node) {
+		target := aliasTarget(node)
+		if target == nil || target.Kind != ast.KindIdentifier {
+			return
+		}
+		reportTarget(ctx, target, thisAssignmentMessage)
+	}
+}
+
+func configuredThisListener(ctx *rule.RuleContext, opts NoThisAliasOptions) func(node *ast.Node) {
+	return func(node *ast.Node) {
+		target := aliasTarget(node)
+		if target == nil {
+			return
+		}
+
+		if target.Kind == ast.KindIdentifier {
+			name := target.AsIdentifier().Text
+			for _, allowedName := range opts.AllowedNames {
+				if name == allowedName {
+					return
+				}
+			}
+			reportTarget(ctx, target, thisAssignmentMessage)
+			return
+		}
+
+		if !opts.AllowDestructuring {
+			reportTarget(ctx, target, thisDestructureMessage)
+		}
+	}
+}
+
 var NoThisAliasRule = rule.CreateRule(rule.Rule{
 	Name: "no-this-alias",
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		options := rule.LegacyUnwrapOptions(_options)
-		opts := NoThisAliasOptions{
-			AllowDestructuring: true,
-			AllowedNames:       []string{},
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		if len(options) == 0 {
+			return rule.RuleListeners{ast.KindThisKeyword: defaultThisListener(&ctx)}
 		}
-
-		// Parse options with dual-format support
-		if options != nil {
-			var optsMap map[string]interface{}
-			var ok bool
-
-			// Handle array format: [{ option: value }]
-			if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-				optsMap, ok = optArray[0].(map[string]interface{})
-			} else {
-				// Handle direct object format: { option: value }
-				optsMap, ok = options.(map[string]interface{})
-			}
-
-			if ok {
-				if allowDestructuring, ok := optsMap["allowDestructuring"].(bool); ok {
-					opts.AllowDestructuring = allowDestructuring
-				}
-				if allowedNames, ok := optsMap["allowedNames"].([]interface{}); ok {
-					for _, name := range allowedNames {
-						if nameStr, ok := name.(string); ok {
-							opts.AllowedNames = append(opts.AllowedNames, nameStr)
-						}
-					}
-				}
-			}
+		opts := parseOptions(options)
+		if opts.AllowDestructuring && len(opts.AllowedNames) == 0 {
+			return rule.RuleListeners{ast.KindThisKeyword: defaultThisListener(&ctx)}
 		}
-
-		return rule.RuleListeners{
-			ast.KindThisKeyword: func(node *ast.Node) {
-				target := aliasTarget(node)
-				if target == nil {
-					return
-				}
-
-				if opts.AllowDestructuring && target.Kind != ast.KindIdentifier {
-					return
-				}
-
-				if target.Kind == ast.KindIdentifier {
-					name := target.AsIdentifier().Text
-					for _, allowedName := range opts.AllowedNames {
-						if name == allowedName {
-							return
-						}
-					}
-					ctx.ReportNode(target, rule.RuleMessage{
-						Id:          "thisAssignment",
-						Description: "Unexpected aliasing of `this` to local variable.",
-					})
-					return
-				}
-
-				ctx.ReportNode(target, rule.RuleMessage{
-					Id:          "thisDestructure",
-					Description: "Destructuring `this` is not allowed.",
-				})
-			},
-		}
+		return rule.RuleListeners{ast.KindThisKeyword: configuredThisListener(&ctx, opts)}
 	},
 })

--- a/internal/plugins/typescript/rules/no_this_alias/no_this_alias_test.go
+++ b/internal/plugins/typescript/rules/no_this_alias/no_this_alias_test.go
@@ -32,6 +32,11 @@ func TestNoThisAliasRule(t *testing.T) {
 			{Code: `const [foo] = this;`},
 			{Code: `const [foo, bar] = this;`},
 			{Code: `const self = this;`, Options: map[string]interface{}{"allowedNames": []interface{}{"self"}}},
+			{Code: `const \u0073elf = this;`, Options: map[string]interface{}{"allowedNames": []interface{}{"self"}}},
+			{
+				Code:    `const nested = this;`,
+				Options: []interface{}{[]interface{}{map[string]interface{}{"allowedNames": []interface{}{"nested"}}}},
+			},
 			{Code: `let self = 1; self ||= this;`, Options: map[string]interface{}{"allowedNames": []interface{}{"self"}}},
 			{Code: `setTimeout(() => { this.doWork(); });`},
 		},
@@ -47,6 +52,18 @@ func TestNoThisAliasRule(t *testing.T) {
 				Code: `const self = (((this)));`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "thisAssignment", Line: 1, Column: 7, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
+				Code: `const /* leading */ self = this;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisAssignment", Line: 1, Column: 21, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code: `const \u0074hat = this;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "thisAssignment", Line: 1, Column: 7, EndLine: 1, EndColumn: 16},
 				},
 			},
 			{


### PR DESCRIPTION
## Summary

- Optimize `@typescript-eslint/no-this-alias` at the rule layer by specializing the default-options listener, caching static messages, and computing the diagnostic start without constructing a full token scanner.
- Preserve the existing option formats and exact diagnostic ranges, including leading trivia and escaped identifiers.
- Keep the `ThisKeyword` listener: `ctx.Refs` indexes identifier references rather than `this`, and deferred reporting only helps rules that lazily build fixes or suggestions.

### Benchmark

Same-process comparison against the `main` implementation using a temporary benchmark with 256 generated cases per workload. Values are medians from 10 runs; the benchmark file is not included in this PR.

```sh
go test ./internal/plugins/typescript/rules/no_this_alias -run '^$' -bench '^BenchmarkNoThisAlias' -benchmem -benchtime=500ms -count=10
```

| Workload | Before | After | Time | Before B/op | After B/op | Before allocs/op | After allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Rule setup only | 182.6 ns/op | 172.1 ns/op | -5.7% | 384 | 352 | 4 | 4 |
| Non-alias `this` uses | 1,550 ns/op | 1,529 ns/op | -1.4% | 384 | 352 | 4 | 4 |
| Alias assignments | 27,363 ns/op | 6,638 ns/op | -75.7% | 41,344 | 352 | 260 | 4 |
| Destructuring reports | 18,744 ns/op | 5,664 ns/op | -69.8% | 41,344 | 384 | 260 | 4 |

### Verification

- `go test ./internal/plugins/typescript/rules/no_this_alias -run '^TestNoThisAliasRule$' -count=1`
- Temporary adversarial differential test against the previous implementation, covering assignment operators, parentheses, destructuring, escaped identifiers, trivia, option formats, and disable directives
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=HEAD ./internal/plugins/typescript/rules/no_this_alias/...`

## Related Links

- [typescript-eslint no-this-alias](https://typescript-eslint.io/rules/no-this-alias/)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
