### PR TITLE
perf: optimize default-param-last rule

### DIFF
--- a/internal/plugins/typescript/rules/default_param_last/default_param_last.go
+++ b/internal/plugins/typescript/rules/default_param_last/default_param_last.go
@@ -11,110 +11,18 @@ var DefaultParamLastRule = rule.CreateRule(rule.Rule{
 	Run:  run,
 })
 
+var shouldBeLastMessage = rule.RuleMessage{
+	Id:          "shouldBeLast",
+	Description: "Default parameters should be last.",
+}
+
 func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
-	// Helper function to check if a parameter is optional
-	isOptionalParam := func(node *ast.Node) bool {
-		if node == nil {
-			return false
-		}
-
-		// Check if parameter has optional modifier
-		if node.Kind == ast.KindParameter {
-			param := node.AsParameterDeclaration()
-			if param != nil && param.QuestionToken != nil {
-				return true
-			}
-		}
-
-		return false
-	}
-
-	// Helper function to check if a parameter is a rest parameter
-	isRestParam := func(node *ast.Node) bool {
-		if node == nil {
-			return false
-		}
-
-		// Check for rest parameter (...)
-		if node.Kind == ast.KindParameter {
-			param := node.AsParameterDeclaration()
-			if param != nil && param.DotDotDotToken != nil {
-				return true
-			}
-		}
-
-		return false
-	}
-
-	// Helper function to check if a parameter is plain (no default, not rest, not optional)
-	isPlainParam := func(node *ast.Node) bool {
-		if node == nil {
-			return false
-		}
-
-		// Rest parameter is not plain
-		if isRestParam(node) {
-			return false
-		}
-
-		// Parameter with default value is not plain
-		if node.Kind == ast.KindParameter {
-			param := node.AsParameterDeclaration()
-			if param != nil {
-				// Has initializer (default value)
-				if param.Initializer != nil {
-					return false
-				}
-				// Is optional
-				if param.QuestionToken != nil {
-					return false
-				}
-			}
-		}
-
-		return true
-	}
-
-	// Check function for default parameter positioning
 	checkDefaultParamLast := func(node *ast.Node) {
-		var params []*ast.Node
-
-		// Get parameters based on node type
-		switch node.Kind {
-		case ast.KindFunctionDeclaration:
-			funcDecl := node.AsFunctionDeclaration()
-			if funcDecl != nil && funcDecl.Parameters != nil {
-				params = funcDecl.Parameters.Nodes
-			}
-		case ast.KindFunctionExpression:
-			funcExpr := node.AsFunctionExpression()
-			if funcExpr != nil && funcExpr.Parameters != nil {
-				params = funcExpr.Parameters.Nodes
-			}
-		case ast.KindArrowFunction:
-			arrowFunc := node.AsArrowFunction()
-			if arrowFunc != nil && arrowFunc.Parameters != nil {
-				params = arrowFunc.Parameters.Nodes
-			}
-		case ast.KindMethodDeclaration:
-			methodDecl := node.AsMethodDeclaration()
-			if methodDecl != nil && methodDecl.Parameters != nil {
-				params = methodDecl.Parameters.Nodes
-			}
-		case ast.KindConstructor:
-			constructor := node.AsConstructorDeclaration()
-			if constructor != nil && constructor.Parameters != nil {
-				params = constructor.Parameters.Nodes
-			}
-		default:
+		params := node.Parameters()
+		if len(params) < 2 {
 			return
 		}
 
-		if len(params) == 0 {
-			return
-		}
-
-		// Iterate backward through parameters
 		hasSeenPlainParam := false
 		for i := len(params) - 1; i >= 0; i-- {
 			current := params[i]
@@ -122,45 +30,16 @@ func run(ctx rule.RuleContext, options []any) rule.RuleListeners {
 				continue
 			}
 
-			// Get the actual parameter (unwrap if it's a parameter property)
-			param := current
-			if current.Kind == ast.KindParameter {
-				p := current.AsParameterDeclaration()
-				if p != nil && p.Name() != nil {
-					// Check if parameter has modifiers (public/private/protected/readonly)
-					// which would make it a parameter property
-					hasModifiers := ast.GetCombinedModifierFlags(current)&(ast.ModifierFlagsPublic|ast.ModifierFlagsPrivate|ast.ModifierFlagsProtected|ast.ModifierFlagsReadonly) != 0
-					if hasModifiers {
-						// For parameter properties, check the parameter itself
-						param = current
-					}
-				}
-			}
-
-			// Skip rest parameters - they can come after defaults
-			if isRestParam(param) {
+			param := current.AsParameterDeclaration()
+			if param.DotDotDotToken != nil {
 				continue
 			}
-
-			if isPlainParam(param) {
+			if param.Initializer == nil && param.QuestionToken == nil {
 				hasSeenPlainParam = true
 				continue
 			}
-
-			// Check if this is a default or optional parameter that comes before a plain parameter
 			if hasSeenPlainParam {
-				if param.Kind == ast.KindParameter {
-					paramDecl := param.AsParameterDeclaration()
-					isDefaultParam := paramDecl != nil && paramDecl.Initializer != nil
-					isOptional := isOptionalParam(param)
-
-					if isDefaultParam || isOptional {
-						ctx.ReportNode(current, rule.RuleMessage{
-							Id:          "shouldBeLast",
-							Description: "Default parameters should be last.",
-						})
-					}
-				}
+				ctx.ReportNode(current, shouldBeLastMessage)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Simplify the default-param-last hot path to inspect each parameter declaration once.
- Remove redundant parameter-property modifier checks and helper closures while preserving the existing five listener kinds and diagnostics.
- Return immediately for zero- and one-parameter functions and reuse the static diagnostic message.
- ctx.Refs is intentionally not used because this rule only needs parameter syntax. Deferred reporting is not applicable because the rule has no fixes or suggestions to materialize.

### Performance

Command: go test ./internal/plugins/typescript/rules/default_param_last -run ^$ -bench ^BenchmarkDefaultParamLast -benchmem -benchtime=500ms -count=10

Apple M1 Max, Go 1.26.1. Values are medians of 10 samples from a temporary same-process legacy versus optimized benchmark; the benchmark file is not included in this PR. Listener cases scan 1,280 function-like nodes per operation, and the mixed case emits 2,560 diagnostics per operation.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Rule listener setup | 224.6 ns/op, 400 B/op, 5 allocs/op | 197.8 ns/op, 352 B/op, 4 allocs/op | -11.9% time, -12.0% bytes, -20.0% allocs |
| Valid parameter lists | 53.34 µs/op, 0 allocs/op | 19.54 µs/op, 0 allocs/op | -63.4% time |
| Mixed lists with diagnostics | 248.19 µs/op | 199.21 µs/op | -19.7% time |

### Validation

- Targeted Go rule tests pass.
- Temporary differential attack coverage compared legacy and optimized diagnostic ranges/messages across required, default, optional, rest, destructured, parameter-property, declaration, accessor, and malformed parameter combinations with no differences.
- check-spell passes with 2,549 files checked and 0 issues.
- format:check passes.
- Go lint passes with 0 issues, scoped to the changed default_param_last package and new lines from origin/main.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).