### PR TITLE
perf: port no-undef to ctx.Refs.Resolve, drop RequiresTypeInfo

### DIFF
--- a/internal/plugins/typescript/rules/no_redeclare/no_redeclare_test.go
+++ b/internal/plugins/typescript/rules/no_redeclare/no_redeclare_test.go
@@ -501,6 +501,13 @@ func TestNoRedeclareRule(t *testing.T) {
 					{MessageId: "redeclaredAsBuiltin", Line: 1, Column: 5},
 				},
 			},
+			// eval is in the shared ECMAScript built-in table.
+			{
+				Code: "var eval = 0;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redeclaredAsBuiltin", Line: 1, Column: 5},
+				},
+			},
 			// `Promise` lives in lib.es2015.promise — covered by TS lib detection.
 			{
 				Code: "var Promise = 0;",

--- a/internal/rules/no_global_assign/no_global_assign_test.go
+++ b/internal/rules/no_global_assign/no_global_assign_test.go
@@ -260,6 +260,14 @@ func TestNoGlobalAssignRule(t *testing.T) {
 				},
 			},
 
+			// eval is a read-only ECMAScript built-in
+			{
+				Code: `eval = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "globalShouldNotBeModified", Line: 1, Column: 1},
+				},
+			},
+
 			// Postfix increment on builtin
 			{
 				Code: `String++;`,

--- a/internal/rules/no_redeclare/no_redeclare_extras_test.go
+++ b/internal/rules/no_redeclare/no_redeclare_extras_test.go
@@ -333,6 +333,8 @@ func TestNoRedeclareExtras(t *testing.T) {
 
 			// Locks in upstream findVariablesInScope() detail arm: builtin declaration is first, so user syntax reports builtin-specific message.
 			invalidBuiltin("var Array = 0;", "Array", 1, 5),
+			// eval is in the shared ECMAScript built-in table.
+			invalidBuiltin("var eval = 0;", "eval", 1, 5),
 			// An omitted property in an explicitly supplied empty option object
 			// retains upstream's builtinGlobals: true default.
 			{

--- a/internal/rules/no_undef/no_undef.go
+++ b/internal/rules/no_undef/no_undef.go
@@ -9,6 +9,13 @@ import (
 )
 
 // https://eslint.org/docs/latest/rules/no-undef
+//
+// ctx.Refs.Resolve() walks the binder's lexical scope chain first — the same
+// model ESLint's own no-undef uses, and enough on its own, which is what
+// makes this rule useful on plain JS and other files no type checker runs
+// on. When a TypeChecker is available for the file, Resolve() falls back to
+// it for anything the scope walk can't place, so this rule also recognizes
+// DOM/Node globals and other names known only to the type checker there.
 
 type options struct {
 	checkTypeof bool
@@ -26,16 +33,12 @@ func parseOptions(opts any) options {
 }
 
 var NoUndefRule = rule.Rule{
-	Name:             "no-undef",
-	RequiresTypeInfo: true,
+	Name: "no-undef",
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
 		opts := parseOptions(options)
 
-		// Defense-in-depth: RequiresTypeInfo: true filters this rule out for
-		// gap files / inferred-project files, but if a future caller bypasses
-		// the filter we still want to no-op rather than nil-deref.
-		if ctx.TypeChecker == nil {
+		if ctx.Refs == nil {
 			return rule.RuleListeners{}
 		}
 
@@ -46,26 +49,21 @@ var NoUndefRule = rule.Rule{
 					return
 				}
 
-				// For ShorthandPropertyAssignment ({x}), GetSymbolAtLocation
-				// returns the property symbol which always exists. Use
-				// GetShorthandAssignmentValueSymbol to check the value reference.
-				if node.Parent.Kind == ast.KindShorthandPropertyAssignment {
-					valueSym := ctx.TypeChecker.GetShorthandAssignmentValueSymbol(node.Parent)
-					if valueSym != nil {
-						return
-					}
-				} else {
-					sym := ctx.TypeChecker.GetSymbolAtLocation(node)
-					if sym != nil {
-						return
-					}
+				if ctx.Refs.Resolve(node) != nil {
+					return
 				}
 
 				name := node.Text()
 
-				// Skip identifiers declared via languageOptions.globals or
-				// /* global */ comments (merged into ctx.Globals by the linter).
-				if ctx.Globals[name] {
+				// languageOptions.globals / /* global */ comments (merged into
+				// ctx.Globals) take priority over built-ins: an explicit "off"
+				// entry (present but false) still reports even for a name that
+				// would otherwise be a recognized ECMAScript global.
+				if configured, ok := ctx.Globals[name]; ok {
+					if configured {
+						return
+					}
+				} else if utils.IsECMAScriptGlobal(name) {
 					return
 				}
 
@@ -155,6 +153,35 @@ func shouldSkip(node *ast.Node, checkTypeof bool) bool {
 	// Skip enum member names
 	if parent.Kind == ast.KindEnumMember && parent.Name() == node {
 		return true
+	}
+
+	// Skip meta-property names (`target` in `new.target`, `meta` in
+	// `import.meta`, `defer` in `import.defer`) — syntactic, not identifiers
+	// that reference a variable.
+	if parent.Kind == ast.KindMetaProperty {
+		return true
+	}
+
+	// Skip import attribute keys (`type` in `with { type: "json" }`) —
+	// syntactic names, not references to same-named variables.
+	if parent.Kind == ast.KindImportAttribute && parent.AsImportAttribute().Name() == node {
+		return true
+	}
+
+	// Skip the namespace/name parts of a namespaced JSX tag or attribute
+	// (`<foo:bar attr:name="v" />`) — syntactic, never variable references.
+	if parent.Kind == ast.KindJsxNamespacedName {
+		return true
+	}
+
+	// Skip lowercase JSX tag names (`<div>`): these are JSX intrinsics, not
+	// identifier references. Uppercase tag names (`<Foo>`) reference a
+	// component value and are checked normally.
+	if ast.IsJsxTagName(node) {
+		text := node.Text()
+		if len(text) == 0 || (text[0] >= 'a' && text[0] <= 'z') {
+			return true
+		}
 	}
 
 	return false

--- a/internal/rules/no_undef/no_undef.go
+++ b/internal/rules/no_undef/no_undef.go
@@ -49,22 +49,32 @@ var NoUndefRule = rule.Rule{
 					return
 				}
 
-				if ctx.Refs.Resolve(node) != nil {
-					return
-				}
-
 				name := node.Text()
 
 				// languageOptions.globals / /* global */ comments (merged into
-				// ctx.Globals) take priority over built-ins: an explicit "off"
-				// entry (present but false) still reports even for a name that
-				// would otherwise be a recognized ECMAScript global.
+				// ctx.Globals) take priority over built-ins and over the
+				// checker's lib knowledge; both map lookups come before the
+				// resolver so references to declared or built-in globals never
+				// pay for a failing scope walk plus a checker round trip.
 				if configured, ok := ctx.Globals[name]; ok {
 					if configured {
 						return
 					}
-				} else if utils.IsECMAScriptGlobal(name) {
-					return
+					// An explicit "off" entry un-declares the global: only a
+					// binding this file itself declares can still satisfy the
+					// reference. A symbol the checker fallback found in lib or
+					// ambient declarations elsewhere is the very global that
+					// was switched off, so it still reports.
+					if sym := ctx.Refs.Resolve(node); utils.IsSymbolDeclaredInFile(sym, ctx.SourceFile) {
+						return
+					}
+				} else {
+					if utils.IsECMAScriptGlobal(name) {
+						return
+					}
+					if ctx.Refs.Resolve(node) != nil {
+						return
+					}
 				}
 
 				ctx.ReportNode(node, rule.RuleMessage{
@@ -87,10 +97,15 @@ func shouldSkip(node *ast.Node, checkTypeof bool) bool {
 	parent := node.Parent
 
 	// Skip declaration names (var x, function x, class x, import x, etc.)
-	// Exception: ShorthandPropertyAssignment names ({x}) are declaration names
-	// but also value references, so they must NOT be skipped.
+	// Exceptions: ShorthandPropertyAssignment names ({x}) and the name of a
+	// non-aliased local export (export { x }) are declaration names but also
+	// value references, so they must NOT be skipped. Re-exports
+	// (export { x } from 'mod') reference the other module's binding instead,
+	// and the alias label of export { x as y } is only a label.
 	if ast.IsDeclarationName(node) && parent.Kind != ast.KindShorthandPropertyAssignment {
-		return true
+		if parent.Kind != ast.KindExportSpecifier || parent.PropertyName() != nil || utils.IsReExportSpecifier(parent) {
+			return true
+		}
 	}
 
 	// Skip property names in member access (obj.prop -> skip "prop")

--- a/internal/rules/no_undef/no_undef.md
+++ b/internal/rules/no_undef/no_undef.md
@@ -4,6 +4,10 @@ Disallow the use of undeclared variables.
 
 This rule reports identifiers that reference variables which have not been declared via `var`, `let`, `const`, `function`, `class`, `import`, or as a parameter.
 
+Resolution is lexical scope analysis: declared bindings, standard ECMAScript built-ins (`Array`, `Promise`, `JSON`, `undefined`, and similar), and anything declared through `languageOptions.globals` or a `/* global */` comment. On a file with type information available, names known only to the type checker — DOM/Node globals such as `console` or `window`, or anything declared in a `.d.ts` file — are recognized too.
+
+Enable this rule for files that aren't type-checked. On a type-checked file, `tsc` already reports references to undeclared names.
+
 ## Options
 
 ### `typeof`

--- a/internal/rules/no_undef/no_undef.md
+++ b/internal/rules/no_undef/no_undef.md
@@ -6,7 +6,7 @@ This rule reports identifiers that reference variables which have not been decla
 
 Resolution is lexical scope analysis: declared bindings, standard ECMAScript built-ins (`Array`, `Promise`, `JSON`, `undefined`, and similar), and anything declared through `languageOptions.globals` or a `/* global */` comment. On a file with type information available, names known only to the type checker — DOM/Node globals such as `console` or `window`, or anything declared in a `.d.ts` file — are recognized too.
 
-Enable this rule for files that aren't type-checked. On a type-checked file, `tsc` already reports references to undeclared names.
+Enable this rule for files that aren't type-checked. On a type-checked file, `tsc` already reports references to undeclared names. On files without type information, declare the host globals your code relies on (`console`, `process`, `setTimeout`, and similar) through `languageOptions.globals` or a `/* global */` comment, the same way ESLint's own `no-undef` expects.
 
 ## Options
 

--- a/internal/rules/no_undef/no_undef_nil_tc_test.go
+++ b/internal/rules/no_undef/no_undef_nil_tc_test.go
@@ -1,0 +1,81 @@
+package no_undef
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// TestNoUndefRuleNilTypeChecker pins the rule's behavior on files linted
+// without a TypeChecker (gap files outside every tsconfig): the binder scope
+// walk, ctx.Globals, and the ECMAScript built-in table are then the only
+// sources of defined names, matching ESLint's default of recognizing
+// ECMAScript built-ins but not host globals unless configured.
+func TestNoUndefRuleNilTypeChecker(t *testing.T) {
+	t.Parallel()
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir, "no-undef-nil-tc.ts")
+	code := `var declaredLocal = 1; declaredLocal;
+console.log(1);
+Promise.resolve();
+var buf = new Float16Array(8);
+myConfiguredGlobal;
+myOffGlobal;
+var myOffLocal = 1; myOffLocal;
+undeclaredName123;
+`
+	fs := utils.NewOverlayVFSForFile(filePath, code)
+	program, err := utils.CreateProgram(
+		true, fs, rootDir, "tsconfig.json", utils.CreateCompilerHost(rootDir, fs),
+	)
+	if err != nil {
+		t.Fatalf("CreateProgram: %v", err)
+	}
+	sourceFile := program.GetSourceFile(filePath)
+	if sourceFile == nil {
+		t.Fatalf("source file not found for %s", filePath)
+		return
+	}
+
+	var reported []string
+	ctx := (rule.RuleContext{
+		SourceFile:  sourceFile,
+		Program:     program,
+		TypeChecker: nil, // explicitly nil — this is the path under test
+		Refs:        rule.NewRefStore(sourceFile, program.Options(), nil),
+		Globals: map[string]bool{
+			"myConfiguredGlobal": true,
+			"myOffGlobal":        false,
+			"myOffLocal":         false,
+		},
+	}).WithReporter("test/no-undef", rule.SeverityError, func(d rule.RuleDiagnostic) {
+		reported = append(reported, d.Message.Description)
+	})
+
+	listeners := NoUndefRule.Run(ctx, nil)
+
+	var walk func(n *ast.Node) bool
+	walk = func(n *ast.Node) bool {
+		if cb, ok := listeners[n.Kind]; ok {
+			cb(n)
+		}
+		n.ForEachChild(walk)
+		return false
+	}
+	walk(sourceFile.AsNode())
+
+	want := []string{
+		"'console' is not defined.",
+		"'myOffGlobal' is not defined.",
+		"'undeclaredName123' is not defined.",
+	}
+	if fmt.Sprint(reported) != fmt.Sprint(want) {
+		t.Fatalf("reported = %v, want %v", reported, want)
+	}
+}

--- a/internal/rules/no_undef/no_undef_test.go
+++ b/internal/rules/no_undef/no_undef_test.go
@@ -108,6 +108,19 @@ func TestNoUndefRule(t *testing.T) {
 			// === languageOptions.globals (config) ===
 			{Code: `myConfiguredGlobal;`, Globals: map[string]bool{"myConfiguredGlobal": true}},
 
+			// === "off" global with a same-file declaration: the binding wins ===
+			{Code: `var myOffGlobal123 = 1; myOffGlobal123;`, Globals: map[string]bool{"myOffGlobal123": false}},
+
+			// === ES2025 built-in ===
+			{Code: `var buf = new Float16Array(8);`},
+
+			// === JSX: intrinsic (lowercase) tags are not identifier references ===
+			{Code: `function C() { return <div />; }`, Tsx: true},
+			{Code: `const el = <foo-bar />;`, Tsx: true},
+
+			// === JSX: uppercase tags reference a declared component ===
+			{Code: `function Foo() { return null; } const el = <Foo />;`, Tsx: true},
+
 			// === languageOptions.globals + /*global*/ comment together ===
 			{Code: `/*global fromComment*/ fromConfig; fromComment;`, Globals: map[string]bool{"fromConfig": true}},
 
@@ -208,6 +221,7 @@ func TestNoUndefRule(t *testing.T) {
 			// === Export declared ===
 			{Code: `var exportedVar = 1; export { exportedVar };`},
 			{Code: `var localVar = 2; export { localVar as renamedExport };`},
+			{Code: `type ExportedType = string; export type { ExportedType };`},
 
 			// === delete on declared ===
 			{Code: `var obj = { prop: 1 } as any; delete obj.prop;`},
@@ -347,6 +361,49 @@ func TestNoUndefRule(t *testing.T) {
 				Code: `/*global myOffComment123:off*/ myOffComment123;`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "undef", Line: 1, Column: 32},
+				},
+			},
+
+			// === "off" un-declares a global the checker knows from lib ===
+			{
+				Code: `/*global console:off*/ console.log(1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code:    `setTimeout(() => {}, 100);`,
+				Globals: map[string]bool{"setTimeout": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 1},
+				},
+			},
+
+			// === JSX: undeclared uppercase tag reports on opening and closing
+			// tags alike (typescript-eslint parity) ===
+			{
+				Code: `const el = <UndeclaredComp123 />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: `const el = <UndeclaredComp456></UndeclaredComp456>;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 13},
+					{MessageId: "undef", Line: 1, Column: 33},
+				},
+			},
+
+			// === JSX: hyphenated uppercase tag is still a component reference
+			// (typescript-eslint parity) ===
+			{
+				Code: `const el = <Foo-bar />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 13},
 				},
 			},
 
@@ -909,6 +966,21 @@ func TestNoUndefRule(t *testing.T) {
 				Code: `export { undefLocalExport123 as aliased };`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "undef", Line: 1, Column: 10},
+				},
+			},
+
+			// === Non-aliased local export of an undeclared name reads the
+			// local binding (typescript-eslint parity) ===
+			{
+				Code: `export { undefPlainExport123 };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code: `export type { UndefTypeExport123 };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 15},
 				},
 			},
 

--- a/internal/utils/ecmascript_globals.go
+++ b/internal/utils/ecmascript_globals.go
@@ -22,6 +22,7 @@ var ecmaScriptGlobals = map[string]bool{
 	"encodeURIComponent":   true,
 	"Error":                true,
 	"escape":               true,
+	"eval":                 true,
 	"EvalError":            true,
 	"FinalizationRegistry": true,
 	"Float32Array":         true,

--- a/internal/utils/ecmascript_globals.go
+++ b/internal/utils/ecmascript_globals.go
@@ -25,6 +25,7 @@ var ecmaScriptGlobals = map[string]bool{
 	"eval":                 true,
 	"EvalError":            true,
 	"FinalizationRegistry": true,
+	"Float16Array":         true,
 	"Float32Array":         true,
 	"Float64Array":         true,
 	"Function":             true,

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -95,9 +95,10 @@ func GetReferenceSymbol(node *ast.Node, typeChecker *checker.Checker) *ast.Symbo
 	if parent != nil && parent.Kind == ast.KindShorthandPropertyAssignment {
 		shorthand := parent.AsShorthandPropertyAssignment()
 		if shorthand != nil && shorthand.Name() == node {
-			if symbol := typeChecker.GetShorthandAssignmentValueSymbol(parent); symbol != nil {
-				return symbol
-			}
+			// GetSymbolAtLocation on a shorthand name always returns the
+			// property symbol, even when the value binding ({x} referencing
+			// an undeclared x) doesn't exist, so it cannot substitute here.
+			return typeChecker.GetShorthandAssignmentValueSymbol(parent)
 		}
 	}
 	if parent != nil && parent.Kind == ast.KindExportSpecifier &&


### PR DESCRIPTION
## Summary

- `no-undef` now resolves identifiers through `ctx.Refs.Resolve` (a binder scope walk, falling back to the file's TypeChecker only when one is available) instead of requiring a TypeChecker unconditionally. This matches ESLint's own scope-based `no-undef`, and makes the rule usable on files with no type info at all (plain JS, gap files, LSP inferred-project files).
- Recognized "free" globals are now the real ECMAScript built-ins list (`utils.IsECMAScriptGlobal`) rather than whatever happens to be visible through `lib.d.ts`; `languageOptions.globals` / `/* global */` comments take priority, so an explicit `"off"` entry still reports even for a builtin name.
- `shouldSkip` gained explicit handling for `new.target`/`import.meta`, import attributes (`with { type: "json" }`), and JSX (lowercase intrinsics vs. component references) — cases the removed TypeChecker call handled incidentally and would otherwise have silently mishandled.
- Fixes a real bug in `utils.GetReferenceSymbol` found while building this: for shorthand properties (`{x}`), when `GetShorthandAssignmentValueSymbol` returned nil (undeclared `x`), it fell through to `GetSymbolAtLocation`, which always returns the property symbol, masking the undefined reference. This function is shared by 13 other rules.
- Adds `eval` to the ECMAScript globals list (it was missing; verified against real ESLint that `eval(...)` without config is not flagged).

Drops `RequiresTypeInfo` from `no-undef`.

## Benchmark

Synthetic corpus: 2000 `.ts` files (~8 MiB), each with 20 locally-declared `var`s read 200 times inside a function body, plus a fixed handful of checker-only globals (`console`, `window`, `document`) per file — weighted toward the case this change targets: identifiers resolvable from the binder alone, which the old implementation still paid a `TypeChecker.GetSymbolAtLocation` call for on every single one.

Per-rule time from `--timing all` (summed across workers), 10 runs after a warmup:

| | mean | median |
| --- | --- | --- |
| `main` | 69.5 ms | 69.3 ms |
| this PR | 48.9 ms | 48.7 ms |

Rule time: **-29.6%** (mean), **-29.7%** (median).

End-to-end wall clock on the same corpus (hyperfine, 12 runs + 2 warmup): 369.0 ms ± 18.6 → 358.0 ms ± 17.0, **-3.0%**; smaller than the rule-time delta because this is a type-aware corpus where parse/bind/typecheck dominate total time.

Both binaries produced 0 diagnostics on this corpus (all identifiers resolve), confirming no false positives from the refactor on the exercised patterns. This PR is a behavior change as well as a perf one (drops `RequiresTypeInfo`, fixes the shorthand-property bug, changes which globals are free), so unlike a pure refactor this isn't a byte-identical-diagnostics claim across all inputs — see the Go test suite for the specific behavior changes.

## Validation

- `go test ./internal/rules/no_undef/...`
- `go test` on all 13 other callers of `utils.GetReferenceSymbol` (no regressions from the shorthand-property fix): `no_ex_assign`, `prefer_arrow_callback`, `no_param_reassign`, `no_implied_eval`, `no_import_assign`, `no_loop_func`, `react_hooks/rules/exhaustive_deps`, `react_hooks/rules/rules_of_hooks`, `unicorn/rules/new_for_builtins`, `typescript/rules/no_unused_vars`, `typescript/rules/no_unused_private_class_members`, `react/rules/no_access_state_in_setstate`, `react/rules/jsx_fragments`
- `go test ./internal/utils/...`, `go test ./internal/rule/...`
- `pnpx cspell lint` and `golangci-lint run --new-from-rev=origin/main` on changed files

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).