### PR TITLE
perf: optimize no-useless-escape

### DIFF
--- a/internal/rules/no_useless_escape/no_useless_escape.go
+++ b/internal/rules/no_useless_escape/no_useless_escape.go
@@ -7,7 +7,6 @@
 package no_useless_escape
 
 import (
-	"fmt"
 	"strings"
 	"unicode/utf8"
 
@@ -64,34 +63,28 @@ var NoUselessEscapeRule = rule.Rule{
 }
 
 func parseAllowRegexCharacters(options any) map[string]bool {
-	out := map[string]bool{}
 	optsMap := utils.GetOptionsMap(options)
 	if optsMap == nil {
-		return out
+		return nil
 	}
 	raw, ok := optsMap["allowRegexCharacters"]
 	if !ok {
-		return out
+		return nil
 	}
 	arr, ok := raw.([]interface{})
 	if !ok {
-		return out
+		return nil
 	}
+	var out map[string]bool
 	for _, v := range arr {
 		if s, ok := v.(string); ok {
+			if out == nil {
+				out = make(map[string]bool, len(arr))
+			}
 			out[s] = true
 		}
 	}
 	return out
-}
-
-// validStringEscape mirrors ESLint's VALID_STRING_ESCAPES — the escape
-// characters that produce a different value from their literal form, so the
-// backslash is meaningful. Single-character entries are checked via this map;
-// linebreak runes are checked separately.
-var validStringEscape = map[byte]bool{
-	'\\': true, 'n': true, 'r': true, 'v': true, 't': true,
-	'b': true, 'f': true, 'u': true, 'x': true,
 }
 
 // isLineContinuation reports whether the rune begins a LineTerminatorSequence
@@ -209,33 +202,42 @@ func isDirectiveBlockContainer(node *ast.Node) bool {
 	return false
 }
 
-// rawStartOf returns the source-text start offset of `node`, skipping any
-// leading trivia. For string/template/regex literals this points at the
-// opening delimiter (`'`, `"`, “ ` “, `}`, or `/`).
-func rawStartOf(sourceFile *ast.SourceFile, node *ast.Node) int {
-	return utils.TrimNodeTextRange(sourceFile, node).Pos()
-}
-
-// rawTextOf returns the raw source text of `node` (delimiters included).
-func rawTextOf(sourceFile *ast.SourceFile, node *ast.Node) string {
-	return scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, node, false)
+// rawTextAndStart returns the raw source text of `node` (delimiters included)
+// and its source offset after leading trivia. Computing both together avoids
+// running SkipTrivia twice for every literal. Reparser-transformed literals
+// need the scanner helper's synthesized quotes, so keep its existing behavior
+// on that rare path.
+func rawTextAndStart(sourceFile *ast.SourceFile, node *ast.Node) (string, int) {
+	if ast.NodeIsMissing(node) {
+		return "", node.Pos()
+	}
+	sourceText := sourceFile.Text()
+	rawStart := scanner.SkipTrivia(sourceText, node.Pos())
+	if node.Flags&ast.NodeFlagsReparserTransformedLiteral != 0 {
+		return scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, node, false), rawStart
+	}
+	return sourceText[rawStart:node.End()], rawStart
 }
 
 // checkStringLiteral scans a `'…'` / `"…"` literal for useless escapes.
 func checkStringLiteral(ctx rule.RuleContext, node *ast.Node) {
-	rawStart := rawStartOf(ctx.SourceFile, node)
-	raw := rawTextOf(ctx.SourceFile, node)
+	raw, rawStart := rawTextAndStart(ctx.SourceFile, node)
 	if len(raw) < 2 {
 		return
 	}
 	quote := raw[0]
-	directive := isStringLiteralDirective(ctx.SourceFile, node)
+	directive := false
+	directiveChecked := false
 	scanLiteralEscapes(raw, func(escapeIdx int, escapedRune rune, escapedRuneSize int) {
 		if isValidStringEscapeRune(escapedRune) {
 			return
 		}
 		if escapedRuneSize == 1 && byte(escapedRune) == quote {
 			return
+		}
+		if !directiveChecked {
+			directive = isStringLiteralDirective(ctx.SourceFile, node)
+			directiveChecked = true
 		}
 		reportEscape(ctx, rawStart, escapeIdx, escapedDisplayText(raw, escapeIdx, escapedRune, escapedRuneSize), directive, false)
 	})
@@ -253,8 +255,7 @@ func checkStringLiteral(ctx rule.RuleContext, node *ast.Node) {
 // Template literals are never directives, so the suggestion message is always
 // the standard `removeEscape`.
 func checkTemplateElement(ctx rule.RuleContext, node *ast.Node) {
-	rawStart := rawStartOf(ctx.SourceFile, node)
-	raw := rawTextOf(ctx.SourceFile, node)
+	raw, rawStart := rawTextAndStart(ctx.SourceFile, node)
 	scanLiteralEscapes(raw, func(escapeIdx int, escapedRune rune, escapedRuneSize int) {
 		// `\`` is the template quote escape — always valid.
 		if escapedRune == '`' {
@@ -292,7 +293,8 @@ func escapedDisplayText(raw string, escapeIdx int, escapedRune rune, escapedRune
 }
 
 func isValidStringEscapeRune(r rune) bool {
-	if r < 128 && validStringEscape[byte(r)] {
+	switch r {
+	case '\\', 'n', 'r', 'v', 't', 'b', 'f', 'u', 'x':
 		return true
 	}
 	return isLineContinuation(r)
@@ -316,6 +318,11 @@ func scanLiteralEscapes(raw string, cb func(escapeIdx int, escapedRune rune, esc
 		}
 		next := raw[i+1]
 		if next >= '0' && next <= '9' {
+			i += 2
+			continue
+		}
+		if next < utf8.RuneSelf {
+			cb(i, rune(next), 1)
 			i += 2
 			continue
 		}
@@ -343,40 +350,66 @@ func scanLiteralEscapes(raw string, cb func(escapeIdx int, escapedRune rune, esc
 // regexpp AST is a `ClassIntersection` / `ClassSubtraction` operator.
 func reportEscape(ctx rule.RuleContext, rawStart, startOffset int, escapedText string, directive bool, disableEscapeBackslash bool) {
 	rangeStart := rawStart + startOffset
-	rangeEnd := rangeStart + 1
-	textRange := core.NewTextRange(rangeStart, rangeEnd)
+	textRange := core.NewTextRange(rangeStart, rangeStart+1)
 
-	suggestions := make([]rule.RuleSuggestion, 0, 2)
-	removeMsg := rule.RuleMessage{
+	ctx.ReportRangeWithDeferredSuggestions(textRange, unnecessaryEscapeMessage(escapedText), func() []rule.RuleSuggestion {
+		removeMsg := removeEscapeMessage
+		if directive {
+			removeMsg = removeEscapeDirectiveMessage
+		}
+		removeSuggestion := rule.RuleSuggestion{
+			Message:  removeMsg,
+			FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(textRange)},
+		}
+		if disableEscapeBackslash {
+			return []rule.RuleSuggestion{removeSuggestion}
+		}
+		return []rule.RuleSuggestion{
+			removeSuggestion,
+			{
+				Message: escapeBackslashMessage,
+				FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(
+					core.NewTextRange(rangeStart, rangeStart),
+					"\\",
+				)},
+			},
+		}
+	})
+}
+
+var (
+	removeEscapeMessage = rule.RuleMessage{
 		Id:          "removeEscape",
 		Description: "Remove the `\\`. This maintains the current functionality.",
 	}
-	if directive {
-		removeMsg = rule.RuleMessage{
-			Id:          "removeEscapeDoNotKeepSemantics",
-			Description: "Remove the `\\` if it was inserted by mistake.",
+	removeEscapeDirectiveMessage = rule.RuleMessage{
+		Id:          "removeEscapeDoNotKeepSemantics",
+		Description: "Remove the `\\` if it was inserted by mistake.",
+	}
+	escapeBackslashMessage = rule.RuleMessage{
+		Id:          "escapeBackslash",
+		Description: "Replace the `\\` with `\\\\` to include the actual backslash character.",
+	}
+	unnecessaryEscapeASCIIMessages = func() [utf8.RuneSelf]rule.RuleMessage {
+		var messages [utf8.RuneSelf]rule.RuleMessage
+		for character := range messages {
+			messages[character] = rule.RuleMessage{
+				Id:          "unnecessaryEscape",
+				Description: "Unnecessary escape character: \\" + string(rune(character)) + ".",
+			}
 		}
+		return messages
+	}()
+)
+
+func unnecessaryEscapeMessage(escapedText string) rule.RuleMessage {
+	if len(escapedText) == 1 && escapedText[0] < utf8.RuneSelf {
+		return unnecessaryEscapeASCIIMessages[escapedText[0]]
 	}
-	suggestions = append(suggestions, rule.RuleSuggestion{
-		Message:  removeMsg,
-		FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(textRange)},
-	})
-	if !disableEscapeBackslash {
-		suggestions = append(suggestions, rule.RuleSuggestion{
-			Message: rule.RuleMessage{
-				Id:          "escapeBackslash",
-				Description: "Replace the `\\` with `\\\\` to include the actual backslash character.",
-			},
-			FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(
-				core.NewTextRange(rangeStart, rangeStart),
-				"\\",
-			)},
-		})
-	}
-	ctx.ReportRangeWithSuggestions(textRange, rule.RuleMessage{
+	return rule.RuleMessage{
 		Id:          "unnecessaryEscape",
-		Description: fmt.Sprintf("Unnecessary escape character: \\%s.", escapedText),
-	}, suggestions...)
+		Description: "Unnecessary escape character: \\" + escapedText + ".",
+	}
 }
 
 // ----------------------------------------------------------------------------
@@ -403,38 +436,29 @@ type regexClassFrame struct {
 // reservedDoublePunctuator mirrors REGEX_CLASS_SET_RESERVED_DOUBLE_PUNCTUATOR
 // in the ESLint source: characters that, when doubled inside a v-mode class,
 // form a reserved-syntax pair (e.g. `&&`, `++`).
-var reservedDoublePunctuator = map[byte]bool{
-	'!': true, '#': true, '$': true, '%': true, '&': true,
-	'*': true, '+': true, ',': true, '.': true, ':': true,
-	';': true, '<': true, '=': true, '>': true, '?': true,
-	'@': true, '^': true, '`': true, '~': true,
-}
+var reservedDoublePunctuator = makeByteSet(
+	'!', '#', '$', '%', '&', '*', '+', ',', '.', ':', ';', '<', '=', '>',
+	'?', '@', '^', '`', '~',
+)
 
 // regexGeneralEscape mirrors REGEX_GENERAL_ESCAPES: characters whose `\X` form
 // is meaningful in any regex position (assertions, character-class shorthands,
 // hex/unicode escape leaders, octal/backreference digits, the `]` escape).
-var regexGeneralEscape = map[byte]bool{
-	'\\': true, 'b': true, 'c': true, 'd': true, 'D': true, 'f': true,
-	'n': true, 'p': true, 'P': true, 'r': true, 's': true, 'S': true,
-	't': true, 'v': true, 'w': true, 'W': true, 'x': true, 'u': true,
-	'0': true, '1': true, '2': true, '3': true, '4': true, '5': true,
-	'6': true, '7': true, '8': true, '9': true, ']': true,
-}
+var regexGeneralEscape = makeByteSet(
+	'\\', 'b', 'c', 'd', 'D', 'f', 'n', 'p', 'P', 'r', 's', 'S', 't', 'v',
+	'w', 'W', 'x', 'u', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+	']',
+)
 
 // regexNonClassExtra adds the characters whose `\X` is meaningful outside any
 // character class (regex metacharacters), on top of regexGeneralEscape.
-var regexNonClassExtra = map[byte]bool{
-	'^': true, '/': true, '.': true, '$': true, '*': true, '+': true,
-	'?': true, '[': true, '{': true, '}': true, '|': true, '(': true,
-	')': true, 'B': true, 'k': true,
-}
+var regexNonClassExtra = makeByteSet(
+	'^', '/', '.', '$', '*', '+', '?', '[', '{', '}', '|', '(', ')', 'B', 'k',
+)
 
 // regexClassSetExtra adds the characters whose `\X` is meaningful inside a
 // v-mode character class, on top of regexGeneralEscape.
-var regexClassSetExtra = map[byte]bool{
-	'q': true, '/': true, '[': true, '{': true, '}': true,
-	'|': true, '(': true, ')': true, '-': true,
-}
+var regexClassSetExtra = makeByteSet('q', '/', '[', '{', '}', '|', '(', ')', '-')
 
 // regexAllowedNonClass / regexAllowedClassU / regexAllowedClassV are the three
 // resolved allow-sets (per ESLint's three context branches), pre-merged at
@@ -452,8 +476,7 @@ var (
 // negate flag, presence of `--`/`&&` in that class). The pre-scan in
 // preScanClass populates the frame metadata before we reach inner content.
 func validateRegExp(ctx rule.RuleContext, node *ast.Node, allowed map[string]bool) {
-	rawStart := rawStartOf(ctx.SourceFile, node)
-	text := rawTextOf(ctx.SourceFile, node)
+	text, rawStart := rawTextAndStart(ctx.SourceFile, node)
 	pattern, flagsStr := utils.ExtractRegexPatternAndFlags(text)
 	if pattern == "" {
 		return
@@ -496,12 +519,7 @@ func validateRegExp(ctx rule.RuleContext, node *ast.Node, allowed map[string]boo
 			// v-mode set operator `--` / `&&` — consumed as one unit.
 			i += 2
 		default:
-			_, w := utf8.DecodeRuneInString(pattern[i:])
-			if w == 0 {
-				i++
-			} else {
-				i += w
-			}
+			i++
 		}
 	}
 }
@@ -583,13 +601,10 @@ func readRegexEscape(pattern string, i int, flags utils.RegexFlags, inClass bool
 
 	// Single-character identity escape `\X`. Decode the rune to handle
 	// multi-byte X (very rare but possible in identity-escape position).
-	r, w := utf8.DecodeRuneInString(pattern[i+1:])
-	if w == 0 {
-		return 1, 0, 0, false
+	if next < utf8.RuneSelf {
+		return 2, next, 1, true
 	}
-	if w == 1 {
-		return 2, byte(r), 1, true
-	}
+	_, w := utf8.DecodeRuneInString(pattern[i+1:])
 	// Multi-byte identity escape. ESLint's set-membership checks operate on
 	// single ASCII chars; a multi-byte X is never "valid" in any of those
 	// sets, so treating it as a flagged identity is the safe path. Callers
@@ -627,7 +642,7 @@ func handleRegexIdentityEscape(
 		return
 	}
 	escapedText := pattern[escapeIdx+1 : escapeIdx+1+escapedSize]
-	if allowed[escapedText] {
+	if allowed != nil && allowed[escapedText] {
 		return
 	}
 	// Multi-byte identity escapes never match the ASCII-keyed allow sets, so
@@ -638,14 +653,14 @@ func handleRegexIdentityEscape(
 	}
 
 	inClass := len(stack) > 0
-	var allowedSet map[byte]bool
+	var allowedSet *byteSet
 	switch {
 	case !inClass:
-		allowedSet = regexAllowedNonClass
+		allowedSet = &regexAllowedNonClass
 	case flags.UnicodeSets:
-		allowedSet = regexAllowedClassV
+		allowedSet = &regexAllowedClassV
 	default:
-		allowedSet = regexAllowedClassU
+		allowedSet = &regexAllowedClassU
 	}
 	if allowedSet[escapedByte] {
 		return
@@ -745,12 +760,7 @@ func preScanClass(pattern string, start int, flags utils.RegexFlags) regexClassF
 			frame.hasSetOp = true
 			i += 2
 		default:
-			_, w := utf8.DecodeRuneInString(pattern[i:])
-			if w == 0 {
-				i++
-			} else {
-				i += w
-			}
+			i++
 		}
 	}
 	return frame
@@ -824,19 +834,24 @@ func patternParses(pattern string, flags utils.RegexFlags) bool {
 			depth--
 			i++
 		default:
-			_, w := utf8.DecodeRuneInString(pattern[i:])
-			if w == 0 {
-				i++
-			} else {
-				i += w
-			}
+			i++
 		}
 	}
 	return depth == 0
 }
 
-func mergeByteSets(sets ...map[byte]bool) map[byte]bool {
-	out := make(map[byte]bool, 64)
+type byteSet [256]bool
+
+func makeByteSet(bytes ...byte) byteSet {
+	var out byteSet
+	for _, b := range bytes {
+		out[b] = true
+	}
+	return out
+}
+
+func mergeByteSets(sets ...byteSet) byteSet {
+	var out byteSet
 	for _, s := range sets {
 		for k, v := range s {
 			if v {

--- a/internal/rules/no_useless_escape/no_useless_escape_test.go
+++ b/internal/rules/no_useless_escape/no_useless_escape_test.go
@@ -1,9 +1,17 @@
 package no_useless_escape
 
 import (
+	"slices"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -1595,6 +1603,152 @@ func TestNoUselessEscapeRule(t *testing.T) {
 	)
 }
 
+func TestReportEscapeDefersSuggestions(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, `"\#"`, core.ScriptKindTS)
+
+	for _, testCase := range []struct {
+		name            string
+		demand          rule.EditDemand
+		wantSuggestions bool
+	}{
+		{name: "diagnostics only", demand: rule.EditDemandNone},
+		{name: "autofix only", demand: rule.EditDemandAutofix},
+		{name: "suggestions", demand: rule.EditDemandSuggestion, wantSuggestions: true},
+		{name: "all edits", demand: rule.EditDemandAll, wantSuggestions: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var diagnostics []rule.RuleDiagnostic
+			ctx := rule.RuleContext{SourceFile: sourceFile}.WithDiagnosticConsumer(
+				NoUselessEscapeRule.Name,
+				rule.SeverityError,
+				rule.DiagnosticConsumer{
+					Demand: testCase.demand,
+					Report: func(diagnostic rule.RuleDiagnostic) {
+						diagnostics = append(diagnostics, diagnostic)
+					},
+				},
+			)
+
+			reportEscape(ctx, 0, 1, "#", false, false)
+
+			if len(diagnostics) != 1 {
+				t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+			}
+			hasSuggestions := diagnostics[0].Suggestions != nil
+			if hasSuggestions != testCase.wantSuggestions {
+				t.Fatalf("suggestions present = %v, want %v", hasSuggestions, testCase.wantSuggestions)
+			}
+			if hasSuggestions && len(*diagnostics[0].Suggestions) != 2 {
+				t.Fatalf("suggestions = %d, want 2", len(*diagnostics[0].Suggestions))
+			}
+		})
+	}
+}
+
+func TestRawTextAndStartParity(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/raw-text.ts",
+		Path:     "/raw-text.ts",
+	}, "const stringValue = /* comment */\n  \"\\#\";\n"+
+		"const templateValue = /* comment */ `head\\@${value}middle\\_${other}tail\\#`;\n"+
+		"const regexValue = /* comment */ /before\\;[é]after/u;\n", core.ScriptKindTS)
+
+	literalCount := 0
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		switch node.Kind {
+		case ast.KindStringLiteral,
+			ast.KindNoSubstitutionTemplateLiteral,
+			ast.KindTemplateHead,
+			ast.KindTemplateMiddle,
+			ast.KindTemplateTail,
+			ast.KindRegularExpressionLiteral:
+			literalCount++
+			gotText, gotStart := rawTextAndStart(sourceFile, node)
+			wantText := scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, node, false)
+			wantStart := utils.TrimNodeTextRange(sourceFile, node).Pos()
+			if gotText != wantText || gotStart != wantStart {
+				t.Errorf(
+					"kind %s: rawTextAndStart() = (%q, %d), want (%q, %d)",
+					node.Kind.String(), gotText, gotStart, wantText, wantStart,
+				)
+			}
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if literalCount != 5 {
+		t.Fatalf("literal nodes = %d, want 5", literalCount)
+	}
+}
+
+func TestScanLiteralEscapesParity(t *testing.T) {
+	alphabet := []string{"a", "\\", "0", "9", "#", "é", "😀", string([]byte{0xff})}
+	for length := range 5 {
+		combinations := 1
+		for range length {
+			combinations *= len(alphabet)
+		}
+		for encoded := range combinations {
+			var raw strings.Builder
+			value := encoded
+			for range length {
+				raw.WriteString(alphabet[value%len(alphabet)])
+				value /= len(alphabet)
+			}
+			input := raw.String()
+			got := collectLiteralEscapes(scanLiteralEscapes, input)
+			want := collectLiteralEscapes(scanLiteralEscapesBeforeOptimization, input)
+			if !slices.Equal(got, want) {
+				t.Fatalf("scanLiteralEscapes(%q) = %#v, want %#v", input, got, want)
+			}
+		}
+	}
+}
+
+type literalEscapeEvent struct {
+	index int
+	r     rune
+	size  int
+}
+
+func collectLiteralEscapes(
+	scan func(string, func(int, rune, int)),
+	raw string,
+) []literalEscapeEvent {
+	var events []literalEscapeEvent
+	scan(raw, func(index int, r rune, size int) {
+		events = append(events, literalEscapeEvent{index: index, r: r, size: size})
+	})
+	return events
+}
+
+func scanLiteralEscapesBeforeOptimization(raw string, cb func(int, rune, int)) {
+	for i := 0; i < len(raw); {
+		if raw[i] != '\\' {
+			i++
+			continue
+		}
+		if i+1 >= len(raw) {
+			return
+		}
+		next := raw[i+1]
+		if next >= '0' && next <= '9' {
+			i += 2
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(raw[i+1:])
+		if size == 0 {
+			return
+		}
+		cb(i, r, size)
+		i += 1 + size
+	}
+}
+
 // =============================================================================
 // Hardening tests for the regex pattern parser. These cover malformed-input
 // skip behavior (matching ESLint's regexpp try/catch) and boundary conditions
@@ -1644,13 +1798,13 @@ func TestPatternParses(t *testing.T) {
 
 func TestPreScanClass(t *testing.T) {
 	tests := []struct {
-		name        string
-		pattern     string
-		start       int
-		flagStr     string
-		wantNegate  bool
-		wantSetOp   bool
-		wantEnd     int
+		name       string
+		pattern    string
+		start      int
+		flagStr    string
+		wantNegate bool
+		wantSetOp  bool
+		wantEnd    int
 	}{
 		{name: "simple", pattern: "[abc]", start: 0, flagStr: "", wantEnd: 5},
 		{name: "negated", pattern: "[^abc]", start: 0, flagStr: "", wantNegate: true, wantEnd: 6},


### PR DESCRIPTION
## Summary

- avoid per-literal token scanner allocation by sharing raw text and trivia offset extraction
- defer suggestion construction until requested and reuse cached diagnostic messages
- replace hot-path regex maps and unnecessary UTF-8 decoding with allocation-free byte lookups
- preserve missing/transformed-node behavior and add edit-demand, raw-text, and exhaustive scanner parity coverage

### Benchmark

Temporary rule-local Go benchmark (not committed), run on Apple M1 Max with Go 1.26.1 and `GOMAXPROCS=1`. Each case scans 768 literal nodes per operation; invalid cases emit 3,072 diagnostics per operation. Values are means across 8 runs with `-benchmem -benchtime=500ms`.

| Case | Before | After | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| clean / diagnostics only | 204.5 µs | 42.0 µs | -79.5% (4.87x) | 178,664 → 440 | 2,570 → 9 |
| invalid / diagnostics only | 1,226.2 µs | 108.3 µs | -91.2% (11.32x) | 1,063,461 → 440 | 22,794 → 9 |
| invalid / suggestions | 1,222.4 µs | 608.1 µs | -50.3% (2.01x) | 1,063,462 → 614,840 | 22,794 → 12,297 |

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
