### PR TITLE
perf: optimize no-extra-non-null-assertion diagnostics

### DIFF
--- a/internal/plugins/typescript/rules/no_extra_non_null_assertion/no_extra_non_null_assertion.go
+++ b/internal/plugins/typescript/rules/no_extra_non_null_assertion/no_extra_non_null_assertion.go
@@ -16,10 +16,13 @@ var NoExtraNonNullAssertionRule = rule.CreateRule(rule.Rule{
 		}
 
 		reportExtraNonNull := func(node *ast.Node) {
-			expression := node.AsNonNullExpression().Expression
-			s := scanner.GetScannerForSourceFile(ctx.SourceFile, expression.End())
-			fix := rule.RuleFixRemoveRange(s.TokenRange())
-			ctx.ReportNodeWithFixes(node, msg, fix)
+			// A parsed NonNullExpression ends immediately after its `!`, so the
+			// fix needs neither token lookup nor any surrounding trivia.
+			fixRange := node.Loc.WithPos(node.End() - 1)
+			reportRange := node.Loc.WithPos(scanner.SkipTrivia(ctx.SourceFile.Text(), node.Pos()))
+			ctx.ReportRangeWithDeferredFixes(reportRange, msg, func() []rule.RuleFix {
+				return []rule.RuleFix{rule.RuleFixRemoveRange(fixRange)}
+			})
 		}
 
 		return rule.RuleListeners{

--- a/internal/plugins/typescript/rules/no_extra_non_null_assertion/no_extra_non_null_assertion_test.go
+++ b/internal/plugins/typescript/rules/no_extra_non_null_assertion/no_extra_non_null_assertion_test.go
@@ -208,5 +208,78 @@ function foo(bar?: { n: number }) {
 				},
 			},
 		},
+		// Leading trivia must not become part of the diagnostic, and the fix
+		// still removes exactly the redundant assertion token.
+		{
+			Code: `const result = /* leading */ value!!;`,
+			Output: []string{
+				`const result = /* leading */ value!;`,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noExtraNonNullAssertion",
+					Line:      1,
+					Column:    30,
+					EndLine:   1,
+					EndColumn: 36,
+				},
+			},
+		},
+		// Comments between assertions are preserved verbatim by the fix.
+		{
+			Code: `const result = value /* first */ ! /* second */ !;`,
+			Output: []string{
+				`const result = value /* first */  /* second */ !;`,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noExtraNonNullAssertion"},
+			},
+		},
+		// The token range remains byte-exact when the expression contains
+		// multi-byte source text.
+		{
+			Code: `const result = 数据!!;`,
+			Output: []string{
+				`const result = 数据!;`,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noExtraNonNullAssertion"},
+			},
+		},
+		// Every redundant token in a longer assertion chain gets its own
+		// non-overlapping fix.
+		{
+			Code: `const result = value!!!;`,
+			Output: []string{
+				`const result = value!;`,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noExtraNonNullAssertion"},
+				{MessageId: "noExtraNonNullAssertion"},
+			},
+		},
+		// Exercise the optional element-access branch in addition to the
+		// existing property-access and call cases.
+		{
+			Code: `
+function foo(bar?: number[]) {
+  return bar!?.[0];
+}
+`,
+			Output: []string{`
+function foo(bar?: number[]) {
+  return bar?.[0];
+}
+`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noExtraNonNullAssertion",
+					Line:      3,
+					Column:    10,
+					EndLine:   3,
+					EndColumn: 14,
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
## Summary

- Defer autofix construction for `@typescript-eslint/no-extra-non-null-assertion` until the consumer requests fixes.
- Derive the diagnostic start with `scanner.SkipTrivia` and the redundant `!` range from the parsed `NonNullExpression` boundary, avoiding per-diagnostic scanner allocation while preserving source trivia.
- Add adversarial coverage for leading trivia, comments between assertions, multi-byte source text, longer assertion chains, and optional element access.
- Keep the optimization entirely within the rule. `ctx.Refs` was evaluated but is not applicable because this rule is syntax-only and performs no symbol or reference resolution.

### Benchmark

Temporary rule-local benchmark, removed before commit: 8 files × 128 mixed cases, producing 7,168 diagnostics per run. Results are medians of 6 runs on Go 1.26.1, darwin/arm64, Apple M1 Max.

`go test -run=^$ -bench=^BenchmarkNoExtraNonNullAssertion$ -benchmem -benchtime=1s -count=6 ./tests/bench-go`

| Mode | Metric | Before | After | Delta |
| --- | ---: | ---: | ---: | ---: |
| Diagnostics only | ns/op | 2,594,871 | 1,613,635 | -37.8% |
| Diagnostics only | B/op | 2,646,930 | 9,104 | -99.7% |
| Diagnostics only | allocs/op | 28,787 | 115 | -99.6% |
| Autofix | ns/op | 2,588,141 | 1,961,153 | -24.2% |
| Autofix | B/op | 2,646,929 | 353,168 | -86.7% |
| Autofix | allocs/op | 28,787 | 14,451 | -49.8% |

A separate zero-diagnostic workload with 8,192 valid single assertions showed no common-path regression: median 870,429 → 849,613 ns/op (-2.4%), with B/op and allocs/op unchanged.

### Validation

- `go test ./internal/plugins/typescript/rules/no_extra_non_null_assertion -run ^TestNoExtraNonNullAssertionRule$ -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_extra_non_null_assertion`

## Related Links

- https://typescript-eslint.io/rules/no-extra-non-null-assertion

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).