### PR TITLE
perf: optimize no-unsafe-declaration-merging

### DIFF
--- a/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging.go
+++ b/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging.go
@@ -6,11 +6,28 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-func buildUnsafeMergingMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "unsafeMerging",
-		Description: "Unsafe declaration merging between classes and interfaces.",
+type declarationKinds uint8
+
+const (
+	declarationKindClass declarationKinds = 1 << iota
+	declarationKindInterface
+	declarationScanCacheThreshold = 8
+)
+
+func declarationKind(kind ast.Kind) declarationKinds {
+	switch kind {
+	case ast.KindClassDeclaration:
+		return declarationKindClass
+	case ast.KindInterfaceDeclaration:
+		return declarationKindInterface
+	default:
+		return 0
 	}
+}
+
+var unsafeMergingMessage = rule.RuleMessage{
+	Id:          "unsafeMerging",
+	Description: "Unsafe declaration merging between classes and interfaces.",
 }
 
 // nearestLocalsContainer climbs from the given node's parent to the nearest
@@ -31,85 +48,118 @@ func nearestLocalsContainer(node *ast.Node) *ast.Node {
 	return p
 }
 
-var NoUnsafeDeclarationMergingRule = rule.CreateRule(rule.Rule{
-	Name:             "no-unsafe-declaration-merging",
-	RequiresTypeInfo: true,
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		// reportIfUnsafeMerge mirrors upstream's scope-manager probe in
-		// behavior while using tsgo's TypeChecker as the symbol source.
-		//
-		// Upstream does two things that look like implementation details
-		// but are part of the rule's observable contract; we reproduce
-		// both:
-		//
-		//   1. The interface listener calls sourceCode.getScope(node),
-		//      which for a generic interface returns the type-parameter
-		//      scope. That scope does not contain the interface's own
-		//      name, so the lookup fails and the listener returns
-		//      without reporting. ESLint thus skips the interface side
-		//      whenever the interface has type parameters; the class
-		//      listener uses .upper and is not affected.
-		//
-		//   2. Both listeners look up the name in a single lexical scope.
-		//      A class and interface that share a name only count as
-		//      "merging" if they live in the same enclosing scope (same
-		//      SourceFile, same namespace block, same `declare module`
-		//      block, …). Cross-`declare module` blocks and external-
-		//      module class augmentation therefore never fire upstream,
-		//      even though TypeScript really does merge the symbols.
-		//
-		// We keep TypeChecker.GetSymbolAtLocation as the source of truth
-		// for "is there a merge at all", then filter symbol.Declarations
-		// down to those sharing the same enclosing LocalsContainer as
-		// the current declaration. The filter is what implements (2);
-		// the early return on type parameters implements (1).
-		reportIfUnsafeMerge := func(declNode *ast.Node, name *ast.Node, unsafeKind ast.Kind) {
-			if name == nil {
-				return
-			}
+type mergeRuleState struct {
+	ctx                rule.RuleContext
+	scopeKindsBySymbol map[*ast.Symbol]map[*ast.Node]declarationKinds
+}
 
-			if declNode.Kind == ast.KindInterfaceDeclaration {
-				iface := declNode.AsInterfaceDeclaration()
-				if iface.TypeParameters != nil && len(iface.TypeParameters.Nodes) > 0 {
-					return
-				}
-			}
+func (s *mergeRuleState) checkClass(node *ast.Node) {
+	s.reportIfUnsafeMerge(node, node.AsClassDeclaration().Name(), ast.KindInterfaceDeclaration)
+}
 
-			symbol := ctx.TypeChecker.GetSymbolAtLocation(name)
-			// `export default class Foo {}` binds the class to the synthetic
-			// __default symbol; the module-scope `Foo` local (which is what
-			// merges with `interface Foo {}`) is a separate symbol in the
-			// enclosing LocalsContainer. Recover it before the merge check.
-			if symbol != nil && symbol.Name == ast.InternalSymbolNameDefault {
-				if container := nearestLocalsContainer(declNode); container != nil {
-					if local := ast.GetLocals(container)[name.Text()]; local != nil {
-						symbol = local
-					}
-				}
-			}
-			if symbol == nil || len(symbol.Declarations) <= 1 {
-				return
-			}
+func (s *mergeRuleState) checkInterface(node *ast.Node) {
+	s.reportIfUnsafeMerge(node, node.AsInterfaceDeclaration().Name(), ast.KindClassDeclaration)
+}
 
-			scope := utils.FindEnclosingScope(declNode)
-			for _, decl := range symbol.Declarations {
-				if decl == declNode || decl.Kind != unsafeKind {
-					continue
-				}
-				if utils.FindEnclosingScope(decl) == scope {
-					ctx.ReportNode(name, buildUnsafeMergingMessage())
-					return
-				}
+// reportIfUnsafeMerge mirrors upstream's scope-manager probe in behavior
+// while using tsgo's binder symbol as the binding source.
+//
+// Upstream does two things that look like implementation details but are part
+// of the rule's observable contract; we reproduce both:
+//
+//  1. The interface listener calls sourceCode.getScope(node), which for a
+//     generic interface returns the type-parameter scope. That scope does not
+//     contain the interface's own name, so the lookup fails and the listener
+//     returns without reporting. ESLint thus skips the interface side whenever
+//     the interface has type parameters; the class listener uses .upper and is
+//     not affected.
+//  2. Both listeners look up the name in a single lexical scope. A class and
+//     interface that share a name only count as "merging" if they live in the
+//     same enclosing scope (same SourceFile, namespace block, `declare module`
+//     block, etc.). Cross-`declare module` blocks and external-module class
+//     augmentation therefore never fire upstream, even though TypeScript does
+//     merge the symbols.
+//
+// The binder has already attached every same-binding declaration to the
+// declaration node's symbol before lint traversal begins. Reading it directly
+// avoids a checker lookup for every class and interface. We still filter
+// symbol.Declarations by enclosing scope because export symbols can be shared
+// by separate namespace or ambient-module blocks. The filter implements (2);
+// the early return on type parameters implements (1).
+func (s *mergeRuleState) reportIfUnsafeMerge(declNode *ast.Node, name *ast.Node, unsafeKind ast.Kind) {
+	if name == nil {
+		return
+	}
+
+	if declNode.Kind == ast.KindInterfaceDeclaration {
+		iface := declNode.AsInterfaceDeclaration()
+		if iface.TypeParameters != nil && len(iface.TypeParameters.Nodes) > 0 {
+			return
+		}
+	}
+
+	symbol := declNode.Symbol()
+	// `export default class Foo {}` binds the class to the synthetic
+	// __default symbol; the module-scope `Foo` local (which is what
+	// merges with `interface Foo {}`) is a separate symbol in the
+	// enclosing LocalsContainer. Prefer the binder's direct link to that
+	// local, with the Locals lookup retained as a defensive fallback.
+	if symbol != nil && symbol.Name == ast.InternalSymbolNameDefault {
+		if local := declNode.LocalSymbol(); local != nil {
+			symbol = local
+		} else if container := nearestLocalsContainer(declNode); container != nil {
+			if local := ast.GetLocals(container)[name.Text()]; local != nil {
+				symbol = local
 			}
 		}
+	}
+	if symbol == nil || len(symbol.Declarations) <= 1 {
+		return
+	}
 
+	scope := utils.FindEnclosingScope(declNode)
+	hasUnsafeDeclaration := false
+	if len(symbol.Declarations) <= declarationScanCacheThreshold {
+		for _, declaration := range symbol.Declarations {
+			if declaration.Kind == unsafeKind && utils.FindEnclosingScope(declaration) == scope {
+				hasUnsafeDeclaration = true
+				break
+			}
+		}
+	} else {
+		if s.scopeKindsBySymbol == nil {
+			s.scopeKindsBySymbol = make(map[*ast.Symbol]map[*ast.Node]declarationKinds)
+		}
+		kindsByScope := s.scopeKindsBySymbol[symbol]
+		if kindsByScope == nil {
+			kindsByScope = make(map[*ast.Node]declarationKinds)
+			for _, declaration := range symbol.Declarations {
+				kind := declarationKind(declaration.Kind)
+				if kind != 0 {
+					declarationScope := utils.FindEnclosingScope(declaration)
+					kindsByScope[declarationScope] |= kind
+				}
+			}
+			s.scopeKindsBySymbol[symbol] = kindsByScope
+		}
+		hasUnsafeDeclaration = kindsByScope[scope]&declarationKind(unsafeKind) != 0
+	}
+	if hasUnsafeDeclaration {
+		s.ctx.ReportNode(name, unsafeMergingMessage)
+	}
+}
+
+var NoUnsafeDeclarationMergingRule = rule.CreateRule(rule.Rule{
+	Name: "no-unsafe-declaration-merging",
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		// Declaration merges are almost always pairs. Keep that common path as
+		// a tiny slice scan, and only build an index for unusually large merged
+		// symbols so adversarial input cannot make every listener scan the same
+		// declaration list repeatedly.
+		state := mergeRuleState{ctx: ctx}
 		return rule.RuleListeners{
-			ast.KindClassDeclaration: func(node *ast.Node) {
-				reportIfUnsafeMerge(node, node.AsClassDeclaration().Name(), ast.KindInterfaceDeclaration)
-			},
-			ast.KindInterfaceDeclaration: func(node *ast.Node) {
-				reportIfUnsafeMerge(node, node.AsInterfaceDeclaration().Name(), ast.KindClassDeclaration)
-			},
+			ast.KindClassDeclaration:     state.checkClass,
+			ast.KindInterfaceDeclaration: state.checkInterface,
 		}
 	},
 })

--- a/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging_extras_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_declaration_merging/no_unsafe_declaration_merging_extras_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -100,6 +101,28 @@ namespace B {
   interface Foo {
     y: number;
   }
+}
+`},
+
+		// Reopened namespaces share an export symbol in the TypeScript binder,
+		// but each namespace body is a distinct scope in the upstream rule.
+		{Code: `
+namespace Reopened {
+  export interface Foo {}
+}
+namespace Reopened {
+  export class Foo {}
+}
+`},
+
+		// Plain blocks use separate binder symbols even though the rule's
+		// enclosing-scope helper deliberately ignores ordinary block nodes.
+		{Code: `
+{
+  interface Foo {}
+}
+{
+  class Foo {}
 }
 `},
 
@@ -241,6 +264,21 @@ namespace nested {
 }
 `},
 	}, []rule_tester.InvalidTestCase{
+		// A class and interface in the same ordinary block share one binder
+		// symbol and must still be diagnosed on both declaration names.
+		{
+			Code: `
+{
+  interface Foo {}
+  class Foo {}
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeMerging", Line: 3, Column: 13},
+				{MessageId: "unsafeMerging", Line: 4, Column: 9},
+			},
+		},
+
 		// ---- Branch lock-in: class + interface inside the same namespace ----
 		{
 			Code: `
@@ -469,4 +507,39 @@ interface Foo {}
 			},
 		},
 	})
+}
+
+func TestNoUnsafeDeclarationMergingWithoutTypeChecker(t *testing.T) {
+	if NoUnsafeDeclarationMergingRule.RequiresTypeInfo {
+		t.Fatal("binder-based rule must run without type information")
+	}
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	_, sourceFile, err := helper.CreateTestProgram(`
+interface Foo {}
+class Foo {}
+`, "no-unsafe-declaration-merging-no-checker.ts", "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	comments := rule.NewCommentStore(sourceFile)
+	reports := 0
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithReporter(NoUnsafeDeclarationMergingRule.Name, rule.SeverityError, func(rule.RuleDiagnostic) {
+		reports++
+	})
+	listeners := NoUnsafeDeclarationMergingRule.Run(ctx, nil)
+	for _, statement := range sourceFile.Statements.Nodes {
+		if listener := listeners[statement.Kind]; listener != nil {
+			listener(statement)
+		}
+	}
+
+	if reports != 2 {
+		t.Fatalf("got %d reports without a TypeChecker, want 2", reports)
+	}
 }


### PR DESCRIPTION
## Summary

- Replace per-declaration TypeChecker resolution with the declaration symbols already produced by the TypeScript binder, and remove the unnecessary type-information requirement.
- Preserve upstream behavior for generic interfaces, lexical-scope boundaries, mixed exports, and named default-export classes.
- Add a lazy per-symbol scope index for unusually large declaration merges, plus regression coverage for namespace/block boundaries and nil TypeChecker execution.

### Benchmark

Isolated rule initialization + listener benchmark on a prebuilt TypeScript Program (darwin/arm64, Apple M1 Max, Go 1.26.1, 500ms benchtime, 10-run median):

| Case | Before | After | Delta | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| 2,000 unpaired declarations | 70,433 ns/op | 27,971 ns/op | -60.3% | 384 → 368 | 6 → 5 |
| 1,000 class/interface pairs | 215,635 ns/op | 172,779 ns/op | -19.9% | 320,384 → 320,368 | 2,006 → 2,005 |
| 1,999 interfaces + one trailing same-name class | 3,761,949 ns/op | 190,419 ns/op | -94.9% | 320,384 → 320,752 | 2,006 → 2,009 |

The last case intentionally attacks the old repeated declaration scan. Its lazy scope index adds 368 B and 3 allocations while making the path about 19.8x faster. A pre-change CPU profile attributed 0.80s of 0.89s cumulative listener time to GetSymbolAtLocation.

### Validation

- go test ./internal/plugins/typescript/rules/no_unsafe_declaration_merging -count=1
- pnpm run check-spell
- pnpm run format:check
- golangci-lint on the two changed Go files: 0 issues
- Temporary checker-vs-binder differential corpus: 260 scope/export/generic shapes, repeated 5 times with identical diagnostic positions

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).