### PR TITLE
refactor(rule): converge binding-symbol lookups on utils helpers

### DIFF
--- a/internal/rules/no_const_assign/no_const_assign.go
+++ b/internal/rules/no_const_assign/no_const_assign.go
@@ -41,17 +41,9 @@ var NoConstAssignRule = rule.Rule{
 					if varDecl == nil || varDecl.Name() == nil {
 						continue
 					}
-					utils.CollectBindingNames(varDecl.Name(), func(ident *ast.Node, _ string) {
-						// The binder attaches the symbol to the enclosing
-						// declaration (VariableDeclaration or BindingElement).
-						bindingDecl := ident.Parent
-						if bindingDecl == nil || bindingDecl.Name() != ident {
-							return
-						}
-						if sym := bindingDecl.Symbol(); sym != nil {
-							constSymbols[sym] = true
-						}
-					})
+					for _, sym := range utils.BindingSymbols(varDecl.Name()) {
+						constSymbols[sym] = true
+					}
 				}
 			},
 

--- a/internal/rules/no_import_assign/no_import_assign.go
+++ b/internal/rules/no_import_assign/no_import_assign.go
@@ -72,10 +72,7 @@ func makeImportedBinding(nameNode *ast.Node, isNamespace bool, symbol *ast.Symbo
 
 // importBindingSymbol returns the binder-owned alias symbol used by ctx.Refs.
 func importBindingSymbol(nameNode *ast.Node) *ast.Symbol {
-	if nameNode == nil || nameNode.Parent == nil || nameNode.Parent.Name() != nameNode {
-		return nil
-	}
-	return nameNode.Parent.Symbol()
+	return utils.BindingNameSymbol(nameNode)
 }
 
 func checkerImportBindingSymbol(nameNode *ast.Node, ctx *rule.RuleContext) *ast.Symbol {

--- a/internal/rules/no_var/no_var.go
+++ b/internal/rules/no_var/no_var.go
@@ -92,13 +92,8 @@ func canFix(node *ast.Node, ctx *rule.RuleContext) bool {
 			continue
 		}
 		utils.CollectBindingNames(varDecl.Name(), func(ident *ast.Node, _ string) {
-			// The binder attaches the symbol to the enclosing declaration
-			// (VariableDeclaration or BindingElement). Binder symbols are the
-			// currency of ctx.Refs, so use them on the declaration side too.
-			if decl := ident.Parent; decl != nil && decl.Name() == ident {
-				if sym := decl.Symbol(); sym != nil {
-					vars = append(vars, varInfo{nameNode: ident, sym: sym})
-				}
+			if sym := utils.BindingNameSymbol(ident); sym != nil {
+				vars = append(vars, varInfo{nameNode: ident, sym: sym})
 			}
 		})
 	}

--- a/internal/rules/prefer_const/prefer_const.go
+++ b/internal/rules/prefer_const/prefer_const.go
@@ -185,14 +185,7 @@ var PreferConstRule = rule.Rule{
 
 // shouldReport determines whether a candidate should be reported as "use const".
 func shouldReport(c *candidateInfo, declNode *ast.Node, ctx *rule.RuleContext, opts preferConstOptions, hasInitializer bool) bool {
-	// The binder attaches the symbol to the enclosing declaration
-	// (VariableDeclaration or BindingElement). ctx.Refs is keyed by that
-	// binder symbol, not by checker.GetSymbolAtLocation results.
-	decl := c.nameNode.Parent
-	if decl == nil || decl.Name() != c.nameNode {
-		return false
-	}
-	sym := decl.Symbol()
+	sym := utils.BindingNameSymbol(c.nameNode)
 	if sym == nil {
 		return false
 	}


### PR DESCRIPTION
Replaces the hand-written `CollectBindingNames` → `Parent.Symbol()` copies in no-const-assign, no-var, prefer-const, and no-import-assign with the `utils.BindingSymbols` / `utils.BindingNameSymbol` helpers introduced on the base branch. No behavior change.

Stacked on #1492.