### PR TITLE
perf: optimize no-require-imports

### DIFF
--- a/internal/plugins/typescript/rules/no_require_imports/no_require_imports.go
+++ b/internal/plugins/typescript/rules/no_require_imports/no_require_imports.go
@@ -5,22 +5,14 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
-
-type NoRequireImportsOptions struct {
-	Allow         []string `json:"allow"`
-	AllowAsImport bool     `json:"allowAsImport"`
-}
-
-// isStringOrTemplateLiteral checks if a node is a string literal or template literal
-func isStringOrTemplateLiteral(node *ast.Node) bool {
-	return (node.Kind == ast.KindStringLiteral) ||
-		(node.Kind == ast.KindTemplateExpression && node.AsTemplateExpression().TemplateSpans == nil) ||
-		(node.Kind == ast.KindNoSubstitutionTemplateLiteral)
-}
 
 // getStaticStringValue extracts static string value from literal or template
 func getStaticStringValue(node *ast.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
 	switch node.Kind {
 	case ast.KindStringLiteral:
 		return node.AsStringLiteral().Text, true
@@ -37,145 +29,27 @@ func getStaticStringValue(node *ast.Node) (string, bool) {
 	return "", false
 }
 
-// isGlobalRequire checks if the require is the global require function
-func isGlobalRequire(ctx rule.RuleContext, node *ast.Node) bool {
-	// Walk up to find the source file and traverse all variable declarations
-	sourceFile := ctx.SourceFile
-	if sourceFile == nil {
-		return true
-	}
-
-	// Check if 'require' is defined anywhere in the current scope context
-	return !isRequireLocallyDefined(sourceFile, node)
-}
-
-// isRequireLocallyDefined checks if require is locally defined in any containing scope
-func isRequireLocallyDefined(sourceFile *ast.SourceFile, callNode *ast.Node) bool {
-	// Start from the call node and walk up through containing scopes
-	currentNode := callNode
-
-	for currentNode != nil {
-		// Check the immediate parent context for local require definitions
-		if hasLocalRequireInContext(currentNode) {
-			return true
-		}
-		currentNode = currentNode.Parent
-	}
-
-	// Also check the top-level statements
-	return hasLocalRequireInStatements(sourceFile.Statements)
-}
-
-// hasLocalRequireInContext checks if a node's immediate context defines require
-func hasLocalRequireInContext(node *ast.Node) bool {
-	if node == nil || node.Parent == nil {
-		return false
-	}
-
-	parent := node.Parent
-
-	// Check for variable statements that declare 'require'
-	switch parent.Kind {
-	case ast.KindVariableStatement:
-		varStmt := parent.AsVariableStatement()
-		if varStmt.DeclarationList != nil {
-			declList := varStmt.DeclarationList.AsVariableDeclarationList()
-			for _, declarator := range declList.Declarations.Nodes {
-				varDecl := declarator.AsVariableDeclaration()
-				if ast.IsIdentifier(varDecl.Name()) && varDecl.Name().AsIdentifier().Text == "require" {
-					return true
-				}
-			}
-		}
-	case ast.KindBlock:
-		// Check all statements in the block for require declarations
-		block := parent.AsBlock()
-		return hasLocalRequireInStatements(block.Statements)
-	case ast.KindSourceFile:
-		// Check all top-level statements
-		sourceFile := parent.AsSourceFile()
-		return hasLocalRequireInStatements(sourceFile.Statements)
-	}
-
-	return false
-}
-
-// hasLocalRequireInStatements checks if any statements define a local 'require'
-func hasLocalRequireInStatements(statements *ast.NodeList) bool {
-	if statements == nil {
-		return false
-	}
-
-	for _, stmt := range statements.Nodes {
-		if hasRequireDeclaration(stmt) {
-			return true
-		}
-	}
-	return false
-}
-
-// hasRequireDeclaration checks if a statement declares a 'require' variable
-func hasRequireDeclaration(stmt *ast.Node) bool {
-	switch stmt.Kind {
-	case ast.KindVariableStatement:
-		varStmt := stmt.AsVariableStatement()
-		if varStmt.DeclarationList != nil {
-			declList := varStmt.DeclarationList.AsVariableDeclarationList()
-			for _, declarator := range declList.Declarations.Nodes {
-				varDecl := declarator.AsVariableDeclaration()
-				if ast.IsIdentifier(varDecl.Name()) && varDecl.Name().AsIdentifier().Text == "require" {
-					return true
-				}
-			}
-		}
-	case ast.KindBlock:
-		block := stmt.AsBlock()
-		return hasLocalRequireInStatements(block.Statements)
-	}
-	return false
+var noRequireImportsMessage = rule.RuleMessage{
+	Id:          "noRequireImports",
+	Description: "A `require()` style import is forbidden.",
 }
 
 var NoRequireImportsRule = rule.CreateRule(rule.Rule{
 	Name: "no-require-imports",
 	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
 		options := rule.LegacyUnwrapOptions(_options)
-		opts := NoRequireImportsOptions{
-			Allow:         []string{},
-			AllowAsImport: false,
-		}
-
-		// Parse options with dual-format support (handles both array and object formats)
-		if options != nil {
-			var optsMap map[string]interface{}
-			var ok bool
-
-			// Handle array format: [{ option: value }]
-			if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
-				optsMap, ok = optArray[0].(map[string]interface{})
-			} else {
-				// Handle direct object format: { option: value }
-				optsMap, ok = options.(map[string]interface{})
-			}
-
-			if ok {
-				if allow, ok := optsMap["allow"].([]interface{}); ok {
-					for _, pattern := range allow {
-						if str, ok := pattern.(string); ok {
-							opts.Allow = append(opts.Allow, str)
-						}
-					}
-				}
-				if allowAsImport, ok := optsMap["allowAsImport"].(bool); ok {
-					opts.AllowAsImport = allowAsImport
-				}
-			}
-		}
-
-		// Compile regex patterns
+		optsMap := utils.GetOptionsMap(options)
+		allowAsImport, _ := optsMap["allowAsImport"].(bool)
 		var allowPatterns []*regexp.Regexp
-		for _, pattern := range opts.Allow {
-			if compiled, err := regexp.Compile(pattern); err == nil {
-				allowPatterns = append(allowPatterns, compiled)
+		if allow, ok := optsMap["allow"].([]interface{}); ok {
+			for _, rawPattern := range allow {
+				pattern, ok := rawPattern.(string)
+				if !ok {
+					continue
+				}
+				if compiled, err := regexp.Compile(pattern); err == nil {
+					allowPatterns = append(allowPatterns, compiled)
+				}
 			}
 		}
 
@@ -191,74 +65,43 @@ var NoRequireImportsRule = rule.CreateRule(rule.Rule{
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
 				callExpr := node.AsCallExpression()
-
-				// Check if this is a require call or require?.() call
-				var isRequireCall bool
-
-				if ast.IsIdentifier(callExpr.Expression) {
-					identifier := callExpr.Expression.AsIdentifier()
-					if identifier.Text == "require" {
-						isRequireCall = true
-					}
-				} else if callExpr.QuestionDotToken != nil {
-					// Handle optional chaining: require?.()
-					// The expression should be require for require?.()
-					if ast.IsIdentifier(callExpr.Expression) {
-						identifier := callExpr.Expression.AsIdentifier()
-						if identifier != nil && identifier.Text == "require" {
-							isRequireCall = true
-						}
-					}
-				}
-
-				if !isRequireCall {
-					return
-				}
-
-				// Check if it's the global require
-				if !isGlobalRequire(ctx, node) {
+				requireIdentifier := callExpr.Expression
+				if !ast.IsIdentifier(requireIdentifier) || requireIdentifier.AsIdentifier().Text != "require" {
 					return
 				}
 
 				// Check if first argument matches allowed patterns
-				if len(callExpr.Arguments.Nodes) > 0 && isStringOrTemplateLiteral(callExpr.Arguments.Nodes[0]) {
-					if argValue, ok := getStaticStringValue(callExpr.Arguments.Nodes[0]); ok {
-						if isImportPathAllowed(argValue) {
-							return
-						}
+				if len(callExpr.Arguments.Nodes) > 0 {
+					if argValue, ok := getStaticStringValue(callExpr.Arguments.Nodes[0]); ok && isImportPathAllowed(argValue) {
+						return
 					}
 				}
 
-				// Report the error
-				ctx.ReportNode(node, rule.RuleMessage{
-					Id:          "noRequireImports",
-					Description: "A `require()` style import is forbidden.",
-				})
+				// Ignore user-land bindings named require. Resolve follows the
+				// binder's lexical scope chain, while the declaration-in-file check
+				// keeps ambient/config globals classified as the CommonJS require.
+				if symbol := ctx.Refs.Resolve(requireIdentifier); utils.IsValueSymbolDeclaredInFile(symbol, ctx.SourceFile) {
+					return
+				}
+
+				ctx.ReportNode(node, noRequireImportsMessage)
 			},
 
 			ast.KindExternalModuleReference: func(node *ast.Node) {
 				extModRef := node.AsExternalModuleReference()
 
 				// Check if expression matches allowed patterns
-				if isStringOrTemplateLiteral(extModRef.Expression) {
-					if argValue, ok := getStaticStringValue(extModRef.Expression); ok {
-						if isImportPathAllowed(argValue) {
-							return
-						}
-					}
+				if argValue, ok := getStaticStringValue(extModRef.Expression); ok && isImportPathAllowed(argValue) {
+					return
 				}
 
 				// Check if allowAsImport is true and parent is TSImportEqualsDeclaration
-				if opts.AllowAsImport && node.Parent != nil &&
+				if allowAsImport && node.Parent != nil &&
 					node.Parent.Kind == ast.KindImportEqualsDeclaration {
 					return
 				}
 
-				// Report the error
-				ctx.ReportNode(node, rule.RuleMessage{
-					Id:          "noRequireImports",
-					Description: "A `require()` style import is forbidden.",
-				})
+				ctx.ReportNode(node, noRequireImportsMessage)
 			},
 		}
 	},

--- a/internal/plugins/typescript/rules/no_require_imports/no_require_imports_test.go
+++ b/internal/plugins/typescript/rules/no_require_imports/no_require_imports_test.go
@@ -24,6 +24,62 @@ import { createRequire } from 'module';
 const require = createRequire();
 require('remark-preset-prettier');
 		`},
+		{Code: `
+function load(require: (id: string) => unknown) {
+  return require('package');
+}
+		`},
+		{Code: `
+function load({ require }: { require: (id: string) => unknown }) {
+  return require('package');
+}
+		`},
+		{Code: `
+try {
+  run();
+} catch (require) {
+  require('package');
+}
+		`},
+		{Code: `
+import require from 'custom-loader';
+require('package');
+		`},
+		{Code: `
+function require(id: string): unknown {
+  return id;
+}
+require('package');
+		`},
+		{Code: `
+{
+  require('package');
+  const require = customRequire;
+}
+		`},
+		{Code: `
+const loader = function require() {
+  return require('package');
+};
+		`},
+		{Code: `
+const Loader = class require {
+  static load() {
+    return require('package');
+  }
+};
+		`},
+		{Code: `
+const require = customRequire;
+function load(value = require('package')) {
+  return value;
+}
+		`},
+		{Code: `
+function load(require = require('package')) {
+  return require;
+}
+		`},
 
 		// Allow patterns
 		{
@@ -155,6 +211,78 @@ var lib5 = require('lib5'),
 					MessageId: "noRequireImports",
 					Line:      3,
 					Column:    10,
+				},
+			},
+		},
+		{
+			Code: `
+function load(require: (id: string) => unknown) {
+  require('local');
+}
+require('global');
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noRequireImports",
+					Line:      5,
+					Column:    1,
+				},
+			},
+		},
+		{
+			Code: `
+{
+  const require = customRequire;
+  require('local');
+}
+require('global');
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noRequireImports",
+					Line:      6,
+					Column:    1,
+				},
+			},
+		},
+		{
+			Code: `
+type require = (id: string) => unknown;
+require('global');
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noRequireImports",
+					Line:      3,
+					Column:    1,
+				},
+			},
+		},
+		{
+			Code: `
+function load(
+  value = require('global'),
+) {
+  const require = customRequire;
+  return value;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noRequireImports",
+					Line:      3,
+					Column:    11,
+				},
+			},
+		},
+		{
+			Code:    "require('global');",
+			Globals: map[string]bool{"require": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noRequireImports",
+					Line:      1,
+					Column:    1,
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- Replace repeated ancestor and statement-list scans with scope-aware `ctx.Refs.Resolve` lookups, removing quadratic behavior across repeated `require()` calls.
- Preserve global and ambient `require` reporting while correctly recognizing local parameters, destructuring bindings, imports, function/class expression names, and block-scoped declarations.
- Reuse the diagnostic message and streamline option/static-string handling without changing the rule framework.

### Benchmark

Command: `go test ./internal/plugins/typescript/rules/no_require_imports -run "^$" -bench "^BenchmarkNoRequireImports$" -benchmem -count=6 -benchtime=100x -cpu=1`

Environment: Apple M1 Max, darwin/arm64. Each operation evaluates 512 `require()` calls. Values are medians from six runs; the temporary benchmark harness is not included in this PR.

| Scenario | Before | After | Time | Speedup | Allocations |
| --- | ---: | ---: | ---: | ---: | ---: |
| Unchecked global | 1,203,911 ns/op | 104,089 ns/op | -91.4% | 11.6x | unchanged: 512 allocs/op |
| Unchecked local | 567,166 ns/op | 48,368 ns/op | -91.5% | 11.7x | unchanged: 0 allocs/op |
| Real-checker global | 1,281,965 ns/op | 240,145 ns/op | -81.3% | 5.3x | unchanged: 512 allocs/op |
| Real-checker local | 562,234 ns/op | 47,765 ns/op | -91.5% | 11.8x | unchanged: 0 allocs/op |

### Validation

- `go test ./internal/plugins/typescript/rules/no_require_imports -run "^TestNoRequireImportsRule$" -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/typescript/rules/no_require_imports`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; no user-facing configuration change).