### PR TITLE
perf: optimize prefer-enum-initializers

### DIFF
--- a/internal/plugins/typescript/rules/prefer_enum_initializers/prefer_enum_initializers.go
+++ b/internal/plugins/typescript/rules/prefer_enum_initializers/prefer_enum_initializers.go
@@ -1,7 +1,6 @@
 package prefer_enum_initializers
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/microsoft/typescript-go/shim/ast"
@@ -12,7 +11,7 @@ import (
 func buildDefineInitializerMessage(name string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "defineInitializer",
-		Description: fmt.Sprintf("The value of the member '%s' should be explicitly defined.", name),
+		Description: "The value of the member '" + name + "' should be explicitly defined.",
 		Data:        map[string]string{"name": name},
 	}
 }
@@ -20,7 +19,7 @@ func buildDefineInitializerMessage(name string) rule.RuleMessage {
 func buildDefineInitializerSuggestionMessage(name, suggested string) rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "defineInitializerSuggestion",
-		Description: fmt.Sprintf("Can be fixed to %s = %s", name, suggested),
+		Description: "Can be fixed to " + name + " = " + suggested,
 		Data:        map[string]string{"name": name, "suggested": suggested},
 	}
 }
@@ -28,6 +27,7 @@ func buildDefineInitializerSuggestionMessage(name, suggested string) rule.RuleMe
 var PreferEnumInitializersRule = rule.CreateRule(rule.Rule{
 	Name: "prefer-enum-initializers",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		sourceText := ctx.SourceFile.Text()
 		return rule.RuleListeners{
 			ast.KindEnumDeclaration: func(node *ast.Node) {
 				enumDecl := node.AsEnumDeclaration()
@@ -41,31 +41,34 @@ var PreferEnumInitializersRule = rule.CreateRule(rule.Rule{
 						continue
 					}
 
-					name := utils.TrimmedNodeText(ctx.SourceFile, memberNode)
-					indexStr := strconv.Itoa(index)
-					nextStr := strconv.Itoa(index + 1)
-					stringSuggested := "'" + name + "'"
+					memberRange := utils.TrimNodeTextRange(ctx.SourceFile, memberNode)
+					name := sourceText[memberRange.Pos():memberRange.End()]
 
-					ctx.ReportNodeWithSuggestions(memberNode, buildDefineInitializerMessage(name),
-						rule.RuleSuggestion{
-							Message: buildDefineInitializerSuggestionMessage(name, indexStr),
-							FixesArr: []rule.RuleFix{
-								rule.RuleFixReplace(ctx.SourceFile, memberNode, name+" = "+indexStr),
+					ctx.ReportRangeWithDeferredSuggestions(memberRange, buildDefineInitializerMessage(name), func() []rule.RuleSuggestion {
+						indexStr := strconv.Itoa(index)
+						nextStr := strconv.Itoa(index + 1)
+						stringSuggested := "'" + name + "'"
+						// Keep the three single-fix suggestions in one backing array.
+						fixes := [...]rule.RuleFix{
+							rule.RuleFixReplaceRange(memberRange, name+" = "+indexStr),
+							rule.RuleFixReplaceRange(memberRange, name+" = "+nextStr),
+							rule.RuleFixReplaceRange(memberRange, name+" = "+stringSuggested),
+						}
+						return []rule.RuleSuggestion{
+							{
+								Message:  buildDefineInitializerSuggestionMessage(name, indexStr),
+								FixesArr: fixes[0:1:1],
 							},
-						},
-						rule.RuleSuggestion{
-							Message: buildDefineInitializerSuggestionMessage(name, nextStr),
-							FixesArr: []rule.RuleFix{
-								rule.RuleFixReplace(ctx.SourceFile, memberNode, name+" = "+nextStr),
+							{
+								Message:  buildDefineInitializerSuggestionMessage(name, nextStr),
+								FixesArr: fixes[1:2:2],
 							},
-						},
-						rule.RuleSuggestion{
-							Message: buildDefineInitializerSuggestionMessage(name, stringSuggested),
-							FixesArr: []rule.RuleFix{
-								rule.RuleFixReplace(ctx.SourceFile, memberNode, name+" = "+stringSuggested),
+							{
+								Message:  buildDefineInitializerSuggestionMessage(name, stringSuggested),
+								FixesArr: fixes[2:3:3],
 							},
-						},
-					)
+						}
+					})
 				}
 			},
 		}

--- a/internal/plugins/typescript/rules/prefer_enum_initializers/prefer_enum_initializers_extras_test.go
+++ b/internal/plugins/typescript/rules/prefer_enum_initializers/prefer_enum_initializers_extras_test.go
@@ -7,9 +7,14 @@
 package prefer_enum_initializers
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
@@ -1228,4 +1233,88 @@ namespace A {
 			},
 		},
 	})
+}
+
+func TestPreferEnumInitializersSuggestionDemand(t *testing.T) {
+	const source = "enum Direction { /* leading */ Up, Down }"
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/prefer-enum-initializers-suggestion-demand.ts",
+		Path:     "/prefer-enum-initializers-suggestion-demand.ts",
+	}, source, core.ScriptKindTS)
+	enumDeclaration := sourceFile.Statements.Nodes[0]
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{
+			SourceFile:     sourceFile,
+			Comments:       comments,
+			DisableManager: rule.NewDisableManager(sourceFile, comments),
+		}.WithDiagnosticConsumer(PreferEnumInitializersRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			},
+		})
+		PreferEnumInitializersRule.Run(ctx, nil)[ast.KindEnumDeclaration](enumDeclaration)
+		return diagnostics
+	}
+
+	type expectedMember struct {
+		name        string
+		start       int
+		suggestions []string
+	}
+	expected := []expectedMember{
+		{name: "Up", start: strings.Index(source, "Up"), suggestions: []string{"0", "1", "'Up'"}},
+		{name: "Down", start: strings.Index(source, "Down"), suggestions: []string{"1", "2", "'Down'"}},
+	}
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		diagnostics := run(demand)
+		if len(diagnostics) != len(expected) {
+			t.Fatalf("demand %d produced %d diagnostics, want %d", demand, len(diagnostics), len(expected))
+		}
+		for index, diagnostic := range diagnostics {
+			want := expected[index]
+			if diagnostic.Range.Pos() != want.start || diagnostic.Range.End() != want.start+len(want.name) {
+				t.Errorf("demand %d diagnostic %d range = %v, want [%d,%d)", demand, index, diagnostic.Range, want.start, want.start+len(want.name))
+			}
+			if diagnostic.Message.Id != "defineInitializer" ||
+				diagnostic.Message.Description != "The value of the member '"+want.name+"' should be explicitly defined." ||
+				diagnostic.Message.Data["name"] != want.name {
+				t.Errorf("demand %d diagnostic %d message = %#v", demand, index, diagnostic.Message)
+			}
+			if diagnostic.FixesPtr != nil {
+				t.Errorf("demand %d diagnostic %d unexpectedly materialized an autofix", demand, index)
+			}
+			if demand&rule.EditDemandSuggestion == 0 {
+				if diagnostic.Suggestions != nil {
+					t.Errorf("demand %d diagnostic %d materialized suggestions", demand, index)
+				}
+				continue
+			}
+			if diagnostic.Suggestions == nil || len(*diagnostic.Suggestions) != len(want.suggestions) {
+				t.Fatalf("demand %d diagnostic %d suggestions = %#v", demand, index, diagnostic.Suggestions)
+			}
+			for suggestionIndex, suggestion := range *diagnostic.Suggestions {
+				suggested := want.suggestions[suggestionIndex]
+				if suggestion.Message.Id != "defineInitializerSuggestion" ||
+					suggestion.Message.Description != "Can be fixed to "+want.name+" = "+suggested ||
+					suggestion.Message.Data["name"] != want.name ||
+					suggestion.Message.Data["suggested"] != suggested {
+					t.Errorf("demand %d diagnostic %d suggestion %d message = %#v", demand, index, suggestionIndex, suggestion.Message)
+				}
+				fixes := suggestion.Fixes()
+				if len(fixes) != 1 || fixes[0].Range != diagnostic.Range || fixes[0].Text != want.name+" = "+suggested {
+					t.Errorf("demand %d diagnostic %d suggestion %d fixes = %#v", demand, index, suggestionIndex, fixes)
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- compute each uninitialized enum member's trimmed range once and reuse it for the diagnostic and all suggestion fixes
- defer suggestion messages, replacement text, and fixes until the diagnostic consumer requests suggestions
- replace formatting on the hot path with direct string construction and share one fixed backing array across the three single-fix suggestions
- keep the rule independent of `ctx.Refs`, since it only inspects enum declaration members and performs no symbol-reference queries
- add coverage for all edit-demand modes, including exact messages, ranges, structured data, and suggestion fixes

### Benchmark

Environment: Apple M1 Max, darwin/arm64, Go 1.26.1. The temporary benchmark processed one enum with 100 uninitialized members. Before and after implementations ran in the same benchmark binary; values below are the median of 10 runs with 1,000 fixed iterations per run.

```sh
go test ./internal/plugins/typescript/rules/prefer_enum_initializers \
  -run '^$' \
  -bench '^BenchmarkPreferEnumInitializers$' \
  -benchmem -benchtime=1000x -count=10 -cpu=1
```

| Mode | Time | Bytes | Allocations |
| --- | ---: | ---: | ---: |
| Diagnostics only | 195,483 → 34,282 ns/op (-82.5%) | 279,217 → 56,000 B/op (-79.9%) | 3,301 → 400 allocs/op (-87.9%) |
| Suggestions requested | 198,574 → 118,582 ns/op (-40.3%) | 279,217 → 204,800 B/op (-26.7%) | 3,301 → 2,001 allocs/op (-39.4%) |

### Validation

- `go test ./internal/plugins/typescript/rules/prefer_enum_initializers -count=1`
- `golangci-lint run internal/plugins/typescript/rules/prefer_enum_initializers/prefer_enum_initializers.go internal/plugins/typescript/rules/prefer_enum_initializers/prefer_enum_initializers_extras_test.go`
- `pnpm run check-spell`
- `pnpm run format:check`
- adversarial old/new `RuleDiagnostic` parity comparison across mixed, nested, suppressed, quoted, Unicode, and 128-member enum inputs under all four edit-demand modes

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
