### PR TITLE
perf: optimize no-useless-backreference

### DIFF
--- a/internal/rules/no_useless_backreference/no_useless_backreference.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference.go
@@ -259,6 +259,21 @@ func isBuiltinRegExpCallee(ctx rule.RuleContext, callee *ast.Node, calleeCache *
 		name := callee.AsIdentifier().Text
 		if name == "RegExp" {
 			// Direct `RegExp` reference — must not be shadowed.
+			// RefStore resolves same-file bindings with the binder's scope walk,
+			// avoiding IsShadowed's repeated scans of enclosing statements. Its
+			// checker fallback still recognizes the standard-library global and
+			// ambient augmentations.
+			if ctx.Refs != nil {
+				if sym := ctx.Refs.Resolve(callee); sym != nil {
+					return !utils.IsSymbolDeclaredInFile(sym, ctx.SourceFile)
+				}
+				// With a checker, failure to resolve is authoritative. Without one,
+				// globals are outside RefStore's binder-only scope, so retain the
+				// syntactic fallback below.
+				if ctx.TypeChecker != nil {
+					return false
+				}
+			}
 			if utils.IsShadowed(callee, "RegExp") {
 				return false
 			}

--- a/internal/rules/no_useless_backreference/no_useless_backreference_test.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference_test.go
@@ -52,6 +52,7 @@ RegExp(new String('\\1(a)'));`},
 			{Code: `function foo() { var RegExp; RegExp('\\1(a)', 'u'); }`},
 			{Code: `function foo(RegExp) { new RegExp('\\1(a)'); }`},
 			{Code: `if (foo) { const RegExp = bar; RegExp('\\1(a)'); }`},
+			{Code: `namespace RegExp {} RegExp('\\1(a)');`},
 			// SKIP: rslint does not support ESLint's /*globals*/ directive comments
 			// `/* globals RegExp:off */ new RegExp('\\1(a)');`
 			// `RegExp('\\1(a)');` with languageOptions.globals { RegExp: "off" }
@@ -615,6 +616,54 @@ func TestImportedRegExpConstructorAlias(t *testing.T) {
 			diagnostics = append(diagnostics, diagnostic)
 		},
 		nil,
+		nil,
+	)
+	if len(diagnostics) != 1 || diagnostics[0].Message.Id != "forward" {
+		t.Fatalf("diagnostics = %#v; want one forward report", diagnostics)
+	}
+}
+
+func TestRegExpResolutionWithoutTypeInfo(t *testing.T) {
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir, "file.ts")
+	fs := utils.NewOverlayVFS(bundled.WrapFS(osvfs.FS()), map[string]string{
+		filePath: `
+RegExp("\\1(a)");
+{
+	const RegExp = (pattern: string) => pattern;
+	RegExp("\\1(a)");
+}`,
+	})
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceFile := program.GetSourceFile(filePath)
+	if sourceFile == nil {
+		t.Fatal("file.ts was not loaded")
+	}
+
+	var diagnostics []rule.RuleDiagnostic
+	linter.RunLinterInProgram(
+		program,
+		[]string{sourceFile.FileName()},
+		nil,
+		nil,
+		func(*ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:     NoUselessBackreferenceRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return NoUselessBackreferenceRule.Run(ctx, nil)
+				},
+			}}
+		},
+		false,
+		func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+		map[string]struct{}{}, // Keep the Program/RefStore but withhold the checker.
 		nil,
 	)
 	if len(diagnostics) != 1 || diagnostics[0].Message.Id != "forward" {

--- a/internal/rules/no_useless_backreference/parser.go
+++ b/internal/rules/no_useless_backreference/parser.go
@@ -135,10 +135,7 @@ func (p *rxParser) parseAlternatives(parent *rxNode, expectClose bool) bool {
 	for p.pos < len(p.pattern) {
 		c := p.pattern[p.pos]
 		if c == ')' {
-			if !expectClose {
-				return false
-			}
-			return true
+			return expectClose
 		}
 		if c == '|' {
 			p.pos++
@@ -150,11 +147,7 @@ func (p *rxParser) parseAlternatives(parent *rxNode, expectClose bool) bool {
 		}
 	}
 
-	if expectClose {
-		return false
-	}
-
-	return true
+	return !expectClose
 }
 
 func (p *rxParser) parseTerm(parent *rxNode) bool {

--- a/internal/rules/no_useless_backreference/parser.go
+++ b/internal/rules/no_useless_backreference/parser.go
@@ -34,16 +34,11 @@ const (
 // rxNode is a node in the lightweight regex AST. Only the fields relevant to
 // the rule are populated.
 type rxNode struct {
-	kind     rxNodeKind
-	start    int // byte offset of the construct's first char in the pattern
-	end      int // byte offset one past the last char
-	raw      string
-	parent   *rxNode
-	children []*rxNode
-
-	// for capturing groups
-	name   string // empty for unnamed groups
-	number int    // 1-based; 0 for non-capturing groups
+	kind   rxNodeKind
+	start  int // byte offset of the construct's first char in the pattern
+	end    int // byte offset one past the last char
+	raw    string
+	parent *rxNode
 
 	// for lookarounds
 	isAhead bool
@@ -62,7 +57,7 @@ func isNegativeLookaround(n *rxNode) bool { return n != nil && n.kind == nkLooka
 // parsePattern parses a regex pattern and returns the root Pattern node and a
 // flat list of backreference nodes. Returns ok=false on syntax errors.
 func parsePattern(pattern string, flags utils.RegexFlags) (root *rxNode, backrefs []*rxNode, ok bool) {
-	totalGroups, hasNamedGroups, scanOk := scanGroups(pattern, flags)
+	totalGroups, hasNamedGroups, nodeCapacity, backrefCapacity, scanOk := scanGroups(pattern, flags)
 	if !scanOk {
 		return nil, nil, false
 	}
@@ -72,10 +67,15 @@ func parsePattern(pattern string, flags utils.RegexFlags) (root *rxNode, backref
 		flags:          flags,
 		totalGroups:    totalGroups,
 		hasNamedGroups: hasNamedGroups,
-		namedGroups:    map[string][]*rxNode{},
+		nodes:          make([]rxNode, 0, nodeCapacity),
+		numberedGroups: make([]*rxNode, 0, totalGroups),
+		backrefs:       make([]*rxNode, 0, backrefCapacity),
+	}
+	if hasNamedGroups {
+		p.namedGroups = make(map[string][]*rxNode, totalGroups)
 	}
 
-	root = &rxNode{kind: nkPattern, start: 0, end: len(pattern), raw: pattern}
+	root = p.newNode(rxNode{kind: nkPattern})
 	if !p.parseAlternatives(root, false) {
 		return nil, nil, false
 	}
@@ -87,7 +87,7 @@ func parsePattern(pattern string, flags utils.RegexFlags) (root *rxNode, backref
 		if br.refName != "" {
 			br.resolved = p.namedGroups[br.refName]
 		} else if br.refNum > 0 && br.refNum <= len(p.numberedGroups) {
-			br.resolved = []*rxNode{p.numberedGroups[br.refNum-1]}
+			br.resolved = p.numberedGroups[br.refNum-1 : br.refNum]
 		}
 		if len(br.resolved) == 0 {
 			return nil, nil, false
@@ -107,13 +107,30 @@ type rxParser struct {
 	numberedGroups []*rxNode
 	namedGroups    map[string][]*rxNode
 	backrefs       []*rxNode
+	nodes          []rxNode
+}
+
+// newNode allocates parser nodes from one pre-sized backing array. scanGroups
+// computes an upper bound before parsing, so pointers into nodes stay stable
+// and a regex pays for one node allocation instead of one allocation per
+// structural construct. The fallback keeps pointer stability if a future
+// parser extension creates a node the scan does not yet count.
+func (p *rxParser) newNode(node rxNode) *rxNode {
+	if len(p.nodes) == cap(p.nodes) {
+		result := new(rxNode)
+		*result = node
+		return result
+	}
+	p.nodes = p.nodes[:len(p.nodes)+1]
+	result := &p.nodes[len(p.nodes)-1]
+	*result = node
+	return result
 }
 
 // parseAlternatives consumes alternatives separated by `|`, ending at either
 // `)` (when expectClose) or end-of-input.
 func (p *rxParser) parseAlternatives(parent *rxNode, expectClose bool) bool {
-	alt := &rxNode{kind: nkAlternative, start: p.pos, parent: parent}
-	parent.children = append(parent.children, alt)
+	alt := p.newNode(rxNode{kind: nkAlternative, parent: parent})
 
 	for p.pos < len(p.pattern) {
 		c := p.pattern[p.pos]
@@ -121,16 +138,11 @@ func (p *rxParser) parseAlternatives(parent *rxNode, expectClose bool) bool {
 			if !expectClose {
 				return false
 			}
-			alt.end = p.pos
-			alt.raw = p.pattern[alt.start:alt.end]
 			return true
 		}
 		if c == '|' {
-			alt.end = p.pos
-			alt.raw = p.pattern[alt.start:alt.end]
 			p.pos++
-			alt = &rxNode{kind: nkAlternative, start: p.pos, parent: parent}
-			parent.children = append(parent.children, alt)
+			alt = p.newNode(rxNode{kind: nkAlternative, parent: parent})
 			continue
 		}
 		if !p.parseTerm(alt) {
@@ -142,8 +154,6 @@ func (p *rxParser) parseAlternatives(parent *rxNode, expectClose bool) bool {
 		return false
 	}
 
-	alt.end = p.pos
-	alt.raw = p.pattern[alt.start:alt.end]
 	return true
 }
 
@@ -240,13 +250,13 @@ func (p *rxParser) parseGroup(parent *rxNode) bool {
 		switch c {
 		case ':':
 			p.pos += 2
-			node = &rxNode{kind: nkGroup, start: start, parent: parent}
+			node = p.newNode(rxNode{kind: nkGroup, start: start, parent: parent})
 		case '=':
 			p.pos += 2
-			node = &rxNode{kind: nkLookaround, start: start, parent: parent, isAhead: true, negate: false}
+			node = p.newNode(rxNode{kind: nkLookaround, start: start, parent: parent, isAhead: true})
 		case '!':
 			p.pos += 2
-			node = &rxNode{kind: nkLookaround, start: start, parent: parent, isAhead: true, negate: true}
+			node = p.newNode(rxNode{kind: nkLookaround, start: start, parent: parent, isAhead: true, negate: true})
 		case '<':
 			if p.pos+2 >= len(p.pattern) {
 				return false
@@ -254,10 +264,10 @@ func (p *rxParser) parseGroup(parent *rxNode) bool {
 			switch p.pattern[p.pos+2] {
 			case '=':
 				p.pos += 3
-				node = &rxNode{kind: nkLookaround, start: start, parent: parent, isAhead: false, negate: false}
+				node = p.newNode(rxNode{kind: nkLookaround, start: start, parent: parent})
 			case '!':
 				p.pos += 3
-				node = &rxNode{kind: nkLookaround, start: start, parent: parent, isAhead: false, negate: true}
+				node = p.newNode(rxNode{kind: nkLookaround, start: start, parent: parent, negate: true})
 			default:
 				// (?<name>...)
 				p.pos += 2 // consume `?<`
@@ -272,7 +282,7 @@ func (p *rxParser) parseGroup(parent *rxNode) bool {
 				p.pos = nameEnd + 1
 				p.numberedGroups = append(p.numberedGroups, nil)
 				num := len(p.numberedGroups)
-				node = &rxNode{kind: nkCapturingGroup, start: start, parent: parent, name: name, number: num}
+				node = p.newNode(rxNode{kind: nkCapturingGroup, start: start, parent: parent})
 				p.numberedGroups[num-1] = node
 				p.namedGroups[name] = append(p.namedGroups[name], node)
 			}
@@ -282,11 +292,9 @@ func (p *rxParser) parseGroup(parent *rxNode) bool {
 	} else {
 		p.numberedGroups = append(p.numberedGroups, nil)
 		num := len(p.numberedGroups)
-		node = &rxNode{kind: nkCapturingGroup, start: start, parent: parent, number: num}
+		node = p.newNode(rxNode{kind: nkCapturingGroup, start: start, parent: parent})
 		p.numberedGroups[num-1] = node
 	}
-
-	parent.children = append(parent.children, node)
 
 	if !p.parseAlternatives(node, true) {
 		return false
@@ -322,15 +330,14 @@ func (p *rxParser) parseEscape(parent *rxNode) bool {
 				}
 				if nameEnd < len(p.pattern) && nameEnd > p.pos+3 {
 					name := p.pattern[p.pos+3 : nameEnd]
-					bref := &rxNode{
+					bref := p.newNode(rxNode{
 						kind:    nkBackref,
 						start:   p.pos,
 						end:     nameEnd + 1,
 						raw:     p.pattern[p.pos : nameEnd+1],
 						parent:  parent,
 						refName: name,
-					}
-					parent.children = append(parent.children, bref)
+					})
 					p.backrefs = append(p.backrefs, bref)
 					p.pos = nameEnd + 1
 					return true
@@ -353,15 +360,14 @@ func (p *rxParser) parseEscape(parent *rxNode) bool {
 		}
 		n, _ := strconv.Atoi(p.pattern[p.pos+1 : end])
 		if p.flags.UV() || n <= p.totalGroups {
-			bref := &rxNode{
+			bref := p.newNode(rxNode{
 				kind:   nkBackref,
 				start:  p.pos,
 				end:    end,
 				raw:    p.pattern[p.pos:end],
 				parent: parent,
 				refNum: n,
-			}
-			parent.children = append(parent.children, bref)
+			})
 			p.backrefs = append(p.backrefs, bref)
 			p.pos = end
 			return true
@@ -385,28 +391,46 @@ func (p *rxParser) parseEscape(parent *rxNode) bool {
 
 // scanGroups walks the pattern to count capturing groups and detect whether
 // any are named. Skips over character classes and escapes correctly.
-func scanGroups(pattern string, flags utils.RegexFlags) (totalGroups int, hasNamedGroups bool, ok bool) {
+func scanGroups(pattern string, flags utils.RegexFlags) (
+	totalGroups int,
+	hasNamedGroups bool,
+	nodeCapacity int,
+	backrefCapacity int,
+	ok bool,
+) {
+	// Pattern and its first alternative always exist. Each group contributes
+	// its own node and first alternative; each `|` contributes another
+	// alternative; and each backreference-looking escape can contribute at
+	// most one backreference node. This is an upper bound because some numeric
+	// escapes are later classified as octal.
+	nodeCapacity = 2
 	i := 0
 	for i < len(pattern) {
 		c := pattern[i]
 		switch c {
 		case '\\':
+			if i+1 < len(pattern) &&
+				(pattern[i+1] == 'k' || pattern[i+1] >= '1' && pattern[i+1] <= '9') {
+				nodeCapacity++
+				backrefCapacity++
+			}
 			step, escOk := skipBackrefAwareEscape(pattern, i, flags)
 			if !escOk {
-				return 0, false, false
+				return 0, false, 0, 0, false
 			}
 			i += step
 		case '[':
 			end, classOk := utils.ClassEnd(pattern, i, flags)
 			if !classOk {
-				return 0, false, false
+				return 0, false, 0, 0, false
 			}
 			i = end
 		case '(':
+			nodeCapacity += 2
 			i++
 			if i < len(pattern) && pattern[i] == '?' {
 				if i+1 >= len(pattern) {
-					return 0, false, false
+					return 0, false, 0, 0, false
 				}
 				next := pattern[i+1]
 				if next == ':' || next == '=' || next == '!' {
@@ -428,16 +452,19 @@ func scanGroups(pattern string, flags utils.RegexFlags) (totalGroups int, hasNam
 						nameEnd++
 					}
 					if nameEnd >= len(pattern) || nameEnd == i {
-						return 0, false, false
+						return 0, false, 0, 0, false
 					}
 					totalGroups++
 					hasNamedGroups = true
 					i = nameEnd + 1
 					continue
 				}
-				return 0, false, false
+				return 0, false, 0, 0, false
 			}
 			totalGroups++
+		case '|':
+			nodeCapacity++
+			i++
 		default:
 			_, w := utf8.DecodeRuneInString(pattern[i:])
 			if w == 0 {
@@ -447,7 +474,7 @@ func scanGroups(pattern string, flags utils.RegexFlags) (totalGroups int, hasNam
 			}
 		}
 	}
-	return totalGroups, hasNamedGroups, true
+	return totalGroups, hasNamedGroups, nodeCapacity, backrefCapacity, true
 }
 
 // skipBackrefAwareEscape wraps utils.SkipPatternEscape with extra handling


### PR DESCRIPTION
## Summary

- Resolve direct `RegExp` references through the shared `ctx.Refs` binder index, avoiding repeated enclosing-statement scans while preserving checker fallback for lib and ambient symbols.
- Allocate the lightweight regex AST from a pre-sized node arena, preallocate group/backreference slices, and remove unused node fields.
- Preserve the syntax-only fallback when type information is unavailable, plus the existing checker path for imported, ambient, and flow-narrowed constructor aliases.
- Extend the existing rule test file with namespace-shadowing and no-type-info RefStore coverage.

Deferred report APIs were not used: this rule emits diagnostics without fixes or suggestions, while those APIs only defer optional edit artifacts.

### Benchmark

Temporary benchmark harness (not committed), Apple M1 Max, darwin/arm64:

`go test ./internal/rules/no_useless_backreference -run '^$' -bench '^BenchmarkNoUselessBackreference' -benchmem -benchtime=300ms -count=10`

Values are medians across 10 runs.

| Benchmark | Time before | Time after | Time | B/op before | B/op after | B/op | allocs/op before | allocs/op after | allocs |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| parser/simple-forward | 450.2 ns | 220.8 ns | -51.0% | 912 | 592 | -35.1% | 13 | 3 | -76.9% |
| parser/nested-lookarounds | 2.536 µs | 1.013 µs | -60.1% | 4,872 | 3,152 | -35.3% | 63 | 3 | -95.2% |
| parser/duplicate-names | 1.767 µs | 956.0 ns | -45.9% | 3,296 | 2,304 | -30.1% | 40 | 8 | -80.0% |
| parser/long-valid | 4.848 µs | 2.228 µs | -54.1% | 9,456 | 6,160 | -34.9% | 97 | 3 | -96.9% |
| rule/regex-heavy | 792.2 µs | 567.4 µs | -28.4% | 1,276,809 | 959,144 | -24.9% | 16,456 | 6,471 | -60.7% |
| rule/constructor-heavy | 6.343 ms | 513.2 µs | -91.9% | 749,484 | 541,707 | -27.7% | 10,084 | 3,915 | -61.2% |
| rule/call-heavy-no-match | 347.4 µs | 344.3 µs | -0.9% | 33,462 | 33,462 | 0.0% | 330 | 330 | 0.0% |

The unchanged call-heavy negative path provides a guard against shifting work onto unrelated calls.

### Validation

- `go test ./internal/rules/no_useless_backreference -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run ./internal/rules/no_useless_backreference`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).