### PR TITLE
perf: optimize no-nonoctal-decimal-escape

### DIFF
--- a/internal/rules/no_nonoctal_decimal_escape/no_nonoctal_decimal_escape.go
+++ b/internal/rules/no_nonoctal_decimal_escape/no_nonoctal_decimal_escape.go
@@ -1,29 +1,36 @@
 package no_nonoctal_decimal_escape
 
 import (
-	"fmt"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // https://eslint.org/docs/latest/rules/no-nonoctal-decimal-escape
 var NoNonoctalDecimalEscapeRule = rule.Rule{
 	Name: "no-nonoctal-decimal-escape",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		sourceText := ctx.SourceFile.Text()
 		return rule.RuleListeners{
 			ast.KindStringLiteral: func(node *ast.Node) {
-				trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
-				rawStart := trimmedRange.Pos()
-				raw := ctx.SourceFile.Text()[rawStart:trimmedRange.End()]
-
-				if !containsBackslashDigit89(raw) {
+				// Ordinary string literals containing \8 or \9 carry this flag.
+				// JSX attribute strings are scanned in verbatim mode, so their token
+				// flags do not describe escapes and they need the raw-text fallback.
+				literal := node.AsStringLiteral()
+				if literal.TokenFlags&ast.TokenFlagsContainsInvalidEscape == 0 &&
+					(node.Parent == nil || node.Parent.Kind != ast.KindJsxAttribute) {
 					return
 				}
 
-				for _, hit := range scanDecimalEscapes(raw) {
+				rawStart := scanner.SkipTrivia(sourceText, node.Pos())
+				rawEnd := node.End()
+				if rawStart < 0 || rawStart >= rawEnd || rawEnd > len(sourceText) {
+					return
+				}
+
+				decimalEscapes := newDecimalEscapeIterator(sourceText[rawStart:rawEnd])
+				for hit, ok := decimalEscapes.next(); ok; hit, ok = decimalEscapes.next() {
 					reportDecimalEscape(ctx, rawStart, hit)
 				}
 			},
@@ -42,16 +49,17 @@ type decimalEscapeHit struct {
 	decimalEscape       string
 }
 
-func containsBackslashDigit89(raw string) bool {
-	for i := 0; i+1 < len(raw); i++ {
-		if raw[i] == '\\' && (raw[i+1] == '8' || raw[i+1] == '9') {
-			return true
-		}
-	}
-	return false
+type decimalEscapeIterator struct {
+	raw                 string
+	offset              int
+	previousEscapeStart int
 }
 
-// scanDecimalEscapes walks raw source text and returns every \8 / \9 hit.
+func newDecimalEscapeIterator(raw string) decimalEscapeIterator {
+	return decimalEscapeIterator{raw: raw, previousEscapeStart: -1}
+}
+
+// next walks raw source text and returns the next \8 / \9 hit.
 // Mirrors ESLint's regex
 //
 //	(?:[^\\]|(?<previousEscape>\\.))*?(?<decimalEscape>\\[89])
@@ -61,127 +69,166 @@ func containsBackslashDigit89(raw string) bool {
 // is immediately adjacent to the decimal escape — any unescaped character
 // between them clears it. We replicate that by resetting `previousEscape`
 // whenever a non-backslash byte is consumed.
-func scanDecimalEscapes(raw string) []decimalEscapeHit {
-	var hits []decimalEscapeHit
-	previousEscape := ""
-	previousEscapeStart := -1
-	n := len(raw)
-	for i := 0; i < n; {
-		if raw[i] != '\\' {
-			i++
-			previousEscape = ""
-			previousEscapeStart = -1
+func (s *decimalEscapeIterator) next() (decimalEscapeHit, bool) {
+	for s.offset < len(s.raw) {
+		if s.raw[s.offset] != '\\' {
+			s.offset++
+			s.previousEscapeStart = -1
 			continue
 		}
-		if i+1 >= n {
+		if s.offset+1 >= len(s.raw) {
 			break
 		}
-		next := raw[i+1]
+
+		escapeStart := s.offset
+		next := s.raw[escapeStart+1]
 		if next == '8' || next == '9' {
-			hits = append(hits, decimalEscapeHit{
+			previousEscape := ""
+			if s.previousEscapeStart >= 0 {
+				previousEscape = s.raw[s.previousEscapeStart : s.previousEscapeStart+2]
+			}
+			hit := decimalEscapeHit{
 				previousEscape:      previousEscape,
-				previousEscapeStart: previousEscapeStart,
-				decimalEscapeStart:  i,
-				decimalEscapeEnd:    i + 2,
-				decimalEscape:       raw[i : i+2],
-			})
-			i += 2
-			previousEscape = ""
-			previousEscapeStart = -1
-			continue
+				previousEscapeStart: s.previousEscapeStart,
+				decimalEscapeStart:  escapeStart,
+				decimalEscapeEnd:    escapeStart + 2,
+				decimalEscape:       s.raw[escapeStart : escapeStart+2],
+			}
+			s.offset = escapeStart + 2
+			s.previousEscapeStart = -1
+			return hit, true
 		}
-		previousEscape = raw[i : i+2]
-		previousEscapeStart = i
-		i += 2
+
+		s.previousEscapeStart = escapeStart
+		s.offset = escapeStart + 2
 	}
-	return hits
+	return decimalEscapeHit{}, false
 }
 
 func reportDecimalEscape(ctx rule.RuleContext, rawStart int, hit decimalEscapeHit) {
 	decimalEscapeStartAbs := rawStart + hit.decimalEscapeStart
 	decimalEscapeEndAbs := rawStart + hit.decimalEscapeEnd
-	digit := hit.decimalEscape[1:]
+	text := decimalEscapeTextFor(hit.decimalEscape[1])
+	decimalEscapeRange := core.NewTextRange(decimalEscapeStartAbs, decimalEscapeEndAbs)
 
-	suggestions := make([]rule.RuleSuggestion, 0, 3)
-
-	if hit.previousEscape == "\\0" {
-		// "\0\X" — replacing with "\0X" would create a legacy octal escape, so
-		// the rule offers two alternative refactors instead of the single one.
-		previousEscapeStartAbs := rawStart + hit.previousEscapeStart
-		nullEscape := unicodeEscape(0)
-		combined := nullEscape + digit
-		suggestions = append(suggestions, rule.RuleSuggestion{
-			Message: rule.RuleMessage{
-				Id:          "refactor",
-				Description: refactorMessage("\\0"+hit.decimalEscape, combined),
-			},
-			FixesArr: []rule.RuleFix{
-				rule.RuleFixReplaceRange(
-					core.NewTextRange(previousEscapeStartAbs, decimalEscapeEndAbs),
-					combined,
-				),
-			},
-		})
-		digitUnicode := unicodeEscape(rune(digit[0]))
-		suggestions = append(suggestions, rule.RuleSuggestion{
-			Message: rule.RuleMessage{
-				Id:          "refactor",
-				Description: refactorMessage(hit.decimalEscape, digitUnicode),
-			},
-			FixesArr: []rule.RuleFix{
-				rule.RuleFixReplaceRange(
-					core.NewTextRange(decimalEscapeStartAbs, decimalEscapeEndAbs),
-					digitUnicode,
-				),
-			},
-		})
-	} else {
-		suggestions = append(suggestions, rule.RuleSuggestion{
-			Message: rule.RuleMessage{
-				Id:          "refactor",
-				Description: refactorMessage(hit.decimalEscape, digit),
-			},
-			FixesArr: []rule.RuleFix{
-				rule.RuleFixReplaceRange(
-					core.NewTextRange(decimalEscapeStartAbs, decimalEscapeEndAbs),
-					digit,
-				),
-			},
-		})
-	}
-
-	escaped := "\\" + hit.decimalEscape
-	suggestions = append(suggestions, rule.RuleSuggestion{
-		Message: rule.RuleMessage{
-			Id:          "escapeBackslash",
-			Description: escapeBackslashMessage(hit.decimalEscape, escaped),
+	ctx.ReportRangeWithDeferredSuggestions(
+		decimalEscapeRange,
+		text.diagnostic,
+		func() []rule.RuleSuggestion {
+			return buildDecimalEscapeSuggestions(rawStart, decimalEscapeRange, hit, text)
 		},
-		FixesArr: []rule.RuleFix{
-			rule.RuleFixReplaceRange(
-				core.NewTextRange(decimalEscapeStartAbs, decimalEscapeEndAbs),
-				escaped,
-			),
-		},
-	})
-
-	ctx.ReportRangeWithSuggestions(
-		core.NewTextRange(decimalEscapeStartAbs, decimalEscapeEndAbs),
-		rule.RuleMessage{
-			Id:          "decimalEscape",
-			Description: fmt.Sprintf("Don't use '%s' escape sequence.", hit.decimalEscape),
-		},
-		suggestions...,
 	)
 }
 
-func unicodeEscape(ch rune) string {
-	return fmt.Sprintf("\\u%04x", ch)
+type decimalEscapeText struct {
+	digit                  string
+	digitUnicode           string
+	nullAndDigitUnicode    string
+	escaped                string
+	diagnostic             rule.RuleMessage
+	refactor               rule.RuleMessage
+	refactorNullAndDigit   rule.RuleMessage
+	refactorDigitAsUnicode rule.RuleMessage
+	escapeBackslash        rule.RuleMessage
 }
 
-func refactorMessage(original, replacement string) string {
-	return fmt.Sprintf("Replace '%s' with '%s'. This maintains the current functionality.", original, replacement)
+var decimalEscapeTexts = [...]decimalEscapeText{
+	{
+		digit:               "8",
+		digitUnicode:        `\u0038`,
+		nullAndDigitUnicode: `\u00008`,
+		escaped:             `\\8`,
+		diagnostic: rule.RuleMessage{
+			Id:          "decimalEscape",
+			Description: `Don't use '\8' escape sequence.`,
+		},
+		refactor: rule.RuleMessage{
+			Id:          "refactor",
+			Description: `Replace '\8' with '8'. This maintains the current functionality.`,
+		},
+		refactorNullAndDigit: rule.RuleMessage{
+			Id:          "refactor",
+			Description: `Replace '\0\8' with '\u00008'. This maintains the current functionality.`,
+		},
+		refactorDigitAsUnicode: rule.RuleMessage{
+			Id:          "refactor",
+			Description: `Replace '\8' with '\u0038'. This maintains the current functionality.`,
+		},
+		escapeBackslash: rule.RuleMessage{
+			Id:          "escapeBackslash",
+			Description: `Replace '\8' with '\\8' to include the actual backslash character.`,
+		},
+	},
+	{
+		digit:               "9",
+		digitUnicode:        `\u0039`,
+		nullAndDigitUnicode: `\u00009`,
+		escaped:             `\\9`,
+		diagnostic: rule.RuleMessage{
+			Id:          "decimalEscape",
+			Description: `Don't use '\9' escape sequence.`,
+		},
+		refactor: rule.RuleMessage{
+			Id:          "refactor",
+			Description: `Replace '\9' with '9'. This maintains the current functionality.`,
+		},
+		refactorNullAndDigit: rule.RuleMessage{
+			Id:          "refactor",
+			Description: `Replace '\0\9' with '\u00009'. This maintains the current functionality.`,
+		},
+		refactorDigitAsUnicode: rule.RuleMessage{
+			Id:          "refactor",
+			Description: `Replace '\9' with '\u0039'. This maintains the current functionality.`,
+		},
+		escapeBackslash: rule.RuleMessage{
+			Id:          "escapeBackslash",
+			Description: `Replace '\9' with '\\9' to include the actual backslash character.`,
+		},
+	},
 }
 
-func escapeBackslashMessage(original, replacement string) string {
-	return fmt.Sprintf("Replace '%s' with '%s' to include the actual backslash character.", original, replacement)
+func decimalEscapeTextFor(digit byte) *decimalEscapeText {
+	if digit == '8' {
+		return &decimalEscapeTexts[0]
+	}
+	return &decimalEscapeTexts[1]
+}
+
+type decimalEscapeSuggestionBundle struct {
+	fixes       [3]rule.RuleFix
+	suggestions [3]rule.RuleSuggestion
+}
+
+func (b *decimalEscapeSuggestionBundle) set(index int, message rule.RuleMessage, textRange core.TextRange, text string) {
+	b.fixes[index] = rule.RuleFixReplaceRange(textRange, text)
+	b.suggestions[index] = rule.RuleSuggestion{
+		Message:  message,
+		FixesArr: b.fixes[index : index+1 : index+1],
+	}
+}
+
+func buildDecimalEscapeSuggestions(
+	rawStart int,
+	decimalEscapeRange core.TextRange,
+	hit decimalEscapeHit,
+	text *decimalEscapeText,
+) []rule.RuleSuggestion {
+	bundle := &decimalEscapeSuggestionBundle{}
+	if hit.previousEscape == "\\0" {
+		// "\0\X" — replacing with "\0X" would create a legacy octal escape, so
+		// the rule offers two alternative refactors instead of the single one.
+		bundle.set(
+			0,
+			text.refactorNullAndDigit,
+			core.NewTextRange(rawStart+hit.previousEscapeStart, decimalEscapeRange.End()),
+			text.nullAndDigitUnicode,
+		)
+		bundle.set(1, text.refactorDigitAsUnicode, decimalEscapeRange, text.digitUnicode)
+		bundle.set(2, text.escapeBackslash, decimalEscapeRange, text.escaped)
+		return bundle.suggestions[:3:3]
+	}
+
+	bundle.set(0, text.refactor, decimalEscapeRange, text.digit)
+	bundle.set(1, text.escapeBackslash, decimalEscapeRange, text.escaped)
+	return bundle.suggestions[:2:2]
 }

--- a/internal/rules/no_nonoctal_decimal_escape/no_nonoctal_decimal_escape_test.go
+++ b/internal/rules/no_nonoctal_decimal_escape/no_nonoctal_decimal_escape_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/bundled"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
@@ -262,12 +263,228 @@ func TestScanDecimalEscapes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := scanDecimalEscapes(tt.raw)
+			got := collectDecimalEscapes(tt.raw)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("scanDecimalEscapes(%q) = %#v, want %#v", tt.raw, got, tt.want)
+				t.Errorf("decimal escape scan of %q = %#v, want %#v", tt.raw, got, tt.want)
 			}
 		})
 	}
+}
+
+func collectDecimalEscapes(raw string) []decimalEscapeHit {
+	var hits []decimalEscapeHit
+	decimalEscapes := newDecimalEscapeIterator(raw)
+	for hit, ok := decimalEscapes.next(); ok; hit, ok = decimalEscapes.next() {
+		hits = append(hits, hit)
+	}
+	return hits
+}
+
+func FuzzDecimalEscapeIteratorParity(f *testing.F) {
+	for _, seed := range []string{
+		``,
+		`'\8'`,
+		`'\\8'`,
+		`'\\\8'`,
+		`'\0\8\9'`,
+		"'\\\n\\8'",
+		"'\\\xf0\x9f\x91\x8d\\9'",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		got := collectDecimalEscapes(raw)
+		want := referenceScanDecimalEscapes(raw)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("decimal escape scan of %q = %#v, want %#v", raw, got, want)
+		}
+	})
+}
+
+// referenceScanDecimalEscapes preserves the original collect-all scanner so
+// the allocation-free iterator can be checked against it independently.
+func referenceScanDecimalEscapes(raw string) []decimalEscapeHit {
+	var hits []decimalEscapeHit
+	previousEscape := ""
+	previousEscapeStart := -1
+	for i := 0; i < len(raw); {
+		if raw[i] != '\\' {
+			i++
+			previousEscape = ""
+			previousEscapeStart = -1
+			continue
+		}
+		if i+1 >= len(raw) {
+			break
+		}
+		next := raw[i+1]
+		if next == '8' || next == '9' {
+			hits = append(hits, decimalEscapeHit{
+				previousEscape:      previousEscape,
+				previousEscapeStart: previousEscapeStart,
+				decimalEscapeStart:  i,
+				decimalEscapeEnd:    i + 2,
+				decimalEscape:       raw[i : i+2],
+			})
+			i += 2
+			previousEscape = ""
+			previousEscapeStart = -1
+			continue
+		}
+		previousEscape = raw[i : i+2]
+		previousEscapeStart = i
+		i += 2
+	}
+	return hits
+}
+
+func TestNoNonoctalDecimalEscapeFastPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		code       string
+		scriptKind core.ScriptKind
+		wantRanges []string
+	}{
+		{
+			name: "other invalid escapes do not report",
+			code: `const values = ['\xG', '\uZZZZ', '\1', '\08', '\09'];`,
+		},
+		{
+			name:       "ordinary string token flags retain decimal escapes",
+			code:       `const values = ['\8', '\9', '\\8', '\\9'];`,
+			wantRanges: []string{`\8`, `\9`},
+		},
+		{
+			name:       "leading trivia is excluded from the raw literal",
+			code:       `const value = /* '\8' */ '\9';`,
+			wantRanges: []string{`\9`},
+		},
+		{
+			name:       "jsx attributes use raw-text fallback",
+			code:       `const element = <div first='\8' second="\\9" third="safe" />;`,
+			scriptKind: core.ScriptKindTSX,
+			wantRanges: []string{`\8`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scriptKind := tt.scriptKind
+			if scriptKind == core.ScriptKindUnknown {
+				scriptKind = core.ScriptKindTS
+			}
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/fast-path.ts",
+				Path:     "/fast-path.ts",
+			}, tt.code, scriptKind)
+			diagnostics := runRuleOnParsedSource(t, sourceFile, rule.EditDemandNone)
+			if len(diagnostics) != len(tt.wantRanges) {
+				t.Fatalf("diagnostics = %d, want %d", len(diagnostics), len(tt.wantRanges))
+			}
+			for i, diagnostic := range diagnostics {
+				got := sourceFile.Text()[diagnostic.Range.Pos():diagnostic.Range.End()]
+				if got != tt.wantRanges[i] {
+					t.Errorf("diagnostic %d range text = %q, want %q", i, got, tt.wantRanges[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNoNonoctalDecimalEscapeEditDemand(t *testing.T) {
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts",
+		Path:     "/edit-demand.ts",
+	}, `const value = '\0\8\9';`, core.ScriptKindTS)
+
+	diagnostics := make(map[rule.EditDemand][]rule.RuleDiagnostic)
+	for _, demand := range []rule.EditDemand{
+		rule.EditDemandNone,
+		rule.EditDemandAutofix,
+		rule.EditDemandSuggestion,
+		rule.EditDemandAll,
+	} {
+		diagnostics[demand] = runRuleOnParsedSource(t, sourceFile, demand)
+	}
+
+	allEdits := diagnostics[rule.EditDemandAll]
+	if len(allEdits) != 2 {
+		t.Fatalf("all-edits diagnostics = %d, want 2", len(allEdits))
+	}
+	for demand, got := range diagnostics {
+		if len(got) != len(allEdits) {
+			t.Fatalf("demand %d diagnostics = %d, want %d", demand, len(got), len(allEdits))
+		}
+		for i, diagnostic := range got {
+			if diagnostic.Range != allEdits[i].Range || !reflect.DeepEqual(diagnostic.Message, allEdits[i].Message) {
+				t.Errorf("demand %d changed diagnostic %d identity", demand, i)
+			}
+			wantSuggestions := demand&rule.EditDemandSuggestion != 0
+			if (diagnostic.Suggestions != nil) != wantSuggestions {
+				t.Errorf("demand %d diagnostic %d suggestions present = %v, want %v", demand, i, diagnostic.Suggestions != nil, wantSuggestions)
+			}
+			if diagnostic.FixesPtr != nil {
+				t.Errorf("demand %d diagnostic %d unexpectedly has autofixes", demand, i)
+			}
+		}
+	}
+
+	for i, diagnostic := range allEdits {
+		if diagnostic.Suggestions == nil {
+			t.Fatalf("all-edits diagnostic %d has no suggestions", i)
+		}
+	}
+	if got := len(*allEdits[0].Suggestions); got != 3 {
+		t.Errorf("adjacent-null suggestions = %d, want 3", got)
+	}
+	if got := len(*allEdits[1].Suggestions); got != 2 {
+		t.Errorf("ordinary suggestions = %d, want 2", got)
+	}
+	wantSuggestionDescriptions := [][]string{
+		{
+			`Replace '\0\8' with '\u00008'. This maintains the current functionality.`,
+			`Replace '\8' with '\u0038'. This maintains the current functionality.`,
+			`Replace '\8' with '\\8' to include the actual backslash character.`,
+		},
+		{
+			`Replace '\9' with '9'. This maintains the current functionality.`,
+			`Replace '\9' with '\\9' to include the actual backslash character.`,
+		},
+	}
+	for diagnosticIndex, diagnostic := range allEdits {
+		for suggestionIndex, suggestion := range *diagnostic.Suggestions {
+			if got, want := suggestion.Message.Description, wantSuggestionDescriptions[diagnosticIndex][suggestionIndex]; got != want {
+				t.Errorf("diagnostic %d suggestion %d description = %q, want %q", diagnosticIndex, suggestionIndex, got, want)
+			}
+		}
+	}
+}
+
+func runRuleOnParsedSource(t *testing.T, sourceFile *ast.SourceFile, demand rule.EditDemand) []rule.RuleDiagnostic {
+	t.Helper()
+	comments := rule.NewCommentStore(sourceFile)
+	var diagnostics []rule.RuleDiagnostic
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(NoNonoctalDecimalEscapeRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+		Demand: demand,
+		Report: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+	listeners := NoNonoctalDecimalEscapeRule.Run(ctx, nil)
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
 }
 
 // TestNoNonoctalDecimalEscapeRule runs the rule against TypeScript fixtures.


### PR DESCRIPTION
## Summary

- Skip ordinary string literals that cannot contain decimal escapes by using the parser's invalid-escape token flag, while retaining raw scanning for JSX attributes.
- Replace the collect-all/double-scan path with a single-pass iterator and defer suggestion construction until the consumer requests suggestions.
- Keep the optimization rule-local and preserve diagnostic ranges, messages, suggestion order, and fixes.

### Benchmark

Command: `GOMAXPROCS=1 go test ./internal/rules/no_nonoctal_decimal_escape -run '^$' -bench '^BenchmarkNoNonoctalDecimalEscape$' -benchmem -benchtime=750ms -count=10`

Environment: Apple M1 Max, darwin/arm64, Go 1.26.1. Values are medians across 10 runs; the temporary benchmark was not committed.

| Workload | Before | After | Change | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| 512 ordinary literals, no matches | 61,728 ns/op | 1,148 ns/op | -98.14% (53.79x) | 81,920 -> 0 | 512 -> 0 |
| 128 dense literals, 384 diagnostics, no suggestions requested | 413,679 ns/op | 18,181 ns/op | -95.61% (22.75x) | 317,460 -> 0 | 8,192 -> 0 |
| 128 dense literals, 384 diagnostics with suggestions | 418,282 ns/op | 86,654 ns/op | -79.28% (4.83x) | 317,460 -> 119,808 | 8,192 -> 768 |

### Validation

- Targeted `no_nonoctal_decimal_escape` Go tests passed.
- Differential fuzzing passed 96,028 executions against the pre-optimization scanner.
- `pnpm check-spell` passed.
- `pnpm format:check` passed.
- `golangci-lint` passed on the two changed Go files with 0 issues.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
