### PR TITLE
feat: expose symbol id and object from type data

### DIFF
--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -55,8 +55,10 @@ type FuncSignature struct {
 	Result checker.TypeId `json:"result"`
 }
 type TypeInfo struct {
-	Id    checker.TypeId `json:"id"`
-	Flags int            `json:"flags"`
+	Id          checker.TypeId `json:"id"`
+	Flags       int            `json:"flags"`
+	ObjectFlags int            `json:"object_flags,omitempty"`
+	Symbol      ast.SymbolId   `json:"symbol,omitempty"`
 }
 type SymbolTable = map[NodeReference]SymbolInfo
 type TypeTable = map[NodeReference]TypeInfo
@@ -211,10 +213,15 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 
 		typeID := ty.Id()
 		if _, exists := semantic.Typetab[typeID]; !exists {
-			semantic.Typetab[typeID] = TypeInfo{
-				Id:    typeID,
-				Flags: int(ty.Flags()),
+			typeInfo := TypeInfo{
+				Id:          typeID,
+				Flags:       int(ty.Flags()),
+				ObjectFlags: int(ty.ObjectFlags()),
 			}
+			if symbol := ty.Symbol(); symbol != nil {
+				typeInfo.Symbol = ast.GetSymbolId(symbol)
+			}
+			semantic.Typetab[typeID] = typeInfo
 			semantic.TypeExtra.Name[int(typeID)] = []byte(tc.TypeToString(ty))
 			callSignatures := tc.GetCallSignatures(ty)
 			if len(callSignatures) > 0 {

--- a/cmd/tsgo/semantic_test.go
+++ b/cmd/tsgo/semantic_test.go
@@ -201,11 +201,17 @@ const primitiveValue = 1;
 		}
 	}
 
-	anonymousID := symbols["anonymousValue"]
-	anonymousTypeID := fixture.semantic.Sym2type[anonymousID]
-	if typeInfo := fixture.semantic.Typetab[anonymousTypeID]; typeInfo.Symbol == 0 {
-		t.Fatal("object literal type has no declaration symbol")
-	}
+anonymousID, ok := symbols["anonymousValue"]
+if !ok || anonymousID == 0 {
+	t.Fatalf("symbol %q not found", "anonymousValue")
+}
+anonymousTypeID, ok := fixture.semantic.Sym2type[anonymousID]
+if !ok || anonymousTypeID == 0 {
+	t.Fatalf("type for symbol %q not found", "anonymousValue")
+}
+if typeInfo, ok := fixture.semantic.Typetab[anonymousTypeID]; !ok || typeInfo.Symbol == 0 {
+	t.Fatal("object literal type has no declaration symbol")
+}
 
 	primitiveID := symbols["primitiveValue"]
 	primitiveTypeID := fixture.semantic.Sym2type[primitiveID]

--- a/cmd/tsgo/semantic_test.go
+++ b/cmd/tsgo/semantic_test.go
@@ -166,6 +166,54 @@ func TestSemanticSnapshot_ElementAccess(t *testing.T) {
 	}
 }
 
+func TestSemanticTypeDeclarationSymbols(t *testing.T) {
+	fixture := buildSemanticFixture(t, `
+class ClassType {}
+interface InterfaceType {}
+const classValue = new ClassType();
+let interfaceValue: InterfaceType;
+const anonymousValue = {};
+const primitiveValue = 1;
+`)
+
+	symbols := map[string]ast.SymbolId{}
+	for symbolID, symbol := range fixture.semantic.Symtab {
+		symbols[string(symbol.Name)] = symbolID
+	}
+
+	for name, expectedName := range map[string]string{
+		"classValue":     "ClassType",
+		"interfaceValue": "InterfaceType",
+	} {
+		symbolID := symbols[name]
+		if symbolID == 0 {
+			t.Fatalf("symbol %q not found", name)
+		}
+		typeID := fixture.semantic.Sym2type[symbolID]
+		typeInfo := fixture.semantic.Typetab[typeID]
+		if typeInfo.Symbol == 0 {
+			t.Fatalf("type of %q has no declaration symbol", name)
+		}
+
+		typeSymbol := fixture.semantic.Symtab[typeInfo.Symbol]
+		if got := string(typeSymbol.Name); got != expectedName {
+			t.Fatalf("type of %q points to symbol %q, want %q", name, got, expectedName)
+		}
+	}
+
+	anonymousID := symbols["anonymousValue"]
+	anonymousTypeID := fixture.semantic.Sym2type[anonymousID]
+	if typeInfo := fixture.semantic.Typetab[anonymousTypeID]; typeInfo.Symbol == 0 {
+		t.Fatal("object literal type has no declaration symbol")
+	}
+
+	primitiveID := symbols["primitiveValue"]
+	primitiveTypeID := fixture.semantic.Sym2type[primitiveID]
+	if typeInfo := fixture.semantic.Typetab[primitiveTypeID]; typeInfo.Symbol != 0 {
+		t.Fatalf("primitive type unexpectedly points to symbol %d", typeInfo.Symbol)
+	}
+}
+
 func TestSym2sym_ImportAlias(t *testing.T) {
 	tmpDir := t.TempDir()
 	tsconfigPath := filepath.Join(tmpDir, "tsconfig.json")

--- a/crates/tsgo-client/src/proto.rs
+++ b/crates/tsgo-client/src/proto.rs
@@ -93,6 +93,10 @@ pub struct ExternalSymbol {
 pub struct TypeData {
     pub id: u32,
     pub flags: u32,
+    #[serde(default)]
+    pub object_flags: u32,
+    #[serde(default)]
+    pub symbol: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
## Summary

This PR exposes symbol id and object flag from type data for rslim to perform type updates and analysis.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
