### PR TITLE
perf: optimize no-dupe-keys

### DIFF
--- a/internal/rules/no_dupe_keys/no_dupe_keys.go
+++ b/internal/rules/no_dupe_keys/no_dupe_keys.go
@@ -1,12 +1,84 @@
 package no_dupe_keys
 
 import (
-	"fmt"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+type propertyKind uint8
+
+const (
+	propertyKindInit propertyKind = iota
+	propertyKindGet
+	propertyKindSet
+)
+
+type propertyState uint8
+
+const (
+	propertyStateInit propertyState = 1 << iota
+	propertyStateGet
+	propertyStateSet
+)
+
+// Keep common object literals allocation-free while bounding lookup cost for
+// generated or configuration-heavy objects.
+const inlineObjectStateCapacity = 16
+
+type objectState struct {
+	names    [inlineObjectStateCapacity]string
+	states   [inlineObjectStateCapacity]propertyState
+	count    int
+	overflow map[string]propertyState
+}
+
+func registerProperty(state propertyState, kind propertyKind) (propertyState, bool) {
+	var flag propertyState
+	var conflicts propertyState
+	switch kind {
+	case propertyKindGet:
+		flag = propertyStateGet
+		conflicts = propertyStateInit | propertyStateGet
+	case propertyKindSet:
+		flag = propertyStateSet
+		conflicts = propertyStateInit | propertyStateSet
+	default:
+		flag = propertyStateInit
+		conflicts = propertyStateInit | propertyStateGet | propertyStateSet
+	}
+	return state | flag, state&conflicts != 0
+}
+
+func (state *objectState) register(name string, kind propertyKind) bool {
+	if state.overflow != nil {
+		current := state.overflow[name]
+		var duplicate bool
+		state.overflow[name], duplicate = registerProperty(current, kind)
+		return duplicate
+	}
+
+	for index := range state.count {
+		if state.names[index] == name {
+			var duplicate bool
+			state.states[index], duplicate = registerProperty(state.states[index], kind)
+			return duplicate
+		}
+	}
+	if state.count < len(state.names) {
+		state.names[state.count] = name
+		state.states[state.count], _ = registerProperty(0, kind)
+		state.count++
+		return false
+	}
+
+	state.overflow = make(map[string]propertyState, inlineObjectStateCapacity*2)
+	for index := range state.count {
+		state.overflow[state.names[index]] = state.states[index]
+	}
+	state.overflow[name], _ = registerProperty(0, kind)
+	return false
+}
 
 // https://eslint.org/docs/latest/rules/no-dupe-keys
 var NoDupeKeysRule = rule.Rule{
@@ -15,21 +87,22 @@ var NoDupeKeysRule = rule.Rule{
 		return rule.RuleListeners{
 			ast.KindObjectLiteralExpression: func(node *ast.Node) {
 				objLit := node.AsObjectLiteralExpression()
-				if objLit == nil || objLit.Properties == nil {
+				if objLit == nil || objLit.Properties == nil || len(objLit.Properties.Nodes) < 2 {
 					return
 				}
-
-				type propInfo struct {
-					get  bool
-					set  bool
-					init bool
-				}
-				properties := make(map[string]*propInfo)
+				state := objectState{}
 
 				for _, prop := range objLit.Properties.Nodes {
-					// Skip spread elements
-					if prop.Kind == ast.KindSpreadAssignment {
+					var kind propertyKind
+					switch prop.Kind {
+					case ast.KindSpreadAssignment:
 						continue
+					case ast.KindGetAccessor:
+						kind = propertyKindGet
+					case ast.KindSetAccessor:
+						kind = propertyKindSet
+					default:
+						kind = propertyKindInit
 					}
 
 					nameNode := prop.Name()
@@ -37,7 +110,18 @@ var NoDupeKeysRule = rule.Rule{
 						continue
 					}
 
-					name, isStatic := utils.GetStaticPropertyName(nameNode)
+					var name string
+					var isStatic = true
+					switch nameNode.Kind {
+					case ast.KindIdentifier:
+						name = nameNode.AsIdentifier().Text
+					case ast.KindStringLiteral:
+						name = nameNode.AsStringLiteral().Text
+					case ast.KindBigIntLiteral:
+						name = utils.NormalizeBigIntLiteral(nameNode.AsBigIntLiteral().Text)
+					default:
+						name, isStatic = utils.GetStaticPropertyName(nameNode)
+					}
 					if !isStatic {
 						continue
 					}
@@ -48,38 +132,11 @@ var NoDupeKeysRule = rule.Rule{
 						continue
 					}
 
-					info, exists := properties[name]
-					if !exists {
-						info = &propInfo{}
-						properties[name] = info
-					}
-
-					switch prop.Kind {
-					case ast.KindGetAccessor:
-						if info.get || info.init {
-							ctx.ReportNode(prop, rule.RuleMessage{
-								Id:          "unexpected",
-								Description: fmt.Sprintf("Duplicate key '%s'.", name),
-							})
-						}
-						info.get = true
-					case ast.KindSetAccessor:
-						if info.set || info.init {
-							ctx.ReportNode(prop, rule.RuleMessage{
-								Id:          "unexpected",
-								Description: fmt.Sprintf("Duplicate key '%s'.", name),
-							})
-						}
-						info.set = true
-					default:
-						// init (PropertyAssignment, ShorthandPropertyAssignment, MethodDeclaration)
-						if info.init || info.get || info.set {
-							ctx.ReportNode(prop, rule.RuleMessage{
-								Id:          "unexpected",
-								Description: fmt.Sprintf("Duplicate key '%s'.", name),
-							})
-						}
-						info.init = true
+					if state.register(name, kind) {
+						ctx.ReportNode(prop, rule.RuleMessage{
+							Id:          "unexpected",
+							Description: "Duplicate key '" + name + "'.",
+						})
 					}
 				}
 			},

--- a/internal/rules/no_dupe_keys/no_dupe_keys_test.go
+++ b/internal/rules/no_dupe_keys/no_dupe_keys_test.go
@@ -1,6 +1,7 @@
 package no_dupe_keys
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
@@ -17,11 +18,14 @@ func TestNoDupeKeysRule(t *testing.T) {
 			{Code: `var x = { a: 1, b: 2 };`},
 			{Code: `var x = { a: 1, b: 2, c: 3 };`},
 			{Code: `var x = { get a() {}, set a(v) {} };`},
+			{Code: `var x = { set a(v) {}, get a() {} };`},
 			{Code: `var x = { [Symbol()]: 1, [Symbol()]: 2 };`},
 			{Code: `var x = { "": 1, " ": 2 };`},
 			// __proto__ as proto setter is allowed to appear multiple times
 			{Code: `var x = { __proto__: foo, __proto__: bar };`},
 			{Code: `var x = { "__proto__": foo, "__proto__": bar };`},
+			{Code: `var x = { __proto__: null, ["__proto__"]: null };`},
+			{Code: `var x = { ["__proto__"]: null, __proto__: null };`},
 		},
 		[]rule_tester.InvalidTestCase{
 			{
@@ -47,6 +51,37 @@ func TestNoDupeKeysRule(t *testing.T) {
 				Code: `var x = { "a": 1, "a": 2 };`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `var x = { "a": 1, a: 2 };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `var x = { get a() {}, set a(v) {}, get a() {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code: `var x = { set a(v) {}, get a() {}, set a(v) {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code: `var x = { get a() {}, set a(v) {}, a: 1 };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code: `var x = { a: 1, get a() {}, set a(v) {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+					{MessageId: "unexpected", Line: 1, Column: 29},
 				},
 			},
 			// Computed __proto__ is a regular property, not a proto setter
@@ -84,6 +119,123 @@ func TestNoDupeKeysRule(t *testing.T) {
 					{MessageId: "unexpected", Line: 1, Column: 25},
 				},
 			},
+			{
+				Code:   `var x = { a: 1, ["a"]: 2 };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `var x = { 1n: "a", 1: "b" };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `var x = { 1_0: "a", 10: "b" };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `var x = { "/x/g": "a", [/x/g]: "b" };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `var x = { ["__proto__"]: null, __proto__ };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
 		},
 	)
+}
+
+type referencePropertyInfo struct {
+	get  bool
+	set  bool
+	init bool
+}
+
+func registerReferenceProperty(info referencePropertyInfo, kind propertyKind) (referencePropertyInfo, bool) {
+	var duplicate bool
+	switch kind {
+	case propertyKindGet:
+		duplicate = info.get || info.init
+		info.get = true
+	case propertyKindSet:
+		duplicate = info.set || info.init
+		info.set = true
+	default:
+		duplicate = info.init || info.get || info.set
+		info.init = true
+	}
+	return info, duplicate
+}
+
+func TestRegisterPropertyExhaustive(t *testing.T) {
+	const operationCount = 9
+	var visit func(propertyState, referencePropertyInfo, int)
+	visit = func(state propertyState, reference referencePropertyInfo, depth int) {
+		if depth == operationCount {
+			return
+		}
+		for kind := propertyKindInit; kind <= propertyKindSet; kind++ {
+			gotState, gotDuplicate := registerProperty(state, kind)
+			wantState, wantDuplicate := registerReferenceProperty(reference, kind)
+			if gotDuplicate != wantDuplicate {
+				t.Fatalf("depth %d kind %d: duplicate = %v, want %v", depth, kind, gotDuplicate, wantDuplicate)
+			}
+			visit(gotState, wantState, depth+1)
+		}
+	}
+	visit(0, referencePropertyInfo{}, 0)
+}
+
+func TestObjectStateMatchesReference(t *testing.T) {
+	nameCount := inlineObjectStateCapacity*2 + 3
+	state := objectState{}
+	reference := make(map[string]referencePropertyInfo, nameCount)
+	seed := uint64(0x9e3779b97f4a7c15)
+
+	for operation := range 10_000 {
+		seed = seed*6364136223846793005 + 1
+		nameIndex := operation
+		if nameIndex >= nameCount {
+			nameIndex = int(seed % uint64(nameCount))
+		}
+		var name string
+		switch nameIndex {
+		case 0:
+			name = ""
+		case 1:
+			name = "__proto__"
+		default:
+			name = "property" + strconv.Itoa(nameIndex)
+		}
+		kind := propertyKind(seed % 3)
+
+		wantInfo, wantDuplicate := registerReferenceProperty(reference[name], kind)
+		reference[name] = wantInfo
+		if gotDuplicate := state.register(name, kind); gotDuplicate != wantDuplicate {
+			t.Fatalf("operation %d (%q, kind=%d): duplicate = %v, want %v", operation, name, kind, gotDuplicate, wantDuplicate)
+		}
+		if operation < inlineObjectStateCapacity && state.overflow != nil {
+			t.Fatalf("operation %d: state promoted before inline capacity was exhausted", operation)
+		}
+		if operation == inlineObjectStateCapacity && state.overflow == nil {
+			t.Fatal("state did not promote after inline capacity was exhausted")
+		}
+	}
+
+	if state.overflow == nil {
+		t.Fatal("adversarial sequence did not exercise overflow storage")
+	}
+	for name, info := range reference {
+		var want propertyState
+		if info.init {
+			want |= propertyStateInit
+		}
+		if info.get {
+			want |= propertyStateGet
+		}
+		if info.set {
+			want |= propertyStateSet
+		}
+		if got := state.overflow[name]; got != want {
+			t.Fatalf("state for %q = %d, want %d", name, got, want)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Keep up to 16 static property names in allocation-free inline object state, then promote larger objects to a bounded-capacity map with compact bit states.
- Skip object literals that cannot contain duplicates and fast-path identifier, string, and BigInt property names while retaining the shared static-name normalization fallback.
- Preserve getter/setter, computed-name, spread, nested-object, and __proto__ semantics. Also fix direct BigInt keys such as 1n so they compare correctly with numeric keys, matching ESLint.
- ctx.Refs is intentionally not used because this syntax-only rule compares declarations within one object and performs no symbol/reference resolution.
- Deferred reporting is not applicable because diagnostics have no fixes, suggestions, or other optional payload to materialize.
- Documentation is not required because configuration and public behavior are unchanged apart from correcting the BigInt-key false negative.

### Performance

Temporary rule-local benchmark, removed before commit. The rsbuild and rspack corpora were parsed once per sample; only repeated no-dupe-keys object-listener execution was timed. Results are medians of 6 runs on Go 1.26.1, darwin/arm64, Apple M1 Max.

`NO_DUPE_KEYS_BENCH_CORPORA=/path/to/rsbuild:/path/to/rspack go test ./internal/rules/no_dupe_keys -run ^$ -bench ^BenchmarkNoDupeKeysRealRepos$ -benchmem -benchtime=1s -count=6`

| Corpus | Objects/op | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| rsbuild | 7,649 | 974,337 → 272,819 (-72.0%) | 104,512 → 42,610 (-59.2%) | 12,647 → 314 (-97.5%) |
| rspack | 33,330 | 7,051,658 → 3,122,847 (-55.7%) | 889,801 → 387,928 (-56.4%) | 72,663 → 924 (-98.7%) |

### Validation

- `go test ./internal/rules/no_dupe_keys -count=1`
- Exhaustive 3^9 getter/setter/init state-machine comparison
- Deterministic 10,000-operation inline/overflow comparison against the previous boolean state model
- Temporary per-diagnostic parity harness over 40,979 object literals from rsbuild and rspack
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/rules/no_dupe_keys`

## Related Links

- https://eslint.org/docs/latest/rules/no-dupe-keys

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
