### PR TITLE
perf: optimize no-import-assign traversal

### DIFF
--- a/internal/rules/no_import_assign/no_import_assign.go
+++ b/internal/rules/no_import_assign/no_import_assign.go
@@ -3,6 +3,7 @@ package no_import_assign
 import (
 	"cmp"
 	"slices"
+	"strings"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -17,6 +18,11 @@ type importedBinding struct {
 	symbol      *ast.Symbol
 }
 
+type importedBindingMessageCache struct {
+	direct string
+	member string
+}
+
 type importedBindingViolationKind uint8
 
 const (
@@ -26,19 +32,25 @@ const (
 )
 
 type importedBindingViolation struct {
-	node    *ast.Node
-	binding importedBinding
-	kind    importedBindingViolationKind
+	node         *ast.Node
+	bindingIndex int
+	kind         importedBindingViolationKind
 }
 
 type importedBindingGroup struct {
-	bindings   []importedBinding
-	violations []importedBindingViolation
+	declaration *ast.Node
+	bindings    []importedBinding
+	violations  []importedBindingViolation
 }
 
 type importedBindingTarget struct {
 	groupIndex   int
 	bindingIndex int
+}
+
+type importedBindingTargets struct {
+	first      importedBindingTarget
+	additional []importedBindingTarget
 }
 
 type noImportAssignRefStoreMode uint8
@@ -353,9 +365,9 @@ func collectImportedBindings(
 	return bindings
 }
 
-func hasMultipleTopLevelImportedBindings(sourceFile *ast.SourceFile) bool {
+func countTopLevelImportedBindings(sourceFile *ast.SourceFile, limit int) int {
 	if sourceFile == nil || sourceFile.Statements == nil {
-		return false
+		return 0
 	}
 
 	count := 0
@@ -366,16 +378,16 @@ func hasMultipleTopLevelImportedBindings(sourceFile *ast.SourceFile) bool {
 		forEachImportedBindingName(statement, func(*ast.Node, bool) {
 			count++
 		})
-		if count >= 2 {
-			return true
+		if count >= limit {
+			return count
 		}
 	}
-	return false
+	return count
 }
 
 func classifyImportedBindingViolation(
 	node *ast.Node,
-	binding importedBinding,
+	binding *importedBinding,
 	ctx *rule.RuleContext,
 ) importedBindingViolationKind {
 	if utils.IsWriteReference(node) {
@@ -387,46 +399,96 @@ func classifyImportedBindingViolation(
 	return importedBindingViolationNone
 }
 
-func reportImportedBindingViolation(ctx *rule.RuleContext, violation importedBindingViolation) {
-	switch violation.kind {
+func importedBindingMessage(
+	binding *importedBinding,
+	kind importedBindingViolationKind,
+	cache *importedBindingMessageCache,
+) rule.RuleMessage {
+	switch kind {
 	case importedBindingViolationDirect:
-		ctx.ReportNode(violation.node, rule.RuleMessage{
+		description := cache.direct
+		if description == "" {
+			description = "'" + binding.name + "' is read-only."
+			cache.direct = description
+		}
+		return rule.RuleMessage{
 			Id:          "readonly",
-			Description: "'" + violation.binding.name + "' is read-only.",
-		})
+			Description: description,
+		}
 	case importedBindingViolationMember:
-		ctx.ReportNode(violation.node, rule.RuleMessage{
+		description := cache.member
+		if description == "" {
+			description = "The members of '" + binding.name + "' are read-only."
+			cache.member = description
+		}
+		return rule.RuleMessage{
 			Id:          "readonlyMember",
-			Description: "The members of '" + violation.binding.name + "' are read-only.",
-		})
+			Description: description,
+		}
 	}
+	return rule.RuleMessage{}
+}
+
+func reportImportedBindingViolation(
+	ctx *rule.RuleContext,
+	binding *importedBinding,
+	violation importedBindingViolation,
+	cache *importedBindingMessageCache,
+) {
+	if violation.kind == importedBindingViolationNone {
+		return
+	}
+	if cache == nil {
+		switch violation.kind {
+		case importedBindingViolationDirect:
+			ctx.ReportNode(violation.node, rule.RuleMessage{
+				Id:          "readonly",
+				Description: "'" + binding.name + "' is read-only.",
+			})
+		case importedBindingViolationMember:
+			ctx.ReportNode(violation.node, rule.RuleMessage{
+				Id:          "readonlyMember",
+				Description: "The members of '" + binding.name + "' are read-only.",
+			})
+		}
+		return
+	}
+	ctx.ReportNode(
+		violation.node,
+		importedBindingMessage(binding, violation.kind, cache),
+	)
 }
 
 func reportImportedBindingGroup(ctx *rule.RuleContext, bindings []importedBinding) {
 	if len(bindings) == 1 {
-		binding := bindings[0]
+		binding := &bindings[0]
 		for _, reference := range ctx.Refs.References(binding.symbol) {
 			kind := classifyImportedBindingViolation(reference, binding, ctx)
 			if kind != importedBindingViolationNone {
-				reportImportedBindingViolation(ctx, importedBindingViolation{
-					node:    reference,
-					binding: binding,
-					kind:    kind,
-				})
+				reportImportedBindingViolation(
+					ctx,
+					binding,
+					importedBindingViolation{
+						node: reference,
+						kind: kind,
+					},
+					nil,
+				)
 			}
 		}
 		return
 	}
 
 	var violations []importedBindingViolation
-	for _, binding := range bindings {
+	for bindingIndex := range bindings {
+		binding := &bindings[bindingIndex]
 		for _, reference := range ctx.Refs.References(binding.symbol) {
 			kind := classifyImportedBindingViolation(reference, binding, ctx)
 			if kind != importedBindingViolationNone {
 				violations = append(violations, importedBindingViolation{
-					node:    reference,
-					binding: binding,
-					kind:    kind,
+					node:         reference,
+					bindingIndex: bindingIndex,
+					kind:         kind,
 				})
 			}
 		}
@@ -439,7 +501,12 @@ func reportImportedBindingGroup(ctx *rule.RuleContext, bindings []importedBindin
 		return cmp.Compare(a.node.Pos(), b.node.Pos())
 	})
 	for _, violation := range violations {
-		reportImportedBindingViolation(ctx, violation)
+		reportImportedBindingViolation(
+			ctx,
+			&bindings[violation.bindingIndex],
+			violation,
+			nil,
+		)
 	}
 }
 
@@ -489,7 +556,7 @@ func walkImportedBindingGroups(
 					referenceSymbol = resolveReferenceSymbol(node)
 				}
 				for _, target := range targets {
-					binding := groups[target.groupIndex].bindings[target.bindingIndex]
+					binding := &groups[target.groupIndex].bindings[target.bindingIndex]
 					if binding.symbol != nil && resolveReferenceSymbol != nil &&
 						referenceSymbol != binding.symbol {
 						continue
@@ -500,9 +567,9 @@ func walkImportedBindingGroups(
 						groups[target.groupIndex].violations = append(
 							groups[target.groupIndex].violations,
 							importedBindingViolation{
-								node:    node,
-								binding: binding,
-								kind:    kind,
+								node:         node,
+								bindingIndex: target.bindingIndex,
+								kind:         kind,
 							},
 						)
 					}
@@ -517,9 +584,15 @@ func walkImportedBindingGroups(
 	}
 	walk(ctx.SourceFile.AsNode())
 
-	for _, group := range groups {
+	for groupIndex := range groups {
+		group := &groups[groupIndex]
 		for _, violation := range group.violations {
-			reportImportedBindingViolation(ctx, violation)
+			reportImportedBindingViolation(
+				ctx,
+				&group.bindings[violation.bindingIndex],
+				violation,
+				nil,
+			)
 		}
 	}
 }
@@ -542,7 +615,8 @@ func walkImportedBindingReferences(
 		}
 
 		if node.Kind == ast.KindIdentifier {
-			for _, binding := range bindings {
+			for bindingIndex := range bindings {
+				binding := &bindings[bindingIndex]
 				if node.Text() != binding.name || isImportBindingName(node) {
 					continue
 				}
@@ -554,11 +628,15 @@ func walkImportedBindingReferences(
 
 				kind := classifyImportedBindingViolation(node, binding, ctx)
 				if kind != importedBindingViolationNone {
-					reportImportedBindingViolation(ctx, importedBindingViolation{
-						node:    node,
-						binding: binding,
-						kind:    kind,
-					})
+					reportImportedBindingViolation(
+						ctx,
+						binding,
+						importedBindingViolation{
+							node: node,
+							kind: kind,
+						},
+						nil,
+					)
 				}
 			}
 		}
@@ -589,8 +667,8 @@ func allBindingGroupsHaveSymbols(groups []importedBindingGroup) bool {
 	return true
 }
 
-func noImportAssignListeners(
-	ctx rule.RuleContext,
+func noImportAssignScanListeners(
+	ctx *rule.RuleContext,
 	refStoreMode noImportAssignRefStoreMode,
 ) rule.RuleListeners {
 	var checkerReferenceSymbol func(*ast.Node) *ast.Symbol
@@ -598,15 +676,6 @@ func noImportAssignListeners(
 		checkerReferenceSymbol = func(node *ast.Node) *ast.Symbol {
 			return utils.GetReferenceSymbol(node, ctx.TypeChecker)
 		}
-	}
-
-	// Keep the original one-listener compatibility path for the common
-	// single-binding case. It avoids every aggregation closure/allocation and
-	// is already optimal for one source walk.
-	if refStoreMode == noImportAssignRefStoreAuto &&
-		ctx.TypeChecker != nil &&
-		!hasMultipleTopLevelImportedBindings(ctx.SourceFile) {
-		refStoreMode = noImportAssignRefStoreDisabled
 	}
 
 	if refStoreMode != noImportAssignRefStoreAuto {
@@ -619,16 +688,16 @@ func noImportAssignListeners(
 						return
 					}
 					if allBindingsHaveSymbols(bindings) {
-						reportImportedBindingGroup(&ctx, bindings)
+						reportImportedBindingGroup(ctx, bindings)
 						return
 					}
 				}
 
 				bindings := collectImportedBindings(node, func(nameNode *ast.Node) *ast.Symbol {
-					return checkerImportBindingSymbol(nameNode, &ctx)
+					return checkerImportBindingSymbol(nameNode, ctx)
 				})
 				if len(bindings) != 0 {
-					walkImportedBindingReferences(&ctx, bindings, checkerReferenceSymbol)
+					walkImportedBindingReferences(ctx, bindings, checkerReferenceSymbol)
 				}
 			},
 		}
@@ -641,7 +710,7 @@ func noImportAssignListeners(
 		resolveReferenceSymbol = ctx.Refs.Resolve
 	} else if ctx.TypeChecker != nil {
 		resolveBindingSymbol = func(nameNode *ast.Node) *ast.Symbol {
-			return checkerImportBindingSymbol(nameNode, &ctx)
+			return checkerImportBindingSymbol(nameNode, ctx)
 		}
 	}
 
@@ -670,7 +739,7 @@ func noImportAssignListeners(
 			// exact without materializing the reverse-reference index.
 			if bindingCount == 1 {
 				walkImportedBindingReferences(
-					&ctx,
+					ctx,
 					firstGroup.bindings,
 					resolveReferenceSymbol,
 				)
@@ -689,7 +758,7 @@ func noImportAssignListeners(
 				for groupIndex := range groups {
 					for bindingIndex := range groups[groupIndex].bindings {
 						binding := &groups[groupIndex].bindings[bindingIndex]
-						binding.symbol = checkerImportBindingSymbol(binding.nameNode, &ctx)
+						binding.symbol = checkerImportBindingSymbol(binding.nameNode, ctx)
 					}
 				}
 				resolveReferenceSymbol = checkerReferenceSymbol
@@ -698,9 +767,384 @@ func noImportAssignListeners(
 			// A single selective scan avoids both repeated walks and RefStore's
 			// unrelated-name buckets. RefStore.Resolve provides binder identity
 			// without materializing the full reverse-reference index.
-			walkImportedBindingGroups(&ctx, groups, resolveReferenceSymbol)
+			walkImportedBindingGroups(ctx, groups, resolveReferenceSymbol)
 		},
 	}
+}
+
+func collectTopLevelImportedBindingGroups(
+	sourceFile *ast.SourceFile,
+	resolveBindingSymbol func(*ast.Node) *ast.Symbol,
+) ([]importedBindingGroup, int) {
+	if sourceFile == nil || sourceFile.Statements == nil {
+		return nil, 0
+	}
+
+	var groups []importedBindingGroup
+	bindingCount := 0
+	for _, statement := range sourceFile.Statements.Nodes {
+		if statement.Kind != ast.KindImportDeclaration {
+			continue
+		}
+		bindings := collectImportedBindings(statement, resolveBindingSymbol)
+		if len(bindings) == 0 {
+			continue
+		}
+		groups = append(groups, importedBindingGroup{
+			declaration: statement,
+			bindings:    bindings,
+		})
+		bindingCount += len(bindings)
+	}
+	return groups, bindingCount
+}
+
+func replaceImportedBindingSymbolsWithChecker(
+	groups []importedBindingGroup,
+	ctx *rule.RuleContext,
+) {
+	for groupIndex := range groups {
+		for bindingIndex := range groups[groupIndex].bindings {
+			binding := &groups[groupIndex].bindings[bindingIndex]
+			binding.symbol = checkerImportBindingSymbol(binding.nameNode, ctx)
+		}
+	}
+}
+
+func collectImportedBindingViolation(
+	ctx *rule.RuleContext,
+	groups []importedBindingGroup,
+	targets importedBindingTargets,
+	node *ast.Node,
+	resolveReferenceSymbol func(*ast.Node) *ast.Symbol,
+) {
+	if isImportBindingName(node) {
+		return
+	}
+
+	kind := importedBindingViolationNone
+	if utils.IsWriteReference(node) {
+		kind = importedBindingViolationDirect
+	} else {
+		for targetIndex := 0; targetIndex <= len(targets.additional); targetIndex++ {
+			target := targets.first
+			if targetIndex != 0 {
+				target = targets.additional[targetIndex-1]
+			}
+			if groups[target.groupIndex].bindings[target.bindingIndex].isNamespace {
+				if isMemberWrite(node, ctx) {
+					kind = importedBindingViolationMember
+				}
+				break
+			}
+		}
+	}
+	if kind == importedBindingViolationNone {
+		return
+	}
+
+	var referenceSymbol *ast.Symbol
+	if resolveReferenceSymbol != nil {
+		referenceSymbol = resolveReferenceSymbol(node)
+	}
+	for targetIndex := 0; targetIndex <= len(targets.additional); targetIndex++ {
+		target := targets.first
+		if targetIndex != 0 {
+			target = targets.additional[targetIndex-1]
+		}
+		binding := &groups[target.groupIndex].bindings[target.bindingIndex]
+		if kind == importedBindingViolationMember && !binding.isNamespace {
+			continue
+		}
+		if binding.symbol != nil && resolveReferenceSymbol != nil &&
+			referenceSymbol != binding.symbol {
+			continue
+		}
+		groups[target.groupIndex].violations = append(
+			groups[target.groupIndex].violations,
+			importedBindingViolation{
+				node:         node,
+				bindingIndex: target.bindingIndex,
+				kind:         kind,
+			},
+		)
+	}
+}
+
+func forEachIdentifierInWriteTarget(node *ast.Node, visit func(*ast.Node)) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindIdentifier {
+		visit(node)
+		return false
+	}
+	// Nested writes and calls receive their own listener callback later in the
+	// shared traversal. Leave them to that callback so one identifier cannot
+	// be collected twice from overlapping write targets.
+	switch node.Kind {
+	case ast.KindBinaryExpression:
+		if ast.IsAssignmentExpression(node, false) {
+			return true
+		}
+	case ast.KindPrefixUnaryExpression:
+		operator := node.AsPrefixUnaryExpression().Operator
+		if operator == ast.KindPlusPlusToken || operator == ast.KindMinusMinusToken {
+			return true
+		}
+	case ast.KindPostfixUnaryExpression, ast.KindDeleteExpression, ast.KindCallExpression:
+		return true
+	}
+	deferredNestedWrite := false
+	node.ForEachChild(func(child *ast.Node) bool {
+		if forEachIdentifierInWriteTarget(child, visit) {
+			deferredNestedWrite = true
+		}
+		return false
+	})
+	return deferredNestedWrite
+}
+
+func noImportAssignIntegratedListeners(
+	ctx rule.RuleContext,
+	groups []importedBindingGroup,
+	bindingCount int,
+	resolveBindingSymbol func(*ast.Node) *ast.Symbol,
+	resolveReferenceSymbol func(*ast.Node) *ast.Symbol,
+	checkerReferenceSymbol func(*ast.Node) *ast.Symbol,
+) rule.RuleListeners {
+	if ctx.Refs != nil && ctx.TypeChecker != nil &&
+		!allBindingGroupsHaveSymbols(groups) {
+		replaceImportedBindingSymbolsWithChecker(groups, &ctx)
+		resolveBindingSymbol = func(nameNode *ast.Node) *ast.Symbol {
+			return checkerImportBindingSymbol(nameNode, &ctx)
+		}
+		resolveReferenceSymbol = checkerReferenceSymbol
+	}
+
+	targetsByName := make(map[string]importedBindingTargets, bindingCount)
+	hasNamespaceBinding := false
+	for groupIndex := range groups {
+		for bindingIndex, binding := range groups[groupIndex].bindings {
+			hasNamespaceBinding = hasNamespaceBinding || binding.isNamespace
+			targets, exists := targetsByName[binding.name]
+			target := importedBindingTarget{
+				groupIndex:   groupIndex,
+				bindingIndex: bindingIndex,
+			}
+			if exists {
+				targets.additional = append(targets.additional, target)
+			} else {
+				targets.first = target
+			}
+			targetsByName[binding.name] = targets
+		}
+	}
+
+	needsFallbackScan := false
+	needsViolationSort := false
+	checkIdentifier := func(node *ast.Node) {
+		if needsFallbackScan {
+			return
+		}
+		targets, exists := targetsByName[node.Text()]
+		if !exists {
+			return
+		}
+		collectImportedBindingViolation(
+			&ctx,
+			groups,
+			targets,
+			node,
+			resolveReferenceSymbol,
+		)
+	}
+	checkWriteTarget := func(node *ast.Node) {
+		if forEachIdentifierInWriteTarget(node, checkIdentifier) {
+			needsViolationSort = true
+		}
+	}
+
+	listeners := rule.RuleListeners{
+		ast.KindImportDeclaration: func(node *ast.Node) {
+			if node.Parent != nil && node.Parent.Kind == ast.KindSourceFile {
+				return
+			}
+			bindings := collectImportedBindings(node, resolveBindingSymbol)
+			if len(bindings) == 0 {
+				return
+			}
+			groups = append(groups, importedBindingGroup{
+				declaration: node,
+				bindings:    bindings,
+			})
+			needsFallbackScan = true
+		},
+		ast.KindBinaryExpression: func(node *ast.Node) {
+			if !ast.IsAssignmentExpression(node, false) {
+				return
+			}
+			binary := node.AsBinaryExpression()
+			if binary == nil {
+				return
+			}
+			checkWriteTarget(binary.Left)
+		},
+		ast.KindPrefixUnaryExpression: func(node *ast.Node) {
+			prefix := node.AsPrefixUnaryExpression()
+			if prefix == nil ||
+				(prefix.Operator != ast.KindPlusPlusToken &&
+					prefix.Operator != ast.KindMinusMinusToken) {
+				return
+			}
+			checkWriteTarget(prefix.Operand)
+		},
+		ast.KindPostfixUnaryExpression: func(node *ast.Node) {
+			postfix := node.AsPostfixUnaryExpression()
+			if postfix == nil ||
+				(postfix.Operator != ast.KindPlusPlusToken &&
+					postfix.Operator != ast.KindMinusMinusToken) {
+				return
+			}
+			checkWriteTarget(postfix.Operand)
+		},
+		ast.KindForInStatement: func(node *ast.Node) {
+			statement := node.AsForInOrOfStatement()
+			if statement != nil {
+				checkWriteTarget(statement.Initializer)
+			}
+		},
+		ast.KindForOfStatement: func(node *ast.Node) {
+			statement := node.AsForInOrOfStatement()
+			if statement != nil {
+				checkWriteTarget(statement.Initializer)
+			}
+		},
+		ast.KindEndOfFile: func(*ast.Node) {
+			if needsFallbackScan {
+				slices.SortStableFunc(groups, func(a, b importedBindingGroup) int {
+					return cmp.Compare(a.declaration.Pos(), b.declaration.Pos())
+				})
+				for groupIndex := range groups {
+					groups[groupIndex].violations = nil
+				}
+				if ctx.Refs != nil && ctx.TypeChecker != nil &&
+					!allBindingGroupsHaveSymbols(groups) {
+					replaceImportedBindingSymbolsWithChecker(groups, &ctx)
+					resolveReferenceSymbol = checkerReferenceSymbol
+				}
+				walkImportedBindingGroups(&ctx, groups, resolveReferenceSymbol)
+				return
+			}
+
+			violationCount := 0
+			for groupIndex := range groups {
+				violationCount += len(groups[groupIndex].violations)
+			}
+			var messageCaches []importedBindingMessageCache
+			if violationCount > bindingCount {
+				messageCaches = make([]importedBindingMessageCache, bindingCount)
+			}
+
+			cacheOffset := 0
+			for groupIndex := range groups {
+				group := &groups[groupIndex]
+				if needsViolationSort {
+					slices.SortStableFunc(
+						group.violations,
+						func(a, b importedBindingViolation) int {
+							return cmp.Compare(a.node.Pos(), b.node.Pos())
+						},
+					)
+				}
+				for _, violation := range group.violations {
+					var cache *importedBindingMessageCache
+					if messageCaches != nil {
+						cache = &messageCaches[cacheOffset+violation.bindingIndex]
+					}
+					reportImportedBindingViolation(
+						&ctx,
+						&group.bindings[violation.bindingIndex],
+						violation,
+						cache,
+					)
+				}
+				cacheOffset += len(group.bindings)
+			}
+		},
+	}
+
+	if hasNamespaceBinding {
+		listeners[ast.KindDeleteExpression] = func(node *ast.Node) {
+			deleteExpression := node.AsDeleteExpression()
+			if deleteExpression != nil {
+				checkWriteTarget(deleteExpression.Expression)
+			}
+		}
+		listeners[ast.KindCallExpression] = func(node *ast.Node) {
+			callExpression := node.AsCallExpression()
+			if callExpression == nil || callExpression.Arguments == nil ||
+				len(callExpression.Arguments.Nodes) == 0 {
+				return
+			}
+			checkWriteTarget(callExpression.Arguments.Nodes[0])
+		}
+	}
+	return listeners
+}
+
+func noImportAssignListeners(
+	ctx rule.RuleContext,
+	refStoreMode noImportAssignRefStoreMode,
+) rule.RuleListeners {
+	if refStoreMode != noImportAssignRefStoreAuto {
+		return noImportAssignScanListeners(&ctx, refStoreMode)
+	}
+	topLevelBindingCount := countTopLevelImportedBindings(ctx.SourceFile, 2)
+	if topLevelBindingCount < 2 {
+		// An ImportDeclaration always contains the literal keyword in source.
+		// Avoid registering listeners when even recovered syntax cannot contain
+		// one; otherwise keep the compatibility listener for nested imports.
+		if topLevelBindingCount == 0 && ctx.SourceFile != nil &&
+			!strings.Contains(ctx.SourceFile.Text(), "import") {
+			return nil
+		}
+		if ctx.TypeChecker != nil {
+			return noImportAssignScanListeners(&ctx, noImportAssignRefStoreDisabled)
+		}
+		return noImportAssignScanListeners(&ctx, noImportAssignRefStoreAuto)
+	}
+
+	var checkerReferenceSymbol func(*ast.Node) *ast.Symbol
+	if ctx.TypeChecker != nil {
+		checkerReferenceSymbol = func(node *ast.Node) *ast.Symbol {
+			return utils.GetReferenceSymbol(node, ctx.TypeChecker)
+		}
+	}
+
+	resolveBindingSymbol := func(*ast.Node) *ast.Symbol { return nil }
+	resolveReferenceSymbol := checkerReferenceSymbol
+	if ctx.Refs != nil {
+		resolveBindingSymbol = importBindingSymbol
+		resolveReferenceSymbol = ctx.Refs.Resolve
+	} else if ctx.TypeChecker != nil {
+		resolveBindingSymbol = func(nameNode *ast.Node) *ast.Symbol {
+			return checkerImportBindingSymbol(nameNode, &ctx)
+		}
+	}
+
+	groups, bindingCount := collectTopLevelImportedBindingGroups(
+		ctx.SourceFile,
+		resolveBindingSymbol,
+	)
+	return noImportAssignIntegratedListeners(
+		ctx,
+		groups,
+		bindingCount,
+		resolveBindingSymbol,
+		resolveReferenceSymbol,
+		checkerReferenceSymbol,
+	)
 }
 
 // NoImportAssignRule disallows assigning to imported bindings.

--- a/internal/rules/no_import_assign/no_import_assign_test.go
+++ b/internal/rules/no_import_assign/no_import_assign_test.go
@@ -680,6 +680,32 @@ func TestNoImportAssignStrategiesMatch(t *testing.T) {
 					ns.deep.value = 1;`,
 		},
 		{
+			name: "integrated namespace mutation roots",
+			code: `import * as ns from "ns";
+				import { value } from "value";
+				ns.property = 1;
+				ns["element"]++;
+				++ns.prefix;
+				delete ((ns)).deleted;
+				for (ns.key in source);
+				for (ns.item of source);
+				({ property: ns.destructured, ...ns } = source);
+				Object.assign(((ns)), source);
+				Object["defineProperty"](ns, key, descriptor);
+				Reflect.set(ns, key, value);
+				[value] = source;
+				(value as any) = 1;
+				ns.deep.property = 2;
+				Object.assign(target, ns);`,
+		},
+		{
+			name: "integrated nested write ordering and deduplication",
+			code: `import { first, second } from "values";
+				[(first = 1), second] = source;
+				foo(first = 2);
+				delete object[(second += 1)];`,
+		},
+		{
 			name: "local shadows and syntactic names",
 			code: `import { value } from "value";
 				import * as ns from "ns";
@@ -694,10 +720,12 @@ func TestNoImportAssignStrategiesMatch(t *testing.T) {
 		{
 			name: "shadowed mutation globals",
 			code: `import * as ns from "ns";
+				import { marker } from "marker";
 				{ const Object = factory; Object.assign(ns, source); }
 				Object.assign(ns, source);
 				function f(Reflect) { Reflect.set(ns, key, value); }
-				Reflect.set(ns, key, value);`,
+				Reflect.set(ns, key, value);
+				marker = 1;`,
 		},
 		{
 			name: "type-only imports",


### PR DESCRIPTION
## Summary

- skip listener registration when the source cannot contain an import declaration
- keep the existing single-binding scan, while multi-binding files collect only assignment/update/loop/delete/mutation-call targets during the linter's shared traversal
- use `ctx.Refs.Resolve` only for candidate writes and defer grouped reports to EOF, preserving diagnostic order and recovered-syntax fallbacks
- cache repeated binding messages only for dense diagnostic sets
- extend the existing strategy-differential tests with mutation roots, nested-write ordering/deduplication, and shadowed Object/Reflect cases

### Benchmark

Command:

```sh
go test ./internal/rules/no_import_assign -run '^$' -bench '^BenchmarkNoImportAssign/(no_imports|single_sparse|many_sparse|many_dense)/auto$' -benchmem -benchtime=300ms -count=8
```

Environment: darwin/arm64, Apple M1 Max, Go 1.26.1. Values are medians of 8 runs.

| Scenario | Before | After | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| no imports | 196,044 ns/op | 110,804 ns/op | -43.5% | 3,123 → 2,803 (-10.3%) | 32 → 27 (-15.6%) |
| single sparse | 291,287 ns/op | 289,935 ns/op | -0.5% | 3,669 → 3,669 | 37 → 37 |
| many sparse | 329,692 ns/op | 269,643 ns/op | -18.2% | 12,764 → 12,513 (-2.0%) | 129 → 131 (+1.6%) |
| many dense | 408,096 ns/op | 311,650 ns/op | -23.6% | 177,702 → 118,282 (-33.4%) | 1,201 → 709 (-41.0%) |

### Verification

- `go test ./internal/rules/no_import_assign -run '^TestNoImportAssign' -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/rules/no_import_assign`

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
