### PR TITLE
perf: optimize prefer-number-properties

### DIFF
--- a/internal/plugins/unicorn/rules/prefer_number_properties/prefer_number_properties.go
+++ b/internal/plugins/unicorn/rules/prefer_number_properties/prefer_number_properties.go
@@ -3,8 +3,11 @@ package prefer_number_properties
 import (
 	_ "embed"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -29,22 +32,6 @@ type globalReference struct {
 	property    string
 }
 
-var safeGlobalProperties = map[string]bool{
-	"parseInt":   true,
-	"parseFloat": true,
-	"NaN":        true,
-	"Infinity":   true,
-	"isNaN":      false,
-	"isFinite":   false,
-}
-
-var globalObjectNames = map[string]struct{}{
-	"globalThis": {},
-	"global":     {},
-	"window":     {},
-	"self":       {},
-}
-
 // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v64.0.0/docs/rules/prefer-number-properties.md
 var PreferNumberPropertiesRule = rule.Rule{
 	Name:   "unicorn/prefer-number-properties",
@@ -53,45 +40,43 @@ var PreferNumberPropertiesRule = rule.Rule{
 		opts := parseOptions(options)
 
 		report := func(ref globalReference) {
-			if !enabled(ref.name, opts) {
-				return
-			}
 			if isLeftHandSide(ref.node) {
 				return
 			}
 
+			textRange := utils.TrimNodeTextRange(ctx.SourceFile, ref.node)
 			msg := buildErrorMessage(ref.property, ref.description)
-			fixes := buildFixes(ctx.SourceFile, ref)
-			if safeGlobalProperties[ref.name] {
-				ctx.ReportRangeWithFixes(utils.TrimNodeTextRange(ctx.SourceFile, ref.node), msg, fixes...)
+			if isSafeGlobalProperty(ref.name) {
+				ctx.ReportRangeWithDeferredFixes(textRange, msg, func() []rule.RuleFix {
+					return buildFixes(ctx.SourceFile, ref, textRange)
+				})
 				return
 			}
 
-			ctx.ReportRangeWithSuggestions(
-				utils.TrimNodeTextRange(ctx.SourceFile, ref.node),
-				msg,
-				rule.RuleSuggestion{
+			ctx.ReportRangeWithDeferredSuggestions(textRange, msg, func() []rule.RuleSuggestion {
+				return []rule.RuleSuggestion{{
 					Message:  buildSuggestionMessage(ref.property, ref.description),
-					FixesArr: fixes,
-				},
-			)
+					FixesArr: buildFixes(ctx.SourceFile, ref, textRange),
+				}}
+			})
 		}
 
 		return rule.RuleListeners{
 			ast.KindIdentifier: func(node *ast.Node) {
 				name := node.AsIdentifier().Text
-				if !isTrackedGlobalName(name) || utils.IsNonReferenceIdentifier(node) || utils.IsShadowed(node, name) {
+				if !isTrackedGlobalName(name) || !enabled(name, opts) ||
+					utils.IsNonReferenceIdentifier(node) || isShadowed(&ctx, node, name) {
 					return
 				}
 				report(referenceFromNode(node, name))
 			},
 			ast.KindPropertyAccessExpression: func(node *ast.Node) {
-				if ref, ok := globalMemberReference(node); ok {
+				if ref, ok := globalMemberReference(&ctx, node, opts); ok {
 					report(ref)
 				}
 			},
 			ast.KindElementAccessExpression: func(node *ast.Node) {
-				if ref, ok := globalMemberReference(node); ok {
+				if ref, ok := globalMemberReference(&ctx, node, opts); ok {
 					report(ref)
 				}
 			},
@@ -128,8 +113,39 @@ func enabled(name string, opts preferNumberPropertiesOptions) bool {
 }
 
 func isTrackedGlobalName(name string) bool {
-	_, ok := safeGlobalProperties[name]
-	return ok
+	switch name {
+	case "parseInt", "parseFloat", "NaN", "Infinity", "isNaN", "isFinite":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSafeGlobalProperty(name string) bool {
+	switch name {
+	case "parseInt", "parseFloat", "NaN", "Infinity":
+		return true
+	default:
+		return false
+	}
+}
+
+func isGlobalObjectName(name string) bool {
+	switch name {
+	case "globalThis", "global", "window", "self":
+		return true
+	default:
+		return false
+	}
+}
+
+func isShadowed(ctx *rule.RuleContext, node *ast.Node, name string) bool {
+	if ctx.Refs != nil {
+		if symbol := ctx.Refs.Resolve(node); symbol != nil {
+			return utils.IsValueSymbolDeclaredInFile(symbol, ctx.SourceFile)
+		}
+	}
+	return utils.IsShadowed(node, name)
 }
 
 func referenceFromNode(node *ast.Node, name string) globalReference {
@@ -151,9 +167,9 @@ func referenceFromNode(node *ast.Node, name string) globalReference {
 	}
 }
 
-func globalMemberReference(node *ast.Node) (globalReference, bool) {
+func globalMemberReference(ctx *rule.RuleContext, node *ast.Node, opts preferNumberPropertiesOptions) (globalReference, bool) {
 	propertyName, ok := utils.AccessExpressionStaticName(node)
-	if !ok || !isTrackedGlobalName(propertyName) {
+	if !ok || !isTrackedGlobalName(propertyName) || !enabled(propertyName, opts) {
 		return globalReference{}, false
 	}
 
@@ -162,7 +178,7 @@ func globalMemberReference(node *ast.Node) (globalReference, bool) {
 		return globalReference{}, false
 	}
 	objectName := object.AsIdentifier().Text
-	if _, ok := globalObjectNames[objectName]; !ok || utils.IsShadowed(object, objectName) {
+	if !isGlobalObjectName(objectName) || isShadowed(ctx, object, objectName) {
 		return globalReference{}, false
 	}
 
@@ -219,9 +235,8 @@ func buildSuggestionMessage(property, description string) rule.RuleMessage {
 	}
 }
 
-func buildFixes(sf *ast.SourceFile, ref globalReference) []rule.RuleFix {
+func buildFixes(sf *ast.SourceFile, ref globalReference, textRange core.TextRange) []rule.RuleFix {
 	replacement := "Number." + ref.property
-	textRange := utils.TrimNodeTextRange(sf, ref.node)
 
 	if ast.IsIdentifier(ref.node) {
 		if shorthand := ref.node.Parent; shorthand != nil && shorthand.Kind == ast.KindShorthandPropertyAssignment {
@@ -231,6 +246,28 @@ func buildFixes(sf *ast.SourceFile, ref globalReference) []rule.RuleFix {
 		}
 	}
 
-	replacement = utils.SafeReplacementText(sf, ref.node, replacement)
+	replacement = safeNumberReplacementText(sf, textRange, replacement)
 	return []rule.RuleFix{rule.RuleFixReplaceRange(textRange, replacement)}
+}
+
+// safeNumberReplacementText is the rule-specific fast path for
+// utils.SafeReplacementText. Every replacement starts and ends with an
+// identifier character, so only an immediately adjacent identifier character
+// can merge with it. Looking at the two boundary runes avoids scanning all
+// preceding tokens again for every reported reference.
+func safeNumberReplacementText(sf *ast.SourceFile, textRange core.TextRange, replacement string) string {
+	text := sf.Text()
+	if textRange.Pos() > 0 {
+		before, _ := utf8.DecodeLastRuneInString(text[:textRange.Pos()])
+		if scanner.IsIdentifierPart(before) {
+			replacement = " " + replacement
+		}
+	}
+	if textRange.End() < len(text) {
+		after, _ := utf8.DecodeRuneInString(text[textRange.End():])
+		if scanner.IsIdentifierPart(after) {
+			replacement += " "
+		}
+	}
+	return replacement
 }

--- a/internal/plugins/unicorn/rules/prefer_number_properties/prefer_number_properties_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_number_properties/prefer_number_properties_extras_test.go
@@ -39,6 +39,10 @@ func TestPreferNumberPropertiesExtras(t *testing.T) {
 			{Code: `function f(window) { return window.parseFloat(value); }`},
 			{Code: `function f(globalThis) { return (globalThis as any).NaN; }`},
 
+			// ---- RefStore: body declarations shadow body reads, including before their declaration ----
+			{Code: `function f() { parseInt("10", 2); var parseInt = custom; }`},
+			{Code: `{ parseFloat("1"); const parseFloat = custom; }`},
+
 			// ---- Dimension 4: value-space declarations shadow globals; type-only declarations do not ----
 			{Code: `namespace NaN {}; NaN;`},
 			{Code: `enum NaN {}; NaN;`},
@@ -63,6 +67,14 @@ func TestPreferNumberPropertiesExtras(t *testing.T) {
 			// N/A: overload/abstract/declare body-absent forms do not contain value reads beyond declaration names.
 		},
 		[]rule_tester.InvalidTestCase{
+			// ---- RefStore: parameter initializers run outside the function body's var environment ----
+			fixed(`function f(value = parseInt("10", 2)) { var parseInt = custom; return value; }`, `function f(value = Number.parseInt("10", 2)) { var parseInt = custom; return value; }`, "parseInt", "parseInt", 1, 20, 1, 28),
+			fixed(`function f(value = window.parseFloat("1")) { var window = custom; return value; }`, `function f(value = Number.parseFloat("1")) { var window = custom; return value; }`, "parseFloat", "parseFloat", 1, 20, 1, 37),
+
+			// ---- RefStore: type-only and augmented declarations do not shadow runtime globals ----
+			fixed("type parseInt = (value: string) => number;\nparseInt(\"10\", 2);", "type parseInt = (value: string) => number;\nNumber.parseInt(\"10\", 2);", "parseInt", "parseInt", 2, 1, 2, 9),
+			fixed("export {};\ndeclare global { const NaN: number; }\nNaN;", "export {};\ndeclare global { const NaN: number; }\nNumber.NaN;", "NaN", "NaN", 3, 1, 3, 4),
+
 			// ---- Dimension 4: parenthesized references are transparent ----
 			fixed(`(parseFloat)("10.5");`, `(Number.parseFloat)("10.5");`, "parseFloat", "parseFloat", 1, 2, 1, 12),
 			fixed(`((NaN));`, `((Number.NaN));`, "NaN", "NaN", 1, 3, 1, 6),


### PR DESCRIPTION
## Summary

- Resolve tracked globals through ctx.Refs before falling back to the syntactic shadow scan.
- Skip disabled properties early and use fixed-name switches on the identifier hot path.
- Defer fix and suggestion construction until the consumer requests edits.
- Replace repeated token-prefix scans with a rule-local constant-time boundary check while preserving token separation.
- Add scope regression coverage for hoisting, parameter initializers, type-only declarations, and global augmentation.

### Benchmark

Command: go test ./internal/plugins/unicorn/rules/prefer_number_properties -run ^$ -bench ^BenchmarkPreferNumberProperties$ -benchmem -benchtime=500ms -count=6

Environment: Go 1.26.1, darwin/arm64, Apple M1 Max. Values are medians from six runs; the temporary benchmark file is not included in this PR.

| Workload | Before time/op | After time/op | Delta | Before B/op | After B/op | Before allocs/op | After allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| No matches | 132.7 µs | 107.2 µs | -19.2% | 3,399 | 3,425 | 39 | 39 |
| Global matches, no edits | 86.63 ms | 829.3 µs | -99.0% | 1,512,645 | 446,227 | 13,667 | 4,648 |
| Global matches, all edits | 82.12 ms | 962.1 µs | -98.8% | 1,509,021 | 589,924 | 13,654 | 8,105 |
| Shadowed references | 408.1 µs | 346.5 µs | -15.1% | 3,539 | 3,548 | 39 | 39 |

Validation:

- go test ./internal/plugins/unicorn/rules/prefer_number_properties
- targeted edit-demand attack under the race detector
- pnpm run check-spell
- pnpm run format:check
- pnpm exec golangci-lint run --new-from-rev=origin/main ./internal/plugins/unicorn/rules/prefer_number_properties/...

## Related Links

- None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).