### PR TITLE
perf: optimize no-unexpected-multiline

### DIFF
--- a/internal/rules/no_unexpected_multiline/no_unexpected_multiline.go
+++ b/internal/rules/no_unexpected_multiline/no_unexpected_multiline.go
@@ -1,17 +1,13 @@
 package no_unexpected_multiline
 
 import (
-	"regexp"
 	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
-
-var regexFlagMatcher = regexp.MustCompile(`^[gimsuy]+$`)
 
 var messageFunction = rule.RuleMessage{
 	Id:          "function",
@@ -36,7 +32,6 @@ var NoUnexpectedMultilineRule = rule.Rule{
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		sf := ctx.SourceFile
 		text := sf.Text()
-		lineMap := sf.ECMALineMap()
 
 		// reportTokenBreakAfter checks whether the next non-trivia token after
 		// `expr` starts on a different line than the source position of
@@ -50,9 +45,7 @@ var NoUnexpectedMultilineRule = rule.Rule{
 			if tokenStart >= len(text) {
 				return
 			}
-			exprEndLine := scanner.ComputeLineOfPosition(lineMap, exprEnd)
-			tokenLine := scanner.ComputeLineOfPosition(lineMap, tokenStart)
-			if exprEndLine == tokenLine {
+			if !hasLineTerminator(text, exprEnd, tokenStart) {
 				return
 			}
 			// ESLint reports a single-character range for `[` / `(`. Don't use
@@ -100,9 +93,7 @@ var NoUnexpectedMultilineRule = rule.Rule{
 				if prevPos < 0 {
 					return
 				}
-				prevLine := scanner.ComputeLineOfPosition(lineMap, prevPos)
-				backtickLine := scanner.ComputeLineOfPosition(lineMap, backtick)
-				if prevLine == backtickLine {
+				if !hasLineTerminator(text, prevPos+1, backtick) {
 					return
 				}
 				ctx.ReportRange(core.NewTextRange(backtick, backtick+1), messageTaggedTemplate)
@@ -111,6 +102,13 @@ var NoUnexpectedMultilineRule = rule.Rule{
 			ast.KindBinaryExpression: func(node *ast.Node) {
 				bin := node.AsBinaryExpression()
 				if bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindSlashToken {
+					return
+				}
+				// A break before the first slash is required regardless of the
+				// surrounding AST shape or the token after the second slash. Reject
+				// ordinary same-line division before doing either of those checks.
+				firstSlashRange := core.NewTextRange(bin.OperatorToken.End()-1, bin.OperatorToken.End())
+				if !hasLineTerminator(text, bin.Left.End(), firstSlashRange.Pos()) {
 					return
 				}
 				// Mirror ESLint's `BinaryExpression > BinaryExpression.left`
@@ -140,53 +138,141 @@ var NoUnexpectedMultilineRule = rule.Rule{
 				if afterPos >= len(text) {
 					return
 				}
-				identEnd, ok := scanIdentifier(text, afterPos)
-				if !ok {
-					return
-				}
-				if !regexFlagMatcher.MatchString(text[afterPos:identEnd]) {
+				if !matchesRegexFlagIdentifier(text, afterPos) {
 					return
 				}
 
-				// checkForBreakAfter(node.left): compare lines of
-				// `bin.Left.End()` (= last char of the numerator, possibly the
-				// closing `)` of a paren-wrapped left) and the first `/`
-				// (= bin.OperatorToken). Use TrimNodeTextRange so we land on
-				// the trimmed start of the slash, not its leading trivia.
-				firstSlashRange := utils.TrimNodeTextRange(sf, bin.OperatorToken)
-				leftEnd := bin.Left.End()
-				leftLine := scanner.ComputeLineOfPosition(lineMap, leftEnd)
-				slashLine := scanner.ComputeLineOfPosition(lineMap, firstSlashRange.Pos())
-				if leftLine == slashLine {
-					return
-				}
 				ctx.ReportRange(firstSlashRange, messageDivision)
 			},
 		}
 	},
 }
 
-// scanIdentifier walks the identifier starting at `pos` (if any) and returns
-// the position right after its last character. Uses the tsgo scanner's
-// Unicode-aware identifier helpers and full UTF-8 rune decoding so we agree
-// with the parser on what counts as an identifier — mirroring ESLint's
-// `tokenAfterOperator.type === "Identifier"` check by construction. Returns
-// ok=false when no identifier starts at `pos`.
-func scanIdentifier(text string, pos int) (int, bool) {
-	if pos >= len(text) {
-		return pos, false
-	}
-	startCh, size := utf8.DecodeRuneInString(text[pos:])
-	if startCh == utf8.RuneError || !scanner.IsIdentifierStart(startCh) {
-		return pos, false
-	}
-	end := pos + size
-	for end < len(text) {
-		ch, sz := utf8.DecodeRuneInString(text[end:])
-		if ch == utf8.RuneError || !scanner.IsIdentifierPart(ch) {
-			break
+// hasLineTerminator reports whether text[start:end] contains an ECMAScript
+// line terminator. Checking the short gap between two tokens directly avoids
+// resolving both positions through the source file's full line map.
+func hasLineTerminator(text string, start int, end int) bool {
+	for i := start; i < end; i++ {
+		switch text[i] {
+		case '\r', '\n':
+			return true
+		case 0xe2:
+			// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are the
+			// two non-ASCII ECMAScript line terminators (E2 80 A8/A9).
+			if i+2 < end && text[i+1] == 0x80 && (text[i+2] == 0xa8 || text[i+2] == 0xa9) {
+				return true
+			}
 		}
-		end += sz
 	}
-	return end, true
+	return false
+}
+
+// matchesRegexFlagIdentifier implements ESLint's Identifier-token plus
+// /^[gimsuy]+$/ check. Plain identifiers stay on the allocation-free source
+// scan; Unicode escapes are decoded in place so their identifier value (for
+// example, g\u0069 -> gi) is compared without constructing a token string.
+func matchesRegexFlagIdentifier(text string, pos int) bool {
+	matched := false
+	for pos < len(text) {
+		ch := rune(text[pos])
+		if isRegexFlag(ch) {
+			matched = true
+			pos++
+			continue
+		}
+
+		if ch == '\\' {
+			decoded, end, ok := scanIdentifierUnicodeEscape(text, pos)
+			if !ok {
+				return matched
+			}
+			if matched {
+				if !scanner.IsIdentifierPart(decoded) {
+					return true
+				}
+			} else if !scanner.IsIdentifierStart(decoded) {
+				return false
+			}
+			if !isRegexFlag(decoded) {
+				return false
+			}
+			matched = true
+			pos = end
+			continue
+		}
+
+		decoded, _ := utf8.DecodeRuneInString(text[pos:])
+		if decoded != utf8.RuneError && scanner.IsIdentifierPart(decoded) {
+			return false
+		}
+		return matched
+	}
+	return matched
+}
+
+func isRegexFlag(ch rune) bool {
+	switch ch {
+	case 'g', 'i', 'm', 's', 'u', 'y':
+		return true
+	default:
+		return false
+	}
+}
+
+// scanIdentifierUnicodeEscape decodes the identifier escape at pos and
+// returns the first byte after it. Both ECMAScript forms are accepted:
+// \uXXXX and \u{X...}.
+func scanIdentifierUnicodeEscape(text string, pos int) (rune, int, bool) {
+	const maxUnicodeCodePoint uint32 = 0x10ffff
+
+	if pos+2 > len(text) || text[pos] != '\\' || text[pos+1] != 'u' {
+		return 0, pos, false
+	}
+
+	pos += 2
+	if pos < len(text) && text[pos] == '{' {
+		pos++
+		digitStart := pos
+		value := uint32(0)
+		validValue := true
+		for pos < len(text) && isHexDigit(text[pos]) {
+			if value > (maxUnicodeCodePoint-hexValue(text[pos]))/16 {
+				validValue = false
+			} else if validValue {
+				value = value*16 + hexValue(text[pos])
+			}
+			pos++
+		}
+		if pos == digitStart || pos >= len(text) || text[pos] != '}' || !validValue {
+			return 0, pos, false
+		}
+		return rune(value), pos + 1, true
+	}
+
+	if pos+4 > len(text) {
+		return 0, pos, false
+	}
+	value := uint32(0)
+	for end := pos + 4; pos < end; pos++ {
+		if !isHexDigit(text[pos]) {
+			return 0, pos, false
+		}
+		value = value*16 + hexValue(text[pos])
+	}
+	return rune(value), pos, true
+}
+
+func isHexDigit(ch byte) bool {
+	return ch >= '0' && ch <= '9' || ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F'
+}
+
+func hexValue(ch byte) uint32 {
+	switch {
+	case ch >= '0' && ch <= '9':
+		return uint32(ch - '0')
+	case ch >= 'a' && ch <= 'f':
+		return uint32(ch-'a') + 10
+	default:
+		return uint32(ch-'A') + 10
+	}
 }

--- a/internal/rules/no_unexpected_multiline/no_unexpected_multiline_test.go
+++ b/internal/rules/no_unexpected_multiline/no_unexpected_multiline_test.go
@@ -272,8 +272,16 @@ function () {}
 			{Code: "tag`hi 🎉`"},
 			// Unicode identifier immediately after the second `/` — must NOT
 			// match `^[gimsuy]+$` (ASCII regex), so no division report. This
-			// stress-tests the UTF-8 decoding in scanIdentifier.
+			// stress-tests the UTF-8 identifier-boundary scan.
 			{Code: "foo\n/bar/日本"},
+			// Escaped identifier value decodes to `ga`, which is not made only
+			// of regex flags even though its raw source starts with `g`.
+			{Code: "foo\n/bar/g\\u0061"},
+			// The escape decoder must also reject non-ASCII identifier parts.
+			{Code: "foo\n/bar/g\\u03c0"},
+			// Non-breaking space is ECMAScript whitespace, but not a line
+			// terminator; it must not turn this call into a multiline hazard.
+			{Code: "foo\u00a0(bar)"},
 			// Unicode identifier as numerator with division across lines —
 			// the rule's checks are byte-position based but should treat the
 			// multi-byte name as a single identifier source-text-wise.
@@ -588,6 +596,69 @@ function () {}
 				Code: "x\n/y/i",
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "division",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// Identifier escapes are matched by their decoded token value, as
+			// ESLint does, rather than by a prefix of their raw source text.
+			{
+				Code: "foo\n/bar/g\\u0069",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "foo\n/bar/\\u0067i",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			// `is` is a contextual TypeScript keyword but an Identifier token
+			// for ESLint's expression grammar; its escaped spelling must match.
+			{
+				Code: "foo\n/bar/\\u0069s",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "foo\n/bar/g\\u{69}",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "division",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+
+			// Every ECMAScript line terminator, including the CRLF sequence,
+			// must be recognized in the short source gap between tokens.
+			{
+				Code: "foo\r\n(bar)",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "foo\r(bar)",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "foo\u2028(bar)",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "function",
+					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
+				}},
+			},
+			{
+				Code: "foo\u2029[bar]",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "property",
 					Line:      2, Column: 1, EndLine: 2, EndColumn: 2,
 				}},
 			},


### PR DESCRIPTION
## Summary

- Avoid full line-map lookups by checking ECMAScript line terminators directly in the short trivia gap between tokens.
- Reject ordinary same-line division before parent/flag analysis and derive the one-byte slash range without allocating a scanner.
- Match regex-flag identifiers without regexp or token-string allocations, including decoded Unicode identifier escapes for ESLint parity.
- Keep the optimization entirely inside the rule. `ctx.Refs` is not applicable to token-gap syntax and would materialize an unrelated reference index; deferred reports are not applicable because this rule has no fixes or suggestions.

### Benchmark

`go test ./internal/rules/no_unexpected_multiline -run '^$' -bench '^BenchmarkNoUnexpectedMultiline$' -benchmem -benchtime=300ms -count=8 -cpu=1`

Temporary benchmark harness, not committed. Values are medians of 8 runs on Apple M1 Max.

| Scenario | Before | After | Time | allocs/op | B/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| Common same-line | 226,734 ns/op | 70,926 ns/op | -68.7% | 8 → 8 | 560 → 464 |
| Multiline hazards | 363,801 ns/op | 74,181 ns/op | -79.6% | 520 → 8 | 82,483 → 464 |
| Comment trivia | 216,880 ns/op | 87,222 ns/op | -59.8% | 8 → 8 | 560 → 464 |
| Division-heavy | 570,845 ns/op | 159,009 ns/op | -72.1% | 1,032 → 8 | 164,403 → 464 |
| Escaped flags | 126,460 ns/op | 28,275 ns/op | -77.6% | 520 → 8 | 82,483 → 464 |

Adversarial validation also compared 819 legacy/new diagnostic-and-range combinations and 3,380 raw/escaped identifier combinations against the tsgo scanner oracle.

### Validation

- `go test ./internal/rules/no_unexpected_multiline -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run ./internal/rules/no_unexpected_multiline/...`

## Related Links

- https://eslint.org/docs/latest/rules/no-unexpected-multiline

## Checklist

- [x] Tests updated (including escaped identifiers and all ECMAScript line terminators).
- [x] Documentation updated (not required; no user-facing configuration change).