### PR TITLE
test: adapt no-useless-backreference test to embedfs Root

### DIFF
--- a/internal/rules/no_useless_backreference/no_useless_backreference_test.go
+++ b/internal/rules/no_useless_backreference/no_useless_backreference_test.go
@@ -623,8 +623,8 @@ func TestImportedRegExpConstructorAlias(t *testing.T) {
 
 func TestRegExpResolutionWithoutTypeInfo(t *testing.T) {
 	rootDir := fixtures.GetRootDir()
-	filePath := tspath.ResolvePath(rootDir, "file.ts")
-	fs := utils.NewOverlayVFS(bundled.WrapFS(osvfs.FS()), map[string]string{
+	filePath := tspath.ResolvePath(rootDir.Dir, "file.ts")
+	fs := utils.NewOverlayVFS(rootDir.FS, map[string]string{
 		filePath: `
 RegExp("\\1(a)");
 {
@@ -632,8 +632,8 @@ RegExp("\\1(a)");
 	RegExp("\\1(a)");
 }`,
 	})
-	host := utils.CreateCompilerHost(rootDir, fs)
-	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	host := utils.CreateCompilerHost(rootDir.Dir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir.Dir, "tsconfig.json", host)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

`TestRegExpResolutionWithoutTypeInfo`, added in #1520, was written against the old fixtures API, where `fixtures.GetRootDir()` returned a string and the VFS was built from `bundled.WrapFS(osvfs.FS())`. #1507 had already changed it to return an `embedfs.Root`, but #1520 branched off before that and only added a new function, so the two merged without a textual conflict and the package no longer builds.

Use `rootDir.Dir` and `rootDir.FS` instead, matching the other tests in the file.

## Related Links

- #1520
- #1507

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
