### PR TITLE
chore(deps): upgrade eslint-plugin-unicorn to 72

### DIFF
--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/unicorn.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/unicorn.test.ts
@@ -6,13 +6,8 @@
 import { runConformanceSuite } from './conformance.js';
 import type { DiffCase } from './harness.js';
 
-/** 141 rules that report IDENTICALLY on a minimal trigger. */
+/** 139 rules that report IDENTICALLY on a minimal trigger. */
 const CASES: DiffCase[] = [
-  {
-    pkg: 'eslint-plugin-unicorn',
-    rule: 'better-regex',
-    code: 'const re = /[0-9]/;\n',
-  },
   {
     pkg: 'eslint-plugin-unicorn',
     rule: 'catch-error-name',
@@ -31,7 +26,7 @@ const CASES: DiffCase[] = [
   {
     pkg: 'eslint-plugin-unicorn',
     rule: 'consistent-destructuring',
-    code: 'const {a} = foo;\nconsole.log(foo.b);\n',
+    code: 'const {a} = foo;\nconsole.log(foo.a);\n',
   },
   {
     pkg: 'eslint-plugin-unicorn',
@@ -50,6 +45,11 @@ const CASES: DiffCase[] = [
   },
   {
     pkg: 'eslint-plugin-unicorn',
+    rule: 'consistent-json-file-read',
+    code: "import fs from 'node:fs/promises';\nconst pkg = JSON.parse(await fs.readFile('./package.json'));\n",
+  },
+  {
+    pkg: 'eslint-plugin-unicorn',
     rule: 'consistent-template-literal-escape',
     code: 'const a = `$\\{foo}`;\n',
   },
@@ -57,6 +57,11 @@ const CASES: DiffCase[] = [
     pkg: 'eslint-plugin-unicorn',
     rule: 'custom-error-definition',
     code: 'class fooError extends Error {}\n',
+  },
+  {
+    pkg: 'eslint-plugin-unicorn',
+    rule: 'dom-node-dataset',
+    code: "declare const element: any;\nelement.setAttribute('data-unicorn', 'foo');\n",
   },
   {
     pkg: 'eslint-plugin-unicorn',
@@ -90,6 +95,11 @@ const CASES: DiffCase[] = [
   },
   {
     pkg: 'eslint-plugin-unicorn',
+    rule: 'name-replacements',
+    code: 'const e = 1;\nconsole.log(e);\n',
+  },
+  {
+    pkg: 'eslint-plugin-unicorn',
     rule: 'new-for-builtins',
     code: 'const m = Map();\n',
   },
@@ -107,11 +117,6 @@ const CASES: DiffCase[] = [
     pkg: 'eslint-plugin-unicorn',
     rule: 'no-array-callback-reference',
     code: 'const result = array.map(callback);\n',
-  },
-  {
-    pkg: 'eslint-plugin-unicorn',
-    rule: 'no-array-for-each',
-    code: 'array.forEach((x) => {\n\tconsole.log(x);\n});\n',
   },
   {
     pkg: 'eslint-plugin-unicorn',
@@ -155,13 +160,13 @@ const CASES: DiffCase[] = [
   },
   {
     pkg: 'eslint-plugin-unicorn',
-    rule: 'no-for-loop',
-    code: 'const arr = [1, 2, 3];\nfor (let i = 0; i < arr.length; i++) {\n  console.log(arr[i]);\n}',
+    rule: 'no-for-each',
+    code: 'array.forEach((x) => {\n\tconsole.log(x);\n});\n',
   },
   {
     pkg: 'eslint-plugin-unicorn',
-    rule: 'no-hex-escape',
-    code: 'const x = "\\x41";',
+    rule: 'no-for-loop',
+    code: 'const arr = [1, 2, 3];\nfor (let i = 0; i < arr.length; i++) {\n  console.log(arr[i]);\n}',
   },
   {
     pkg: 'eslint-plugin-unicorn',
@@ -373,7 +378,7 @@ const CASES: DiffCase[] = [
   {
     pkg: 'eslint-plugin-unicorn',
     rule: 'prefer-array-flat',
-    code: 'const foo = [].concat(maybeArray);\n',
+    code: 'const foo = [].concat(...bar);\n',
   },
   {
     pkg: 'eslint-plugin-unicorn',
@@ -437,11 +442,6 @@ const CASES: DiffCase[] = [
   },
   {
     pkg: 'eslint-plugin-unicorn',
-    rule: 'prefer-dom-node-dataset',
-    code: "declare const element: any;\nelement.setAttribute('data-unicorn', 'foo');\n",
-  },
-  {
-    pkg: 'eslint-plugin-unicorn',
     rule: 'prefer-dom-node-remove',
     code: 'declare const parentNode: any;\ndeclare const childNode: any;\nparentNode.removeChild(childNode);\n',
   },
@@ -474,11 +474,6 @@ const CASES: DiffCase[] = [
     pkg: 'eslint-plugin-unicorn',
     rule: 'prefer-includes',
     code: 'declare const arr: number[];\nconst x = arr.indexOf(1) !== -1;\n',
-  },
-  {
-    pkg: 'eslint-plugin-unicorn',
-    rule: 'prefer-json-parse-buffer',
-    code: "import fs from 'node:fs';\nconst data = JSON.parse(fs.readFileSync('./foo.json', 'utf8'));\n",
   },
   {
     pkg: 'eslint-plugin-unicorn',
@@ -647,8 +642,8 @@ const CASES: DiffCase[] = [
   },
   {
     pkg: 'eslint-plugin-unicorn',
-    rule: 'prevent-abbreviations',
-    code: 'const e = 1;\nconsole.log(e);\n',
+    rule: 'prefer-unicode-code-point-escapes',
+    code: 'const x = "\\x41";',
   },
   {
     pkg: 'eslint-plugin-unicorn',
@@ -716,7 +711,7 @@ const CASES: DiffCase[] = [
 const CLEAN_CASES: DiffCase[] = [
   {
     pkg: 'eslint-plugin-unicorn',
-    rule: 'no-array-for-each',
+    rule: 'no-for-each',
     code: 'for (const x of array) { console.log(x); }\n',
   },
   {

--- a/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/unicorn.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/eslint-plugin-conformance/unicorn.test.ts
@@ -6,7 +6,7 @@
 import { runConformanceSuite } from './conformance.js';
 import type { DiffCase } from './harness.js';
 
-/** 139 rules that report IDENTICALLY on a minimal trigger. */
+/** 140 rules that report IDENTICALLY on a minimal trigger. */
 const CASES: DiffCase[] = [
   {
     pkg: 'eslint-plugin-unicorn',

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -1,6 +1,6 @@
 import type { RslintConfigEntry } from '../define-config.js';
 
-// Aligned with official eslint-plugin-unicorn@64.x recommended.
+// Aligned with official eslint-plugin-unicorn@72.x recommended.
 // Rules commented out with "not implemented" are in the official preset but not yet available.
 // The official preset also injects `languageOptions.globals` (Array, Promise, Map, …);
 // rslint's config entry doesn't expose a `globals` field, so that part is omitted.
@@ -10,155 +10,344 @@ const recommended: RslintConfigEntry = {
     // Core ESLint rules disabled by upstream once their unicorn equivalents take over.
     // Keep them enabled (i.e. don't override) until the unicorn replacements are implemented,
     // otherwise users would lose all coverage for these patterns.
+    // 'logical-assignment-operators': 'off',
     // 'no-negated-condition': 'off',
     // 'no-nested-ternary': 'off',
+    // 'no-process-exit': 'off',
 
-    // 'unicorn/better-regex': 'off', // not implemented
+    // 'unicorn/better-dom-traversing': 'error', // not implemented
     // 'unicorn/catch-error-name': 'error', // not implemented
+    // 'unicorn/class-reference-in-static-methods': 'error', // not implemented
+    // 'unicorn/comment-content': 'off', // not implemented
     // 'unicorn/consistent-assert': 'error', // not implemented
+    // 'unicorn/consistent-boolean-name': 'error', // not implemented
+    // 'unicorn/consistent-class-member-order': 'error', // not implemented
+    // 'unicorn/consistent-compound-words': 'error', // not implemented
+    // 'unicorn/consistent-conditional-object-spread': 'error', // not implemented
     // 'unicorn/consistent-date-clone': 'error', // not implemented
     // 'unicorn/consistent-destructuring': 'off', // not implemented
     // 'unicorn/consistent-empty-array-spread': 'error', // not implemented
     // 'unicorn/consistent-existence-index-check': 'error', // not implemented
+    // 'unicorn/consistent-export-decorator-position': 'error', // not implemented
     // 'unicorn/consistent-function-scoping': 'error', // not implemented
+    // 'unicorn/consistent-function-style': 'off', // not implemented
+    // 'unicorn/consistent-json-file-read': 'error', // not implemented
+    // 'unicorn/consistent-optional-chaining': 'error', // not implemented
     // 'unicorn/consistent-template-literal-escape': 'error', // not implemented
+    // 'unicorn/consistent-tuple-labels': 'error', // not implemented
     // 'unicorn/custom-error-definition': 'off', // not implemented
+    // 'unicorn/default-export-style': 'error', // not implemented
+    // 'unicorn/dom-node-dataset': 'error', // not implemented
     // 'unicorn/empty-brace-spaces': 'error', // not implemented
     // 'unicorn/error-message': 'error', // not implemented
     // 'unicorn/escape-case': 'error', // not implemented
     // 'unicorn/expiring-todo-comments': 'error', // not implemented
     // 'unicorn/explicit-length-check': 'error', // not implemented
+    // 'unicorn/explicit-timer-delay': 'error', // not implemented
     'unicorn/filename-case': 'error',
+    // 'unicorn/id-match': 'off', // not implemented
     // 'unicorn/import-style': 'error', // not implemented
     // 'unicorn/isolated-functions': 'error', // not implemented
+    // 'unicorn/logical-assignment-operators': 'error', // not implemented
+    // 'unicorn/max-nested-calls': 'error', // not implemented
+    // 'unicorn/name-replacements': 'error', // not implemented
     'unicorn/new-for-builtins': 'error',
     // 'unicorn/no-abusive-eslint-disable': 'error', // not implemented
     // 'unicorn/no-accessor-recursion': 'error', // not implemented
+    // 'unicorn/no-accidental-bitwise-operator': 'error', // not implemented
     // 'unicorn/no-anonymous-default-export': 'error', // not implemented
     // 'unicorn/no-array-callback-reference': 'error', // not implemented
-    // 'unicorn/no-array-for-each': 'error', // not implemented
+    // 'unicorn/no-array-concat-in-loop': 'error', // not implemented
+    // 'unicorn/no-array-fill-with-reference-type': 'error', // not implemented
+    // 'unicorn/no-array-from-fill': 'error', // not implemented
+    // 'unicorn/no-array-front-mutation': 'off', // not implemented
     // 'unicorn/no-array-method-this-argument': 'error', // not implemented
     // 'unicorn/no-array-reduce': 'error', // not implemented
     // 'unicorn/no-array-reverse': 'error', // not implemented
     // 'unicorn/no-array-sort': 'error', // not implemented
+    // 'unicorn/no-array-sort-for-min-max': 'error', // not implemented
+    // 'unicorn/no-array-splice': 'error', // not implemented
+    // 'unicorn/no-asterisk-prefix-in-documentation-comments': 'off', // not implemented
+    // 'unicorn/no-async-promise-finally': 'error', // not implemented
     // 'unicorn/no-await-expression-member': 'error', // not implemented
     // 'unicorn/no-await-in-promise-methods': 'error', // not implemented
+    // 'unicorn/no-blob-to-file': 'error', // not implemented
+    // 'unicorn/no-boolean-sort-comparator': 'error', // not implemented
+    // 'unicorn/no-break-in-nested-loop': 'error', // not implemented
+    // 'unicorn/no-canvas-to-image': 'error', // not implemented
+    // 'unicorn/no-chained-comparison': 'error', // not implemented
+    // 'unicorn/no-collection-bracket-access': 'error', // not implemented
+    // 'unicorn/no-computed-property-existence-check': 'error', // not implemented
+    // 'unicorn/no-confusing-array-splice': 'error', // not implemented
+    // 'unicorn/no-confusing-array-with': 'error', // not implemented
     // 'unicorn/no-console-spaces': 'error', // not implemented
+    // 'unicorn/no-constant-zero-expression': 'error', // not implemented
+    // 'unicorn/no-declarations-before-early-exit': 'error', // not implemented
     // 'unicorn/no-document-cookie': 'error', // not implemented
+    // 'unicorn/no-double-comparison': 'error', // not implemented
+    // 'unicorn/no-duplicate-if-branches': 'error', // not implemented
+    // 'unicorn/no-duplicate-logical-operands': 'error', // not implemented
+    // 'unicorn/no-duplicate-loops': 'error', // not implemented
+    // 'unicorn/no-duplicate-set-values': 'error', // not implemented
     // 'unicorn/no-empty-file': 'error', // not implemented
+    // 'unicorn/no-error-property-assignment': 'error', // not implemented
+    // 'unicorn/no-exports-in-scripts': 'error', // not implemented
+    // 'unicorn/no-for-each': 'error', // not implemented
     // 'unicorn/no-for-loop': 'error', // not implemented
-    // 'unicorn/no-hex-escape': 'error', // not implemented
+    // 'unicorn/no-global-object-property-assignment': 'error', // not implemented
     // 'unicorn/no-immediate-mutation': 'error', // not implemented
+    // 'unicorn/no-impossible-length-comparison': 'error', // not implemented
+    // 'unicorn/no-incorrect-query-selector': 'error', // not implemented
+    // 'unicorn/no-incorrect-template-string-interpolation': 'error', // not implemented
     'unicorn/no-instanceof-builtins': 'error',
+    // 'unicorn/no-invalid-argument-count': 'error', // not implemented
+    // 'unicorn/no-invalid-character-comparison': 'error', // not implemented
     // 'unicorn/no-invalid-fetch-options': 'error', // not implemented
+    // 'unicorn/no-invalid-file-input-accept': 'off', // not implemented
     // 'unicorn/no-invalid-remove-event-listener': 'error', // not implemented
+    // 'unicorn/no-invalid-well-known-symbol-methods': 'error', // not implemented
     // 'unicorn/no-keyword-prefix': 'off', // not implemented
+    // 'unicorn/no-late-current-target-access': 'error', // not implemented
+    // 'unicorn/no-late-event-control': 'error', // not implemented
     // 'unicorn/no-lonely-if': 'error', // not implemented
+    // 'unicorn/no-loop-iterable-mutation': 'error', // not implemented
     // 'unicorn/no-magic-array-flat-depth': 'error', // not implemented
+    // 'unicorn/no-manually-wrapped-comments': 'off', // not implemented
+    // 'unicorn/no-mismatched-map-key': 'error', // not implemented
+    // 'unicorn/no-misrefactored-assignment': 'error', // not implemented
+    // 'unicorn/no-missing-local-resource': 'off', // not implemented
+    // 'unicorn/no-multiple-promise-resolver-calls': 'error', // not implemented
     // 'unicorn/no-named-default': 'error', // not implemented
+    // 'unicorn/no-negated-array-predicate': 'error', // not implemented
+    // 'unicorn/no-negated-comparison': 'error', // not implemented
     // 'unicorn/no-negated-condition': 'error', // not implemented
     // 'unicorn/no-negation-in-equality-check': 'error', // not implemented
     // 'unicorn/no-nested-ternary': 'error', // not implemented
     // 'unicorn/no-new-array': 'error', // not implemented
     // 'unicorn/no-new-buffer': 'error', // not implemented
+    // 'unicorn/no-non-function-verb-prefix': 'error', // not implemented
+    // 'unicorn/no-nonstandard-builtin-properties': 'error', // not implemented
     // 'unicorn/no-null': 'error', // not implemented
     // 'unicorn/no-object-as-default-parameter': 'error', // not implemented
+    // 'unicorn/no-object-methods-with-collections': 'error', // not implemented
+    // 'unicorn/no-optional-chaining-on-undeclared-variable': 'error', // not implemented
     // 'unicorn/no-process-exit': 'error', // not implemented
+    // 'unicorn/no-redundant-comparison': 'error', // not implemented
+    // 'unicorn/no-return-array-push': 'error', // not implemented
+    // 'unicorn/no-selector-as-dom-name': 'error', // not implemented
+    // 'unicorn/no-shorthand-property-overrides': 'error', // not implemented
     // 'unicorn/no-single-promise-in-promise-methods': 'error', // not implemented
     'unicorn/no-static-only-class': 'error',
+    // 'unicorn/no-subtraction-comparison': 'error', // not implemented
     'unicorn/no-thenable': 'error',
     // 'unicorn/no-this-assignment': 'error', // not implemented
+    // 'unicorn/no-this-outside-of-class': 'error', // not implemented
+    // 'unicorn/no-top-level-assignment-in-function': 'error', // not implemented
+    // 'unicorn/no-top-level-side-effects': 'error', // not implemented
+    // 'unicorn/no-transition-all': 'error', // not implemented
     // 'unicorn/no-typeof-undefined': 'error', // not implemented
+    // 'unicorn/no-uncalled-method': 'error', // not implemented
+    // 'unicorn/no-undeclared-class-members': 'error', // not implemented
     // 'unicorn/no-unnecessary-array-flat-depth': 'error', // not implemented
+    // 'unicorn/no-unnecessary-array-flat-map': 'error', // not implemented
     // 'unicorn/no-unnecessary-array-splice-count': 'error', // not implemented
     // 'unicorn/no-unnecessary-await': 'error', // not implemented
+    // 'unicorn/no-unnecessary-boolean-comparison': 'error', // not implemented
+    // 'unicorn/no-unnecessary-fetch-options': 'error', // not implemented
+    // 'unicorn/no-unnecessary-global-this': 'error', // not implemented
+    // 'unicorn/no-unnecessary-nested-ternary': 'error', // not implemented
     // 'unicorn/no-unnecessary-polyfills': 'error', // not implemented
     // 'unicorn/no-unnecessary-slice-end': 'error', // not implemented
+    // 'unicorn/no-unnecessary-splice': 'error', // not implemented
+    // 'unicorn/no-unnecessary-string-trim': 'error', // not implemented
     // 'unicorn/no-unreadable-array-destructuring': 'error', // not implemented
+    // 'unicorn/no-unreadable-for-of-expression': 'error', // not implemented
     // 'unicorn/no-unreadable-iife': 'error', // not implemented
+    // 'unicorn/no-unreadable-new-expression': 'off', // not implemented
+    // 'unicorn/no-unreadable-object-destructuring': 'error', // not implemented
+    // 'unicorn/no-unsafe-buffer-conversion': 'error', // not implemented
+    // 'unicorn/no-unsafe-dom-html': 'off', // not implemented
+    // 'unicorn/no-unsafe-promise-all-settled-values': 'error', // not implemented
+    // 'unicorn/no-unsafe-property-key': 'error', // not implemented
+    // 'unicorn/no-unsafe-string-replacement': 'error', // not implemented
+    // 'unicorn/no-unused-array-method-return': 'error', // not implemented
     // 'unicorn/no-unused-properties': 'off', // not implemented
+    // 'unicorn/no-useless-boolean-cast': 'error', // not implemented
+    // 'unicorn/no-useless-coercion': 'error', // not implemented
     // 'unicorn/no-useless-collection-argument': 'error', // not implemented
+    // 'unicorn/no-useless-compound-assignment': 'error', // not implemented
+    // 'unicorn/no-useless-concat': 'error', // not implemented
+    // 'unicorn/no-useless-continue': 'error', // not implemented
+    // 'unicorn/no-useless-delete-check': 'error', // not implemented
+    // 'unicorn/no-useless-else': 'error', // not implemented
     // 'unicorn/no-useless-error-capture-stack-trace': 'error', // not implemented
     // 'unicorn/no-useless-fallback-in-spread': 'error', // not implemented
     // 'unicorn/no-useless-iterator-to-array': 'error', // not implemented
     // 'unicorn/no-useless-length-check': 'error', // not implemented
+    // 'unicorn/no-useless-logical-operand': 'error', // not implemented
+    // 'unicorn/no-useless-override': 'error', // not implemented
     // 'unicorn/no-useless-promise-resolve-reject': 'error', // not implemented
+    // 'unicorn/no-useless-re-export': 'error', // not implemented
+    // 'unicorn/no-useless-recursion': 'error', // not implemented
     // 'unicorn/no-useless-spread': 'error', // not implemented
     'unicorn/no-useless-switch-case': 'error',
+    // 'unicorn/no-useless-template-literals': 'error', // not implemented
     // 'unicorn/no-useless-undefined': 'error', // not implemented
+    // 'unicorn/no-xor-as-exponentiation': 'error', // not implemented
     // 'unicorn/no-zero-fractions': 'error', // not implemented
     // 'unicorn/number-literal-case': 'error', // not implemented
     // 'unicorn/numeric-separators-style': 'error', // not implemented
+    // 'unicorn/operator-assignment': 'error', // not implemented
+    // 'unicorn/prefer-abort-signal-any': 'error', // not implemented
+    // 'unicorn/prefer-abort-signal-timeout': 'error', // not implemented
     // 'unicorn/prefer-add-event-listener': 'error', // not implemented
+    // 'unicorn/prefer-add-event-listener-options': 'error', // not implemented
+    // 'unicorn/prefer-aggregate-error': 'error', // not implemented
     // 'unicorn/prefer-array-find': 'error', // not implemented
-    // 'unicorn/prefer-array-flat': 'error', // not implemented
+    'unicorn/prefer-array-flat': 'error',
     'unicorn/prefer-array-flat-map': 'error',
+    // 'unicorn/prefer-array-from-async': 'error', // not implemented
+    // 'unicorn/prefer-array-from-map': 'error', // not implemented
+    // 'unicorn/prefer-array-from-range': 'error', // not implemented
     // 'unicorn/prefer-array-index-of': 'error', // not implemented
+    // 'unicorn/prefer-array-iterable-methods': 'error', // not implemented
+    // 'unicorn/prefer-array-last-methods': 'error', // not implemented
+    // 'unicorn/prefer-array-slice': 'error', // not implemented
     // 'unicorn/prefer-array-some': 'error', // not implemented
     // 'unicorn/prefer-at': 'error', // not implemented
+    // 'unicorn/prefer-await': 'error', // not implemented
     // 'unicorn/prefer-bigint-literals': 'error', // not implemented
     // 'unicorn/prefer-blob-reading-methods': 'error', // not implemented
+    // 'unicorn/prefer-block-statement-over-iife': 'error', // not implemented
+    // 'unicorn/prefer-boolean-return': 'error', // not implemented
     // 'unicorn/prefer-class-fields': 'error', // not implemented
     // 'unicorn/prefer-classlist-toggle': 'error', // not implemented
     // 'unicorn/prefer-code-point': 'error', // not implemented
+    // 'unicorn/prefer-continue': 'error', // not implemented
     // 'unicorn/prefer-date-now': 'error', // not implemented
     // 'unicorn/prefer-default-parameters': 'error', // not implemented
+    // 'unicorn/prefer-direct-iteration': 'error', // not implemented
+    // 'unicorn/prefer-dispose': 'off', // not implemented
     // 'unicorn/prefer-dom-node-append': 'error', // not implemented
-    // 'unicorn/prefer-dom-node-dataset': 'error', // not implemented
+    // 'unicorn/prefer-dom-node-html-methods': 'error', // not implemented
     // 'unicorn/prefer-dom-node-remove': 'error', // not implemented
+    // 'unicorn/prefer-dom-node-replace-children': 'error', // not implemented
     // 'unicorn/prefer-dom-node-text-content': 'error', // not implemented
+    // 'unicorn/prefer-early-return': 'error', // not implemented
+    // 'unicorn/prefer-else-if': 'error', // not implemented
+    // 'unicorn/prefer-error-is-error': 'off', // not implemented
     // 'unicorn/prefer-event-target': 'error', // not implemented
+    // 'unicorn/prefer-explicit-viewport-units': 'off', // not implemented
     // 'unicorn/prefer-export-from': 'error', // not implemented
+    // 'unicorn/prefer-flat-math-min-max': 'error', // not implemented
+    // 'unicorn/prefer-get-or-insert-computed': 'error', // not implemented
+    // 'unicorn/prefer-global-number-constants': 'error', // not implemented
     // 'unicorn/prefer-global-this': 'error', // not implemented
+    // 'unicorn/prefer-group-by': 'error', // not implemented
+    // 'unicorn/prefer-has-check': 'error', // not implemented
+    // 'unicorn/prefer-hoisting-branch-code': 'error', // not implemented
+    // 'unicorn/prefer-https': 'error', // not implemented
+    // 'unicorn/prefer-identifier-import-export-specifiers': 'error', // not implemented
     // 'unicorn/prefer-import-meta-properties': 'off', // not implemented
     // 'unicorn/prefer-includes': 'error', // not implemented
-    // 'unicorn/prefer-json-parse-buffer': 'off', // not implemented
+    // 'unicorn/prefer-includes-over-repeated-comparisons': 'error', // not implemented
+    // 'unicorn/prefer-iterable-in-constructor': 'error', // not implemented
+    // 'unicorn/prefer-iterator-concat': 'off', // not implemented
+    // 'unicorn/prefer-iterator-helpers': 'error', // not implemented
+    // 'unicorn/prefer-iterator-to-array': 'error', // not implemented
+    // 'unicorn/prefer-iterator-to-array-at-end': 'error', // not implemented
     // 'unicorn/prefer-keyboard-event-key': 'error', // not implemented
+    // 'unicorn/prefer-location-assign': 'error', // not implemented
     // 'unicorn/prefer-logical-operator-over-ternary': 'error', // not implemented
+    // 'unicorn/prefer-map-from-entries': 'error', // not implemented
+    // 'unicorn/prefer-math-abs': 'error', // not implemented
+    // 'unicorn/prefer-math-constants': 'error', // not implemented
     // 'unicorn/prefer-math-min-max': 'error', // not implemented
     // 'unicorn/prefer-math-trunc': 'error', // not implemented
+    // 'unicorn/prefer-minimal-ternary': 'error', // not implemented
     // 'unicorn/prefer-modern-dom-apis': 'error', // not implemented
     // 'unicorn/prefer-modern-math-apis': 'error', // not implemented
     // 'unicorn/prefer-module': 'error', // not implemented
     // 'unicorn/prefer-native-coercion-functions': 'error', // not implemented
     // 'unicorn/prefer-negative-index': 'error', // not implemented
     'unicorn/prefer-node-protocol': 'error',
+    // 'unicorn/prefer-number-coercion': 'error', // not implemented
+    // 'unicorn/prefer-number-is-safe-integer': 'error', // not implemented
     'unicorn/prefer-number-properties': 'error',
+    // 'unicorn/prefer-object-define-properties': 'error', // not implemented
+    // 'unicorn/prefer-object-destructuring-defaults': 'error', // not implemented
     // 'unicorn/prefer-object-from-entries': 'error', // not implemented
+    // 'unicorn/prefer-object-iterable-methods': 'error', // not implemented
+    // 'unicorn/prefer-observer-apis': 'error', // not implemented
     // 'unicorn/prefer-optional-catch-binding': 'error', // not implemented
+    // 'unicorn/prefer-path2d': 'error', // not implemented
+    // 'unicorn/prefer-private-class-fields': 'error', // not implemented
+    // 'unicorn/prefer-promise-try': 'error', // not implemented
+    // 'unicorn/prefer-promise-with-resolvers': 'error', // not implemented
     // 'unicorn/prefer-prototype-methods': 'error', // not implemented
     // 'unicorn/prefer-query-selector': 'error', // not implemented
+    // 'unicorn/prefer-queue-microtask': 'error', // not implemented
     // 'unicorn/prefer-reflect-apply': 'error', // not implemented
+    // 'unicorn/prefer-regexp-escape': 'off', // not implemented
     // 'unicorn/prefer-regexp-test': 'error', // not implemented
     // 'unicorn/prefer-response-static-json': 'error', // not implemented
+    // 'unicorn/prefer-scoped-selector': 'error', // not implemented
     // 'unicorn/prefer-set-has': 'error', // not implemented
+    // 'unicorn/prefer-set-methods': 'error', // not implemented
     // 'unicorn/prefer-set-size': 'error', // not implemented
+    // 'unicorn/prefer-short-arrow-method': 'off', // not implemented
     // 'unicorn/prefer-simple-condition-first': 'error', // not implemented
+    // 'unicorn/prefer-simple-sort-comparator': 'error', // not implemented
+    // 'unicorn/prefer-simplified-conditions': 'error', // not implemented
+    // 'unicorn/prefer-single-array-predicate': 'error', // not implemented
     // 'unicorn/prefer-single-call': 'error', // not implemented
+    // 'unicorn/prefer-single-object-destructuring': 'error', // not implemented
+    // 'unicorn/prefer-single-replace': 'error', // not implemented
+    // 'unicorn/prefer-smaller-scope': 'error', // not implemented
+    // 'unicorn/prefer-split-limit': 'error', // not implemented
     // 'unicorn/prefer-spread': 'error', // not implemented
+    // 'unicorn/prefer-string-match-all': 'error', // not implemented
+    // 'unicorn/prefer-string-pad-start-end': 'error', // not implemented
     // 'unicorn/prefer-string-raw': 'error', // not implemented
+    // 'unicorn/prefer-string-repeat': 'error', // not implemented
     // 'unicorn/prefer-string-replace-all': 'error', // not implemented
     // 'unicorn/prefer-string-slice': 'error', // not implemented
     // 'unicorn/prefer-string-starts-ends-with': 'error', // not implemented
     // 'unicorn/prefer-string-trim-start-end': 'error', // not implemented
     // 'unicorn/prefer-structured-clone': 'error', // not implemented
     // 'unicorn/prefer-switch': 'error', // not implemented
+    // 'unicorn/prefer-temporal': 'off', // not implemented
     // 'unicorn/prefer-ternary': 'error', // not implemented
+    // 'unicorn/prefer-then-catch': 'error', // not implemented
+    // 'unicorn/prefer-toggle-attribute': 'error', // not implemented
     // 'unicorn/prefer-top-level-await': 'error', // not implemented
     // 'unicorn/prefer-type-error': 'error', // not implemented
-    // 'unicorn/prevent-abbreviations': 'error', // not implemented
+    // 'unicorn/prefer-type-literal-last': 'error', // not implemented
+    // 'unicorn/prefer-uint8array-base64': 'off', // not implemented
+    // 'unicorn/prefer-unary-minus': 'error', // not implemented
+    // 'unicorn/prefer-unicode-code-point-escapes': 'error', // not implemented
+    // 'unicorn/prefer-url-can-parse': 'error', // not implemented
+    // 'unicorn/prefer-url-href': 'error', // not implemented
+    // 'unicorn/prefer-url-search-parameters': 'error', // not implemented
+    // 'unicorn/prefer-while-loop-condition': 'error', // not implemented
     // 'unicorn/relative-url-style': 'error', // not implemented
     'unicorn/require-array-join-separator': 'error',
+    // 'unicorn/require-array-sort-compare': 'error', // not implemented
+    // 'unicorn/require-css-escape': 'error', // not implemented
+    // 'unicorn/require-frontmatter-fields': 'off', // not implemented
     // 'unicorn/require-module-attributes': 'error', // not implemented
     // 'unicorn/require-module-specifiers': 'error', // not implemented
     'unicorn/require-number-to-fixed-digits-argument': 'error',
+    // 'unicorn/require-passive-events': 'error', // not implemented
     // 'unicorn/require-post-message-target-origin': 'off', // not implemented
+    // 'unicorn/require-proxy-trap-boolean-return': 'error', // not implemented
     // 'unicorn/string-content': 'off', // not implemented
     // 'unicorn/switch-case-braces': 'error', // not implemented
     // 'unicorn/switch-case-break-position': 'error', // not implemented
     // 'unicorn/template-indent': 'error', // not implemented
     // 'unicorn/text-encoding-identifier-case': 'error', // not implemented
     // 'unicorn/throw-new-error': 'error', // not implemented
+    // 'unicorn/try-complexity': 'off', // not implemented
   },
 };
 

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -213,7 +213,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/prefer-array-iterable-methods': 'error', // not implemented
     // 'unicorn/prefer-array-last-methods': 'error', // not implemented
     // 'unicorn/prefer-array-slice': 'error', // not implemented
-    // 'unicorn/prefer-array-some': 'error', // not implemented
+    'unicorn/prefer-array-some': 'error',
     // 'unicorn/prefer-at': 'error', // not implemented
     // 'unicorn/prefer-await': 'error', // not implemented
     // 'unicorn/prefer-bigint-literals': 'error', // not implemented
@@ -292,8 +292,8 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/prefer-regexp-test': 'error', // not implemented
     // 'unicorn/prefer-response-static-json': 'error', // not implemented
     // 'unicorn/prefer-scoped-selector': 'error', // not implemented
-    // 'unicorn/prefer-set-methods': 'error', // not implemented
     'unicorn/prefer-set-has': 'error',
+    // 'unicorn/prefer-set-methods': 'error', // not implemented
     // 'unicorn/prefer-set-size': 'error', // not implemented
     // 'unicorn/prefer-short-arrow-method': 'off', // not implemented
     // 'unicorn/prefer-simple-condition-first': 'error', // not implemented

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ catalogs:
       specifier: 4.0.3
       version: 4.0.3
     eslint-plugin-unicorn:
-      specifier: ^64.0.0
-      version: 64.0.0
+      specifier: ^72.0.0
+      version: 72.0.0
     eslint-scope:
       specifier: ^9.1.2
       version: 9.1.2
@@ -445,7 +445,7 @@ importers:
         version: 26.1.1
       '@typescript-eslint/parser':
         specifier: 'catalog:'
-        version: 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/rule-tester':
         specifier: workspace:*
         version: link:../rule-tester
@@ -457,7 +457,7 @@ importers:
         version: 10.8.0(jiti@2.7.0)
       eslint-plugin-cypress:
         specifier: 'catalog:'
-        version: 6.4.3(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))
+        version: 6.4.3(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))
       eslint-plugin-es-x:
         specifier: 'catalog:'
         version: 9.7.0(eslint@10.8.0(jiti@2.7.0))
@@ -478,7 +478,7 @@ importers:
         version: 4.0.3(eslint@10.8.0(jiti@2.7.0))
       eslint-plugin-unicorn:
         specifier: 'catalog:'
-        version: 64.0.0(eslint@10.8.0(jiti@2.7.0))
+        version: 72.0.0(eslint@10.8.0(jiti@2.7.0))
 
   packages/rslint-wasm:
     dependencies:
@@ -512,7 +512,7 @@ importers:
         version: 4.64.0(tslib@2.8.1)
       prebundle:
         specifier: 'catalog:'
-        version: 1.6.5(typescript@5.9.3)
+        version: 1.6.5(typescript@6.0.3)
 
   packages/rule-tester:
     dependencies:
@@ -1063,6 +1063,10 @@ packages:
 
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/css-tree@4.0.5':
+    resolution: {integrity: sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/object-schema@3.0.5':
@@ -3455,10 +3459,6 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
-  clean-regexp@1.0.0:
-    resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
-    engines: {node: '>=4'}
-
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -3549,6 +3549,10 @@ packages:
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
+
+  convert-hrtime@5.0.0:
+    resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
+    engines: {node: '>=12'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -3665,6 +3669,10 @@ packages:
 
   des.js@1.1.0:
     resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
+
+  detect-indent@7.0.2:
+    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
+    engines: {node: '>=12.20'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -3818,10 +3826,6 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
-  escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
-
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -3871,11 +3875,11 @@ packages:
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
-  eslint-plugin-unicorn@64.0.0:
-    resolution: {integrity: sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA==}
-    engines: {node: ^20.10.0 || >=21.0.0}
+  eslint-plugin-unicorn@72.0.0:
+    resolution: {integrity: sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==}
+    engines: {node: '>=22'}
     peerDependencies:
-      eslint: '>=9.38.0'
+      eslint: '>=10.4'
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -4091,6 +4095,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  function-timeout@1.0.2:
+    resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
+    engines: {node: '>=18'}
+
   functional-red-black-tree@1.0.1:
     resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
 
@@ -4296,6 +4304,10 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
+  identifier-regex@1.1.0:
+    resolution: {integrity: sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==}
+    engines: {node: '>=18'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -4415,6 +4427,10 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-identifier@1.1.0:
+    resolution: {integrity: sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==}
+    engines: {node: '>=18'}
 
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -4742,6 +4758,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  make-asynchronous@1.1.0:
+    resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
+    engines: {node: '>=18'}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -4834,6 +4854,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.29.0:
+    resolution: {integrity: sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==}
 
   mdurl@2.1.0:
     resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
@@ -5171,6 +5194,10 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  p-event@6.0.1:
+    resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
+    engines: {node: '>=16.17'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -5190,6 +5217,10 @@ packages:
   p-map@7.0.6:
     resolution: {integrity: sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==}
     engines: {node: '>=18'}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -5343,6 +5374,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quote-js-string@0.1.0:
+    resolution: {integrity: sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==}
+    engines: {node: '>=22'}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -5555,6 +5590,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -5992,6 +6031,10 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  super-regex@1.1.0:
+    resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
+    engines: {node: '>=18'}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -6071,6 +6114,10 @@ packages:
     engines: {node: '>=10.18'}
     peerDependencies:
       tslib: ^2
+
+  time-span@5.1.0:
+    resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
+    engines: {node: '>=12'}
 
   timers-browserify@2.0.12:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
@@ -6319,6 +6366,9 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -6732,6 +6782,11 @@ snapshots:
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
+
+  '@eslint/css-tree@4.0.5':
+    dependencies:
+      mdn-data: 2.29.0
+      source-map-js: 1.2.1
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -8516,24 +8571,24 @@ snapshots:
 
   '@types/vscode@1.125.0': {}
 
-  '@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.8.0(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.65.0
       debug: 4.4.3(supports-color@8.1.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8542,24 +8597,24 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
 
-  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.65.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9092,10 +9147,6 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
-  clean-regexp@1.0.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -9168,6 +9219,8 @@ snapshots:
   constants-browserify@1.0.0: {}
 
   content-type@2.0.0: {}
+
+  convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -9304,6 +9357,8 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
+
+  detect-indent@7.0.2: {}
 
   detect-libc@2.1.2: {}
 
@@ -9479,18 +9534,16 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-string-regexp@1.0.5: {}
-
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-cypress@6.4.3(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0)):
+  eslint-plugin-cypress@6.4.3(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
       eslint: 10.8.0(jiti@2.7.0)
       globals: 17.7.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
 
   eslint-plugin-es-x@9.7.0(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
@@ -9533,25 +9586,29 @@ snapshots:
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
 
-  eslint-plugin-unicorn@64.0.0(eslint@10.8.0(jiti@2.7.0)):
+  eslint-plugin-unicorn@72.0.0(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
+      '@eslint/css-tree': 4.0.5
+      browserslist: 4.28.7
       change-case: 5.4.4
       ci-info: 4.4.0
-      clean-regexp: 1.0.0
       core-js-compat: 3.49.0
+      detect-indent: 7.0.2
+      entities: 4.5.0
       eslint: 10.8.0(jiti@2.7.0)
       find-up-simple: 1.0.1
       globals: 17.7.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
-      jsesc: 3.1.0
+      is-identifier: 1.1.0
       pluralize: 8.0.0
-      regexp-tree: 0.1.27
+      quote-js-string: 0.1.0
       regjsparser: 0.13.2
+      reserved-identifiers: 1.2.0
       semver: 7.8.5
       strip-indent: 4.1.1
+      yaml: 2.9.0
 
   eslint-scope@9.1.2:
     dependencies:
@@ -9783,6 +9840,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  function-timeout@1.0.2: {}
 
   functional-red-black-tree@1.0.1: {}
 
@@ -10091,6 +10150,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  identifier-regex@1.1.0:
+    dependencies:
+      reserved-identifiers: 1.2.0
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -10185,6 +10248,11 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-identifier@1.1.0:
+    dependencies:
+      identifier-regex: 1.1.0
+      super-regex: 1.1.0
 
   is-inside-container@1.0.0:
     dependencies:
@@ -10488,6 +10556,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  make-asynchronous@1.1.0:
+    dependencies:
+      p-event: 6.0.1
+      type-fest: 4.41.0
+      web-worker: 1.5.0
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.5
@@ -10699,6 +10773,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.29.0: {}
 
   mdurl@2.1.0: {}
 
@@ -11254,6 +11330,10 @@ snapshots:
       - debug
       - supports-color
 
+  p-event@6.0.1:
+    dependencies:
+      p-timeout: 6.1.4
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -11271,6 +11351,8 @@ snapshots:
       p-limit: 4.0.0
 
   p-map@7.0.6: {}
+
+  p-timeout@6.1.4: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -11384,13 +11466,13 @@ snapshots:
       tunnel-agent: 0.6.0
     optional: true
 
-  prebundle@1.6.5(typescript@5.9.3):
+  prebundle@1.6.5(typescript@6.0.3):
     dependencies:
       '@vercel/ncc': 0.38.4
       cac: 7.0.0
       prettier: 3.9.6
       rollup: 4.62.2
-      rollup-plugin-dts: 6.4.1(rollup@4.62.2)(typescript@5.9.3)
+      rollup-plugin-dts: 6.4.1(rollup@4.62.2)(typescript@6.0.3)
       terser: 5.49.0
     transitivePeerDependencies:
       - typescript
@@ -11436,6 +11518,8 @@ snapshots:
   querystring-es3@0.2.1: {}
 
   queue-microtask@1.2.3: {}
+
+  quote-js-string@0.1.0: {}
 
   randombytes@2.1.0:
     dependencies:
@@ -11716,6 +11800,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  reserved-identifiers@1.2.0: {}
+
   resolve@1.22.12:
     dependencies:
       es-errors: 1.3.0
@@ -11742,14 +11828,14 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
-  rollup-plugin-dts@6.4.1(rollup@4.62.2)(typescript@5.9.3):
+  rollup-plugin-dts@6.4.1(rollup@4.62.2)(typescript@6.0.3):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
       convert-source-map: 2.0.0
       magic-string: 0.30.21
       rollup: 4.62.2
-      typescript: 5.9.3
+      typescript: 6.0.3
     optionalDependencies:
       '@babel/code-frame': 7.29.7
 
@@ -12178,6 +12264,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  super-regex@1.1.0:
+    dependencies:
+      function-timeout: 1.0.2
+      make-asynchronous: 1.1.0
+      time-span: 5.1.0
+
   supports-color@10.2.2: {}
 
   supports-color@7.2.0:
@@ -12265,6 +12357,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  time-span@5.1.0:
+    dependencies:
+      convert-hrtime: 5.0.0
+
   timers-browserify@2.0.12:
     dependencies:
       setimmediate: 1.0.5
@@ -12299,10 +12395,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  ts-api-utils@2.5.0(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -12512,6 +12604,8 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   web-namespaces@2.0.1: {}
+
+  web-worker@1.5.0: {}
 
   whatwg-encoding@3.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,7 @@ catalog:
   eslint-plugin-security: ^4.0.1
   eslint-plugin-simple-import-sort: ^13.0.0
   eslint-plugin-sonarjs: 4.0.3
-  eslint-plugin-unicorn: ^64.0.0
+  eslint-plugin-unicorn: ^72.0.0
   eslint-scope: ^9.1.2
   eslint-visitor-keys: ^5.0.1
   espree: ^11.2.0

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -305,6 +305,7 @@ middot
 minimatch
 misalign
 miscategorise
+misrefactored
 Mlym
 mmap
 mobx


### PR DESCRIPTION
## Summary

Bump the pnpm catalog pin for `eslint-plugin-unicorn` from `^64.0.0` to `^72.0.0` (149 → 341 rules), and realign the two things generated against 64.x: the recommended preset and the conformance suite. One rule name disappeared (`no-array-for-each` → `no-for-each`), two narrowed their triggers, and five were deprecated into no-ops (`create = () => ({})`) and replaced with their successors — `better-regex` has none, so it is the one case lost outright.

## Follow-up

The 12 natively-ported unicorn rules were written against 64.x and at least `prefer-array-flat` now diverges from v72 (upstream narrowed it to require a spread).