### PR TITLE
perf: optimize no-array-constructor hot paths

### DIFF
--- a/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor.go
+++ b/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor.go
@@ -14,6 +14,16 @@ func useLiteralMessage() rule.RuleMessage {
 	}
 }
 
+func sourceMayUseArrayConstructor(sourceFile *ast.SourceFile) bool {
+	// Parsed identifier names are normalized, including Unicode escapes. Stay
+	// conservative for direct callers that do not provide parser metadata.
+	if sourceFile == nil || sourceFile.Identifiers == nil {
+		return true
+	}
+	_, ok := sourceFile.Identifiers["Array"]
+	return ok
+}
+
 func buildArrayConstructorFixes(
 	sourceText string,
 	node *ast.Node,
@@ -43,70 +53,77 @@ func buildArrayConstructorFixes(
 	}
 }
 
+// Keep listener construction outside Run so the context captured by check
+// does not escape on files rejected by the identifier fast path.
+func noArrayConstructorListeners(ctx rule.RuleContext) rule.RuleListeners {
+	check := func(node *ast.Node) {
+		var callee *ast.Node
+		var args *ast.NodeList
+		var typeArgs *ast.NodeList
+
+		switch node.Kind {
+		case ast.KindCallExpression:
+			callExpr := node.AsCallExpression()
+			callee = callExpr.Expression
+			args = callExpr.Arguments
+			typeArgs = callExpr.TypeArguments
+		case ast.KindNewExpression:
+			newExpr := node.AsNewExpression()
+			callee = newExpr.Expression
+			args = newExpr.Arguments
+			typeArgs = newExpr.TypeArguments
+		default:
+			return
+		}
+
+		// ESTree does not expose grouping parentheses around a callee. Match
+		// that behavior without unwrapping TypeScript-only outer expressions
+		// such as non-null or `as` expressions.
+		if callee == nil {
+			return
+		}
+		if callee.Kind == ast.KindParenthesizedExpression {
+			callee = ast.SkipParentheses(callee)
+		}
+
+		// Check if callee is an Identifier named "Array"
+		if callee.Kind != ast.KindIdentifier {
+			return
+		}
+		identifier := callee.AsIdentifier()
+		if identifier.Text != "Array" {
+			return
+		}
+
+		// Skip if there are type arguments (e.g., Array<Foo>())
+		if typeArgs != nil && len(typeArgs.Nodes) > 0 {
+			return
+		}
+
+		// Skip if there's exactly 1 argument (e.g., Array(5))
+		if args != nil && len(args.Nodes) == 1 {
+			return
+		}
+
+		sourceText := ctx.SourceFile.Text()
+		reportRange := core.NewTextRange(scanner.SkipTrivia(sourceText, node.Pos()), node.End())
+		ctx.ReportRangeWithDeferredFixes(reportRange, useLiteralMessage(), func() []rule.RuleFix {
+			return buildArrayConstructorFixes(sourceText, node, args, reportRange)
+		})
+	}
+
+	return rule.RuleListeners{
+		ast.KindCallExpression: check,
+		ast.KindNewExpression:  check,
+	}
+}
+
 var NoArrayConstructorRule = rule.CreateRule(rule.Rule{
 	Name: "no-array-constructor",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		check := func(node *ast.Node) {
-			var callee *ast.Node
-			var args *ast.NodeList
-			var typeArgs *ast.NodeList
-
-			switch node.Kind {
-			case ast.KindCallExpression:
-				callExpr := node.AsCallExpression()
-				callee = callExpr.Expression
-				args = callExpr.Arguments
-				typeArgs = callExpr.TypeArguments
-			case ast.KindNewExpression:
-				newExpr := node.AsNewExpression()
-				callee = newExpr.Expression
-				args = newExpr.Arguments
-				typeArgs = newExpr.TypeArguments
-			default:
-				return
-			}
-
-			// ESTree does not expose grouping parentheses around a callee. Match
-			// that behavior without unwrapping TypeScript-only outer expressions
-			// such as non-null or `as` expressions.
-			if callee == nil {
-				return
-			}
-			callee = ast.SkipParentheses(callee)
-
-			// Check if callee is an Identifier named "Array"
-			if callee.Kind != ast.KindIdentifier {
-				return
-			}
-			identifier := callee.AsIdentifier()
-			if identifier.Text != "Array" {
-				return
-			}
-
-			// Skip if there are type arguments (e.g., Array<Foo>())
-			if typeArgs != nil && len(typeArgs.Nodes) > 0 {
-				return
-			}
-
-			// Skip if there's exactly 1 argument (e.g., Array(5))
-			argCount := 0
-			if args != nil {
-				argCount = len(args.Nodes)
-			}
-			if argCount == 1 {
-				return
-			}
-
-			sourceText := ctx.SourceFile.Text()
-			reportRange := core.NewTextRange(scanner.SkipTrivia(sourceText, node.Pos()), node.End())
-			ctx.ReportRangeWithDeferredFixes(reportRange, useLiteralMessage(), func() []rule.RuleFix {
-				return buildArrayConstructorFixes(sourceText, node, args, reportRange)
-			})
+		if !sourceMayUseArrayConstructor(ctx.SourceFile) {
+			return nil
 		}
-
-		return rule.RuleListeners{
-			ast.KindCallExpression: check,
-			ast.KindNewExpression:  check,
-		}
+		return noArrayConstructorListeners(ctx)
 	},
 })

--- a/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor_test.go
+++ b/internal/plugins/typescript/rules/no_array_constructor/no_array_constructor_test.go
@@ -13,6 +13,39 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
+func TestSourceMayUseArrayConstructor(t *testing.T) {
+	if !sourceMayUseArrayConstructor(nil) || !sourceMayUseArrayConstructor(&ast.SourceFile{}) {
+		t.Fatal("missing parser identifier metadata must conservatively keep listeners")
+	}
+
+	for _, testCase := range []struct {
+		name string
+		code string
+		want bool
+	}{
+		{name: "ordinary call", code: `service.method()`, want: false},
+		{name: "string only", code: `const value = "Array()"`, want: false},
+		{name: "computed property is conservative", code: `service["Array"]()`, want: true},
+		{name: "array call", code: `Array()`, want: true},
+		{name: "escaped array identifier", code: `Arr\u0061y()`, want: true},
+		{name: "array property", code: `service.Array()`, want: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/source.ts",
+				Path:     "/source.ts",
+			}, testCase.code, core.ScriptKindTS)
+			if got := sourceMayUseArrayConstructor(sourceFile); got != testCase.want {
+				t.Fatalf("sourceMayUseArrayConstructor(%q) = %v, want %v", testCase.code, got, testCase.want)
+			}
+			listeners := NoArrayConstructorRule.Run(rule.RuleContext{SourceFile: sourceFile}, nil)
+			if got := len(listeners) != 0; got != testCase.want {
+				t.Fatalf("listener presence for %q = %v, want %v", testCase.code, got, testCase.want)
+			}
+		})
+	}
+}
+
 func TestNoArrayConstructorRule(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoArrayConstructorRule, []rule_tester.ValidTestCase{
 		// Single argument (creates array with size)
@@ -302,6 +335,23 @@ func TestNoArrayConstructorExtras(t *testing.T) {
 			{Code: `new (Array)(value);`},
 		},
 		[]rule_tester.InvalidTestCase{
+			// SourceFile.Identifiers and the AST both normalize identifier
+			// escapes, so the file-level fast path must retain these reports.
+			{
+				Code: `Arr\u0061y(a, b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useLiteral", Line: 1, Column: 1},
+				},
+				Output: []string{`[a, b];`},
+			},
+			{
+				Code: `new Arr\u0061y();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useLiteral", Line: 1, Column: 1},
+				},
+				Output: []string{`[];`},
+			},
+
 			// This typescript-eslint wrapper is intentionally syntactic: a
 			// local binding named Array still matches.
 			{


### PR DESCRIPTION
## Summary

- Skip listener registration when the parser identifier table proves that a file cannot contain an Array callee.
- Keep listener construction behind that guard so the captured RuleContext does not escape on rejected files, making the common no-match path allocation-free.
- Avoid unconditional parenthesis unwrapping and simplify the single-argument fast path for files that do contain Array.
- Preserve ReportRangeWithDeferredFixes so suppressed and diagnostics-only reports still avoid fix construction.
- Keep the rule syntactic and do not use ctx.Refs: upstream intentionally reports locally shadowed Array bindings, so symbol-based filtering would change correctness.
- Extend the existing test file with conservative metadata fallback and Unicode-escaped Array coverage.

### Benchmark

Command: go test -buildvcs=false ./internal/plugins/typescript/rules/no_array_constructor -run ^$ -bench ^BenchmarkNoArrayConstructorRule$ -benchmem -count=10 -benchtime=1000x -cpu=1

Environment: Apple M1 Max, darwin/arm64, Go 1.26.1. Values are medians from ten runs with 1,000 fixed iterations. Parsing and candidate-event collection are outside the timed region; each operation executes Rule.Run and the listeners it registers against a reused parsed AST and diagnostic consumer. The temporary benchmark harness is not committed.

| Scenario | Time | Bytes | Allocations |
| --- | ---: | ---: | ---: |
| No Array; 400 unrelated call/new events | 6.460 µs → 13.1 ns (-99.8%) | 352 → 0 B/op | 4 → 0 allocs/op |
| Sparse; 400 unrelated events plus 2 diagnostics | 5.976 → 4.699 µs (-21.4%) | 352 → 352 B/op | 4 → 4 allocs/op |
| Sparse with autofix demand | 6.031 → 4.872 µs (-19.2%) | 496 → 496 B/op | 8 → 8 allocs/op |
| Dense; 600 events and 400 diagnostics | 17.06 → 17.23 µs (+1.0%) | 352 → 352 B/op | 4 → 4 allocs/op |
| Dense with autofix demand | 41.49 → 41.22 µs (-0.6%) | 29,152 → 29,152 B/op | 804 → 804 allocs/op |

The report-heavy dense cases remain within ±1.0%; the improvement targets the common absent and sparse-match paths.

### Validation

- go test -buildvcs=false ./internal/plugins/typescript/rules/no_array_constructor -count=1
- Supplemental adversarial cases cover parser metadata fallback, escaped identifiers, grouping and TypeScript wrappers, recovery ASTs, edit demand, and overlapping fixes.
- pnpm run check-spell
- pnpm run format:check
- pnpm exec golangci-lint run internal/plugins/typescript/rules/no_array_constructor/no_array_constructor.go internal/plugins/typescript/rules/no_array_constructor/no_array_constructor_test.go

## Related Links

- https://typescript-eslint.io/rules/no-array-constructor/
- https://github.com/web-infra-dev/rslint/pull/1412

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; rule behavior and configuration are unchanged).