### PR TITLE
perf: optimize no-octal hot paths

### DIFF
--- a/internal/rules/no_octal/no_octal.go
+++ b/internal/rules/no_octal/no_octal.go
@@ -2,34 +2,37 @@ package no_octal
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/utils"
 )
+
+const legacyOctalTokenFlags = ast.TokenFlagsOctal | ast.TokenFlagsContainsLeadingZero
+
+var noOctalMessage = rule.RuleMessage{
+	Id:          "noOctal",
+	Description: "Octal literals should not be used.",
+}
 
 // https://eslint.org/docs/latest/rules/no-octal
 var NoOctalRule = rule.Rule{
 	Name: "no-octal",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		sourceText := ctx.SourceFile.Text()
 		return rule.RuleListeners{
 			ast.KindNumericLiteral: func(node *ast.Node) {
-				// tsgo normalizes NumericLiteral.Text at parse time (e.g. "01234" -> "668"),
-				// so we must read the raw source to distinguish a legacy octal from a decimal.
-				raw := utils.TrimmedNodeText(ctx.SourceFile, node)
-				if isOctalLiteralRaw(raw) {
-					ctx.ReportNode(node, rule.RuleMessage{
-						Id:          "noOctal",
-						Description: "Octal literals should not be used.",
-					})
+				// NumericLiteral.Text is normalized, but the parser preserves whether
+				// the raw token was a legacy octal or a leading-zero decimal in flags.
+				if node.AsNumericLiteral().TokenFlags&legacyOctalTokenFlags == 0 {
+					return
 				}
+
+				// Node.Pos may include leading trivia. Skip only that trivia on the
+				// rare report path instead of rescanning every numeric token.
+				ctx.ReportRange(
+					node.Loc.WithPos(scanner.SkipTrivia(sourceText, node.Pos())),
+					noOctalMessage,
+				)
 			},
 		}
 	},
-}
-
-// isOctalLiteralRaw reports whether a NumericLiteral's raw source text denotes a
-// legacy octal literal or a leading-zero decimal (e.g. `08`, `09.1`).
-// Matches ESLint's `^0\d` check on `node.raw` — hex (`0x`), modern octal (`0o`),
-// binary (`0b`), and fractional literals (`0.1`) are excluded by construction.
-func isOctalLiteralRaw(raw string) bool {
-	return len(raw) >= 2 && raw[0] == '0' && raw[1] >= '0' && raw[1] <= '9'
 }

--- a/internal/rules/no_octal/no_octal_test.go
+++ b/internal/rules/no_octal/no_octal_test.go
@@ -3,60 +3,112 @@ package no_octal
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-func TestIsOctalLiteralRaw(t *testing.T) {
+func TestNoOctalParsedLiterals(t *testing.T) {
 	tests := []struct {
-		name     string
-		raw      string
-		expected bool
+		name        string
+		code        string
+		wantReports int
+		wantText    string
 	}{
 		// ---- ESLint upstream invalid cases (legacy octal + leading-zero decimal) ----
-		{name: "01234", raw: "01234", expected: true},
-		{name: "07", raw: "07", expected: true},
-		{name: "00", raw: "00", expected: true},
-		{name: "08 (leading-zero decimal)", raw: "08", expected: true},
-		{name: "09.1", raw: "09.1", expected: true},
-		{name: "09e1", raw: "09e1", expected: true},
-		{name: "09.1e1", raw: "09.1e1", expected: true},
-		{name: "018", raw: "018", expected: true},
-		{name: "019.1", raw: "019.1", expected: true},
-		{name: "019e1", raw: "019e1", expected: true},
-		{name: "019.1e1", raw: "019.1e1", expected: true},
+		{name: "01234", code: "01234", wantReports: 1, wantText: "01234"},
+		{name: "07", code: "07", wantReports: 1, wantText: "07"},
+		{name: "00", code: "00", wantReports: 1, wantText: "00"},
+		{name: "08 (leading-zero decimal)", code: "08", wantReports: 1, wantText: "08"},
+		{name: "09.1", code: "09.1", wantReports: 1, wantText: "09.1"},
+		{name: "09e1", code: "09e1", wantReports: 1, wantText: "09e1"},
+		{name: "09.1e1", code: "09.1e1", wantReports: 1, wantText: "09.1e1"},
+		{name: "018", code: "018", wantReports: 1, wantText: "018"},
+		{name: "019.1", code: "019.1", wantReports: 1, wantText: "019.1"},
+		{name: "019e1", code: "019e1", wantReports: 1, wantText: "019e1"},
+		{name: "019.1e1", code: "019.1e1", wantReports: 1, wantText: "019.1e1"},
+		{name: "separator after legacy octal token", code: "01_2", wantReports: 1, wantText: "01"},
+		{name: "separator after leading-zero token", code: "08_9", wantReports: 1, wantText: "08"},
 
 		// ---- ESLint upstream valid cases ----
-		{name: "0", raw: "0", expected: false},
-		{name: "0.1", raw: "0.1", expected: false},
-		{name: "0.5e1", raw: "0.5e1", expected: false},
-		{name: "0x1234", raw: "0x1234", expected: false},
-		{name: "0X5", raw: "0X5", expected: false},
+		{name: "0", code: "0"},
+		{name: "0.1", code: "0.1"},
+		{name: "0.5e1", code: "0.5e1"},
+		{name: "0x1234", code: "0x1234"},
+		{name: "0X5", code: "0X5"},
 
 		// ---- Modern literal forms (correctly excluded) ----
-		{name: "0o17", raw: "0o17", expected: false},
-		{name: "0O17", raw: "0O17", expected: false},
-		{name: "0b101", raw: "0b101", expected: false},
-		{name: "0B101", raw: "0B101", expected: false},
+		{name: "0o17", code: "0o17"},
+		{name: "0O17", code: "0O17"},
+		{name: "0b101", code: "0b101"},
+		{name: "0B101", code: "0B101"},
+		{name: "invalid separator after zero", code: "0_1"},
 
 		// ---- Plain decimals ----
-		{name: "1", raw: "1", expected: false},
-		{name: "123", raw: "123", expected: false},
-		{name: "1.5", raw: "1.5", expected: false},
-		{name: "1e5", raw: "1e5", expected: false},
-		{name: ".5", raw: ".5", expected: false},
+		{name: "1", code: "1"},
+		{name: "123", code: "123"},
+		{name: "1.5", code: "1.5"},
+		{name: "1e5", code: "1e5"},
+		{name: ".5", code: ".5"},
 
-		// ---- Boundary: too short to be 0-prefixed ----
-		{name: "empty", raw: "", expected: false},
+		// ---- Report range excludes leading trivia and unary operators ----
+		{name: "leading trivia", code: "/* 077 */\n\t01234", wantReports: 1, wantText: "01234"},
+		{name: "unary minus", code: "-077", wantReports: 1, wantText: "077"},
+
+		// ---- Suppression still keys off the trimmed literal start ----
+		{name: "disabled next line", code: "/* eslint-disable-next-line no-octal */\n077"},
+		{name: "other rule disabled", code: "/* eslint-disable-next-line other-rule */\n077", wantReports: 1, wantText: "077"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isOctalLiteralRaw(tt.raw); got != tt.expected {
-				t.Errorf("isOctalLiteralRaw(%q) = %v, want %v", tt.raw, got, tt.expected)
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/literal.js",
+				Path:     "/literal.js",
+			}, tt.code, core.ScriptKindJS)
+			diagnostics := runNoOctalOnParsedSource(sourceFile)
+			if len(diagnostics) != tt.wantReports {
+				t.Fatalf("diagnostics = %d, want %d", len(diagnostics), tt.wantReports)
+			}
+			if tt.wantReports != 0 {
+				diagnostic := diagnostics[0]
+				gotText := sourceFile.Text()[diagnostic.Range.Pos():diagnostic.Range.End()]
+				if gotText != tt.wantText {
+					t.Errorf("diagnostic range text = %q, want %q", gotText, tt.wantText)
+				}
+				if diagnostic.Message.Id != "noOctal" {
+					t.Errorf("message ID = %q, want noOctal", diagnostic.Message.Id)
+				}
 			}
 		})
 	}
+}
+
+func runNoOctalOnParsedSource(sourceFile *ast.SourceFile) []rule.RuleDiagnostic {
+	comments := rule.NewCommentStore(sourceFile)
+	var diagnostics []rule.RuleDiagnostic
+	ctx := rule.RuleContext{
+		SourceFile:     sourceFile,
+		Comments:       comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(NoOctalRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+		Report: func(diagnostic rule.RuleDiagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	})
+	listeners := NoOctalRule.Run(ctx, nil)
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	return diagnostics
 }
 
 func TestNoOctalRule(t *testing.T) {


### PR DESCRIPTION
## Summary

- Use the TypeScript parser's `TokenFlagsOctal` and `TokenFlagsContainsLeadingZero` metadata instead of rescanning every numeric literal.
- Compute the trimmed diagnostic range only on the report path with `scanner.SkipTrivia`, and reuse the immutable diagnostic message.
- Extend parsed-source coverage for upstream literal forms, trivia and unary ranges, parser recovery around separators, and suppression directives.

### Benchmark

Command:

```sh
go test ./internal/rules/no_octal -run '^$' -bench '^BenchmarkNoOctalRule$' -benchmem -count=10
```

Environment: Apple M1 Max, darwin/arm64. Values are medians of 10 runs. The temporary benchmark invoked the rule listener over 2,816 valid literals per operation, or 4,352 mixed literals with 2,816 reports per operation; the benchmark file is not committed.

| Case | Before | After | Time | Allocations |
| --- | ---: | ---: | ---: | ---: |
| Valid literals | 1,040,640 ns/op, 1,603,010 B/op, 13,827 allocs/op | 6,663 ns/op, 0 B/op, 0 allocs/op | -99.36% | -100% |
| Mixed literals | 1,843,789 ns/op, 1,895,693 B/op, 27,394 allocs/op | 56,403 ns/op, 0 B/op, 0 allocs/op | -96.94% | -100% |

`ctx.Refs` is unrelated to literal classification, and deferred reports only defer fix or suggestion construction, while `no-octal` emits diagnostics without edits. Neither applies to this rule-level hot path.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
