### PR TITLE
perf: optimize no-async-promise-executor

### DIFF
--- a/internal/rules/no_async_promise_executor/no_async_promise_executor.go
+++ b/internal/rules/no_async_promise_executor/no_async_promise_executor.go
@@ -1,95 +1,182 @@
 package no_async_promise_executor
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/binder"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-func buildAsyncMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "async",
-		Description: "Promise executor functions should not be async.",
+var asyncMessage = rule.RuleMessage{
+	Id:          "async",
+	Description: "Promise executor functions should not be async.",
+}
+
+func sourceMayUsePromise(sourceFile *ast.SourceFile) bool {
+	// Parsed identifier names are normalized, including Unicode escapes. Every
+	// async executor also spells the contextual keyword contiguously; matches in
+	// comments and strings are harmless false positives. Stay conservative for
+	// direct callers that do not provide parser metadata.
+	if sourceFile == nil || sourceFile.Identifiers == nil {
+		return true
+	}
+	_, ok := sourceFile.Identifiers["Promise"]
+	return ok && strings.Contains(sourceFile.Text(), "async")
+}
+
+func enclosingPromiseScope(node *ast.Node) *ast.Node {
+	for current := node.Parent; current != nil; current = current.Parent {
+		if ast.IsLocalsContainer(current) {
+			return current
+		}
+	}
+	return nil
+}
+
+func sourceHasPromiseBinding(ctx rule.RuleContext) bool {
+	if ctx.SourceFile == nil || !ctx.SourceFile.IsBound() {
+		return true
+	}
+
+	// Binder keeps every locals container in one source-ordered chain. A full
+	// miss proves all Promise candidates in the file are global, so subsequent
+	// scope changes need no individual resolution.
+	for container := ctx.SourceFile.AsNode(); container != nil; {
+		data := container.LocalsContainerData()
+		if data == nil {
+			return true
+		}
+		if len(data.Locals) != 0 && data.Locals["Promise"] != nil {
+			return true
+		}
+		if (container.Kind == ast.KindFunctionExpression || container.Kind == ast.KindClassExpression) &&
+			container.Name() != nil && container.Name().Text() == "Promise" {
+			return true
+		}
+		container = data.NextContainer
+	}
+	return false
+}
+
+func isGlobalPromiseReference(ctx rule.RuleContext, identifier *ast.Node) bool {
+	if ctx.Program != nil && ctx.SourceFile != nil && ctx.SourceFile.IsBound() {
+		if ast.IsGlobalSourceFile(ctx.SourceFile.AsNode()) && ctx.SourceFile.Locals["Promise"] != nil {
+			// ESLint stores user declarations and configured globals in one
+			// global-scope variable. Any source definition, including a type-only
+			// one, makes isGlobalReference return false for that name.
+			return false
+		}
+		// RefStore.Resolve falls back to the TypeChecker for globals. This rule
+		// only needs to disprove a global by finding a local binding, so use the
+		// same binder scope walk without paying for that global fallback.
+		resolver := binder.NameResolver{CompilerOptions: ctx.Program.Options()}
+		if ast.IsGlobalSourceFile(ctx.SourceFile.AsNode()) {
+			resolver.Globals = ctx.SourceFile.Locals
+		}
+		return resolver.Resolve(
+			identifier,
+			"Promise",
+			ast.SymbolFlagsValue|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias,
+			nil,
+			true,  // isUse
+			false, // excludeGlobals
+		) == nil
+	}
+	return !utils.IsShadowed(identifier, "Promise")
+}
+
+type noAsyncPromiseExecutorState struct {
+	ctx                   rule.RuleContext
+	cachedScope           *ast.Node
+	cachedGlobal          bool
+	hasCachedScope        bool
+	checkedFileBindings   bool
+	fileHasPromiseBinding bool
+}
+
+func (state *noAsyncPromiseExecutorState) check(node *ast.Node) {
+	newExpression := node.AsNewExpression()
+	callee := newExpression.Expression
+	if callee != nil && callee.Kind == ast.KindParenthesizedExpression {
+		callee = ast.SkipParentheses(callee)
+	}
+	if callee == nil || callee.Kind != ast.KindIdentifier ||
+		callee.AsIdentifier().Text != "Promise" {
+		return
+	}
+
+	arguments := newExpression.Arguments
+	if arguments == nil || len(arguments.Nodes) == 0 {
+		return
+	}
+
+	executor := arguments.Nodes[0]
+	if executor == nil {
+		return
+	}
+	if executor.Kind == ast.KindParenthesizedExpression {
+		executor = ast.SkipParentheses(executor)
+	}
+	if executor == nil ||
+		(executor.Kind != ast.KindFunctionExpression && executor.Kind != ast.KindArrowFunction) {
+		return
+	}
+
+	modifiers := executor.Modifiers()
+	if modifiers == nil || modifiers.ModifierFlags&ast.ModifierFlagsAsync == 0 {
+		return
+	}
+
+	scope := enclosingPromiseScope(callee)
+	if !state.hasCachedScope || state.cachedScope != scope {
+		state.cachedScope = scope
+		if state.hasCachedScope && !state.checkedFileBindings {
+			state.fileHasPromiseBinding = sourceHasPromiseBinding(state.ctx)
+			state.checkedFileBindings = true
+		}
+		if state.checkedFileBindings && !state.fileHasPromiseBinding {
+			state.cachedGlobal = true
+		} else {
+			state.cachedGlobal = isGlobalPromiseReference(state.ctx, callee)
+		}
+		state.hasCachedScope = true
+	}
+	if !state.cachedGlobal {
+		return
+	}
+
+	for _, modifier := range modifiers.Nodes {
+		if modifier != nil && modifier.Kind == ast.KindAsyncKeyword {
+			// The modifier end is already the exact token end. Skip only its
+			// leading trivia so dense reports do not allocate a scanner per token.
+			state.ctx.ReportRange(core.NewTextRange(
+				scanner.SkipTrivia(state.ctx.SourceFile.Text(), modifier.Pos()),
+				modifier.End(),
+			), asyncMessage)
+			return
+		}
 	}
 }
 
-// NoAsyncPromiseExecutorRule disallows using an async function as a Promise executor
+func noAsyncPromiseExecutorListeners(ctx rule.RuleContext) rule.RuleListeners {
+	state := &noAsyncPromiseExecutorState{ctx: ctx}
+	return rule.RuleListeners{ast.KindNewExpression: state.check}
+}
+
+// NoAsyncPromiseExecutorRule disallows using an async function as a Promise executor.
 var NoAsyncPromiseExecutorRule = rule.Rule{
 	Name: "no-async-promise-executor",
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		return rule.RuleListeners{
-			ast.KindNewExpression: func(node *ast.Node) {
-				if node == nil {
-					return
-				}
-
-				// Check if it's a new Promise(...) expression
-				expr := node.Expression()
-				if expr == nil || expr.Kind != ast.KindIdentifier {
-					return
-				}
-
-				if expr.Text() != "Promise" {
-					return
-				}
-
-				// Get the arguments
-				args := node.Arguments()
-				if len(args) == 0 {
-					return
-				}
-
-				// Check the first argument (executor function)
-				executor := args[0]
-				if executor == nil {
-					return
-				}
-
-				// Unwrap parentheses to get to the actual function
-				actualExecutor := executor
-				for actualExecutor != nil && actualExecutor.Kind == ast.KindParenthesizedExpression {
-					actualExecutor = actualExecutor.Expression()
-				}
-
-				if actualExecutor == nil {
-					return
-				}
-
-				// Check if the executor is an async function
-				var isAsync bool
-				var asyncKeywordNode *ast.Node
-
-				switch actualExecutor.Kind {
-				case ast.KindFunctionExpression:
-					// Check for async keyword
-					mods := actualExecutor.Modifiers()
-					if mods != nil {
-						for _, mod := range mods.Nodes {
-							if mod != nil && mod.Kind == ast.KindAsyncKeyword {
-								isAsync = true
-								asyncKeywordNode = mod
-								break
-							}
-						}
-					}
-
-				case ast.KindArrowFunction:
-					// Arrow functions can be async
-					mods := actualExecutor.Modifiers()
-					if mods != nil {
-						for _, mod := range mods.Nodes {
-							if mod != nil && mod.Kind == ast.KindAsyncKeyword {
-								isAsync = true
-								asyncKeywordNode = mod
-								break
-							}
-						}
-					}
-				}
-
-				if isAsync && asyncKeywordNode != nil {
-					ctx.ReportNode(asyncKeywordNode, buildAsyncMessage())
-				}
-			},
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		if !sourceMayUsePromise(ctx.SourceFile) {
+			return nil
 		}
+		if declared, ok := ctx.Globals["Promise"]; ok && !declared {
+			return nil
+		}
+		return noAsyncPromiseExecutorListeners(ctx)
 	},
 }

--- a/internal/rules/no_async_promise_executor/no_async_promise_executor_test.go
+++ b/internal/rules/no_async_promise_executor/no_async_promise_executor_test.go
@@ -3,9 +3,48 @@ package no_async_promise_executor
 import (
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
+
+func TestSourceMayUsePromise(t *testing.T) {
+	if !sourceMayUsePromise(nil) || !sourceMayUsePromise(&ast.SourceFile{}) {
+		t.Fatal("missing parser metadata must conservatively keep listeners")
+	}
+
+	for _, testCase := range []struct {
+		name string
+		code string
+		want bool
+	}{
+		{name: "unrelated code", code: `new Worker(() => {});`, want: false},
+		{name: "promise without async text", code: `new Promise(resolve => resolve());`, want: false},
+		{name: "async without promise identifier", code: `const work = async () => {};`, want: false},
+		{name: "string only", code: `const marker = "Promise async";`, want: false},
+		{name: "async executor", code: `new Promise(async () => {});`, want: true},
+		{name: "escaped promise identifier", code: `new Prom\u0069se(async () => {});`, want: true},
+		{name: "conservative property match", code: `service.Promise(async () => {});`, want: true},
+		{name: "conservative async string match", code: `const marker = "async"; new Promise(resolve => resolve());`, want: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/source.ts",
+				Path:     "/source.ts",
+			}, testCase.code, core.ScriptKindTS)
+			if got := sourceMayUsePromise(sourceFile); got != testCase.want {
+				t.Fatalf("sourceMayUsePromise(%q) = %v, want %v", testCase.code, got, testCase.want)
+			}
+			listeners := NoAsyncPromiseExecutorRule.Run(rule.RuleContext{SourceFile: sourceFile}, nil)
+			if got := len(listeners) != 0; got != testCase.want {
+				t.Fatalf("listener presence for %q = %v, want %v", testCase.code, got, testCase.want)
+			}
+		})
+	}
+}
 
 func TestNoAsyncPromiseExecutorRule(t *testing.T) {
 	rule_tester.RunRuleTester(
@@ -19,6 +58,33 @@ func TestNoAsyncPromiseExecutorRule(t *testing.T) {
 			{Code: `new Promise((resolve, reject) => {})`},
 			{Code: `new Promise((resolve, reject) => {}, async function unrelated() {})`},
 			{Code: `new Foo(async (resolve, reject) => {})`},
+			{Code: `Promise(async (resolve, reject) => {})`},
+			{Code: `new globalThis.Promise(async (resolve, reject) => {})`},
+			{Code: `new Promise((async () => {}) as () => void)`},
+			{Code: `const async = () => {}; new Promise(async)`},
+			{Code: `new Promise(...[async () => {}])`},
+			// Only global Promise references are checked.
+			{Code: `/* global Promise:off */ new Promise(async (resolve, reject) => {})`},
+			{Code: `new Promise(async (resolve, reject) => {})`, Globals: map[string]bool{"Promise": false}},
+			{Code: `let Promise; new Promise(async (resolve, reject) => {})`},
+			{Code: `function f() { new Promise(async (resolve, reject) => {}); var Promise; }`},
+			{Code: `function f(Promise) { new Promise(async (resolve, reject) => {}); }`},
+			{Code: `function f({ Promise }) { new Promise(async () => {}); }`},
+			{Code: `try {} catch (Promise) { new Promise(async () => {}); }`},
+			{Code: `{ new Promise(async () => {}); let Promise; }`},
+			{Code: `let Promise; new (Promise)(async () => {});`},
+			{Code: `for (let Promise of values) new Promise(async () => {});`},
+			{Code: `switch (value) { case 0: new Promise(async () => {}); break; case 1: let Promise; }`},
+			{Code: `function f(Promise = globalThis.Promise) { new Promise(async () => {}); }`},
+			{Code: `const f = function Promise() { new Promise(async () => {}); };`},
+			{Code: `const C = class Promise { static { new Promise(async () => {}); } };`},
+			{Code: `import Promise from "promise"; new Promise(async () => {});`},
+			{Code: `import { Promise } from "promise"; new Promise(async () => {});`},
+			{Code: `class Promise {} new Promise(async () => {});`},
+			{Code: `function Promise() {} new Promise(async () => {});`},
+			{Code: `namespace Promise {} new Promise(async () => {});`},
+			{Code: `interface Promise {} new Promise(async () => {});`},
+			{Code: `type Promise = {}; new Promise(async () => {});`},
 		},
 		// Invalid cases
 		[]rule_tester.InvalidTestCase{
@@ -55,6 +121,79 @@ func TestNoAsyncPromiseExecutorRule(t *testing.T) {
 						Line:      1,
 						Column:    17,
 					},
+				},
+			},
+			{
+				Code: `new (((Promise)))((((async function* () {}))))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "async",
+						Line:      1,
+						Column:    22,
+					},
+				},
+			},
+			{
+				Code: `new Promise<unknown>(/* executor */ async () => {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "async", Line: 1, Column: 37, EndLine: 1, EndColumn: 42},
+				},
+			},
+
+			// Parser identifier metadata normalizes escaped identifier text.
+			{
+				Code: `new Prom\u0069se(async () => {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "async",
+						Line:      1,
+						Column:    18,
+					},
+				},
+			},
+			{
+				Code: `export {}; interface Promise {} new Promise(async () => {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "async"},
+				},
+			},
+			{
+				Code: `{ type Promise = {}; new Promise(async () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "async"},
+				},
+			},
+			{
+				Code: `function f<Promise>() { new Promise(async () => {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "async"},
+				},
+			},
+			{
+				Code: `
+function f(value = new Promise(async () => {})) {
+  new Promise(async () => {});
+  var Promise;
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "async", Line: 2, Column: 32},
+				},
+			},
+
+			// A shadowed nested scope must not poison the cached outer scope.
+			{
+				Code: `
+new Promise(async () => {});
+{
+  let Promise;
+  new Promise(async () => {});
+}
+new Promise(async () => {});
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "async", Line: 2, Column: 13},
+					{MessageId: "async", Line: 7, Column: 13},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- Add a source-level fast path that skips listener registration when parser metadata proves there is no `Promise` identifier or the source contains no `async` keyword.
- Match `new Promise(...)` through direct AST fields, unwrap only ESTree-equivalent parentheses, and cache binder-only global-reference classification while respecting local shadowing and `Promise: off`.
- Keep reference resolution at the rule layer: `ctx.Refs.Resolve` was evaluated but its global TypeChecker fallback regressed sparse matches, so the optimized path walks binder scopes and scans the binder container chain only when multiple scopes need classification.
- Report the exact `async` token range with `SkipTrivia`, avoiding one scanner allocation per diagnostic. Deferred report APIs do not help this rule because it has no fixes or suggestions to construct.
- Extend the existing test file with upstream-compatible and adversarial cases covering shadowing, Unicode escapes, TypeScript wrappers, scope-cache transitions, and exact diagnostic ranges.

### Benchmark

Temporary paired legacy/current benchmark code was used and removed before commit.

```sh
go test -buildvcs=false ./internal/rules/no_async_promise_executor \
  -run '^$' \
  -bench '^BenchmarkNoAsyncPromiseExecutor(Legacy|Optimized)$' \
  -benchmem -count=10 -benchtime=5000x -cpu=1
```

Environment: Apple M1 Max, darwin/arm64, Go 1.26.1. Values are medians from 10 runs of 5,000 fixed iterations.

| Scenario | Time/op (legacy → optimized) | Time | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| No `Promise`; 400 unrelated `new` events | 2.032 µs → 15.67 ns | -99.2% | 352 → 0 | 4 → 0 |
| Sparse; 400 events, 2 diagnostics | 2.378 µs → 1.826 µs | -23.2% | 672 → 368 | 6 → 4 |
| Dense valid; 400 synchronous executors | 4.131 µs → 253.1 ns | -93.9% | 352 → 0 | 4 → 0 |
| Dense; 400 diagnostics | 57.67 µs → 13.16 µs | -77.2% | 64,352 → 368 | 404 → 4 |
| 400 diagnostics in 400 distinct scopes | 59.27 µs → 17.33 µs | -70.8% | 64,352 → 368 | 404 → 4 |

### Validation

- `go test -buildvcs=false ./internal/rules/no_async_promise_executor -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `pnpm exec golangci-lint run internal/rules/no_async_promise_executor/no_async_promise_executor.go internal/rules/no_async_promise_executor/no_async_promise_executor_test.go`
- Adversarial review covered global/local `Promise` classification, hoisting and TDZ cases, nested and named scopes, imports/type-only declarations, direct calls versus construction, wrappers, escapes, and diagnostic boundaries.

## Related Links

- https://eslint.org/docs/latest/rules/no-async-promise-executor
- https://github.com/web-infra-dev/rslint/pull/386

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; configuration and documented rule behavior are unchanged).
