### PR TITLE
perf: optimize require-yield hot paths

### DIFF
--- a/internal/rules/require_yield/require_yield.go
+++ b/internal/rules/require_yield/require_yield.go
@@ -1,31 +1,108 @@
 package require_yield
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-func buildMissingYieldMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "missingYield",
-		Description: "This generator function does not have 'yield'.",
-	}
+var missingYieldMessage = rule.RuleMessage{
+	Id:          "missingYield",
+	Description: "This generator function does not have 'yield'.",
 }
 
 func isGenerator(node *ast.Node) bool {
-	return ast.GetFunctionFlags(node)&ast.FunctionFlagsGenerator != 0
+	switch node.Kind {
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindMethodDeclaration:
+		return node.BodyData().AsteriskToken != nil
+	}
+	return false
 }
 
 type stackFrame struct {
-	node  *ast.Node
-	count int
+	node     *ast.Node
+	hasYield bool
+}
+
+func startSkippingDecorators(sourceText string, node *ast.Node) int {
+	pos := node.Pos()
+	if modifiers := node.Modifiers(); modifiers != nil {
+		for _, modifier := range modifiers.Nodes {
+			if modifier != nil && modifier.Kind == ast.KindDecorator && modifier.End() > pos {
+				pos = modifier.End()
+			}
+		}
+	}
+	return scanner.SkipTrivia(sourceText, pos)
+}
+
+func functionDeclarationHeadStart(sourceText string, node *ast.Node) int {
+	pos := node.Pos()
+	if modifiers := node.Modifiers(); modifiers != nil {
+		for _, modifier := range modifiers.Nodes {
+			if modifier == nil {
+				continue
+			}
+			if modifier.Kind == ast.KindExportKeyword || modifier.Kind == ast.KindDefaultKeyword {
+				pos = modifier.End()
+				continue
+			}
+			return scanner.SkipTrivia(sourceText, modifier.Pos())
+		}
+	}
+	return scanner.SkipTrivia(sourceText, pos)
+}
+
+func generatorHeadRange(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	parameters := node.ParameterList()
+	if parameters == nil {
+		return utils.GetFunctionHeadLoc(sourceFile, node)
+	}
+
+	// ParameterList.Pos is the full start of the first parameter (or the
+	// closing paren), so the preceding byte is the opening paren consumed by
+	// the parser. Validate the invariant and retain the generic scanner-based
+	// helper as an error-recovery fallback.
+	sourceText := sourceFile.Text()
+	openParen := parameters.Pos() - 1
+	if openParen < 0 || openParen >= len(sourceText) || sourceText[openParen] != '(' {
+		return utils.GetFunctionHeadLoc(sourceFile, node)
+	}
+
+	var start int
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		start = functionDeclarationHeadStart(sourceText, node)
+	case ast.KindMethodDeclaration:
+		start = startSkippingDecorators(sourceText, node)
+	case ast.KindFunctionExpression:
+		parent := node.Parent
+		if parent != nil && (parent.Kind == ast.KindPropertyAssignment || parent.Kind == ast.KindPropertyDeclaration) {
+			start = startSkippingDecorators(sourceText, parent)
+		} else {
+			start = scanner.SkipTrivia(sourceText, node.Pos())
+		}
+	default:
+		return utils.GetFunctionHeadLoc(sourceFile, node)
+	}
+	if start < 0 || start > openParen {
+		return utils.GetFunctionHeadLoc(sourceFile, node)
+	}
+	return core.NewTextRange(start, openParen)
 }
 
 // https://eslint.org/docs/latest/rules/require-yield
 var RequireYieldRule = rule.Rule{
 	Name: "require-yield",
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		if !strings.Contains(ctx.SourceFile.Text(), "*") {
+			return nil
+		}
+
 		stack := make([]stackFrame, 0, 8)
 
 		enter := func(node *ast.Node) {
@@ -39,17 +116,10 @@ var RequireYieldRule = rule.Rule{
 			}
 			top := stack[n-1]
 			stack = stack[:n-1]
-			// PropertyDeclaration initializer and ClassStaticBlockDeclaration
-			// both represent implicit-constructor-like scopes that are never
-			// themselves generators.
-			if top.node.Kind == ast.KindPropertyDeclaration ||
-				top.node.Kind == ast.KindClassStaticBlockDeclaration {
-				return
-			}
-			if isGenerator(top.node) && top.count == 0 && utils.HasNonEmptyFunctionBody(top.node) {
+			if isGenerator(top.node) && !top.hasYield && utils.HasNonEmptyFunctionBody(top.node) {
 				ctx.ReportRange(
-					utils.GetFunctionHeadLoc(ctx.SourceFile, top.node),
-					buildMissingYieldMessage(),
+					generatorHeadRange(ctx.SourceFile, top.node),
+					missingYieldMessage,
 				)
 			}
 		}
@@ -61,7 +131,7 @@ var RequireYieldRule = rule.Rule{
 					continue
 				}
 				if node.Pos() >= bp && node.End() <= be {
-					stack[i].count++
+					stack[i].hasYield = true
 					return
 				}
 			}

--- a/internal/rules/require_yield/require_yield_test.go
+++ b/internal/rules/require_yield/require_yield_test.go
@@ -1,8 +1,12 @@
 package require_yield
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
@@ -567,4 +571,95 @@ func TestRequireYieldRule(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestGeneratorHeadRangeAdversarialSyntax(t *testing.T) {
+	tests := []struct {
+		name        string
+		code        string
+		startMarker string
+		endMarker   string
+	}{
+		{
+			name:        "exported async declaration with comments and generic function type",
+			code:        `export /* export */ default /* default */ async function /* star */ *named<T extends () => void> /* params */ (/* actual */ value: T) { return; }`,
+			startMarker: "async function",
+			endMarker:   "(/* actual */",
+		},
+		{
+			name: "decorated computed method with nested parens",
+			code: `declare const dec: (...args: any[]) => any;
+declare const key: (...args: any[]) => PropertyKey;
+class A {
+  @dec(() => "(")
+  public static async /* star */ *[key("(", () => ")")]<T extends () => void> /* params */ (/* actual */ value: T) { return; }
+}`,
+			startMarker: "public static async",
+			endMarker:   "(/* actual */",
+		},
+		{
+			name: "decorated field function expression",
+			code: `declare const dec: (...args: any[]) => any;
+class A {
+  @dec(() => "(")
+  public field = function /* star */ *named<T extends () => void> /* params */ (/* actual */ value: T) { return; };
+}`,
+			startMarker: "public field",
+			endMarker:   "(/* actual */",
+		},
+		{
+			name:        "computed object property function expression",
+			code:        `const object = { [(() => "(")()]: function /* star */ *named<T extends () => void> /* params */ (/* actual */ value: T) { return; } };`,
+			startMarker: "[(() =>",
+			endMarker:   "(/* actual */",
+		},
+		{
+			name:        "standalone async function expression",
+			code:        `const fn = (/* leading */ async function /* star */ *named<T extends () => void> /* params */ (/* actual */ value: T) { return; });`,
+			startMarker: "async function",
+			endMarker:   "(/* actual */",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/file.ts",
+				Path:     "/file.ts",
+			}, tt.code, core.ScriptKindTS)
+
+			var generator *ast.Node
+			var walk func(*ast.Node)
+			walk = func(node *ast.Node) {
+				if node == nil || generator != nil {
+					return
+				}
+				if isGenerator(node) {
+					generator = node
+					return
+				}
+				node.ForEachChild(func(child *ast.Node) bool {
+					walk(child)
+					return generator != nil
+				})
+			}
+			walk(sourceFile.AsNode())
+			if generator == nil {
+				t.Fatal("generator not found")
+			}
+
+			wantStart := strings.Index(tt.code, tt.startMarker)
+			wantEnd := strings.Index(tt.code, tt.endMarker)
+			if wantStart < 0 || wantEnd < 0 {
+				t.Fatal("invalid test markers")
+			}
+			got := generatorHeadRange(sourceFile, generator)
+			if got.Pos() != wantStart || got.End() != wantEnd {
+				t.Fatalf(
+					"head range = [%d, %d) %q, want [%d, %d)",
+					got.Pos(), got.End(), tt.code[got.Pos():got.End()], wantStart, wantEnd,
+				)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Skip listener registration when the source cannot contain a generator.
- Derive generator report ranges from parser-owned parameter boundaries and allocation-free trivia scans, while retaining the generic scanner path for parser recovery.
- Track yield presence as a boolean and read the generator asterisk directly from the AST.
- Add adversarial coverage for comments, decorators, computed names, function expressions, and generic constraints containing nested parentheses.
- Keep the optimization entirely within `require-yield`. `ctx.Refs` is not applicable to this syntax-only scope attribution, and deferred reports only defer fixes or suggestions, which this rule does not produce.

### Benchmark

Temporary benchmark files were removed before commit. Measurements are medians of 10 runs on an Apple M1 Max with Go 1.26.1:

```sh
go test ./internal/rules/require_yield -run '^$' -bench '^BenchmarkRequireYield$' -benchmem -benchtime=500ms -count=10
go test ./internal/rules/require_yield -run '^$' -bench '^BenchmarkRequireYieldNoGenerators(Baseline)?$' -benchmem -benchtime=500ms -count=10
```

| Workload | Version | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| Generator/report heavy | Before | 507,464 | 119,065 | 774 |
| Generator/report heavy | After | 433,476 | 3,824 | 54 |
| No generator syntax | Before | 217,486 | 3,713 | 54 |
| No generator syntax | After | 113,138 | 2,636 | 26 |

- Generator/report-heavy: **14.58% faster**, **96.79% fewer bytes**, **93.02% fewer allocations**.
- No-generator syntax: **47.98% faster**, **29.02% fewer bytes**, **51.85% fewer allocations**.

### Validation

- `go test ./internal/rules/require_yield -run '^(TestRequireYieldRule|TestGeneratorHeadRangeAdversarialSyntax)$' -count=1`
- `pnpm run check-spell`
- `pnpm run format:check`
- `golangci-lint run --new-from-rev=origin/main ./internal/rules/require_yield`

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
