### PR TITLE
ci: add timeout to Go test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
   test-go:
     name: Test Go
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Add a 60-minute timeout to the Test Go matrix jobs.
- Stop resource-starved runners from leaving test jobs stuck indefinitely.

## Related Links

- https://github.com/web-infra-dev/rslint/actions/runs/30799156057/job/91639479476

## Checklist

- [x] Tests updated (not required for this workflow-only change).
- [x] Documentation updated (not required).